### PR TITLE
feat(dashboard): distinguish status favicon silhouettes

### DIFF
--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -87,10 +87,14 @@ The tab favicon follows the most urgent visible tile. It is red when any tile is
 red, orange when there are no red tiles but at least one orange tile, and green
 otherwise. Gray tiles do not turn the favicon gray. The page uses one URL-backed
 PNG favicon. Scalable source artwork is used only to generate and verify those
-raster assets; it is not part of the runtime dependency graph. The red favicon
-starts sad and becomes a crying face after the dashboard stays red for one
-continuous hour. The server retains the elapsed time across reloads. Returning
-below red resets it once every collector due in the same pass has finished.
+raster assets; it is not part of the runtime dependency graph. The green face is
+a rounded square, the orange warning face is a triangle, and the red faces are
+octagons. The eyes and mouth of the warning face sit ten percent of the canvas
+height below the level the other faces use, which places them in the wide part
+of the triangle instead of near its apex. The red favicon starts sad and
+becomes a crying face after the dashboard stays red for one continuous hour. The
+server retains the elapsed time across reloads. Returning below red resets it
+once every collector due in the same pass has finished.
 
 After changing `favicon-artwork.ts`, regenerate the embedded PNGs and their
 content-based cache version from the dashboard package directory:

--- a/packages/dashboard/favicon-artwork.ts
+++ b/packages/dashboard/favicon-artwork.ts
@@ -9,6 +9,31 @@ const FAVICON_COLORS: Record<FaviconFace, string> = {
   "bad-crying": "#e2504a",
 };
 
