### PR TITLE
fix(storage): keep the first accepted space host route

### DIFF
--- a/docs/specs/pattern-imports/README.md
+++ b/docs/specs/pattern-imports/README.md
@@ -102,7 +102,7 @@ general piece origin model is described in `../piece-source-lifecycle.md`.
 | Slug cells: generic **redirect link to any cell** (`setSlugLink` is target-agnostic; only `resolvePieceAddress` layers a "must be a piece" check) | `packages/piece/src/slugs.ts` | Slugs can name pieces *or* patterns today, mechanically |
 | Slug ids: `hashOf({causal:{space, slug}})`; slug grammar `[a-z0-9]+(-[a-z0-9]+)*`, ≤80 chars; **`isSlugAddress(t) = !t.includes(":")`** | `packages/runner/src/slugs.ts` | The existing slug-vs-URI discriminator the grammar reuses |
 | `loadPatternByIdentity(entryIdentity, symbol, space)` | `packages/runner/src/pattern-manager.ts` | Existing by-identity load path the resolver builds on |
-| Per-space host routing: `spaceHostMap` seeds routes, `registerSpaceHost` adds a route before a space opens, and the home-space site table hydrates durable hints; foreign-host sessions are ordinary authenticated memory sessions | `packages/runner/src/storage/v2-remote-session.ts`, `packages/runner/src/storage/v2.ts`, and `packages/runtime-client/backends/runtime-processor.ts` | Reads work for a foreign space whose route is already known. A seeded route can only be confirmed. The first accepted late hint remains stable before and after the space opens. Initial table hydration selects the last valid HTTP or HTTPS entry for each space without replacing a route already accepted through IPC. A conflicting table route accepted first makes later IPC registration fail. Applying a host from an explicit `cf://` reference remains planned |
+| Per-space host routing: `spaceHostMap` seeds routes, `registerSpaceHost` adds a route, and the home-space site table hydrates durable hints; foreign-host sessions are ordinary authenticated memory sessions | `packages/runner/src/storage/v2-remote-session.ts`, `packages/runner/src/storage/v2.ts`, and `packages/runtime-client/backends/runtime-processor.ts` | Reads work for a foreign space whose route is already known. A seeded route can only be confirmed. An unseeded default-host provider remains provisional until the first hint arrives or its session accepts a stateful operation. A different host cancels unfinished session setup, replaces the provisional replica, makes overlapping read-only callers use the hinted replica, and loads dependencies discovered from the hinted data. Transactions based on the old replica are rejected. A different-host hint conflicts after an ordinary or scheduler transaction, ACL setup transaction, or SQLite source registration is accepted for issue, even if its acknowledgement later fails. The first accepted late hint then remains stable. Initial table hydration selects the last valid HTTP or HTTPS entry for each space without replacing a route already accepted through IPC. A conflicting table route accepted first makes later IPC registration fail. Applying a host from an explicit `cf://` reference remains planned |
 
 ### The two "pattern by hash" handles, explicitly
 
@@ -656,12 +656,13 @@ provenance-relevant flow flagged under § Security.
 ### 4. Cross-host references: no service surface at all
 
 A runtime is no longer bound to one memory host. `spaceHostMap` seeds known
-routes when storage is constructed. `registerSpaceHost` can register a later
-hint before that space opens, and the home-space site table hydrates durable
-hints into a new runtime. A foreign-host connection is an ordinary
-authenticated memory session. These mechanisms remain interim. This design
-depends only on the property that a space's cells are readable wherever the
-space lives, not on the current map or site-table shape.
+routes when storage is constructed. `registerSpaceHost` can register the first
+later hint even when an unseeded space already opened provisionally through the
+default host. The home-space site table hydrates durable hints into a new
+runtime. A foreign-host connection is an ordinary authenticated memory
+session. These mechanisms remain interim. This design depends only on the
+property that a space's cells are readable wherever the space lives, not on the
+current map or site-table shape.
 
 Once a route is in effect, a `cf://host/space/ref` reference resolves exactly
 like a local one. Slug chase, piece metadata, and `pattern:<identity>` source
@@ -685,12 +686,19 @@ Consequences:
 - **The host segment supplies a late-bound route hint.** The resolver must
   register that hint on the ordinary storage manager before it opens the
   referenced space. A seeded route wins for the current session. An accepted
-  late hint must also remain stable before the first open; a different hint is
-  a conflict. After the space opens, registration can only confirm the hint
-  that was already in effect. Any other registration attempt fails rather than
-  opening a second connection for the same space. Host-qualified import
-  resolution must use this registration path before opening the referenced
-  space.
+  late hint remains stable before and after the first open; a different hint is
+  a conflict. An earlier default-host read is provisional rather than an
+  accepted route. The first hint invalidates that replica, reconnects it
+  through the hinted host, and replays its reads and newly discovered
+  dependencies. It cancels unfinished connection, mount, and ACL work. Read-only
+  operations that overlap replacement use the hinted replica. Transactions
+  based on the provisional replica are rejected so they can recompute from the
+  intended data. A different-host hint can replace an operation that is still
+  waiting for a session. Once the session accepts an ordinary or scheduler
+  transaction, ACL setup transaction, or SQLite source registration for issue,
+  the route is fixed even if acknowledgement later fails. Host-qualified
+  import resolution must still use this registration path before opening the
+  referenced space.
 - A cacheable, anonymous HTTP mirror for published patterns (CDN-style
   distribution to readers with no fabric identity) remains *possible* later.
   It would need an explicit anonymous visibility policy that covers the whole
@@ -861,11 +869,16 @@ unchanged.
    canonical reference must persist the route in the home-space site table
    after live registration accepts it and before committing the hostless
    reference. A seeded route can only be confirmed. Once a late hint is
-   accepted, a different hint is a conflict even before the space opens. After
-   the space opens, only the hint already in effect can be confirmed. Any other
-   attempt fails rather than silently changing the route. This settles how a
-   known hint enters the current session. It does not settle host discovery,
-   availability, failover, or space relocation.
+   accepted, a different hint is a conflict before or after the space opens.
+   An unseeded default-host provider remains provisional until its first hint or
+   until its session accepts a stateful operation, whichever happens first. A
+   different host cancels unfinished initial or reconnect session setup, clears
+   and reconnects the provider, then replays its registered reads so reactive
+   consumers observe the intended data. Read-only operations that overlap
+   replacement move to the hinted replica. Transactions based on the
+   provisional replica are rejected. This settles how a known hint enters the
+   current session. It does not settle host discovery, availability, failover,
+   or replacement of an explicit route.
 3. **Runtime-fingerprint interaction.** A runtime fingerprint change creates a
    new executable identity for an importer whose reachable graph contains an
    external dependency, even when its authored source and fabric pins are
@@ -983,5 +996,4 @@ unchanged.
    or more than one host can serve the same space. Revisit how route changes
    are authenticated, how stale site-table entries are replaced, whether
    failover is allowed, and how an open session closes and reconnects without
-   losing or duplicating work. The site-table watcher currently races the first
-   space open, so reliable bootstrap ordering also remains part of this topic.
+   losing or duplicating work after a seed or hint has made the route explicit.

--- a/docs/specs/pattern-imports/README.md
+++ b/docs/specs/pattern-imports/README.md
@@ -102,7 +102,7 @@ general piece origin model is described in `../piece-source-lifecycle.md`.
 | Slug cells: generic **redirect link to any cell** (`setSlugLink` is target-agnostic; only `resolvePieceAddress` layers a "must be a piece" check) | `packages/piece/src/slugs.ts` | Slugs can name pieces *or* patterns today, mechanically |
 | Slug ids: `hashOf({causal:{space, slug}})`; slug grammar `[a-z0-9]+(-[a-z0-9]+)*`, ≤80 chars; **`isSlugAddress(t) = !t.includes(":")`** | `packages/runner/src/slugs.ts` | The existing slug-vs-URI discriminator the grammar reuses |
 | `loadPatternByIdentity(entryIdentity, symbol, space)` | `packages/runner/src/pattern-manager.ts` | Existing by-identity load path the resolver builds on |
-| Per-space host routing: `spaceHostMap` seeds routes, `registerSpaceHost` adds a route before a space opens, and the home-space site table hydrates durable hints; foreign-host sessions are ordinary authenticated memory sessions | `packages/runner/src/storage/v2-remote-session.ts`, `packages/runner/src/storage/v2.ts`, and `packages/runtime-client/backends/runtime-processor.ts` | Reads work for a foreign space whose route is already known. A seeded route can only be confirmed. A later hint currently replaces an earlier late hint while the space remains unopened. After the space opens, only its previously registered matching hint can be confirmed. Applying a host from an explicit `cf://` reference remains planned |
+| Per-space host routing: `spaceHostMap` seeds routes, `registerSpaceHost` adds a route before a space opens, and the home-space site table hydrates durable hints; foreign-host sessions are ordinary authenticated memory sessions | `packages/runner/src/storage/v2-remote-session.ts`, `packages/runner/src/storage/v2.ts`, and `packages/runtime-client/backends/runtime-processor.ts` | Reads work for a foreign space whose route is already known. A seeded route can only be confirmed. The first accepted late hint remains stable before and after the space opens. Initial table hydration selects the last valid HTTP or HTTPS entry for each space without replacing a route already accepted through IPC. A conflicting table route accepted first makes later IPC registration fail. Applying a host from an explicit `cf://` reference remains planned |
 
 ### The two "pattern by hash" handles, explicitly
 
@@ -688,9 +688,9 @@ Consequences:
   late hint must also remain stable before the first open; a different hint is
   a conflict. After the space opens, registration can only confirm the hint
   that was already in effect. Any other registration attempt fails rather than
-  opening a second connection for the same space. The current registry still
-  replaces a different late hint before the first open. Host-qualified import
-  resolution must add this conflict guard when it adopts the registration path.
+  opening a second connection for the same space. Host-qualified import
+  resolution must use this registration path before opening the referenced
+  space.
 - A cacheable, anonymous HTTP mirror for published patterns (CDN-style
   distribution to readers with no fabric identity) remains *possible* later.
   It would need an explicit anonymous visibility policy that covers the whole
@@ -863,10 +863,9 @@ unchanged.
    reference. A seeded route can only be confirmed. Once a late hint is
    accepted, a different hint is a conflict even before the space opens. After
    the space opens, only the hint already in effect can be confirmed. Any other
-   attempt fails rather than silently changing the route. The current registry
-   still needs the pre-open conflict guard. This settles how a known hint enters
-   the current session. It does not settle host discovery, availability,
-   failover, or space relocation.
+   attempt fails rather than silently changing the route. This settles how a
+   known hint enters the current session. It does not settle host discovery,
+   availability, failover, or space relocation.
 3. **Runtime-fingerprint interaction.** A runtime fingerprint change creates a
    new executable identity for an importer whose reachable graph contains an
    external dependency, even when its authored source and fabric pins are

--- a/docs/specs/pattern-imports/implementation-plan.md
+++ b/docs/specs/pattern-imports/implementation-plan.md
@@ -1189,12 +1189,15 @@ One integration test (runner-level, in-process, two "deploys"):
   secondary session. A seeded route can only be confirmed. Once a late hint is
   accepted, a different hint is a conflict even before the space opens. After
   the space opens, only the hint already in effect can be confirmed. The
-  current registry still needs the pre-open conflict guard. Dynamic
-  registration and site-table hydration exist as foundations, but
-  import-resolver integration, host failure, and space relocation remain work.
-  Cross-host publication also needs CFC label propagation for fetched source
-  (spec § Security). A possible public-pattern HTTP endpoint remains open under
-  the public distribution question in the spec.
+  registry enforces these conflict rules. Initial site-table hydration selects
+  the last valid HTTP or HTTPS entry for each space without replacing a route
+  already accepted through IPC. A conflicting table route accepted first makes
+  later IPC registration fail. Dynamic registration and site-table hydration
+  exist as foundations, but import-resolver integration, host failure, and
+  space relocation remain work. Cross-host publication also needs CFC label
+  propagation for fetched source (spec § Security). A possible public-pattern
+  HTTP endpoint remains open under the public distribution question in the
+  spec.
 - **M4 explicit subpaths**: extend lifecycle source ingestion and retained
   publications with the following behavior.
 

--- a/docs/specs/pattern-imports/implementation-plan.md
+++ b/docs/specs/pattern-imports/implementation-plan.md
@@ -1187,17 +1187,21 @@ One integration test (runner-level, in-process, two "deploys"):
   ACL. Host-qualified refs register their accepted hint through the ordinary
   per-space storage manager before opening the target space. Do not use a
   secondary session. A seeded route can only be confirmed. Once a late hint is
-  accepted, a different hint is a conflict even before the space opens. After
-  the space opens, only the hint already in effect can be confirmed. The
-  registry enforces these conflict rules. Initial site-table hydration selects
-  the last valid HTTP or HTTPS entry for each space without replacing a route
-  already accepted through IPC. A conflicting table route accepted first makes
-  later IPC registration fail. Dynamic registration and site-table hydration
-  exist as foundations, but import-resolver integration, host failure, and
-  space relocation remain work. Cross-host publication also needs CFC label
-  propagation for fetched source (spec § Security). A possible public-pattern
-  HTTP endpoint remains open under the public distribution question in the
-  spec.
+  accepted, a different hint is a conflict before or after the space opens. An
+  unseeded provider opened through the default host remains provisional while
+  it is read-only. Its first hint can replace that provider. Overlapping reads
+  follow the replay, which also loads dependencies discovered from the hinted
+  data. A different-host hint can replace an operation that is waiting for a
+  session. The route becomes fixed when the session accepts a stateful
+  operation for issue, even if acknowledgement later fails. Initial site-table
+  hydration selects the last valid HTTP or HTTPS entry for each space without
+  replacing a route already accepted through IPC.
+  A conflicting table route accepted first makes later IPC registration fail.
+  Dynamic registration and site-table hydration exist as foundations, but
+  import-resolver integration, host failure, and replacement of an explicit
+  route remain work. Cross-host publication also needs CFC label propagation
+  for fetched source (spec § Security). A possible public-pattern HTTP endpoint
+  remains open under the public distribution question in the spec.
 - **M4 explicit subpaths**: extend lifecycle source ingestion and retained
   publications with the following behavior.
 

--- a/docs/specs/piece-source-lifecycle.md
+++ b/docs/specs/piece-source-lifecycle.md
@@ -27,6 +27,10 @@ canonical HTTP or HTTPS URL as the active origin in the same transaction as its
 source-backed creation revision. Programmatically constructed patterns without
 retained source continue to run without restorable history. Retained source
 closures are reverified in the transaction that publishes each history entry.
+An unseeded space now uses the default host provisionally until a stateful
+operation is issued there. Before that cutoff, its first accepted host hint
+replaces the route and replays prior reads, including when a pattern followed a
+link before site-table hydration completed.
 
 This lifecycle slice is partial. Revisions retain the existing verified
 `pattern:<identity>` source-document closure rather than the complete authored
@@ -137,11 +141,51 @@ retains the supplied URL in history and must persist the space DID to host route
 before it commits a hostless canonical target. If the route cannot be persisted,
 the origin transition fails without changing the piece. The transition also
 registers the accepted hint on the ordinary storage manager before opening the
-origin space. It does not create a secondary session. A conflicting seeded
-route or previously accepted late hint fails the transition. After the origin
-space opens, only the hint that was already registered can be confirmed. Any
-other route attempt fails the transition. A later load hydrates the durable
-route before resolving the canonical fabric target.
+origin space. It does not create a secondary session. A seeded route or a
+previously accepted late hint is authoritative, so a conflicting hint fails the
+transition.
+
+The default host is only a provisional route for a space that has neither a
+seed nor an accepted hint. The first accepted hint may replace that provisional
+route after its provider opens. Storage clears the provisional replica, closes
+its session, and cancels connection, initial or reconnect session signature
+creation, mount, and ACL setup work that is still in progress. It does not wait
+for the provisional host to respond. Storage opens the same provider through
+the hinted host and replays every document read registered on it. An
+asynchronous read-only operation that overlaps replacement restarts on the
+hinted replica and returns that result instead of the provisional replica's
+closure error. These operations include document reads, entity listing and
+lookup, scheduler snapshot listing, and SQLite queries.
+An existing `synced()` barrier follows the replacement and waits for those
+replayed reads on the hinted replica.
+Replay also loads CFC schema documents discovered from the hinted data.
+Reactive consumers therefore receive the intended data when site-table
+hydration loses the race with link traversal.
+
+A transaction keeps the replica from which it read its basis. Replacement
+makes a transaction holding the provisional replica inconsistent. Its commit
+is rejected and may be retried from the hinted data; it cannot carry a result
+calculated from missing provisional data into the intended host.
+Immediately before a transaction mutation is accepted for issue, storage
+rechecks every replica that supplied the transaction's read basis. This
+includes read spaces other than the mutation's target space. If any read-basis
+replica was replaced, storage rejects the transaction before handing the
+mutation to any host.
+
+Replacement is allowed until the provisional session accepts a stateful
+operation for issue. Stateful operations are ordinary transactions, scheduler
+transactions, ACL setup transactions, and injected SQLite source registration.
+Work that is still waiting for a session does not prevent replacement. When the
+hint wins that race, the old replica is invalidated before the waiting work can
+issue. A failure before issuance also leaves the route provisional.
+
+Once a stateful operation is handed to the provisional host, the route becomes
+authoritative. This remains true when the client later reports an error because
+the host may have committed the operation before its acknowledgement was lost.
+A hint naming another host is then a conflict. A hint matching the default host
+makes the route authoritative without reconnecting. After the first hint is
+accepted, a different hint remains a conflict. A later load hydrates the
+durable route before resolving the canonical fabric target.
 
 An origin is not proof of the bytes currently running. The content-addressed
 `patternIdentity` is that proof. A fabric URL that names a content-addressed
@@ -581,25 +625,65 @@ The operation never persists a hint that the live registry has already
 rejected.
 
 The runtime does not open a short-lived secondary session for origin
-resolution. A configured route and an existing live connection remain stable
-for the current session. A seeded route can only be confirmed. Once a late hint
-is accepted, a different hint is a conflict even before the space opens. After
-the space opens, only the hint already in effect can be confirmed. Any other
-attempt fails without changing the piece. It does not silently reconnect or
-allow two live connections to disagree about where the same space resides.
+resolution. A seeded route can only be confirmed. Once a late hint is accepted,
+a different hint is a conflict before or after the space opens.
+
+Opening an unseeded space on the default host does not accept that fallback as
+its route. If no stateful operation has been issued, the first late hint still
+wins. If it names another host, the storage manager invalidates and closes the
+provisional replica, replaces it in place, and settles its queued and in-flight
+reads even if its connection has not opened. Route cancellation closes
+connection, initial or reconnect session signature creation, mount, and ACL
+setup work that is still in progress. The manager then replays its registered
+document reads on the hinted host. Asynchronous document reads, entity listing
+and lookup, scheduler snapshot listing, and SQLite queries that overlap
+replacement follow the hinted replica rather than returning the provisional
+close result. A `synced()` call that already started also waits for the
+replacement and its replay. Replay includes CFC schema documents discovered
+from the hinted entities. Existing reactive readers observe the hinted space's
+data, and convergence does not remain blocked on the provisional connection.
+
+Work already holding the invalidated replica cannot commit through it. A
+transaction that read from that replica becomes inconsistent and must recompute
+from the hinted data. The issue boundary checks every read-basis space, not only
+the write target, before it hands a mutation to a host. Session construction
+checks the route generation before each mount and after each asynchronous setup
+step. It also receives the route cancellation signal, so an abandoned
+connection, signature operation, mount, or ACL query settles instead of
+remaining alive beside the replacement.
+
+The manager refuses to replace a provisional replica after its session accepts
+any stateful operation for issue. Stateful operations include ordinary and
+scheduler transactions, ACL setup transactions, and injected SQLite source
+registration. The route is fixed at issuance rather than successful
+acknowledgement because a reported error does not prove that the host rejected
+the operation. A hint can still replace work that is waiting for a session or
+is rejected before the session accepts it. Route generations prevent
+invalidated work from starting a later mount or issuing a mutation after
+replacement. Waiting scheduler observations and SQLite registrations settle
+against the invalidated replica instead of blocking convergence. Storage
+rejects only the scheduler observations whose read routes were invalidated. It
+still issues valid observations from the same batch, and a failed earlier batch
+does not strand observations queued behind it. A semantic transaction waits for
+every scheduler-observation batch that was queued ahead of it, including a
+batch another waiter has already started. If an earlier batch fails, the
+semantic transaction is not issued and receives that failure. Its unused
+sequence number is not added to the failure's retry condition. A hint that names
+the default host confirms the provisional route without rebuilding the replica.
 
 This policy settles ingestion of a known host hint. It does not yet make route
 discovery reliable. Host unavailability, replicated hosts, failover, stale
-site-table entries, authenticated space relocation, and closing and reopening
-an affected live session remain open design work.
+site-table entries, authenticated replacement of an explicit route, and
+replicated-host failover remain open design work.
 
 | Capability | Repository status | Remaining work |
 |---|---|---|
-| Register a late host hint before a space opens | **Implemented** | `StorageManager.registerSpaceHost` adds the route. A seed can only be confirmed, and an opened space accepts only its previously registered matching hint |
+| Register a late host hint before a space opens | **Implemented** | `StorageManager.registerSpaceHost` adds the route. A seed can only be confirmed, and the first accepted late hint becomes authoritative |
 | Keep an accepted late hint stable before opening | **Implemented** | `StorageManager.registerSpaceHost` accepts the first late hint and rejects a different hint before or after the space opens |
-| Hydrate durable hints in a new runtime | **Implemented** | The runtime processor watches the home-space site table, selects its last valid HTTP or HTTPS entry for each space, and registers those hints. A route already accepted through IPC remains fixed; a conflicting table route accepted first makes later IPC registration fail |
+| Replace a provisional default route after opening | **Implemented** | The first late hint invalidates an unseeded provider that opened through the default host before its session accepts a stateful operation. It cancels unfinished connection, initial or reconnect session signature creation, mount, and ACL work. Registered document reads, existing sync barriers, and overlapping read-only calls continue through the hinted host, including verified CFC schema documents discovered from the hinted data. Transactions based on the old replica are rejected as inconsistent at issue time, including when they write another space. Invalid scheduler observations do not reject or strand valid observations. A matching default-host hint confirms without reconnecting. Ordinary and scheduler transactions, ACL setup, and SQLite source registration fix the route when issued, even if acknowledgement later fails |
+| Hydrate durable hints in a new runtime | **Implemented** | The runtime processor watches the home-space site table, selects its last valid HTTP or HTTPS entry for each space, and registers those hints. Hydration can replace a provisional default route. A route already accepted through IPC remains fixed; a conflicting table route accepted first makes later IPC registration fail |
 | Accept a host-qualified piece origin | **Origin integration required** | No source lifecycle operation persists and registers a `cf://` hint before resolving and committing the origin |
-| Recover from host failure or space movement | **Reliability design required** | There is no authoritative route-change, failover, or live close-and-reopen protocol |
+| Replace an explicit route after host failure or space movement | **Reliability design required** | There is no authenticated route-change or failover protocol after a seed or late hint becomes authoritative |
 
 ## Reconciliation when a piece loads
 
@@ -884,13 +968,19 @@ The implementation evidence for this table is concentrated in:
 - Storage supports late registration of a space-to-host hint before that space
   opens. The runtime processor hydrates durable hints from the home-space site
   table by selecting its last valid HTTP or HTTPS entry for each space. A
-  seeded route can only be confirmed. An opened space accepts only its
-  previously registered matching hint. The first accepted late hint also
-  remains stable before the space opens, including against a later table
-  update. IPC callers must check the registration result and stop before
-  mounting on a conflict. Historical fabric origin resolution can register a
-  matching live route, but it does not yet persist that route through the site
-  table.
+  seeded route can only be confirmed. An unseeded default-host provider remains
+  provisional until its session accepts a stateful operation. The first
+  accepted hint can replace it, cancel unfinished session setup, clear its
+  replica, and replay its reads so running patterns observe the hinted space.
+  A provisional provider can move while an operation is waiting for a session.
+  Invalidated transactions are rejected and recompute from the hinted replica.
+  Once an ordinary or scheduler transaction, ACL setup transaction, or SQLite
+  source registration is issued, the route remains fixed even if its
+  acknowledgement fails. The first accepted late hint remains stable,
+  including against a later table update.
+  IPC callers must check the registration result and stop before mounting on a
+  conflict. Historical fabric origin resolution can register a matching live
+  route, but it does not yet persist that route through the site table.
 - Tooling exposes the immutable source ref, optional repository locator,
   authored entry path, current origin, revision history, and lifecycle actions
   separately.
@@ -940,8 +1030,10 @@ The implementation evidence for this table is concentrated in:
    accepted space-to-host route before removing the host from the canonical
    target. Validate and register the route before writing it to the site table,
    then open the origin space. Honor the conflict guards for seeded routes and
-   previously accepted late hints. Once the space opens, fail any hint that was
-   not already registered and matching. Do not create a secondary session.
+   previously accepted late hints. Treat an unseeded default-host provider as
+   provisional until its first hint arrives or a stateful operation is issued.
+   Before a stateful operation is issued, allow the first hint to replace and
+   reload the provider. Do not create a secondary session.
    Keep the supplied canonical URL in history. Do not make shortlink retention
    part of the lifecycle contract until the open provenance question is
    settled. Any later alias provenance must remain separate from active origins
@@ -1002,7 +1094,8 @@ The implementation evidence for this table is concentrated in:
    cross-space authorization and provenance, web and fabric URL policy,
    mutable versus content-addressed fabric targets, explicit pins, durable host
    routing after reload, conflicts between late hints before a target opens,
-   route conflicts after a target opens, space-root creation from a default,
+   replacement of a provisional default route after a target opens, conflicts
+   with an explicit route after a target opens, space-root creation from a default,
    changes to a default after root creation, tracked and detached root baseline
    migration, source-less legacy roots, relative-path normalization,
    root-interface rejection, runtime-fingerprint rebuilds, authorized upstream

--- a/docs/specs/piece-source-lifecycle.md
+++ b/docs/specs/piece-source-lifecycle.md
@@ -54,7 +54,7 @@ otherwise complete first-time creation command into an unimplemented command.
 
 ## Last updated
 
-2026-07-28
+2026-07-29
 
 ## Terms
 
@@ -596,8 +596,8 @@ an affected live session remain open design work.
 | Capability | Repository status | Remaining work |
 |---|---|---|
 | Register a late host hint before a space opens | **Implemented** | `StorageManager.registerSpaceHost` adds the route. A seed can only be confirmed, and an opened space accepts only its previously registered matching hint |
-| Keep an accepted late hint stable before opening | **Conflict guard required** | `StorageManager.registerSpaceHost` currently replaces a different late hint while the space remains unopened |
-| Hydrate durable hints in a new runtime | **Implemented** | The runtime processor watches the home-space site table and registers its entries. Callers that need ordering must also register through IPC before the first open |
+| Keep an accepted late hint stable before opening | **Implemented** | `StorageManager.registerSpaceHost` accepts the first late hint and rejects a different hint before or after the space opens |
+| Hydrate durable hints in a new runtime | **Implemented** | The runtime processor watches the home-space site table, selects its last valid HTTP or HTTPS entry for each space, and registers those hints. A route already accepted through IPC remains fixed; a conflicting table route accepted first makes later IPC registration fail |
 | Accept a host-qualified piece origin | **Origin integration required** | No source lifecycle operation persists and registers a `cf://` hint before resolving and committing the origin |
 | Recover from host failure or space movement | **Reliability design required** | There is no authoritative route-change, failover, or live close-and-reopen protocol |
 
@@ -883,11 +883,14 @@ The implementation evidence for this table is concentrated in:
   exception.
 - Storage supports late registration of a space-to-host hint before that space
   opens. The runtime processor hydrates durable hints from the home-space site
