### PR TITLE
feat(cli): select view languages from metadata

### DIFF
--- a/docs/plans/cf-view-language-coverage.md
+++ b/docs/plans/cf-view-language-coverage.md
@@ -1,9 +1,11 @@
 # `cf view` language and syntax coverage plan
 
-Status: In progress. Unknown named files and filename-free source use plain
-text, while filename-free transformed compiler output keeps its TypeScript
-default. Piped source can select a language directly or through a virtual
-filename. Python files with recognized extensions now have syntax highlighting.
+Status: In progress. Unknown named files and filename-free source without a
+recognized shebang use plain text, while filename-free transformed compiler
+output keeps its TypeScript default. Piped source can select a language directly
+or through a virtual filename. Declarative metadata can now describe extensions,
+exact names, compound patterns, explicit aliases, and direct interpreter
+shebangs. Python files with recognized extensions now have syntax highlighting.
 The order is provisional because recent activity was measured in six of the 24
 active organization repositories.
 
@@ -87,7 +89,7 @@ relative value. Record the reason in this plan.
 - [x] Preserve the intentional TypeScript default only for transformed
   compiler output that has no filename.
 - [x] Add `--language` and `--filename` overrides for piped input.
-- [ ] Represent extensions, exact filenames, compound filename patterns,
+- [x] Represent extensions, exact filenames, compound filename patterns,
   aliases, and shebang interpreters as language metadata.
 - [ ] Keep content detection only for unambiguous containers such as unified
   diffs.
@@ -124,8 +126,8 @@ notebook selects JSON or line-oriented JSON without broad suffix guesses.
 ## Stage 2: Python
 
 - [x] Highlight `.py`, `.pyi`, and `.pyw` files.
-- [ ] Recognize extensionless programs from direct Python and `uv run`
-  shebangs.
+- [x] Recognize extensionless programs from direct Python shebangs.
+- [ ] Recognize extensionless programs from `uv run` shebangs.
 - [ ] Add class, function, async function, and decorated-definition structure.
 - [ ] Add representative Loom, Specs, Legibility, Raia, and gVisor fixtures.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -6,13 +6,14 @@
 files, and unified diffs. Named Markdown, JSON, JSONC, YAML, and Python files
 use their own syntax highlighting. Transformed compiler output piped without a
 filename keeps TypeScript highlighting when its module header identifies it.
-Other filename-free source and named files with unrecognized syntax are shown as
-plain text. For piped source, `--filename` selects syntax as though the input
-had that name, while `--language` selects one of `typescript`, `markdown`,
-`json`, `yaml`, `python`, or `plain-text` directly. Both options keep the pipe
-read-only and suppress unified-diff auto-detection. An explicit language takes
-priority when both options are present. Use `--diff` instead when the pipe is a
-unified diff.
+Python interpreter shebangs select Python for otherwise unrecognized names.
+Node, Deno, and Bun shebangs select the TypeScript and JavaScript language
+family. Other filename-free source and named files with unrecognized syntax are
+shown as plain text. For piped source, `--filename` selects syntax as though the
+input had that name. `--language` selects a language by its stable identifier or
+alias. Both options keep the pipe read-only and suppress unified-diff
+auto-detection. An explicit language takes priority when both options are
+present. Use `--diff` instead when the pipe is a unified diff.
 
 Markdown files can switch between the source and a rendered terminal view with
 `V`. The rendered view formats headings, emphasis, links, quotes, lists, task

--- a/packages/cli/commands/view.ts
+++ b/packages/cli/commands/view.ts
@@ -1,7 +1,7 @@
 import { Command } from "@cliffy/command";
 import { type ColorWhen, ViewError, viewMain } from "../lib/view/mod.ts";
 import { cliText } from "../lib/cli-name.ts";
