### PR TITLE
fix(cli): stop forced-stream fallback from inventing verbs

### DIFF
--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -1333,6 +1333,36 @@ async function tryResolvePieceCallableAt(
   };
 }
 
+/**
+ * Return the forced-stream view used to dispatch a legacy handler only when
+ * the same cell, without that imposed schema, is independently recognizable
+ * as a stream.
+ *
+ * The order is load-bearing: testing the forced view itself is circular,
+ * because Cell.isStream() accepts the `asCell: ["stream"]` marker that this
+ * function adds. That would classify every ordinary result property as a
+ * handler.
+ */
+function forcedStreamCellForHandler(
+  pieceCell: any,
+  callableName: string,
+): any | null {
+  if (
+    typeof pieceCell?.key !== "function" ||
+    !isHandlerCell(pieceCell.key(callableName))
+  ) {
+    return null;
+  }
+
+  return pieceCell.asSchema({
+    type: "object",
+    properties: {
+      [callableName]: { asCell: ["stream"] },
+    },
+    required: [callableName],
+  }).key(callableName);
+}
+
 async function tryResolvePieceHandler(
   piece: any,
   manager: any,
@@ -1344,26 +1374,17 @@ async function tryResolvePieceHandler(
     return null;
   }
 
-  const streamRoot = pieceCell.asSchema({
-    type: "object",
-    properties: {
-      [callableName]: { asCell: ["stream"] },
-    },
-    required: [callableName],
-  });
-  const streamCell = streamRoot.key(callableName);
-  if (!isHandlerCell(streamCell)) {
+  const streamCell = forcedStreamCellForHandler(pieceCell, callableName);
+  if (!streamCell) {
     return null;
   }
 
-  // Dispatch through the cell whose stream-ness this path just proved, not a
-  // second cell built by reading the schema back from links. Both address the
-  // same target — `getResult` is the identity on the piece cell — so they
-  // differ only in schema, and a link-derived schema is exactly what defeated
-  // the ordinary detection paths above. Sending on that cell takes `.set()`'s
-  // non-stream branch (`packages/runner/src/cell.ts:1316`) and fails with
-  // "Transaction required for .set()" instead of queueing the event, so a verb
-  // this path lists is a verb that could not be called.
+  // Dispatch through the forced view, not a second cell built by reading the
+  // schema back from links. Both address the same target — `getResult` is the
+  // identity on the piece cell — but the link-derived cell is exactly what
+  // defeated the ordinary detection paths above. Sending on that cell takes
+  // `.set()`'s non-stream branch (`packages/runner/src/cell.ts:1316`) and fails
+  // with "Transaction required for .set()" instead of queueing the event.
   const rootCell = await piece.result.getCell();
   const linkDerivedCell = rootCell.key(callableName).asSchemaFromLinks();
   return {
@@ -1617,12 +1638,7 @@ export async function listPieceCallables(
     }
     for (const name of rejected) {
       if (listings.has(name)) continue;
-      const streamRoot = pieceCell.asSchema({
-        type: "object",
-        properties: { [name]: { asCell: ["stream"] } },
-        required: [name],
-      });
-      if (!isHandlerCell(streamRoot.key(name))) continue;
+      if (!forcedStreamCellForHandler(pieceCell, name)) continue;
       const callableCell = resultRoot.key(name).asSchemaFromLinks();
       const spec = callableCommandSpec(callableCell, "handler");
       listings.set(name, {

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -1143,16 +1143,31 @@ describe("forced-stream fallback dispatch", () => {
       key: () => emptyChild,
     };
 
-    const rootValue = { hiddenPing: {} };
+    const dataCell = {
+      schema: { type: "number" } as JSONSchema,
+      get: () => 3,
+      getRaw: () => 3,
+      asSchemaFromLinks: () => dataCell,
+      key: () => emptyChild,
+    };
+    const rootValue = { hiddenPing: {}, topicCount: 3 };
     const rootCell = {
       schema: {
         type: "object",
-        properties: { hiddenPing: { type: "object" } },
+        properties: {
+          hiddenPing: { type: "object" },
+          topicCount: { type: "number" },
+        },
       } as JSONSchema,
       get: () => rootValue,
       getRaw: () => rootValue,
       asSchemaFromLinks: () => rootCell,
-      key: (name: string) => name === "hiddenPing" ? linkDerivedCell : absent,
+      key: (name: string) =>
+        name === "hiddenPing"
+          ? linkDerivedCell
+          : name === "topicCount"
+          ? dataCell
+          : absent,
     };
     // The input root offers nothing, so resolution falls past both ordinary
     // paths to the forced cast.
@@ -1179,6 +1194,12 @@ describe("forced-stream fallback dispatch", () => {
     const piece = {
       getCell: () => ({
         get: () => rootValue,
+        // Handler evidence comes from the unmodified live cell. The forced
+        // schema view reports every name as a stream by construction, so it
+        // must never be used as the evidence.
+        key: (name: string) => ({
+          isStream: () => name === "hiddenPing",
+        }),
         asSchema: () => ({ key: () => streamCell }),
       }),
       input: {
@@ -1257,6 +1278,26 @@ describe("forced-stream fallback dispatch", () => {
     expect(result.resolved.commandSpec.inputSchema).toEqual(
       harness.linkDerivedCell.schema,
     );
+  });
+
+  it("does not dispatch an ordinary data field through the forced-stream fallback", async () => {
+    const harness = createFallbackHarness();
+
+    await expect(
+      executePieceCallable(
+        config,
+        "topicCount",
+        [],
+        {
+          loadManager: () => Promise.resolve(harness.manager as never),
+          loadPiece: () => Promise.resolve(harness.piece as never),
+          isStdinTerminal: () => true,
+        },
+      ),
+    ).rejects.toThrow('Callable "topicCount" not found');
+
+    expect(harness.sends).toEqual([]);
+    expect(harness.dataWrites).toEqual([]);
   });
 });
 

--- a/packages/cli/test/piece-verbs.test.ts
+++ b/packages/cli/test/piece-verbs.test.ts
@@ -112,22 +112,29 @@ describe("listPieceCallables", () => {
       },
     );
 
-    // "hiddenPing" defeats ordinary detection (plain object value/schema) but
-    // succeeds through the forced stream cast — resolvePieceCallable's third
-    // path — so the listing must include it. "\u00e9dit" pins byte ordering:
-    // utf8Compare puts it AFTER "setup"/"search" (0xC3 > s), where locale
-    // collation would interleave it linguistically.
-    const pieceRootValue = { hiddenPing: {}, "\u00e9dit": { $stream: true } };
+    // "hiddenPing" defeats ordinary result/input detection (plain object
+    // value/schema) but the unmodified piece cell still identifies it as a
+    // stream, so the legacy fallback must include it. "topicCount" reproduces
+    // a real data field: the forced view below calls every name a stream, but
+    // the unmodified cell does not. "\u00e9dit" pins byte ordering.
+    const pieceRootValue = {
+      hiddenPing: {},
+      topicCount: 3,
+      "\u00e9dit": { $stream: true },
+    };
     const piece = {
       result: { getCell: () => Promise.resolve(resultRoot) },
       input: { getCell: () => Promise.resolve(inputRoot) },
       getPatternRef: () => Promise.resolve(TEST_PATTERN_REF),
       getCell: () => ({
         get: () => pieceRootValue,
+        key: (name: string) => ({
+          isStream: () => name === "hiddenPing" || name === "\u00e9dit",
+        }),
         asSchema: (_s: unknown) => ({
-          key: (name: string) => ({
-            isStream: () => name === "hiddenPing" || name === "\u00e9dit",
-          }),
+          // This is true for every name because the caller imposed a stream
+          // schema. It is a dispatch view, not evidence that a handler exists.
+          key: (_name: string) => ({ isStream: () => true }),
         }),
       }),
     };


### PR DESCRIPTION
## Problem

Against the live Topics board, `cf piece verbs` reported eleven handlers even though the pattern exposes only three. Ordinary result fields such as `$NAME`, `$UI`, `topics`, and `topicCount` were presented as callable, and the same fallback could let `cf piece call` attempt to dispatch an ordinary data field.

The legacy fallback imposed `asCell: ["stream"]` on each candidate and then asked `isHandlerCell()` whether that forced view was a stream. `Cell.isStream()` accepts that schema marker, so the check proved its own assumption and classified every candidate as a handler.

## Fix

- Check the candidate on the unmodified piece cell for independent stream evidence first.
- Build the forced-stream view only after that proof, retaining it solely for dispatch compatibility with legacy/link-derived handlers.
- Add regressions showing that a genuine fallback handler is still listed and callable, while an ordinary numeric field is neither listed nor dispatched.

## Verification

- `deno test -A test/piece-verbs.test.ts test/piece-call.test.ts`: 7 passed, 43 steps
- `deno fmt --check`, `deno lint`, `deno check`, and `git diff --check`: pass
- Read-only query against the reported Topics instance now returns exactly `addTopic`, `setMyName`, and `submitTopic`; no event was sent and no state was changed
- Full CLI suite: 1,643 passed; two untouched color-output assertions fail in this environment and also fail when run in isolation

## Review focus

Is the unmodified piece-cell `isStream()` result the intended independent source of truth for this legacy fallback? It recognizes the legitimate stream representations without allowing the dispatch-only schema cast to become evidence.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the CLI forced-stream fallback so `cf piece verbs` and `cf piece call` only treat real stream handlers as callables, preventing ordinary data fields from being listed or dispatched.

- **Bug Fixes**
  - Check the unmodified piece cell for stream evidence before building any forced-stream view.
  - Build the forced-stream view only after proof, and use it only for dispatch (not as detection evidence).
  - Update callable listing and resolution to skip data fields like `topicCount` that previously appeared as handlers.
  - Add regression tests to ensure a real fallback handler is listed/callable and a numeric field is neither listed nor dispatched.

<sup>Written for commit d156e67710e2cb86628cceef08ce7f07e5e57e9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

