### PR TITLE
Roll Deno to 2.9.4

### DIFF
--- a/Dockerfile.dashboard
+++ b/Dockerfile.dashboard
@@ -14,7 +14,7 @@
 #     --build-arg DASHBOARD_GIT_COMMIT=$(git rev-parse HEAD) \
 #     -t us-central1-docker.pkg.dev/commontools-core/containers/dev-dashboard:$(git rev-parse HEAD) .
 
-FROM --platform=linux/amd64 denoland/deno:2.8.1
+FROM --platform=linux/amd64 denoland/deno:2.9.4
 
 WORKDIR /app
 COPY . .

--- a/Dockerfile.toolshed
+++ b/Dockerfile.toolshed
@@ -8,7 +8,7 @@
 #   docker build -f Dockerfile.toolshed --build-arg COMMIT_SHA=$(git rev-parse HEAD) \
 #     -t us-central1-docker.pkg.dev/commontools-core/containers/toolshed:m0 .
 
-FROM denoland/deno:2.8.1 AS builder
+FROM denoland/deno:2.9.4 AS builder
 
 WORKDIR /build/labs
 COPY . .
@@ -21,7 +21,7 @@ RUN sed -i 's|await Deno\.rename(shellOut, toolshedShellFrontend);|await new Den
 ARG COMMIT_SHA
 RUN COMMIT_SHA=$COMMIT_SHA deno task build-binaries
 
-FROM denoland/deno:2.8.1
+FROM denoland/deno:2.9.4
 
 COPY --from=builder /build/labs/dist/toolshed /usr/local/bin/toolshed
 

--- a/docs/development/DEPENDENCIES.md
+++ b/docs/development/DEPENDENCIES.md
@@ -148,19 +148,19 @@ against it:
 - `tasks/check.sh` (run by `deno task check`, the pre-commit hook, and CI)
   reads the pin for its version warning, and accepts the surrounding range set
   in its `DENO_VERSION_MIN`/`DENO_VERSION_MAX` variables.
-- `Dockerfile.toolshed` repeats the version in its `FROM` lines, which cannot
-  read another file.
+- `Dockerfile.dashboard` and `Dockerfile.toolshed` repeat the version in their
+  `FROM` lines, which cannot read another file.
 
-To bump the toolchain: update the version in `mise.toml` and both `FROM` lines
-in `Dockerfile.toolshed`, and move the `tasks/check.sh` range if the new
-version falls outside it.
+To bump the toolchain: update the version in `mise.toml` and every
+`denoland/deno` `FROM` line in the root deployment Dockerfiles, and move the
+`tasks/check.sh` range if the new version falls outside it.
 
 `deno task check-deno-pins` (also a CI step) catches a bump that misses one of
-those. It checks that every `denoland/deno` tag in `Dockerfile.toolshed` equals
-the pin, that the `tasks/check.sh` range contains the pin, that `check.sh` and
-the `deno-setup` action both still read `mise.toml` rather than a hardcoded
-version, and that the action holds no version literal that disagrees with the
-pin.
+those. It checks that every `denoland/deno` tag in the root deployment
+Dockerfiles equals the pin, that the `tasks/check.sh` range contains the pin,
+that `check.sh` and the `deno-setup` action both still read `mise.toml` rather
+than a hardcoded version, and that the action holds no version literal that
+disagrees with the pin.
 
 ### TypeScript
 
@@ -432,8 +432,8 @@ whichever version resolves and whichever compiler checks them.
 Two things make this class of breakage easy to miss. `deno task check` does not
 cover every package: `cf-harness` is type checked only by its own test task, so
 its type errors surface in a test shard rather than the Check job. And CI pins
-Deno 2.8.1 while `tasks/check.sh` accepts any 2.8.x, so a local check and CI can
-disagree about what type checks.
+Deno 2.9.4 while `tasks/check.sh` accepts any 2.8.x or 2.9.x, so a local check
+and CI can disagree about what type checks.
 
 ### Astral
 

--- a/docs/plans/cf-harness-codex-subscription-auth.md
+++ b/docs/plans/cf-harness-codex-subscription-auth.md
@@ -1,14 +1,12 @@
 # cf-harness Codex Subscription Authentication — Implementation Plan
 
 Status: Implemented in `cf-harness` and covered by automated tests. Remaining
-shipping gates are live-account smoke tests, security review, root validation
-under the repository-supported Deno version, and Loom host/UI policy wiring.
+shipping gates are live-account smoke tests, security review, and Loom host/UI
+policy wiring.
 
-Validation snapshot (2026-07-23): all 500 `cf-harness` tests pass; direct type
-checking, package lint/format, docs checks, unused-dependency checks, and diff
-whitespace checks pass. The aggregate root `deno task check` stops at its
-version guard because this workspace has Deno 2.9.3 while the repository
-requires Deno >=2.8.0 and <2.9.0.
+Validation snapshot (2026-07-29): the repository pins Deno 2.9.4. The aggregate
+root `deno task check` and `deno task test` pass, including the `cf-harness`
+checks and tests.
 
 This plan adds an opt-in way for a `cf-harness` user to use their ChatGPT/Codex
 subscription instead of an OpenAI Platform API key, first through the local CLI

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-deno = "2.8.1"
+deno = "2.9.4"
 
 # Puts this checkout's `bin/cf` on PATH, so `cf` resolves to the worktree you
 # are standing in. Shell completion needs a `cf` on PATH to work at all — see

--- a/packages/deno-web-test/cli.ts
+++ b/packages/deno-web-test/cli.ts
@@ -3,6 +3,13 @@ import { Manifest } from "./manifest.ts";
 import { buildTestDir } from "./utils.ts";
 import { Runner } from "./runner.ts";
 
+const stderrBoundary = Deno.env.get("DENO_WEB_TEST_STDERR_BOUNDARY");
+if (stderrBoundary) {
+  Deno.stderr.writeSync(
+    new TextEncoder().encode(`${stderrBoundary}\n`),
+  );
+}
+
 // {*_,*.,}test.{ts, tsx, mts, js, mjs, jsx}
 const manifest = await Manifest.create(Deno.cwd(), [...Deno.args]);
 await buildTestDir(manifest);

--- a/packages/deno-web-test/harness/index.html
+++ b/packages/deno-web-test/harness/index.html
@@ -1,10 +1,10 @@
 <style>
-  li[state="success"] {
-    background-color: green;
-  }
-  li[state="error"] {
-    background-color: red;
-  }
+li[state="success"] {
+  background-color: green;
+}
+li[state="error"] {
+  background-color: red;
+}
 </style>
 <h1>Deno Web Test</h1>
 <h2 id="title"></h2>

--- a/packages/deno-web-test/test/base.test.ts
+++ b/packages/deno-web-test/test/base.test.ts
@@ -79,3 +79,24 @@ Deno.test("dependency downloads do not enter harness stderr", function () {
     );
   }
 });
+
+Deno.test("non-SGR control sequences do not identify Deno diagnostics", function () {
+  const encoder = new TextEncoder();
+  for (const sequence of ["\x1b[>4;2m", "\x1b[ 31m"]) {
+    const output: Deno.CommandOutput = {
+      code: 0,
+      success: true,
+      signal: null,
+      stdout: encoder.encode("test output"),
+      stderr: encoder.encode(
+        `Task test deno run cli.ts *.test.ts\n${sequence}Download https://example.test/from-application\n`,
+      ),
+    };
+
+    assertEquals(
+      sanitizeDenoWebTestOutput(output),
+      output,
+      `preserves ${JSON.stringify(sequence)}`,
+    );
+  }
+});