-import { languageIds } from "../lib/view/languages/language.ts";
+import { languageNames } from "../lib/view/languages/language.ts";
 
 const description = cliText(
   `Interactive, syntax-aware pager for transformed patterns, source files and diffs.
@@ -11,14 +11,16 @@ files. Transformed TypeScript is parsed with the same parser the transformer
 uses, so blocks, closures, schemas, type positions and Common Fabric builders
 (pattern/lift/handler/…) are coloured exactly as the compiler sees them.
 Markdown, JSON, JSONC, YAML and Python files use syntax highlighting selected
-from their names. Filename-free compiler output keeps TypeScript highlighting
-when its transformed-module header identifies it. Other unnamed source and
-named files with unrecognized syntax remain plain text. Piped source can select
-syntax explicitly with '--language' or supply a virtual name with '--filename'.
-Either option suppresses unified-diff auto-detection; use '--diff' instead for a
-diff. The Markdown language also has a rendered view that formats headings,
-lists, quotes, tables, links, emphasis and code while retaining source line
-positions. Source views remain verbatim and add colour only.
+from language metadata. Python interpreter shebangs select Python. Node, Deno
+and Bun shebangs select the TypeScript and JavaScript language family.
+Filename-free compiler output keeps TypeScript highlighting when its
+transformed-module header identifies it. Other unnamed source and named files
+with unrecognized syntax remain plain text. Piped source can select syntax
+explicitly with '--language' or supply a virtual name with '--filename'. Either
+option suppresses unified-diff auto-detection; use '--diff' instead for a diff.
+The Markdown language also has a rendered view that formats headings, lists,
+quotes, tables, links, emphasis and code while retaining source line positions.
+Source views remain verbatim and add colour only.
 
 Unified diffs are detected automatically: piping 'git diff' in gives added and
 removed lines their tints, full syntax colour, a structure tree of the code
@@ -76,7 +78,7 @@ export const view = new Command()
   )
   .option(
     "--language <language:string>",
-    `Select piped source explicitly: ${languageIds().join(", ")}.`,
+    `Select piped source explicitly: ${languageNames().join(", ")}.`,
   )
   .option(
     "--filename <filename:string>",

--- a/packages/cli/lib/completion/static.ts
+++ b/packages/cli/lib/completion/static.ts
@@ -7,7 +7,7 @@
  */
 
 import type { Option } from "@cliffy/command";
-import { languageIds } from "../view/languages/language.ts";
+import { languageNames } from "../view/languages/language.ts";
 import type { AnyCommand, CompletionLine, PreParseGlobal } from "./line.ts";
 import { longName, PRE_PARSE_GLOBALS } from "./line.ts";
 
@@ -23,12 +23,12 @@ export interface Candidate {
  * are facts about the CLI's accepted vocabulary, not about live data.
  *
  * `log-level` mirrors `lib/log-level.ts`; `color` mirrors the corresponding
- * `cf view` option. Language identifiers come from the view language registry.
+ * `cf view` option. Language names come from the view language registry.
  */
 const ENUMERATED_OPTION_VALUES: Readonly<Record<string, readonly string[]>> = {
   "log-level": ["debug", "info", "warn", "error", "silent"],
   "color": ["auto", "always", "never"],
-  "language": languageIds(),
+  "language": languageNames(),
   "cfc-mode": ["off", "warn", "enforce"],
 };
 

--- a/packages/cli/lib/view/editsource.ts
+++ b/packages/cli/lib/view/editsource.ts
@@ -198,10 +198,12 @@ export interface EditPolicy {
 }
 
 /** An on-disk file: the document text is the file, edits write straight back. */
-export function fileSource(path: string): EditableSource {
-  // The language is chosen once, from the path, and every edit-time operation
-  // dispatches through it.
-  const language = languageForFile(path);
+export function fileSource(
+  path: string,
+  language: Language = languageForFile(path),
+): EditableSource {
+  // The language is chosen once, and every edit-time operation dispatches
+  // through it.
   const render = sourceRenderer(language, path);
   return {
     label: shortName(path),

--- a/packages/cli/lib/view/filegateway.ts
+++ b/packages/cli/lib/view/filegateway.ts
@@ -6,6 +6,7 @@
  */
 import { basename, dirname, join } from "@std/path";
 import { type EditableSource, fileSource } from "./editsource.ts";
+import { languageForSource } from "./languages/language.ts";
 
 export interface DirEntry {
   readonly name: string;
@@ -50,7 +51,10 @@ export function realFileGateway(): FileGateway {
     open: (absPath) => {
       try {
         const text = Deno.readTextFileSync(absPath);
-        return { source: fileSource(absPath), text };
+        return {
+          source: fileSource(absPath, languageForSource(absPath, text)),
+          text,
+        };
       } catch {
         return null;
       }

--- a/packages/cli/lib/view/languages/json/json.ts
+++ b/packages/cli/lib/view/languages/json/json.ts
@@ -25,11 +25,6 @@ import type { Highlighter } from "../language.ts";
 import { cpLen } from "../../ansi.ts";
 import { computeLineStarts, lineIndexOf } from "../../lines.ts";
 
-/** Whether `fileName` names a JSON or JSONC file. */
-export function isJsonPath(fileName: string | undefined): boolean {
-  return fileName !== undefined && /\.jsonc?$/i.test(fileName);
-}
-
 interface Token {
   readonly start: number;
   readonly end: number;

--- a/packages/cli/lib/view/languages/json/language.ts
+++ b/packages/cli/lib/view/languages/json/language.ts
@@ -11,7 +11,6 @@ import type { Language } from "../language.ts";
 import { remapStructure } from "../../diffremap.ts";
 import {
   createJsonHighlighter,
-  isJsonPath,
   jsonDocument,
   jsonHighlightLines,
 } from "./json.ts";
@@ -19,7 +18,13 @@ import {
 export const jsonLanguage: Language = {
   id: "json",
 
-  matches: (fileName) => isJsonPath(fileName),
+  metadata: {
+    extensions: [".json", ".jsonc"],
+    filenames: [],
+    filenamePatterns: [/\.jsonc?\.example$/i],
+    aliases: ["jsonc"],
+    interpreters: [],
+  },
 
   parseDocument: (text) => jsonDocument(text),
 

--- a/packages/cli/lib/view/languages/language.ts
+++ b/packages/cli/lib/view/languages/language.ts
@@ -3,10 +3,10 @@
  * colour, navigate, edit and (optionally) reason about it, plus selecting the
  * right language for a file. A language is a stateless strategy object: one
  * instance describes each supported syntax, and plain text handles input that
- * has no recognized filename. The pager selects the right one for a file ONCE
- * (via {@link languageForFile}) and then dispatches every operation through
- * that object's methods — there is no per-operation branch on the file
- * extension.
+ * has no recognized filename or shebang. The pager selects the right one for a
+ * source ONCE (via {@link languageForSource}) and then dispatches every
+ * operation through that object's methods — there is no per-operation branch
+ * on the file extension.
  *
  * Per-file mutable state (a warm incremental parse, a language service) is not
  * held on the language; the language is a factory for the small stateful
@@ -103,18 +103,34 @@ export interface HunkStructureContext {
   readonly definitions: Map<string, Definition[]>;
 }
 
+/** An exact executable basename or regular expression for a shebang. */
+export type InterpreterPattern = string | RegExp;
+
 /**
- * A source language the pager can render and navigate. Selection asks each
- * language {@link matches} once per file; all later work is method dispatch.
+ * Declarative names that select a language. Extensions include their leading
+ * dot and compare without case. Exact filenames and regular-expression
+ * patterns match a path's basename. Aliases name explicit language overrides.
+ * Interpreters match executable basenames extracted from shebangs.
+ */
+export interface LanguageMetadata {
+  readonly extensions: readonly string[];
+  readonly filenames: readonly string[];
+  readonly filenamePatterns: readonly RegExp[];
+  readonly aliases: readonly string[];
+  readonly interpreters: readonly InterpreterPattern[];
+}
+
+/**
+ * A source language the pager can render and navigate. Selection reads each
+ * language's metadata once per source; all later work is method dispatch.
  */
 export interface Language {
   /** Stable identifier, such as `"typescript"`, `"markdown"`, `"json"`,
    * `"yaml"`, `"python"`, or `"plain-text"`. */
   readonly id: string;
 
-  /** Does this language claim `fileName`? Consulted in order by {@link
-   * languageForFile}. */
-  matches(fileName: string | undefined): boolean;
+  /** Filename, explicit-name, and shebang selectors for this language. */
+  readonly metadata: LanguageMetadata;
 
   /** Parse `text` into the full document model: coloured lines, a structure
    * tree, and a name → definition index. `fileName` is advisory. */
@@ -213,9 +229,7 @@ export function renderedLinesFor(
 
 /**
  * Every language the pager knows, most specific first, built on first use.
- * Plain text comes last because it claims every named file left after the
- * syntax-specific languages. The fallback below also uses it when no filename
- * exists.
+ * Plain text comes last and remains the fallback after metadata selection.
  *
  * The list is lazy so this module's top level never reads the concrete language
  * singletons: they and this module form an import cycle (a language's semantic
@@ -235,18 +249,76 @@ function allLanguages(): readonly Language[] {
   ];
 }
 
-/** The language for `fileName` — the first that claims it. Plain text handles
- * unknown named files and input without a filename. */
-export function languageForFile(fileName: string | undefined): Language {
-  for (const language of allLanguages()) {
-    if (language.matches(fileName)) return language;
+/** Whether metadata claims a filename. */
+export function metadataMatchesFilename(
+  metadata: LanguageMetadata,
+  fileName: string | undefined,
+): boolean {
+  if (fileName === undefined) return false;
+  const filename = basename(fileName);
+  const lower = filename.toLowerCase();
+  if (
+    metadata.extensions.some((extension) =>
+      lower.endsWith(extension.toLowerCase())
+    )
+  ) {
+    return true;
   }
-  return plainTextLanguage;
+  if (metadata.filenames.includes(filename)) return true;
+  return metadata.filenamePatterns.some((pattern) =>
+    regularExpressionMatches(pattern, filename)
+  );
 }
 
-/** Look up a language by its stable identifier for an explicit override. */
-export function languageForId(id: string): Language | undefined {
-  return allLanguages().find((language) => language.id === id);
+/** The language selected by filename metadata, with plain text as fallback. */
+export function languageForFile(fileName: string | undefined): Language {
+  return languageMatchingFilename(fileName) ?? plainTextLanguage;
+}
+
+function languageMatchingFilename(
+  fileName: string | undefined,
+): Language | undefined {
+  for (const language of allLanguages()) {
+    if (metadataMatchesFilename(language.metadata, fileName)) return language;
+  }
+  return undefined;
+}
+
+/**
+ * Select a language for complete source. A recognized filename takes
+ * precedence. A filename with no metadata match can defer to a shebang.
+ */
+export function languageForSource(
+  fileName: string | undefined,
+  text: string,
+): Language {
+  const byFilename = languageMatchingFilename(fileName);
+  if (byFilename !== undefined) return byFilename;
+  return languageForShebang(text) ?? plainTextLanguage;
+}
+
+let languagesByName: ReadonlyMap<string, Language> | undefined;
+function namedLanguages(): ReadonlyMap<string, Language> {
+  if (languagesByName !== undefined) return languagesByName;
+  const named = new Map<string, Language>();
+  for (const language of allLanguages()) {
+    for (const name of [language.id, ...language.metadata.aliases]) {
+      const existing = named.get(name);
+      if (existing !== undefined) {
+        throw new Error(
+          `Language name "${name}" belongs to both ${existing.id} and ${language.id}`,
+        );
+      }
+      named.set(name, language);
+    }
+  }
+  languagesByName = named;
+  return named;
+}
+
+/** Look up a language by its stable identifier or alias. */
+export function languageForName(name: string): Language | undefined {
+  return namedLanguages().get(name);
 }
 
 /** Stable identifiers accepted by an explicit language override. */
@@ -254,10 +326,141 @@ export function languageIds(): string[] {
   return allLanguages().map((language) => language.id);
 }
 
+/** Stable identifiers and aliases accepted by an explicit language override. */
+export function languageNames(): string[] {
+  return [...namedLanguages().keys()];
+}
+
 /** The TypeScript default for filename-free `cf check --show-transformed`
  * output. The caller checks the compiler's module header before selecting it. */
 export function languageForTransformedOutput(): Language {
   return typeScriptLanguage;
+}
+
+function basename(path: string): string {
+  return path.split(/[\\/]/).pop() ?? path;
+}
+
+function languageForShebang(text: string): Language | undefined {
+  const interpreter = shebangInterpreter(text);
+  if (interpreter === undefined) return undefined;
+  return allLanguages().find((language) =>
+    language.metadata.interpreters.some((pattern) =>
+      typeof pattern === "string"
+        ? pattern === interpreter
+        : regularExpressionMatches(pattern, interpreter)
+    )
+  );
+}
+
+function regularExpressionMatches(pattern: RegExp, value: string): boolean {
+  pattern.lastIndex = 0;
+  const matches = pattern.test(value);
+  pattern.lastIndex = 0;
+  return matches;
+}
+
+/**
+ * Extract the executable basename from a direct shebang or an `env` shebang.
+ * `env -S` supplies the command after the split-string flag.
+ */
+function shebangInterpreter(text: string): string | undefined {
+  const end = text.indexOf("\n");
+  const firstLine = (end < 0 ? text : text.slice(0, end)).replace(/\r$/, "");
+  if (!firstLine.startsWith("#!")) return undefined;
+  const words = splitShebangWords(firstLine.slice(2));
+  if (words.length === 0) return undefined;
+  const direct = basename(words[0]);
+  if (direct !== "env") return direct;
+  return envCommand(words.slice(1));
+}
+
+function envCommand(words: readonly string[]): string | undefined {
+  for (let index = 0; index < words.length; index++) {
+    const word = words[index];
+    if (word === "--") {
+      return words[index + 1] === undefined
+        ? undefined
+        : basename(words[index + 1]);
+    }
+    if (word === "-S" || word === "--split-string") {
+      return envCommand(words.slice(index + 1));
+    }
+    if (word.startsWith("--split-string=")) {
+      return envCommand([
+        word.slice("--split-string=".length),
+        ...words.slice(index + 1),
+      ]);
+    }
+    const combinedSplit = word.match(/^-[iv0]*S(.*)$/);
+    if (combinedSplit !== null) {
+      const inline = combinedSplit[1];
+      return envCommand(
+        inline.length > 0
+          ? [inline, ...words.slice(index + 1)]
+          : words.slice(index + 1),
+      );
+    }
+    if (
+      word === "-u" || word === "--unset" || word === "-C" ||
+      word === "--chdir" || word === "-P" || word === "--path" ||
+      word === "-a" || word === "--argv0"
+    ) {
+      index++;
+      continue;
+    }
+    if (word.startsWith("-") || /^[^=]+=/.test(word)) continue;
+    return basename(word);
+  }
+  return undefined;
+}
+
+function splitShebangWords(input: string): string[] {
+  const words: string[] = [];
+  let word = "";
+  let started = false;
+  let quote: "'" | '"' | undefined;
+  let escaped = false;
+
+  for (const char of input) {
+    if (escaped) {
+      word += char;
+      started = true;
+      escaped = false;
+      continue;
+    }
+    if (quote !== undefined) {
+      if (char === quote) {
+        quote = undefined;
+        started = true;
+      } else if (char === "\\" && quote === '"') {
+        escaped = true;
+      } else {
+        word += char;
+        started = true;
+      }
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      quote = char;
+      started = true;
+    } else if (char === "\\") {
+      escaped = true;
+      started = true;
+    } else if (/\s/.test(char)) {
+      if (started) {
+        words.push(word);
+        word = "";
+        started = false;
+      }
+    } else {
+      word += char;
+      started = true;
+    }
+  }
+  if (escaped) word += "\\";
+  if (started) words.push(word);
+  return words;
 }
 
 /** The distinct languages a set of files resolves to, in first-seen order. */

--- a/packages/cli/lib/view/languages/language.ts
+++ b/packages/cli/lib/view/languages/language.ts
@@ -386,32 +386,48 @@ function shebangInterpreter(text: string): string | undefined {
 
 function envCommandFromShebang(input: string): string | undefined {
   const matches = [...input.matchAll(/\S+/g)];
+  let options = true;
   for (let index = 0; index < matches.length; index++) {
     const match = matches[index];
     const word = match[0];
-    const rest = input.slice((match.index ?? 0) + word.length);
-    if (word === "--") {
-      const command = matches[index + 1]?.[0];
-      return command === undefined ? undefined : basename(command);
+    if (options) {
+      const rest = input.slice(match.index! + word.length);
+      if (word === "--") {
+        options = false;
+        continue;
+      }
+      if (word === "-S" || word === "--split-string") {
+        return splitEnvCommand(rest);
+      }
+      if (word.startsWith("--split-string=")) {
+        return splitEnvCommand(word.slice("--split-string=".length) + rest);
+      }
+      const combinedSplitOffset = envCombinedSplitOffset(word);
+      if (combinedSplitOffset !== undefined) {
+        return splitEnvCommand(word.slice(combinedSplitOffset) + rest);
+      }
+      if (envOptionTakesFollowingWord(word)) {
+        index++;
+        continue;
+      }
+      if (word.startsWith("-")) continue;
     }
-    if (word === "-S" || word === "--split-string") {
-      return splitEnvCommand(rest);
-    }
-    if (word.startsWith("--split-string=")) {
-      return splitEnvCommand(word.slice("--split-string=".length) + rest);
-    }
-    const combinedSplit = word.match(/^-[iv0]*S(.*)$/);
-    if (combinedSplit !== null) {
-      return splitEnvCommand(combinedSplit[1] + rest);
-    }
-    if (envOptionTakesFollowingWord(word)) {
-      index++;
+    if (/^[^=]+=/.test(word)) {
+      options = false;
       continue;
     }
-    if (word.startsWith("-") || /^[^=]+=/.test(word)) continue;
     return basename(word);
   }
   return undefined;
+}
+
+function envCombinedSplitOffset(word: string): number | undefined {
+  if (!word.startsWith("-")) return undefined;
+  let index = 1;
+  while (word[index] === "i" || word[index] === "v" || word[index] === "0") {
+    index++;
+  }
+  return word[index] === "S" ? index + 1 : undefined;
 }
 
 function envOptionTakesFollowingWord(word: string): boolean {
@@ -430,63 +446,168 @@ function splitEnvCommand(input: string): string | undefined {
   return words === undefined ? undefined : envCommand(words);
 }
 
-function envCommand(words: readonly string[]): string | undefined {
-  for (let index = 0; index < words.length; index++) {
-    const word = words[index];
-    if (word === "--") {
-      return words[index + 1] === undefined
-        ? undefined
-        : basename(words[index + 1]);
+interface EnvWord {
+  readonly text: string;
+  readonly stable: boolean;
+}
+
+interface EnvWordFrame {
+  readonly words: readonly EnvWord[];
+  index: number;
+}
+
+function nextEnvWord(frames: EnvWordFrame[]): EnvWord | undefined {
+  while (frames.length > 0) {
+    const frame = frames[frames.length - 1];
+    if (frame.index < frame.words.length) {
+      return frame.words[frame.index++];
     }
-    if (word === "-S" || word === "--split-string") {
-      return envCommand(words.slice(index + 1));
-    }
-    if (word.startsWith("--split-string=")) {
-      return envCommand([
-        word.slice("--split-string=".length),
-        ...words.slice(index + 1),
-      ]);
-    }
-    const combinedSplit = word.match(/^-[iv0]*S(.*)$/);
-    if (combinedSplit !== null) {
-      const inline = combinedSplit[1];
-      return envCommand(
-        inline.length > 0
-          ? [inline, ...words.slice(index + 1)]
-          : words.slice(index + 1),
-      );
-    }
-    if (envOptionTakesFollowingWord(word)) {
-      index++;
-      continue;
-    }
-    if (word.startsWith("-") || /^[^=]+=/.test(word)) continue;
-    return basename(word);
+    frames.pop();
   }
   return undefined;
 }
 
-function splitShebangWords(input: string): string[] | undefined {
-  const words: string[] = [];
+function envWord(text: string, stable: boolean): EnvWord {
+  return {
+    text,
+    stable: stable && text.length > 0,
+  };
+}
+
+function envWordSuffix(word: EnvWord, start: number): EnvWord {
+  const text = word.text.slice(start);
+  return {
+    text,
+    stable: word.stable && text.length > 0 && !text.startsWith("#"),
+  };
+}
+
+function splitEnvWord(word: EnvWord): EnvWord[] | undefined {
+  return word.stable ? [word] : splitShebangWords(word.text);
+}
+
+function envCommand(initialWords: readonly EnvWord[]): string | undefined {
+  const frames: EnvWordFrame[] = [{ words: initialWords, index: 0 }];
+  let options = true;
+  for (;;) {
+    const word = nextEnvWord(frames);
+    if (word === undefined) return undefined;
+    const text = word.text;
+    if (options) {
+      if (text === "--") {
+        options = false;
+        continue;
+      }
+      let splitString: EnvWord | undefined;
+      if (text === "-S" || text === "--split-string") {
+        splitString = nextEnvWord(frames);
+        if (splitString === undefined) return undefined;
+      } else if (text.startsWith("--split-string=")) {
+        splitString = envWordSuffix(word, "--split-string=".length);
+      } else {
+        const combinedSplitOffset = envCombinedSplitOffset(text);
+        if (combinedSplitOffset !== undefined) {
+          splitString = combinedSplitOffset < text.length
+            ? envWordSuffix(word, combinedSplitOffset)
+            : nextEnvWord(frames);
+          if (splitString === undefined) return undefined;
+        }
+      }
+      if (splitString !== undefined) {
+        const splitWords = splitEnvWord(splitString);
+        if (splitWords === undefined) return undefined;
+        frames.push({ words: splitWords, index: 0 });
+        continue;
+      }
+      if (envOptionTakesFollowingWord(text)) {
+        if (nextEnvWord(frames) === undefined) return undefined;
+        continue;
+      }
+      if (text.startsWith("-")) continue;
+    }
+    if (/^[^=]+=/.test(text)) {
+      options = false;
+      continue;
+    }
+    return basename(text);
+  }
+}
+
+const ENV_SPLIT_ESCAPES: Readonly<Record<string, string | undefined>> = {
+  f: "\f",
+  n: "\n",
+  r: "\r",
+  t: "\t",
+  v: "\v",
+  " ": " ",
+  "\t": "\t",
+  "#": "#",
+  "$": "$",
+  '"': '"',
+  "'": "'",
+  "\\": "\\",
+};
+
+function splitShebangWords(input: string): EnvWord[] | undefined {
+  const words: EnvWord[] = [];
   let word = "";
+  let stable = true;
   let started = false;
   let quote: "'" | '"' | undefined;
   let escaped = false;
 
-  for (const char of input) {
+  for (let index = 0; index < input.length; index++) {
+    const char = input[index];
     if (escaped) {
-      word += char;
-      started = true;
       escaped = false;
+      if (quote === "'" && char !== "'" && char !== "\\") {
+        word += `\\${char}`;
+        stable = false;
+        started = true;
+        continue;
+      }
+      if (char === "c") {
+        if (quote === '"') return undefined;
+        break;
+      }
+      if (char === "_") {
+        if (quote === '"') {
+          word += " ";
+          stable = false;
+          started = true;
+        } else if (started) {
+          words.push(envWord(word, stable));
+          word = "";
+          stable = true;
+          started = false;
+        }
+        continue;
+      }
+      const replacement = ENV_SPLIT_ESCAPES[char];
+      if (replacement === undefined) return undefined;
+      stable &&= envTextIsStable(replacement, word.length === 0);
+      word += replacement;
+      started = true;
+      continue;
+    }
+    if (char === "$" && quote !== "'") {
+      const variable = input.slice(index).match(
+        /^\$\{[A-Za-z_][A-Za-z0-9_]*\}/,
+      )?.[0];
+      if (variable === undefined) return undefined;
+      word += variable;
+      started = true;
+      index += variable.length - 1;
       continue;
     }
     if (quote !== undefined) {
       if (char === quote) {
         quote = undefined;
         started = true;
-      } else if (char === "\\" && quote === '"') {
+      } else if (char === "\\") {
         escaped = true;
       } else {
+        stable &&= envTextIsStable(char, word.length === 0);
         word += char;
         started = true;
       }
@@ -497,21 +618,28 @@ function splitShebangWords(input: string): string[] | undefined {
       started = true;
     } else if (char === "\\") {
       escaped = true;
-      started = true;
-    } else if (/\s/.test(char)) {
+    } else if (char === " " || char === "\t") {
       if (started) {
-        words.push(word);
+        words.push(envWord(word, stable));
         word = "";
+        stable = true;
         started = false;
       }
+    } else if (char === "#" && !started) {
+      break;
     } else {
+      stable &&= envTextIsStable(char, word.length === 0);
       word += char;
       started = true;
     }
   }
   if (escaped || quote !== undefined) return undefined;
-  if (started) words.push(word);
+  if (started) words.push(envWord(word, stable));
   return words;
+}
+
+function envTextIsStable(text: string, atStart: boolean): boolean {
+  return !/[ \t\\'"$]/.test(text) && !(atStart && text.startsWith("#"));
 }
 
 /** The distinct languages a set of files resolves to, in first-seen order. */

--- a/packages/cli/lib/view/languages/language.ts
+++ b/packages/cli/lib/view/languages/language.ts
@@ -299,9 +299,15 @@ export function languageForSource(
 
 let languagesByName: ReadonlyMap<string, Language> | undefined;
 function namedLanguages(): ReadonlyMap<string, Language> {
-  if (languagesByName !== undefined) return languagesByName;
+  return languagesByName ??= indexLanguagesByName(allLanguages());
+}
+
+/** Build the explicit-name index and reject ambiguous identifiers or aliases. */
+export function indexLanguagesByName(
+  languages: readonly Language[],
+): ReadonlyMap<string, Language> {
   const named = new Map<string, Language>();
-  for (const language of allLanguages()) {
+  for (const language of languages) {
     for (const name of [language.id, ...language.metadata.aliases]) {
       const existing = named.get(name);
       if (existing !== undefined) {
@@ -312,7 +318,6 @@ function namedLanguages(): ReadonlyMap<string, Language> {
       named.set(name, language);
     }
   }
-  languagesByName = named;
   return named;
 }
 
@@ -368,11 +373,61 @@ function shebangInterpreter(text: string): string | undefined {
   const end = text.indexOf("\n");
   const firstLine = (end < 0 ? text : text.slice(0, end)).replace(/\r$/, "");
   if (!firstLine.startsWith("#!")) return undefined;
-  const words = splitShebangWords(firstLine.slice(2));
-  if (words.length === 0) return undefined;
-  const direct = basename(words[0]);
+  const command = firstLine.slice(2).trimStart();
+  if (command.length === 0) return undefined;
+  const separator = command.search(/\s/);
+  const executable = separator < 0 ? command : command.slice(0, separator);
+  const direct = basename(executable);
   if (direct !== "env") return direct;
-  return envCommand(words.slice(1));
+  return envCommandFromShebang(
+    separator < 0 ? "" : command.slice(separator),
+  );
+}
+
+function envCommandFromShebang(input: string): string | undefined {
+  const matches = [...input.matchAll(/\S+/g)];
+  for (let index = 0; index < matches.length; index++) {
+    const match = matches[index];
+    const word = match[0];
+    const rest = input.slice((match.index ?? 0) + word.length);
+    if (word === "--") {
+      const command = matches[index + 1]?.[0];
+      return command === undefined ? undefined : basename(command);
+    }
+    if (word === "-S" || word === "--split-string") {
+      return splitEnvCommand(rest);
+    }
+    if (word.startsWith("--split-string=")) {
+      return splitEnvCommand(word.slice("--split-string=".length) + rest);
+    }
+    const combinedSplit = word.match(/^-[iv0]*S(.*)$/);
+    if (combinedSplit !== null) {
+      return splitEnvCommand(combinedSplit[1] + rest);
+    }
+    if (envOptionTakesFollowingWord(word)) {
+      index++;
+      continue;
+    }
+    if (word.startsWith("-") || /^[^=]+=/.test(word)) continue;
+    return basename(word);
+  }
+  return undefined;
+}
+
+function envOptionTakesFollowingWord(word: string): boolean {
+  if (
+    word === "--unset" || word === "--chdir" || word === "--path" ||
+    word === "--argv0"
+  ) {
+    return true;
+  }
+  const grouped = word.match(/^-[iv0]*[uCPa](.*)$/);
+  return grouped !== null && grouped[1].length === 0;
+}
+
+function splitEnvCommand(input: string): string | undefined {
+  const words = splitShebangWords(input);
+  return words === undefined ? undefined : envCommand(words);
 }
 
 function envCommand(words: readonly string[]): string | undefined {
@@ -401,11 +456,7 @@ function envCommand(words: readonly string[]): string | undefined {
           : words.slice(index + 1),
       );
     }
-    if (
-      word === "-u" || word === "--unset" || word === "-C" ||
-      word === "--chdir" || word === "-P" || word === "--path" ||
-      word === "-a" || word === "--argv0"
-    ) {
+    if (envOptionTakesFollowingWord(word)) {
       index++;
       continue;
     }
@@ -415,7 +466,7 @@ function envCommand(words: readonly string[]): string | undefined {
   return undefined;
 }
 
-function splitShebangWords(input: string): string[] {
+function splitShebangWords(input: string): string[] | undefined {
   const words: string[] = [];
   let word = "";
   let started = false;
@@ -458,7 +509,7 @@ function splitShebangWords(input: string): string[] {
       started = true;
     }
   }
-  if (escaped) word += "\\";
+  if (escaped || quote !== undefined) return undefined;
   if (started) words.push(word);
   return words;
 }

--- a/packages/cli/lib/view/languages/markdown/language.ts
+++ b/packages/cli/lib/view/languages/markdown/language.ts
@@ -11,7 +11,6 @@ import type { HunkStructureContext, Language } from "../language.ts";
 import {
   createMarkdownHighlighter,
   highlightMarkdownLines,
-  isMarkdownPath,
   markdownDocument,
   markdownHeadingNodes,
   renderMarkdownLines,
@@ -20,7 +19,13 @@ import {
 export const markdownLanguage: Language = {
   id: "markdown",
 
-  matches: (fileName) => isMarkdownPath(fileName),
+  metadata: {
+    extensions: [".md", ".markdown", ".mdown", ".mkd", ".mdx"],
+    filenames: [],
+    filenamePatterns: [],
+    aliases: ["md"],
+    interpreters: [],
+  },
 
   parseDocument: (text) => markdownDocument(text),
 

--- a/packages/cli/lib/view/languages/markdown/markdown.ts
+++ b/packages/cli/lib/view/languages/markdown/markdown.ts
@@ -24,12 +24,6 @@ import { computeLineStarts, lineIndexOf } from "../../lines.ts";
 import { Lexer } from "marked";
 import { decodeHTMLStrict as decodeEntities } from "entities";
 
-/** Whether `fileName` names a Markdown file. */
-export function isMarkdownPath(fileName: string | undefined): boolean {
-  return fileName !== undefined &&
-    /\.(md|markdown|mdown|mkd|mdx)$/i.test(fileName);
-}
-
 /** Colour Markdown text into rendered lines. */
 export function highlightMarkdownLines(text: string): Line[] {
   const raw = text.split("\n");

--- a/packages/cli/lib/view/languages/plain-text/language.ts
+++ b/packages/cli/lib/view/languages/plain-text/language.ts
@@ -1,8 +1,7 @@
 /**
  * The plain-text language for input whose syntax `cf view` cannot select from
- * a filename. It must remain last in the language registry because it claims
- * every named file left after the syntax-specific languages; the registry also
- * returns it when no filename exists.
+ * a filename or shebang. It remains last in the language registry and is the
+ * registry's fallback.
  */
 import type { Language } from "../language.ts";
 import {
@@ -14,7 +13,13 @@ import {
 export const plainTextLanguage: Language = {
   id: "plain-text",
 
-  matches: (fileName) => fileName !== undefined,
+  metadata: {
+    extensions: [".txt"],
+    filenames: ["LICENSE", "NOTICE"],
+    filenamePatterns: [/^(?:LICENSE|NOTICE)\..+$/i],
+    aliases: ["text", "plaintext"],
+    interpreters: [],
+  },
 
   parseDocument: (text) => plainTextDocument(text),
 

--- a/packages/cli/lib/view/languages/python/language.ts
+++ b/packages/cli/lib/view/languages/python/language.ts
@@ -6,7 +6,6 @@
 import type { Language } from "../language.ts";
 import {
   createPythonHighlighter,
-  isPythonPath,
   pythonDocument,
   pythonHighlightLines,
 } from "./python.ts";
@@ -14,7 +13,16 @@ import {
 export const pythonLanguage: Language = {
   id: "python",
 
-  matches: (fileName) => isPythonPath(fileName),
+  metadata: {
+    extensions: [".py", ".pyi", ".pyw"],
+    filenames: [],
+    filenamePatterns: [],
+    aliases: ["py"],
+    interpreters: [
+      /^python(?:\d+(?:\.\d+)*)?$/,
+      /^pypy(?:\d+(?:\.\d+)*)?$/,
+    ],
+  },
 
   parseDocument: (text) => pythonDocument(text),
 

--- a/packages/cli/lib/view/languages/python/python.ts
+++ b/packages/cli/lib/view/languages/python/python.ts
@@ -13,11 +13,6 @@ import { cpLen } from "../../ansi.ts";
 import { computeLineStarts, lineIndexOf } from "../../lines.ts";
 import type { Highlighter } from "../language.ts";
 
-/** Whether `fileName` names a Python source or stub file. */
-export function isPythonPath(fileName: string | undefined): boolean {
-  return fileName !== undefined && /\.(py|pyi|pyw)$/i.test(fileName);
-}
-
 interface Token {
   readonly start: number;
   readonly end: number;

--- a/packages/cli/lib/view/languages/typescript/language.ts
+++ b/packages/cli/lib/view/languages/typescript/language.ts
@@ -19,10 +19,22 @@ import { createDiffSemantics, createSemantics } from "./semantics.ts";
 export const typeScriptLanguage: Language = {
   id: "typescript",
 
-  // Claims the TypeScript / JavaScript family (`.ts`, `.tsx`, `.mts`, `.cts`,
-  // `.js`, `.jsx`, `.mjs`, `.cjs`).
-  matches: (fileName) =>
-    fileName !== undefined && /\.[cm]?[jt]sx?$/i.test(fileName),
+  metadata: {
+    extensions: [
+      ".ts",
+      ".tsx",
+      ".mts",
+      ".cts",
+      ".js",
+      ".jsx",
+      ".mjs",
+      ".cjs",
+    ],
+    filenames: [],
+    filenamePatterns: [],
+    aliases: ["ts", "javascript", "js"],
+    interpreters: ["deno", "node", "nodejs", "bun"],
+  },
 
   parseDocument: (text, fileName) => parseDocument(text, fileName),
 

--- a/packages/cli/lib/view/languages/yaml/language.ts
+++ b/packages/cli/lib/view/languages/yaml/language.ts
@@ -6,7 +6,6 @@
 import type { Language } from "../language.ts";
 import {
   createYamlHighlighter,
-  isYamlPath,
   yamlDocument,
   yamlHighlightLines,
 } from "./yaml.ts";
@@ -14,7 +13,13 @@ import {
 export const yamlLanguage: Language = {
   id: "yaml",
 
-  matches: (fileName) => isYamlPath(fileName),
+  metadata: {
+    extensions: [".yaml", ".yml"],
+    filenames: [],
+    filenamePatterns: [],
+    aliases: ["yml"],
+    interpreters: [],
+  },
 
   parseDocument: (text) => yamlDocument(text),
 

--- a/packages/cli/lib/view/languages/yaml/yaml.ts
+++ b/packages/cli/lib/view/languages/yaml/yaml.ts
@@ -8,11 +8,6 @@ import type { Document, Line, Span, TokenClass } from "../../model.ts";
 import { cpLen } from "../../ansi.ts";
 import type { Highlighter } from "../language.ts";
 
-/** Whether `fileName` names a YAML file. */
-export function isYamlPath(fileName: string | undefined): boolean {
-  return fileName !== undefined && /\.ya?ml$/i.test(fileName);
-}
-
 interface QuoteState {
   readonly quote: "'" | '"';
   readonly cls: TokenClass;

--- a/packages/cli/lib/view/mod.ts
+++ b/packages/cli/lib/view/mod.ts
@@ -6,8 +6,8 @@
  * representation and exits, mirroring how `less`/`bat` behave when their
  * output is redirected.
  * Filename-free compiler output keeps the transformed TypeScript default.
- * Other filename-free source uses plain text unless an explicit language or
- * virtual filename selects another language.
+ * Other source uses filename and shebang metadata unless an explicit language
+ * selects another language.
  */
 import { renderLineColored } from "./highlight.ts";
 import { runPager } from "./pager.ts";
@@ -24,9 +24,10 @@ import {
   distinctLanguages,
   type Language,
   languageForFile,
-  languageForId,
+  languageForName,
+  languageForSource,
   languageForTransformedOutput,
-  languageIds,
+  languageNames,
   type Semantics,
 } from "./languages/language.ts";
 import {
@@ -111,11 +112,11 @@ function pipedSelection(options: ViewOptions): SourceSelection {
   if (options.language === undefined) {
     return { fileName: options.filename };
   }
-  const language = languageForId(options.language);
+  const language = languageForName(options.language);
   if (!language) {
     throw new ViewError(
       `cf view: unknown language "${options.language}". Available languages: ${
-        languageIds().join(", ")
+        languageNames().join(", ")
       }`,
     );
   }
@@ -220,14 +221,14 @@ export function buildView(
   const language = selection.language ??
     (transformedOutput
       ? languageForTransformedOutput()
-      : languageForFile(fileName));
+      : languageForSource(fileName, text));
   const doc = language.parseDocument(text, fileName);
   return {
     doc,
     semantics: () =>
       language.createSemantics?.(text, { cwd: safeCwd(), fileName }),
     // A real file is editable; a pipe (transformed output, etc.) is not.
-    editSource: file ? fileSource(file) : readonlySource(
+    editSource: file ? fileSource(file, language) : readonlySource(
       "This view is of a pipe — there is no underlying file to edit.",
       language,
       fileName,

--- a/packages/cli/test/completion-output.test.ts
+++ b/packages/cli/test/completion-output.test.ts
@@ -9,7 +9,7 @@ import {
   bashCompletionScript,
   zshCompletionScript,
 } from "../lib/completion/script.ts";
-import { languageIds } from "../lib/view/languages/language.ts";
+import { languageNames } from "../lib/view/languages/language.ts";
 import { main } from "../commands/main.ts";
 
 function staticFor(line: string): string[] {
@@ -87,8 +87,8 @@ Deno.test("--log-level=<value> keeps the inline prefix on candidates", async () 
   assertEquals(await completeFor("cf --log-level=de"), ["--log-level=debug"]);
 });
 
-Deno.test("cf view --language completes its accepted identifiers", async () => {
-  assertEquals(await completeFor("cf view --language "), languageIds());
+Deno.test("cf view --language completes its accepted names", async () => {
+  assertEquals(await completeFor("cf view --language "), languageNames());
 });
 
 Deno.test("candidates are filtered by the typed prefix", async () => {

--- a/packages/cli/test/view-cli.test.ts
+++ b/packages/cli/test/view-cli.test.ts
@@ -95,10 +95,10 @@ Deno.test("cf view --filename selects piped source by its virtual name", async (
   assertEquals(stdout, ["Title with weight"]);
 });
 
-Deno.test("cf view --language overrides a piped virtual filename", async () => {
+Deno.test("cf view --language aliases override a piped virtual filename", async () => {
   const source = "# Title with **weight**\n";
   const { code, stdout } = await cf(
-    "view --plain --rendered --color never --language markdown --filename notes.txt",
+    "view --plain --rendered --color never --language md --filename notes.txt",
     source,
   );
   assertEquals(code, 0);

--- a/packages/cli/test/view-filegateway-cov.test.ts
+++ b/packages/cli/test/view-filegateway-cov.test.ts
@@ -128,6 +128,23 @@ Deno.test("realFileGateway.open: reads a file into an editable source and its te
   });
 });
 
+Deno.test("realFileGateway.open: keeps shebang selection in the editable source", async () => {
+  await withTempDir((dir) => {
+    const path = join(dir, "greet");
+    const contents = "#!/usr/bin/env python3\ndef greet():\n    return 'hi'\n";
+    Deno.writeTextFileSync(path, contents);
+
+    const opened = realFileGateway().open(path);
+    assert(opened !== null);
+    assert(
+      opened.source.parse(contents).lines.flatMap((line) => line.spans).some(
+        (span) => span.cls === "storageKeyword" && span.text === "def",
+      ),
+      "the editable source retains Python selection",
+    );
+  });
+});
+
 Deno.test("realFileGateway.open: returns null when the file cannot be read", () => {
   const gw = realFileGateway();
   const missing = join(Deno.cwd(), "definitely-not-a-real-file-xyz-12345.ts");

--- a/packages/cli/test/view-json.test.ts
+++ b/packages/cli/test/view-json.test.ts
@@ -10,7 +10,6 @@ import { assert, assertEquals } from "@std/assert";
 import { join } from "@std/path";
 import {
   createJsonHighlighter,
-  isJsonPath,
   jsonDocument,
   jsonHighlightLines,
 } from "../lib/view/languages/json/json.ts";
@@ -34,21 +33,13 @@ function classesOf(lines: readonly Line[], token: string): Set<TokenClass> {
   return out;
 }
 
-Deno.test("json: isJsonPath recognises json extensions", () => {
-  assert(isJsonPath("deno.json"));
-  assert(isJsonPath("/a/b/tsconfig.jsonc"));
-  assert(isJsonPath("UPPER.JSON"));
-  assert(!isJsonPath("main.ts"));
-  assert(!isJsonPath("README.md"));
-  assert(!isJsonPath(undefined));
-});
-
-Deno.test("json: the registry selects JSON for .json and .jsonc", () => {
+Deno.test("json: language metadata selects JSON filenames", () => {
   assertEquals(languageForFile("deno.json").id, "json");
-  assertEquals(languageForFile("cfg.jsonc").id, "json");
-  // Other registered selections remain unchanged.
+  assertEquals(languageForFile("/a/b/tsconfig.jsonc").id, "json");
+  assertEquals(languageForFile("UPPER.JSON").id, "json");
+  assertEquals(languageForFile("config.json.example").id, "json");
   assertEquals(languageForFile("main.ts").id, "typescript");
-  assertEquals(languageForFile("notes.md").id, "markdown");
+  assertEquals(languageForFile("README.md").id, "markdown");
   assertEquals(languageForFile(undefined).id, "plain-text");
 });
 

--- a/packages/cli/test/view-language.test.ts
+++ b/packages/cli/test/view-language.test.ts
@@ -10,6 +10,7 @@ import { join } from "@std/path";
 import {
   diffSemanticsFor,
   distinctLanguages,
+  indexLanguagesByName,
   languageForFile,
   languageForName,
   languageForSource,
@@ -118,6 +119,26 @@ Deno.test("languageForName: identifiers and aliases resolve explicit overrides",
   ]);
 });
 
+Deno.test("language names reject ambiguous identifiers and aliases", () => {
+  const collidingLanguage = {
+    ...markdownLanguage,
+    id: "other-markdown",
+    metadata: {
+      ...markdownLanguage.metadata,
+      aliases: ["typescript"],
+    },
+  };
+  assertThrows(
+    () =>
+      indexLanguagesByName([
+        typeScriptLanguage,
+        collidingLanguage,
+      ]),
+    Error,
+    'Language name "typescript" belongs to both typescript and other-markdown',
+  );
+});
+
 Deno.test("languageForSource: filenames precede direct and env shebangs", () => {
   assertEquals(
     languageForSource(
@@ -133,6 +154,18 @@ Deno.test("languageForSource: filenames precede direct and env shebangs", () => 
     ),
     typeScriptLanguage,
   );
+  for (
+    const shebang of [
+      '#!/usr/bin/python3 "unterminated',
+      "#!/usr/bin/python3 trailing\\",
+    ]
+  ) {
+    assertEquals(
+      languageForSource("tool", `${shebang}\n`),
+      pythonLanguage,
+      shebang,
+    );
+  }
   assertEquals(
     languageForSource(
       "tool",
@@ -142,9 +175,20 @@ Deno.test("languageForSource: filenames precede direct and env shebangs", () => 
   );
   for (
     const shebang of [
+      "#!/usr/bin/env -v CF_VIEW_REVIEW=1 python3",
+      "#!/usr/bin/env --unset PYTHONPATH python3",
+      "#!/usr/bin/env -iu PYTHONPATH python3",
+      "#!/usr/bin/env -iP /usr/bin python3",
+      "#!/usr/bin/env -iC /tmp python3",
+      "#!/usr/bin/env -iuPYTHONPATH python3",
       "#!/usr/bin/env -S CF_VIEW_REVIEW=1 python3 -u",
       '#!/usr/bin/env -S CF_VIEW_REVIEW="quoted value" python3 -u',
       "#!/usr/bin/env -S -u PYTHONPATH python3",
+      "#!/usr/bin/env -S -iu PYTHONPATH python3",
+      "#!/usr/bin/env -S -iP /usr/bin python3",
+      "#!/usr/bin/env -S -iC /tmp python3",
+      "#!/usr/bin/env -S -iuPYTHONPATH python3",
+      "#!/usr/bin/env --split-string python3 -u",
       "#!/usr/bin/env --split-string=CF_VIEW_REVIEW=1 python3 -u",
       "#!/usr/bin/env -vS python3 -S",
       "#!/usr/bin/env -vSpython3 -S",
@@ -192,6 +236,56 @@ Deno.test("languageForSource: filenames precede direct and env shebangs", () => 
     languageForSource("tool", "#!/usr/bin/env bash\necho plain\n"),
     plainTextLanguage,
   );
+});
+
+Deno.test("languageForSource: malformed and option-only shebangs fall back safely", () => {
+  assertEquals(languageForSource("tool", "#!   \n"), plainTextLanguage);
+  assertEquals(
+    languageForSource("tool", "#!/usr/bin/env -- python3\n"),
+    pythonLanguage,
+  );
+  assertEquals(
+    languageForSource("tool", "#!/usr/bin/env --\n"),
+    plainTextLanguage,
+  );
+  assertEquals(
+    languageForSource("tool", "#!/usr/bin/env\n"),
+    plainTextLanguage,
+  );
+  assertEquals(
+    languageForSource("tool", "#!/usr/bin/env -u PATH\n"),
+    plainTextLanguage,
+  );
+  for (
+    const shebang of [
+      '#!/usr/bin/env python3 "unterminated',
+      "#!/usr/bin/env python3 argument\\",
+    ]
+  ) {
+    assertEquals(
+      languageForSource("tool", `${shebang}\n`),
+      pythonLanguage,
+      shebang,
+    );
+  }
+  for (
+    const shebang of [
+      '#!/usr/bin/env "python3"',
+      "#!/usr/bin/env py\\thon3",
+      "#!/usr/bin/env python3\\x",
+      '#!/usr/bin/env "python3\\x"',
+      "#!/usr/bin/env python3\\",
+      '#!/usr/bin/env "python3',
+      "#!/usr/bin/env 'python3",
+      '#!/usr/bin/env -S "python3',
+    ]
+  ) {
+    assertEquals(
+      languageForSource("tool", `${shebang}\n`),
+      plainTextLanguage,
+      shebang,
+    );
+  }
 });
 
 Deno.test("distinctLanguages: dedupes in first-seen order", () => {

--- a/packages/cli/test/view-language.test.ts
+++ b/packages/cli/test/view-language.test.ts
@@ -1,6 +1,6 @@
 /**
- * Language selection: `languageForFile` picks a language by extension and uses
- * plain text when no filename matches. Transformed compiler output selects
+ * Language selection: declarative metadata covers filenames, aliases, and
+ * shebangs, with plain text when none match. Transformed compiler output selects
  * TypeScript through a separate path. `distinctLanguages` dedupes the languages
  * a diff touches, and `diffSemanticsFor` composes the diff view's semantic layer
  * from the languages present, scoped to each one's files.
@@ -11,9 +11,13 @@ import {
   diffSemanticsFor,
   distinctLanguages,
   languageForFile,
-  languageForId,
+  languageForName,
+  languageForSource,
   languageForTransformedOutput,
   languageIds,
+  type LanguageMetadata,
+  languageNames,
+  metadataMatchesFilename,
   renderedLinesFor,
 } from "../lib/view/languages/language.ts";
 import { typeScriptLanguage } from "../lib/view/languages/typescript/language.ts";
@@ -34,6 +38,9 @@ Deno.test("languageForFile: named files resolve and missing names use plain text
   for (const ts of ["a.ts", "a.tsx", "a.mts", "a.cts", "a.js", "a.jsx"]) {
     assertEquals(languageForFile(ts).id, "typescript", ts);
   }
+  for (const name of ["a.mtsx", "a.ctsx", "a.mjsx", "a.cjsx"]) {
+    assertEquals(languageForFile(name).id, "plain-text", name);
+  }
   assertEquals(languageForFile("README.md").id, "markdown");
   assertEquals(languageForFile("deno.jsonc").id, "json");
   assertEquals(languageForFile("workflow.yml").id, "yaml");
@@ -44,6 +51,24 @@ Deno.test("languageForFile: named files resolve and missing names use plain text
   assertEquals(languageForTransformedOutput().id, "typescript");
 });
 
+Deno.test("language metadata matches extensions, exact names, and compound patterns", () => {
+  const metadata: LanguageMetadata = {
+    extensions: [".demo"],
+    filenames: ["BUILD"],
+    filenamePatterns: [/^Dockerfile\..+$/i],
+    aliases: ["example"],
+    interpreters: ["example-runner"],
+  };
+
+  assert(metadataMatchesFilename(metadata, "/repo/source.DEMO"));
+  assert(metadataMatchesFilename(metadata, "/repo/BUILD"));
+  assert(metadataMatchesFilename(metadata, "containers/Dockerfile.x86_64"));
+  assert(metadataMatchesFilename(metadata, "containers/DOCKERFILE.debug"));
+  assert(!metadataMatchesFilename(metadata, "/repo/build"));
+  assert(!metadataMatchesFilename(metadata, "/repo/demo"));
+  assert(!metadataMatchesFilename(metadata, undefined));
+});
+
 Deno.test("languageForFile: named JavaScript uses the TypeScript-family parser", () => {
   const source = "export const answer = 42;\n";
   const doc = languageForFile("answer.js").parseDocument(source, "answer.js");
@@ -51,15 +76,21 @@ Deno.test("languageForFile: named JavaScript uses the TypeScript-family parser",
   assert(doc.lines[0].spans.some((span) => span.cls === "storageKeyword"));
 });
 
-Deno.test("languageForId: stable identifiers resolve explicit overrides", () => {
-  assertEquals(languageForId("typescript"), typeScriptLanguage);
-  assertEquals(languageForId("markdown"), markdownLanguage);
-  assertEquals(languageForId("json"), jsonLanguage);
-  assertEquals(languageForId("yaml"), yamlLanguage);
-  assertEquals(languageForId("python"), pythonLanguage);
-  assertEquals(languageForId("plain-text"), plainTextLanguage);
-  assertEquals(languageForId("TypeScript"), undefined);
-  assertEquals(languageForId("ruby"), undefined);
+Deno.test("languageForName: identifiers and aliases resolve explicit overrides", () => {
+  assertEquals(languageForName("typescript"), typeScriptLanguage);
+  assertEquals(languageForName("js"), typeScriptLanguage);
+  assertEquals(languageForName("markdown"), markdownLanguage);
+  assertEquals(languageForName("md"), markdownLanguage);
+  assertEquals(languageForName("json"), jsonLanguage);
+  assertEquals(languageForName("jsonc"), jsonLanguage);
+  assertEquals(languageForName("yaml"), yamlLanguage);
+  assertEquals(languageForName("yml"), yamlLanguage);
+  assertEquals(languageForName("python"), pythonLanguage);
+  assertEquals(languageForName("py"), pythonLanguage);
+  assertEquals(languageForName("plain-text"), plainTextLanguage);
+  assertEquals(languageForName("plaintext"), plainTextLanguage);
+  assertEquals(languageForName("TypeScript"), undefined);
+  assertEquals(languageForName("ruby"), undefined);
   assertEquals(languageIds(), [
     "typescript",
     "markdown",
@@ -68,6 +99,99 @@ Deno.test("languageForId: stable identifiers resolve explicit overrides", () => 
     "python",
     "plain-text",
   ]);
+  assertEquals(languageNames(), [
+    "typescript",
+    "ts",
+    "javascript",
+    "js",
+    "markdown",
+    "md",
+    "json",
+    "jsonc",
+    "yaml",
+    "yml",
+    "python",
+    "py",
+    "plain-text",
+    "text",
+    "plaintext",
+  ]);
+});
+
+Deno.test("languageForSource: filenames precede direct and env shebangs", () => {
+  assertEquals(
+    languageForSource(
+      "tool",
+      "#!/usr/bin/python3.12\nprint('selected from a direct shebang')\n",
+    ),
+    pythonLanguage,
+  );
+  assertEquals(
+    languageForSource(
+      undefined,
+      "#!/usr/bin/env -S deno run --allow-read\nconsole.log('deno');\n",
+    ),
+    typeScriptLanguage,
+  );
+  assertEquals(
+    languageForSource(
+      "tool",
+      "#!/usr/bin/env -u PYTHONPATH python3\nprint('env options');\n",
+    ),
+    pythonLanguage,
+  );
+  for (
+    const shebang of [
+      "#!/usr/bin/env -S CF_VIEW_REVIEW=1 python3 -u",
+      '#!/usr/bin/env -S CF_VIEW_REVIEW="quoted value" python3 -u',
+      "#!/usr/bin/env -S -u PYTHONPATH python3",
+      "#!/usr/bin/env --split-string=CF_VIEW_REVIEW=1 python3 -u",
+      "#!/usr/bin/env -vS python3 -S",
+      "#!/usr/bin/env -vSpython3 -S",
+      "#!/usr/bin/env python3 --split-string=node",
+    ]
+  ) {
+    assertEquals(
+      languageForSource("tool", `${shebang}\nprint('env split string');\n`),
+      pythonLanguage,
+      shebang,
+    );
+  }
+  for (const interpreter of ["deno", "node", "nodejs", "bun"]) {
+    assertEquals(
+      languageForSource(
+        "tool",
+        `#!/usr/bin/env ${interpreter}\nconsole.log('selected');\n`,
+      ),
+      typeScriptLanguage,
+      interpreter,
+    );
+  }
+  assertEquals(
+    languageForSource(
+      "notes.md",
+      "#!/usr/bin/env python3\n# Markdown filename wins\n",
+    ),
+    markdownLanguage,
+  );
+  assertEquals(
+    languageForSource(
+      "notes.txt",
+      "#!/usr/bin/env python3\nprint('plain-text filename wins');\n",
+    ),
+    plainTextLanguage,
+  );
+  assertEquals(
+    languageForSource(
+      "LICENSE",
+      "#!/usr/bin/env python3\nprint('exact filename wins');\n",
+    ),
+    plainTextLanguage,
+  );
+  assertEquals(
+    languageForSource("tool", "#!/usr/bin/env bash\necho plain\n"),
+    plainTextLanguage,
+  );
 });
 
 Deno.test("distinctLanguages: dedupes in first-seen order", () => {

--- a/packages/cli/test/view-language.test.ts
+++ b/packages/cli/test/view-language.test.ts
@@ -176,6 +176,7 @@ Deno.test("languageForSource: filenames precede direct and env shebangs", () => 
   for (
     const shebang of [
       "#!/usr/bin/env -v CF_VIEW_REVIEW=1 python3",
+      "#!/usr/bin/env -- CF_VIEW_REVIEW=1 python3",
       "#!/usr/bin/env --unset PYTHONPATH python3",
       "#!/usr/bin/env -iu PYTHONPATH python3",
       "#!/usr/bin/env -iP /usr/bin python3",
@@ -188,6 +189,36 @@ Deno.test("languageForSource: filenames precede direct and env shebangs", () => 
       "#!/usr/bin/env -S -iP /usr/bin python3",
       "#!/usr/bin/env -S -iC /tmp python3",
       "#!/usr/bin/env -S -iuPYTHONPATH python3",
+      "#!/usr/bin/env -S -- python3",
+      "#!/usr/bin/env -S -- CF_VIEW_REVIEW=1 python3",
+      "#!/usr/bin/env -S -S python3",
+      '#!/usr/bin/env -S -S "" python3',
+      '#!/usr/bin/env -S -S "-u" PYTHONPATH python3',
+      '#!/usr/bin/env -S -S "--" CF_VIEW_REVIEW=1 python3',
+      '#!/usr/bin/env -S -S "python3 -u"',
+      '#!/usr/bin/env -S -S "CF_VIEW_REVIEW=1" python3',
+      '#!/usr/bin/env -S --split-string "python3 -u"',
+      "#!/usr/bin/env -S --split-string=python3",
+      '#!/usr/bin/env -S --split-string="python3 -u"',
+      '#!/usr/bin/env -S --split-string="CF_VIEW_REVIEW=1" python3',
+      "#!/usr/bin/env -S -vS python3",
+      "#!/usr/bin/env -S -vSpython3",
+      '#!/usr/bin/env -S -vS"python3 -u"',
+      "#!/usr/bin/env -S -S#ignored python3",
+      "#!/usr/bin/env -S --split-string=#ignored python3",
+      "#!/usr/bin/env -S CF=has\\\\backslash python3",
+      '#!/usr/bin/env -S "CF=has\\$dollar" python3',
+      "#!/usr/bin/env -S 'CF=has\\ttext' python3",
+      "#!/usr/bin/env -S CF=one\\ two python3",
+      "#!/usr/bin/env -S CF=one\\\ttwo python3",
+      '#!/usr/bin/env -S "CF=one\\ two" python3',
+      "#!/usr/bin/env -S CF=one\\_python3",
+      '#!/usr/bin/env -S "CF=one\\_two" python3',
+      "#!/usr/bin/env -S ${CF_VIEW_BIN}/python3",
+      '#!/usr/bin/env -S "${CF_VIEW_BIN}/python3"',
+      "#!/usr/bin/env -S '$CF_VIEW_BIN/python3'",
+      "#!/usr/bin/env -S python3\\c ignored",
+      "#!/usr/bin/env -S python3 # ignored",
       "#!/usr/bin/env --split-string python3 -u",
       "#!/usr/bin/env --split-string=CF_VIEW_REVIEW=1 python3 -u",
       "#!/usr/bin/env -vS python3 -S",
@@ -199,6 +230,16 @@ Deno.test("languageForSource: filenames precede direct and env shebangs", () => 
       languageForSource("tool", `${shebang}\nprint('env split string');\n`),
       pythonLanguage,
       shebang,
+    );
+  }
+  const deeplyNestedSplit = "--split-string=".repeat(20_000);
+  for (const command of ["python3", "${CF_VIEW_BIN}/python3"]) {
+    assertEquals(
+      languageForSource(
+        "tool",
+        `#!/usr/bin/env -S ${deeplyNestedSplit}${command}\n`,
+      ),
+      pythonLanguage,
     );
   }
   for (const interpreter of ["deno", "node", "nodejs", "bun"]) {
@@ -253,6 +294,14 @@ Deno.test("languageForSource: malformed and option-only shebangs fall back safel
     plainTextLanguage,
   );
   assertEquals(
+    languageForSource("tool", "#!/usr/bin/env -S\n"),
+    plainTextLanguage,
+  );
+  assertEquals(
+    languageForSource("tool", "#!/usr/bin/env -S --\n"),
+    plainTextLanguage,
+  );
+  assertEquals(
     languageForSource("tool", "#!/usr/bin/env -u PATH\n"),
     plainTextLanguage,
   );
@@ -278,6 +327,27 @@ Deno.test("languageForSource: malformed and option-only shebangs fall back safel
       '#!/usr/bin/env "python3',
       "#!/usr/bin/env 'python3",
       '#!/usr/bin/env -S "python3',
+      "#!/usr/bin/env -S -u",
+      "#!/usr/bin/env -S -S",
+      "#!/usr/bin/env -S -vS",
+      "#!/usr/bin/env -S -S '\"python3'",
+      "#!/usr/bin/env -S py\\thon3",
+      '#!/usr/bin/env -S "py\\thon3"',
+      "#!/usr/bin/env -S python3\\x",
+      '#!/usr/bin/env -S "python3\\c"',
+      "#!/usr/bin/env -S # python3",
+      "#!/usr/bin/env -S -S#/usr/bin/python3",
+      "#!/usr/bin/env -S --split-string=#/usr/bin/python3",
+      "#!/usr/bin/env -S $CF_VIEW_BIN/python3",
+      "#!/usr/bin/env -S $*/python3",
+      "#!/usr/bin/env -S ${}/python3",
+      "#!/usr/bin/env -S ${1}/python3",
+      "#!/usr/bin/env -S ${A-B}/python3",
+      "#!/usr/bin/env -S ${CF_VIEW_BIN/python3",
+      '#!/usr/bin/env -S "$CF_VIEW_BIN/python3"',
+      "#!/usr/bin/env CF_VIEW_REVIEW=1 -S python3",
+      "#!/usr/bin/env -S CF_VIEW_REVIEW=1 -S python3",
+      '#!/usr/bin/env -S -S "CF_VIEW_REVIEW=1" -S python3',
     ]
   ) {
     assertEquals(

--- a/packages/cli/test/view-markdown.test.ts
+++ b/packages/cli/test/view-markdown.test.ts
@@ -7,7 +7,6 @@ import { assert, assertEquals } from "@std/assert";
 import { join } from "@std/path";
 import {
   highlightMarkdownLines,
-  isMarkdownPath,
   markdownDocument,
 } from "../lib/view/languages/markdown/markdown.ts";
 import { languageForFile } from "../lib/view/languages/language.ts";
@@ -16,13 +15,13 @@ import { buildDiffDocument, type DiffWorkspace } from "../lib/view/diffdoc.ts";
 import { createDiffHighlighter } from "../lib/view/diffedit.ts";
 import { spanStyle } from "../lib/view/highlight.ts";
 
-Deno.test("markdown: isMarkdownPath recognises markdown extensions", () => {
-  assert(isMarkdownPath("README.md"));
-  assert(isMarkdownPath("/a/b/AGENTS.markdown"));
-  assert(isMarkdownPath("notes.MD"));
-  assert(!isMarkdownPath("foo.ts"));
-  assert(!isMarkdownPath("foo.tsx"));
-  assert(!isMarkdownPath(undefined));
+Deno.test("markdown: language metadata recognises markdown extensions", () => {
+  assertEquals(languageForFile("README.md").id, "markdown");
+  assertEquals(languageForFile("/a/b/AGENTS.markdown").id, "markdown");
+  assertEquals(languageForFile("notes.MD").id, "markdown");
+  assertEquals(languageForFile("foo.ts").id, "typescript");
+  assertEquals(languageForFile("foo.tsx").id, "typescript");
+  assertEquals(languageForFile(undefined).id, "plain-text");
 });
 
 Deno.test("markdown: headings, code, lists, quotes and prose get distinct, non-TS colours", () => {

--- a/packages/cli/test/view-mod-cov.test.ts
+++ b/packages/cli/test/view-mod-cov.test.ts
@@ -80,6 +80,24 @@ Deno.test("buildView: a virtual filename selects piped source without making it 
   assertEquals(r.editSource.parse(source), r.doc);
 });
 
+Deno.test("buildView: a shebang selects an extensionless source and its editor", () => {
+  const source = "#!/usr/bin/env python3\ndef greet():\n    return 'hello'\n";
+  const piped = buildView(source);
+  const file = buildView(source, "greet");
+
+  for (const view of [piped, file]) {
+    assert(
+      view.doc.lines.flatMap((line) => line.spans).some((span) =>
+        span.cls === "storageKeyword" && span.text === "def"
+      ),
+      "the Python shebang selects Python highlighting",
+    );
+    assertEquals(view.editSource.parse(source), view.doc);
+  }
+  assertEquals(piped.editSource.editable, false);
+  assertEquals(file.editSource.editable, true);
+});
+
 Deno.test("buildView: an explicit language takes priority over a virtual filename", () => {
   const source = "# **Piped heading**\n";
   const r = buildView(source, undefined, undefined, {

--- a/packages/cli/test/view-python.test.ts
+++ b/packages/cli/test/view-python.test.ts
@@ -6,7 +6,6 @@ import { assert, assertEquals } from "@std/assert";
 import { join } from "@std/path";
 import {
   createPythonHighlighter,
-  isPythonPath,
   pythonDocument,
   pythonHighlightLines,
 } from "../lib/view/languages/python/python.ts";
@@ -54,12 +53,15 @@ function tempWorkspace(root: string): DiffWorkspace {
   };
 }
 
-Deno.test("python: path matching recognises source, stub, and windowed files", () => {
+Deno.test("python: metadata selects source, stub, and windowed files", () => {
   for (const path of ["main.py", "types.pyi", "app.pyw", "/tmp/UPPER.PY"]) {
-    assert(isPythonPath(path), path);
+    assertEquals(languageForFile(path).id, "python", path);
   }
   for (const path of ["module.pyc", "archive.pyz", "notes.md", undefined]) {
-    assert(!isPythonPath(path), String(path));
+    assert(
+      languageForFile(path).id !== "python",
+      `${String(path)} selected Python`,
+    );
   }
 });
 

--- a/packages/cli/test/view-yaml.test.ts
+++ b/packages/cli/test/view-yaml.test.ts
@@ -6,7 +6,6 @@ import { assert, assertEquals, assertStrictEquals } from "@std/assert";
 import { join } from "@std/path";
 import {
   createYamlHighlighter,
-  isYamlPath,
   yamlDocument,
   yamlHighlightLines,
 } from "../lib/view/languages/yaml/yaml.ts";
@@ -32,14 +31,15 @@ function classesOf(lines: readonly Line[], token: string): Set<TokenClass> {
 }
 
 Deno.test("yaml: path matching recognizes yml and yaml", () => {
-  assert(isYamlPath("config.yaml"));
-  assert(isYamlPath("/repo/.github/workflows/check.yml"));
-  assert(isYamlPath("UPPER.YAML"));
-  assert(!isYamlPath("config.json"));
-  assert(!isYamlPath("yaml.ts"));
-  assert(!isYamlPath(undefined));
   assertEquals(languageForFile("config.yaml").id, "yaml");
-  assertEquals(languageForFile("check.yml").id, "yaml");
+  assertEquals(
+    languageForFile("/repo/.github/workflows/check.yml").id,
+    "yaml",
+  );
+  assertEquals(languageForFile("UPPER.YAML").id, "yaml");
+  assertEquals(languageForFile("config.json").id, "json");
+  assertEquals(languageForFile("yaml.ts").id, "typescript");
+  assertEquals(languageForFile(undefined).id, "plain-text");
 });
 
 Deno.test("yaml: keys and scalar types receive distinct classes", () => {


### PR DESCRIPTION
Language selection was spread across parser-specific filename predicates. Those predicates could not expose exact names, compound patterns, aliases, or shebang interpreters through one registry.

Add required metadata for extensions, exact filenames, filename patterns, explicit aliases, and interpreter patterns. Route filename matching, explicit overrides, direct-source shebang selection, and file-picker editing through the shared registry. Keep recognized filename metadata ahead of shebang selection.

Handle direct interpreters and env split-string forms without treating interpreter arguments as env options. Preserve quoted assignment values while selecting Python, Deno, Node, or Bun scripts.

Define metadata for every existing language, recognize JSON example filenames, and replace the broad TypeScript-family regular expression with exact supported extensions. Update help, completion, reference documentation, tests, and the live coverage plan.

Verified with the affected CLI tests, repository type checking, repo-wide formatting and lint checks, and independent forward and reverse adversarial reviews.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch `cf view` language selection to a shared metadata registry for filenames, aliases, and shebangs. Adds faithful shebang detection (direct and `env -S`) for Python and the TS/JS family (Node, Deno, Bun), keeps filename precedence, and preserves the chosen language in editors and the file picker.

- **New Features**
  - Registry metadata: extensions, exact names, patterns, aliases, interpreters; replaces per-language predicates.
  - `--language` accepts identifiers or aliases; completion lists all registry names.
  - Recognize JSON example filenames; narrow TS/JS matching to exact extensions; apply shebang selection to real files via the file gateway.

- **Bug Fixes**
  - Parse `env -S` split strings faithfully: model quoting, escapes, comments, and variable syntax; handle nested and grouped options without recursion.
  - Do not apply split-string rules to ordinary `env` arguments; consume long and combined short option operands before selecting the command.
  - Reject duplicate identifiers or aliases in the registry to prevent ambiguity.

<sup>Written for commit 24008f613b6958e7c23d48f06070be9fac25f2e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

