### PR TITLE
docs(plans): a test pattern creates stores; it is never an upgrade target

### DIFF
--- a/docs/plans/pattern-update-state-continuity.md
+++ b/docs/plans/pattern-update-state-continuity.md
@@ -441,22 +441,40 @@ exactly what a migrated-forward database no longer holds.
       (`home.test.tsx` instantiates `Home({})` and drives it with
       `action()`/`assert()`), so the state they produce is real pattern state
       written through real handlers.
-- [ ] Replay by applying today's pattern to EVERY recorded instantiation, and
+- [ ] Replay by applying today's PATTERN to EVERY recorded instantiation, and
       report the count — "updated 0 patterns" must never read as success.
+- [ ] Make the replay path REFUSE a `*.test.tsx` entry, with its own case in
+      `pattern-vintage-run.test.ts`. See the invariant below: a test pattern
+      creates stores and is never an upgrade target, and this is the guard that
+      keeps that from being merely written down.
 - [ ] Capture on identity change, committed — not uploaded as an artifact
       (see the decision above).
 - [ ] Retention, if any, weighed as LOST COVERAGE against working-tree disk —
       not applied as housekeeping, and still structurally unable to reach
       `pinned/`.
 
-**Finding the update targets — the hard part, and a measured dead end.**
+**INVARIANT: a test pattern creates stores. It is never an upgrade target.**
 
-A test-populated store puts the TEST pattern at the top; the pattern under test
-is a nested instance (`Home({})`) with no stable id. Applying today's test
-pattern at the top was tried and **makes the gate weaker**: measured, the
-additive-required break that stage 3 catches (exit 1, naming the field) exits 0,
-because materializing the test pattern never re-runs the CFC schema merge
-against the inner pattern's own stored envelope. Do not take that shortcut.
+The test pattern's whole role is to produce a fresh, populated store for later
+rounds to upgrade. It is a capture-time tool and must never appear on the replay
+side. The upgrade always applies **the pattern**, never the test that exercised
+it.
+
+Enforce this mechanically rather than by comment. The replay path must REFUSE a
+program whose entry resolves to a `*.test.tsx`, and the refusal needs its own
+case in `pattern-vintage-run.test.ts`. Prose is what failed the first time:
+"don't take that shortcut" was already the plan's wording when the shortcut got
+taken anyway, because at the moment of writing the code it looks like the
+obvious way to reach the root.
+
+Why it is wrong, measured rather than argued: a test-populated store puts the
+TEST pattern at the top, with the pattern under test a nested instance
+(`Home({})`) that has no stable id. Applying today's test pattern there **makes
+the gate weaker** — the additive-required break that stage 3 catches (exit 1,
+naming the field) exits 0, because materializing the test pattern never re-runs
+the CFC schema merge against the inner pattern's own stored envelope. The gate
+keeps reporting success while checking nothing, which is this tier's worst
+failure mode and the third time it has appeared in this work.
 
 Three ways to get the targets were compared:
 


### PR DESCRIPTION
A one-file follow-up to [#5156], turning an invariant that prose failed to
protect into a requirement with a mechanical guard.

## The rule

A test pattern's role in the vintage regime is **capture only** — produce a
fresh, populated store for later rounds to upgrade. It must never appear on the
replay side. The upgrade always applies **the pattern**, never the test that
exercised it.

## Why prose wasn't enough

The plan already said *"do not take that shortcut"* about applying today's test
pattern at a store's top. The shortcut got taken anyway while building stage 4,
because at the moment of writing the code it looks like the obvious way to reach
the root — the test pattern *is* what sits at the top of a test-populated store.

So stage 4 now carries a checklist item instead of a warning: **the replay path
refuses a `*.test.tsx` entry**, with its own case in
`pattern-vintage-run.test.ts`.

## What it costs to get wrong, measured

A test-populated store puts the test at the top, with the pattern under test a
nested instance (`Home({})`) that has no stable id. Applying today's test
pattern there **makes the gate weaker**: the additive-required break that stage 3
catches — exit 1, naming the field — exits **0**, because materializing the test
pattern never re-runs the CFC schema merge against the inner pattern's own
stored envelope.

The gate keeps reporting success while checking nothing. That is this tier's
worst failure mode, and the third time it has surfaced in this work — after a
stranding assertion that an unrestored fixture satisfied equally well, and a
compile failure that exited 0 having printed no verdict at all.

Docs only; `deno task check-docs` passes (523 blocks).

[#5156]: https://github.com/commontoolsinc/labs/pull/5156

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies and hardens the plan: a test pattern only captures state (creates stores) and must never be an upgrade target in vintage replay. Adds a stage-4 checklist guard requiring the replay path to refuse `*.test.tsx` entries and to cover this with a `pattern-vintage-run.test.ts` case, preventing a measured failure that weakens the gate when a test is applied at the store root.

<sup>Written for commit 72130f9ca91bf57061a9aa572b033187ab4abf31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

