### PR TITLE
feat(dashboard,ci): denser, attempt-aware performance history views

### DIFF
--- a/docs/development/CI_PERFORMANCE.md
+++ b/docs/development/CI_PERFORMANCE.md
@@ -101,8 +101,9 @@ duration. Matrix jobs are grouped using the trailing-parenthesis base names from
 persistent imbalance.
 
 For a requested history window, the collector retains every successful main
-push build when there are at most 90. Larger sets are reduced to about 90 time
-buckets, keeping the newest build in each bucket.
+push build when there are at most 200. Larger sets are sorted chronologically
+and reduced to exactly 200 builds spread evenly through that run sequence,
+including its oldest and newest builds.
 
 ## Step Phase Markers
 
@@ -111,6 +112,13 @@ segments — setup, work, and shutdown — so the shared scaffolding around a jo
 visually separated from the job's own work. For a matrix job this shows, per
 shard, how much wall time is setup that every shard repeats versus the unique
 work that one shard does.
+
+When the chart contains one workflow run, it draws every execution of a rerun
+job on the same row at its actual time. Each bar carries its own duration
+beside it, and its tooltip names the attempt and how that attempt ended. Failed
+attempts end in a red cross, and the delay before a retry stays blank. Charts
+covering several workflow runs use the latest execution of each job from each
+run when calculating their aggregate bars.
 
 The chart decides a step's phase from the emoji its name starts with. The emoji
 is the marker: the script never reads step wording, only the leading emoji. Every

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -197,6 +197,11 @@ workflow attempt. While GitHub reruns a workflow, the prior attempt's conclusion
 remains visible and the tile marks the activity as **build rerunning**. A new
 workflow run still appears as **next build running**.
 
+The **labs ci duration** and **loom ci duration** tiles use successful main push
+runs. Each duration starts when GitHub creates the workflow run for the landed
+commit and ends when that run finishes, so it includes runner queueing and
+reruns.
+
 ## Credentials
 
 Every tile that reads a private source is gated on its own env var(s) and grays
@@ -502,7 +507,7 @@ Notes:
     Cache entries written before CPU identity was stored are fetched again.
     Each completed artifact check is persisted before it is counted as
     finished. Only new runs and attempts are fetched after the first fill or a
-    server restart. The shortest-view buckets are about 16 minutes wide. The
+    server restart. The shortest-view buckets are about 8 minutes wide. The
     first cache fill can therefore download more artifacts.
   - Its **runtime benchmarks** view at `/bench?view=runtime` shows one coloured
     line per CPU for **every** benchmark. The lines share a calendar-time axis.
@@ -514,8 +519,12 @@ Notes:
     max) and whether to group by source **file** or sort by latest **duration**
     or **trend**. A "hide green" checkbox drops the steady ones. A slider from 1
     through 45 days changes the visible calendar range. The displayed samples
-    are spread across at most 90 time buckets, so a shorter window uses more of
-    the collected samples per day. Keyboard arrows adjust the window without
+    are spread across at most 200 time buckets, so a shorter window uses more of
+    the collected samples per day. Each graph chooses its vertical scale after
+    ignoring the two lowest and two highest displayed values; those points stay
+    in the line but no longer determine the scale, so they may clip instead of
+    flattening the rest of the history. A graph with fewer than 20 values uses
+    its complete range. Keyboard arrows adjust the window without
     moving focus. Enter applies the range immediately. Another selector carries
     the range into its own navigation, and leaving the controls applies it
     directly. Each row shows one latest value and trend from the CPU with the
@@ -540,19 +549,24 @@ Notes:
     base name used by `scripts/ci-gantt.ts` are shown together. Each group starts
     with a slowest-shard line, followed by the individual shard lines. The
     slider covers 1 through 45 days. It keeps every successful main build when
-    there are at most 90, then uses about 90 time buckets and keeps the newest
-    build in each bucket for larger sets. A coverage label compares the sampled
-    builds shown with every successful main build in the selected range. The
-    view can group by job or sort every line by latest duration or robust trend.
+    there are at most 200. Larger sets keep exactly 200 builds spread evenly
+    through the chronological run sequence. A coverage label compares the
+    sampled builds shown with every successful main build in the selected
+    range. The view can group by job or sort every line by latest duration or
+    robust trend. Its graphs use the same vertical-scale trimming as runtime
+    benchmark history.
     It renders cached history immediately. The progress panel remains visible
     as Idle between collections, then shows live collection progress with
     cached, queued, requested, responded, outstanding, and failed run counts.
+    On both history pages, a failed collection remains in the Idle panel until
+    a later collection for that history view succeeds.
     Open runtime benchmark and CI history pages check for newer server data once
     a minute. An open Gantt regenerates every 30 minutes and whenever its tab
     becomes visible. CI refreshes share a 30-minute GitHub freshness window, so
-    multiple pages do not repeat the same API reads. Moving the window slider
-    starts or joins the matching collection without cancelling wider-window
-    work already in progress.
+    multiple pages do not repeat the same API reads. Runtime and CI history
+    checks wait through the same window after GitHub rejects a collection.
+    Moving the window slider starts or joins the matching collection without
+    cancelling wider-window work already in progress.
   - Every GitHub API request made by the three performance views reserves rate
     capacity before it starts. Each guarded request batch reads GitHub's current
     rate-limit status before reserving. Collection stops before projected
@@ -572,6 +586,8 @@ Notes:
     CI history and the detailed `/bench?view=gantt` view use the same entries.
     The three performance views share one selector and preserve the applicable
     repository, range, sort, and runtime statistic while moving between them.
+    They also share the styles for their page header, selector, controls,
+    progress panel, time axis, and history rows.
     The next collection loads those timings before reading GitHub, so it only
     fetches jobs for new sampled runs, uncached Gantt runs, and new attempts.
     Cached history remains visible when no GitHub token is configured or a

--- a/packages/dashboard/benchmark-history-cache.test.ts
+++ b/packages/dashboard/benchmark-history-cache.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals, assertRejects, assertThrows } from "@std/assert";
 import {
   BENCHMARK_HISTORY_CACHE_DAYS,
+  BENCHMARK_HISTORY_SAMPLING_VERSION,
   BenchmarkHistoryStore,
   type BenchmarkStats,
 } from "./benchmark-history-cache.ts";
@@ -438,7 +439,7 @@ Deno.test("runtime benchmark history rejects malformed cache structures before m
   }
 });
 
