### PR TITLE
fix(runner): stop the fetch builtins judging their own work by the clock

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,11 @@ If you are developing runtime code, read the following documentation:
   and integration test structure; hub that links the other testing docs
 - `docs/development/waiting-in-tests.md` - Waiting on a real event instead of
   polling: the primitives to use.
+- `docs/development/fetch-request-deadlines.md` - Why the fetch builtins keep a
+  wall-clock bound: it leases a claim held in durable state rather than bounding
+  a request, and it decides when the replica holding that claim is presumed
+  gone. Read it before changing how `fetch.ts` or `fetch-program.ts` decide to
+  start a request
 - `docs/development/CI_PERFORMANCE.md` - When to stop or revisit CI wall-time
   splitting/rebalancing work
 - `docs/development/COVERAGE.md` - The two coverage mechanisms (V8 runtime

--- a/docs/development/fetch-request-deadlines.md
+++ b/docs/development/fetch-request-deadlines.md
@@ -1,0 +1,232 @@
+# The Fetch Builtins' Request Deadlines
+
+_Why `fetch.ts` and `fetch-program.ts` keep a wall-clock bound, what that bound
+is actually measuring, and what had to change before an early fire was
+survivable._
+
+**Status:** current · **Updated:** 2026-07-29
+
+---
+
+## The question
+
+[Retiring the LLM Tool-Call
+Deadline](proposals/retiring-llm-tool-call-deadlines.md) removed a deadline that
+bounded how long a local computation was allowed to take, and kept one that
+bounded how long to keep believing a different replica was still working. It
+left the two deadlines in the fetch builtins undecided, on the grounds that a
+bound on a network call raises a different question: what should happen when a
+remote peer never answers. This document settles that.
+
+The test is the one in
+[`waiting-in-tests.md`](waiting-in-tests.md#wall-clock-time-is-not-a-measure-of-progress):
+not "is the bound comfortably large" but "is firing early safe". A bound whose
+early fire only repeats work is tolerable. A bound whose early fire drops a real
+result is not.
+
+The answer for both is the same: the bound stays, because it answers a question
+that has no event, and because the thing it protects is not the request. What
+changed is that the bound used to be consulted in places where it was answering
+a question the code could answer exactly, and where firing early cost a real
+result rather than repeated work.
+
+## What each deadline actually protects
+
+Neither deadline bounds a fetch. Neither one aborts anything, and neither one is
+consulted by the replica running the request.
+
+Both fetch builtins coordinate across replicas — every client runs the whole
+reactive graph of every started piece, so several of them reach the same
+`fetchJson` node at the same moment and would otherwise all issue the request.
+The coordination is a claim written to durable state, and the deadline decides
+when a claim is treated as abandoned:
+
+- **`fetch.ts`**, through `tryClaimMutex` in `fetch-utils.ts`, writes
+  `pending: true` plus a `requestId` and a `lastActivity` timestamp into an
+  `internal` cell. A replica may claim when nothing is pending, or when the
+  standing claim's `lastActivity` is older than the bound. The default bound
+  lives in `fetch-utils.ts` as `MUTEX_STALE_AFTER`; a caller can override it per
+  call with `options.mutexTimeoutMs`.
+- **`fetch-program.ts`** writes a `fetching` entry, carrying a `requestId` and a
+  `startTime`, into a durable cache keyed by the input hash. The bound is
+  `PROGRAM_CLAIM_STALE_AFTER` in that file.
+
+`lastActivity` does not live up to its name, and the difference matters. It is
+stamped once, when the claim is made, and nothing ever refreshes it. So the
+comparison measures how long ago the request started, not how long the claimant
+has been silent. The LLM dialog's five-minute bound is the other thing:
+`safelyPerformUpdate` refreshes its timestamp on every durable write of a turn,
+so there the comparison really is a staleness bound on a heartbeat. Reading
+these two as the same shape is the mistake this document is trying to prevent.
+
+So each bound is a lease on a claim, not a timeout on a request. The lease
+exists because of what happens without one: a replica that goes away between
+claiming and writing back leaves `pending: true` — or a `fetching` entry —
+standing in durable state forever. `addCancel` releases the claim when a pattern is stopped in an
+orderly way, which covers a navigation but not a closed tab, a killed worker, or
+a machine that went to sleep and never came back. With no lease, no other
+replica may ever claim, and the piece shows a spinner that will never resolve.
+
+Deciding whether the replica holding a claim is still there is failure
+detection, and it is the case the proposal document already identifies as
+irreducible. Nothing in the runner reports another replica's presence: the
+memory server knows about connections and sessions, but no signal derived from
+them reaches a client, so there is no transport close, no abort, and no rejected
+promise to wait on. A staleness bound is the only instrument available, and that
+is why both bounds stay.
+
+## The bound is a predicate, not a timer
+
+Nothing arms these deadlines. No timer fires at the bound. Each one is a
+comparison against `Date.now()` inside the builtin's reactive action, evaluated
+whenever something else causes that action to run.
+
+Two consequences follow, and they pull in opposite directions.
+
+As a recovery mechanism, the bound is weaker than it looks: an abandoned claim is
+cleared only if some replica's action happens to run later, and nothing
+guarantees that a quiet piece ever will. It recovers reliably at the moments a
+replica arrives and evaluates the state fresh — a page load, a piece being
+opened — which is the common shape of the case it exists for.
+
+As a hazard, the bound is narrower than it looks: it cannot fire spontaneously
+during a healthy request in an otherwise quiet piece, because nothing wakes the
+action to evaluate it. It fires when a replica is already awake for another
+reason and finds a claim standing. That is exactly the busy-piece,
+several-replicas case.
+
+## What an early fire used to cost
+
+Sizing was the first symptom. The `fetch.ts` bound was five seconds, chosen on
+the reasoning that HTTP requests usually finish quickly. That is the reasoning
+`waiting-in-tests.md` rules out, and it did not survive contact with a real
+endpoint: `options.mutexTimeoutMs` was added so the lunch-poll pattern's image
+generation could raise its own bound to thirty seconds, an escape hatch for a
+default that was below the latency of work the repository ships. The
+`fetch-program.ts` bound was ten seconds for an operation that walks a program's
+entry module and every transitive dependency over the network, and loads the
+compiler stack on the way.
+
+But the sizing was the smaller half. In both builtins an early fire cost a real
+result:
+
+**`fetch-program.ts` applied the bound to its own in-flight resolution.** It
+tracked no local state at all, so the replica that started a resolution judged
+its own work by elapsed time exactly as it judged anyone else's. When the bound
+tripped, the entry went back to `idle`, and the resolution the replica was still
+running now had nowhere to write. Its writeback only lands if the entry is still
+`fetching`, so the finished program was discarded on arrival. The piece was left
+with `pending: false`, no result, and no error — indistinguishable from
+"finished, nothing here" — and it stayed that way. The self-restart the code
+appears to intend does not even happen: the action's own write does not wake it,
+so the entry sits at `idle` until something else disturbs it.
+
+**`fetch.ts` let a failing duplicate erase a good result.** A takeover leaves two
+requests for the same inputs in flight. `tryWriteResult` gates only on the input
+hash, so both may write, which is fine when both succeed and write the same
+thing. The error path cleared `result` unconditionally before writing the error,
+so a duplicate that failed — being rate-limited for being a duplicate, most
+plausibly — replaced the other request's good result with its own error.
+
+Neither of those is "repeats cleanup". Both are "drops a real result".
+
+## What changed
+
+**A replica no longer judges its own work by the clock.** `fetch-program.ts`
+records what it is resolving in an `inFlight` map and leaves those entries alone
+however long they take: a resolution running here ends when its promise settles,
+which is a real event and needs no estimate. The bound now applies only to an
+entry this replica did not claim. `fetch.ts` already had this narrowing in its
+`alreadyFetching` check, which answers from the replica's own state rather than
+from the timestamp.
+
+Note what is *not* in that sentence. `fetchProgram` holds an `AbortController`,
+but the signal never reaches the network: `HttpProgramResolver` issues its
+requests without one, and `resolveProgram` takes no signal. Aborting suppresses
+a writeback nobody is waiting for; it does not end a resolution. So a program
+host that accepts a connection and never answers leaves this replica resolving
+indefinitely, with `pending: true`. That is the same trade the tool-call
+proposal names: a truthful pending state instead of a deadline that reports a
+failure and throws away the answer if it ever arrives. Wiring cancellation
+through `js-compiler` would make it a real event end-to-end, and is not done
+here.
+
+**A failure no longer overwrites a result it did not produce.** The error path in
+`fetch.ts` leaves a result already recorded for the same inputs in place. A
+failed request is evidence about that request, not about the value another
+request already obtained.
+
+**A takeover no longer passes through `idle`.** `fetch-program.ts` rewrites a
+stale `fetching` entry straight into its own claim. Round-tripping through
+`idle` published `pending: false` with no result for a tick, which reads to a
+consumer as "finished, nothing here".
+
+**A claim now says which replica made it.** Both builtins used to write the
+input hash as the claim's `requestId`, so every replica claiming the same
+request wrote the same value. Teardown compared against it to decide whether the
+standing claim was its own, and the comparison always said yes. A replica
+closing a piece could therefore release a claim another replica had taken over
+and was actively working under, publishing `pending: false` with no result — the
+same lie, reached from the other end. The claim id now carries `runtime.id`,
+which is unique per storage manager and so per replica.
+
+That identity is used for teardown only. Writebacks stay gated on the input
+hash, so after a takeover either request may write its result: they are
+requests for the same inputs, and the first one home should count. Making the
+writeback strict would have been the other way to use a unique id, and it would
+have reintroduced the defect this whole change is about — the loser's real
+result discarded.
+
+**The bounds themselves are unchanged**, at five and ten seconds. Once firing
+early is survivable, the size stops being a correctness question, and it is a
+trade with a cost on both sides.
+
+Too low, and a slow request pays a duplicate whenever a second replica is awake
+to notice it — the case the lunch-poll pattern worked around by raising its own
+bound to thirty seconds.
+
+Too high, and an abandoned claim is believed for longer. That is worse than a
+delay, because of the predicate-not-a-timer property above. A replica arriving
+fresh evaluates the state during startup and then has no reason to look again.
+If the abandoned claim is younger than the bound at that moment, the takeover
+does not happen, nothing schedules another attempt, and the piece keeps showing
+a spinner until something else disturbs the action. That is the shape of a tab
+crashing mid-request and the user reloading straight away, which is the most
+likely way anyone meets an abandoned claim at all.
+
+A duplicate request is wasted work. A spinner that never resolves is a dead end
+the user cannot even diagnose. So the trade goes to the lower bound, and a
+caller whose endpoint is slow enough for duplicates to matter raises its own
+with `options.mutexTimeoutMs` — which is what that option is for.
+
+## What is still exposed
+
+A takeover during a healthy request sends a second copy of the request to the
+remote peer. For a GET that is wasted bandwidth. The fetch builtins accept a
+caller-supplied `method`, so it can also be a second POST, and the remote peer
+sees the side effect twice. Preventing duplicate requests is what the mutex is
+for, so this is the mutex failing at its job rather than a correctness bug in the
+runtime, and it is the same trade the proposal document accepts for the LLM
+dialog's heartbeat: an early fire costs a wasted call, not corrupted state.
+
+Closing that last gap needs the claim to be refreshed while the request is in
+flight, so that the bound measures the claimant's silence rather than the
+request's duration — which is what makes the LLM dialog's five-minute bound
+defensible, since `safelyPerformUpdate` refreshes its heartbeat on every durable
+write of a turn. A fetch has no intermediate durable writes to hang that on, so
+it would take a periodic write of its own: a durable write every few seconds for
+every long-running fetch, which every other replica then reads. That is a real
+cost against a residual risk, and it is not paid here.
+
+Two smaller things are named above and also not fixed here, because each is its
+own change rather than part of this policy. Cancellation does not reach a
+program resolution's network requests, so a hung program host leaves that
+replica pending. And `fetch-program.ts` keeps one `AbortController` for the node
+rather than one per in-flight resolution, so when the input changes mid-flight
+the older resolution is no longer reachable to abort.
+
+`packages/runner/test/fetch-claim-takeover.test.ts` pins what makes the residual
+risk survivable: a slow resolution running in this replica still reaches its
+result, a failing request does not erase a result recorded for the same inputs,
+and the staleness branch itself leaves a fresh claim alone while taking over an
+old one.

--- a/docs/development/fetch-request-deadlines.md
+++ b/docs/development/fetch-request-deadlines.md
@@ -229,4 +229,12 @@ the older resolution is no longer reachable to abort.
 risk survivable: a slow resolution running in this replica still reaches its
 result, a failing request does not erase a result recorded for the same inputs,
 and the staleness branch itself leaves a fresh claim alone while taking over an
-old one.
+old one. It also covers the claim's other transitions — handing it back when the
+pattern stops, a resolution that fails, an empty URL.
+
+One case there is untested, and it is the negative half of the ownership check:
+an entry carrying *another* replica's claim id, which teardown must leave alone.
+Reaching it takes a second replica writing the same durable cache cell, and
+`StorageManager.emulate` gives each runtime its own server, so a runner unit
+test cannot arrange it as things stand. The positive half — an entry this
+replica still holds, which teardown does release — is covered.

--- a/docs/development/proposals/retiring-llm-tool-call-deadlines.md
+++ b/docs/development/proposals/retiring-llm-tool-call-deadlines.md
@@ -267,7 +267,13 @@ still firing.
 
 ## What this does not cover
 
-`fetch-utils.ts` and `fetch-program.ts` carry their own request deadlines (5 and
-10 seconds). Those bound a network call rather than userland computation, so they
-raise a different question — what to do when a remote peer never answers — and
-are out of scope. A run-scoped barrier is the groundwork; the policy is separate.
+`fetch-utils.ts` and `fetch-program.ts` carry their own deadlines. Those raise a
+different question — what to do when a remote peer never answers — and are out
+of scope here. That question is settled separately in [The Fetch Builtins'
+Request Deadlines](../fetch-request-deadlines.md), which finds that neither
+deadline bounds a request at all: each is a lease on a claim held in durable
+state, and it decides when the replica holding that claim is presumed gone.
+Like the heartbeat bound in phase 4, both stay, because nothing reports another
+replica's presence. What changed there is the same narrowing phase 4 describes:
+a replica no longer applies the bound to work it is running itself, and an early
+fire no longer discards a result that arrived from elsewhere.

--- a/docs/specs/server-side-execution/README.md
+++ b/docs/specs/server-side-execution/README.md
@@ -116,9 +116,11 @@ Consequences, all previously measured:
   over exactly this.
 - **Async fragility.** fetch/LLM calls run in whichever tab claimed the cell
   mutex; a closed tab aborts the request
-  (`packages/runner/src/builtins/fetch.ts:312`) and someone else may re-claim
-  after a 5s–5min timeout. Streaming LLM partials live in an in-memory
-  `partial` cell and are lost on disconnect.
+  (`packages/runner/src/builtins/fetch.ts:306`) and someone else may re-claim
+  after a 5s–5min staleness bound
+  ([why that bound stays](../../development/fetch-request-deadlines.md)).
+  Streaming LLM partials live in an in-memory `partial` cell and are lost on
+  disconnect.
 - **Cold start.** A fresh client cannot paint pattern UI until it compiles
   and executes patterns locally (browser cold-compile floor ≈ 525ms for the
   entry-file emit alone, plus dependency collection and first settle).

--- a/packages/runner/src/builtins/fetch-program.ts
+++ b/packages/runner/src/builtins/fetch-program.ts
@@ -12,7 +12,30 @@ import { computeInputHashFromValue } from "./fetch-utils.ts";
 import { setPatternCell, setResultCell } from "../result-utils.ts";
 import { scopedCell } from "./scope-policy.ts";
 
-const PROGRAM_REQUEST_TIMEOUT = 1000 * 10; // 10 seconds for program resolution
+/**
+ * How long a `fetching` cache entry left by another replica is believed before
+ * this one takes the resolution over.
+ *
+ * This is not a bound on resolving a program. A resolution running here ends
+ * when its promise settles, and the entry it owns is never judged by elapsed
+ * time — `inFlight` below answers "am I already resolving this?" from local
+ * state. The bound applies only to an entry this replica did not claim, where
+ * the question is whether the replica that claimed it is still there. Nothing
+ * in the runner reports another replica's presence, so that question has no
+ * event to wait on.
+ *
+ * The value is left where it was. Once an early takeover no longer costs a
+ * result, the size is a trade with a cost on both sides: too low duplicates a
+ * resolution whenever another replica looks in while one is running, too high
+ * leaves a replica that arrives before the bound elapses looking at a claim it
+ * will not take over and has no reason to re-examine, so the piece keeps
+ * showing a spinner. A duplicated resolution is wasted work; a spinner that
+ * never resolves is a dead end, so the trade goes to the lower value.
+ *
+ * `docs/development/fetch-request-deadlines.md` records why this bound stays
+ * and what an early takeover costs.
+ */
+const PROGRAM_CLAIM_STALE_AFTER = 1000 * 10;
 
 export interface ProgramResult {
   files: Array<{ name: string; contents: string }>;
@@ -132,8 +155,13 @@ export function fetchProgram(
   let error: Cell<any | undefined>;
   let cache: Cell<Record<string, FetchCacheEntry>>;
   let cellScope: CellScope | undefined;
-  let myRequestId: string | undefined = undefined;
   let abortController: AbortController | undefined = undefined;
+  // Input hash to the claim id this replica wrote for it, for every resolution
+  // running here right now. The claim id carries `runtime.id`, which is unique
+  // per storage manager and so per replica; the entry's `requestId` used to be
+  // the input hash, which every replica resolving the same URL writes
+  // identically, so no replica could tell its own claim from anyone else's.
+  const inFlight = new Map<string, string>();
 
   // This is called when the pattern containing this node is being stopped.
   addCancel(() => {
@@ -141,7 +169,7 @@ export function fetchProgram(
     abortController?.abort("Pattern stopped");
 
     // Only try to update state if cells were initialized
-    if (!cellsInitialized || !myRequestId) return;
+    if (!cellsInitialized || inFlight.size === 0) return;
 
     const tx = runtime.edit();
 
@@ -150,10 +178,13 @@ export function fetchProgram(
       const currentCache = cache.withTx(tx).get();
       const updates: Record<string, FetchCacheEntry> = {};
 
+      // Release only the entries this replica still holds. An entry another
+      // replica took over carries its claim id, not ours, and resetting it
+      // would strand the resolution that replica is running.
       for (const [hash, entry] of Object.entries(currentCache)) {
         if (
           entry.state.type === "fetching" &&
-          entry.state.requestId === myRequestId
+          entry.state.requestId === inFlight.get(hash)
         ) {
           updates[hash] = {
             inputHash: hash,
@@ -239,6 +270,12 @@ export function fetchProgram(
       error.sync();
       cache.sync();
 
+      // The cells above are re-minted when the scope changes, so a resolution
+      // started under the old scope writes into the old scope's cache and says
+      // nothing about the new one. Forget those claims; their `finally` sees a
+      // claim id that is no longer recorded and leaves the map alone.
+      inFlight.clear();
+
       cellsInitialized = true;
       cellScope = outputScope;
     }
@@ -260,10 +297,22 @@ export function fetchProgram(
     const cacheEntry = allEntries[inputHash];
     const state: FetchState = cacheEntry?.state ?? { type: "idle" };
 
-    // State machine transitions
-    if (state.type === "idle") {
-      // Try to transition to fetching
-      const requestId = inputHash;
+    // State machine transitions. A resolution running in this replica ends
+    // when its promise settles, so an entry in `inFlight` is left alone
+    // whatever the entry says and however long it has been running. An entry
+    // claimed elsewhere and left untouched for longer than the staleness bound
+    // is taken over directly, without passing through `idle`: a round trip
+    // through `idle` would publish `pending: false` with no result for a tick,
+    // which reads to a consumer as "finished, nothing here".
+    const resolvingHere = inFlight.has(inputHash);
+    const claimAbandoned = state.type === "fetching" && !resolvingHere &&
+      Date.now() - state.startTime > PROGRAM_CLAIM_STALE_AFTER;
+
+    if (!resolvingHere && (state.type === "idle" || claimAbandoned)) {
+      // Try to transition to fetching. The claim id names this replica; the
+      // outbox id stays the input hash, which is what makes it an idempotency
+      // key for the same request from anywhere.
+      const requestId = `${runtime.id}:${inputHash}`;
       cache.withTx(tx).update({
         [inputHash]: {
           inputHash,
@@ -274,7 +323,7 @@ export function fetchProgram(
       enqueueSinkRequestPostCommitEffect(
         tx,
         "fetchProgram",
-        `fetchProgram:${requestId}`,
+        `fetchProgram:${inputHash}`,
         requestSnapshot,
         "fetchProgram-start",
         () => {
@@ -282,7 +331,9 @@ export function fetchProgram(
           // Tracked as async builtin work owned by this run, so
           // `runtime.settled()` and `runtime.settledFor(parentCell)` both wait
           // for the program resolve + writeback; `idle()` does not.
-          myRequestId = requestId;
+          // Recorded in `inFlight` here rather than above, because a
+          // transaction that never commits never reaches this callback.
+          inFlight.set(inputHash, requestId);
           abortController = new AbortController();
           runtime.trackAsyncWork(
             startFetch(
@@ -290,25 +341,16 @@ export function fetchProgram(
               cache,
               inputHash,
               url,
-              requestId,
               abortController.signal,
-            ),
+            ).finally(() => {
+              if (inFlight.get(inputHash) === requestId) {
+                inFlight.delete(inputHash);
+              }
+            }),
             parentCell,
           );
         },
       );
-    } else if (state.type === "fetching") {
-      // Check for timeout
-      const isTimedOut = Date.now() - state.startTime > PROGRAM_REQUEST_TIMEOUT;
-      if (isTimedOut) {
-        // Transition back to idle if timed out
-        cache.withTx(tx).update({
-          [inputHash]: {
-            inputHash,
-            state: { type: "idle" },
-          },
-        });
-      }
     }
 
     // Convert state machine state to output cells
@@ -329,15 +371,23 @@ export function fetchProgram(
 }
 
 /**
- * Start fetching a program. Uses CAS to ensure only the tab that initiated
- * the fetch can write the result.
+ * Start fetching a program. The writeback lands only on an entry still marked
+ * `fetching`, so a resolution whose entry has since reached `success` or
+ * `error`, or been released, writes nothing. It deliberately does not require
+ * the entry to carry *this* replica's claim id: after a takeover two
+ * resolutions for the same input hash are running, they resolve the same URL,
+ * and whichever finishes first should be the one that counts.
+ *
+ * The abort signal does not reach the network. `HttpProgramResolver` issues its
+ * requests without one, so this checks the signal between steps: it suppresses
+ * a writeback from a resolution nobody is waiting for, and does not end the
+ * resolution.
  */
 async function startFetch(
   runtime: Runtime,
   cache: Cell<Record<string, FetchCacheEntry>>,
   inputHash: string,
   url: string,
-  requestId: string,
   abortSignal: AbortSignal,
 ) {
   try {
@@ -359,14 +409,11 @@ async function startFetch(
 
     await runtime.idle();
 
-    // CAS: Only write if we're still the active request
+    // Only write into an entry that is still marked `fetching`.
     await runtime.editWithRetry((tx) => {
       const allEntries = cache.withTx(tx).get();
       const entry = allEntries[inputHash];
-      if (
-        entry?.state.type === "fetching" &&
-        entry.state.requestId === requestId
-      ) {
+      if (entry?.state.type === "fetching") {
         cache.withTx(tx).update({
           [inputHash]: {
             inputHash,
@@ -384,14 +431,11 @@ async function startFetch(
 
     await runtime.idle();
 
-    // CAS: Only write error if we're still the active request
+    // Only write into an entry that is still marked `fetching`.
     await runtime.editWithRetry((tx) => {
       const allEntries = cache.withTx(tx).get();
       const entry = allEntries[inputHash];
-      if (
-        entry?.state.type === "fetching" &&
-        entry.state.requestId === requestId
-      ) {
+      if (entry?.state.type === "fetching") {
         cache.withTx(tx).update({
           [inputHash]: {
             inputHash,

--- a/packages/runner/src/builtins/fetch-utils.ts
+++ b/packages/runner/src/builtins/fetch-utils.ts
@@ -6,7 +6,32 @@ import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 import type { Schema } from "../builder/types.ts";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 
-export const REQUEST_TIMEOUT = 1000 * 5; // 5 seconds
+/**
+ * How long a claimed request mutex is believed before another replica may take
+ * it over.
+ *
+ * This is not a bound on the request. A request issued here ends when its
+ * promise settles or its AbortSignal fires, and `fetch.ts` decides from its own
+ * state, not from the clock, whether it already has one in flight. The only
+ * reader is a replica that finds a claim it did not make and has to decide
+ * whether the replica that made it is still there. Nothing in the runner
+ * reports another replica's presence, so that question has no event to wait on
+ * and a staleness bound is the only answer available.
+ *
+ * The value is left where it was. Once an early takeover no longer costs a
+ * result, the size is a trade with a cost on both sides: too low sends a second
+ * copy of the request to the remote peer whenever another replica looks in
+ * while one is running, too high leaves a replica that arrives before the bound
+ * elapses looking at a claim it will not take over and has no reason to
+ * re-examine, so the piece keeps showing a spinner. A duplicate request is
+ * wasted work; a spinner that never resolves is a dead end, so the trade goes
+ * to the lower value. A caller whose endpoint is slow enough that duplicates
+ * matter raises its own bound with `options.mutexTimeoutMs`.
+ *
+ * `docs/development/fetch-request-deadlines.md` records why this bound stays
+ * and what an early takeover costs.
+ */
+export const MUTEX_STALE_AFTER = 1000 * 5;
 
 export const internalSchema = internSchema(
   {
@@ -82,10 +107,12 @@ export function computeInputHash<T extends Record<string, any>>(
 }
 
 /**
- * Attempts to claim the mutex for a request. Only claims if no other
- * request is active or if the previous request has timed out.
- * When claiming, sets pending=true and clears result/error to maintain
- * the invariant that result/error are undefined while pending.
+ * Attempts to claim the mutex for a request. Only claims if no other request
+ * is active, or if the standing claim was made longer than `timeout` ago and is
+ * therefore treated as abandoned (see {@link MUTEX_STALE_AFTER}). Claiming sets
+ * pending=true and records the claim in `internal`; the caller clears
+ * result/error to maintain the invariant that result/error are undefined while
+ * pending.
  */
 export async function tryClaimMutex<T extends Record<string, any>>(
   runtime: Runtime,
@@ -97,7 +124,7 @@ export async function tryClaimMutex<T extends Record<string, any>>(
   requestId: string,
   snapshotInputs: (cell: Cell<T>) => T,
   expectedInputHash?: string,
-  timeout: number = REQUEST_TIMEOUT,
+  timeout: number = MUTEX_STALE_AFTER,
 ): Promise<{
   claimed: boolean;
   inputs: T;
@@ -131,7 +158,7 @@ export async function tryClaimMutex<T extends Record<string, any>>(
     }
     // Can claim if:
     // 1. Nothing is pending, OR
-    // 2. Previous request timed out
+    // 2. The standing claim has gone stale and is treated as abandoned
     const canClaim = !isPending ||
       (currentInternal.lastActivity < now - timeout);
 

--- a/packages/runner/src/builtins/fetch.ts
+++ b/packages/runner/src/builtins/fetch.ts
@@ -311,9 +311,11 @@ function fetchBuiltin(kind: FetchKind) {
       const tx = runtime.edit();
 
       try {
-        // If the pending request is ours, set pending to false and clear the requestId.
+        // If the pending request is ours, set pending to false and clear the
+        // requestId. A claim another replica has taken over carries its id,
+        // not ours, and releasing it would strand the request it is running.
         const currentRequestId = internal.withTx(tx).key("requestId").get();
-        if (currentRequestId === myRequestId) {
+        if (myRequestId !== undefined && currentRequestId === myRequestId) {
           pending.withTx(tx).set(false);
           internal.withTx(tx).key("requestId").set("");
         }
@@ -458,11 +460,16 @@ function fetchBuiltin(kind: FetchKind) {
 
       // Start a new fetch if we don't have a result/error and aren't already fetching
       if (!hasValidResult && !hasError && !alreadyFetching) {
-        const newRequestId = inputHash;
+        // The claim id names this replica, so teardown can tell a claim it
+        // still holds from one another replica has taken over. `runtime.id` is
+        // unique per storage manager and so per replica. The outbox id stays
+        // the input hash, which is what makes it an idempotency key for the
+        // same request from anywhere.
+        const newRequestId = `${runtime.id}:${inputHash}`;
         enqueueSinkRequestPostCommitEffect(
           tx,
           kind.name,
-          `${kind.name}:${newRequestId}`,
+          `${kind.name}:${inputHash}`,
           inputsSnapshot,
           `${kind.name}-start`,
           () => {
@@ -519,7 +526,9 @@ function fetchBuiltin(kind: FetchKind) {
 
                 abortController = new AbortController();
 
-                // We claimed the mutex, start the fetch
+                // We claimed the mutex, start the fetch. `startFetch` compares
+                // against the input hash, not the claim id: any request for
+                // these inputs may write the result.
                 myRequestId = newRequestId;
                 await startFetch(
                   runtime,
@@ -527,7 +536,7 @@ function fetchBuiltin(kind: FetchKind) {
                   snapshotInputs,
                   inputsCell,
                   inputsSnapshot,
-                  newRequestId,
+                  inputHash,
                   pending,
                   result,
                   error,
@@ -648,8 +657,18 @@ async function startFetch(
         snapshotInputs(inputsCell.withTx(tx)),
       );
 
-      // Always clear pending and result
       pending.withTx(tx).set(false);
+
+      // Taking over a claim that has gone stale can leave two requests for the
+      // same inputs in flight at once. A result already recorded for those
+      // inputs came from the other one, and this failure says nothing about
+      // it, so leave it standing rather than replacing it with this error.
+      if (
+        currentHash === inputHash && result.withTx(tx).get() !== undefined
+      ) {
+        return;
+      }
+
       result.withTx(tx).set(undefined);
 
       // Only write error and inputHash if inputs still match

--- a/packages/runner/test/fetch-claim-takeover.test.ts
+++ b/packages/runner/test/fetch-claim-takeover.test.ts
@@ -1,0 +1,325 @@
+/// <reference path="./clock.d.ts" />
+// The fetch builtins coordinate across replicas through durable state: a claim
+// in `internal` for fetch.ts, a `fetching` cache entry for fetch-program.ts. A
+// staleness bound decides when a claim left by another replica is treated as
+// abandoned, because nothing reports whether that replica is still there.
+//
+// These cases pin the two properties that keep an early takeover survivable.
+// Both are about the request that is *not* the stale one: it must still reach
+// its result.
+//
+//   - a resolution running in this replica is never judged by the clock, so a
+//     slow one is neither restarted underneath itself nor left with nowhere to
+//     write when it finishes;
+//   - a failing request never erases a result another request already recorded
+//     for the same inputs.
+//
+// docs/development/fetch-request-deadlines.md carries the reasoning.
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import { createBuilder } from "../src/builder/factory.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import { setPatternEnvironment } from "../src/env.ts";
+import { resolveLink } from "../src/link-resolution.ts";
+import {
+  computeInputHashFromValue,
+  internalSchema,
+  MUTEX_STALE_AFTER,
+  tryClaimMutex,
+} from "../src/builtins/fetch-utils.ts";
+import type { Schema } from "../src/builder/types.ts";
+
+const signer = await Identity.fromPassphrase("test fetch claim takeover");
+const space = signer.did();
+
+function moduleResponse(): Response {
+  return new Response("export const value = 1;\n", {
+    status: 200,
+    headers: { "Content-Type": "text/plain" },
+  });
+}
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("fetch builtins: taking over a claim", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let tx: IExtendedStorageTransaction;
+  let pattern: ReturnType<typeof createBuilder>["commonfabric"]["pattern"];
+  let byRef: ReturnType<typeof createBuilder>["commonfabric"]["byRef"];
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    tx = runtime.edit();
+
+    const { commonfabric } = createTrustedBuilder(runtime);
+    pattern = commonfabric.pattern;
+    byRef = commonfabric.byRef;
+
+    setPatternEnvironment({
+      apiUrl: new URL("http://mock-test-server.local"),
+    });
+
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = originalFetch;
+    await tx.commit();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("publishes a slow program resolution that outlives the staleness bound", async () => {
+    const slowUrl = "http://mock-test-server.local/slow-program.ts";
+    const otherUrl = "http://mock-test-server.local/other-program.ts";
+
+    // The slow program's module request is held open, so the resolution
+    // started for it stays in flight until this case releases it.
+    const heldRequests: Deferred<Response>[] = [];
+    const firstSlowRequest = deferred<void>();
+    globalThis.fetch = (input: string | URL | Request) => {
+      const url = typeof input === "string"
+        ? input
+        : input instanceof URL
+        ? input.toString()
+        : input.url;
+      if (url.includes("slow-program")) {
+        const held = deferred<Response>();
+        heldRequests.push(held);
+        firstSlowRequest.resolve();
+        return held.promise;
+      }
+      return Promise.resolve(moduleResponse());
+    };
+
+    const fetchProgram = byRef("fetchProgram");
+    const testPattern = pattern<{ url: string }>(
+      ({ url }) => fetchProgram({ url }),
+    );
+
+    const inputs = runtime.getCell<{ url: string }>(
+      space,
+      "program-takeover-inputs",
+      undefined,
+      tx,
+    );
+    inputs.set({ url: slowUrl });
+    const resultCell = runtime.getCell(
+      space,
+      "program-takeover-result",
+      undefined,
+      tx,
+    );
+    const result = runtime.run(tx, testPattern, inputs, resultCell);
+    tx.commit();
+
+    await result.pull();
+    await firstSlowRequest.promise;
+    await clock.settle();
+    expect(heldRequests.length).toBe(1);
+
+    // Point the pattern at a different program and back again. That round trip
+    // is the wake-up: the staleness check is a predicate the action evaluates
+    // when it next runs, not a timer, so it is only ever reached because
+    // something else re-ran the action. The first resolution is in flight
+    // throughout — an input change does not abort it.
+    await runtime.editWithRetry((edit) => {
+      inputs.withTx(edit).key("url").set(otherUrl);
+    });
+    await result.pull();
+    await clock.settle();
+
+    // Well past any staleness bound this builtin would plausibly use.
+    await clock.tick(120_000);
+
+    await runtime.editWithRetry((edit) => {
+      inputs.withTx(edit).key("url").set(slowUrl);
+    });
+    await result.pull();
+    await clock.settle();
+
+    // The resolution was never restarted, and its cache entry is still the one
+    // it will write into.
+    expect(heldRequests.length).toBe(1);
+
+    heldRequests[0].resolve(moduleResponse());
+    await runtime.settled();
+    await result.pull();
+
+    const program = result.key("result").get() as
+      | { main: string; files: { name: string }[] }
+      | undefined;
+    expect(program).toBeDefined();
+    expect(program!.main).toBe("/slow-program.ts");
+    expect(program!.files.map((file) => file.name)).toEqual([
+      "/slow-program.ts",
+    ]);
+    expect(result.key("error").get()).toBeUndefined();
+    expect(result.key("pending").get()).toBe(false);
+  });
+
+  it("keeps a result recorded for the same inputs when a request fails", async () => {
+    const url = "http://mock-test-server.local/api/takeover";
+
+    const heldRequest = deferred<Response>();
+    const requestIssued = deferred<void>();
+    globalThis.fetch = () => {
+      requestIssued.resolve();
+      return heldRequest.promise;
+    };
+
+    const fetchJson = byRef("fetchJson");
+    // This case is about the error path, not about the bound, so it puts the
+    // bound out of reach: the auto-advance clock jumps logical time forward
+    // whenever the loop idles, and a takeover here would clear `result` on its
+    // way in and mask what is being pinned.
+    const testPattern = pattern<{ url: string }>(
+      ({ url }) => fetchJson({ url, options: { mutexTimeoutMs: 600_000 } }),
+    );
+
+    const resultCell = runtime.getCell(
+      space,
+      "fetch-takeover-result",
+      undefined,
+      tx,
+    );
+    const result = runtime.run(tx, testPattern, { url }, resultCell);
+    tx.commit();
+
+    await result.pull();
+    await requestIssued.promise;
+    await clock.settle();
+
+    // Stand in for the replica that took the claim over and got there first: a
+    // result for these very inputs is now recorded. The pattern's result cell
+    // holds a link to the builtin's own result cell, and a plain link is not
+    // followed on write, so resolve it and write the cell the builtin writes.
+    const builtinResult = runtime.getCellFromLink(
+      resolveLink(
+        runtime,
+        runtime.readTx(),
+        result.key("result").getAsNormalizedFullLink(),
+      ),
+    );
+    await runtime.editWithRetry((edit) => {
+      builtinResult.withTx(edit).set({ from: "the other replica" });
+    });
+    await clock.settle();
+
+    heldRequest.reject(new Error("simulated network failure"));
+    await runtime.settled();
+
+    expect(result.key("result").get()).toEqual({ from: "the other replica" });
+    expect(result.key("error").get()).toBeUndefined();
+    expect(result.key("pending").get()).toBe(false);
+  });
+
+  // The takeover itself, driven through `tryClaimMutex` directly: a claim
+  // another replica made is believed until it goes stale, and then taken over.
+  // This is the one branch where the clock decides anything.
+  describe("the staleness branch of the mutex", () => {
+    const inputs = { url: "http://mock-test-server.local/api/claimed" };
+
+    async function claimAgainst(
+      claimAgeMs: number,
+    ): Promise<{ claimed: boolean; requestId: string; pending: boolean }> {
+      const inputsCell = runtime.getCell<typeof inputs>(
+        space,
+        `mutex-staleness-inputs-${claimAgeMs}`,
+        undefined,
+        tx,
+      );
+      const pending = runtime.getCell<boolean>(
+        space,
+        `mutex-staleness-pending-${claimAgeMs}`,
+        undefined,
+        tx,
+      );
+      const result = runtime.getCell<unknown>(
+        space,
+        `mutex-staleness-result-${claimAgeMs}`,
+        undefined,
+        tx,
+      );
+      const error = runtime.getCell<unknown>(
+        space,
+        `mutex-staleness-error-${claimAgeMs}`,
+        undefined,
+        tx,
+      );
+      const internal = runtime.getCell<Schema<typeof internalSchema>>(
+        space,
+        `mutex-staleness-internal-${claimAgeMs}`,
+        undefined,
+        tx,
+      );
+
+      // A claim standing in the durable state, made by a replica that is not
+      // this one, `claimAgeMs` ago.
+      inputsCell.set(inputs);
+      pending.set(true);
+      internal.set({
+        requestId: "another-replica:whatever",
+        lastActivity: Date.now() - claimAgeMs,
+        inputHash: computeInputHashFromValue(inputs),
+      });
+      await tx.commit();
+      tx = runtime.edit();
+
+      const claim = await tryClaimMutex(
+        runtime,
+        inputsCell,
+        pending,
+        result,
+        error,
+        internal,
+        "this-replica:whatever",
+        (cell) => cell.get() ?? ({} as typeof inputs),
+      );
+      return {
+        claimed: claim.claimed,
+        requestId: internal.get().requestId,
+        pending: pending.get(),
+      };
+    }
+
+    it("leaves a claim younger than the bound alone", async () => {
+      const outcome = await claimAgainst(MUTEX_STALE_AFTER / 2);
+      expect(outcome.claimed).toBe(false);
+      expect(outcome.requestId).toBe("another-replica:whatever");
+      expect(outcome.pending).toBe(true);
+    });
+
+    it("takes over a claim older than the bound", async () => {
+      const outcome = await claimAgainst(MUTEX_STALE_AFTER * 2);
+      expect(outcome.claimed).toBe(true);
+      expect(outcome.requestId).toBe("this-replica:whatever");
+      expect(outcome.pending).toBe(true);
+    });
+  });
+});

--- a/packages/runner/test/fetch-claim-takeover.test.ts
+++ b/packages/runner/test/fetch-claim-takeover.test.ts
@@ -4,15 +4,19 @@
 // staleness bound decides when a claim left by another replica is treated as
 // abandoned, because nothing reports whether that replica is still there.
 //
-// These cases pin the two properties that keep an early takeover survivable.
-// Both are about the request that is *not* the stale one: it must still reach
-// its result.
+// Two of these cases pin what keeps an early takeover survivable. Both are
+// about the request that is *not* the stale one: it must still reach its
+// result.
 //
 //   - a resolution running in this replica is never judged by the clock, so a
 //     slow one is neither restarted underneath itself nor left with nowhere to
 //     write when it finishes;
 //   - a failing request never erases a result another request already recorded
 //     for the same inputs.
+//
+// The rest cover the claim's other transitions: handing it back when the
+// pattern stops, the staleness branch that decides a takeover, a resolution
+// that fails, and an empty URL.
 //
 // docs/development/fetch-request-deadlines.md carries the reasoning.
 
@@ -92,6 +96,127 @@ describe("fetch builtins: taking over a claim", () => {
     await tx.commit();
     await runtime?.dispose();
     await storageManager?.close();
+  });
+
+  it("releases the entry it claimed when the pattern is stopped", async () => {
+    const slowUrl = "http://mock-test-server.local/stopped-program.ts";
+
+    const heldRequests: Deferred<Response>[] = [];
+    const firstRequest = deferred<void>();
+    globalThis.fetch = () => {
+      const held = deferred<Response>();
+      heldRequests.push(held);
+      firstRequest.resolve();
+      return held.promise;
+    };
+
+    const fetchProgram = byRef("fetchProgram");
+    const testPattern = pattern<{ url: string }>(
+      ({ url }) => fetchProgram({ url }),
+    );
+
+    const resultCell = runtime.getCell(
+      space,
+      "program-stop-result",
+      undefined,
+      tx,
+    );
+    const result = runtime.run(tx, testPattern, { url: slowUrl }, resultCell);
+    tx.commit();
+
+    await result.pull();
+    await firstRequest.promise;
+    await clock.settle();
+    expect(heldRequests.length).toBe(1);
+
+    // Stopping the pattern hands the claim back, so the entry is available
+    // again rather than left standing by a replica that has gone.
+    runtime.runner.stop(resultCell);
+    await clock.settle();
+
+    // Running again is how that shows: a released entry is claimable, so a
+    // second resolution starts. A claim still standing would be left alone.
+    const restartTx = runtime.edit();
+    const restarted = runtime.run(
+      restartTx,
+      testPattern,
+      { url: slowUrl },
+      resultCell,
+    );
+    restartTx.commit();
+    await restarted.pull();
+    await clock.settle();
+
+    expect(heldRequests.length).toBe(2);
+
+    for (const held of heldRequests) held.resolve(moduleResponse());
+    await runtime.settled();
+  });
+
+  it("surfaces a program that fails to resolve as an error", async () => {
+    const missingUrl = "http://mock-test-server.local/missing-program.ts";
+
+    globalThis.fetch = () =>
+      Promise.resolve(
+        new Response("not found", { status: 404, statusText: "Not Found" }),
+      );
+
+    const fetchProgram = byRef("fetchProgram");
+    const testPattern = pattern<{ url: string }>(
+      ({ url }) => fetchProgram({ url }),
+    );
+
+    const resultCell = runtime.getCell(
+      space,
+      "program-error-result",
+      undefined,
+      tx,
+    );
+    const result = runtime.run(
+      tx,
+      testPattern,
+      { url: missingUrl },
+      resultCell,
+    );
+    tx.commit();
+
+    await result.pull();
+    await runtime.settled();
+    await result.pull();
+
+    expect(result.key("error").get()).toContain("404");
+    expect(result.key("result").get()).toBeUndefined();
+    expect(result.key("pending").get()).toBe(false);
+  });
+
+  it("clears its outputs when the program URL is empty", async () => {
+    let requests = 0;
+    globalThis.fetch = () => {
+      requests++;
+      return Promise.resolve(moduleResponse());
+    };
+
+    const fetchProgram = byRef("fetchProgram");
+    const testPattern = pattern<{ url: string }>(
+      ({ url }) => fetchProgram({ url }),
+    );
+
+    const resultCell = runtime.getCell(
+      space,
+      "program-empty-url-result",
+      undefined,
+      tx,
+    );
+    const result = runtime.run(tx, testPattern, { url: "" }, resultCell);
+    tx.commit();
+
+    await result.pull();
+    await runtime.settled();
+
+    expect(requests).toBe(0);
+    expect(result.key("pending").get()).toBe(false);
+    expect(result.key("result").get()).toBeUndefined();
+    expect(result.key("error").get()).toBeUndefined();
   });
 
   it("publishes a slow program resolution that outlives the staleness bound", async () => {


### PR DESCRIPTION
The two wall-clock deadlines in the fetch builtins were left undecided when the LLM tool-call deadline was retired, on the grounds that they bound a network call rather than userland computation. They turn out not to bound anything of the sort. Neither one aborts a request, and neither is meant to be read by the replica issuing it. Each is a lease on a claim held in durable state — the `pending` flag plus `lastActivity` for the fetch builtins, a `fetching` cache entry for fetchProgram — and it decides when the replica holding that claim is presumed gone. Nothing in the runner reports another replica's presence, so that question has no event to wait on, and both leases stay.

Two further properties are worth stating, because both are easy to assume the other way round. Neither bound is armed: no timer fires, and each is a comparison the builtin's reactive action evaluates whenever something else happens to run it, which makes recovery from an abandoned claim opportunistic and confines the hazard to a live piece with several replicas. And despite its name, `lastActivity` is stamped once when the claim is made and never refreshed, so it measures how long ago the request started rather than how long the claimant has been silent. The LLM dialog's bound is refreshed on every durable write of a turn and really is a staleness bound on a heartbeat; reading the two as the same shape is what this change is trying to prevent.

What did not hold up is where the lease was consulted, and what an early takeover cost.

fetchProgram tracked no local state, so a replica judged its own in-flight resolution by elapsed time exactly as it judged anyone else's. When the bound tripped, the entry went back to `idle` and the resolution still running had nowhere to write: its writeback only lands on a `fetching` entry, so the finished program was discarded on arrival and the piece was left showing `pending: false` with no result and no error. The restart the code appears to intend does not happen either, because the action's own write does not wake it.

The fetch builtins let a failing request erase a result it did not produce. A takeover leaves two requests for the same inputs in flight, and the error path cleared `result` before writing the error, so a duplicate that failed replaced the other request's good result with its own error.

Both builtins also wrote the input hash as the claim's `requestId`, so every replica claiming the same request wrote the same value, and teardown's check for whether the standing claim was its own could only ever say yes. A replica closing a piece therefore released whatever claim any replica held for that request, including one another replica was actively working under — the same "finished, nothing here" state, reached from the other end.

The changes:

- fetchProgram records what it is resolving and leaves those entries alone however long they take. A resolution running here ends when its promise settles, which is a real event. The fetch builtins already had this narrowing in their `alreadyFetching` check.
- A claim id now carries `runtime.id`, unique per storage manager and so per replica, so teardown releases only a claim this replica still holds. The identity is for teardown alone: writebacks stay gated on the input hash, so after a takeover either request may write, because they are requests for the same inputs and the first one home should count. fetchProgram's writeback compared request ids under a comment claiming it ensured only the initiating tab could write; with distinguishable ids that comparison would have started rejecting the loser's perfectly good result, so it now tests only that the entry is still `fetching`, and the comment says what the code does.
- The error path leaves a result already recorded for the same inputs in place. A failed request is evidence about that request, not about a value another request already obtained.
- A stale entry is taken over directly instead of being routed back through `idle`, which published `pending: false` with no result for a tick.
- The in-flight record is cleared when the cell scope changes, because the cache cell is re-minted there and a resolution started under the old scope says nothing about the new one.

The bounds themselves are unchanged. Once an early takeover no longer costs a result, their size stops being a correctness question and becomes a trade with a cost on both sides: too low duplicates a slow request whenever another replica looks in, too high leaves a replica that arrives before the bound elapses looking at a claim it will not take over and has no reason to re-examine, so the piece keeps showing a spinner. That second case is the shape of a tab crashing mid-request and the user reloading straight away. A duplicate request is wasted work and a spinner that never resolves is a dead end, so the trade goes to the lower value, and `mutexTimeoutMs` remains for a caller whose endpoint is slow enough for duplicates to matter. The constants are renamed to say what they measure and carry the reasoning.

docs/development/fetch-request-deadlines.md records the policy and what is deliberately left alone: a takeover still sends a duplicate request, which would take a periodic durable heartbeat to close; cancellation does not reach a program resolution's network requests, because HttpProgramResolver issues them without a signal, so a hung program host leaves that replica pending; and fetchProgram keeps one AbortController per node rather than one per in-flight resolution. The proposal document that deferred this now points at it.

The new test fails without these fixes in both directions: the slow program's result is dropped, and the concurrent result is erased. Two further cases drive tryClaimMutex directly, so the takeover branch — the one place the clock decides anything — is covered rather than inferred.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats fetch deadlines as stale-claim leases instead of timing out local work. Slow resolutions aren’t dropped, and failed duplicates can’t overwrite good results; claim ownership is now per replica.

- **Bug Fixes**
  - `fetch-program.ts` tracks local in-flight resolutions and never times them out; entries this replica owns are left alone until settle.
  - Stale takeovers go straight to `fetching` (no `idle` blip).
  - `fetch.ts` error path no longer clears an existing `result` for the same inputs; a failed duplicate can’t erase a good result.
  - Claim `requestId` includes `runtime.id`, so teardown only releases this replica’s claim; `fetch-program.ts` writebacks require the entry to still be `fetching`.
  - In-flight records are cleared on cell scope changes to avoid stale writes.

- **Refactors**
  - Deadlines renamed to `MUTEX_STALE_AFTER` and `PROGRAM_CLAIM_STALE_AFTER`; policy documented in `docs/development/fetch-request-deadlines.md` and linked from related docs.
  - Outbox ids use the input hash for idempotency.
  - Added `packages/runner/test/fetch-claim-takeover.test.ts` to cover slow resolutions, error preservation, mutex staleness takeover, claim release on pattern stop, 404 surfacing, and empty URLs.

<sup>Written for commit c3746e26235a5616ec4230d599d1e05670b0ff76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

