### PR TITLE
docs(why): correct two claims that the code contradicts

### DIFF
--- a/docs/why.md
+++ b/docs/why.md
@@ -1,3 +1,7 @@
+*Draft. The argument is settled enough to write down; the wording is
+not, and the claims below are checked against the code as of this
+commit. If one of them stops being true, fix it here.*
+
 Personal computing was supposed to make computers personal. Instead,
 your mail lives on someone else's machine, under someone else's rules.
 We are all renters in our digital lives. The landlords didn't win an
@@ -37,7 +41,8 @@ What already runs, in this repository, today:
   dataflow — run `cf check <pattern> --show-transformed` and it prints
   the exact code the runtime executes, no trust required
 - the flow checking that evaluates those policies, in
-  `packages/runner/` — observe mode today, see 5 below
+  `packages/runner/` — enforcing on explicit boundaries today, with the
+  propagation still behind a flag, see 5 below
 - a hundred-odd running patterns in `packages/patterns/`, counters to
   group chat — enough to show the runtime isn't bent around one use
   case, and nowhere near the number that would matter
@@ -59,14 +64,25 @@ What we hold:
 2. Every line is open source. The runtime proves itself to you before
    your data arrives — you are never trusting our word, you are checking
    the machine's.
-3. Your data leaves with you, whole, policies and all. No one you did
-   not choose can hold it, and no one can hold it hostage.
-4. Software is multiplayer without a landlord. State lives where no
-   participant can lock the others out of it.
-5. The unfinished parts, plainly: the flow checking runs in observe
-   mode today, strict-by-default is the current work, and robustness
-   and performance are not there yet. That is a real gap, and it is
-   ours to close.
+3. Your data leaves with you, whole, policies and all. A copy is not a
+   downgrade — the rules travel with it, so leaving costs you nothing
+   but the leaving.
+4. Software should be multiplayer without a landlord. This is the one
+   we have not built. A space still has a host that enforces access and
+   can revoke a participant mid-session
+   (`#revokeDeauthorizedSessions`, `packages/memory/v2/server.ts`), and
+   there is no delegation yet — `Delegation = never` in
+   `packages/memory/interface.ts`, with a comment saying what it is
+   meant to become. The landlord is smaller than it was. It is not
+   gone.
+5. The other unfinished parts, plainly: the checker refuses a commit
+   that crosses a boundary it was told about, which is the third of
+   four rungs (`enforce-explicit`); the viral part — labels propagating
+   into everything derived from a value — is written but defaults to
+   off, and is rolling out. Strict-by-default is the current work.
+   Robustness and performance are not there yet. The dial table in
+   `docs/specs/cfc-enforcement-matrix.md` lists what each host runs
+   today, rather than what we would like it to.
 
 Here is what "policies ride with the data" means in practice. A program
 that imports your mail gets an access token that could read all of it.


### PR DESCRIPTION
## Why

`docs/why.md` (#4965) makes claims a reader is invited to go check. Two
of them did not survive checking, and the doc's whole argument is that
you should not have to take our word for anything.

**Claim 4** said state lives where no participant can lock the others
out of it. A space still has a host that enforces an ACL and revokes a
de-authorized participant mid-session (`#revokeDeauthorizedSessions` in
`packages/memory/v2/server.ts`), and `Delegation = never` in
`packages/memory/interface.ts` — no delegation chains yet. It was the
most checkable claim in the file and the one a skeptical reader reaches
for first.

**"observe mode today"** — in the bullet list and again in claim 5 — was
wrong in both directions. `cfcEnforcementMode` defaults to
`enforce-explicit`, the third of four rungs, which *rejects* a commit
rather than observing it. What actually defaults to `off` is
`cfcFlowLabels`, the propagation. The doc understated the enforcement
and overstated the propagation in the same phrase.

## What Changed

- Claim 4 states the gap it used to paper over, and keeps the goal as a
  goal: "The landlord is smaller than it was. It is not gone."
- Claim 3's absolute ("no one can hold it hostage") is reworded to the
  portability point it was actually making, so it no longer contradicts
  4.
- Claim 5 names the rung and the flag, and points at
  `docs/specs/cfc-enforcement-matrix.md`, whose host table lists what
  each host runs today.
- A draft note at the top, and a standing instruction: if a claim stops
  being true, fix it here.

## Test plan

Each claim re-verified against source rather than against the previous
draft — `runtime.ts:1003`, `runtime-presets.ts:256`,
`cfc-enforcement-matrix.md:149` (host table),
`memory/interface.ts:95`, `memory/v2/server.ts:1184`.
`deno task check-docs` green (523 blocks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected inaccurate claims in `docs/why.md` and clarified current enforcement defaults so the doc matches the code and doesn’t overstate capabilities.

- **Bug Fixes**
  - Updated Claim 4 to reflect current host ACLs and lack of delegation (`#revokeDeauthorizedSessions` in `packages/memory/v2/server.ts`, `Delegation = never` in `packages/memory/interface.ts`).
  - Reworded Claim 3 to emphasize portability; fixed Claim 5 to name the `enforce-explicit` default and that `cfcFlowLabels` propagation is off by default, with a link to `docs/specs/cfc-enforcement-matrix.md`.
  - Added a draft note and instruction to keep claims in sync with the code.

<sup>Written for commit 9418f565b3e72d1f3af55e4da18f0160354d828d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

