### PR TITLE
point more strongly to docs/AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,12 +27,15 @@ outside the layer stack.
 
 ## Documentation Lifecycle
 
-Documentation is split into two categories with different obligations. The full
-rules are in `docs/README.md`; the short version:
+Whenever editing documentation, read [docs/README.md](docs/README.md) and follow
+the rules therein. These include:
 
 - **Live** documentation (everything outside `docs/history/`) describes the
   current system or pending plans. If your change alters behavior that a live
   document describes, update that document in the same change.
+- Live documentation must be forward-looking, and should not refer to previous
+  states of the repository or justify decisions based on past choices.
+  Everything should stand on its own merits in a forward-looking fashion.
 - **Historical** documentation (`docs/history/`) holds point-in-time records:
   audits, reports, investigation findings, executed plans, superseded designs.
   Never edit their content, and never treat them as descriptions of the current


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Strengthened guidance in `AGENTS.md` by requiring editors to read and follow `docs/README.md`, and by adding a clear rule that live docs are forward‑looking and must be updated with behavior changes.
Also tightened the split from historical docs, stating that live docs shouldn’t reference past states or justify decisions based on history.

<sup>Written for commit def8fddd486101e6e3df5e2ce9e0483687ff9c94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

