### PR TITLE
ci: gate release artifacts on pattern migration checks

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -1101,10 +1101,15 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
+    # A release artifact must not outlive a failed pattern-migration gate.
+    # Production deploys consume this artifact without rerunning those gates.
     needs:
       [
         "test",
         "check",
+        "pattern-compat",
+        "pattern-vintage",
+        "baselines-append-only",
         "build-toolshed",
         "build-bg-piece-service",
         "build-cf",


### PR DESCRIPTION
## Summary

- require pattern contract compatibility before binary attestation
- require vintage replay before binary attestation
- require the append-only baseline guard before binary attestation

## Why

Production deployment downloads the attested artifact for a selected SHA without rerunning these migration checks. Previously, the checks participated in the pull-request aggregate status but were not dependencies of the main-branch artifact publication job, so a deployable artifact could be published after a migration gate failed.

This PR only closes that workflow dependency gap. It does not change vintage capture or replay behavior.

## Validation

- `git diff --check`
- `deno fmt --check .github/workflows/deno.yml`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate main-branch release artifacts on pattern migration checks to prevent publishing/attesting when migrations fail. The release job now depends on `pattern-compat`, `pattern-vintage`, and `baselines-append-only`, matching production which consumes attested artifacts without rerunning these gates.

<sup>Written for commit 26200ce1f26403cffc6242b77f645022d2f2e19a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

