### PR TITLE
fix(schema-generator): preserve null in boolean unions

### DIFF
--- a/docs/specs/schema-generator/ts_to_json_schema_mapping.md
+++ b/docs/specs/schema-generator/ts_to_json_schema_mapping.md
@@ -452,8 +452,10 @@ Default paths of §7:
   `anyOf` pairs (`test/utils.ts:454-466`).
 - **All-literal unions** → `{ enum: [...] }` with **no `type` key**; `null`
   joins the enum when present; `undefined` never does (it forces the anyOf
-  path); the exact pair `true | false` re-collapses to `{ type: "boolean" }`
-  (`:176-214`). This is also what TS enums hit (§4).
+  path). The pair `true | false` re-collapses to `{ type: "boolean" }`. When
+  that pair is nullable, it emits
+  `{ anyOf: [{ type: "boolean" }, { type: "null" }] }` (`:176-217`). This is
+  also what TS enums hit (§4).
 - **`{ type: "undefined" }` preservation**: undefined members are kept, not
   stripped (`:132-135`).
 - **General case** → `anyOf` with **primitive merging**

--- a/packages/schema-generator/src/formatters/union-formatter.ts
+++ b/packages/schema-generator/src/formatters/union-formatter.ts
@@ -203,8 +203,11 @@ export class UnionFormatter implements TypeFormatter {
       const nonBoolValues = values.filter((v) => typeof v !== "boolean");
 
       if (boolValues.length === 2 && nonBoolValues.length === 0) {
-        // Union of true | false becomes regular boolean type
-        return { type: "boolean" };
+        // TypeScript represents boolean as the union true | false. Preserve a
+        // nullable member when collapsing those literals to boolean.
+        return hasNull
+          ? { anyOf: [{ type: "boolean" }, { type: "null" }] }
+          : { type: "boolean" };
       }
 
       // Include null in enum values if present (null can be a runtime value, unlike undefined)

--- a/packages/schema-generator/test/literal-encoding-paths.test.ts
+++ b/packages/schema-generator/test/literal-encoding-paths.test.ts
@@ -56,6 +56,97 @@ describe("literal encoding across analysis paths", () => {
     });
   });
 
+  it("preserves nullable booleans across both analysis paths", async () => {
+    const code = `type MaybeBoolean = boolean | null;`;
+    const generator = new SchemaGenerator();
+    const { type, checker, typeNode } = await getTypeFromCode(
+      code,
+      "MaybeBoolean",
+    );
+    const expected = {
+      anyOf: [{ type: "boolean" }, { type: "null" }],
+    };
+
+    expect(generator.generateSchema(type, checker, typeNode)).toEqual(expected);
+    expect(
+      generator.generateSchemaFromSyntheticTypeNode(typeNode!, checker),
+    ).toEqual(expected);
+  });
+
+  it("preserves null beside explicit boolean literals on both paths", async () => {
+    const code = `type MaybeBoolean = true | false | null;`;
+    const generator = new SchemaGenerator();
+    const { type, checker, typeNode } = await getTypeFromCode(
+      code,
+      "MaybeBoolean",
+    );
+
+    expect(generator.generateSchema(type, checker, typeNode)).toEqual({
+      anyOf: [{ type: "boolean" }, { type: "null" }],
+    });
+    expect(
+      generator.generateSchemaFromSyntheticTypeNode(typeNode!, checker),
+    ).toEqual({
+      anyOf: [
+        { type: "boolean", const: true },
+        { type: "boolean", const: false },
+        { type: "null" },
+      ],
+    });
+  });
+
+  it("keeps nullable single boolean literals narrow on both paths", async () => {
+    for (const literal of ["true", "false"] as const) {
+      const code = `type MaybeBoolean = ${literal} | null;`;
+      const generator = new SchemaGenerator();
+      const { type, checker, typeNode } = await getTypeFromCode(
+        code,
+        "MaybeBoolean",
+      );
+      const value = literal === "true";
+
+      expect(generator.generateSchema(type, checker, typeNode)).toEqual({
+        anyOf: [
+          { type: "boolean", enum: [value] },
+          { type: "null" },
+        ],
+      });
+      expect(
+        generator.generateSchemaFromSyntheticTypeNode(typeNode!, checker),
+      ).toEqual({
+        anyOf: [
+          { type: "boolean", const: value },
+          { type: "null" },
+        ],
+      });
+    }
+  });
+
+  it("preserves undefined in nullable booleans on both paths", async () => {
+    const code = `type MaybeBoolean = boolean | null | undefined;`;
+    const generator = new SchemaGenerator();
+    const { type, checker, typeNode } = await getTypeFromCode(
+      code,
+      "MaybeBoolean",
+    );
+
+    expect(generator.generateSchema(type, checker, typeNode)).toEqual({
+      anyOf: [
+        { type: ["null", "undefined"] },
+        { type: "boolean" },
+      ],
+    });
+    expect(
+      generator.generateSchemaFromSyntheticTypeNode(typeNode!, checker),
+    ).toEqual({
+      anyOf: [
+        { type: "boolean" },
+        { type: "null" },
+        { type: "undefined" },
+      ],
+    });
+  });
+
   it("bound object nodes converge (property literals re-resolve onto the type path)", async () => {
     const code = `type Shape = { kind: "point"; x: number };`;
     const generator = new SchemaGenerator();

--- a/packages/schema-generator/test/widen-literals.test.ts
+++ b/packages/schema-generator/test/widen-literals.test.ts
@@ -100,4 +100,14 @@ describe("widenLiterals option", () => {
       type: "boolean",
     });
   });
