### PR TITLE
test(runner): wait on a sink for the inspectConfLabel result, not a poll

### DIFF
--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -734,6 +734,26 @@ reveals the next hop, for a bounded number of rounds. A sink reports committed
 changes; it does not drive that traversal. Polling the pull until it converges is
 the honest wait.
 
+Reaching a lazily scheduled node, on the other hand, is not a reason to keep a
+pull, and that is where this section is easiest to over-read. The scheduler
+runs a computation only while it is reachable from a live root — an effect, a
+materializer, or a node marked as provisionally demanded — so a node whose
+output nothing observes stays dormant however long a test waits. `pull()`
+supplies such a root: it subscribes an action that reads the cell, marked as an
+effect, and cancels it once the scheduler goes idle. `cell.sink()` subscribes
+the same kind of root and holds it until the caller cancels, so a wait built on
+`waitForCellValue` keeps the node awake for the whole wait rather than for one
+scheduler cycle. Where demand is the only thing the pull supplied, the sink
+supplies it too and the loop around the pull was doing nothing.
+
+`packages/runner/test/cfc-inspect-conf-label-builtin.test.ts` is the worked
+example. Its waits were a bounded `pull()` poll, on the grounds that the pull
+drives the `inspectConfLabel` builtin's node; they are now single
+`waitForCellValue` calls with no loop and no bound. That the demand is what
+matters, and not the pull, is checkable: replace the wait with
+`runtime.settled()` followed by a storage sync and a plain read, and every case
+reads the result cell as undefined, because nothing ever asked for its value.
+
 ### Race, backpressure, and convergence tests
 
 Here the poll measures eventual convergence across timing the test does not

--- a/packages/runner/test/cfc-inspect-conf-label-builtin.test.ts
+++ b/packages/runner/test/cfc-inspect-conf-label-builtin.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
+import { waitForCellValue } from "@commonfabric/integration/wait-for-cell-value";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";
 import { parseLink } from "../src/link-utils.ts";
@@ -66,21 +67,23 @@ const seedLabeledDoc = async (
   return id;
 };
 
