### PR TITLE
Add benchmarks for `isArrayWithOnlyIndexProperties()`

### DIFF
--- a/packages/utils/src/arrays.bench.ts
+++ b/packages/utils/src/arrays.bench.ts
@@ -1,0 +1,90 @@
+/**
+ * `isArrayWithOnlyIndexProperties()` Performance Benchmarks
+ *
+ * This predicate is called once per array node by the fabric membership,
+ * cloning, and conversion walks, so its cost is paid per container rather than
+ * once per operation. Two properties are worth tracking over time:
+ *
+ * 1. **Absolute cost against array length.** Asking an array for its own keys
+ *    scales with `length`, not with how many elements are actually present:
+ *    measured on V8, a two-element array costs about 1 µs at `length` 1000 and
+ *    about 700 µs at `length` 1e6. A sparse array is therefore priced by its
+ *    extent, which is worth knowing before treating sparseness as free.
+ *
+ * 2. **The plain/proxied split.** These two go in opposite directions, so a
+ *    single number is misleading. `Reflect.ownKeys()` does not get the
+ *    EnumCache fast path that `Object.keys()` gets on an ordinary array, which
+ *    costs it there. On a `Proxy` it wins instead: `Object.keys()` fires an
+ *    `ownKeys` trap plus a `getOwnPropertyDescriptor` trap per key to filter
+ *    for enumerability, where `Reflect.ownKeys()` fires exactly one trap. The
+ *    runtime proxies heavily, so the proxied figure is not a curiosity.
+ *
+ * Engines retune as usage shifts, so treat a large move here as news about the
+ * engine rather than as noise.
+ */
+
+import { isArrayWithOnlyIndexProperties } from "@commonfabric/utils/arrays";
+
+/** Sizes spanning "typical container" to "large collection". */
+const SIZES = [3, 100, 1000] as const;
+
+for (const size of SIZES) {
+  const array: unknown[] = Array.from({ length: size }, (_, i) => i);
+  // A pass-through proxy, the shape a cell projection presents.
+  const asProxy = new Proxy(array, {});
+
+  Deno.bench({
+    name: `plain array (${size})`,
+    group: `size ${size}`,
+    baseline: true,
+    fn() {
+      isArrayWithOnlyIndexProperties(array);
+    },
+  });
+
+  Deno.bench({
+    name: `proxied array (${size})`,
+    group: `size ${size}`,
+    fn() {
+      isArrayWithOnlyIndexProperties(asProxy);
+    },
+  });
+}
+
+/** Sparse, to track the cost of extent as distinct from element count. */
+const sparse: unknown[] = [];
+sparse.length = 100_000;
+sparse[0] = "first";
+sparse[99_999] = "last";
+
+/** The same two elements in a small extent, as the comparison that isolates it. */
+const compact: unknown[] = ["first", "last"];
+
+/** Rejected for a named property, which short-circuits on the last key. */
+const named = [1, 2, 3] as unknown[] & { foo?: string };
+named.foo = "bar";
+
+Deno.bench({
+  name: "compact array (2 elements, length 2)",
+  group: "shapes",
+  baseline: true,
+  fn() {
+    isArrayWithOnlyIndexProperties(compact);
+  },
+});
+
+Deno.bench({
+  name: "sparse array (2 elements, length 100k)",
+  group: "shapes",
+  fn() {
+    isArrayWithOnlyIndexProperties(sparse);
+  },
+});
+
+Deno.bench({
+  name: "rejected: array with a named property",
+  group: "shapes",
+  fn() {
+    isArrayWithOnlyIndexProperties(named);
+  },
+});


### PR DESCRIPTION
Adds benchmarks for `isArrayWithOnlyIndexProperties()`, which runs once per array node in the fabric membership, cloning, and conversion walks — a per-container cost that nothing tracked.

Independent of #5167 and mergeable in either order; the function exists either way, and this measures whichever implementation is current.

## Why two dimensions rather than one number

**The plain/proxied split.** Measured 8× (3 elements) to 19× (1000) in favour of plain arrays. `Object.keys()` on a `Proxy` fires an `ownKeys` trap *plus* a `getOwnPropertyDescriptor` trap per key, to filter for enumerability. The runtime proxies heavily — cell projections, query results — so the proxied figure is the one that describes real traffic, and it is not the one you get by benchmarking a literal.

**Extent versus element count.** The same two elements cost **25.6 ns** at `length` 2 and **88.7 µs** at `length` 100 000. That surprised me, so I checked whether it was a property of this predicate or of the engine:

```
len=     1000  keys=2  Object.keys=2.9us   Reflect.ownKeys=1.2us
len=    10000  keys=2  Object.keys=13.0us  Reflect.ownKeys=11.5us
len=   100000  keys=2  Object.keys=106.1us Reflect.ownKeys=74.4us
len=  1000000  keys=2  Object.keys=855.9us Reflect.ownKeys=696.3us
```

Both primitives grow ~10× per 10× of `length` on a two-element array. V8 scans the index range regardless of how many elements are present, so **sparseness is priced by extent**, not by content. Worth knowing before treating a sparse array as cheap — and worth a tripwire, since it is exactly the kind of thing an engine might change.

## Why bother

Engine tuning follows how JS actually gets used, and this codebase's profile is unusual twice over: heavy own-key enumeration *and* heavy proxying. If either of these numbers moves substantially, that is more likely news about the engine than noise — but only if something is watching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJwf3YGTzF42U7WBdAq4Pf


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Deno benchmarks for `isArrayWithOnlyIndexProperties()` to track per-array cost across array shapes. Covers plain vs proxied arrays and sparse-extent effects to surface engine/runtime regressions.

- **New Features**
  - Adds `packages/utils/src/arrays.bench.ts`.
  - Bench sizes: 3, 100, 1000 for plain and proxied arrays.
  - Shape cases: compact 2-element, sparse length 100_000 with 2 elements, and array rejected by a named property.
  - Uses `Deno.bench` and `isArrayWithOnlyIndexProperties()` from `@commonfabric/utils/arrays`.

<sup>Written for commit e7e1353589101b2be49900813995fc2eee986f9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