-Deno.test("runtime benchmark history reads manifests written before result labels", async () => {
+Deno.test("runtime benchmark history refreshes legacy manifests without dropping their runs", async () => {
   const directory = await Deno.makeTempDir({ prefix: "benchmark-history-" });
   const file = `${directory}/history.json`;
   const now = Date.now();
@@ -462,6 +463,16 @@ Deno.test("runtime benchmark history reads manifests written before result label
     const store = new BenchmarkHistoryStore(file);
     await store.load();
     assertEquals(store.refresh?.result, "data");
+    assertEquals(store.refresh?.samplingVersion, undefined);
+    assertEquals(store.refreshedAt, 0);
+    assertEquals(store.refreshedRuns()?.map((run) => run.runId), [550]);
+
+    store.markRefreshed(now, store.list());
+    assertEquals(
+      store.refresh?.samplingVersion,
+      BENCHMARK_HISTORY_SAMPLING_VERSION,
+    );
+    assertEquals(store.refreshedAt, now);
   } finally {
     await Deno.remove(directory, { recursive: true });
   }

--- a/packages/dashboard/benchmark-history-cache.ts
+++ b/packages/dashboard/benchmark-history-cache.ts
@@ -4,6 +4,7 @@
 import { dashboardCacheFile } from "./history-files.ts";
 
 export const BENCHMARK_HISTORY_CACHE_DAYS = 60;
+export const BENCHMARK_HISTORY_SAMPLING_VERSION = 1;
 
 const DAY_MS = 86_400_000;
 const STORE_VERSION = 1;
@@ -42,6 +43,7 @@ interface BenchmarkRunReference {
 
 export interface BenchmarkRefreshManifest {
   refreshedAt: number;
+  samplingVersion?: number;
   runs: BenchmarkRunReference[];
   result: BenchmarkRefreshResult;
 }
@@ -109,6 +111,9 @@ const isRefreshManifest = (
   if (typeof value !== "object" || value === null) return false;
   const refresh = value as BenchmarkRefreshManifest;
   return Number.isFinite(refresh.refreshedAt) && refresh.refreshedAt >= 0 &&
+    (refresh.samplingVersion === undefined ||
+      Number.isInteger(refresh.samplingVersion) &&
+        refresh.samplingVersion > 0) &&
     Array.isArray(refresh.runs) && refresh.runs.every(isRunReference) &&
     (refresh.result === undefined ||
       ["data", "no-runs", "data-unavailable", "no-metric"].includes(
@@ -225,6 +230,9 @@ export class BenchmarkHistoryStore {
         ) {
           refresh = {
             refreshedAt: value.refresh.refreshedAt,
+            ...(value.refresh.samplingVersion === undefined
+              ? {}
+              : { samplingVersion: value.refresh.samplingVersion }),
             runs: value.refresh.runs.map((run) => ({ ...run })),
             result: value.refresh.result ??
               (value.refresh.runs.length ? "data" : "no-runs"),
@@ -342,6 +350,8 @@ export class BenchmarkHistoryStore {
 
   get refreshedAt(): number {
     return this.#refresh && this.#refresh.refreshedAt > this.#invalidatedAt &&
+        this.#refresh.samplingVersion ===
+          BENCHMARK_HISTORY_SAMPLING_VERSION &&
         this.#refresh.refreshedAt <= Date.now()
       ? this.#refresh.refreshedAt
       : 0;
@@ -351,6 +361,9 @@ export class BenchmarkHistoryStore {
     if (!this.#refresh || !this.#resolve(this.#refresh)) return null;
     return {
       refreshedAt: this.#refresh.refreshedAt,
+      ...(this.#refresh.samplingVersion === undefined
+        ? {}
+        : { samplingVersion: this.#refresh.samplingVersion }),
       runs: this.#refresh.runs.map((run) => ({ ...run })),
       result: this.#refresh.result,
     };
@@ -373,7 +386,12 @@ export class BenchmarkHistoryStore {
       runId: run.runId,
       runAttempt: run.runAttempt,
     }));
-    const refresh = { refreshedAt: at, runs: references, result };
+    const refresh = {
+      refreshedAt: at,
+      samplingVersion: BENCHMARK_HISTORY_SAMPLING_VERSION,
+      runs: references,
+      result,
+    };
     if (!this.#resolve(refresh)) {
       throw new Error("Runtime benchmark refresh contains an uncached run.");
     }

--- a/packages/dashboard/ci-job-cache.test.ts
+++ b/packages/dashboard/ci-job-cache.test.ts
@@ -3,6 +3,7 @@ import {
   type CachedCiHistoryRefresh,
   type CachedCiRun,
   CI_JOB_CACHE_DAYS,
+  CI_JOB_HISTORY_SAMPLING_VERSION,
   CiJobHistoryStore,
 } from "./ci-job-cache.ts";
 
@@ -54,6 +55,115 @@ function cachedRun(
   };
 }
 
+Deno.test("CI job cache refreshes legacy and outdated samples without dropping their runs", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "ci-job-cache-" });
+  const file = `${directory}/history.json`;
+  const run = cachedRun(90);
+  try {
+    await Deno.writeTextFile(
+      file,
+      JSON.stringify({
+        version: 1,
+        runs: [run],
+        refreshes: [
+          {
+            repo: REPO,
+            workflow: WORKFLOW,
+            days: 7,
+            refreshedAt: NOW,
+            successfulRunTimes: [NOW],
+            sampledRuns: [{ runId: run.runId, runAttempt: run.runAttempt }],
+            failedRunCount: 0,
+            failedRunTimes: [],
+            stale: false,
+          },
+          {
+            repo: REPO,
+            workflow: WORKFLOW,
+            days: 8,
+            refreshedAt: NOW,
+            samplingVersion: CI_JOB_HISTORY_SAMPLING_VERSION - 1,
+            successfulRunTimes: [NOW],
+            sampledRuns: [{ runId: run.runId, runAttempt: run.runAttempt }],
+            failedRunCount: 0,
+            failedRunTimes: [],
+            stale: false,
+          },
+        ],
+      }),
+    );
+
+    const store = new CiJobHistoryStore(file);
+    await store.load();
+
+    assertEquals(store.refresh(REPO, WORKFLOW, 7)?.samplingVersion, undefined);
+    assertEquals(store.freshRefresh(REPO, WORKFLOW, 7), undefined);
+    assertEquals(store.refreshedRuns(REPO, WORKFLOW, 7), [run]);
+    assertEquals(
+      store.refresh(REPO, WORKFLOW, 8)?.samplingVersion,
+      CI_JOB_HISTORY_SAMPLING_VERSION - 1,
+    );
+    assertEquals(store.freshRefresh(REPO, WORKFLOW, 8), undefined);
+    assertEquals(store.refreshedRuns(REPO, WORKFLOW, 8), [run]);
+
+    store.markRefreshed(
+      REPO,
+      WORKFLOW,
+      7,
+      NOW,
+      [NOW],
+      [{ runId: run.runId, runAttempt: run.runAttempt }],
+      0,
+      [],
+      false,
+    );
+    assertEquals(
+      store.freshRefresh(REPO, WORKFLOW, 7)?.samplingVersion,
+      CI_JOB_HISTORY_SAMPLING_VERSION,
+    );
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("CI job cache rejects a sampling version that is not a version", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "ci-job-cache-" });
+  const file = `${directory}/history.json`;
+  try {
+    const store = new CiJobHistoryStore(file);
+    const mark = (samplingVersion: number | null) =>
+      store.markRefreshed(
+        REPO,
+        WORKFLOW,
+        7,
+        NOW,
+        [NOW],
+        [],
+        0,
+        [],
+        false,
+        samplingVersion,
+      );
+
+    for (const invalid of [0, -1, 1.5, Number.NaN, Infinity]) {
+      assertThrows(
+        () => mark(invalid),
+        Error,
+        "CI job history refresh has an invalid sampling version.",
+      );
+    }
+    assertEquals(store.refresh(REPO, WORKFLOW, 7), undefined);
+
+    // A null version records a sample of unknown provenance: it is stored
+    // without a version, and it is never fresh.
+    mark(null);
+    assertEquals(store.refresh(REPO, WORKFLOW, 7)?.samplingVersion, undefined);
+    assertEquals(store.freshRefresh(REPO, WORKFLOW, 7), undefined);
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
 Deno.test("CI job cache rejects malformed persisted structures before merging", async () => {
   const directory = await Deno.makeTempDir({ prefix: "ci-job-cache-" });
   const valid = cachedRun(1);
@@ -61,6 +171,8 @@ Deno.test("CI job cache rejects malformed persisted structures before merging", 
   invalidStep.gantt.jobs[0].steps = [null] as never;
   const invalidJob = structuredClone(valid);
   invalidJob.gantt.jobs = [null] as never;
+  const invalidAttempt = structuredClone(valid);
+  invalidAttempt.gantt.jobs[0].attempt = 0;
   const invalidGantt = { ...valid, gantt: null };
   const invalidSha = { ...valid, headSha: "not-a-commit" };
   const cases: { value: unknown; message: string }[] = [
@@ -83,6 +195,10 @@ Deno.test("CI job cache rejects malformed persisted structures before merging", 
     },
     {
       value: { version: 1, runs: [invalidStep] },
+      message: "Invalid CI job history cache entry",
+    },
+    {
+      value: { version: 1, runs: [invalidAttempt] },
       message: "Invalid CI job history cache entry",
     },
     {

--- a/packages/dashboard/ci-job-cache.ts
+++ b/packages/dashboard/ci-job-cache.ts
@@ -5,6 +5,7 @@
 import { dashboardCacheFile } from "./history-files.ts";
 
 export const CI_JOB_CACHE_DAYS = 60;
+export const CI_JOB_HISTORY_SAMPLING_VERSION = 2;
 
 const DAY_MS = 86_400_000;
 const STORE_VERSION = 1;
@@ -23,6 +24,7 @@ export interface CachedCiGanttStep {
 }
 
 export interface CachedCiGanttJob {
+  attempt?: number;
   name: string;
   status: string;
   conclusion: string | null;
@@ -64,6 +66,7 @@ export interface CachedCiHistoryRefresh {
   workflow: string;
   days: number;
   refreshedAt: number;
+  samplingVersion?: number;
   successfulRunTimes: number[];
   sampledRuns: CachedCiRunReference[];
   failedRunCount: number;
@@ -121,7 +124,9 @@ const isCachedGanttStep = (value: unknown): value is CachedCiGanttStep => {
 const isCachedGanttJob = (value: unknown): value is CachedCiGanttJob => {
   if (typeof value !== "object" || value === null) return false;
   const job = value as CachedCiGanttJob;
-  return typeof job.name === "string" && typeof job.status === "string" &&
+  return (job.attempt === undefined ||
+      Number.isInteger(job.attempt) && job.attempt > 0) &&
+    typeof job.name === "string" && typeof job.status === "string" &&
     isNullableString(job.conclusion) && isNullableString(job.started_at) &&
     isNullableString(job.completed_at) && Array.isArray(job.steps) &&
     job.steps.every(isCachedGanttStep);
@@ -160,6 +165,9 @@ const isCachedRefresh = (
     typeof refresh.workflow === "string" &&
     Number.isInteger(refresh.days) && refresh.days > 0 &&
     Number.isFinite(refresh.refreshedAt) && refresh.refreshedAt >= 0 &&
+    (refresh.samplingVersion === undefined ||
+      Number.isInteger(refresh.samplingVersion) &&
+        refresh.samplingVersion > 0) &&
     Array.isArray(refresh.successfulRunTimes) &&
     refresh.successfulRunTimes.every(Number.isFinite) &&
     Array.isArray(refresh.sampledRuns) &&
@@ -509,6 +517,7 @@ export class CiJobHistoryStore {
       refreshKey(repo, workflow, days),
     );
     return refresh && refresh.refreshedAt <= Date.now() &&
+        refresh.samplingVersion === CI_JOB_HISTORY_SAMPLING_VERSION &&
         (!invalidation || refresh.refreshedAt > invalidation.invalidatedAt)
       ? refresh
       : undefined;
@@ -533,10 +542,17 @@ export class CiJobHistoryStore {
     failedRunCount: number,
     failedRunTimes: number[],
     stale: boolean,
+    samplingVersion: number | null = CI_JOB_HISTORY_SAMPLING_VERSION,
   ): void {
     if (!Number.isFinite(refreshedAt) || refreshedAt < 0) return;
     if (!Number.isInteger(failedRunCount) || failedRunCount < 0) {
       throw new Error("CI job history refresh has an invalid failure count.");
+    }
+    if (
+      samplingVersion !== null &&
+      (!Number.isInteger(samplingVersion) || samplingVersion <= 0)
+    ) {
+      throw new Error("CI job history refresh has an invalid sampling version.");
     }
     const key = refreshKey(repo, workflow, days);
     const current = this.#refreshes.get(key);
@@ -546,6 +562,7 @@ export class CiJobHistoryStore {
       workflow,
       days,
       refreshedAt,
+      ...(samplingVersion === null ? {} : { samplingVersion }),
       successfulRunTimes: successfulRunTimes.filter(Number.isFinite).sort(
         (a, b) => a - b,
       ),

--- a/packages/dashboard/ci-job-history.test.ts
+++ b/packages/dashboard/ci-job-history.test.ts
@@ -33,11 +33,19 @@ import {
 import {
   type CachedCiHistoryRefresh,
   CI_JOB_CACHE_DAYS,
+  CI_JOB_HISTORY_SAMPLING_VERSION,
   CiJobHistoryStore,
 } from "./ci-job-cache.ts";
-import { CI_WORKFLOW, LOOM_CI_WORKFLOW, LOOM_REPO, REPO } from "./config.ts";
+import {
+  CI_RUNS_MAX,
+  CI_WORKFLOW,
+  LOOM_CI_WORKFLOW,
+  LOOM_REPO,
+  REPO,
+} from "./config.ts";
 import { github } from "./lib.ts";
 import { GitHubRateLimitBudgetError } from "./github-rate-limit.ts";
+import { PERFORMANCE_VIEW_STYLES } from "./performance-views.ts";
 
 // Existing collector tests exercise history and persistence behavior against
 // precise request stubs. The rate-budget implementation has its own tests.
@@ -185,16 +193,21 @@ Deno.test("CI job history keeps every eligible build at the point target", () =>
   );
 });
 
-Deno.test("CI job history samples the newest build per bucket above the point target", () => {
+Deno.test("CI job history sampling matches the main tile run limit", () => {
+  assertEquals(CI_HISTORY_POINT_TARGET, CI_RUNS_MAX);
+});
+
+Deno.test("CI job history keeps the exact target across clustered builds", () => {
   const clustered = Array.from(
     { length: CI_HISTORY_POINT_TARGET + 1 },
     (_, index) => workflowRun(1_000 + index, NOW - HOUR - index * 1_000),
   );
 
-  assertEquals(
-    sampleWorkflowRuns(clustered, NOW).map((run) => run.id),
-    [1_000],
-  );
+  const sampled = sampleWorkflowRuns(clustered, NOW);
+  assertEquals(sampled.length, CI_HISTORY_POINT_TARGET);
+  assertEquals(new Set(sampled.map((run) => run.id)).size, sampled.length);
+  assertEquals(sampled[0].id, 1_000 + CI_HISTORY_POINT_TARGET);
+  assertEquals(sampled.at(-1)?.id, 1_000);
 });
 
 Deno.test("CI job history keeps a similar point count when the window gets shorter", () => {
@@ -218,10 +231,8 @@ Deno.test("CI job history keeps a similar point count when the window gets short
     CI_HISTORY_MIN_DAYS,
   );
 
-  assert(full.length <= CI_HISTORY_POINT_TARGET + 1);
-  assert(short.length <= CI_HISTORY_POINT_TARGET + 1);
-  assert(full.length >= CI_HISTORY_POINT_TARGET - 1);
-  assert(short.length >= CI_HISTORY_POINT_TARGET - 1);
+  assertEquals(full.length, CI_HISTORY_POINT_TARGET);
+  assertEquals(short.length, CI_HISTORY_POINT_TARGET);
   assert(
     short.every((run) =>
       Date.parse(run.run_started_at) >= NOW - CI_HISTORY_MIN_DAYS * DAY
@@ -319,6 +330,7 @@ Deno.test("CI job history page shows the slowest shard, every shard, and unshard
   );
 
   assertStringIncludes(html, "<title>CI job history</title>");
+  assertStringIncludes(html, PERFORMANCE_VIEW_STYLES);
   assertStringIncludes(
     html,
     'href="/bench?view=ci&amp;repo=labs&amp;days=45&amp;sort=job&amp;stat=p99" aria-current="page"',
@@ -360,7 +372,11 @@ Deno.test("CI job history page shows the slowest shard, every shard, and unshard
   assertStringIncludes(html, "Slowest shard duration · last seen Jun 20");
   assertStringIncludes(
     html,
-    "Every successful main run is sampled when the selected window contains at most 90",
+    "Every successful main run is sampled when the selected window contains at most 200",
+  );
+  assertStringIncludes(
+    html,
+    "Larger sets keep exactly 200 builds spread evenly through the chronological run sequence",
   );
   assertStringIncludes(
     html,
@@ -369,6 +385,46 @@ Deno.test("CI job history page shows the slowest shard, every shard, and unshard
   assertStringIncludes(html, '<strong id="fetch-title">Idle</strong>');
   assertStringIncludes(html, "0 outstanding");
   assertEquals([...html.matchAll(/class="crow /g)].length, 6);
+});
+
+Deno.test("CI history graphs ignore two values at each end when twenty are shown", () => {
+  const seconds = [
+    102,
+    11,
+    1,
+    26,
+    101,
+    12,
+    2,
+    13,
+    14,
+    15,
+    16,
+    17,
+    18,
+    19,
+    20,
+    21,
+    22,
+    23,
+    24,
+    25,
+  ];
+  const snapshot = buildCiJobHistory(seconds.map((value, index) => ({
+    runId: 10_000 + index,
+    runUrl: `https://example.test/runs/${10_000 + index}`,
+    at: NOW - (seconds.length - 1 - index) * HOUR,
+    overallSeconds: value,
+    jobs: [{ name: "Check", seconds: value }],
+  })));
+  const points = ciJobHistoryPage(snapshot, "job")
+    .match(/<polyline points="([^"]+)"/)?.[1]
+    .split(" ")
+    .map((point) => Number(point.split(",")[1]));
+
+  assert(points);
+  assertEquals(points.filter((point) => point < 0).length, 2);
+  assertEquals(points.filter((point) => point > 26).length, 2);
 });
 
 Deno.test("CI job history trend sort is flat and includes groups and exact job names", () => {
@@ -517,6 +573,18 @@ Deno.test("CI job history page exposes live collection progress without disablin
   );
   assertStringIncludes(
     html,
+    'else if ("lastRequestError" in state) renderIdle(state.lastRequestError || "");',
+  );
+  assertStringIncludes(
+    html,
+    "else if (!collectionFailed) renderIdle();",
+  );
+  assertStringIncludes(
+    html,
+    "else delete fetchProgress.dataset.lastRequestError;",
+  );
+  assertStringIncludes(
+    html,
     "if (!eventStream && !collectionFailed && !transportFailed) renderIdle()",
   );
   assertStringIncludes(html, "transportFailed = true");
@@ -618,6 +686,73 @@ Deno.test("CI fetch progress panel retains a completed collection warning", () =
   );
 });
 
+Deno.test("CI fetch progress panel retains the last failed collection", () => {
+  const html = ciFetchProgressPanel({
+    id: "ci-failed",
+    source: "labs",
+    days: 45,
+    phase: "error",
+    discoveryRequestsMade: 1,
+    discoveryResponsesReceived: 1,
+    discoveryOutstandingRequests: 0,
+    totalRuns: 12,
+    cachedRuns: 0,
+    requestsMade: 0,
+    responsesReceived: 0,
+    sharedRequests: 0,
+    sharedResponses: 0,
+    successfulResponses: 0,
+    failedResponses: 1,
+    completedRuns: 0,
+    queuedRuns: 12,
+    outstandingRequests: 0,
+    needsReload: false,
+    updatedAt: NOW,
+    error: "source unreachable",
+  });
+
+  assertStringIncludes(html, 'class="fetch-progress error"');
+  assertStringIncludes(html, '<strong id="fetch-title">Idle</strong>');
+  assertStringIncludes(
+    html,
+    'data-last-request-error="source unreachable"',
+  );
+  assertStringIncludes(
+    html,
+    '<p id="fetch-detail">Last collection stopped: source unreachable</p>',
+  );
+  assert(!html.includes("No requests in progress."));
+});
+
+Deno.test("CI job history response keeps a remembered failure in its idle panel", async () => {
+  const cached = buildCiJobHistory(historySamples());
+  const provider = {
+    cached: () => Promise.resolve(cached),
+    startRefresh: () => ({
+      progress: null,
+      result: Promise.resolve(cached),
+    }),
+    lastRefreshError: () => "source unreachable",
+  };
+
+  const response = await ciJobHistoryResponse(
+    new URL("http://x/bench?view=ci"),
+    provider,
+    "response-token",
+  );
+  const html = await response.text();
+
+  assertStringIncludes(html, 'class="fetch-progress error"');
+  assertStringIncludes(
+    html,
+    '<p id="fetch-detail">Last collection stopped: source unreachable</p>',
+  );
+  assertStringIncludes(
+    html,
+    'else if ("lastRequestError" in state) renderIdle(state.lastRequestError || "");',
+  );
+});
+
 Deno.test("CI job history response uses a refresh that completed after its cache read", async () => {
   const cached = buildCiJobHistory([{
     runId: 7_101,
@@ -711,6 +846,7 @@ Deno.test("CI job history update check uses the selected repository and window",
   assertEquals(selected?.source, CI_HISTORY_SOURCES.loom);
   assertEquals(selected?.days, 9);
   assertEquals(state.progress, progress);
+  assertEquals(state.lastRequestError, null);
   assertEquals(typeof state.version, "string");
   assertEquals(response.headers.get("cache-control"), "no-store");
 });
@@ -741,10 +877,120 @@ Deno.test("CI job history update checks freshness-gate a failed collection", asy
       ),
       null,
     );
+    const checked = await ciJobHistoryCheckResponse(
+      new URL("http://x/bench/check?view=ci&repo=labs&days=7"),
+      test.collector,
+      "check-token",
+    );
+    const state = await checked.json();
+    assertEquals(state.progress, null);
+    assertEquals(state.lastRequestError, "temporarily unavailable");
+    assertEquals(
+      test.collector.lastRefreshError(CI_HISTORY_SOURCES.labs, 14),
+      null,
+    );
     assertEquals(calls, 1);
+
+    let releaseRecovery!: (response: Response) => void;
+    const recoveryResponse = new Promise<Response>((resolve) => {
+      releaseRecovery = resolve;
+    });
+    globalThis.fetch = () => recoveryResponse;
+    const recovery = test.collector.startRefresh(
+      "check-token",
+      CI_HISTORY_SOURCES.labs,
+      7,
+    );
+    const joinedRecovery = test.collector.startRefreshForCheck(
+      "check-token",
+      CI_HISTORY_SOURCES.labs,
+      7,
+    );
+    releaseRecovery(Response.json({
+      total_count: 0,
+      workflow_runs: [],
+    }));
+    assert(joinedRecovery);
+    assertEquals(joinedRecovery.progress?.id, recovery.progress?.id);
+    await recovery.result;
+    assertEquals(
+      test.collector.lastRefreshError(CI_HISTORY_SOURCES.labs, 7),
+      null,
+    );
   } finally {
     globalThis.fetch = originalFetch;
     await test.cleanup();
+  }
+});
+
+Deno.test("CI history retains a failed request until replacement data is persisted", async () => {
+  const directory = await Deno.makeTempDir({
+    prefix: "ci-job-history-failure-persistence-",
+  });
+  const originalFetch = globalThis.fetch;
+  let blockSave = false;
+  let markSaveStarted!: () => void;
+  let releaseSave!: () => void;
+  const saveStarted = new Promise<void>((resolve) => {
+    markSaveStarted = resolve;
+  });
+  const saveGate = new Promise<void>((resolve) => {
+    releaseSave = resolve;
+  });
+  class BlockingStore extends CiJobHistoryStore {
+    override async save(now = Date.now()): Promise<void> {
+      if (blockSave) {
+        markSaveStarted();
+        await saveGate;
+      }
+      await super.save(now);
+    }
+  }
+  const collector = new CiJobHistoryCollector(
+    new BlockingStore(`${directory}/history.json`),
+  );
+
+  try {
+    globalThis.fetch = () =>
+      Promise.resolve(new Response("unavailable", { status: 503 }));
+    const failed = collector.startRefresh(
+      "failure-token",
+      CI_HISTORY_SOURCES.labs,
+      7,
+    );
+    await assertRejects(() => failed.result);
+    assertEquals(
+      collector.lastRefreshError(CI_HISTORY_SOURCES.labs, 7),
+      "temporarily unavailable",
+    );
+
+    globalThis.fetch = () =>
+      Promise.resolve(Response.json({
+        total_count: 0,
+        workflow_runs: [],
+      }));
+    blockSave = true;
+    const recovery = collector.startRefresh(
+      "recovery-token",
+      CI_HISTORY_SOURCES.labs,
+      7,
+    );
+    await saveStarted;
+    assertEquals(
+      collector.lastRefreshError(CI_HISTORY_SOURCES.labs, 7),
+      "temporarily unavailable",
+    );
+
+    releaseSave();
+    await recovery.result;
+    assertEquals(
+      collector.lastRefreshError(CI_HISTORY_SOURCES.labs, 7),
+      null,
+    );
+  } finally {
+    releaseSave();
+    globalThis.fetch = originalFetch;
+    await Deno.remove(directory, { recursive: true });
   }
 });
 
@@ -1799,6 +2045,10 @@ Deno.test("CI job history reuses a fresh completed collection after a dashboard 
     const persisted = JSON.parse(await Deno.readTextFile(test.file));
     assertEquals(persisted.refreshes.length, 1);
     assertEquals(persisted.refreshes[0].days, CI_HISTORY_DAYS);
+    assertEquals(
+      persisted.refreshes[0].samplingVersion,
+      CI_JOB_HISTORY_SAMPLING_VERSION,
+    );
     assertEquals(persisted.refreshes[0].successfulRunTimes, [now]);
     assertEquals(persisted.refreshes[0].sampledRuns, [{
       runId: run.id,
@@ -1877,7 +2127,185 @@ Deno.test("CI job history reuses a fresh completed collection after a dashboard 
   }
 });
 
-Deno.test("CI job history preserves an all-failed refresh warning after restart", async () => {
+Deno.test("CI job history does not rebuild a matching persisted manifest", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "ci-job-history-test-" });
+  class CachedReadCollector extends CiJobHistoryCollector {
+    cachedReads = 0;
+
+    override cached(
+      ...args: Parameters<CiJobHistoryCollector["cached"]>
+    ): ReturnType<CiJobHistoryCollector["cached"]> {
+      this.cachedReads++;
+      return super.cached(...args);
+    }
+  }
+  const run = workflowRun(9_105, Date.now() - HOUR);
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (input) => {
+    const url = String(input);
+    return Promise.resolve(
+      url.includes(`/actions/workflows/${CI_WORKFLOW}/runs?`)
+        ? Response.json({ workflow_runs: [run] })
+        : Response.json({ jobs: [apiJob("Check", 90)] }),
+    );
+  };
+
+  try {
+    const collector = new CachedReadCollector(
+      new CiJobHistoryStore(`${directory}/history.json`),
+    );
+    assertEquals(
+      (await collector.startRefresh("matching-manifest-token").result)
+        .runCount,
+      1,
+    );
+    assertEquals(collector.cachedReads, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("CI job history does not bless a preserved legacy sample", async () => {
+  const test = await temporaryCollector();
+  const now = Date.now();
+  const first = workflowRun(9_106, now - HOUR);
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (input) => {
+    const url = String(input);
+    return Promise.resolve(
+      url.includes(`/actions/workflows/${CI_WORKFLOW}/runs?`)
+        ? Response.json({ workflow_runs: [first] })
+        : Response.json({ jobs: [apiJob("Check", 90)] }),
+    );
+  };
+
+  try {
+    await test.collector.startRefresh("legacy-sample-token").result;
+    const persisted = JSON.parse(await Deno.readTextFile(test.file));
+    delete persisted.refreshes[0].samplingVersion;
+    const reruns = Array.from(
+      { length: CI_HISTORY_POINT_TARGET + 1 },
+      (_, index) =>
+        workflowRun(
+          first.id + index,
+          now - HOUR - index * 1_000,
+          { run_attempt: 2 },
+        ),
+    );
+    persisted.refreshes[0].successfulRunTimes = reruns.map((run) =>
+      Date.parse(run.run_started_at)
+    );
+    await Deno.writeTextFile(test.file, JSON.stringify(persisted));
+
+    globalThis.fetch = (input) => {
+      const url = String(input);
+      return Promise.resolve(
+        url.includes(`/actions/workflows/${CI_WORKFLOW}/runs?`)
+          ? Response.json({ workflow_runs: reruns })
+          : new Response("unavailable", { status: 503 }),
+      );
+    };
+    const store = new CiJobHistoryStore(test.file);
+    const collector = new CiJobHistoryCollector(store);
+    const baseline = await collector.cached(
+      CI_HISTORY_SOURCES.labs,
+      CI_HISTORY_DAYS,
+      now,
+    );
+    assertEquals(baseline?.runCount, 1);
+
+    const result = await collector.startRefresh(
+      "legacy-sample-token",
+      CI_HISTORY_SOURCES.labs,
+      CI_HISTORY_DAYS,
+      baseline,
+    ).result;
+    assertEquals(result.runCount, 1);
+    assertEquals(result.stale, true);
+    assertEquals(
+      store.refresh(REPO, CI_WORKFLOW, CI_HISTORY_DAYS)?.samplingVersion,
+      undefined,
+    );
+    assertEquals(
+      store.freshRefresh(REPO, CI_WORKFLOW, CI_HISTORY_DAYS),
+      undefined,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+    await test.cleanup();
+  }
+});
+
+Deno.test("CI job history does not bless a preserved manifestless sample", async () => {
+  const test = await temporaryCollector();
+  const now = Date.now();
+  const first = workflowRun(9_107, now - HOUR);
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (input) => {
+    const url = String(input);
+    return Promise.resolve(
+      url.includes(`/actions/workflows/${CI_WORKFLOW}/runs?`)
+        ? Response.json({ workflow_runs: [first] })
+        : Response.json({ jobs: [apiJob("Check", 90)] }),
+    );
+  };
+
+  try {
+    await test.collector.startRefresh("manifestless-sample-token").result;
+    const persisted = JSON.parse(await Deno.readTextFile(test.file));
+    persisted.refreshes = [];
+    await Deno.writeTextFile(test.file, JSON.stringify(persisted));
+    const reruns = Array.from(
+      { length: CI_HISTORY_POINT_TARGET + 1 },
+      (_, index) =>
+        workflowRun(
+          first.id + index,
+          now - HOUR - index * 1_000,
+          { run_attempt: 2 },
+        ),
+    );
+
+    globalThis.fetch = (input) => {
+      const url = String(input);
+      return Promise.resolve(
+        url.includes(`/actions/workflows/${CI_WORKFLOW}/runs?`)
+          ? Response.json({ workflow_runs: reruns })
+          : new Response("unavailable", { status: 503 }),
+      );
+    };
+    const store = new CiJobHistoryStore(test.file);
+    const collector = new CiJobHistoryCollector(store);
+    const baseline = await collector.cached(
+      CI_HISTORY_SOURCES.labs,
+      CI_HISTORY_DAYS,
+      now,
+    );
+    assertEquals(baseline?.runCount, 1);
+
+    const result = await collector.startRefresh(
+      "manifestless-sample-token",
+      CI_HISTORY_SOURCES.labs,
+      CI_HISTORY_DAYS,
+      baseline,
+    ).result;
+    assertEquals(result.runCount, 1);
+    assertEquals(result.stale, true);
+    assertEquals(
+      store.refresh(REPO, CI_WORKFLOW, CI_HISTORY_DAYS)?.samplingVersion,
+      undefined,
+    );
+    assertEquals(
+      store.freshRefresh(REPO, CI_WORKFLOW, CI_HISTORY_DAYS),
+      undefined,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+    await test.cleanup();
+  }
+});
+
+Deno.test("CI job history preserves an all-failed refresh warning and retries after restart", async () => {
   const test = await temporaryCollector();
   const now = Date.now();
   const run = workflowRun(9_104, now - HOUR);
@@ -1942,10 +2370,93 @@ Deno.test("CI job history preserves an all-failed refresh warning after restart"
       7,
       cached,
     );
+    assert(refresh.progress);
+    assertEquals((await refresh.result).stale, true);
+    assertEquals(calls, callsBeforeRestart + 2);
+  } finally {
+    globalThis.fetch = originalFetch;
+    await test.cleanup();
+  }
+});
+
+Deno.test("CI job history preserves current sampling provenance after an all-failed refresh", async () => {
+  const test = await temporaryCollector();
+  const now = Date.now();
+  let clock = now;
+  const run = workflowRun(9_108, now - HOUR);
+  let failing = false;
+  let calls = 0;
+  const originalNow = Date.now;
+  const originalFetch = globalThis.fetch;
+  Date.now = () => clock;
+  globalThis.fetch = (input) => {
+    const url = String(input);
+    calls++;
+    if (url.includes(`/actions/workflows/${CI_WORKFLOW}/runs?`)) {
+      return Promise.resolve(Response.json({
+        workflow_runs: [{ ...run, run_attempt: failing ? 2 : 1 }],
+      }));
+    }
+    if (url.includes(`/actions/runs/${run.id}/`)) {
+      if (failing) {
+        clock++;
+        return Promise.resolve(new Response("unavailable", { status: 503 }));
+      }
+      return Promise.resolve(Response.json({ jobs: [apiJob("Check", 90)] }));
+    }
+    return Promise.resolve(new Response("not found", { status: 404 }));
+  };
+
+  try {
+    await test.collector.startRefresh(
+      "current-sample-token",
+      CI_HISTORY_SOURCES.labs,
+      CI_HISTORY_DAYS,
+    ).result;
+    clock += HOUR;
+    failing = true;
+
+    const store = new CiJobHistoryStore(test.file);
+    const second = new CiJobHistoryCollector(store);
+    const baseline = await second.cached(
+      CI_HISTORY_SOURCES.labs,
+      CI_HISTORY_DAYS,
+      clock,
+    );
+    assertEquals(baseline?.runCount, 1);
+    const failed = await second.startRefresh(
+      "current-sample-token",
+      CI_HISTORY_SOURCES.labs,
+      CI_HISTORY_DAYS,
+      baseline,
+    ).result;
+    assertEquals(failed.runCount, 1);
+    assertEquals(failed.stale, true);
+    assertEquals(
+      store.refresh(REPO, CI_WORKFLOW, CI_HISTORY_DAYS)?.samplingVersion,
+      CI_JOB_HISTORY_SAMPLING_VERSION,
+    );
+
+    const callsBeforeRestart = calls;
+    const restarted = new CiJobHistoryCollector(
+      new CiJobHistoryStore(test.file),
+    );
+    const cached = await restarted.cached(
+      CI_HISTORY_SOURCES.labs,
+      CI_HISTORY_DAYS,
+      Date.now(),
+    );
+    const refresh = restarted.startRefresh(
+      "current-sample-token",
+      CI_HISTORY_SOURCES.labs,
+      CI_HISTORY_DAYS,
+      cached,
+    );
     assertEquals(refresh.progress, null);
     assertEquals((await refresh.result).stale, true);
     assertEquals(calls, callsBeforeRestart);
   } finally {
+    Date.now = originalNow;
     globalThis.fetch = originalFetch;
     await test.cleanup();
   }
@@ -2593,6 +3104,132 @@ Deno.test("a selected-run Gantt repairs cached responses with no drawable jobs",
     );
   } finally {
     console.error = originalError;
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("a selected-run Gantt expands a collapsed rerun cache", async () => {
+  const directory = await Deno.makeTempDir({
+    prefix: "ci-gantt-selected-rerun-cache-test-",
+  });
+  const file = `${directory}/history.json`;
+  const run = workflowRun(9_118, NOW, {
+    run_attempt: 2,
+    name: "CI",
+    head_sha: HEAD_SHA,
+    path: `.github/workflows/${CI_WORKFLOW}`,
+  });
+  const firstStart = NOW - HOUR;
+  const retryStart = NOW;
+  const jobAt = (
+    attempt: number,
+    start: number,
+    conclusion: string,
+  ) => ({
+    ...apiJob("Retried job", attempt * 60, conclusion),
+    started_at: new Date(start).toISOString(),
+    completed_at: new Date(start + attempt * 60_000).toISOString(),
+  });
+  const store = new CiJobHistoryStore(file);
+  await store.load();
+  store.set({
+    repo: REPO,
+    workflow: CI_WORKFLOW,
+    runId: run.id,
+    runAttempt: run.run_attempt,
+    headSha: HEAD_SHA,
+    runUrl: run.html_url,
+    at: NOW,
+    overallSeconds: 120,
+    jobs: [{ name: "Retried job", seconds: 120 }],
+    gantt: {
+      status: run.status,
+      conclusion: run.conclusion,
+      event: run.event,
+      headBranch: run.head_branch ?? undefined,
+      startedAt: run.run_started_at,
+      workflowName: run.name,
+      jobs: [{
+        name: "Retried job",
+        status: "completed",
+        conclusion: "success",
+        started_at: new Date(firstStart).toISOString(),
+        completed_at: new Date(firstStart + 60_000).toISOString(),
+        steps: [],
+      }],
+    },
+  });
+  await store.save(NOW);
+  const requestedAttempts: number[] = [];
+  const collector = new RateLimitedCiJobHistoryCollector(
+    store,
+    <T>(path: string): Promise<T> => {
+      const match = path.match(/\/attempts\/(\d+)\/jobs/);
+      if (!match) throw new Error(`unexpected selected-run request: ${path}`);
+      const attempt = Number(match[1]);
+      requestedAttempts.push(attempt);
+      return Promise.resolve({
+        jobs: [
+          attempt === 1
+            ? jobAt(1, firstStart, "failure")
+            : jobAt(2, retryStart, "success"),
+        ],
+      } as T);
+    },
+  );
+  try {
+    await assertRejects(
+      () =>
+        collector.gantt(
+          undefined,
+          CI_HISTORY_SOURCES.labs,
+          { limit: 1, mainOnly: true },
+          NOW,
+        ),
+      Error,
+      "Set GH_TOKEN",
+    );
+    const result = await collector.gantt(
+      "selected-run-token",
+      CI_HISTORY_SOURCES.labs,
+      {
+        limit: 1,
+        mainOnly: true,
+        headSha: HEAD_SHA,
+        selectedRuns: [{ runId: run.id, runAttempt: run.run_attempt }],
+      },
+      NOW,
+      [run],
+    );
+    assertEquals(requestedAttempts, [1, 2]);
+    assertEquals(
+      result.runs[0].jobs.map((job) => [
+        job.attempt,
+        job.conclusion,
+        job.started_at,
+      ]),
+      [
+        [1, "failure", new Date(firstStart).toISOString()],
+        [2, "success", new Date(retryStart).toISOString()],
+      ],
+    );
+    const persisted = JSON.parse(await Deno.readTextFile(file));
+    assertEquals(
+      persisted.runs[0].gantt.jobs.map(
+        (job: { attempt?: number }) => job.attempt,
+      ),
+      [1, 2],
+    );
+    assertEquals(
+      (await collector.gantt(
+        undefined,
+        CI_HISTORY_SOURCES.labs,
+        { limit: 1, mainOnly: true },
+        NOW,
+      )).runs[0].jobs.map((job) => job.attempt),
+      [1, 2],
+    );
+  } finally {
     await Deno.remove(directory, { recursive: true });
   }
 });
@@ -4151,7 +4788,7 @@ Deno.test("CI job history refreshes the complete latest job set after a subset r
   }
 });
 
-Deno.test("CI Gantt keeps rerun jobs on the first attempt timeline", async () => {
+Deno.test("CI Gantt keeps every execution of a rerun job", async () => {
   const test = await temporaryCollector();
   const runId = 9_205;
   const firstStart = NOW - HOUR;
@@ -4167,14 +4804,20 @@ Deno.test("CI Gantt keeps rerun jobs on the first attempt timeline", async () =>
     if (url.includes(`/actions/runs/${runId}/attempts/1/jobs`)) {
       return Promise.resolve(Response.json({
         jobs: [
-          jobAt("Check", 100, firstStart),
-          jobAt("Retried job", 100, firstStart + 120_000),
+          { ...jobAt("Check", 100, firstStart), id: 100 },
+          {
+            ...jobAt("Retried job", 100, firstStart + 120_000),
+            conclusion: "failure",
+          },
         ],
       }));
     }
     if (url.includes(`/actions/runs/${runId}/attempts/2/jobs`)) {
       return Promise.resolve(Response.json({
-        jobs: [jobAt("Retried job", 200, retryStart)],
+        jobs: [
+          { ...jobAt("Check", 100, firstStart), id: 200 },
+          jobAt("Retried job", 200, retryStart),
+        ],
       }));
     }
     return Promise.resolve(new Response("not found", { status: 404 }));
@@ -4202,16 +4845,39 @@ Deno.test("CI Gantt keeps rerun jobs on the first attempt timeline", async () =>
       NOW,
       [run],
     );
-    const retried = gantt.runs[0].jobs.find((job) =>
-      job.name === "Retried job"
+    assertEquals(
+      gantt.runs[0].jobs.filter((job) => job.name === "Check").map((job) => ({
+        attempt: job.attempt,
+        startedAt: job.started_at,
+      })),
+      [{
+        attempt: 1,
+        startedAt: new Date(firstStart).toISOString(),
+      }],
     );
     assertEquals(
-      retried?.started_at,
-      new Date(firstStart + 120_000).toISOString(),
-    );
-    assertEquals(
-      retried?.completed_at,
-      new Date(firstStart + 220_000).toISOString(),
+      gantt.runs[0].jobs.filter((job) => job.name === "Retried job").map(
+        (job) => ({
+          attempt: job.attempt,
+          conclusion: job.conclusion,
+          startedAt: job.started_at,
+          completedAt: job.completed_at,
+        }),
+      ),
+      [
+        {
+          attempt: 1,
+          conclusion: "failure",
+          startedAt: new Date(firstStart + 120_000).toISOString(),
+          completedAt: new Date(firstStart + 220_000).toISOString(),
+        },
+        {
+          attempt: 2,
+          conclusion: "success",
+          startedAt: new Date(retryStart).toISOString(),
+          completedAt: new Date(retryStart + 200_000).toISOString(),
+        },
+      ],
     );
   } finally {
     globalThis.fetch = originalFetch;
@@ -4555,9 +5221,10 @@ Deno.test("CI job history ignores invalid job times and uses a timed rerun in th
       { limit: 1, mainOnly: true, allConclusions: false },
       NOW,
     );
-    assertEquals(gantt.runs[0].jobs[0].conclusion, "success");
+    const retry = gantt.runs[0].jobs.find((job) => job.attempt === 2);
+    assertEquals(retry?.conclusion, "success");
     assertEquals(
-      gantt.runs[0].jobs[0].started_at,
+      retry?.started_at,
       apiJob("Retry", 30).started_at,
     );
   } finally {

--- a/packages/dashboard/ci-job-history.ts
+++ b/packages/dashboard/ci-job-history.ts
@@ -6,6 +6,7 @@ import {
   type CachedCiGanttJob,
   type CachedCiRun,
   type CachedCiRunReference,
+  CI_JOB_HISTORY_SAMPLING_VERSION,
   CiJobHistoryStore,
 } from "./ci-job-cache.ts";
 import { CI_WORKFLOW, LOOM_CI_WORKFLOW, LOOM_REPO, REPO } from "./config.ts";
@@ -28,14 +29,15 @@ import {
 } from "./trend.ts";
 import {
   PERFORMANCE_CHECK_MS,
+  PERFORMANCE_HISTORY_SCALE_MIN_VALUES,
+  PERFORMANCE_HISTORY_SCALE_TRIM,
+  PERFORMANCE_VIEW_STYLES,
   performanceViewNav,
 } from "./performance-views.ts";
 
 export const CI_HISTORY_DAYS = 45;
 export const CI_HISTORY_MIN_DAYS = 1;
-export const CI_HISTORY_POINT_TARGET = 90;
-export const CI_HISTORY_BUCKET_HOURS = CI_HISTORY_DAYS * 24 /
-  CI_HISTORY_POINT_TARGET;
+export const CI_HISTORY_POINT_TARGET = 200;
 
 const DAY_MS = 86_400_000;
 const JOBS_PER_PAGE = 100;
@@ -385,27 +387,26 @@ export function ciHistoryBucketMs(days: number): number {
   return days * DAY_MS / CI_HISTORY_POINT_TARGET;
 }
 
-function sampleNewestPerBucket<T>(
+function sampleEvenlyAcrossRuns<T>(
   values: T[],
   at: (value: T) => number,
   cutoff: number,
-  bucketMs: number,
 ): T[] {
-  const eligible = values.filter((value) => {
-    const time = at(value);
-    return Number.isFinite(time) && time >= cutoff;
-  });
+  const eligible = values
+    .filter((value) => {
+      const time = at(value);
+      return Number.isFinite(time) && time >= cutoff;
+    })
+    .sort((a, b) => at(a) - at(b));
   if (eligible.length <= CI_HISTORY_POINT_TARGET) {
-    return eligible.sort((a, b) => at(a) - at(b));
+    return eligible;
   }
-  const buckets = new Map<number, T>();
-  for (const value of eligible) {
-    const time = at(value);
-    const bucket = Math.floor((time - cutoff) / bucketMs);
-    const current = buckets.get(bucket);
-    if (!current || time > at(current)) buckets.set(bucket, value);
-  }
-  return [...buckets.values()].sort((a, b) => at(a) - at(b));
+  const last = eligible.length - 1;
+  return Array.from(
+    { length: CI_HISTORY_POINT_TARGET },
+    (_, index) =>
+      eligible[Math.round(index * last / (CI_HISTORY_POINT_TARGET - 1))],
+  );
 }
 
 export function sampleWorkflowRuns(
@@ -415,11 +416,10 @@ export function sampleWorkflowRuns(
 ): WorkflowRun[] {
   const eligible = successfulMainWorkflowRuns(runs, now, days);
   const cutoff = now - days * DAY_MS;
-  return sampleNewestPerBucket(
+  return sampleEvenlyAcrossRuns(
     eligible,
     runTime,
     cutoff,
-    ciHistoryBucketMs(days),
   );
 }
 
@@ -589,8 +589,9 @@ function isDrawableGanttJob(job: ApiJob | CachedCiGanttJob): boolean {
   return job.conclusion !== "skipped" && hasJobTiming(job);
 }
 
-function ganttJob(job: ApiJob): CachedCiGanttJob {
+function ganttJob(job: ApiJob, attempt: number): CachedCiGanttJob {
   return {
+    attempt,
     name: job.name,
     status: job.status ?? "completed",
     conclusion: job.conclusion,
@@ -633,41 +634,36 @@ async function fetchRunJobs(
   source: CiHistorySource,
   request: GitHubRequest,
 ): Promise<CiRunTiming> {
-  let jobs: ApiJob[];
-  let ganttJobs: ApiJob[];
-  if (run.run_attempt > 1) {
-    const complete = new Map<string, ApiJob>();
-    let firstAttempt: ApiJob[] = [];
-    for (let attempt = 1; attempt <= run.run_attempt; attempt++) {
-      const attempted = await fetchJobPage(
-        `actions/runs/${run.id}/attempts/${attempt}/jobs`,
-        token,
-        source,
-        request,
-      );
-      if (attempt === 1) firstAttempt = attempted;
-      for (const job of attempted) complete.set(job.name, job);
-    }
-    jobs = [...complete.values()];
-    ganttJobs = firstAttempt.map((job) => {
-      const latest = complete.get(job.name)!;
-      if (!hasJobTiming(job) && hasJobTiming(latest)) return latest;
-      return {
-        ...job,
-        status: latest.status,
-        conclusion: latest.conclusion,
-      };
-    });
-  } else {
-    jobs = await fetchJobPage(
-      `actions/runs/${run.id}/attempts/1/jobs`,
+  const complete = new Map<string, ApiJob>();
+  const ganttExecutions = new Map<
+    string,
+    { attempt: number; job: ApiJob }
+  >();
+  for (let attempt = 1; attempt <= run.run_attempt; attempt++) {
+    const attempted = await fetchJobPage(
+      `actions/runs/${run.id}/attempts/${attempt}/jobs`,
       token,
       source,
       request,
     );
-    ganttJobs = jobs;
+    for (const job of attempted) {
+      complete.set(job.name, job);
+      // GitHub repeats an earlier successful job in later failed-job rerun
+      // responses with a new job ID. Its name and timestamps stay the same. A
+      // job that ran again has new timestamps and gets a separate Gantt bar.
+      const execution = [
+        job.name,
+        job.started_at ?? "",
+        job.completed_at ?? "",
+      ].join("\u0000");
+      if (!ganttExecutions.has(execution)) {
+        ganttExecutions.set(execution, { attempt, job });
+      }
+    }
   }
-  if (!ganttJobs.some(isDrawableGanttJob)) {
+  const jobs = [...complete.values()];
+  const ganttJobs = [...ganttExecutions.values()];
+  if (!ganttJobs.some(({ job }) => isDrawableGanttJob(job))) {
     throw new Error(
       `No completed CI job timings were returned for run ${run.id} attempt ${run.run_attempt}.`,
     );
@@ -681,7 +677,7 @@ async function fetchRunJobs(
   return {
     jobs: timed.map((job) => job.timing),
     overallSeconds: start && end > start ? (end - start) / 1_000 : 0,
-    ganttJobs: ganttJobs.map(ganttJob),
+    ganttJobs: ganttJobs.map(({ attempt, job }) => ganttJob(job, attempt)),
   };
 }
 
@@ -922,6 +918,15 @@ function hasDrawableGanttTiming(run: CachedCiRun): boolean {
   return run.gantt.jobs.some(isDrawableGanttJob);
 }
 
+function hasAttemptMetadata(run: CachedCiRun): boolean {
+  return run.runAttempt === 1 ||
+    run.gantt.jobs.every((job) => job.attempt !== undefined);
+}
+
+function hasAttemptAwareGanttTiming(run: CachedCiRun): boolean {
+  return hasDrawableGanttTiming(run) && hasAttemptMetadata(run);
+}
+
 function workflowRunFromCache(
   run: CachedCiRun,
   source: CiHistorySource,
@@ -964,12 +969,14 @@ export class CiJobHistoryCollector {
   #jobRequests = new Map<string, Promise<CachedCiRun>>();
   #latest = new Map<string, CiJobHistorySnapshot>();
   #sampledRuns = new Map<string, CachedCiRunReference[]>();
+  #samplingVersions = new Map<string, number | null>();
   #snapshotRevisions = new Map<string, number>();
   #progressById = new Map<string, CiJobProgressRecord>();
   #progressByKey = new Map<string, CiJobProgressRecord>();
   #progressSequence = 0;
   #refreshedAt = new Map<string, { at: number; revision: number }>();
   #refreshFailureAt = new Map<CiHistorySourceKey, number>();
+  #refreshFailureError = new Map<string, string>();
   #refreshRequests = new Map<string, Promise<CiJobHistorySnapshot>>();
   #recentWorkflowRuns = new Map<string, { at: number; runs: WorkflowRun[] }>();
   #selectedWorkflowRuns = new Map<
@@ -1198,13 +1205,12 @@ export class CiJobHistoryCollector {
     const refreshedRuns =
       resolvedRefreshRuns?.filter((run) => run.at >= cutoff && run.at <= now) ??
         resolvedRefreshRuns;
-    const runs = refreshedRuns ?? sampleNewestPerBucket(
+    const runs = refreshedRuns ?? sampleEvenlyAcrossRuns(
       this.#store.list(source.repo, source.workflow, cutoff).filter(
         isSuccessfulMainCachedRun,
       ),
       (run) => run.at,
       cutoff,
-      ciHistoryBucketMs(days),
     );
     if (!runs.length && !refresh) {
       return current ? inRequestedWindow(current, now, days) : null;
@@ -1230,6 +1236,12 @@ export class CiJobHistoryCollector {
         runId: run.runId,
         runAttempt: run.runAttempt,
       })),
+    );
+    this.#samplingVersions.set(
+      key,
+      refresh
+        ? refresh.samplingVersion ?? null
+        : null,
     );
     this.#latest.set(key, value);
     this.#snapshotRevisions.set(
@@ -1277,15 +1289,18 @@ export class CiJobHistoryCollector {
         run.head_sha,
       );
     }
-    const repairCachedEntry = exactAttempt && cached !== undefined &&
-      !hasDrawableGanttTiming(cached);
+    const repairCachedEntry = cached !== undefined &&
+      (exactAttempt
+        ? !hasAttemptAwareGanttTiming(cached)
+        : !hasAttemptMetadata(cached));
     if (
       cached &&
       (exactAttempt
         ? cached.runAttempt === run.run_attempt &&
           cached.headSha === expectedHeadSha &&
-          hasDrawableGanttTiming(cached)
-        : cached.runAttempt >= run.run_attempt)
+          hasAttemptAwareGanttTiming(cached)
+        : cached.runAttempt >= run.run_attempt &&
+          hasAttemptMetadata(cached))
     ) {
       return { kind: "cached", result: Promise.resolve(cached) };
     }
@@ -1409,11 +1424,10 @@ export class CiJobHistoryCollector {
     const successfulRunTimes = successfulRuns.map(runTime).sort((a, b) =>
       a - b
     );
-    const runs = sampleNewestPerBucket(
+    const runs = sampleEvenlyAcrossRuns(
       successfulRuns,
       runTime,
       now - days * DAY_MS,
-      ciHistoryBucketMs(days),
     );
     const priorRefresh = this.#store.refresh(
       source.repo,
@@ -1561,7 +1575,14 @@ export class CiJobHistoryCollector {
         "CI job history could not preserve the exact previous run set.",
       );
     }
+    const previousSamplingVersion = this.#samplingVersions.has(key)
+      ? this.#samplingVersions.get(key)!
+      : priorRefresh?.samplingVersion ?? null;
+    const samplingVersion = preservePrevious
+      ? previousSamplingVersion
+      : CI_JOB_HISTORY_SAMPLING_VERSION;
     this.#sampledRuns.set(key, sampledRuns);
+    this.#samplingVersions.set(key, samplingVersion);
     this.#latest.set(key, value);
     this.#snapshotRevisions.set(
       key,
@@ -1693,7 +1714,7 @@ export class CiJobHistoryCollector {
       );
       if (
         persisted?.headSha === options.headSha &&
-        hasDrawableGanttTiming(persisted)
+        hasAttemptAwareGanttTiming(persisted)
       ) {
         resolved.set(selected.runId, workflowRunFromCache(persisted, source));
         continue;
@@ -1842,11 +1863,13 @@ export class CiJobHistoryCollector {
         );
         if (
           !run || run.headSha !== options.headSha ||
-          !hasDrawableGanttTiming(run)
+          !hasAttemptAwareGanttTiming(run)
         ) return [];
         return [run];
       })
-      : this.#store.list(source.repo, source.workflow);
+      : this.#store.list(source.repo, source.workflow).filter(
+        hasAttemptMetadata,
+      );
     const runs = candidates
       .filter((run) =>
         !options.mainOnly ||
@@ -1975,8 +1998,9 @@ export class CiJobHistoryCollector {
       return !entry ||
         (exactSelection
           ? entry.headSha !== normalized.headSha ||
-            !hasDrawableGanttTiming(entry)
-          : entry.runAttempt < run.run_attempt) ||
+            !hasAttemptAwareGanttTiming(entry)
+          : entry.runAttempt < run.run_attempt ||
+            !hasAttemptMetadata(entry)) ||
         Boolean(this.#pendingJobsForRun(run, source, exactSelection));
     });
     if (progress) {
@@ -2058,8 +2082,9 @@ export class CiJobHistoryCollector {
         !entry ||
         (exactSelection
           ? entry.headSha !== normalized.headSha ||
-            !hasDrawableGanttTiming(entry)
-          : entry.runAttempt < run.run_attempt)
+            !hasAttemptAwareGanttTiming(entry)
+          : entry.runAttempt < run.run_attempt ||
+            !hasAttemptMetadata(entry))
       ) return [];
       return [ganttInputRun(entry)];
     });
@@ -2236,18 +2261,21 @@ export class CiJobHistoryCollector {
       .then((runs) => this.collect(token, now, source, days, runs, progress))
       .then(async (collectedValue) => {
         let value = collectedValue;
-        this.#refreshFailureAt.delete(source.key);
         const refreshedAt = Date.now();
         const previousRefresh = this.#store.refresh(
           source.repo,
           source.workflow,
           days,
         );
+        const samplingVersion = this.#samplingVersions.has(key)
+          ? this.#samplingVersions.get(key)!
+          : CI_JOB_HISTORY_SAMPLING_VERSION;
         const expectedRefresh = {
           repo: source.repo,
           workflow: source.workflow,
           days,
           refreshedAt,
+          ...(samplingVersion === null ? {} : { samplingVersion }),
           successfulRunTimes: [...(value.successfulRunTimes ?? [])].filter(
             Number.isFinite,
           ).sort((a, b) => a - b),
@@ -2269,6 +2297,7 @@ export class CiJobHistoryCollector {
           value.failedRunCount,
           value.failedRunTimes,
           value.stale,
+          samplingVersion,
         );
         try {
           await this.#saveCache(now);
@@ -2307,6 +2336,8 @@ export class CiJobHistoryCollector {
           });
         } else this.#refreshedAt.delete(key);
         const fingerprint = snapshotFingerprint(value);
+        this.#refreshFailureAt.delete(source.key);
+        this.#refreshFailureError.delete(key);
         this.#updateProgress(progress, {
           phase: "complete",
           needsReload: [...progress.baselines].some((value) =>
@@ -2334,13 +2365,15 @@ export class CiJobHistoryCollector {
         const message = reportedError instanceof Error
           ? reportedError.message
           : String(reportedError);
+        const safeMessage = friendlyError(message);
+        this.#refreshFailureError.set(key, safeMessage);
         console.error(
           `CI job history refresh failed for ${source.repo}:`,
           message,
         );
         this.#updateProgress(progress, {
           phase: "error",
-          error: friendlyError(message),
+          error: safeMessage,
         });
         throw reportedError;
       })
@@ -2355,9 +2388,22 @@ export class CiJobHistoryCollector {
     days = CI_HISTORY_DAYS,
     baseline?: CiJobHistorySnapshot | null,
   ): CiJobRefresh | null {
+    if (this.#refreshRequests.has(snapshotKey(source, days))) {
+      return this.startRefresh(token, source, days, baseline);
+    }
     const failedAt = this.#refreshFailureAt.get(source.key);
-    if (failedAt && Date.now() - failedAt < REFRESH_MS) return null;
+    const age = failedAt === undefined ? -1 : Date.now() - failedAt;
+    if (
+      failedAt !== undefined && age >= 0 && age < REFRESH_MS
+    ) return null;
     return this.startRefresh(token, source, days, baseline);
+  }
+
+  lastRefreshError(
+    source = CI_HISTORY_SOURCES.labs,
+    days = CI_HISTORY_DAYS,
+  ): string | null {
+    return this.#refreshFailureError.get(snapshotKey(source, days)) ?? null;
   }
 
   async refresh(
@@ -2442,6 +2488,10 @@ function renderSeries(
     undefined,
     SPARK_FADE[status],
     xs,
+    {
+      trim: PERFORMANCE_HISTORY_SCALE_TRIM,
+      minValues: PERFORMANCE_HISTORY_SCALE_MIN_VALUES,
+    },
   );
   const pointSpan = times.length > 1 ? times[times.length - 1] - times[0] : 0;
   return {
@@ -2495,16 +2545,9 @@ interface CiHistoryPageOptions {
   days?: number;
   runtimeStat?: string;
   progress?: CiJobFetchProgress;
+  lastRequestError?: string;
   fragment?: boolean;
 }
-
-export const CI_FETCH_PROGRESS_STYLES = `
-  .fetch-progress{background:#16181d;border:1px solid #2f333c;border-radius:10px;padding:10px 12px;margin:0 0 12px}
-  .fetch-progress.error,.fetch-progress.warning{border-color:rgba(224,168,82,.42)}
-  .fetch-head{display:flex;justify-content:space-between;gap:12px;align-items:baseline;font-size:12px;color:#c7ccd4}
-  .fetch-head strong{font-weight:600}.fetch-head span,#fetch-detail{font-variant-numeric:tabular-nums;color:#878d97}
-  .fetch-progress progress{display:block;width:100%;height:7px;margin:7px 0 6px;accent-color:#6ea8fe}
-  #fetch-detail{font-size:11px;margin:0}`;
 
 interface CiFetchProgressPanelOptions {
   ariaLabel?: string;
@@ -2512,6 +2555,7 @@ interface CiFetchProgressPanelOptions {
   snapshotVersion?: string;
   refreshOnComplete?: boolean;
   progressUrl?: string;
+  lastRequestError?: string;
 }
 
 export function ciFetchProgressPanel(
@@ -2520,6 +2564,11 @@ export function ciFetchProgressPanel(
 ): string {
   const progressIdle = !progress || progress.phase === "complete" ||
     progress.phase === "error";
+  const lastRequestError = progress?.phase === "error"
+    ? progress.error ?? "unknown error"
+    : !progress
+    ? options.lastRequestError
+    : undefined;
   const progressTitle = progressIdle
     ? "Idle"
     : progress.phase === "discovering"
@@ -2530,10 +2579,8 @@ export function ciFetchProgressPanel(
     : progress.phase === "discovering"
     ? `${progress.discoveryOutstandingRequests} outstanding`
     : `${progress.completedRuns} / ${progress.totalRuns || "?"}`;
-  const progressDetail = progress?.phase === "error"
-    ? `Last collection stopped: ${
-      escapeHtml(progress.error ?? "unknown error")
-    }`
+  const progressDetail = lastRequestError
+    ? `Last collection stopped: ${escapeHtml(lastRequestError)}`
     : progressIdle && progress?.warning
     ? escapeHtml(progress.warning)
     : !progressIdle && progress?.phase === "discovering"
@@ -2554,9 +2601,16 @@ export function ciFetchProgressPanel(
     options.progressUrl
       ? `data-progress-url="${escapeHtml(options.progressUrl)}"`
       : "",
+    lastRequestError
+      ? `data-last-request-error="${escapeHtml(lastRequestError)}"`
+      : "",
   ].filter(Boolean).join(" ");
   return `<section class="fetch-progress${
-    progressIdle && progress?.warning ? " warning" : ""
+    lastRequestError
+      ? " error"
+      : progressIdle && progress?.warning
+      ? " warning"
+      : ""
   }" id="fetch-progress" aria-live="polite"${
     attributes ? ` ${attributes}` : ""
   }><div class="fetch-head"><strong id="fetch-title">${progressTitle}</strong><span id="fetch-total">${progressTotal}</span></div><progress id="fetch-bar" max="${
@@ -2728,10 +2782,6 @@ export function ciJobHistoryPage(
   const refreshNotice = notices.map((notice) =>
     `<p class="refresh-error">${escapeHtml(notice)}</p>`
   ).join("");
-  const bucketHours = ciHistoryBucketMs(days) / 3_600_000;
-  const bucketLabel = bucketHours >= 10
-    ? String(Math.round(bucketHours))
-    : bucketHours.toFixed(1).replace(/\.0$/, "");
   const viewNav = performanceViewNav("ci", {
     repo: source.key,
     days,
@@ -2757,6 +2807,7 @@ export function ciJobHistoryPage(
       progressActive && (!snapshot || snapshot.runCount === 0 || !hasSeries),
     ),
     progressUrl,
+    lastRequestError: options.lastRequestError,
   });
   const coverageHtml = snapshot
     ? `<p class="coverage">Coverage: ${snapshot.runCount} sampled build${
@@ -2773,52 +2824,25 @@ export function ciJobHistoryPage(
     ${progressHtml}${coverageHtml}
     <p class="legend">Job start-to-finish duration. Overall CI runs from the first job start to the last job completion. A shard group's line is the longest-running shard in each run. Lower is faster; colour follows the selected ${days}-day trend. Duration sort uses the latest sample.</p>
     ${refreshNotice}${body}
-    <p class="note">Every successful main run is sampled when the selected window contains at most ${CI_HISTORY_POINT_TARGET}. Larger sets keep the newest run per ${bucketLabel}-hour bucket from <a href="${
+    <p class="note">Every successful main run is sampled when the selected window contains at most ${CI_HISTORY_POINT_TARGET}. Larger sets keep exactly ${CI_HISTORY_POINT_TARGET} builds spread evenly through the chronological run sequence from <a href="${
     escapeHtml(workflowUrl)
   }" target="_blank" rel="noopener">${
     escapeHtml(source.workflow)
-  } runs ↗</a>. The window adjusts its sampling interval to keep about ${CI_HISTORY_POINT_TARGET} points. Values come from GitHub's job start and completion times. The detailed Gantt uses the same cached runs.</p>
+  } runs ↗</a>. Values come from GitHub's job start and completion times. The detailed Gantt uses the same cached runs.</p>
   </div>`;
   if (options.fragment) return rangeContent;
   return `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>CI job history</title>
 <style>
-  body{box-sizing:border-box;width:100%;margin:0;background:#0d0e11;color:#e7e9ee;font-family:-apple-system,Segoe UI,Roboto,sans-serif;padding:18px 20px 26px;max-width:1100px;margin:0 auto}
-  .top{display:flex;align-items:baseline;gap:10px;margin-bottom:12px;flex-wrap:wrap}
-  .top b{font-size:16px;font-weight:600}.top span{font-size:12px;color:#6f757f}
-  a.back,.note a{color:#6ea8fe;text-decoration:none;font-size:13px}
-  .views{display:flex;gap:6px;margin:0 0 14px}
-  .views a,.controls a{font-size:13px;color:#c7ccd4;text-decoration:none;border:1px solid #2f333c;border-radius:6px;padding:4px 10px}
-  .views a.on,.controls a.on{background:#6ea8fe;border-color:#6ea8fe;color:#0d0e11}
-  .controls{display:flex;flex-wrap:wrap;align-items:center;gap:6px;background:#16181d;border:1px solid #23262d;border-radius:12px;padding:12px 14px;margin-bottom:8px}
-  .controls .lbl{font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:#878d97;margin-right:6px}
-  .controls .field{display:flex;align-items:center;gap:7px;font-size:12px;color:#9aa0ab;margin-right:8px}
-  .controls .choice-group{display:flex;align-items:center;gap:6px}
-  .controls select{background:#0d0e11;color:#c7ccd4;border:1px solid #2f333c;border-radius:6px;padding:4px 7px}
-  .controls input[type=range]{width:150px}.controls output{color:#c7ccd4;min-width:46px;font-variant-numeric:tabular-nums}
-  .legend{font-size:11px;color:#777d87;margin:0 0 12px}.coverage{font-size:11px;color:#c7ccd4;font-variant-numeric:tabular-nums;margin:0 0 12px}
-  ${CI_FETCH_PROGRESS_STYLES}
-  .axisrow{display:flex;gap:18px;margin:0 14px 4px}.timeaxis{flex:0 0 42%;display:flex;justify-content:space-between;color:#666c76;font-size:10px}
-  h2{font-size:12px;letter-spacing:.04em;color:#878d97;font-weight:600;margin:20px 0 8px;font-family:ui-monospace,Menlo,monospace}
+  ${PERFORMANCE_VIEW_STYLES}
+  .coverage{font-size:11px;color:#c7ccd4;font-variant-numeric:tabular-nums;margin:0 0 12px}
   h2 span{font-family:-apple-system,Segoe UI,Roboto,sans-serif;font-weight:400;color:#666c76;margin-left:6px}
-  .clist{display:flex;flex-direction:column;gap:7px}
-  .crow{display:flex;align-items:center;gap:18px;background:#16181d;border:1px solid #23262d;border-radius:10px;padding:8px 14px}
-  .crow.good{border-color:rgba(67,197,116,.34);background:rgba(67,197,116,.06)}
-  .crow.warn{border-color:rgba(224,168,82,.42);background:rgba(224,168,82,.07)}
-  .crow.bad{border-color:rgba(226,80,74,.5);background:rgba(226,80,74,.09)}
   .crow.aggregate{border-left-width:4px}
   .crow.overall{border-left:4px solid #6ea8fe}.overall-section{margin-bottom:20px}
-  .cspark{flex:0 0 42%;min-width:0;position:relative}.cspark>div,.cspark>svg{margin-top:0!important}
-  .cmeta{flex:1 1 auto;min-width:0;display:flex;flex-direction:column;gap:2px}
-  .cname{font-size:13px;color:#c7ccd4;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
   .cdetail{font-size:11px;color:#777d87}
-  .cval{flex:none;display:flex;flex-direction:column;align-items:flex-end;color:#e7e9ee;text-decoration:none;font-size:18px;font-weight:600;font-variant-numeric:tabular-nums}
-  .ctrend{font-size:11px;font-weight:400;color:#9aa0ab}
-  .empty,.refresh-error{color:#9aa0ab;font-size:14px}.refresh-error{color:#e0a852}
-  .note{font-size:11px;color:#666c76;margin-top:22px}.note a{font-size:11px}
-  label.chk{font-size:13px;color:#c7ccd4;display:inline-flex;align-items:center;gap:6px;margin-left:auto;cursor:pointer;user-select:none}
+  .cval{flex:none;display:flex;flex-direction:column;align-items:flex-end;text-decoration:none}
   body.hide-green .crow.good{display:none}body.hide-green section:has(.clist):not(:has(.crow:not(.good))){display:none}
   .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
-  @media(max-width:640px){.timeaxis{flex:1}.crow{align-items:stretch;gap:7px;flex-wrap:wrap}.cspark{flex:1 0 100%}.cmeta{flex:1 1 55%}.cval{font-size:16px}.controls label.chk{margin-left:0}.controls .field{flex:1 1 100%}.controls input[type=range]{flex:1;width:auto}}
+  @media(max-width:640px){.cmeta{flex:1 1 55%}.cval{font-size:16px}}
 </style></head><body>
   <div class="top"><a class="back" href="/">← dashboard</a><b>Performance history</b><span>${
     escapeHtml(source.repo)
@@ -2846,7 +2870,7 @@ export function ciJobHistoryPage(
     ciPageHref(source, days, "trend", runtimeStat)
   }"${
     sort === "trend" ? ' aria-current="true"' : ""
-  }>trend</a></nav><label class="chk"><input type="checkbox" id="hg"> hide green</label></form>
+  }>trend</a></nav><label class="check trailing"><input type="checkbox" id="hg"> hide green</label></form>
   ${rangeContent}
 <script>
   const hg = document.getElementById("hg"), days = document.getElementById("days"), daysv = document.getElementById("daysv"), repo = document.getElementById("repo"), controls = days.form, KEY = "ciJobsHideGreen", DEFAULT_DAYS = days.value;
@@ -2902,15 +2926,20 @@ export function ciJobHistoryPage(
   });
   repo.addEventListener("change", () => repo.form.requestSubmit());
 
-  const renderIdle = () => {
-    collectionFailed = false;
+  const renderIdle = (lastRequestError = fetchProgress.dataset.lastRequestError || "") => {
+    collectionFailed = Boolean(lastRequestError);
     transportFailed = false;
-    fetchProgress.classList.remove("error");
+    if (lastRequestError) {
+      fetchProgress.dataset.lastRequestError = lastRequestError;
+    } else delete fetchProgress.dataset.lastRequestError;
+    fetchProgress.classList.toggle("error", collectionFailed);
     title.textContent = "Idle";
     total.textContent = "0 outstanding";
     bar.max = 1;
     bar.value = 0;
-    detail.textContent = "No requests in progress.";
+    detail.textContent = lastRequestError
+      ? "Last collection stopped: " + lastRequestError
+      : "No requests in progress.";
   };
   const refreshRangeWhenIdle = () => {
     if (navigating) return;
@@ -2938,6 +2967,9 @@ export function ciJobHistoryPage(
     collectionFailed = state.phase === "error";
     transportFailed = false;
     fetchProgress.classList.remove("error");
+    if (collectionFailed) {
+      fetchProgress.dataset.lastRequestError = state.error || "unknown error";
+    } else delete fetchProgress.dataset.lastRequestError;
     if (state.phase === "discovering") {
       title.textContent = "Finding workflow runs…";
       total.textContent = state.discoveryOutstandingRequests + " outstanding";
@@ -2966,7 +2998,8 @@ export function ciJobHistoryPage(
       total.textContent = "0 outstanding";
       bar.max = 1;
       bar.value = 0;
-      detail.textContent = "Last collection stopped: " + (state.error || "unknown error");
+      detail.textContent = "Last collection stopped: " +
+        fetchProgress.dataset.lastRequestError;
       eventStream?.close();
       eventStream = null;
       connectedProgressUrl = "";
@@ -3021,6 +3054,7 @@ export function ciJobHistoryPage(
         connectProgress("/bench/ci-progress?id=" + encodeURIComponent(state.progress.id));
         renderProgress(state.progress);
       } else if (serverVersionChanged) refreshRangeWhenIdle();
+      else if ("lastRequestError" in state) renderIdle(state.lastRequestError || "");
       else if (!collectionFailed) renderIdle();
     } catch {
       if (!eventStream && !collectionFailed && !transportFailed) renderIdle();
@@ -3219,7 +3253,12 @@ type CiJobHistoryProvider =
     CiJobHistoryCollector,
     "cached" | "startRefresh"
   >
-  & Partial<Pick<CiJobHistoryCollector, "startRefreshForCheck">>;
+  & Partial<
+    Pick<
+      CiJobHistoryCollector,
+      "lastRefreshError" | "startRefreshForCheck"
+    >
+  >;
 
 export async function ciJobHistoryCheckResponse(
   url: URL,
@@ -3240,8 +3279,15 @@ export async function ciJobHistoryCheckResponse(
       else snapshot = await refresh.result;
     }
   }
+  const lastRequestError = progress
+    ? null
+    : collector.lastRefreshError?.(source, days) ?? null;
   return Response.json(
-    { version: ciJobHistorySnapshotVersion(snapshot), progress },
+    {
+      version: ciJobHistorySnapshotVersion(snapshot),
+      progress,
+      lastRequestError,
+    },
     { headers: { "cache-control": "no-store" } },
   );
 }
@@ -3256,6 +3302,7 @@ export async function ciJobHistoryResponse(
   let snapshot = await collector.cached(source, days);
   let refreshError: string | undefined;
   let progress: CiJobFetchProgress | undefined;
+  let lastRequestError: string | undefined;
   if (!token) {
     refreshError = snapshot?.runCount
       ? "Set GH_TOKEN to refresh CI job history."
@@ -3265,6 +3312,9 @@ export async function ciJobHistoryResponse(
     progress = refresh.progress ?? undefined;
     if (progress) void refresh.result.catch(() => {});
     else snapshot = await refresh.result;
+  }
+  if (!progress) {
+    lastRequestError = collector.lastRefreshError?.(source, days) ?? undefined;
   }
   return new Response(
     ciJobHistoryPage(
@@ -3276,6 +3326,7 @@ export async function ciJobHistoryResponse(
         days,
         runtimeStat: url.searchParams.get("stat") ?? undefined,
         progress,
+        lastRequestError,
         fragment: url.searchParams.get("fragment") === "range",
       },
     ),

--- a/packages/dashboard/ctx.test.ts
+++ b/packages/dashboard/ctx.test.ts
@@ -7,6 +7,7 @@ import { CI_RUNS_MAX, CI_RUNS_MAX_AGE_DAYS, CI_WORKFLOW, LOOM_CI_WORKFLOW, LOOM_
 import type { Ctx, Run } from "./types.ts";
 
 function run(over: Partial<Run> = {}): Run {
+  const startedAt = new Date(Date.now() - 3_600_000).toISOString();
   return {
     id: 1,
     status: "completed",
@@ -15,7 +16,8 @@ function run(over: Partial<Run> = {}): Run {
     event: "push",
     head_sha: "sha",
     display_title: "t",
-    run_started_at: new Date(Date.now() - 3_600_000).toISOString(),
+    created_at: startedAt,
+    run_started_at: startedAt,
     updated_at: new Date().toISOString(),
     html_url: "",
     head_commit: { message: "t (#1)" },

--- a/packages/dashboard/lib.test.ts
+++ b/packages/dashboard/lib.test.ts
@@ -128,6 +128,25 @@ Deno.test("sparkline: scale normalizes to the recent runs, clipping old spikes",
   assertEquals(clean.slice(1), recent);
 });
 
+Deno.test("sparkline: a trimmed scale ignores ranked extremes without reordering points", () => {
+  const values = [101, 10, 0, 25, 100, 11, 1, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24];
+  const scale = { trim: 2, minValues: 20 };
+  const svg = sparkline(values, "#111", undefined, undefined, undefined, scale);
+  const ys = svg.match(/<polyline points="([^"]*)"/)![1].trim().split(" ")
+    .map((point) => parseFloat(point.split(",")[1]));
+
+  assertEquals(values, [101, 10, 0, 25, 100, 11, 1, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24]); // sorting the scale does not mutate the line
+  assert(ys[0] < 0 && ys[4] < 0, "the two highest values should clip above the chart");
+  assert(ys[2] > 26 && ys[6] > 26, "the two lowest values should clip below the chart");
+  assert(ys[1] >= 0 && ys[1] <= 26 && ys[3] >= 0 && ys[3] <= 26, "20 points should enable trimming");
+
+  const short = Array.from({ length: 19 }, (_, value) => value);
+  assertEquals(
+    sparkline(short, "#111", undefined, undefined, undefined, scale),
+    sparkline(short, "#111"),
+  );
+});
+
 Deno.test("sparkline: highlight scaleAll keeps the whole series in view, still drawing the tail", () => {
   const y = (pt: string) => parseFloat(pt.split(",")[1]);
   const polys = (svg: string) => [...svg.matchAll(/<polyline points="([^"]*)"/g)].map((m) => m[1].trim().split(" ").map(y));
@@ -191,6 +210,38 @@ Deno.test("multiSparkline: overlaid lines on one shared scale; < 2 points is emp
   ]);
   assert(/right:0[^"]*color:#0a0[^"]*">3<\/span>/.test(labeled), "team label at right, in the line color");
   assert(/right:0[^"]*color:#00a[^"]*">6<\/span>/.test(labeled), "visitor label at right, in the line color");
+});
+
+Deno.test("multiSparkline: a trimmed shared scale pools series and centers a flat interior", () => {
+  const scale = { trim: 2, minValues: 20 };
+  const lines = [
+    { vals: [101, 10, 0, 25, 100, 11, 1, 12, 13, 14], color: "#0a0" },
+    { vals: [15, 16, 17, 18, 19, 20, 21, 22, 23, 24], color: "#00a" },
+  ];
+  const svg = multiSparkline(lines, { scale });
+  const ys = [...svg.matchAll(/<polyline points="([^"]*)"/g)]
+    .flatMap((match) => match[1].trim().split(" "))
+    .map((point) => parseFloat(point.split(",")[1]));
+
+  assertEquals(ys.length, 20);
+  assertEquals(ys.filter((y) => y > 34).length, 2);
+  assertEquals(ys.filter((y) => y < 0).length, 2);
+  assertEquals(ys.filter((y) => y >= 0 && y <= 34).length, 16);
+
+  const short = [
+    { vals: Array.from({ length: 9 }, (_, value) => value), color: "#0a0" },
+    { vals: Array.from({ length: 10 }, (_, value) => value + 9), color: "#00a" },
+  ];
+  assertEquals(multiSparkline(short, { scale }), multiSparkline(short));
+
+  const flat = multiSparkline([
+    { vals: [0, 10, 10, 10, 10, 10, 10, 10, 10, 100], color: "#0a0" },
+    { vals: [1, 10, 10, 10, 10, 10, 10, 10, 10, 101], color: "#00a" },
+  ], { scale });
+  const flatYs = [...flat.matchAll(/<polyline points="([^"]*)"/g)]
+    .flatMap((match) => match[1].trim().split(" "))
+    .map((point) => parseFloat(point.split(",")[1]));
+  assertEquals(flatYs.filter((y) => y === 17).length, 16);
 });
 
 Deno.test("multiSparkline: fadeFrom gradients each line", () => {

--- a/packages/dashboard/lib.ts
+++ b/packages/dashboard/lib.ts
@@ -256,6 +256,16 @@ export function durationTag(ms: number): string {
   return `<span style="position:absolute;left:1px;bottom:0;font-size:9px;line-height:1;color:#c7ccd4;pointer-events:none">${escapeHtml(humanSpan(ms))}</span>`;
 }
 
+function scaleValues(
+  vals: number[],
+  scale: { trim?: number; minValues?: number } | undefined,
+): number[] {
+  const count = Math.max(0, Math.floor(scale?.trim ?? 0));
+  const minimum = Math.max(count * 2 + 2, scale?.minValues ?? 0);
+  if (count === 0 || vals.length < minimum) return vals;
+  return [...vals].sort((a, b) => a - b).slice(count, -count);
+}
+
 // A trend line from a numeric series (oldest -> newest). With `highlight`, the
 // trailing `count` points are overdrawn in a second color (e.g. to pick out the
 // most recent runs against a longer trend). The vertical scale is normalized to
@@ -266,13 +276,17 @@ export function durationTag(ms: number): string {
 // fraction 0..1 of the width (for placing several sparklines on one shared axis —
 // e.g. a real time axis); a series that doesn't reach the ends occupies only part
 // of the width. Without it, points are spaced evenly. The line has no label of its
-// own — a tile's `duration` slot draws the span in the corner.
+// own — a tile's `duration` slot draws the span in the corner. `scale.trim`
+// excludes that many values from each end of the sorted scale inputs without
+// removing the points themselves. A series below `scale.minValues`, or too short
+// to leave two scale values, keeps its full range.
 export function sparkline(
   vals: number[],
   color: string,
   highlight?: { count: number; color: string; scaleAll?: boolean },
   fadeFrom?: string,
   xs?: number[],
+  scale?: { trim?: number; minValues?: number },
 ): string {
   if (vals.length < 2) return "";
   const w = 220, h = 26;
@@ -280,7 +294,8 @@ export function sparkline(
   // series in view while still brightening the tail (for series whose recent
   // window can sit far from the historical range, e.g. a near-zero error rate).
   const recent = highlight && !highlight.scaleAll ? vals.slice(-highlight.count) : vals;
-  const lo = Math.min(...recent), hi = Math.max(...recent);
+  const scaled = scaleValues(recent, scale);
+  const lo = Math.min(...scaled), hi = Math.max(...scaled);
   const pad = (hi - lo) * 0.125 || 0.5; // 12.5% each side ≈ +25% range; a floor for a flat series
   const min = lo - pad, rng = (hi + pad) - min;
   // Place each point at its `xs` fraction of the width (shared axis), else evenly.
@@ -330,7 +345,8 @@ export function sparkline(
 // fraction of the chart. `showSinglePoint` draws explicit markers for a
 // one-sample series and for points isolated by those breaks. All overlays are
 // HTML or gradients, so preserveAspectRatio="none" cannot distort them. The
-// span it covers is drawn separately by a tile's `duration` slot.
+// span it covers is drawn separately by a tile's `duration` slot. `opts.scale`
+// has the same trimming behavior as `sparkline`.
 export function multiSparkline(
   series: {
     vals: number[];
@@ -341,7 +357,11 @@ export function multiSparkline(
     maxXGap?: number;
     showSinglePoint?: boolean;
   }[],
-  opts: { fadeFrom?: string; highlight?: { count: number } } = {},
+  opts: {
+    fadeFrom?: string;
+    highlight?: { count: number };
+    scale?: { trim?: number; minValues?: number };
+  } = {},
 ): string {
   const drawable = series.filter((line) =>
     line.vals.length >= 2 ||
@@ -349,7 +369,11 @@ export function multiSparkline(
   );
   const all = drawable.flatMap((line) => line.vals);
   if (!all.length) return "";
-  const w = 220, h = 34, min = Math.min(...all), max = Math.max(...all), rng = (max - min) || 1;
+  const scaled = scaleValues(all, opts.scale);
+  const lo = Math.min(...scaled), hi = Math.max(...scaled);
+  // Match sparkline's centered flat range when trimming leaves two equal values.
+  const pad = scaled === all || lo !== hi ? 0 : 0.5;
+  const w = 220, h = 34, min = lo - pad, max = hi + pad, rng = (max - min) || 1;
   const yv = (v: number) => h - 3 - ((v - min) / rng) * (h - 6);
 
   // Each line fades from `fadeFrom` on the left up to its own color, reaching full

--- a/packages/dashboard/performance-views.ts
+++ b/packages/dashboard/performance-views.ts
@@ -10,6 +10,52 @@ export interface PerformanceViewState {
 }
 
 export const PERFORMANCE_CHECK_MS = 60_000;
+export const PERFORMANCE_HISTORY_SCALE_MIN_VALUES = 20;
+export const PERFORMANCE_HISTORY_SCALE_TRIM = 2;
+
+export const PERFORMANCE_PROGRESS_STYLES = `
+  .fetch-progress{background:#16181d;border:1px solid #2f333c;border-radius:10px;padding:10px 12px;margin:0 0 12px}
+  .fetch-progress.error,.fetch-progress.warning{border-color:rgba(224,168,82,.42)}
+  .fetch-head{display:flex;justify-content:space-between;gap:12px;align-items:baseline;font-size:12px;color:#c7ccd4}
+  .fetch-head strong{font-weight:600}.fetch-head span,#fetch-detail{font-variant-numeric:tabular-nums;color:#878d97}
+  .fetch-progress progress{display:block;width:100%;height:7px;margin:7px 0 6px;accent-color:#6ea8fe}
+  #fetch-detail{font-size:11px;margin:0}`;
+
+export const PERFORMANCE_VIEW_STYLES = `
+  body{box-sizing:border-box;width:100%;margin:0 auto;background:#0d0e11;color:#e7e9ee;font-family:-apple-system,Segoe UI,Roboto,sans-serif;padding:18px 20px 26px;max-width:1100px}
+  .top{display:flex;align-items:baseline;gap:10px;margin-bottom:14px;flex-wrap:wrap}
+  .top b{font-size:16px;font-weight:600}.top span{font-size:12px;color:#6f757f}
+  a.back{color:#6ea8fe;text-decoration:none;font-size:13px}
+  .views{display:flex;gap:6px;margin:0 0 14px}
+  .views a,.controls a{font-size:13px;color:#c7ccd4;text-decoration:none;border:1px solid #2f333c;border-radius:6px;padding:4px 10px}
+  .controls a{font-variant-numeric:tabular-nums}.controls a:hover{border-color:#3a4150}
+  .views a.on,.controls a.on{background:#6ea8fe;border-color:#6ea8fe;color:#0d0e11}
+  .controls{display:flex;flex-wrap:wrap;align-items:center;gap:6px;background:#16181d;border:1px solid #23262d;border-radius:12px;padding:12px 14px;margin-bottom:8px}
+  .controls .lbl{font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:#878d97;margin-right:6px}
+  .controls .field{display:flex;align-items:center;gap:7px;font-size:12px;color:#9aa0ab;margin-right:8px}
+  .controls .choice-group{display:flex;flex-wrap:wrap;align-items:center;gap:6px}
+  .controls select{background:#0d0e11;color:#c7ccd4;border:1px solid #2f333c;border-radius:6px;padding:4px 7px}
+  .controls input[type=range]{width:150px}.controls output{color:#c7ccd4;min-width:46px;font-variant-numeric:tabular-nums}
+  .controls label.check{font-size:13px;color:#c7ccd4;display:inline-flex;align-items:center;gap:6px;cursor:pointer;user-select:none}
+  .controls label.trailing{margin-left:auto}
+  .legend{font-size:11px;color:#777d87;margin:0 0 12px}
+  ${PERFORMANCE_PROGRESS_STYLES}
+  .axisrow{display:flex;gap:18px;margin:0 14px 4px}.timeaxis{flex:0 0 42%;display:flex;justify-content:space-between;color:#666c76;font-size:10px}
+  h2{font-size:12px;letter-spacing:.04em;color:#878d97;font-weight:600;margin:20px 0 8px;font-family:ui-monospace,Menlo,monospace}
+  .blist,.clist{display:flex;flex-direction:column;gap:7px}
+  .brow,.crow{display:flex;align-items:center;gap:18px;background:#16181d;border:1px solid #23262d;border-radius:10px;padding:8px 14px}
+  .brow.good,.crow.good{border-color:rgba(67,197,116,.34);background:rgba(67,197,116,.06)}
+  .brow.warn,.crow.warn{border-color:rgba(224,168,82,.42);background:rgba(224,168,82,.07)}
+  .brow.bad,.crow.bad{border-color:rgba(226,80,74,.5);background:rgba(226,80,74,.09)}
+  .bspark,.cspark{flex:0 0 42%;min-width:0;position:relative}
+  .bspark>div,.bspark>svg,.cspark>div,.cspark>svg{margin-top:0!important}
+  .bmeta,.cmeta{flex:1 1 auto;min-width:0;display:flex;flex-direction:column;gap:2px}
+  .bname,.cname{font-size:13px;color:#c7ccd4;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .bval,.cval{color:#e7e9ee;font-size:18px;font-weight:600;font-variant-numeric:tabular-nums}
+  .btrend,.ctrend{font-size:11px;font-weight:400;color:#9aa0ab}
+  .empty,.refresh-error{color:#9aa0ab;font-size:14px}.refresh-error{color:#e0a852}
+  .note{font-size:11px;color:#666c76;margin-top:22px}.note a{color:#6ea8fe;text-decoration:none}
+  @media(max-width:640px){.timeaxis{flex:1}.brow,.crow{align-items:stretch;gap:7px;flex-wrap:wrap}.bspark,.cspark{flex:1 0 100%}.controls .field,.controls .choice-group{flex:1 1 100%}.controls input[type=range]{flex:1;width:auto;min-width:0}.controls label.trailing{margin-left:0}}`;
 
 const labels: Record<PerformanceView, string> = {
   runtime: "Runtime benchmarks",

--- a/packages/dashboard/server.test.ts
+++ b/packages/dashboard/server.test.ts
@@ -46,6 +46,7 @@ function sourceRun(id: number, title: string): Run {
     event: "push",
     head_sha: `sha-${id}`,
     display_title: title,
+    created_at: new Date(Date.now() - id * 60_000).toISOString(),
     run_started_at: new Date(Date.now() - id * 60_000).toISOString(),
     updated_at: new Date().toISOString(),
     html_url: "",

--- a/packages/dashboard/tiles.test.ts
+++ b/packages/dashboard/tiles.test.ts
@@ -43,6 +43,7 @@ function ctx(
 let nextRunId = 1;
 
 function run(over: Partial<Run>): Run {
+  const startedAt = new Date(Date.now() - 3_600_000).toISOString();
   return {
     id: nextRunId++,
     status: "completed",
@@ -51,7 +52,8 @@ function run(over: Partial<Run>): Run {
     event: "push",
     head_sha: "sha",
     display_title: "t",
-    run_started_at: new Date(Date.now() - 3_600_000).toISOString(),
+    created_at: startedAt,
+    run_started_at: startedAt,
     updated_at: new Date().toISOString(),
     html_url: "",
     head_commit: { message: "t (#1)" },
@@ -141,6 +143,7 @@ Deno.test("ci-duration window: the 6h window when it has >= 20 runs, else the mo
   const now = Date.now();
   const at = (minsAgo: number) =>
     run({
+      created_at: new Date(now - minsAgo * 60_000).toISOString(),
       run_started_at: new Date(now - minsAgo * 60_000).toISOString(),
       updated_at: new Date(now - minsAgo * 60_000 + 5 * 60_000).toISOString(),
     });
@@ -165,6 +168,7 @@ Deno.test("ci-duration: only runs that passed end to end count", async () => {
   const now = Date.now();
   const at = (i: number, over: Partial<Run>) =>
     run({
+      created_at: new Date(now - i * 60_000).toISOString(),
       run_started_at: new Date(now - i * 60_000).toISOString(),
       updated_at: new Date(now - i * 60_000 + 5 * 60_000).toISOString(),
       ...over,
@@ -175,12 +179,47 @@ Deno.test("ci-duration: only runs that passed end to end count", async () => {
     at(1, { conclusion: "cancelled" }),
     at(2, { conclusion: "timed_out" }),
     at(3, { status: "in_progress", conclusion: null }),
+    at(4, { event: "workflow_dispatch", conclusion: "success" }),
   ];
-  // Only the 20 successful runs are counted; the rest are ignored.
+  // Only the 20 successful push runs are counted; the rest are ignored.
   assertStringIncludes(
     (await labsCiDuration.collect(ctx(runs))).sub ?? "",
     "20 passing runs in the last 6h",
   );
+});
+
+Deno.test("ci-duration: a run without a usable landing span is dropped", async () => {
+  const now = Date.now();
+  const usable = run({
+    created_at: new Date(now - 10 * 60_000).toISOString(),
+    run_started_at: new Date(now - 10 * 60_000).toISOString(),
+    updated_at: new Date(now).toISOString(),
+  });
+  // A final update at or before the landing trigger, and a landing trigger that
+  // does not parse. Both would otherwise reach the median as a duration of zero
+  // or NaN minutes.
+  const endsBeforeItLands = run({
+    created_at: new Date(now).toISOString(),
+    run_started_at: new Date(now).toISOString(),
+    updated_at: new Date(now - 60_000).toISOString(),
+  });
+  const unparseableLanding = run({
+    created_at: "the fourteenth of never",
+    run_started_at: new Date(now - 20 * 60_000).toISOString(),
+    updated_at: new Date(now).toISOString(),
+  });
+
+  const mixed = await labsCiDuration.collect(
+    ctx([usable, endsBeforeItLands, unparseableLanding]),
+  );
+  assertEquals(mixed.value, "10m");
+  assertStringIncludes(mixed.sub ?? "", "last 1 passing runs");
+
+  const none = await labsCiDuration.collect(
+    ctx([endsBeforeItLands, unparseableLanding]),
+  );
+  assertEquals(none.status, "unknown");
+  assertEquals(none.value, "—");
 });
 
 Deno.test("recent-runs: wide, failure tip -> bad, rows link to the landing PR", async () => {

--- a/packages/dashboard/tiles/benchmark.test.ts
+++ b/packages/dashboard/tiles/benchmark.test.ts
@@ -32,7 +32,12 @@ import {
   trendPct,
   trendStatus,
 } from "./benchmark.ts";
-import { CI_HISTORY_MIN_DAYS, ciHistoryBucketMs } from "../ci-job-history.ts";
+import {
+  CI_HISTORY_MIN_DAYS,
+  CI_HISTORY_POINT_TARGET,
+  ciHistoryBucketMs,
+} from "../ci-job-history.ts";
+import { PERFORMANCE_VIEW_STYLES } from "../performance-views.ts";
 
 const DAY = 86_400_000;
 const HOUR = 3_600_000;
@@ -536,6 +541,7 @@ Deno.test("fresh runtime history serves the page and update check without discov
     assertEquals(await check.json(), {
       version: checkIsolated.benchmarkSnapshotVersion(),
       progress: null,
+      lastRequestError: null,
     });
     assertEquals(calls, []);
   } finally {
@@ -787,6 +793,18 @@ Deno.test("runtime history shows live artifact progress and keeps collection run
     );
     assertStringIncludes(
       html,
+      'else if ("lastRequestError" in state) renderIdle(state.lastRequestError || "");',
+    );
+    assertStringIncludes(
+      html,
+      "else if (!collectionFailed) renderIdle();",
+    );
+    assertStringIncludes(
+      html,
+      "else delete fetchProgress.dataset.lastRequestError;",
+    );
+    assertStringIncludes(
+      html,
       "if (!eventStream && !collectionFailed && !transportFailed) renderIdle()",
     );
     assertStringIncludes(html, "transportFailed = true");
@@ -846,6 +864,11 @@ Deno.test("/bench before any data shows an idle progress panel", async () => {
     html,
     'href="/bench?view=gantt&amp;repo=labs&amp;days=45&amp;sort=job&amp;stat=p99">CI run Gantt</a>',
   );
+  assertStringIncludes(
+    html,
+    "charts reduce longer windows to about 200 evenly spaced points",
+  );
+  assertStringIncludes(html, PERFORMANCE_VIEW_STYLES);
   assert(
     !html.includes('class="brow'),
     "no rows are drawn with nothing to draw",
@@ -2324,7 +2347,7 @@ Deno.test("/bench?sort=duration lists the longest displayed benchmark first", as
 
 Deno.test("/bench history windows keep about the same chart point count", () => {
   const now = 45 * DAY;
-  const step = 10 * 60_000;
+  const step = 5 * 60_000;
   const points = Array.from(
     { length: Math.floor(45 * DAY / step) + 1 },
     (_, index) => ({ at: now - index * step }),
@@ -2336,8 +2359,14 @@ Deno.test("/bench history windows keep about the same chart point count", () => 
     ciHistoryBucketMs(CI_HISTORY_MIN_DAYS),
   );
 
-  assert(full.length >= 89 && full.length <= 91);
-  assert(short.length >= 89 && short.length <= 91);
+  assert(
+    full.length >= CI_HISTORY_POINT_TARGET - 1 &&
+      full.length <= CI_HISTORY_POINT_TARGET + 1,
+  );
+  assert(
+    short.length >= CI_HISTORY_POINT_TARGET - 1 &&
+      short.length <= CI_HISTORY_POINT_TARGET + 1,
+  );
 });
 
 Deno.test("representative benchmark CPU prefers coverage, recency, then name", () => {
@@ -2372,7 +2401,7 @@ Deno.test("representative benchmark CPU prefers coverage, recency, then name", (
 
 Deno.test("benchmark collection retains enough runs for the shortest history window", () => {
   const now = 45 * DAY;
-  const step = 10 * 60_000;
+  const step = 5 * 60_000;
   const runs = Array.from(
     { length: Math.floor(45 * DAY / step) + 1 },
     (_, index) => ghRun(30_000 + index, now - index * step),
@@ -2387,7 +2416,10 @@ Deno.test("benchmark collection retains enough runs for the shortest history win
     now,
   );
 
-  assert(short.length >= 89 && short.length <= 91);
+  assert(
+    short.length >= CI_HISTORY_POINT_TARGET - 1 &&
+      short.length <= CI_HISTORY_POINT_TARGET + 1,
+  );
 });
 
 Deno.test("/bench: the measurement selector changes what is plotted", async () => {
@@ -2418,6 +2450,84 @@ Deno.test("/bench: the measurement selector changes what is plotted", async () =
     await page("?sort=nonsense"),
     "<h2>packages/html/render.bench.ts</h2>",
   );
+});
+
+Deno.test("/bench runtime graphs ignore two values at each end when twenty are shown", async () => {
+  const directory = await Deno.makeTempDir({ prefix: "benchmark-scale-" });
+  const previousCacheDirectory = Deno.env.get("DASHBOARD_CACHE_DIR");
+  const values = [
+    102,
+    11,
+    1,
+    26,
+    101,
+    12,
+    2,
+    13,
+    14,
+    15,
+    16,
+    17,
+    18,
+    19,
+    20,
+    21,
+    22,
+    23,
+    24,
+    25,
+  ];
+  Deno.env.set("DASHBOARD_CACHE_DIR", directory);
+  try {
+    const store = new BenchmarkHistoryStore(
+      `${directory}/fabric-wall-benchmark-history.json`,
+    );
+    await store.load();
+    const cached = values.map((value, index) =>
+      store.set({
+        runId: 120_000 + index,
+        runAttempt: 1,
+        at: BASE - (values.length - 1 - index) * DAY,
+        cpu: TEST_CPU,
+        metrics: new Map([[
+          "packages/a/scale.bench.ts > scale",
+          {
+            min: value,
+            avg: value,
+            max: value,
+            p75: value,
+            p99: value,
+            p995: value,
+            p999: value,
+          },
+        ]]),
+      })
+    );
+    store.markRefreshed(Date.now(), cached);
+    await store.save();
+
+    const isolated = await import(
+      `./benchmark.ts?scale=${crypto.randomUUID()}`
+    );
+    const response = await isolated.benchmarkHistoryResponse(
+      new URL("http://x/bench?view=runtime"),
+      ctx(),
+    );
+    const html = await response.text();
+    const points = html
+      .match(/<polyline points="([^"]+)"/)?.[1]
+      .split(" ")
+      .map((point: string) => Number(point.split(",")[1]));
+
+    assert(points, html);
+    assertEquals(points.filter((point: number) => point < 0).length, 2);
+    assertEquals(points.filter((point: number) => point > 34).length, 2);
+  } finally {
+    if (previousCacheDirectory === undefined) {
+      Deno.env.delete("DASHBOARD_CACHE_DIR");
+    } else Deno.env.set("DASHBOARD_CACHE_DIR", previousCacheDirectory);
+    await Deno.remove(directory, { recursive: true });
+  }
 });
 
 Deno.test("/bench: the history slider selects and clamps the displayed days", async () => {
@@ -3107,13 +3217,37 @@ Deno.test("runtime history reports a recent failed collection without starting a
   const directory = await Deno.makeTempDir({ prefix: "benchmark-failure-" });
   const previousCacheDirectory = Deno.env.get("DASHBOARD_CACHE_DIR");
   const originalFetch = globalThis.fetch;
+  let workflowRequests = 0;
   Deno.env.set("DASHBOARD_CACHE_DIR", directory);
   globalThis.fetch = ((input: RequestInfo | URL) => {
     const url = new URL(input instanceof Request ? input.url : String(input));
     if (url.pathname === "/rate_limit") return Promise.resolve(serve({})(url));
+    workflowRequests++;
     return Promise.resolve(new Response("unavailable", { status: 503 }));
   }) as typeof fetch;
   try {
+    const store = new BenchmarkHistoryStore();
+    await store.load();
+    store.set({
+      runId: 130_001,
+      runAttempt: 1,
+      at: BASE,
+      cpu: TEST_CPU,
+      metrics: new Map([[
+        "packages/a/failure.bench.ts > cached result",
+        {
+          min: 10,
+          avg: 10,
+          max: 10,
+          p75: 10,
+          p99: 10,
+          p995: 10,
+          p999: 10,
+        },
+      ]]),
+    });
+    await store.save();
+
     const isolated = await import(
       `./benchmark.ts?failure=${crypto.randomUUID()}`
     );
@@ -3123,6 +3257,7 @@ Deno.test("runtime history reports a recent failed collection without starting a
       tokenContext,
     );
     const firstHtml = await first.text();
+    assertStringIncludes(firstHtml, "failure.bench.ts");
     const id = firstHtml.match(/runtime-progress\?id=([^"&]+)/)?.[1];
     assert(id);
     assertStringIncludes(
@@ -3132,11 +3267,44 @@ Deno.test("runtime history reports a recent failed collection without starting a
       '"phase":"error"',
     );
 
+    const check = await isolated.benchmarkHistoryCheckResponse(tokenContext);
+    const checkState = await check.json();
+    assertEquals(checkState.progress, null);
+    assertEquals(checkState.lastRequestError, "temporarily unavailable");
+
+    const originalNow = Date.now;
+    Date.now = () => originalNow() + 31 * 60_000;
+    try {
+      const laterCheck = await isolated.benchmarkHistoryCheckResponse(ctx());
+      const laterState = await laterCheck.json();
+      assertEquals(laterState.progress, null);
+      assertEquals(laterState.lastRequestError, "temporarily unavailable");
+    } finally {
+      Date.now = originalNow;
+    }
+
     const second = await isolated.benchmarkHistoryResponse(
       new URL("http://x/bench?view=runtime"),
       tokenContext,
     );
-    assertStringIncludes(await second.text(), "Last collection stopped:");
+    const secondHtml = await second.text();
+    assertStringIncludes(secondHtml, "failure.bench.ts");
+    assertStringIncludes(secondHtml, 'class="fetch-progress error"');
+    assertStringIncludes(
+      secondHtml,
+      'data-last-request-error="temporarily unavailable"',
+    );
+    assertStringIncludes(
+      secondHtml,
+      '<p id="fetch-detail">Last collection stopped: temporarily unavailable</p>',
+    );
+    assertEquals(
+      secondHtml.match(
+        /<p id="fetch-detail">Last collection stopped: temporarily unavailable<\/p>/g,
+      )?.length,
+      1,
+    );
+    assertEquals(workflowRequests, 1);
   } finally {
     globalThis.fetch = originalFetch;
     if (previousCacheDirectory === undefined) {

--- a/packages/dashboard/tiles/benchmark.ts
+++ b/packages/dashboard/tiles/benchmark.ts
@@ -70,6 +70,9 @@ import {
 } from "../config.ts";
 import {
   PERFORMANCE_CHECK_MS,
+  PERFORMANCE_HISTORY_SCALE_MIN_VALUES,
+  PERFORMANCE_HISTORY_SCALE_TRIM,
+  PERFORMANCE_VIEW_STYLES,
   performanceViewHref,
   performanceViewNav,
 } from "../performance-views.ts";
@@ -1189,6 +1192,12 @@ function benchmarkRefreshRecentlyFailed(now = Date.now()): boolean {
   );
 }
 
+function benchmarkLastRequestError(): string | null {
+  return benchmarkRefreshFailedAt
+    ? benchmarkRefreshError || "temporarily unavailable"
+    : null;
+}
+
 function benchmarkServerContext(): Ctx {
   return {
     runs: () => Promise.resolve([]),
@@ -1325,10 +1334,7 @@ export async function benchmarkHistoryResponse(
       ? "Set GH_TOKEN to refresh runtime benchmark history."
       : "Set GH_TOKEN to collect runtime benchmark history.";
   }
-  if (token && benchmarkRefreshRecentlyFailed()) {
-    refreshError = `Last collection stopped: ${benchmarkRefreshError}`;
-  }
-  if (token && !refreshError) {
+  if (token && !benchmarkRefreshRecentlyFailed()) {
     const refresh = startBenchmarkRefresh(
       ctx,
       baseline,
@@ -1338,6 +1344,9 @@ export async function benchmarkHistoryResponse(
     if (progress) void refresh.result;
     else await refresh.result;
   }
+  const lastRequestError = progress
+    ? undefined
+    : benchmarkLastRequestError() ?? undefined;
   return new Response(
     benchPage(
       url.searchParams.get("stat") ?? DEFAULT_LABEL,
@@ -1348,6 +1357,7 @@ export async function benchmarkHistoryResponse(
       {
         progress,
         refreshError,
+        lastRequestError,
         fragment: url.searchParams.get("fragment") === "range",
       },
     ),
@@ -1375,8 +1385,9 @@ export async function benchmarkHistoryCheckResponse(
     if (progress) void refresh.result;
     else await refresh.result;
   }
+  const lastRequestError = progress ? null : benchmarkLastRequestError();
   return Response.json(
-    { version: benchmarkSnapshotVersion(), progress },
+    { version: benchmarkSnapshotVersion(), progress, lastRequestError },
     { headers: { "cache-control": "no-store" } },
   );
 }
@@ -1487,6 +1498,7 @@ const dateLabel = (at: number): string =>
 interface BenchmarkPageOptions {
   progress?: BenchmarkFetchProgress;
   refreshError?: string;
+  lastRequestError?: string;
   fragment?: boolean;
 }
 
@@ -1530,6 +1542,11 @@ export function benchPage(
   const progress = options.progress;
   const progressIdle = !progress || progress.phase === "complete" ||
     progress.phase === "error";
+  const lastRequestError = progress?.phase === "error"
+    ? progress.error ?? "unknown error"
+    : !progress
+    ? options.lastRequestError
+    : undefined;
   const progressTitle = progressIdle
     ? "Idle"
     : progress.phase === "discovering"
@@ -1538,10 +1555,8 @@ export function benchPage(
   const progressTotal = progressIdle
     ? "0 outstanding"
     : `${progress.completedRuns} / ${progress.totalRuns || "?"}`;
-  const progressDetail = progress?.phase === "error"
-    ? `Last collection stopped: ${
-      escapeHtml(progress.error ?? "unknown error")
-    }`
+  const progressDetail = lastRequestError
+    ? `Last collection stopped: ${escapeHtml(lastRequestError)}`
     : !progressIdle && progress
     ? `${progress.cachedRuns} cached · ${progress.requestsMade} artifact checks made · ${progress.responsesReceived} responded · ${progress.outstandingRequests} outstanding · ${progress.queuedRuns} queued`
     : "No requests in progress.";
@@ -1550,20 +1565,25 @@ export function benchPage(
       escapeHtml(encodeURIComponent(progress.id))
     }`
     : "";
-  const progressHtml =
-    `<section class="fetch-progress" id="fetch-progress" aria-live="polite" data-check-url="/bench/check?view=runtime" data-snapshot-version="${
-      escapeHtml(version)
-    }" data-refresh-on-complete="${
-      progress && !progressIdle && !snapshot.length ? "1" : "0"
-    }"${
-      progressUrl ? ` data-progress-url="${progressUrl}"` : ""
-    }><div class="fetch-head"><strong id="fetch-title">${progressTitle}</strong><span id="fetch-total">${progressTotal}</span></div><progress id="fetch-bar" max="${
-      progressIdle ? 1 : Math.max(1, progress?.totalRuns ?? 1)
-    }"${
-      !progressIdle && progress && !progress.totalRuns
-        ? ""
-        : ` value="${progressIdle ? 0 : progress?.completedRuns ?? 0}"`
-    } aria-label="Runtime benchmark fetch progress"></progress><p id="fetch-detail">${progressDetail}</p></section>`;
+  const progressHtml = `<section class="fetch-progress${
+    lastRequestError ? " error" : ""
+  }" id="fetch-progress" aria-live="polite" data-check-url="/bench/check?view=runtime" data-snapshot-version="${
+    escapeHtml(version)
+  }" data-refresh-on-complete="${
+    progress && !progressIdle && !snapshot.length ? "1" : "0"
+  }"${
+    lastRequestError
+      ? ` data-last-request-error="${escapeHtml(lastRequestError)}"`
+      : ""
+  }${
+    progressUrl ? ` data-progress-url="${progressUrl}"` : ""
+  }><div class="fetch-head"><strong id="fetch-title">${progressTitle}</strong><span id="fetch-total">${progressTotal}</span></div><progress id="fetch-bar" max="${
+    progressIdle ? 1 : Math.max(1, progress?.totalRuns ?? 1)
+  }"${
+    !progressIdle && progress && !progress.totalRuns
+      ? ""
+      : ` value="${progressIdle ? 0 : progress?.completedRuns ?? 0}"`
+  } aria-label="Runtime benchmark fetch progress"></progress><p id="fetch-detail">${progressDetail}</p></section>`;
   const refreshNotice = options.refreshError && snapshot.length
     ? `<p class="refresh-error">${escapeHtml(options.refreshError)}</p>`
     : "";
@@ -1636,7 +1656,13 @@ export function benchPage(
           maxXGap: CPU_LINE_MAX_X_GAP,
           showSinglePoint: true,
         })),
-        { fadeFrom: SPARK_FADE[status] },
+        {
+          fadeFrom: SPARK_FADE[status],
+          scale: {
+            trim: PERFORMANCE_HISTORY_SCALE_TRIM,
+            minValues: PERFORMANCE_HISTORY_SCALE_MIN_VALUES,
+          },
+        },
       );
       return [{
         key: s.key,
@@ -1779,47 +1805,15 @@ export function benchPage(
     escapeHtml(stat.label)
   }</title>
 <style>
-  body{box-sizing:border-box;width:100%;margin:0;background:#0d0e11;color:#e7e9ee;font-family:-apple-system,Segoe UI,Roboto,sans-serif;padding:18px 20px 26px;max-width:1100px;margin:0 auto}
-  .top{display:flex;align-items:baseline;gap:10px;margin-bottom:14px;flex-wrap:wrap}
-  .top b{font-size:16px;font-weight:600}.top span{font-size:12px;color:#6f757f}
-  a.back{color:#6ea8fe;text-decoration:none;font-size:13px}
-  .views{display:flex;gap:6px;margin:0 0 14px}
-  .views a{font-size:13px;color:#c7ccd4;text-decoration:none;border:1px solid #2f333c;border-radius:6px;padding:4px 10px}
-  .views a.on{background:#6ea8fe;border-color:#6ea8fe;color:#0d0e11}
-  .controls{display:flex;flex-wrap:wrap;align-items:center;gap:6px;background:#16181d;border:1px solid #23262d;border-radius:12px;padding:12px 14px;margin-bottom:8px}
-  .controls .lbl{font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:#878d97;margin-right:6px}
-  .controls .field{display:flex;align-items:center;gap:7px;font-size:12px;color:#9aa0ab;margin-right:8px}
-  .controls .choice-group{display:flex;flex-wrap:wrap;align-items:center;gap:6px}
-  .controls input[type=range]{width:150px}.controls output{color:#c7ccd4;min-width:46px;font-variant-numeric:tabular-nums}
-  a.stat{font-size:13px;color:#c7ccd4;text-decoration:none;border:1px solid #2f333c;border-radius:6px;padding:3px 9px;font-variant-numeric:tabular-nums}
-  a.stat:hover{border-color:#3a4150}
-  a.stat.on{background:#6ea8fe;border-color:#6ea8fe;color:#0d0e11}
-  .legend{font-size:11px;color:#666c76;margin:0 0 16px}
-  .fetch-progress{background:#16181d;border:1px solid #2f333c;border-radius:10px;padding:10px 12px;margin:0 0 12px}
-  .fetch-progress.error{border-color:rgba(224,168,82,.42)}
-  .fetch-head{display:flex;justify-content:space-between;gap:12px;align-items:baseline;font-size:12px;color:#c7ccd4}
-  .fetch-head strong{font-weight:600}.fetch-head span,#fetch-detail{font-variant-numeric:tabular-nums;color:#878d97}
-  .fetch-progress progress{display:block;width:100%;height:7px;margin:7px 0 6px;accent-color:#6ea8fe}
-  #fetch-detail{font-size:11px;margin:0}
-  .axisrow{display:flex;gap:18px;margin:0 14px 4px}.timeaxis{flex:0 0 42%;display:flex;justify-content:space-between;color:#666c76;font-size:10px}
-  h2{font-size:12px;letter-spacing:.04em;color:#878d97;font-weight:600;margin:20px 0 8px;font-family:ui-monospace,Menlo,monospace}
-  .blist{display:flex;flex-direction:column;gap:7px}
-  .brow{display:flex;align-items:center;gap:18px;background:#16181d;border:1px solid #23262d;border-radius:10px;padding:8px 14px}
-  .brow.good{border-color:rgba(67,197,116,.34);background:rgba(67,197,116,.06)}
-  .brow.warn{border-color:rgba(224,168,82,.42);background:rgba(224,168,82,.07)}
-  .brow.bad{border-color:rgba(226,80,74,.5);background:rgba(226,80,74,.09)}
-  .bmeta{flex:1 1 auto;min-width:0;display:flex;flex-direction:column;gap:2px}
-  .bname{font-size:13px;color:#c7ccd4;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-  .bval{font-size:18px;font-weight:600;font-variant-numeric:tabular-nums;display:flex;align-items:baseline;min-width:0}
+  ${PERFORMANCE_VIEW_STYLES}
+  .bval{display:flex;align-items:baseline;min-width:0}
   .bval .cpu-id{margin-right:7px;align-self:center}
   .bval a.cpu-id{text-decoration:none}
   .bval a.cpu-id:hover{border-color:#6ea8fe;color:#fff}
   .bval a.cpu-id:focus-visible{outline:2px solid #6ea8fe;outline-offset:2px}
-  .btrend{font-size:12px;font-weight:400;color:#9aa0ab;margin-left:8px}
+  .btrend{margin-left:8px}
   .swatch{display:inline-block;width:8px;height:8px;border-radius:2px;flex:none;box-shadow:0 0 0 1px rgba(255,255,255,.42)}
   .cpu-id{display:inline-flex;align-items:center;justify-content:center;border:1px solid var(--cpu-color,#454b56);border-radius:4px;padding:1px 4px;font-size:9px;line-height:1.2;font-weight:500;color:#c7ccd4;white-space:nowrap}
-  .bspark{flex:0 0 42%;min-width:0;position:relative}
-  .bspark>div,.bspark>svg{margin-top:0!important}
   .cpu-legend{margin-top:22px}.cpu-legend-title{margin:0 0 8px}
   .cpu-keys{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:7px}
   .cpu-key{display:flex;align-items:flex-start;gap:8px;background:#16181d;border:1px solid #23262d;border-radius:8px;padding:8px 10px}
@@ -1827,13 +1821,8 @@ export function benchPage(
   .cpu-key>.swatch,.cpu-key>.cpu-id{margin-top:3px}.cpu-description{min-width:0}
   .cpu-name{display:block;font-size:12px;color:#c7ccd4;overflow-wrap:anywhere}
   .cpu-detail{display:block;font-size:10px;color:#878d97;margin-top:2px}
-  .empty,.refresh-error{color:#9aa0ab;font-size:14px}.refresh-error{color:#e0a852}
-  .note{font-size:11px;color:#666c76;margin-top:22px}
-  .note a{color:#6ea8fe;text-decoration:none}
-  label.chk{font-size:13px;color:#c7ccd4;display:inline-flex;align-items:center;gap:6px;margin-left:auto;cursor:pointer;user-select:none}
   body.hide-green .brow.good{display:none}
   body.hide-green .benchmark-group:not(:has(.brow:not(.good))){display:none}
-  @media(max-width:640px){.timeaxis{flex:1}.brow{align-items:stretch;gap:7px;flex-wrap:wrap}.bspark{flex:1 0 100%}.controls .field,.controls .choice-group{flex:1 1 100%}.controls input[type=range]{flex:1;width:auto}.controls label.chk{margin-left:0}}
 </style></head><body data-snapshot-version="${escapeHtml(version)}">
   <div class="top"><a class="back" href="/">← dashboard</a><b>Performance history</b><span>${
     escapeHtml(REPO)
@@ -1843,7 +1832,7 @@ export function benchPage(
     escapeHtml(stat.label)
   }"><input type="hidden" name="sort" value="${sort}"><label class="field" for="days">window <output id="daysv" for="days">${days} day${
     days === 1 ? "" : "s"
-  }</output><input type="range" id="days" name="days" min="${CI_HISTORY_MIN_DAYS}" max="${CI_HISTORY_DAYS}" step="1" value="${days}"></label><nav class="choice-group" aria-label="Benchmark metric"><span class="lbl">metric</span>${statSel}</nav><nav class="choice-group" aria-label="Sort benchmarks"><span class="lbl">sort</span>${sortSel}</nav><label class="chk"><input type="checkbox" id="hg"> hide green</label></form>
+  }</output><input type="range" id="days" name="days" min="${CI_HISTORY_MIN_DAYS}" max="${CI_HISTORY_DAYS}" step="1" value="${days}"></label><nav class="choice-group" aria-label="Benchmark metric"><span class="lbl">metric</span>${statSel}</nav><nav class="choice-group" aria-label="Sort benchmarks"><span class="lbl">sort</span>${sortSel}</nav><label class="check trailing"><input type="checkbox" id="hg"> hide green</label></form>
   ${rangeContent}
 <script>
   const hg = document.getElementById("hg"), days = document.getElementById("days"), daysv = document.getElementById("daysv"), controls = days.form, KEY = "benchHideGreen", DEFAULT_DAYS = days.value;
@@ -1906,15 +1895,20 @@ export function benchPage(
     rangeRequest?.abort();
     eventStream?.close();
   });
-  const renderIdle = () => {
-    collectionFailed = false;
+  const renderIdle = (lastRequestError = fetchProgress.dataset.lastRequestError || "") => {
+    collectionFailed = Boolean(lastRequestError);
     transportFailed = false;
-    fetchProgress.classList.remove("error");
+    if (lastRequestError) {
+      fetchProgress.dataset.lastRequestError = lastRequestError;
+    } else delete fetchProgress.dataset.lastRequestError;
+    fetchProgress.classList.toggle("error", collectionFailed);
     title.textContent = "Idle";
     total.textContent = "0 outstanding";
     bar.max = 1;
     bar.value = 0;
-    detail.textContent = "No requests in progress.";
+    detail.textContent = lastRequestError
+      ? "Last collection stopped: " + lastRequestError
+      : "No requests in progress.";
   };
   const refreshRangeWhenIdle = () => {
     if (navigating) return;
@@ -1942,6 +1936,9 @@ export function benchPage(
     collectionFailed = state.phase === "error";
     transportFailed = false;
     fetchProgress.classList.remove("error");
+    if (collectionFailed) {
+      fetchProgress.dataset.lastRequestError = state.error || "unknown error";
+    } else delete fetchProgress.dataset.lastRequestError;
     if (state.phase === "discovering") {
       title.textContent = "Finding benchmark runs…";
       total.textContent = "starting";
@@ -1966,7 +1963,8 @@ export function benchPage(
       total.textContent = "0 outstanding";
       bar.max = 1;
       bar.value = 0;
-      detail.textContent = "Last collection stopped: " + (state.error || "unknown error");
+      detail.textContent = "Last collection stopped: " +
+        fetchProgress.dataset.lastRequestError;
       eventStream?.close();
       eventStream = null;
       connectedProgressUrl = "";
@@ -2021,6 +2019,7 @@ export function benchPage(
         connectProgress("/bench/runtime-progress?id=" + encodeURIComponent(state.progress.id));
         renderProgress(state.progress);
       } else if (serverVersionChanged) refreshRangeWhenIdle();
+      else if ("lastRequestError" in state) renderIdle(state.lastRequestError || "");
       else if (!collectionFailed) renderIdle();
     } catch {
       if (!eventStream && !collectionFailed && !transportFailed) renderIdle();

--- a/packages/dashboard/tiles/ci-duration.test.ts
+++ b/packages/dashboard/tiles/ci-duration.test.ts
@@ -19,6 +19,7 @@ import {
   renderGantt,
   renderGanttRoute,
 } from "./ci-duration.ts";
+import { PERFORMANCE_VIEW_STYLES } from "../performance-views.ts";
 
 const SVG = new TextEncoder().encode(
   '<svg xmlns="http://www.w3.org/2000/svg"><text>chart</text></svg>',
@@ -33,6 +34,7 @@ function ctx(runs: Run[]): Ctx {
 }
 
 function run(over: Partial<Run>): Run {
+  const startedAt = new Date(Date.now() - 3_600_000).toISOString();
   return {
     id: 1,
     status: "completed",
@@ -41,7 +43,8 @@ function run(over: Partial<Run>): Run {
     event: "push",
     head_sha: "sha",
     display_title: "t",
-    run_started_at: new Date(Date.now() - 3_600_000).toISOString(),
+    created_at: startedAt,
+    run_started_at: startedAt,
     updated_at: new Date().toISOString(),
     html_url: "",
     head_commit: { message: "t (#1)" },
@@ -197,6 +200,7 @@ Deno.test("the Gantt page shares the performance view selector", async () => {
     '<meta name="viewport" content="width=device-width, initial-scale=1">',
   );
   assertStringIncludes(html, "<title>CI run Gantt</title>");
+  assertStringIncludes(html, PERFORMANCE_VIEW_STYLES);
   assertStringIncludes(html, `${REPO} · ${CI_WORKFLOW}`);
   assertStringIncludes(html, `href="/"`); // a way back to the dashboard
   assertStringIncludes(
@@ -702,6 +706,7 @@ Deno.test("ci-duration: no passing runs is gray, never a false green", async () 
 Deno.test("ci-duration: the median minutes set the status against the thresholds", async () => {
   const mins = (m: number) =>
     run({
+      created_at: new Date(Date.now() - m * 60_000).toISOString(),
       run_started_at: new Date(Date.now() - m * 60_000).toISOString(),
       updated_at: new Date().toISOString(),
     });
@@ -727,6 +732,21 @@ Deno.test("ci-duration: the median minutes set the status against the thresholds
   const v = await labsCiDuration.collect(ctx([mins(10), mins(10), mins(180)]));
   assertEquals([v.status, v.value], ["good", "10m"]);
   assertStringIncludes(v.sub ?? "", "last 3 passing runs"); // under the 20-run bar -> count window
+});
+
+Deno.test("ci-duration measures from landing through completion", async () => {
+  const now = Date.now();
+  const view = await labsCiDuration.collect(
+    ctx([
+      run({
+        created_at: new Date(now - 15 * 60_000).toISOString(),
+        run_started_at: new Date(now - 5 * 60_000).toISOString(),
+        updated_at: new Date(now).toISOString(),
+      }),
+    ]),
+  );
+
+  assertEquals(view.value, "15m");
 });
 
 Deno.test("ci-duration: an even window takes the mean of the two middle runs", () => {

--- a/packages/dashboard/tiles/ci-duration.ts
+++ b/packages/dashboard/tiles/ci-duration.ts
@@ -24,7 +24,6 @@ import {
   REPO,
 } from "../config.ts";
 import {
-  CI_FETCH_PROGRESS_STYLES,
   ciCommitGanttProgressResponse,
   ciFetchProgressPanel,
   type CiGanttInput,
@@ -38,7 +37,11 @@ import {
   collectCommitCiGanttInput,
   GANTT_MAX_RUNS,
 } from "../ci-job-history.ts";
-import { performanceViewNav } from "../performance-views.ts";
+import {
+  PERFORMANCE_PROGRESS_STYLES,
+  PERFORMANCE_VIEW_STYLES,
+  performanceViewNav,
+} from "../performance-views.ts";
 
 const CIGANTT = fromFileUrl(
   new URL("../../../scripts/ci-gantt.ts", import.meta.url),
@@ -175,40 +178,27 @@ export function ciGanttPage(url: URL): string {
   });
   return `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>CI run Gantt</title>
 <style>
-  body{margin:0;background:#0d0e11;color:#e7e9ee;font-family:-apple-system,Segoe UI,Roboto,sans-serif;padding:18px 20px 26px;max-width:1100px;margin:0 auto}
-  .top{display:flex;align-items:baseline;gap:10px;margin-bottom:12px;flex-wrap:wrap}
-  .top b{font-size:16px;font-weight:600}.top span{font-size:12px;color:#6f757f}
-  a.back{color:#6ea8fe;text-decoration:none;font-size:13px}
-  .views{display:flex;gap:6px;margin:0 0 14px}
-  .views a{font-size:13px;color:#c7ccd4;text-decoration:none;border:1px solid #2f333c;border-radius:6px;padding:4px 10px}
-  .views a.on{background:#6ea8fe;border-color:#6ea8fe;color:#0d0e11}
-  .controls{display:flex;flex-wrap:wrap;gap:20px;align-items:center;background:#16181d;border:1px solid #23262d;border-radius:12px;padding:14px 16px;margin-bottom:14px}
-  .controls label{font-size:13px;color:#c7ccd4;display:flex;align-items:center;gap:8px;flex:none}
-  .controls input[type=range]{width:200px}
-  .controls select{background:#0d0e11;color:#e7e9ee;border:1px solid #2f333c;border-radius:6px;padding:3px 6px}
-  ${CI_FETCH_PROGRESS_STYLES}
+  ${PERFORMANCE_VIEW_STYLES}
   .imgwrap{background:#0c0d11;border:1px solid #23262d;border-radius:12px;padding:10px;overflow:auto;min-height:60px}
   #g{width:100%;height:auto;display:none}
-  .hint{font-size:11px;color:#666c76;margin-top:12px}
-  @media(max-width:640px){.controls{gap:14px}.controls label{flex:1 1 100%}.controls input[type=range]{width:auto;min-width:0;flex:1}}
 </style></head><body>
   <div class="top"><a class="back" href="/">← dashboard</a><b>Performance history</b><span>${
     escapeHtml(source.repo)
   } · ${escapeHtml(source.workflow)} · scripts/ci-gantt.ts</span></div>
   ${viewNav}
   <div class="controls">
-    <label>repository <select id="repo"><option value="labs"${
+    <label class="field" for="repo">repository <select id="repo"><option value="labs"${
     source.key === "labs" ? " selected" : ""
   }>labs</option><option value="loom"${
     source.key === "loom" ? " selected" : ""
   }>loom</option></select></label>
-    <label>runs to include <input type="range" id="limit" min="1" max="150" step="1" value="60"><b id="limitv">60</b></label>
-    <label><input type="checkbox" id="mainOnly" checked> main pushes only</label>
-    <label><input type="checkbox" id="allConcl"> include failed/cancelled in timing</label>
+    <label class="field" for="limit">runs to include <output id="limitv" for="limit">60</output><input type="range" id="limit" min="1" max="150" step="1" value="60"></label>
+    <label class="check"><input type="checkbox" id="mainOnly" checked> main pushes only</label>
+    <label class="check"><input type="checkbox" id="allConcl"> include failed/cancelled in timing</label>
   </div>
   ${ciFetchProgressPanel(undefined, { ariaLabel: "CI Gantt fetch progress" })}
   <div class="imgwrap"><img id="g" alt="CI Gantt chart"></div>
-  <p class="hint">Run, job, and step timings share the persistent server cache used by CI history. Regeneration reads cached past runs and fetches only missing runs or newer attempts.</p>
+  <p class="note">Run, job, and step timings share the persistent server cache used by CI history. Regeneration reads cached past runs and fetches only missing runs or newer attempts.</p>
 <script>
   const $ = (id) => document.getElementById(id);
   const g = $('g'), fetchProgress = $('fetch-progress'), title = $('fetch-title'), total = $('fetch-total'), detail = $('fetch-detail'), bar = $('fetch-bar');
@@ -546,7 +536,7 @@ export function ciCommitGanttPage(url: URL): string {
   .top{display:flex;align-items:baseline;gap:10px;margin-bottom:14px;flex-wrap:wrap}
   .top b{font-size:16px;font-weight:600}.top span{font-size:12px;color:#6f757f}
   a{color:#6ea8fe;text-decoration:none}.back{font-size:13px}.commit{font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
-  ${CI_FETCH_PROGRESS_STYLES}
+  ${PERFORMANCE_PROGRESS_STYLES}
   .imgwrap{background:#0c0d11;border:1px solid #23262d;border-radius:12px;padding:10px;overflow:auto;min-height:60px}
   #g{width:100%;height:auto;display:none}
   .empty{background:#16181d;border:1px solid #2f333c;border-radius:12px;padding:18px;color:#9aa0ab}
@@ -666,35 +656,45 @@ function makeCiDuration(
           hint: opts.hint,
         };
       }
-      // Only runs that passed end to end: a failed/cancelled/timed-out run's
-      // wall-clock time isn't a representative CI duration.
-      const passed = runs.filter((r) =>
-        r.status === "completed" && r.conclusion === "success"
-      );
-      const durMins = (r: Run) =>
-        (Date.parse(r.updated_at) - Date.parse(r.run_started_at)) / 60000;
+      // Only complete, successful push runs with a usable landing-to-finish
+      // span contribute to the duration.
+      const passed = runs.flatMap((run) => {
+        if (
+          run.event !== "push" || run.status !== "completed" ||
+          run.conclusion !== "success"
+        ) {
+          return [];
+        }
+        const landedAt = Date.parse(run.created_at);
+        const finishedAt = Date.parse(run.updated_at);
+        if (
+          !Number.isFinite(landedAt) || !Number.isFinite(finishedAt) ||
+          finishedAt <= landedAt
+        ) {
+          return [];
+        }
+        return [{ landedAt, durationMins: (finishedAt - landedAt) / 60_000 }];
+      });
       // Median window = the successful runs in the last DUR_MAX_AGE_HOURS, or the
       // most recent DUR_MIN_RUNS — whichever has more runs.
       const cutoff = Date.now() - DUR_MAX_AGE_HOURS * 3_600_000;
       const inTimeCount =
-        passed.filter((r) => Date.parse(r.run_started_at) >= cutoff).length;
+        passed.filter((run) => run.landedAt >= cutoff).length;
       const usingTime = inTimeCount >= DUR_MIN_RUNS; // time window wins when it has enough runs
       // A count-based prefix (not the filter set itself) so the median runs are
       // always the newest slice of passed — which is what the sparkline
       // highlights. passed is created-at ordered, so a re-run can otherwise
       // make the filter set non-contiguous with the front.
       const window = passed.slice(0, usingTime ? inTimeCount : DUR_MIN_RUNS);
-      const durs = window.map(durMins).sort((a, b) => a - b);
+      const durs = window.map((run) => run.durationMins).sort((a, b) => a - b);
       const medianMins = Math.round(median(durs));
       // The sparkline spans every successful run (oldest -> newest). window is
       // always the newest slice of passed, so the runs feeding the median are the
       // trailing window.length points — drawn brighter over the dimmer long-run
       // trend.
-      const series = [...passed].reverse().map(durMins);
+      const series = [...passed].reverse().map((run) => run.durationMins);
       // How long the sparkline spans (oldest to newest run), for the corner label.
-      const times = passed.map((r) => Date.parse(r.run_started_at)).filter((
-        t,
-      ) => !Number.isNaN(t));
+      const times = passed.map((run) => run.landedAt);
       const spanMs = times.length >= 2
         ? Math.max(...times) - Math.min(...times)
         : 0;

--- a/packages/dashboard/tiles/main-build.test.ts
+++ b/packages/dashboard/tiles/main-build.test.ts
@@ -20,6 +20,7 @@ function ctx(runs: Run[]): Ctx {
 let nextRunId = 1;
 
 function run(over: Partial<Run>): Run {
+  const startedAt = new Date(Date.now() - 3_600_000).toISOString();
   return {
     id: nextRunId++,
     status: "completed",
@@ -28,7 +29,8 @@ function run(over: Partial<Run>): Run {
     event: "push",
     head_sha: "sha",
     display_title: "t",
-    run_started_at: new Date(Date.now() - 3_600_000).toISOString(),
+    created_at: startedAt,
+    run_started_at: startedAt,
     updated_at: new Date().toISOString(),
     html_url: "",
     head_commit: { message: "t (#1)" },

--- a/packages/dashboard/types.ts
+++ b/packages/dashboard/types.ts
@@ -60,6 +60,7 @@ export interface Run {
   event: string;
   head_sha: string;
   display_title: string;
+  created_at: string;
   run_started_at: string;
   updated_at: string;
   html_url: string;

--- a/scripts/ci-gantt.test.ts
+++ b/scripts/ci-gantt.test.ts
@@ -1,0 +1,248 @@
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+
+const SCRIPT = new URL("./ci-gantt.ts", import.meta.url).href;
+const START = Date.parse("2026-07-20T10:00:00Z");
+
+interface TestJob {
+  attempt: number;
+  name: string;
+  status: string;
+  conclusion: string;
+  started_at: string;
+  completed_at: string;
+  steps: {
+    name: string;
+    number: number;
+    conclusion: string;
+    started_at: string;
+    completed_at: string;
+  }[];
+}
+
+function job(
+  name: string,
+  attempt: number,
+  startSeconds: number,
+  durationSeconds: number,
+  conclusion = "success",
+): TestJob {
+  const startedAt = new Date(START + startSeconds * 1_000).toISOString();
+  const completedAt = new Date(
+    START + (startSeconds + durationSeconds) * 1_000,
+  ).toISOString();
+  return {
+    attempt,
+    name,
+    status: "completed",
+    conclusion,
+    started_at: startedAt,
+    completed_at: completedAt,
+    steps: [{
+      name: "🧪 Test",
+      number: 1,
+      conclusion,
+      started_at: startedAt,
+      completed_at: completedAt,
+    }],
+  };
+}
+
+function inputRun(databaseId: number, jobs: TestJob[]) {
+  return {
+    run: {
+      attempt: Math.max(...jobs.map((value) => value.attempt)),
+      databaseId,
+      status: "completed",
+      conclusion: "success",
+      event: "push",
+      headBranch: "main",
+      startedAt: new Date(START).toISOString(),
+      workflowName: "CI",
+    },
+    jobs,
+  };
+}
+
+async function render(input: unknown): Promise<string> {
+  const result = await runGantt(input);
+  assert(result.success, result.stderr);
+  return result.svg;
+}
+
+async function runGantt(
+  input: unknown,
+): Promise<{ success: boolean; stderr: string; svg: string }> {
+  const directory = await Deno.makeTempDir({ prefix: "ci-gantt-test-" });
+  const inputPath = `${directory}/input.json`;
+  const outputPath = `${directory}/output.svg`;
+  try {
+    await Deno.writeTextFile(inputPath, JSON.stringify(input));
+    const output = await new Deno.Command(Deno.execPath(), {
+      args: [
+        "run",
+        `--allow-read=${inputPath}`,
+        `--allow-write=${outputPath}`,
+        SCRIPT,
+        "--input",
+        inputPath,
+        "--out",
+        outputPath,
+        "--theme",
+        "dark",
+        "--min-runs",
+        "1",
+      ],
+      stdout: "piped",
+      stderr: "piped",
+    }).output();
+    return {
+      success: output.success,
+      stderr: new TextDecoder().decode(output.stderr),
+      svg: output.success ? await Deno.readTextFile(outputPath) : "",
+    };
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+}
+
+function attemptBar(
+  svg: string,
+  attempt: number,
+  result: string,
+  duration: string,
+  conclusion = result,
+): { x: number; y: number; width: number } {
+  const match = svg.match(
+    new RegExp(
+      `<g data-attempt="${attempt}" data-result="${result}">` +
+        `<title>Attempt ${attempt}: ${conclusion}, ${duration}</title>\\s*` +
+        `<rect x="([\\d.]+)" y="([\\d.]+)" width="([\\d.]+)"`,
+    ),
+  );
+  assert(match, `missing attempt ${attempt} ${conclusion} ${duration}`);
+  return {
+    x: Number(match[1]),
+    y: Number(match[2]),
+    width: Number(match[3]),
+  };
+}
+
+function attemptDuration(
+  svg: string,
+  attempt: number,
+  result: string,
+  duration: string,
+  conclusion = result,
+): { x: number; y: number } {
+  const match = svg.match(
+    new RegExp(
+      `<g data-attempt="${attempt}" data-result="${result}">` +
+        `<title>Attempt ${attempt}: ${conclusion}, ${duration}</title>` +
+        `[\\s\\S]*?<text class="attempt-duration" x="([\\d.]+)" ` +
+        `y="([\\d.]+)"[^>]*>${duration}</text></g>`,
+    ),
+  );
+  assert(match, `missing duration for attempt ${attempt} ${duration}`);
+  return { x: Number(match[1]), y: Number(match[2]) };
+}
+
+Deno.test("single-run CI Gantt draws every rerun attempt on one row", async () => {
+  const svg = await render({
+    runs: [
+      inputRun(42, [
+        job("Retried job", 1, 60, 60, "failure"),
+        job("Retried job", 2, 7_260, 120),
+        job("Timed out job", 1, 180, 75, "timed_out"),
+        job("Timed out job", 2, 300, 90),
+        job("Downstream", 2, 7_380, 60),
+      ]),
+    ],
+  });
+
+  const failed = attemptBar(svg, 1, "failure", "1:00");
+  const succeeded = attemptBar(svg, 2, "success", "2:00");
+  const timedOut = attemptBar(svg, 1, "failure", "1:15", "timed_out");
+  const timedOutRetry = attemptBar(svg, 2, "success", "1:30");
+  assertEquals(failed.y, succeeded.y);
+  assertEquals(timedOut.y, timedOutRetry.y);
+  assert(succeeded.x > failed.x + failed.width + 500);
+  const timedOutDuration = attemptDuration(
+    svg,
+    1,
+    "failure",
+    "1:15",
+    "timed_out",
+  );
+  const timedOutRetryDuration = attemptDuration(svg, 2, "success", "1:30");
+  assert(timedOutDuration.y > timedOutRetryDuration.y);
+  assertEquals(svg.match(/class="attempt-failure"/g)?.length, 2);
+  const timedOutRetryMarkup = "<title>Attempt 2: success, 1:30</title>";
+  const timedOutFailureMarkup =
+    '<g class="attempt-failure" data-attempt="1"><title>Attempt 1: timed_out, 1:15</title>';
+  const timedOutRetryIndex = svg.indexOf(timedOutRetryMarkup);
+  assert(timedOutRetryIndex >= 0);
+  assert(
+    svg.indexOf(timedOutFailureMarkup, timedOutRetryIndex) >
+      timedOutRetryIndex,
+  );
+  assertStringIncludes(svg, "<title>Attempt 1: timed_out, 1:15</title>");
+  assertEquals(svg.includes('class="attempt-label"'), false);
+  assertEquals(svg.includes(">a1"), false);
+  assertEquals(svg.includes(">a2"), false);
+  const failedAttempt = svg.match(
+    /<g data-attempt="1" data-result="failure"><title>Attempt 1: failure, 1:00<\/title>[\s\S]*?<\/g>/,
+  )?.[0];
+  assert(failedAttempt);
+  assertStringIncludes(failedAttempt, ">1:00</text>");
+  const successfulAttempt = svg.match(
+    /<g data-attempt="2" data-result="success"><title>Attempt 2: success, 2:00<\/title>[\s\S]*?<\/g>/,
+  )?.[0];
+  assert(successfulAttempt);
+  assertStringIncludes(successfulAttempt, ">2:00</text>");
+  assertEquals(successfulAttempt.includes("attempt-failure"), false);
+  assertStringIncludes(svg, "failed attempts end in ×");
+});
+
+Deno.test("CI Gantt rejects a rerun whose jobs carry no attempt", async () => {
+  const collapsed: Partial<TestJob> = { ...job("Retried job", 1, 60, 120) };
+  delete collapsed.attempt;
+  const rerun = inputRun(42, [job("Retried job", 2, 60, 120)]);
+  const rejected = await runGantt({ runs: [{ ...rerun, jobs: [collapsed] }] });
+
+  assertEquals(rejected.success, false);
+  assertStringIncludes(
+    rejected.stderr,
+    "run 42 reports 2 attempts but has jobs with no attempt",
+  );
+
+  // One attempt needs no provenance, so cached data from before attempts were
+  // recorded still draws.
+  const legacy: Partial<TestJob> = { ...job("Only job", 1, 60, 120) };
+  delete legacy.attempt;
+  const single = inputRun(43, [job("Only job", 1, 60, 120)]);
+  const drawn = await runGantt({ runs: [{ ...single, jobs: [legacy] }] });
+
+  assertEquals(drawn.success, true);
+  assertStringIncludes(drawn.svg, "Only job");
+});
+
+Deno.test("multi-run CI Gantt keeps one aggregate bar per job", async () => {
+  const svg = await render({
+    runs: [
+      inputRun(42, [
+        job("Retried job", 1, 60, 60, "failure"),
+        job("Retried job", 2, 180, 120),
+      ]),
+      inputRun(43, [
+        job("Retried job", 1, 60, 180),
+      ]),
+    ],
+  });
+
+  assertEquals(svg.includes('data-attempt="'), false);
+  assertEquals(svg.includes('class="attempt-failure"'), false);
+  assertStringIncludes(svg, "median of 2 completed runs");
+  assertStringIncludes(svg, "whiskers = min/max");
+  assertStringIncludes(svg, ">2:30<tspan");
+  assertStringIncludes(svg, ">2:00–3:00</tspan>");
+});

--- a/scripts/ci-gantt.ts
+++ b/scripts/ci-gantt.ts
@@ -5,12 +5,14 @@
 
 // Draw a Gantt chart of a typical CI run from the last N workflow runs on GitHub.
 //
-// For every job (each matrix shard counts as its own job) the chart shows the
-// median start-to-finish bar plus the min and max of the observed start and
-// finish times as whiskers, and the median duration with its min-max range as
-// text. Jobs are grouped into waves ("tiers") inferred from when they start.
-// The output is a PNG whose width scales with run length and whose height scales
-// with the number of jobs.
+// Across several workflow runs, each job (including each matrix shard) shows
+// the median start-to-finish bar plus the min and max of the observed start and
+// finish times as whiskers. A chart of one workflow run instead keeps every
+// execution from every attempt on one row per job. Failed executions end in a
+// red cross, and the blank space between attempts remains visible. Jobs are
+// grouped into waves ("tiers") inferred from when they start. The output is a
+// PNG whose width scales with run length and whose height scales with the number
+// of jobs.
 //
 // Each median bar is split into "setup", "work" and "shutdown" segments so the
 // shared scaffolding around a job (checkout, tool install, cache restore,
@@ -80,7 +82,8 @@ const MIN_RUNS_OVERRIDE = args.includes("--min-runs")
   : null;
 // Sampled charts use successful jobs by default. Exact-run charts include every
 // non-skipped job.
-const SUCCESS_ONLY = !RUN_IDS.length && !args.includes("--all-conclusions");
+const DEFAULT_SUCCESS_ONLY = !RUN_IDS.length &&
+  !args.includes("--all-conclusions");
 // Restrict to pushes to main (post-land), excluding pre-land pull_request runs.
 const MAIN_ONLY = args.includes("--main-only");
 
@@ -204,6 +207,7 @@ interface Step {
 }
 
 interface Job {
+  attempt?: number;
   name: string;
   status: string;
   conclusion: string | null;
@@ -216,11 +220,36 @@ interface GanttInput {
   runs: { run: Run; jobs: Job[] }[];
 }
 
-function hasTiming(job: Job): boolean {
-  if (!job.started_at || !job.completed_at) return false;
-  const st = Date.parse(job.started_at);
-  const en = Date.parse(job.completed_at);
-  return Number.isFinite(st) && Number.isFinite(en) && en > st;
+function jobAttempt(job: Job): number {
+  const attempt = job.attempt;
+  return typeof attempt === "number" && Number.isSafeInteger(attempt) &&
+      attempt > 0
+    ? attempt
+    : 1;
+}
+
+function failedConclusion(conclusion: string | null): boolean {
+  return conclusion === "failure" || conclusion === "timed_out" ||
+    conclusion === "startup_failure";
+}
+
+function executionKey(job: Job): string {
+  return [
+    job.name,
+    job.started_at ?? "",
+    job.completed_at ?? "",
+  ].join("\u0000");
+}
+
+function latestJobsByName(jobs: Job[]): Job[] {
+  const latest = new Map<string, Job>();
+  for (const job of jobs) {
+    const current = latest.get(job.name);
+    if (!current || jobAttempt(current) <= jobAttempt(job)) {
+      latest.set(job.name, job);
+    }
+  }
+  return [...latest.values()];
 }
 
 // ---------------------------------------------------------------------------
@@ -348,6 +377,16 @@ interface JobAgg {
   count: number;
   mainOnly: boolean; // never observed on a pull_request
   phase: Record<Phase, number>; // median seconds spent in each phase
+  attempts: JobAttempt[];
+}
+
+interface JobAttempt {
+  attempt: number;
+  conclusion: string | null;
+  start: number;
+  end: number;
+  dur: number;
+  phase: Record<Phase, number>;
 }
 
 function shardKeyOf(name: string): string {
@@ -384,6 +423,18 @@ if (INPUT) {
     throw new Error("CI Gantt input must contain a runs array.");
   }
   jobsPerRun = input.runs;
+  // Every job of a run with several attempts carries the attempt it ran in.
+  // Input without that describes one attempt of a run that had more.
+  for (const { run, jobs } of jobsPerRun) {
+    if (
+      (run.attempt ?? 1) > 1 &&
+      jobs.some((job) => job.attempt === undefined)
+    ) {
+      throw new Error(
+        `CI Gantt input for run ${run.databaseId} reports ${run.attempt} attempts but has jobs with no attempt.`,
+      );
+    }
+  }
   runs = jobsPerRun.map(({ run }) => run);
   console.error(`Loaded ${runs.length} cached run(s) for ${REPO}.`);
 } else {
@@ -415,31 +466,27 @@ if (INPUT) {
       if ((i + 1) % 10 === 0) {
         console.error(`  ${i + 1}/${completedRuns.length}`);
       }
-      let jobs = await fetchJobs(
-        `/repos/${REPO}/actions/runs/${run.databaseId}/attempts/1/jobs`,
-      );
-      if ((run.attempt ?? 1) > 1) {
-        const latestJobs = await fetchJobs(
-          `/repos/${REPO}/actions/runs/${run.databaseId}/jobs`,
+      const executions = new Map<string, Job>();
+      for (let attempt = 1; attempt <= (run.attempt ?? 1); attempt++) {
+        const attempted = await fetchJobs(
+          `/repos/${REPO}/actions/runs/${run.databaseId}/attempts/${attempt}/jobs`,
         );
-        const latestByName = new Map(
-          latestJobs.map((job) => [job.name, job]),
-        );
-        jobs = jobs.map((job) => {
-          const latest = latestByName.get(job.name);
-          if (latest && !hasTiming(job) && hasTiming(latest)) return latest;
-          return latest
-            ? { ...job, status: latest.status, conclusion: latest.conclusion }
-            : job;
-        });
+        for (const job of attempted) {
+          const execution = executionKey(job);
+          if (!executions.has(execution)) {
+            executions.set(execution, { ...job, attempt });
+          }
+        }
       }
-      return { run, jobs };
+      return { run, jobs: [...executions.values()] };
     },
   );
 }
 
 const completed = runs.filter((run) => run.status === "completed");
 jobsPerRun = jobsPerRun.filter(({ run }) => run.status === "completed");
+const singleRun = jobsPerRun.length === 1;
+const successOnly = singleRun ? false : DEFAULT_SUCCESS_ONLY;
 
 // Accumulate timings keyed by exact job name (each shard is its own key).
 const acc = new Map<
@@ -450,6 +497,7 @@ const acc = new Map<
     dur: number[];
     events: Set<string>;
     phase: Record<Phase, number[]>; // per-run seconds in each phase
+    attempts: JobAttempt[];
   }
 >();
 // Step names that carried no known marker, surfaced at the end so a missing
@@ -465,9 +513,10 @@ for (const { run, jobs } of jobsPerRun) {
     .filter((value) => Number.isFinite(value));
   const t0 = Math.min(...startCandidates);
   if (!Number.isFinite(t0)) continue;
-  for (const j of jobs) {
+  const chartJobs = singleRun ? jobs : latestJobsByName(jobs);
+  for (const j of chartJobs) {
     if (
-      SUCCESS_ONLY ? j.conclusion !== "success" : j.conclusion === "skipped"
+      successOnly ? j.conclusion !== "success" : j.conclusion === "skipped"
     ) {
       continue;
     }
@@ -489,6 +538,7 @@ for (const { run, jobs } of jobsPerRun) {
           dur: [],
           events: new Set(),
           phase: { setup: [], work: [], shutdown: [], other: [] },
+          attempts: [],
         },
       );
     }
@@ -517,11 +567,23 @@ for (const { run, jobs } of jobsPerRun) {
     if (PHASE_ORDER.some((p) => perPhase[p] > 0)) {
       for (const p of PHASE_ORDER) e.phase[p].push(perPhase[p]);
     }
+    if (singleRun) {
+      e.attempts.push({
+        attempt: jobAttempt(j),
+        conclusion: j.conclusion,
+        start: startOff,
+        end: endOff,
+        dur,
+        phase: perPhase,
+      });
+    }
   }
 }
 
 const minRuns = MIN_RUNS_OVERRIDE ??
-  (RUN_IDS.length ? 1 : Math.max(5, Math.round(0.1 * completed.length)));
+  (RUN_IDS.length || singleRun
+    ? 1
+    : Math.max(5, Math.round(0.1 * completed.length)));
 
 const aggregates: JobAgg[] = [];
 for (const [name, e] of acc) {
@@ -533,20 +595,32 @@ for (const [name, e] of acc) {
   for (const p of PHASE_ORDER) {
     phase[p] = e.phase[p].length ? stat(e.phase[p]).med : 0;
   }
+  const attempts = [...e.attempts].sort((a, b) =>
+    a.start - b.start || a.attempt - b.attempt
+  );
+  const firstStart = attempts[0]?.start;
+  const finalEnd = attempts.length
+    ? Math.max(...attempts.map((attempt) => attempt.end))
+    : undefined;
   aggregates.push({
     name,
     base: name.replace(/\s*\([^)]*\)\s*$/, ""),
     shardKey: shardKeyOf(name),
-    start: stat(e.start),
-    end: stat(e.end),
+    start: singleRun && firstStart !== undefined
+      ? { min: firstStart, med: firstStart, max: firstStart }
+      : stat(e.start),
+    end: singleRun && finalEnd !== undefined
+      ? { min: finalEnd, med: finalEnd, max: finalEnd }
+      : stat(e.end),
     dur: stat(e.dur),
-    count: e.start.length,
+    count: singleRun ? 1 : e.start.length,
     // The deploy/attest tail is "main only" relative to PR runs. Exact-run and
     // main-only charts put every job into start-time tiers.
     mainOnly: RUN_IDS.length || MAIN_ONLY
       ? false
       : !e.events.has("pull_request"),
     phase,
+    attempts,
   });
 }
 if (unmarkedSteps.size) {
@@ -625,6 +699,38 @@ const chartX0 = NAME_X + LEFT_COL;
 const chartW = maxEnd * pxPerSec;
 const totalW = Math.round(chartX0 + chartW + RIGHT_PAD);
 const x = (sec: number) => chartX0 + sec * pxPerSec;
+const DURATION_LABEL_CHAR_W = 6.2;
+const DURATION_LABEL_LANE_H = 12;
+
+function attemptDurationPlacements(attempts: JobAttempt[]) {
+  const placements: {
+    attempt: JobAttempt;
+    text: string;
+    left: number;
+    right: number;
+    lane: number;
+  }[] = [];
+  for (let index = 0; index < attempts.length; index++) {
+    const attempt = attempts[index];
+    const text = clock(attempt.dur);
+    const left = x(attempt.end) +
+      (failedConclusion(attempt.conclusion) ? 8 : 5);
+    const right = left + text.length * DURATION_LABEL_CHAR_W;
+    const overlapsLaterBar = attempts.slice(index + 1).some((later) =>
+      left < x(later.end) && right > x(later.start)
+    );
+    let lane = overlapsLaterBar ? 1 : 0;
+    while (
+      placements.some((placed) =>
+        placed.lane === lane && left < placed.right && right > placed.left
+      )
+    ) {
+      lane++;
+    }
+    placements.push({ attempt, text, left, right, lane });
+  }
+  return placements;
+}
 
 interface Palette {
   bg: string;
@@ -633,6 +739,7 @@ interface Palette {
   grid: string;
   axis: string;
   main: string; // main-branch-only bars
+  failure: string;
   whisker: string;
   envelope: string; // neutral fill for the min-start..max-end range
   // Phase segment colors. Work is the deep, saturated blue so the job's own work
@@ -652,6 +759,7 @@ const THEMES: Record<string, Palette> = {
     grid: "#e7e7e7",
     axis: "#8a8a8a",
     main: "#8a897f",
+    failure: "#cf222e",
     whisker: "#2a2a2a",
     envelope: "#aab2bd",
     setup: "#6ba7bd",
@@ -666,6 +774,7 @@ const THEMES: Record<string, Palette> = {
     grid: "#23262d",
     axis: "#6a7079",
     main: "#7c828c",
+    failure: "#f85149",
     whisker: "#8a93a5",
     envelope: "#454b54",
     setup: "#345f92",
@@ -711,6 +820,48 @@ const interval = intervals.find((c) => c * pxPerSec >= 70) ?? 1800;
 let y = PAD + TITLE_H + AXIS_H;
 const gridTop = PAD + TITLE_H + AXIS_H - 8;
 
+function drawPhaseBar(
+  top: number,
+  start: number,
+  end: number,
+  phase: Record<Phase, number>,
+  mainOnly: boolean,
+) {
+  const mb = x(start), me = x(end);
+  const barW = Math.max(2, me - mb);
+  const segs = PHASE_ORDER
+    .map((p) => ({ p, sec: phase[p] }))
+    .filter((segment) => segment.sec > 0);
+  const phaseTotal = segs.reduce((sum, segment) => sum + segment.sec, 0);
+  if (phaseTotal > 0) {
+    let cumulative = 0;
+    let previousX = mb;
+    for (const segment of segs) {
+      cumulative += segment.sec;
+      const nextX = mb + (cumulative / phaseTotal) * barW;
+      body.push(
+        `<rect x="${previousX.toFixed(1)}" y="${top}" width="${
+          Math.max(0.5, nextX - previousX).toFixed(1)
+        }" height="${BAR_H}" fill="${C[segment.p]}"/>`,
+      );
+      previousX = nextX;
+    }
+  } else {
+    body.push(
+      `<rect x="${mb.toFixed(1)}" y="${top}" width="${
+        barW.toFixed(1)
+      }" height="${BAR_H}" rx="2" fill="${C.work}"/>`,
+    );
+  }
+  if (mainOnly) {
+    body.push(
+      `<rect x="${mb.toFixed(1)}" y="${top}" width="${
+        barW.toFixed(1)
+      }" height="${BAR_H}" rx="2" fill="url(#hatch)"/>`,
+    );
+  }
+}
+
 function drawSection(title: string, jobs: JobAgg[]) {
   body.push(
     `<text x="${NAME_X}" y="${
@@ -722,74 +873,100 @@ function drawSection(title: string, jobs: JobAgg[]) {
     const top = y;
     const cy = top + BAR_H / 2;
     const xs = x(j.start.min), xe = x(j.end.max);
+    const durationPlacements = singleRun
+      ? attemptDurationPlacements(j.attempts)
+      : [];
 
-    // envelope: full min-start to max-end extent
-    body.push(
-      `<rect x="${xs.toFixed(1)}" y="${top}" width="${
-        Math.max(1, xe - xs).toFixed(1)
-      }" height="${BAR_H}" rx="2" fill="${C.envelope}" fill-opacity="0.25"/>`,
-    );
-    // median bar, split into phase segments. Segment widths are the median time
-    // in each phase, scaled so they fill the median start-to-finish span.
-    const mb = x(j.start.med), me = x(j.end.med);
-    const barW = Math.max(2, me - mb);
-    const segs = PHASE_ORDER
-      .map((p) => ({ p, sec: j.phase[p] }))
-      .filter((s) => s.sec > 0);
-    const phaseTotal = segs.reduce((sum, s) => sum + s.sec, 0);
-    if (phaseTotal > 0) {
-      let cum = 0;
-      let prevX = mb;
-      for (const s of segs) {
-        cum += s.sec;
-        const nextX = mb + (cum / phaseTotal) * barW;
+    if (singleRun) {
+      const failedAttempts: JobAttempt[] = [];
+      for (const placement of durationPlacements) {
+        const attempt = placement.attempt;
         body.push(
-          `<rect x="${prevX.toFixed(1)}" y="${top}" width="${
-            Math.max(0.5, nextX - prevX).toFixed(1)
-          }" height="${BAR_H}" fill="${C[s.p]}"/>`,
+          `<g data-attempt="${attempt.attempt}" data-result="${
+            failedConclusion(attempt.conclusion)
+              ? "failure"
+              : attempt.conclusion === "success"
+              ? "success"
+              : "other"
+          }"><title>Attempt ${attempt.attempt}: ${
+            esc(attempt.conclusion ?? "unknown")
+          }, ${clock(attempt.dur)}</title>`,
         );
-        prevX = nextX;
+        drawPhaseBar(
+          top,
+          attempt.start,
+          attempt.end,
+          attempt.phase,
+          j.mainOnly,
+        );
+        if (failedConclusion(attempt.conclusion)) {
+          failedAttempts.push(attempt);
+        }
+        body.push(
+          `<text class="attempt-duration" x="${placement.left.toFixed(1)}" y="${
+            top + BAR_H + placement.lane * DURATION_LABEL_LANE_H
+          }" font-size="11" fill="${C.text}">${clock(attempt.dur)}</text></g>`,
+        );
+      }
+      for (const attempt of failedAttempts) {
+        const failedAt = x(attempt.end);
+        const radius = 4;
+        body.push(
+          `<g class="attempt-failure" data-attempt="${attempt.attempt}"><title>Attempt ${attempt.attempt}: ${
+            esc(attempt.conclusion ?? "unknown")
+          }, ${clock(attempt.dur)}</title><path d="M ${
+            (failedAt - radius).toFixed(1)
+          } ${(cy - radius).toFixed(1)} L ${(failedAt + radius).toFixed(1)} ${
+            (cy + radius).toFixed(1)
+          } M ${(failedAt + radius).toFixed(1)} ${(cy - radius).toFixed(1)} L ${
+            (failedAt - radius).toFixed(1)
+          } ${
+            (cy + radius).toFixed(1)
+          }" fill="none" stroke="${C.failure}" stroke-width="2" stroke-linecap="round"/></g>`,
+        );
       }
     } else {
-      // No step timing for this job: fall back to a plain work-colored bar.
+      // The envelope covers the full min-start to max-end extent.
       body.push(
-        `<rect x="${mb.toFixed(1)}" y="${top}" width="${
-          barW.toFixed(1)
-        }" height="${BAR_H}" rx="2" fill="${C.work}"/>`,
+        `<rect x="${xs.toFixed(1)}" y="${top}" width="${
+          Math.max(1, xe - xs).toFixed(1)
+        }" height="${BAR_H}" rx="2" fill="${C.envelope}" fill-opacity="0.25"/>`,
       );
+      drawPhaseBar(top, j.start.med, j.end.med, j.phase, j.mainOnly);
     }
-    if (j.mainOnly) {
-      body.push(
-        `<rect x="${mb.toFixed(1)}" y="${top}" width="${
-          barW.toFixed(1)
-        }" height="${BAR_H}" rx="2" fill="url(#hatch)"/>`,
-      );
-    }
-    // whiskers for start and finish ranges: a "<" at the min, a ">" at the max
-    const whisker = (lo: number, hi: number, w: number) => {
-      const a = x(lo), b = x(hi);
-      if (b - a < 1.5) return;
-      const h = 3;
-      const d = Math.min(3, (b - a) / 2);
-      const f = (n: number) => n.toFixed(1);
-      const stroke =
-        `fill="none" stroke="${C.whisker}" stroke-width="${w}" stroke-linecap="round" stroke-linejoin="round"`;
-      body.push(
-        `<line x1="${f(a)}" y1="${f(cy)}" x2="${f(b)}" y2="${
-          f(cy)
-        }" stroke="${C.whisker}" stroke-width="${w}"/>` +
-          `<polyline points="${f(a + d)},${f(cy - h)} ${f(a)},${f(cy)} ${
-            f(a + d)
-          },${f(cy + h)}" ${stroke}/>` +
-          `<polyline points="${f(b - d)},${f(cy - h)} ${f(b)},${f(cy)} ${
-            f(b - d)
-          },${f(cy + h)}" ${stroke}/>`,
-      );
-    };
-    whisker(j.start.min, j.start.max, 0.8);
-    whisker(j.end.min, j.end.max, 1.4);
 
-    // labels: run count and job name on the left, median (min-max) duration right
+    if (!singleRun) {
+      // Whiskers mark the range of observed start and finish times.
+      const whisker = (lo: number, hi: number, width: number) => {
+        const a = x(lo), b = x(hi);
+        if (b - a < 1.5) return;
+        const height = 3;
+        const depth = Math.min(3, (b - a) / 2);
+        const fixed = (value: number) => value.toFixed(1);
+        const stroke =
+          `fill="none" stroke="${C.whisker}" stroke-width="${width}" stroke-linecap="round" stroke-linejoin="round"`;
+        body.push(
+          `<line x1="${fixed(a)}" y1="${fixed(cy)}" x2="${fixed(b)}" y2="${
+            fixed(cy)
+          }" stroke="${C.whisker}" stroke-width="${width}"/>` +
+            `<polyline points="${fixed(a + depth)},${fixed(cy - height)} ${
+              fixed(a)
+            },${fixed(cy)} ${fixed(a + depth)},${
+              fixed(cy + height)
+            }" ${stroke}/>` +
+            `<polyline points="${fixed(b - depth)},${fixed(cy - height)} ${
+              fixed(b)
+            },${fixed(cy)} ${fixed(b - depth)},${
+              fixed(cy + height)
+            }" ${stroke}/>`,
+        );
+      };
+      whisker(j.start.min, j.start.max, 0.8);
+      whisker(j.end.min, j.end.max, 1.4);
+    }
+
+    // Labels show the run count and job name on the left. Aggregate charts
+    // show the median and range.
     body.push(
       `<text x="${PAD + COUNT_COL - 10}" y="${
         (top + BAR_H).toFixed(1)
@@ -800,15 +977,21 @@ function drawSection(title: string, jobs: JobAgg[]) {
         (top + BAR_H).toFixed(1)
       }" font-size="11" fill="${C.text}">${esc(j.name)}</text>`,
     );
-    body.push(
-      `<text x="${(xe + 8).toFixed(1)}" y="${
-        (top + BAR_H).toFixed(1)
-      }" font-size="11" fill="${C.text}">${clock(j.dur.med)}` +
-        `<tspan dx="6" fill="${C.sub}" font-size="10">${clock(j.dur.min)}–${
-          clock(j.dur.max)
-        }</tspan></text>`,
+    if (!singleRun) {
+      body.push(
+        `<text x="${(xe + 8).toFixed(1)}" y="${
+          (top + BAR_H).toFixed(1)
+        }" font-size="11" fill="${C.text}">${clock(j.dur.med)}` +
+          `<tspan dx="6" fill="${C.sub}" font-size="10">${clock(j.dur.min)}–${
+            clock(j.dur.max)
+          }</tspan></text>`,
+      );
+    }
+    const durationLanes = Math.max(
+      0,
+      ...durationPlacements.map((placement) => placement.lane),
     );
-    y += ROW_H;
+    y += ROW_H + durationLanes * DURATION_LABEL_LANE_H;
   }
   y += SECTION_GAP;
 }
@@ -878,7 +1061,26 @@ if (aggregates.some((j) => j.phase.other > 0)) {
   legendBox(C.other, false, "other (unmarked)");
 }
 if (mainJobs.length) legendBox(C.main, true, "main branch only");
-{
+const hasFailedAttempts = aggregates.some((job) =>
+  job.attempts.some((attempt) => failedConclusion(attempt.conclusion))
+);
+if (hasFailedAttempts) {
+  const centerX = lx + 5;
+  const centerY = legendY - 4;
+  const radius = 4;
+  legend.push(
+    `<path d="M ${centerX - radius} ${centerY - radius} L ${centerX + radius} ${
+      centerY + radius
+    } M ${centerX + radius} ${centerY - radius} L ${centerX - radius} ${
+      centerY + radius
+    }" fill="none" stroke="${C.failure}" stroke-width="2" stroke-linecap="round"/>`,
+    `<text x="${
+      lx + 15
+    }" y="${legendY}" font-size="11" fill="${C.sub}">failed attempt</text>`,
+  );
+  lx += 105;
+}
+if (!singleRun) {
   const cyl = legendY - 4, a = lx, b = lx + 22;
   const stroke =
     `fill="none" stroke="${C.whisker}" stroke-width="1.1" stroke-linecap="round" stroke-linejoin="round"`;
@@ -892,12 +1094,12 @@ if (mainJobs.length) legendBox(C.main, true, "main branch only");
       }" ${stroke}/>`,
   );
   lx = b;
+  legend.push(
+    `<text x="${
+      lx + 6
+    }" y="${legendY}" font-size="11" fill="${C.sub}">&lt; min … max &gt; of start &amp; finish</text>`,
+  );
 }
-legend.push(
-  `<text x="${
-    lx + 6
-  }" y="${legendY}" font-size="11" fill="${C.sub}">&lt; min … max &gt; of start &amp; finish</text>`,
-);
 
 const totalH = Math.round(legendY + 16);
 
@@ -907,27 +1109,30 @@ const runKind = MAIN_ONLY ? "main push" : "run";
 const workflowNames = new Set(
   completed.map((run) => run.workflowName).filter((name) => !!name),
 );
-const workflowLabel = RUN_IDS.length
+const workflowLabel = RUN_IDS.length || singleRun
   ? workflowNames.size === 1 ? [...workflowNames][0] : "selected workflows"
   : WORKFLOW;
-const exactRun = RUN_IDS.length === 1 ? completed[0] : null;
+const exactRun = singleRun ? completed[0] : null;
 const exactBranch = exactRun?.headBranch ? `, ${exactRun.headBranch}` : "";
 const titleScope = exactRun
   ? `run ${exactRun.databaseId} (${exactRun.event}${exactBranch})`
   : RUN_IDS.length
   ? `${completed.length} selected runs`
   : `typical ${runKind}`;
-const titleCount = RUN_IDS.length
+const titleCount = singleRun
+  ? "1 completed run"
+  : RUN_IDS.length
   ? `${completed.length} completed ${completed.length === 1 ? "run" : "runs"}`
   : `median of ${completed.length} completed ${
     MAIN_ONLY ? "main pushes" : "runs"
   }`;
 const title = `${REPO} · ${workflowLabel} — ${titleScope} (${titleCount})`;
-const subtitle =
-  `Bars = median start to finish, split into setup/work/shutdown by step; ` +
-  `whiskers = min/max; text = median (min–max) duration; ` +
-  `${
-    SUCCESS_ONLY ? "successful jobs only" : "all conclusions"
+const subtitle = singleRun
+  ? `Bars = each job attempt from start to finish, split into setup/work/shutdown by step; failed attempts end in ×; all conclusions; ${runKind} finishes ~${
+    clock(prFinish)
+  } · generated ${date}`
+  : `Bars = median start to finish, split into setup/work/shutdown by step; whiskers = min/max; text = median (min–max) duration; ${
+    successOnly ? "successful jobs only" : "all conclusions"
   }; ${runKind} finishes ~${clock(prFinish)} · generated ${date}`;
 
 const svg = [


### PR DESCRIPTION
The dashboard has three drill-down performance pages: runtime benchmarks, CI duration history, and the CI Gantt chart. They showed a coarser and less accurate picture of CI than the main dashboard they drill into, and they had drifted apart from each other visually. This works through seven related problems in those pages, in the sampling that feeds them, and in the Gantt script.

CI duration now measures from the moment a commit lands. The tile used to start its clock when GitHub began the current run attempt. That omitted the time the commit spent queueing, and it reset the start whenever a failed workflow was rerun. The shared run shape carries the workflow creation timestamp, and each successful duration is calculated from that timestamp through the run's final update, so it includes runner queueing and rerun time. Malformed spans are discarded before they can enter the median or the sparkline. Only complete, successful push runs are counted: workflow dispatches and scheduled runs also have creation timestamps, but they do not represent a commit landing on the main branch, so including them distorted the median.

History graphs hold 200 points instead of about 90. At the current CI rate the old target discarded too much of the run-to-run shape that these detailed views exist to expose. The new target matches the main dashboard's 200-run window, so a drill-down covers the same depth as the tile it came from. Runtime artifact collection uses eight-minute buckets for its shortest view, and both runtime and CI graphs use proportionally narrower buckets across longer windows.

CI history sampling now fills that target. Fixed clock-time buckets can retain far fewer builds than the configured target, because main pushes cluster during working hours and leave many buckets empty. A window with enough eligible builds therefore stayed close to the old density even after the target rose. Eligible builds are now sorted chronologically, and exactly the configured number are taken from evenly distributed positions in that sequence, including its oldest and newest builds.

Persisted sampling manifests carry the version of the algorithm that produced them, versioned separately from the cache file format. A manifest written by an older algorithm no longer counts as fresh, so a prior under-filled selection is replaced, while the job timings already cached for those runs remain available for immediate rendering. The sampling version is part of the comparison between a completed refresh and its persisted manifest, which avoids rebuilding cached data after a successful refresh. When every newly selected run fails and the collector keeps the previous sample, that sample's earlier version is carried forward rather than being certified as a current selection. Cached runs with no exact refresh manifest have unknown provenance: they can still be shown, but they stay marked stale and the next request retries collection.

A few extreme measurements no longer flatten a graph. Each vertical scale is chosen after removing the two lowest and two highest displayed values, provided at least twenty values are present. Every point stays in the rendered line, so a removed point may clip instead of compressing everything else. A shorter series keeps its full range. The two shared drawing helpers take the trimming as an option, and both history pages pass it.

A failed collection stays on screen until it is replaced. The most recent GitHub collection failure remains visible in the runtime benchmark and CI duration progress panels until a later collection for that history view succeeds. Update checks return the remembered failure without reporting it as an active request, and cached graphs are preserved while the error is shown. CI retry throttling stays source-wide, while the failure message is stored per repository and per selected history window. A CI failure is cleared only after replacement data has been persisted and validated. The browser's copy of that state is synchronized so that an explicit recovery clears it, while a response from an older server does not erase it.

The three pages share the styles they had each grown their own copies of. The shared performance navigation module now defines the page shell, selector, controls, progress panel, time axis, and history row rules. The commit-specific Gantt page reuses the progress subset, and the Gantt form markup is normalized to the same component classes. Rules specific to one chart stay with their own page. A test asserts that every full performance page includes the shared stylesheet.

Single-run Gantt charts draw every rerun attempt. They used to combine the first attempt's timing with the latest conclusion, which hid successful retries and made a delayed retry look as though it had run alongside the original jobs. Each distinct job execution is now kept with the workflow attempt it belongs to, and every attempt is drawn on one job row at the time it actually ran. Each attempt's duration is written beside its own bar, moving to additional lines when a quick retry leaves too little horizontal room. The delay before a retry stays blank. A failed or timed-out execution ends in a red cross, drawn above later bars so that it stays visible and keeps the tooltip for its own attempt. Charts covering several workflow runs stay statistical: they select the latest execution of each job before calculating aggregate bars. Collapsed rerun cache entries written by the old collector are rejected until they can be refetched with attempt-aware data.

The dashboard README and the CI performance guide are updated to describe the new target, the sampling, the scale trimming, the retained failures, the shared styles, and the per-attempt bars.

Verification:
- the dashboard package test suite, 574 tests, all passing
- the scripts package test suite, which covers the Gantt renderer
- repository-wide deno fmt --check, clean across 4273 files
- repository-wide deno lint, clean across 4246 files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes performance history denser and attempt-aware, aligns runtime, CI duration, and the Gantt chart with the main dashboard, and adds guards to prevent misleading charts. CI duration now measures from commit landing; history windows match 200 runs; single-run Gantt charts show every attempt.

- **New Features**
  - CI duration is calculated from workflow creation to finish and includes queueing and reruns. Only successful main push runs count; malformed spans are ignored.
  - History shows 200 points selected evenly across the window. Runtime’s shortest buckets are 8 minutes; both runtime and CI scale bucket widths for longer windows.
  - Vertical scales trim extremes for clearer charts: with 20+ values, the two lowest and two highest are dropped from scale calculations; all points still render.
  - Single-run Gantt charts draw each rerun attempt on one job row at the time it ran, with per-attempt labels and a red cross for failed attempts. Delays between attempts remain blank. Multi-run charts remain statistical.

- **Refactors**
  - Shared styles, progress panel, and navigation across performance pages in `packages/dashboard`; the Gantt page is aligned and tests assert the shared stylesheet is included.
  - Sampling manifests record an algorithm version. Outdated selections refresh without dropping already-cached runs; unknown-provenance cached runs display but remain marked stale.
  - Progress panels keep the last GitHub collection failure visible until a successful refresh persists, with client state synchronized.
  - Stricter validation prevents bad charts: the CI duration tile drops runs with unusable spans; the history store rejects invalid sampling versions; and `scripts/ci-gantt.ts` errors when a run reports multiple attempts but jobs lack attempt data (single-attempt caches still render). Documentation updated accordingly.

<sup>Written for commit 5e6e3af1942b7e2b8d8e55e95353dd3ba6f0cb2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