-const waitForStatus = async (result: Cell<any>): Promise<unknown> => {
-  // `pull()` — a standing observation — drives the pull-based scheduler;
-  // a bare storage sync would leave the builtin's node dormant.
-  const timeoutMs = 5000;
-  const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
-    const value = await result.pull() as { status?: string } | undefined;
-    if (value?.status !== undefined) {
-      // Plain-JSON snapshot so exact toEqual comparisons see bytes, not a
-      // live query proxy.
-      return JSON.parse(JSON.stringify(value));
-    }
-    await new Promise((resolve) => setTimeout(resolve, 10));
-  }
-  throw new Error("Timeout waiting for inspectConfLabel result status");
+const waitForStatus = async (
+  runtime: Runtime,
+  result: Cell<any>,
+): Promise<unknown> => {
+  // The builtin's node runs only while something demands its output, so the
+  // wait has to hold a standing observation of the result cell rather than
+  // sample it. `waitForCellValue` sinks on the cell, and a sink subscribes as
+  // a scheduler effect that reads the value — the liveness root that keeps the
+  // node awake — for as long as the wait is outstanding.
+  const value = await waitForCellValue<{ status?: string }>(
+    runtime,
+    result,
+    (value) => value?.status !== undefined,
+  );
+  // Plain-JSON snapshot so exact toEqual comparisons see bytes, not a
+  // live query proxy.
+  return JSON.parse(JSON.stringify(value));
 };
 
 const storedConfidentialityOf = (
@@ -153,7 +156,10 @@ describe("inspectConfLabel builtin (inv-12 Stage 2)", () => {
       runtime.prepareTxForCommit(tx);
       tx.commit();
 
-      const value = await waitForStatus(result) as InspectConfLabelResult;
+      const value = await waitForStatus(
+        runtime,
+        result,
+      ) as InspectConfLabelResult;
       await runtime.idle();
 
       expect(value.status).toBe("ok");
@@ -233,7 +239,10 @@ describe("inspectConfLabel builtin (inv-12 Stage 2)", () => {
       runtime.prepareTxForCommit(tx);
       tx.commit();
 
-      const value = await waitForStatus(result) as InspectConfLabelResult;
+      const value = await waitForStatus(
+        runtime,
+        result,
+      ) as InspectConfLabelResult;
       await runtime.idle();
       expect(value.status).toBe("ok");
 
@@ -274,7 +283,7 @@ describe("inspectConfLabel builtin (inv-12 Stage 2)", () => {
       runtime.prepareTxForCommit(tx);
       tx.commit();
 
-      const value = await waitForStatus(result);
+      const value = await waitForStatus(runtime, result);
       await runtime.idle();
       expect(value).toEqual({ status: "notAvailable" });
     });
@@ -308,7 +317,7 @@ describe("inspectConfLabel builtin (inv-12 Stage 2)", () => {
       runtime.prepareTxForCommit(tx);
       tx.commit();
 
-      const value = await waitForStatus(result);
+      const value = await waitForStatus(runtime, result);
       await runtime.idle();
       expect(value).toEqual({ status: "notAvailable" });
     });
@@ -329,7 +338,7 @@ describe("inspectConfLabel builtin (inv-12 Stage 2)", () => {
       runtime.prepareTxForCommit(tx);
       tx.commit();
 
-      const value = await waitForStatus(result);
+      const value = await waitForStatus(runtime, result);
       await runtime.idle();
       expect(value).toEqual({ status: "notAvailable" });
     });
@@ -354,7 +363,7 @@ describe("inspectConfLabel builtin (inv-12 Stage 2)", () => {
       runtime.prepareTxForCommit(tx);
       tx.commit();
 
-      const value = await waitForStatus(result);
+      const value = await waitForStatus(runtime, result);
       await runtime.idle();
       expect(value).toEqual({ status: "notAvailable" });
     });
@@ -385,7 +394,7 @@ describe("inspectConfLabel builtin (inv-12 Stage 2)", () => {
       runtime.prepareTxForCommit(tx);
       tx.commit();
 
-      const value = await waitForStatus(result);
+      const value = await waitForStatus(runtime, result);
       await runtime.idle();
       // The match exists, but the result cannot carry its label (flow labels
       // are not persisting): the fail-closed arm returns the SAME
@@ -425,7 +434,7 @@ describe("inspectConfLabel builtin (inv-12 Stage 2)", () => {
       runtime.prepareTxForCommit(tx);
       tx.commit();
 
-      const value = await waitForStatus(result);
+      const value = await waitForStatus(runtime, result);
       await runtime.idle();
       // Establishing this miss consulted only public type observations, so
       // it flows under any dial.


### PR DESCRIPTION
The `inspectConfLabel` builtin tests waited for their result cell through a bounded poll: a five-second wall-clock deadline around a loop that called `Cell.pull()` and slept ten milliseconds between attempts, throwing "Timeout waiting for inspectConfLabel result status" when the deadline passed. That is the deadline, retry-loop and sleep shape that AGENTS.md and docs/development/waiting-in-tests.md rule out, and none of the exceptions that document catalogues applies here.

The loop's comment argued that the `pull()` call was load-bearing: it is a standing observation that keeps the builtin's node running, and a bare storage sync would leave that node dormant. The observation is real, but it is not specific to `pull()`. The scheduler runs a computation only while it is reachable from a live root — an effect, a materializer, or a node marked as provisionally demanded. `pull()` supplies one by subscribing an action that reads the cell, marked as an effect, then cancelling it once the scheduler goes idle. `Cell.sink()` subscribes the same kind of root and holds it until the caller cancels. So the sink that `waitForCellValue` registers to wake the wait also keeps the builtin's node awake, and for the whole wait rather than for a single scheduler cycle.

Each wait is therefore now one `waitForCellValue` call carrying the predicate the poll used, `status !== undefined`, with no loop and no bound. The helper still snapshots the matched value through JSON so the exact `toEqual` comparisons downstream compare plain data rather than a live query proxy. The helper takes the runtime as its first argument, because `waitForCellValue` applies its predicate only to a value read once that runtime's scheduler is quiescent.

Three checks back the reasoning. The full runner suite passes. Replacing the wait with `runtime.settled()`, a storage sync and a plain read leaves every case reading the result cell as undefined, which is what establishes that the demand root is load-bearing and that the sink supplies it. And making the predicate unsatisfiable fails the file in about fifty milliseconds with Deno's "Promise resolution is still pending but the event loop has already resolved", so the removed deadline was not what kept an unsatisfiable wait from hanging.

The fake-clock harness did not catch this. Its tripwire is that a positive-delay timer armed from a `test/` file freezes, so a test that waits on a sleep deadlocks and announces itself. Every one of these waits was satisfied by its first `pull()`, so the ten-millisecond sleep was never armed and the tripwire never fired. The `check-no-waitfor` task did not catch it either: that scan only covers `integration/` directories, and this is a unit test with a locally defined helper.

waiting-in-tests.md gains a note under "A pull that drives its own loading", because that section is the one a reader would cite as cover for keeping a poll like this. Driving a lazily scheduled node is not a reason to keep a pull; what keeps the pattern harness on a poll is the link-target traversal its pull also performs, which a sink does not do.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the poll-and-timeout in `inspectConfLabel` tests with a sink-based wait via `waitForCellValue`, making the tests deterministic and aligned with our waiting guidelines. Updated docs to clarify that sinks keep lazy nodes alive, so polls aren’t needed.

- **Refactors**
  - Use `waitForCellValue` with predicate `status !== undefined`; removed the loop and 5s timeout.
  - `waitForStatus` now takes `Runtime` and holds a sink to keep the node demanded during the wait.
  - Snapshot values to plain JSON for exact `toEqual` comparisons.
  - Verified: runner suite passes; unsatisfiable predicate fails fast; reads without demand return `undefined`.

<sup>Written for commit 5eb9ae96983980301baab3a2ca314e9d88e581e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

