### PR TITLE
test(runner): wait on the llm dialog through the shared quiescent wait

### DIFF
--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -193,9 +193,12 @@ The runner's llm tests wait on that shape often enough to have a name for it.
 `waitForLlmSettled`, in `packages/runner/test/support/llm-result.ts`, resolves
 once `llm`, `generateText` or `generateObject` has finished a request. It is a
 call to `waitForCellValue` carrying the predicate those builtins settle on,
-`pending === false`, and it holds no wait machinery of its own. Reach for it
-rather than re-deriving that predicate: reading at quiescence is what makes it
-honest, and the helper's comment records why.
+`pending === false`, and it holds no wait machinery of its own. Its neighbour
+`waitForLlmMessages` adds a message count to that predicate, which is how an
+`llmDialog` test names the turn it is waiting for — every turn ends in the same
+settled state, so the count is what tells one from the next. Reach for them
+rather than re-deriving those predicates: reading at quiescence is what makes
+them honest, and the helpers' comments record why.
 
 Some traps are worth knowing before you hand-roll one of these against a
 runtime. They cost real debugging to find, and they are why the helper takes a

--- a/packages/runner/test/cfc-agent-prompt-injection-demo.test.ts
+++ b/packages/runner/test/cfc-agent-prompt-injection-demo.test.ts
@@ -14,6 +14,7 @@ import type {
 } from "@commonfabric/api";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
 import { Runtime } from "../src/runtime.ts";
+import { waitForLlmMessages } from "./support/llm-result.ts";
 import { createLLMFriendlyLink } from "../src/link-types.ts";
 import { LLMMessageSchema } from "../src/builtins/llm-schemas.ts";
 
@@ -365,29 +366,7 @@ async function setupDemoAgent(
     await storageManager.close();
   };
 