+
+  it("preserves null when collapsing nullable boolean literals", async () => {
+    const expected = {
+      anyOf: [{ type: "boolean" }, { type: "null" }],
+    };
+    expect(await generate(`type B = boolean | null;`, "B", WIDEN)).toEqual(
+      expected,
+    );
+    expect(await generate(`type B = boolean | null;`, "B")).toEqual(expected);
+  });
 });

--- a/packages/ts-transformers/test/fixtures/schema-injection/literal-widen-explicit-type-args.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/literal-widen-explicit-type-args.expected.jsx
@@ -16,6 +16,8 @@ const __cfAmdHooks = undefined;
 //   new Cell<number>(10) → new Cell<number>(10, { type: "number" })
 //   new Cell<string>("hello") → new Cell<string>("hello", { type: "string" })
 //   new Cell<boolean>(true) → new Cell<boolean>(true, { type: "boolean" })
+//   new Cell<boolean | null>(null)
+//     → new Cell<boolean | null>(null, { anyOf: [{ type: "boolean" }, { type: "null" }] })
 export default function TestLiteralWidenExplicitTypeArgs() {
     const _c1 = new Cell<number>(10, {
         type: "number"
@@ -26,6 +28,13 @@ export default function TestLiteralWidenExplicitTypeArgs() {
     const _c3 = new Cell<boolean>(true, {
         type: "boolean"
     } as const satisfies __cfHelpers.JSONSchema).for("_c3", true);
+    const _c4 = new Cell<boolean | null>(null, {
+        anyOf: [{
+                type: "boolean"
+            }, {
+                type: "null"
+            }]
+    } as const satisfies __cfHelpers.JSONSchema).for("_c4", true);
     return null;
 }
 __cfHardenFn(TestLiteralWidenExplicitTypeArgs);

--- a/packages/ts-transformers/test/fixtures/schema-injection/literal-widen-explicit-type-args.input.tsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/literal-widen-explicit-type-args.input.tsx
@@ -5,10 +5,13 @@ import { Cell } from "commonfabric";
 //   new Cell<number>(10) → new Cell<number>(10, { type: "number" })
 //   new Cell<string>("hello") → new Cell<string>("hello", { type: "string" })
 //   new Cell<boolean>(true) → new Cell<boolean>(true, { type: "boolean" })
+//   new Cell<boolean | null>(null)
+//     → new Cell<boolean | null>(null, { anyOf: [{ type: "boolean" }, { type: "null" }] })
 export default function TestLiteralWidenExplicitTypeArgs() {
   const _c1 = new Cell<number>(10);
   const _c2 = new Cell<string>("hello");
   const _c3 = new Cell<boolean>(true);
+  const _c4 = new Cell<boolean | null>(null);
 
   return null;
 }

--- a/packages/ts-transformers/test/fixtures/schema-transform/nullable-boolean.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/nullable-boolean.expected.jsx
@@ -1,0 +1,53 @@
+function __cfHardenFn(fn: Function) {
+    Object.freeze(fn);
+    const prototype = fn.prototype;
+    if (prototype && typeof prototype === "object") {
+        Object.freeze(prototype);
+    }
+    return fn;
+}
+import { __cfHelpers } from "commonfabric";
+import { pattern } from "commonfabric";
+const define = undefined;
+const runtimeDeps = undefined;
+const __cfAmdHooks = undefined;
+interface Input {
+    flag: boolean | null;
+}
+interface Output {
+    flag: boolean | null;
+}
+// FIXTURE: nullable-boolean
+// Verifies: pattern input and output schemas retain null in boolean unions.
+//   boolean | null → { anyOf: [{ type: "boolean" }, { type: "null" }] }
+export default pattern((__cf_pattern_input) => {
+    const flag = __cf_pattern_input.key("flag");
+    return ({ flag });
+}, {
+    type: "object",
+    properties: {
+        flag: {
+            anyOf: [{
+                    type: "boolean"
+                }, {
+                    type: "null"
+                }]
+        }
+    },
+    required: ["flag"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        flag: {
+            anyOf: [{
+                    type: "boolean"
+                }, {
+                    type: "null"
+                }]
+        }
+    },
+    required: ["flag"]
+} as const satisfies __cfHelpers.JSONSchema);
+// @ts-ignore: Internals
+function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
+__cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/schema-transform/nullable-boolean.input.tsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/nullable-boolean.input.tsx
@@ -1,0 +1,14 @@
+import { pattern } from "commonfabric";
+
+interface Input {
+  flag: boolean | null;
+}
+
+interface Output {
+  flag: boolean | null;
+}
+
+// FIXTURE: nullable-boolean
+// Verifies: pattern input and output schemas retain null in boolean unions.
+//   boolean | null → { anyOf: [{ type: "boolean" }, { type: "null" }] }
+export default pattern<Input, Output>(({ flag }) => ({ flag }));


### PR DESCRIPTION
TypeScript represents boolean as the literal union true or false. The schema formatter collapses that pair to the boolean type, but its all-literal path discarded a null member from boolean or null.

Emit an anyOf containing boolean and null for nullable full booleans while retaining the compact boolean schema for non-nullable unions. Keep single boolean literals narrow and preserve undefined when it is also present. Update the type-to-schema mapping specification accordingly.

Cover type-based and synthetic-node generation, literal widening, explicit boolean-literal boundaries, pattern input and output schemas, and explicit nullable Cell schema injection. The direct regressions and transformer goldens emit a bare boolean with the previous formatter, so they detect the lost-null behavior.

Verified with the schema-generator test suite (289 steps), the ts-transformers test suite (752 steps), both package check tasks, repository-wide deno fmt --check, and repository-wide deno lint.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes lost nulls in boolean unions during schema generation. `boolean | null` now emits `{ anyOf: [{ type: "boolean" }, { type: "null" }] }`, while `true | false` still collapses to `{ type: "boolean" }`.

- **Bug Fixes**
  - Update `schema-generator` `UnionFormatter` to preserve `null` when collapsing boolean literals.
  - Keep single boolean literals narrow with `null`, and preserve `undefined` when present.
  - Ensure consistent output across type-based and synthetic-node paths, and with literal widening.
  - Update mapping docs and add tests in `schema-generator` and `ts-transformers` (pattern input/output and `Cell<boolean | null>` schema injection).

<sup>Written for commit 09a6f6414cae09e901d149eb50213411844c3efe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

