### PR TITLE
fix(cli): expose called member definitions in view cards

### DIFF
--- a/packages/cli/lib/view/card.ts
+++ b/packages/cli/lib/view/card.ts
@@ -149,9 +149,21 @@ export function buildPeekCard(
 
   append(outlineSection(node, expanded));
   append(usesSection(doc, node, expanded));
-  append(depsSection(doc, node, definitionOf, identUses, expanded));
+  const dependencies = depsSection(
+    doc,
+    node,
+    definitionOf,
+    identUses,
+    expanded,
+  );
+  append(dependencies);
   append(externalSection(definitionOf, identUses, expanded));
-  append(deferredDefinitionsSection(deferredIdentUses));
+  append(
+    deferredDefinitionsSection(
+      deferredIdentUses,
+      dependencies.deferredDependencies,
+    ),
+  );
 
   // Drop a trailing blank for tidiness.
   while (info.length > 0 && info[info.length - 1].text === "") info.pop();
@@ -495,7 +507,7 @@ function depsSection(
   definitionOf: DefinitionLookup | undefined,
   identUses: readonly IdentUse[],
   expanded: boolean,
-): Section {
+): Section & { deferredDependencies: number } {
   const deps = findDependencies(doc, node);
   const processedOffsets = definitionOf
     ? new Set(identUses.map((use) => use.useOffset))
@@ -511,8 +523,12 @@ function depsSection(
     defEndOffset?: number;
     definitionOffset: number;
   }[] = [];
+  let deferredDependencies = 0;
   for (const d of deps) {
-    if (processedOffsets && !processedOffsets.has(d.useOffset)) continue;
+    if (processedOffsets && !processedOffsets.has(d.useOffset)) {
+      deferredDependencies++;
+      continue;
+    }
     const jump = dependencyJump(doc, d, definitionOf);
     if (jump.external) continue; // a same-named external def; in "defined elsewhere"
     candidates.push({
@@ -607,10 +623,12 @@ function depsSection(
       candidate.definitionOffset,
     );
   }
-  if (rows.length === 0) return { lines: [], targets: [] };
+  if (rows.length === 0) {
+    return { lines: [], targets: [], deferredDependencies };
+  }
   const lines: Line[] = [heading(`depends on · ${rows.length}`), ...rows];
   if (more > 0) pushMore(lines, targets, more);
-  return { lines, targets };
+  return { lines, targets, deferredDependencies };
 }
 
 /**
@@ -729,14 +747,25 @@ function cachedDefinitionLookup(semantics: Semantics): DefinitionLookup {
 
 /** A collapsed card resolves a bounded prefix of symbol uses. This selectable
  * row rebuilds the card with every remaining position resolved. */
-function deferredDefinitionsSection(count: number): Section {
+function deferredDefinitionsSection(
+  count: number,
+  possibleDependencies: number,
+): Section {
   if (count === 0) return { lines: [], targets: [] };
+  const possible = possibleDependencies === 0
+    ? ""
+    : ` · ${possibleDependencies} possible ${
+      possibleDependencies === 1 ? "dependency" : "dependencies"
+    }`;
   return {
     lines: [
       heading("definition lookup"),
       row(
         ["  … inspect ", "comment"],
-        [`${count} remaining use${count === 1 ? "" : "s"}`, "comment"],
+        [
+          `${count} remaining use${count === 1 ? "" : "s"}${possible}`,
+          "comment",
+        ],
       ),
     ],
     targets: [{

--- a/packages/cli/lib/view/card.ts
+++ b/packages/cli/lib/view/card.ts
@@ -18,10 +18,11 @@ import type {
 } from "./model.ts";
 import {
   ancestorsOf,
-  collectIdentUses,
+  collectIdentUsesBounded,
   type Dependency,
   findDependencies,
   findReferences,
+  type IdentUse,
 } from "./references.ts";
 import { basename } from "@std/path";
 import { cpLen } from "./ansi.ts";
@@ -73,6 +74,7 @@ export interface PeekCard {
 const MAX_CHILDREN = 14;
 const MAX_USES = 10;
 const MAX_DEPS = 10;
+const MAX_SEMANTIC_USES = 40;
 
 export function buildPeekCard(
   doc: Document,
@@ -95,6 +97,18 @@ export function buildPeekCard(
     ? node.meta.typeText
     : undefined;
   const typeText = inferredType ?? syntacticType;
+  const collectedIdentUses = semantics
+    ? collectIdentUsesBounded(
+      doc,
+      node,
+      expanded ? Number.POSITIVE_INFINITY : MAX_SEMANTIC_USES,
+    )
+    : { uses: [], total: 0 };
+  const identUses = collectedIdentUses.uses;
+  const deferredIdentUses = collectedIdentUses.total - identUses.length;
+  const definitionOf = semantics
+    ? cachedDefinitionLookup(semantics)
+    : undefined;
 
   const append = (section: Section) => {
     if (section.lines.length === 0) return;
@@ -135,8 +149,9 @@ export function buildPeekCard(
 
   append(outlineSection(node, expanded));
   append(usesSection(doc, node, expanded));
-  append(depsSection(doc, node, semantics, expanded));
-  append(externalSection(doc, node, semantics, expanded));
+  append(depsSection(doc, node, definitionOf, identUses, expanded));
+  append(externalSection(definitionOf, identUses, expanded));
+  append(deferredDefinitionsSection(deferredIdentUses));
 
   // Drop a trailing blank for tidiness.
   while (info.length > 0 && info[info.length - 1].text === "") info.pop();
@@ -477,35 +492,120 @@ function usesSection(
 function depsSection(
   doc: Document,
   node: StructureNode,
-  semantics: Semantics | undefined,
+  definitionOf: DefinitionLookup | undefined,
+  identUses: readonly IdentUse[],
   expanded: boolean,
 ): Section {
   const deps = findDependencies(doc, node);
-  const rows: Line[] = [];
-  const targets: TargetRel[] = [];
-  let more = 0;
+  const processedOffsets = definitionOf
+    ? new Set(identUses.map((use) => use.useOffset))
+    : undefined;
+  const candidates: {
+    useOffset: number;
+    name: string;
+    displayName: string;
+    kind: StructureNode["kind"];
+    destLine: number;
+    destCol: number;
+    defOffset: number;
+    defEndOffset?: number;
+    definitionOffset: number;
+  }[] = [];
   for (const d of deps) {
-    const jump = dependencyJump(doc, d, semantics);
+    if (processedOffsets && !processedOffsets.has(d.useOffset)) continue;
+    const jump = dependencyJump(doc, d, definitionOf);
     if (jump.external) continue; // a same-named external def; in "defined elsewhere"
-    if (!expanded && rows.length >= MAX_DEPS) {
-      more++;
-      continue;
-    }
-    targets.push({
-      relLine: rows.length + 1, // +1 for the heading prepended below
+    candidates.push({
+      useOffset: d.useOffset,
+      name: d.name,
+      displayName: d.name,
+      kind: d.kind,
       destLine: jump.destLine,
       destCol: 0,
       defOffset: jump.defOffset,
       defEndOffset: jump.defEndOffset,
+      definitionOffset: jump.defOffset,
+    });
+  }
+
+  if (definitionOf) {
+    for (const use of identUses) {
+      if (!use.exactDefinitionOnly) continue;
+      const inBlob = definitionOf(use.useOffset).find((target) =>
+        target.blobOffset !== undefined
+      );
+      if (inBlob?.blobOffset === undefined) continue;
+      if (
+        inBlob.blobOffset >= node.startOffset &&
+        inBlob.blobOffset < node.endOffset
+      ) {
+        continue;
+      }
+      const targetNode = enclosingNode(doc, inBlob.blobOffset);
+      candidates.push({
+        useOffset: use.useOffset,
+        name: use.name,
+        displayName: use.displayName ?? use.name,
+        kind: targetNode?.kind ?? "node",
+        destLine: inBlob.line,
+        destCol: inBlob.col ?? targetNode?.startCol ?? 0,
+        defOffset: targetNode?.startOffset ?? inBlob.blobOffset,
+        defEndOffset: targetNode?.endOffset,
+        definitionOffset: inBlob.blobOffset,
+      });
+    }
+  }
+  candidates.sort((a, b) => a.useOffset - b.useOffset);
+
+  const rows: Line[] = [];
+  const targets: TargetRel[] = [];
+  const seenTargets = new Set<string>();
+  let more = 0;
+  const add = (
+    name: string,
+    displayName: string,
+    kind: StructureNode["kind"],
+    destLine: number,
+    destCol: number,
+    defOffset: number,
+    defEndOffset?: number,
+    definitionOffset = defOffset,
+  ) => {
+    const key = `${name}\0${definitionOffset}`;
+    if (seenTargets.has(key)) return;
+    seenTargets.add(key);
+    if (!expanded && rows.length >= MAX_DEPS) {
+      more++;
+      return;
+    }
+    targets.push({
+      relLine: rows.length + 1,
+      destLine,
+      destCol,
+      defOffset,
+      defEndOffset,
     });
     rows.push(row(
       ["  ", "plain"],
-      [d.name, "callName"],
+      [displayName, "callName"],
       ["  ", "plain"],
-      [`${d.kind}`, "comment"],
+      [kind, "comment"],
       ["  line ", "comment"],
-      [`${jump.destLine + 1}`, "number"],
+      [`${destLine + 1}`, "number"],
     ));
+  };
+
+  for (const candidate of candidates) {
+    add(
+      candidate.name,
+      candidate.displayName,
+      candidate.kind,
+      candidate.destLine,
+      candidate.destCol,
+      candidate.defOffset,
+      candidate.defEndOffset,
+      candidate.definitionOffset,
+    );
   }
   if (rows.length === 0) return { lines: [], targets: [] };
   const lines: Line[] = [heading(`depends on · ${rows.length}`), ...rows];
@@ -524,15 +624,15 @@ function depsSection(
 function dependencyJump(
   doc: Document,
   dep: Dependency,
-  semantics?: Semantics,
+  definitionOf?: DefinitionLookup,
 ): {
   destLine: number;
   defOffset: number;
   defEndOffset?: number;
   external: boolean;
 } {
-  if (semantics) {
-    const defs = semantics.definitionOf(dep.useOffset);
+  if (definitionOf) {
+    const defs = definitionOf(dep.useOffset);
     const inBlob = defs.find((t) => t.blobOffset !== undefined);
     if (inBlob?.blobOffset !== undefined) {
       const node = enclosingNode(doc, inBlob.blobOffset);
@@ -566,20 +666,25 @@ const MAX_EXTERNAL = 8;
  * that file at the definition.
  */
 function externalSection(
-  doc: Document,
-  node: StructureNode,
-  semantics: Semantics | undefined,
+  definitionOf: DefinitionLookup | undefined,
+  identUses: readonly IdentUse[],
   expanded: boolean,
 ): Section {
-  if (!semantics) return { lines: [], targets: [] };
+  if (!definitionOf) return { lines: [], targets: [] };
   const rows: Line[] = [];
   const targets: TargetRel[] = [];
+  const seenTargets = new Set<string>();
   let more = 0;
-  for (const use of collectIdentUses(doc, node)) {
-    const defs = semantics.definitionOf(use.useOffset);
+  for (const use of identUses) {
+    const defs = definitionOf(use.useOffset);
     if (defs.some((t) => t.blobOffset !== undefined)) continue; // in-blob → deps
     const ext = defs.find((t) => t.filePath);
     if (!ext) continue;
+    const targetKey = `${use.name}\0${ext.filePath}\0${
+      ext.fileOffset ?? `line:${ext.line}:col:${ext.col ?? 0}`
+    }`;
+    if (seenTargets.has(targetKey)) continue;
+    seenTargets.add(targetKey);
     if (!expanded && rows.length >= MAX_EXTERNAL) {
       more++;
       continue;
@@ -587,12 +692,12 @@ function externalSection(
     targets.push({
       relLine: rows.length + 1, // +1 for the heading prepended below
       destLine: ext.line,
-      destCol: 0,
+      destCol: ext.col ?? 0,
       filePath: ext.filePath,
     });
     rows.push(row(
       ["  ", "plain"],
-      [use.name, "callName"],
+      [use.displayName ?? use.name, "callName"],
       ["  ", "comment"],
       [basename(ext.filePath!), "typeName"],
       [`:${ext.line + 1}`, "number"],
@@ -605,6 +710,42 @@ function externalSection(
   ];
   if (more > 0) pushMore(lines, targets, more);
   return { lines, targets };
+}
+
+type DefinitionLookup = Semantics["definitionOf"];
+
+/** Share position-based definition results across the card's local and external
+ * sections, including semantic implementations that do no caching themselves. */
+function cachedDefinitionLookup(semantics: Semantics): DefinitionLookup {
+  const cache = new Map<number, ReturnType<DefinitionLookup>>();
+  return (offset) => {
+    const cached = cache.get(offset);
+    if (cached) return cached;
+    const definitions = semantics.definitionOf(offset);
+    cache.set(offset, definitions);
+    return definitions;
+  };
+}
+
+/** A collapsed card resolves a bounded prefix of symbol uses. This selectable
+ * row rebuilds the card with every remaining position resolved. */
+function deferredDefinitionsSection(count: number): Section {
+  if (count === 0) return { lines: [], targets: [] };
+  return {
+    lines: [
+      heading("definition lookup"),
+      row(
+        ["  … inspect ", "comment"],
+        [`${count} remaining use${count === 1 ? "" : "s"}`, "comment"],
+      ),
+    ],
+    targets: [{
+      relLine: 1,
+      destLine: 0,
+      destCol: 0,
+      expand: true,
+    }],
+  };
 }
 
 /**

--- a/packages/cli/lib/view/languages/language.ts
+++ b/packages/cli/lib/view/languages/language.ts
@@ -48,6 +48,8 @@ export interface DefTarget {
   readonly fileOffset?: number;
   /** 0-based line of the definition (document line in-document, file otherwise). */
   readonly line: number;
+  /** 0-based display column of the definition. */
+  readonly col?: number;
   /** A trimmed one-line preview of the definition site. */
   readonly preview: string;
 }

--- a/packages/cli/lib/view/languages/typescript/parse.ts
+++ b/packages/cli/lib/view/languages/typescript/parse.ts
@@ -142,6 +142,8 @@ interface GlobalSpan {
   end: number;
   cls: TokenClass;
   bracketDepth?: number;
+  exactDefinitionName?: string;
+  exactDefinitionDisplayName?: string;
 }
 
 /** Parse `text` into the document model. */
@@ -303,7 +305,19 @@ export function highlightLineEditLocally(
           text: after,
           spans: before.spans.map((current, index) =>
             index === spanIndex
-              ? { ...current, text: newSpanText }
+              ? {
+                ...current,
+                text: newSpanText,
+                exactDefinitionName: current.exactDefinitionName === undefined
+                  ? undefined
+                  : newSpanText.slice(1, -1),
+                exactDefinitionDisplayName:
+                  current.exactDefinitionName === undefined
+                    ? undefined
+                    : quotedDefinitionDisplayName(
+                      newSpanText.slice(1, -1),
+                    ),
+              }
               : index > spanIndex
               ? { ...current, col: current.col + columnDelta }
               : current
@@ -740,6 +754,12 @@ function spansToLinesRange(
           text: segText,
           cls: span.cls,
           bracketDepth: span.bracketDepth,
+          exactDefinitionName: pos === span.start
+            ? span.exactDefinitionName
+            : undefined,
+          exactDefinitionDisplayName: pos === span.start
+            ? span.exactDefinitionDisplayName
+            : undefined,
         });
         lineCol[idx] += cpLen(segText);
       }
@@ -768,7 +788,9 @@ function lineEq(a: Line, b: Line): boolean {
     const y = b.spans[i];
     if (
       x.col !== y.col || x.text !== y.text || x.cls !== y.cls ||
-      x.bracketDepth !== y.bracketDepth
+      x.bracketDepth !== y.bracketDepth ||
+      x.exactDefinitionName !== y.exactDefinitionName ||
+      x.exactDefinitionDisplayName !== y.exactDefinitionDisplayName
     ) {
       return false;
     }
@@ -868,11 +890,14 @@ function buildGlobalSpans(
       classifyTrivia(text, prevEnd, token.start, spans);
     }
     const cls = classifyToken(token.node, schemaSet);
+    const definitionTarget = callTargetDefinition(token.node);
     spans.push({
       start: token.start,
       end: token.end,
       cls,
       bracketDepth: cls === "bracket" ? bracketDepths.get(token) : undefined,
+      exactDefinitionName: definitionTarget?.name,
+      exactDefinitionDisplayName: definitionTarget?.displayName,
     });
     prevEnd = token.end;
   }
@@ -1017,11 +1042,72 @@ function classifyIdentifier(
   return "identifier";
 }
 
-function isCalleeOfCall(node: ts.Node): boolean {
-  const p = node.parent;
+function isCalleeOfCall(node: ts.Expression): boolean {
+  let expression = node;
+  let p = expression.parent;
+  while (
+    p &&
+    (ts.isParenthesizedExpression(p) || ts.isAsExpression(p) ||
+      ts.isSatisfiesExpression(p) || ts.isNonNullExpression(p) ||
+      ts.isTypeAssertionExpression(p) ||
+      ts.isExpressionWithTypeArguments(p)) &&
+    p.expression === expression
+  ) {
+    expression = p;
+    p = expression.parent;
+  }
   return !!p &&
     (ts.isCallExpression(p) || ts.isNewExpression(p)) &&
-    p.expression === node;
+    p.expression === expression;
+}
+
+function callTargetDefinition(
+  node: ts.Node,
+): { name: string; displayName: string } | undefined {
+  const p = node.parent;
+  if (
+    ts.isPropertyAccessExpression(p) && p.name === node &&
+    isCalleeOfCall(p)
+  ) {
+    const name = (node as ts.Identifier | ts.PrivateIdentifier).text;
+    return { name, displayName: name };
+  }
+  if (
+    ts.isElementAccessExpression(p) && p.argumentExpression === node &&
+    isCalleeOfCall(p) &&
+    (ts.isStringLiteral(node) ||
+      ts.isNoSubstitutionTemplateLiteral(node) ||
+      ts.isNumericLiteral(node))
+  ) {
+    return {
+      name: node.text,
+      displayName: ts.isNumericLiteral(node)
+        ? node.text
+        : quotedDefinitionDisplayName(node.text),
+    };
+  }
+  if (
+    ts.isNumericLiteral(node) && ts.isPrefixUnaryExpression(p) &&
+    p.operand === node &&
+    (p.operator === SK.PlusToken || p.operator === SK.MinusToken)
+  ) {
+    const access = p.parent;
+    if (
+      ts.isElementAccessExpression(access) &&
+      access.argumentExpression === p &&
+      isCalleeOfCall(access)
+    ) {
+      const name = `${p.operator === SK.MinusToken ? "-" : "+"}${node.text}`;
+      return { name, displayName: name };
+    }
+  }
+  return undefined;
+}
+
+function quotedDefinitionDisplayName(text: string): string {
+  return JSON.stringify(text)
+    .replaceAll("\u2028", "\\u2028")
+    .replaceAll("\u2029", "\\u2029");
 }
 
 /** True when `node` sits inside a type annotation/argument (vs an expression). */
@@ -2412,6 +2498,12 @@ function spansToLines(
           text: segText,
           cls: span.cls,
           bracketDepth: span.bracketDepth,
+          exactDefinitionName: pos === span.start
+            ? span.exactDefinitionName
+            : undefined,
+          exactDefinitionDisplayName: pos === span.start
+            ? span.exactDefinitionDisplayName
+            : undefined,
         });
         lineCol[li] += cpLen(segText);
       }

--- a/packages/cli/lib/view/languages/typescript/semantics.ts
+++ b/packages/cli/lib/view/languages/typescript/semantics.ts
@@ -744,4 +744,8 @@ function typeQuery(
 }
 
 /** Internals exposed for tests only. */
-export const _internal = { lazyProgram, makeHost };
+export const _internal = {
+  lazyProgram,
+  makeHost,
+  signedNumericElementDefinitions,
+};

--- a/packages/cli/lib/view/languages/typescript/semantics.ts
+++ b/packages/cli/lib/view/languages/typescript/semantics.ts
@@ -29,6 +29,7 @@ import type {
   SemanticsOptions as Options,
 } from "../language.ts";
 import { languageForFile } from "../language.ts";
+import { cpLen } from "../../ansi.ts";
 
 interface SectionFile {
   /** Virtual file name (the section header path, or `fileName`). */
@@ -101,18 +102,23 @@ export function createSemantics(
       if (cached) return cached;
       let out: DefTarget[] = [];
       try {
-        if (build() && service) {
+        const program = build();
+        if (program && service) {
           const section = sectionAt(offset);
           if (section) {
             const local = offset - section.start;
-            const defs = service.getDefinitionAtPosition(section.name, local) ??
-              [];
+            const defs = definitionsAtPosition(
+              service,
+              program,
+              section.name,
+              local,
+            );
             for (const d of defs) {
               const sec = sectionByVfile.get(d.fileName);
               if (sec) {
                 const blobOffset = sec.start + d.textSpan.start;
-                const { line, preview } = lineAndPreview(text, blobOffset);
-                out.push({ name: d.name, blobOffset, line, preview });
+                const { line, col, preview } = lineAndPreview(text, blobOffset);
+                out.push({ name: d.name, blobOffset, line, col, preview });
               } else {
                 // A real file. Skip libs / anything outside the workspace —
                 // jumping into lib.d.ts for `Set` is noise, not a definition.
@@ -124,6 +130,7 @@ export function createSemantics(
                   filePath: d.fileName,
                   fileOffset: d.textSpan.start,
                   line: at.line,
+                  col: at.col,
                   preview: at.preview,
                 });
               }
@@ -194,18 +201,29 @@ export function createDiffSemantics(
       if (cached) return cached;
       let out: DefTarget[] = [];
       try {
-        if (build() && service) {
+        const program = build();
+        if (program && service) {
           const at = maps.toFile(offset);
           if (at) {
-            const defs = service.getDefinitionAtPosition(at.path, at.offset) ??
-              [];
+            const defs = definitionsAtPosition(
+              service,
+              program,
+              at.path,
+              at.offset,
+            );
             for (const d of defs) {
               // A definition on a line the diff shows maps back into the diff;
               // anything else within the workspace opens as an external file.
               const inDiff = maps.fromFile(d.fileName, d.textSpan.start);
               if (inDiff !== null) {
-                const { line, preview } = lineAndPreview(diffText, inDiff);
-                out.push({ name: d.name, blobOffset: inDiff, line, preview });
+                const { line, col, preview } = lineAndPreview(diffText, inDiff);
+                out.push({
+                  name: d.name,
+                  blobOffset: inDiff,
+                  line,
+                  col,
+                  preview,
+                });
                 continue;
               }
               const content = readReal(d.fileName);
@@ -216,6 +234,7 @@ export function createDiffSemantics(
                 filePath: d.fileName,
                 fileOffset: d.textSpan.start,
                 line: atDef.line,
+                col: atDef.col,
                 preview: atDef.preview,
               });
             }
@@ -237,6 +256,77 @@ export function createDiffSemantics(
       }
     },
   };
+}
+
+interface DefinitionSite {
+  readonly name: string;
+  readonly fileName: string;
+  readonly textSpan: ts.TextSpan;
+}
+
+function definitionsAtPosition(
+  service: ts.LanguageService,
+  program: ts.Program,
+  fileName: string,
+  offset: number,
+): readonly DefinitionSite[] {
+  const direct = service.getDefinitionAtPosition(fileName, offset) ?? [];
+  if (direct.length > 0) return direct;
+  return signedNumericElementDefinitions(program, fileName, offset);
+}
+
+/** Resolve signed numeric element keys through the receiver's property symbol. */
+function signedNumericElementDefinitions(
+  program: ts.Program,
+  fileName: string,
+  offset: number,
+): DefinitionSite[] {
+  const source = program.getSourceFile(fileName);
+  if (!source) return [];
+  let current: ts.Node | undefined = deepestNodeAt(source, offset);
+  while (current && !ts.isElementAccessExpression(current)) {
+    current = current.parent;
+  }
+  if (!current) return [];
+  const argument = current.argumentExpression;
+  if (
+    !argument || !ts.isPrefixUnaryExpression(argument) ||
+    !ts.isNumericLiteral(argument.operand) ||
+    (argument.operator !== ts.SyntaxKind.PlusToken &&
+      argument.operator !== ts.SyntaxKind.MinusToken)
+  ) {
+    return [];
+  }
+  const magnitude = Number(argument.operand.text);
+  if (!Number.isFinite(magnitude)) return [];
+  const value = argument.operator === ts.SyntaxKind.MinusToken
+    ? -magnitude
+    : magnitude;
+  const checker = program.getTypeChecker();
+  const receiver = checker.getNonNullableType(
+    checker.getTypeAtLocation(current.expression),
+  );
+  const symbol = checker.getPropertyOfType(receiver, String(value));
+  if (!symbol) return [];
+  return (symbol.declarations ?? []).map((declaration) => ({
+    name: symbol.getName(),
+    fileName: declaration.getSourceFile().fileName,
+    textSpan: {
+      start: declaration.getStart(),
+      length: declaration.getWidth(),
+    },
+  }));
+}
+
+function deepestNodeAt(source: ts.SourceFile, offset: number): ts.Node {
+  let found: ts.Node = source;
+  const visit = (node: ts.Node): void => {
+    if (offset < node.getFullStart() || offset >= node.getEnd()) return;
+    found = node;
+    node.forEachChild(visit);
+  };
+  visit(source);
+  return found;
 }
 
 /** The cleaned type string of the node at `local` in `fileName`, or null. */
@@ -266,7 +356,7 @@ function typeStringAt(
 function lineAndPreview(
   content: string,
   offset: number,
-): { line: number; preview: string } {
+): { line: number; col: number; preview: string } {
   const clamped = Math.max(0, Math.min(offset, content.length));
   let line = 0;
   for (let i = 0; i < clamped; i++) if (content[i] === "\n") line++;
@@ -276,6 +366,7 @@ function lineAndPreview(
   const preview = content.slice(start, end).trim();
   return {
     line,
+    col: cpLen(content.slice(start, clamped)),
     preview: preview.length > 72 ? `${preview.slice(0, 71)}…` : preview,
   };
 }

--- a/packages/cli/lib/view/model.ts
+++ b/packages/cli/lib/view/model.ts
@@ -59,6 +59,10 @@ export interface Span {
   readonly cls: TokenClass;
   /** Nesting depth for `bracket` spans, used for rainbow colouring. */
   readonly bracketDepth?: number;
+  /** Symbol name to resolve only at this position, not by matching span text. */
+  readonly exactDefinitionName?: string;
+  /** Single-line spelling used when displaying an exact definition target. */
+  readonly exactDefinitionDisplayName?: string;
   /** Rich-text modifiers used by rendered document views. */
   readonly bold?: boolean;
   readonly italic?: boolean;

--- a/packages/cli/lib/view/references.ts
+++ b/packages/cli/lib/view/references.ts
@@ -55,7 +55,12 @@ export function findReferences(
   const refs: Reference[] = [];
   for (let line = 0; line < doc.lines.length; line++) {
     for (const span of doc.lines[line].spans) {
-      if (span.text !== name || !IDENT_CLASSES.has(span.cls)) continue;
+      if (
+        span.text !== name || !IDENT_CLASSES.has(span.cls) ||
+        span.exactDefinitionName !== undefined
+      ) {
+        continue;
+      }
       // Bound by the node's actual span, including column bounds on the boundary
       // lines, so a sibling occurrence on the same line as (but outside the
       // column range of) the node is not mistaken for one inside it.
@@ -88,7 +93,7 @@ export function findDependencies(
   const seen = new Map<string, Dependency>();
   for (let line = node.startLine; line <= node.endLine; line++) {
     const row = doc.lines[line];
-    if (!row) continue;
+    if (!row || row.bg === "del") continue;
     // Running UTF-16 char offset of each span on this line (spans are gapless).
     let charOffset = lineStarts[line] ?? 0;
     for (const span of row.spans) {
@@ -99,7 +104,12 @@ export function findDependencies(
       // not mistaken for a dependency.
       if (line === node.startLine && span.col < node.startCol) continue;
       if (line === node.endLine && span.col >= node.endCol) continue;
-      if (!IDENT_CLASSES.has(span.cls)) continue;
+      if (
+        !IDENT_CLASSES.has(span.cls) ||
+        span.exactDefinitionName !== undefined
+      ) {
+        continue;
+      }
       const text = span.text;
       if (text === node.name || seen.has(text)) continue;
       const defs = doc.definitions.get(text);
@@ -125,40 +135,81 @@ export function findDependencies(
 /** An identifier occurrence inside a node, by name and char offset. */
 export interface IdentUse {
   readonly name: string;
+  readonly displayName?: string;
   readonly useOffset: number;
+  readonly exactDefinitionOnly?: true;
+}
+
+export interface IdentUseCollection {
+  readonly uses: IdentUse[];
+  readonly total: number;
 }
 
 /**
- * Distinct identifiers used inside `node`, in first-use order, each with the
- * char offset of that first use. Used to resolve cross-file definitions via the
- * semantic service (which the name index cannot see).
+ * Identifier use sites inside `node`, in source order. Ordinary identifier
+ * spellings are deduplicated at their first use. Exact-position uses are
+ * retained individually because equal spellings can resolve to different
+ * definitions. Used to resolve cross-file definitions via the semantic service,
+ * which the name index cannot see.
  */
 export function collectIdentUses(
   doc: Document,
   node: StructureNode,
-  limit = 40,
 ): IdentUse[] {
+  return collectIdentUsesBounded(doc, node, Number.POSITIVE_INFINITY).uses;
+}
+
+/** Collect at most `limit` use sites while counting every eligible site. */
+export function collectIdentUsesBounded(
+  doc: Document,
+  node: StructureNode,
+  limit: number,
+): IdentUseCollection {
   const lineStarts = lineStartOffsets(doc);
   const seen = new Set<string>();
   const out: IdentUse[] = [];
+  let total = 0;
   for (let line = node.startLine; line <= node.endLine; line++) {
     const row = doc.lines[line];
-    if (!row) continue;
+    if (!row || row.bg === "del") continue;
     let charOffset = lineStarts[line] ?? 0;
     for (const span of row.spans) {
       const spanOffset = charOffset;
       charOffset += span.text.length;
       if (line === node.startLine && span.col < node.startCol) continue;
       if (line === node.endLine && span.col >= node.endCol) continue;
-      if (!IDENT_CLASSES.has(span.cls)) continue;
-      const text = span.text;
-      if (text === node.name || seen.has(text)) continue;
-      seen.add(text);
-      out.push({ name: text, useOffset: spanOffset });
-      if (out.length >= limit) return out;
+      if (
+        !IDENT_CLASSES.has(span.cls) &&
+        span.exactDefinitionName === undefined
+      ) {
+        continue;
+      }
+      const text = span.exactDefinitionName ?? span.text;
+      const displayName = span.exactDefinitionDisplayName ?? text;
+      const exactDefinitionOnly = span.exactDefinitionName !== undefined;
+      const dedupeByName = !exactDefinitionOnly;
+      if (
+        spanOffset === node.nameOffset || (dedupeByName && seen.has(text))
+      ) {
+        continue;
+      }
+      if (dedupeByName) seen.add(text);
+      total++;
+      if (out.length < limit) {
+        out.push(
+          exactDefinitionOnly
+            ? {
+              name: text,
+              displayName,
+              useOffset: spanOffset,
+              exactDefinitionOnly: true,
+            }
+            : { name: text, useOffset: spanOffset },
+        );
+      }
     }
   }
-  return out;
+  return { uses: out, total };
 }
 
 /** Char offset where each line begins, derived from the verbatim text. */

--- a/packages/cli/lib/view/session.ts
+++ b/packages/cli/lib/view/session.ts
@@ -1329,7 +1329,9 @@ export class Session {
     // workspace prefix and drop the identifying part.
     const name = target.filePath!.split(/[\\/]/).pop() ?? target.filePath!;
     this.overlay = {
-      title: `${name}  ·  line ${target.destLine + 1}`,
+      title: `${name}  ·  line ${target.destLine + 1}, column ${
+        target.destCol + 1
+      }`,
       info: lines,
       mode: "info",
       targets: [],

--- a/packages/cli/test/view-card-cov.test.ts
+++ b/packages/cli/test/view-card-cov.test.ts
@@ -397,6 +397,164 @@ function fakeSemantics(
   };
 }
 
+Deno.test("card: deferred semantic dependencies remain in the folded count", () => {
+  let src = "// transformed: /app.ts\n";
+  for (let i = 0; i < 41; i++) src += `const dep${i} = ${i};\n`;
+  src += "function consumer() {\n  return " +
+    Array.from({ length: 41 }, (_, i) => `dep${i}`).join(" + ") + ";\n}\n";
+  const doc = parseDocument(src);
+  const consumer = doc.flatStructure.find((n) => n.name === "consumer")!;
+  const first = doc.flatStructure.find((n) => n.name === "dep0")!;
+  let definitionCalls = 0;
+  const semantics = fakeSemantics(() => {
+    definitionCalls++;
+    return [{
+      name: "dep0",
+      blobOffset: first.startOffset,
+      line: first.startLine,
+      preview: "const dep0 = 0;",
+    }];
+  });
+
+  const text = infoText(doc, consumer, semantics);
+  assertEquals(
+    definitionCalls,
+    40,
+    "the collapsed card keeps semantic lookup within its prefix",
+  );
+  assert(
+    text.includes("30 more"),
+    `all resolved folded dependencies are counted: ${text}`,
+  );
+  assert(
+    text.includes("1 possible dependency"),
+    `the unresolved dependency is counted without a speculative row: ${text}`,
+  );
+  assert(
+    text.includes("1 remaining use"),
+    `the deferred semantic use can still be expanded: ${text}`,
+  );
+});
+
+Deno.test("card: a deferred dependency does not use a same-named local jump", () => {
+  let src = "// transformed: /app.ts\nconst ext = 1;\n";
+  src += "function consumer() {\n";
+  for (let i = 0; i < 40; i++) src += `  unknown${i};\n`;
+  src += "  return ext();\n}\n";
+  const doc = parseDocument(src);
+  const consumer = doc.flatStructure.find((n) => n.name === "consumer")!;
+  const localExt = doc.flatStructure.find((n) => n.name === "ext")!;
+  const semantics = fakeSemantics((offset) =>
+    doc.text.slice(offset, offset + 3) === "ext"
+      ? [{
+        name: "ext",
+        filePath: "/workspace/external.ts",
+        fileOffset: 0,
+        line: 0,
+        col: 0,
+        preview: "export function ext() {}",
+      }]
+      : []
+  );
+
+  const collapsed = buildPeekCard(doc, consumer, semantics);
+  const collapsedText = collapsed.info.map((line) => line.text).join("\n");
+  assert(
+    !collapsedText.split("\n").some((line) => line.startsWith("  ext  ")),
+    `the deferred use has no speculative local row: ${collapsedText}`,
+  );
+  assert(
+    !collapsed.targets.some((target) =>
+      target.defOffset === localExt.startOffset
+    ),
+    `the deferred use has no speculative local jump: ${collapsedText}`,
+  );
+  assert(
+    collapsedText.includes("1 remaining use"),
+    `the unresolved use can be expanded: ${collapsedText}`,
+  );
+  assert(
+    collapsedText.includes("1 possible dependency"),
+    `the syntactic match is labelled as unresolved: ${collapsedText}`,
+  );
+
+  const expanded = buildPeekCard(doc, consumer, semantics, true);
+  const expandedText = expanded.info.map((line) => line.text).join("\n");
+  assert(
+    expandedText.includes("  ext  external.ts:1"),
+    `expansion shows the semantic external target: ${expandedText}`,
+  );
+  assert(
+    expanded.targets.some((target) =>
+      target.filePath === "/workspace/external.ts"
+    ),
+    "the expanded row jumps to the external definition",
+  );
+});
+
+Deno.test("card: a call target defined inside the selected node is not a dependency", () => {
+  const doc = parseDocument(`// transformed: /app.ts
+function consumer() {
+  const worker = { run(): void {} };
+  worker.run();
+}
+`);
+  const consumer = doc.flatStructure.find((n) => n.name === "consumer")!;
+  const method = doc.flatStructure.find((n) =>
+    n.kind === "method" && n.name === "run"
+  )!;
+  let resolvedCalls = 0;
+  const semantics = fakeSemantics((offset) => {
+    if (doc.text.slice(offset, offset + 3) !== "run") return [];
+    resolvedCalls++;
+    return [{
+      name: "run",
+      blobOffset: method.startOffset,
+      line: method.startLine,
+      preview: method.label,
+    }];
+  });
+
+  const text = infoText(doc, consumer, semantics);
+  assert(resolvedCalls > 0, "the call target is resolved");
+  assert(
+    !text.includes("DEPENDS ON"),
+    `a definition inside the selected function is omitted: ${text}`,
+  );
+});
+
+Deno.test("card: repeated calls to one target produce one dependency", () => {
+  const doc = parseDocument(`// transformed: /app.ts
+const worker = { run(): void {} };
+[worker.run(), worker.run()];
+`);
+  const statement = doc.flatStructure.find((n) =>
+    n.kind === "statement" && n.startLine === 2
+  )!;
+  const worker = doc.flatStructure.find((n) => n.name === "worker")!;
+  const method = doc.flatStructure.find((n) =>
+    n.kind === "method" && n.name === "run"
+  )!;
+  const semantics = fakeSemantics((offset) => {
+    const target = doc.text.slice(offset, offset + 3) === "run"
+      ? method
+      : worker;
+    return [{
+      name: target.name!,
+      blobOffset: target.startOffset,
+      line: target.startLine,
+      preview: target.label,
+    }];
+  });
+
+  const text = infoText(doc, statement, semantics);
+  assertEquals(
+    text.split("\n").filter((line) => line.startsWith("  run  ")).length,
+    1,
+    `the repeated target has one row: ${text}`,
+  );
+});
+
 Deno.test("card: a dependency that resolves in-blob jumps to its enclosing node", () => {
   const doc = parseDocument(`// transformed: /app.ts
 const helper = 1;

--- a/packages/cli/test/view-diff.test.ts
+++ b/packages/cli/test/view-diff.test.ts
@@ -7,6 +7,7 @@ import {
   realWorkspace,
 } from "../lib/view/diffdoc.ts";
 import { createDiffSemantics } from "../lib/view/languages/typescript/semantics.ts";
+import type { Semantics } from "../lib/view/languages/language.ts";
 import { buildPeekCard } from "../lib/view/card.ts";
 import { renderLineColored } from "../lib/view/highlight.ts";
 import { renderFrame, type ViewState } from "../lib/view/render.ts";
@@ -1368,6 +1369,58 @@ Deno.test("card: uses over a diff exclude the removed side", () => {
   } finally {
     Deno.removeSync(root, { recursive: true });
   }
+});
+
+Deno.test("card: removed calls do not consume the definition lookup budget", () => {
+  const removed = Array.from(
+    { length: 40 },
+    () => "-  oldWorker.run(),",
+  ).join("\n");
+  const diff = `diff --git a/m.ts b/m.ts
+--- a/m.ts
++++ b/m.ts
+@@ -1,42 +1,3 @@
+ [
+${removed}
++  liveWorker.stop(),
+ ];
+`;
+  const model = parseDiff(diff)!;
+  const current = "[\n  liveWorker.stop(),\n];\n";
+  const { doc } = buildDiffDocument(diff, model, {
+    resolve: (path) => `/repo/${path}`,
+    read: () => current,
+  });
+  const statement = doc.flatStructure.find((node) =>
+    node.kind === "statement" && node.label === "["
+  )!;
+  const lookedUp: number[] = [];
+  const sem: Semantics = {
+    typeAt: () => null,
+    prewarm: () => {},
+    fileLines: () => null,
+    definitionOf: (offset) => {
+      lookedUp.push(offset);
+      return diff.slice(offset).startsWith("stop")
+        ? [{
+          name: "stop",
+          filePath: "/repo/ext.ts",
+          fileOffset: 0,
+          line: 0,
+          col: 0,
+          preview: "stop(): void",
+        }]
+        : [];
+    },
+  };
+  const card = buildPeekCard(doc, statement, sem);
+  const text = card.info.map((line) => line.text).join("\n");
+  assertEquals(
+    lookedUp.map((offset) => diff.slice(offset).match(/^\w+/)?.[0]).sort(),
+    ["liveWorker", "stop"],
+  );
+  assert(text.includes("  stop  ext.ts:1"), `live call is listed: ${text}`);
+  assert(!text.includes("remaining uses"), `nothing live is deferred: ${text}`);
 });
 
 // --- object-literal properties are navigable in a diff hunk ------------------

--- a/packages/cli/test/view-highlighter.test.ts
+++ b/packages/cli/test/view-highlighter.test.ts
@@ -28,7 +28,10 @@ function firstDiff(a: readonly Line[], b: readonly Line[]): number {
     for (let j = 0; j < sa.length; j++) {
       if (
         sa[j].col !== sb[j].col || sa[j].text !== sb[j].text ||
-        sa[j].cls !== sb[j].cls || sa[j].bracketDepth !== sb[j].bracketDepth
+        sa[j].cls !== sb[j].cls ||
+        sa[j].bracketDepth !== sb[j].bracketDepth ||
+        sa[j].exactDefinitionName !== sb[j].exactDefinitionName ||
+        sa[j].exactDefinitionDisplayName !== sb[j].exactDefinitionDisplayName
       ) {
         return i;
       }

--- a/packages/cli/test/view-parse-cov.test.ts
+++ b/packages/cli/test/view-parse-cov.test.ts
@@ -105,6 +105,16 @@ Deno.test("highlightLineEditLocally: unchanged text returns the original line", 
   assert(highlightLineEditLocally(before, before.text) === before);
 });
 
+Deno.test("highlightLineEditLocally: editing a called member key refreshes its definition name", () => {
+  const before = createHighlighter('worker["run"]();', "m.ts").lines[0];
+  const after = highlightLineEditLocally(before, 'worker["stop"]();');
+  assert(after, "the quoted-string fast path handles the edit");
+  const key = after.spans.find((span) => span.text === '"stop"');
+  assert(key, "the edited key remains one string span");
+  assertEquals(key.exactDefinitionName, "stop");
+  assertEquals(key.exactDefinitionDisplayName, '"stop"');
+});
+
 // --- safeStartLine walk-back past a multi-line token (lines 459, 460) --------
 
 /** Assert that the incremental highlighter's result for `edited` is identical
@@ -120,8 +130,12 @@ function assertIncrementalMatches(
   for (let i = 0; i < full.length; i++) {
     assertEquals(inc[i].text, full[i].text, `line ${i} text`);
     assertEquals(
-      inc[i].spans.map((s) => `${s.cls}:${s.text}:${s.bracketDepth}`),
-      full[i].spans.map((s) => `${s.cls}:${s.text}:${s.bracketDepth}`),
+      inc[i].spans.map((s) =>
+        `${s.cls}:${s.text}:${s.bracketDepth}:${s.exactDefinitionName}:${s.exactDefinitionDisplayName}`
+      ),
+      full[i].spans.map((s) =>
+        `${s.cls}:${s.text}:${s.bracketDepth}:${s.exactDefinitionName}:${s.exactDefinitionDisplayName}`
+      ),
       `line ${i} spans`,
     );
   }
@@ -132,6 +146,22 @@ Deno.test("createHighlighter: an edit inside a multi-line template matches a ful
   // re-highlights from the statement boundary and matches a full parse.
   const base = "const t = `line one\nline two\nline three`;\nconst x = 1;\n";
   assertIncrementalMatches(base, base.replace("line two", "line TWO"));
+});
+
+Deno.test("createHighlighter: an edited multi-line call key has one lookup marker", () => {
+  const base = "worker[`line one\nline two`]();\nconst x = 1;\n";
+  const hl = createHighlighter(base, "m.ts");
+  const lines = hl.update(base.replace("line two", "line TWO"));
+  assertEquals(
+    lines.flatMap((line) => line.spans)
+      .filter((span) => span.exactDefinitionName !== undefined)
+      .map((span) => [
+        span.text,
+        span.exactDefinitionName,
+        span.exactDefinitionDisplayName,
+      ]),
+    [["`line one", "line one\nline TWO", '"line one\\nline TWO"']],
+  );
 });
 
 Deno.test("createHighlighter: editing a statement whose line opens inside an earlier block comment", () => {

--- a/packages/cli/test/view-parse-gate.test.ts
+++ b/packages/cli/test/view-parse-gate.test.ts
@@ -71,7 +71,33 @@ Deno.test("gate 836: leaf identifiers are classified by their parent context", (
   );
   assert(
     classesOf(doc, "toString").has("propertyName"),
-    "`.toString` is a propertyName",
+    "the member call `.toString()` keeps its propertyName classification",
+  );
+  assert(
+    doc.lines.flatMap((line) => line.spans).some((span) =>
+      span.text === "toString" && span.exactDefinitionName === "toString"
+    ),
+    "the member call uses exact-position definition lookup",
+  );
+});
+
+Deno.test("called element keys carry one exact-position lookup marker", () => {
+  const doc = parseDocument(
+    "worker[-1](); worker[+1](); worker[`line one\nline two`]();",
+  );
+  assertEquals(
+    doc.lines.flatMap((line) => line.spans)
+      .filter((span) => span.exactDefinitionName !== undefined)
+      .map((span) => [
+        span.text,
+        span.exactDefinitionName,
+        span.exactDefinitionDisplayName,
+      ]),
+    [
+      ["1", "-1", "-1"],
+      ["1", "+1", "+1"],
+      ["`line one", "line one\nline two", '"line one\\nline two"'],
+    ],
   );
 });
 

--- a/packages/cli/test/view-references-cov.test.ts
+++ b/packages/cli/test/view-references-cov.test.ts
@@ -3,6 +3,7 @@ import { parseDocument, SAMPLE } from "./view-helpers.ts";
 import {
   ancestorsOf,
   collectIdentUses,
+  collectIdentUsesBounded,
   findDependencies,
 } from "../lib/view/references.ts";
 import type {
@@ -25,13 +26,14 @@ function ident(
 
 /** Assemble a synthetic Document from line texts plus per-line spans. */
 function makeDoc(
-  lines: { text: string; spans: Span[] }[],
+  lines: { text: string; spans: Span[]; bg?: Line["bg"] }[],
   definitions: Map<string, Definition[]> = new Map(),
 ): Document {
   const text = lines.map((l) => l.text).join("\n");
   const modelLines: Line[] = lines.map((l) => ({
     text: l.text,
     spans: l.spans,
+    bg: l.bg,
   }));
   return {
     text,
@@ -99,6 +101,27 @@ Deno.test("findDependencies: real document still resolves a cross-node dep", () 
   assert(deps.some((d) => d.name === "__cfLift_1"));
 });
 
+Deno.test("findDependencies: removed diff lines do not contribute dependencies", () => {
+  const dep: Definition = {
+    name: "helper",
+    kind: "function",
+    startLine: 0,
+    endLine: 0,
+    startOffset: 0,
+    endOffset: 6,
+  };
+  const doc = makeDoc(
+    [{
+      text: "helper",
+      spans: [ident(0, "helper", "callName")],
+      bg: "del",
+    }],
+    new Map([["helper", [dep]]]),
+  );
+  const n = node({ startOffset: 100, endOffset: 200 });
+  assertEquals(findDependencies(doc, n), []);
+});
+
 Deno.test("collectIdentUses: skips line indices past the end of the document", () => {
   const doc = makeDoc([
     { text: "alpha beta", spans: [ident(0, "alpha"), ident(6, "beta")] },
@@ -115,6 +138,47 @@ Deno.test("collectIdentUses: skips line indices past the end of the document", (
   // Both identifiers on the present line are collected; the missing rows are
   // skipped without error.
   assertEquals(uses.map((u) => u.name), ["alpha", "beta"]);
+});
+
+Deno.test("collectIdentUses: removed diff lines do not consume the result limit", () => {
+  const doc = makeDoc([
+    { text: "old", spans: [ident(0, "old")], bg: "del" },
+    { text: "live", spans: [ident(0, "live")] },
+  ]);
+  const n = node({ endLine: 1 });
+  assertEquals(collectIdentUsesBounded(doc, n, 1), {
+    uses: [{ name: "live", useOffset: 4 }],
+    total: 1,
+  });
+});
+
+Deno.test("collectIdentUses: a bounded collection counts omitted exact uses", () => {
+  const doc = makeDoc([{
+    text: "runrunrun",
+    spans: [
+      { ...ident(0, "run"), exactDefinitionName: "run" },
+      { ...ident(3, "run"), exactDefinitionName: "run" },
+      { ...ident(6, "run"), exactDefinitionName: "run" },
+    ],
+  }]);
+  const n = node({});
+  assertEquals(collectIdentUsesBounded(doc, n, 2), {
+    uses: [
+      {
+        name: "run",
+        displayName: "run",
+        useOffset: 0,
+        exactDefinitionOnly: true,
+      },
+      {
+        name: "run",
+        displayName: "run",
+        useOffset: 3,
+        exactDefinitionOnly: true,
+      },
+    ],
+    total: 3,
+  });
 });
 
 Deno.test("collectIdentUses: drops end-line spans at or past endCol", () => {
@@ -135,11 +199,17 @@ Deno.test("collectIdentUses: drops end-line spans at or past endCol", () => {
   assertEquals(uses.map((u) => u.name), ["alpha"]);
 });
 
-Deno.test("collectIdentUses: stops once the limit is reached", () => {
+Deno.test("collectIdentUses: keeps exact-position uses with equal spellings", () => {
   const doc = makeDoc([
     {
-      text: "alpha beta gamma",
-      spans: [ident(0, "alpha"), ident(6, "beta"), ident(11, "gamma")],
+      text: "alpha alpha alpha",
+      spans: [
+        ident(0, "alpha"),
+        { col: 5, text: " ", cls: "whitespace" },
+        { ...ident(6, "alpha"), exactDefinitionName: "alpha" },
+        { col: 11, text: " ", cls: "whitespace" },
+        { ...ident(12, "alpha"), exactDefinitionName: "alpha" },
+      ],
     },
   ]);
   const n = node({
@@ -150,12 +220,21 @@ Deno.test("collectIdentUses: stops once the limit is reached", () => {
     endCol: 1000,
   });
 
-  const limited = collectIdentUses(doc, n, 2);
-  assertEquals(limited.map((u) => u.name), ["alpha", "beta"]);
-  // Without the cap, all three are returned, confirming the early return is
-  // what trimmed the list.
-  const all = collectIdentUses(doc, n, 40);
-  assertEquals(all.map((u) => u.name), ["alpha", "beta", "gamma"]);
+  assertEquals(collectIdentUses(doc, n), [
+    { name: "alpha", useOffset: 0 },
+    {
+      name: "alpha",
+      displayName: "alpha",
+      useOffset: 6,
+      exactDefinitionOnly: true,
+    },
+    {
+      name: "alpha",
+      displayName: "alpha",
+      useOffset: 12,
+      exactDefinitionOnly: true,
+    },
+  ]);
 });
 
 Deno.test("ancestorsOf: a node absent from the flat list has no ancestors", () => {

--- a/packages/cli/test/view-references.test.ts
+++ b/packages/cli/test/view-references.test.ts
@@ -2,6 +2,7 @@ import { assert, assertEquals } from "@std/assert";
 import { parseDocument, SAMPLE } from "./view-helpers.ts";
 import {
   ancestorsOf,
+  collectIdentUses,
   findDependencies,
   findReferences,
 } from "../lib/view/references.ts";
@@ -146,6 +147,34 @@ Deno.test("findDependencies: excludes the node's own declarations", () => {
   const deps = findDependencies(doc, p);
   // `t` and `url` are declared inside the pattern, not dependencies.
   assert(!deps.some((d) => d.name === "t"), "local binding t is not a dep");
+});
+
+Deno.test("findDependencies: member calls do not match same-named declarations", () => {
+  for (const name of ["run", "render", "__cfLift_1"]) {
+    const doc = parseDocument(`function ${name}() {}
+worker.${name}();`);
+    const statement = doc.flatStructure.find((node) =>
+      node.startLine === 1 &&
+      (node.kind === "statement" || node.kind === "builder")
+    )!;
+    assertEquals(findDependencies(doc, statement), [], name);
+  }
+});
+
+Deno.test("collectIdentUses: a called member can match the selected binding's name", () => {
+  const doc = parseDocument("const run = worker.run();");
+  const binding = doc.flatStructure.find((node) => node.name === "run")!;
+  const uses = collectIdentUses(doc, binding);
+  assert(
+    uses.some((use) =>
+      use.name === "run" && use.useOffset === doc.text.lastIndexOf("run")
+    ),
+    "the called member remains available for an exact-position lookup",
+  );
+  assert(
+    !uses.some((use) => use.useOffset === binding.nameOffset),
+    "the binding declaration is not a use",
+  );
 });
 
 Deno.test("ancestorsOf: chain from section down to the parent", () => {

--- a/packages/cli/test/view-semantics-gate.test.ts
+++ b/packages/cli/test/view-semantics-gate.test.ts
@@ -256,7 +256,92 @@ Deno.test("makeHost: a repeated read of the same file is served from the cache",
     const second = host.readFile!(file); // returned from fileCache
     assertEquals(first, "export const dep = 1;\n");
     assertEquals(second, first);
+    assertEquals(host.directoryExists!(dir), true);
+    assertEquals(host.directoryExists!(join(dir, "missing")), false);
   } finally {
     Deno.removeSync(dir, { recursive: true });
+  }
+});
+
+Deno.test("signed numeric definitions reject positions that do not name a supported key", () => {
+  const fileName = "/signed-numeric.ts";
+  const text = `const key = 1;
+const value = { [-1](): void {} };
+value[1];
+value[-key];
+value[!1];
+value[+1e999];
+value[-2];
+value[-1];
+`;
+  const host = _internal.makeHost(
+    [{ name: fileName, start: 0, end: text.length, text }],
+    {},
+    undefined,
+    CWD,
+    CWD,
+  );
+  const service = ts.createLanguageService(host, ts.createDocumentRegistry());
+  try {
+    const program = service.getProgram();
+    assert(program, "the test source produces a TypeScript program");
+    const atArgument = (snippet: string): number => {
+      const start = text.indexOf(snippet);
+      assert(start >= 0, `source contains ${snippet}`);
+      return start + snippet.indexOf("[") + 1;
+    };
+
+    assertEquals(
+      _internal.signedNumericElementDefinitions(
+        program!,
+        "/missing.ts",
+        0,
+      ),
+      [],
+    );
+    assertEquals(
+      _internal.signedNumericElementDefinitions(
+        program!,
+        fileName,
+        text.length,
+      ),
+      [],
+    );
+    assertEquals(
+      _internal.signedNumericElementDefinitions(
+        program!,
+        fileName,
+        text.indexOf("const key"),
+      ),
+      [],
+    );
+    for (
+      const snippet of [
+        "value[1]",
+        "value[-key]",
+        "value[!1]",
+        "value[+1e999]",
+        "value[-2]",
+      ]
+    ) {
+      assertEquals(
+        _internal.signedNumericElementDefinitions(
+          program!,
+          fileName,
+          atArgument(snippet),
+        ),
+        [],
+        `${snippet} has no supported signed numeric definition`,
+      );
+    }
+    const definitions = _internal.signedNumericElementDefinitions(
+      program!,
+      fileName,
+      atArgument("value[-1]"),
+    );
+    assertEquals(definitions.length, 1);
+    assertEquals(definitions[0].name, "-1");
+  } finally {
+    service.dispose();
   }
 });

--- a/packages/cli/test/view-semantics.test.ts
+++ b/packages/cli/test/view-semantics.test.ts
@@ -504,6 +504,313 @@ const flag = ext();`;
   }
 });
 
+Deno.test("card: an external method called by a statement is defined elsewhere", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    Deno.writeTextFileSync(
+      join(root, "deno.json"),
+      JSON.stringify({ imports: { ext: "./ext.ts" } }),
+    );
+    Deno.writeTextFileSync(
+      join(root, "ext.ts"),
+      `export class Worker {
+  run(): void {}
+}
+export const worker = new Worker();
+`,
+    );
+    for (
+      const [call, displayName] of [
+        ["worker.run()", "run"],
+        ["(worker.run)()", "run"],
+        ["worker.run!()", "run"],
+        ["(worker.run as () => void)()", "run"],
+        ["(worker.run<string>)()", "run"],
+        ['worker["run"]()', '"run"'],
+        ["worker[`run`]()", '"run"'],
+      ]
+    ) {
+      const blob = `// transformed: /main.ts
+import { worker } from "ext";
+${call};`;
+      const doc = parseDocument(blob);
+      const statement = doc.flatStructure.find((node) =>
+        node.kind === "statement" && node.startLine === 2
+      )!;
+      const sem = createSemantics(blob, { cwd: root })!;
+      const card = buildPeekCard(doc, statement, sem);
+      const text = card.info
+        .map((line) => line.text)
+        .join("\n");
+      assert(
+        text.includes(`  ${displayName}  ext.ts:2`),
+        `${call} lists its called method as defined elsewhere: ${text}`,
+      );
+      assert(
+        card.targets.some((target) =>
+          target.filePath?.endsWith("ext.ts") &&
+          target.destLine === 1 &&
+          target.destCol === 2
+        ),
+        `${call} has a jump target at its external declaration`,
+      );
+    }
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
+Deno.test("card: literal call keys have safe one-line display names", () => {
+  const blob = `// transformed: /main.ts
+const worker = {
+  [""](): void {},
+  [\`line one
+line two\`](): void {},
+  ["\\u2028"](): void {},
+  ["\\u2029"](): void {},
+};
+[worker[""](), worker[\`line one
+line two\`](), worker["\\u2028"](), worker["\\u2029"]()];
+`;
+  const doc = parseDocument(blob);
+  const statement = doc.flatStructure.find((node) =>
+    node.kind === "statement" && node.label.startsWith("[worker")
+  )!;
+  const sem = createSemantics(blob, { cwd: CWD })!;
+  const card = buildPeekCard(doc, statement, sem);
+  const text = card.info.map((line) => line.text).join("\n");
+  assert(text.includes('  ""  method'), `empty key is quoted: ${text}`);
+  assert(
+    text.includes('  "line one\\nline two"  method'),
+    `multiline key is escaped: ${text}`,
+  );
+  assert(
+    text.includes('  "\\u2028"  method'),
+    `line separator is escaped: ${text}`,
+  );
+  assert(
+    text.includes('  "\\u2029"  method'),
+    `paragraph separator is escaped: ${text}`,
+  );
+  for (const line of card.info) {
+    assert(!line.text.includes("\n"), "card model lines remain single-line");
+    assert(
+      !/[\u2028\u2029]/u.test(line.text),
+      "card model lines contain no Unicode line separators",
+    );
+    assertEquals(line.spans.map((span) => span.text).join(""), line.text);
+  }
+});
+
+Deno.test("card: signed numeric method calls are defined elsewhere", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    Deno.writeTextFileSync(
+      join(root, "deno.json"),
+      JSON.stringify({ imports: { ext: "./ext.ts" } }),
+    );
+    Deno.writeTextFileSync(
+      join(root, "ext.ts"),
+      `export const numbered = {
+  [-1](): void {},
+  [+1](): void {},
+};
+`,
+    );
+    const blob = `// transformed: /main.ts
+import { numbered } from "ext";
+[numbered[-1](), numbered[+1]()];`;
+    const doc = parseDocument(blob);
+    const statement = doc.flatStructure.find((node) =>
+      node.kind === "statement" && node.startLine === 2
+    )!;
+    const sem = createSemantics(blob, { cwd: root })!;
+    const card = buildPeekCard(doc, statement, sem);
+    const text = card.info.map((line) => line.text).join("\n");
+    assert(text.includes("  -1  ext.ts:2"), `negative key is listed: ${text}`);
+    assert(text.includes("  +1  ext.ts:3"), `positive key is listed: ${text}`);
+    assertEquals(
+      card.targets
+        .filter((target) =>
+          target.filePath?.endsWith("ext.ts") &&
+          /^[ ]+[+-]1[ ]+/.test(card.info[target.cardLine]?.text ?? "")
+        )
+        .map((target) => [target.destLine, target.destCol]),
+      [[1, 2], [2, 2]],
+    );
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
+Deno.test("card: equal method names keep distinct external jump targets", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    Deno.writeTextFileSync(
+      join(root, "deno.json"),
+      JSON.stringify({ imports: { ext: "./ext.ts" } }),
+    );
+    Deno.writeTextFileSync(
+      join(root, "ext.ts"),
+      "export const first = { run(): void {} }; " +
+        "export const second = { run(): void {} };\n",
+    );
+    const calls = [
+      ...Array.from({ length: 40 }, () => "first.run()"),
+      "second.run()",
+    ].join(", ");
+    const blob = `// transformed: /main.ts
+import { first, second } from "ext";
+${calls};`;
+    const doc = parseDocument(blob);
+    const statement = doc.flatStructure.find((node) =>
+      node.kind === "statement" && node.startLine === 2
+    )!;
+    const sem = createSemantics(blob, { cwd: root })!;
+    const card = buildPeekCard(doc, statement, sem, true);
+    assertEquals(
+      card.info
+        .filter((line) => line.text.startsWith("  run  "))
+        .map((line) => line.text),
+      ["  run  ext.ts:1", "  run  ext.ts:1"],
+    );
+    const runTargets = card.targets.filter((target) =>
+      target.filePath?.endsWith("ext.ts") &&
+      card.info[target.cardLine]?.text.startsWith("  run  ")
+    );
+    assertEquals(runTargets.length, 2);
+    assertEquals(runTargets.map((target) => target.destLine), [0, 0]);
+    assertEquals(
+      new Set(runTargets.map((target) => target.destCol)).size,
+      2,
+      "same-line method declarations retain distinct destination columns",
+    );
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
+Deno.test("card: collapsed definition lookup is bounded and expandable", () => {
+  const calls = Array.from({ length: 1_000 }, () => "worker.run()").join(", ");
+  const blob = `// transformed: /main.ts
+${calls};`;
+  const doc = parseDocument(blob);
+  const statement = doc.flatStructure.find((node) =>
+    node.kind === "statement" && node.startLine === 1
+  )!;
+  let definitionCalls = 0;
+  const sem: Semantics = {
+    typeAt: () => null,
+    prewarm: () => {},
+    fileLines: () => null,
+    definitionOf: () => {
+      definitionCalls++;
+      return [{
+        name: "run",
+        filePath: "/workspace/ext.ts",
+        fileOffset: 0,
+        line: 0,
+        col: 0,
+        preview: "",
+      }];
+    },
+  };
+  const card = buildPeekCard(doc, statement, sem);
+  assertEquals(
+    definitionCalls,
+    40,
+    "the collapsed card resolves only its bounded prefix",
+  );
+  assert(
+    card.info.some((line) => line.text.includes("961 remaining uses")),
+    "the card says how much definition lookup remains",
+  );
+  assert(
+    card.targets.some((target) => target.expand),
+    "the remaining lookup can be expanded",
+  );
+});
+
+Deno.test("card: a called in-document method is a dependency jump", () => {
+  const blob = `// transformed: /main.ts
+const worker = { render(): void {} };
+worker.render();`;
+  const doc = parseDocument(blob);
+  const call = doc.flatStructure.find((node) =>
+    node.kind === "builder" && node.startLine === 2
+  )!;
+  const method = doc.flatStructure.find((node) =>
+    node.kind === "method" && node.label.includes("render")
+  )!;
+  const sem = createSemantics(blob, { cwd: CWD })!;
+  const card = buildPeekCard(doc, call, sem);
+  const text = card.info.map((line) => line.text).join("\n");
+  assert(
+    text.includes("  render  method  line 2"),
+    `called method is listed as a dependency: ${text}`,
+  );
+  assert(
+    card.targets.some((target) =>
+      target.defOffset === method.startOffset && target.destLine === 1
+    ),
+    "called method has an in-document jump target",
+  );
+});
+
+Deno.test("card: local function properties retain distinct exact destinations", () => {
+  const definitionLine =
+    "const worker = { first: { run: () => 1 }, second: { run: () => 2 } };";
+  const blob = `// transformed: /main.ts
+${definitionLine}
+[worker.first.run(), worker.second.run()];`;
+  const doc = parseDocument(blob);
+  const statement = doc.flatStructure.find((node) =>
+    node.kind === "statement" && node.startLine === 2
+  )!;
+  const sem = createSemantics(blob, { cwd: CWD })!;
+  const card = buildPeekCard(doc, statement, sem);
+  const runTargets = card.targets.filter((target) =>
+    card.info[target.cardLine]?.text.startsWith("  run  ")
+  );
+  assertEquals(runTargets.length, 2);
+  assertEquals(runTargets.map((target) => target.destLine), [1, 1]);
+  assertEquals(
+    runTargets.map((target) => target.destCol).sort((a, b) => a - b),
+    [definitionLine.indexOf("run"), definitionLine.lastIndexOf("run")],
+  );
+});
+
+Deno.test("card: exact and name-index dependencies stay in source order", () => {
+  const declarations = Array.from(
+    { length: 10 },
+    (_, index) => `const d${index} = ${index};`,
+  ).join("\n");
+  const blob = `// transformed: /main.ts
+const worker = { run(..._values: number[]): void {} };
+${declarations}
+worker.run(d0, d1, d2, d3, d4, d5, d6, d7, d8, d9);`;
+  const doc = parseDocument(blob);
+  const statement = doc.flatStructure.find((node) =>
+    node.kind === "statement" && node.startLine === 12
+  )!;
+  const sem = createSemantics(blob, { cwd: CWD })!;
+  const card = buildPeekCard(doc, statement, sem);
+  const runLine = card.info.findIndex((line) =>
+    line.text.startsWith("  run  ")
+  );
+  const firstArgumentLine = card.info.findIndex((line) =>
+    line.text.startsWith("  d0  ")
+  );
+  assert(
+    runLine >= 0,
+    "the called method fits in the collapsed dependency list",
+  );
+  assert(
+    runLine < firstArgumentLine,
+    "the called method precedes the arguments that follow it in source",
+  );
+});
+
 Deno.test("card: a dependency jumps to the exact binding across a name collision", () => {
   // `helper` is declared in two sections; /main imports it from /b.ts.
   const blob = `// transformed: /a.ts

--- a/packages/cli/test/view-session-cov.test.ts
+++ b/packages/cli/test/view-session-cov.test.ts
@@ -217,7 +217,14 @@ function externalSession(destLine = 1, fileLines = 3): {
     prewarm: () => {},
     fileLines: (p) => p === filePath ? parseDocument(fileText).lines : null,
     definitionOf: () => [
-      { name: "ext", filePath, fileOffset: 0, line: destLine + 1, preview: "" },
+      {
+        name: "ext",
+        filePath,
+        fileOffset: 0,
+        line: destLine + 1,
+        col: 4,
+        preview: "",
+      },
     ],
   };
   const doc = parseDocument(`// transformed: /m.ts\nconst flag = ext();`);
@@ -342,6 +349,10 @@ Deno.test("session: Enter on a 'defined elsewhere' entry, then Esc, returns to t
   assert(
     s.view().overlay!.title.includes("ext.ts"),
     "opened the external file",
+  );
+  assert(
+    s.view().overlay!.title.includes("line 3, column 5"),
+    "shows the exact definition position",
   );
   assert(
     s.view().overlay!.footer.includes("esc back"),


### PR DESCRIPTION
Property call targets such as worker.run() were classified for syntax highlighting but omitted from exact semantic definition lookup. Statement info cards therefore listed the receiver while hiding the called method and its jump target.

Mark dot and literal element-access callees for position-based lookup without changing their syntax classes. Keep equal names until their semantic destinations are known. Preserve exact destination columns, and merge local method targets with ordinary dependencies in source order.

Limit semantic lookup while a card is collapsed. Exclude removed diff lines, and expose remaining uses through the existing card expansion flow. Keep decoded keys for lookup while rendering quoted and escaped labels in the card.

Cover direct, wrapped, generic, literal, and signed numeric calls. Cover same-named methods on different receivers, same-line declarations, name collisions, removed diff lines, bounded expansion, safe literal labels, and incremental highlighting metadata.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show called member definitions in view cards and enable jump‑to‑definition for them (e.g., worker.run()). Fix missing method targets, show exact line and column, and keep lookup fast on collapsed cards with safe deferral.

- **New Features**
  - Show called member targets (dot and element access, including signed numeric keys), even through parens/casts/generics/non‑null; merge with normal deps in source order.
  - Preserve and display exact destination columns (cards and external overlay); literal keys render as safe one‑line labels (quoted/escaped).
  - Bound semantic lookup on collapsed cards with a “definition lookup” row that shows remaining uses and possible dependencies; cache per‑card definition lookups.

- **Bug Fixes**
  - Exclude removed diff lines from dependency/semantic scans and from the lookup budget.
  - Prevent false matches and speculative jumps: do not use same‑named local fallbacks for deferred uses, keep distinct targets for equal method names and same‑line declarations, resolve name collisions correctly, and omit call targets defined inside the selected node.

<sup>Written for commit 28fc7c5fe388063eca8f3a2a95f6845642d9ce10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