--- a/packages/deno-web-test/test/base.test.ts
+++ b/packages/deno-web-test/test/base.test.ts
@@ -7,12 +7,6 @@ Deno.test("smoke test", async function () {
   const stdoutText = decode(stdout);
   const stderrText = decode(stderr);
 
-  // While the test package is pulled out of the workspace
-  // during testing, ensure we use the same version in `success-project`
-  // as the outer workspace so that we don't get terminal spam
-  // from downloading new versions, breaking stdout/stderr
-  // parsers in the tests
-
   assert(success, "test successful");
   assert(/add-sync ... ok/.test(stdoutText), "test output ok");
   assert(/add-async ... ok/.test(stdoutText), "test output ok");
@@ -26,8 +20,9 @@ Deno.test("smoke test", async function () {
   assert(stderrText.split("\n")[1] === "", "stderr has no other messages");
 });
 
-Deno.test("dependency downloads do not enter harness stderr", function () {
+Deno.test("dependency downloads before the harness boundary are removed", function () {
   const encoder = new TextEncoder();
+  const boundary = "deno-web-test:test-boundary";
   for (const colorized of [false, true]) {
     const taskLine = colorized
       ? "\x1b[0m\x1b[32mTask\x1b[0m \x1b[0m\x1b[36mtest\x1b[0m deno run cli.ts *.test.ts\n"
@@ -44,7 +39,8 @@ Deno.test("dependency downloads do not enter harness stderr", function () {
         warning,
     );
     const afterInvalidByte = encoder.encode(
-      "\n" + downloadLine("https://example.test/from-application"),
+      `\n${boundary}\n` +
+        downloadLine("https://example.test/from-application"),
     );
     const stderr = new Uint8Array(
       beforeInvalidByte.length + 1 + afterInvalidByte.length,
@@ -60,17 +56,22 @@ Deno.test("dependency downloads do not enter harness stderr", function () {
       stdout: encoder.encode("test output"),
       stderr,
     };
-
-    const expectedTask = encoder.encode(taskLine + warning);
-    const expectedStderr = new Uint8Array(
-      expectedTask.length + 1 + afterInvalidByte.length,
+    const expectedBeforeInvalidByte = encoder.encode(taskLine + warning);
+    const expectedAfterInvalidByte = encoder.encode(
+      "\n" + downloadLine("https://example.test/from-application"),
     );
-    expectedStderr.set(expectedTask);
-    expectedStderr[expectedTask.length] = 0xff;
-    expectedStderr.set(afterInvalidByte, expectedTask.length + 1);
+    const expectedStderr = new Uint8Array(
+      expectedBeforeInvalidByte.length + 1 + expectedAfterInvalidByte.length,
+    );
+    expectedStderr.set(expectedBeforeInvalidByte);
+    expectedStderr[expectedBeforeInvalidByte.length] = 0xff;
+    expectedStderr.set(
+      expectedAfterInvalidByte,
+      expectedBeforeInvalidByte.length + 1,
+    );
 
     assertEquals(
-      sanitizeDenoWebTestOutput(output),
+      sanitizeDenoWebTestOutput(output, boundary),
       {
         ...output,
         stderr: expectedStderr,
@@ -80,22 +81,29 @@ Deno.test("dependency downloads do not enter harness stderr", function () {
   }
 });
 
-Deno.test("non-SGR control sequences do not identify Deno diagnostics", function () {
+Deno.test("non-SGR control sequences remain before the boundary", function () {
   const encoder = new TextEncoder();
+  const boundary = "deno-web-test:test-boundary";
   for (const sequence of ["\x1b[>4;2m", "\x1b[ 31m"]) {
+    const taskLine = "Task test deno run cli.ts *.test.ts\n";
+    const applicationLine =
+      `${sequence}Download https://example.test/from-application\n`;
     const output: Deno.CommandOutput = {
       code: 0,
       success: true,
       signal: null,
       stdout: encoder.encode("test output"),
       stderr: encoder.encode(
-        `Task test deno run cli.ts *.test.ts\n${sequence}Download https://example.test/from-application\n`,
+        `${taskLine}${applicationLine}${boundary}\n`,
       ),
     };
 
     assertEquals(
-      sanitizeDenoWebTestOutput(output),
-      output,
+      sanitizeDenoWebTestOutput(output, boundary),
+      {
+        ...output,
+        stderr: encoder.encode(taskLine + applicationLine),
+      },
       `preserves ${JSON.stringify(sequence)}`,
     );
   }
@@ -103,6 +111,7 @@ Deno.test("non-SGR control sequences do not identify Deno diagnostics", function
 
 Deno.test("application download lines remain in harness stderr", function () {
   const encoder = new TextEncoder();
+  const boundary = "deno-web-test:test-boundary";
   for (const colorized of [false, true]) {
     const taskLine = colorized
       ? "\x1b[0m\x1b[32mTask\x1b[0m \x1b[0m\x1b[36mtest\x1b[0m deno run cli.ts *.test.ts\n"
@@ -115,12 +124,20 @@ Deno.test("application download lines remain in harness stderr", function () {
       success: true,
       signal: null,
       stdout: encoder.encode("test output"),
-      stderr: encoder.encode(taskLine + applicationLine),
+      stderr: encoder.encode(
+        taskLine +
+          applicationLine.replace("example.test", "registry.npmjs.org") +
+          `${boundary}\n` +
+          applicationLine,
+      ),
     };
 
     assertEquals(
-      sanitizeDenoWebTestOutput(output),
-      output,
+      sanitizeDenoWebTestOutput(output, boundary),
+      {
+        ...output,
+        stderr: encoder.encode(taskLine + applicationLine),
+      },
       colorized ? "colorized application output" : "plain application output",
     );
   }

--- a/packages/deno-web-test/test/base.test.ts
+++ b/packages/deno-web-test/test/base.test.ts
@@ -1,6 +1,6 @@
-import { assert } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
 import { decode } from "@commonfabric/utils/encoding";
-import { runDenoWebTest } from "./utils.ts";
+import { runDenoWebTest, stripDenoDownloadDiagnostics } from "./utils.ts";
 
 Deno.test("smoke test", async function () {
   const { success, stdout, stderr } = await runDenoWebTest("success-project");
@@ -26,15 +26,17 @@ Deno.test("smoke test", async function () {
   assert(stderrText.split("\n")[1] === "", "stderr has no other messages");
 });
 
-Deno.test("dependency downloads do not enter harness stderr", async function () {
-  const { success, stderr } = await runDenoWebTest("success-project", {
-    reload: "npm:typescript",
-  });
-  const stderrText = decode(stderr);
+Deno.test("dependency downloads do not enter harness stderr", function () {
+  const stderr = new TextEncoder().encode(
+    "Task test deno run cli.ts *.test.ts\n" +
+      "Download https://registry.npmjs.org/esbuild\n" +
+      "Download https://registry.npmjs.org/typescript\n" +
+      "Warning experimentalDecorators is deprecated\n",
+  );
 
-  assert(success, "test successful");
-  assert(
-    !stderrText.includes("Download"),
-    `stderr has no download diagnostics:\n${stderrText}`,
+  assertEquals(
+    decode(stripDenoDownloadDiagnostics(stderr)),
+    "Task test deno run cli.ts *.test.ts\n" +
+      "Warning experimentalDecorators is deprecated\n",
   );
 });

--- a/packages/deno-web-test/test/base.test.ts
+++ b/packages/deno-web-test/test/base.test.ts
@@ -1,6 +1,6 @@
 import { assert, assertEquals } from "@std/assert";
 import { decode } from "@commonfabric/utils/encoding";
-import { runDenoWebTest, stripDenoDownloadDiagnostics } from "./utils.ts";
+import { runDenoWebTest, sanitizeDenoWebTestOutput } from "./utils.ts";
 
 Deno.test("smoke test", async function () {
   const { success, stdout, stderr } = await runDenoWebTest("success-project");
@@ -27,16 +27,46 @@ Deno.test("smoke test", async function () {
 });
 
 Deno.test("dependency downloads do not enter harness stderr", function () {
-  const stderr = new TextEncoder().encode(
+  const encoder = new TextEncoder();
+  const beforeInvalidByte = encoder.encode(
     "Task test deno run cli.ts *.test.ts\n" +
       "Download https://registry.npmjs.org/esbuild\n" +
-      "Download https://registry.npmjs.org/typescript\n" +
-      "Warning experimentalDecorators is deprecated\n",
+      "Download http://registry.npmjs.org/typescript\n" +
+      "Warning with non-UTF-8 byte: ",
   );
+  const afterInvalidByte = encoder.encode(
+    "\nDownload https://example.test/from-application\n",
+  );
+  const stderr = new Uint8Array(
+    beforeInvalidByte.length + 1 + afterInvalidByte.length,
+  );
+  stderr.set(beforeInvalidByte);
+  stderr[beforeInvalidByte.length] = 0xff;
+  stderr.set(afterInvalidByte, beforeInvalidByte.length + 1);
+
+  const output: Deno.CommandOutput = {
+    code: 0,
+    success: true,
+    signal: null,
+    stdout: encoder.encode("test output"),
+    stderr,
+  };
+
+  const expectedTask = encoder.encode(
+    "Task test deno run cli.ts *.test.ts\nWarning with non-UTF-8 byte: ",
+  );
+  const expectedStderr = new Uint8Array(
+    expectedTask.length + 1 + afterInvalidByte.length,
+  );
+  expectedStderr.set(expectedTask);
+  expectedStderr[expectedTask.length] = 0xff;
+  expectedStderr.set(afterInvalidByte, expectedTask.length + 1);
 
   assertEquals(
-    decode(stripDenoDownloadDiagnostics(stderr)),
-    "Task test deno run cli.ts *.test.ts\n" +
-      "Warning experimentalDecorators is deprecated\n",
+    sanitizeDenoWebTestOutput(output),
+    {
+      ...output,
+      stderr: expectedStderr,
+    },
   );
 });

--- a/packages/deno-web-test/test/base.test.ts
+++ b/packages/deno-web-test/test/base.test.ts
@@ -25,3 +25,16 @@ Deno.test("smoke test", async function () {
   assert(stderrText.split("\n").length === 2, "stderr has no other messages");
   assert(stderrText.split("\n")[1] === "", "stderr has no other messages");
 });
+
+Deno.test("dependency downloads do not enter harness stderr", async function () {
+  const { success, stderr } = await runDenoWebTest("success-project", {
+    reload: "npm:typescript",
+  });
+  const stderrText = decode(stderr);
+
+  assert(success, "test successful");
+  assert(
+    !stderrText.includes("Download"),
+    `stderr has no download diagnostics:\n${stderrText}`,
+  );
+});

--- a/packages/deno-web-test/test/base.test.ts
+++ b/packages/deno-web-test/test/base.test.ts
@@ -100,3 +100,28 @@ Deno.test("non-SGR control sequences do not identify Deno diagnostics", function
     );
   }
 });
+
+Deno.test("application download lines remain in harness stderr", function () {
+  const encoder = new TextEncoder();
+  for (const colorized of [false, true]) {
+    const taskLine = colorized
+      ? "\x1b[0m\x1b[32mTask\x1b[0m \x1b[0m\x1b[36mtest\x1b[0m deno run cli.ts *.test.ts\n"
+      : "Task test deno run cli.ts *.test.ts\n";
+    const applicationLine = colorized
+      ? "\x1b[0m\x1b[32mDownload\x1b[0m https://example.test/from-application\n"
+      : "Download https://example.test/from-application\n";
+    const output: Deno.CommandOutput = {
+      code: 0,
+      success: true,
+      signal: null,
+      stdout: encoder.encode("test output"),
+      stderr: encoder.encode(taskLine + applicationLine),
+    };
+
+    assertEquals(
+      sanitizeDenoWebTestOutput(output),
+      output,
+      colorized ? "colorized application output" : "plain application output",
+    );
+  }
+});

--- a/packages/deno-web-test/test/base.test.ts
+++ b/packages/deno-web-test/test/base.test.ts
@@ -28,45 +28,54 @@ Deno.test("smoke test", async function () {
 
 Deno.test("dependency downloads do not enter harness stderr", function () {
   const encoder = new TextEncoder();
-  const beforeInvalidByte = encoder.encode(
-    "Task test deno run cli.ts *.test.ts\n" +
-      "Download https://registry.npmjs.org/esbuild\n" +
-      "Download http://registry.npmjs.org/typescript\n" +
-      "Warning with non-UTF-8 byte: ",
-  );
-  const afterInvalidByte = encoder.encode(
-    "\nDownload https://example.test/from-application\n",
-  );
-  const stderr = new Uint8Array(
-    beforeInvalidByte.length + 1 + afterInvalidByte.length,
-  );
-  stderr.set(beforeInvalidByte);
-  stderr[beforeInvalidByte.length] = 0xff;
-  stderr.set(afterInvalidByte, beforeInvalidByte.length + 1);
+  for (const colorized of [false, true]) {
+    const taskLine = colorized
+      ? "\x1b[0m\x1b[32mTask\x1b[0m \x1b[0m\x1b[36mtest\x1b[0m deno run cli.ts *.test.ts\n"
+      : "Task test deno run cli.ts *.test.ts\n";
+    const downloadLine = (url: string) =>
+      colorized
+        ? `\x1b[0m\x1b[32mDownload\x1b[0m ${url}\n`
+        : `Download ${url}\n`;
+    const warning = "Warning with non-UTF-8 byte: ";
+    const beforeInvalidByte = encoder.encode(
+      taskLine +
+        downloadLine("https://registry.npmjs.org/esbuild") +
+        downloadLine("http://registry.npmjs.org/typescript") +
+        warning,
+    );
+    const afterInvalidByte = encoder.encode(
+      "\n" + downloadLine("https://example.test/from-application"),
+    );
+    const stderr = new Uint8Array(
+      beforeInvalidByte.length + 1 + afterInvalidByte.length,
+    );
+    stderr.set(beforeInvalidByte);
+    stderr[beforeInvalidByte.length] = 0xff;
+    stderr.set(afterInvalidByte, beforeInvalidByte.length + 1);
 
-  const output: Deno.CommandOutput = {
-    code: 0,
-    success: true,
-    signal: null,
-    stdout: encoder.encode("test output"),
-    stderr,
-  };
+    const output: Deno.CommandOutput = {
+      code: 0,
+      success: true,
+      signal: null,
+      stdout: encoder.encode("test output"),
+      stderr,
+    };
 
-  const expectedTask = encoder.encode(
-    "Task test deno run cli.ts *.test.ts\nWarning with non-UTF-8 byte: ",
-  );
-  const expectedStderr = new Uint8Array(
-    expectedTask.length + 1 + afterInvalidByte.length,
-  );
-  expectedStderr.set(expectedTask);
-  expectedStderr[expectedTask.length] = 0xff;
-  expectedStderr.set(afterInvalidByte, expectedTask.length + 1);
+    const expectedTask = encoder.encode(taskLine + warning);
+    const expectedStderr = new Uint8Array(
+      expectedTask.length + 1 + afterInvalidByte.length,
+    );
+    expectedStderr.set(expectedTask);
+    expectedStderr[expectedTask.length] = 0xff;
+    expectedStderr.set(afterInvalidByte, expectedTask.length + 1);
 
-  assertEquals(
-    sanitizeDenoWebTestOutput(output),
-    {
-      ...output,
-      stderr: expectedStderr,
-    },
-  );
+    assertEquals(
+      sanitizeDenoWebTestOutput(output),
+      {
+        ...output,
+        stderr: expectedStderr,
+      },
+      colorized ? "colorized diagnostics" : "plain diagnostics",
+    );
+  }
 });

--- a/packages/deno-web-test/test/utils.ts
+++ b/packages/deno-web-test/test/utils.ts
@@ -20,8 +20,9 @@ function skipSgrSequences(
     while (
       end < value.length &&
       (
-        value[end] >= 0x30 && value[end] <= 0x3f ||
-        value[end] >= 0x20 && value[end] <= 0x2f
+        value[end] >= 0x30 && value[end] <= 0x39 ||
+        value[end] === 0x3a ||
+        value[end] === 0x3b
       )
     ) {
       end++;

--- a/packages/deno-web-test/test/utils.ts
+++ b/packages/deno-web-test/test/utils.ts
@@ -6,7 +6,7 @@ const dirname = import.meta.dirname as string;
 const CLI_PATH = path.join(dirname, "..", "cli.ts");
 const DenoWebTestCache: Map<string, Promise<Deno.CommandOutput>> = new Map();
 const encoder = new TextEncoder();
-const TASK_PREFIX = encoder.encode("Task ");
+const STDERR_BOUNDARY_ENV = "DENO_WEB_TEST_STDERR_BOUNDARY";
 const DOWNLOAD_HTTP_PREFIX = encoder.encode("Download http://");
 const DOWNLOAD_HTTPS_PREFIX = encoder.encode("Download https://");
 
@@ -51,45 +51,73 @@ function startsWithVisibleBytes(
   return true;
 }
 
+function indexOfBytes(
+  value: Uint8Array,
+  target: Uint8Array,
+): number {
+  for (let start = 0; start <= value.length - target.length; start++) {
+    let matches = true;
+    for (let i = 0; i < target.length; i++) {
+      if (value[start + i] !== target[i]) {
+        matches = false;
+        break;
+      }
+    }
+    if (matches) {
+      return start;
+    }
+  }
+  return -1;
+}
+
 function stripDenoDownloadDiagnostics(
   stderr: Uint8Array<ArrayBuffer>,
+  boundary: Uint8Array,
 ): Uint8Array<ArrayBuffer> {
-  const taskLineEnd = stderr.indexOf(0x0a);
-  if (
-    taskLineEnd === -1 ||
-    !startsWithVisibleBytes(stderr, TASK_PREFIX, 0)
-  ) {
+  const boundaryStart = indexOfBytes(stderr, boundary);
+  if (boundaryStart === -1) {
     return stderr;
   }
 
-  const downloadsStart = taskLineEnd + 1;
-  let downloadsEnd = downloadsStart;
-  while (
-    startsWithVisibleBytes(stderr, DOWNLOAD_HTTP_PREFIX, downloadsEnd) ||
-    startsWithVisibleBytes(stderr, DOWNLOAD_HTTPS_PREFIX, downloadsEnd)
-  ) {
-    const lineEnd = stderr.indexOf(0x0a, downloadsEnd);
-    downloadsEnd = lineEnd === -1 ? stderr.length : lineEnd + 1;
+  const retained: Uint8Array[] = [];
+  let retainedLength = stderr.length - boundary.length;
+  let lineStart = 0;
+  while (lineStart < boundaryStart) {
+    const lineBreak = stderr.indexOf(0x0a, lineStart);
+    const lineEnd = lineBreak === -1 || lineBreak >= boundaryStart
+      ? boundaryStart
+      : lineBreak + 1;
+    if (
+      startsWithVisibleBytes(stderr, DOWNLOAD_HTTP_PREFIX, lineStart) ||
+      startsWithVisibleBytes(stderr, DOWNLOAD_HTTPS_PREFIX, lineStart)
+    ) {
+      retainedLength -= lineEnd - lineStart;
+    } else {
+      retained.push(stderr.subarray(lineStart, lineEnd));
+    }
+    lineStart = lineEnd;
   }
+  retained.push(stderr.subarray(boundaryStart + boundary.length));
 
-  if (downloadsEnd === downloadsStart) {
-    return stderr;
+  const filtered = new Uint8Array(retainedLength);
+  let offset = 0;
+  for (const part of retained) {
+    filtered.set(part, offset);
+    offset += part.length;
   }
-
-  const filtered = new Uint8Array(
-    stderr.length - (downloadsEnd - downloadsStart),
-  );
-  filtered.set(stderr.subarray(0, downloadsStart));
-  filtered.set(stderr.subarray(downloadsEnd), downloadsStart);
   return filtered;
 }
 
 export function sanitizeDenoWebTestOutput(
   output: Deno.CommandOutput,
+  boundary: string,
 ): Deno.CommandOutput {
   return {
     ...output,
-    stderr: stripDenoDownloadDiagnostics(output.stderr),
+    stderr: stripDenoDownloadDiagnostics(
+      output.stderr,
+      encoder.encode(`${boundary}\n`),
+    ),
   };
 }
 
@@ -142,13 +170,19 @@ export const runDenoWebTest = async (
     throw new Error("Failed to run `deno install`");
   }
 
+  const stderrBoundary = `deno-web-test:${crypto.randomUUID()}`;
   const output = new Deno.Command(Deno.execPath(), {
     args: [
       "task",
       "test",
     ],
     cwd: tmpProjectPath,
-  }).output().then(sanitizeDenoWebTestOutput);
+    env: {
+      [STDERR_BOUNDARY_ENV]: stderrBoundary,
+    },
+  }).output().then((output) =>
+    sanitizeDenoWebTestOutput(output, stderrBoundary)
+  );
   DenoWebTestCache.set(projectDir, output);
   return output;
 };

--- a/packages/deno-web-test/test/utils.ts
+++ b/packages/deno-web-test/test/utils.ts
@@ -37,11 +37,17 @@ export const runDenoWebTest = async (
     `deno run --allow-env --allow-read --allow-write --allow-run --allow-net ${CLI_PATH} *.test.ts`;
   await Deno.writeTextFile(manifestPath, JSON.stringify(manifest));
 
-  // Run `deno install` first to not clutter up stderr
-  // with downloading messages in CI.
+  // Populate the cache for the harness and each test entrypoint before the task.
+  const testEntrypoints = [...Deno.readDirSync(tmpProjectPath)]
+    .filter((entry) => entry.isFile && entry.name.endsWith(".test.ts"))
+    .map((entry) => path.join(tmpProjectPath, entry.name))
+    .sort();
   const { success: installSuccess } = await new Deno.Command(Deno.execPath(), {
     args: [
       "install",
+      "--entrypoint",
+      CLI_PATH,
+      ...testEntrypoints,
     ],
     cwd: tmpProjectPath,
   }).output();

--- a/packages/deno-web-test/test/utils.ts
+++ b/packages/deno-web-test/test/utils.ts
@@ -17,6 +17,12 @@ export function stripDenoDownloadDiagnostics(
   return new TextEncoder().encode(withoutDownloads);
 }
 
+export function sanitizeDenoWebTestOutput(
+  output: Deno.CommandOutput,
+): Deno.CommandOutput {
+  return output;
+}
+
 // Runs deno-web-test in `projectDir` and caches
 // the results for multiple test usages.
 //

--- a/packages/deno-web-test/test/utils.ts
+++ b/packages/deno-web-test/test/utils.ts
@@ -10,18 +10,42 @@ const TASK_PREFIX = encoder.encode("Task ");
 const DOWNLOAD_HTTP_PREFIX = encoder.encode("Download http://");
 const DOWNLOAD_HTTPS_PREFIX = encoder.encode("Download https://");
 
-function startsWithBytes(
+function skipSgrSequences(
+  value: Uint8Array,
+  offset: number,
+): number {
+  let next = offset;
+  while (value[next] === 0x1b && value[next + 1] === 0x5b) {
+    let end = next + 2;
+    while (
+      end < value.length &&
+      (
+        value[end] >= 0x30 && value[end] <= 0x3f ||
+        value[end] >= 0x20 && value[end] <= 0x2f
+      )
+    ) {
+      end++;
+    }
+    if (value[end] !== 0x6d) {
+      break;
+    }
+    next = end + 1;
+  }
+  return next;
+}
+
+function startsWithVisibleBytes(
   value: Uint8Array,
   prefix: Uint8Array,
   offset: number,
 ): boolean {
-  if (offset + prefix.length > value.length) {
-    return false;
-  }
+  let valueIndex = offset;
   for (let i = 0; i < prefix.length; i++) {
-    if (value[offset + i] !== prefix[i]) {
+    valueIndex = skipSgrSequences(value, valueIndex);
+    if (value[valueIndex] !== prefix[i]) {
       return false;
     }
+    valueIndex++;
   }
   return true;
 }
@@ -32,7 +56,7 @@ function stripDenoDownloadDiagnostics(
   const taskLineEnd = stderr.indexOf(0x0a);
   if (
     taskLineEnd === -1 ||
-    !startsWithBytes(stderr, TASK_PREFIX, 0)
+    !startsWithVisibleBytes(stderr, TASK_PREFIX, 0)
   ) {
     return stderr;
   }
@@ -40,8 +64,8 @@ function stripDenoDownloadDiagnostics(
   const downloadsStart = taskLineEnd + 1;
   let downloadsEnd = downloadsStart;
   while (
-    startsWithBytes(stderr, DOWNLOAD_HTTP_PREFIX, downloadsEnd) ||
-    startsWithBytes(stderr, DOWNLOAD_HTTPS_PREFIX, downloadsEnd)
+    startsWithVisibleBytes(stderr, DOWNLOAD_HTTP_PREFIX, downloadsEnd) ||
+    startsWithVisibleBytes(stderr, DOWNLOAD_HTTPS_PREFIX, downloadsEnd)
   ) {
     const lineEnd = stderr.indexOf(0x0a, downloadsEnd);
     downloadsEnd = lineEnd === -1 ? stderr.length : lineEnd + 1;

--- a/packages/deno-web-test/test/utils.ts
+++ b/packages/deno-web-test/test/utils.ts
@@ -6,6 +6,10 @@ const dirname = import.meta.dirname as string;
 const CLI_PATH = path.join(dirname, "..", "cli.ts");
 const DenoWebTestCache: Map<string, Promise<Deno.CommandOutput>> = new Map();
 
+interface RunDenoWebTestOptions {
+  reload?: string;
+}
+
 // Runs deno-web-test in `projectDir` and caches
 // the results for multiple test usages.
 //
@@ -15,8 +19,10 @@ const DenoWebTestCache: Map<string, Promise<Deno.CommandOutput>> = new Map();
 // before running tests.
 export const runDenoWebTest = async (
   projectDir: string,
+  options: RunDenoWebTestOptions = {},
 ): Promise<Deno.CommandOutput> => {
-  const fromCache = DenoWebTestCache.get(projectDir);
+  const cacheKey = JSON.stringify([projectDir, options]);
+  const fromCache = DenoWebTestCache.get(cacheKey);
   if (fromCache) {
     return fromCache;
   }
@@ -33,8 +39,9 @@ export const runDenoWebTest = async (
   const manifest = parseJsonc(await Deno.readTextFile(manifestPath)) as {
     tasks: { test: string };
   };
+  const reload = options.reload ? `--reload=${options.reload} ` : "";
   manifest.tasks.test =
-    `deno run --allow-env --allow-read --allow-write --allow-run --allow-net ${CLI_PATH} *.test.ts`;
+    `deno run ${reload}--allow-env --allow-read --allow-write --allow-run --allow-net ${CLI_PATH} *.test.ts`;
   await Deno.writeTextFile(manifestPath, JSON.stringify(manifest));
 
   // Populate the cache for the harness and each test entrypoint before the task.
@@ -62,6 +69,6 @@ export const runDenoWebTest = async (
     ],
     cwd: tmpProjectPath,
   }).output();
-  DenoWebTestCache.set(projectDir, output);
+  DenoWebTestCache.set(cacheKey, output);
   return output;
 };

--- a/packages/deno-web-test/test/utils.ts
+++ b/packages/deno-web-test/test/utils.ts
@@ -41,7 +41,7 @@ export const runDenoWebTest = async (
   };
   const reload = options.reload ? `--reload=${options.reload} ` : "";
   manifest.tasks.test =
-    `deno run ${reload}--allow-env --allow-read --allow-write --allow-run --allow-net ${CLI_PATH} *.test.ts`;
+    `deno run --quiet ${reload}--allow-env --allow-read --allow-write --allow-run --allow-net ${CLI_PATH} *.test.ts`;
   await Deno.writeTextFile(manifestPath, JSON.stringify(manifest));
 
   // Populate the cache for the harness and each test entrypoint before the task.

--- a/packages/deno-web-test/test/utils.ts
+++ b/packages/deno-web-test/test/utils.ts
@@ -6,8 +6,10 @@ const dirname = import.meta.dirname as string;
 const CLI_PATH = path.join(dirname, "..", "cli.ts");
 const DenoWebTestCache: Map<string, Promise<Deno.CommandOutput>> = new Map();
 
-interface RunDenoWebTestOptions {
-  reload?: string;
+export function stripDenoDownloadDiagnostics(
+  stderr: Uint8Array,
+): Uint8Array {
+  return stderr;
 }
 
 // Runs deno-web-test in `projectDir` and caches
@@ -19,10 +21,8 @@ interface RunDenoWebTestOptions {
 // before running tests.
 export const runDenoWebTest = async (
   projectDir: string,
-  options: RunDenoWebTestOptions = {},
 ): Promise<Deno.CommandOutput> => {
-  const cacheKey = JSON.stringify([projectDir, options]);
-  const fromCache = DenoWebTestCache.get(cacheKey);
+  const fromCache = DenoWebTestCache.get(projectDir);
   if (fromCache) {
     return fromCache;
   }
@@ -39,9 +39,8 @@ export const runDenoWebTest = async (
   const manifest = parseJsonc(await Deno.readTextFile(manifestPath)) as {
     tasks: { test: string };
   };
-  const reload = options.reload ? `--reload=${options.reload} ` : "";
   manifest.tasks.test =
-    `deno run --quiet ${reload}--allow-env --allow-read --allow-write --allow-run --allow-net ${CLI_PATH} *.test.ts`;
+    `deno run --quiet --allow-env --allow-read --allow-write --allow-run --allow-net ${CLI_PATH} *.test.ts`;
   await Deno.writeTextFile(manifestPath, JSON.stringify(manifest));
 
   // Populate the cache for the harness and each test entrypoint before the task.
@@ -69,6 +68,6 @@ export const runDenoWebTest = async (
     ],
     cwd: tmpProjectPath,
   }).output();
-  DenoWebTestCache.set(cacheKey, output);
+  DenoWebTestCache.set(projectDir, output);
   return output;
 };

--- a/packages/deno-web-test/test/utils.ts
+++ b/packages/deno-web-test/test/utils.ts
@@ -9,7 +9,12 @@ const DenoWebTestCache: Map<string, Promise<Deno.CommandOutput>> = new Map();
 export function stripDenoDownloadDiagnostics(
   stderr: Uint8Array,
 ): Uint8Array {
-  return stderr;
+  const text = new TextDecoder().decode(stderr);
+  const withoutDownloads = text.replace(
+    /^Download https?:\/\/[^\r\n]*(?:\r?\n|$)/gm,
+    "",
+  );
+  return new TextEncoder().encode(withoutDownloads);
 }
 
 // Runs deno-web-test in `projectDir` and caches
@@ -40,7 +45,7 @@ export const runDenoWebTest = async (
     tasks: { test: string };
   };
   manifest.tasks.test =
-    `deno run --quiet --allow-env --allow-read --allow-write --allow-run --allow-net ${CLI_PATH} *.test.ts`;
+    `deno run --allow-env --allow-read --allow-write --allow-run --allow-net ${CLI_PATH} *.test.ts`;
   await Deno.writeTextFile(manifestPath, JSON.stringify(manifest));
 
   // Populate the cache for the harness and each test entrypoint before the task.
@@ -67,7 +72,10 @@ export const runDenoWebTest = async (
       "test",
     ],
     cwd: tmpProjectPath,
-  }).output();
+  }).output().then((result) => ({
+    ...result,
+    stderr: stripDenoDownloadDiagnostics(result.stderr),
+  }));
   DenoWebTestCache.set(projectDir, output);
   return output;
 };

--- a/packages/deno-web-test/test/utils.ts
+++ b/packages/deno-web-test/test/utils.ts
@@ -5,22 +5,67 @@ import { parse as parseJsonc } from "@std/jsonc";
 const dirname = import.meta.dirname as string;
 const CLI_PATH = path.join(dirname, "..", "cli.ts");
 const DenoWebTestCache: Map<string, Promise<Deno.CommandOutput>> = new Map();
+const encoder = new TextEncoder();
+const TASK_PREFIX = encoder.encode("Task ");
+const DOWNLOAD_HTTP_PREFIX = encoder.encode("Download http://");
+const DOWNLOAD_HTTPS_PREFIX = encoder.encode("Download https://");
 
-export function stripDenoDownloadDiagnostics(
-  stderr: Uint8Array,
+function startsWithBytes(
+  value: Uint8Array,
+  prefix: Uint8Array,
+  offset: number,
+): boolean {
+  if (offset + prefix.length > value.length) {
+    return false;
+  }
+  for (let i = 0; i < prefix.length; i++) {
+    if (value[offset + i] !== prefix[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function stripDenoDownloadDiagnostics(
+  stderr: Uint8Array<ArrayBuffer>,
 ): Uint8Array<ArrayBuffer> {
-  const text = new TextDecoder().decode(stderr);
-  const withoutDownloads = text.replace(
-    /^Download https?:\/\/[^\r\n]*(?:\r?\n|$)/gm,
-    "",
+  const taskLineEnd = stderr.indexOf(0x0a);
+  if (
+    taskLineEnd === -1 ||
+    !startsWithBytes(stderr, TASK_PREFIX, 0)
+  ) {
+    return stderr;
+  }
+
+  const downloadsStart = taskLineEnd + 1;
+  let downloadsEnd = downloadsStart;
+  while (
+    startsWithBytes(stderr, DOWNLOAD_HTTP_PREFIX, downloadsEnd) ||
+    startsWithBytes(stderr, DOWNLOAD_HTTPS_PREFIX, downloadsEnd)
+  ) {
+    const lineEnd = stderr.indexOf(0x0a, downloadsEnd);
+    downloadsEnd = lineEnd === -1 ? stderr.length : lineEnd + 1;
+  }
+
+  if (downloadsEnd === downloadsStart) {
+    return stderr;
+  }
+
+  const filtered = new Uint8Array(
+    stderr.length - (downloadsEnd - downloadsStart),
   );
-  return new TextEncoder().encode(withoutDownloads);
+  filtered.set(stderr.subarray(0, downloadsStart));
+  filtered.set(stderr.subarray(downloadsEnd), downloadsStart);
+  return filtered;
 }
 
 export function sanitizeDenoWebTestOutput(
   output: Deno.CommandOutput,
 ): Deno.CommandOutput {
-  return output;
+  return {
+    ...output,
+    stderr: stripDenoDownloadDiagnostics(output.stderr),
+  };
 }
 
 // Runs deno-web-test in `projectDir` and caches
@@ -78,10 +123,7 @@ export const runDenoWebTest = async (
       "test",
     ],
     cwd: tmpProjectPath,
-  }).output().then((result) => ({
-    ...result,
-    stderr: stripDenoDownloadDiagnostics(result.stderr),
-  }));
+  }).output().then(sanitizeDenoWebTestOutput);
   DenoWebTestCache.set(projectDir, output);
   return output;
 };

--- a/packages/deno-web-test/test/utils.ts
+++ b/packages/deno-web-test/test/utils.ts
@@ -8,7 +8,7 @@ const DenoWebTestCache: Map<string, Promise<Deno.CommandOutput>> = new Map();
 
 export function stripDenoDownloadDiagnostics(
   stderr: Uint8Array,
-): Uint8Array {
+): Uint8Array<ArrayBuffer> {
   const text = new TextDecoder().decode(stderr);
   const withoutDownloads = text.replace(
     /^Download https?:\/\/[^\r\n]*(?:\r?\n|$)/gm,

--- a/packages/identity/examples/index.html
+++ b/packages/identity/examples/index.html
@@ -2,85 +2,87 @@
 <html>
   <head>
     <style>
-      body {
-        background-color: #eee;
-      }
-      body[state] #auth {
-        display: none;
-      }
-      #register, #login, #authenticated {
-        display: none;
-      }
-      body[state="register"] #register {
-        display: flex;
-      }
-      body[state="login"] #login {
-        display: flex;
-      }
-      body[state="authenticated"] #unauthenticated {
-        display: none;
-      }
-      body[state="authenticated"] #authenticated {
-        display: flex;
-      }
-      #verification {
-        display: none;
-      }
-      #verification > * {
-        display: none;
-      }
-      #verification[state] {
-        display: flex;
-      }
-      #verification[state="verified"] .verified {
-        display: block;
-        color: lime;
-      }
-      #verification[state="unverified"] .unverified {
-        display: block;
-        color: red;
-      }
-      #registersuccess {
-        display: none;
-        background-color: lime;
-        text-align: center;
-      }
-      #registersuccess[enabled] {
-        display: block;
-      }
-      #container {
-        padding: 50px;
-        border: 1px solid #ccc;
-        background-color: #fff;
-        width: 50%;
-        margin: 50px auto;
-      }
-      .vstack {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-      }
-      .hstack {
-        display: flex;
-        flex-direction: row;
-        align-items: center;
-        justify-content: center;
-      }
-      .vstack > * {
-        flex: 1;
-      }
-      .hstack > * {
-        flex: 1;
-      }
-      button {
-        padding: 5px;
-        margin: 5px;
-        min-width: 300px;
-      }
-      label {
-        padding: 10px;
-      }
+    body {
+      background-color: #eee;
+    }
+    body[state] #auth {
+      display: none;
+    }
+    #register,
+    #login,
+    #authenticated {
+      display: none;
+    }
+    body[state="register"] #register {
+      display: flex;
+    }
+    body[state="login"] #login {
+      display: flex;
+    }
+    body[state="authenticated"] #unauthenticated {
+      display: none;
+    }
+    body[state="authenticated"] #authenticated {
+      display: flex;
+    }
+    #verification {
+      display: none;
+    }
+    #verification > * {
+      display: none;
+    }
+    #verification[state] {
+      display: flex;
+    }
+    #verification[state="verified"] .verified {
+      display: block;
+      color: lime;
+    }
+    #verification[state="unverified"] .unverified {
+      display: block;
+      color: red;
+    }
+    #registersuccess {
+      display: none;
+      background-color: lime;
+      text-align: center;
+    }
+    #registersuccess[enabled] {
+      display: block;
+    }
+    #container {
+      padding: 50px;
+      border: 1px solid #ccc;
+      background-color: #fff;
+      width: 50%;
+      margin: 50px auto;
+    }
+    .vstack {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+    }
+    .hstack {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      justify-content: center;
+    }
+    .vstack > * {
+      flex: 1;
+    }
+    .hstack > * {
+      flex: 1;
+    }
+    button {
+      padding: 5px;
+      margin: 5px;
+      min-width: 300px;
+    }
+    label {
+      padding: 10px;
+    }
     </style>
   </head>
   <body>
@@ -127,129 +129,129 @@
       </nav>
     </div>
     <script type="module">
-      import { Identity, KeyStore, PassKey } from "../dist/identity.js";
-      const $ = (s) => document.querySelector(s);
-      const ROOT_KEY = "$ROOT_KEY";
-      const encoder = new TextEncoder();
-      let passKeyDeferred = defer();
-      let rootKey = null;
-      let store = null;
+    import { Identity, KeyStore, PassKey } from "../dist/identity.js";
+    const $ = (s) => document.querySelector(s);
+    const ROOT_KEY = "$ROOT_KEY";
+    const encoder = new TextEncoder();
+    let passKeyDeferred = defer();
+    let rootKey = null;
+    let store = null;
 
-      (async function init() {
-        // Show registration success if we were redirected
-        // from a successful registration
-        maybeDisplayRegisterSuccess();
+    (async function init() {
+      // Show registration success if we were redirected
+      // from a successful registration
+      maybeDisplayRegisterSuccess();
 
-        // Open the key store at the default location.
-        store = await KeyStore.open();
+      // Open the key store at the default location.
+      store = await KeyStore.open();
 
-        // First check if we've already stored a root key.
-        let rootKey = await store.get(ROOT_KEY);
-        if (rootKey) {
-          setRootKey(rootKey);
+      // First check if we've already stored a root key.
+      let rootKey = await store.get(ROOT_KEY);
+      if (rootKey) {
+        setRootKey(rootKey);
+        return;
+      }
+
+      // If no root key set, wait for user to authenticate a PassKey,
+      // either by creating a new one, or reauthenticating.
+      let passKey = await passKeyDeferred.promise;
+      // Create a root key derive from the pass key.
+      rootKey = await passKey.createRootKey();
+      // Store root key to storage for subsequent page loads
+      await store.set(ROOT_KEY, rootKey);
+      setRootKey(rootKey);
+    })();
+
+    async function setRootKey(key) {
+      rootKey = key;
+      setState("authenticated");
+    }
+
+    async function setPassKey(passkey) {
+      console.log("Setting passkey", passkey);
+      passKeyDeferred.resolve(passkey);
+    }
+
+    async function getKey() {
+      let rootKey = await PassKey.get({
+        userVerification: "discouraged",
+      });
+      setPassKey(rootKey);
+    }
+
+    $("#register-submit").addEventListener("click", async (e) => {
+      const name = $("#register-name").value;
+      const displayName = $("#register-display-name").value;
+      console.log(`Creating key ${name}:${displayName}`);
+      await PassKey.create(name, displayName);
+      showRegisterSuccess();
+    });
+
+    $("#sign-message").addEventListener("input", async (e) => {
+      console.assert(rootKey);
+      const data = encoder.encode(e.target.value);
+      const signature = await rootKey.sign(data);
+      $("#signature").innerText = btoa(
+        String.fromCharCode(...new Uint8Array(signature)),
+      );
+      setVerificationStatus(
+        await rootKey.verifier().verify(signature, data),
+      );
+    });
+
+    $("#clear-db").addEventListener("click", async (e) => {
+      if (store) {
+        await store.clear();
+        window.location.reload();
+      }
+    });
+
+    $("#auth").addEventListener("click", (e) => {
+      switch (e.target.id) {
+        case "show-register": {
+          setState("register");
           return;
         }
-
-        // If no root key set, wait for user to authenticate a PassKey,
-        // either by creating a new one, or reauthenticating.
-        let passKey = await passKeyDeferred.promise;
-        // Create a root key derive from the pass key.
-        rootKey = await passKey.createRootKey();
-        // Store root key to storage for subsequent page loads
-        await store.set(ROOT_KEY, rootKey);
-        setRootKey(rootKey);
-      })();
-
-      async function setRootKey(key) {
-        rootKey = key;
-        setState("authenticated");
-      }
-
-      async function setPassKey(passkey) {
-        console.log("Setting passkey", passkey);
-        passKeyDeferred.resolve(passkey);
-      }
-
-      async function getKey() {
-        let rootKey = await PassKey.get({
-          userVerification: "discouraged",
-        });
-        setPassKey(rootKey);
-      }
-
-      $("#register-submit").addEventListener("click", async (e) => {
-        const name = $("#register-name").value;
-        const displayName = $("#register-display-name").value;
-        console.log(`Creating key ${name}:${displayName}`);
-        await PassKey.create(name, displayName);
-        showRegisterSuccess();
-      });
-
-      $("#sign-message").addEventListener("input", async (e) => {
-        console.assert(rootKey);
-        const data = encoder.encode(e.target.value);
-        const signature = await rootKey.sign(data);
-        $("#signature").innerText = btoa(
-          String.fromCharCode(...new Uint8Array(signature)),
-        );
-        setVerificationStatus(
-          await rootKey.verifier().verify(signature, data),
-        );
-      });
-
-      $("#clear-db").addEventListener("click", async (e) => {
-        if (store) {
-          await store.clear();
-          window.location.reload();
-        }
-      });
-
-      $("#auth").addEventListener("click", (e) => {
-        switch (e.target.id) {
-          case "show-register": {
-            setState("register");
-            return;
-          }
-          case "show-login": {
-            getKey();
-            setState("login");
-            return;
-          }
-        }
-      });
-
-      function setVerificationStatus(isVerified) {
-        $("#verification").setAttribute(
-          "state",
-          isVerified ? "verified" : "unverified",
-        );
-      }
-
-      function setState(state) {
-        document.body.setAttribute("state", state);
-      }
-
-      function showRegisterSuccess() {
-        const url = new URL(window.location.href);
-        window.location.href = `${url.origin}${url.pathname}?registersuccess`;
-      }
-
-      function maybeDisplayRegisterSuccess() {
-        const url = new URL(window.location.href);
-        if (url.searchParams.has("registersuccess")) {
-          $("#registersuccess").setAttribute("enabled", "");
+        case "show-login": {
+          getKey();
+          setState("login");
+          return;
         }
       }
+    });
 
-      function defer() {
-        let resolve;
-        let reject;
-        const promise = new Promise((res, rej) => {
-          resolve = res;
-          reject = rej;
-        });
-        return { promise, resolve, reject };
+    function setVerificationStatus(isVerified) {
+      $("#verification").setAttribute(
+        "state",
+        isVerified ? "verified" : "unverified",
+      );
+    }
+
+    function setState(state) {
+      document.body.setAttribute("state", state);
+    }
+
+    function showRegisterSuccess() {
+      const url = new URL(window.location.href);
+      window.location.href = `${url.origin}${url.pathname}?registersuccess`;
+    }
+
+    function maybeDisplayRegisterSuccess() {
+      const url = new URL(window.location.href);
+      if (url.searchParams.has("registersuccess")) {
+        $("#registersuccess").setAttribute("enabled", "");
       }
+    }
+
+    function defer() {
+      let resolve;
+      let reject;
+      const promise = new Promise((res, rej) => {
+        resolve = res;
+        reject = rej;
+      });
+      return { promise, resolve, reject };
+    }
     </script>
   </body>
 </html>

--- a/packages/runner/test/fetch-mutex-auth.test.ts
+++ b/packages/runner/test/fetch-mutex-auth.test.ts
@@ -106,7 +106,7 @@ describe("fetch-json mutex mechanism: protected request auth", () => {
     tx.commit();
 
     await result.pull();
-    await result.pull();
+    await runtime.settled();
 
     const call = fetchCalls.find((call) =>
       call.url === "http://mock-test-server.local/api/agent-tools/web-search"
@@ -178,7 +178,7 @@ describe("fetch-json mutex mechanism: protected request auth", () => {
     tx.commit();
 
     await result.pull();
-    await result.pull();
+    await runtime.settled();
 
     const call = fetchCalls.find((call) =>
       call.url === "http://mock-test-server.local/api/agent-tools/web-search"
@@ -243,7 +243,7 @@ describe("fetch-json mutex mechanism: protected request auth", () => {
     tx.commit();
 
     await result.pull();
-    await result.pull();
+    await runtime.settled();
 
     const call = fetchCalls.find((call) =>
       call.url === "http://external.test/api/agent-tools/web-search"

--- a/packages/shell/public/index.html
+++ b/packages/shell/public/index.html
@@ -9,13 +9,13 @@
     />
     <meta name="color-scheme" content="light dark" />
     <script>
-      // Apply saved theme preference before first paint to prevent flash
-      try {
-        const t = localStorage.getItem("cf-theme-preference");
-        if (t === "light" || t === "dark") {
-          document.documentElement.setAttribute("data-theme", t);
-        }
-      } catch (e) {}
+    // Apply saved theme preference before first paint to prevent flash
+    try {
+      const t = localStorage.getItem("cf-theme-preference");
+      if (t === "light" || t === "dark") {
+        document.documentElement.setAttribute("data-theme", t);
+      }
+    } catch (e) {}
     </script>
     <title>Common Fabric</title>
     <link rel="stylesheet" href="/styles/index.css" />

--- a/packages/shell/public/styles/index.css
+++ b/packages/shell/public/styles/index.css
@@ -1,5 +1,7 @@
 /* CSS Reset and Base Styles */
-*, *::before, *::after {
+*,
+*::before,
+*::after {
   box-sizing: border-box;
 }
 
@@ -99,7 +101,8 @@ html {
   width: 100vw;
 }
 
-body, html {
+body,
+html {
   height: 100%;
 }
 

--- a/packages/shell/src/components/CFLogo.ts
+++ b/packages/shell/src/components/CFLogo.ts
@@ -13,7 +13,8 @@ export class CFLogo extends LitElement {
     }
 
     @keyframes bounce {
-      0%, 100% {
+      0%,
+      100% {
         transform: translateY(0);
       }
       50% {

--- a/packages/shell/src/components/OmniLayout.ts
+++ b/packages/shell/src/components/OmniLayout.ts
@@ -235,8 +235,7 @@ export class XOmniLayout extends LitElement {
           <div
             class="resize-handle"
             @pointerdown="${this.handleResizeStart}"
-          >
-          </div>
+          ></div>
           <div class="sidebar-content">
             <slot name="sidebar"></slot>
           </div>

--- a/packages/shell/src/components/PieceLink.ts
+++ b/packages/shell/src/components/PieceLink.ts
@@ -11,7 +11,8 @@ import {
 
 export class PieceLinkElement extends LitElement {
   static override styles = css`
-    a, a:visited {
+    a,
+    a:visited {
       color: var(--primary-font, "#000");
     }
   `;

--- a/packages/shell/src/views/DebuggerView.ts
+++ b/packages/shell/src/views/DebuggerView.ts
@@ -496,7 +496,8 @@ export class XDebuggerView extends LitElement {
     }
 
     @keyframes pulse {
-      0%, 100% {
+      0%,
+      100% {
         opacity: 1;
       }
       50% {
@@ -1649,7 +1650,6 @@ export class XDebuggerView extends LitElement {
 
     if (keys.length === 0) {
       return html`
-
       `;
     }
 
@@ -1659,7 +1659,6 @@ export class XDebuggerView extends LitElement {
           const stats = timingData[key];
           if (!stats.cdf || stats.cdf.length === 0) {
             return html`
-
             `;
           }
 
@@ -1787,7 +1786,6 @@ export class XDebuggerView extends LitElement {
 
     if (cdf.length === 0) {
       return html`
-
       `;
     }
 

--- a/packages/shell/src/views/LoginView.ts
+++ b/packages/shell/src/views/LoginView.ts
@@ -98,7 +98,8 @@ export class XLoginView extends BaseView {
       gap: 0.5rem;
     }
 
-    input, textarea {
+    input,
+    textarea {
       width: 100%;
       padding: 0.75rem 1rem;
       margin-bottom: 0.5rem;

--- a/packages/shell/src/views/QuickJumpView.ts
+++ b/packages/shell/src/views/QuickJumpView.ts
@@ -276,7 +276,6 @@ export class XQuickJumpView extends BaseView {
   override render() {
     if (!this.visible) {
       return html`
-
       `;
     }
     const results = this.filtered();
@@ -309,7 +308,9 @@ export class XQuickJumpView extends BaseView {
             `
           )} ${results.length === 0
             ? html`
-              <li class="item"><div class="name">No matches</div></li>
+              <li class="item">
+                <div class="name">No matches</div>
+              </li>
             `
             : ""}
         </ul>

--- a/packages/shell/src/views/SchedulerGraphView.ts
+++ b/packages/shell/src/views/SchedulerGraphView.ts
@@ -474,7 +474,8 @@ export class XSchedulerGraph extends LitElement {
 
     /* Size boost animation for triggered nodes when zoomed out */
     @keyframes node-size-boost {
-      0%, 100% {
+      0%,
+      100% {
         transform: scale(1);
       }
       15% {

--- a/packages/ui/LLM-COMPONENT-INSTRUCTIONS.md
+++ b/packages/ui/LLM-COMPONENT-INSTRUCTIONS.md
@@ -370,8 +370,7 @@ await input.pressSequentially("user@example.com");
   label="Review"
   size="sm"
   style="--cf-chip-background: linear-gradient(135deg, #5f89ff, #4d77fb); --cf-chip-color: white"
->
-</cf-chip>
+></cf-chip>
 
 <!-- Removable -->
 <cf-chip label="Tag" removable></cf-chip>

--- a/packages/ui/src/v2/components/cf-autolayout/cf-autolayout.ts
+++ b/packages/ui/src/v2/components/cf-autolayout/cf-autolayout.ts
@@ -125,9 +125,9 @@ export class CFAutoLayout extends BaseElement {
     .sidebar-left {
       border-right: 1px solid
         var(
-          --cf-theme-color-border,
-          #e5e7eb
-        );
+        --cf-theme-color-border,
+        #e5e7eb
+      );
       border-top-right-radius: var(
         --cf-theme-border-radius,
         var(--cf-border-radius-md, 0.375rem)
@@ -140,9 +140,9 @@ export class CFAutoLayout extends BaseElement {
     .sidebar-right {
       border-left: 1px solid
         var(
-          --cf-theme-color-border,
-          #e5e7eb
-        );
+        --cf-theme-color-border,
+        #e5e7eb
+      );
       border-top-left-radius: var(
         --cf-theme-border-radius,
         var(--cf-border-radius-md, 0.375rem)
@@ -191,9 +191,9 @@ export class CFAutoLayout extends BaseElement {
         background: transparent;
         border: 1px solid
           var(
-            --cf-theme-color-border,
-            #e5e7eb
-          );
+          --cf-theme-color-border,
+          #e5e7eb
+        );
         border-radius: var(
           --cf-theme-border-radius,
           var(--cf-border-radius-md, 0.375rem)
@@ -344,9 +344,9 @@ export class CFAutoLayout extends BaseElement {
         );
         border-top: 1px solid
           var(
-            --cf-theme-color-border,
-            #e0e0e0
-          );
+          --cf-theme-color-border,
+          #e0e0e0
+        );
         padding: 0 var(--cf-theme-spacing-normal, 0.5rem);
         z-index: 40;
       }
@@ -356,9 +356,9 @@ export class CFAutoLayout extends BaseElement {
         border-top: none;
         border-bottom: 1px solid
           var(
-            --cf-theme-color-border,
-            #e0e0e0
-          );
+          --cf-theme-color-border,
+          #e0e0e0
+        );
       }
       .mobile-bar .tabs {
         display: flex;
@@ -607,8 +607,7 @@ export class CFAutoLayout extends BaseElement {
           class="scrim"
           @click="${() => this._closePanels()}"
           aria-hidden="true"
-        >
-        </div>
+        ></div>
 
         <div class="mobile-bar ${classMap({
           top: this.tabsPosition === "top",

--- a/packages/ui/src/v2/components/cf-chat/cf-chat.ts
+++ b/packages/ui/src/v2/components/cf-chat/cf-chat.ts
@@ -120,9 +120,9 @@ export class CFChat extends BaseElement {
           var(--cf-spacing-3, 0.75rem)
         )
           var(
-            --cf-theme-spacing-padding-bubble-horizontal,
-            var(--cf-spacing-4, 1rem)
-          );
+          --cf-theme-spacing-padding-bubble-horizontal,
+          var(--cf-spacing-4, 1rem)
+        );
         border-radius: var(
           --cf-theme-border-radius,
           var(--cf-border-radius-lg, 0.5rem)
@@ -159,7 +159,9 @@ export class CFChat extends BaseElement {
       }
 
       @keyframes typingBounce {
-        0%, 80%, 100% {
+        0%,
+        80%,
+        100% {
           opacity: 0.3;
           transform: scale(0.8);
         }

--- a/packages/ui/src/v2/components/cf-chip/cf-chip.ts
+++ b/packages/ui/src/v2/components/cf-chip/cf-chip.ts
@@ -88,12 +88,12 @@ export class CFChip extends BaseElement {
         );
         border: 1px solid
           var(
-            --cf-chip-border-color,
-            var(
-              --cf-theme-color-border,
-              var(--cf-colors-gray-300, #d5d7dd)
-            )
-          );
+          --cf-chip-border-color,
+          var(
+            --cf-theme-color-border,
+            var(--cf-colors-gray-300, #d5d7dd)
+          )
+        );
         border-radius: var(
           --cf-chip-border-radius,
           var(--cf-border-radius-full, 9999px)
@@ -158,9 +158,9 @@ export class CFChip extends BaseElement {
       .chip:has(.chip-action:focus-visible) {
         outline: 2px solid
           var(
-            --cf-theme-color-focus-ring,
-            var(--cf-theme-color-primary, var(--cf-colors-primary-500, #4979fa))
-          );
+          --cf-theme-color-focus-ring,
+          var(--cf-theme-color-primary, var(--cf-colors-primary-500, #4979fa))
+        );
         outline-offset: 2px;
       }
 
@@ -312,9 +312,9 @@ export class CFChip extends BaseElement {
       .chip-remove:focus-visible {
         outline: 2px solid
           var(
-            --cf-theme-color-focus-ring,
-            var(--cf-theme-color-primary, var(--cf-colors-primary-500, #4979fa))
-          );
+          --cf-theme-color-focus-ring,
+          var(--cf-theme-color-primary, var(--cf-colors-primary-500, #4979fa))
+        );
         outline-offset: 2px;
         opacity: 1;
       }

--- a/packages/ui/src/v2/components/cf-fab/styles.ts
+++ b/packages/ui/src/v2/components/cf-fab/styles.ts
@@ -48,7 +48,8 @@ export const fabAnimations = css`
 
   /* Pulse animation for notification indicator */
   @keyframes fabPulse {
-    0%, 100% {
+    0%,
+    100% {
       opacity: 1;
       transform: scale(1);
     }

--- a/packages/ui/src/v2/components/cf-file-download/cf-file-download.ts
+++ b/packages/ui/src/v2/components/cf-file-download/cf-file-download.ts
@@ -168,7 +168,8 @@ export class CFFileDownload extends BaseElement {
       }
 
       @keyframes gentle-pulse {
-        0%, 100% {
+        0%,
+        100% {
           opacity: 1;
         }
         50% {
@@ -178,13 +179,16 @@ export class CFFileDownload extends BaseElement {
 
       /* Shake animation for "not available" feedback */
       @keyframes shake {
-        0%, 100% {
+        0%,
+        100% {
           transform: translateX(0);
         }
-        20%, 60% {
+        20%,
+        60% {
           transform: translateX(-4px);
         }
-        40%, 80% {
+        40%,
+        80% {
           transform: translateX(4px);
         }
       }

--- a/packages/ui/src/v2/components/cf-file-input/cf-file-input.ts
+++ b/packages/ui/src/v2/components/cf-file-input/cf-file-input.ts
@@ -353,7 +353,6 @@ export class CFFileInput extends BaseElement {
 
     if (!this.showPreview || currentFiles.length === 0) {
       return html`
-
       `;
     }
 

--- a/packages/ui/src/v2/components/cf-keybind/cf-keybind.ts
+++ b/packages/ui/src/v2/components/cf-keybind/cf-keybind.ts
@@ -104,7 +104,6 @@ export class CFKeybind extends BaseElement {
   override render() {
     // Non-visual helper component
     return html`
-
     `;
   }
 

--- a/packages/ui/src/v2/components/cf-map/cf-map.ts
+++ b/packages/ui/src/v2/components/cf-map/cf-map.ts
@@ -348,8 +348,7 @@ export class CFMap extends BaseElement {
         role="application"
         aria-label="Interactive map"
         tabindex="0"
-      >
-      </div>
+      ></div>
     `;
   }
 

--- a/packages/ui/src/v2/components/cf-message-beads/cf-message-beads.ts
+++ b/packages/ui/src/v2/components/cf-message-beads/cf-message-beads.ts
@@ -355,8 +355,7 @@ export class CFMessageBeads extends BaseElement {
           aria-label="${beadLabel(msg)}"
           @mouseenter="${(e: Event) => this._onBeadEnter(e, i)}"
           @mouseleave="${this._onBeadLeave}"
-        >
-        </li>
+        ></li>
       `;
     });
 

--- a/packages/ui/src/v2/components/cf-modal/cf-modal.ts
+++ b/packages/ui/src/v2/components/cf-modal/cf-modal.ts
@@ -452,8 +452,7 @@ export class CFModal extends BaseElement {
       <div
         class="backdrop"
         part="backdrop"
-      >
-      </div>
+      ></div>
 
       <div
         class="container"

--- a/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.ts
+++ b/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.ts
@@ -1058,8 +1058,7 @@ export class CFPieceMenu extends BaseElement {
         class="backdrop"
         @click="${() => this.close()}"
         @contextmenu="${this._onBackdropContextMenu}"
-      >
-      </div>
+      ></div>
       <div class="menu" role="menu" style="left: ${left}px; top: ${top}px">
         <div class="menu-title">Piece ${this.cell!.id()}</div>
         ${entries.map((entry) =>

--- a/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
@@ -294,11 +294,11 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
         mix-blend-mode: screen;
         background:
           radial-gradient(
-            circle at var(--seal-mx, 50%) var(--seal-my, 50%),
-            rgba(255, 255, 255, 1) 0%,
-            rgba(255, 255, 255, 0.6) 11%,
-            rgba(255, 255, 255, 0) 32%
-          ),
+          circle at var(--seal-mx, 50%) var(--seal-my, 50%),
+          rgba(255, 255, 255, 1) 0%,
+          rgba(255, 255, 255, 0.6) 11%,
+          rgba(255, 255, 255, 0) 32%
+        ),
           radial-gradient(
           circle at var(--seal-mx, 50%) var(--seal-my, 50%),
           hsl(var(--seal-sheen-hue, 200) 100% 72% / 0.9) 0%,

--- a/packages/ui/src/v2/components/cf-progress/cf-progress.ts
+++ b/packages/ui/src/v2/components/cf-progress/cf-progress.ts
@@ -110,8 +110,7 @@ export class CFProgress extends BaseElement {
           part="indicator"
           role="presentation"
           style="${styleMap(indicatorStyles)}"
-        >
-        </div>
+        ></div>
       </div>
     `;
   }

--- a/packages/ui/src/v2/components/cf-scroll-area/cf-scroll-area.ts
+++ b/packages/ui/src/v2/components/cf-scroll-area/cf-scroll-area.ts
@@ -240,8 +240,8 @@ export class CFScrollArea extends BaseElement {
         ${showVertical
           ? html`
             <div class="scrollbar scrollbar-vertical" part="scrollbar-vertical">
-              <div class="scrollbar-thumb scrollbar-thumb-vertical" part="thumb-vertical">
-              </div>
+              <div class="scrollbar-thumb scrollbar-thumb-vertical"
+                part="thumb-vertical"></div>
             </div>
           `
           : ""} ${showHorizontal
@@ -250,8 +250,7 @@ export class CFScrollArea extends BaseElement {
               <div
                 class="scrollbar-thumb scrollbar-thumb-horizontal"
                 part="thumb-horizontal"
-              >
-              </div>
+              ></div>
             </div>
           `
           : ""}

--- a/packages/ui/src/v2/components/cf-separator/cf-separator.ts
+++ b/packages/ui/src/v2/components/cf-separator/cf-separator.ts
@@ -102,8 +102,7 @@ export class CFSeparator extends BaseElement {
         part="separator"
         role="${this.decorative ? "none" : "separator"}"
         aria-orientation="${this.decorative ? null : this.orientation}"
-      >
-      </div>
+      ></div>
     `;
   }
 }

--- a/packages/ui/src/v2/components/cf-slider/cf-slider.ts
+++ b/packages/ui/src/v2/components/cf-slider/cf-slider.ts
@@ -403,8 +403,7 @@ export class CFSlider extends BaseElement {
             role="presentation"
             @mousedown="${this._handleThumbMouseDown}"
             @touchstart="${this._handleThumbTouchStart}"
-          >
-          </div>
+          ></div>
         </div>
       </div>
     `;

--- a/packages/ui/src/v2/components/cf-tab/cf-tab.ts
+++ b/packages/ui/src/v2/components/cf-tab/cf-tab.ts
@@ -83,8 +83,7 @@ export class CFTab extends BaseElement {
       }
 
       /* Vertical orientation styles */
-      :host-context(cf-tab-list[orientation="vertical"])
-        .tab[data-selected="true"]::after {
+      :host-context(cf-tab-list[orientation="vertical"]) .tab[data-selected="true"]::after {
         top: 0;
         bottom: 0;
         left: -1px;
@@ -123,8 +122,7 @@ export class CFTab extends BaseElement {
       }
 
       /* Hover on unselected chip tab */
-      :host([data-variant="chip"])
-        .tab:hover:not(:disabled):not([data-selected="true"]) {
+      :host([data-variant="chip"]) .tab:hover:not(:disabled):not([data-selected="true"]) {
         background: var(
           --cf-theme-color-surface-hover,
           var(--cf-colors-gray-200, #eceef1)
@@ -140,9 +138,9 @@ export class CFTab extends BaseElement {
         );
         border: 1px solid
           var(
-            --cf-theme-color-border,
-            var(--cf-colors-gray-300, #d5d7dd)
-          );
+          --cf-theme-color-border,
+          var(--cf-colors-gray-300, #d5d7dd)
+        );
         color: var(--cf-theme-color-text, var(--cf-colors-gray-900, #16181d));
         font-weight: var(--cf-font-weight-medium, 500);
       }

--- a/packages/ui/src/v2/components/cf-tools-chip/cf-tools-chip.ts
+++ b/packages/ui/src/v2/components/cf-tools-chip/cf-tools-chip.ts
@@ -120,7 +120,9 @@ export class CFToolsChip extends BaseElement {
         box-sizing: border-box;
       }
 
-      *, *::before, *::after {
+      *,
+      *::before,
+      *::after {
         box-sizing: inherit;
       }
 

--- a/scripts/benchmark-object-hashing/browser.html
+++ b/scripts/benchmark-object-hashing/browser.html
@@ -5,34 +5,36 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Object Hashing Benchmark - Browser</title>
     <style>
-      body {
-        font-family: "Courier New", monospace;
-        padding: 20px;
-        max-width: 1400px;
-        margin: 0 auto;
-        background: #1e1e1e;
-        color: #d4d4d4;
-      }
-      h1, h2, h3 {
-        color: #4ec9b0;
-      }
-      pre {
-        background: #2d2d2d;
-        padding: 10px;
-        border-radius: 4px;
-        overflow-x: auto;
-        white-space: pre-wrap;
-        font-size: 11px;
-      }
-      .status {
-        color: #ce9178;
-      }
-      .complete {
-        color: #4ec9b0;
-      }
-      .error {
-        color: #f48771;
-      }
+    body {
+      font-family: "Courier New", monospace;
+      padding: 20px;
+      max-width: 1400px;
+      margin: 0 auto;
+      background: #1e1e1e;
+      color: #d4d4d4;
+    }
+    h1,
+    h2,
+    h3 {
+      color: #4ec9b0;
+    }
+    pre {
+      background: #2d2d2d;
+      padding: 10px;
+      border-radius: 4px;
+      overflow-x: auto;
+      white-space: pre-wrap;
+      font-size: 11px;
+    }
+    .status {
+      color: #ce9178;
+    }
+    .complete {
+      color: #4ec9b0;
+    }
+    .error {
+      color: #f48771;
+    }
     </style>
   </head>
   <body>
@@ -41,426 +43,425 @@
     <div id="output"></div>
 
     <script type="module">
-      const outputDiv = document.getElementById("output");
-      const statusDiv = document.getElementById("status");
+    const outputDiv = document.getElementById("output");
+    const statusDiv = document.getElementById("status");
 
-      function log(message) {
-        const pre = document.createElement("pre");
-        pre.textContent = message;
-        outputDiv.appendChild(pre);
-        console.log(message);
-      }
+    function log(message) {
+      const pre = document.createElement("pre");
+      pre.textContent = message;
+      outputDiv.appendChild(pre);
+      console.log(message);
+    }
 
-      async function main() {
-        try {
-          statusDiv.textContent = "Loading libraries from esm.sh...";
+    async function main() {
+      try {
+        statusDiv.textContent = "Loading libraries from esm.sh...";
 
-          const [
-            MerkleReference,
-            objectHash,
-            hashIt,
-            fastStableStringify,
-            safeStableStringify,
-            { sha256 },
-            { blake2b },
-            { blake3 },
-            { createSHA256, createBLAKE3 },
-            dagCbor,
-            { CID },
-            multihash,
-          ] = await Promise.all([
-            import("https://esm.sh/merkle-reference@2.2.0"),
-            import("https://esm.sh/object-hash@3.0.0"),
-            import("https://esm.sh/hash-it@6.0.0"),
-            import("https://esm.sh/fast-json-stable-stringify@2.1.0"),
-            import("https://esm.sh/safe-stable-stringify@2.5.0"),
-            import("https://esm.sh/@noble/hashes@1.4.0/sha256"),
-            import("https://esm.sh/@noble/hashes@1.4.0/blake2b"),
-            import("https://esm.sh/@noble/hashes@1.4.0/blake3"),
-            import("https://esm.sh/hash-wasm@4.11.0"),
-            import("https://esm.sh/@ipld/dag-cbor@9.2.1"),
-            import("https://esm.sh/multiformats@13.3.2/cid"),
-            import("https://esm.sh/multiformats@13.3.2/hashes/digest"),
-          ]);
+        const [
+          MerkleReference,
+          objectHash,
+          hashIt,
+          fastStableStringify,
+          safeStableStringify,
+          { sha256 },
+          { blake2b },
+          { blake3 },
+          { createSHA256, createBLAKE3 },
+          dagCbor,
+          { CID },
+          multihash,
+        ] = await Promise.all([
+          import("https://esm.sh/merkle-reference@2.2.0"),
+          import("https://esm.sh/object-hash@3.0.0"),
+          import("https://esm.sh/hash-it@6.0.0"),
+          import("https://esm.sh/fast-json-stable-stringify@2.1.0"),
+          import("https://esm.sh/safe-stable-stringify@2.5.0"),
+          import("https://esm.sh/@noble/hashes@1.4.0/sha256"),
+          import("https://esm.sh/@noble/hashes@1.4.0/blake2b"),
+          import("https://esm.sh/@noble/hashes@1.4.0/blake3"),
+          import("https://esm.sh/hash-wasm@4.11.0"),
+          import("https://esm.sh/@ipld/dag-cbor@9.2.1"),
+          import("https://esm.sh/multiformats@13.3.2/cid"),
+          import("https://esm.sh/multiformats@13.3.2/hashes/digest"),
+        ]);
 
-          const blake2b256 = (data) => blake2b(data, { dkLen: 32 });
+        const blake2b256 = (data) => blake2b(data, { dkLen: 32 });
 
-          statusDiv.textContent = "Creating test data...";
+        statusDiv.textContent = "Creating test data...";
 
-          // Test data - focused on VDOM-like structures
-          const testData = {
-            small: {
-              simple: { a: 1, b: 2, c: 3 },
-              nested: { a: { b: { c: 1 } } },
-              mixed: { a: [1, 2], b: { c: 3 }, d: "hello" },
-            },
-            large: {
-              wide: Object.fromEntries(
-                Array.from({ length: 500 }, (_, i) => [`key${i}`, i]),
-              ),
-              deep: (() => {
-                let obj = { value: "bottom" };
-                for (let i = 0; i < 50; i++) obj = { nested: obj };
-                return obj;
-              })(),
-            },
-            vdom: {
-              simpleComponent: {
-                type: "div",
-                props: {
-                  className: "container mx-auto p-4",
-                  style: { display: "flex" },
+        // Test data - focused on VDOM-like structures
+        const testData = {
+          small: {
+            simple: { a: 1, b: 2, c: 3 },
+            nested: { a: { b: { c: 1 } } },
+            mixed: { a: [1, 2], b: { c: 3 }, d: "hello" },
+          },
+          large: {
+            wide: Object.fromEntries(
+              Array.from({ length: 500 }, (_, i) => [`key${i}`, i]),
+            ),
+            deep: (() => {
+              let obj = { value: "bottom" };
+              for (let i = 0; i < 50; i++) obj = { nested: obj };
+              return obj;
+            })(),
+          },
+          vdom: {
+            simpleComponent: {
+              type: "div",
+              props: {
+                className: "container mx-auto p-4",
+                style: { display: "flex" },
+              },
+              children: [
+                {
+                  type: "h1",
+                  props: { className: "text-2xl" },
+                  children: ["Hello"],
                 },
+                { type: "p", props: {}, children: ["World"] },
+              ],
+            },
+            formComponent: {
+              type: "form",
+              props: { className: "space-y-4" },
+              children: Array.from({ length: 10 }, (_, i) => ({
+                type: "div",
+                props: { className: "form-group" },
                 children: [
                   {
-                    type: "h1",
-                    props: { className: "text-2xl" },
-                    children: ["Hello"],
+                    type: "label",
+                    props: { htmlFor: `field-${i}` },
+                    children: [`Field ${i}`],
                   },
-                  { type: "p", props: {}, children: ["World"] },
+                  {
+                    type: "input",
+                    props: {
+                      type: "text",
+                      id: `field-${i}`,
+                      name: `field_${i}`,
+                    },
+                    children: [],
+                  },
                 ],
-              },
-              formComponent: {
-                type: "form",
-                props: { className: "space-y-4" },
-                children: Array.from({ length: 10 }, (_, i) => ({
-                  type: "div",
-                  props: { className: "form-group" },
+              })),
+            },
+            dataTable: {
+              type: "table",
+              props: { className: "min-w-full" },
+              children: [{
+                type: "tbody",
+                props: {},
+                children: Array.from({ length: 50 }, (_, i) => ({
+                  type: "tr",
+                  props: { key: `row-${i}` },
                   children: [
+                    { type: "td", props: {}, children: [String(i)] },
                     {
-                      type: "label",
-                      props: { htmlFor: `field-${i}` },
-                      children: [`Field ${i}`],
+                      type: "td",
+                      props: {},
+                      children: [`User ${i}`],
                     },
                     {
-                      type: "input",
-                      props: {
-                        type: "text",
-                        id: `field-${i}`,
-                        name: `field_${i}`,
-                      },
-                      children: [],
+                      type: "td",
+                      props: {},
+                      children: [`user${i}@example.com`],
                     },
                   ],
                 })),
-              },
-              dataTable: {
-                type: "table",
-                props: { className: "min-w-full" },
-                children: [{
-                  type: "tbody",
-                  props: {},
-                  children: Array.from({ length: 50 }, (_, i) => ({
-                    type: "tr",
-                    props: { key: `row-${i}` },
+              }],
+            },
+            dashboard: {
+              type: "div",
+              props: { className: "flex" },
+              children: [
+                {
+                  type: "nav",
+                  props: { className: "w-64" },
+                  children: Array.from({ length: 10 }, (_, i) => ({
+                    type: "a",
+                    props: { href: `/section/${i}` },
+                    children: [`Menu ${i}`],
+                  })),
+                },
+                {
+                  type: "main",
+                  props: { className: "flex-1" },
+                  children: Array.from({ length: 4 }, (_, i) => ({
+                    type: "div",
+                    props: { className: "card" },
                     children: [
-                      { type: "td", props: {}, children: [String(i)] },
                       {
-                        type: "td",
+                        type: "h3",
                         props: {},
-                        children: [`User ${i}`],
+                        children: [`Card ${i}`],
                       },
                       {
-                        type: "td",
-                        props: {},
-                        children: [`user${i}@example.com`],
+                        type: "div",
+                        props: { className: "chart" },
+                        children: Array.from(
+                          { length: 20 },
+                          (_, j) => ({
+                            type: "div",
+                            props: {
+                              style: {
+                                height: `${Math.random() * 100}%`,
+                              },
+                            },
+                            children: [],
+                          }),
+                        ),
                       },
                     ],
                   })),
-                }],
-              },
-              dashboard: {
-                type: "div",
-                props: { className: "flex" },
-                children: [
-                  {
-                    type: "nav",
-                    props: { className: "w-64" },
-                    children: Array.from({ length: 10 }, (_, i) => ({
-                      type: "a",
-                      props: { href: `/section/${i}` },
-                      children: [`Menu ${i}`],
-                    })),
-                  },
-                  {
-                    type: "main",
-                    props: { className: "flex-1" },
-                    children: Array.from({ length: 4 }, (_, i) => ({
-                      type: "div",
-                      props: { className: "card" },
-                      children: [
-                        {
-                          type: "h3",
-                          props: {},
-                          children: [`Card ${i}`],
-                        },
-                        {
-                          type: "div",
-                          props: { className: "chart" },
-                          children: Array.from(
-                            { length: 20 },
-                            (_, j) => ({
-                              type: "div",
-                              props: {
-                                style: {
-                                  height: `${Math.random() * 100}%`,
-                                },
-                              },
-                              children: [],
-                            }),
-                          ),
-                        },
-                      ],
-                    })),
-                  },
-                ],
-              },
+                },
+              ],
             },
-          };
+          },
+        };
 
-          statusDiv.textContent = "Creating hash functions...";
+        statusDiv.textContent = "Creating hash functions...";
 
-          const hashFunctions = {};
-          hashFunctions["noble"] = (data) => sha256(data);
+        const hashFunctions = {};
+        hashFunctions["noble"] = (data) => sha256(data);
 
-          const sha256Hasher = await createSHA256();
-          hashFunctions["hash-wasm"] = (data) => {
-            sha256Hasher.init();
-            sha256Hasher.update(data);
-            return sha256Hasher.digest("binary");
-          };
+        const sha256Hasher = await createSHA256();
+        hashFunctions["hash-wasm"] = (data) => {
+          sha256Hasher.init();
+          sha256Hasher.update(data);
+          return sha256Hasher.digest("binary");
+        };
 
-          const blake3Hasher = await createBLAKE3();
-          hashFunctions["blake3-wasm"] = (data) => {
-            blake3Hasher.init();
-            blake3Hasher.update(data);
-            return blake3Hasher.digest("binary");
-          };
+        const blake3Hasher = await createBLAKE3();
+        hashFunctions["blake3-wasm"] = (data) => {
+          blake3Hasher.init();
+          blake3Hasher.update(data);
+          return blake3Hasher.digest("binary");
+        };
 
-          statusDiv.textContent = "Creating strategies...";
+        statusDiv.textContent = "Creating strategies...";
 
-          const strategies = {};
-          const encoder = new TextEncoder();
-          const toHex = (hash) =>
-            Array.from(hash).map((b) => b.toString(16).padStart(2, "0"))
-              .join("");
+        const strategies = {};
+        const encoder = new TextEncoder();
+        const toHex = (hash) =>
+          Array.from(hash).map((b) => b.toString(16).padStart(2, "0"))
+            .join("");
 
-          // merkle-reference with default (noble)
-          strategies["merkle-reference[noble]"] = (obj) =>
-            MerkleReference.refer(obj).toString();
+        // merkle-reference with default (noble)
+        strategies["merkle-reference[noble]"] = (obj) =>
+          MerkleReference.refer(obj).toString();
 
-          // merkle-reference with hash-wasm
-          const treeBuilderWasm = MerkleReference.Tree.createBuilder(
-            hashFunctions["hash-wasm"],
-          );
-          strategies["merkle-reference[hash-wasm]"] = (obj) =>
-            treeBuilderWasm.refer(obj).toString();
+        // merkle-reference with hash-wasm
+        const treeBuilderWasm = MerkleReference.Tree.createBuilder(
+          hashFunctions["hash-wasm"],
+        );
+        strategies["merkle-reference[hash-wasm]"] = (obj) =>
+          treeBuilderWasm.refer(obj).toString();
 
-          // merkle-reference with blake3-wasm
-          const treeBuilderBlake3 = MerkleReference.Tree.createBuilder(
-            hashFunctions["blake3-wasm"],
-          );
-          strategies["merkle-reference[blake3-wasm]"] = (obj) =>
-            treeBuilderBlake3.refer(obj).toString();
+        // merkle-reference with blake3-wasm
+        const treeBuilderBlake3 = MerkleReference.Tree.createBuilder(
+          hashFunctions["blake3-wasm"],
+        );
+        strategies["merkle-reference[blake3-wasm]"] = (obj) =>
+          treeBuilderBlake3.refer(obj).toString();
 
-          // object-hash
-          strategies["object-hash"] = (obj) => objectHash.default(obj);
+        // object-hash
+        strategies["object-hash"] = (obj) => objectHash.default(obj);
 
-          // hash-it
-          strategies["hash-it"] = (obj) => hashIt.default(obj).toString();
+        // hash-it
+        strategies["hash-it"] = (obj) => hashIt.default(obj).toString();
 
-          // safe-stable-stringify with all hash functions
-          for (
-            const [hashName, hashFn] of Object.entries(hashFunctions)
-          ) {
-            strategies[`safe-stable-stringify+${hashName}`] = (obj) => {
-              const str = safeStableStringify.default(obj);
-              return toHex(hashFn(encoder.encode(str)));
-            };
-          }
-          strategies["safe-stable-stringify+blake3"] = (obj) => {
+        // safe-stable-stringify with all hash functions
+        for (
+          const [hashName, hashFn] of Object.entries(hashFunctions)
+        ) {
+          strategies[`safe-stable-stringify+${hashName}`] = (obj) => {
             const str = safeStableStringify.default(obj);
-            return toHex(blake3(encoder.encode(str)));
+            return toHex(hashFn(encoder.encode(str)));
           };
-
-          // dag-cbor with all hash functions
-          for (
-            const [hashName, hashFn] of Object.entries(hashFunctions)
-          ) {
-            strategies[`dag-cbor+${hashName}`] = (obj) =>
-              toHex(hashFn(dagCbor.encode(obj)));
-          }
-          strategies["dag-cbor+blake3"] = (obj) =>
-            toHex(blake3(dagCbor.encode(obj)));
-
-          // Benchmark with fresh objects (no caching)
-          async function benchmark(strategy, templateData, iterations) {
-            const jsonStr = JSON.stringify(templateData);
-            const objects = Array.from(
-              { length: iterations },
-              () => JSON.parse(jsonStr),
-            );
-
-            // Warmup
-            for (let i = 0; i < Math.min(50, iterations / 10); i++) {
-              strategy(objects[i % objects.length]);
-            }
-
-            const start = performance.now();
-            for (let i = 0; i < iterations; i++) {
-              strategy(objects[i]);
-            }
-            return performance.now() - start;
-          }
-
-          function testStability(strategy) {
-            const obj1 = { a: 1, b: 2, c: 3 };
-            const obj2 = { c: 3, b: 2, a: 1 };
-            return strategy(obj1) === strategy(obj2);
-          }
-
-          statusDiv.textContent = "Running benchmarks...";
-          log("=== Object Hashing Benchmark (Browser) ===\n");
-          log(
-            "Note: Using fresh objects each iteration (no caching effects)\n",
-          );
-
-          // Stability test
-          log("## Stability Test\n");
-          for (const [name, strategy] of Object.entries(strategies)) {
-            const stable = testStability(strategy);
-            log(
-              `${name.padEnd(35)} ${stable ? "✓ STABLE" : "✗ UNSTABLE"}`,
-            );
-          }
-
-          const results = {};
-          const testCases = [
-            {
-              cat: "small",
-              name: "simple",
-              data: testData.small.simple,
-              iter: 500,
-            },
-            {
-              cat: "small",
-              name: "nested",
-              data: testData.small.nested,
-              iter: 500,
-            },
-            {
-              cat: "small",
-              name: "mixed",
-              data: testData.small.mixed,
-              iter: 500,
-            },
-            {
-              cat: "large",
-              name: "wide",
-              data: testData.large.wide,
-              iter: 50,
-            },
-            {
-              cat: "large",
-              name: "deep",
-              data: testData.large.deep,
-              iter: 50,
-            },
-            {
-              cat: "vdom",
-              name: "simple",
-              data: testData.vdom.simpleComponent,
-              iter: 200,
-            },
-            {
-              cat: "vdom",
-              name: "form",
-              data: testData.vdom.formComponent,
-              iter: 50,
-            },
-            {
-              cat: "vdom",
-              name: "table",
-              data: testData.vdom.dataTable,
-              iter: 30,
-            },
-            {
-              cat: "vdom",
-              name: "dashboard",
-              data: testData.vdom.dashboard,
-              iter: 30,
-            },
-          ];
-
-          for (const tc of testCases) {
-            log(`\n## ${tc.cat}/${tc.name}\n`);
-            statusDiv.textContent = `Running: ${tc.cat}/${tc.name}...`;
-
-            for (const [name, strategy] of Object.entries(strategies)) {
-              try {
-                const time = await benchmark(
-                  strategy,
-                  tc.data,
-                  tc.iter,
-                );
-                const ops = (tc.iter / time) * 1000;
-                if (!results[name]) results[name] = {};
-                results[name][`${tc.cat}/${tc.name}`] = ops;
-
-                const opsStr = ops > 1000000
-                  ? `${(ops / 1000000).toFixed(1)}M`
-                  : ops > 1000
-                  ? `${(ops / 1000).toFixed(1)}K`
-                  : ops.toFixed(0);
-                log(
-                  `${name.padEnd(35)} ${time.toFixed(1)}ms (${opsStr} ops/sec)`,
-                );
-              } catch (err) {
-                log(`${name.padEnd(35)} ERROR: ${err.message}`);
-              }
-            }
-          }
-
-          // Summary
-          log("\n\n=== SUMMARY (ops/sec) ===\n");
-          const names = Object.keys(strategies);
-          const tests = testCases.map((t) => `${t.cat}/${t.name}`);
-
-          log(
-            "Strategy".padEnd(35) +
-              tests.map((t) => t.split("/")[1].substring(0, 8).padEnd(10)).join(
-                "",
-              ),
-          );
-          log("-".repeat(35 + tests.length * 10));
-
-          for (const name of names) {
-            const vals = tests.map((t) => {
-              const v = results[name]?.[t];
-              if (!v) return "N/A".padEnd(10);
-              return (v > 1000000
-                ? `${(v / 1000000).toFixed(1)}M`
-                : v > 1000
-                ? `${(v / 1000).toFixed(1)}K`
-                : v.toFixed(0)).padEnd(10);
-            });
-            log(name.padEnd(35) + vals.join(""));
-          }
-
-          log("\n=== DONE ===");
-          statusDiv.className = "complete";
-          statusDiv.textContent = "Benchmark complete!";
-          window.benchmarkResults = results;
-          window.benchmarkComplete = true;
-        } catch (err) {
-          statusDiv.className = "error";
-          statusDiv.textContent = `Error: ${err.message}`;
-          log(`\nERROR: ${err.message}\n${err.stack}`);
-          console.error(err);
         }
-      }
+        strategies["safe-stable-stringify+blake3"] = (obj) => {
+          const str = safeStableStringify.default(obj);
+          return toHex(blake3(encoder.encode(str)));
+        };
 
-      main();
+        // dag-cbor with all hash functions
+        for (
+          const [hashName, hashFn] of Object.entries(hashFunctions)
+        ) {
+          strategies[`dag-cbor+${hashName}`] = (obj) =>
+            toHex(hashFn(dagCbor.encode(obj)));
+        }
+        strategies["dag-cbor+blake3"] = (obj) => toHex(blake3(dagCbor.encode(obj)));
+
+        // Benchmark with fresh objects (no caching)
+        async function benchmark(strategy, templateData, iterations) {
+          const jsonStr = JSON.stringify(templateData);
+          const objects = Array.from(
+            { length: iterations },
+            () => JSON.parse(jsonStr),
+          );
+
+          // Warmup
+          for (let i = 0; i < Math.min(50, iterations / 10); i++) {
+            strategy(objects[i % objects.length]);
+          }
+
+          const start = performance.now();
+          for (let i = 0; i < iterations; i++) {
+            strategy(objects[i]);
+          }
+          return performance.now() - start;
+        }
+
+        function testStability(strategy) {
+          const obj1 = { a: 1, b: 2, c: 3 };
+          const obj2 = { c: 3, b: 2, a: 1 };
+          return strategy(obj1) === strategy(obj2);
+        }
+
+        statusDiv.textContent = "Running benchmarks...";
+        log("=== Object Hashing Benchmark (Browser) ===\n");
+        log(
+          "Note: Using fresh objects each iteration (no caching effects)\n",
+        );
+
+        // Stability test
+        log("## Stability Test\n");
+        for (const [name, strategy] of Object.entries(strategies)) {
+          const stable = testStability(strategy);
+          log(
+            `${name.padEnd(35)} ${stable ? "✓ STABLE" : "✗ UNSTABLE"}`,
+          );
+        }
+
+        const results = {};
+        const testCases = [
+          {
+            cat: "small",
+            name: "simple",
+            data: testData.small.simple,
+            iter: 500,
+          },
+          {
+            cat: "small",
+            name: "nested",
+            data: testData.small.nested,
+            iter: 500,
+          },
+          {
+            cat: "small",
+            name: "mixed",
+            data: testData.small.mixed,
+            iter: 500,
+          },
+          {
+            cat: "large",
+            name: "wide",
+            data: testData.large.wide,
+            iter: 50,
+          },
+          {
+            cat: "large",
+            name: "deep",
+            data: testData.large.deep,
+            iter: 50,
+          },
+          {
+            cat: "vdom",
+            name: "simple",
+            data: testData.vdom.simpleComponent,
+            iter: 200,
+          },
+          {
+            cat: "vdom",
+            name: "form",
+            data: testData.vdom.formComponent,
+            iter: 50,
+          },
+          {
+            cat: "vdom",
+            name: "table",
+            data: testData.vdom.dataTable,
+            iter: 30,
+          },
+          {
+            cat: "vdom",
+            name: "dashboard",
+            data: testData.vdom.dashboard,
+            iter: 30,
+          },
+        ];
+
+        for (const tc of testCases) {
+          log(`\n## ${tc.cat}/${tc.name}\n`);
+          statusDiv.textContent = `Running: ${tc.cat}/${tc.name}...`;
+
+          for (const [name, strategy] of Object.entries(strategies)) {
+            try {
+              const time = await benchmark(
+                strategy,
+                tc.data,
+                tc.iter,
+              );
+              const ops = (tc.iter / time) * 1000;
+              if (!results[name]) results[name] = {};
+              results[name][`${tc.cat}/${tc.name}`] = ops;
+
+              const opsStr = ops > 1000000
+                ? `${(ops / 1000000).toFixed(1)}M`
+                : ops > 1000
+                ? `${(ops / 1000).toFixed(1)}K`
+                : ops.toFixed(0);
+              log(
+                `${name.padEnd(35)} ${time.toFixed(1)}ms (${opsStr} ops/sec)`,
+              );
+            } catch (err) {
+              log(`${name.padEnd(35)} ERROR: ${err.message}`);
+            }
+          }
+        }
+
+        // Summary
+        log("\n\n=== SUMMARY (ops/sec) ===\n");
+        const names = Object.keys(strategies);
+        const tests = testCases.map((t) => `${t.cat}/${t.name}`);
+
+        log(
+          "Strategy".padEnd(35) +
+            tests.map((t) => t.split("/")[1].substring(0, 8).padEnd(10)).join(
+              "",
+            ),
+        );
+        log("-".repeat(35 + tests.length * 10));
+
+        for (const name of names) {
+          const vals = tests.map((t) => {
+            const v = results[name]?.[t];
+            if (!v) return "N/A".padEnd(10);
+            return (v > 1000000
+              ? `${(v / 1000000).toFixed(1)}M`
+              : v > 1000
+              ? `${(v / 1000).toFixed(1)}K`
+              : v.toFixed(0)).padEnd(10);
+          });
+          log(name.padEnd(35) + vals.join(""));
+        }
+
+        log("\n=== DONE ===");
+        statusDiv.className = "complete";
+        statusDiv.textContent = "Benchmark complete!";
+        window.benchmarkResults = results;
+        window.benchmarkComplete = true;
+      } catch (err) {
+        statusDiv.className = "error";
+        statusDiv.textContent = `Error: ${err.message}`;
+        log(`\nERROR: ${err.message}\n${err.stack}`);
+        console.error(err);
+      }
+    }
+
+    main();
     </script>
   </body>
 </html>

--- a/skills/lit-component/references/component-patterns.md
+++ b/skills/lit-component/references/component-patterns.md
@@ -82,8 +82,7 @@ export class CFSeparator extends BaseElement {
         class="separator ${this.orientation}"
         part="separator"
         role="${this.decorative ? "none" : "separator"}"
-      >
-      </div>
+      ></div>
     `;
   }
 }

--- a/tasks/check-deno-pins.test.ts
+++ b/tasks/check-deno-pins.test.ts
@@ -21,12 +21,16 @@ const REPO_ROOT = dirname(dirname(fromFileUrl(import.meta.url)));
 // file name alone would pass here for a reason production could not reproduce.
 function alignedFiles() {
   return {
-    miseToml: '[tools]\ndeno = "2.8.1"\n',
-    dockerfile: "FROM denoland/deno:2.8.1 AS builder\n" +
-      "RUN deno install --frozen\n" +
-      "FROM denoland/deno:2.8.1\n",
+    miseToml: '[tools]\ndeno = "2.9.4"\n',
+    dockerfiles: {
+      "Dockerfile.dashboard":
+        "FROM --platform=linux/amd64 denoland/deno:2.9.4\n",
+      "Dockerfile.toolshed": "FROM denoland/deno:2.9.4 AS builder\n" +
+        "RUN deno install --frozen\n" +
+        "FROM denoland/deno:2.9.4\n",
+    },
     checkSh: "# The exact Deno version is pinned in mise.toml.\n" +
-      'DENO_VERSION_MIN="2.8.0"\nDENO_VERSION_MAX="2.9.0"\n' +
+      'DENO_VERSION_MIN="2.8.0"\nDENO_VERSION_MAX="2.10.0"\n' +
       `DENO_PINS="$(sed -n 's/^deno = "\\([^"]*\\)"$/\\1/p' mise.toml)"\n`,
     denoSetupAction: '    description: "Defaults to the pin in mise.toml."\n' +
       "    # The repository's Deno version is pinned once, in mise.toml.\n" +
@@ -76,8 +80,18 @@ Deno.test("findProblems flags a Deno pin defined twice", () => {
 });
 
 Deno.test("parseDockerfileDenoVersions finds every FROM line", () => {
-  const versions = parseDockerfileDenoVersions(alignedFiles().dockerfile);
-  assertEquals(versions, ["2.8.1", "2.8.1"]);
+  assertEquals(
+    parseDockerfileDenoVersions(
+      alignedFiles().dockerfiles["Dockerfile.dashboard"],
+    ),
+    ["2.9.4"],
+  );
+  assertEquals(
+    parseDockerfileDenoVersions(
+      alignedFiles().dockerfiles["Dockerfile.toolshed"],
+    ),
+    ["2.9.4", "2.9.4"],
+  );
 });
 
 Deno.test("parseDockerfileDenoVersions reads past flags and a lowercase FROM", () => {
@@ -100,7 +114,7 @@ Deno.test("parseDockerfileDenoVersions drops a digest", () => {
 Deno.test("parseCheckShRange extracts min and max", () => {
   assertEquals(parseCheckShRange(alignedFiles().checkSh), {
     min: "2.8.0",
-    max: "2.9.0",
+    max: "2.10.0",
   });
 });
 
@@ -162,18 +176,29 @@ Deno.test("findProblems flags a non-exact pin", () => {
 });
 
 Deno.test("findProblems flags a mismatched Dockerfile image", () => {
-  const files = {
-    ...alignedFiles(),
-    dockerfile: "FROM denoland/deno:2.8.0 AS builder\n" +
-      "FROM denoland/deno:2.8.1\n",
-  };
-  const problems = findProblems(files);
-  assertEquals(problems.length, 1);
-  assert(problems[0].includes("2.8.0"));
+  for (const path of Object.keys(alignedFiles().dockerfiles)) {
+    const files = {
+      ...alignedFiles(),
+      dockerfiles: {
+        ...alignedFiles().dockerfiles,
+        [path]: "FROM denoland/deno:2.8.0\n",
+      },
+    };
+    const problems = findProblems(files);
+    assertEquals(problems.length, 1, path);
+    assert(problems[0].includes(path), problems[0]);
+    assert(problems[0].includes("2.8.0"), problems[0]);
+  }
 });
 
 Deno.test("findProblems flags a Dockerfile without deno images", () => {
-  const files = { ...alignedFiles(), dockerfile: "FROM debian:12\n" };
+  const files = {
+    ...alignedFiles(),
+    dockerfiles: {
+      ...alignedFiles().dockerfiles,
+      "Dockerfile.dashboard": "FROM debian:12\n",
+    },
+  };
   assertEquals(findProblems(files).length, 1);
 });
 
@@ -196,7 +221,7 @@ Deno.test("findProblems flags a range bound that is not exact", () => {
     const withMax = findProblems({
       ...alignedFiles(),
       checkSh: alignedFiles().checkSh.replace(
-        'DENO_VERSION_MAX="2.9.0"',
+        'DENO_VERSION_MAX="2.10.0"',
         `DENO_VERSION_MAX="${bad}"`,
       ),
     });
@@ -210,7 +235,7 @@ Deno.test("findProblems flags both range bounds when both are malformed", () => 
     ...alignedFiles(),
     checkSh: alignedFiles().checkSh
       .replace('DENO_VERSION_MIN="2.8.0"', 'DENO_VERSION_MIN="2.8"')
-      .replace('DENO_VERSION_MAX="2.9.0"', 'DENO_VERSION_MAX="2.9"'),
+      .replace('DENO_VERSION_MAX="2.10.0"', 'DENO_VERSION_MAX="2.10"'),
   });
   assertEquals(problems.length, 2);
 });
@@ -219,8 +244,8 @@ Deno.test("findProblems flags a range that excludes the pin", () => {
   const files = {
     ...alignedFiles(),
     checkSh: alignedFiles().checkSh
-      .replace('DENO_VERSION_MIN="2.8.0"', 'DENO_VERSION_MIN="2.9.0"')
-      .replace('DENO_VERSION_MAX="2.9.0"', 'DENO_VERSION_MAX="2.10.0"'),
+      .replace('DENO_VERSION_MIN="2.8.0"', 'DENO_VERSION_MIN="2.10.0"')
+      .replace('DENO_VERSION_MAX="2.10.0"', 'DENO_VERSION_MAX="2.11.0"'),
   };
   const problems = findProblems(files);
   assertEquals(problems.length, 1);
@@ -236,7 +261,7 @@ Deno.test("findProblems flags an action that stops reading mise.toml", () => {
     denoSetupAction: '    description: "Defaults to the pin in mise.toml."\n' +
       "    # The repository's Deno version is pinned once, in mise.toml.\n" +
       "      run: |\n" +
-      '        version="2.8.1"\n',
+      '        version="2.9.4"\n',
   };
   const problems = findProblems(files);
   assertEquals(problems.length, 1);
@@ -247,7 +272,7 @@ Deno.test("findProblems flags a check.sh that stops reading mise.toml", () => {
   const files = {
     ...alignedFiles(),
     checkSh: "# The exact Deno version is pinned in mise.toml.\n" +
-      'DENO_VERSION_MIN="2.8.0"\nDENO_VERSION_MAX="2.9.0"\n',
+      'DENO_VERSION_MIN="2.8.0"\nDENO_VERSION_MAX="2.10.0"\n',
   };
   const problems = findProblems(files);
   assertEquals(problems.length, 1);
@@ -257,8 +282,11 @@ Deno.test("findProblems flags a check.sh that stops reading mise.toml", () => {
 Deno.test("findProblems flags a Dockerfile stage stale behind a flag", () => {
   const files = {
     ...alignedFiles(),
-    dockerfile: "FROM --platform=linux/amd64 denoland/deno:2.5.0 AS builder\n" +
-      "FROM denoland/deno:2.8.1\n",
+    dockerfiles: {
+      ...alignedFiles().dockerfiles,
+      "Dockerfile.dashboard":
+        "FROM --platform=linux/amd64 denoland/deno:2.5.0\n",
+    },
   };
   const problems = findProblems(files);
   assertEquals(problems.length, 1);
@@ -268,8 +296,12 @@ Deno.test("findProblems flags a Dockerfile stage stale behind a flag", () => {
 Deno.test("findProblems accepts a digest-pinned image on the pin", () => {
   const files = {
     ...alignedFiles(),
-    dockerfile: "FROM denoland/deno:2.8.1@sha256:abc123 AS builder\n" +
-      "FROM denoland/deno:2.8.1\n",
+    dockerfiles: {
+      ...alignedFiles().dockerfiles,
+      "Dockerfile.toolshed":
+        "FROM denoland/deno:2.9.4@sha256:abc123 AS builder\n" +
+        "FROM denoland/deno:2.9.4\n",
+    },
   };
   assertEquals(findProblems(files), []);
 });
@@ -289,7 +321,7 @@ Deno.test("findProblems accepts a literal in the action equal to the pin", () =>
   const files = {
     ...alignedFiles(),
     denoSetupAction: alignedFiles().denoSetupAction +
-      'default: "2.8.1"\n',
+      'default: "2.9.4"\n',
   };
   assertEquals(findProblems(files), []);
 });
@@ -315,7 +347,9 @@ async function fixtureTree(
     recursive: true,
   });
   await Deno.writeTextFile(join(root, "mise.toml"), files.miseToml);
-  await Deno.writeTextFile(join(root, "Dockerfile.toolshed"), files.dockerfile);
+  for (const [path, contents] of Object.entries(files.dockerfiles)) {
+    await Deno.writeTextFile(join(root, path), contents);
+  }
   await Deno.writeTextFile(join(root, "tasks", "check.sh"), files.checkSh);
   await Deno.writeTextFile(
     join(root, ".github", "actions", "deno-setup", "action.yml"),
@@ -352,7 +386,7 @@ Deno.test("main reports the pin and returns 0 on aligned files", async () => {
       code = await main(root);
     });
     assertEquals(code, 0);
-    assert(out.includes("Deno toolchain pins are aligned: 2.8.1"));
+    assert(out.includes("Deno toolchain pins are aligned: 2.9.4"));
   } finally {
     await Deno.remove(root, { recursive: true });
   }
@@ -361,9 +395,12 @@ Deno.test("main reports the pin and returns 0 on aligned files", async () => {
 Deno.test("main reports each problem and returns 1 when misaligned", async () => {
   const root = await fixtureTree({
     ...alignedFiles(),
-    dockerfile: "FROM denoland/deno:2.5.0 AS builder\n",
+    dockerfiles: {
+      ...alignedFiles().dockerfiles,
+      "Dockerfile.toolshed": "FROM denoland/deno:2.5.0 AS builder\n",
+    },
     checkSh: alignedFiles().checkSh.replace(
-      'DENO_VERSION_MAX="2.9.0"',
+      'DENO_VERSION_MAX="2.10.0"',
       'DENO_VERSION_MAX="2.9"',
     ),
   });

--- a/tasks/check-deno-pins.ts
+++ b/tasks/check-deno-pins.ts
@@ -4,11 +4,11 @@
 // the pin in mise.toml.
 //
 // mise.toml is the canonical pin: mise installs that version for developers,
-// and .github/actions/deno-setup reads it at job time for CI. Two other places
+// and .github/actions/deno-setup reads it at job time for CI. Other places
 // encode a version and can drift, so this script checks them:
 //
-// - Dockerfile.toolshed bakes the version into its FROM lines, which cannot
-//   read a file. Each denoland/deno image tag must equal the pin.
+// - The root deployment Dockerfiles bake the version into their FROM lines,
+//   which cannot read a file. Each denoland/deno image tag must equal the pin.
 // - tasks/check.sh accepts a range of versions (so a developer without mise
 //   can still build, at the cost of a warning). The range must contain the
 //   pin, otherwise the version mise installs would fail the check.
@@ -23,7 +23,10 @@ import { dirname, fromFileUrl, join } from "@std/path";
 const REPO_ROOT = dirname(dirname(fromFileUrl(import.meta.url)));
 
 const MISE_TOML = "mise.toml";
-const DOCKERFILE = "Dockerfile.toolshed";
+const DOCKERFILES = [
+  "Dockerfile.dashboard",
+  "Dockerfile.toolshed",
+] as const;
 const CHECK_SH = "tasks/check.sh";
 const DENO_SETUP_ACTION = ".github/actions/deno-setup/action.yml";
 
@@ -111,7 +114,7 @@ export function versionInRange(
 // of each misalignment found. An empty result means everything agrees.
 export function findProblems(files: {
   miseToml: string;
-  dockerfile: string;
+  dockerfiles: Record<string, string>;
   checkSh: string;
   denoSetupAction: string;
 }): string[] {
@@ -134,16 +137,20 @@ export function findProblems(files: {
     ];
   }
 
-  const dockerVersions = parseDockerfileDenoVersions(files.dockerfile);
-  if (dockerVersions.length === 0) {
-    problems.push(`${DOCKERFILE}: no denoland/deno FROM lines found`);
-  }
-  for (const version of dockerVersions) {
-    if (version !== pin) {
-      problems.push(
-        `${DOCKERFILE}: FROM denoland/deno:${version} does not match the ` +
-          `${MISE_TOML} pin ${pin}`,
-      );
+  for (const dockerfile of DOCKERFILES) {
+    const dockerVersions = parseDockerfileDenoVersions(
+      files.dockerfiles[dockerfile] ?? "",
+    );
+    if (dockerVersions.length === 0) {
+      problems.push(`${dockerfile}: no denoland/deno FROM lines found`);
+    }
+    for (const version of dockerVersions) {
+      if (version !== pin) {
+        problems.push(
+          `${dockerfile}: FROM denoland/deno:${version} does not match the ` +
+            `${MISE_TOML} pin ${pin}`,
+        );
+      }
     }
   }
 
@@ -208,7 +215,11 @@ export async function main(root: string = REPO_ROOT): Promise<number> {
   const read = (path: string) => Deno.readTextFile(join(root, path));
   const files = {
     miseToml: await read(MISE_TOML),
-    dockerfile: await read(DOCKERFILE),
+    dockerfiles: Object.fromEntries(
+      await Promise.all(
+        DOCKERFILES.map(async (path) => [path, await read(path)]),
+      ),
+    ),
     checkSh: await read(CHECK_SH),
     denoSetupAction: await read(DENO_SETUP_ACTION),
   };

--- a/tasks/check.sh
+++ b/tasks/check.sh
@@ -18,7 +18,7 @@ cd "${baseDir}"
 # a warning when the version differs from the pin.
 # tasks/check-deno-pins.ts verifies that the range contains the pin.
 DENO_VERSION_MIN="2.8.0"
-DENO_VERSION_MAX="2.9.0"
+DENO_VERSION_MAX="2.10.0"
 if [[ ! -f mise.toml ]]; then
   # Checked before the read: `set -e` would otherwise abort on sed's exit
   # status with only sed's own message.


### PR DESCRIPTION
See individual commits.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Roll Deno to 2.9.4 repo-wide, update deployment images and version guards, and harden the web test harness to ignore Deno dependency download noise without hiding app output. This keeps builds consistent, widens supported local versions, and strengthens pin validation.

- **Dependencies**
  - Pin `deno` 2.9.4 in `mise.toml` and in `FROM` lines for `Dockerfile.dashboard` and `Dockerfile.toolshed` (`denoland/deno:2.9.4`).
  - Widen `tasks/check.sh` acceptance to 2.8.0–<2.10.0.
  - Extend `tasks/check-deno-pins` to audit both root Dockerfiles; update docs and tests.

- **Bug Fixes**
  - `packages/deno-web-test`: preinstall the harness and all test entrypoints; emit a per-run stderr boundary and filter only pre-boundary “Download http(s)://” lines (ANSI-SGR aware, preserves all other bytes); add coverage.
  - `packages/runner`: auth mutex tests now wait on `runtime.settled()` before assertions.
  - Apply `deno fmt` 2.9.4 output across HTML/CSS/Markdown and tagged templates.

<sup>Written for commit 78710ac8c6e5654f0e3aa095bbb98acf8cc96135. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