+const OCTAGON = `<path d="M10 2h12l8 8v12l-8 8H10l-8-8V10Z"/>`;
+const FAVICON_SHAPES: Record<FaviconFace, string> = {
+  good: `<rect x="2" y="2" width="28" height="28" rx="9"/>`,
+  warn: `<path d="M16 2 30 29H2Z"/>`,
+  bad: OCTAGON,
+  "bad-crying": OCTAGON,
+};
+
+const FAVICON_EYES: Record<FaviconFace, readonly [number, number]> = {
+  good: [12, 20],
+  warn: [13, 19],
+  bad: [12, 20],
+  "bad-crying": [12, 20],
+};
+
+// Downward shift of the eyes, mouth, and any extra features, in canvas units.
+// The warning face drops by ten percent of the 32-unit canvas height, which
+// puts its features in the wide part of the triangle rather than near the apex.
+const FAVICON_FACE_DROPS: Record<FaviconFace, number> = {
+  good: 0,
+  warn: 3.2,
+  bad: 0,
+  "bad-crying": 0,
+};
+
 const SMILE = "M11 19c2.8 2.6 7.2 2.6 10 0";
 const FAVICON_MOUTHS: Record<FaviconFace, string> = {
   good: SMILE,
@@ -22,20 +47,27 @@ const FAVICON_DETAILS: Record<FaviconFace, string> = {
   warn: "",
   bad: "",
   "bad-crying": `
-    <path d="M9.5 11.2l3.5 1M22.5 11.2l-3.5 1" fill="none" stroke="#16181d" stroke-width="1.4" stroke-linecap="round"/>
+    <path d="M9.5 11.2l3.5 1M22.5 11.2l-3.5 1" fill="none" stroke="#16181d" stroke-width="1.8" stroke-linecap="round"/>
     <path d="M12 16.5c-1 1.3-1.4 2.2-1.4 3a1.4 1.4 0 0 0 2.8 0c0-.8-.4-1.7-1.4-3Z" fill="#9edcff"/>`,
 };
 
 export function faviconSvg(status: FaviconFace): string {
   const color = FAVICON_COLORS[status];
+  const shape = FAVICON_SHAPES[status];
+  const [leftEye, rightEye] = FAVICON_EYES[status];
   const mouth = FAVICON_MOUTHS[status];
   const details = FAVICON_DETAILS[status];
+  const drop = FAVICON_FACE_DROPS[status];
+  const shift = drop === 0 ? "" : ` transform="translate(0 ${drop})"`;
   return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-    <rect x="1" y="1" width="30" height="30" rx="9" fill="#16181d" stroke="#23262d" stroke-width="2"/>
-    <rect x="5" y="5" width="22" height="22" rx="7" fill="${color}"/>
-    <circle cx="12" cy="14" r="1.7" fill="#16181d"/>
-    <circle cx="20" cy="14" r="1.7" fill="#16181d"/>
-    ${details}
-    <path d="${mouth}" fill="none" stroke="#16181d" stroke-width="1.8" stroke-linecap="round"/>
+    <g fill="${color}" stroke="#16181d" stroke-width="2" stroke-linejoin="round">
+      ${shape}
+    </g>
+    <g${shift}>
+      <circle cx="${leftEye}" cy="14" r="2" fill="#16181d"/>
+      <circle cx="${rightEye}" cy="14" r="2" fill="#16181d"/>
+      ${details}
+      <path d="${mouth}" fill="none" stroke="#16181d" stroke-width="2.2" stroke-linecap="round"/>
+    </g>
   </svg>`;
 }

--- a/packages/dashboard/favicon-png.generated.ts
+++ b/packages/dashboard/favicon-png.generated.ts
@@ -6,82 +6,68 @@ function decodePng(encoded: string): Uint8Array {
 }
 
 export const FAVICON_VERSION =
-  "64f9277ef7334a62929c866c88a0a7c2f6d76e92a90b21004f6089b6b40eeb9e";
+  "ff2c588d7e036104b8bc81803f6737b08ee1fa7c2ab7e03570e1f0f9757559bd";
 
 export const FAVICON_PNG = {
   "good": decodePng(
-    "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAADiklEQVR4nNWXTUwTURDH57VdoJQvE8Cg" +
-      "JErkwwQL7aVeTNSTB0nUmMhVPGnkYjTxCBxNNDFRoze8YmLUBA+exEQvvbCAJFJq0IgxVhIK9Itut+t/" +
-      "dilt6TZtaZXwS97uvHmbffNm5n0JykNnj/MCacJFQjuj8Zu0JqhLQASF0GT8Ywr/kP0Lc2+gzCHHgK5e" +
-      "l0tTkuMaaS5UK4YgIQvJMrQ4L8uobpNlQGd33wg6HiWQTKqUUBRS1QSKSpqmQVs8QgiyWq0oNrJJElks" +
-      "VmihJzHq982OQdQRKDrofBSdj0AkJb5JsVgUUmVgY6qra0iqqkZNr9/yL8w+hGgYwG5PKuo0RIpGw/rI" +
-      "/wXsCbvdAYnIIlndHA7dAIx+GqN3mY3c6qii5vPd1OA5TDUdTdAUJrYUpHXvT1p56yM1HIcmTU2NXfcE" +
-      "QiEjFG5xrNt1kUh9xTEPhzbwSZoDZzuobcgNIyTUSkcNK/RrfJpW3y+hZgD3U62jbisnrJcERq/HPr4Z" +
-      "o02UFNx5+7AHUvksP/ZmGcH5UIUCL4wJzPcpJPjpaCREiUQCzbALbu95OoD37ka+E/bEwo1JvI1w2Gw2" +
-      "stfWwRv0ASHoW+VFJrSxRqmpdnDwBLVe6YVUOQIv5un3xGdIRhjq6htZCsIAp97rxnoQT4Ou++eKTrhi" +
-      "4cRcvPMOkkF9g/F/UwOcLwfxrDxzlyfwNCjZAI4jZzRjNjMKtTNlGZCZybwutF1zQ0pTqJ3Z3wawiwNb" +
-      "WdyKWbLTxYXambIMqAT724Dv9z5RMhKn9pseklod0OSiBMK0/MRLUovDdBkv04CP+g7Hy3TzQDc5eltR" +
-      "WtBCFJ7/gxKglUlj9+Od88jdU2jJpiwDGM5ynuuccGZw4rUPn9QNMKNoA7oeYCk+2gQpF+583busL63R" +
-      "b0FoiOz4lpfuBk+7boQZMXy7eNt0Ke4LYjNq3KPNaC3vdnz82QBZas1HUyrJiEJfrufZjv/HgYRnEIct" +
-      "RdaBJPNIFgmHKBUGho04hCV1t57gkf945M3qnN2fdSTDE4dSp4xu+/MeSjHtOLPzJeZOOOF4yqamZSbp" +
-      "QynN+H1zLryR9Xt9LGdSuQBRv5hwPmSGoxzY7Rx3HjmDevbFJEWmEZwT7ImKX80yOmeyDGA4HJqiPkd3" +
-      "/ahWDHQ0IyTrVXY7qttAbw7PDkHJzOt5I9QlINZS13ONLPJXn/wayhz+AvKyGXr6gdeQAAAAAElFTkSu" +
-      "QmCC",
+    "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAADJklEQVR4nNWXMUwTYRTH39emBFOjJYGD" +
+      "UlqLMZpAjcfCZCJODpIomshG1M3o4uQmZXQwcdDopIYNE0UTXAUTJxZqLCQy2EqB0pOkQGwgkvb8v2uv" +
+      "HPbaa67Uhl/S6/u+S/P+99777r0KajAVBbR3+q+oOSELUgdUIWRSVQ+2rRFiQ6hqRCUxIxxqJLWa+IBd" +
+      "U0wF+HxBeTeXewWHMpa1I0TE5XDcWlmJR7DaR4kAqSMwSqSGCRwJeuhYfxe5e9uoubuFnG4Xdq3JZnZp" +
+      "J5amzPwv2ppdpu34BnYZEVbWlsZgFBH4FIHzMJxDAFHr5dPkvd0HqzZYjDIRpfWPi1jBoRD3U8mlJzA1" +
+      "igK0sGezczDpxIPzeHIfrINja3aFfj76AovI5XT26ekoCpC8gTnO+UE9uRnJl3P5SKAmlOSS5kQTIHUG" +
+      "r1IuO8k5P/X4EnbqA6cj9vATaTXhcA4pq/H3eQGF3LffCJE03Ev1RJmYp9SbKCwxhoIMawLaO/wzKtGF" +
+      "k2MXyR2SsFM/MlGFfoxOExx/Tq0lBvCNCHgDaeTf0zN+reqjZhdOw8LIOwRAbKAOWvICOvwIANHZt8O4" +
+      "1p9v1ydwRTrWEqJqARy65WezsIi67vaXpMrqvhFbAr7fmaI/SgYWUZPkpjPPB2HtYXXfiC0BnDfOH9PU" +
+      "Bgcv9juwum/ElgAtxE8LIb5XGmKr+0ZsCThIDqeAhZFJXPPhLdeouOHoaegZH8LVHJsC9oqMZ4SjIcwI" +
+      "wRasiHbiafodzfd+hl9m/FIrhy0B7NzY18vB3VQaDmkiymEiIID2pB5n1ZV+yHC1c6i5o2XmFewQJiap" +
+      "MD35KlY/ww/C0cS7eBPNyKMJaHwzanQ7lvSBBINnN6JglQa7cPhjePrtWHr/QMJIXn+EVDrHRVT/kYy+" +
+      "KsmEjC2YBRo+lDJ6LRBoHcRxQk3Umg4Ou4Kcr08tYgWH5cZyHaMIrgmOBB+zZhyzasWw053CMU1Px4pt" +
+      "+l/nTIkARktHLvuaUBNY1g5y7nI4b+phN2IqQEfSTkdO1v6ckpAJLytsV4HYxG+0P6fkcES42rFpSkUB" +
+      "/4O/Cam/MHcVf0MAAAAASUVORK5CYII=",
   ),
   "warn": decodePng(
-    "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAADGklEQVR4nO2XTUwTQRTH33RboFCEg4mJ" +
-      "JCZGwANpWQ5yhaOJJsDNqAc9eBcTPfJ19SB3Y/SgxhuQaOKxXPHAQsOBUmNigomJCcV+027H/9tlYUu3" +
-      "bsuuX4m/ZHbfTJt9b957M/NGUAP6L0cnSAqVhByX/CbZi+EWEGkhpIZvxPENLbWdWMFgHXUGDAypqixX" +
-      "n0uSKrq+IUhoIhS4u7OlaegeUWNA/2BsFornCFSrOlXKZdL1CppOUkqMNo8QghRFQQtSMBSiQEDBKMZJ" +
-      "zKWSm/MQDQSaAZTPQfksRCoflKhYLEDyBzamvb2DQm3t6Bn96dT25iJE0wB2e7Wsr0OkQiFnzPxXwJ4I" +
-      "h7sgEQVCygiHwzAAs1/H7FWnmXeHg3Rj7ByNRXtpsK8TI+4kd/O0mkjTm9WvlClUMHJMR0fY8ARCoSEU" +
-      "I+LSoDpJpC9xzHPZDP5yzPXRszQ9dQFGmPFrlUxBpydLn+nt2jf0TOB+6uyKHOaEMiUweyP2B6UildAs" +
-      "WPnMzYuQvLPw+lONEZwPbWjwwrzAeo8jwccK+SxVKqa72O3LMzG82UrvsCcmFzbxNr8fDAYp3BmBN2gV" +
-      "IYjt8SaTzeyTtdTuXe1DOw/JP56+/4K2C8kMQ6S7h6U0DIgaWjPf03iavHw41HTCNQsn5u3HW5BMus/0" +
-      "4gkTnAxYW7yCp/+M3v+Ap0nLBnAcOaMZp5Xh9jvjyYB5ZPK7w0zmfeEBlNhx+535tw1gF1tZzKvkpIvd" +
-      "fmc8GeAH/w3wZMCjZymKJ/YguXMN58iswzniyQB7lrvheRW8wlY84PNWvIOt+JbzVhxL4zDq+UOH0X7D" +
-      "43gFx3HEYS2fhiz2iIlGx/HvKEhOJnBNQWIvyfK5LFlhYNgITqbTeoJnztWQXTm7v6YkwxNFaVSD2uGf" +
-      "FaXjKEqbTUxOuLhrUUobqWRCxfsvKMsZKxcgGhcTzgd7OLzAbue488wZ9GsvJhZ2Izgn2BO+X81sypka" +
-      "AxgOhyzrL6BuGF3fgKINEVLusNvRPQLjzvDqEFS1X897MNwCYt+6nksKaB+T2jIG6/gBFEHyayNGp7EA" +
+    "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAC3klEQVR4nMWWXUhTYRzGn3dGpmSIxHY2" +
+      "2TgDqSDIVOg27UoocN1VNxkkJHhRgUE38+OmywgEA5MMoi5VKPAq9TbIsm76EDYmujMJkwzFaDs97+yY" +
+      "mztn5xw/9oM/57//NvY8z3nPu1egxOxKgNcfes8LlpKJBl5c4VqAogTbM8BTtvAANzRtfgQucC3Ap4Ri" +
+      "OnQVREDEU1oizNYxguUYw72/ppyvgOTyhusUHAtQVbV6bSMTg65XD3adwup6GveGv0GmUHHE0xCPx1f4" +
+      "Mds4FuBVQr2A3tNYV4XHFCC5NfAZM3Or7ETfkpbohQMcCVDz3DdRhOQdf7yTIiDESmW5J+wkBUcCCrk3" +
+      "cJuCbQGqiXsDtynYFmDl3sBNCrYEqEXcG7hJwZYAuh+h++sXzx1Hz7UwrOgensP0px/UIB6lkonbHFki" +
+      "WJYoiqpmkI6xxVi0HoGaw+zMWVz+jUj/LDu5RZeFNS0ehwVFBThxb9D3IobXb7+zE8+4FtphgWCZku/+" +
+      "1/ofPJlY5CvgZmsAJ2or2QFfF9Zy5kcrDtlOwVJAvvtI/0dGvAFJgP8DY9Ez7FBwbjcFwSpIvnt57y/c" +
+      "n2EKaU5Al2V486CRHQrO7a4FUwE+f3BU1xG5ct6Hu5dDnAAvp1N4OJpgB9zh7Crfk5jN7aQgWDug+2a6" +
+      "n5Ruxum+ilcD+e8n2T6TFJrLWRtTkOkwhRamMIU8CgrwKcFJHWjuaK1FBxfVbhji4hyaWJA/NJXS5ls4" +
+      "ykGwcrBy74ZiKewQYOa+c+ALt9qf7IrTVHcMg10n2W1ilYJgbWHlfvtKL4b8vnwSDKxSyBFg5l4iHyt5" +
+      "9rODPCvKx3Y7ZikIVhZvQI0gkx6VX37efTrH/V5glsKWAOOYHeWOd4k7337wintCP/cGeYA1jvGCxXv/" +
+      "/5g9Ht3cXveLNm7b8lZ6/h3jswIM9zhAjBSyArz+4AfoqGd7cAjMLiXnz2YFlJKSC/gL42ypMOYMleAA" +
       "AAAASUVORK5CYII=",
   ),
   "bad": decodePng(
-    "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAADeklEQVR4nN2XS08TURTHz+20tEB5aEQt" +
-      "wUACtCampY0u3MEHEB9LdKMb91r3LXs1rt3oRlz6gA8AOxeaDhATW0oikYCK0UJb2tJOx/+ZYUpf0ELr" +
-      "85fc6bl3mjn/e86Ze+8I2ochl/sKqcJLQh1T+ZfUbgwfAhETQpXxjFk8Q46GF19hsIIKAcPnvF41m3+i" +
-      "kupFt2kIErKwmG4tvZdldAuUCBhyegJwHCSQzyuUy2ZJUXJoCqmqitH6EUKQJEloZjJbLGQySRjFOIlg" +
-      "NLIwCVNDoGnAeRDOAzApu5OhdDoFqzmwGKvVRpYWK3pa/040vPAIpi6Aw57PKiGYlEoltZn/CjgSra3t" +
-      "sIhMFsnH6dAEYPYhzN5bbeYdZokmTp+g0eOd5GqzYaQ24e00zX3fouefv1E8p2BkD5utVYsEUiEjFT4x" +
-      "6PReJVJecM6TiTj+ssd4zzG6O+CgDuTyKMRROw8/rtP0xg/0dBB+amu379aEdE1g9lrudzJpyqAZsPPA" +
-      "YB+sxplcXi0RwfXQgoYoTAq877Mo8NHUdoJyuRxu62F/7XMdeeblcCQuh8KFdJjNZmptsyMaNIcUeCBN" +
-      "7U7EN8l41W73nUI7Cat5PF79ivYFlp4Ge0cXWzEIcGte41sxXHWeeYbrLrh64cK8sbAES6ejsxtXSKgm" +
-      "4O1FN67N58KbRVx1Di2A88gVzVR7M2rdZxoSEEQlz+xW8oTjBPn7HbD2qHWf+bcFcIi5khl+Q8pDXOs+" +
-      "05CAZvB/COBQz2zEaD2zQ+GkvnS72m3ksLbQpZ7uqqE3aFgAO36wslZYUsvhJdzf36sJqUZDAu5FVmgW" +
-      "W6wdTnip5pXyfKe+t7/bSmptCttvAuLGsHXfd/bjTil1C5jCUuyEg2L8EMAPDwyeoV6rBSOVrGWy2Pk+" +
-      "aekIlu2kESzF16svxZ4YNqOuP7QZbe67HU/7zpJdMqHXOAklT+OhD4XaKdmOh37DgcSoH4OSA0nxkWw7" +
-      "mSAjDQyL8A/0HjkSPPMgaqLYOYe/5EiGKw6lbhluRw46lHJllxfmfnDBsdODD6U0H40sevH7FxzLGaMW" +
-      "YGofJlwPxeloBA47551nzqBf+mFiUCyCa4Ij0fRPsyLnTIkAhtOhZpWncDeCbtOAo3lhkW5y2NEtgPHq" +
-      "8NshKF/8ed6F4UMgNo3Pc5VM8nJEfonBCn4CaOoZephfYj8AAAAASUVORK5CYII=",
+    "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAACIUlEQVR4nNWV30obQRTGvzSlsUmVthRp" +
+      "ipZTCg0ESpVa6J3JC/QBel/at6h9i5be+wD6AIl3goqKEIggBhUjQVSi8R/GeM7q6CbZ2VnXHcTfxeac" +
+      "zMX327O7MzHcM0YBInp+eHJeQKs1xG1wYrGFZOJRvlKp7HGnxVeAwoYrAkhoBcgV/iH1FP+y79Abj/OK" +
+      "mf1mEz9Lq1huHHGCv4SnAN0hXBFUokuAIghXBJFoE6AIwxUmiWsBshCu8JNwBMhiuEIn4Qj0p9/O2wxX" +
+      "dErUqmvDlwKvB1v8g8KXrLVwhUjkZ0pcAbWt9VibwOzXj3y1z8j0El9vKTBXb+DPygZXwO/3A/jcl+Lq" +
+      "BtO6m1AC3+bL2Dw55Qp4k3iCieEMVzeY1t2EEsjNlnBw1uQKSHPAZEeAad1NKAEZ8djViMc8RmxadxNK" +
+      "IEoetoCMemq3jnLjmOsD/gc87mfIpHow+qKPa/3oFaEEZAP5v1HDeHWbOz3f06/wY6Dfd0MLJZDnt3z/" +
+      "6i0ffSl3yned7OEOKB9eTmNqp84d0Ps4jsJIlitvtAJ+W7F8ZoK84TketRdFfjTqSyhqBGSS3VtxenAB" +
+      "LXzK8GH01/Jh9IsPo7JzGGGxVl0fcgTIOY6bRZsSneHJRDxXUcexQBYldOG8xK0LsiDhFy60CQgUoYQp" +
+      "XOgSECgCiSDhgqeAQHeQCBouaAUEcklwe3sM4YKvgEBhJQKEC0YB21wAk/bqMM78EUMAAAAASUVORK5C" +
+      "YII=",
   ),
   "bad-crying": decodePng(
-    "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAEHUlEQVR4nNWXS2wbVRSG/+tHHSd2kpYC" +
-      "dVSU0uaBipzYAiR2iVC35bFCLQtgA2JJkw0LFEeqlE2EkFjBhm5oFyBRKDtYpDuQqDxNxCOOw0NUaYFC" +
-      "49iO49rj4T8zHXsmdp5jEP2kO3PuHXvuf8859zEKWzAwHH8OhkpAGeOG3GH0snkPqFWlDI3vmOM7tOzi" +
-      "wmdsbKJJwODjiYRRqX1owEiw2jYUlKaCvleXvtM0Vuu4BAwMjUyx4xRIraajWqlA16ssOgzDYOvuUUrB" +
-      "7/ezBBAIBuHz+dnKdqhUNjM/TdNEsZiw8xQ7n6KJyt0yNjZKtNqDiAmFOhA8EGLNrL+ZXZx/l6YlQNxe" +
-      "q+hpmiiViubI/w3EE+FwFy3AF/QnJRymAI4+zdEnWo08GvDjzJHDGDvUjeHODrbszOL6Bq7+vYZLt24j" +
-      "X9XZ0qCjI2x6gqHQGIqkOjGUeB7QP5WYFwt5/qTB6QcP4tyxGKKM5X7IM3fe+eUmrvx5hzULuh+dXZF7" +
-      "OeF/QXH0ZuzvljdQZrGRzqdOHKXlnenlGy4Rkg8HWOiFacX5PscEHyutF1CtVvnYcvvnyeF9j3wz4oln" +
-      "04v1cAQCAYQ7I/QGrjIEI5Rm9BbyOdhT7bWjD7M8RKt9fHDjD5bfaVlhiER7xFqlgLjZa35tlVeLj0YG" +
-      "XQknf36iu8ssu+HaWtEszkFIYr40v0TLItrdyysltBLw7dNxXi1WyhWcXVhCge6T0IgImRVydyIdStbL" +
-      "XVwd4W8vxgfRFwryqcWTXy/warFrATbpfBGzzOhbFHTqgR689WgfWxvM/LyCr/7K4Qg7nOTMSUbdAgVP" +
-      "AlLM5C/uZfKZ2GFM9MdoNdjpuXB/C5CpJMkoSHJtnqI7PRc8CRAq4QivQLBU4HXveBZw7Y0ZBLhZjV44" +
-      "z9re8SQg33cc35x7DyUuWOW3X8aXmQwKdLsQobtl6R47FG3pehtPAlaeOoWPYyfxycykKaIVsk7MDvU3" +
-      "rRE2ngRczpVw/ocsLeDFR2J4JhqudzR3Zw2yAF26eZs1mJuYeGQzuxZwkUvxkGMplpe//v1PtLZ+uSA7" +
-      "nux8wvsnj9cFChkuxWdbL8Ujq9yMerbbjESAzPMJrnDjB7vZsjUiQqbj7HB/037SYjPKbbkdX0k+xuTy" +
-      "seadgl7D6fSP5h4huLbjgf/gQDKZ+RVzPKLZhHgYqR9InEey9WIBdhgEETFxrG/fnpCRp5Z/c3Uu7ncd" +
-      "yXjloTSusdvR7Q6l4zyUOhNzOyThpFPZnm232zQOpbiezSwkeP8fHMsFOxdomh8mkg/OcHhB3C5xl5EL" +
-      "rLs/TGycIiQnxBNt/zRzdC64BAgSDqOiX2B3o6y2DXZ0XQX9r4jbWa3D9tbI7FCoOT/Pe9i8B1TO/jw3" +
-      "4NOWM9plNjbxD51GTHqLW/xKAAAAAElFTkSuQmCC",
+    "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAACw0lEQVR4nMWVXUiTURjH/3Pa1E1RSnND" +
+      "62QfgiBqJXSp0GUJ3UV0nXUrdK0XQTdhUDd5E12EdG11F+hNVKRtEQwmZNPlZrMw9uG2bK7n2Tru6/3y" +
+      "3YY/2LvneQ/s/3vPe3aOBYeMroAQom0ntbeATGaIWuNYLJ5mW92Y3+//TZ0qmgLCbLjEgISqgCgIP2dv" +
+      "wmz/KbRYrTSiTzSdxoT3G1biCUrQllAUEBWES4xKlAmIKoRLjEgUCYgqhkv0JPYFRA3CJVoSWQFRw3CJ" +
+      "mkRWoNN5wl3LcEmpRDi0PpwT6OrJ0BcWRvrLwoOpXcysBXGh1YHzrXb0NTfSXXV8O0l8isSxHIlh8qQL" +
+      "LlsD3c3DEmMfvVQB4c2ApUhg6dIAXYtZph+b8K5SlcNlO4LrzmO40XWUujxzm7/wIvSThP9Ql2O2v5fE" +
+      "7VQVc/H9F7oaFGB4Fp6HtjC/tY1keg/8quYGztBInmueFQSSKTRa6zDe0Y6bzg6SLX56yYEFmHG3j0Ry" +
+      "T8ezMD/cR1UevfFCTAmMLnkR+5umCnBSwMuSAL3xQkwJ8FqY/vqdKmD6dHfZu9UbL8SUALPb5KAr0JCI" +
+      "0dU8pgWW79xHfSKOwWf3qDOPKYGoqxcfJh9j1f0O6w/u4u3GBqL/33lLvRWj7a24Qqtfa+olpgSCI5fx" +
+      "KA68efqQOnVudR+nTydV6pgSmFr7gdehMFXAWYcdY22O/aflBbi4HcltscRVmokpWohqqAoobcUM73Iz" +
+      "/iBVyE4zr3Il+F/wijYrZlK4ynZLRnkrdvZ4kMFgH+1wTxQOIymgFS6REkoCHH6bDiMfz5QFn8OhwFBW" +
+      "QGSP4/SilkSllIY326yjfnkcM6KGEmrhNERtAaIGElrhTJEAI6oooRfOlAkwogoSRsIZRQFGVCBhNJxR" +
+      "FWBEgQS1B0cnnNEUYIRZCQPhjK5ArfkHJ0gkP3COH7oAAAAASUVORK5CYII=",
   ),
 } as const;

--- a/packages/dashboard/favicon.test.ts
+++ b/packages/dashboard/favicon.test.ts
@@ -22,29 +22,44 @@ Deno.test("faviconStatus: red wins, then orange, and gray never replaces green",
 Deno.test("favicon artwork: each face has one matching URL-backed raster icon", () => {
   const artwork: Record<
     FaviconFace,
-    { color: string; mouth: string; detail?: string }
+    {
+      color: string;
+      shape: string;
+      eyes: readonly [number, number];
+      mouth: string;
+      drop?: number;
+      detail?: string;
+    }
   > = {
     good: {
       color: "#43c574",
+      shape: `<rect x="2" y="2" width="28" height="28" rx="9"/>`,
+      eyes: [12, 20],
       mouth: `d="M11 19c2.8 2.6 7.2 2.6 10 0"`,
     },
-    warn: { color: "#e0a852", mouth: `d="M11 20h10"` },
+    warn: {
+      color: "#e0a852",
+      shape: `<path d="M16 2 30 29H2Z"/>`,
+      eyes: [13, 19],
+      mouth: `d="M11 20h10"`,
+      drop: 3.2,
+    },
     bad: {
       color: "#e2504a",
+      shape: `<path d="M10 2h12l8 8v12l-8 8H10l-8-8V10Z"/>`,
+      eyes: [12, 20],
       mouth: `d="M11 21c2.8-2.6 7.2-2.6 10 0"`,
     },
     "bad-crying": {
       color: "#e2504a",
+      shape: `<path d="M10 2h12l8 8v12l-8 8H10l-8-8V10Z"/>`,
+      eyes: [12, 20],
       mouth: `d="M10.5 22c3-4 8-4 11 0"`,
       detail: `fill="#9edcff"`,
     },
   };
-  for (
-    const [status, { color, mouth, detail }] of Object.entries(artwork) as [
-      FaviconFace,
-      { color: string; mouth: string; detail?: string },
-    ][]
-  ) {
+  for (const status of FAVICON_FACES) {
+    const { color, shape, eyes, mouth, drop, detail } = artwork[status];
     assertEquals(
       faviconHref(status),
       `/favicon.png?status=${status}&v=${FAVICON_VERSION}`,
@@ -60,8 +75,16 @@ Deno.test("favicon artwork: each face has one matching URL-backed raster icon", 
     }
     const svg = faviconSvg(status);
     assertStringIncludes(svg, `fill="${color}"`);
-    assertStringIncludes(svg, `<circle cx="12" cy="14"`);
+    assertStringIncludes(svg, shape);
+    assertStringIncludes(svg, `<circle cx="${eyes[0]}" cy="14" r="2"`);
+    assertStringIncludes(svg, `<circle cx="${eyes[1]}" cy="14" r="2"`);
     assertStringIncludes(svg, `<path ${mouth}`);
+    assertStringIncludes(svg, `stroke-width="2.2"`);
+    if (drop === undefined) {
+      assert(!svg.includes("translate"), `${status} keeps its face level`);
+    } else {
+      assertStringIncludes(svg, `<g transform="translate(0 ${drop})">`);
+    }
     if (detail) assertStringIncludes(svg, detail);
     if (status === "bad-crying") {
       assertStringIncludes(svg, `d="M12 16.5`);


### PR DESCRIPTION
The dashboard's tab favicon carried the status only in its color: all four faces were the same rounded square, tinted green, orange, or red. Anyone who cannot separate those hues, or who is glancing at a small tab strip, had no second cue to fall back on.

Give each status its own outline. The green face keeps the rounded square, the orange warning face becomes a triangle, and both red faces become octagons, echoing the road signs those colors already imply. The colored shapes now reach closer to the edge of the 32-pixel canvas and the facial features are thicker, so the silhouette survives being drawn at tab size. The warning face also moves its eyes inward, because the triangle is narrow where they sit.

A triangle is widest at its base, so features drawn at the height the other faces use crowd the apex and leave the lower half empty. Each face therefore gets an optional downward shift of its eyes, mouth, and any extra features, and the warning face takes a shift of 3.2 units, which is ten percent of the canvas height. The features move together inside a group that carries the shift, so no coordinate has to be re-authored by hand, and a face with no shift emits no group transform at all.

Regenerate the embedded PNGs and the content-derived cache version, so tabs holding an old icon fetch the new one. Strengthen the artwork test to assert the shape and feature geometry of every face, including the presence of the warning face's shift and its absence on the other three. Document the silhouette contract and the shift in the dashboard README.

Verified with the complete dashboard test task, including the raster parity test that re-renders the source artwork and compares it byte for byte against the committed PNGs, and the browser test, plus repository-wide formatting and lint checks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the dashboard tab favicon legible without relying on color alone. Each status now has its own silhouette (green rounded square, orange triangle, red octagon) with thicker features that read at tab size.

- **New Features**
  - Added per-status shapes and eye positions, plus an optional downward feature shift (3.2 units for `warn`).
  - Updated SVG paths and stroke widths; shapes reach closer to the 32px canvas edge.
  - Regenerated favicon PNGs and bumped `FAVICON_VERSION` so browsers fetch the new assets.
  - Strengthened tests to verify shape, eyes, mouth geometry, and that only `warn` uses the shift.
  - Updated the dashboard README with the silhouette rules and the `warn` face shift.

<sup>Written for commit 989510077849d749a81db218e04d094f1248a802. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