-  table. A seeded route can only be confirmed. An opened space accepts only its
-  previously registered matching hint. Before a space opens, however, a new
-  late hint currently replaces the previous one. Historical fabric origin
-  resolution can register a matching live route, but it does not yet persist
-  that route through the site table.
+  table by selecting its last valid HTTP or HTTPS entry for each space. A
+  seeded route can only be confirmed. An opened space accepts only its
+  previously registered matching hint. The first accepted late hint also
+  remains stable before the space opens, including against a later table
+  update. IPC callers must check the registration result and stop before
+  mounting on a conflict. Historical fabric origin resolution can register a
+  matching live route, but it does not yet persist that route through the site
+  table.
 - Tooling exposes the immutable source ref, optional repository locator,
   authored entry path, current origin, revision history, and lifecycle actions
   separately.
@@ -936,15 +939,15 @@ The implementation evidence for this table is concentrated in:
    alias resolution outside the lifecycle resolver. Persist an
    accepted space-to-host route before removing the host from the canonical
    target. Validate and register the route before writing it to the site table,
-   then open the origin space. Fail a conflicting seeded route or previously
-   accepted late hint, including before the first open. Once the space opens,
-   fail any hint that was not already registered and matching. Do not create a
-   secondary session. Keep the supplied canonical URL in history. Do not make
-   shortlink retention part of the lifecycle contract until the open provenance
-   question is settled. Any later alias provenance must remain separate from
-   active origins and repoint targets. Keep `patternRepository` separate and
-   clear it when newly generated or directly edited code no longer belongs to
-   that repository.
+   then open the origin space. Honor the conflict guards for seeded routes and
+   previously accepted late hints. Once the space opens, fail any hint that was
+   not already registered and matching. Do not create a secondary session.
+   Keep the supplied canonical URL in history. Do not make shortlink retention
+   part of the lifecycle contract until the open provenance question is
+   settled. Any later alias provenance must remain separate from active origins
+   and repoint targets. Keep `patternRepository` separate and clear it when
+   newly generated or directly edited code no longer belongs to that
+   repository.
 4. Add origin reconciliation to the ordinary piece start path. Add an
    event-driven subscription while an unpinned mutable fabric origin is
    running. Observe its source revision rather than only its executable

--- a/packages/background-piece-service/test/disconnected-websocket.ts
+++ b/packages/background-piece-service/test/disconnected-websocket.ts
@@ -1,0 +1,23 @@
+class DisconnectedWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  constructor(_url: string | URL) {
+    throw new DOMException(
+      "Test WebSocket connections are disabled",
+      "NetworkError",
+    );
+  }
+}
+
+export function installDisconnectedWebSocket(): () => void {
+  const original = globalThis.WebSocket;
+  (globalThis as unknown as { WebSocket: typeof WebSocket }).WebSocket =
+    DisconnectedWebSocket as unknown as typeof WebSocket;
+  return () => {
+    (globalThis as unknown as { WebSocket: typeof WebSocket }).WebSocket =
+      original;
+  };
+}