-  return { result, recipientHandle, linkPath, dispose };
-}
-
-function waitForMessages(result: any, expectedCount: number) {
-  let cancel: () => void;
-  let timeout: ReturnType<typeof setTimeout>;
-  return new Promise<void>((resolve, reject) => {
-    timeout = setTimeout(() => {
-      reject(
-        new Error(
-          `Timeout waiting for ${expectedCount} messages and pending=false`,
-        ),
-      );
-    }, 5000);
-    cancel = result.sink(({ pending, messages }: any = {}) => {
-      if (pending === false && messages?.length === expectedCount) {
-        resolve();
-      }
-    });
-  }).finally(() => {
-    clearTimeout(timeout);
-    cancel();
-  });
+  return { runtime, result, recipientHandle, linkPath, dispose };
 }
 
 describe("CFC agent prompt-injection demo (end-to-end via mock)", () => {
@@ -450,7 +429,7 @@ describe("CFC agent prompt-injection demo (end-to-end via mock)", () => {
       const addMessage = await t.result.key("addMessage").pull();
       addMessage.send({ role: "user", content: DEMO_PROMPT });
       // user + assistant(read) + tool + assistant(send) + tool + final = 6
-      await waitForMessages(t.result, 6);
+      await waitForLlmMessages(t.runtime, t.result, 6);
 
       // The central invariant: the injected recipient was never mailed.
       const emails =
@@ -546,7 +525,7 @@ describe("CFC agent prompt-injection demo (end-to-end via mock)", () => {
       const addMessage = await t.result.key("addMessage").pull();
       addMessage.send({ role: "user", content: DEMO_PROMPT });
       // user + 3×(assistant tool-call + tool result) + final = 8
-      await waitForMessages(t.result, 8);
+      await waitForLlmMessages(t.runtime, t.result, 8);
 
       // The end-to-end by-reference contract: the reference the model passed
       // to sendMail was handed to it INSIDE the conversation — the

--- a/packages/runner/test/cfc-llm-derived-stamp.test.ts
+++ b/packages/runner/test/cfc-llm-derived-stamp.test.ts
@@ -16,6 +16,7 @@ import { parseLink } from "../src/link-utils.ts";
 import { ID, type JSONSchema } from "../src/builder/types.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
 import { LLMMessageSchema } from "../src/builtins/llm-schemas.ts";
+import { waitForLlmMessages } from "./support/llm-result.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-llm-derived-stamp");
 
@@ -281,25 +282,7 @@ describe("llmDialog LlmDerived stamping (end to end)", () => {
       const addMessage = await result.key("addMessage").pull();
       addMessage.send({ role: "user", content: "Hello" });
 
-      await new Promise<void>((resolve, reject) => {
-        const timeout = setTimeout(
-          () => reject(new Error("Timeout waiting for assistant reply")),
-          5000,
-        );
-        const cancel = result.sink(
-          ({ pending, messages }: {
-            pending?: boolean;
-            messages?: readonly unknown[];
-          } = {}) => {
-            if (pending === false && messages?.length === 2) {
-              clearTimeout(timeout);
-              cancel();
-              resolve();
-            }
-          },
-        );
-      });
-      await runtime.idle();
+      await waitForLlmMessages(runtime, result, 2);
 
       // The contract is the PERSISTED metadata on each message's own entity
       // doc (messages carry [ID] and split); read it there directly — the
@@ -397,25 +380,7 @@ describe("llmDialog LlmDerived stamping (end to end)", () => {
       const addMessage = await result.key("addMessage").pull();
       addMessage.send({ role: "user", content: "Hello" });
 
-      await new Promise<void>((resolve, reject) => {
-        const timeout = setTimeout(
-          () => reject(new Error("Timeout waiting for assistant reply")),
-          5000,
-        );
-        const cancel = result.sink(
-          ({ pending, messages }: {
-            pending?: boolean;
-            messages?: readonly unknown[];
-          } = {}) => {
-            if (pending === false && messages?.length === 2) {
-              clearTimeout(timeout);
-              cancel();
-              resolve();
-            }
-          },
-        );
-      });
-      await runtime.idle();
+      await waitForLlmMessages(runtime, result, 2);
 
       const messagesCell = result.key("messages");
       const rtx = runtime.edit();

--- a/packages/runner/test/llm-conversation-fixture.test.ts
+++ b/packages/runner/test/llm-conversation-fixture.test.ts
@@ -27,6 +27,7 @@ import { Runtime } from "../src/runtime.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 import { LLMMessageSchema } from "../src/builtins/llm-schemas.ts";
 import { join } from "@std/path";
+import { waitForLlmMessages, waitForLlmSettled } from "./support/llm-result.ts";
 
 const signer = await Identity.fromPassphrase("test operator fixtures");
 const space = signer.did();
@@ -115,7 +116,7 @@ describe("conversation fixtures", () => {
 
     // Turn 1: send greeting
     addMessage.send({ role: "user", content: "Hello" });
-    await waitForMessages(result, 2);
+    await waitForLlmMessages(runtime, result, 2);
 
     // Verify turn 1
     const msgs1 = (await result.key("messages").pull())!;
@@ -124,7 +125,7 @@ describe("conversation fixtures", () => {
 
     // Turn 2: send follow-up
     addMessage.send({ role: "user", content: "How are you?" });
-    await waitForMessages(result, 4);
+    await waitForLlmMessages(runtime, result, 4);
 
     // Verify turn 2
     const msgs2 = (await result.key("messages").pull())!;
@@ -186,7 +187,7 @@ describe("conversation fixtures", () => {
 
     // Turn 1: greeting
     addMessage.send({ role: "user", content: "Hello" });
-    await waitForMessages(result, 2);
+    await waitForLlmMessages(runtime, result, 2);
 
     expect((await result.key("messages").pull())![1].content).toBe(
       "Hi there! How can I help you today?",
@@ -198,7 +199,7 @@ describe("conversation fixtures", () => {
       content: "What's the weather in San Francisco?",
     });
     // user msg + assistant tool-call + tool result + assistant final = 4 new msgs
-    await waitForMessages(result, 6);
+    await waitForLlmMessages(runtime, result, 6);
 
     const msgs = (await result.key("messages").pull())!;
     // Verify tool call was made
@@ -266,7 +267,7 @@ describe("conversation fixtures", () => {
       role: "user",
       content: "What is the meaning of life?",
     });
-    await waitForMessages(result, 2);
+    await waitForLlmMessages(runtime, result, 2);
 
     const msgs = (await result.key("messages").pull())!;
     expect(msgs[1].content).toBe("The answer is 42.");
@@ -310,8 +311,7 @@ describe("conversation fixtures", () => {
     const result = runtime.run(tx, testPattern, {}, resultCell);
     tx.commit();
 
-    await waitForPending(result);
-    await runtime.idle();
+    await waitForLlmSettled(runtime, result);
 
     expect(result.key("pending").get()).toBe(false);
     expect(result.key("result").get()).toEqual({
@@ -320,51 +320,3 @@ describe("conversation fixtures", () => {
     });
   });
 });
-
-function waitForMessages(result: any, expectedCount: number) {
-  let cancel: () => void;
-  let timeout: ReturnType<typeof setTimeout>;
-  return new Promise<void>((resolve, reject) => {
-    timeout = setTimeout(() => {
-      reject(
-        new Error(
-          `Timeout waiting for ${expectedCount} messages and pending=false`,
-        ),
-      );
-    }, 5000);
-    cancel = result.sink(({ pending, messages }: any = {}) => {
-      if (pending === false && messages?.length === expectedCount) {
-        resolve();
-      }
-    });
-  }).finally(() => {
-    clearTimeout(timeout);
-    cancel();
-  });
-}
-
-function waitForPending(result: any) {
-  let cancel: () => void;
-  let timeout: ReturnType<typeof setTimeout>;
-  return new Promise<void>((resolve, reject) => {
-    timeout = setTimeout(() => {
-      reject(new Error("Timeout waiting for pending to become false"));
-    }, 5000);
-    cancel = result.asSchema({
-      type: "object",
-      properties: {
-        pending: { type: "boolean" },
-        error: true,
-        result: true,
-      },
-      default: {},
-    }).sink(({ pending, error, result: r }: any = {}) => {
-      if (pending === false && (error !== undefined || r !== undefined)) {
-        resolve();
-      }
-    });
-  }).finally(() => {
-    clearTimeout(timeout);
-    cancel?.();
-  });
-}

--- a/packages/runner/test/llm-dialog-outbox.test.ts
+++ b/packages/runner/test/llm-dialog-outbox.test.ts
@@ -18,6 +18,7 @@ import {
   TransactionWrapper,
 } from "../src/storage/extended-storage-transaction.ts";
 import { LLMMessageSchema } from "../src/builtins/llm-schemas.ts";
+import { waitForLlmMessages } from "./support/llm-result.ts";
 
 const signer = await Identity.fromPassphrase("test llm-dialog outbox");
 const space = signer.did();
@@ -130,7 +131,7 @@ describe("llmDialog outbox mechanism", () => {
       const addMessage = await result.key("addMessage").pull();
       addMessage.send({ role: "user", content: prompt });
 
-      await waitForMessages(result, 2);
+      await waitForLlmMessages(runtime, result, 2);
 
       expect(outboxEffects.length).toBeGreaterThan(0);
       expect(outboxEffects[0].kind).toBe("llmDialog-start");
@@ -142,25 +143,3 @@ describe("llmDialog outbox mechanism", () => {
     }
   });
 });
-
-function waitForMessages(result: any, expectedCount: number) {
-  let cancel: () => void;
-  let timeout: ReturnType<typeof setTimeout>;
-  return new Promise<void>((resolve, reject) => {
-    timeout = setTimeout(() => {
-      reject(
-        new Error(
-          `Timeout waiting for ${expectedCount} messages and pending=false`,
-        ),
-      );
-    }, 5000);
-    cancel = result.sink(({ pending, messages }: any = {}) => {
-      if (pending === false && messages?.length === expectedCount) {
-        resolve();
-      }
-    });
-  }).finally(() => {
-    clearTimeout(timeout);
-    cancel();
-  });
-}

--- a/packages/runner/test/llm-dialog.test.ts
+++ b/packages/runner/test/llm-dialog.test.ts
@@ -20,6 +20,7 @@ import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 import { LLMMessageSchema } from "../src/builtins/llm-schemas.ts";
 import { llmToolExecutionHelpers } from "../src/builtins/llm-dialog.ts";
 import { createLLMFriendlyLink } from "../src/link-types.ts";
+import { waitForLlmMessages } from "./support/llm-result.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
@@ -138,11 +139,11 @@ describe("llmDialog", () => {
 
     // Turn 1: send greeting
     addMessage.send({ role: "user", content: "Hello" });
-    await expect(waitForMessages(result, 2)).resolves.toBeUndefined();
+    await waitForLlmMessages(runtime, result, 2);
 
     // Turn 2: send follow-up
     addMessage.send({ role: "user", content: "How are you?" });
-    await expect(waitForMessages(result, 4)).resolves.toBeUndefined();
+    await waitForLlmMessages(runtime, result, 4);
 
     const msgs = (await result.key("messages").pull())!;
     expect(msgs[0].content).toBe("Hello");
@@ -224,7 +225,7 @@ describe("llmDialog", () => {
     const run = await result.key("run").pull();
     run.send({});
 
-    await expect(waitForMessages(result, 2)).resolves.toBeUndefined();
+    await waitForLlmMessages(runtime, result, 2);
 
     const msgs = (await result.key("messages").pull())!;
     expect(msgs[0].content).toBe("Hello from handler");
@@ -334,7 +335,7 @@ describe("llmDialog", () => {
     });
 
     // user msg + assistant tool-call + tool result + assistant final = 4
-    await expect(waitForMessages(result, 4)).resolves.toBeUndefined();
+    await waitForLlmMessages(runtime, result, 4);
 
     expect(toolCalled).toBe(true);
 
@@ -447,7 +448,7 @@ describe("llmDialog", () => {
     const addMessage = await result.key("addMessage").pull();
     addMessage.send({ role: "user", content: "Send the email." });
 
-    await expect(waitForMessages(result, 2)).resolves.toBeUndefined();
+    await waitForLlmMessages(runtime, result, 2);
     expect(capturedToolSchema).toMatchObject({
       type: "object",
       properties: {
@@ -1033,7 +1034,7 @@ describe("llmDialog", () => {
     const addMessage = await result.key("addMessage").pull();
     addMessage.send({ role: "user", content: "Start the safe workflow." });
 
-    await expect(waitForMessages(result, 2)).resolves.toBeUndefined();
+    await waitForLlmMessages(runtime, result, 2);
     const messages = (await result.key("messages").pull())!;
     expect(messages.at(-1)?.content).toBe("Tool catalog is available.");
   });
@@ -1168,7 +1169,7 @@ describe("llmDialog", () => {
     const addMessage = await result.key("addMessage").pull();
     addMessage.send({ role: "user", content: "Start the workflow." });
 
-    await expect(waitForMessages(result, 6)).resolves.toBeUndefined();
+    await waitForLlmMessages(runtime, result, 6);
 
     const messages = (await result.key("messages").pull())!;
     expect(messages[4].role).toBe("tool");
@@ -1264,7 +1265,7 @@ describe("llmDialog", () => {
     const addMessage = await result.key("addMessage").pull();
 
     addMessage.send({ role: "user", content: "Please pin this cell" });
-    await expect(waitForMessages(result, 4)).resolves.toBeUndefined();
+    await waitForLlmMessages(runtime, result, 4);
 
     const pinnedCells = await result.key("pinnedCells").pull();
     expect(pinnedCells).toBeDefined();
@@ -1385,7 +1386,7 @@ describe("llmDialog", () => {
 
     // First pin a cell
     addMessage.send({ role: "user", content: "Please pin this cell" });
-    await expect(waitForMessages(result, 4)).resolves.toBeUndefined();
+    await waitForLlmMessages(runtime, result, 4);
 
     let pinnedCells = await result.key("pinnedCells").pull();
     expect(pinnedCells?.length).toBe(1);
@@ -1393,7 +1394,7 @@ describe("llmDialog", () => {
 
     // Now unpin it
     addMessage.send({ role: "user", content: "Please unpin that cell" });
-    await expect(waitForMessages(result, 8)).resolves.toBeUndefined();
+    await waitForLlmMessages(runtime, result, 8);
 
     pinnedCells = await result.key("pinnedCells").pull();
     expect(pinnedCells).toBeDefined();
@@ -1490,7 +1491,7 @@ describe("llmDialog", () => {
     });
 
     // Wait for response
-    await expect(waitForMessages(result, 2)).resolves.toBeUndefined();
+    await waitForLlmMessages(runtime, result, 2);
 
     // Verify context cells appear in pinnedCells output
     const pinnedCells = await result.key("pinnedCells").pull();
@@ -1631,7 +1632,7 @@ describe("llmDialog", () => {
     });
 
     // Wait for: user message, assistant tool call, tool result, final response
-    await expect(waitForMessages(result, 4)).resolves.toBeUndefined();
+    await waitForLlmMessages(runtime, result, 4);
 
     // Verify pinnedCells output contains both context cell and tool-pinned cell
     const pinnedCells = await result.key("pinnedCells").pull();
@@ -1731,7 +1732,7 @@ describe("llmDialog", () => {
       content: "Reply without built-in tools.",
     });
 
-    await expect(waitForMessages(result, 2)).resolves.toBeUndefined();
+    await waitForLlmMessages(runtime, result, 2);
 
     expect(capturedRequest).toBeDefined();
     expect(Object.keys(capturedRequest.tools ?? {})).toEqual(["ping"]);
@@ -1820,7 +1821,7 @@ describe("llmDialog", () => {
       content: "Reply without built-in tools.",
     });
 
-    await expect(waitForMessages(result, 2)).resolves.toBeUndefined();
+    await waitForLlmMessages(runtime, result, 2);
 
     expect(capturedRequest).toBeDefined();
     expect(Object.keys(capturedRequest.tools ?? {})).toEqual(["ping"]);
@@ -1919,7 +1920,7 @@ describe("llmDialog", () => {
       content: "Reply with handler tools available.",
     });
 
-    await expect(waitForMessages(result, 2)).resolves.toBeUndefined();
+    await waitForLlmMessages(runtime, result, 2);
 
     expect(capturedRequest).toBeDefined();
     expect(Object.keys(capturedRequest.tools ?? {})).toEqual(["ping"]);
@@ -2055,7 +2056,7 @@ describe("llmDialog", () => {
       addMessage.send({ role: "user", content: "Read the briefing." });
 
       // user, assistant(tool-call), tool(result), assistant(final).
-      await expect(waitForMessages(result, 4)).resolves.toBeUndefined();
+      await waitForLlmMessages(ceilingRuntime, result, 4);
 
       const messages = (await result.key("messages").pull())!;
       const toolMessage = messages[2];
@@ -2240,7 +2241,7 @@ describe("llmDialog", () => {
     const addMessage = await result.key("addMessage").pull();
     addMessage.send({ role: "user", content: "Start the workflow." });
 
-    await waitForMessages(result, 4);
+    await waitForLlmMessages(runtime, result, 4);
     const messages = (await result.key("messages").pull())!;
     // The conversation reaches its third request whether the delegate returned
     // data or an error, so the closing assertion below cannot see an abandoned
@@ -2257,25 +2258,3 @@ describe("llmDialog", () => {
     expect(messages.at(-1)?.content).toBe("Delegate completed.");
   });
 });
-
-function waitForMessages(result: any, expectedCount: number) {
-  let cancel: () => void;
-  let timeout: ReturnType<typeof setTimeout>;
-  return new Promise<void>((resolve, reject) => {
-    timeout = setTimeout(() => {
-      reject(
-        new Error(
-          `Timeout waiting for ${expectedCount} messages and pending=false`,
-        ),
-      );
-    }, 5000);
-    cancel = result.sink(({ pending, messages }: any = {}) => {
-      if (pending === false && messages?.length === expectedCount) {
-        resolve();
-      }
-    });
-  }).finally(() => {
-    clearTimeout(timeout);
-    cancel();
-  });
-}

--- a/packages/runner/test/support/llm-result.ts
+++ b/packages/runner/test/support/llm-result.ts
@@ -9,7 +9,7 @@ export interface LlmResultState<T = unknown> {
   error?: string;
   partial?: string;
   requestHash?: string;
-  messages?: unknown;
+  messages?: readonly unknown[];
   groundingSources?: unknown;
 }
 
@@ -49,5 +49,32 @@ export function waitForLlmSettled<T = unknown>(
     runtime,
     cell,
     (value) => value?.pending === false,
+  );
+}
+
+/**
+ * Resolve with the value of `llmDialog`'s result cell, once the conversation
+ * has settled on exactly `expectedCount` messages.
+ *
+ * A turn appends the user's message, and appends again once the request
+ * settles. A tool call adds the call and its result to the turn that made it.
+ * So the first exchange leaves two messages and the second leaves four, and a
+ * count names the turn a test waits for. Every turn ends in the same settled
+ * state, and the count is what tells them apart.
+ *
+ * Everything `waitForLlmSettled` says about `runtime` and about reading at
+ * quiescence applies here too.
+ */
+export function waitForLlmMessages(
+  runtime: Runtime,
+  // deno-lint-ignore no-explicit-any
+  cell: Cell<any>,
+  expectedCount: number,
+): Promise<LlmResultState> {
+  return waitForCellValue<LlmResultState>(
+    runtime,
+    cell,
+    (value) =>
+      value?.pending === false && value.messages?.length === expectedCount,
   );
 }


### PR DESCRIPTION
Five test files in packages/runner/test each carried their own copy of a deadline-based helper that waited for an llmDialog conversation to reach a given message count, and both of the things that helper does are traps.

It armed a `setTimeout` that rejected after five seconds. Because that timer is scheduled from a file under `test/`, the runner's fake-clock preload classes it as a test timer and freezes it, so it has never fired — the deadline has been inert code. The moment a case using it runs on the real clock the deadline becomes live and caps what that case can observe, which is exactly the failure mode the repository's rule against timeouts in tests exists to prevent. Worse while it stays inert, an unreachable wait fails with Deno's generic pending promise error rather than the message the helper advertises, so the helper claims a backstop it does not provide.

It also cancelled the sink from the continuation the sink callback resolved. Finalizing the action that reported a value resubscribes it, so a cancel issued from there is undone and the sink keeps firing. Nothing broke, because the per-test runtime disposal tore the subscription down anyway, but none of the waits actually unsubscribed.

Both problems are already solved by `waitForCellValue` in packages/integration: it carries no deadline and no poll interval, applies its predicate only to a value read after `runtime.idle()` rather than to whatever the sink reported mid-flight, and idles before cancelling. This change names the dialog predicate once as `waitForLlmMessages` in packages/runner/test/support/llm-result.ts, next to the `waitForLlmSettled` that already wraps the same primitive for the single-request builtins, and points all five files at it. The wait needs to know which runtime's scheduler to idle, so each call site now passes one; the case that builds a second runtime to test a confidentiality ceiling passes that one rather than the shared fixture's.

That includes the subagent-tool case that arrived in llm-dialog.test.ts when the dynamic-schema subagent file was folded back in. It had been written against `waitForCellValue`, because its file ran on the real clock where the deadline was live; the fold moved it onto the local helper and under the fake clock. It goes back to the shared wait.

Two waits nearby get the same treatment. The conversation-fixture file's `waitForPending`, a deadline-based wait for a `generateObject` request to settle, becomes a `waitForLlmSettled` call — the assertions that follow it already check the generated object, which is what distinguishes a request that answered from one that never went out. The stamping test's two inline copies, which cancel from inside the sink callback rather than from a continuation, become calls to the shared helper.

`LlmResultState.messages` was declared `unknown`, which would have forced the new helper to cast before reading `length`. It is now `readonly unknown[]`, which is what the llm builtins write there, so the helper reads the field directly and a caller can read it off the returned state without a cast of its own. Every test file importing that module type-checks unchanged.

Verified with the runner package's test task (1088 tests, 5681 steps, all passing), `deno check` on every file importing the support module, and `deno fmt --check`, `deno lint` and `deno task check-docs` at the repository root.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced all per‑test timeout waits in `llmDialog` tests with a shared, runtime‑aware quiescent wait to deflake runs and ensure clean teardown. Added `waitForLlmMessages`, updated call sites to pass the correct `Runtime`, tightened types, and updated docs.

- **Bug Fixes**
  - Added `waitForLlmMessages` next to `waitForLlmSettled`, both wrapping `waitForCellValue` to read at quiescence with no deadlines.
  - Removed duplicated deadline helpers across five tests and switched to the shared wait; also replaced the conversation fixture’s `waitForPending` with `waitForLlmSettled`. The confidentiality‑ceiling case now passes its own `Runtime`.
  - Prevented lingering subscriptions by idling before cancel via the shared helper.
  - Typed `LlmResultState.messages` as `readonly unknown[]` and updated `docs/development/waiting-in-tests.md` to cover both helpers.

<sup>Written for commit 51cb281293def3258bb54d2fbfd616ea5cd7fc4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

