### PR TITLE
fix(cli): restrict automatic diff detection to containers

### DIFF
--- a/docs/plans/cf-view-language-coverage.md
+++ b/docs/plans/cf-view-language-coverage.md
@@ -6,6 +6,9 @@ output keeps its TypeScript default. Piped source can select a language directly
 or through a virtual filename. Declarative metadata can now describe extensions,
 exact names, compound patterns, explicit aliases, and direct interpreter
 shebangs. Python files with recognized extensions now have syntax highlighting.
+Automatic container detection is limited to structurally identified raw unified
+diffs and standard Git commit output. Recognized shebangs and transformed
+compiler headers remain explicit source selectors.
 The order is provisional because recent activity was measured in six of the 24
 active organization repositories.
 
@@ -91,7 +94,7 @@ relative value. Record the reason in this plan.
 - [x] Add `--language` and `--filename` overrides for piped input.
 - [x] Represent extensions, exact filenames, compound filename patterns,
   aliases, and shebang interpreters as language metadata.
-- [ ] Keep content detection only for unambiguous containers such as unified
+- [x] Keep content detection only for unambiguous containers such as unified
   diffs.
 - [ ] Detect known binary files and NUL-containing input before source
   decoding.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -15,6 +15,12 @@ alias. Both options keep the pipe read-only and suppress unified-diff
 auto-detection. An explicit language takes priority when both options are
 present. Use `--diff` instead when the pipe is a unified diff.
 
+Automatic container detection is limited to structurally identified raw unified
+diffs and standard Git commit output. A raw diff starts at the first nonblank
+line. Recognized shebangs and transformed compiler headers remain explicit
+selectors. JSON-, YAML-, Markdown-, Python-, and other language-shaped source is
+not guessed from its syntax.
+
 Markdown files can switch between the source and a rendered terminal view with
 `V`. The rendered view formats headings, emphasis, links, quotes, lists, task
 markers, tables, rules, and code. The same view is available for Markdown files

--- a/packages/cli/commands/view.ts
+++ b/packages/cli/commands/view.ts
@@ -22,10 +22,13 @@ The Markdown language also has a rendered view that formats headings, lists,
 quotes, tables, links, emphasis and code while retaining source line positions.
 Source views remain verbatim and add colour only.
 
-Unified diffs are detected automatically: piping 'git diff' in gives added and
-removed lines their tints, full syntax colour, a structure tree of the code
-each hunk touches, and the semantic features (inferred types, go-to-definition)
-answered against the CURRENT state of the workspace files the diff names.
+Raw unified diffs are detected automatically when their structural header is
+the first nonblank line. Standard Git commit output is detected from its complete
+header. Other source content is not used to guess a language. Piping 'git diff'
+in gives added and removed lines their tints, full syntax colour, a structure
+tree of the code each hunk touches, and the semantic features (inferred types,
+go-to-definition) answered against the CURRENT state of the workspace files the
+diff names.
 
 COMMON USAGE:
   cf check ./pattern.tsx --show-transformed --no-run | cf view

--- a/packages/cli/lib/view/diff.ts
+++ b/packages/cli/lib/view/diff.ts
@@ -70,23 +70,68 @@ function clean(line: string): string {
   return line.endsWith("\r") ? line.slice(0, -1) : line;
 }
 