--- a/packages/background-piece-service/test/service-modules.test.ts
+++ b/packages/background-piece-service/test/service-modules.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, it } from "@std/testing/bdd";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import {
   assert,
   assertEquals,
@@ -49,11 +49,13 @@ import {
   runIfMain as runCastIfMain,
 } from "../cast-admin.ts";
 import * as backgroundPieceService from "../src/lib.ts";
+import { installDisconnectedWebSocket } from "./disconnected-websocket.ts";
 
 const TEST_DID = "did:key:z6Mktestspace";
 const OTHER_DID = "did:key:z6Mkotherspace";
 const PIECE_ID = `fid1:${"a".repeat(54)}`;
 const OTHER_PIECE_ID = `fid1:${"b".repeat(54)}`;
+const TEST_API_URL = "https://background-piece-service.invalid";
 
 async function runDenoSubprocess(args: string[]): Promise<void> {
   const coverageDir = Deno.env.get("DENO_COVERAGE_DIR");
@@ -282,9 +284,10 @@ async function withRealWorker<T>(
     ) => Promise<Record<string, unknown>>,
   ) => Promise<T>,
 ): Promise<T> {
-  const worker = new Worker(new URL("../src/worker.ts", import.meta.url).href, {
-    type: "module",
-  });
+  const worker = new Worker(
+    new URL("./worker-test-entry.ts", import.meta.url).href,
+    { type: "module" },
+  );
   const messages: Record<string, unknown>[] = [];
   const waiters: {
     predicate: (message: Record<string, unknown>) => boolean;
@@ -912,7 +915,7 @@ describe("background worker", () => {
         WorkerIPCMessageType.Initialize,
         {
           did: identity.did(),
-          toolshedUrl: "memory://bg-worker-test",
+          toolshedUrl: TEST_API_URL,
           rawIdentity: identity.serialize(),
           experimental: { modernCellRep: true },
         },
@@ -926,7 +929,7 @@ describe("background worker", () => {
         WorkerIPCMessageType.Initialize,
         {
           did: identity.did(),
-          toolshedUrl: "memory://bg-worker-test",
+          toolshedUrl: TEST_API_URL,
           rawIdentity: identity.serialize(),
         },
       );
@@ -1166,7 +1169,7 @@ describe("background piece service entry point", () => {
     const identity = await Identity.generate({ implementation: "noble" });
     const runtime = createMainRuntime(
       {
-        API_URL: "memory://main-runtime-test",
+        API_URL: TEST_API_URL,
         OPERATOR_PASS: "operator",
         IDENTITY: undefined,
         ENV: "test",
@@ -1342,6 +1345,17 @@ describe("background piece service entry point", () => {
 });
 
 describe("cast admin entry point", () => {
+  let restoreWebSocket: (() => void) | undefined;
+
+  beforeEach(() => {
+    restoreWebSocket = installDisconnectedWebSocket();
+  });
+
+  afterEach(() => {
+    restoreWebSocket?.();
+    restoreWebSocket = undefined;
+  });
+
   function fakeCastDependencies(
     overrides: Partial<CastAdminDependencies> = {},
   ): CastAdminDependencies & { exitCodes: number[] } {
@@ -1411,7 +1425,7 @@ describe("cast admin entry point", () => {
     assertEquals(dependencies.envGet, Deno.env.get);
 
     const identity = await Identity.generate({ implementation: "noble" });
-    const runtime = createCastRuntime("memory://cast-default-deps", identity);
+    const runtime = createCastRuntime(TEST_API_URL, identity);
     try {
       const session = await dependencies.createSession({
         identity,
@@ -1427,7 +1441,7 @@ describe("cast admin entry point", () => {
   it("compiles the actual admin pattern source", async () => {
     const identity = await Identity.generate({ implementation: "noble" });
     const runtime = createUncachedCompileRuntime(
-      "memory://cast-admin-compile",
+      TEST_API_URL,
       identity,
     );
     try {
@@ -1476,7 +1490,7 @@ describe("cast admin entry point", () => {
 
   it("creates the cast runtime", async () => {
     const identity = await Identity.generate({ implementation: "noble" });
-    const runtime = createCastRuntime("memory://cast-runtime-test", identity);
+    const runtime = createCastRuntime(TEST_API_URL, identity);
     const cell = runtime.getCell(identity.did(), "cast-runtime-test", {
       type: "object",
       properties: {},
@@ -1490,7 +1504,7 @@ describe("cast admin entry point", () => {
     const identity = await Identity.generate({ implementation: "noble" });
     const consulted = new Set<string>();
     const runtime = createCastRuntime(
-      "memory://cast-env-reader",
+      TEST_API_URL,
       identity,
       (key) => {
         consulted.add(key);

--- a/packages/background-piece-service/test/worker-module-subprocess.ts
+++ b/packages/background-piece-service/test/worker-module-subprocess.ts
@@ -111,7 +111,7 @@ try {
       type: WorkerIPCMessageType.Initialize,
       data: {
         did: identity.did(),
-        toolshedUrl: "memory://worker-handler-test",
+        toolshedUrl: "https://background-piece-service.invalid",
         rawIdentity: identity.serialize(),
       },
     },

--- a/packages/background-piece-service/test/worker-test-entry.ts
+++ b/packages/background-piece-service/test/worker-test-entry.ts
@@ -1,0 +1,4 @@
+import { installDisconnectedWebSocket } from "./disconnected-websocket.ts";
+
+installDisconnectedWebSocket();
+await import("../src/worker.ts");

--- a/packages/home-schemas/spaces.ts
+++ b/packages/home-schemas/spaces.ts
@@ -33,12 +33,14 @@ export type SpacesList = Schema<typeof spacesListSchema>;
  * daemon (syncing its served sources) and link-receipt flows.
  *
  * Entries are HINTS: unverified in v0 (the space's own log is the
- * integrity boundary, not the host), and a hint must never silently
- * re-point a space the runtime already opened.
+ * integrity boundary, not the host). The first hint may replace an
+ * unseeded default-host provider, but it cannot replace a seed or an
+ * earlier accepted hint.
  *
  * SECURITY (v0, explicit): the table is ordinary home-space data, so
  * ANYTHING with home-space write access — including patterns running
- * there — can steer where a not-yet-opened space is fetched from.
+ * there — can steer where an unseeded space is fetched from, including
+ * a space already opened provisionally through the default host.
  * That is a deliberate v0 trade (matching "don't even verify in the
  * first month") and the forcing function for audience-binding the
  * session handshake before host hints ever come from less-trusted
@@ -46,9 +48,9 @@ export type SpacesList = Schema<typeof spacesListSchema>;
  *
  * Table semantics: an array with no uniqueness constraint. During initial
  * hydration, the last valid HTTP or HTTPS entry for a DID is the candidate
- * route. A route already accepted by the runtime remains fixed, including
- * before the space opens. Removing an entry does not unregister an accepted
- * route until the runtime restarts.
+ * route. A seed or accepted hint remains fixed. A default-host fallback is
+ * provisional until the first hint is accepted. Removing an entry does not
+ * unregister an accepted route until the runtime restarts.
  */
 export const spaceHostEntrySchema = {
   type: "object",

--- a/packages/home-schemas/spaces.ts
+++ b/packages/home-schemas/spaces.ts
@@ -44,10 +44,11 @@ export type SpacesList = Schema<typeof spacesListSchema>;
  * session handshake before host hints ever come from less-trusted
  * data.
  *
- * Table semantics: an array with no uniqueness constraint — for an
- * unopened space, the LAST entry for a did wins; REMOVING an entry
- * does not unregister an already-learned hint until the runtime
- * restarts.
+ * Table semantics: an array with no uniqueness constraint. During initial
+ * hydration, the last valid HTTP or HTTPS entry for a DID is the candidate
+ * route. A route already accepted by the runtime remains fixed, including
+ * before the space opens. Removing an entry does not unregister an accepted
+ * route until the runtime restarts.
  */
 export const spaceHostEntrySchema = {
   type: "object",

--- a/packages/memory/test/v2-client-test.ts
+++ b/packages/memory/test/v2-client-test.ts
@@ -110,6 +110,189 @@ const asyncHandshakeTransport = (helloOk: FabricValue): Transport => {
   };
 };
 
+const abortAfterResponse = (
+  controller: AbortController,
+  responseType: "hello" | "session.open",
+  reason: unknown,
+): Transport => {
+  const transport = handshakeTransport(HELLO_OK);
+  return {
+    ...transport,
+    async send(payload: string): Promise<void> {
+      const message = decodeMemoryBoundary(payload) as { type?: string };
+      await transport.send(payload);
+      if (message.type === responseType) controller.abort(reason);
+    },
+  };
+};
+
+const abortAfterListenerRemovals = (
+  controller: AbortController,
+  count: number,
+  reason: unknown,
+): AbortSignal => {
+  let removals = 0;
+  return new Proxy(controller.signal, {
+    get(target, property) {
+      if (property === "removeEventListener") {
+        return (
+          ...args: Parameters<AbortSignal["removeEventListener"]>
+        ): void => {
+          target.removeEventListener(...args);
+          removals++;
+          if (removals === count) controller.abort(reason);
+        };
+      }
+      const value = Reflect.get(target, property, target);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+};
+
+Deno.test("memory v2 client rejects an already cancelled connection", async () => {
+  const controller = new AbortController();
+  controller.abort(new Error("cancel before connect"));
+  const base = handshakeTransport(HELLO_OK);
+  let sends = 0;
+  const transport: Transport = {
+    ...base,
+    send(payload: string): Promise<void> {
+      sends++;
+      return base.send(payload);
+    },
+  };
+
+  await assertRejects(
+    () => connect({ transport, signal: controller.signal }),
+    Error,
+    "cancel before connect",
+  );
+  assertEquals(sends, 0);
+});
+
+Deno.test("memory v2 client observes cancellation after hello", async () => {
+  const controller = new AbortController();
+  const reason = new Error("cancel after hello");
+
+  await assertRejects(
+    () =>
+      connect({
+        transport: abortAfterResponse(controller, "hello", reason),
+        signal: controller.signal,
+      }),
+    Error,
+    reason.message,
+  );
+});
+
+Deno.test("memory v2 client rejects an already cancelled mount", async () => {
+  const client = await connect({ transport: handshakeTransport(HELLO_OK) });
+  const controller = new AbortController();
+  controller.abort(new Error("cancel before mount"));
+  let authCalls = 0;
+  try {
+    await assertRejects(
+      () =>
+        client.mount(
+          "did:key:z6Mk-memory-v2-cancel-before-mount",
+          {},
+          () => {
+            authCalls++;
+          },
+          controller.signal,
+        ),
+      Error,
+      "cancel before mount",
+    );
+    assertEquals(authCalls, 0);
+  } finally {
+    await client.close();
+  }
+});
+
+Deno.test("memory v2 client propagates a synchronous mount auth failure", async () => {
+  const client = await connect({ transport: handshakeTransport(HELLO_OK) });
+  const controller = new AbortController();
+  try {
+    await assertRejects(
+      () =>
+        client.mount(
+          "did:key:z6Mk-memory-v2-mount-auth-failure",
+          {},
+          () => {
+            throw new Error("mount auth failed");
+          },
+          controller.signal,
+        ),
+      Error,
+      "mount auth failed",
+    );
+  } finally {
+    await client.close();
+  }
+});
+
+Deno.test("memory v2 client observes cancellation during mount auth", async () => {
+  const client = await connect({ transport: handshakeTransport(HELLO_OK) });
+  const controller = new AbortController();
+  const reason = new Error("cancel during mount auth");
+  try {
+    await assertRejects(
+      () =>
+        client.mount(
+          "did:key:z6Mk-memory-v2-cancel-during-mount-auth",
+          {},
+          () => {
+            controller.abort(reason);
+          },
+          controller.signal,
+        ),
+      Error,
+      reason.message,
+    );
+  } finally {
+    await client.close();
+  }
+});
+
+Deno.test("memory v2 client observes cancellation after session open", async () => {
+  const cases = [
+    {
+      reason: new Error("cancel after session open"),
+      message: "cancel after session open",
+    },
+    {
+      reason: "cancel after session open without an error",
+      message: "memory session mount cancelled",
+    },
+  ];
+
+  for (const [index, testCase] of cases.entries()) {
+    const client = await connect({ transport: handshakeTransport(HELLO_OK) });
+    const controller = new AbortController();
+    const signal = abortAfterListenerRemovals(
+      controller,
+      2,
+      testCase.reason,
+    );
+    try {
+      await assertRejects(
+        () =>
+          client.mount(
+            `did:key:z6Mk-memory-v2-cancel-after-session-open-${index}`,
+            {},
+            undefined,
+            signal,
+          ),
+        Error,
+        testCase.message,
+      );
+    } finally {
+      await client.close();
+    }
+  }
+});
+
 Deno.test("memory v2 client marks only a new outstanding commit as issued", async () => {
   const client = await connect({
     transport: handshakeTransport(HELLO_OK),

--- a/packages/memory/test/v2-client-test.ts
+++ b/packages/memory/test/v2-client-test.ts
@@ -110,6 +110,38 @@ const asyncHandshakeTransport = (helloOk: FabricValue): Transport => {
   };
 };
 
+Deno.test("memory v2 client marks only a new outstanding commit as issued", async () => {
+  const client = await connect({
+    transport: handshakeTransport(HELLO_OK),
+  });
+  const session = await client.mount(
+    "did:key:z6Mk-memory-v2-before-issue",
+  );
+  const commit = {
+    localSeq: 1,
+    reads: { confirmed: [], pending: [] },
+    operations: [{
+      op: "set" as const,
+      id: "of:before-issue",
+      value: { value: { count: 1 } },
+    }],
+  };
+  let firstIssues = 0;
+  let duplicateIssues = 0;
+
+  const first = session.transact(commit, () => firstIssues++);
+  const duplicate = session.transact(commit, () => duplicateIssues++);
+  const settled = Promise.allSettled([first, duplicate]);
+
+  assertEquals(firstIssues, 1);
+  assertEquals(duplicateIssues, 0);
+  await client.close();
+  assertEquals(
+    (await settled).map((result) => result.status),
+    ["rejected", "rejected"],
+  );
+});
+
 Deno.test("memory v2 client rejects malformed async hello session.open metadata", async () => {
   await assertRejects(
     () =>

--- a/packages/memory/test/v2-client-test.ts
+++ b/packages/memory/test/v2-client-test.ts
@@ -126,23 +126,52 @@ const abortAfterResponse = (
   };
 };
 
-const abortAfterListenerRemovals = (
+const trackAbortListeners = (
   controller: AbortController,
-  count: number,
-  reason: unknown,
-): AbortSignal => {
+  onRemoval?: (count: number) => void,
+): { signal: AbortSignal; abortListenerCount: () => number } => {
+  let active = 0;
   let removals = 0;
-  return new Proxy(controller.signal, {
+  return {
+    signal: new Proxy(controller.signal, {
+      get(target, property) {
+        if (property === "addEventListener") {
+          return (
+            ...args: Parameters<AbortSignal["addEventListener"]>
+          ): void => {
+            target.addEventListener(...args);
+            if (args[0] === "abort") active++;
+          };
+        }
+        if (property === "removeEventListener") {
+          return (
+            ...args: Parameters<AbortSignal["removeEventListener"]>
+          ): void => {
+            target.removeEventListener(...args);
+            if (args[0] === "abort") {
+              active--;
+              removals++;
+              onRemoval?.(removals);
+            }
+          };
+        }
+        const value = Reflect.get(target, property, target);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }),
+    abortListenerCount: () => active,
+  };
+};
+
+const abortBetweenInitialAndPostStartChecks = (
+  reason: Error,
+): AbortSignal => {
+  const signal = new AbortController().signal;
+  let abortedReads = 0;
+  return new Proxy(signal, {
     get(target, property) {
-      if (property === "removeEventListener") {
-        return (
-          ...args: Parameters<AbortSignal["removeEventListener"]>
-        ): void => {
-          target.removeEventListener(...args);
-          removals++;
-          if (removals === count) controller.abort(reason);
-        };
-      }
+      if (property === "aborted") return ++abortedReads > 1;
+      if (property === "reason") return reason;
       const value = Reflect.get(target, property, target);
       return typeof value === "function" ? value.bind(target) : value;
     },
@@ -213,6 +242,7 @@ Deno.test("memory v2 client rejects an already cancelled mount", async () => {
 Deno.test("memory v2 client propagates a synchronous mount auth failure", async () => {
   const client = await connect({ transport: handshakeTransport(HELLO_OK) });
   const controller = new AbortController();
+  const tracked = trackAbortListeners(controller);
   try {
     await assertRejects(
       () =>
@@ -222,30 +252,33 @@ Deno.test("memory v2 client propagates a synchronous mount auth failure", async 
           () => {
             throw new Error("mount auth failed");
           },
-          controller.signal,
+          tracked.signal,
         ),
       Error,
       "mount auth failed",
     );
+    assertEquals(tracked.abortListenerCount(), 0);
   } finally {
     await client.close();
   }
 });
 
-Deno.test("memory v2 client observes cancellation during mount auth", async () => {
+Deno.test("memory v2 client observes cancellation after mount auth starts", async () => {
   const client = await connect({ transport: handshakeTransport(HELLO_OK) });
-  const controller = new AbortController();
   const reason = new Error("cancel during mount auth");
+  const authFailure = new Error("mount auth completed after cancellation");
+  const signal = abortBetweenInitialAndPostStartChecks(reason);
   try {
     await assertRejects(
       () =>
         client.mount(
           "did:key:z6Mk-memory-v2-cancel-during-mount-auth",
           {},
-          () => {
-            controller.abort(reason);
-          },
-          controller.signal,
+          () =>
+            Promise.resolve().then(() => {
+              throw authFailure;
+            }),
+          signal,
         ),
       Error,
       reason.message,
@@ -270,10 +303,11 @@ Deno.test("memory v2 client observes cancellation after session open", async () 
   for (const [index, testCase] of cases.entries()) {
     const client = await connect({ transport: handshakeTransport(HELLO_OK) });
     const controller = new AbortController();
-    const signal = abortAfterListenerRemovals(
+    const tracked = trackAbortListeners(
       controller,
-      2,
-      testCase.reason,
+      (removals) => {
+        if (removals === 2) controller.abort(testCase.reason);
+      },
     );
     try {
       await assertRejects(
@@ -282,11 +316,12 @@ Deno.test("memory v2 client observes cancellation after session open", async () 
             `did:key:z6Mk-memory-v2-cancel-after-session-open-${index}`,
             {},
             undefined,
-            signal,
+            tracked.signal,
           ),
         Error,
         testCase.message,
       );
+      assertEquals(tracked.abortListenerCount(), 0);
     } finally {
       await client.close();
     }

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -49,6 +49,7 @@ export type Transport = {
 
 export type ConnectOptions = {
   transport: Transport;
+  signal?: AbortSignal;
 };
 
 export type MountOptions = {
@@ -107,6 +108,42 @@ const compareEntitySnapshot = (
   (left.scope ?? "space").localeCompare(right.scope ?? "space") ||
   left.id.localeCompare(right.id);
 
+const runWithAbortSignal = async <T>(
+  signal: AbortSignal | undefined,
+  fallbackMessage: string,
+  start: () => T | PromiseLike<T>,
+): Promise<T> => {
+  const abortError = (): Error =>
+    signal?.reason instanceof Error
+      ? signal.reason
+      : new Error(fallbackMessage);
+  if (signal?.aborted) {
+    throw abortError();
+  }
+  if (signal === undefined) {
+    return await start();
+  }
+
+  const cancelled = Promise.withResolvers<never>();
+  const cancel = (): void => cancelled.reject(abortError());
+  signal.addEventListener("abort", cancel, { once: true });
+  let work: Promise<T>;
+  try {
+    work = Promise.resolve(start());
+  } catch (error) {
+    signal.removeEventListener("abort", cancel);
+    throw error;
+  }
+  if (signal.aborted) {
+    cancel();
+  }
+  try {
+    return await Promise.race([work, cancelled.promise]);
+  } finally {
+    signal.removeEventListener("abort", cancel);
+  }
+};
+
 export class Client {
   #pending = new Map<string, PromiseWithResolvers<unknown>>();
   #spaces = new Set<SpaceSession>();
@@ -135,8 +172,25 @@ export class Client {
 
   static async connect(options: ConnectOptions): Promise<Client> {
     const client = new Client(options.transport);
-    await client.hello();
-    return client;
+    const abortError = (): Error =>
+      options.signal?.reason instanceof Error
+        ? options.signal.reason
+        : new Error("memory client connection cancelled");
+    const closeForAbort = (): void => {
+      void client.close().catch(() => {});
+    };
+    options.signal?.addEventListener("abort", closeForAbort, { once: true });
+    try {
+      if (options.signal?.aborted) throw abortError();
+      await client.hello();
+      if (options.signal?.aborted) throw abortError();
+      return client;
+    } catch (error) {
+      await client.close().catch(() => {});
+      throw options.signal?.aborted ? abortError() : error;
+    } finally {
+      options.signal?.removeEventListener("abort", closeForAbort);
+    }
   }
 
   /** The flags the SERVER advertised in its `hello.ok` (null before the first
@@ -161,13 +215,28 @@ export class Client {
     space: string,
     options: MountOptions = {},
     openAuthFactory?: SessionOpenAuthFactory,
+    signal?: AbortSignal,
   ): Promise<SpaceSession> {
-    const auth = await openAuthFactory?.(
-      space,
-      options,
-      this.sessionOpenAuthContext(),
+    const auth = await runWithAbortSignal(
+      signal,
+      "memory session mount cancelled",
+      () =>
+        openAuthFactory?.(
+          space,
+          options,
+          this.sessionOpenAuthContext(),
+        ),
     );
-    const result = await this.openSession(space, options, auth);
+    const result = await runWithAbortSignal(
+      signal,
+      "memory session mount cancelled",
+      () => this.openSession(space, options, auth),
+    );
+    if (signal?.aborted) {
+      throw signal.reason instanceof Error
+        ? signal.reason
+        : new Error("memory session mount cancelled");
+    }
     const session = new SpaceSession(
       this,
       space,
@@ -175,6 +244,7 @@ export class Client {
       result.sessionToken,
       result.serverSeq,
       openAuthFactory,
+      signal,
     );
     this.#spaces.add(session);
     return session;
@@ -260,13 +330,15 @@ export class Client {
   private async hello(): Promise<void> {
     const ack = Promise.withResolvers<void>();
     this.#helloPending = ack;
-    await this.transport.send(encodeMemoryBoundary({
-      type: "hello",
-      protocol: MEMORY_PROTOCOL,
-      flags: getMemoryProtocolFlags(),
-    }));
     try {
-      await ack.promise;
+      await Promise.all([
+        this.transport.send(encodeMemoryBoundary({
+          type: "hello",
+          protocol: MEMORY_PROTOCOL,
+          flags: getMemoryProtocolFlags(),
+        })),
+        ack.promise,
+      ]);
       this.#connected = true;
     } finally {
       this.#helloPending = null;
@@ -545,6 +617,7 @@ export class SpaceSession {
     sessionToken: string | undefined,
     serverSeq: number,
     private readonly openAuthFactory?: SessionOpenAuthFactory,
+    private readonly routeSignal?: AbortSignal,
   ) {
     this.#sessionId = sessionId;
     this.#sessionToken = sessionToken;
@@ -579,13 +652,21 @@ export class SpaceSession {
     }
   }
 
-  async transact(commit: ClientCommit): Promise<AppliedCommit> {
+  /**
+   * `beforeIssue` runs after the open-session check and before this mutation
+   * enters the session's outstanding request state. Throwing prevents issue.
+   */
+  async transact(
+    commit: ClientCommit,
+    beforeIssue?: () => void,
+  ): Promise<AppliedCommit> {
     this.#assertOpen();
     const existing = this.#outstandingCommits.get(commit.localSeq);
     if (existing) {
       return await existing.pending.promise;
     }
 
+    beforeIssue?.();
     const pending = Promise.withResolvers<AppliedCommit>();
     this.#outstandingCommits.set(commit.localSeq, {
       commit,
@@ -695,11 +776,14 @@ export class SpaceSession {
   async registerSqliteDiskSource(
     id: string,
     path: string,
+    beforeIssue?: () => void,
   ): Promise<SqliteRegisterDiskSourceResult> {
     this.#assertOpen();
+    const requestId = crypto.randomUUID();
+    beforeIssue?.();
     return await this.client.request<SqliteRegisterDiskSourceResult>({
       type: "sqlite.register-disk-source",
-      requestId: crypto.randomUUID(),
+      requestId,
       space: this.space,
       sessionId: this.#sessionId,
       id,
@@ -1188,16 +1272,26 @@ export class SpaceSession {
       seenSeq: this.#serverSeq,
       sessionToken: this.#sessionToken,
     };
-    const auth = await this.openAuthFactory?.(
-      this.space,
-      session,
-      this.client.sessionOpenAuthContext(),
+    const auth = await runWithAbortSignal(
+      this.routeSignal,
+      "memory session route cancelled",
+      () =>
+        this.openAuthFactory?.(
+          this.space,
+          session,
+          this.client.sessionOpenAuthContext(),
+        ),
     );
-    const restored = await this.client.openSession(this.space, {
-      sessionId: this.#sessionId,
-      seenSeq: this.#serverSeq,
-      sessionToken: this.#sessionToken,
-    }, auth);
+    const restored = await runWithAbortSignal(
+      this.routeSignal,
+      "memory session route cancelled",
+      () =>
+        this.client.openSession(this.space, {
+          sessionId: this.#sessionId,
+          seenSeq: this.#serverSeq,
+          sessionToken: this.#sessionToken,
+        }, auth),
+    );
     const sessionChanged = restored.sessionId !== oldSessionId;
     const sessionReplaced = sessionChanged || restored.resumed !== true;
     this.#sessionId = restored.sessionId;

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -1,4 +1,5 @@
 export { Runtime } from "./runtime.ts";
+export { normalizeSpaceHost } from "./space-host.ts";
 export type {
   ConsoleHandler,
   ConsoleHandlerOutput,

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -134,6 +134,7 @@ import {
   type UnsafeHostTrust,
   type UnsafeHostTrustOptions,
 } from "./unsafe-host-trust.ts";
+import { normalizeSpaceHost } from "./space-host.ts";
 
 const isFullNormalizedLinkShape = (
   value: unknown,
@@ -965,9 +966,10 @@ export class Runtime {
     // Validate eagerly, mirroring the storage layer's resolver: a
     // malformed host should fail at configuration time naming the
     // space, not mid-builtin as a bare Invalid URL.
+    const normalizedSpaceHostMap: Record<string, string> = {};
     for (const [space, host] of Object.entries(options.spaceHostMap ?? {})) {
       try {
-        new URL(host);
+        normalizedSpaceHostMap[space] = normalizeSpaceHost(host).toString();
       } catch (cause) {
         throw new Error(
           `Invalid spaceHostMap entry for ${space}: "${host}"`,
@@ -980,7 +982,7 @@ export class Runtime {
     // space → host never changes), so a caller mutating their object
     // after construction must not change routing.
     this.spaceHostMap = options.spaceHostMap
-      ? Object.freeze({ ...options.spaceHostMap })
+      ? Object.freeze(normalizedSpaceHostMap)
       : undefined;
     // Default is a late-bound wrapper that reads `globalThis.fetch` at call time,
     // preserving the existing behavior where a test overrides the global AFTER
@@ -2087,16 +2089,25 @@ export class Runtime {
   }
 
   /**
-   * Record a runtime-learned host hint for a space (the v0 site-table
-   * flow). Storage decides first — the seed map wins and an opened
-   * space is never silently re-pointed — and compute routing follows
-   * exactly when storage accepted, keeping the two layers in agreement.
-   * Returns whether the hint is in effect.
+   * Record a runtime-learned HTTP or HTTPS host hint for a space (the v0
+   * site-table flow). Storage decides first. A seed, an accepted late hint,
+   * or an open connection fixes the route for the session. Compute routing
+   * follows when storage accepts the hint. Returns whether storage accepted
+   * or confirmed the hint.
    */
   registerSpaceHost(space: MemorySpace, host: string): boolean {
-    const accept = this.storageManager.registerSpaceHost?.(space, host);
+    let normalized: string;
+    try {
+      normalized = normalizeSpaceHost(host).toString();
+    } catch (cause) {
+      throw new Error(
+        `Invalid host for space ${space}: "${host}"`,
+        { cause },
+      );
+    }
+    const accept = this.storageManager.registerSpaceHost?.(space, normalized);
     if (accept === undefined) return false; // manager has no remote resolution
-    if (accept) this.#dynamicHosts.set(space, host);
+    if (accept) this.#dynamicHosts.set(space, normalized);
     return accept;
   }
 

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -2090,10 +2090,11 @@ export class Runtime {
 
   /**
    * Record a runtime-learned HTTP or HTTPS host hint for a space (the v0
-   * site-table flow). Storage decides first. A seed, an accepted late hint,
-   * or an open connection fixes the route for the session. Compute routing
-   * follows when storage accepts the hint. Returns whether storage accepted
-   * or confirmed the hint.
+   * site-table flow). Storage decides first. A seed or an accepted late hint
+   * fixes the route for the session. A default-host provider stays provisional
+   * while it is read-only. The first hint can replace it and replay its reads.
+   * Compute routing follows when storage accepts the hint. Returns whether
+   * storage accepted or confirmed the hint.
    */
   registerSpaceHost(space: MemorySpace, host: string): boolean {
     let normalized: string;

--- a/packages/runner/src/space-host.ts
+++ b/packages/runner/src/space-host.ts
@@ -1,0 +1,13 @@
+/**
+ * Parse a shared per-space host route. Storage and compute requests use the
+ * same route, so only HTTP and HTTPS base URLs are valid.
+ */
+export const normalizeSpaceHost = (host: string | URL): URL => {
+  const parsed = new URL(host);
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new TypeError(
+      `Unsupported space host protocol: ${parsed.protocol}`,
+    );
+  }
+  return parsed;
+};

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -147,8 +147,11 @@ export interface IStorageManager extends IStorageSubscriptionCapability {
    * Record a runtime-learned HTTP or HTTPS host hint for a space
    * (federation site table). Optional: managers without remote resolution
    * (emulated/test) simply don't implement it. Returns true when the
-   * hint is accepted or confirms a configured or accepted route. Returns
-   * false on a conflict or when the space opened without that late hint.
+   * hint is accepted or confirms a configured or accepted route. The first
+   * hint can replace an unseeded provider's provisional default route before
+   * that route issues a stateful operation. Returns false on a conflict with a
+   * seed or accepted hint, or after a stateful operation has been issued
+   * through the provisional route.
    */
   registerSpaceHost?(space: MemorySpace, host: string): boolean;
 
@@ -784,6 +787,13 @@ export interface IStorageTransaction {
    * failures are logged).
    */
   enableMultiSpaceWrites?(order?: readonly MemorySpace[]): void;
+  /**
+   * Confirm that every replica supplying this transaction's read basis is
+   * still the active replica for its space. Storage calls this immediately
+   * before issuing a mutation so a route replacement cannot carry a result
+   * computed from the old replica into another space.
+   */
+  validateReplicaRoutes?(): Result<Unit, IStorageTransactionInconsistent>;
   /**
    * Optional read-only mode hook used by runtime-generated fallback read
    * transactions.
@@ -1583,6 +1593,7 @@ export type StorageTransactionFailed =
   | StorageTransactionRejected;
 
 export type StorageTransactionRejected =
+  | IStorageTransactionInconsistent
   | IConflictError
   | IPreconditionFailedError
   | IStoreError
@@ -1746,6 +1757,7 @@ export type PushError =
   | IQueryError
   | IStoreError
   | IConnectionError
+  | IStorageTransactionInconsistent
   | IConflictError
   | IPreconditionFailedError
   | TransactionError

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -144,11 +144,11 @@ export interface IStorageManager extends IStorageSubscriptionCapability {
   open(space: MemorySpace): IStorageProviderWithReplica;
 
   /**
-   * Record a runtime-learned host hint for a space (federation site
-   * table). Optional: managers without remote, per-space resolution
+   * Record a runtime-learned HTTP or HTTPS host hint for a space
+   * (federation site table). Optional: managers without remote resolution
    * (emulated/test) simply don't implement it. Returns true when the
-   * hint is in effect; false when refused (seeded differently, or the
-   * space's connection is already open to another host).
+   * hint is accepted or confirms a configured or accepted route. Returns
+   * false on a conflict or when the space opened without that late hint.
    */
   registerSpaceHost?(space: MemorySpace, host: string): boolean;
 

--- a/packages/runner/src/storage/v2-remote-session.ts
+++ b/packages/runner/src/storage/v2-remote-session.ts
@@ -3,6 +3,7 @@ import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { type MemorySpace, type Signer } from "@commonfabric/memory/interface";
 import * as MemoryClient from "@commonfabric/memory/v2/client";
 import { MEMORY_PROTOCOL } from "@commonfabric/memory/v2";
+import { normalizeSpaceHost } from "../space-host.ts";
 
 export interface SessionFactory {
   /** Opt in to StorageManager's ACL genesis handshake. Scripted factories used
@@ -42,6 +43,30 @@ export const toSpaceWebSocketAddress = (
 export const MEMORY_STORAGE_PATH = "/api/storage/memory";
 
 /**
+ * Resolve a shared HTTP or HTTPS space host to the memory storage endpoint.
+ * Space hosts also serve compute requests, so WebSocket-only URLs are not
+ * valid routes.
+ */
+export const storageAddressForHost = (host: string | URL): URL => {
+  return new URL(MEMORY_STORAGE_PATH, normalizeSpaceHost(host));
+};
+
+const storageAddressForMemoryHost = (host: URL): URL => {
+  const parsed = new URL(host);
+  if (
+    parsed.protocol !== "http:" &&
+    parsed.protocol !== "https:" &&
+    parsed.protocol !== "ws:" &&
+    parsed.protocol !== "wss:"
+  ) {
+    throw new TypeError(
+      `Unsupported memory host protocol: ${parsed.protocol}`,
+    );
+  }
+  return new URL(MEMORY_STORAGE_PATH, parsed);
+};
+
+/**
  * Validity window stamped onto each signed `session.open`.
  * `session.open` is a live handshake sent when a connection opens, so a few
  * minutes covers clock skew and round-trip time while bounding replay.
@@ -63,17 +88,17 @@ export const createStorageAddressResolver = (
   defaultHost: URL,
   spaceHostMap?: Record<string, string>,
   /**
-   * Late-bound host hints (space DID → host base URL) learned at
+   * Late-bound host hints mapping a space DID to a host base URL, learned at
    * runtime, e.g. from the home-space site table. Consulted AFTER the
-   * seed map and BEFORE the default. The caller owns mutation rules
-   * (a hint must never re-point an already-opened space).
+   * seed map and BEFORE the default. The caller keeps the first accepted
+   * hint stable, including after the space opens.
    */
   dynamicHosts?: ReadonlyMap<string, string>,
 ): (space: MemorySpace) => URL => {
   const overrides = new Map<string, URL>();
   for (const [space, host] of Object.entries(spaceHostMap ?? {})) {
     try {
-      overrides.set(space, new URL(MEMORY_STORAGE_PATH, host));
+      overrides.set(space, storageAddressForHost(host));
     } catch (cause) {
       throw new Error(
         `Invalid spaceHostMap entry for ${space}: "${host}"`,
@@ -81,12 +106,12 @@ export const createStorageAddressResolver = (
       );
     }
   }
-  const fallback = new URL(MEMORY_STORAGE_PATH, defaultHost);
+  const fallback = storageAddressForMemoryHost(defaultHost);
   return (space) => {
     const seeded = overrides.get(space);
     if (seeded) return new URL(seeded);
     const dynamic = dynamicHosts?.get(space);
-    if (dynamic) return new URL(MEMORY_STORAGE_PATH, dynamic);
+    if (dynamic) return storageAddressForHost(dynamic);
     return new URL(fallback);
   };
 };

--- a/packages/runner/src/storage/v2-remote-session.ts
+++ b/packages/runner/src/storage/v2-remote-session.ts
@@ -14,6 +14,7 @@ export interface SessionFactory {
     space: MemorySpace,
     signer?: Signer,
     mountOptions?: MemoryClient.MountOptions,
+    signal?: AbortSignal,
   ): Promise<{
     client: MemoryClient.Client;
     session: MemoryClient.SpaceSession;
@@ -258,27 +259,50 @@ export class RemoteSessionFactory implements SessionFactory {
     space: MemorySpace,
     signer = this.defaultSigner,
     mountOptions: MemoryClient.MountOptions = {},
+    signal?: AbortSignal,
   ) {
-    const client = await MemoryClient.connect({
-      transport: new WebSocketTransport(
-        toSpaceWebSocketAddress(this.resolveAddress(space), space),
-      ),
-    });
-    const session = await client.mount(
-      space,
-      mountOptions,
-      (
-        targetSpace: string,
-        descriptor: MemoryClient.MountOptions,
-        context: MemoryClient.SessionOpenAuthContext,
-      ) =>
-        this.#createSessionOpenAuth(
-          signer,
-          targetSpace as MemorySpace,
-          descriptor,
-          context,
-        ),
+    const transport = new WebSocketTransport(
+      toSpaceWebSocketAddress(this.resolveAddress(space), space),
     );
-    return { client, session };
+    let client: MemoryClient.Client | undefined;
+    const abortError = (): Error =>
+      signal?.reason instanceof Error
+        ? signal.reason
+        : new Error("memory replica route replaced");
+
+    try {
+      if (signal?.aborted) throw abortError();
+      client = await MemoryClient.connect({ transport, signal });
+      const closeForAbort = (): void => {
+        void client?.close().catch(() => {});
+      };
+      signal?.addEventListener("abort", closeForAbort, { once: true });
+      if (signal?.aborted) throw abortError();
+      try {
+        const session = await client.mount(
+          space,
+          mountOptions,
+          (
+            targetSpace: string,
+            descriptor: MemoryClient.MountOptions,
+            context: MemoryClient.SessionOpenAuthContext,
+          ) =>
+            this.#createSessionOpenAuth(
+              signer,
+              targetSpace as MemorySpace,
+              descriptor,
+              context,
+            ),
+          signal,
+        );
+        if (signal?.aborted) throw abortError();
+        return { client, session };
+      } finally {
+        signal?.removeEventListener("abort", closeForAbort);
+      }
+    } catch (error) {
+      await (client?.close() ?? transport.close()).catch(() => {});
+      throw signal?.aborted ? abortError() : error;
+    }
   }
 }

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -63,6 +63,7 @@ import {
   claim,
   load as loadInline,
   read as readAttestation,
+  StateInconsistency,
 } from "./transaction/attestation.ts";
 import {
   applyMutablePathWrite,
@@ -2025,7 +2026,7 @@ export class V2StorageTransaction implements IStorageTransaction {
       return { error: validation.error };
     }
 
-    const replica = this.storage.open(writeSpace).replica;
+    const replica = this.replicaForCommit(writeSpace);
     if (!replica.commitNative) {
       throw new Error("memory v2 replica does not support commitNative()");
     }
@@ -2138,7 +2139,7 @@ export class V2StorageTransaction implements IStorageTransaction {
   ): Promise<Result<Unit, StorageTransactionRejected>> {
     for (let i = 0; i < commits.length; i++) {
       const { space, native } = commits[i];
-      const replica = this.storage.open(space).replica;
+      const replica = this.replicaForCommit(space);
       if (!replica.commitNative) {
         throw new Error("memory v2 replica does not support commitNative()");
       }
@@ -2315,6 +2316,13 @@ export class V2StorageTransaction implements IStorageTransaction {
     return branch;
   }
 
+  private replicaForCommit(
+    space: MemorySpace,
+  ): ReturnType<IStorageManager["open"]>["replica"] {
+    return this.#branches.get(space)?.replica ??
+      this.storage.open(space).replica;
+  }
+
   private document(
     branch: SpaceBranch,
     address: Pick<IMemoryAddress, "id" | "type" | "scope">,
@@ -2377,7 +2385,35 @@ export class V2StorageTransaction implements IStorageTransaction {
     };
   }
 
+  validateReplicaRoutes(): Result<Unit, IStorageTransactionInconsistent> {
+    for (const [space, branch] of this.#branches) {
+      const currentReplica = this.storage.open(space).replica;
+      if (currentReplica !== branch.replica) {
+        const firstDocument = branch.docs.values().next().value;
+        if (firstDocument !== undefined) {
+          const { address, value: expected } = firstDocument.initial;
+          const actual = toTransactionDocumentValue(
+            currentReplica.getDocument(address.id as URI, address.scope),
+          );
+          return {
+            error: StateInconsistency({
+              address,
+              expected,
+              actual,
+              space,
+            }),
+          };
+        }
+      }
+    }
+    return { ok: {} };
+  }
+
   private validate(): Result<Unit, IStorageTransactionInconsistent> {
+    const routes = this.validateReplicaRoutes();
+    if (routes.error) {
+      return routes;
+    }
     for (const branch of this.#branches.values()) {
       for (const doc of branch.docs.values()) {
         if (!doc.validated) {

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -146,6 +146,7 @@ import {
   createStorageAddressResolver,
   RemoteSessionFactory,
   type SessionFactory,
+  storageAddressForHost,
 } from "./v2-remote-session.ts";
 import * as V2Transaction from "./v2-transaction.ts";
 import { normalizeCellScope } from "../scope.ts";
@@ -590,7 +591,8 @@ export interface Options {
   /**
    * Base URL of the default memory host. The storage endpoint path
    * (`/api/storage/memory`) is joined internally — pass the host, not
-   * the full endpoint.
+   * the full endpoint. This storage-only route may use HTTP, HTTPS,
+   * WebSocket, or secure WebSocket.
    */
   memoryHost: URL;
   /**
@@ -912,21 +914,22 @@ export class StorageManager implements IStorageManager {
   }
 
   /**
-   * Record a runtime-learned host hint for a space (e.g. from the
-   * home-space site table). Returns true when the hint is (now) in
-   * effect for the space's storage connection. Refusals, by design:
+   * Record a runtime-learned HTTP or HTTPS host hint for a space (e.g. from
+   * the home-space site table). Returns true when the hint is accepted or
+   * confirms a configured or previously accepted route. Refusals:
    *
    * - The seed map wins: a seeded space cannot be re-pointed.
-   * - An already-OPENED space keeps its connection — a hint must never
-   *   silently re-point live storage (re-pointing requires an explicit
-   *   close, which is lifecycle follow-up work).
+   * - The first accepted late hint remains in effect.
+   * - A space that opened without a late hint accepts no new late hint.
    *
    * Idempotent when the hint matches what is already in effect.
    */
   registerSpaceHost(space: MemorySpace, host: string): boolean {
     let normalized: string;
     try {
-      normalized = new URL(host).toString();
+      const parsed = new URL(host);
+      storageAddressForHost(parsed);
+      normalized = parsed.toString();
     } catch (cause) {
       throw new Error(
         `Invalid host for space ${space}: "${host}"`,
@@ -938,12 +941,13 @@ export class StorageManager implements IStorageManager {
       return new URL(seeded).toString() === normalized;
     }
     const existing = this.#dynamicHosts.get(space);
-    if (this.#providers.has(space)) {
-      // Connection already established — only confirmable, not changeable.
-      return existing !== undefined &&
-        new URL(existing).toString() === normalized;
+    if (existing !== undefined) {
+      return existing === normalized;
     }
-    this.#dynamicHosts.set(space, host);
+    if (this.#providers.has(space)) {
+      return false;
+    }
+    this.#dynamicHosts.set(space, normalized);
     return true;
   }
 

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -79,6 +79,7 @@ import type {
   IStorageProviderWithReplica,
   IStorageSubscription,
   IStorageTransaction,
+  IStorageTransactionInconsistent,
   NativeStorageCommit,
   PullError,
   PushError,
@@ -147,6 +148,7 @@ import {
   RemoteSessionFactory,
   type SessionFactory,
   storageAddressForHost,
+  toWebSocketAddress,
 } from "./v2-remote-session.ts";
 import * as V2Transaction from "./v2-transaction.ts";
 import { normalizeCellScope } from "../scope.ts";
@@ -598,9 +600,10 @@ export interface Options {
   /**
    * Optional space DID → host base URL overrides. A space listed here
    * opens its storage connection against that host; absent map or
-   * absent entry resolves to `memoryHost`. The map is fixed for the
-   * manager's lifetime (the per-space provider cache assumes space →
-   * host never changes).
+   * absent entry initially resolves to `memoryHost`. The map is fixed for
+   * the manager's lifetime. A first late hint can replace a provisional
+   * `memoryHost` route for an unseeded space before that route issues a
+   * stateful operation.
    */
   spaceHostMap?: Record<string, string>;
   id?: string;
@@ -865,6 +868,8 @@ export class StorageManager implements IStorageManager {
   #seedHosts: Record<string, string>;
   /** Late-bound host hints; see registerSpaceHost. */
   #dynamicHosts = new Map<string, string>();
+  /** WebSocket storage endpoint used by an unseeded, unhinted space. */
+  #defaultStorageRoute?: string;
   /** Late-bound marker sink (the Runtime's telemetry bus); see setTelemetry. */
   #telemetry?: TelemetrySink;
 
@@ -911,6 +916,14 @@ export class StorageManager implements IStorageManager {
     // open(), so refusal logic must see the same fixed facts — a
     // caller mutating their map object must not desynchronize them.
     this.#seedHosts = Object.freeze({ ...(options.spaceHostMap ?? {}) });
+    try {
+      const resolveDefault = createStorageAddressResolver(options.memoryHost);
+      this.#defaultStorageRoute = toWebSocketAddress(
+        resolveDefault("did:key:route-comparison" as MemorySpace),
+      ).toString();
+    } catch {
+      // A custom session factory may use a non-network memoryHost placeholder.
+    }
   }
 
   /**
@@ -920,7 +933,11 @@ export class StorageManager implements IStorageManager {
    *
    * - The seed map wins: a seeded space cannot be re-pointed.
    * - The first accepted late hint remains in effect.
-   * - A space that opened without a late hint accepts no new late hint.
+   * - A provider opened through the default route is provisional until its
+   *   session accepts a stateful operation. Its first accepted hint replaces
+   *   that route and replays its reads.
+   * - A different-host hint cannot replace a route after a stateful operation
+   *   is issued.
    *
    * Idempotent when the hint matches what is already in effect.
    */
@@ -944,10 +961,17 @@ export class StorageManager implements IStorageManager {
     if (existing !== undefined) {
       return existing === normalized;
     }
-    if (this.#providers.has(space)) {
+    const provider = this.#providers.get(space);
+    const replacesDefaultRoute = provider !== undefined &&
+      this.#defaultStorageRoute !==
+        toWebSocketAddress(storageAddressForHost(normalized)).toString();
+    if (replacesDefaultRoute && !provider.canReplaceProvisionalReplica()) {
       return false;
     }
     this.#dynamicHosts.set(space, normalized);
+    if (replacesDefaultRoute) {
+      this.trackUntilSettled(provider.replaceProvisionalReplica());
+    }
     return true;
   }
 
@@ -967,17 +991,28 @@ export class StorageManager implements IStorageManager {
       // a derived space key for named spaces, the connection must authenticate
       // as the active user.
       const signer = this.as;
+      const routeState: ProviderRouteState = { generation: 0 };
       provider = new Provider({
         as: signer,
         space,
         settings: this.#settings,
         subscription: this.#subscription,
+        routeState,
         createSession: this.#sessionFactory.supportsAclBootstrap === true
-          ? () => this.#createInitializedSession(space, signer)
-          : () =>
+          ? (routeGeneration, routeSignal) =>
+            this.#createInitializedSession(
+              space,
+              signer,
+              routeState,
+              routeGeneration,
+              routeSignal,
+            )
+          : (_routeGeneration, routeSignal) =>
             this.#sessionFactory.create(space, signer, {
               sessionId: this.#sessionId,
-            }),
+            }, routeSignal),
+        syncReplayDependencies: (document) =>
+          this.syncCfcSchemaDocument(space, document),
         getTelemetry: () => this.#telemetry,
       });
       this.#providers.set(space, provider);
@@ -1002,106 +1037,177 @@ export class StorageManager implements IStorageManager {
   async #createInitializedSession(
     space: MemorySpace,
     signer: Signer,
-  ): Promise<{
-    client: MemoryV2Client.Client;
-    session: MemoryV2Client.SpaceSession;
-  }> {
-    const normal = await this.#sessionFactory.create(space, signer, {
-      sessionId: this.#sessionId,
-    });
-    if (this.#sessionFactory.supportsAclBootstrap !== true) return normal;
-    const isHomeSpace = signer.did() === space;
-    const spaceIdentity = isHomeSpace
-      ? signer
-      : this.#spaceIdentities.get(space);
-    if (spaceIdentity === undefined) return normal;
-
-    const openedServerSeq = normal.session.serverSeq;
-    const aclId = `of:${space}`;
-    const aclResult = await normal.session.queryGraph({
-      roots: [{ id: aclId, selector: { path: [], schema: false } }],
-    });
-    const aclSnapshot = aclResult.entities.find((entity) =>
-      entity.id === aclId && (entity.scope ?? "space") === "space"
-    );
-    const aclNeverCreated = aclSnapshot?.seq === 0 &&
-      aclSnapshot.document === null;
-    if (!aclNeverCreated || (!isHomeSpace && openedServerSeq !== 0)) {
-      return normal;
-    }
-
-    // Do not reuse the bootstrap session for replica work: both it and the
-    // replica allocate localSeq from 1, and named spaces must switch back from
-    // the space signer to the active user before any user-scoped operation.
-    // Preserve the normal session token before detaching it so the final user
-    // mount resumes the construction-wide manager session instead of trying to
-    // replace that still-live id without its token.
-    const resumeNormal: MemoryV2Client.MountOptions = {
-      sessionId: normal.session.sessionId,
-      seenSeq: normal.session.serverSeq,
-      ...(normal.session.sessionToken !== undefined
-        ? { sessionToken: normal.session.sessionToken }
-        : {}),
+    routeState: ProviderRouteState,
+    routeGeneration: number,
+    routeSignal: AbortSignal,
+  ): Promise<OpenedSpaceSession> {
+    const assertCurrentRoute = (): void => {
+      if (
+        routeSignal.aborted ||
+        routeState.generation !== routeGeneration
+      ) {
+        throw routeSignal.reason instanceof Error
+          ? routeSignal.reason
+          : new Error("memory replica route replaced");
+      }
     };
-    await normal.client.close();
-    let bootstrapSessionId = crypto.randomUUID();
-    while (bootstrapSessionId === this.#sessionId) {
-      bootstrapSessionId = crypto.randomUUID();
-    }
-    const bootstrap = await this.#sessionFactory.create(
-      space,
-      spaceIdentity,
-      { sessionId: bootstrapSessionId },
-    );
+    const activeClients = new Set<MemoryV2Client.Client>();
+    const closeActiveClients = (): void => {
+      for (const client of activeClients) {
+        void client.close().catch(() => {});
+      }
+    };
+    const track = (opened: OpenedSpaceSession): OpenedSpaceSession => {
+      activeClients.add(opened.client);
+      assertCurrentRoute();
+      return opened;
+    };
+    routeSignal.addEventListener("abort", closeActiveClients, { once: true });
+    let completed = false;
+
     try {
-      const current = await bootstrap.session.queryGraph({
+      assertCurrentRoute();
+      const normal = track(
+        await this.#sessionFactory.create(
+          space,
+          signer,
+          { sessionId: this.#sessionId },
+          routeSignal,
+        ),
+      );
+      if (this.#sessionFactory.supportsAclBootstrap !== true) {
+        completed = true;
+        return normal;
+      }
+      const isHomeSpace = signer.did() === space;
+      const spaceIdentity = isHomeSpace
+        ? signer
+        : this.#spaceIdentities.get(space);
+      if (spaceIdentity === undefined) {
+        completed = true;
+        return normal;
+      }
+
+      const openedServerSeq = normal.session.serverSeq;
+      const aclId = `of:${space}`;
+      const aclResult = await normal.session.queryGraph({
         roots: [{ id: aclId, selector: { path: [], schema: false } }],
       });
-      const snapshot = current.entities.find((entity) =>
+      assertCurrentRoute();
+      const aclSnapshot = aclResult.entities.find((entity) =>
         entity.id === aclId && (entity.scope ?? "space") === "space"
       );
-      // Recheck emptiness in the authority session. In `off` mode an unrelated
-      // writer can still populate the space between the first inspection and
-      // bootstrap; that turns it into the named legacy-public case and must
-      // not be claimed. Home remains the explicit exception.
-      const aclStillNeverCreated = snapshot?.seq === 0 &&
-        snapshot.document === null;
-      if (aclStillNeverCreated && (isHomeSpace || current.serverSeq === 0)) {
-        try {
-          const bootstrapAcl = isHomeSpace
-            ? { [signer.did()]: "OWNER" }
-            : { [signer.did()]: "OWNER", "*": "WRITE" };
-          await bootstrap.session.transact({
-            localSeq: 1,
-            reads: {
-              confirmed: [{
+      const aclNeverCreated = aclSnapshot?.seq === 0 &&
+        aclSnapshot.document === null;
+      if (!aclNeverCreated || (!isHomeSpace && openedServerSeq !== 0)) {
+        completed = true;
+        return normal;
+      }
+
+      // Do not reuse the bootstrap session for replica work: both it and the
+      // replica allocate localSeq from 1, and named spaces must switch back from
+      // the space signer to the active user before any user-scoped operation.
+      // Preserve the normal session token before detaching it so the final user
+      // mount resumes the construction-wide manager session instead of trying to
+      // replace that still-live id without its token.
+      const resumeNormal: MemoryV2Client.MountOptions = {
+        sessionId: normal.session.sessionId,
+        seenSeq: normal.session.serverSeq,
+        ...(normal.session.sessionToken !== undefined
+          ? { sessionToken: normal.session.sessionToken }
+          : {}),
+      };
+      activeClients.delete(normal.client);
+      await normal.client.close();
+      assertCurrentRoute();
+      let bootstrapSessionId = crypto.randomUUID();
+      while (bootstrapSessionId === this.#sessionId) {
+        bootstrapSessionId = crypto.randomUUID();
+      }
+      const bootstrap = track(
+        await this.#sessionFactory.create(
+          space,
+          spaceIdentity,
+          { sessionId: bootstrapSessionId },
+          routeSignal,
+        ),
+      );
+      try {
+        assertCurrentRoute();
+        const current = await bootstrap.session.queryGraph({
+          roots: [{ id: aclId, selector: { path: [], schema: false } }],
+        });
+        assertCurrentRoute();
+        const snapshot = current.entities.find((entity) =>
+          entity.id === aclId && (entity.scope ?? "space") === "space"
+        );
+        // Recheck emptiness in the authority session. In `off` mode an
+        // unrelated writer can still populate the space between the first
+        // inspection and bootstrap; that turns it into the named legacy-public
+        // case and must not be claimed. Home remains the explicit exception.
+        const aclStillNeverCreated = snapshot?.seq === 0 &&
+          snapshot.document === null;
+        if (
+          aclStillNeverCreated &&
+          (isHomeSpace || current.serverSeq === 0)
+        ) {
+          try {
+            const bootstrapAcl = isHomeSpace
+              ? { [signer.did()]: "OWNER" }
+              : { [signer.did()]: "OWNER", "*": "WRITE" };
+            await bootstrap.session.transact({
+              localSeq: 1,
+              reads: {
+                confirmed: [{
+                  id: aclId,
+                  path: toDocumentPath([]),
+                  seq: snapshot?.seq ?? 0,
+                }],
+                pending: [],
+              },
+              operations: [{
+                op: "set",
                 id: aclId,
-                path: toDocumentPath([]),
-                seq: snapshot?.seq ?? 0,
+                value: { value: bootstrapAcl },
               }],
-              pending: [],
-            },
-            operations: [{
-              op: "set",
-              id: aclId,
-              value: { value: bootstrapAcl },
-            }],
-          });
-        } catch (error) {
-          // A concurrent space-authorized initializer may win between the
-          // point read and commit. Reopening as the user below is the
-          // authoritative outcome: it succeeds only if the winning ACL grants
-          // access. Other failures are real bootstrap errors.
-          if (!(error instanceof Error) || error.name !== "ConflictError") {
-            throw error;
+            }, () => {
+              assertCurrentRoute();
+              routeState.writeIssuedGeneration = routeGeneration;
+            });
+          } catch (error) {
+            // A concurrent space-authorized initializer may win between the
+            // point read and commit. Reopening as the user below is the
+            // authoritative outcome: it succeeds only if the winning ACL grants
+            // access. Other failures are real bootstrap errors.
+            if (!(error instanceof Error) || error.name !== "ConflictError") {
+              throw error;
+            }
           }
         }
+      } finally {
+        activeClients.delete(bootstrap.client);
+        await bootstrap.client.close();
       }
-    } finally {
-      await bootstrap.client.close();
-    }
 
-    return await this.#sessionFactory.create(space, signer, resumeNormal);
+      assertCurrentRoute();
+      const resumed = track(
+        await this.#sessionFactory.create(
+          space,
+          signer,
+          resumeNormal,
+          routeSignal,
+        ),
+      );
+      completed = true;
+      return resumed;
+    } finally {
+      if (!completed) {
+        routeSignal.removeEventListener("abort", closeActiveClients);
+        await Promise.allSettled(
+          [...activeClients].map((client) => client.close()),
+        );
+      }
+    }
   }
 
   async close(): Promise<void> {
@@ -1406,7 +1512,7 @@ export class StorageManager implements IStorageManager {
   private async syncCfcSchemaDocument(
     space: MemorySpace,
     document: EntityDocument | undefined,
-  ): Promise<unknown> {
+  ): Promise<Error | undefined> {
     const cfc = isRecord(document?.cfc) ? document.cfc : undefined;
     const schemaHash = cfc?.schemaHash;
     if (typeof schemaHash !== "string" || schemaHash.length === 0) {
@@ -1610,17 +1716,42 @@ export class StorageManager implements IStorageManager {
   }
 }
 
+type ProviderRouteState = {
+  generation: number;
+  writeIssuedGeneration?: number;
+};
+
+type OpenedSpaceSession = {
+  client: MemoryV2Client.Client;
+  session: MemoryV2Client.SpaceSession;
+};
+
 type ProviderOptions = {
   as: Signer;
   space: MemorySpace;
   settings: IRemoteStorageProviderSettings;
   subscription: IStorageSubscription;
-  createSession: () => Promise<{
-    client: MemoryV2Client.Client;
-    session: MemoryV2Client.SpaceSession;
-  }>;
+  routeState: ProviderRouteState;
+  createSession: (
+    routeGeneration: number,
+    routeSignal: AbortSignal,
+  ) => Promise<OpenedSpaceSession>;
+  syncReplayDependencies: (
+    document: EntityDocument | undefined,
+  ) => Promise<Error | undefined>;
   /** Late-bound: resolves to the Runtime's telemetry bus once attached. */
   getTelemetry?: () => TelemetrySink | undefined;
+};
+
+type SpaceReplicaOptions = Omit<ProviderOptions, "createSession"> & {
+  routeGeneration: number;
+  createSession: () => Promise<OpenedSpaceSession>;
+};
+
+type ProviderSyncRequest = {
+  uri: URI;
+  selector: SchemaPathSelector;
+  scope?: CellScope;
 };
 
 /**
@@ -1631,13 +1762,26 @@ type ProviderOptions = {
 type TelemetrySink = { submit(marker: RuntimeTelemetryMarker): void };
 
 class Provider implements IStorageProviderWithReplica {
-  readonly replica: SpaceReplica;
+  replica: SpaceReplica;
+  #syncRequests = new Map<string, ProviderSyncRequest>();
   #destroyed = false;
+  #routeAbort = new AbortController();
 
   constructor(
     readonly options: ProviderOptions,
   ) {
-    this.replica = new SpaceReplica(options);
+    this.replica = this.createReplica();
+  }
+
+  private createReplica(): SpaceReplica {
+    const routeGeneration = this.options.routeState.generation;
+    const routeSignal = this.#routeAbort.signal;
+    return new SpaceReplica({
+      ...this.options,
+      routeGeneration,
+      createSession: () =>
+        this.options.createSession(routeGeneration, routeSignal),
+    });
   }
 
   send(
@@ -1654,13 +1798,85 @@ class Provider implements IStorageProviderWithReplica {
     selector?: SchemaPathSelector,
     scope?: CellScope,
   ): Promise<Result<Unit, Error>> {
-    return this.replica.sync(uri, selector, scope) as Promise<
+    const [[address, normalizedSelector]] = normalizeSyncEntries([[
+      { id: uri, type: DOCUMENT_MIME, scope },
+      selector,
+    ]]);
+    this.#syncRequests.set(
+      watchIdForEntry(address, normalizedSelector),
+      { uri, selector: normalizedSelector, scope },
+    );
+    return this.replica.sync(uri, normalizedSelector, scope) as Promise<
       Result<Unit, Error>
     >;
   }
 
+  private async replaySync(
+    replica: SpaceReplica,
+    uri: URI,
+    selector: SchemaPathSelector,
+    scope?: CellScope,
+  ): Promise<Result<Unit, PullError>> {
+    const result = await replica.sync(uri, selector, scope);
+    if (result.error !== undefined || uri.startsWith("cid:")) {
+      return result;
+    }
+    const dependencyFailure = await this.options.syncReplayDependencies(
+      replica.getDocument(uri, scope),
+    );
+    return dependencyFailure === undefined
+      ? result
+      : { error: dependencyFailure as PullError };
+  }
+
+  private followReplacement<T>(
+    read: (replica: SpaceReplica) => Promise<T>,
+  ): Promise<T> {
+    const replica = this.replica;
+    return read(replica).then(
+      (result) =>
+        this.replica !== replica && !this.#destroyed
+          ? read(this.replica)
+          : result,
+      (error) => {
+        if (this.replica !== replica && !this.#destroyed) {
+          return read(this.replica);
+        }
+        throw error;
+      },
+    );
+  }
+
+  canReplaceProvisionalReplica(): boolean {
+    const { generation, writeIssuedGeneration } = this.options.routeState;
+    return writeIssuedGeneration !== generation;
+  }
+
+  async replaceProvisionalReplica(): Promise<void> {
+    if (this.#destroyed) {
+      return;
+    }
+    const previous = this.replica;
+    this.#routeAbort.abort(new Error("memory replica route replaced"));
+    this.options.routeState.generation++;
+    this.#routeAbort = new AbortController();
+    const replacement = this.createReplica();
+    this.replica = replacement;
+    previous.redirectOverlappingReadsTo((uri, selector, scope) =>
+      this.replaySync(replacement, uri, selector, scope)
+    );
+    previous.reset();
+    previous.closeNow();
+    const requests = [...this.#syncRequests.values()];
+    await Promise.all(
+      requests.map(({ uri, selector, scope }) =>
+        this.replaySync(replacement, uri, selector, scope)
+      ),
+    );
+  }
+
   synced(): Promise<void> {
-    return this.replica.synced();
+    return this.followReplacement((replica) => replica.synced());
   }
 
   authorizationError(): Error | undefined {
@@ -1668,27 +1884,31 @@ class Provider implements IStorageProviderWithReplica {
   }
 
   ensureSession(): Promise<void> {
-    return this.replica.ensureSession();
+    return this.followReplacement((replica) => replica.ensureSession());
   }
 
   listEntityIds(): Promise<string[] | undefined> {
-    return this.replica.listEntityIds();
+    return this.followReplacement((replica) => replica.listEntityIds());
   }
 
   listEntityIdPage(
     options: EntityIdListOptions = {},
   ): Promise<EntityIdListResult | undefined> {
-    return this.replica.listEntityIdPage(options);
+    return this.followReplacement((replica) =>
+      replica.listEntityIdPage(options)
+    );
   }
 
   entityIdExists(id: string): Promise<boolean | undefined> {
-    return this.replica.entityIdExists(id);
+    return this.followReplacement((replica) => replica.entityIdExists(id));
   }
 
   listSchedulerActionSnapshots(
     query: SchedulerActionSnapshotQuery = {},
   ): Promise<SchedulerSnapshotListResult> {
-    return this.replica.listSchedulerActionSnapshots(query);
+    return this.followReplacement((replica) =>
+      replica.listSchedulerActionSnapshots(query)
+    );
   }
 
   areSchedulerAddressesCurrentAtOrBelow(
@@ -1709,7 +1929,9 @@ class Provider implements IStorageProviderWithReplica {
     sql: string,
     params?: SqliteParamsWire,
   ): Promise<SqliteQueryResult> {
-    return this.replica.sqliteQuery(db, sql, params);
+    return this.followReplacement((replica) =>
+      replica.sqliteQuery(db, sql, params)
+    );
   }
 
   sqliteServerCommitRowLabelEval(): boolean {
@@ -1739,12 +1961,16 @@ class Provider implements IStorageProviderWithReplica {
       return;
     }
     this.#destroyed = true;
+    this.#routeAbort.abort(new Error("memory replica closed"));
+    this.options.routeState.generation++;
     await this.replica.close();
   }
 
   async destroyNow(): Promise<void> {
     if (!this.#destroyed) {
       this.#destroyed = true;
+      this.#routeAbort.abort(new Error("memory replica closed"));
+      this.options.routeState.generation++;
     }
     await this.replica.closeNow();
   }
@@ -1787,7 +2013,16 @@ type NativeCommitOperation =
 type SchedulerObservationBatchEntry = {
   commit: SchedulerObservationCommit;
   pending: PromiseWithResolvers<Result<Unit, StorageTransactionRejected>>;
+  source?: IStorageTransaction;
+  batchGeneration: number;
 };
+
+class StorageTransactionRejectionError extends Error {
+  constructor(readonly rejection: StorageTransactionRejected) {
+    super(rejection.message);
+    this.name = rejection.name;
+  }
+}
 
 /**
  * A commit that has been issued (optimistic write applied, verdict not yet
@@ -1877,6 +2112,10 @@ class SpaceReplica implements ISpaceReplica {
   // teardown rejects every in-flight request.
   readonly #suppressedVerdicts = new Set<Promise<void>>();
   readonly #schedulerObservationBatch: SchedulerObservationBatchEntry[] = [];
+  readonly #unsettledSchedulerObservations = new Set<
+    SchedulerObservationBatchEntry
+  >();
+  #schedulerObservationBatchGeneration = 0;
   #schedulerObservationFlushScheduled = false;
   #schedulerObservationFlushPromise:
     | Promise<Result<Unit, StorageTransactionRejected>>
@@ -1899,6 +2138,7 @@ class SpaceReplica implements ISpaceReplica {
   #watchedIds = new Set<string>();
   #nextLocalSeq = 1;
   #closed = false;
+  readonly #closeSignal = Promise.withResolvers<void>();
   #getTelemetry: () => TelemetrySink | undefined;
   #caughtUpLocalSeq = 0;
   #caughtUpLocalSeqWaiters: {
@@ -1924,19 +2164,40 @@ class SpaceReplica implements ISpaceReplica {
   // denial. `authorizationError()` reports it as a throwable error; `synced()`
   // stays silent so a denied cross-space link remains a silent absent read.
   #lastAuthorizationError: IAuthorizationError | null = null;
+  readonly #routeState: ProviderRouteState;
+  readonly #routeGeneration: number;
+  #replacementRead:
+    | ((
+      uri: URI,
+      selector: SchemaPathSelector,
+      scope?: CellScope,
+    ) => Promise<Result<Unit, PullError>>)
+    | undefined;
 
   #settings: IRemoteStorageProviderSettings;
 
-  constructor(options: ProviderOptions) {
+  constructor(options: SpaceReplicaOptions) {
     this.#space = options.space;
     this.#subscription = options.subscription;
     this.#createSession = options.createSession;
     this.#getTelemetry = options.getTelemetry ?? (() => undefined);
     this.#settings = options.settings;
+    this.#routeState = options.routeState;
+    this.#routeGeneration = options.routeGeneration;
   }
 
   did(): MemorySpace {
     return this.#space;
+  }
+
+  redirectOverlappingReadsTo(
+    replacementRead: (
+      uri: URI,
+      selector: SchemaPathSelector,
+      scope?: CellScope,
+    ) => Promise<Result<Unit, PullError>>,
+  ): void {
+    this.#replacementRead = replacementRead;
   }
 
   get(entry: IMemoryAddress): State | undefined {
@@ -1948,10 +2209,23 @@ class SpaceReplica implements ISpaceReplica {
     selector?: SchemaPathSelector,
     scope?: CellScope,
   ): Promise<Result<Unit, PullError>> {
-    return await this.pull([[
+    const replacementAtStart = this.#replacementRead;
+    const result = await this.pull([[
       { id: uri, type: DOCUMENT_MIME as MIME, scope },
       selector,
     ]]);
+    const replacement = this.#replacementRead;
+    if (replacementAtStart === undefined && replacement !== undefined) {
+      return await replacement(
+        uri,
+        normalizeSyncEntries([[
+          { id: uri, type: DOCUMENT_MIME, scope },
+          selector,
+        ]])[0][1],
+        scope,
+      );
+    }
+    return result;
   }
 
   sinkDocument(
@@ -2053,7 +2327,7 @@ class SpaceReplica implements ISpaceReplica {
   }
 
   async ensureSession(): Promise<void> {
-    await this.sessionHandle();
+    await this.activeSessionHandle();
   }
 
   async sqliteQuery(
@@ -2061,12 +2335,12 @@ class SpaceReplica implements ISpaceReplica {
     sql: string,
     params?: SqliteParamsWire,
   ): Promise<SqliteQueryResult> {
-    const { session } = await this.sessionHandle();
+    const { session } = await this.activeSessionHandle();
     return await session.sqliteQuery(db, sql, params);
   }
 
   async listEntityIds(): Promise<string[] | undefined> {
-    const { client, session } = await this.sessionHandle();
+    const { client, session } = await this.activeSessionHandle();
     if (client.serverFlags?.entityIdListing !== true) {
       return undefined;
     }
@@ -2093,7 +2367,7 @@ class SpaceReplica implements ISpaceReplica {
   async listEntityIdPage(
     options: EntityIdListOptions = {},
   ): Promise<EntityIdListResult | undefined> {
-    const { client, session } = await this.sessionHandle();
+    const { client, session } = await this.activeSessionHandle();
     if (
       client.serverFlags?.entityIdListing !== true ||
       client.serverFlags.entityIdPagination !== true
@@ -2104,7 +2378,7 @@ class SpaceReplica implements ISpaceReplica {
   }
 
   async entityIdExists(id: string): Promise<boolean | undefined> {
-    const { client, session } = await this.sessionHandle();
+    const { client, session } = await this.activeSessionHandle();
     if (client.serverFlags?.entityIdLookup !== true) {
       return undefined;
     }
@@ -2127,8 +2401,12 @@ class SpaceReplica implements ISpaceReplica {
     id: string,
     path: string,
   ): Promise<SqliteRegisterDiskSourceResult> {
-    const { session } = await this.sessionHandle();
-    return await session.registerSqliteDiskSource(id, path);
+    const { session } = await this.activeSessionHandle();
+    return await session.registerSqliteDiskSource(
+      id,
+      path,
+      () => this.markRouteWriteIssued(),
+    );
   }
 
   async listSchedulerActionSnapshots(
@@ -2137,7 +2415,7 @@ class SpaceReplica implements ISpaceReplica {
     if (!getPersistentSchedulerStateConfig()) {
       return { serverSeq: 0, snapshots: [] };
     }
-    const { client, session } = await this.sessionHandle();
+    const { client, session } = await this.activeSessionHandle();
     // Optional capability, negotiated at hello: a server that did not
     // advertise `persistentSchedulerState` keeps no scheduler rows (and an
     // older build may not know the message at all) — treat as "no snapshots"
@@ -2185,6 +2463,7 @@ class SpaceReplica implements ISpaceReplica {
 
   async close(): Promise<void> {
     this.#closed = true;
+    this.#closeSignal.resolve();
     this.resetConflictAdmissionState();
     this.rejectCaughtUpLocalSeqWaiters(new Error("memory replica closed"));
     // Settle any queued (not-yet-sent) watch refresh first so its pull promise
@@ -2304,6 +2583,7 @@ class SpaceReplica implements ISpaceReplica {
 
   closeNow(): void {
     this.#closed = true;
+    this.#closeSignal.resolve();
     this.resetConflictAdmissionState();
     this.cancelQueuedWatchRefresh();
     this.#watchView?.close();
@@ -2564,7 +2844,7 @@ class SpaceReplica implements ISpaceReplica {
     type: "pull" | "integrate" = "pull",
   ): Promise<Result<Unit, PullError>> {
     try {
-      const { session } = await this.sessionHandle();
+      const { session } = await this.activeSessionHandle();
       // Per-session (no global): mirror the storage setting onto the session so
       // its watch-mutation family (set + add) uses the ordered-issue concurrent
       // path. Idempotent; cheap to re-assert each refresh. Optional-chained so
@@ -2726,7 +3006,7 @@ class SpaceReplica implements ISpaceReplica {
   ): Promise<void> {
     while (true) {
       const next = await iterator.next();
-      if (next.done) {
+      if (next.done || this.#closed) {
         return;
       }
       this.applySessionSync(next.value, "integrate");
@@ -2755,16 +3035,31 @@ class SpaceReplica implements ISpaceReplica {
     const pending = Promise.withResolvers<
       Result<Unit, StorageTransactionRejected>
     >();
-    this.#schedulerObservationBatch.push({
+    const entry: SchedulerObservationBatchEntry = {
       commit: {
         localSeq,
         reads: this.buildReads(source, localSeq),
         schedulerObservation,
       },
       pending,
+      source,
+      batchGeneration: this.#schedulerObservationBatchGeneration,
+    };
+    this.#schedulerObservationBatch.push(entry);
+    this.#unsettledSchedulerObservations.add(entry);
+    void pending.promise.then(() => {
+      this.#unsettledSchedulerObservations.delete(entry);
     });
     this.scheduleSchedulerObservationFlush();
     return pending.promise;
+  }
+
+  private schedulerObservationDependenciesBefore(
+    localSeq: number,
+  ): Promise<Result<Unit, StorageTransactionRejected>>[] {
+    return [...this.#unsettledSchedulerObservations]
+      .filter((entry) => entry.commit.localSeq < localSeq)
+      .map((entry) => entry.pending.promise);
   }
 
   private scheduleSchedulerObservationFlush(): void {
@@ -2782,25 +3077,24 @@ class SpaceReplica implements ISpaceReplica {
     Result<Unit, StorageTransactionRejected>
   > {
     let lastResult: Result<Unit, StorageTransactionRejected> = { ok: {} };
+    let firstError: Result<Unit, StorageTransactionRejected> | undefined;
     while (true) {
-      if (this.#schedulerObservationFlushPromise) {
-        lastResult = await this.#schedulerObservationFlushPromise;
-        if (
-          this.#schedulerObservationBatch.length === 0 ||
-          "error" in lastResult
-        ) {
-          return lastResult;
+      const activeFlush = this.#schedulerObservationFlushPromise;
+      if (activeFlush) {
+        lastResult = await activeFlush;
+        if ("error" in lastResult) {
+          firstError ??= lastResult;
         }
         continue;
       }
 
       if (this.#schedulerObservationBatch.length === 0) {
-        return lastResult;
+        return firstError ?? lastResult;
       }
 
       lastResult = await this.startSchedulerObservationBatchFlush();
       if ("error" in lastResult) {
-        return lastResult;
+        firstError ??= lastResult;
       }
     }
   }
@@ -2808,7 +3102,16 @@ class SpaceReplica implements ISpaceReplica {
   private startSchedulerObservationBatchFlush(): Promise<
     Result<Unit, StorageTransactionRejected>
   > {
-    const entries = this.#schedulerObservationBatch.splice(0);
+    const batchGeneration = this.#schedulerObservationBatch[0].batchGeneration;
+    const nextGeneration = this.#schedulerObservationBatch.findIndex((entry) =>
+      entry.batchGeneration !== batchGeneration
+    );
+    const entries = this.#schedulerObservationBatch.splice(
+      0,
+      nextGeneration === -1
+        ? this.#schedulerObservationBatch.length
+        : nextGeneration,
+    );
     const localSeq = this.#nextLocalSeq++;
     const commit: ClientCommit = {
       localSeq,
@@ -2831,7 +3134,7 @@ class SpaceReplica implements ISpaceReplica {
       // the whole session's writes starve). Fail closed instead: drop the
       // observations — the feature degrades to flag-off semantics (resumes
       // re-run fresh) while semantic traffic proceeds untouched.
-      const { client } = await this.sessionHandle();
+      const { client } = await this.activeSessionHandle();
       if (client.serverFlags?.persistentSchedulerState !== true) {
         return { ok: {} };
       }
@@ -2864,7 +3167,35 @@ class SpaceReplica implements ISpaceReplica {
         ...commit,
         schedulerObservationBatch: wireEntries.map((entry) => entry.commit),
       };
-      return await this.pushCommit(localSeq, [], wireBatch, undefined);
+      const routeSources: IStorageTransaction[] = [];
+      const prepareIssue = (issueCommit: ClientCommit): boolean => {
+        const issueEntries: SchedulerObservationBatchEntry[] = [];
+        for (const entry of wireEntries) {
+          const validation = entry.source?.validateReplicaRoutes?.();
+          if (validation?.error !== undefined) {
+            entry.pending.resolve({ error: validation.error });
+            continue;
+          }
+          issueEntries.push(entry);
+          if (
+            entry.source !== undefined &&
+            !routeSources.includes(entry.source)
+          ) {
+            routeSources.push(entry.source);
+          }
+        }
+        issueCommit.schedulerObservationBatch = issueEntries.map((entry) =>
+          entry.commit
+        );
+        return issueEntries.length > 0;
+      };
+      return await this.pushCommit(
+        localSeq,
+        [],
+        wireBatch,
+        undefined,
+        { routeSources, prepareIssue },
+      );
     })()
       .then((result) => {
         for (const entry of entries) {
@@ -2912,6 +3243,8 @@ class SpaceReplica implements ISpaceReplica {
     }
 
     const localSeq = this.#nextLocalSeq++;
+    // Observations created after this direct commit form a later batch.
+    this.#schedulerObservationBatchGeneration++;
     if (source !== undefined) {
       recordCommitLocalSeq(source, this.#space, localSeq);
     }
@@ -3002,6 +3335,7 @@ class SpaceReplica implements ISpaceReplica {
           operations,
           commit,
           source,
+          { waitForSchedulerObservations: true },
         ),
     );
     this.#commitPromises.add(promise);
@@ -3128,7 +3462,18 @@ class SpaceReplica implements ISpaceReplica {
     operations: NativeCommitOperation[],
     commit: ClientCommit,
     source?: IStorageTransaction,
+    options: {
+      routeSources?: readonly IStorageTransaction[];
+      prepareIssue?: (commit: ClientCommit) => boolean;
+      waitForSchedulerObservations?: boolean;
+    } = {},
   ): Promise<Result<Unit, StorageTransactionRejected>> {
+    const routeSources = options.routeSources ??
+      (source === undefined ? [] : [source]);
+    const schedulerObservationDependencies =
+      options.waitForSchedulerObservations === true
+        ? this.schedulerObservationDependenciesBefore(localSeq)
+        : [];
     // Register BEFORE any await: commitOperations calls pushCommit
     // synchronously after applyPending, so registration is atomic with the
     // optimistic write — a dependency drop can never slip between the two.
@@ -3218,20 +3563,24 @@ class SpaceReplica implements ISpaceReplica {
         spaceDid: this.#space,
       });
       try {
-        if (
-          operations.length > 0 &&
-          (this.#schedulerObservationBatch.length > 0 ||
-            this.#schedulerObservationFlushPromise)
-        ) {
-          const flushResult = await this.flushSchedulerObservationBatch();
-          const rejection = flushResult.error;
+        if (schedulerObservationDependencies.length > 0) {
+          const flushResults = await Promise.all(
+            schedulerObservationDependencies,
+          );
+          const rejection = flushResults.find((result) =>
+            result.error !== undefined
+          )?.error;
           if (rejection !== undefined) {
-            const error = new Error(rejection.message);
-            error.name = rejection.name ?? "TransactionError";
-            throw error;
+            throw new StorageTransactionRejectionError(rejection);
           }
         }
-        const { client, session } = await this.sessionHandle();
+        const { client, session } = await this.activeSessionHandle();
+        if (
+          options.prepareIssue !== undefined &&
+          !options.prepareIssue(commit)
+        ) {
+          return { ok: {} };
+        }
         // Wire-compat: only a server advertising `pendingReadStacks` can
         // resolve array dependency sets — otherwise collapse each to its
         // top-of-stack element before sending.
@@ -3285,7 +3634,10 @@ class SpaceReplica implements ISpaceReplica {
         if (inFlight === undefined) {
           // No pending reads → no dependency that can be dropped from under
           // this commit; keep the direct await.
-          const applied = await session.transact(wireCommit);
+          const applied = await session.transact(
+            wireCommit,
+            () => this.markRouteWriteIssued(routeSources),
+          );
           this.confirmPending(localSeq, operations, applied);
           telemetry?.submit({
             type: "storage.push.complete",
@@ -3297,7 +3649,10 @@ class SpaceReplica implements ISpaceReplica {
         // Race the server verdict against a locally-fabricated rejection (a
         // dependency dropped mid-flight, or a replica reset). A server
         // rejection wins the race by REJECTING it, landing in the catch below.
-        const verdict = session.transact(wireCommit);
+        const verdict = session.transact(
+          wireCommit,
+          () => this.markRouteWriteIssued(routeSources),
+        );
         const outcome = await Promise.race([
           verdict.then((applied) => ({ applied })),
           inFlight.localRejection.promise.then((rejection) => ({ rejection })),
@@ -3328,15 +3683,27 @@ class SpaceReplica implements ISpaceReplica {
         });
         return { ok: {} };
       } catch (error) {
-        const rejection = toRejectedError(error, commit, this.#space);
+        let cause = error;
+        if (this.#replacementRead !== undefined) {
+          const routeConflict = new Error("memory replica route replaced");
+          routeConflict.name = "ConflictError";
+          cause = routeConflict;
+        }
+        const schedulerDependencyRejection =
+          cause instanceof StorageTransactionRejectionError ? cause : undefined;
+        const rejection = schedulerDependencyRejection !== undefined
+          ? schedulerDependencyRejection.rejection
+          : toRejectedError(cause, commit, this.#space);
         telemetry?.submit({
           type: "storage.push.error",
           id: pushOpId,
           error: rejection.name ?? "TransactionError",
         });
-        this.attachProviderReadyToRetry(rejection, localSeq);
-        if (admissionMode !== "off" && rejection.name === "ConflictError") {
-          this.recordStaleFloor(commit, localSeq);
+        if (schedulerDependencyRejection === undefined) {
+          this.attachProviderReadyToRetry(rejection, localSeq);
+          if (admissionMode !== "off" && rejection.name === "ConflictError") {
+            this.recordStaleFloor(commit, localSeq);
+          }
         }
         // Counted (even while silent) so multi-writer churn can be read back via
         // getLoggerCounts(): "commit-conflict" is a stale-seq-basis rejection that
@@ -3362,6 +3729,58 @@ class SpaceReplica implements ISpaceReplica {
     } finally {
       this.settleInFlightCommit(localSeq);
     }
+  }
+
+  private markRouteWriteIssued(
+    sources: readonly IStorageTransaction[] = [],
+  ): void {
+    for (const source of sources) {
+      const validation = source.validateReplicaRoutes?.();
+      if (validation?.error !== undefined) {
+        throw Object.assign(
+          new Error(validation.error.message),
+          validation.error,
+        );
+      }
+    }
+    if (
+      this.#closed ||
+      this.#routeState.generation !== this.#routeGeneration
+    ) {
+      throw new Error("memory replica route replaced");
+    }
+    this.#routeState.writeIssuedGeneration = this.#routeGeneration;
+  }
+
+  private assertActiveRoute(): void {
+    if (
+      this.#closed ||
+      this.#routeState.generation !== this.#routeGeneration
+    ) {
+      throw new Error("memory replica closed");
+    }
+  }
+
+  private activeSessionHandle(): Promise<OpenedSpaceSession> {
+    try {
+      this.assertActiveRoute();
+    } catch (error) {
+      return Promise.reject(error);
+    }
+    const handle = this.sessionHandle();
+    if (this.#sessionClient !== undefined) {
+      return handle;
+    }
+    return Promise.race([
+      handle.then((value) => ({ value })),
+      this.#closeSignal.promise.then(() => ({ value: undefined })),
+    ]).then((opened) => {
+      if (opened.value === undefined) {
+        throw new Error("memory replica closed");
+      }
+      this.assertActiveRoute();
+      return opened.value;
+    });
   }
 
   // Shared rejection tail for both real conflicts and pre-empted commits: wait
@@ -4152,14 +4571,26 @@ class SpaceReplica implements ISpaceReplica {
     client: MemoryV2Client.Client;
     session: MemoryV2Client.SpaceSession;
   }> {
+    if (this.#closed) {
+      return Promise.reject(new Error("memory replica closed"));
+    }
     if (this.#sessionHandle === undefined) {
       // Defer the factory call until after #sessionHandle is installed. Session
       // setup can synchronously re-enter provider work (notably home-space ACL
       // bootstrap); calling the factory inline leaves a window where that work
       // starts a second mount with the same explicit session id and revokes the
       // first mount before it can commit.
-      const handle = Promise.resolve().then(() => this.#createSession()).then(
-        (resolved) => {
+      const handle = Promise.resolve().then(() => {
+        this.assertActiveRoute();
+        return this.#createSession();
+      }).then(
+        async (resolved) => {
+          try {
+            this.assertActiveRoute();
+          } catch (error) {
+            await resolved.client.close();
+            throw error;
+          }
           this.#sessionClient = resolved.client;
           this.#sessionSession = resolved.session;
           return resolved;
@@ -4229,6 +4660,9 @@ const toRejectedError = (
   const name = error instanceof Error
     ? error.name
     : (error as { name?: unknown })?.name;
+  if (name === "StorageTransactionInconsistent") {
+    return error as IStorageTransactionInconsistent;
+  }
   // `error` may be a primitive or null — never throw while normalizing a
   // commit failure, that would mask the real rejection.
   const precondition = (error as { precondition?: unknown })?.precondition;

--- a/packages/runner/test/memory-v2-remote-session.test.ts
+++ b/packages/runner/test/memory-v2-remote-session.test.ts
@@ -74,6 +74,8 @@ describe("per-space storage address resolution", () => {
   it("rejects an unsupported default memory host protocol", () => {
     expect(() => createStorageAddressResolver(new URL("ftp://host-a.test")))
       .toThrow("Unsupported memory host protocol: ftp:");
+    expect(() => createStorageAddressResolver(new URL("memory://local")))
+      .toThrow("Unsupported memory host protocol: memory:");
   });
 
   it("resolves a mapped space to its host and others to the default", () => {

--- a/packages/runner/test/memory-v2-remote-session.test.ts
+++ b/packages/runner/test/memory-v2-remote-session.test.ts
@@ -5,6 +5,7 @@ import type { MemorySpace, URI } from "@commonfabric/memory/interface";
 import {
   createStorageAddressResolver,
   MEMORY_STORAGE_PATH,
+  storageAddressForHost,
   toSpaceWebSocketAddress,
   toWebSocketAddress,
   WebSocketTransport,
@@ -58,6 +59,23 @@ describe("per-space storage address resolution", () => {
     );
   });
 
+  it("preserves a WebSocket-only default memory host", () => {
+    const resolve = createStorageAddressResolver(
+      new URL("wss://host-a.test/some/base/"),
+    );
+    expect(resolve(spaceA).toString()).toBe(
+      `wss://host-a.test${MEMORY_STORAGE_PATH}`,
+    );
+    expect(toSpaceWebSocketAddress(resolve(spaceA), spaceA).protocol).toBe(
+      "wss:",
+    );
+  });
+
+  it("rejects an unsupported default memory host protocol", () => {
+    expect(() => createStorageAddressResolver(new URL("ftp://host-a.test")))
+      .toThrow("Unsupported memory host protocol: ftp:");
+  });
+
   it("resolves a mapped space to its host and others to the default", () => {
     const resolve = createStorageAddressResolver(
       new URL("https://host-a.test"),
@@ -105,6 +123,19 @@ describe("per-space storage address resolution", () => {
       createStorageAddressResolver(
         new URL("https://host-a.test"),
         { [spaceB]: "not a url" },
+      )
+    ).toThrow(`Invalid spaceHostMap entry for ${spaceB}`);
+  });
+
+  it("rejects a host protocol that cannot serve storage and compute", () => {
+    expect(() => storageAddressForHost("ftp://host-b.test"))
+      .toThrow("Unsupported space host protocol");
+    expect(() => storageAddressForHost("wss://host-b.test"))
+      .toThrow("Unsupported space host protocol");
+    expect(() =>
+      createStorageAddressResolver(
+        new URL("https://host-a.test"),
+        { [spaceB]: "ftp://host-b.test" },
       )
     ).toThrow(`Invalid spaceHostMap entry for ${spaceB}`);
   });
@@ -180,8 +211,8 @@ describe("StorageManager per-space host wiring", () => {
   });
 });
 
-// Site-table v0: runtime-learned host hints. The registry's refusal
-// semantics ARE the contract — seed wins, opened spaces never re-point.
+// Site-table v0: runtime-learned host hints. The first configured or accepted
+// route remains in effect for the manager's lifetime.
 describe("StorageManager.registerSpaceHost", () => {
   const spaceSeeded = "did:key:z6Mk-register-seeded" as MemorySpace;
   const spaceLearned = "did:key:z6Mk-register-learned" as MemorySpace;
@@ -207,7 +238,7 @@ describe("StorageManager.registerSpaceHost", () => {
       .toBe(false);
   });
 
-  it("never re-points an opened space, and the hint routes a fresh open", async () => {
+  it("keeps the first accepted hint before and after opening a space", async () => {
     const realWebSocket = globalThis.WebSocket;
     (globalThis as { WebSocket: unknown }).WebSocket = RecordingWebSocket;
     RecordingWebSocket.dialed.length = 0;
@@ -215,6 +246,10 @@ describe("StorageManager.registerSpaceHost", () => {
       const manager = await makeManager();
       expect(manager.registerSpaceHost(spaceLearned, "http://host-b.test"))
         .toBe(true);
+      expect(manager.registerSpaceHost(spaceLearned, "http://host-b.test/"))
+        .toBe(true);
+      expect(manager.registerSpaceHost(spaceLearned, "http://host-c.test"))
+        .toBe(false);
       manager.open(spaceLearned).sync("of:register-probe" as URI)
         .catch(() => {});
       await RecordingWebSocket.whenDialed(1);
@@ -240,6 +275,20 @@ describe("StorageManager.registerSpaceHost", () => {
     const manager = await makeManager();
     expect(() => manager.registerSpaceHost(spaceLearned, "not a url"))
       .toThrow(`Invalid host for space ${spaceLearned}`);
+  });
+
+  it("rejects an unusable first hint without fixing the route", async () => {
+    const manager = await makeManager();
+    expect(() =>
+      manager.registerSpaceHost(
+        spaceLearned,
+        "mailto:memory@example.test",
+      )
+    ).toThrow(`Invalid host for space ${spaceLearned}`);
+    expect(() => manager.registerSpaceHost(spaceLearned, "wss://host-b.test"))
+      .toThrow(`Invalid host for space ${spaceLearned}`);
+    expect(manager.registerSpaceHost(spaceLearned, "https://host-b.test"))
+      .toBe(true);
   });
 });
 

--- a/packages/runner/test/memory-v2-remote-session.test.ts
+++ b/packages/runner/test/memory-v2-remote-session.test.ts
@@ -1,16 +1,24 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
-import type { MemorySpace, URI } from "@commonfabric/memory/interface";
+import type { MemorySpace, Signer, URI } from "@commonfabric/memory/interface";
+import {
+  decodeMemoryBoundary,
+  encodeMemoryBoundary,
+  getMemoryProtocolFlags,
+  MEMORY_PROTOCOL,
+} from "@commonfabric/memory/v2";
 import {
   createStorageAddressResolver,
   MEMORY_STORAGE_PATH,
+  RemoteSessionFactory,
   storageAddressForHost,
   toSpaceWebSocketAddress,
   toWebSocketAddress,
   WebSocketTransport,
 } from "../src/storage/v2-remote-session.ts";
 import { StorageManager } from "../src/storage/v2.ts";
+import { TEST_HELLO_SESSION_OPEN } from "./memory-v2-test-utils.ts";
 
 describe("memory v2 remote session websocket address", () => {
   it("upgrades http and https urls to websocket protocols", () => {
@@ -213,8 +221,8 @@ describe("StorageManager per-space host wiring", () => {
   });
 });
 
-// Site-table v0: runtime-learned host hints. The first configured or accepted
-// route remains in effect for the manager's lifetime.
+// Site-table v0: runtime-learned host hints. A default-host connection remains
+// provisional until the first configured or accepted route is known.
 describe("StorageManager.registerSpaceHost", () => {
   const spaceSeeded = "did:key:z6Mk-register-seeded" as MemorySpace;
   const spaceLearned = "did:key:z6Mk-register-learned" as MemorySpace;
@@ -240,12 +248,13 @@ describe("StorageManager.registerSpaceHost", () => {
       .toBe(false);
   });
 
-  it("keeps the first accepted hint before and after opening a space", async () => {
+  it("keeps an accepted hint stable and replaces a provisional default route", async () => {
     const realWebSocket = globalThis.WebSocket;
     (globalThis as { WebSocket: unknown }).WebSocket = RecordingWebSocket;
     RecordingWebSocket.dialed.length = 0;
+    let manager: Awaited<ReturnType<typeof makeManager>> | undefined;
     try {
-      const manager = await makeManager();
+      manager = await makeManager();
       expect(manager.registerSpaceHost(spaceLearned, "http://host-b.test"))
         .toBe(true);
       expect(manager.registerSpaceHost(spaceLearned, "http://host-b.test/"))
@@ -266,9 +275,17 @@ describe("StorageManager.registerSpaceHost", () => {
       manager.open(spaceOpened).sync("of:register-probe" as URI)
         .catch(() => {});
       await RecordingWebSocket.whenDialed(2);
+      expect(new URL(RecordingWebSocket.dialed[1]).host).toBe("host-a.test");
       expect(manager.registerSpaceHost(spaceOpened, "http://host-d.test"))
+        .toBe(true);
+      await RecordingWebSocket.whenDialed(3);
+      expect(new URL(RecordingWebSocket.dialed[2]).host).toBe("host-d.test");
+      expect(manager.registerSpaceHost(spaceOpened, "http://host-d.test"))
+        .toBe(true);
+      expect(manager.registerSpaceHost(spaceOpened, "http://host-e.test"))
         .toBe(false);
     } finally {
+      await manager?.closeNow();
       (globalThis as { WebSocket: unknown }).WebSocket = realWebSocket;
     }
   });
@@ -305,12 +322,39 @@ describe("WebSocketTransport failure signalling", () => {
     static readonly CLOSED = 3;
     static instances: DrivableWebSocket[] = [];
     readyState = DrivableWebSocket.CONNECTING;
+    readonly sent: string[] = [];
+    #sentWaiters: Array<{ count: number; resolve: () => void }> = [];
     constructor(readonly url: string | URL) {
       super();
       DrivableWebSocket.instances.push(this);
     }
-    send(_payload: string): void {}
-    close(): void {}
+    send(payload: string): void {
+      this.sent.push(payload);
+      this.#sentWaiters = this.#sentWaiters.filter((waiter) => {
+        if (this.sent.length >= waiter.count) {
+          waiter.resolve();
+          return false;
+        }
+        return true;
+      });
+    }
+    whenSent(count: number): Promise<void> {
+      if (this.sent.length >= count) return Promise.resolve();
+      return new Promise((resolve) =>
+        this.#sentWaiters.push({ count, resolve })
+      );
+    }
+    openConnection(): void {
+      this.readyState = DrivableWebSocket.OPEN;
+      this.dispatchEvent(new Event("open"));
+    }
+    receive(payload: string): void {
+      this.dispatchEvent(new MessageEvent("message", { data: payload }));
+    }
+    close(): void {
+      this.readyState = DrivableWebSocket.CLOSED;
+      this.dispatchEvent(new Event("close"));
+    }
   }
 
   // Install the drivable socket, hand the body a transport and its socket, then
@@ -353,6 +397,170 @@ describe("WebSocketTransport failure signalling", () => {
       // A close before opening is not an error, so the receiver gets none.
       expect(closeCalled).toBe(true);
       expect(closeError).toBeUndefined();
+    });
+  });
+
+  it("cancels a remote session while its websocket is opening", async () => {
+    const signer = await Identity.fromPassphrase(
+      "cancel-opening-remote-session",
+    );
+    const space = signer.did();
+    const controller = new AbortController();
+    const reason = new Error("memory replica route replaced");
+    await withTransport(async (_transport, socket) => {
+      const factory = new RemoteSessionFactory(
+        () => new URL("wss://memory.test/api/storage/memory"),
+        signer,
+      );
+      const opening = factory.create(
+        space,
+        signer,
+        {},
+        controller.signal,
+      );
+
+      controller.abort(reason);
+
+      await expect(opening).rejects.toBe(reason);
+      expect(socket().readyState).toBe(DrivableWebSocket.CLOSED);
+    });
+  });
+
+  it("cancels a remote session while its session signature is pending", async () => {
+    const identity = await Identity.fromPassphrase(
+      "cancel-signing-remote-session",
+    );
+    const signingStarted = Promise.withResolvers<void>();
+    const releaseSigning = Promise.withResolvers<void>();
+    const signer: Signer = {
+      did: () => identity.did(),
+      verifier: identity.verifier,
+      async sign(payload) {
+        signingStarted.resolve();
+        await releaseSigning.promise;
+        return await identity.sign(payload);
+      },
+    };
+    const controller = new AbortController();
+    const reason = new Error("memory replica route replaced");
+
+    await withTransport(async (_transport, socket) => {
+      const factory = new RemoteSessionFactory(
+        () => new URL("wss://memory.test/api/storage/memory"),
+        signer,
+      );
+      const opening = factory.create(
+        signer.did(),
+        signer,
+        {},
+        controller.signal,
+      );
+      const activeSocket = socket();
+      activeSocket.openConnection();
+      await activeSocket.whenSent(1);
+      activeSocket.receive(encodeMemoryBoundary({
+        type: "hello.ok",
+        protocol: MEMORY_PROTOCOL,
+        flags: getMemoryProtocolFlags(),
+        sessionOpen: TEST_HELLO_SESSION_OPEN,
+      }));
+      await signingStarted.promise;
+
+      controller.abort(reason);
+
+      await expect(opening).rejects.toBe(reason);
+      expect(activeSocket.readyState).toBe(DrivableWebSocket.CLOSED);
+      expect(activeSocket.sent).toHaveLength(1);
+      releaseSigning.resolve();
+    });
+  });
+
+  it("cancels reconnect session signing before closing the old client", async () => {
+    const identity = await Identity.fromPassphrase(
+      "cancel-reconnect-signing-remote-session",
+    );
+    const reconnectSigningStarted = Promise.withResolvers<void>();
+    const releaseReconnectSigning = Promise.withResolvers<void>();
+    let signatures = 0;
+    const signer: Signer = {
+      did: () => identity.did(),
+      verifier: identity.verifier,
+      async sign(payload) {
+        signatures++;
+        if (signatures === 2) {
+          reconnectSigningStarted.resolve();
+          await releaseReconnectSigning.promise;
+        }
+        return await identity.sign(payload);
+      },
+    };
+    const controller = new AbortController();
+    const reason = new Error("memory replica route replaced");
+
+    await withTransport(async (_transport, socket) => {
+      const factory = new RemoteSessionFactory(
+        () => new URL("wss://memory.test/api/storage/memory"),
+        signer,
+      );
+      let opened:
+        | Awaited<ReturnType<RemoteSessionFactory["create"]>>
+        | undefined;
+      try {
+        const opening = factory.create(
+          signer.did(),
+          signer,
+          {},
+          controller.signal,
+        );
+        const initialSocket = socket();
+        initialSocket.openConnection();
+        await initialSocket.whenSent(1);
+        initialSocket.receive(encodeMemoryBoundary({
+          type: "hello.ok",
+          protocol: MEMORY_PROTOCOL,
+          flags: getMemoryProtocolFlags(),
+          sessionOpen: TEST_HELLO_SESSION_OPEN,
+        }));
+        await initialSocket.whenSent(2);
+        const initialOpen = decodeMemoryBoundary(initialSocket.sent[1]) as {
+          requestId: string;
+        };
+        initialSocket.receive(encodeMemoryBoundary({
+          type: "response",
+          requestId: initialOpen.requestId,
+          ok: {
+            sessionId: "session:cancel-reconnect-signing",
+            sessionToken: "token:cancel-reconnect-signing",
+            serverSeq: 0,
+            sessionOpen: TEST_HELLO_SESSION_OPEN,
+          },
+        }));
+        opened = await opening;
+
+        initialSocket.close();
+        const reconnectSocket = socket();
+        expect(reconnectSocket).not.toBe(initialSocket);
+        reconnectSocket.openConnection();
+        await reconnectSocket.whenSent(1);
+        reconnectSocket.receive(encodeMemoryBoundary({
+          type: "hello.ok",
+          protocol: MEMORY_PROTOCOL,
+          flags: getMemoryProtocolFlags(),
+          sessionOpen: TEST_HELLO_SESSION_OPEN,
+        }));
+        await reconnectSigningStarted.promise;
+
+        controller.abort(reason);
+        await opened.client.close();
+
+        expect(reconnectSocket.readyState).toBe(DrivableWebSocket.CLOSED);
+        expect(reconnectSocket.sent).toHaveLength(1);
+        expect(signatures).toBe(2);
+      } finally {
+        controller.abort(reason);
+        releaseReconnectSigning.resolve();
+        await opened?.client.close();
+      }
     });
   });
 

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -13,12 +13,14 @@ import { Identity } from "@commonfabric/identity";
 import type { FabricValue } from "@commonfabric/api";
 import type { MIME, URI } from "@commonfabric/memory/interface";
 import {
+  type CommitPrecondition,
   type EntityDocument,
   getMemoryProtocolFlags,
   type PatchOp,
   resetPersistentSchedulerStateConfig,
   type SessionSync,
   setPersistentSchedulerStateConfig,
+  type SqliteOperation,
 } from "@commonfabric/memory/v2";
 import { EmptyReconstructionContext } from "@commonfabric/data-model/codec-common";
 import {
@@ -104,6 +106,7 @@ type ScriptedOutcome =
     kind: "accept";
     remoteInterleave?: RemoteCommit;
     responseGate?: Promise<void>;
+    onReceipt?: () => void;
     /**
      * Skip validateReads for this commit. Forces the "impossible" late
      * accept — a server verdict resolving a pending dependency the client
@@ -120,17 +123,20 @@ type ScriptedOutcome =
     retryAfterSeq?: number;
     remoteInterleave?: RemoteCommit;
     responseGate?: Promise<void>;
+    onReceipt?: () => void;
   }
   | {
     kind: "dropThenReplayAccept";
     remoteInterleave?: RemoteCommit;
     responseGate?: Promise<void>;
+    onReceipt?: () => void;
   }
   | {
     kind: "dropThenReplayReject";
     message?: string;
     remoteInterleave?: RemoteCommit;
     responseGate?: Promise<void>;
+    onReceipt?: () => void;
   };
 type RemoteCommit = {
   label: string;
@@ -458,9 +464,9 @@ class ScriptedModelTransport extends ScriptedSessionTransport {
         // cascade tests (and the stress bookkeeping) use it to distinguish
         // "sent, verdict in flight" from "never sent".
         this.model.transactLocalSeqs.push(commit.localSeq);
-        const responseGate = this.model.scripted.get(
-          commit.localSeq,
-        )?.responseGate;
+        const scripted = this.model.scripted.get(commit.localSeq);
+        scripted?.onReceipt?.();
+        const responseGate = scripted?.responseGate;
         const verdictTask = new Promise<void>((resolveVerdict) => {
           setTimeout(() => {
             void (async () => {
@@ -585,6 +591,8 @@ const createHarness = (
           | { op: "delete"; id: URI; type: MIME }
         >;
         schedulerObservation?: unknown;
+        preconditions?: readonly CommitPrecondition[];
+        sqliteOps?: readonly SqliteOperation[];
       },
       source?: unknown,
     ): Promise<
@@ -704,6 +712,16 @@ const schedulerObservationFor = (actionId: string) => ({
   status: "success",
 });
 
+const schedulerBatchActionIds = (harness: Harness): string[][] =>
+  [...harness.model.applied.values()]
+    .filter((record) => record.commit.schedulerObservationBatch !== undefined)
+    .sort((left, right) => left.applied.seq - right.applied.seq)
+    .map((record) =>
+      record.commit.schedulerObservationBatch!.map((entry) =>
+        (entry.schedulerObservation as { actionId: string }).actionId
+      )
+    );
+
 Deno.test("memory v2 ignores no-op scheduler observations when persistent scheduler state is off", async () => {
   resetPersistentSchedulerStateConfig();
   const harness = createHarness();
@@ -797,6 +815,226 @@ Deno.test("memory v2 flushes no-op scheduler batches before semantic writes", as
     await harness.close();
     resetPersistentSchedulerStateConfig();
   }
+});
+
+Deno.test("memory v2 keeps a semantic write behind every queued scheduler batch", async () => {
+  setPersistentSchedulerStateConfig(true);
+  const harness = createHarness();
+  const firstStarted = Promise.withResolvers<void>();
+  const releaseFirst = Promise.withResolvers<void>();
+  const secondStarted = Promise.withResolvers<void>();
+  const releaseSecond = Promise.withResolvers<void>();
+  try {
+    const first = harness.replica.commitNative({
+      operations: [],
+      schedulerObservation: schedulerObservationFor("action:first"),
+    });
+    harness.model.setOutcome(2, {
+      kind: "accept",
+      responseGate: releaseFirst.promise,
+      onReceipt: () => firstStarted.resolve(),
+    });
+    await firstStarted.promise;
+
+    const second = harness.replica.commitNative({
+      operations: [],
+      schedulerObservation: schedulerObservationFor("action:second"),
+    });
+    harness.model.setOutcome(5, {
+      kind: "accept",
+      responseGate: releaseSecond.promise,
+      onReceipt: () => secondStarted.resolve(),
+    });
+    await Promise.resolve();
+
+    const write = harness.replica.commitNative({
+      operations: [{
+        op: "set",
+        id: DOCS.A,
+        type: DOCUMENT_MIME,
+        value: { value: valueFor("write") },
+      }],
+    });
+
+    releaseFirst.resolve();
+    await secondStarted.promise;
+    await Promise.resolve();
+    assertEquals(harness.model.transactLocalSeqs, [2, 5]);
+
+    releaseSecond.resolve();
+    await Promise.all([
+      assertResultOk(first),
+      assertResultOk(second),
+      assertResultOk(write),
+    ]);
+    assertEquals(harness.model.transactLocalSeqs, [2, 5, 4]);
+  } finally {
+    releaseFirst.resolve();
+    releaseSecond.resolve();
+    await harness.close();
+    resetPersistentSchedulerStateConfig();
+  }
+});
+
+Deno.test("memory v2 does not hold a semantic write behind a later scheduler batch", async () => {
+  setPersistentSchedulerStateConfig(true);
+  const harness = createHarness();
+  const firstStarted = Promise.withResolvers<void>();
+  const releaseFirst = Promise.withResolvers<void>();
+  const secondStarted = Promise.withResolvers<void>();
+  const releaseSecond = Promise.withResolvers<void>();
+  let writeWasIssued = false;
+  try {
+    const first = harness.replica.commitNative({
+      operations: [],
+      schedulerObservation: schedulerObservationFor("action:first"),
+    });
+    harness.model.setOutcome(2, {
+      kind: "accept",
+      responseGate: releaseFirst.promise,
+      onReceipt: () => firstStarted.resolve(),
+    });
+    await firstStarted.promise;
+
+    const write = harness.replica.commitNative({
+      operations: [{
+        op: "set",
+        id: DOCS.A,
+        type: DOCUMENT_MIME,
+        value: { value: valueFor("write") },
+      }],
+    });
+    harness.model.setOutcome(3, {
+      kind: "accept",
+      onReceipt: () => {
+        writeWasIssued = true;
+      },
+    });
+
+    const second = harness.replica.commitNative({
+      operations: [],
+      schedulerObservation: schedulerObservationFor("action:second"),
+    });
+    harness.model.setOutcome(5, {
+      kind: "accept",
+      responseGate: releaseSecond.promise,
+      onReceipt: () => secondStarted.resolve(),
+    });
+
+    releaseFirst.resolve();
+    await secondStarted.promise;
+    await Promise.resolve();
+    assert(writeWasIssued);
+
+    releaseSecond.resolve();
+    await Promise.all([
+      assertResultOk(first),
+      assertResultOk(write),
+      assertResultOk(second),
+    ]);
+  } finally {
+    releaseFirst.resolve();
+    releaseSecond.resolve();
+    await harness.close();
+    resetPersistentSchedulerStateConfig();
+  }
+});
+
+Deno.test("memory v2 separates observations across a semantic write boundary", async () => {
+  setPersistentSchedulerStateConfig(true);
+  const harness = createHarness();
+  try {
+    const first = harness.replica.commitNative({
+      operations: [],
+      schedulerObservation: schedulerObservationFor("action:first"),
+    });
+    const write = harness.replica.commitNative({
+      operations: [{
+        op: "set",
+        id: DOCS.A,
+        type: DOCUMENT_MIME,
+        value: { value: valueFor("write") },
+      }],
+    });
+    const second = harness.replica.commitNative({
+      operations: [],
+      schedulerObservation: schedulerObservationFor("action:second"),
+    });
+
+    await Promise.all([
+      assertResultOk(first),
+      assertResultOk(write),
+      assertResultOk(second),
+    ]);
+    assertEquals(schedulerBatchActionIds(harness), [
+      ["action:first"],
+      ["action:second"],
+    ]);
+  } finally {
+    await harness.close();
+    resetPersistentSchedulerStateConfig();
+  }
+});
+
+const assertNonDocumentSchedulerBoundary = async (
+  directCommit: Parameters<Harness["replica"]["commitNative"]>[0],
+) => {
+  setPersistentSchedulerStateConfig(true);
+  const harness = createHarness();
+  try {
+    const first = harness.replica.commitNative({
+      operations: [],
+      schedulerObservation: schedulerObservationFor("action:first"),
+    });
+    const direct = harness.replica.commitNative(directCommit);
+    const second = harness.replica.commitNative({
+      operations: [],
+      schedulerObservation: schedulerObservationFor("action:second"),
+    });
+    harness.model.setOutcome(4, {
+      kind: "rejectConflict",
+      message: "preceding observation rejected",
+    });
+
+    await assertConflict(first, "preceding observation rejected");
+    await assertConflict(direct, "preceding observation rejected");
+    await assertResultOk(second);
+    assertEquals(harness.model.transactLocalSeqs, [4, 5]);
+    assertEquals(
+      harness.model.rejected.get(4)?.commit.schedulerObservationBatch?.map(
+        (entry) =>
+          (entry.schedulerObservation as { actionId: string }).actionId,
+      ),
+      ["action:first"],
+    );
+    assertEquals(schedulerBatchActionIds(harness), [["action:second"]]);
+  } finally {
+    await harness.close();
+    resetPersistentSchedulerStateConfig();
+  }
+};
+
+Deno.test("memory v2 keeps a sqlite-only commit inside its scheduler boundary", async () => {
+  await assertNonDocumentSchedulerBoundary({
+    operations: [],
+    sqliteOps: [{
+      op: "sqlite",
+      db: { id: "of:scheduler-sqlite-boundary" },
+      sql: "CREATE TABLE boundary (value TEXT)",
+    }],
+  });
+});
+
+Deno.test("memory v2 keeps a preconditioned direct commit inside its scheduler boundary", async () => {
+  await assertNonDocumentSchedulerBoundary({
+    operations: [],
+    schedulerObservation: schedulerObservationFor("action:preconditioned"),
+    preconditions: [{
+      kind: "entity-value-hash",
+      id: DOCS.C,
+      valueHash: null,
+    }],
+  });
 });
 
 const visibleValue = (provider: TestProvider, id: URI) => {
@@ -2831,6 +3069,81 @@ Deno.test("memory v2 stacked commits: a rejected scheduler-batch flush rejects t
     await assertConflict(observation, "observation batch rejected");
     assertEquals(harness.model.transactLocalSeqs, [3]);
   } finally {
+    await harness.close();
+    resetPersistentSchedulerStateConfig();
+  }
+});
+
+Deno.test("memory v2 stacked commits: a scheduler-batch conflict does not wait for an unsent write sequence", async () => {
+  setPersistentSchedulerStateConfig(true);
+  setConflictAdmissionMode("preempt");
+  const harness = await createHarness();
+  const batchStarted = Promise.withResolvers<void>();
+  const releaseBatch = Promise.withResolvers<void>();
+  try {
+    const observation = harness.replica.commitNative({
+      operations: [],
+      schedulerObservation: schedulerObservationFor("action:retryable-batch"),
+    });
+    harness.model.setOutcome(2, {
+      kind: "rejectConflict",
+      message: "retryable observation batch rejected",
+      retryAfterSeq: 0,
+      responseGate: releaseBatch.promise,
+      onReceipt: () => batchStarted.resolve(),
+    });
+    await batchStarted.promise;
+
+    const retryReplica = harness.replica as unknown as {
+      waitForCaughtUpLocalSeq(localSeq: number): Promise<void>;
+    };
+    const waitedLocalSeqs: number[] = [];
+    retryReplica.waitForCaughtUpLocalSeq = (localSeq) => {
+      waitedLocalSeqs.push(localSeq);
+      return localSeq <= 2 ? Promise.resolve() : Promise.reject(
+        new Error(`waited for unsent localSeq=${localSeq}`),
+      );
+    };
+
+    const write = harness.replica.commitNative({
+      operations: [{
+        op: "set",
+        id: DOCS.A,
+        type: DOCUMENT_MIME,
+        value: { value: valueFor("write") },
+      }],
+    });
+    releaseBatch.resolve();
+    await harness.transport.drainVerdicts();
+    harness.pushSync({ caughtUpLocalSeq: 2 });
+
+    const [observationResult, writeResult] = await Promise.all([
+      observation,
+      write,
+    ]);
+    assertExists(observationResult.error);
+    assertExists(writeResult.error);
+    assertEquals(writeResult.error.message, observationResult.error.message);
+    const readyToRetry = (writeResult.error as {
+      readyToRetry?: () => Promise<void>;
+    }).readyToRetry;
+    assertExists(readyToRetry);
+    await readyToRetry();
+    assertEquals(waitedLocalSeqs.includes(3), false);
+
+    const nextWrite = harness.replica.commitNative({
+      operations: [{
+        op: "set",
+        id: DOCS.B,
+        type: DOCUMENT_MIME,
+        value: { value: valueFor("next-write") },
+      }],
+    }, sourceFromReads([{ id: DOCS.A }]));
+    await assertResultOk(nextWrite);
+    assertEquals(harness.model.transactLocalSeqs, [2, 4]);
+  } finally {
+    releaseBatch.resolve();
+    setConflictAdmissionMode(undefined);
     await harness.close();
     resetPersistentSchedulerStateConfig();
   }

--- a/packages/runner/test/memory-v2-subscription.test.ts
+++ b/packages/runner/test/memory-v2-subscription.test.ts
@@ -846,8 +846,16 @@ describe("Memory v2 storage notifications", () => {
     const client = {
       close: () => Promise.resolve(),
     } as unknown as MemoryV2Client.Client;
+    const watchStarted = Promise.withResolvers<void>();
+    const watchResponse = Promise.withResolvers<{
+      view: MemoryV2Client.WatchView;
+      sync: SessionSync;
+    }>();
     const session = {
-      watchAddSync: () => Promise.resolve({ view, sync }),
+      watchAddSync: () => {
+        watchStarted.resolve();
+        return watchResponse.promise;
+      },
     } as unknown as MemoryV2Client.SpaceSession;
     const sessionFactory: SessionFactory = {
       create: () => Promise.resolve({ client, session }),
@@ -861,11 +869,14 @@ describe("Memory v2 storage notifications", () => {
     const provider = testStorageManager.open(space);
     const replica = provider.replica as unknown as WatchRefreshHarness;
 
-    replica.closeNow();
-    const result = await replica.refreshWatchSet([[
+    const refresh = replica.refreshWatchSet([[
       { id: "of:late-refresh" as URI, type: "application/json" as MIME },
       { path: [], schema: false },
     ]]);
+    await watchStarted.promise;
+    replica.closeNow();
+    watchResponse.resolve({ view, sync });
+    const result = await refresh;
 
     expect(result.error?.message).toBe("memory replica closed");
     expect((await view.subscribeSync().next()).done).toBe(true);

--- a/packages/runner/test/runtime-host-for-space.test.ts
+++ b/packages/runner/test/runtime-host-for-space.test.ts
@@ -62,9 +62,61 @@ describe("Runtime.registerSpaceHost", () => {
       await runtime.dispose();
     }
   });
+
+  it("rejects non-HTTP hints before forwarding them to storage", async () => {
+    const storageVerdicts: Array<[string, string]> = [];
+    const storageManager = Object.assign(
+      StorageManager.emulate({ as: signer }),
+      {
+        registerSpaceHost(space: string, host: string) {
+          storageVerdicts.push([space, host]);
+          return true;
+        },
+      },
+    );
+    const runtime = new Runtime({
+      apiUrl: new URL("http://host-a.test/"),
+      storageManager,
+    });
+    try {
+      for (
+        const host of [
+          "ws://host-b.test",
+          "wss://host-b.test",
+          "ftp://host-b.test",
+        ]
+      ) {
+        expect(() => runtime.registerSpaceHost(spaceB, host))
+          .toThrow(`Invalid host for space ${spaceB}`);
+      }
+      expect(storageVerdicts).toEqual([]);
+
+      expect(runtime.registerSpaceHost(spaceB, "https://host-b.test"))
+        .toBe(true);
+      expect(storageVerdicts).toEqual([
+        [spaceB, "https://host-b.test/"],
+      ]);
+      expect(runtime.mappedHostFor(spaceB)).toBe("https://host-b.test/");
+    } finally {
+      await runtime.dispose();
+    }
+  });
 });
 
 describe("Runtime.hostForSpace", () => {
+  it("rejects seeded hosts that cannot serve HTTP requests", () => {
+    for (
+      const host of [
+        "ws://host-b.test",
+        "wss://host-b.test",
+        "ftp://host-b.test",
+      ]
+    ) {
+      expect(() => makeRuntime({ [spaceB]: host }))
+        .toThrow(`Invalid spaceHostMap entry for ${spaceB}`);
+    }
+  });
+
   it("resolves mapped spaces to their host and others to apiUrl", async () => {
     const runtime = makeRuntime({ [spaceB]: "http://host-b.test" });
     try {

--- a/packages/runner/test/space-host-late-hint.test.ts
+++ b/packages/runner/test/space-host-late-hint.test.ts
@@ -1,0 +1,1789 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import type { MemorySpace, Signer, URI } from "@commonfabric/memory/interface";
+import {
+  resetPersistentSchedulerStateConfig,
+  setPersistentSchedulerStateConfig,
+} from "@commonfabric/memory/v2";
+import * as MemoryV2Client from "@commonfabric/memory/v2/client";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
+import {
+  type Options,
+  type SessionFactory,
+  StorageManager,
+} from "../src/storage/v2.ts";
+import type { IStorageTransaction } from "../src/storage/interface.ts";
+import { StateInconsistency } from "../src/storage/transaction/attestation.ts";
+import { Runtime } from "../src/runtime.ts";
+import { loadSchemaDocument } from "../src/cfc/prepare.ts";
+import {
+  TEST_MEMORY_SERVER_AUTH,
+  testPrincipalSessionOpenAuthFactory,
+} from "./memory-v2-test-utils.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+
+class LoopbackSessionFactory implements SessionFactory {
+  constructor(
+    private readonly serverForSpace: (
+      space: MemorySpace,
+    ) => MemoryV2Server.Server,
+  ) {}
+
+  async create(
+    space: MemorySpace,
+    signer?: Signer,
+    mountOptions: MemoryV2Client.MountOptions = {},
+    _signal?: AbortSignal,
+  ) {
+    const client = await MemoryV2Client.connect({
+      transport: MemoryV2Client.loopback(this.serverForSpace(space)),
+    });
+    const session = await client.mount(
+      space,
+      mountOptions,
+      testPrincipalSessionOpenAuthFactory(signer),
+    );
+    return { client, session };
+  }
+}
+
+class TestStorageManager extends StorageManager {
+  static create(
+    signer: Signer,
+    sessionFactory: SessionFactory,
+  ): TestStorageManager {
+    return new TestStorageManager({
+      as: signer,
+      memoryHost: new URL("https://default-toolshed.test"),
+    }, sessionFactory);
+  }
+
+  private constructor(options: Options, sessionFactory: SessionFactory) {
+    super(options, sessionFactory);
+  }
+}
+
+const makeServer = (name: string): MemoryV2Server.Server =>
+  new MemoryV2Server.Server({
+    store: new URL(`memory://${name}`),
+    authorizeSessionOpen(message) {
+      const principal = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof principal === "string" ? principal : undefined;
+    },
+    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
+  });
+
+const schedulerObservation = {
+  version: 1,
+  branch: "",
+  pieceId: "of:late-hint-piece",
+  processGeneration: 1,
+  actionId: "action:late-hint",
+  actionKind: "computation",
+  implementationFingerprint: "impl:late-hint",
+  runtimeFingerprint: "runtime:late-hint",
+  observedAtSeq: 0,
+  transactionKind: "action-run",
+  reads: [],
+  shallowReads: [],
+  actualChangedWrites: [],
+  currentKnownWrites: [],
+  declaredWrites: [],
+  materializerWriteEnvelopes: [],
+  status: "success",
+};
+
+describe("late space host hints", () => {
+  it("confirms the default host without rebuilding its provider", async () => {
+    const signer = await Identity.fromPassphrase("matching-default-host-hint");
+    const targetSpace = (await Identity.fromPassphrase(
+      "matching-default-host-target",
+    )).did();
+    const targetId = "of:matching-default-host-target" as URI;
+    const defaultServer = makeServer("matching-default-host");
+    let targetSessions = 0;
+    const manager = TestStorageManager.create(
+      signer,
+      new LoopbackSessionFactory(() => {
+        targetSessions++;
+        return defaultServer;
+      }),
+    );
+
+    try {
+      const provider = manager.open(targetSpace);
+      const firstRead = await provider.sync(targetId, {
+        path: [],
+        schema: true,
+      });
+      expect(firstRead.error).toBeUndefined();
+      expect(targetSessions).toBe(1);
+
+      expect(
+        manager.registerSpaceHost(
+          targetSpace,
+          "https://default-toolshed.test",
+        ),
+      ).toBe(true);
+      await manager.crossSpaceSettled();
+
+      expect(manager.open(targetSpace)).toBe(provider);
+      expect(targetSessions).toBe(1);
+      expect(
+        manager.registerSpaceHost(
+          targetSpace,
+          "https://different-toolshed.test",
+        ),
+      ).toBe(false);
+    } finally {
+      await manager.close();
+      await defaultServer.close();
+    }
+  });
+
+  it("replays a read that first opened against the default host", async () => {
+    const signer = await Identity.fromPassphrase("late-space-host-hint");
+    const targetSpace = (await Identity.fromPassphrase(
+      "late-space-host-target",
+    )).did();
+    const targetId = "of:late-space-host-target" as URI;
+    const schema = internSchema({
+      type: "object",
+      properties: { name: { type: "string" } },
+    }, true);
+    const schemaHash = schema.taggedHashString;
+    const schemaId = `cid:${schemaHash}` as URI;
+    const defaultServer = makeServer("late-space-host-default");
+    const hintedServer = makeServer("late-space-host-hinted");
+    const writer = TestStorageManager.create(
+      signer,
+      new LoopbackSessionFactory(() => hintedServer),
+    );
+    let targetSessions = 0;
+    const reader = TestStorageManager.create(
+      signer,
+      new LoopbackSessionFactory((space) => {
+        if (space !== targetSpace) return defaultServer;
+        targetSessions++;
+        return targetSessions === 1 ? defaultServer : hintedServer;
+      }),
+    );
+
+    try {
+      const writerProvider = writer.open(targetSpace) as unknown as {
+        send(
+          batch: {
+            uri: URI;
+            value: {
+              value: unknown;
+              cfc?: { schemaHash: string };
+            };
+          }[],
+        ): Promise<{ error?: unknown }>;
+      };
+      const written = await writerProvider.send([
+        {
+          uri: targetId,
+          value: {
+            value: { name: "intended data" },
+            cfc: { schemaHash },
+          },
+        },
+        {
+          uri: schemaId,
+          value: {
+            value: schema.schema,
+          },
+        },
+      ]);
+      expect(written.error).toBeUndefined();
+      await writer.synced();
+
+      const provider = reader.open(targetSpace);
+      const provisionalReplica = provider.replica;
+      const firstRead = await provider.sync(targetId, {
+        path: [],
+        schema: true,
+      });
+      expect(firstRead.error).toBeUndefined();
+      expect(provider.replica.getDocument(targetId)).toBeUndefined();
+
+      expect(
+        reader.registerSpaceHost(
+          targetSpace,
+          "https://hinted-toolshed.test",
+        ),
+      ).toBe(true);
+      await reader.crossSpaceSettled();
+
+      expect(reader.open(targetSpace)).toBe(provider);
+      expect(provider.replica).not.toBe(provisionalReplica);
+      expect(provider.replica.getDocument(targetId)).toEqual({
+        value: { name: "intended data" },
+        cfc: { schemaHash },
+      });
+      expect(provider.replica.getDocument(schemaId)).toEqual({
+        value: schema.schema,
+      });
+      const runtime = new Runtime({
+        apiUrl: new URL("https://default-toolshed.test"),
+        storageManager: reader,
+      });
+      try {
+        expect(
+          loadSchemaDocument(runtime.edit(), targetSpace, schemaHash),
+        ).toEqual(schema.schema);
+      } finally {
+        await runtime.dispose();
+      }
+      const staleRead = await (
+        provisionalReplica as typeof provisionalReplica & {
+          sync(
+            uri: URI,
+            selector: { path: string[]; schema: boolean },
+          ): Promise<{ error?: { message: string } }>;
+        }
+      ).sync(targetId, { path: [], schema: true });
+      expect(staleRead.error?.message).toContain("memory replica closed");
+      expect(targetSessions).toBe(2);
+    } finally {
+      await reader.close();
+      await writer.close();
+      await defaultServer.close();
+      await hintedServer.close();
+    }
+  });
+
+  it("rejects a transaction based on the replaced provisional replica", async () => {
+    const signer = await Identity.fromPassphrase("late-hint-stale-transaction");
+    const targetSpace = (await Identity.fromPassphrase(
+      "late-hint-stale-transaction-target",
+    )).did();
+    const targetId = "of:late-hint-stale-transaction-target" as URI;
+    const defaultServer = makeServer("late-hint-stale-transaction-default");
+    const hintedServer = makeServer("late-hint-stale-transaction-hinted");
+    const writer = TestStorageManager.create(
+      signer,
+      new LoopbackSessionFactory(() => hintedServer),
+    );
+    let targetSessions = 0;
+    const reader = TestStorageManager.create(
+      signer,
+      new LoopbackSessionFactory(() =>
+        targetSessions++ === 0 ? defaultServer : hintedServer
+      ),
+    );
+
+    try {
+      const seeded = await (writer.open(targetSpace) as unknown as {
+        send(
+          batch: { uri: URI; value: { value: { name: string } } }[],
+        ): Promise<{ error?: unknown }>;
+      }).send([{
+        uri: targetId,
+        value: { value: { name: "intended data" } },
+      }]);
+      expect(seeded.error).toBeUndefined();
+      await writer.synced();
+
+      const provider = reader.open(targetSpace);
+      expect((await provider.sync(targetId)).error).toBeUndefined();
+      expect(provider.replica.getDocument(targetId)).toBeUndefined();
+
+      const stale = reader.edit();
+      const address = {
+        space: targetSpace,
+        id: targetId,
+        type: "application/json" as const,
+        path: [],
+      };
+      expect(stale.read(address).ok?.value).toBeUndefined();
+      expect(
+        stale.write(address, { name: "derived from missing data" }).error,
+      ).toBeUndefined();
+
+      expect(
+        reader.registerSpaceHost(
+          targetSpace,
+          "https://hinted-toolshed.test",
+        ),
+      ).toBe(true);
+      await reader.crossSpaceSettled();
+
+      const rejected = await stale.commit();
+      expect(rejected.error?.name).toBe("StorageTransactionInconsistent");
+      expect(provider.replica.getDocument(targetId)).toEqual({
+        value: { name: "intended data" },
+      });
+      expect(await hintedServer.readDocument(targetSpace, targetId)).toEqual({
+        value: { name: "intended data" },
+      });
+      expect(await defaultServer.readDocument(targetSpace, targetId))
+        .toBeNull();
+    } finally {
+      await reader.close();
+      await writer.close();
+      await defaultServer.close();
+      await hintedServer.close();
+    }
+  });
+
+  it("rejects a provisional transaction when the hint arrives during commit", async () => {
+    const signer = await Identity.fromPassphrase(
+      "late-hint-committing-transaction",
+    );
+    const targetSpace = (await Identity.fromPassphrase(
+      "late-hint-committing-transaction-target",
+    )).did();
+    const targetId = "of:late-hint-committing-transaction-target" as URI;
+    const hintedServer = makeServer("late-hint-committing-transaction-hinted");
+    const writer = TestStorageManager.create(
+      signer,
+      new LoopbackSessionFactory(() => hintedServer),
+    );
+    const openingStarted = Promise.withResolvers<void>();
+    const hintedFactory = new LoopbackSessionFactory(() => hintedServer);
+    let sessionCreations = 0;
+    const reader = TestStorageManager.create(signer, {
+      create(space, sessionSigner, mountOptions, signal) {
+        sessionCreations++;
+        if (sessionCreations === 1) {
+          openingStarted.resolve();
+          return new Promise((_, reject) => {
+            const rejectForAbort = () =>
+              reject(
+                signal?.reason instanceof Error
+                  ? signal.reason
+                  : new Error("memory replica route replaced"),
+              );
+            if (signal?.aborted) {
+              rejectForAbort();
+            } else {
+              signal?.addEventListener("abort", rejectForAbort, {
+                once: true,
+              });
+            }
+          });
+        }
+        return hintedFactory.create(
+          space,
+          sessionSigner,
+          mountOptions,
+          signal,
+        );
+      },
+    });
+
+    try {
+      const seeded = await (writer.open(targetSpace) as unknown as {
+        send(
+          batch: { uri: URI; value: { value: { name: string } } }[],
+        ): Promise<{ error?: unknown }>;
+      }).send([{
+        uri: targetId,
+        value: { value: { name: "intended data" } },
+      }]);
+      expect(seeded.error).toBeUndefined();
+      await writer.synced();
+
+      const stale = reader.edit();
+      const address = {
+        space: targetSpace,
+        id: targetId,
+        type: "application/json" as const,
+        path: [],
+      };
+      expect(stale.read(address).ok?.value).toBeUndefined();
+      expect(
+        stale.write(address, { name: "derived from missing data" }).error,
+      ).toBeUndefined();
+      const committing = stale.commit();
+      await openingStarted.promise;
+
+      expect(
+        reader.registerSpaceHost(
+          targetSpace,
+          "https://hinted-toolshed.test",
+        ),
+      ).toBe(true);
+
+      expect((await committing).error?.name).toBe("ConflictError");
+      expect(await hintedServer.readDocument(targetSpace, targetId)).toEqual({
+        value: { name: "intended data" },
+      });
+      expect((await reader.open(targetSpace).sync(targetId)).error)
+        .toBeUndefined();
+      expect(reader.open(targetSpace).replica.getDocument(targetId)).toEqual({
+        value: { name: "intended data" },
+      });
+    } finally {
+      await reader.close();
+      await writer.close();
+      await hintedServer.close();
+    }
+  });
+
+  it("rejects a write to another space when its linked read route changes during commit", async () => {
+    const signer = await Identity.fromPassphrase(
+      "late-hint-cross-space-transaction",
+    );
+    const targetSpace = (await Identity.fromPassphrase(
+      "late-hint-cross-space-transaction-target",
+    )).did();
+    const targetId = "of:late-hint-cross-space-target" as URI;
+    const resultId = "of:late-hint-cross-space-result" as URI;
+    const defaultServer = makeServer("late-hint-cross-space-default");
+    const hintedServer = makeServer("late-hint-cross-space-hinted");
+    const defaultFactory = new LoopbackSessionFactory(() => defaultServer);
+    const hintedFactory = new LoopbackSessionFactory(() => hintedServer);
+    const writer = TestStorageManager.create(signer, hintedFactory);
+    const writeSessionStarted = Promise.withResolvers<void>();
+    const releaseWriteSession = Promise.withResolvers<void>();
+    let targetSessions = 0;
+    const reader = TestStorageManager.create(signer, {
+      async create(space, sessionSigner, mountOptions, signal) {
+        if (space === targetSpace) {
+          const factory = targetSessions++ === 0
+            ? defaultFactory
+            : hintedFactory;
+          return await factory.create(
+            space,
+            sessionSigner,
+            mountOptions,
+            signal,
+          );
+        }
+        if (space === signer.did()) {
+          writeSessionStarted.resolve();
+          await releaseWriteSession.promise;
+        }
+        return await defaultFactory.create(
+          space,
+          sessionSigner,
+          mountOptions,
+          signal,
+        );
+      },
+    });
+
+    try {
+      const seeded = await (writer.open(targetSpace) as unknown as {
+        send(
+          batch: { uri: URI; value: { value: { name: string } } }[],
+        ): Promise<{ error?: unknown }>;
+      }).send([{
+        uri: targetId,
+        value: { value: { name: "intended data" } },
+      }]);
+      expect(seeded.error).toBeUndefined();
+      await writer.synced();
+
+      const targetProvider = reader.open(targetSpace);
+      expect((await targetProvider.sync(targetId)).error).toBeUndefined();
+      expect(targetProvider.replica.getDocument(targetId)).toBeUndefined();
+
+      const stale = reader.edit();
+      const target = stale.read({
+        space: targetSpace,
+        id: targetId,
+        type: "application/json",
+        path: ["name"],
+      });
+      expect(target.ok?.value).toBeUndefined();
+      expect(
+        stale.write({
+          space: signer.did(),
+          id: resultId,
+          type: "application/json",
+          path: [],
+        }, { seen: target.ok?.value ?? "missing" }).error,
+      ).toBeUndefined();
+
+      const committing = stale.commit();
+      await writeSessionStarted.promise;
+      expect(
+        reader.registerSpaceHost(
+          targetSpace,
+          "https://hinted-toolshed.test",
+        ),
+      ).toBe(true);
+      await reader.crossSpaceSettled();
+      expect(targetProvider.replica.getDocument(targetId)).toEqual({
+        value: { name: "intended data" },
+      });
+
+      releaseWriteSession.resolve();
+      const rejected = await committing;
+      expect(rejected.error?.name).toBe("StorageTransactionInconsistent");
+      expect(
+        await defaultServer.readDocument(signer.did(), resultId),
+      ).toBeNull();
+      expect(reader.open(signer.did()).replica.getDocument(resultId))
+        .toBeUndefined();
+    } finally {
+      releaseWriteSession.resolve();
+      await reader.close();
+      await writer.close();
+      await defaultServer.close();
+      await hintedServer.close();
+    }
+  });
+
+  it("moves an overlapping entity listing to the hinted host", async () => {
+    const signer = await Identity.fromPassphrase("late-hint-entity-list");
+    const targetSpace = (await Identity.fromPassphrase(
+      "late-hint-entity-list-target",
+    )).did();
+    const targetId = "of:late-hint-entity-list-target" as URI;
+    const hintedServer = makeServer("late-hint-entity-list-hinted");
+    const writer = TestStorageManager.create(
+      signer,
+      new LoopbackSessionFactory(() => hintedServer),
+    );
+    const openingStarted = Promise.withResolvers<void>();
+    const openingCancelled = Promise.withResolvers<void>();
+    const hintedFactory = new LoopbackSessionFactory(() => hintedServer);
+    let sessionCreations = 0;
+    const reader = TestStorageManager.create(signer, {
+      create(space, sessionSigner, mountOptions, signal) {
+        sessionCreations++;
+        if (sessionCreations === 1) {
+          openingStarted.resolve();
+          return new Promise((_, reject) => {
+            const rejectForAbort = () => {
+              openingCancelled.resolve();
+              reject(
+                signal?.reason instanceof Error
+                  ? signal.reason
+                  : new Error("memory replica route replaced"),
+              );
+            };
+            if (signal?.aborted) {
+              rejectForAbort();
+            } else {
+              signal?.addEventListener("abort", rejectForAbort, {
+                once: true,
+              });
+            }
+          });
+        }
+        return hintedFactory.create(
+          space,
+          sessionSigner,
+          mountOptions,
+          signal,
+        );
+      },
+    });
+
+    try {
+      const seeded = await (writer.open(targetSpace) as unknown as {
+        send(
+          batch: { uri: URI; value: { value: { name: string } } }[],
+        ): Promise<{ error?: unknown }>;
+      }).send([{
+        uri: targetId,
+        value: { value: { name: "intended data" } },
+      }]);
+      expect(seeded.error).toBeUndefined();
+      await writer.synced();
+
+      const listing = reader.open(targetSpace).listEntityIds!();
+      await openingStarted.promise;
+      expect(
+        reader.registerSpaceHost(
+          targetSpace,
+          "https://hinted-toolshed.test",
+        ),
+      ).toBe(true);
+
+      await openingCancelled.promise;
+      expect(await listing).toContain(targetId);
+      await reader.crossSpaceSettled();
+      expect(sessionCreations).toBe(2);
+    } finally {
+      await reader.close();
+      await writer.close();
+      await hintedServer.close();
+    }
+  });
+
+  it("keeps an existing synced barrier open until hinted reads replay", async () => {
+    const signer = await Identity.fromPassphrase("late-hint-synced-barrier");
+    const targetSpace = (await Identity.fromPassphrase(
+      "late-hint-synced-barrier-target",
+    )).did();
+    const targetId = "of:late-hint-synced-barrier-target" as URI;
+    const hintedServer = makeServer("late-hint-synced-barrier-hinted");
+    const hintedFactory = new LoopbackSessionFactory(() => hintedServer);
+    const writer = TestStorageManager.create(signer, hintedFactory);
+    const provisionalSessionStarted = Promise.withResolvers<void>();
+    const hintedSessionStarted = Promise.withResolvers<void>();
+    const releaseHintedSession = Promise.withResolvers<void>();
+    let sessionCreations = 0;
+    const reader = TestStorageManager.create(signer, {
+      async create(space, sessionSigner, mountOptions, signal) {
+        sessionCreations++;
+        if (sessionCreations === 1) {
+          provisionalSessionStarted.resolve();
+          return await new Promise((_, reject) => {
+            const rejectForAbort = () =>
+              reject(
+                signal?.reason instanceof Error
+                  ? signal.reason
+                  : new Error("memory replica route replaced"),
+              );
+            if (signal?.aborted) {
+              rejectForAbort();
+            } else {
+              signal?.addEventListener("abort", rejectForAbort, {
+                once: true,
+              });
+            }
+          });
+        }
+        hintedSessionStarted.resolve();
+        await releaseHintedSession.promise;
+        return await hintedFactory.create(
+          space,
+          sessionSigner,
+          mountOptions,
+          signal,
+        );
+      },
+    });
+
+    try {
+      const seeded = await (writer.open(targetSpace) as unknown as {
+        send(
+          batch: { uri: URI; value: { value: { name: string } } }[],
+        ): Promise<{ error?: unknown }>;
+      }).send([{
+        uri: targetId,
+        value: { value: { name: "intended data" } },
+      }]);
+      expect(seeded.error).toBeUndefined();
+      await writer.synced();
+
+      const provider = reader.open(targetSpace);
+      const provisionalReplica = provider.replica as typeof provider.replica & {
+        synced(): Promise<void>;
+      };
+      const reading = provider.sync(targetId);
+      await provisionalSessionStarted.promise;
+      const synced = provider.synced();
+      let syncedSettled = false;
+      synced.then(() => {
+        syncedSettled = true;
+      }, () => {
+        syncedSettled = true;
+      });
+      expect(
+        reader.registerSpaceHost(
+          targetSpace,
+          "https://hinted-toolshed.test",
+        ),
+      ).toBe(true);
+      await hintedSessionStarted.promise;
+
+      await provisionalReplica.synced();
+      await Promise.resolve();
+      expect(syncedSettled).toBe(false);
+
+      releaseHintedSession.resolve();
+      await synced;
+      expect((await reading).error).toBeUndefined();
+      expect(provider.replica.getDocument(targetId)).toEqual({
+        value: { name: "intended data" },
+      });
+      expect(sessionCreations).toBe(2);
+    } finally {
+      releaseHintedSession.resolve();
+      await reader.close();
+      await writer.close();
+      await hintedServer.close();
+    }
+  });
+
+  it("settles an in-flight provisional read before replaying it", async () => {
+    const signer = await Identity.fromPassphrase("pending-space-host-hint");
+    const targetSpace = (await Identity.fromPassphrase(
+      "pending-space-host-target",
+    )).did();
+    const targetId = "of:pending-space-host-target" as URI;
+    const hintedServer = makeServer("pending-space-host-hinted");
+    const pendingSession = Promise.withResolvers<{
+      client: MemoryV2Client.Client;
+      session: MemoryV2Client.SpaceSession;
+    }>();
+    const provisionalSessionStarted = Promise.withResolvers<void>();
+    const hintedFactory = new LoopbackSessionFactory(() => hintedServer);
+    const writer = TestStorageManager.create(signer, hintedFactory);
+    let targetSessions = 0;
+    const reader = TestStorageManager.create(signer, {
+      create(space, sessionSigner, mountOptions) {
+        targetSessions++;
+        if (targetSessions === 1) {
+          provisionalSessionStarted.resolve();
+          return pendingSession.promise;
+        }
+        return hintedFactory.create(space, sessionSigner, mountOptions);
+      },
+    });
+
+    try {
+      const writerProvider = writer.open(targetSpace) as unknown as {
+        send(
+          batch: { uri: URI; value: { value: { name: string } } }[],
+        ): Promise<{ error?: unknown }>;
+      };
+      const written = await writerProvider.send([{
+        uri: targetId,
+        value: { value: { name: "intended data" } },
+      }]);
+      expect(written.error).toBeUndefined();
+      await writer.synced();
+
+      const provider = reader.open(targetSpace);
+      const firstRead = provider.sync(targetId, {
+        path: [],
+        schema: true,
+      });
+      reader.trackUntilSettled(firstRead);
+      await provisionalSessionStarted.promise;
+
+      expect(
+        reader.registerSpaceHost(
+          targetSpace,
+          "https://hinted-toolshed.test",
+        ),
+      ).toBe(true);
+      await reader.crossSpaceSettled();
+
+      const firstResult = await firstRead;
+      expect(firstResult.error).toBeUndefined();
+      expect(provider.replica.getDocument(targetId)).toEqual({
+        value: { name: "intended data" },
+      });
+      expect(reader.pendingCrossSpacePromiseCount()).toBe(0);
+      expect(targetSessions).toBe(2);
+    } finally {
+      await reader.close();
+      await writer.close();
+      await hintedServer.close();
+    }
+  });
+
+  it("moves a deferred session open without starting the old factory", async () => {
+    const signer = await Identity.fromPassphrase(
+      "deferred-provisional-session",
+    );
+    const targetSpace = (await Identity.fromPassphrase(
+      "deferred-provisional-session-target",
+    )).did();
+    const hintedServer = makeServer("deferred-provisional-session-hinted");
+    const hintedFactory = new LoopbackSessionFactory(() => hintedServer);
+    let sessionCreations = 0;
+    const manager = TestStorageManager.create(signer, {
+      create(space, sessionSigner, mountOptions) {
+        sessionCreations++;
+        return hintedFactory.create(space, sessionSigner, mountOptions);
+      },
+    });
+
+    try {
+      const provider = manager.open(targetSpace);
+      const provisionalOpening = provider.ensureSession!();
+
+      expect(
+        manager.registerSpaceHost(
+          targetSpace,
+          "https://hinted-toolshed.test",
+        ),
+      ).toBe(true);
+      await provisionalOpening;
+      await manager.crossSpaceSettled();
+
+      await provider.ensureSession!();
+      expect(sessionCreations).toBe(1);
+    } finally {
+      await manager.close();
+      await hintedServer.close();
+    }
+  });
+
+  it("replaces the provisional route before a waiting write is issued", async () => {
+    const signer = await Identity.fromPassphrase("provisional-route-write");
+    const targetSpace = (await Identity.fromPassphrase(
+      "provisional-route-write-target",
+    )).did();
+    const targetId = "of:provisional-route-write-target" as URI;
+    const defaultServer = makeServer("provisional-route-write-default");
+    const pendingSession = Promise.withResolvers<{
+      client: MemoryV2Client.Client;
+      session: MemoryV2Client.SpaceSession;
+    }>();
+    const sessionStarted = Promise.withResolvers<void>();
+    const manager = TestStorageManager.create(
+      signer,
+      {
+        create() {
+          sessionStarted.resolve();
+          return pendingSession.promise;
+        },
+      },
+    );
+
+    try {
+      const provider = manager.open(targetSpace);
+      const replica = provider.replica;
+      const write = (provider as unknown as {
+        send(
+          batch: { uri: URI; value: { value: { name: string } } }[],
+        ): Promise<{ error?: unknown }>;
+      }).send([{
+        uri: targetId,
+        value: { value: { name: "acknowledged data" } },
+      }]);
+
+      await sessionStarted.promise;
+      expect(
+        manager.registerSpaceHost(
+          targetSpace,
+          "https://different-toolshed.test",
+        ),
+      ).toBe(true);
+      await manager.crossSpaceSettled();
+
+      const written = await write;
+      expect(written.error).toBeDefined();
+
+      expect(manager.open(targetSpace)).toBe(provider);
+      expect(provider.replica).not.toBe(replica);
+      expect(
+        await defaultServer.readDocument(targetSpace, targetId),
+      ).toBeNull();
+    } finally {
+      await manager.close();
+      await defaultServer.close();
+    }
+  });
+
+  it("keeps the provisional route after a write reaches its host", async () => {
+    const signer = await Identity.fromPassphrase(
+      "issued-provisional-route-write",
+    );
+    const targetSpace = (await Identity.fromPassphrase(
+      "issued-provisional-route-write-target",
+    )).did();
+    const targetId = "of:issued-provisional-route-write-target" as URI;
+    const defaultServer = makeServer("issued-provisional-route-write-default");
+    const manager = TestStorageManager.create(
+      signer,
+      new LoopbackSessionFactory(() => defaultServer),
+    );
+
+    try {
+      const provider = manager.open(targetSpace);
+      const replica = provider.replica;
+      const written = await (provider as unknown as {
+        send(
+          batch: { uri: URI; value: { value: { name: string } } }[],
+        ): Promise<{ error?: unknown }>;
+      }).send([{
+        uri: targetId,
+        value: { value: { name: "acknowledged data" } },
+      }]);
+      expect(written.error).toBeUndefined();
+
+      expect(
+        manager.registerSpaceHost(
+          targetSpace,
+          "https://different-toolshed.test",
+        ),
+      ).toBe(false);
+      expect(provider.replica).toBe(replica);
+      expect(provider.replica.getDocument(targetId)).toEqual({
+        value: { name: "acknowledged data" },
+      });
+    } finally {
+      await manager.close();
+      await defaultServer.close();
+    }
+  });
+
+  it("keeps the route when a committed write loses its acknowledgement", async () => {
+    const signer = await Identity.fromPassphrase(
+      "lost-acknowledgement-route-write",
+    );
+    const targetSpace = (await Identity.fromPassphrase(
+      "lost-acknowledgement-route-write-target",
+    )).did();
+    const targetId = "of:lost-acknowledgement-route-write-target" as URI;
+    const defaultServer = makeServer("lost-acknowledgement-route-default");
+    const factory = new LoopbackSessionFactory(() => defaultServer);
+    const manager = TestStorageManager.create(
+      signer,
+      {
+        async create(space, sessionSigner, mountOptions) {
+          const connection = await factory.create(
+            space,
+            sessionSigner,
+            mountOptions,
+          );
+          const transact = connection.session.transact.bind(
+            connection.session,
+          );
+          connection.session.transact = async (commit, beforeIssue) => {
+            await transact(commit, beforeIssue);
+            throw new Error("write acknowledgement lost");
+          };
+          return connection;
+        },
+      },
+    );
+
+    try {
+      const provider = manager.open(targetSpace);
+      const written = await (provider as unknown as {
+        send(
+          batch: { uri: URI; value: { value: { name: string } } }[],
+        ): Promise<{ error?: unknown }>;
+      }).send([{
+        uri: targetId,
+        value: { value: { name: "committed data" } },
+      }]);
+      expect(written.error).toBeDefined();
+      expect(
+        await defaultServer.readDocument(targetSpace, targetId),
+      ).toEqual({ value: { name: "committed data" } });
+
+      expect(
+        manager.registerSpaceHost(
+          targetSpace,
+          "https://different-toolshed.test",
+        ),
+      ).toBe(false);
+    } finally {
+      await manager.close();
+      await defaultServer.close();
+    }
+  });
+
+  it("can replace a provisional route after a pre-send write failure", async () => {
+    const signer = await Identity.fromPassphrase(
+      "failed-provisional-route-write",
+    );
+    const targetSpace = (await Identity.fromPassphrase(
+      "failed-provisional-route-write-target",
+    )).did();
+    const targetId = "of:failed-provisional-route-write-target" as URI;
+    const manager = TestStorageManager.create(signer, {
+      create() {
+        return Promise.reject(new Error("provisional connection failed"));
+      },
+    });
+
+    try {
+      const provider = manager.open(targetSpace);
+      const written = await (provider as unknown as {
+        send(
+          batch: { uri: URI; value: { value: { name: string } } }[],
+        ): Promise<{ error?: unknown }>;
+      }).send([{
+        uri: targetId,
+        value: { value: { name: "uncommitted data" } },
+      }]);
+      expect(written.error).toBeDefined();
+
+      expect(
+        manager.registerSpaceHost(
+          targetSpace,
+          "https://hinted-toolshed.test",
+        ),
+      ).toBe(true);
+      await manager.crossSpaceSettled();
+    } finally {
+      await manager.close();
+    }
+  });
+
+  it("can replace a provisional route after a closed session rejects a write", async () => {
+    const signer = await Identity.fromPassphrase(
+      "closed-provisional-route-write",
+    );
+    const targetSpace = (await Identity.fromPassphrase(
+      "closed-provisional-route-write-target",
+    )).did();
+    const targetId = "of:closed-provisional-route-write-target" as URI;
+    const defaultServer = makeServer("closed-provisional-route-default");
+    const factory = new LoopbackSessionFactory(() => defaultServer);
+    let opened:
+      | {
+        client: MemoryV2Client.Client;
+        session: MemoryV2Client.SpaceSession;
+      }
+      | undefined;
+    const manager = TestStorageManager.create(signer, {
+      async create(space, sessionSigner, mountOptions) {
+        opened = await factory.create(space, sessionSigner, mountOptions);
+        return opened;
+      },
+    });
+
+    try {
+      const provider = manager.open(targetSpace);
+      await provider.ensureSession!();
+      await opened!.session.close();
+
+      const written = await (provider as unknown as {
+        send(
+          batch: { uri: URI; value: { value: { name: string } } }[],
+        ): Promise<{ error?: unknown }>;
+      }).send([{
+        uri: targetId,
+        value: { value: { name: "uncommitted data" } },
+      }]);
+      expect(written.error).toBeDefined();
+
+      expect(
+        manager.registerSpaceHost(
+          targetSpace,
+          "https://hinted-toolshed.test",
+        ),
+      ).toBe(true);
+      await manager.crossSpaceSettled();
+    } finally {
+      await manager.close();
+      await defaultServer.close();
+    }
+  });
+
+  it("cancels an in-progress provisional ACL query before replay", async () => {
+    const signer = await Identity.fromPassphrase("late-hint-acl-user");
+    const spaceIdentity = await Identity.fromPassphrase("late-hint-acl-space");
+    const targetSpace = spaceIdentity.did();
+    const targetId = "of:late-hint-acl-target" as URI;
+    const defaultServer = makeServer("late-hint-acl-default");
+    const hintedServer = makeServer("late-hint-acl-hinted");
+    const bootstrapQueryStarted = Promise.withResolvers<void>();
+    const bootstrapQueryCancelled = Promise.withResolvers<void>();
+    const bootstrapClosed = Promise.withResolvers<void>();
+    const tokenOrigins = new Map<string, "default" | "hinted">();
+    let staleResumeAttempts = 0;
+    let useHintedServer = false;
+    let gateDefaultBootstrap = true;
+    const manager = TestStorageManager.create(signer, {
+      supportsAclBootstrap: true,
+      async create(space, sessionSigner, mountOptions = {}) {
+        const origin = useHintedServer ? "hinted" : "default";
+        if (
+          origin === "hinted" &&
+          mountOptions.sessionToken !== undefined &&
+          tokenOrigins.get(mountOptions.sessionToken) === "default"
+        ) {
+          staleResumeAttempts++;
+        }
+        const server = origin === "hinted" ? hintedServer : defaultServer;
+        const connection = await new LoopbackSessionFactory(() => server)
+          .create(space, sessionSigner, mountOptions);
+        if (connection.session.sessionToken !== undefined) {
+          tokenOrigins.set(connection.session.sessionToken, origin);
+        }
+        if (
+          gateDefaultBootstrap &&
+          server === defaultServer &&
+          sessionSigner?.did() === spaceIdentity.did()
+        ) {
+          gateDefaultBootstrap = false;
+          const queryGraph = connection.session.queryGraph.bind(
+            connection.session,
+          );
+          connection.session.queryGraph = async (query) => {
+            bootstrapQueryStarted.resolve();
+            await bootstrapQueryCancelled.promise;
+            return await queryGraph(query);
+          };
+          const close = connection.client.close.bind(connection.client);
+          connection.client.close = async () => {
+            bootstrapQueryCancelled.reject(
+              new Error("provisional ACL query cancelled"),
+            );
+            try {
+              await close();
+            } finally {
+              bootstrapClosed.resolve();
+            }
+          };
+        }
+        return connection;
+      },
+    });
+    manager.registerSpaceIdentity(spaceIdentity);
+
+    try {
+      const provider = manager.open(targetSpace);
+      const firstRead = provider.sync(targetId, {
+        path: [],
+        schema: true,
+      });
+      await bootstrapQueryStarted.promise;
+
+      useHintedServer = true;
+      expect(
+        manager.registerSpaceHost(
+          targetSpace,
+          "https://hinted-toolshed.test",
+        ),
+      ).toBe(true);
+
+      await bootstrapClosed.promise;
+      expect((await firstRead).error).toBeUndefined();
+      await manager.crossSpaceSettled();
+      expect(staleResumeAttempts).toBe(0);
+      expect(
+        await defaultServer.readDocument(targetSpace, `of:${targetSpace}`),
+      ).toBeNull();
+      expect(
+        await hintedServer.readDocument(targetSpace, `of:${targetSpace}`),
+      ).toEqual({
+        value: {
+          [signer.did()]: "OWNER",
+          "*": "WRITE",
+        },
+      });
+    } finally {
+      bootstrapQueryCancelled.reject(
+        new Error("provisional ACL query cancelled"),
+      );
+      await manager.close();
+      await defaultServer.close();
+      await hintedServer.close();
+    }
+  });
+
+  it("does not issue ACL setup after immediate manager disposal", async () => {
+    const signer = await Identity.fromPassphrase("disposed-acl-user");
+    const spaceIdentity = await Identity.fromPassphrase("disposed-acl-space");
+    const targetSpace = spaceIdentity.did();
+    const defaultServer = makeServer("disposed-acl-default");
+    const bootstrapQueryStarted = Promise.withResolvers<void>();
+    const bootstrapQueryCancelled = Promise.withResolvers<void>();
+    const bootstrapClosed = Promise.withResolvers<void>();
+    let aclTransactions = 0;
+    const factory = new LoopbackSessionFactory(() => defaultServer);
+    const manager = TestStorageManager.create(signer, {
+      supportsAclBootstrap: true,
+      async create(space, sessionSigner, mountOptions = {}) {
+        const connection = await factory.create(
+          space,
+          sessionSigner,
+          mountOptions,
+        );
+        if (sessionSigner?.did() === spaceIdentity.did()) {
+          const queryGraph = connection.session.queryGraph.bind(
+            connection.session,
+          );
+          connection.session.queryGraph = async (query) => {
+            bootstrapQueryStarted.resolve();
+            await bootstrapQueryCancelled.promise;
+            return await queryGraph(query);
+          };
+          const transact = connection.session.transact.bind(
+            connection.session,
+          );
+          connection.session.transact = (commit, beforeIssue) =>
+            transact(commit, () => {
+              beforeIssue?.();
+              aclTransactions++;
+            });
+          const close = connection.client.close.bind(connection.client);
+          connection.client.close = async () => {
+            bootstrapQueryCancelled.reject(
+              new Error("disposed ACL query cancelled"),
+            );
+            try {
+              await close();
+            } finally {
+              bootstrapClosed.resolve();
+            }
+          };
+        }
+        return connection;
+      },
+    });
+    manager.registerSpaceIdentity(spaceIdentity);
+
+    try {
+      const firstRead = manager.open(targetSpace).sync(
+        "of:disposed-acl-target" as URI,
+        { path: [], schema: true },
+      );
+      await bootstrapQueryStarted.promise;
+
+      await manager.closeNow();
+      await bootstrapClosed.promise;
+
+      expect((await firstRead).error).toBeDefined();
+      expect(aclTransactions).toBe(0);
+      expect(
+        await defaultServer.readDocument(targetSpace, `of:${targetSpace}`),
+      ).toBeNull();
+    } finally {
+      bootstrapQueryCancelled.reject(
+        new Error("disposed ACL query cancelled"),
+      );
+      await manager.closeNow();
+      await defaultServer.close();
+    }
+  });
+
+  it("keeps the provisional route after issuing its ACL setup write", async () => {
+    const signer = await Identity.fromPassphrase(
+      "issued-acl-provisional-user",
+    );
+    const spaceIdentity = await Identity.fromPassphrase(
+      "issued-acl-provisional-space",
+    );
+    const targetSpace = spaceIdentity.did();
+    const defaultServer = makeServer("issued-acl-provisional-default");
+    const factory = new LoopbackSessionFactory(() => defaultServer);
+    const manager = TestStorageManager.create(signer, {
+      supportsAclBootstrap: true,
+      create: (space, sessionSigner, mountOptions) =>
+        factory.create(space, sessionSigner, mountOptions),
+    });
+    manager.registerSpaceIdentity(spaceIdentity);
+
+    try {
+      const read = await manager.open(targetSpace).sync(
+        "of:issued-acl-provisional-target" as URI,
+      );
+      expect(read.error).toBeUndefined();
+      expect(
+        await defaultServer.readDocument(targetSpace, `of:${targetSpace}`),
+      ).toEqual({
+        value: {
+          [signer.did()]: "OWNER",
+          "*": "WRITE",
+        },
+      });
+
+      expect(
+        manager.registerSpaceHost(
+          targetSpace,
+          "https://different-toolshed.test",
+        ),
+      ).toBe(false);
+    } finally {
+      await manager.close();
+      await defaultServer.close();
+    }
+  });
+
+  it("settles a scheduler observation waiting on a replaced route", async () => {
+    setPersistentSchedulerStateConfig(true);
+    const signer = await Identity.fromPassphrase(
+      "late-hint-scheduler-observation",
+    );
+    const targetSpace = (await Identity.fromPassphrase(
+      "late-hint-scheduler-observation-target",
+    )).did();
+    const pendingSession = Promise.withResolvers<{
+      client: MemoryV2Client.Client;
+      session: MemoryV2Client.SpaceSession;
+    }>();
+    const sessionStarted = Promise.withResolvers<void>();
+    const manager = TestStorageManager.create(signer, {
+      create() {
+        sessionStarted.resolve();
+        return pendingSession.promise;
+      },
+    });
+
+    try {
+      const replica = manager.open(targetSpace).replica as unknown as {
+        commitNative(transaction: {
+          operations: [];
+          schedulerObservation: unknown;
+        }): Promise<{ error?: unknown }>;
+      };
+      const observation = replica.commitNative({
+        operations: [],
+        schedulerObservation,
+      });
+      await sessionStarted.promise;
+
+      expect(
+        manager.registerSpaceHost(
+          targetSpace,
+          "https://hinted-toolshed.test",
+        ),
+      ).toBe(true);
+      await manager.crossSpaceSettled();
+
+      expect((await observation).error).toBeDefined();
+    } finally {
+      await manager.close();
+      resetPersistentSchedulerStateConfig();
+    }
+  });
+
+  it("drains observations after a rejected batch without releasing a waiting write", async () => {
+    setPersistentSchedulerStateConfig(true);
+    const signer = await Identity.fromPassphrase(
+      "late-hint-scheduler-queued-after-rejection",
+    );
+    const resultId = "of:late-hint-scheduler-waiting-write" as URI;
+    const server = makeServer("late-hint-scheduler-queued-after-rejection");
+    const factory = new LoopbackSessionFactory(() => server);
+    const firstBatchStarted = Promise.withResolvers<void>();
+    const releaseFirstBatch = Promise.withResolvers<void>();
+    const secondBatchIssued = Promise.withResolvers<void>();
+    let schedulerBatchCount = 0;
+    const manager = TestStorageManager.create(signer, {
+      async create(space, sessionSigner, mountOptions, signal) {
+        const connection = await factory.create(
+          space,
+          sessionSigner,
+          mountOptions,
+          signal,
+        );
+        const transact = connection.session.transact.bind(connection.session);
+        connection.session.transact = async (commit, beforeIssue) => {
+          if (commit.schedulerObservationBatch !== undefined) {
+            schedulerBatchCount++;
+            if (schedulerBatchCount === 1) {
+              firstBatchStarted.resolve();
+              await releaseFirstBatch.promise;
+              throw new Error("first scheduler batch rejected");
+            }
+            if (
+              commit.schedulerObservationBatch.some((entry) =>
+                (entry.schedulerObservation as { actionId?: string })
+                  .actionId === "action:queued-after-rejection"
+              )
+            ) {
+              secondBatchIssued.resolve();
+            }
+          }
+          return await transact(commit, beforeIssue);
+        };
+        return connection;
+      },
+    });
+
+    try {
+      const provider = manager.open(signer.did());
+      const replica = provider.replica as unknown as {
+        commitNative(transaction: {
+          operations: [];
+          schedulerObservation: unknown;
+        }): Promise<{ error?: unknown }>;
+      };
+      const first = replica.commitNative({
+        operations: [],
+        schedulerObservation: {
+          ...schedulerObservation,
+          actionId: "action:rejected-batch",
+        },
+      });
+      await firstBatchStarted.promise;
+
+      const waitingWrite = (provider as unknown as {
+        send(
+          batch: { uri: URI; value: { value: { released: boolean } } }[],
+        ): Promise<{ error?: { message?: string } }>;
+      }).send([{
+        uri: resultId,
+        value: { value: { released: true } },
+      }]);
+      const second = replica.commitNative({
+        operations: [],
+        schedulerObservation: {
+          ...schedulerObservation,
+          actionId: "action:queued-after-rejection",
+        },
+      });
+      releaseFirstBatch.resolve();
+
+      expect((await first).error).toBeDefined();
+      expect((await second).error).toBeUndefined();
+      expect((await waitingWrite).error?.message).toContain(
+        "first scheduler batch rejected",
+      );
+      await secondBatchIssued.promise;
+      expect(schedulerBatchCount).toBe(2);
+      expect(await server.readDocument(signer.did(), resultId)).toBeNull();
+    } finally {
+      releaseFirstBatch.resolve();
+      await manager.close();
+      await server.close();
+      resetPersistentSchedulerStateConfig();
+    }
+  });
+
+  it("rejects only stale observations in a mixed scheduler batch", async () => {
+    setPersistentSchedulerStateConfig(true);
+    const signer = await Identity.fromPassphrase(
+      "late-hint-mixed-scheduler-batch",
+    );
+    const targetSpace = (await Identity.fromPassphrase(
+      "late-hint-mixed-scheduler-target",
+    )).did();
+    const targetId = "of:late-hint-mixed-scheduler-target" as URI;
+    const defaultServer = makeServer("late-hint-mixed-scheduler-default");
+    const hintedServer = makeServer("late-hint-mixed-scheduler-hinted");
+    const defaultFactory = new LoopbackSessionFactory(() => defaultServer);
+    const hintedFactory = new LoopbackSessionFactory(() => hintedServer);
+    const writer = TestStorageManager.create(signer, hintedFactory);
+    const issuedBatches: string[][] = [];
+    let targetSessions = 0;
+    const reader = TestStorageManager.create(signer, {
+      async create(space, sessionSigner, mountOptions, signal) {
+        const connection = space === targetSpace
+          ? await (targetSessions++ === 0 ? defaultFactory : hintedFactory)
+            .create(space, sessionSigner, mountOptions, signal)
+          : await defaultFactory.create(
+            space,
+            sessionSigner,
+            mountOptions,
+            signal,
+          );
+        if (space === signer.did()) {
+          const transact = connection.session.transact.bind(
+            connection.session,
+          );
+          connection.session.transact = async (commit, beforeIssue) => {
+            if (commit.schedulerObservationBatch !== undefined) {
+              issuedBatches.push(
+                commit.schedulerObservationBatch.map((entry) =>
+                  (entry.schedulerObservation as { actionId: string }).actionId
+                ),
+              );
+            }
+            return await transact(commit, beforeIssue);
+          };
+        }
+        return connection;
+      },
+    });
+
+    try {
+      const seeded = await (writer.open(targetSpace) as unknown as {
+        send(
+          batch: { uri: URI; value: { value: { name: string } } }[],
+        ): Promise<{ error?: unknown }>;
+      }).send([{
+        uri: targetId,
+        value: { value: { name: "intended data" } },
+      }]);
+      expect(seeded.error).toBeUndefined();
+      await writer.synced();
+
+      const targetProvider = reader.open(targetSpace);
+      expect((await targetProvider.sync(targetId)).error).toBeUndefined();
+      expect(targetProvider.replica.getDocument(targetId)).toBeUndefined();
+      const stale = reader.edit();
+      expect(
+        stale.read({
+          space: targetSpace,
+          id: targetId,
+          type: "application/json",
+          path: [],
+        }).ok?.value,
+      ).toBeUndefined();
+
+      const replica = reader.open(signer.did()).replica as unknown as {
+        commitNative(
+          transaction: {
+            operations: [];
+            schedulerObservation: unknown;
+          },
+          source?: IStorageTransaction,
+        ): Promise<{ error?: unknown }>;
+      };
+      const staleObservation = replica.commitNative({
+        operations: [],
+        schedulerObservation: {
+          ...schedulerObservation,
+          actionId: "action:stale-mixed-observation",
+        },
+      }, stale);
+      const validObservation = replica.commitNative({
+        operations: [],
+        schedulerObservation: {
+          ...schedulerObservation,
+          actionId: "action:valid-mixed-observation",
+        },
+      });
+
+      expect(
+        reader.registerSpaceHost(
+          targetSpace,
+          "https://hinted-toolshed.test",
+        ),
+      ).toBe(true);
+      await reader.crossSpaceSettled();
+
+      const staleResult = await staleObservation;
+      const staleError = staleResult.error as
+        | {
+          name?: string;
+          address?: unknown;
+          from?: unknown;
+        }
+        | undefined;
+      expect(staleError?.name).toBe("StorageTransactionInconsistent");
+      expect(staleError?.address).toBeDefined();
+      expect(typeof staleError?.from).toBe("function");
+      expect((await validObservation).error).toBeUndefined();
+      expect(issuedBatches).toEqual([["action:valid-mixed-observation"]]);
+    } finally {
+      await reader.close();
+      await writer.close();
+      await defaultServer.close();
+      await hintedServer.close();
+      resetPersistentSchedulerStateConfig();
+    }
+  });
+
+  it("preserves scheduler inconsistency details for a waiting write", async () => {
+    setPersistentSchedulerStateConfig(true);
+    const signer = await Identity.fromPassphrase(
+      "late-hint-scheduler-inconsistency-details",
+    );
+    const resultId = "of:late-hint-scheduler-inconsistency-result" as URI;
+    const server = makeServer("late-hint-scheduler-inconsistency-details");
+    const manager = TestStorageManager.create(
+      signer,
+      new LoopbackSessionFactory(() => server),
+    );
+    const address = {
+      id: "of:late-hint-stale-basis" as URI,
+      type: "application/json" as const,
+      path: [],
+    };
+    const inconsistency = StateInconsistency({
+      address,
+      expected: undefined,
+      actual: { intended: true },
+      space: signer.did(),
+    });
+    let validations = 0;
+    const source = {
+      getReadActivities: () => [],
+      validateReplicaRoutes: () => {
+        validations++;
+        return validations === 1 ? { ok: {} } : { error: inconsistency };
+      },
+    } as unknown as IStorageTransaction;
+
+    try {
+      const provider = manager.open(signer.did());
+      const observation = (
+        provider.replica as unknown as {
+          commitNative(
+            transaction: {
+              operations: [];
+              schedulerObservation: unknown;
+            },
+            source?: IStorageTransaction,
+          ): Promise<{ error?: unknown }>;
+        }
+      ).commitNative({
+        operations: [],
+        schedulerObservation: {
+          ...schedulerObservation,
+          actionId: "action:structured-inconsistency",
+        },
+      }, source);
+      const write = (provider as unknown as {
+        send(
+          batch: { uri: URI; value: { value: { derived: boolean } } }[],
+        ): Promise<{ error?: unknown }>;
+      }).send([{
+        uri: resultId,
+        value: { value: { derived: true } },
+      }]);
+
+      const observationError = (await observation).error as
+        | {
+          name?: string;
+          address?: unknown;
+          from?: unknown;
+        }
+        | undefined;
+      const writeError = (await write).error as
+        | {
+          name?: string;
+          address?: unknown;
+          from?: unknown;
+        }
+        | undefined;
+      expect(observationError?.name).toBe("StorageTransactionInconsistent");
+      expect(writeError?.name).toBe("StorageTransactionInconsistent");
+      expect(writeError?.address).toEqual(address);
+      expect(typeof writeError?.from).toBe("function");
+      expect(await server.readDocument(signer.did(), resultId)).toBeNull();
+    } finally {
+      await manager.close();
+      await server.close();
+      resetPersistentSchedulerStateConfig();
+    }
+  });
+
+  it("settles waiting disk registration and pins an issued registration", async () => {
+    const signer = await Identity.fromPassphrase(
+      "late-hint-disk-registration",
+    );
+    const targetSpace = (await Identity.fromPassphrase(
+      "late-hint-disk-registration-target",
+    )).did();
+    const hintedServer = makeServer("late-hint-disk-registration-hinted");
+    const hintedFactory = new LoopbackSessionFactory(() => hintedServer);
+    const pendingSession = Promise.withResolvers<{
+      client: MemoryV2Client.Client;
+      session: MemoryV2Client.SpaceSession;
+    }>();
+    const sessionStarted = Promise.withResolvers<void>();
+    let sessionCreations = 0;
+    const manager = TestStorageManager.create(signer, {
+      create(space, sessionSigner, mountOptions) {
+        sessionCreations++;
+        if (sessionCreations === 1) {
+          sessionStarted.resolve();
+          return pendingSession.promise;
+        }
+        return hintedFactory.create(space, sessionSigner, mountOptions);
+      },
+    });
+    const diskPath = Deno.makeTempFileSync({ suffix: ".sqlite" });
+
+    try {
+      const provider = manager.open(targetSpace);
+      const provisionalRegistration = provider.registerSqliteDiskSource!(
+        "of:provisional-disk",
+        diskPath,
+      );
+      await sessionStarted.promise;
+
+      expect(
+        manager.registerSpaceHost(
+          targetSpace,
+          "https://hinted-toolshed.test",
+        ),
+      ).toBe(true);
+      await manager.crossSpaceSettled();
+      await expect(provisionalRegistration).rejects.toThrow(
+        "memory replica closed",
+      );
+
+      await provider.registerSqliteDiskSource!(
+        "of:hinted-disk",
+        diskPath,
+      );
+      expect(
+        manager.registerSpaceHost(
+          targetSpace,
+          "https://different-toolshed.test",
+        ),
+      ).toBe(false);
+      expect(sessionCreations).toBe(2);
+    } finally {
+      await manager.close();
+      Deno.removeSync(diskPath);
+      await hintedServer.close();
+    }
+  });
+
+  it("updates a running pattern after its first linked read misses", async () => {
+    const signer = await Identity.fromPassphrase("late-hint-pattern");
+    const targetSpace = (await Identity.fromPassphrase(
+      "late-hint-pattern-target",
+    )).did();
+    const targetId = "of:late-hint-pattern-target" as URI;
+    const defaultServer = makeServer("late-hint-pattern-default");
+    const hintedServer = makeServer("late-hint-pattern-hinted");
+    const writer = TestStorageManager.create(
+      signer,
+      new LoopbackSessionFactory(() => hintedServer),
+    );
+    let targetSessions = 0;
+    const reader = TestStorageManager.create(
+      signer,
+      new LoopbackSessionFactory((space) => {
+        if (space !== targetSpace) return defaultServer;
+        targetSessions++;
+        return targetSessions === 1 ? defaultServer : hintedServer;
+      }),
+    );
+    const runtime = new Runtime({
+      apiUrl: new URL("https://default-toolshed.test"),
+      storageManager: reader,
+    });
+
+    try {
+      const writerProvider = writer.open(targetSpace) as unknown as {
+        send(
+          batch: { uri: URI; value: { value: { name: string } } }[],
+        ): Promise<{ error?: unknown }>;
+      };
+      const written = await writerProvider.send([{
+        uri: targetId,
+        value: { value: { name: "intended data" } },
+      }]);
+      expect(written.error).toBeUndefined();
+      await writer.synced();
+
+      const target = runtime.getCellFromLink<{ name?: string }>({
+        id: targetId,
+        path: [],
+        space: targetSpace,
+        scope: "space",
+      }, {
+        type: "object",
+        properties: { name: { type: "string" } },
+      });
+      const { lift, pattern } = createTrustedBuilder(runtime).commonfabric;
+      const readName = lift(
+        (value: { name?: string } | undefined) => value?.name ?? "missing",
+      );
+      const Root = pattern<{ target?: { name?: string } }>(({ target }) => ({
+        seen: readName(target),
+      }));
+      const tx = runtime.edit();
+      const resultCell = runtime.getCell<{ seen?: string }>(
+        signer.did(),
+        "late hint pattern result",
+        undefined,
+        tx,
+      );
+      const result = runtime.run(tx, Root, { target }, resultCell);
+      const committed = await tx.commit();
+      expect(committed.error).toBeUndefined();
+      await result.pull();
+      expect(result.key("seen").get()).toBeUndefined();
+
+      expect(
+        runtime.registerSpaceHost(
+          targetSpace,
+          "https://hinted-toolshed.test",
+        ),
+      ).toBe(true);
+      await reader.crossSpaceSettled();
+      await runtime.idle();
+
+      expect(await result.key("seen").pull()).toBe("intended data");
+      expect(targetSessions).toBe(2);
+    } finally {
+      await runtime.dispose();
+      await writer.close();
+      await defaultServer.close();
+      await hintedServer.close();
+    }
+  });
+});

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -5,6 +5,7 @@ import { taggedHashStringOf } from "@commonfabric/data-model/value-hash";
 import type { MemorySpace } from "@commonfabric/memory/interface";
 import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import type { PieceManager } from "@commonfabric/piece";
 import { PieceController, PiecesController } from "@commonfabric/piece/ops";
 import {
   browserWorkerParamsFromInitializationData,
@@ -31,7 +32,7 @@ import {
   getCell,
   mapCellRefsToSigilLinks,
 } from "./utils.ts";
-import { entityIdFrom, Runtime } from "@commonfabric/runner";
+import { entityIdFrom, Runtime, RuntimeTelemetry } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
 import * as V2Storage from "../../runner/src/storage/v2.ts";
@@ -3008,19 +3009,25 @@ describe("RuntimeProcessor per-space piece contexts", () => {
     expect(calls).toBe(1);
   });
 
-  it("watchSiteTable registers table entries, isolating bad ones", async () => {
+  it("watchSiteTable uses the last usable entry per space without replacing an accepted route", async () => {
     const { runtime } = createRuntime();
     const { siteTableCause, siteTableSchema } = await import(
       "@commonfabric/home-schemas"
     );
     const registered: Array<[string, string]> = [];
+    let resolveRegistered = () => {};
+    const entriesRegistered = new Promise<void>((resolve) => {
+      resolveRegistered = resolve;
+    });
+    const registeredRoute = "did:key:z6Mk-table-b" as MemorySpace;
+    const registerSpaceHost = runtime.registerSpaceHost.bind(runtime);
+    expect(registerSpaceHost(registeredRoute, "http://ipc-host.test/"))
+      .toBe(true);
     Object.assign(runtime, {
       registerSpaceHost: (space: string, host: string) => {
         registered.push([space, host]);
-        // Malformed hosts throw in the real registry — simulate to
-        // assert per-entry isolation.
-        if (host === "not a url") throw new Error("Invalid host");
-        return host !== "http://refused.test/";
+        if (registered.length === 3) resolveRegistered();
+        return registerSpaceHost(space as MemorySpace, host);
       },
     });
     const userDid = runtime.userIdentityDID;
@@ -3033,28 +3040,56 @@ describe("RuntimeProcessor per-space piece contexts", () => {
     table.withTx(tx).set([
       { did: "did:key:z6Mk-table-a", host: "http://host-a.test/" },
       { did: "not-a-did", host: "http://ignored.test/" },
-      { did: "did:key:z6Mk-table-bad", host: "not a url" },
-      { did: "did:key:z6Mk-table-b", host: "http://refused.test/" },
+      { did: registeredRoute, host: "http://stale-table.test/" },
       { did: "did:key:z6Mk-table-c", host: "http://host-c.test/" },
+      { did: "did:key:z6Mk-table-a", host: "http://host-a-new.test/" },
+      { did: "did:key:z6Mk-table-a", host: "not a url" },
     ]);
     await tx.commit();
 
-    const processor = { runtime } as unknown as RuntimeProcessor;
+    const { PieceManager: PieceManagerConstructor } = await import(
+      "@commonfabric/piece"
+    );
+    const pieceManager = new PieceManagerConstructor(
+      { as: cfcSigner, space: userDid },
+      runtime,
+    );
+    const cc = new PiecesController(pieceManager);
+    const ProcessorConstructor = RuntimeProcessor as unknown as new (
+      runtime: Runtime,
+      pieceManager: PieceManager,
+      cc: PiecesController,
+      initSpace: MemorySpace,
+      identity: Identity,
+      telemetry: RuntimeTelemetry,
+    ) => RuntimeProcessor;
+    const processor = new ProcessorConstructor(
+      runtime,
+      pieceManager,
+      cc,
+      userDid,
+      cfcSigner,
+      new RuntimeTelemetry(),
+    );
     try {
-      (RuntimeProcessor.prototype as unknown as {
-        watchSiteTable(): void;
-      }).watchSiteTable.call(processor);
-      await runtime.idle();
-      // Microtask drain: sync() resolution + first sink fire.
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      processor.watchSiteTable();
+      await entriesRegistered;
       expect(registered).toEqual([
-        ["did:key:z6Mk-table-a", "http://host-a.test/"],
-        ["did:key:z6Mk-table-bad", "not a url"],
-        ["did:key:z6Mk-table-b", "http://refused.test/"],
+        ["did:key:z6Mk-table-a", "http://host-a-new.test/"],
+        [registeredRoute, "http://stale-table.test/"],
         ["did:key:z6Mk-table-c", "http://host-c.test/"],
       ]);
+      expect(runtime.mappedHostFor(registeredRoute)).toBe(
+        "http://ipc-host.test/",
+      );
+      const tableRoute = "did:key:z6Mk-table-a" as MemorySpace;
+      expect(registerSpaceHost(tableRoute, "http://late-ipc.test/"))
+        .toBe(false);
+      expect(runtime.mappedHostFor(tableRoute)).toBe(
+        "http://host-a-new.test/",
+      );
     } finally {
-      await runtime.dispose();
+      await processor.dispose();
     }
   });
 

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -31,6 +31,7 @@ import {
   isCellResult,
   markRendererInputTx,
   markUiInputBlindWriteTx,
+  normalizeSpaceHost,
   PatternCoverageCollector,
   Runtime,
   runtimePresets,
@@ -649,10 +650,10 @@ export class RuntimeProcessor {
       space,
       processor.renderMembershipProvider,
     );
-    // Site-table v0: the home space carries did → host hints; the
+    // Site-table v0: the home space carries space-to-host hints; the
     // runtime reads them as its live host lookup (2026-06-09 federation
-    // session — "move the lookup into the runtime itself"). Refusals
-    // (seeded differently / space already open) are by design; failures
+    // session — "move the lookup into the runtime itself"). A seeded route,
+    // an earlier hint, or an open connection can reject an entry. Failures
     // here must not block worker boot.
     processor.watchSiteTable();
     return processor;
@@ -662,16 +663,17 @@ export class RuntimeProcessor {
   #siteTableWarned = new Set<string>();
 
   /**
-   * Subscribe to the home-space site table and register each entry as
-   * a host hint. Fire-and-forget: resolution hints are an enhancement,
-   * never a boot dependency.
+   * Subscribe to the home-space site table and register the last valid HTTP or
+   * HTTPS entry for each space as a host hint. Fire-and-forget: resolution
+   * hints are an enhancement, never a boot dependency.
    *
    * ORDERING CONTRACT for embedders: this subscription races the first
    * mount. An embedder about to mount a space it just learned the host
    * for must push the hint via the RegisterSpaceHost IPC BEFORE that
-   * mount — once a space opens against the default host, the
-   * opened-space rule pins it for the session. The table is the
-   * durable record; the IPC is the ordering guarantee.
+   * mount and proceed only when registration succeeds. A route already
+   * accepted from the table remains fixed and rejects a conflicting IPC
+   * hint. The table is the durable record; the IPC checks the route before
+   * the mount opens a connection.
    */
   watchSiteTable(): void {
     try {
@@ -687,22 +689,44 @@ export class RuntimeProcessor {
         if (this._isDisposed) return;
         this.#siteTableCancel = table.sink(
           (entries: Readonly<SiteTable> | undefined) => {
+            const latestEntries = new Map<
+              string,
+              { did: DID; host: string }
+            >();
             for (const entry of entries ?? []) {
-              if (!entry?.did || !entry.host) continue;
-              if (!String(entry.did).startsWith("did:")) continue;
+              if (
+                typeof entry?.did !== "string" ||
+                typeof entry.host !== "string" ||
+                entry.host.length === 0 ||
+                !entry.did.startsWith("did:")
+              ) {
+                continue;
+              }
+              try {
+                const host = normalizeSpaceHost(entry.host);
+                latestEntries.set(entry.did, {
+                  did: entry.did as DID,
+                  host: host.toString(),
+                });
+              } catch (error) {
+                console.warn(
+                  `[RuntimeProcessor] Ignoring invalid site-table entry for ${entry.did}:`,
+                  error instanceof Error ? error.message : error,
+                );
+              }
+            }
+            for (const entry of latestEntries.values()) {
               try {
                 const accepted = this.runtime.registerSpaceHost(
-                  entry.did as DID,
+                  entry.did,
                   entry.host,
                 );
-                // The dual of "never silently re-point": never silently
-                // fail to take effect. Warn (once per fact) when the
-                // hint lost — usually the boot race: the space opened
-                // against the default host first.
+                // Warn once per rejected fact. A seeded route, an earlier
+                // hint, or an open connection can fix a different host.
                 if (!accepted) {
                   const key = `${entry.did}|${entry.host}`;
                   const effective = this.runtime.hostForSpace(
-                    entry.did as DID,
+                    entry.did,
                   ).toString();
                   if (
                     effective !== new URL(entry.host).toString() &&
@@ -711,7 +735,7 @@ export class RuntimeProcessor {
                     this.#siteTableWarned.add(key);
                     console.warn(
                       `[RuntimeProcessor] Site-table hint for ${entry.did} not in effect ` +
-                        `(space already open or seeded elsewhere); using ${effective}`,
+                        `(space route already fixed elsewhere); using ${effective}`,
                     );
                   }
                 }

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -652,9 +652,9 @@ export class RuntimeProcessor {
     );
     // Site-table v0: the home space carries space-to-host hints; the
     // runtime reads them as its live host lookup (2026-06-09 federation
-    // session — "move the lookup into the runtime itself"). A seeded route,
-    // an earlier hint, or an open connection can reject an entry. Failures
-    // here must not block worker boot.
+    // session — "move the lookup into the runtime itself"). A seeded route or
+    // earlier hint can reject an entry. A default-host provider is provisional.
+    // Failures here must not block worker boot.
     processor.watchSiteTable();
     return processor;
   }
@@ -667,13 +667,12 @@ export class RuntimeProcessor {
    * HTTPS entry for each space as a host hint. Fire-and-forget: resolution
    * hints are an enhancement, never a boot dependency.
    *
-   * ORDERING CONTRACT for embedders: this subscription races the first
-   * mount. An embedder about to mount a space it just learned the host
-   * for must push the hint via the RegisterSpaceHost IPC BEFORE that
-   * mount and proceed only when registration succeeds. A route already
-   * accepted from the table remains fixed and rejects a conflicting IPC
-   * hint. The table is the durable record; the IPC checks the route before
-   * the mount opens a connection.
+   * ORDERING CONTRACT for embedders: push a newly learned hint through the
+   * RegisterSpaceHost IPC before relying on that space, and proceed only when
+   * registration succeeds. The first hint can replace a provisional
+   * default-host provider that has not issued a write. A route already accepted
+   * from the table remains fixed and rejects a conflicting IPC hint. The table
+   * is the durable record.
    */
   watchSiteTable(): void {
     try {
@@ -721,8 +720,8 @@ export class RuntimeProcessor {
                   entry.did,
                   entry.host,
                 );
-                // Warn once per rejected fact. A seeded route, an earlier
-                // hint, or an open connection can fix a different host.
+                // Warn once per rejected fact. A seeded route or an earlier
+                // accepted hint can fix a different host.
                 if (!accepted) {
                   const key = `${entry.did}|${entry.host}`;
                   const effective = this.runtime.hostForSpace(
@@ -735,7 +734,7 @@ export class RuntimeProcessor {
                     this.#siteTableWarned.add(key);
                     console.warn(
                       `[RuntimeProcessor] Site-table hint for ${entry.did} not in effect ` +
-                        `(space route already fixed elsewhere); using ${effective}`,
+                        `(explicit space route already fixed); using ${effective}`,
                     );
                   }
                 }

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -330,18 +330,19 @@ export interface ResolveSpaceNameRequest extends BaseRequest {
 }
 
 /**
- * Record a runtime-learned host hint for a space (site-table v0).
+ * Record a runtime-learned HTTP or HTTPS host hint for a space (site-table v0).
  * The durable record is the home-space site table; this IPC lets an
  * embedder make a just-learned hint (e.g. from a share link) effective
  * on the live runtime without waiting for a sync round-trip. The
- * worker's refusal semantics apply: seed wins, opened spaces are never
- * re-pointed.
+ * worker returns whether it accepted or confirmed the hint. A seed, an
+ * accepted late hint, or an open connection fixes the route for the session.
  *
  * ORDERING CONTRACT: an embedder that will mount a space it just
  * learned the host for must send this BEFORE the first mount of that
- * space — once a space opens against the default host, the
- * opened-space rule pins it for the session. The table is the durable
- * record; this IPC is the ordering guarantee.
+ * space and proceed only when the worker returns true. An accepted
+ * site-table route can reject a conflicting IPC hint. The IPC checks
+ * the route before the mount opens a connection; it does not override
+ * a route already accepted for the session.
  */
 export interface RegisterSpaceHostRequest extends BaseRequest {
   type: RequestType.RegisterSpaceHost;

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -335,14 +335,14 @@ export interface ResolveSpaceNameRequest extends BaseRequest {
  * embedder make a just-learned hint (e.g. from a share link) effective
  * on the live runtime without waiting for a sync round-trip. The
  * worker returns whether it accepted or confirmed the hint. A seed, an
- * accepted late hint, or an open connection fixes the route for the session.
+ * accepted late hint fixes the route for the session. A read-only unseeded
+ * provider opened through the default host remains provisional.
  *
- * ORDERING CONTRACT: an embedder that will mount a space it just
- * learned the host for must send this BEFORE the first mount of that
- * space and proceed only when the worker returns true. An accepted
- * site-table route can reject a conflicting IPC hint. The IPC checks
- * the route before the mount opens a connection; it does not override
- * a route already accepted for the session.
+ * ORDERING CONTRACT: an embedder sends a newly learned hint before it relies
+ * on the space and proceeds only when the worker returns true. The first hint
+ * replaces and reloads a read-only provisional default-host provider. An
+ * accepted site-table route can reject a conflicting IPC hint. The IPC does
+ * not override a seed or route already accepted for the session.
  */
 export interface RegisterSpaceHostRequest extends BaseRequest {
   type: RequestType.RegisterSpaceHost;

--- a/packages/runtime-client/runtime-client.ts
+++ b/packages/runtime-client/runtime-client.ts
@@ -388,11 +388,13 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
   }
 
   /**
-   * Record a runtime-learned host hint for a space (site-table v0):
-   * makes a just-learned `space → host` fact effective on the live
-   * runtime. The durable record belongs in the home-space site table;
-   * this is the immediate, in-session half. Returns whether the hint
-   * is in effect (seed wins; an opened space is never re-pointed).
+   * Record a runtime-learned HTTP or HTTPS host hint for a space
+   * (site-table v0). This makes a just-learned space-to-host fact effective
+   * on the live runtime. The durable record belongs in the home-space table;
+   * this is the immediate, in-session half. Returns whether the worker
+   * accepted or confirmed the hint. A seed, an accepted late hint, or
+   * an open connection fixes the route for the session. Callers must
+   * not mount the space under this hint when the method returns false.
    */
   async registerSpaceHost(space: DID, host: string): Promise<boolean> {
     const res = await this.#conn.request<RequestType.RegisterSpaceHost>({

--- a/packages/runtime-client/runtime-client.ts
+++ b/packages/runtime-client/runtime-client.ts
@@ -392,9 +392,10 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
    * (site-table v0). This makes a just-learned space-to-host fact effective
    * on the live runtime. The durable record belongs in the home-space table;
    * this is the immediate, in-session half. Returns whether the worker
-   * accepted or confirmed the hint. A seed, an accepted late hint, or
-   * an open connection fixes the route for the session. Callers must
-   * not mount the space under this hint when the method returns false.
+   * accepted or confirmed the hint. A seed or accepted late hint fixes the
+   * route for the session. The first hint can replace a read-only provisional
+   * default-host provider and replay its reads. Callers must not mount the space
+   * under this hint when the method returns false.
    */
   async registerSpaceHost(space: DID, host: string): Promise<boolean> {
     const res = await this.#conn.request<RequestType.RegisterSpaceHost>({


### PR DESCRIPTION
A runtime-learned per-space host could replace an earlier accepted hint before the space opened. A late site-table update could therefore redirect storage and compute after an IPC hint had already been accepted.

Keep the first configured or accepted route fixed for the manager session. Reject conflicting registrations both before and after a connection opens. Validate shared space routes as HTTP or HTTPS at both runtime and storage boundaries. Preserve the broader protocol set for the storage-only default memory host.

During site-table hydration, select the final usable entry for each space. Do not let a malformed duplicate hide an earlier usable route. Report registration verdicts so callers can stop before mounting on a conflict.

Add storage, runtime, and worker regression tests for both route orderings, duplicate entries, invalid schemes, and WebSocket-only defaults. Replace timer-based watcher synchronization with an event-driven assertion. Update the lifecycle and import plans to mark the conflict guard implemented.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix per‑space host routing so the first configured or accepted HTTP(S) route stays fixed for the session. Treat the default host as provisional until the first hint or a stateful op; on a late hint, cancel pending work, switch hosts, replay reads, and harden memory client connect/mount cancellation with tests.

- **Bug Fixes**
  - Keep the first route per space fixed; return verdicts so callers can stop on conflicts before or after open.
  - Make default‑host providers provisional until a host hint or any stateful op issues; on a winning hint, replace the replica and replay reads/schemas, moving overlapping read‑only work and sync barriers.
  - Reject transactions whose read‑basis replica just changed (including cross‑space writes); once any op reaches its host, keep that route authoritative.
  - Validate shared routes as HTTP/HTTPS at runtime and storage; preserve WS/WSS only for the default `memoryHost`. Site‑table hydration selects the last valid HTTP(S) per space and won’t override an accepted route; add connect/mount cancellation guards with targeted tests.

- **Migration**
  - Call `registerSpaceHost(space, host)` before mounting and proceed only when it returns true; use HTTP/HTTPS hosts (optional: pre‑validate with `@commonfabric/runner` `normalizeSpaceHost`).
  - Unseeded spaces opened through the default host are provisional until the first hint or a stateful write; a late accepted hint will switch hosts and replay prior reads.

<sup>Written for commit 5d57b601e9b03ca6c0cffbfb4d6e109ca9063979. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

