### PR TITLE
fix(hooks): restore the pre-commit and subagent-stop hooks, corrected

### DIFF
--- a/.claude/scripts/common/checks.ts
+++ b/.claude/scripts/common/checks.ts
@@ -1,0 +1,135 @@
+/**
+ * The fmt/lint/check battery, scoped to a file list and a worktree.
+ *
+ * Shared by the pre-commit and subagent-stop hooks so that the two agree on
+ * which files a check can meaningfully be pointed at. Every check here is
+ * read-only: a hook that reformats the tree it is inspecting turns a report
+ * into an edit, and an edit nobody asked for in a tree nobody is working in.
+ */
+
+/**
+ * Schema-generator fixture inputs use bare Cell/Stream/Writable types injected
+ * by a custom TypeScript compiler host (CELL_BRAND_PRELUDE in
+ * schema-generator/test/utils.ts), so `deno check` cannot resolve them: the
+ * prelude is a template string, not a file it can be pointed at.
+ *
+ * They are checked, just not here. `test/fixtures-runner.test.ts` batch
+ * type-checks every one of them through that same host on each run of the
+ * package's tests, on by default and disabled only with SKIP_INPUT_CHECK. That
+ * is the stricter of the two checks, because it is the compiler the generator
+ * itself uses. Skip them rather than teaching this hook a second, weaker way to
+ * check them — a copy of the prelude here would be a second source of truth
+ * free to drift from the one that matters.
+ */
+function isSchemaFixtureInput(path: string): boolean {
+  return path.includes("schema-generator/test/fixtures/") &&
+    path.endsWith(".input.ts");
+}
+
+/**
+ * The static type assets are what the pattern compiler serves to authored code
+ * as its standard library and type modules, not modules of this repo. `.d.ts`
+ * ends in `.ts`, so they reach this filter. Checking them declares a second
+ * standard library alongside Deno's own: `es2023.d.ts` redeclares `lib.es5`
+ * members with different types, and `jsx.d.ts` and `commonfabric.d.ts` fail on
+ * their own too. `deno.jsonc` keeps this directory out of fmt and lint, and
+ * `tasks/check.sh` never lists it.
+ *
+ * The one file here that is not a declaration, `types/cfc.ts`, is also covered
+ * elsewhere and in a way that matters more: it is generated from
+ * packages/api/cfc-authoring.ts, and `deno task check-cfc-types` regenerates it
+ * and fails on any difference. CI runs that. A `deno check` here would say only
+ * that it parses, never that it still mirrors the authoring surface.
+ */
+function isStaticTypeAsset(path: string): boolean {
+  return path.includes("packages/static/assets/");
+}
+
+/**
+ * The runner's test files read a global `clock`, declared ambiently in
+ * packages/runner/test/clock.d.ts with no import anywhere. `tasks/check.sh`
+ * sees that declaration because it checks the package directory as one
+ * program; checking a handful of files on their own does not, and every such
+ * file then fails with "Cannot find name 'clock'". Pass the declaration
+ * alongside so the check matches what CI does.
+ *
+ * This differs from the two skips above in what the file needs, not in how
+ * much it deserves checking. Those files are checked by machinery better
+ * suited to them and could only be checked worse here; these need one more
+ * file in the same invocation, which is cheap and exact.
+ */
+const AMBIENT_DECLARATIONS: Array<[prefix: string, declaration: string]> = [
+  ["packages/runner/test/", "packages/runner/test/clock.d.ts"],
+];
+
+function ambientDeclarationsFor(paths: string[]): string[] {
+  return AMBIENT_DECLARATIONS
+    .filter(([prefix, declaration]) =>
+      paths.some((p) => p.startsWith(prefix) && p !== declaration)
+    )
+    .map(([, declaration]) => declaration);
+}
+
+/** Files `deno check` can be pointed at individually. */
+export function typeCheckable(files: string[]): string[] {
+  return files.filter((f) =>
+    /\.(ts|tsx)$/.test(f) && !isSchemaFixtureInput(f) && !isStaticTypeAsset(f)
+  );
+}
+
+async function runDeno(
+  worktree: string,
+  label: string,
+  args: string[],
+): Promise<string | null> {
+  const result = await new Deno.Command("deno", {
+    args,
+    cwd: worktree,
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+  if (result.success) return null;
+  const stderr = new TextDecoder().decode(result.stderr);
+  // Every path was excluded by deno.jsonc — nothing was actually checked.
+  if (stderr.includes("No target files found")) return null;
+  const stdout = new TextDecoder().decode(result.stdout);
+  return `${label}:\n${stdout || stderr}`;
+}
+
+/**
+ * Run fmt/lint/check over `files`, relative to `worktree`. Returns one string
+ * per failing check, empty when everything passed.
+ *
+ * `deno fmt --check`, never `deno fmt`: the caller is told what to reformat and
+ * decides whether to do it.
+ */
+export async function checkFiles(
+  worktree: string,
+  files: string[],
+): Promise<string[]> {
+  if (files.length === 0) return [];
+  const tsFiles = typeCheckable(files);
+
+  const results = await Promise.all([
+    runDeno(worktree, "Formatting issues found", ["fmt", "--check", ...files]),
+    runDeno(worktree, "Lint errors", ["lint", ...files]),
+    tsFiles.length > 0
+      ? runDeno(worktree, "Type check failed", [
+        "check",
+        ...ambientDeclarationsFor(tsFiles),
+        ...tsFiles,
+      ])
+      : null,
+  ]);
+
+  const errors = results.filter((e): e is string => e !== null);
+
+  // Formatting is the one failure with a one-command remedy, and `--check`
+  // names the files but not the fix. Spell it out, scoped to these files, so
+  // the fix stays as narrow as the report.
+  if (errors.some((e) => e.startsWith("Formatting issues found"))) {
+    errors.push(`To fix formatting:\n  deno fmt ${files.join(" ")}`);
+  }
+
+  return errors;
+}

--- a/.claude/scripts/common/checks.ts
+++ b/.claude/scripts/common/checks.ts
@@ -101,6 +101,24 @@ export function typeCheckable(files: string[]): string[] {
 const FORMATTING_LABEL = "Formatting issues found";
 
 /**
+ * `--no-lock` because `deno check` rewrites `deno.lock` whenever a checked
+ * file's dependency graph names a specifier the lock does not have yet — the
+ * ordinary "add a dependency" commit. `deno.lock` is *tracked*, and this runs
+ * before the user's command, so that write landed in their commit: verified, a
+ * commit of one file came out containing two. Type errors are still reported;
+ * only lockfile integrity goes unchecked here, and CI checks that against the
+ * real lock.
+ */
+function typeCheck(worktree: string, tsFiles: string[]): Promise<Ran> {
+  return runDeno(worktree, "Type check failed", [
+    "check",
+    "--no-lock",
+    ...ambientDeclarationsFor(worktree, tsFiles),
+    ...tsFiles,
+  ]);
+}
+
+/**
  * What one `deno` invocation did: failed with output, passed over a known number
  * of files, or ran on nothing.
  *
@@ -227,13 +245,7 @@ export async function checkFiles(
   const [fmt, lint, check] = await Promise.all([
     runDeno(worktree, FORMATTING_LABEL, ["fmt", "--check", ...checked]),
     runDeno(worktree, "Lint errors", ["lint", ...checked]),
-    tsFiles.length > 0
-      ? runDeno(worktree, "Type check failed", [
-        "check",
-        ...ambientDeclarationsFor(worktree, tsFiles),
-        ...tsFiles,
-      ])
-      : "no-targets" as Ran,
+    tsFiles.length > 0 ? typeCheck(worktree, tsFiles) : "no-targets" as Ran,
   ]);
   runs.push(["fmt", checked.length, fmt]);
   runs.push(["lint", checked.length, lint]);

--- a/.claude/scripts/common/checks.ts
+++ b/.claude/scripts/common/checks.ts
@@ -100,11 +100,26 @@ export function typeCheckable(files: string[]): string[] {
 
 const FORMATTING_LABEL = "Formatting issues found";
 
-/** What one `deno` invocation did: failed with output, passed, or ran on nothing. */
+/**
+ * What one `deno` invocation did: failed with output, passed over a known number
+ * of files, or ran on nothing.
+ *
+ * The count matters. deno silently narrows a file list to what its config
+ * includes, so a mixed list — one excluded path, one real one — exits 0 having
+ * looked at half of it. Reporting that as a clean pass over the whole list is
+ * the exact laundering this type was introduced to stop, and it went on
+ * happening because only the *all*-excluded case was detected.
+ */
 type Ran =
   | { failure: string; soft?: boolean }
-  | "passed"
+  | { passed: true; sawFiles: number | null }
   | "no-targets";
+
+/** deno's own tally of what it looked at, when it prints one. */
+function filesSeen(output: string): number | null {
+  const m = output.match(/Checked (\d+) file/);
+  return m ? Number(m[1]) : null;
+}
 
 async function runDeno(
   worktree: string,
@@ -130,12 +145,14 @@ async function runDeno(
       soft: true,
     };
   }
-  if (result.success) return "passed";
+  const stdout = new TextDecoder().decode(result.stdout);
   const stderr = new TextDecoder().decode(result.stderr);
-  // Every path was excluded by deno.jsonc — nothing was actually checked. Not a
+  if (result.success) {
+    return { passed: true, sawFiles: filesSeen(stdout) ?? filesSeen(stderr) };
+  }
+  // Every path was excluded by config — nothing was actually checked. Not a
   // failure, but not a pass either, and the caller has to be able to say so.
   if (stderr.includes("No target files found")) return "no-targets";
-  const stdout = new TextDecoder().decode(result.stdout);
   return { failure: `${label}:\n${stdout || stderr}` };
 }
 
@@ -145,8 +162,10 @@ export interface CheckOutcome {
   checked: string[];
   /** Candidates that are not on disk, so could not be checked. */
   missing: string[];
-  /** Checks that ran on nothing because deno.jsonc excludes these paths. */
+  /** Checks that ran on nothing at all — no file here is theirs to look at. */
   inapplicable: string[];
+  /** Checks that saw only some of the files, as "fmt (2 of 5)". */
+  partial: string[];
   /** Checks that could not be launched at all. Report, never block. */
   unavailable: string[];
   /** One entry per failing check, plus a remedy line for formatting. */
@@ -163,11 +182,12 @@ function quoteForShell(path: string): string {
  * `deno fmt --check`, never `deno fmt`: the caller is told what to reformat and
  * decides whether to do it.
  *
- * The outcome distinguishes checked from skipped from inapplicable, because the
- * alternative is a gate that says "all checks passed" when it checked nothing —
- * which is how an unchecked change gets laundered into an approved one. That is
- * not hypothetical for this repo: `deno.jsonc` excludes `.claude/` from fmt and
- * lint, so for the hook scripts themselves only the type check ever runs.
+ * The outcome distinguishes checked from skipped from partial from inapplicable,
+ * because the alternative is a gate that says "all checks passed" when it checked
+ * nothing — which is how an unchecked change gets laundered into an approved one.
+ * That is not hypothetical for this repo: `deno.jsonc` excludes `docs/` and
+ * `packages/static/assets/` from fmt, so any commit mixing those with code gets a
+ * partial pass that used to report as a whole one.
  */
 export async function checkFiles(
   worktree: string,
@@ -196,14 +216,15 @@ export async function checkFiles(
       checked,
       missing,
       inapplicable: [],
+      partial: [],
       unavailable: [],
       errors: [],
     };
   }
   const tsFiles = typeCheckable(checked);
 
-  const labels = ["fmt", "lint", "check"];
-  const results = await Promise.all([
+  const runs: Array<[label: string, expected: number, result: Ran]> = [];
+  const [fmt, lint, check] = await Promise.all([
     runDeno(worktree, FORMATTING_LABEL, ["fmt", "--check", ...checked]),
     runDeno(worktree, "Lint errors", ["lint", ...checked]),
     tsFiles.length > 0
@@ -214,18 +235,31 @@ export async function checkFiles(
       ])
       : "no-targets" as Ran,
   ]);
+  runs.push(["fmt", checked.length, fmt]);
+  runs.push(["lint", checked.length, lint]);
+  runs.push(["check", tsFiles.length, check]);
 
   const errors: string[] = [];
   const inapplicable: string[] = [];
+  const partial: string[] = [];
   const unavailable: string[] = [];
-  results.forEach((result, i) => {
-    if (result === "no-targets") inapplicable.push(labels[i]);
-    else if (result === "passed") return;
-    // A check that could not be launched is not a verdict on the code. Surface
-    // it, but never block on it.
-    else if (result.soft) unavailable.push(result.failure);
-    else errors.push(result.failure);
-  });
+  for (const [label, expected, result] of runs) {
+    if (result === "no-targets") {
+      inapplicable.push(label);
+    } else if ("passed" in result) {
+      // A pass over fewer files than we asked about is a pass over fewer files
+      // than we asked about, and has to read that way.
+      if (result.sawFiles !== null && result.sawFiles < expected) {
+        partial.push(`${label} (${result.sawFiles} of ${expected})`);
+      }
+    } else if (result.soft) {
+      // A check that could not be launched is not a verdict on the code. Surface
+      // it, but never block on it.
+      unavailable.push(result.failure);
+    } else {
+      errors.push(result.failure);
+    }
+  }
 
   // Formatting is the one failure with a one-command remedy, and `--check`
   // names the files but not the fix. Spell it out, scoped to these files, so
@@ -236,5 +270,5 @@ export async function checkFiles(
     );
   }
 
-  return { checked, missing, inapplicable, unavailable, errors };
+  return { checked, missing, inapplicable, partial, unavailable, errors };
 }

--- a/.claude/scripts/common/checks.ts
+++ b/.claude/scripts/common/checks.ts
@@ -167,7 +167,7 @@ export interface CheckOutcome {
   /** Checks that saw only some of the files, as "fmt (2 of 5)". */
   partial: string[];
   /** Checks that could not be launched at all. Report, never block. */
-  unavailable: string[];
+  unavailable: Array<{ check: string; message: string }>;
   /** One entry per failing check, plus a remedy line for formatting. */
   errors: string[];
 }
@@ -242,7 +242,7 @@ export async function checkFiles(
   const errors: string[] = [];
   const inapplicable: string[] = [];
   const partial: string[] = [];
-  const unavailable: string[] = [];
+  const unavailable: Array<{ check: string; message: string }> = [];
   for (const [label, expected, result] of runs) {
     if (result === "no-targets") {
       inapplicable.push(label);
@@ -255,7 +255,7 @@ export async function checkFiles(
     } else if (result.soft) {
       // A check that could not be launched is not a verdict on the code. Surface
       // it, but never block on it.
-      unavailable.push(result.failure);
+      unavailable.push({ check: label, message: result.failure });
     } else {
       errors.push(result.failure);
     }

--- a/.claude/scripts/common/checks.ts
+++ b/.claude/scripts/common/checks.ts
@@ -46,28 +46,49 @@ function isStaticTypeAsset(path: string): boolean {
 }
 
 /**
- * The runner's test files read a global `clock`, declared ambiently in
- * packages/runner/test/clock.d.ts with no import anywhere. `tasks/check.sh`
- * sees that declaration because it checks the package directory as one
- * program; checking a handful of files on their own does not, and every such
- * file then fails with "Cannot find name 'clock'". Pass the declaration
- * alongside so the check matches what CI does.
+ * Test files read globals — `clock`, `TestContext.settle` — declared ambiently
+ * in a `.d.ts` beside them with no import anywhere. `tasks/check.sh` sees those
+ * declarations because it checks the package directory as one program; checking
+ * a handful of files on their own does not, and every such file then fails with
+ * "Cannot find name 'clock'". Pass the declarations alongside so the check
+ * matches what CI does.
  *
- * This differs from the two skips above in what the file needs, not in how
- * much it deserves checking. Those files are checked by machinery better
- * suited to them and could only be checked worse here; these need one more
- * file in the same invocation, which is cheap and exact.
+ * This differs from the two skips above in what the file needs, not in how much
+ * it deserves checking. Those files are checked by machinery better suited to
+ * them and could only be checked worse here; these need one more file in the
+ * same invocation, which is cheap and exact.
+ *
+ * Discovered from the tree rather than listed. A hardcoded list named only
+ * packages/runner, so editing a test under packages/background-piece-service or
+ * packages/html — both of which have their own test/clock.d.ts — failed the
+ * check for a global that is in fact declared. A list is also a thing to
+ * forget: the next package to grow a test/*.d.ts would break the same way.
  */
-const AMBIENT_DECLARATIONS: Array<[prefix: string, declaration: string]> = [
-  ["packages/runner/test/", "packages/runner/test/clock.d.ts"],
-];
-
-function ambientDeclarationsFor(paths: string[]): string[] {
-  return AMBIENT_DECLARATIONS
-    .filter(([prefix, declaration]) =>
-      paths.some((p) => p.startsWith(prefix) && p !== declaration)
-    )
-    .map(([, declaration]) => declaration);
+function ambientDeclarationsFor(
+  worktree: string,
+  paths: string[],
+): string[] {
+  const declarations = new Set<string>();
+  const testDirs = new Set(
+    paths.map((p) => p.match(/^(.*\/test)\//)?.[1]).filter((d) =>
+      d !== undefined
+    ),
+  );
+  for (const dir of testDirs) {
+    let entries: Iterable<Deno.DirEntry>;
+    try {
+      entries = Deno.readDirSync(`${worktree}/${dir}`);
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (!entry.isFile || !entry.name.endsWith(".d.ts")) continue;
+      const declaration = `${dir}/${entry.name}`;
+      // Already being checked in its own right; passing it twice is an error.
+      if (!paths.includes(declaration)) declarations.add(declaration);
+    }
+  }
+  return [...declarations].sort();
 }
 
 /** Files `deno check` can be pointed at individually. */
@@ -77,71 +98,143 @@ export function typeCheckable(files: string[]): string[] {
   );
 }
 
+const FORMATTING_LABEL = "Formatting issues found";
+
+/** What one `deno` invocation did: failed with output, passed, or ran on nothing. */
+type Ran =
+  | { failure: string; soft?: boolean }
+  | "passed"
+  | "no-targets";
+
 async function runDeno(
   worktree: string,
   label: string,
   args: string[],
-): Promise<string | null> {
-  const result = await new Deno.Command("deno", {
-    args,
-    cwd: worktree,
-    stdout: "piped",
-    stderr: "piped",
-  }).output();
-  if (result.success) return null;
+): Promise<Ran> {
+  let result: Deno.CommandOutput;
+  try {
+    result = await new Deno.Command("deno", {
+      args,
+      cwd: worktree,
+      stdout: "piped",
+      stderr: "piped",
+    }).output();
+  } catch (error) {
+    // Spawning can throw outright — argv past ARG_MAX is the reachable case.
+    // An uncaught throw here exits non-zero, which for a PreToolUse hook is a
+    // failure report on a commit that may be perfectly fine. Report and pass.
+    return {
+      failure: `${label} could not run:\n${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      soft: true,
+    };
+  }
+  if (result.success) return "passed";
   const stderr = new TextDecoder().decode(result.stderr);
-  // Every path was excluded by deno.jsonc — nothing was actually checked.
-  if (stderr.includes("No target files found")) return null;
+  // Every path was excluded by deno.jsonc — nothing was actually checked. Not a
+  // failure, but not a pass either, and the caller has to be able to say so.
+  if (stderr.includes("No target files found")) return "no-targets";
   const stdout = new TextDecoder().decode(result.stdout);
-  return `${label}:\n${stdout || stderr}`;
+  return { failure: `${label}:\n${stdout || stderr}` };
+}
+
+/** What `checkFiles` actually did — never just "it was fine". */
+export interface CheckOutcome {
+  /** Files that exist and were handed to deno. */
+  checked: string[];
+  /** Candidates that are not on disk, so could not be checked. */
+  missing: string[];
+  /** Checks that ran on nothing because deno.jsonc excludes these paths. */
+  inapplicable: string[];
+  /** Checks that could not be launched at all. Report, never block. */
+  unavailable: string[];
+  /** One entry per failing check, plus a remedy line for formatting. */
+  errors: string[];
+}
+
+function quoteForShell(path: string): string {
+  return /^[\w./@:+-]+$/.test(path) ? path : `'${path.replace(/'/g, "'\\''")}'`;
 }
 
 /**
- * Run fmt/lint/check over `files`, relative to `worktree`. Returns one string
- * per failing check, empty when everything passed.
+ * Run fmt/lint/check over `candidates`, relative to `worktree`.
  *
  * `deno fmt --check`, never `deno fmt`: the caller is told what to reformat and
  * decides whether to do it.
+ *
+ * The outcome distinguishes checked from skipped from inapplicable, because the
+ * alternative is a gate that says "all checks passed" when it checked nothing —
+ * which is how an unchecked change gets laundered into an approved one. That is
+ * not hypothetical for this repo: `deno.jsonc` excludes `.claude/` from fmt and
+ * lint, so for the hook scripts themselves only the type check ever runs.
  */
 export async function checkFiles(
   worktree: string,
   candidates: string[],
-): Promise<string[]> {
+): Promise<CheckOutcome> {
   // A path that is not there cannot be checked, and pointing deno at one turns
   // into a reported failure that reads like a real defect. Callers legitimately
   // arrive with such paths: a subagent's transcript records every file it ever
   // wrote, including scratch files it went on to delete.
-  const files = candidates.filter((f) => {
+  const checked: string[] = [];
+  const missing: string[] = [];
+  for (const f of candidates) {
     try {
       Deno.statSync(`${worktree}/${f}`);
-      return true;
-    } catch {
-      return false;
+      checked.push(f);
+    } catch (error) {
+      // Only absence means "not ours to check". A permission or I/O error is a
+      // real condition; dropping it here would delete a check silently, so let
+      // the file through and let deno report whatever it finds.
+      if (error instanceof Deno.errors.NotFound) missing.push(f);
+      else checked.push(f);
     }
-  });
-  if (files.length === 0) return [];
-  const tsFiles = typeCheckable(files);
+  }
+  if (checked.length === 0) {
+    return {
+      checked,
+      missing,
+      inapplicable: [],
+      unavailable: [],
+      errors: [],
+    };
+  }
+  const tsFiles = typeCheckable(checked);
 
+  const labels = ["fmt", "lint", "check"];
   const results = await Promise.all([
-    runDeno(worktree, "Formatting issues found", ["fmt", "--check", ...files]),
-    runDeno(worktree, "Lint errors", ["lint", ...files]),
+    runDeno(worktree, FORMATTING_LABEL, ["fmt", "--check", ...checked]),
+    runDeno(worktree, "Lint errors", ["lint", ...checked]),
     tsFiles.length > 0
       ? runDeno(worktree, "Type check failed", [
         "check",
-        ...ambientDeclarationsFor(tsFiles),
+        ...ambientDeclarationsFor(worktree, tsFiles),
         ...tsFiles,
       ])
-      : null,
+      : "no-targets" as Ran,
   ]);
 
-  const errors = results.filter((e): e is string => e !== null);
+  const errors: string[] = [];
+  const inapplicable: string[] = [];
+  const unavailable: string[] = [];
+  results.forEach((result, i) => {
+    if (result === "no-targets") inapplicable.push(labels[i]);
+    else if (result === "passed") return;
+    // A check that could not be launched is not a verdict on the code. Surface
+    // it, but never block on it.
+    else if (result.soft) unavailable.push(result.failure);
+    else errors.push(result.failure);
+  });
 
   // Formatting is the one failure with a one-command remedy, and `--check`
   // names the files but not the fix. Spell it out, scoped to these files, so
   // the fix stays as narrow as the report.
-  if (errors.some((e) => e.startsWith("Formatting issues found"))) {
-    errors.push(`To fix formatting:\n  deno fmt ${files.join(" ")}`);
+  if (errors.some((e) => e.startsWith(FORMATTING_LABEL))) {
+    errors.push(
+      `To fix formatting:\n  deno fmt ${checked.map(quoteForShell).join(" ")}`,
+    );
   }
 
-  return errors;
+  return { checked, missing, inapplicable, unavailable, errors };
 }

--- a/.claude/scripts/common/checks.ts
+++ b/.claude/scripts/common/checks.ts
@@ -105,8 +105,20 @@ async function runDeno(
  */
 export async function checkFiles(
   worktree: string,
-  files: string[],
+  candidates: string[],
 ): Promise<string[]> {
+  // A path that is not there cannot be checked, and pointing deno at one turns
+  // into a reported failure that reads like a real defect. Callers legitimately
+  // arrive with such paths: a subagent's transcript records every file it ever
+  // wrote, including scratch files it went on to delete.
+  const files = candidates.filter((f) => {
+    try {
+      Deno.statSync(`${worktree}/${f}`);
+      return true;
+    } catch {
+      return false;
+    }
+  });
   if (files.length === 0) return [];
   const tsFiles = typeCheckable(files);
 

--- a/.claude/scripts/common/guard.ts
+++ b/.claude/scripts/common/guard.ts
@@ -37,7 +37,10 @@ export async function parseCommand(): Promise<string> {
 /**
  * Returns true if the command is a git commit (with message content
  * that should not be inspected for command patterns).
+ *
+ * Re-exported rather than defined here so there is one answer to "is this a
+ * commit?" across all the hooks. The version this replaced missed
+ * `git -C <dir> commit`, which for these callers meant a commit message
+ * mentioning `node` or a legacy CLI was inspected as if it were a command.
  */
-export function isGitCommit(cmd: string): boolean {
-  return /\bgit\s+commit\b/.test(cmd);
-}
+export { isGitCommit } from "./worktree.ts";

--- a/.claude/scripts/common/worktree.test.ts
+++ b/.claude/scripts/common/worktree.test.ts
@@ -257,13 +257,13 @@ Deno.test("gitAddInvocations resolves each add on its own terms", () => {
     dirArgs: [],
     flags: [],
     paths: ["bad.ts"],
-    mutating: false,
+    dryRunnable: true,
   });
   assertEquals(one("git add -A -- bad.ts && git commit -m x"), {
     dirArgs: [],
     flags: ["-A"],
     paths: ["bad.ts"],
-    mutating: false,
+    dryRunnable: true,
   });
 
   // A redirect is not a pathspec. `>/dev/null` reached git as one, git failed,
@@ -285,12 +285,20 @@ Deno.test("gitAddInvocations resolves each add on its own terms", () => {
     ["ok.ts", "bad.ts"],
   );
 
-  // An editing flag writes to the index even under --dry-run, so it must be
-  // recognised and left alone rather than run.
-  assertEquals(one("git add -e && git commit -m x")?.mutating, true);
-  assertEquals(one("git add --edit && git commit -m x")?.mutating, true);
-  assertEquals(one("git add -Ae && git commit -m x")?.mutating, true);
-  assertEquals(one("git add -A && git commit -m x")?.mutating, false);
+  // An editing flag writes to the index even under --dry-run, so it must never
+  // be run. git accepts unambiguous abbreviations, so every prefix of --edit
+  // mutates too — `--e`, `--ed`, `--edi` were all verified to stage. A blacklist
+  // of exact words caught none of them, which is why this is a whitelist.
+  const dry = (c: string) => one(c)?.dryRunnable;
+  for (const f of ["-e", "--edit", "--edi", "--ed", "--e", "-Ae", "-p", "-i"]) {
+    assertEquals(dry(`git add ${f} && git commit -m x`), false, f);
+  }
+  // ...while the flags actually used stay resolvable.
+  for (
+    const f of ["-A", "-u", "-f", "-Au", "--all", "--update", "--chmod=+x"]
+  ) {
+    assertEquals(dry(`git add ${f} && git commit -m x`), true, f);
+  }
 
   // The add's directory is where the *add* runs, not where the commit does.
   assertEquals(one("git add foo.ts && cd sub && git commit -m x")?.dirArgs, []);

--- a/.claude/scripts/common/worktree.test.ts
+++ b/.claude/scripts/common/worktree.test.ts
@@ -1,0 +1,224 @@
+import { assertEquals } from "@std/assert";
+import {
+  isGitCommit,
+  splitAtGitSubcommand,
+  targetDirArgs,
+  withoutQuotedSpans,
+} from "./worktree.ts";
+
+/**
+ * The command parser decides which worktree a commit is judged against, from a
+ * string the agent wrote. Every entry below is a shape that once produced a
+ * wrong answer: the wrong tree, a silent bypass, or a block on files nobody was
+ * committing. A table is the honest form for this — each row is one sentence
+ * about shell syntax, and the bugs it guards against were all one row each.
+ *
+ * `null` means "cannot determine, skip and do not block". Preferring it to a
+ * guess is the design: a wrong tree blocks correct work, and `--no-verify` is
+ * the only way past.
+ */
+const TARGET_DIR_CASES: Array<
+  [name: string, cmd: string, want: string[] | null]
+> = [
+  // --- the plain forms ---
+  ["bare commit", "git commit -m x", []],
+  ["cd then commit", "cd /a && git commit -m x", ["-C", "/a"]],
+  ["git -C", "git -C /a commit -m x", ["-C", "/a"]],
+  ["cd and -C compose", "cd /a && git -C /b commit -m x", [
+    "-C",
+    "/a",
+    "-C",
+    "/b",
+  ]],
+  // Every cd is passed on, in order. git composes them exactly as a shell
+  // does — verified: a later absolute `-C` overrides, a relative one appends —
+  // so /b wins here without us having to decide that ourselves.
+  ["successive absolute cds", "cd /a; cd /b; git commit -m x", [
+    "-C",
+    "/a",
+    "-C",
+    "/b",
+  ]],
+  ["relative cd", "cd packages/runner && git commit -m x", [
+    "-C",
+    "packages/runner",
+  ]],
+  ["add -A before commit", "cd /a && git add -A && git commit -m x", [
+    "-C",
+    "/a",
+  ]],
+
+  // --- quoting ---
+  ["single-quoted cd", "cd '/a b' && git commit -m x", ["-C", "/a b"]],
+  ["double-quoted cd", 'cd "/a b" && git commit -m x', ["-C", "/a b"]],
+  ["quoted -C", 'git -C "/a b" commit -m x', ["-C", "/a b"]],
+  ["quoted -c value", 'git -c user.name="A B" commit -m x', []],
+
+  // --- the commit message is free text, never a command ---
+  ["cd in message", "git commit -m 'cd /evil && rm -rf /'", []],
+  ["work-tree in message", "git commit -m 'explain --work-tree'", []],
+  ["git-dir in message", 'git commit -m "fix --git-dir= handling"', []],
+  ["add in message", "git commit -m 'run git add -A first'", []],
+
+  // --- explicit overrides we do not model ---
+  ["--work-tree", "git --work-tree=/a commit -m x", null],
+  ["--git-dir", "git --git-dir=/a/.git commit -m x", null],
+
+  // --- multi-line scripts, the common agent shape ---
+  ["cd on its own line", "cd /a\ngit commit -m x", ["-C", "/a"]],
+  ["cd on a later line", "git status\ncd /a\ngit commit -m x", ["-C", "/a"]],
+  [
+    "heredoc body is data",
+    "cat > f <<'EOF'\ncd /evil\nEOF\ngit commit -m x",
+    null,
+  ],
+  [
+    "heredoc after commit is fine",
+    "cd /a && git commit -F - <<'EOF'\nmsg\nEOF",
+    [
+      "-C",
+      "/a",
+    ],
+  ],
+
+  // --- subshells: a cd inside one does not outlive it, and telling whether
+  // --- the commit shares it is parsing. Refuse rather than guess.
+  ["subshell around both", "(cd /a && git commit -m x)", null],
+  [
+    "subshell around only the add",
+    "(cd /a && git add -A) && git commit -m x",
+    null,
+  ],
+  [
+    "command substitution",
+    "X=$(cd /a && git rev-parse HEAD) && git commit -m x",
+    null,
+  ],
+  [
+    "subshell after a real cd",
+    "cd /a && (cd /b && ls) && git commit -m x",
+    null,
+  ],
+
+  // --- brace groups run in the current shell, so their cd holds ---
+  ["brace group", "{ cd /a; git commit -m x; }", ["-C", "/a"]],
+
+  // --- quoted text is data: it may not create, move, or become a match ---
+  [
+    "quoted -C in an echo",
+    'echo "git -C /other commit" && git commit -m x',
+    [],
+  ],
+  [
+    "quoted mention before a real cd",
+    'echo "git commit" && cd /a && git commit -m x',
+    [
+      "-C",
+      "/a",
+    ],
+  ],
+  ["grep for the phrase is not a commit", "rg 'git commit' docs/", []],
+
+  // --- cds compose; the last one alone was resolved against the wrong base ---
+  ["absolute then relative", "cd /a && cd sub && git commit -m x", [
+    "-C",
+    "/a",
+    "-C",
+    "sub",
+  ]],
+  ["pushd moves the shell too", "pushd /a && git commit -m x", ["-C", "/a"]],
+  ["popd is unmodellable", "pushd /a && popd && git commit -m x", null],
+];
+
+Deno.test("targetDirArgs resolves the directory a commit lands in", () => {
+  for (const [name, cmd, want] of TARGET_DIR_CASES) {
+    assertEquals(targetDirArgs(cmd), want, `${name}: ${JSON.stringify(cmd)}`);
+  }
+});
+
+/**
+ * A commit that is not recognised is a commit that is never checked, so the
+ * detector has to see every way git can be steered to `commit`.
+ */
+const IS_COMMIT_CASES: Array<[cmd: string, want: boolean]> = [
+  ["git commit -m x", true],
+  ["git -C /a commit -m x", true],
+  ['git -C "/a b" commit -m x', true],
+  ['git -c user.name="A B" commit -m x', true],
+  ["git --no-pager commit -m x", true],
+  ["git -C /a -c core.hooksPath=/dev/null commit -m x", true],
+  ["git status", false],
+  ["git add -A", false],
+  ["echo commit", false],
+  // Quoted: data, not an invocation. Blocking `rg` on staged-file errors is a
+  // failure of the same kind as blocking a commit on another branch's.
+  ["rg 'git commit' docs/", false],
+  ['echo "remember to git commit -m wip"', false],
+];
+
+Deno.test("isGitCommit does not backtrack exponentially", () => {
+  // An optional value on every option gave N options 2^N readings, and a failed
+  // match explored them all: 24 tokens took 1.6s on a hook that runs on every
+  // Bash call. This shape is the one that triggered it.
+  const flags = Array.from({ length: 30 }, (_, i) => `--exclude dir${i}`).join(
+    " ",
+  );
+  const cmd = `rsync -av ${flags} src/ dst/`;
+  const start = performance.now();
+  assertEquals(isGitCommit(cmd), false);
+  const elapsed = performance.now() - start;
+  if (elapsed > 250) {
+    throw new Error(`took ${elapsed.toFixed(0)}ms; expected well under 250ms`);
+  }
+});
+
+Deno.test("isGitCommit sees every steering form", () => {
+  for (const [cmd, want] of IS_COMMIT_CASES) {
+    assertEquals(isGitCommit(cmd), want, cmd);
+  }
+});
+
+Deno.test("withoutQuotedSpans hides message text from flag scans", () => {
+  // The bug this exists for: a message mentioning -a swept the whole dirty tree.
+  const flagRe = /(?:^|\s)(?:--all(?:\s|$)|-[a-zA-Z]*a[a-zA-Z]*(?:\s|$))/;
+  assertEquals(
+    flagRe.test(withoutQuotedSpans(' -m "honour the -a flag"')),
+    false,
+  );
+  assertEquals(
+    flagRe.test(withoutQuotedSpans(" -m 'use -am for speed'")),
+    false,
+  );
+  // ...while a real flag, before or after the message, still registers.
+  assertEquals(flagRe.test(withoutQuotedSpans(' -am "msg"')), true);
+  assertEquals(flagRe.test(withoutQuotedSpans(' -m "msg" -a')), true);
+  // And --no-verify in prose must not disable the hook.
+  const noVerify = /(?:^|\s)--no-verify(?:\s|$)/;
+  assertEquals(
+    noVerify.test(withoutQuotedSpans(' -m "docs: --no-verify escape"')),
+    false,
+  );
+  assertEquals(noVerify.test(withoutQuotedSpans(" --no-verify -m x")), true);
+});
+
+Deno.test("splitAtGitSubcommand keeps each pattern in its own region", () => {
+  const { before, options, after } = splitAtGitSubcommand(
+    "cd /a && git -C /b commit -m 'git add -A'",
+    "commit",
+  );
+  assertEquals(before, "cd /a && ");
+  assertEquals(options, "-C /b ");
+  assertEquals(after, " -m 'git add -A'");
+
+  // A `git add` is found in `before` even when git is steered with globals.
+  assertEquals(
+    splitAtGitSubcommand("git -C /b add -A && ", "add").after,
+    " -A && ",
+  );
+  // No match leaves the whole string as `before`, so callers scan nothing new.
+  assertEquals(splitAtGitSubcommand("git status", "commit"), {
+    before: "git status",
+    options: "",
+    after: "",
+  });
+});

--- a/.claude/scripts/common/worktree.test.ts
+++ b/.claude/scripts/common/worktree.test.ts
@@ -118,6 +118,30 @@ const TARGET_DIR_CASES: Array<
     ],
   ],
   ["grep for the phrase is not a commit", "rg 'git commit' docs/", []],
+  // An escaped quote must not end the span early: the tail would be unmasked,
+  // and text carrying its own separator was read as commands again.
+  [
+    "escaped quote smuggling a cd",
+    String.raw`echo "a \" && cd /evil && echo \"" && git commit -m x`,
+    [],
+  ],
+  [
+    "escaped quote smuggling a ;cd",
+    String.raw`echo "x\" ; cd /evil ; echo \"" && git commit -m x`,
+    [],
+  ],
+  // ...while an escape before a genuine cd leaves that cd intact.
+  [
+    "escape then a real cd",
+    String.raw`printf "%s" "x\"" && cd /real && git commit -m x`,
+    ["-C", "/real"],
+  ],
+  // An apostrophe in prose must not pair with a later one and blank a real cd.
+  [
+    "apostrophe in a double-quoted string",
+    `echo "it's fine" && cd /a && echo "don't" && git commit -m x`,
+    ["-C", "/a"],
+  ],
 
   // --- cds compose; the last one alone was resolved against the wrong base ---
   ["absolute then relative", "cd /a && cd sub && git commit -m x", [
@@ -199,6 +223,16 @@ Deno.test("withoutQuotedSpans hides message text from flag scans", () => {
     false,
   );
   assertEquals(noVerify.test(withoutQuotedSpans(" --no-verify -m x")), true);
+  // Escapes are handled here too, from sharing the mask: ending the span at the
+  // first `"` left the tail visible, and a flag in that tail counted.
+  assertEquals(
+    flagRe.test(withoutQuotedSpans(String.raw` -m "a \" -a \""`)),
+    false,
+  );
+  assertEquals(
+    noVerify.test(withoutQuotedSpans(String.raw` -m "a \" --no-verify \""`)),
+    false,
+  );
 });
 
 Deno.test("splitAtGitSubcommand keeps each pattern in its own region", () => {

--- a/.claude/scripts/common/worktree.test.ts
+++ b/.claude/scripts/common/worktree.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals } from "@std/assert";
 import {
   argumentRegion,
+  commitsAllTracked,
   gitAddInvocations,
   isGitCommit,
   shellWords,
@@ -120,7 +121,10 @@ const TARGET_DIR_CASES: Array<
       "/a",
     ],
   ],
-  ["grep for the phrase is not a commit", "rg 'git commit' docs/", []],
+  // Not a commit at all, so there is no commit whose directory to report: null,
+  // meaning "no answer", rather than [] meaning "here, with no redirects".
+  // Unreachable through the hook, which gates on isGitCommit first.
+  ["grep for the phrase is not a commit", "rg 'git commit' docs/", null],
   // An escaped quote must not end the span early: the tail would be unmasked,
   // and text carrying its own separator was read as commands again.
   [
@@ -184,6 +188,10 @@ const IS_COMMIT_CASES: Array<[cmd: string, want: boolean]> = [
 ];
 
 Deno.test("isGitCommit does not backtrack exponentially", () => {
+  // The ceiling below is deliberately absurd for a linear parse (microseconds).
+  // A tighter one would be a wall-clock invariant on shared CI, which is flaky;
+  // this only trips on the 2^N blowup it exists for, which measured 9.6 SECONDS
+  // at 26 tokens. Correctness is asserted separately, above and below.
   // An optional value on every option gave N options 2^N readings, and a failed
   // match explored them all: 24 tokens took 1.6s on a hook that runs on every
   // Bash call. This shape is the one that triggered it.
@@ -195,8 +203,10 @@ Deno.test("isGitCommit does not backtrack exponentially", () => {
   const start = performance.now();
   assertEquals(isGitCommit(cmd), false);
   const elapsed = performance.now() - start;
-  if (elapsed > 250) {
-    throw new Error(`took ${elapsed.toFixed(0)}ms; expected well under 250ms`);
+  if (elapsed > 3000) {
+    throw new Error(
+      `took ${elapsed.toFixed(0)}ms; exponential backtracking has returned`,
+    );
   }
 });
 
@@ -314,6 +324,28 @@ Deno.test("gitAddInvocations resolves each add on its own terms", () => {
   // No add in the command, and an add named only inside the message.
   assertEquals(gitAddInvocations("git commit -m x"), []);
   assertEquals(gitAddInvocations("git commit -m 'run git add -A'"), []);
+});
+
+Deno.test("commitsAllTracked reads flags, not attached values", () => {
+  // Real `-a` forms.
+  for (const f of ["-a", "-am", "-va", "--all", "-a -m x"]) {
+    assertEquals(commitsAllTracked(` ${f} `), true, f);
+  }
+  // An attached message value is a value, not more flags. `git commit -mdata`
+  // read as `-a` swept every tracked change and blocked on unrelated errors.
+  for (const f of ["-mdata", "-ma", "-m x", "--amend", "-Fafile", "-m", "-v"]) {
+    assertEquals(commitsAllTracked(` ${f} `), false, f);
+  }
+});
+
+Deno.test("over the option bound, a commit is still recognised", () => {
+  // The bounded regex gives up past 12 globals. Giving up there once meant
+  // isGitCommit said false and the hook skipped the commit silently; now the
+  // linear scan still sees it, and targetDirArgs refuses rather than guessing.
+  const many = Array.from({ length: 20 }, (_, i) => `-c k${i}=v${i}`).join(" ");
+  const cmd = `git ${many} commit -m x`;
+  assertEquals(isGitCommit(cmd), true);
+  assertEquals(targetDirArgs(cmd), null);
 });
 
 Deno.test("shellWords splits on the mask and unquotes", () => {

--- a/.claude/scripts/common/worktree.test.ts
+++ b/.claude/scripts/common/worktree.test.ts
@@ -2,6 +2,7 @@ import { assertEquals } from "@std/assert";
 import {
   argumentRegion,
   commitsAllTracked,
+  commitSkipsVerify,
   gitAddInvocations,
   isGitCommit,
   shellWords,
@@ -336,6 +337,37 @@ Deno.test("commitsAllTracked reads flags, not attached values", () => {
   for (const f of ["-mdata", "-ma", "-m x", "--amend", "-Fafile", "-m", "-v"]) {
     assertEquals(commitsAllTracked(` ${f} `), false, f);
   }
+});
+
+Deno.test("commitSkipsVerify honours both spellings", () => {
+  for (const f of ["--no-verify", "-n", "-nm x", "-vn"]) {
+    assertEquals(commitSkipsVerify(` ${f} `), true, f);
+  }
+  // An attached value is a value: `-mn` is a message of "n".
+  for (const f of ["-m x", "-mn", "-man", "-a", "--amend", "--no-edit"]) {
+    assertEquals(commitSkipsVerify(` ${f} `), false, f);
+  }
+});
+
+Deno.test("a line continuation is neither a separator nor an argument", () => {
+  // `git add \<newline> bad.ts` cut the region at the newline and handed git a
+  // lone backslash, so bad.ts was staged, committed and never checked.
+  const cmd = "git add \\\n  bad.ts && git commit -m x";
+  assertEquals(gitAddInvocations(cmd)?.[0]?.paths, ["bad.ts"]);
+});
+
+Deno.test("an unexpanded glob is not resolvable", () => {
+  // The shell expands `*.ts` to this directory; git's pathspec matches
+  // recursively. Resolving it here blocked commits on files in subdirectories
+  // that the command never staged.
+  assertEquals(
+    gitAddInvocations("git add *.ts && git commit -m x")?.[0]?.dryRunnable,
+    false,
+  );
+  assertEquals(
+    gitAddInvocations("git add ok.ts && git commit -m x")?.[0]?.dryRunnable,
+    true,
+  );
 });
 
 Deno.test("over the option bound, a commit is still recognised", () => {

--- a/.claude/scripts/common/worktree.test.ts
+++ b/.claude/scripts/common/worktree.test.ts
@@ -359,6 +359,12 @@ Deno.test("git's -- sentinel ends flag parsing", () => {
   // ...while a real flag before the sentinel still counts.
   assertEquals(commitSkipsVerify(" -n -m x"), true);
   assertEquals(commitsAllTracked(" -am x"), true);
+  // ...and a `--` that is an option's *value* is not the sentinel at all.
+  assertEquals(commitsAllTracked(" -m -- -a "), true);
+  assertEquals(commitSkipsVerify(" -m -- -n "), true);
+  assertEquals(commitSkipsVerify(" --message -- -n "), true);
+  // An attached value consumes nothing, so the sentinel after it still counts.
+  assertEquals(commitSkipsVerify(" -mmsg -- -n"), false);
 });
 
 Deno.test("commitFlagRegion keeps the command, drops redirections", () => {

--- a/.claude/scripts/common/worktree.test.ts
+++ b/.claude/scripts/common/worktree.test.ts
@@ -1,6 +1,9 @@
 import { assertEquals } from "@std/assert";
 import {
+  argumentRegion,
+  gitAddInvocation,
   isGitCommit,
+  shellWords,
   splitAtGitSubcommand,
   targetDirArgs,
   withoutQuotedSpans,
@@ -235,6 +238,50 @@ Deno.test("withoutQuotedSpans hides message text from flag scans", () => {
   );
 });
 
+Deno.test("gitAddInvocation resolves the add on its own terms", () => {
+  // A quoted pathspec must survive. Blanking quotes here produced no arguments
+  // at all, so the file was never checked and the commit went through.
+  assertEquals(
+    gitAddInvocation('git add "packages/foo.ts" && git commit -m x')?.words,
+    ["packages/foo.ts"],
+  );
+  // A pathspec containing a separator is one word, not two commands.
+  assertEquals(
+    gitAddInvocation(`git add 'a&b.ts' && git commit -m x`)?.words,
+    ["a&b.ts"],
+  );
+  // The add's directory is where the *add* runs, not where the commit does.
+  assertEquals(
+    gitAddInvocation("git add foo.ts && cd sub && git commit -m x")?.dirArgs,
+    [],
+  );
+  assertEquals(
+    gitAddInvocation("cd sub && git add foo.ts && cd .. && git commit -m x")
+      ?.dirArgs,
+    ["-C", "sub"],
+  );
+  // And its own `-C` still counts.
+  assertEquals(
+    gitAddInvocation("git -C /a add -A && git -C /a commit -m x")?.dirArgs,
+    ["-C", "/a"],
+  );
+  // No add in the command at all.
+  assertEquals(gitAddInvocation("git commit -m x"), null);
+  // A `git add` named only inside the message is not an add.
+  assertEquals(gitAddInvocation("git commit -m 'run git add -A'"), null);
+});
+
+Deno.test("shellWords splits on the mask and unquotes", () => {
+  assertEquals(shellWords(`  -A  "a b.ts"  'c&d.ts'  plain.ts `), [
+    "-A",
+    "a b.ts",
+    "c&d.ts",
+    "plain.ts",
+  ]);
+  assertEquals(argumentRegion(" foo.ts && git commit"), " foo.ts ");
+  assertEquals(argumentRegion(` 'a&b.ts' && git commit`), ` 'a&b.ts' `);
+});
+
 Deno.test("splitAtGitSubcommand keeps each pattern in its own region", () => {
   const { before, options, after } = splitAtGitSubcommand(
     "cd /a && git -C /b commit -m 'git add -A'",
@@ -251,6 +298,7 @@ Deno.test("splitAtGitSubcommand keeps each pattern in its own region", () => {
   );
   // No match leaves the whole string as `before`, so callers scan nothing new.
   assertEquals(splitAtGitSubcommand("git status", "commit"), {
+    matched: false,
     before: "git status",
     options: "",
     after: "",

--- a/.claude/scripts/common/worktree.test.ts
+++ b/.claude/scripts/common/worktree.test.ts
@@ -305,9 +305,14 @@ Deno.test("gitAddInvocations resolves each add on its own terms", () => {
   for (const f of ["-e", "--edit", "--edi", "--ed", "--e", "-Ae", "-p", "-i"]) {
     assertEquals(dry(`git add ${f} && git commit -m x`), false, f);
   }
+  // `-A` and `-u` are mutually exclusive to git, which exits 128 on the pair, so
+  // accepting the cluster produced an empty dry run and dropped those files.
+  for (const f of ["-Au", "-uA", "-Aufnv"]) {
+    assertEquals(dry(`git add ${f} && git commit -m x`), false, f);
+  }
   // ...while the flags actually used stay resolvable.
   for (
-    const f of ["-A", "-u", "-f", "-Au", "--all", "--update", "--chmod=+x"]
+    const f of ["-A", "-u", "-f", "-Av", "--all", "--update", "--chmod=+x"]
   ) {
     assertEquals(dry(`git add ${f} && git commit -m x`), true, f);
   }

--- a/.claude/scripts/common/worktree.test.ts
+++ b/.claude/scripts/common/worktree.test.ts
@@ -1,7 +1,7 @@
 import { assertEquals } from "@std/assert";
 import {
   argumentRegion,
-  gitAddInvocation,
+  gitAddInvocations,
   isGitCommit,
   shellWords,
   splitAtGitSubcommand,
@@ -187,10 +187,11 @@ Deno.test("isGitCommit does not backtrack exponentially", () => {
   // An optional value on every option gave N options 2^N readings, and a failed
   // match explored them all: 24 tokens took 1.6s on a hook that runs on every
   // Bash call. This shape is the one that triggered it.
-  const flags = Array.from({ length: 30 }, (_, i) => `--exclude dir${i}`).join(
-    " ",
-  );
-  const cmd = `rsync -av ${flags} src/ dst/`;
+  // Consecutive *bare* flags with no values — the shape that actually
+  // backtracks. Built as `--exclude dirN`, this measured nothing: a non-flag
+  // value after each option breaks the chain after one iteration.
+  const flags = Array.from({ length: 30 }, (_, i) => `--flag${i}`).join(" ");
+  const cmd = `ls ~/src/git ${flags} src/ dst/`;
   const start = performance.now();
   assertEquals(isGitCommit(cmd), false);
   const elapsed = performance.now() - start;
@@ -238,37 +239,73 @@ Deno.test("withoutQuotedSpans hides message text from flag scans", () => {
   );
 });
 
-Deno.test("gitAddInvocation resolves the add on its own terms", () => {
+Deno.test("gitAddInvocations resolves each add on its own terms", () => {
+  const one = (cmd: string) => gitAddInvocations(cmd)?.[0];
+
   // A quoted pathspec must survive. Blanking quotes here produced no arguments
   // at all, so the file was never checked and the commit went through.
-  assertEquals(
-    gitAddInvocation('git add "packages/foo.ts" && git commit -m x')?.words,
-    ["packages/foo.ts"],
-  );
+  assertEquals(one('git add "packages/foo.ts" && git commit -m x')?.paths, [
+    "packages/foo.ts",
+  ]);
   // A pathspec containing a separator is one word, not two commands.
+  assertEquals(one(`git add 'a&b.ts' && git commit -m x`)?.paths, ["a&b.ts"]);
+
+  // The caller's own `--` is a sentinel, not a flag. Classifying by a leading
+  // dash re-emitted it ahead of ours and git died on the duplicate, so the file
+  // list came back empty and the commit passed in silence.
+  assertEquals(one("git add -- bad.ts && git commit -m x"), {
+    dirArgs: [],
+    flags: [],
+    paths: ["bad.ts"],
+    mutating: false,
+  });
+  assertEquals(one("git add -A -- bad.ts && git commit -m x"), {
+    dirArgs: [],
+    flags: ["-A"],
+    paths: ["bad.ts"],
+    mutating: false,
+  });
+
+  // A redirect is not a pathspec. `>/dev/null` reached git as one, git failed,
+  // and the commit passed unchecked.
+  assertEquals(one("git add -A >/dev/null && git commit -m x")?.paths, []);
+  // The file descriptor is part of the operator: leaving the `2` behind made it
+  // a pathspec, git failed on it, and the whole list came back empty.
+  assertEquals(one("git add foo.ts 2>/dev/null && git commit -m x")?.paths, [
+    "foo.ts",
+  ]);
+  assertEquals(one("git add foo.ts >>log 2>&1 && git commit -m x")?.paths, [
+    "foo.ts",
+  ]);
+
+  // Every add, not just the first: bad.ts was staged and never checked.
   assertEquals(
-    gitAddInvocation(`git add 'a&b.ts' && git commit -m x`)?.words,
-    ["a&b.ts"],
+    gitAddInvocations("git add ok.ts && git add bad.ts && git commit -m x")
+      ?.flatMap((a) => a.paths),
+    ["ok.ts", "bad.ts"],
   );
+
+  // An editing flag writes to the index even under --dry-run, so it must be
+  // recognised and left alone rather than run.
+  assertEquals(one("git add -e && git commit -m x")?.mutating, true);
+  assertEquals(one("git add --edit && git commit -m x")?.mutating, true);
+  assertEquals(one("git add -Ae && git commit -m x")?.mutating, true);
+  assertEquals(one("git add -A && git commit -m x")?.mutating, false);
+
   // The add's directory is where the *add* runs, not where the commit does.
+  assertEquals(one("git add foo.ts && cd sub && git commit -m x")?.dirArgs, []);
   assertEquals(
-    gitAddInvocation("git add foo.ts && cd sub && git commit -m x")?.dirArgs,
-    [],
-  );
-  assertEquals(
-    gitAddInvocation("cd sub && git add foo.ts && cd .. && git commit -m x")
-      ?.dirArgs,
+    one("cd sub && git add foo.ts && cd .. && git commit -m x")?.dirArgs,
     ["-C", "sub"],
   );
-  // And its own `-C` still counts.
-  assertEquals(
-    gitAddInvocation("git -C /a add -A && git -C /a commit -m x")?.dirArgs,
-    ["-C", "/a"],
-  );
-  // No add in the command at all.
-  assertEquals(gitAddInvocation("git commit -m x"), null);
-  // A `git add` named only inside the message is not an add.
-  assertEquals(gitAddInvocation("git commit -m 'run git add -A'"), null);
+  assertEquals(one("git -C /a add -A && git -C /a commit -m x")?.dirArgs, [
+    "-C",
+    "/a",
+  ]);
+
+  // No add in the command, and an add named only inside the message.
+  assertEquals(gitAddInvocations("git commit -m x"), []);
+  assertEquals(gitAddInvocations("git commit -m 'run git add -A'"), []);
 });
 
 Deno.test("shellWords splits on the mask and unquotes", () => {
@@ -279,6 +316,8 @@ Deno.test("shellWords splits on the mask and unquotes", () => {
     "plain.ts",
   ]);
   assertEquals(argumentRegion(" foo.ts && git commit"), " foo.ts ");
+  assertEquals(argumentRegion(" foo.ts 2>/dev/null && x"), " foo.ts ");
+  assertEquals(argumentRegion(" foo.ts >out"), " foo.ts ");
   assertEquals(argumentRegion(` 'a&b.ts' && git commit`), ` 'a&b.ts' `);
 });
 

--- a/.claude/scripts/common/worktree.test.ts
+++ b/.claude/scripts/common/worktree.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals } from "@std/assert";
 import {
   argumentRegion,
+  commitFlagRegion,
   commitsAllTracked,
   commitSkipsVerify,
   gitAddInvocations,
@@ -349,6 +350,39 @@ Deno.test("commitSkipsVerify honours both spellings", () => {
   }
 });
 
+Deno.test("git's -- sentinel ends flag parsing", () => {
+  // A file *named* like an option is a pathspec after `--`. Reading it as one
+  // turned the hook off (`-n`) or swept the tree (`-a`), leaving it unchecked.
+  assertEquals(commitSkipsVerify(" -- -n"), false);
+  assertEquals(commitSkipsVerify(" -m x -- -n"), false);
+  assertEquals(commitsAllTracked(" -- -a"), false);
+  // ...while a real flag before the sentinel still counts.
+  assertEquals(commitSkipsVerify(" -n -m x"), true);
+  assertEquals(commitsAllTracked(" -am x"), true);
+});
+
+Deno.test("commitFlagRegion keeps the command, drops redirections", () => {
+  // A commit's flags can sit either side of a redirection — it is all one
+  // command — and stopping at one meant blocking a commit git was told to skip.
+  assertEquals(
+    commitSkipsVerify(commitFlagRegion(" -m x >/dev/null --no-verify")),
+    true,
+  );
+  assertEquals(
+    commitSkipsVerify(commitFlagRegion(" -m x 2>err --no-verify")),
+    true,
+  );
+  // ...but a *later command's* flags are not this commit's.
+  assertEquals(
+    commitsAllTracked(commitFlagRegion(" -m x && git status -a")),
+    false,
+  );
+  assertEquals(
+    commitSkipsVerify(commitFlagRegion(" -m x && git commit --no-verify")),
+    false,
+  );
+});
+
 Deno.test("a line continuation is neither a separator nor an argument", () => {
   // `git add \<newline> bad.ts` cut the region at the newline and handed git a
   // lone backslash, so bad.ts was staged, committed and never checked.
@@ -362,6 +396,12 @@ Deno.test("an unexpanded glob is not resolvable", () => {
   // that the command never staged.
   assertEquals(
     gitAddInvocations("git add *.ts && git commit -m x")?.[0]?.dryRunnable,
+    false,
+  );
+  // Brace expansion is the shell's; git has none, so the dry run matched nothing
+  // and the files it does stage went unchecked.
+  assertEquals(
+    gitAddInvocations("git add {a,b}.ts && git commit -m x")?.[0]?.dryRunnable,
     false,
   );
   assertEquals(

--- a/.claude/scripts/common/worktree.ts
+++ b/.claude/scripts/common/worktree.ts
@@ -483,8 +483,17 @@ const SAFE_ADD_LONG = new Set([
   "--no-warn-embedded-repo",
 ]);
 
-/** Short clusters of safe flags only: all, update, force, dry-run, verbose. */
-const SAFE_ADD_SHORT = /^-[Aufnv]+$/;
+/**
+ * Short clusters of safe flags only: all, update, force, dry-run, verbose.
+ *
+ * `-A` and `-u` are mutually exclusive to git, which exits 128 on the pair — so
+ * accepting `-Au` produced an empty dry run and silently dropped those files
+ * from the list.
+ */
+function isSafeShortCluster(flag: string): boolean {
+  if (!/^-[Aufnv]+$/.test(flag)) return false;
+  return !(flag.includes("A") && flag.includes("u"));
+}
 
 /**
  * `--refresh` is deliberately absent, and its absence is the third correction to
@@ -499,7 +508,7 @@ const SAFE_ADD_SHORT = /^-[Aufnv]+$/;
  * run.
  */
 function isSafeAddFlag(flag: string): boolean {
-  if (SAFE_ADD_SHORT.test(flag)) return true;
+  if (isSafeShortCluster(flag)) return true;
   // `--chmod` only in its attached form. Separated (`--chmod +x`), the value is
   // an argument we would classify as a pathspec and move after `--`, leaving
   // git with a `--chmod` that has lost its parameter: it fails, the file list

--- a/.claude/scripts/common/worktree.ts
+++ b/.claude/scripts/common/worktree.ts
@@ -263,14 +263,20 @@ function maskQuotesOnly(text: string): string {
  * commit here at all.
  */
 function looksLikeGitCommit(masked: string): boolean {
-  const tokens = masked.split(/\s+/).filter(Boolean);
-  for (let i = 0; i < tokens.length; i++) {
-    if (tokens[i] !== "git" && !tokens[i].endsWith("/git")) continue;
-    let j = i + 1;
-    while (j < tokens.length && tokens[j].startsWith("-")) {
-      j += VALUE_OPTIONS.includes(tokens[j]) ? 2 : 1;
+  // Per command, not across the whole string. Walking whitespace tokens through
+  // separators made `git --no-pager; commit` look like a commit — two commands,
+  // neither of them one — and since the block-node and block-legacy-cli hooks
+  // treat "is a commit" as their exemption, that waved their guards through too.
+  for (const segment of masked.split(/[;&|\n]+/)) {
+    const tokens = segment.split(/\s+/).filter(Boolean);
+    for (let i = 0; i < tokens.length; i++) {
+      if (tokens[i] !== "git" && !tokens[i].endsWith("/git")) continue;
+      let j = i + 1;
+      while (j < tokens.length && tokens[j].startsWith("-")) {
+        j += VALUE_OPTIONS.includes(tokens[j]) ? 2 : 1;
+      }
+      if (tokens[j] === "commit") return true;
     }
-    if (tokens[j] === "commit") return true;
   }
   return false;
 }
@@ -333,6 +339,22 @@ export function splitAtGitCommit(
  * Found on the mask so `git add 'a&b.ts'` is one argument rather than two
  * commands.
  */
+/**
+ * The flag region of a `git commit`: its own command, with redirections removed.
+ *
+ * Distinct from `argumentRegion`, which stops at a redirection because for
+ * `git add` everything after one is not a pathspec. A commit's flags can sit on
+ * either side of it — `git commit -m x >/dev/null --no-verify` is one command —
+ * and stopping early there meant the hook blocked a commit git had been told
+ * explicitly to skip.
+ */
+export function commitFlagRegion(after: string): string {
+  const masked = maskQuotedSpans(after);
+  const sep = masked.search(/[;\n&|]/);
+  const region = sep === -1 ? after : after.slice(0, sep);
+  return withoutQuotedSpans(region).replace(/\d*[<>]+\s*\S+/g, " ");
+}
+
 export function argumentRegion(text: string): string {
   // Redirections end the argument list too, and the whole operator has to go,
   // file descriptor included. Cutting at the bare `>` left the `2` of
@@ -527,12 +549,14 @@ export function gitAddInvocations(cmd: string): GitAddInvocation[] | null {
       dirArgs,
       flags,
       paths,
-      // An unexpanded glob is not the same pathspec the shell will produce:
-      // `git add *.ts` expands to this directory, while git's pathspec matches
-      // recursively. Resolving it here blocked commits on files in
-      // subdirectories that the command never staged.
+      // An unexpanded glob or brace is not the pathspec the shell will produce.
+      // `git add *.ts` expands to this directory while git's pathspec matches
+      // recursively, so resolving it blocked commits on subdirectory files the
+      // command never staged. `git add {a,b}.ts` is the mirror image: git has no
+      // brace expansion, so the dry run matched nothing and the files it does
+      // stage went unchecked.
       dryRunnable: flags.every(isSafeAddFlag) &&
-        !paths.some((p) => /[*?[]/.test(p)),
+        !paths.some((p) => /[*?[{]/.test(p)),
     });
 
     const advance = add.before.length +
@@ -645,9 +669,10 @@ function expand(raw: string): string {
  * work when spelled the way git documents it first.
  */
 export function commitSkipsVerify(commitFlags: string): boolean {
-  if (/(?:^|\s)--no-verify(?:\s|$)/.test(commitFlags)) return true;
+  const flags = beforePathspecSentinel(commitFlags);
+  if (/(?:^|\s)--no-verify(?:\s|$)/.test(flags)) return true;
   const VALUE_TAKING = "mFcCtSu";
-  for (const m of commitFlags.matchAll(/(?:^|\s)-([A-Za-z]+)/g)) {
+  for (const m of flags.matchAll(/(?:^|\s)-([A-Za-z]+)/g)) {
     for (const ch of m[1]) {
       if (ch === "n") return true;
       if (VALUE_TAKING.includes(ch)) break;
@@ -656,10 +681,23 @@ export function commitSkipsVerify(commitFlags: string): boolean {
   return false;
 }
 
+/**
+ * `commitFlags` truncated at git's `--` sentinel, after which every token is a
+ * pathspec however it is spelled.
+ *
+ * Without it, committing a file *named* `-n` — `git commit -- -n` — read as
+ * `--no-verify` and turned the hook off, leaving that file unchecked.
+ */
+function beforePathspecSentinel(commitFlags: string): string {
+  const m = commitFlags.match(/(?:^|\s)--(?=\s|$)/);
+  return m?.index === undefined ? commitFlags : commitFlags.slice(0, m.index);
+}
+
 export function commitsAllTracked(commitFlags: string): boolean {
-  if (/(?:^|\s)--all(?:\s|$)/.test(commitFlags)) return true;
+  const flags = beforePathspecSentinel(commitFlags);
+  if (/(?:^|\s)--all(?:\s|$)/.test(flags)) return true;
   const VALUE_TAKING = "mFcCtSu";
-  for (const m of commitFlags.matchAll(/(?:^|\s)-([A-Za-z]+)/g)) {
+  for (const m of flags.matchAll(/(?:^|\s)-([A-Za-z]+)/g)) {
     for (const ch of m[1]) {
       if (ch === "a") return true;
       if (VALUE_TAKING.includes(ch)) break;

--- a/.claude/scripts/common/worktree.ts
+++ b/.claude/scripts/common/worktree.ts
@@ -110,19 +110,22 @@ export function isGitCommit(cmd: string): boolean {
 /**
  * `cmd` split around the `git … commit` invocation.
  *
- * Callers want the two halves for different reasons, and both matter: earlier
- * commands (a `git add`, a `cd`) are only meaningful in `before`, while the
- * commit's own flags are in `after`. Splitting here also keeps pattern
- * searches out of the commit message, which can contain any text at all —
- * including something that reads exactly like a `git add`.
+ * Each part answers a different question and only one part can answer it:
+ * earlier commands (a `git add`, a `cd`) live in `before`, git's own global
+ * options in `options`, the commit's flags in `after`. Splitting once, here,
+ * is also what keeps every pattern search out of the commit message — which is
+ * free to contain text reading exactly like a `git add` or a `cd`.
  */
 export function splitAtGitCommit(
   cmd: string,
-): { before: string; after: string } {
+): { before: string; options: string; after: string } {
   const m = cmd.match(GIT_COMMIT);
-  if (!m || m.index === undefined) return { before: cmd, after: "" };
+  if (!m || m.index === undefined) {
+    return { before: cmd, options: "", after: "" };
+  }
   return {
     before: cmd.slice(0, m.index),
+    options: m[1] ?? "",
     after: cmd.slice(m.index + m[0].length),
   };
 }
@@ -142,12 +145,9 @@ export function targetDirArgs(cmd: string): string[] | null {
   // deliberately do not try to model. Refuse rather than answer wrongly.
   if (/--git-dir[=\s]|--work-tree[=\s]/.test(cmd)) return null;
 
-  // Isolate the `git … commit` invocation. The options between `git` and
-  // `commit` are the only place a `-C` can affect the commit, and anchoring
-  // here keeps us out of the commit *message*, which may contain anything.
-  const invocation = cmd.match(GIT_COMMIT);
-  const optionsBeforeCommit = invocation?.[1] ?? "";
-  const prefix = invocation ? cmd.slice(0, invocation.index) : cmd;
+  // The options between `git` and `commit` are the only place a `-C` can affect
+  // the commit; `before` is the only place a `cd` can.
+  const { before: prefix, options } = splitAtGitCommit(cmd);
 
   const args: string[] = [];
 
@@ -165,7 +165,7 @@ export function targetDirArgs(cmd: string): string[] | null {
 
   // Then each `-C` the commit itself carries, in order.
   for (
-    const m of optionsBeforeCommit.matchAll(
+    const m of options.matchAll(
       /-C\s+("[^"]*"|'[^']*'|[^\s]+)/g,
     )
   ) {

--- a/.claude/scripts/common/worktree.ts
+++ b/.claude/scripts/common/worktree.ts
@@ -157,7 +157,7 @@ const BOOLEAN_OPTION = String.raw`-{1,2}\w[\w-]*`;
  */
 const GLOBAL_OPTION = String.raw`(?:(?:${
   VALUE_OPTIONS.join("|")
-})(?:=|\s+)${SHELL_WORD}|${BOOLEAN_OPTION})\s+`;
+})(?:=|[^\S\n]+)${SHELL_WORD}|${BOOLEAN_OPTION})[^\S\n]+`;
 
 const MAX_GLOBAL_OPTIONS = 12;
 
@@ -172,7 +172,7 @@ const MAX_GLOBAL_OPTIONS = 12;
 function gitSubcommand(subcommand: string): RegExp {
   return new RegExp(
     String
-      .raw`\bgit\s+((?:${GLOBAL_OPTION}){0,${MAX_GLOBAL_OPTIONS}})${subcommand}(?![-\w])`,
+      .raw`\bgit[^\S\n]+((?:${GLOBAL_OPTION}){0,${MAX_GLOBAL_OPTIONS}})${subcommand}(?![-\w])`,
   );
 }
 
@@ -523,7 +523,16 @@ export function gitAddInvocations(cmd: string): GitAddInvocation[] | null {
   let consumed = 0;
 
   while (true) {
-    const add = splitAtGitSubcommand(region, "add");
+    // `stage` is git's documented synonym for `add`, and went unmodelled.
+    const byAdd = splitAtGitSubcommand(region, "add");
+    const byStage = splitAtGitSubcommand(region, "stage");
+    const add = !byAdd.matched
+      ? byStage
+      : !byStage.matched
+      ? byAdd
+      : byAdd.before.length <= byStage.before.length
+      ? byAdd
+      : byStage;
     if (!add.matched) break;
 
     // The prefix for this add is everything in the original command up to it.
@@ -668,37 +677,111 @@ function expand(raw: string): string {
  * was honoured — so the escape hatch the tests call "the only way past" did not
  * work when spelled the way git documents it first.
  */
+/**
+ * The option tokens of a commit: its own flags, with each option's *value*
+ * stepped over and everything from `--` onwards dropped.
+ *
+ * Regexing the region for dash-shaped text let a value vote on its own option.
+ * `git commit -m --no-verify` has a message of "--no-verify" and verification
+ * fully on, but read as a flag it turned the hook off — exit 0, no output. The
+ * mirror, `git commit -m -a`, blocked a correct commit on unstaged files.
+ */
+function commitOptionTokens(commitFlags: string): string[] {
+  const tokens = commitFlags.match(/\S+/g) ?? [];
+  const options: string[] = [];
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    if (token === "--") break;
+    if (!token.startsWith("-")) continue;
+    options.push(token);
+    if (consumesNextToken(token)) i++;
+  }
+  return options;
+}
+
+/** Every short flag in `token` up to the first that takes an attached value. */
+function shortFlagsOf(token: string): string {
+  if (!/^-[A-Za-z]+$/.test(token)) return "";
+  let flags = "";
+  for (const ch of token.slice(1)) {
+    if (VALUE_TAKING_SHORT.includes(ch)) break;
+    flags += ch;
+  }
+  return flags;
+}
+
+/**
+ * True when `token` is `full` or an unambiguous abbreviation of it.
+ *
+ * git resolves `--no-veri` to `--no-verify`, so matching the exact string only
+ * meant the documented escape hatch did not work spelled the way git accepts it,
+ * and the hook blocked a commit it had been told to skip. This is the same
+ * polarity error the `git add` whitelist was rewritten to fix, on the other side.
+ */
+function isAbbrevOf(token: string, full: string, shortest: number): boolean {
+  return token.length >= shortest && full.startsWith(token);
+}
+
 export function commitSkipsVerify(commitFlags: string): boolean {
-  const flags = beforePathspecSentinel(commitFlags);
-  if (/(?:^|\s)--no-verify(?:\s|$)/.test(flags)) return true;
-  const VALUE_TAKING = "mFcCtSu";
-  for (const m of flags.matchAll(/(?:^|\s)-([A-Za-z]+)/g)) {
-    for (const ch of m[1]) {
-      if (ch === "n") return true;
-      if (VALUE_TAKING.includes(ch)) break;
-    }
+  for (const token of commitOptionTokens(commitFlags)) {
+    // "--no-v" is the shortest prefix no other git-commit option shares.
+    if (isAbbrevOf(token, "--no-verify", 6)) return true;
+    if (shortFlagsOf(token).includes("n")) return true;
   }
   return false;
 }
 
 /**
- * `commitFlags` truncated at git's `--` sentinel, after which every token is a
- * pathspec however it is spelled.
- *
- * Without it, committing a file *named* `-n` — `git commit -- -n` — read as
- * `--no-verify` and turned the hook off, leaving that file unchecked.
+ * True when the command asks git for something other than a commit: `--help`,
+ * `-h` and `--dry-run` all create nothing, so blocking them is a hard block on a
+ * read-only command — and `--dry-run` is the canonical way to preview a commit.
  */
-function beforePathspecSentinel(commitFlags: string): string {
-  // Option values have to be stepped over, not scanned. In `git commit -m -- -a`
-  // the `--` is the message: treating it as the sentinel truncated here and hid
-  // the `-a` behind it, so the commit staged tracked changes nothing checked.
-  const tokens = [...commitFlags.matchAll(/\S+/g)];
+export function commitCreatesNothing(commitFlags: string): boolean {
+  for (const token of commitOptionTokens(commitFlags)) {
+    if (isAbbrevOf(token, "--help", 6) || token === "-h") return true;
+    if (isAbbrevOf(token, "--dry-run", 7)) return true;
+  }
+  return false;
+}
+
+/**
+ * The pathspecs a commit carries, which change what it contains: given paths,
+ * git commits *those* (its `--only` default), not the index.
+ *
+ * Unmodelled, the hook judged the index while git committed something else —
+ * skipping a dirty file the commit did include, and in the worst case reporting
+ * "checks passed on 1 file" about a staged file the commit left behind.
+ */
+export function commitPathspecs(commitFlags: string): string[] {
+  const tokens = commitFlags.match(/\S+/g) ?? [];
+  const paths: string[] = [];
+  let sentinel = false;
   for (let i = 0; i < tokens.length; i++) {
-    const token = tokens[i][0];
-    if (token === "--") return commitFlags.slice(0, tokens[i].index);
+    const token = tokens[i];
+    if (sentinel) {
+      paths.push(token);
+      continue;
+    }
+    if (token === "--") {
+      sentinel = true;
+      continue;
+    }
+    if (!token.startsWith("-")) {
+      paths.push(token);
+      continue;
+    }
     if (consumesNextToken(token)) i++;
   }
-  return commitFlags;
+  return paths;
+}
+
+/** True when `-i`/`--include` adds the index to a pathspec commit. */
+export function commitIncludesIndex(commitFlags: string): boolean {
+  for (const token of commitOptionTokens(commitFlags)) {
+    if (isAbbrevOf(token, "--include", 9)) return true;
+    if (shortFlagsOf(token).includes("i")) return true;
+  }
+  return false;
 }
 
 /** True when `token` takes the following word as its value. */
@@ -713,7 +796,10 @@ function consumesNextToken(token: string): boolean {
   return false;
 }
 
-const VALUE_TAKING_SHORT = "mFcCtSu";
+// Short options taking a separate value. `-u[<mode>]` and `-S[<keyid>]` are
+// deliberately absent: their values are attached only, so they consume nothing,
+// and claiming otherwise stepped over a real `--` sentinel.
+const VALUE_TAKING_SHORT = "mFcCt";
 const VALUE_TAKING_LONG = new Set([
   "--message",
   "--file",
@@ -747,14 +833,9 @@ function maskRedirections(text: string): string {
 }
 
 export function commitsAllTracked(commitFlags: string): boolean {
-  const flags = beforePathspecSentinel(commitFlags);
-  if (/(?:^|\s)--all(?:\s|$)/.test(flags)) return true;
-  const VALUE_TAKING = "mFcCtSu";
-  for (const m of flags.matchAll(/(?:^|\s)-([A-Za-z]+)/g)) {
-    for (const ch of m[1]) {
-      if (ch === "a") return true;
-      if (VALUE_TAKING.includes(ch)) break;
-    }
+  for (const token of commitOptionTokens(commitFlags)) {
+    if (token === "--all") return true;
+    if (shortFlagsOf(token).includes("a")) return true;
   }
   return false;
 }

--- a/.claude/scripts/common/worktree.ts
+++ b/.claude/scripts/common/worktree.ts
@@ -349,10 +349,21 @@ export function splitAtGitCommit(
  * explicitly to skip.
  */
 export function commitFlagRegion(after: string): string {
+  return maskRedirections(withoutQuotedSpans(commitRawRegion(after)));
+}
+
+/**
+ * The commit's own command, quotes intact.
+ *
+ * `commitFlagRegion` blanks quoted spans, which is right for reading flags and
+ * fatal for reading pathspecs: `git commit -m x "my file.ts"` lost its pathspec
+ * altogether, so the hook fell back to judging the index — the same false
+ * verdict that modelling pathspecs was meant to end.
+ */
+export function commitRawRegion(after: string): string {
   const masked = maskRedirections(maskQuotedSpans(after));
   const sep = masked.search(/[;\n&|]/);
-  const region = sep === -1 ? after : after.slice(0, sep);
-  return maskRedirections(withoutQuotedSpans(region));
+  return sep === -1 ? after : after.slice(0, sep);
 }
 
 export function argumentRegion(text: string): string {
@@ -710,22 +721,9 @@ function shortFlagsOf(token: string): string {
   return flags;
 }
 
-/**
- * True when `token` is `full` or an unambiguous abbreviation of it.
- *
- * git resolves `--no-veri` to `--no-verify`, so matching the exact string only
- * meant the documented escape hatch did not work spelled the way git accepts it,
- * and the hook blocked a commit it had been told to skip. This is the same
- * polarity error the `git add` whitelist was rewritten to fix, on the other side.
- */
-function isAbbrevOf(token: string, full: string, shortest: number): boolean {
-  return token.length >= shortest && full.startsWith(token);
-}
-
 export function commitSkipsVerify(commitFlags: string): boolean {
   for (const token of commitOptionTokens(commitFlags)) {
-    // "--no-v" is the shortest prefix no other git-commit option shares.
-    if (isAbbrevOf(token, "--no-verify", 6)) return true;
+    if (resolveCommitOption(token) === "--no-verify") return true;
     if (shortFlagsOf(token).includes("n")) return true;
   }
   return false;
@@ -738,8 +736,9 @@ export function commitSkipsVerify(commitFlags: string): boolean {
  */
 export function commitCreatesNothing(commitFlags: string): boolean {
   for (const token of commitOptionTokens(commitFlags)) {
-    if (isAbbrevOf(token, "--help", 6) || token === "-h") return true;
-    if (isAbbrevOf(token, "--dry-run", 7)) return true;
+    const name = resolveCommitOption(token);
+    if (name === "--help" || name === "--dry-run") return true;
+    if (token === "-h") return true;
   }
   return false;
 }
@@ -752,8 +751,15 @@ export function commitCreatesNothing(commitFlags: string): boolean {
  * skipping a dirty file the commit did include, and in the worst case reporting
  * "checks passed on 1 file" about a staged file the commit left behind.
  */
-export function commitPathspecs(commitFlags: string): string[] {
-  const tokens = commitFlags.match(/\S+/g) ?? [];
+export function commitPathspecs(rawRegion: string): string[] | null {
+  // Split on the mask so a quoted pathspec containing spaces stays one word, and
+  // unquoted so the word itself survives — the same shape as shellWords.
+  const masked = maskQuotedSpans(rawRegion);
+  const spans = [...masked.matchAll(/\S+/g)];
+  const tokens = spans.map((m) =>
+    unquote(rawRegion.slice(m.index, m.index + m[0].length))
+  );
+
   const paths: string[] = [];
   let sentinel = false;
   for (let i = 0; i < tokens.length; i++) {
@@ -770,23 +776,126 @@ export function commitPathspecs(commitFlags: string): string[] {
       paths.push(token);
       continue;
     }
+    if (token.startsWith("--")) {
+      const name = resolveCommitOption(token);
+      // `--pathspec-from-file` names contents in a file we do not read, and an
+      // option we cannot identify may do the same. Returning an empty list here
+      // would send the caller back to judging the index; say we do not know.
+      if (name === null || name === "ambiguous") return null;
+      if (name === "--pathspec-from-file") return null;
+    }
     if (consumesNextToken(token)) i++;
   }
   return paths;
 }
 
+/** One layer of quoting removed, leaving the word as the shell would pass it. */
+function unquote(word: string): string {
+  if (word.length >= 2) {
+    const first = word[0];
+    if ((first === '"' || first === "'") && word.endsWith(first)) {
+      return word.slice(1, -1);
+    }
+  }
+  return word;
+}
+
 /** True when `-i`/`--include` adds the index to a pathspec commit. */
 export function commitIncludesIndex(commitFlags: string): boolean {
   for (const token of commitOptionTokens(commitFlags)) {
-    if (isAbbrevOf(token, "--include", 9)) return true;
+    if (resolveCommitOption(token) === "--include") return true;
     if (shortFlagsOf(token).includes("i")) return true;
   }
   return false;
 }
 
+/**
+ * git-commit's long options, and whether each takes its value as a *separate*
+ * word. Options whose value is optional (`--untracked-files[=<mode>]`,
+ * `--gpg-sign[=<keyid>]`) take it attached only, so they consume nothing.
+ *
+ * The table exists because git resolves any unambiguous abbreviation: `--mess`
+ * is `--message`, `--inc` is `--include`, `--dr` is `--dry-run`. Matching exact
+ * spellings meant each of those was mishandled in its own way — an unrecognised
+ * `--mess` left its message looking like a pathspec, an unrecognised `--inc`
+ * dropped the staged files from the file set, and an unrecognised `--dr` blocked
+ * a read-only preview. One resolver, so the whole class is handled once.
+ */
+const COMMIT_OPTIONS: Record<string, { separateValue: boolean }> = {
+  "--all": { separateValue: false },
+  "--allow-empty": { separateValue: false },
+  "--allow-empty-message": { separateValue: false },
+  "--amend": { separateValue: false },
+  "--author": { separateValue: true },
+  "--branch": { separateValue: false },
+  "--cleanup": { separateValue: true },
+  "--date": { separateValue: true },
+  "--dry-run": { separateValue: false },
+  "--edit": { separateValue: false },
+  "--file": { separateValue: true },
+  "--fixup": { separateValue: true },
+  "--gpg-sign": { separateValue: false },
+  "--help": { separateValue: false },
+  "--include": { separateValue: false },
+  "--long": { separateValue: false },
+  "--message": { separateValue: true },
+  "--no-edit": { separateValue: false },
+  "--no-gpg-sign": { separateValue: false },
+  "--no-post-rewrite": { separateValue: false },
+  "--no-signoff": { separateValue: false },
+  "--no-status": { separateValue: false },
+  "--no-verify": { separateValue: false },
+  "--null": { separateValue: false },
+  "--only": { separateValue: false },
+  "--pathspec-file-nul": { separateValue: false },
+  "--pathspec-from-file": { separateValue: true },
+  "--patch": { separateValue: false },
+  "--porcelain": { separateValue: false },
+  "--quiet": { separateValue: false },
+  "--reedit-message": { separateValue: true },
+  "--reset-author": { separateValue: false },
+  "--reuse-message": { separateValue: true },
+  "--short": { separateValue: false },
+  "--signoff": { separateValue: false },
+  "--squash": { separateValue: true },
+  "--status": { separateValue: false },
+  "--template": { separateValue: true },
+  "--trailer": { separateValue: true },
+  "--untracked-files": { separateValue: false },
+  "--verbose": { separateValue: false },
+  "--verify": { separateValue: false },
+};
+
+const COMMIT_OPTION_NAMES = Object.keys(COMMIT_OPTIONS);
+
+/**
+ * The long option `token` names, resolving abbreviations the way git does.
+ *
+ * `"ambiguous"` when a prefix matches more than one option — git errors on those,
+ * so there is no commit to judge. `null` when nothing matches, which we must
+ * treat as "this command does something we do not model" rather than assume
+ * harmless.
+ */
+export function resolveCommitOption(
+  token: string,
+): string | null | "ambiguous" {
+  const name = token.split("=")[0];
+  if (!name.startsWith("--")) return null;
+  if (name in COMMIT_OPTIONS) return name;
+  const matches = COMMIT_OPTION_NAMES.filter((o) => o.startsWith(name));
+  if (matches.length === 1) return matches[0];
+  return matches.length > 1 ? "ambiguous" : null;
+}
+
 /** True when `token` takes the following word as its value. */
 function consumesNextToken(token: string): boolean {
-  if (VALUE_TAKING_LONG.has(token)) return true;
+  if (token.startsWith("--")) {
+    // An `=` carries the value with it, so nothing further is consumed.
+    if (token.includes("=")) return false;
+    const name = resolveCommitOption(token);
+    return typeof name === "string" && name !== "ambiguous" &&
+      COMMIT_OPTIONS[name].separateValue;
+  }
   if (!/^-[A-Za-z]+$/.test(token)) return false;
   for (const ch of token.slice(1)) {
     // A value-taking short flag consumes the next word only when its own value
@@ -800,22 +909,6 @@ function consumesNextToken(token: string): boolean {
 // deliberately absent: their values are attached only, so they consume nothing,
 // and claiming otherwise stepped over a real `--` sentinel.
 const VALUE_TAKING_SHORT = "mFcCt";
-const VALUE_TAKING_LONG = new Set([
-  "--message",
-  "--file",
-  "--reuse-message",
-  "--reedit-message",
-  "--template",
-  "--gpg-sign",
-  "--untracked-files",
-  "--author",
-  "--date",
-  "--cleanup",
-  "--fixup",
-  "--squash",
-  "--trailer",
-  "--pathspec-from-file",
-]);
 
 /**
  * Blank redirections, descriptor and all, preserving length.

--- a/.claude/scripts/common/worktree.ts
+++ b/.claude/scripts/common/worktree.ts
@@ -170,8 +170,17 @@ const GIT_COMMIT = gitSubcommand("commit");
  * delimiter here, so a masked span cannot match anything we look for.
  */
 function maskQuotedSpans(text: string): string {
+  // `\\.` in the double-quoted branch is load-bearing. Ending that branch at
+  // the first `"` meant an escaped quote closed the span early, leaving the rest
+  // of the message unmasked — and unmasked text carrying its own separator got
+  // read as commands again:
+  //
+  //   echo "a \" && cd /evil && echo \"" && git commit -m x
+  //
+  // resolved to /evil. A single-quoted span has no escapes in the shell, so
+  // that branch is a plain run to the next quote.
   return text.replace(
-    /"[^"]*"|'[^']*'/g,
+    /"(?:[^"\\]|\\.)*"|'[^']*'/g,
     (span) => "\0".repeat(span.length),
   );
 }
@@ -341,7 +350,11 @@ function expand(raw: string): string {
  * Flags after the message (`git commit -m "x" -a`) still register.
  */
 export function withoutQuotedSpans(text: string): string {
-  return text.replace(/"[^"]*"|'[^']*'/g, " ");
+  // Built on the same mask, not a second copy of the quote grammar: two
+  // spellings of "what is quoted" would drift, and this one guards the flag
+  // scan while that one guards the directory. NUL becomes a space so the
+  // surviving flags stay separated for the `(?:^|\s)` anchors.
+  return maskQuotedSpans(text).replaceAll("\0", " ");
 }
 
 /**

--- a/.claude/scripts/common/worktree.ts
+++ b/.claude/scripts/common/worktree.ts
@@ -67,14 +67,25 @@ export async function worktreeRoot(dir: string): Promise<string | null> {
  * branch of our repo" (check it) from "an unrelated project" (leave it alone).
  */
 export async function repositoryId(dir: string): Promise<string | null> {
+  // Ask git for an absolute answer rather than normalising one ourselves. Left
+  // to its own devices git replies relative to the directory it ran in inside a
+  // main worktree (`../../.git` from a subdirectory) and absolutely inside a
+  // linked one — and resolving that relative form against the wrong base
+  // yielded a path outside the repo, so this returned null and both hooks
+  // silently skipped every check. The bug was invisible from a linked worktree,
+  // which is exactly where it was measured.
+  const absolute = await git(dir, [
+    "rev-parse",
+    "--path-format=absolute",
+    "--git-common-dir",
+  ]);
+  if (absolute) return await realPath(absolute);
+
+  // Older git without --path-format: resolve against `dir`, git's own base.
   const common = await git(dir, ["rev-parse", "--git-common-dir"]);
   if (!common) return null;
-  // git answers relatively (".git") inside the main worktree and absolutely
-  // inside a linked one. Normalise through the filesystem so the two forms of
-  // the same repository compare equal.
   if (common.startsWith("/")) return await realPath(common);
-  const root = await worktreeRoot(dir);
-  return root ? await realPath(`${root}/${common}`) : null;
+  return await realPath(`${dir}/${common}`);
 }
 
 async function realPath(p: string): Promise<string | null> {
@@ -92,42 +103,119 @@ export async function sameRepository(a: string, b: string): Promise<boolean> {
 }
 
 /**
- * A `git … commit` invocation, capturing whatever global options sit between
- * `git` and `commit`.
+ * One global option in a `git <globals> <subcommand>` invocation.
  *
- * Those options are the reason this is not simply /git\s+commit/: written that
+ * A value may be quoted, and may mix quoted and bare spans the way a shell word
+ * does (`-c user.name="A B"`), so it is matched as a sequence of those rather
+ * than a run of non-space characters. That is not a cosmetic distinction:
+ * `git -C "/a b" commit` went unrecognised while the value pattern was
+ * `[^\s]+`, and an unrecognised commit is an unchecked one.
+ */
+/**
+ * git's global options that take a value. Every other token before the
+ * subcommand is a boolean flag.
+ *
+ * Listing them is what keeps the invocation pattern from backtracking
+ * exponentially. When any option *might* have taken a value, N of them had 2^N
+ * readings and a failed match explored them all: 24 flag-like tokens after a
+ * word ending in "git" took 1.6 seconds, on a hook that runs on every Bash
+ * call. Here each branch consumes a determined number of tokens.
+ */
+const VALUE_OPTIONS = [
+  "-C",
+  "-c",
+  "--exec-path",
+  "--git-dir",
+  "--work-tree",
+  "--namespace",
+  "--super-prefix",
+  "--config-env",
+];
+
+const SHELL_WORD = String.raw`(?:[^\s"']|"[^"]*"|'[^']*')+`;
+
+const GLOBAL_OPTION = String.raw`(?:(?:${
+  VALUE_OPTIONS.join("|")
+})(?:=|\s+)${SHELL_WORD}|-{1,2}[\w-]+)\s+`;
+
+/**
+ * Matches `git <globals> <subcommand>`, capturing the globals.
+ *
+ * Those globals are the reason this is not simply /git\s+commit/: written that
  * way, `git -C <dir> commit` does not match, and the hook that used it waved
  * through every commit aimed at another worktree — the one case it most needed
- * to inspect. Matching the options is also what lets us find a `-C` at all.
+ * to inspect. Matching them is also what lets us find a `-C` at all.
  */
-const GIT_COMMIT = /\bgit\s+((?:-{1,2}[^\s]+(?:[=\s]+[^\s]+)?\s+)*)commit\b/;
+function gitSubcommand(subcommand: string): RegExp {
+  return new RegExp(String.raw`\bgit\s+((?:${GLOBAL_OPTION})*)${subcommand}\b`);
+}
+
+const GIT_COMMIT = gitSubcommand("commit");
+
+/**
+ * `text` with the *contents* of quoted spans replaced by a filler character,
+ * preserving length so offsets into the result still address the original.
+ *
+ * Quoted text is data. Until it was masked, it was parsed as command syntax and
+ * got to choose what the hook did:
+ *
+ *   echo "git -C /other/worktree commit" && git commit -m x
+ *
+ * matched the quoted mention first, took `-C /other/worktree` from a string
+ * literal, and blocked the commit on an unrelated tree's errors. A quoted
+ * mention could equally move the split past a real `cd` and hide it, or make
+ * `rg 'git commit' docs/` — not a commit at all — run checks and fail.
+ *
+ * NUL is the filler: it is not whitespace, not a word character, and not any
+ * delimiter here, so a masked span cannot match anything we look for.
+ */
+function maskQuotedSpans(text: string): string {
+  return text.replace(
+    /"[^"]*"|'[^']*'/g,
+    (span) => "\0".repeat(span.length),
+  );
+}
 
 /** True when `cmd` contains a `git commit`, however git is steered to it. */
 export function isGitCommit(cmd: string): boolean {
-  return GIT_COMMIT.test(cmd);
+  return GIT_COMMIT.test(maskQuotedSpans(cmd));
 }
 
 /**
- * `cmd` split around the `git … commit` invocation.
+ * `cmd` split around a `git … <subcommand>` invocation.
  *
  * Each part answers a different question and only one part can answer it:
  * earlier commands (a `git add`, a `cd`) live in `before`, git's own global
- * options in `options`, the commit's flags in `after`. Splitting once, here,
- * is also what keeps every pattern search out of the commit message — which is
- * free to contain text reading exactly like a `git add` or a `cd`.
+ * options in `options`, the subcommand's arguments in `after`. Splitting once,
+ * here, is what keeps every pattern search out of the commit message — free to
+ * contain text reading exactly like a `git add`, a `cd`, or a `--work-tree`.
  */
-export function splitAtGitCommit(
+export function splitAtGitSubcommand(
   cmd: string,
+  subcommand: string,
 ): { before: string; options: string; after: string } {
-  const m = cmd.match(GIT_COMMIT);
+  // Located on the masked copy so quoted text cannot be the match, but sliced
+  // out of the original so callers get real values back. The mask preserves
+  // length, which is what makes those two the same offsets.
+  const masked = maskQuotedSpans(cmd);
+  const m = masked.match(gitSubcommand(subcommand));
   if (!m || m.index === undefined) {
     return { before: cmd, options: "", after: "" };
   }
+  const optionsStart = m.index + m[0].length - (m[1] ?? "").length -
+    subcommand.length;
   return {
     before: cmd.slice(0, m.index),
-    options: m[1] ?? "",
+    options: cmd.slice(optionsStart, optionsStart + (m[1] ?? "").length),
     after: cmd.slice(m.index + m[0].length),
   };
+}
+
+/** `cmd` split around its `git … commit`. */
+export function splitAtGitCommit(
+  cmd: string,
+): { before: string; options: string; after: string } {
+  return splitAtGitSubcommand(cmd, "commit");
 }
 
 /**
@@ -141,29 +229,67 @@ export function splitAtGitCommit(
  * callers should report that and pass rather than guess.
  */
 export function targetDirArgs(cmd: string): string[] | null {
-  // An explicit tree override changes the answer completely and has forms we
-  // deliberately do not try to model. Refuse rather than answer wrongly.
-  if (/--git-dir[=\s]|--work-tree[=\s]/.test(cmd)) return null;
-
   // The options between `git` and `commit` are the only place a `-C` can affect
   // the commit; `before` is the only place a `cd` can.
   const { before: prefix, options } = splitAtGitCommit(cmd);
 
+  // An explicit tree override changes the answer completely and has forms we
+  // deliberately do not try to model. Refuse rather than answer wrongly — but
+  // only when it is really one of git's options. Searching the whole command
+  // meant `git commit -m 'handle --work-tree correctly'` refused to resolve,
+  // and refusing to resolve turns every check off: a commit message could
+  // silently disable the hook by describing it.
+  if (/--git-dir|--work-tree/.test(options)) return null;
+
+  // Two shapes a regex cannot read, where guessing produced a *confidently
+  // wrong* tree rather than no answer:
+  //
+  // Parentheses. A `cd` inside `( … )` or `$( … )` does not outlive the
+  // subshell, so `(cd /a && git add -A) && git commit` must not resolve to
+  // /a — but `(cd /a && git commit)` must. Telling those apart means knowing
+  // whether the commit shares the subshell, which is parsing, not matching.
+  //
+  // Heredocs. Their body is data, and a line of data reading `cd /elsewhere`
+  // is not a command. Only `before` matters: `git commit -F - <<'EOF'` keeps
+  // its heredoc after the commit, where we never look.
+  //
+  // So refuse. Skipping a check is a cost; asserting the wrong branch's errors
+  // against someone's commit is the bug this module exists to remove.
+  const maskedPrefix = maskQuotedSpans(prefix);
+  if (/[()]/.test(maskedPrefix)) return null;
+  if (maskedPrefix.includes("<<")) return null;
+  // `popd` returns to a directory we never saw pushed. Nothing to compose.
+  if (/(?:^|[;&|{\n])\s*popd\b/.test(maskedPrefix)) return null;
+
   const args: string[] = [];
 
-  // The last `cd` before the commit wins, as it would in the shell. Require a
-  // command boundary so `--author "cd fred"` cannot masquerade as one — but
-  // count `(` and `{` as boundaries too, because `(cd dir && git commit)` is a
-  // real form and missing its `cd` puts us back to judging the wrong tree.
-  const cds = [
-    ...prefix.matchAll(
-      /(?:^|[;&|({])\s*cd\s+("[^"]*"|'[^']*'|[^\s;&|)}]+)/g,
-    ),
-  ];
-  const lastCd = cds.at(-1)?.[1];
-  if (lastCd) args.push("-C", expand(lastCd));
+  // Every `cd` before the commit, in order — not just the last. They compose:
+  // `cd /a && cd sub` ends in /a/sub, and taking only `cd sub` resolved it
+  // against whatever directory the hook happened to start in. Passing them all
+  // to git reproduces the composition exactly, absolute paths overriding
+  // earlier ones just as they do in a shell.
+  //
+  // A command boundary is required so `--author "cd fred"` cannot masquerade as
+  // one. A newline is such a boundary: agents write commit sequences as
+  // multi-line scripts, and while `\n` was missing every `cd` after the first
+  // line was invisible — the original bug, surviving in its most common form.
+  // `{` counts too; unlike `(` a brace group runs in the current shell, so its
+  // `cd` holds. `pushd` moves the shell the same way `cd` does.
+  //
+  // Matched against the mask and read out of the original by index, so a quoted
+  // path arrives intact while quoted prose cannot pose as a command.
+  for (
+    const m of maskedPrefix.matchAll(
+      /(?:^|[;&|{\n])\s*(?:cd|pushd)\s+([^\s;&|}]+)/dg,
+    )
+  ) {
+    const span = m.indices?.[1];
+    if (!span) continue;
+    args.push("-C", expand(prefix.slice(span[0], span[1])));
+  }
 
-  // Then each `-C` the commit itself carries, in order.
+  // Then each `-C` the commit itself carries, in order. git rejects a glued
+  // `-C<path>` ("unknown option"), so a space is required here too.
   for (
     const m of options.matchAll(
       /-C\s+("[^"]*"|'[^']*'|[^\s]+)/g,
@@ -175,18 +301,47 @@ export function targetDirArgs(cmd: string): string[] | null {
   return args;
 }
 
-/** Strip one layer of quoting and expand a leading `~`. */
+/**
+ * Strip one layer of quoting and expand `~` and `$VAR`.
+ *
+ * The shell expands these before git ever sees them; we are reading the command
+ * before it runs, so we have to. `cd "$CLAUDE_PROJECT_DIR" && git commit` is a
+ * shape agents actually write, and without expansion it resolved to nothing.
+ * Single-quoted values are left alone, as the shell leaves them.
+ */
 function expand(raw: string): string {
   let p = raw;
+  const singleQuoted = p.startsWith("'") && p.endsWith("'") && p.length >= 2;
   if (
-    (p.startsWith('"') && p.endsWith('"')) ||
-    (p.startsWith("'") && p.endsWith("'"))
+    singleQuoted || (p.startsWith('"') && p.endsWith('"') && p.length >= 2)
   ) {
     p = p.slice(1, -1);
+  }
+  if (!singleQuoted) {
+    p = p.replace(/\$\{(\w+)\}|\$(\w+)/g, (whole, braced, bare) => {
+      const value = env(braced ?? bare);
+      // An unset variable expands to nothing in the shell. Keeping the literal
+      // would send git looking for a directory named `$FOO`.
+      return value || (value === "" ? "" : whole);
+    });
   }
   if (p === "~") return HOME || p;
   if (p.startsWith("~/") && HOME) return HOME + p.slice(1);
   return p;
+}
+
+/**
+ * `text` with quoted spans blanked out.
+ *
+ * For scanning a region that contains both flags and free text: a commit
+ * message is quoted, so removing quoted spans leaves the flags and drops the
+ * prose. Without this, `git commit -m "fix: honour the -a flag"` read as a
+ * `-a` commit and swept the entire dirty tree — blocking on files the commit
+ * would never have touched, which is the failure this whole change is about.
+ * Flags after the message (`git commit -m "x" -a`) still register.
+ */
+export function withoutQuotedSpans(text: string): string {
+  return text.replace(/"[^"]*"|'[^']*'/g, " ");
 }
 
 /**

--- a/.claude/scripts/common/worktree.ts
+++ b/.claude/scripts/common/worktree.ts
@@ -103,15 +103,6 @@ export async function sameRepository(a: string, b: string): Promise<boolean> {
 }
 
 /**
- * One global option in a `git <globals> <subcommand>` invocation.
- *
- * A value may be quoted, and may mix quoted and bare spans the way a shell word
- * does (`-c user.name="A B"`), so it is matched as a sequence of those rather
- * than a run of non-space characters. That is not a cosmetic distinction:
- * `git -C "/a b" commit` went unrecognised while the value pattern was
- * `[^\s]+`, and an unrecognised commit is an unchecked one.
- */
-/**
  * git's global options that take a value. Every other token before the
  * subcommand is a boolean flag.
  *
@@ -132,11 +123,43 @@ const VALUE_OPTIONS = [
   "--config-env",
 ];
 
+/**
+ * A value may be quoted, and may mix quoted and bare spans the way a shell word
+ * does (`-c user.name="A B"`), so it is matched as a sequence of those rather
+ * than a run of non-space characters. Not cosmetic: `git -C "/a b" commit` went
+ * unrecognised while this was `[^\s]+`, and an unrecognised commit is an
+ * unchecked one.
+ */
 const SHELL_WORD = String.raw`(?:[^\s"']|"[^"]*"|'[^']*')+`;
 
+/**
+ * A boolean global option.
+ *
+ * `\w` after the dashes, not `[\w-]`, is the whole point: with `-{1,2}[\w-]+`,
+ * `--foo` matched two ways — `--` + `foo` and `-` + `-foo` — over the same span,
+ * so N consecutive dash-flags had 2^N parses and a failing match walked all of
+ * them. 24 of them cost 2.4 seconds of hook time; 26 cost 9.6. Requiring a word
+ * character immediately after the dashes leaves exactly one reading.
+ *
+ * The first version of this fix listed the value-taking options (below) to stop
+ * every option consuming one-or-two tokens. That was necessary and insufficient:
+ * the flag branch was still ambiguous with itself, and the regression test built
+ * its input as `--exclude dirN`, which breaks the chain after one iteration and
+ * so measured nothing.
+ */
+const BOOLEAN_OPTION = String.raw`-{1,2}\w[\w-]*`;
+
+/**
+ * Repetition is bounded rather than open. A real `git` invocation carries a
+ * handful of global options; a bound turns any residual ambiguity from
+ * unbounded-exponential into a fixed ceiling, which is the property worth having
+ * on a hook that runs on every Bash call in the session.
+ */
 const GLOBAL_OPTION = String.raw`(?:(?:${
   VALUE_OPTIONS.join("|")
-})(?:=|\s+)${SHELL_WORD}|-{1,2}[\w-]+)\s+`;
+})(?:=|\s+)${SHELL_WORD}|${BOOLEAN_OPTION})\s+`;
+
+const MAX_GLOBAL_OPTIONS = 12;
 
 /**
  * Matches `git <globals> <subcommand>`, capturing the globals.
@@ -147,7 +170,10 @@ const GLOBAL_OPTION = String.raw`(?:(?:${
  * to inspect. Matching them is also what lets us find a `-C` at all.
  */
 function gitSubcommand(subcommand: string): RegExp {
-  return new RegExp(String.raw`\bgit\s+((?:${GLOBAL_OPTION})*)${subcommand}\b`);
+  return new RegExp(
+    String
+      .raw`\bgit\s+((?:${GLOBAL_OPTION}){0,${MAX_GLOBAL_OPTIONS}})${subcommand}\b`,
+  );
 }
 
 const GIT_COMMIT = gitSubcommand("commit");
@@ -170,17 +196,22 @@ const GIT_COMMIT = gitSubcommand("commit");
  * delimiter here, so a masked span cannot match anything we look for.
  */
 function maskQuotedSpans(text: string): string {
-  // `\\.` in the double-quoted branch is load-bearing. Ending that branch at
-  // the first `"` meant an escaped quote closed the span early, leaving the rest
-  // of the message unmasked — and unmasked text carrying its own separator got
-  // read as commands again:
+  // `\\[\s\S]` in the double-quoted branch is load-bearing, and the character
+  // class rather than `.` doubly so: `.` does not match a newline, so a shell
+  // line continuation inside a quoted string ended the span early and reopened
+  // this whole family — a `--no-verify` written across two lines disabled the
+  // hook again, exactly the bypass a test claimed to have closed.
+  //
+  // Ending the branch at the first `"` was the first version of the same
+  // mistake: an escaped quote closed the span, leaving the rest of the message
+  // unmasked, and unmasked text carrying its own separator got read as commands:
   //
   //   echo "a \" && cd /evil && echo \"" && git commit -m x
   //
   // resolved to /evil. A single-quoted span has no escapes in the shell, so
   // that branch is a plain run to the next quote.
   return text.replace(
-    /"(?:[^"\\]|\\.)*"|'[^']*'/g,
+    /"(?:[^"\\]|\\[\s\S])*"|'[^']*'/g,
     (span) => "\0".repeat(span.length),
   );
 }
@@ -236,7 +267,12 @@ export function splitAtGitCommit(
  * commands.
  */
 export function argumentRegion(text: string): string {
-  const sep = maskQuotedSpans(text).search(/[;\n&|]/);
+  // Redirections end the argument list too, and the whole operator has to go,
+  // file descriptor included. Cutting at the bare `>` left the `2` of
+  // `2>/dev/null` behind as a pathspec, git failed on it, the file list came
+  // back empty, and the commit went through unchecked — the same silent pass as
+  // not handling redirection at all.
+  const sep = maskQuotedSpans(text).search(/[;\n&|]|\d*[<>]/);
   return sep === -1 ? text : text.slice(0, sep);
 }
 
@@ -313,23 +349,80 @@ export function dirArgsAt(prefix: string): string[] | null {
 }
 
 /**
- * Where a `git add` in `cmd` runs and what it will be given, or null when the
- * command has no `git add` (or steers it somewhere unmodellable).
+ * Flags that make `git add` write to the index *even with* `--dry-run`.
+ *
+ * `--edit` is the one that matters and the reason this list exists. git rejects
+ * `-i`/`-p` outright under `--dry-run`, but it honours `--edit`: it applies the
+ * patch to the index regardless, and because Claude Code sets `GIT_EDITOR=true`
+ * the editor step is a silent no-op that accepts everything. So a hook whose
+ * entire purpose is to stop touching the trees it inspects staged the user's
+ * working tree for them, before their command had even run — verified against a
+ * scratch repo. An add carrying any of these is not dry-runnable, so we do not
+ * try.
  */
-export function gitAddInvocation(
-  cmd: string,
-): { dirArgs: string[]; words: string[] } | null {
-  const beforeCommit = splitAtGitCommit(cmd).before;
-  const add = splitAtGitSubcommand(beforeCommit, "add");
-  if (!add.matched) return null;
+const MUTATING_ADD_FLAGS = /^--(?:edit|interactive|patch)$|^-[A-Za-z]*[eip]/;
 
-  const dirArgs = dirArgsAt(add.before);
-  if (dirArgs === null) return null;
-  for (const m of add.options.matchAll(/-C\s+("[^"]*"|'[^']*'|[^\s]+)/g)) {
-    dirArgs.push("-C", expand(m[1]));
+export interface GitAddInvocation {
+  dirArgs: string[];
+  /** Options to pass through, `--dry-run` excluded. */
+  flags: string[];
+  /** Pathspecs, to be passed after `--`. */
+  paths: string[];
+  /** True when this add cannot be dry-run without writing to the index. */
+  mutating: boolean;
+}
+
+/**
+ * Every `git add` in `cmd` before its commit: where each runs and what it
+ * stages.
+ *
+ * All of them, not just the first. `git add ok.ts && git add bad.ts && git
+ * commit` reported only ok.ts, so bad.ts was staged, committed, and never
+ * checked — a silent pass.
+ *
+ * `null` when the command steers git somewhere this parser does not model.
+ */
+export function gitAddInvocations(cmd: string): GitAddInvocation[] | null {
+  const invocations: GitAddInvocation[] = [];
+  let region = splitAtGitCommit(cmd).before;
+  let consumed = 0;
+
+  while (true) {
+    const add = splitAtGitSubcommand(region, "add");
+    if (!add.matched) break;
+
+    // The prefix for this add is everything in the original command up to it.
+    const dirArgs = dirArgsAt(cmd.slice(0, consumed + add.before.length));
+    if (dirArgs === null) return null;
+    for (const m of add.options.matchAll(/-C\s+("[^"]*"|'[^']*'|[^\s]+)/g)) {
+      dirArgs.push("-C", expand(m[1]));
+    }
+
+    const words = shellWords(argumentRegion(add.after));
+
+    // Split at the caller's own `--`: after it everything is a pathspec, however
+    // it is spelled. Classifying by a leading `-` alone put that `--` in with
+    // the flags, where it was re-emitted ahead of ours and git died on the
+    // duplicate — `git add -- foo.ts` checked nothing and passed in silence.
+    const sentinel = words.indexOf("--");
+    const head = sentinel === -1 ? words : words.slice(0, sentinel);
+    const tail = sentinel === -1 ? [] : words.slice(sentinel + 1);
+    const flags = head.filter((w) => w.startsWith("-"));
+
+    invocations.push({
+      dirArgs,
+      flags,
+      paths: [...head.filter((w) => !w.startsWith("-")), ...tail],
+      mutating: flags.some((f) => MUTATING_ADD_FLAGS.test(f)),
+    });
+
+    const advance = add.before.length +
+      (region.length - add.before.length - add.after.length);
+    consumed += advance;
+    region = region.slice(advance);
   }
 
-  return { dirArgs, words: shellWords(argumentRegion(add.after)) };
+  return invocations;
 }
 
 /**

--- a/.claude/scripts/common/worktree.ts
+++ b/.claude/scripts/common/worktree.ts
@@ -349,10 +349,10 @@ export function splitAtGitCommit(
  * explicitly to skip.
  */
 export function commitFlagRegion(after: string): string {
-  const masked = maskQuotedSpans(after);
+  const masked = maskRedirections(maskQuotedSpans(after));
   const sep = masked.search(/[;\n&|]/);
   const region = sep === -1 ? after : after.slice(0, sep);
-  return withoutQuotedSpans(region).replace(/\d*[<>]+\s*\S+/g, " ");
+  return maskRedirections(withoutQuotedSpans(region));
 }
 
 export function argumentRegion(text: string): string {
@@ -689,8 +689,61 @@ export function commitSkipsVerify(commitFlags: string): boolean {
  * `--no-verify` and turned the hook off, leaving that file unchecked.
  */
 function beforePathspecSentinel(commitFlags: string): string {
-  const m = commitFlags.match(/(?:^|\s)--(?=\s|$)/);
-  return m?.index === undefined ? commitFlags : commitFlags.slice(0, m.index);
+  // Option values have to be stepped over, not scanned. In `git commit -m -- -a`
+  // the `--` is the message: treating it as the sentinel truncated here and hid
+  // the `-a` behind it, so the commit staged tracked changes nothing checked.
+  const tokens = [...commitFlags.matchAll(/\S+/g)];
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i][0];
+    if (token === "--") return commitFlags.slice(0, tokens[i].index);
+    if (consumesNextToken(token)) i++;
+  }
+  return commitFlags;
+}
+
+/** True when `token` takes the following word as its value. */
+function consumesNextToken(token: string): boolean {
+  if (VALUE_TAKING_LONG.has(token)) return true;
+  if (!/^-[A-Za-z]+$/.test(token)) return false;
+  for (const ch of token.slice(1)) {
+    // A value-taking short flag consumes the next word only when its own value
+    // is not already attached: `-m msg` does, `-mmsg` does not.
+    if (VALUE_TAKING_SHORT.includes(ch)) return token.endsWith(ch);
+  }
+  return false;
+}
+
+const VALUE_TAKING_SHORT = "mFcCtSu";
+const VALUE_TAKING_LONG = new Set([
+  "--message",
+  "--file",
+  "--reuse-message",
+  "--reedit-message",
+  "--template",
+  "--gpg-sign",
+  "--untracked-files",
+  "--author",
+  "--date",
+  "--cleanup",
+  "--fixup",
+  "--squash",
+  "--trailer",
+  "--pathspec-from-file",
+]);
+
+/**
+ * Blank redirections, descriptor and all, preserving length.
+ *
+ * The `&` of `2>&1` is not a command separator, but a search for `[;&|]` cannot
+ * tell — and reading it as one cut the commit's flag region in half, so a
+ * `--no-verify` after a redirect went unseen and the hook blocked a commit git
+ * had been told to skip.
+ */
+function maskRedirections(text: string): string {
+  return text.replace(
+    /&?\d*[<>]{1,2}&?\s*(?:\d+|[^\s;&|]*)/g,
+    (span) => " ".repeat(span.length),
+  );
 }
 
 export function commitsAllTracked(commitFlags: string): boolean {

--- a/.claude/scripts/common/worktree.ts
+++ b/.claude/scripts/common/worktree.ts
@@ -152,10 +152,12 @@ export function targetDirArgs(cmd: string): string[] | null {
   const args: string[] = [];
 
   // The last `cd` before the commit wins, as it would in the shell. Require a
-  // command boundary so `--author "cd fred"` cannot masquerade as one.
+  // command boundary so `--author "cd fred"` cannot masquerade as one — but
+  // count `(` and `{` as boundaries too, because `(cd dir && git commit)` is a
+  // real form and missing its `cd` puts us back to judging the wrong tree.
   const cds = [
     ...prefix.matchAll(
-      /(?:^|[;&|]|&&|\|\|)\s*cd\s+("[^"]*"|'[^']*'|[^\s;&|]+)/g,
+      /(?:^|[;&|({])\s*cd\s+("[^"]*"|'[^']*'|[^\s;&|)}]+)/g,
     ),
   ];
   const lastCd = cds.at(-1)?.[1];

--- a/.claude/scripts/common/worktree.ts
+++ b/.claude/scripts/common/worktree.ts
@@ -1,0 +1,203 @@
+/**
+ * Working-directory resolution for Claude Code hook scripts.
+ *
+ * A hook must decide *which checkout* it is talking about before it runs a
+ * single check, and none of the obvious answers is right on its own. Measured
+ * against a live session (2026-07-29):
+ *
+ * - `$CLAUDE_PROJECT_DIR` is pinned to the checkout the session started in. It
+ *   never follows the agent into another worktree, so it is wrong precisely
+ *   when it matters.
+ * - The hook payload's `cwd` (and `Deno.cwd()`, which equals it) tracks the
+ *   Bash tool's *persisted* shell cwd — a `cd` in an earlier tool call does
+ *   move it. It is the right default, but it is captured BEFORE the command
+ *   runs, so a `cd` or `git -C` inside the very command being inspected is
+ *   invisible to it.
+ * - On `SubagentStop`, the payload's `cwd` is the *parent* session's. A
+ *   subagent given its own worktree reports the parent's directory here; the
+ *   only record of where it actually worked is its own transcript.
+ *
+ * So: parse the command for an explicit target, fall back to the payload cwd,
+ * and resolve the result through git rather than by string surgery. When none
+ * of that yields an answer, say so and let the caller pass — a hook that
+ * cannot tell which tree it is judging must not block a correct commit.
+ */
+
+/**
+ * Read defensively: this module is imported by hooks invoked with differing
+ * permission sets, and a hook that dies on a missing `--allow-env` is itself a
+ * blocker. Without HOME we simply do not expand `~`.
+ */
+export function env(name: string): string {
+  try {
+    return Deno.env.get(name) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+const HOME = env("HOME");
+
+/** Run git in `cwd`; trimmed stdout, or null when git itself failed. */
+async function git(cwd: string, args: string[]): Promise<string | null> {
+  try {
+    const { success, stdout } = await new Deno.Command("git", {
+      args,
+      cwd,
+      stdout: "piped",
+      stderr: "piped",
+    }).output();
+    if (!success) return null;
+    const out = new TextDecoder().decode(stdout).trim();
+    return out || null;
+  } catch {
+    // cwd does not exist, or git is not installed.
+    return null;
+  }
+}
+
+/** The root of the worktree containing `dir`, or null if there is none. */
+export async function worktreeRoot(dir: string): Promise<string | null> {
+  return await git(dir, ["rev-parse", "--show-toplevel"]);
+}
+
+/**
+ * Identity of the *repository* `dir` belongs to. Every worktree of one
+ * repository shares a common git dir, so this is what distinguishes "another
+ * branch of our repo" (check it) from "an unrelated project" (leave it alone).
+ */
+export async function repositoryId(dir: string): Promise<string | null> {
+  const common = await git(dir, ["rev-parse", "--git-common-dir"]);
+  if (!common) return null;
+  // git answers relatively (".git") inside the main worktree and absolutely
+  // inside a linked one. Normalise through the filesystem so the two forms of
+  // the same repository compare equal.
+  if (common.startsWith("/")) return await realPath(common);
+  const root = await worktreeRoot(dir);
+  return root ? await realPath(`${root}/${common}`) : null;
+}
+
+async function realPath(p: string): Promise<string | null> {
+  try {
+    return await Deno.realPath(p);
+  } catch {
+    return null;
+  }
+}
+
+/** True when `a` and `b` are worktrees of the same repository. */
+export async function sameRepository(a: string, b: string): Promise<boolean> {
+  const [ida, idb] = await Promise.all([repositoryId(a), repositoryId(b)]);
+  return ida !== null && ida === idb;
+}
+
+/**
+ * A `git … commit` invocation, capturing whatever global options sit between
+ * `git` and `commit`.
+ *
+ * Those options are the reason this is not simply /git\s+commit/: written that
+ * way, `git -C <dir> commit` does not match, and the hook that used it waved
+ * through every commit aimed at another worktree — the one case it most needed
+ * to inspect. Matching the options is also what lets us find a `-C` at all.
+ */
+const GIT_COMMIT = /\bgit\s+((?:-{1,2}[^\s]+(?:[=\s]+[^\s]+)?\s+)*)commit\b/;
+
+/** True when `cmd` contains a `git commit`, however git is steered to it. */
+export function isGitCommit(cmd: string): boolean {
+  return GIT_COMMIT.test(cmd);
+}
+
+/**
+ * `cmd` split around the `git … commit` invocation.
+ *
+ * Callers want the two halves for different reasons, and both matter: earlier
+ * commands (a `git add`, a `cd`) are only meaningful in `before`, while the
+ * commit's own flags are in `after`. Splitting here also keeps pattern
+ * searches out of the commit message, which can contain any text at all —
+ * including something that reads exactly like a `git add`.
+ */
+export function splitAtGitCommit(
+  cmd: string,
+): { before: string; after: string } {
+  const m = cmd.match(GIT_COMMIT);
+  if (!m || m.index === undefined) return { before: cmd, after: "" };
+  return {
+    before: cmd.slice(0, m.index),
+    after: cmd.slice(m.index + m[0].length),
+  };
+}
+
+/**
+ * git's own `-C` arguments for the directory a shell command will operate in.
+ *
+ * Returned as arguments rather than a path so that git — not us — does the
+ * resolving: git composes repeated `-C` exactly the way a shell would compose
+ * `cd`, including relative segments, and we never have to reimplement that.
+ *
+ * `null` means "this command steers git in a way this parser does not model";
+ * callers should report that and pass rather than guess.
+ */
+export function targetDirArgs(cmd: string): string[] | null {
+  // An explicit tree override changes the answer completely and has forms we
+  // deliberately do not try to model. Refuse rather than answer wrongly.
+  if (/--git-dir[=\s]|--work-tree[=\s]/.test(cmd)) return null;
+
+  // Isolate the `git … commit` invocation. The options between `git` and
+  // `commit` are the only place a `-C` can affect the commit, and anchoring
+  // here keeps us out of the commit *message*, which may contain anything.
+  const invocation = cmd.match(GIT_COMMIT);
+  const optionsBeforeCommit = invocation?.[1] ?? "";
+  const prefix = invocation ? cmd.slice(0, invocation.index) : cmd;
+
+  const args: string[] = [];
+
+  // The last `cd` before the commit wins, as it would in the shell. Require a
+  // command boundary so `--author "cd fred"` cannot masquerade as one.
+  const cds = [
+    ...prefix.matchAll(
+      /(?:^|[;&|]|&&|\|\|)\s*cd\s+("[^"]*"|'[^']*'|[^\s;&|]+)/g,
+    ),
+  ];
+  const lastCd = cds.at(-1)?.[1];
+  if (lastCd) args.push("-C", expand(lastCd));
+
+  // Then each `-C` the commit itself carries, in order.
+  for (
+    const m of optionsBeforeCommit.matchAll(
+      /-C\s+("[^"]*"|'[^']*'|[^\s]+)/g,
+    )
+  ) {
+    args.push("-C", expand(m[1]));
+  }
+
+  return args;
+}
+
+/** Strip one layer of quoting and expand a leading `~`. */
+function expand(raw: string): string {
+  let p = raw;
+  if (
+    (p.startsWith('"') && p.endsWith('"')) ||
+    (p.startsWith("'") && p.endsWith("'"))
+  ) {
+    p = p.slice(1, -1);
+  }
+  if (p === "~") return HOME || p;
+  if (p.startsWith("~/") && HOME) return HOME + p.slice(1);
+  return p;
+}
+
+/**
+ * The worktree a `git commit` command will actually commit to.
+ *
+ * `fallbackCwd` should be the hook payload's `cwd`: correct whenever the
+ * command does not redirect git itself.
+ */
+export async function commitTargetWorktree(
+  cmd: string,
+  fallbackCwd: string,
+): Promise<string | null> {
+  const dirArgs = targetDirArgs(cmd);
+  if (dirArgs === null) return null;
+  return await git(fallbackCwd, [...dirArgs, "rev-parse", "--show-toplevel"]);
+}

--- a/.claude/scripts/common/worktree.ts
+++ b/.claude/scripts/common/worktree.ts
@@ -216,9 +216,34 @@ function maskQuotedSpans(text: string): string {
   );
 }
 
+/**
+ * A backtracking-free `git … commit` check, by walking tokens.
+ *
+ * The bounded regex above is fast but gives up past its option limit, and giving
+ * up there meant `isGitCommit` returned false and the hook skipped the commit in
+ * silence — the one outcome this file is built to avoid. The bound cannot simply
+ * be lifted: measured unbounded, the residual ambiguity between a value-taking
+ * option and a boolean one still runs past 300 seconds. So the regex keeps its
+ * bound for structure, and this decides, in linear time, whether there is a
+ * commit here at all.
+ */
+function looksLikeGitCommit(masked: string): boolean {
+  const tokens = masked.split(/\s+/).filter(Boolean);
+  for (let i = 0; i < tokens.length; i++) {
+    if (tokens[i] !== "git" && !tokens[i].endsWith("/git")) continue;
+    let j = i + 1;
+    while (j < tokens.length && tokens[j].startsWith("-")) {
+      j += VALUE_OPTIONS.includes(tokens[j]) ? 2 : 1;
+    }
+    if (tokens[j] === "commit") return true;
+  }
+  return false;
+}
+
 /** True when `cmd` contains a `git commit`, however git is steered to it. */
 export function isGitCommit(cmd: string): boolean {
-  return GIT_COMMIT.test(maskQuotedSpans(cmd));
+  const masked = maskQuotedSpans(cmd);
+  return GIT_COMMIT.test(masked) || looksLikeGitCommit(masked);
 }
 
 /**
@@ -378,7 +403,6 @@ const SAFE_ADD_LONG = new Set([
   "--ignore-errors",
   "--ignore-removal",
   "--no-ignore-removal",
-  "--refresh",
   "--renormalize",
   "--sparse",
   "--no-warn-embedded-repo",
@@ -387,11 +411,26 @@ const SAFE_ADD_LONG = new Set([
 /** Short clusters of safe flags only: all, update, force, dry-run, verbose. */
 const SAFE_ADD_SHORT = /^-[Aufnv]+$/;
 
+/**
+ * `--refresh` is deliberately absent, and its absence is the third correction to
+ * this guard. It writes the index under `--dry-run` in the racily-clean case —
+ * content matching the index with a stale mtime, which is exactly what a fresh
+ * checkout or a `touch` leaves behind. Isolated in a scratch repo: with content
+ * changed it is inert, with content unchanged the index file is rewritten. An
+ * earlier probe missed it by changing the content first.
+ *
+ * Every name here was verified individually rather than assumed, because the
+ * previous two versions of this guard were each wrong about a flag nobody had
+ * run.
+ */
 function isSafeAddFlag(flag: string): boolean {
   if (SAFE_ADD_SHORT.test(flag)) return true;
-  const name = flag.split("=")[0];
-  if (name === "--chmod") return true;
-  return SAFE_ADD_LONG.has(name);
+  // `--chmod` only in its attached form. Separated (`--chmod +x`), the value is
+  // an argument we would classify as a pathspec and move after `--`, leaving
+  // git with a `--chmod` that has lost its parameter: it fails, the file list
+  // comes back empty, and the commit goes unchecked.
+  if (flag.startsWith("--chmod=")) return true;
+  return SAFE_ADD_LONG.has(flag);
 }
 
 export interface GitAddInvocation {
@@ -470,7 +509,12 @@ export function gitAddInvocations(cmd: string): GitAddInvocation[] | null {
 export function targetDirArgs(cmd: string): string[] | null {
   // The options between `git` and `commit` are the only place a `-C` can affect
   // the commit; `before` is the only place a `cd` can.
-  const { before: prefix, options } = splitAtGitCommit(cmd);
+  const { matched, before: prefix, options } = splitAtGitCommit(cmd);
+
+  // No structural parse — the commit is past the option bound, or there is none.
+  // Either way we have no idea where it lands, and the caller reports that
+  // rather than resolving from a prefix we never located.
+  if (!matched) return null;
 
   // An explicit tree override changes the answer completely and has forms we
   // deliberately do not try to model. Refuse rather than answer wrongly — but
@@ -533,6 +577,30 @@ function expand(raw: string): string {
  * would never have touched, which is the failure this whole change is about.
  * Flags after the message (`git commit -m "x" -a`) still register.
  */
+/**
+ * True when a commit's flags stage all tracked changes (`-a` / `--all`).
+ *
+ * Short flags are read cluster by cluster, stopping at the first one that takes
+ * an attached value, because everything after it *is* that value. `git commit
+ * -mdata` is a valid attached message, and a pattern looking for `a` anywhere in
+ * a dash-token read it as `-a`: the hook then pulled in every tracked change in
+ * the tree and blocked the commit on an unrelated unstaged error. `-ma msg`
+ * likewise means a message of "a", not `-a`.
+ *
+ * `commitFlags` must already have had its quoted spans removed.
+ */
+export function commitsAllTracked(commitFlags: string): boolean {
+  if (/(?:^|\s)--all(?:\s|$)/.test(commitFlags)) return true;
+  const VALUE_TAKING = "mFcCtSu";
+  for (const m of commitFlags.matchAll(/(?:^|\s)-([A-Za-z]+)/g)) {
+    for (const ch of m[1]) {
+      if (ch === "a") return true;
+      if (VALUE_TAKING.includes(ch)) break;
+    }
+  }
+  return false;
+}
+
 export function withoutQuotedSpans(text: string): string {
   // Built on the same mask, not a second copy of the quote grammar: two
   // spellings of "what is quoted" would drift, and this one guards the flag

--- a/.claude/scripts/common/worktree.ts
+++ b/.claude/scripts/common/worktree.ts
@@ -172,7 +172,7 @@ const MAX_GLOBAL_OPTIONS = 12;
 function gitSubcommand(subcommand: string): RegExp {
   return new RegExp(
     String
-      .raw`\bgit\s+((?:${GLOBAL_OPTION}){0,${MAX_GLOBAL_OPTIONS}})${subcommand}\b`,
+      .raw`\bgit\s+((?:${GLOBAL_OPTION}){0,${MAX_GLOBAL_OPTIONS}})${subcommand}(?![-\w])`,
   );
 }
 
@@ -196,6 +196,41 @@ const GIT_COMMIT = gitSubcommand("commit");
  * delimiter here, so a masked span cannot match anything we look for.
  */
 function maskQuotedSpans(text: string): string {
+  return maskLineContinuations(maskComments(maskQuotesOnly(text)));
+}
+
+/**
+ * Blank a `#` comment to end of line. Applied after quoting, so a `#` inside a
+ * string is already NUL and cannot start one.
+ *
+ * `git status # remember to git commit -m x` was read as a commit: the hook then
+ * checked whatever happened to be staged and, finding a fault, exited 2 on a
+ * `git status`. A hard block on a read-only command, with `--no-verify`
+ * meaningless as an escape because there is no commit to pass it to.
+ */
+function maskComments(text: string): string {
+  return text.replace(
+    /(^|\s)#[^\n]*/g,
+    (span, lead: string) => lead + "\0".repeat(span.length - lead.length),
+  );
+}
+
+/**
+ * Turn `\<newline>` into spaces. It is a line continuation: the shell removes it
+ * and joins the lines, so it is neither an argument nor a separator.
+ *
+ *   git add \
+ *     bad.ts && git commit -m x
+ *
+ * cut the argument region at the newline and handed git a lone `\` as the
+ * pathspec, so bad.ts was staged, committed, and never checked. Two spaces, not
+ * one, because the mask must not change any offset.
+ */
+function maskLineContinuations(text: string): string {
+  return text.replace(/\\\n/g, "  ");
+}
+
+function maskQuotesOnly(text: string): string {
   // `\\[\s\S]` in the double-quoted branch is load-bearing, and the character
   // class rather than `.` doubly so: `.` does not match a newline, so a shell
   // line continuation inside a quoted string ended the span early and reopened
@@ -239,6 +274,13 @@ function looksLikeGitCommit(masked: string): boolean {
   }
   return false;
 }
+
+/**
+ * Beyond this, refuse to parse. The mask is quadratic on a long contiguous run
+ * of escaped quotes — 64 KB of them cost 5.8 seconds, paid several times over as
+ * each entry point re-masks — and no real commit command is anywhere near it.
+ */
+export const MAX_COMMAND_LENGTH = 16384;
 
 /** True when `cmd` contains a `git commit`, however git is steered to it. */
 export function isGitCommit(cmd: string): boolean {
@@ -479,12 +521,18 @@ export function gitAddInvocations(cmd: string): GitAddInvocation[] | null {
     const head = sentinel === -1 ? words : words.slice(0, sentinel);
     const tail = sentinel === -1 ? [] : words.slice(sentinel + 1);
     const flags = head.filter((w) => w.startsWith("-"));
+    const paths = [...head.filter((w) => !w.startsWith("-")), ...tail];
 
     invocations.push({
       dirArgs,
       flags,
-      paths: [...head.filter((w) => !w.startsWith("-")), ...tail],
-      dryRunnable: flags.every(isSafeAddFlag),
+      paths,
+      // An unexpanded glob is not the same pathspec the shell will produce:
+      // `git add *.ts` expands to this directory, while git's pathspec matches
+      // recursively. Resolving it here blocked commits on files in
+      // subdirectories that the command never staged.
+      dryRunnable: flags.every(isSafeAddFlag) &&
+        !paths.some((p) => /[*?[]/.test(p)),
     });
 
     const advance = add.before.length +
@@ -589,6 +637,25 @@ function expand(raw: string): string {
  *
  * `commitFlags` must already have had its quoted spans removed.
  */
+/**
+ * True when the commit's flags disable verification.
+ *
+ * `-n` is git-commit's short spelling of `--no-verify`, and only the long form
+ * was honoured — so the escape hatch the tests call "the only way past" did not
+ * work when spelled the way git documents it first.
+ */
+export function commitSkipsVerify(commitFlags: string): boolean {
+  if (/(?:^|\s)--no-verify(?:\s|$)/.test(commitFlags)) return true;
+  const VALUE_TAKING = "mFcCtSu";
+  for (const m of commitFlags.matchAll(/(?:^|\s)-([A-Za-z]+)/g)) {
+    for (const ch of m[1]) {
+      if (ch === "n") return true;
+      if (VALUE_TAKING.includes(ch)) break;
+    }
+  }
+  return false;
+}
+
 export function commitsAllTracked(commitFlags: string): boolean {
   if (/(?:^|\s)--all(?:\s|$)/.test(commitFlags)) return true;
   const VALUE_TAKING = "mFcCtSu";

--- a/.claude/scripts/common/worktree.ts
+++ b/.claude/scripts/common/worktree.ts
@@ -349,18 +349,50 @@ export function dirArgsAt(prefix: string): string[] | null {
 }
 
 /**
- * Flags that make `git add` write to the index *even with* `--dry-run`.
+ * `git add` flags known not to write anything under `--dry-run`.
  *
- * `--edit` is the one that matters and the reason this list exists. git rejects
- * `-i`/`-p` outright under `--dry-run`, but it honours `--edit`: it applies the
- * patch to the index regardless, and because Claude Code sets `GIT_EDITOR=true`
- * the editor step is a silent no-op that accepts everything. So a hook whose
+ * A whitelist, deliberately, and this is the second attempt. `--edit` writes to
+ * the index *even with* `--dry-run` — git rejects `-i`/`-p` outright but honours
+ * `--edit`, applying the patch regardless, and Claude Code sets
+ * `GIT_EDITOR=true` so the editor step silently accepts everything. A hook whose
  * entire purpose is to stop touching the trees it inspects staged the user's
- * working tree for them, before their command had even run — verified against a
- * scratch repo. An add carrying any of these is not dry-runnable, so we do not
- * try.
+ * working tree for them, before their command had run.
+ *
+ * The first attempt blacklisted `--edit`, `--interactive`, `--patch` as exact
+ * words. git accepts any unambiguous abbreviation, so `--e`, `--ed` and `--edi`
+ * all still mutated — verified against a scratch repo, `git write-tree` before
+ * and after. No blacklist can be complete against prefix matching, so the
+ * polarity is wrong for a mutation guard: an unrecognised flag has to mean "do
+ * not run this", not "assume it is fine".
+ *
+ * Rejecting an abbreviation of a *safe* flag costs a skipped file list and says
+ * so. Accepting an abbreviation of an unsafe one costs the read-only contract.
  */
-const MUTATING_ADD_FLAGS = /^--(?:edit|interactive|patch)$|^-[A-Za-z]*[eip]/;
+const SAFE_ADD_LONG = new Set([
+  "--all",
+  "--no-all",
+  "--update",
+  "--force",
+  "--dry-run",
+  "--verbose",
+  "--ignore-errors",
+  "--ignore-removal",
+  "--no-ignore-removal",
+  "--refresh",
+  "--renormalize",
+  "--sparse",
+  "--no-warn-embedded-repo",
+]);
+
+/** Short clusters of safe flags only: all, update, force, dry-run, verbose. */
+const SAFE_ADD_SHORT = /^-[Aufnv]+$/;
+
+function isSafeAddFlag(flag: string): boolean {
+  if (SAFE_ADD_SHORT.test(flag)) return true;
+  const name = flag.split("=")[0];
+  if (name === "--chmod") return true;
+  return SAFE_ADD_LONG.has(name);
+}
 
 export interface GitAddInvocation {
   dirArgs: string[];
@@ -368,8 +400,8 @@ export interface GitAddInvocation {
   flags: string[];
   /** Pathspecs, to be passed after `--`. */
   paths: string[];
-  /** True when this add cannot be dry-run without writing to the index. */
-  mutating: boolean;
+  /** True when every flag is known safe to pass to `git add --dry-run`. */
+  dryRunnable: boolean;
 }
 
 /**
@@ -413,7 +445,7 @@ export function gitAddInvocations(cmd: string): GitAddInvocation[] | null {
       dirArgs,
       flags,
       paths: [...head.filter((w) => !w.startsWith("-")), ...tail],
-      mutating: flags.some((f) => MUTATING_ADD_FLAGS.test(f)),
+      dryRunnable: flags.every(isSafeAddFlag),
     });
 
     const advance = add.before.length +

--- a/.claude/scripts/common/worktree.ts
+++ b/.claude/scripts/common/worktree.ts
@@ -202,18 +202,19 @@ export function isGitCommit(cmd: string): boolean {
 export function splitAtGitSubcommand(
   cmd: string,
   subcommand: string,
-): { before: string; options: string; after: string } {
+): { matched: boolean; before: string; options: string; after: string } {
   // Located on the masked copy so quoted text cannot be the match, but sliced
   // out of the original so callers get real values back. The mask preserves
   // length, which is what makes those two the same offsets.
   const masked = maskQuotedSpans(cmd);
   const m = masked.match(gitSubcommand(subcommand));
   if (!m || m.index === undefined) {
-    return { before: cmd, options: "", after: "" };
+    return { matched: false, before: cmd, options: "", after: "" };
   }
   const optionsStart = m.index + m[0].length - (m[1] ?? "").length -
     subcommand.length;
   return {
+    matched: true,
     before: cmd.slice(0, m.index),
     options: cmd.slice(optionsStart, optionsStart + (m[1] ?? "").length),
     after: cmd.slice(m.index + m[0].length),
@@ -223,8 +224,112 @@ export function splitAtGitSubcommand(
 /** `cmd` split around its `git … commit`. */
 export function splitAtGitCommit(
   cmd: string,
-): { before: string; options: string; after: string } {
+): { matched: boolean; before: string; options: string; after: string } {
   return splitAtGitSubcommand(cmd, "commit");
+}
+
+/**
+ * The argument region of a command: everything up to the first separator that
+ * is not inside quotes.
+ *
+ * Found on the mask so `git add 'a&b.ts'` is one argument rather than two
+ * commands.
+ */
+export function argumentRegion(text: string): string {
+  const sep = maskQuotedSpans(text).search(/[;\n&|]/);
+  return sep === -1 ? text : text.slice(0, sep);
+}
+
+/**
+ * Shell words in `text`, with one layer of quoting removed.
+ *
+ * Split on the mask, so a quoted argument containing spaces stays one word, and
+ * read back out of the original, so the word itself survives. Blanking quotes
+ * before splitting is what erased them: `git add "packages/foo.ts"` produced no
+ * arguments at all, the file was never checked, and the commit sailed through.
+ */
+export function shellWords(text: string): string[] {
+  const masked = maskQuotedSpans(text);
+  return [...masked.matchAll(/\S+/g)].map((m) =>
+    expand(text.slice(m.index, m.index + m[0].length))
+  );
+}
+
+/**
+ * The `-C` arguments in effect after `prefix` has run — every `cd` and `pushd`
+ * it contains, in order.
+ *
+ * `null` for the shapes a regex cannot read; see targetDirArgs.
+ *
+ * Taken at a point in the command, not once for the whole thing, because
+ * different git invocations in one command run in different directories:
+ * `git add foo.ts && cd sub && git commit` stages from here and commits from
+ * there, and resolving the add with the commit's directory looked for the file
+ * in the wrong place and quietly dropped it.
+ */
+export function dirArgsAt(prefix: string): string[] | null {
+  const masked = maskQuotedSpans(prefix);
+
+  // Two shapes a regex cannot read, where guessing produced a *confidently
+  // wrong* tree rather than no answer:
+  //
+  // Parentheses. A `cd` inside `( … )` or `$( … )` does not outlive the
+  // subshell, so `(cd /a && git add -A) && git commit` must not resolve to
+  // /a — but `(cd /a && git commit)` must. Telling those apart means knowing
+  // whether the commit shares the subshell, which is parsing, not matching.
+  //
+  // Heredocs. Their body is data, and a line of data reading `cd /elsewhere`
+  // is not a command.
+  //
+  // So refuse. Skipping a check is a cost; asserting the wrong branch's errors
+  // against someone's commit is the bug this module exists to remove.
+  if (/[()]/.test(masked)) return null;
+  if (masked.includes("<<")) return null;
+  // `popd` returns to a directory we never saw pushed. Nothing to compose.
+  if (/(?:^|[;&|{\n])\s*popd\b/.test(masked)) return null;
+
+  const args: string[] = [];
+
+  // A command boundary is required so `--author "cd fred"` cannot masquerade as
+  // one. A newline is such a boundary: agents write commit sequences as
+  // multi-line scripts, and while `\n` was missing every `cd` after the first
+  // line was invisible — the original bug, surviving in its most common form.
+  // `{` counts too; unlike `(` a brace group runs in the current shell, so its
+  // `cd` holds. `pushd` moves the shell the same way `cd` does.
+  //
+  // Matched against the mask and read out of the original by index, so a quoted
+  // path arrives intact while quoted prose cannot pose as a command.
+  for (
+    const m of masked.matchAll(
+      /(?:^|[;&|{\n])\s*(?:cd|pushd)\s+([^\s;&|}]+)/dg,
+    )
+  ) {
+    const span = m.indices?.[1];
+    if (!span) continue;
+    args.push("-C", expand(prefix.slice(span[0], span[1])));
+  }
+
+  return args;
+}
+
+/**
+ * Where a `git add` in `cmd` runs and what it will be given, or null when the
+ * command has no `git add` (or steers it somewhere unmodellable).
+ */
+export function gitAddInvocation(
+  cmd: string,
+): { dirArgs: string[]; words: string[] } | null {
+  const beforeCommit = splitAtGitCommit(cmd).before;
+  const add = splitAtGitSubcommand(beforeCommit, "add");
+  if (!add.matched) return null;
+
+  const dirArgs = dirArgsAt(add.before);
+  if (dirArgs === null) return null;
+  for (const m of add.options.matchAll(/-C\s+("[^"]*"|'[^']*'|[^\s]+)/g)) {
+    dirArgs.push("-C", expand(m[1]));
+  }
+
+  return { dirArgs, words: shellWords(argumentRegion(add.after)) };
 }
 
 /**
@@ -250,60 +355,14 @@ export function targetDirArgs(cmd: string): string[] | null {
   // silently disable the hook by describing it.
   if (/--git-dir|--work-tree/.test(options)) return null;
 
-  // Two shapes a regex cannot read, where guessing produced a *confidently
-  // wrong* tree rather than no answer:
-  //
-  // Parentheses. A `cd` inside `( … )` or `$( … )` does not outlive the
-  // subshell, so `(cd /a && git add -A) && git commit` must not resolve to
-  // /a — but `(cd /a && git commit)` must. Telling those apart means knowing
-  // whether the commit shares the subshell, which is parsing, not matching.
-  //
-  // Heredocs. Their body is data, and a line of data reading `cd /elsewhere`
-  // is not a command. Only `before` matters: `git commit -F - <<'EOF'` keeps
-  // its heredoc after the commit, where we never look.
-  //
-  // So refuse. Skipping a check is a cost; asserting the wrong branch's errors
-  // against someone's commit is the bug this module exists to remove.
-  const maskedPrefix = maskQuotedSpans(prefix);
-  if (/[()]/.test(maskedPrefix)) return null;
-  if (maskedPrefix.includes("<<")) return null;
-  // `popd` returns to a directory we never saw pushed. Nothing to compose.
-  if (/(?:^|[;&|{\n])\s*popd\b/.test(maskedPrefix)) return null;
-
-  const args: string[] = [];
-
-  // Every `cd` before the commit, in order — not just the last. They compose:
-  // `cd /a && cd sub` ends in /a/sub, and taking only `cd sub` resolved it
-  // against whatever directory the hook happened to start in. Passing them all
-  // to git reproduces the composition exactly, absolute paths overriding
-  // earlier ones just as they do in a shell.
-  //
-  // A command boundary is required so `--author "cd fred"` cannot masquerade as
-  // one. A newline is such a boundary: agents write commit sequences as
-  // multi-line scripts, and while `\n` was missing every `cd` after the first
-  // line was invisible — the original bug, surviving in its most common form.
-  // `{` counts too; unlike `(` a brace group runs in the current shell, so its
-  // `cd` holds. `pushd` moves the shell the same way `cd` does.
-  //
-  // Matched against the mask and read out of the original by index, so a quoted
-  // path arrives intact while quoted prose cannot pose as a command.
-  for (
-    const m of maskedPrefix.matchAll(
-      /(?:^|[;&|{\n])\s*(?:cd|pushd)\s+([^\s;&|}]+)/dg,
-    )
-  ) {
-    const span = m.indices?.[1];
-    if (!span) continue;
-    args.push("-C", expand(prefix.slice(span[0], span[1])));
-  }
+  // Only `before` is scanned for directory changes: `git commit -F - <<'EOF'`
+  // keeps its heredoc after the commit, where a `cd` could not affect it.
+  const args = dirArgsAt(prefix);
+  if (args === null) return null;
 
   // Then each `-C` the commit itself carries, in order. git rejects a glued
   // `-C<path>` ("unknown option"), so a space is required here too.
-  for (
-    const m of options.matchAll(
-      /-C\s+("[^"]*"|'[^']*'|[^\s]+)/g,
-    )
-  ) {
+  for (const m of options.matchAll(/-C\s+("[^"]*"|'[^']*'|[^\s]+)/g)) {
     args.push("-C", expand(m[1]));
   }
 

--- a/.claude/scripts/deno.jsonc
+++ b/.claude/scripts/deno.jsonc
@@ -12,10 +12,10 @@
   // its own files. That is wanted — these scripts had no formatting or lint
   // coverage at all — and it is why comments elsewhere must not claim `.claude/`
   // is still excluded. Type checking comes from `tasks/check.sh`.
-  // `-A`: pre-commit.test.ts drives the hook as a subprocess against a scratch
-  // repository under Deno.makeTempDir(), so it needs run and write. It touches
-  // nothing in the checkout — see the header of that file.
+  // Permissions enumerated rather than `-A`, so what these tests may do is
+  // visible: pre-commit.test.ts drives the hook as a subprocess against a
+  // scratch repository under Deno.makeTempDir(). No network, no FFI.
   "tasks": {
-    "test": "deno test -A --permit-no-files"
+    "test": "deno test --allow-read --allow-write --allow-run --allow-env --permit-no-files"
   }
 }

--- a/.claude/scripts/deno.jsonc
+++ b/.claude/scripts/deno.jsonc
@@ -1,0 +1,16 @@
+{
+  // Dependency guide: ../../docs/development/DEPENDENCIES.md
+  //
+  // A workspace member so that `deno task test` reaches these hook scripts.
+  // They are not a package and export nothing; without a member config the root
+  // runner has no way to run a test here, and the parsing in common/worktree.ts
+  // — which decides whether a commit is blocked — went untested long enough to
+  // ship several wrong answers.
+  //
+  // The root deno.jsonc keeps `.claude/` out of `deno fmt` and `deno lint`, and
+  // that is unchanged: this only adds a test task. Type checking comes from
+  // `tasks/check.sh`, which lists this directory.
+  "tasks": {
+    "test": "deno test --allow-env --allow-read --permit-no-files"
+  }
+}

--- a/.claude/scripts/deno.jsonc
+++ b/.claude/scripts/deno.jsonc
@@ -12,7 +12,10 @@
   // its own files. That is wanted — these scripts had no formatting or lint
   // coverage at all — and it is why comments elsewhere must not claim `.claude/`
   // is still excluded. Type checking comes from `tasks/check.sh`.
+  // `-A`: pre-commit.test.ts drives the hook as a subprocess against a scratch
+  // repository under Deno.makeTempDir(), so it needs run and write. It touches
+  // nothing in the checkout — see the header of that file.
   "tasks": {
-    "test": "deno test --allow-env --allow-read --permit-no-files"
+    "test": "deno test -A --permit-no-files"
   }
 }

--- a/.claude/scripts/deno.jsonc
+++ b/.claude/scripts/deno.jsonc
@@ -7,9 +7,11 @@
   // — which decides whether a commit is blocked — went untested long enough to
   // ship several wrong answers.
   //
-  // The root deno.jsonc keeps `.claude/` out of `deno fmt` and `deno lint`, and
-  // that is unchanged: this only adds a test task. Type checking comes from
-  // `tasks/check.sh`, which lists this directory.
+  // Being a member also brings this directory into `deno fmt` and `deno lint`:
+  // the root deno.jsonc excludes `.claude/`, but a member's own config governs
+  // its own files. That is wanted — these scripts had no formatting or lint
+  // coverage at all — and it is why comments elsewhere must not claim `.claude/`
+  // is still excluded. Type checking comes from `tasks/check.sh`.
   "tasks": {
     "test": "deno test --allow-env --allow-read --permit-no-files"
   }

--- a/.claude/scripts/pattern-maker-post-edit.ts
+++ b/.claude/scripts/pattern-maker-post-edit.ts
@@ -26,8 +26,7 @@ if (
   console.log(JSON.stringify({
     hookSpecificOutput: {
       hookEventName: "PostToolUse",
-      additionalContext:
-        `Run it: deno task cf check ${filePath}`,
+      additionalContext: `Run it: deno task cf check ${filePath}`,
     },
   }));
 }

--- a/.claude/scripts/pre-commit.test.ts
+++ b/.claude/scripts/pre-commit.test.ts
@@ -1,0 +1,213 @@
+import { assertEquals } from "@std/assert";
+
+/**
+ * End-to-end tests for the pre-commit hook.
+ *
+ * The parser has its own table in common/worktree.test.ts, and for eight review
+ * rounds that was the only coverage — which is why the defects kept landing
+ * here instead. They were not parsing mistakes; they were mistakes in how this
+ * file *composes* the parser: which file list reaches `checkFiles`, and in what
+ * order the gates run. Neither is observable from a unit test of a helper.
+ *
+ * So these drive the real hook, against a real repository, and assert the two
+ * things it promises: the right exit code, and nothing written to disk.
+ *
+ * Each test builds its own repository under `Deno.makeTempDir()` and removes it,
+ * so nothing here touches the checkout it runs in — the same property the hook
+ * itself exists to restore.
+ */
+
+const HOOK = new URL("./pre-commit.ts", import.meta.url).pathname;
+
+/** A file `deno check` rejects, whatever the surrounding lint config. */
+const TYPE_ERROR = 'export function broken(): number {\n  return "text";\n}\n';
+const CLEAN = "export const fine = 1;\n";
+
+async function run(cwd: string, args: string[]): Promise<string> {
+  const { stdout } = await new Deno.Command("git", {
+    args: ["--no-optional-locks", ...args],
+    cwd,
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+  return new TextDecoder().decode(stdout).trim();
+}
+
+interface Repo {
+  dir: string;
+  indexHash(): Promise<string>;
+}
+
+async function makeRepo(): Promise<Repo> {
+  const dir = await Deno.makeTempDir({ prefix: "pre-commit-hook-" });
+  await run(dir, ["init", "-q", "."]);
+  await run(dir, ["config", "user.email", "test@example.invalid"]);
+  await run(dir, ["config", "user.name", "Test"]);
+  await Deno.writeTextFile(`${dir}/tracked.ts`, CLEAN);
+  await run(dir, ["add", "tracked.ts"]);
+  await run(dir, ["commit", "-q", "-m", "init"]);
+  return {
+    dir,
+    async indexHash() {
+      const path = await run(dir, ["rev-parse", "--git-path", "index"]);
+      const bytes = await Deno.readFile(`${dir}/${path}`);
+      const digest = await crypto.subtle.digest("SHA-256", bytes);
+      return [...new Uint8Array(digest)].map((b) =>
+        b.toString(16).padStart(2, "0")
+      ).join("");
+    },
+  };
+}
+
+/** Invoke the hook exactly as Claude Code does, and report its exit code. */
+async function hook(repo: Repo, command: string): Promise<number> {
+  const payload = JSON.stringify({
+    cwd: repo.dir,
+    hook_event_name: "PreToolUse",
+    tool_name: "Bash",
+    tool_input: { command },
+  });
+  const child = new Deno.Command(Deno.execPath(), {
+    args: ["run", "--allow-read", "--allow-run", "--allow-env", HOOK],
+    cwd: repo.dir,
+    env: { CLAUDE_PROJECT_DIR: repo.dir },
+    stdin: "piped",
+    stdout: "piped",
+    stderr: "piped",
+  }).spawn();
+  const writer = child.stdin.getWriter();
+  await writer.write(new TextEncoder().encode(payload));
+  await writer.close();
+  const { code } = await child.output();
+  return code;
+}
+
+Deno.test("blocks a staged file that fails a check, and writes nothing", async () => {
+  const repo = await makeRepo();
+  try {
+    await Deno.writeTextFile(`${repo.dir}/bad.ts`, TYPE_ERROR);
+    await run(repo.dir, ["add", "bad.ts"]);
+
+    const before = await repo.indexHash();
+    assertEquals(await hook(repo, "git commit -m x"), 2);
+    // The contract that broke five times in this hook's history. It is asserted
+    // here rather than reasoned about.
+    assertEquals(await repo.indexHash(), before, "hook wrote to the index");
+  } finally {
+    await Deno.remove(repo.dir, { recursive: true });
+  }
+});
+
+Deno.test("judges the commit, not the index", async () => {
+  const repo = await makeRepo();
+  try {
+    // Given pathspecs, git commits those and ignores the index. Judging the
+    // index anyway skipped the file being committed and, with something else
+    // staged, reported a pass about a file the commit did not contain.
+    await Deno.writeTextFile(`${repo.dir}/tracked.ts`, TYPE_ERROR);
+    await Deno.writeTextFile(`${repo.dir}/staged.ts`, CLEAN);
+    await run(repo.dir, ["add", "staged.ts"]);
+
+    assertEquals(await hook(repo, "git commit -m x tracked.ts"), 2);
+    assertEquals(await hook(repo, "git commit -m x -- tracked.ts"), 2);
+    // ...and the reverse: a pathspec that excludes the bad staged file.
+    await Deno.writeTextFile(`${repo.dir}/other.ts`, TYPE_ERROR);
+    await run(repo.dir, ["add", "other.ts"]);
+    await Deno.writeTextFile(`${repo.dir}/tracked.ts`, CLEAN);
+    assertEquals(await hook(repo, "git commit -m x tracked.ts"), 0);
+  } finally {
+    await Deno.remove(repo.dir, { recursive: true });
+  }
+});
+
+Deno.test("an option's value is not a flag", async () => {
+  const repo = await makeRepo();
+  try {
+    await Deno.writeTextFile(`${repo.dir}/bad.ts`, TYPE_ERROR);
+    await run(repo.dir, ["add", "bad.ts"]);
+
+    // `git commit -m --no-verify` has a message of "--no-verify" and
+    // verification fully on. Read as a flag, it turned the hook off in silence.
+    assertEquals(await hook(repo, "git commit -m --no-verify"), 2);
+    assertEquals(await hook(repo, "git commit -m -n"), 2);
+    assertEquals(await hook(repo, "git commit --message -n"), 2);
+    // The real flag, and the abbreviation git also accepts, must both skip.
+    assertEquals(await hook(repo, "git commit -m x --no-verify"), 0);
+    assertEquals(await hook(repo, "git commit -m x --no-veri"), 0);
+    assertEquals(await hook(repo, "git commit -nm x"), 0);
+  } finally {
+    await Deno.remove(repo.dir, { recursive: true });
+  }
+});
+
+Deno.test("never blocks a command that creates no commit", async () => {
+  const repo = await makeRepo();
+  try {
+    await Deno.writeTextFile(`${repo.dir}/bad.ts`, TYPE_ERROR);
+    await run(repo.dir, ["add", "bad.ts"]);
+
+    for (
+      const command of [
+        "git commit --help",
+        "git commit -h",
+        "git commit --dry-run",
+        "git commit-graph write",
+        "git status # remember to git commit -m x",
+        "rg 'git commit' docs/",
+      ]
+    ) {
+      assertEquals(await hook(repo, command), 0, command);
+    }
+  } finally {
+    await Deno.remove(repo.dir, { recursive: true });
+  }
+});
+
+Deno.test("resolves what a `git add` in the same command will stage", async () => {
+  const repo = await makeRepo();
+  try {
+    await Deno.writeTextFile(`${repo.dir}/bad.ts`, TYPE_ERROR);
+    const before = await repo.indexHash();
+
+    // The hook runs before the command, so nothing is staged yet: every one of
+    // these is reachable only by reading the add.
+    for (
+      const command of [
+        "git add bad.ts && git commit -m x",
+        "git add -- bad.ts && git commit -m x",
+        "git stage bad.ts && git commit -m x",
+        "git add ok.ts && git add bad.ts && git commit -m x",
+        "git add bad.ts >/dev/null && git commit -m x",
+        'git add "bad.ts" && git commit -m x',
+      ]
+    ) {
+      assertEquals(await hook(repo, command), 2, command);
+    }
+    // And resolving them stages nothing itself.
+    assertEquals(await repo.indexHash(), before, "hook wrote to the index");
+  } finally {
+    await Deno.remove(repo.dir, { recursive: true });
+  }
+});
+
+Deno.test("an editing flag is never dry-run", async () => {
+  const repo = await makeRepo();
+  try {
+    await Deno.writeTextFile(`${repo.dir}/tracked.ts`, TYPE_ERROR);
+    // Stat-stale but content-identical is the state in which several
+    // read-shaped git commands rewrite the index.
+    await Deno.utime(`${repo.dir}/tracked.ts`, new Date(0), new Date(0));
+
+    const before = await repo.indexHash();
+    // `git add -e` applies its patch to the index even under --dry-run, and
+    // GIT_EDITOR=true accepts it silently.
+    assertEquals(await hook(repo, "git add -e && git commit -m x"), 0);
+    assertEquals(
+      await repo.indexHash(),
+      before,
+      "hook staged the working tree",
+    );
+  } finally {
+    await Deno.remove(repo.dir, { recursive: true });
+  }
+});

--- a/.claude/scripts/pre-commit.test.ts
+++ b/.claude/scripts/pre-commit.test.ts
@@ -36,6 +36,8 @@ async function run(cwd: string, args: string[]): Promise<string> {
 interface Repo {
   dir: string;
   indexHash(): Promise<string>;
+  /** Index bytes + working-tree status + deno.lock: everything a hook must leave alone. */
+  fingerprint(): Promise<string>;
 }
 
 async function makeRepo(): Promise<Repo> {
@@ -46,21 +48,56 @@ async function makeRepo(): Promise<Repo> {
   await Deno.writeTextFile(`${dir}/tracked.ts`, CLEAN);
   await run(dir, ["add", "tracked.ts"]);
   await run(dir, ["commit", "-q", "-m", "init"]);
-  return {
-    dir,
-    async indexHash() {
-      const path = await run(dir, ["rev-parse", "--git-path", "index"]);
-      const bytes = await Deno.readFile(`${dir}/${path}`);
-      const digest = await crypto.subtle.digest("SHA-256", bytes);
-      return [...new Uint8Array(digest)].map((b) =>
-        b.toString(16).padStart(2, "0")
-      ).join("");
-    },
-  };
+  async function sha(path: string): Promise<string> {
+    let bytes: Uint8Array;
+    try {
+      bytes = await Deno.readFile(path);
+    } catch {
+      return "absent";
+    }
+    const digest = await crypto.subtle.digest("SHA-256", bytes.slice());
+    return [...new Uint8Array(digest)].map((b) =>
+      b.toString(16).padStart(2, "0")
+    ).join("");
+  }
+
+  async function indexHash(): Promise<string> {
+    const relative = await run(dir, ["rev-parse", "--git-path", "index"]);
+    return await sha(`${dir}/${relative}`);
+  }
+
+  async function fingerprint(): Promise<string> {
+    return [
+      await indexHash(),
+      await run(dir, ["status", "--porcelain"]),
+      await sha(`${dir}/deno.lock`),
+    ].join("|");
+  }
+
+  return { dir, indexHash, fingerprint };
 }
 
-/** Invoke the hook exactly as Claude Code does, and report its exit code. */
+/**
+ * Invoke the hook exactly as Claude Code does, and report its exit code.
+ *
+ * The read-only contract is asserted here, on every single call, rather than in
+ * a test that remembers to check it. It broke seven times in this hook's
+ * history, twice in code written to fix the previous break, and twice more in
+ * ways that `git write-tree` and the index mtime could not see — so the check
+ * belongs where it cannot be forgotten.
+ */
 async function hook(repo: Repo, command: string): Promise<number> {
+  const before = await repo.fingerprint();
+  const code = await invoke(repo, command);
+  assertEquals(
+    await repo.fingerprint(),
+    before,
+    `hook modified the worktree while inspecting: ${command}`,
+  );
+  return code;
+}
+
+async function invoke(repo: Repo, command: string): Promise<number> {
   const payload = JSON.stringify({
     cwd: repo.dir,
     hook_event_name: "PreToolUse",
@@ -68,7 +105,13 @@ async function hook(repo: Repo, command: string): Promise<number> {
     tool_input: { command },
   });
   const child = new Deno.Command(Deno.execPath(), {
-    args: ["run", "--allow-read", "--allow-run", "--allow-env", HOOK],
+    args: [
+      "run",
+      "--allow-read",
+      "--allow-run",
+      "--allow-env",
+      HOOK,
+    ],
     cwd: repo.dir,
     env: { CLAUDE_PROJECT_DIR: repo.dir },
     stdin: "piped",
@@ -275,6 +318,38 @@ Deno.test("an editing flag is never dry-run", async () => {
       before,
       "hook staged the working tree",
     );
+  } finally {
+    await Deno.remove(repo.dir, { recursive: true });
+  }
+});
+
+Deno.test("leaves a racily-clean index alone", async () => {
+  const repo = await makeRepo();
+  try {
+    // Content matching the index with a differing mtime — what editing a file
+    // and reverting it leaves behind. In that state `git diff <commit>` calls
+    // refresh_index_quietly() and rewrites the index, and `--no-optional-locks`
+    // does not cover it. Every commit shape that names a pathspec, or `-a`,
+    // reached it. Invisible to `git write-tree` and to the index mtime.
+    await Deno.writeTextFile(`${repo.dir}/second.ts`, CLEAN);
+    await run(repo.dir, ["add", "second.ts"]);
+    await run(repo.dir, ["commit", "-q", "-m", "second"]);
+
+    for (
+      const command of [
+        "git commit -m wip tracked.ts",
+        "git commit -m wip -- tracked.ts",
+        "git commit -m wip .",
+        "git commit -i -m wip tracked.ts",
+        "git commit -am wip",
+        "git commit -m wip",
+        "git add tracked.ts && git commit -m wip",
+      ]
+    ) {
+      await Deno.utime(`${repo.dir}/tracked.ts`, new Date(0), new Date(0));
+      // hook() asserts the fingerprint itself; the exit code is incidental here.
+      await hook(repo, command);
+    }
   } finally {
     await Deno.remove(repo.dir, { recursive: true });
   }

--- a/.claude/scripts/pre-commit.test.ts
+++ b/.claude/scripts/pre-commit.test.ts
@@ -190,6 +190,74 @@ Deno.test("resolves what a `git add` in the same command will stage", async () =
   }
 });
 
+Deno.test("resolves the abbreviations git resolves", async () => {
+  const repo = await makeRepo();
+  try {
+    await Deno.writeTextFile(`${repo.dir}/bad.ts`, TYPE_ERROR);
+    await run(repo.dir, ["add", "bad.ts"]);
+
+    // git accepts any unambiguous prefix. Matching exact spellings mishandled
+    // each of these in its own way: `--dr` blocked a read-only preview, `--inc`
+    // dropped the staged files from the file set, `--mess` left its message
+    // looking like a pathspec.
+    for (const command of ["git commit --dr", "git commit --dry"]) {
+      assertEquals(await hook(repo, command), 0, command);
+    }
+    assertEquals(await hook(repo, "git commit -m x --no-ver"), 0);
+    assertEquals(await hook(repo, "git commit --mess x"), 2);
+    assertEquals(await hook(repo, "git commit --inc -m x tracked.ts"), 2);
+    // Contents named in a file we never read: say so rather than fall back to
+    // the index, which is a verdict about a different change.
+    assertEquals(
+      await hook(repo, "git commit -m x --pathspec-from-file=list.txt"),
+      0,
+    );
+  } finally {
+    await Deno.remove(repo.dir, { recursive: true });
+  }
+});
+
+Deno.test("a pathspec containing spaces survives", async () => {
+  const repo = await makeRepo();
+  try {
+    await Deno.writeTextFile(`${repo.dir}/my file.ts`, CLEAN);
+    await run(repo.dir, ["add", "my file.ts"]);
+    await run(repo.dir, ["commit", "-q", "-m", "add spaced"]);
+    await Deno.writeTextFile(`${repo.dir}/my file.ts`, TYPE_ERROR);
+
+    // Reading pathspecs from the quote-blanked flag region lost this one
+    // entirely, and the hook fell back to judging the index instead.
+    assertEquals(await hook(repo, 'git commit -m x "my file.ts"'), 2);
+    assertEquals(await hook(repo, 'git commit -m x -- "my file.ts"'), 2);
+  } finally {
+    await Deno.remove(repo.dir, { recursive: true });
+  }
+});
+
+Deno.test("the multi-commit warning survives every earlier gate", async () => {
+  const repo = await makeRepo();
+  try {
+    await Deno.writeTextFile(`${repo.dir}/bad.ts`, TYPE_ERROR);
+    // Each early exit returns 0, so whichever ran first swallowed this warning
+    // and turned an unmodelled second commit back into a silent pass.
+    for (
+      const first of [
+        "git commit --dry-run",
+        "git commit --help",
+        "git commit -m one --no-verify",
+      ]
+    ) {
+      const code = await hook(
+        repo,
+        `${first} && git add bad.ts && git commit -m two`,
+      );
+      assertEquals(code, 0, first);
+    }
+  } finally {
+    await Deno.remove(repo.dir, { recursive: true });
+  }
+});
+
 Deno.test("an editing flag is never dry-run", async () => {
   const repo = await makeRepo();
   try {

--- a/.claude/scripts/pre-commit.ts
+++ b/.claude/scripts/pre-commit.ts
@@ -20,7 +20,7 @@
 import {
   commitTargetWorktree,
   env,
-  gitAddInvocation,
+  gitAddInvocations,
   isGitCommit,
   sameRepository,
   splitAtGitCommit,
@@ -96,11 +96,11 @@ function git(...args: string[]): Promise<string[]> {
   return gitFrom(worktree, args);
 }
 
-// The `git add` in this command, if any: where it runs and what it stages.
-// Resolved at the add's own position, with its own directory redirects — the
-// add and the commit need not run in the same place, and reusing the commit's
-// looked for the file somewhere it never was.
-const add = gitAddInvocation(cmd);
+// Every `git add` in this command: where each runs and what it stages. Resolved
+// at each add's own position, with its own directory redirects — an add and the
+// commit need not run in the same place, and reusing the commit's looked for the
+// file somewhere it never was.
+const adds = gitAddInvocations(cmd) ?? [];
 
 async function getFilesToCommit(): Promise<string[]> {
   // Already staged by an earlier tool call.
@@ -128,17 +128,27 @@ async function getFilesToCommit(): Promise<string[]> {
   // and lost any path followed by a `;`. `--dry-run` writes nothing — verified
   // against a scratch repo, the index is untouched — and prints one
   // `add '<repo-relative path>'` per file.
-  if (add && add.words.length > 0) {
+  for (const add of adds) {
+    if (add.flags.length === 0 && add.paths.length === 0) continue;
+    if (add.mutating) {
+      // Not dry-runnable without writing to the index. Say so; do not stage on
+      // the user's behalf to satisfy our own curiosity.
+      console.error(
+        "pre-commit: `git add` here carries an editing flag, which writes to " +
+          "the index even under --dry-run. Not resolving its file list.",
+      );
+      continue;
+    }
     for (
       const line of await gitFrom(fallbackCwd, [
         ...add.dirArgs,
         "add",
         "--dry-run",
+        ...add.flags,
         // Everything after this is a pathspec, never an option — so a file
         // named `--cached` cannot become a flag we did not intend to pass.
-        ...add.words.filter((w) => w.startsWith("-")),
         "--",
-        ...add.words.filter((w) => !w.startsWith("-")),
+        ...add.paths,
       ])
     ) {
       const m = line.match(/^add '(.*)'$/);
@@ -157,7 +167,16 @@ async function getFilesToCommit(): Promise<string[]> {
 const MAX_FILES = 400;
 
 const files = await getFilesToCommit();
-if (files.length === 0) Deno.exit(0);
+if (files.length === 0) {
+  // Never silently. Every silent bypass this hook has had looked exactly like
+  // this line: a parse went wrong upstream, the list came back empty, and the
+  // commit sailed through indistinguishably from "nothing to check". One line
+  // of output here would have surfaced all of them.
+  console.error(
+    "pre-commit: no files resolved for this commit; nothing checked.",
+  );
+  Deno.exit(0);
+}
 
 if (files.length > MAX_FILES) {
   console.error(
@@ -171,11 +190,8 @@ if (files.length > MAX_FILES) {
 
 console.error(`Running pre-commit checks in ${worktree} ...`);
 
-const { checked, missing, inapplicable, unavailable, errors } =
-  await checkFiles(
-    worktree,
-    files,
-  );
+const { checked, missing, inapplicable, partial, unavailable, errors } =
+  await checkFiles(worktree, files);
 
 if (unavailable.length > 0) console.error(unavailable.join("\n\n"));
 
@@ -185,9 +201,8 @@ if (errors.length > 0) {
 }
 
 // Say what actually ran. "All checks passed" over an empty file list, or over
-// paths deno.jsonc excludes from fmt and lint, is a pass nobody earned — and
-// this hook exists because a verdict that does not match reality is worse than
-// no verdict at all.
+// paths a check silently narrowed away, is a pass nobody earned — and this hook
+// exists because a verdict that does not match reality is worse than none.
 if (checked.length === 0) {
   console.error(
     `pre-commit: none of the ${files.length} file(s) are on disk; nothing checked.`,
@@ -198,9 +213,10 @@ const ran = ["fmt", "lint", "check"].filter((c) => !inapplicable.includes(c));
 let summary = `Pre-commit checks passed on ${checked.length} file(s)`;
 summary += ran.length > 0 ? ` (${ran.join(", ")}).` : ".";
 if (inapplicable.length > 0) {
-  summary += ` Not run — deno.jsonc excludes these paths: ${
-    inapplicable.join(", ")
-  }.`;
+  summary += ` No files here for: ${inapplicable.join(", ")}.`;
+}
+if (partial.length > 0) {
+  summary += ` Saw only part of the list: ${partial.join(", ")}.`;
 }
 if (missing.length > 0) {
   summary += ` Skipped ${missing.length} missing path(s).`;

--- a/.claude/scripts/pre-commit.ts
+++ b/.claude/scripts/pre-commit.ts
@@ -18,7 +18,7 @@
  */
 
 import {
-  argumentRegion,
+  commitFlagRegion,
   commitsAllTracked,
   commitSkipsVerify,
   commitTargetWorktree,
@@ -28,7 +28,6 @@ import {
   MAX_COMMAND_LENGTH,
   sameRepository,
   splitAtGitCommit,
-  withoutQuotedSpans,
 } from "./common/worktree.ts";
 import { checkFiles } from "./common/checks.ts";
 
@@ -56,18 +55,20 @@ try {
 // `git commit -m one && git commit -m two --no-verify` turned verification off
 // for the first commit too, silently, and the same leak made a later `-am` sweep
 // the whole tree on behalf of an earlier plain commit.
-const commitAfter = splitAtGitCommit(cmd).after;
-const commitFlags = withoutQuotedSpans(argumentRegion(commitAfter));
-
-if (!isGitCommit(cmd) || commitSkipsVerify(commitFlags)) {
-  Deno.exit(0);
-}
-
+// Before anything parses it. The length limit existed but sat after the first
+// three parses, so the quadratic cost it was meant to avoid was already paid.
 if (cmd.length > MAX_COMMAND_LENGTH) {
   console.error(
     `pre-commit: command is ${cmd.length} characters, over the ` +
       `${MAX_COMMAND_LENGTH} this hook will parse. Skipping — not blocked.`,
   );
+  Deno.exit(0);
+}
+
+const commitAfter = splitAtGitCommit(cmd).after;
+const commitFlags = commitFlagRegion(commitAfter);
+
+if (!isGitCommit(cmd) || commitSkipsVerify(commitFlags)) {
   Deno.exit(0);
 }
 

--- a/.claude/scripts/pre-commit.ts
+++ b/.claude/scripts/pre-commit.ts
@@ -22,6 +22,7 @@ import {
   commitFlagRegion,
   commitIncludesIndex,
   commitPathspecs,
+  commitRawRegion,
   commitsAllTracked,
   commitSkipsVerify,
   commitTargetWorktree,
@@ -70,15 +71,13 @@ if (cmd.length > MAX_COMMAND_LENGTH) {
 
 const commitAfter = splitAtGitCommit(cmd).after;
 const commitFlags = commitFlagRegion(commitAfter);
+const commitRaw = commitRawRegion(commitAfter);
 
 if (!isGitCommit(cmd)) Deno.exit(0);
 
-// `--help`, `-h` and `--dry-run` create no commit. Blocking them is a hard block
-// on a read-only command, and `--dry-run` is how you preview a commit.
-if (commitCreatesNothing(commitFlags)) Deno.exit(0);
-
-// Before the skip gate, so a `--no-verify` on the *first* commit does not also
-// swallow the warning that a second one went unmodelled.
+// First of the early exits, not after them: every gate below returns 0, and
+// each one that ran first swallowed this warning, turning an unmodelled second
+// commit back into a silent pass.
 if (splitAtGitCommit(commitAfter).matched) {
   console.error(
     "pre-commit: more than one `git commit` in this command; only the first " +
@@ -86,6 +85,10 @@ if (splitAtGitCommit(commitAfter).matched) {
   );
   Deno.exit(0);
 }
+
+// `--help`, `-h` and `--dry-run` create no commit. Blocking them is a hard block
+// on a read-only command, and `--dry-run` is how you preview a commit.
+if (commitCreatesNothing(commitFlags)) Deno.exit(0);
 
 if (commitSkipsVerify(commitFlags)) Deno.exit(0);
 
@@ -151,7 +154,14 @@ async function getFilesToCommit(): Promise<string[]> {
   // commit did include and, with something unrelated staged, reporting "checks
   // passed on 1 file" about a file the commit left behind: a verdict about the
   // wrong change. `-i`/`--include` is the one form that means index *and* paths.
-  const pathspecs = commitPathspecs(commitFlags);
+  const pathspecs = commitPathspecs(commitRaw);
+  if (pathspecs === null) {
+    console.error(
+      "pre-commit: this commit selects its contents in a way this hook does " +
+        "not model. Skipping — commit not blocked.",
+    );
+    return [];
+  }
   if (pathspecs.length > 0) {
     if (pathspecs.some((p) => /[*?[{]/.test(p))) {
       console.error(

--- a/.claude/scripts/pre-commit.ts
+++ b/.claude/scripts/pre-commit.ts
@@ -130,12 +130,13 @@ async function getFilesToCommit(): Promise<string[]> {
   // `add '<repo-relative path>'` per file.
   for (const add of adds) {
     if (add.flags.length === 0 && add.paths.length === 0) continue;
-    if (add.mutating) {
-      // Not dry-runnable without writing to the index. Say so; do not stage on
-      // the user's behalf to satisfy our own curiosity.
+    if (!add.dryRunnable) {
+      // An unrecognised flag might be `--edit`, which writes to the index even
+      // under --dry-run. Say so; do not stage on the user's behalf to satisfy
+      // our own curiosity.
       console.error(
-        "pre-commit: `git add` here carries an editing flag, which writes to " +
-          "the index even under --dry-run. Not resolving its file list.",
+        "pre-commit: `git add` here carries a flag not known to be safe under " +
+          `--dry-run (${add.flags.join(" ")}). Not resolving its file list.`,
       );
       continue;
     }

--- a/.claude/scripts/pre-commit.ts
+++ b/.claude/scripts/pre-commit.ts
@@ -20,11 +20,10 @@
 import {
   commitTargetWorktree,
   env,
+  gitAddInvocation,
   isGitCommit,
   sameRepository,
   splitAtGitCommit,
-  splitAtGitSubcommand,
-  targetDirArgs,
   withoutQuotedSpans,
 } from "./common/worktree.ts";
 import { checkFiles } from "./common/checks.ts";
@@ -97,18 +96,11 @@ function git(...args: string[]): Promise<string[]> {
   return gitFrom(worktree, args);
 }
 
-// The same redirects the command applies to git. Needed to resolve any paths
-// written on a `git add`, which are relative to the shell's directory.
-const dirArgs = targetDirArgs(cmd) ?? [];
-
-// The `git add` in this command, if any, and its arguments up to the next
-// command separator, message text removed. Parsed with the same globals-aware
-// matcher as the commit, because `git -C <dir> add -A && git -C <dir> commit`
-// is how staging for another worktree is normally written — and a plain
-// /git\s+add/ does not see it, which left that whole flow unchecked.
-const addArgs = withoutQuotedSpans(
-  splitAtGitSubcommand(splitAtGitCommit(cmd).before, "add").after,
-).split(/\s*(?:&&|\|\||;|\n)/)[0].trim();
+// The `git add` in this command, if any: where it runs and what it stages.
+// Resolved at the add's own position, with its own directory redirects — the
+// add and the commit need not run in the same place, and reusing the commit's
+// looked for the file somewhere it never was.
+const add = gitAddInvocation(cmd);
 
 async function getFilesToCommit(): Promise<string[]> {
   // Already staged by an earlier tool call.
@@ -136,14 +128,17 @@ async function getFilesToCommit(): Promise<string[]> {
   // and lost any path followed by a `;`. `--dry-run` writes nothing — verified
   // against a scratch repo, the index is untouched — and prints one
   // `add '<repo-relative path>'` per file.
-  if (addArgs) {
-    const args = addArgs.split(/\s+/).filter(Boolean);
+  if (add && add.words.length > 0) {
     for (
       const line of await gitFrom(fallbackCwd, [
-        ...dirArgs,
+        ...add.dirArgs,
         "add",
         "--dry-run",
-        ...args,
+        // Everything after this is a pathspec, never an option — so a file
+        // named `--cached` cannot become a flag we did not intend to pass.
+        ...add.words.filter((w) => w.startsWith("-")),
+        "--",
+        ...add.words.filter((w) => !w.startsWith("-")),
       ])
     ) {
       const m = line.match(/^add '(.*)'$/);

--- a/.claude/scripts/pre-commit.ts
+++ b/.claude/scripts/pre-commit.ts
@@ -18,6 +18,7 @@
  */
 
 import {
+  commitsAllTracked,
   commitTargetWorktree,
   env,
   gitAddInvocations,
@@ -115,9 +116,7 @@ async function getFilesToCommit(): Promise<string[]> {
   // every untracked file in the tree on the list — in the main worktree, 6000
   // of them including whole nested checkouts — and blocked the commit on files
   // it would never have touched.
-  if (
-    /(?:^|\s)(?:--all(?:\s|$)|-[a-zA-Z]*a[a-zA-Z]*(?:\s|$))/.test(commitFlags)
-  ) {
+  if (commitsAllTracked(commitFlags)) {
     files.push(...await git("diff", "--name-only", "--diff-filter=d", "HEAD"));
   }
 
@@ -140,6 +139,16 @@ async function getFilesToCommit(): Promise<string[]> {
       );
       continue;
     }
+    // An add can be steered somewhere else entirely: `git -C /other add -A &&
+    // git commit`. Its paths are relative to *that* worktree, so folding them in
+    // here would check — and block on — files this commit has never heard of.
+    const addWorktree = (await gitFrom(fallbackCwd, [
+      ...add.dirArgs,
+      "rev-parse",
+      "--show-toplevel",
+    ]))[0];
+    if (addWorktree !== worktree) continue;
+
     for (
       const line of await gitFrom(fallbackCwd, [
         ...add.dirArgs,
@@ -194,7 +203,9 @@ console.error(`Running pre-commit checks in ${worktree} ...`);
 const { checked, missing, inapplicable, partial, unavailable, errors } =
   await checkFiles(worktree, files);
 
-if (unavailable.length > 0) console.error(unavailable.join("\n\n"));
+if (unavailable.length > 0) {
+  console.error(unavailable.map((u) => u.message).join("\n\n"));
+}
 
 if (errors.length > 0) {
   console.error(errors.join("\n\n"));
@@ -210,7 +221,8 @@ if (checked.length === 0) {
   );
   Deno.exit(0);
 }
-const ran = ["fmt", "lint", "check"].filter((c) => !inapplicable.includes(c));
+const notRun = new Set([...inapplicable, ...unavailable.map((u) => u.check)]);
+const ran = ["fmt", "lint", "check"].filter((c) => !notRun.has(c));
 let summary = `Pre-commit checks passed on ${checked.length} file(s)`;
 summary += ran.length > 0 ? ` (${ran.join(", ")}).` : ".";
 if (inapplicable.length > 0) {

--- a/.claude/scripts/pre-commit.ts
+++ b/.claude/scripts/pre-commit.ts
@@ -121,6 +121,26 @@ if (projectDir && !(await sameRepository(worktree, projectDir))) {
 
 // --- Determine which files will be committed ---
 
+/**
+ * NUL-separated fields, for `status --porcelain -z`.
+ *
+ * `-z` for two reasons, each of which broke a parse: the two status columns start
+ * with a space for an unstaged change, and the line-based helper below trims —
+ * correctly, for path lists — so ` M file.ts` shifted a column and lost the first
+ * character of the path. And line-based porcelain double-quotes any path
+ * containing a space, so `"my file.ts"` arrived with its quotes attached and
+ * matched nothing on disk. `-z` neither pads nor quotes.
+ */
+async function gitNulFields(cwd: string, args: string[]): Promise<string[]> {
+  const { stdout } = await new Deno.Command("git", {
+    args: ["--no-optional-locks", ...args],
+    cwd,
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+  return new TextDecoder().decode(stdout).split("\0").filter((f) => f !== "");
+}
+
 async function gitFrom(cwd: string, args: string[]): Promise<string[]> {
   const { stdout } = await new Deno.Command("git", {
     // `--no-optional-locks` because several read-shaped commands are not reads:
@@ -140,6 +160,39 @@ async function gitFrom(cwd: string, args: string[]): Promise<string[]> {
 /** git, run at the worktree root, where its output is worktree-relative. */
 function git(...args: string[]): Promise<string[]> {
   return gitFrom(worktree, args);
+}
+
+/**
+ * Tracked files that differ from HEAD — what a `-a` commit stages, and what a
+ * pathspec commit contains.
+ *
+ * Read from `status --porcelain` rather than `diff <commit>`, which is not the
+ * obvious choice and is the whole point: `git diff HEAD` calls
+ * `refresh_index_quietly()` unconditionally, `--no-optional-locks` does not
+ * cover it, and on any racily-clean file it rewrote the index of the tree it was
+ * inspecting. `status --porcelain` answers the same question — verified to name
+ * the same files — and leaves the index alone.
+ *
+ * A shadow copy of the index also worked, but needed write permission the hook
+ * otherwise does not want, and made a missing permission mean "check nothing".
+ */
+async function changedTrackedFiles(pathspecs: string[]): Promise<string[]> {
+  const args = ["status", "--porcelain", "-z"];
+  if (pathspecs.length > 0) args.push("--", ...pathspecs);
+  const fields = await gitNulFields(worktree, args);
+  const files: string[] = [];
+  for (let i = 0; i < fields.length; i++) {
+    const entry = fields[i];
+    const [index, worktreeState] = [entry[0], entry[1]];
+    // A rename or copy is followed by its original path in the next field.
+    if (index === "R" || index === "C") i++;
+    // Untracked and ignored are not tracked changes; a file deleted in the
+    // worktree cannot be checked.
+    if (index === "?" || index === "!" || worktreeState === "D") continue;
+    if (index === " " && worktreeState === " ") continue;
+    files.push(entry.slice(3));
+  }
+  return files;
 }
 
 // Every `git add` in this command: where each runs and what it stages. Resolved
@@ -170,14 +223,7 @@ async function getFilesToCommit(): Promise<string[]> {
       );
       return [];
     }
-    const only = await git(
-      "diff",
-      "--name-only",
-      "--diff-filter=d",
-      "HEAD",
-      "--",
-      ...pathspecs,
-    );
+    const only = await changedTrackedFiles(pathspecs);
     if (!commitIncludesIndex(commitFlags)) return [...new Set(only)];
     const staged = await git(
       "diff",
@@ -201,7 +247,7 @@ async function getFilesToCommit(): Promise<string[]> {
   // of them including whole nested checkouts — and blocked the commit on files
   // it would never have touched.
   if (commitsAllTracked(commitFlags)) {
-    files.push(...await git("diff", "--name-only", "--diff-filter=d", "HEAD"));
+    files.push(...await changedTrackedFiles([]));
   }
 
   // Whatever a `git add` in this command will stage. Asked of git with

--- a/.claude/scripts/pre-commit.ts
+++ b/.claude/scripts/pre-commit.ts
@@ -19,9 +19,13 @@
 
 import {
   commitTargetWorktree,
+  env,
   isGitCommit,
   sameRepository,
   splitAtGitCommit,
+  splitAtGitSubcommand,
+  targetDirArgs,
+  withoutQuotedSpans,
 } from "./common/worktree.ts";
 import { checkFiles } from "./common/checks.ts";
 
@@ -31,13 +35,21 @@ let cmd = "";
 let payloadCwd = "";
 try {
   const payload = JSON.parse(rawInput);
-  cmd = payload?.tool_input?.command ?? "";
-  payloadCwd = payload?.cwd ?? "";
+  // Typed, not just defaulted: a non-string `command` reached `.match()` and
+  // took the hook down with it. Whatever we cannot read, we do not judge.
+  const raw = payload?.tool_input?.command;
+  cmd = typeof raw === "string" ? raw : "";
+  payloadCwd = typeof payload?.cwd === "string" ? payload.cwd : "";
 } catch {
   Deno.exit(0);
 }
 
-if (!isGitCommit(cmd) || /--no-verify/.test(cmd)) {
+// The commit's own flags, with quoted spans blanked so the message cannot be
+// read as one. `git commit -m "docs: --no-verify escape"` used to disable this
+// hook completely and silently, just by describing it.
+const commitFlags = withoutQuotedSpans(splitAtGitCommit(cmd).after);
+
+if (!isGitCommit(cmd) || /(?:^|\s)--no-verify(?:\s|$)/.test(commitFlags)) {
   Deno.exit(0);
 }
 
@@ -63,70 +75,140 @@ const worktree: string = targetWorktree;
 // Leave other repositories alone. Worktrees of *this* repository are fair game
 // (that is the whole point), but a commit in an unrelated project checked out
 // nearby is none of our business.
-const projectDir = Deno.env.get("CLAUDE_PROJECT_DIR");
+const projectDir = env("CLAUDE_PROJECT_DIR");
 if (projectDir && !(await sameRepository(worktree, projectDir))) {
   Deno.exit(0);
 }
 
 // --- Determine which files will be committed ---
 
-async function git(...args: string[]): Promise<string[]> {
+async function gitFrom(cwd: string, args: string[]): Promise<string[]> {
   const { stdout } = await new Deno.Command("git", {
     args,
-    cwd: worktree,
+    cwd,
     stdout: "piped",
     stderr: "piped",
   }).output();
   return new TextDecoder().decode(stdout).trim().split("\n").filter(Boolean);
 }
 
-// Only ever search the half of the command each pattern can legitimately
-// appear in — a commit message is free to contain the text "git add".
-const { before: preCommit, after: commitFlags } = splitAtGitCommit(cmd);
+/** git, run at the worktree root, where its output is worktree-relative. */
+function git(...args: string[]): Promise<string[]> {
+  return gitFrom(worktree, args);
+}
+
+// The same redirects the command applies to git. Needed to resolve any paths
+// written on a `git add`, which are relative to the shell's directory.
+const dirArgs = targetDirArgs(cmd) ?? [];
+
+// The `git add` in this command, if any, and its arguments up to the next
+// command separator, message text removed. Parsed with the same globals-aware
+// matcher as the commit, because `git -C <dir> add -A && git -C <dir> commit`
+// is how staging for another worktree is normally written — and a plain
+// /git\s+add/ does not see it, which left that whole flow unchecked.
+const addArgs = withoutQuotedSpans(
+  splitAtGitSubcommand(splitAtGitCommit(cmd).before, "add").after,
+).split(/\s*(?:&&|\|\||;|\n)/)[0].trim();
 
 async function getFilesToCommit(): Promise<string[]> {
-  // `-a` / `--all` on the commit, in either the separate or the combined short
-  // form (`-am`). Reading it off the commit's own flags rather than the whole
-  // command is what makes this work for `git -C <dir> commit -am …` too.
-  const commitsAll = /(?:^|\s)(?:--all(?:\s|$)|-[a-zA-Z]*a[a-zA-Z]*(?:\s|$))/
-    .test(commitFlags);
-  const addsAll = /\bgit\s+add\s+(-A|\.)\s*(&|$)/.test(preCommit) || commitsAll;
-
-  if (addsAll) {
-    const tracked = await git("diff", "--name-only", "--diff-filter=d", "HEAD");
-    const untracked = await git("ls-files", "--others", "--exclude-standard");
-    return [...new Set([...tracked, ...untracked])];
-  }
-
-  // Start with files already staged from prior `git add` calls
+  // Already staged by an earlier tool call.
   const files = await git("diff", "--cached", "--name-only", "--diff-filter=d");
 
-  // Add any files from a `git add <paths>` in this command (not yet staged).
-  const addMatch = preCommit.match(/\bgit\s+add\s+(.+?)(?:\s*&&|$)/);
-  if (addMatch) {
-    for (const arg of addMatch[1].trim().split(/\s+/)) {
-      if (!arg.startsWith("-")) files.push(arg);
+  // `-a` / `--all` on the commit, in either the separate or the combined short
+  // form (`-am`). Read off the flags with quoted spans already blanked: while
+  // this scanned the raw text, a message merely *mentioning* `-a` swept the
+  // whole dirty tree and blocked on files the commit would never have staged.
+  //
+  // `-a` stages tracked modifications only. Adding `ls-files --others` here put
+  // every untracked file in the tree on the list — in the main worktree, 6000
+  // of them including whole nested checkouts — and blocked the commit on files
+  // it would never have touched.
+  if (
+    /(?:^|\s)(?:--all(?:\s|$)|-[a-zA-Z]*a[a-zA-Z]*(?:\s|$))/.test(commitFlags)
+  ) {
+    files.push(...await git("diff", "--name-only", "--diff-filter=d", "HEAD"));
+  }
+
+  // Whatever a `git add` in this command will stage. Asked of git with
+  // `--dry-run` rather than worked out here: git alone knows how the pathspec,
+  // the ignore rules and the shell's directory combine. Parsing it ourselves
+  // read `git add .` in a subdirectory as the whole tree, lost absolute paths,
+  // and lost any path followed by a `;`. `--dry-run` writes nothing — verified
+  // against a scratch repo, the index is untouched — and prints one
+  // `add '<repo-relative path>'` per file.
+  if (addArgs) {
+    const args = addArgs.split(/\s+/).filter(Boolean);
+    for (
+      const line of await gitFrom(fallbackCwd, [
+        ...dirArgs,
+        "add",
+        "--dry-run",
+        ...args,
+      ])
+    ) {
+      const m = line.match(/^add '(.*)'$/);
+      if (m) files.push(m[1]);
     }
   }
 
   return [...new Set(files)];
 }
 
+// Above this, the file list stops being a description of one commit and starts
+// being a description of the tree. Checking it would be slow, would report
+// failures the commit is not responsible for, and past ARG_MAX would crash the
+// hook outright — so say so and let the commit through, which is what this hook
+// does with every other question it cannot answer.
+const MAX_FILES = 400;
+
 const files = await getFilesToCommit();
 if (files.length === 0) Deno.exit(0);
 
+if (files.length > MAX_FILES) {
+  console.error(
+    `pre-commit: ${files.length} files in this commit, over the ${MAX_FILES} ` +
+      "this hook will check at once. Skipping — commit not blocked.",
+  );
+  Deno.exit(0);
+}
+
 // --- Run checks ---
 
-console.error(
-  `Running pre-commit checks (fmt, lint, check) in ${worktree} ...`,
-);
+console.error(`Running pre-commit checks in ${worktree} ...`);
 
-const errors = await checkFiles(worktree, files);
+const { checked, missing, inapplicable, unavailable, errors } =
+  await checkFiles(
+    worktree,
+    files,
+  );
+
+if (unavailable.length > 0) console.error(unavailable.join("\n\n"));
 
 if (errors.length > 0) {
   console.error(errors.join("\n\n"));
   Deno.exit(2);
 }
 
-console.error("All pre-commit checks passed.");
+// Say what actually ran. "All checks passed" over an empty file list, or over
+// paths deno.jsonc excludes from fmt and lint, is a pass nobody earned — and
+// this hook exists because a verdict that does not match reality is worse than
+// no verdict at all.
+if (checked.length === 0) {
+  console.error(
+    `pre-commit: none of the ${files.length} file(s) are on disk; nothing checked.`,
+  );
+  Deno.exit(0);
+}
+const ran = ["fmt", "lint", "check"].filter((c) => !inapplicable.includes(c));
+let summary = `Pre-commit checks passed on ${checked.length} file(s)`;
+summary += ran.length > 0 ? ` (${ran.join(", ")}).` : ".";
+if (inapplicable.length > 0) {
+  summary += ` Not run — deno.jsonc excludes these paths: ${
+    inapplicable.join(", ")
+  }.`;
+}
+if (missing.length > 0) {
+  summary += ` Skipped ${missing.length} missing path(s).`;
+}
+console.error(summary);
 Deno.exit(0);

--- a/.claude/scripts/pre-commit.ts
+++ b/.claude/scripts/pre-commit.ts
@@ -18,11 +18,14 @@
  */
 
 import {
+  argumentRegion,
   commitsAllTracked,
+  commitSkipsVerify,
   commitTargetWorktree,
   env,
   gitAddInvocations,
   isGitCommit,
+  MAX_COMMAND_LENGTH,
   sameRepository,
   splitAtGitCommit,
   withoutQuotedSpans,
@@ -44,12 +47,39 @@ try {
   Deno.exit(0);
 }
 
-// The commit's own flags, with quoted spans blanked so the message cannot be
-// read as one. `git commit -m "docs: --no-verify escape"` used to disable this
-// hook completely and silently, just by describing it.
-const commitFlags = withoutQuotedSpans(splitAtGitCommit(cmd).after);
+// This commit's own flags: cut at the next command separator, with quoted spans
+// blanked so a message cannot be read as one.
+//
+// Both halves of that are load-bearing. Reading the raw text let
+// `git commit -m "docs: --no-verify escape"` disable the hook by describing it.
+// Reading to end-of-command let a *later* command do it for real:
+// `git commit -m one && git commit -m two --no-verify` turned verification off
+// for the first commit too, silently, and the same leak made a later `-am` sweep
+// the whole tree on behalf of an earlier plain commit.
+const commitAfter = splitAtGitCommit(cmd).after;
+const commitFlags = withoutQuotedSpans(argumentRegion(commitAfter));
 
-if (!isGitCommit(cmd) || /(?:^|\s)--no-verify(?:\s|$)/.test(commitFlags)) {
+if (!isGitCommit(cmd) || commitSkipsVerify(commitFlags)) {
+  Deno.exit(0);
+}
+
+if (cmd.length > MAX_COMMAND_LENGTH) {
+  console.error(
+    `pre-commit: command is ${cmd.length} characters, over the ` +
+      `${MAX_COMMAND_LENGTH} this hook will parse. Skipping — not blocked.`,
+  );
+  Deno.exit(0);
+}
+
+// Only the first commit in a command is modelled, so anything staged for a
+// second one is invisible. Reporting a clean pass over the first commit's files
+// would be a false verdict on a change that does get committed — worse than a
+// skip, by the standard this hook is held to.
+if (splitAtGitCommit(commitAfter).matched) {
+  console.error(
+    "pre-commit: more than one `git commit` in this command; only the first " +
+      "is modelled. Skipping — commit not blocked.",
+  );
   Deno.exit(0);
 }
 
@@ -84,7 +114,13 @@ if (projectDir && !(await sameRepository(worktree, projectDir))) {
 
 async function gitFrom(cwd: string, args: string[]): Promise<string[]> {
   const { stdout } = await new Deno.Command("git", {
-    args,
+    // `--no-optional-locks` because several read-shaped commands are not reads:
+    // `git status --porcelain` refreshes and rewrites the index, verified in a
+    // scratch repo. That breaks the read-only contract, and it takes
+    // `.git/index.lock` in a tree a sibling agent may be committing in.
+    // `core.quotePath=false` because otherwise a non-ASCII path comes back
+    // octal-escaped and double-quoted, and we would stat that literal string.
+    args: ["--no-optional-locks", "-c", "core.quotePath=false", ...args],
     cwd,
     stdout: "piped",
     stderr: "piped",
@@ -133,9 +169,16 @@ async function getFilesToCommit(): Promise<string[]> {
       // An unrecognised flag might be `--edit`, which writes to the index even
       // under --dry-run. Say so; do not stage on the user's behalf to satisfy
       // our own curiosity.
+      const glob = add.paths.find((p) => /[*?[]/.test(p));
       console.error(
-        "pre-commit: `git add` here carries a flag not known to be safe under " +
-          `--dry-run (${add.flags.join(" ")}). Not resolving its file list.`,
+        glob
+          ? `pre-commit: \`git add ${glob}\` is an unexpanded glob, which git ` +
+            "would match recursively rather than as the shell expanded it. " +
+            "Not resolving its file list."
+          : "pre-commit: `git add` here carries a flag not known to be safe " +
+            `under --dry-run (${
+              add.flags.join(" ")
+            }). Not resolving its file list.`,
       );
       continue;
     }
@@ -147,7 +190,10 @@ async function getFilesToCommit(): Promise<string[]> {
       "rev-parse",
       "--show-toplevel",
     ]))[0];
-    if (addWorktree !== worktree) continue;
+    // Same tree only. Not merely "same repository": a `git add` steered
+    // elsewhere stages files this commit will not contain, and running anything
+    // against an unrelated checkout is outside this hook's remit entirely.
+    if (!addWorktree || addWorktree !== worktree) continue;
 
     for (
       const line of await gitFrom(fallbackCwd, [

--- a/.claude/scripts/pre-commit.ts
+++ b/.claude/scripts/pre-commit.ts
@@ -1,0 +1,132 @@
+#!/usr/bin/env -S deno run --allow-read --allow-run --allow-env
+/**
+ * .claude/scripts/pre-commit.ts
+ *
+ * Claude Code PreToolUse hook that intercepts `git commit` commands.
+ * Runs deno fmt --check, lint, and check on ONLY the files being committed,
+ * in the worktree the commit actually targets.
+ * Exits 2 to block the commit if any check fails.
+ *
+ * This fires BEFORE the Bash command executes, so any `git add` in
+ * the command hasn't run yet. We combine already-staged files (from
+ * `git diff --cached`) with files parsed from the command string.
+ *
+ * The target worktree is derived from the command plus the payload's `cwd`,
+ * never from `$CLAUDE_PROJECT_DIR` — see common/worktree.ts for why each of
+ * those is or is not trustworthy. Getting this wrong is not a near-miss: it
+ * reports another branch's errors against this commit, and blocks on them.
+ */
+
+import {
+  commitTargetWorktree,
+  isGitCommit,
+  sameRepository,
+  splitAtGitCommit,
+} from "./common/worktree.ts";
+import { checkFiles } from "./common/checks.ts";
+
+const rawInput = await new Response(Deno.stdin.readable).text();
+
+let cmd = "";
+let payloadCwd = "";
+try {
+  const payload = JSON.parse(rawInput);
+  cmd = payload?.tool_input?.command ?? "";
+  payloadCwd = payload?.cwd ?? "";
+} catch {
+  Deno.exit(0);
+}
+
+if (!isGitCommit(cmd) || /--no-verify/.test(cmd)) {
+  Deno.exit(0);
+}
+
+// --- Resolve the worktree this commit lands in ---
+
+const fallbackCwd = payloadCwd || Deno.cwd();
+const targetWorktree = await commitTargetWorktree(cmd, fallbackCwd);
+
+if (!targetWorktree) {
+  // Requirement of last resort: a hook that cannot identify the tree it would
+  // be judging must not block. Report the miss so a real misconfiguration is
+  // visible, and let the commit through.
+  console.error(
+    "pre-commit: could not determine which worktree this commit targets " +
+      `(cwd ${fallbackCwd}). Skipping checks — commit not blocked.`,
+  );
+  Deno.exit(0);
+}
+
+// Bound after the guard so the closures below see a plain string.
+const worktree: string = targetWorktree;
+
+// Leave other repositories alone. Worktrees of *this* repository are fair game
+// (that is the whole point), but a commit in an unrelated project checked out
+// nearby is none of our business.
+const projectDir = Deno.env.get("CLAUDE_PROJECT_DIR");
+if (projectDir && !(await sameRepository(worktree, projectDir))) {
+  Deno.exit(0);
+}
+
+// --- Determine which files will be committed ---
+
+async function git(...args: string[]): Promise<string[]> {
+  const { stdout } = await new Deno.Command("git", {
+    args,
+    cwd: worktree,
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+  return new TextDecoder().decode(stdout).trim().split("\n").filter(Boolean);
+}
+
+// Only ever search the half of the command each pattern can legitimately
+// appear in — a commit message is free to contain the text "git add".
+const { before: preCommit, after: commitFlags } = splitAtGitCommit(cmd);
+
+async function getFilesToCommit(): Promise<string[]> {
+  // `-a` / `--all` on the commit, in either the separate or the combined short
+  // form (`-am`). Reading it off the commit's own flags rather than the whole
+  // command is what makes this work for `git -C <dir> commit -am …` too.
+  const commitsAll = /(?:^|\s)(?:--all(?:\s|$)|-[a-zA-Z]*a[a-zA-Z]*(?:\s|$))/
+    .test(commitFlags);
+  const addsAll = /\bgit\s+add\s+(-A|\.)\s*(&|$)/.test(preCommit) || commitsAll;
+
+  if (addsAll) {
+    const tracked = await git("diff", "--name-only", "--diff-filter=d", "HEAD");
+    const untracked = await git("ls-files", "--others", "--exclude-standard");
+    return [...new Set([...tracked, ...untracked])];
+  }
+
+  // Start with files already staged from prior `git add` calls
+  const files = await git("diff", "--cached", "--name-only", "--diff-filter=d");
+
+  // Add any files from a `git add <paths>` in this command (not yet staged).
+  const addMatch = preCommit.match(/\bgit\s+add\s+(.+?)(?:\s*&&|$)/);
+  if (addMatch) {
+    for (const arg of addMatch[1].trim().split(/\s+/)) {
+      if (!arg.startsWith("-")) files.push(arg);
+    }
+  }
+
+  return [...new Set(files)];
+}
+
+const files = await getFilesToCommit();
+if (files.length === 0) Deno.exit(0);
+
+// --- Run checks ---
+
+console.error(
+  `Running pre-commit checks (fmt, lint, check) in ${worktree} ...`,
+);
+
+const errors = await checkFiles(worktree, files);
+
+if (errors.length > 0) {
+  console.error(errors.join("\n\n"));
+  Deno.exit(2);
+}
+
+console.error("All pre-commit checks passed.");
+Deno.exit(0);

--- a/.claude/scripts/pre-commit.ts
+++ b/.claude/scripts/pre-commit.ts
@@ -18,7 +18,10 @@
  */
 
 import {
+  commitCreatesNothing,
   commitFlagRegion,
+  commitIncludesIndex,
+  commitPathspecs,
   commitsAllTracked,
   commitSkipsVerify,
   commitTargetWorktree,
@@ -68,14 +71,14 @@ if (cmd.length > MAX_COMMAND_LENGTH) {
 const commitAfter = splitAtGitCommit(cmd).after;
 const commitFlags = commitFlagRegion(commitAfter);
 
-if (!isGitCommit(cmd) || commitSkipsVerify(commitFlags)) {
-  Deno.exit(0);
-}
+if (!isGitCommit(cmd)) Deno.exit(0);
 
-// Only the first commit in a command is modelled, so anything staged for a
-// second one is invisible. Reporting a clean pass over the first commit's files
-// would be a false verdict on a change that does get committed — worse than a
-// skip, by the standard this hook is held to.
+// `--help`, `-h` and `--dry-run` create no commit. Blocking them is a hard block
+// on a read-only command, and `--dry-run` is how you preview a commit.
+if (commitCreatesNothing(commitFlags)) Deno.exit(0);
+
+// Before the skip gate, so a `--no-verify` on the *first* commit does not also
+// swallow the warning that a second one went unmodelled.
 if (splitAtGitCommit(commitAfter).matched) {
   console.error(
     "pre-commit: more than one `git commit` in this command; only the first " +
@@ -83,6 +86,8 @@ if (splitAtGitCommit(commitAfter).matched) {
   );
   Deno.exit(0);
 }
+
+if (commitSkipsVerify(commitFlags)) Deno.exit(0);
 
 // --- Resolve the worktree this commit lands in ---
 
@@ -141,6 +146,38 @@ function git(...args: string[]): Promise<string[]> {
 const adds = gitAddInvocations(cmd) ?? [];
 
 async function getFilesToCommit(): Promise<string[]> {
+  // Given pathspecs, git commits *those* — its `--only` default — and the index
+  // is beside the point. Judging the index anyway meant skipping a dirty file the
+  // commit did include and, with something unrelated staged, reporting "checks
+  // passed on 1 file" about a file the commit left behind: a verdict about the
+  // wrong change. `-i`/`--include` is the one form that means index *and* paths.
+  const pathspecs = commitPathspecs(commitFlags);
+  if (pathspecs.length > 0) {
+    if (pathspecs.some((p) => /[*?[{]/.test(p))) {
+      console.error(
+        "pre-commit: this commit carries a glob pathspec, which git and the " +
+          "shell expand differently. Skipping — commit not blocked.",
+      );
+      return [];
+    }
+    const only = await git(
+      "diff",
+      "--name-only",
+      "--diff-filter=d",
+      "HEAD",
+      "--",
+      ...pathspecs,
+    );
+    if (!commitIncludesIndex(commitFlags)) return [...new Set(only)];
+    const staged = await git(
+      "diff",
+      "--cached",
+      "--name-only",
+      "--diff-filter=d",
+    );
+    return [...new Set([...only, ...staged])];
+  }
+
   // Already staged by an earlier tool call.
   const files = await git("diff", "--cached", "--name-only", "--diff-filter=d");
 

--- a/.claude/scripts/subagent-stop.ts
+++ b/.claude/scripts/subagent-stop.ts
@@ -202,7 +202,12 @@ if (errors.length > 0) {
 
 async function git(...args: string[]): Promise<string> {
   const { stdout } = await new Deno.Command("git", {
-    args,
+    // `--no-optional-locks`: `git status --porcelain` refreshes and rewrites the
+    // index, verified in a scratch repo. This hook fires once per subagent, so
+    // without it every agent wrote the index of the tree it worked in — and took
+    // `.git/index.lock` there, in exactly the many-agents-one-tree situation
+    // this file's header describes.
+    args: ["--no-optional-locks", ...args],
     cwd: worktree,
     stdout: "piped",
     stderr: "piped",

--- a/.claude/scripts/subagent-stop.ts
+++ b/.claude/scripts/subagent-stop.ts
@@ -180,11 +180,8 @@ if (changed.length === 0) {
   Deno.exit(0);
 }
 
-const { checked, missing, inapplicable, unavailable, errors } =
-  await checkFiles(
-    worktree,
-    changed,
-  );
+const { checked, missing, inapplicable, partial, unavailable, errors } =
+  await checkFiles(worktree, changed);
 
 if (unavailable.length > 0) console.error(unavailable.join("\n\n"));
 
@@ -211,9 +208,9 @@ const [branchName, status] = await Promise.all([
   git("status", "--porcelain"),
 ]);
 
-// Report what ran, not what was attempted. Claiming fmt and lint passed on
-// paths deno.jsonc excludes from both — `.claude/**` among them — is how a gate
-// launders an unchecked change into an approved one.
+// Report what ran, not what was attempted. Claiming a check passed on paths it
+// silently narrowed away is how a gate launders an unchecked change into an
+// approved one.
 const LABELS: Array<[flag: string, name: string]> = [
   ["fmt", "fmt"],
   ["lint", "lint"],
@@ -226,9 +223,10 @@ const ran = LABELS.filter(([flag]) => !inapplicable.includes(flag)).map((
 let context = `Checks passed on ${checked.length} file(s) changed by this ` +
   `subagent` + (ran.length > 0 ? ` (${ran.join(", ")}).` : ".");
 if (inapplicable.length > 0) {
-  context += `\nNot run — deno.jsonc excludes these paths: ${
-    inapplicable.join(", ")
-  }.`;
+  context += `\nNo files here for: ${inapplicable.join(", ")}.`;
+}
+if (partial.length > 0) {
+  context += `\nSaw only part of the list: ${partial.join(", ")}.`;
 }
 if (missing.length > 0) {
   context += `\nSkipped ${missing.length} path(s) no longer on disk.`;

--- a/.claude/scripts/subagent-stop.ts
+++ b/.claude/scripts/subagent-stop.ts
@@ -1,0 +1,177 @@
+#!/usr/bin/env -S deno run --allow-read --allow-run --allow-env
+/**
+ * .claude/scripts/subagent-stop.ts
+ *
+ * Claude Code SubagentStop hook.
+ * - Runs fmt --check / lint / check over the files THIS subagent changed, in
+ *   the worktree it was actually working in.
+ * - Blocks the subagent from stopping if those files fail.
+ * - Otherwise reports branch state as context.
+ *
+ * Two things it deliberately does not do, because doing them made its verdict
+ * useless as a gate:
+ *
+ * Repo-wide checks. A wave of sibling agents editing one tree means a repo-wide
+ * check reports their in-flight edits to whichever agent happens to finish
+ * first, and pre-existing failures on the branch to all of them. Every agent
+ * then spends real tokens investigating a failure it did not cause. Scoped to
+ * the files an agent touched, the verdict is about that agent's work.
+ *
+ * Trusting the payload's `cwd`. On this event it is the *parent* session's
+ * directory; a subagent handed its own worktree is not described by it at all.
+ * The subagent's own transcript records where it worked, so that is what we
+ * read. See common/worktree.ts.
+ */
+
+import { env, sameRepository, worktreeRoot } from "./common/worktree.ts";
+import { checkFiles } from "./common/checks.ts";
+
+const rawInput = await new Response(Deno.stdin.readable).text();
+
+let payload: Record<string, unknown> = {};
+try {
+  payload = JSON.parse(rawInput) ?? {};
+} catch {
+  // A payload we cannot read tells us nothing to check. Do not block on it.
+  Deno.exit(0);
+}
+
+// Prevent infinite loops - if we're already in a stop hook, allow through
+if (payload.stop_hook_active === true) {
+  Deno.exit(0);
+}
+
+/**
+ * What the subagent did, read from its own transcript: the directory it ran in
+ * and the files it wrote. The transcript is append-only and this hook fires
+ * after the agent's last turn, so both are complete by now.
+ */
+function readAgentActivity(
+  transcriptPath: string,
+): { cwd: string | null; files: string[] } {
+  let text: string;
+  try {
+    text = Deno.readTextFileSync(transcriptPath);
+  } catch {
+    return { cwd: null, files: [] };
+  }
+
+  const WRITE_TOOLS = new Set(["Edit", "Write", "NotebookEdit", "MultiEdit"]);
+  let cwd: string | null = null;
+  const files = new Set<string>();
+
+  for (const line of text.split("\n")) {
+    if (!line.trim()) continue;
+    let entry: Record<string, unknown>;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (typeof entry.cwd === "string" && entry.cwd) cwd = entry.cwd;
+
+    const content = (entry.message as { content?: unknown })?.content;
+    if (!Array.isArray(content)) continue;
+    for (const block of content) {
+      if (
+        block?.type !== "tool_use" || !WRITE_TOOLS.has(block?.name)
+      ) continue;
+      const p = block?.input?.file_path ?? block?.input?.notebook_path;
+      if (typeof p === "string" && p) files.add(p);
+    }
+  }
+
+  return { cwd, files: [...files] };
+}
+
+const transcriptPath = typeof payload.agent_transcript_path === "string"
+  ? payload.agent_transcript_path
+  : "";
+const activity = transcriptPath
+  ? readAgentActivity(transcriptPath)
+  : { cwd: null, files: [] };
+
+const payloadCwd = typeof payload.cwd === "string" ? payload.cwd : "";
+const agentDir = activity.cwd ?? payloadCwd;
+
+if (!transcriptPath || !agentDir) {
+  console.log(JSON.stringify({
+    systemMessage:
+      "Subagent checks skipped: could not determine which worktree this " +
+      "subagent was working in. Not blocking.",
+  }));
+  Deno.exit(0);
+}
+
+const resolvedWorktree = await worktreeRoot(agentDir);
+if (!resolvedWorktree) {
+  console.log(JSON.stringify({
+    systemMessage:
+      `Subagent checks skipped: ${agentDir} is not inside a git worktree. ` +
+      "Not blocking.",
+  }));
+  Deno.exit(0);
+}
+
+// Bound after the guard so the closures below see a plain string.
+const worktree: string = resolvedWorktree;
+
+// Another repository checked out nearby is not ours to judge.
+const projectDir = env("CLAUDE_PROJECT_DIR");
+if (projectDir && !(await sameRepository(worktree, projectDir))) {
+  Deno.exit(0);
+}
+
+// Repo-relative, and only files inside the worktree we resolved: a path
+// somewhere else is not something this tree's config can be asked about.
+const prefix = worktree.endsWith("/") ? worktree : `${worktree}/`;
+const changed = activity.files
+  .filter((f) => f.startsWith(prefix))
+  .map((f) => f.slice(prefix.length))
+  .sort();
+
+if (changed.length === 0) {
+  // A subagent that wrote nothing has nothing to answer for. Checking the repo
+  // anyway is what produced the false verdicts this hook used to hand out.
+  Deno.exit(0);
+}
+
+const errors = await checkFiles(worktree, changed);
+
+if (errors.length > 0) {
+  console.error(
+    `Checks failed on files changed by this subagent (in ${worktree}):\n\n` +
+      errors.join("\n\n"),
+  );
+  Deno.exit(2); // Block stop, tell the subagent to fix
+}
+
+async function git(...args: string[]): Promise<string> {
+  const { stdout } = await new Deno.Command("git", {
+    args,
+    cwd: worktree,
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+  return new TextDecoder().decode(stdout).trim();
+}
+
+const [branchName, status] = await Promise.all([
+  git("branch", "--show-current"),
+  git("status", "--porcelain"),
+]);
+
+let context =
+  `Checks passed on the ${changed.length} file(s) changed by this ` +
+  `subagent (fmt, lint, type check).`;
+context += `\nWorktree: ${worktree}`;
+context += `\nBranch: ${branchName}`;
+
+if (status.length > 0) {
+  context +=
+    `\nThere are uncommitted changes. Consider committing if this unit of work is complete.`;
+}
+
+console.log(JSON.stringify({ systemMessage: context }));
+
+Deno.exit(0);

--- a/.claude/scripts/subagent-stop.ts
+++ b/.claude/scripts/subagent-stop.ts
@@ -98,6 +98,11 @@ const activity = transcriptPath
   ? readAgentActivity(transcriptPath)
   : { cwd: null, files: [] };
 
+// The transcript is the authority. Falling back to the payload's `cwd` is
+// falling back to the very signal this file's header calls wrong for this event
+// — right for a subagent sharing the parent's tree, wrong for one given its
+// own. It is used only when the transcript records no cwd at all, and the
+// containment check below is what keeps a wrong guess from doing damage.
 const payloadCwd = typeof payload.cwd === "string" ? payload.cwd : "";
 const agentDir = activity.cwd ?? payloadCwd;
 
@@ -129,10 +134,31 @@ if (projectDir && !(await sameRepository(worktree, projectDir))) {
   Deno.exit(0);
 }
 
-// Repo-relative, and only files inside the worktree we resolved: a path
-// somewhere else is not something this tree's config can be asked about.
-const prefix = worktree.endsWith("/") ? worktree : `${worktree}/`;
-const changed = activity.files
+function canonical(path: string): string | null {
+  try {
+    return Deno.realPathSync(path);
+  } catch {
+    return null;
+  }
+}
+
+// Repo-relative, and only files genuinely inside the worktree we resolved: a
+// path somewhere else is not something this tree's config can be asked about.
+//
+// Canonicalised first, on both sides. A plain string prefix accepts
+// `<worktree>/../sibling/x.ts` — it starts with the prefix, and slicing it
+// leaves `../sibling/x.ts`, which points deno straight back into another
+// agent's tree. That is the cross-worktree pollution this hook is here to end,
+// arriving through the check meant to prevent it. Symlinked paths need the same
+// treatment to be recognised as inside at all.
+const canonicalWorktree = canonical(worktree) ?? worktree;
+const prefix = canonicalWorktree.endsWith("/")
+  ? canonicalWorktree
+  : `${canonicalWorktree}/`;
+const resolved = activity.files.map(canonical).filter((f): f is string =>
+  f !== null
+);
+const changed = resolved
   .filter((f) => f.startsWith(prefix))
   .map((f) => f.slice(prefix.length))
   .sort();
@@ -140,10 +166,27 @@ const changed = activity.files
 if (changed.length === 0) {
   // A subagent that wrote nothing has nothing to answer for. Checking the repo
   // anyway is what produced the false verdicts this hook used to hand out.
+  //
+  // But say so when it wrote something we then discarded: this is the branch a
+  // containment or worktree-resolution mistake hides in, so it must be the one
+  // branch that is never silent.
+  if (activity.files.length > 0) {
+    console.log(JSON.stringify({
+      systemMessage:
+        `Subagent checks skipped: none of its ${activity.files.length} ` +
+        `written file(s) resolved inside ${canonicalWorktree}. Not blocking.`,
+    }));
+  }
   Deno.exit(0);
 }
 
-const errors = await checkFiles(worktree, changed);
+const { checked, missing, inapplicable, unavailable, errors } =
+  await checkFiles(
+    worktree,
+    changed,
+  );
+
+if (unavailable.length > 0) console.error(unavailable.join("\n\n"));
 
 if (errors.length > 0) {
   console.error(
@@ -168,9 +211,28 @@ const [branchName, status] = await Promise.all([
   git("status", "--porcelain"),
 ]);
 
-let context =
-  `Checks passed on the ${changed.length} file(s) changed by this ` +
-  `subagent (fmt, lint, type check).`;
+// Report what ran, not what was attempted. Claiming fmt and lint passed on
+// paths deno.jsonc excludes from both — `.claude/**` among them — is how a gate
+// launders an unchecked change into an approved one.
+const LABELS: Array<[flag: string, name: string]> = [
+  ["fmt", "fmt"],
+  ["lint", "lint"],
+  ["check", "type check"],
+];
+const ran = LABELS.filter(([flag]) => !inapplicable.includes(flag)).map((
+  [, name],
+) => name);
+
+let context = `Checks passed on ${checked.length} file(s) changed by this ` +
+  `subagent` + (ran.length > 0 ? ` (${ran.join(", ")}).` : ".");
+if (inapplicable.length > 0) {
+  context += `\nNot run — deno.jsonc excludes these paths: ${
+    inapplicable.join(", ")
+  }.`;
+}
+if (missing.length > 0) {
+  context += `\nSkipped ${missing.length} path(s) no longer on disk.`;
+}
 context += `\nWorktree: ${worktree}`;
 context += `\nBranch: ${branchName}`;
 

--- a/.claude/scripts/subagent-stop.ts
+++ b/.claude/scripts/subagent-stop.ts
@@ -155,9 +155,14 @@ const canonicalWorktree = canonical(worktree) ?? worktree;
 const prefix = canonicalWorktree.endsWith("/")
   ? canonicalWorktree
   : `${canonicalWorktree}/`;
-const resolved = activity.files.map(canonical).filter((f): f is string =>
-  f !== null
-);
+// A deleted scratch file has no real path, but it is not "somewhere else" — and
+// saying so sent an accurate report about the wrong thing. Fall back to the raw
+// path when it is plainly inside and free of `..`, and let checkFiles report it
+// as no longer on disk.
+const resolved = activity.files.map((f) =>
+  canonical(f) ??
+    (f.startsWith(prefix) && !f.split("/").includes("..") ? f : null)
+).filter((f): f is string => f !== null);
 const changed = resolved
   .filter((f) => f.startsWith(prefix))
   .map((f) => f.slice(prefix.length))
@@ -183,7 +188,9 @@ if (changed.length === 0) {
 const { checked, missing, inapplicable, partial, unavailable, errors } =
   await checkFiles(worktree, changed);
 
-if (unavailable.length > 0) console.error(unavailable.join("\n\n"));
+if (unavailable.length > 0) {
+  console.error(unavailable.map((u) => u.message).join("\n\n"));
+}
 
 if (errors.length > 0) {
   console.error(
@@ -216,9 +223,12 @@ const LABELS: Array<[flag: string, name: string]> = [
   ["lint", "lint"],
   ["check", "type check"],
 ];
-const ran = LABELS.filter(([flag]) => !inapplicable.includes(flag)).map((
-  [, name],
-) => name);
+// A check that could not be launched did not run, so it must not appear in a
+// list of checks that passed: that is a non-verdict presented as approval.
+const notRun = new Set([...inapplicable, ...unavailable.map((u) => u.check)]);
+const ran = LABELS.filter(([flag]) => !notRun.has(flag)).map(([, name]) =>
+  name
+);
 
 let context = `Checks passed on ${checked.length} file(s) changed by this ` +
   `subagent` + (ran.length > 0 ? ` (${ran.join(", ")}).` : ".");

--- a/.claude/scripts/subagent-stop.ts
+++ b/.claude/scripts/subagent-stop.ts
@@ -21,6 +21,13 @@
  * directory; a subagent handed its own worktree is not described by it at all.
  * The subagent's own transcript records where it worked, so that is what we
  * read. See common/worktree.ts.
+ *
+ * The cost of scoping this way, stated plainly: attribution comes from the
+ * Edit/Write tool calls in the transcript, so a file changed through Bash
+ * instead — `sed -i`, a codegen task — is not checked here. That is the
+ * accepted trade. An unattributable check is what made this hook's verdict
+ * worth ignoring, and a gate everyone ignores catches nothing at all. CI and
+ * the pre-commit hook still see those files.
  */
 
 import { env, sameRepository, worktreeRoot } from "./common/worktree.ts";

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -25,6 +25,10 @@
           },
           {
             "type": "command",
+            "command": "deno run --allow-read --allow-run --allow-env \"$CLAUDE_PROJECT_DIR/.claude/scripts/pre-commit.ts\""
+          },
+          {
+            "type": "command",
             "command": "deno run --allow-read --allow-env \"$CLAUDE_PROJECT_DIR/.claude/scripts/deno-test-filter.ts\""
           },
           {
@@ -59,6 +63,17 @@
           {
             "type": "command",
             "command": "deno run --allow-read \"$CLAUDE_PROJECT_DIR/.claude/scripts/post-exit-plan.ts\""
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "deno run --allow-read --allow-run --allow-env \"$CLAUDE_PROJECT_DIR/.claude/scripts/subagent-stop.ts\"",
+            "timeout": 120
           }
         ]
       }

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -38,7 +38,8 @@
     "./packages/fuse",
     "./packages/fs-sync-example",
     "./tasks",
-    "./scripts"
+    "./scripts",
+    "./.claude/scripts"
   ],
   "tasks": {
     "check": "./tasks/check.sh",

--- a/tasks/check.sh
+++ b/tasks/check.sh
@@ -79,8 +79,9 @@ FILES_TO_CHECK=()
 # Directory paths (no glob expansion needed)
 DIRS=(
   # The Claude Code hook scripts. A hook that fails to compile blocks every
-  # commit in the repo, and nothing else here type-checks them: `.claude/` is
-  # excluded from fmt and lint, so this list is their only coverage.
+  # commit in the repo, and nothing else type-checks them: the root `.claude/`
+  # exclusions cover fmt and lint, and its workspace-member config re-enables
+  # those two, but neither reaches `deno check`. This list does.
   ".claude/scripts"
   "packages/api"
   "packages/background-piece-service"

--- a/tasks/check.sh
+++ b/tasks/check.sh
@@ -78,6 +78,10 @@ FILES_TO_CHECK=()
 
 # Directory paths (no glob expansion needed)
 DIRS=(
+  # The Claude Code hook scripts. A hook that fails to compile blocks every
+  # commit in the repo, and nothing else here type-checks them: `.claude/` is
+  # excluded from fmt and lint, so this list is their only coverage.
+  ".claude/scripts"
   "packages/api"
   "packages/background-piece-service"
   "packages/piece"


### PR DESCRIPTION
Rebased onto main after #5210 removed the blocking hooks, so this is now the
**revert-plus-fix**: it re-adds `pre-commit.ts` and `subagent-stop.ts` in
corrected form, and only those. It is purely additive against main.

`block-git-amend.ts` is deliberately **not** restored. Removing it was a separate
decision and it stands: models routed around it with `git reset` plus a fresh
commit, which is strictly worse than the amend it refused — a reset discards the
original commit object, where `--amend` preserves the tree.

`stop-check.ts` and `post-edit-ts.ts` show no diff here: #5210 already carried
those two fixes, which were found during this work.

## Merge this only if the experiment says so

#5210's premise is that these hooks may no longer earn their place. The measure
is whether PRs start failing the `Check` job on fmt/lint/check over the next few
weeks. If they don't, leave this closed. If they do, this branch is what to
restore — though the better shape is still a PostToolUse hook reporting on
`git show --name-only HEAD` after a commit succeeds: no prediction, no shell
parsing, no blocking.

## What was wrong, as originally reported

Both hooks resolved their working directory from the session's checkout rather
than the tree they were inspecting. A commit to one worktree was checked against
— and blocked by — another branch's errors, with `--no-verify` the only way past.
`pre-commit` ran `deno fmt` rather than `--check`, so it silently reformatted a
checkout nobody was working in. `subagent-stop` checked the whole repo, so it
reported pre-existing branch failures to every subagent and sibling agents'
in-flight edits to whichever finished first.

## Measured, not assumed

All three candidate signals disagree, so the hooks were probed live before
anything was changed:

| Signal | PreToolUse | SubagentStop |
|---|---|---|
| `$CLAUDE_PROJECT_DIR` | session checkout, pinned | session checkout, pinned |
| payload `cwd` / `Deno.cwd()` | follows the Bash tool's *persisted* `cd` | **the parent session's dir** |
| `agent_transcript_path` → entry `cwd` | — | **the subagent's real worktree** |

## Eleven review rounds, 85 confirmed defects

Two automated reviewers and repeated adversarial subagent passes. Seven of those
defects were violations of the read-only contract — five introduced by the fix
for the previous one — and CI caught none of the 85. The commit messages record
each finding with its trigger condition; the ones worth knowing regardless of
whether this merges:

- `git status --porcelain` refreshes and **rewrites the index**;
  `--no-optional-locks` covers it.
- `git diff <commit>` also rewrites it, and `--no-optional-locks` does **not**
  cover it. Trigger: a racily-clean file — content matching the index with a
  differing mtime, i.e. edit a file and revert it. Invisible to `git write-tree`
  and to the index mtime; only the index bytes move.
- `git add --dry-run --edit` **stages the working tree**, because `--edit`
  applies its patch regardless and `GIT_EDITOR=true` is set. git accepts `--e`,
  `--ed`, `--edi` for it, so a blacklist cannot hold — the guard is a whitelist.
- `deno check` **rewrites `deno.lock`**, a tracked file, when a checked file
  imports something the lock lacks. Running before the user's command, that write
  landed in their commit.
- Quoted text is data: a commit message mentioning `-a`, `--no-verify` or
  `--work-tree` could sweep the tree, disable the hook, or turn it off entirely.
- git resolves any unambiguous option abbreviation, so exact-string matching
  mishandled `--dr`, `--inc`, `--mess` and `--no-ver` each in its own way.

## Coverage, which did not exist

`.claude/` was excluded from fmt and lint and absent from `tasks/check.sh`, so a
hook that failed to compile — blocking every commit in the repo — would have
shipped silently. `.claude/scripts` is now a workspace member with a test task
and is listed in `tasks/check.sh`.

24 tests: 14 over the command parser, 10 driving the real hook against a scratch
repository. The read-only contract is asserted on **every** hook invocation in
the suite — index bytes, working-tree status and `deno.lock` together — rather
than in tests that remember to check it. Four of the seven contract breaks would
have been caught by that assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)