-/**
- * True when the text reads as a unified diff: a `diff --git` header, or a
- * `---` / `+++` pair followed shortly by an `@@` hunk header.
- */
-export function looksLikeDiff(text: string): boolean {
-  const lines = text.split("\n", 400).map(clean);
-  for (let i = 0; i < lines.length; i++) {
-    if (lines[i].startsWith("diff --git ")) return true;
-    if (
-      lines[i].startsWith("--- ") &&
-      lines[i + 1]?.startsWith("+++ ") &&
-      HUNK_RE.test(lines[i + 2] ?? "")
-    ) {
-      return true;
-    }
+interface ScannedLine {
+  readonly text: string;
+  readonly number: number;
+  readonly nextOffset?: number;
+}
+
+function lineAt(text: string, offset: number, number: number): ScannedLine {
+  const end = text.indexOf("\n", offset);
+  return {
+    text: clean(text.slice(offset, end < 0 ? text.length : end)),
+    number,
+    nextOffset: end < 0 ? undefined : end + 1,
+  };
+}
+
+function firstNonEmptyLine(text: string): ScannedLine | null {
+  let offset = 0;
+  let number = 0;
+  for (;;) {
+    const line = lineAt(text, offset, number);
+    if (line.text.trim().length > 0) return line;
+    if (line.nextOffset === undefined) return null;
+    offset = line.nextOffset;
+    number++;
   }
-  return false;
+}
+
+/**
+ * Detect a raw unified-diff container and return its parsed model. The first
+ * non-empty line must start the container. A Git diff must include classified
+ * metadata or a hunk after its `diff --git` header. A plain unified diff must
+ * start with its `---`, `+++`, and `@@` header sequence.
+ */
+export function detectDiff(text: string): DiffModel | null {
+  const first = firstNonEmptyLine(text);
+  if (!first) return null;
+
+  const git = first.text.startsWith("diff --git ");
+  const second = first.nextOffset === undefined
+    ? undefined
+    : lineAt(text, first.nextOffset, first.number + 1);
+  const third = second?.nextOffset === undefined
+    ? undefined
+    : lineAt(text, second.nextOffset, second.number + 1);
+  const plain = first.text.startsWith("--- ") &&
+    second?.text.startsWith("+++ ") &&
+    HUNK_RE.test(third?.text ?? "");
+  if (!git && !plain) return null;
+
+  const model = parseDiff(text);
+  const firstFile = model?.files.find((file) =>
+    file.headerLine === first.number
+  );
+  if (!model || !firstFile) return null;
+  if (git && firstFile.endLine === firstFile.headerLine) return null;
+  if (plain && firstFile.hunks.length === 0) return null;
+  return model;
+}
+
+/** Whether {@link detectDiff} recognizes the text as a raw unified diff. */
+export function looksLikeDiff(text: string): boolean {
+  return detectDiff(text) !== null;
 }
 
 /** Parse a unified diff. Returns null when no file/hunk structure is found. */

--- a/packages/cli/lib/view/diff.ts
+++ b/packages/cli/lib/view/diff.ts
@@ -125,7 +125,6 @@ export function detectDiff(text: string): DiffModel | null {
   );
   if (!model || !firstFile) return null;
   if (git && firstFile.endLine === firstFile.headerLine) return null;
-  if (plain && firstFile.hunks.length === 0) return null;
   return model;
 }
 

--- a/packages/cli/lib/view/mod.ts
+++ b/packages/cli/lib/view/mod.ts
@@ -13,7 +13,7 @@ import { renderLineColored } from "./highlight.ts";
 import { runPager } from "./pager.ts";
 import type { Document } from "./model.ts";
 import { ViewError } from "./errors.ts";
-import { type DiffModel, looksLikeDiff, parseDiff } from "./diff.ts";
+import { detectDiff, type DiffModel, parseDiff } from "./diff.ts";
 import {
   buildDiffDocument,
   realWorkspace,
@@ -153,10 +153,10 @@ function validateSourceSelection(
  * transformed blob gets the section-based program. Semantics are constructed
  * lazily — only the interactive path needs them.
  *
- * `forceDiff` pins the mode (`--diff` / `--no-diff`); when auto-detecting, a
- * diff is accepted only if a reasonable share of its lines actually parse as
- * diff content — so a source file that merely EMBEDS a diff (in a string, a
- * test fixture) still views as source. Exported for tests.
+ * `forceDiff` pins the mode (`--diff` / `--no-diff`). Automatic detection
+ * accepts raw unified diffs only when the first non-empty line starts a
+ * structurally parseable diff container. Standard Git commit output has its own
+ * complete-header check. Exported for tests.
  *
  * `selection` chooses syntax for piped source. Its virtual filename is
  * advisory and does not make the source editable.
@@ -171,21 +171,24 @@ export function buildView(
   semantics: () => Semantics | undefined;
   editSource: EditableSource;
 } {
-  const commitOutput = looksLikeCommitOutput(text);
   const sourceSelected = selection.language !== undefined ||
     selection.fileName !== undefined;
   validateSourceSelection(file, forceDiff, sourceSelected);
-  const tryDiff = forceDiff ??
-    (!sourceSelected && (looksLikeDiff(text) || commitOutput));
-  const parsedDiff = tryDiff ? parseDiff(text) : null;
+  const detectContent = forceDiff !== false && !sourceSelected;
+  const commitOutput = detectContent && looksLikeCommitOutput(text);
+  const parsedDiff = forceDiff === true || commitOutput
+    ? parseDiff(text)
+    : detectContent
+    ? detectDiff(text)
+    : null;
   const model: DiffModel | null = parsedDiff ??
-    (tryDiff && commitOutput
+    (forceDiff === true || commitOutput
       ? {
         files: [],
         lines: text.split("\n").map(() => ({ kind: "other" as const })),
       }
       : null);
-  if (model && (forceDiff || commitOutput || mostlyDiff(model, text))) {
+  if (model) {
     const ws = realWorkspace(safeCwd());
     // One workspace cache shared by the initial build and every deferred
     // re-parse, so the named files are read and parsed once per session.
@@ -279,20 +282,6 @@ function looksLikeCommitOutput(text: string): boolean {
     /^Author:\s+.*<[^<>]*>$/.test(line) ||
     /^author .*<[^<>]*> -?\d+ [+-]\d{4}$/.test(line)
   );
-}
-
-/** At least a quarter of the non-empty lines parse as diff content. Headers in
- * `git log -p` output are a minority; an embedded diff in a source file is. */
-function mostlyDiff(model: DiffModel, text: string): boolean {
-  const lines = text.split("\n");
-  let nonEmpty = 0;
-  let diffLines = 0;
-  for (let i = 0; i < lines.length; i++) {
-    if (lines[i].trim().length === 0) continue;
-    nonEmpty++;
-    if (model.lines[i]?.kind !== "other") diffLines++;
-  }
-  return nonEmpty > 0 && diffLines / nonEmpty >= 0.25;
 }
 
 function safeCwd(): string {

--- a/packages/cli/test/view-diff.test.ts
+++ b/packages/cli/test/view-diff.test.ts
@@ -164,6 +164,16 @@ Deno.test("diff: detection accepts git and plain unified diffs, rejects code", (
     ),
     "a git header followed by source is not a diff",
   );
+  const malformedGit = "diff --git malformed\n" +
+    "index 0000000..1111111 100644\n";
+  assert(
+    !looksLikeDiff(malformedGit),
+    "a malformed git header does not make a container",
+  );
+  assert(
+    !looksLikeDiff(`${malformedGit}${DIFF}`),
+    "a later valid diff does not rescue a malformed first container",
+  );
   const embedded = `const patch = \`
 diff --git a/x.ts b/x.ts
 --- a/x.ts

--- a/packages/cli/test/view-diff.test.ts
+++ b/packages/cli/test/view-diff.test.ts
@@ -145,12 +145,41 @@ Deno.test("diff: detection accepts git and plain unified diffs, rejects code", (
 +c
 `;
   assert(looksLikeDiff(plain), "plain diff -u detected");
+  assert(looksLikeDiff(`\n \t\n${plain}`), "leading blank lines are ignored");
   assert(!looksLikeDiff(SAMPLE), "transformed blob is not a diff");
   assert(!looksLikeDiff("const x = 1;\nconst y = 2;\n"), "code is not a diff");
   assert(
     !looksLikeDiff("--- header ---\nsome prose\nmore prose\n"),
     "a lone --- line is not a diff",
   );
+  assert(
+    !looksLikeDiff("diff --git a/x.ts b/x.ts\n"),
+    "a lone git header is not a diff",
+  );
+  assert(
+    !looksLikeDiff(
+      "diff --git a/x.ts b/x.ts\n" +
+        "const value = 1;\n" +
+        "export { value };\n",
+    ),
+    "a git header followed by source is not a diff",
+  );
+  const embedded = `const patch = \`
+diff --git a/x.ts b/x.ts
+--- a/x.ts
++++ b/x.ts
+@@ -1 +1 @@
+-old
++new
+\`;
+`;
+  assert(!looksLikeDiff(embedded), "a diff inside source is not a container");
+  const rename = `diff --git a/old.ts b/new.ts
+similarity index 100%
+rename from old.ts
+rename to new.ts
+`;
+  assert(looksLikeDiff(rename), "a metadata-only git diff is detected");
 });
 
 // --- parsing -------------------------------------------------------------------
@@ -1111,14 +1140,14 @@ Deno.test("mod: buildView routes diffs to diff mode, sources to source mode", ()
   // Source code routes to source mode.
   const srcView = buildView("const x = 1;\nconst y = 2;\n");
   assert(!srcView.doc.flatStructure.some((n) => n.kind === "hunk"));
-  // A source file that merely EMBEDS a short diff stays in source mode (the
-  // diff-content share is far below the threshold)…
+  // A source file that embeds a short diff stays in source mode.
   const embedded =
     "const patch = `\n--- a/x.ts\n+++ b/x.ts\n@@ -1,1 +1,1 @@\n-old\n+new\n`;\n" +
     Array.from({ length: 40 }, (_, i) => `const filler${i} = ${i};`).join("\n");
-  assert(looksLikeDiff(embedded), "the heuristic alone would misroute");
+  assert(!looksLikeDiff(embedded), "the embedded patch is not a raw diff");
   assert(!buildView(embedded).doc.flatStructure.some((n) => n.kind === "hunk"));
-  // …unless forced; and --no-diff suppresses a real diff.
+  // Forced diff mode accepts the embedded patch. No-diff mode suppresses a
+  // raw diff.
   assert(
     buildView(embedded, undefined, true).doc.flatStructure.some((n) =>
       n.kind === "hunk"

--- a/packages/cli/test/view-mod-cov.test.ts
+++ b/packages/cli/test/view-mod-cov.test.ts
@@ -41,6 +41,25 @@ Deno.test("buildView: an ordinary pipe with no file is read-only plain text", ()
   assertEquals(r.editSource.editable, false);
 });
 
+Deno.test("buildView: source syntax is not guessed from content", () => {
+  const examples = [
+    ["JSON", '{"value": true}\n'],
+    ["Markdown", "# Heading\n"],
+    ["YAML", "value: true\n"],
+    ["Python", "def greet():\n    pass\n"],
+  ] as const;
+
+  for (const [name, source] of examples) {
+    const classes = buildView(source).doc.lines.flatMap((line) =>
+      line.spans.map((span) => span.cls)
+    );
+    assert(
+      classes.length > 0 && classes.every((className) => className === "plain"),
+      `${name}-shaped unnamed source remains plain text`,
+    );
+  }
+});
+
 Deno.test("buildView: transformed compiler output keeps the TypeScript default", () => {
   const r = buildView(TRANSFORMED);
 
@@ -371,14 +390,39 @@ Deno.test("buildView: forceDiff=false views a real diff as source (--no-diff)", 
   );
 });
 
-Deno.test("buildView: text that only embeds a diff stays source (mostlyDiff is false)", () => {
-  // Looks like a diff at the top, but the bulk is ordinary source, so the
-  // diff-share heuristic rejects it and it renders as plain text.
-  const embedded = "diff --git a/x b/x\n" +
-    Array.from({ length: 40 }, (_, i) => `const v${i} = ${i};`).join("\n") +
-    "\n";
-  const r = buildView(embedded);
+Deno.test("buildView: a source file that embeds a complete diff stays source", () => {
+  const embedded = `const patch = \`
+diff --git a/x.ts b/x.ts
+--- a/x.ts
++++ b/x.ts
+@@ -1 +1 @@
+-old
++new
+\`;
+`;
+  const r = buildView(embedded, "fixture.ts");
   r.semantics();
-  // The first line is not treated as a diff header (no +/- tints across it).
-  assert(r.doc.lines.length > 10);
+  assertEquals(r.editSource.isDiff, undefined);
+  assert(
+    r.doc.flatStructure.some((node) =>
+      node.kind === "variable" && node.name === "patch"
+    ),
+    "the TypeScript source keeps its structure",
+  );
+});
+
+Deno.test("buildView: a git header followed by ordinary source stays source", () => {
+  const source = "diff --git a/x.ts b/x.ts\n" +
+    "const value = 1;\n" +
+    "export { value };\n";
+  const view = buildView(source);
+
+  assertEquals(view.editSource.isDiff, undefined);
+  assertEquals(view.doc.structure, []);
+  assert(
+    view.doc.lines.flatMap((line) => line.spans).every((span) =>
+      span.cls === "plain"
+    ),
+    "the unnamed input remains plain source",
+  );
 });


### PR DESCRIPTION
The view pager searched for diff markers anywhere in the input and then used a line-share threshold. A short source fixture containing a complete patch could therefore enter diff mode, while unrelated filler could change the result.

Require raw Git and plain unified diffs to begin at the first nonblank line, then confirm their structure with the existing parser. Reuse the parsed model so automatic detection does not scan the complete input twice. Keep complete Git commit headers and forced diff mode on their existing dedicated paths.

Add regression coverage for embedded patches, incomplete headers, metadata-only diffs, leading blank lines, explicit mode selection, and language-shaped unnamed source. Update the command help, CLI documentation, and coverage plan to state the new boundary and mark the work item complete.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts CLI diff auto-detection to real containers: only a raw unified diff that starts at the first nonblank line or full Git commit output enters diff mode. This stops embedded patches and language-shaped text from forcing diff mode.

- **Bug Fixes**
  - Require the first nonblank line to start a structural diff; confirm via the parser.
  - Ignore leading blanks; reject incomplete/malformed Git headers; a later valid diff does not rescue an invalid first container.
  - Keep full Git commit output and `--diff`/`--no-diff` behavior unchanged.
  - Accept metadata-only Git diffs; treat embedded patches as source.
  - Do not guess languages for unnamed input (JSON/YAML/Markdown/Python remain plain text).

- **Refactors**
  - Added `detectDiff` and reuse the parsed model to avoid scanning input twice; removed the line-share heuristic and an unreachable guard.
  - Simplified `buildView` routing; updated CLI help, docs, and tests for leading blanks, malformed headers, explicit mode, and edge cases.

<sup>Written for commit 70032903994e1dd6d0407b52c9d7179ef86e5c08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

