### PR TITLE
fix(runner): report rejected storage commits consistently

### DIFF
--- a/packages/runner/src/scheduler/events.ts
+++ b/packages/runner/src/scheduler/events.ts
@@ -53,6 +53,37 @@ const logger = getLogger("scheduler", {
 });
 const EVENT_COMMIT_TELEMETRY_WRITE_LIMIT = 25;
 
+type EventCommitError = {
+  readonly name?: string;
+  readonly message: string;
+  readonly precondition?: IPreconditionFailedError["precondition"];
+};
+
+function normalizeEventCommitRejection(reason: unknown): EventCommitError {
+  if (reason instanceof Error) {
+    return reason as EventCommitError;
+  }
+  if (reason !== null && typeof reason === "object") {
+    const candidate = reason as Partial<EventCommitError>;
+    const precondition = candidate.precondition === "origin-committed" ||
+        candidate.precondition === "receipt-exists"
+      ? candidate.precondition
+      : undefined;
+    return {
+      ...(typeof candidate.name === "string" ? { name: candidate.name } : {}),
+      message: typeof candidate.message === "string"
+        ? candidate.message
+        : "Storage commit promise rejected",
+      ...(precondition ? { precondition } : {}),
+    };
+  }
+  return new Error(
+    reason
+      ? String(reason)
+      : "Storage commit promise rejected without a reason",
+  );
+}
+
 /**
  * A CFC-enforcement-rejected commit on a give-up disposition is silent data
  * loss of user intent — the UI's write simply never lands (labs#4772 shipped
@@ -1083,55 +1114,61 @@ export async function dispatchQueuedEvent(state: {
     // commit() registers itself with the storage manager's pending-commit
     // barrier, which the client-facing idle (Scheduler.idleWithPendingCommits)
     // waits on without blocking the scheduler loop here.
-    tx.commit().then((result) => {
-      const permanentRejection =
-        result.error && isPermanentRejection(result.error)
-          ? (result.error as IPreconditionFailedError).precondition
-          : undefined;
+    const handleCommitResult = (error: EventCommitError | undefined): void => {
+      const permanentRejection = error && isPermanentRejection(error)
+        ? error.precondition
+        : undefined;
       // Classify the commit outcome. A committed write that represents user
       // intent must converge or fail loudly: a stale-basis rejection backs off
       // and retries within a bounded window rather than being dropped; a
       // permanent or non-stale-basis rejection is not retried; an unconverged
       // write surfaces a terminal error.
       const disposition = classifyCommitDisposition(
-        result.error,
+        error,
         queuedEvent,
         state.backpressure,
       );
 
-      state.runtime.telemetry.submit({
-        type: "scheduler.event.commit",
-        handlerId,
-        handlerInfo: state.getActionTelemetryInfo(handler),
-        readCount: log.reads.length + log.shallowReads.length,
-        writeCount: log.writes.length,
-        changedWriteCount: log.writes.length,
-        writes: telemetryWrites,
-        ...(log.writes.length > EVENT_COMMIT_TELEMETRY_WRITE_LIMIT
-          ? { writesTruncated: true }
-          : {}),
-        ...(result.error ? { error: result.error.message } : {}),
-        ...(permanentRejection !== undefined ? { permanentRejection } : {}),
-        ...(disposition.kind === "backoff"
-          ? {
-            retryAttempt: disposition.attempts,
-            backoffMs: disposition.delayMs,
-          }
-          : {}),
-        ...(disposition.kind === "convergence-failed"
-          ? { retryAttempt: disposition.attempts, terminal: "convergence" }
-          : {}),
-        ...(disposition.kind === "permanent" ? { terminal: "permanent" } : {}),
-        ...(disposition.kind === "terminal" ? { terminal: "rule" } : {}),
-      });
+      let telemetryFailure: { readonly error: unknown } | undefined;
+      try {
+        state.runtime.telemetry.submit({
+          type: "scheduler.event.commit",
+          handlerId,
+          handlerInfo: state.getActionTelemetryInfo(handler),
+          readCount: log.reads.length + log.shallowReads.length,
+          writeCount: log.writes.length,
+          changedWriteCount: log.writes.length,
+          writes: telemetryWrites,
+          ...(log.writes.length > EVENT_COMMIT_TELEMETRY_WRITE_LIMIT
+            ? { writesTruncated: true }
+            : {}),
+          ...(error ? { error: error.message } : {}),
+          ...(permanentRejection !== undefined ? { permanentRejection } : {}),
+          ...(disposition.kind === "backoff"
+            ? {
+              retryAttempt: disposition.attempts,
+              backoffMs: disposition.delayMs,
+            }
+            : {}),
+          ...(disposition.kind === "convergence-failed"
+            ? { retryAttempt: disposition.attempts, terminal: "convergence" }
+            : {}),
+          ...(disposition.kind === "permanent"
+            ? { terminal: "permanent" }
+            : {}),
+          ...(disposition.kind === "terminal" ? { terminal: "rule" } : {}),
+        });
+      } catch (error) {
+        telemetryFailure = { error };
+      }
 
       switch (disposition.kind) {
         case "success":
           runFinalCommitCallback();
-          return;
+          break;
         case "give-up":
           runFinalCommitCallback();
-          reportDroppedCfcRejectedWrite(result.error, handlerId);
+          reportDroppedCfcRejectedWrite(error, handlerId);
           logger.warn(
             "scheduler",
             disposition.reason === "non-retryable"
@@ -1139,9 +1176,9 @@ export async function dispatchQueuedEvent(state: {
                 "that re-running cannot resolve; dropping the write without retry"
               : "Event handler commit failed and the caller opted out of " +
                 "retry (retries: false); dropping the write",
-            { error: result.error, handlerId },
+            { error, handlerId },
           );
-          return;
+          break;
         case "backoff":
           logger.warn(
             "scheduler",
@@ -1155,7 +1192,7 @@ export async function dispatchQueuedEvent(state: {
             disposition.deadline,
             disposition.runAt,
           );
-          return;
+          break;
         case "terminal":
           // A deterministic commit-rule refusal: run the final callback and
           // stop. No retry (would recompute the identical refused write) and no
@@ -1167,9 +1204,9 @@ export async function dispatchQueuedEvent(state: {
             "scheduler",
             "Event handler commit terminally rejected (deterministic refusal); " +
               "not retrying",
-            { error: result.error, handlerId },
+            { error, handlerId },
           );
-          return;
+          break;
         case "permanent":
           runFinalCommitCallback();
           if (permanentRejection === "receipt-exists") {
@@ -1184,9 +1221,9 @@ export async function dispatchQueuedEvent(state: {
           logger.warn(
             "scheduler",
             "Event handler commit permanently rejected; not retrying",
-            { error: result.error, handlerId, permanentRejection },
+            { error, handlerId, permanentRejection },
           );
-          return;
+          break;
         case "convergence-failed": {
           runFinalCommitCallback();
           logger.error(
@@ -1201,17 +1238,24 @@ export async function dispatchQueuedEvent(state: {
               handlerId,
               attempts: disposition.attempts,
               elapsedMs: disposition.elapsedMs,
-              cause: result.error,
+              cause: error,
             }),
             action,
           );
-          return;
+          break;
         }
       }
-    }).catch((error) => {
+      if (telemetryFailure !== undefined) {
+        throw telemetryFailure.error;
+      }
+    };
+    tx.commit().then(
+      ({ error }) => handleCommitResult(error),
+      (reason) => handleCommitResult(normalizeEventCommitRejection(reason)),
+    ).catch((error) => {
       logger.error(
         "schedule-error",
-        "Event handler commit promise rejected:",
+        "Event handler commit result handling failed:",
         error,
       );
     });

--- a/packages/runner/src/scheduler/run.ts
+++ b/packages/runner/src/scheduler/run.ts
@@ -118,8 +118,8 @@ export function watchReactiveActionCommit(state: {
   readonly queueExecution: () => void;
   readonly restoreInvalidCauses: () => void;
   readonly getActionId: (action: Action) => string;
-}): void {
-  state.commitPromise.then(async ({ error }) => {
+}): Promise<void> {
+  const handleResult = async (error: unknown): Promise<void> => {
     if (!error) {
       // Clear retries after successful commit.
       state.retries.delete(state.action);
@@ -251,10 +251,17 @@ export function watchReactiveActionCommit(state: {
       // WATCH(scheduler-v2): exhausted retries can leave a piece registered
       // against rolled-back data (accepted zombie — spec §15 decision 9).
     }
-  }).catch((error) => {
+  };
+  return state.commitPromise.then(
+    ({ error }) => handleResult(error),
+    (reason) =>
+      handleResult(
+        reason || new Error("Storage commit promise rejected without a reason"),
+      ),
+  ).catch((error) => {
     logger.error(
       "schedule-error",
-      "Commit promise rejected in finalizeAction:",
+      "Commit result handling failed in finalizeAction:",
       error,
     );
   });

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -1889,15 +1889,30 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     // that promise always resolves, even if the commit fails, in which case it
     // passes an error message as result. An exception here would be an internal
     // error that should propagate.
-    promise.then((result) => {
-      this.runCommitCallbacks(result);
-    }).catch((error) => {
-      logger.error(
-        "storage-error",
-        "Transaction commit promise rejected:",
-        error,
-      );
-    });
+    promise.then(
+      (result) => {
+        this.runCommitCallbacks(result);
+      },
+      (reason) => {
+        const error: CommitError = {
+          name: "StorageTransactionAborted",
+          message: "Transaction commit promise rejected",
+          reason,
+        };
+        this.statusOverride = {
+          status: "error",
+          journal: this.tx.journal,
+          error,
+        };
+        this.clearPostCommitOutbox();
+        this.runCommitCallbacks({ error });
+        logger.error(
+          "storage-error",
+          "Transaction commit promise rejected:",
+          reason,
+        );
+      },
+    );
 
     const result = await promise;
     if (result.ok && !readOnly) {

--- a/packages/runner/test/cell-callbacks.test.ts
+++ b/packages/runner/test/cell-callbacks.test.ts
@@ -14,7 +14,11 @@ import { JSONSchema } from "../src/builder/types.ts";
 import { popFrame, pushFrame } from "../src/builder/pattern.ts";
 import { Runtime } from "../src/runtime.ts";
 import { txToReactivityLog } from "../src/scheduler.ts";
-import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import {
+  type IExtendedStorageTransaction,
+  type IStorageTransaction,
+} from "../src/storage/interface.ts";
+import { ExtendedStorageTransaction } from "../src/storage/extended-storage-transaction.ts";
 import { parseLink } from "../src/link-utils.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
@@ -252,6 +256,53 @@ describe("Cell commit callbacks", () => {
     await tx.commit();
 
     expect(callbackStatuses).toEqual(["error"]);
+  });
+
+  it("runs generic commit callbacks when the storage promise rejects", async () => {
+    const rejection = new Error("storage promise rejected");
+    const inner = {
+      journal: {},
+      clearReadOnly() {},
+      commit: () => Promise.reject(rejection),
+    } as unknown as IStorageTransaction;
+    const extended = new ExtendedStorageTransaction(inner);
+    const callbackErrors: unknown[] = [];
+    const callbackStatuses: string[] = [];
+    extended.enqueuePostCommitEffect({
+      id: "rejected-commit-effect",
+      kind: "test",
+      flush() {
+        throw new Error("a rejected commit must not flush its outbox");
+      },
+    });
+    extended.addCommitCallback((committedTx, result) => {
+      callbackStatuses.push(committedTx.status().status);
+      callbackErrors.push(result.error);
+    });
+    extended.setReadOnly("commit callback rejection test");
+
+    let thrown: unknown;
+    try {
+      await extended.commit();
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBe(rejection);
+    expect(callbackStatuses).toEqual(["error"]);
+    expect(callbackErrors).toHaveLength(1);
+    expect(callbackErrors[0]).toMatchObject({
+      name: "StorageTransactionAborted",
+      reason: rejection,
+    });
+    expect(extended.status()).toMatchObject({
+      status: "error",
+      error: {
+        name: "StorageTransactionAborted",
+        reason: rejection,
+      },
+    });
+    expect(extended.hasPendingPostCommitEffects()).toBe(false);
   });
 
   describe("set operations with arrays", () => {

--- a/packages/runner/test/oncommit-race.test.ts
+++ b/packages/runner/test/oncommit-race.test.ts
@@ -11,6 +11,7 @@ import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
 import { Runtime } from "../src/runtime.ts";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { getLogger } from "@commonfabric/utils/logger";
 
 const signer = await Identity.fromPassphrase("test oncommit race");
 const space = signer.did();
@@ -87,10 +88,10 @@ describe("onCommit callback final outcome", () => {
     expect(pieceRegistryCell.get()).toEqual([]);
   });
 
-  it("fires onCommit once after a conflict is retried and lands", async () => {
+  it("fires onCommit once when the storage commit promise rejects", async () => {
     const streamCell = runtime.getCell<number>(
       space,
-      "fix-demo-stream",
+      "rejected-storage-promise-stream",
       undefined,
       tx,
     );
@@ -99,44 +100,193 @@ describe("onCommit callback final outcome", () => {
     tx = runtime.edit();
     await runtime.storageManager.synced();
 
-    let attempts = 0;
+    const rejection = Object.assign(
+      new Error("forced event commit promise rejection"),
+      { name: "TransactionError" },
+    );
+    let handlerCallCount = 0;
     runtime.scheduler.addEventHandler(
       (handlerTx, event) => {
-        attempts++;
-        streamCell.withTx(handlerTx).set(event + 1);
+        handlerCallCount++;
+        streamCell.withTx(handlerTx).set(event);
+        handlerTx.tx.commit = () => Promise.reject(rejection);
       },
       streamCell.getAsNormalizedFullLink(),
     );
 
-    // Reject the first commit the handler attempts with a transient conflict —
-    // a genuinely retryable failure, unlike a local abort. The scheduler retries
-    // within the backpressure window and the second attempt lands. onCommit must
-    // still fire exactly once, for the winning attempt, not once per attempt.
-    const server = (storageManager as unknown as {
-      server(): {
-        transact: (m: { requestId: string }) => Promise<unknown>;
+    const statuses: string[] = [];
+    const errors: unknown[] = [];
+    runtime.scheduler.queueEvent(
+      streamCell.getAsNormalizedFullLink(),
+      1,
+      true,
+      (committedTx) => {
+        const status = committedTx.status();
+        statuses.push(status.status);
+        if (status.status === "error") {
+          errors.push(status.error);
+        }
+      },
+    );
+
+    await runtime.scheduler.idleWithPendingCommits();
+    await Promise.resolve();
+
+    expect(handlerCallCount).toBe(1);
+    expect(statuses).toEqual(["error"]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      name: "StorageTransactionAborted",
+      reason: rejection,
+    });
+    expect(streamCell.get()).toBe(0);
+  });
+
+  for (
+    const {
+      testName,
+      streamId,
+      rejection,
+      expectedMarker,
+    } of [
+      {
+        testName: "normalizes a plain permanent rejection",
+        streamId: "plain-permanent-rejection-stream",
+        rejection: {
+          name: "PreconditionFailedError",
+          message: "receipt already exists",
+          precondition: "receipt-exists",
+        },
+        expectedMarker: {
+          error: "receipt already exists",
+          permanentRejection: "receipt-exists",
+          terminal: "permanent",
+        },
+      },
+      {
+        testName: "normalizes malformed plain rejection fields",
+        streamId: "plain-malformed-rejection-stream",
+        rejection: {
+          name: 42,
+          message: 42,
+          precondition: "invalid-precondition",
+        },
+        expectedMarker: {
+          error: "Storage commit promise rejected",
+        },
+      },
+    ] as const
+  ) {
+    it(testName, async () => {
+      const streamCell = runtime.getCell<number>(
+        space,
+        streamId,
+        undefined,
+        tx,
+      );
+      streamCell.set(0);
+      await tx.commit();
+      tx = runtime.edit();
+      await runtime.storageManager.synced();
+
+      let handlerCallCount = 0;
+      runtime.scheduler.addEventHandler(
+        (handlerTx, event) => {
+          handlerCallCount++;
+          streamCell.withTx(handlerTx).set(event);
+          handlerTx.tx.commit = () => Promise.reject(rejection);
+        },
+        streamCell.getAsNormalizedFullLink(),
+      );
+
+      const commitMarkers: unknown[] = [];
+      const listener = (event: Event) => {
+        const marker = (event as CustomEvent<{ marker: { type: string } }>)
+          .detail.marker;
+        if (marker.type === "scheduler.event.commit") {
+          commitMarkers.push(marker);
+        }
       };
-    }).server();
-    const originalTransact = server.transact.bind(server);
-    // Reject every commit until the handler has run a second time, so the
-    // handler's own first commit is the one that conflicts (rejecting only "the
-    // next transact" can hit an unrelated observation commit instead). Once the
-    // retry re-runs the handler, its commit lands.
-    server.transact = (message: { requestId: string }) => {
-      if (attempts < 2) {
-        return Promise.resolve({
-          type: "response",
-          requestId: message.requestId,
-          error: {
-            name: "ConflictError",
-            message: "forced retry-then-land conflict",
+      runtime.telemetry.addEventListener("telemetry", listener);
+      try {
+        const statuses: string[] = [];
+        runtime.scheduler.queueEvent(
+          streamCell.getAsNormalizedFullLink(),
+          1,
+          true,
+          (committedTx) => {
+            statuses.push(committedTx.status().status);
           },
-        });
+        );
+
+        await runtime.scheduler.idleWithPendingCommits();
+        await Promise.resolve();
+
+        expect(handlerCallCount).toBe(1);
+        expect(statuses).toEqual(["error"]);
+        expect(commitMarkers).toHaveLength(1);
+        expect(commitMarkers[0]).toMatchObject(expectedMarker);
+        if (!("terminal" in expectedMarker)) {
+          expect(commitMarkers[0]).not.toHaveProperty("permanentRejection");
+          expect(commitMarkers[0]).not.toHaveProperty("terminal");
+        }
+        expect(streamCell.get()).toBe(0);
+      } finally {
+        runtime.telemetry.removeEventListener("telemetry", listener);
       }
-      return originalTransact(message);
-    };
+    });
+  }
+
+  it("settles when event commit telemetry throws", async () => {
+    const streamCell = runtime.getCell<number>(
+      space,
+      "commit-result-handling-error-stream",
+      undefined,
+      tx,
+    );
+    streamCell.set(0);
+    await tx.commit();
+    tx = runtime.edit();
+    await runtime.storageManager.synced();
+
+    let handlerCallCount = 0;
+    runtime.scheduler.addEventHandler(
+      (handlerTx, event) => {
+        handlerCallCount++;
+        streamCell.withTx(handlerTx).set(event);
+      },
+      streamCell.getAsNormalizedFullLink(),
+    );
 
     const statuses: string[] = [];
+    const telemetryError = new Error("commit result telemetry failed");
+    const errorReports: Array<{
+      readonly messages: unknown[];
+      readonly statuses: string[];
+    }> = [];
+    const originalSubmit = runtime.telemetry.submit.bind(runtime.telemetry);
+    const schedulerLogger = getLogger("scheduler");
+    const originalLoggerErrorDescriptor = Object.getOwnPropertyDescriptor(
+      schedulerLogger,
+      "error",
+    );
+    const originalLoggerError = schedulerLogger.error;
+    let commitMarkerAttempts = 0;
+    runtime.telemetry.submit = (marker) => {
+      if (marker.type === "scheduler.event.commit") {
+        commitMarkerAttempts++;
+        throw telemetryError;
+      }
+      originalSubmit(marker);
+    };
+    schedulerLogger.error = (key, ...messages) => {
+      if (
+        messages.includes("Event handler commit result handling failed:")
+      ) {
+        errorReports.push({ messages, statuses: [...statuses] });
+      }
+      originalLoggerError.call(schedulerLogger, key, ...messages);
+    };
     try {
       runtime.scheduler.queueEvent(
         streamCell.getAsNormalizedFullLink(),
@@ -147,20 +297,84 @@ describe("onCommit callback final outcome", () => {
         },
       );
 
-      // The first commit fails on the server asynchronously; the scheduler's
-      // backoff retry re-runs the handler. Advancing the clock fires the
-      // backoff timer so the retry lands before we assert.
+      await runtime.scheduler.idleWithPendingCommits();
+      await Promise.resolve();
+
+      expect(handlerCallCount).toBe(1);
+      expect(commitMarkerAttempts).toBe(1);
+      expect(statuses).toEqual(["done"]);
+      expect(errorReports).toHaveLength(1);
+      expect(errorReports[0]?.statuses).toEqual(["done"]);
+      expect(errorReports[0]?.messages.at(-1)).toBe(telemetryError);
+      expect(streamCell.get()).toBe(1);
+    } finally {
+      runtime.telemetry.submit = originalSubmit;
+      if (originalLoggerErrorDescriptor) {
+        Object.defineProperty(
+          schedulerLogger,
+          "error",
+          originalLoggerErrorDescriptor,
+        );
+      } else {
+        Reflect.deleteProperty(schedulerLogger, "error");
+      }
+    }
+  });
+
+  it(
+    "fires onCommit once after a rejected conflict is retried and lands",
+    async () => {
+      const streamCell = runtime.getCell<number>(
+        space,
+        "fix-demo-stream",
+        undefined,
+        tx,
+      );
+      streamCell.set(0);
+      await tx.commit();
+      tx = runtime.edit();
+      await runtime.storageManager.synced();
+
+      const rejection = Object.assign(
+        new Error("forced retry-then-land conflict"),
+        { name: "ConflictError" },
+      );
+      let attempts = 0;
+      runtime.scheduler.addEventHandler(
+        (handlerTx, event) => {
+          attempts++;
+          streamCell.withTx(handlerTx).set(event + 1);
+          if (attempts === 1) {
+            handlerTx.tx.commit = () => Promise.reject(rejection);
+          }
+        },
+        streamCell.getAsNormalizedFullLink(),
+      );
+
+      // Reject the first commit promise with a transient conflict. The
+      // scheduler classifies the rejection, retries within the backpressure
+      // window, and runs onCommit only for the second attempt that lands.
+      const statuses: string[] = [];
+      runtime.scheduler.queueEvent(
+        streamCell.getAsNormalizedFullLink(),
+        1,
+        true,
+        (committedTx) => {
+          statuses.push(committedTx.status().status);
+        },
+      );
+
+      // Advancing the clock fires the backoff timer so the retry lands before
+      // the assertions.
       await clock.tick(2_000);
       await runtime.idle();
       await runtime.storageManager.synced();
-    } finally {
-      server.transact = originalTransact;
-    }
 
-    expect(attempts).toBe(2);
-    expect(statuses).toEqual(["done"]);
-    expect(streamCell.get()).toBe(2);
-  });
+      expect(attempts).toBe(2);
+      expect(statuses).toEqual(["done"]);
+      expect(streamCell.get()).toBe(2);
+    },
+  );
 
   it("prepares scheduler-managed relevant writes before commit", async () => {
     const streamCell = runtime.getCell<number>(

--- a/packages/runner/test/scheduler-cfc-trigger-reads.test.ts
+++ b/packages/runner/test/scheduler-cfc-trigger-reads.test.ts
@@ -228,7 +228,7 @@ describe("trigger reads survive failed runs", () => {
         ReturnType<IExtendedStorageTransaction["commit"]>
       >,
     );
-    watchReactiveActionCommit({
+    return watchReactiveActionCommit({
       action,
       tx,
       log: { reads: [], shallowReads: [], writes: [] },
@@ -241,10 +241,6 @@ describe("trigger reads survive failed runs", () => {
       queueExecution: () => args.onQueueExecution?.(),
       getActionId: () => "test-action",
       restoreInvalidCauses: args.onRestore,
-    });
-    return commitPromise.then(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
     });
   }
 
@@ -326,9 +322,6 @@ describe("trigger reads survive failed runs", () => {
       onMarkInvalid: () => calls.push("dirty"),
       onQueueExecution: () => calls.push("queue"),
     });
-    // The rejected readiness gate adds microtask hops before the re-queue; a
-    // macrotask flush drains them so the assertion sees the final state.
-    await new Promise((resolve) => setTimeout(resolve, 0));
     expect(calls).toEqual(["restore", "resubscribe", "dirty", "queue"]);
   });
 
@@ -349,7 +342,6 @@ describe("trigger reads survive failed runs", () => {
       onMarkInvalid: () => calls.push("dirty"),
       onQueueExecution: () => calls.push("queue"),
     });
-    await new Promise((resolve) => setTimeout(resolve, 0));
     expect(calls).toEqual(["restore", "resubscribe", "dirty", "queue"]);
   });
 

--- a/packages/runner/test/scheduler-retries.test.ts
+++ b/packages/runner/test/scheduler-retries.test.ts
@@ -94,10 +94,16 @@ describe("reactive retries", () => {
   const runWatcher = async (
     errorName: string | undefined,
     initialRetries: number,
-    // Share `action` + `offBudgetRetries` across calls to accumulate an
-    // off-budget streak; both default to fresh per call.
-    shared?: { action: Action; offBudgetRetries: WeakMap<Action, number> },
+    options: {
+      rejectPromise?: boolean;
+      restoreInvalidCauses?: () => void;
+      shared?: {
+        action: Action;
+        offBudgetRetries: WeakMap<Action, number>;
+      };
+    } = {},
   ) => {
+    const { rejectPromise = false, shared } = options;
     const action = shared?.action ?? ((() => {}) as unknown as Action);
     const retries = new WeakMap<Action, number>();
     if (initialRetries > 0) retries.set(action, initialRetries);
@@ -108,10 +114,13 @@ describe("reactive retries", () => {
     const error = errorName === undefined
       ? undefined
       : { name: errorName, message: `injected ${errorName}` };
-    const commitPromise = Promise.resolve({ error }) as unknown as ReturnType<
-      IExtendedStorageTransaction["commit"]
-    >;
-    watchReactiveActionCommit({
+    const commitPromise =
+      (rejectPromise
+        ? Promise.reject(error)
+        : Promise.resolve({ error })) as unknown as ReturnType<
+          IExtendedStorageTransaction["commit"]
+        >;
+    await watchReactiveActionCommit({
       action,
       tx: {} as IExtendedStorageTransaction,
       log: {} as ReactivityLog,
@@ -127,10 +136,8 @@ describe("reactive retries", () => {
         queued++;
       },
       getActionId: () => "test-action",
-      restoreInvalidCauses: () => {},
+      restoreInvalidCauses: options.restoreInvalidCauses ?? (() => {}),
     });
-    await commitPromise;
-    await new Promise((r) => setTimeout(r, 0));
     return { queued, resubscribed, retries, offBudgetRetries, action };
   };
 
@@ -169,6 +176,61 @@ describe("reactive retries", () => {
     },
   );
 
+  it("retries when the storage commit promise rejects", async () => {
+    const r = await runWatcher("TransactionError", 0, {
+      rejectPromise: true,
+    });
+    expect(r.queued).toBe(1);
+    expect(r.resubscribed).toBe(1);
+    expect(r.retries.get(r.action)).toBe(1);
+  });
+
+  it(
+    "retries a rejected stale-basis error without charging the bounded budget",
+    async () => {
+      const r = await runWatcher("ConflictError", 3, {
+        rejectPromise: true,
+      });
+      expect(r.queued).toBe(1);
+      expect(r.resubscribed).toBe(1);
+      expect(r.retries.get(r.action)).toBe(3);
+      expect(r.offBudgetRetries.get(r.action)).toBe(1);
+    },
+  );
+
+  it(
+    "does not retry a rejected terminal error and clears the retry budget",
+    async () => {
+      const r = await runWatcher("RowLabelCommitError", 3, {
+        rejectPromise: true,
+      });
+      expect(r.queued).toBe(0);
+      expect(r.resubscribed).toBe(0);
+      expect(r.retries.has(r.action)).toBe(false);
+    },
+  );
+
+  it("retries when the storage commit promise rejects without a reason", async () => {
+    const r = await runWatcher(undefined, 0, {
+      rejectPromise: true,
+    });
+    expect(r.queued).toBe(1);
+    expect(r.resubscribed).toBe(1);
+    expect(r.retries.get(r.action)).toBe(1);
+  });
+
+  it("settles when reactive retry handling throws", async () => {
+    const retryHandlingError = new Error("retry handling failed");
+    const r = await runWatcher("TransactionError", 0, {
+      restoreInvalidCauses: () => {
+        throw retryHandlingError;
+      },
+    });
+    expect(r.queued).toBe(0);
+    expect(r.resubscribed).toBe(0);
+    expect(r.retries.get(r.action)).toBe(1);
+  });
+
   it(
     "retries a same-replica-race rejection off the bounded budget",
     async () => {
@@ -198,11 +260,11 @@ describe("reactive retries", () => {
         action: (() => {}) as unknown as Action,
         offBudgetRetries: new WeakMap<Action, number>(),
       };
-      await runWatcher("StorageTransactionInconsistent", 0, shared);
-      await runWatcher("ConflictError", 0, shared);
+      await runWatcher("StorageTransactionInconsistent", 0, { shared });
+      await runWatcher("ConflictError", 0, { shared });
       expect(shared.offBudgetRetries.get(shared.action)).toBe(2);
       // A successful commit ends the streak and clears the count.
-      await runWatcher(undefined, 0, shared);
+      await runWatcher(undefined, 0, { shared });
       expect(shared.offBudgetRetries.has(shared.action)).toBe(false);
     },
   );


### PR DESCRIPTION
Storage commit promises normally resolve with a result, but internal failures can reject. Those rejections bypassed extended transaction callbacks and cleanup, while reactive and event scheduler watchers either ignored them or only logged them. Event onCommit waiters could remain unsettled and retryable conflicts could be dropped.

Route rejected commits through the same observable failure state and scheduler disposition paths as resolved commit errors. Preserve the rejection for callers, notify callbacks with an errored transaction, clear post-commit effects, retry stale-basis conflicts, stop permanent and terminal rejections, and make reactive commit watching awaitable. Add focused coverage for callbacks, cleanup, retry classification, and event final outcomes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle rejected storage commit promises the same way as commit errors so callbacks run, retries are applied, and `onCommit` waiters settle reliably. Telemetry errors no longer block finalization.

- **Bug Fixes**
  - Normalize rejected commit reasons (including plain objects) for correct classification and telemetry; retry stale-basis conflicts, stop permanent/terminal errors, and log dropped CFC writes.
  - `ExtendedStorageTransaction.commit()` converts rejections into a `StorageTransactionAborted` error state, clears post-commit effects, runs commit callbacks, and rethrows to callers.
  - `watchReactiveActionCommit` handles rejected commit promises, updates retry budgets correctly (including off-budget stale-basis retries), and is now awaitable.
  - Apply commit disposition and run final callbacks before emitting telemetry; if telemetry submission throws, log it and still settle `onCommit`.

- **Migration**
  - `watchReactiveActionCommit` now returns a Promise; callers that need deterministic post-commit behavior can `await` it (existing call sites can continue ignoring the return).

<sup>Written for commit 68e65ccb6bd954351930123e472cfd66087b7ec6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

