### PR TITLE
ci-gantt: classify the Blacksmith runner steps and register the repla…

### DIFF
--- a/docs/development/CI_PERFORMANCE.md
+++ b/docs/development/CI_PERFORMANCE.md
@@ -148,6 +148,7 @@ authenticate, and bring test servers and devices up before the real work:
 | 🚧 | guard that fails the build on a banned pattern |
 | 🧪 | run tests |
 | 🧩 | run integration tests |
+| 🔁 | replay captured fixtures under today's source |
 | 🧹 | lint |
 | 🧭 | check skill facts |
 | 📄 | type-check docs |
@@ -179,12 +180,13 @@ before you "correct" a step name back to a more obvious emoji:
 - Downloading logs after a failure is shutdown, so those steps use 📋 rather than
   the 📥 or 📦 download markers.
 
-The steps GitHub injects into every job — `Set up job`, `Post …`, and
-`Complete job` — carry no marker, so the script classifies them by name (setup
-for `Set up job`, shutdown for the other two). Any other step that reaches the
-chart without a recognized marker is counted as "other", drawn in gray, and
-listed on standard error when the script runs, so a missing marker is easy to
-find and fix.
+The steps the runner injects into every job carry no marker, so the script
+classifies them by name. GitHub adds `Set up job`, `Post …`, and `Complete
+job`; the Blacksmith runners add `Set up runner` and `Complete runner`
+alongside them. The two set-up steps count as setup and the rest as shutdown.
+Any other step that reaches the chart without a recognized marker is counted as
+"other", drawn in gray, and listed on standard error when the script runs, so a
+missing marker is easy to find and fix.
 
 ## Root Test Job Shape
 

--- a/scripts/ci-gantt.ts
+++ b/scripts/ci-gantt.ts
@@ -233,8 +233,9 @@ function hasTiming(job: Job): boolean {
 // docs/development/CI_PERFORMANCE.md ("Step phase markers"); keep them in sync.
 // A step whose name carries no known marker lands in "other" and is reported to
 // stderr so a missing marker is easy to spot. In a normal run the only unmarked
-// steps are the ones GitHub injects ("Set up job", "Post …", "Complete job"),
-// which are classified below by name because their wording is not ours to set.
+// steps are the ones the runner injects: "Set up job", "Post …" and "Complete
+// job" from GitHub, plus "Set up runner" and "Complete runner" from Blacksmith.
+// Those are classified below by name because their wording is not ours to set.
 // ---------------------------------------------------------------------------
 
 type Phase = "setup" | "work" | "shutdown" | "other";
@@ -269,6 +270,7 @@ const PHASE_MARKERS: [string, Phase][] = [
   ["🚧", "work"], // guard that fails the build on a banned pattern
   ["🧪", "work"], // run tests
   ["🧩", "work"], // run integration tests
+  ["🔁", "work"], // replay captured fixtures under today's source
   ["🧹", "work"], // lint
   ["🧭", "work"], // check skill facts
   ["📄", "work"], // type-check docs
@@ -296,10 +298,11 @@ function phaseOf(stepName: string): Phase {
   for (const [emoji, phase] of PHASE_MARKERS) {
     if (norm.startsWith(stripVS(emoji))) return phase;
   }
-  // Steps GitHub injects carry no marker; their wording is not ours to set.
+  // Injected steps carry no marker; their wording is not ours to set. GitHub
+  // adds the "job" pair and the "Post …" steps, Blacksmith the "runner" pair.
   if (name.startsWith("Post ")) return "shutdown";
-  if (name === "Set up job") return "setup";
-  if (name === "Complete job") return "shutdown";
+  if (name === "Set up job" || name === "Set up runner") return "setup";
+  if (name === "Complete job" || name === "Complete runner") return "shutdown";
   return "other";
 }
 


### PR DESCRIPTION
…y marker

The Gantt chart splits each CI job bar into setup, work and shutdown by reading the marker emoji each step name starts with. A step with no recognized marker is counted as "other", drawn in gray, and printed to standard error so the missing marker can be fixed. Two kinds of step were landing in that bucket on every run.

The first is the pair of steps the Blacksmith runners inject: "Set up runner" and "Complete runner". The script already special-cased the steps GitHub injects, because their wording is not ours to set, but it only knew GitHub's "Set up job", "Post …" and "Complete job". Our jobs run on Blacksmith runners, which add their own pair alongside GitHub's, so every job in every chart carried two unmarked steps that no workflow edit could ever fix. Classify them the same way as GitHub's: the set-up step is setup, the completion step is shutdown.

The second is 🔁, the marker on deno.yml's "Replay pinned vintages under today's source" step. The emoji was chosen when the step was written but never added to the marker table or the array, which is the one step the vocabulary asks for when a genuinely new kind of step appears. Register it as work — replaying a captured document under today's source is the job's own purpose, not scaffolding around it.

With both in place the chart reports no unmarked steps for a run of this repository's deno.yml.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies Blacksmith runner steps and registers the 🔁 replay marker so CI Gantt charts split jobs correctly and stop showing gray “other” segments. Fixes stderr warnings in runs of deno.yml.

- **Bug Fixes**
  - Classify injected runner steps: "Set up runner" → setup, "Complete runner" → shutdown (aligned with GitHub’s "Set up job" / "Complete job" and "Post …").
  - Map 🔁 to work for "Replay pinned vintages under today's source".
  - Update docs to include the 🔁 marker and explain runner-injected steps.

<sup>Written for commit dc6d9db72f4471ca952c647e67fde9327a5a6ec7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

