### PR TITLE
fix(ci): stop passing a deploy flag the bastion wrapper no longer takes

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -1393,7 +1393,7 @@ jobs:
           host: ${{ secrets.BASTION_HOST }}
           username: bastion
           key: ${{ secrets.BASTION_SSH_PRIVATE_KEY }}
-          script: /opt/cf/deploy.sh rapids ${{ github.sha }} --skip-clusterduck
+          script: /opt/cf/deploy.sh rapids ${{ github.sha }}
 
   # Deploy shell static assets to staging GCS bucket
   deploy-shell-staging:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,10 @@ If you are developing runtime code, read the following documentation:
   start a request
 - `docs/development/CI_PERFORMANCE.md` - When to stop or revisit CI wall-time
   splitting/rebalancing work
+- `docs/development/deploying.md` - How a commit reaches a host: which CI jobs
+  deploy where, and the contract the bastion's deploy wrapper enforces on what
+  they pass it. That wrapper belongs to the infra repository, and the staging
+  deploy jobs run only on `main`, so read this before editing a deploy step
 - `docs/development/COVERAGE.md` - The two coverage mechanisms (V8 runtime
   coverage and transformer-based pattern coverage), which CI job collects which,
   and why the pattern integration jobs do not set `CF_PATTERN_COVERAGE_DIR`

--- a/docs/development/deploying.md
+++ b/docs/development/deploying.md
@@ -1,0 +1,53 @@
+# Deploying a commit
+
+A commit reaches a host by way of the bastion. The deploy jobs in CI open an
+SSH connection to the bastion and run one command there, `/opt/cf/deploy.sh`,
+passing the environment to deploy and the commit to deploy to it. That script
+does the rest: it deploys the binaries that CI already built and uploaded for
+that commit.
+
+Three jobs do this:
+
+| Job | Workflow | Environment passed | Trigger |
+| --- | --- | --- | --- |
+| `deploy-toolshed` | `.github/workflows/deno.yml` | `DEPLOYMENT_ENVIRONMENT` variable | every push to `main` |
+| `deploy-rapids` | `.github/workflows/deno.yml` | `rapids`, written out in the step | every push to `main` |
+| `deploy-estuary` | `.github/workflows/deploy-production.yml` | `DEPLOYMENT_ENVIRONMENT` variable | manual dispatch, naming the ref to deploy |
+
+Two of those read the environment name from a repository variable rather than
+naming it. The value differs between them, because each job declares a
+different GitHub environment, and a variable of the same name is defined in
+each.
+
+Each of the two staging jobs waits on `attest-binaries`, because the script
+deploys binaries rather than building them. There is nothing for it to deploy
+until that job has uploaded the artifacts for the commit. The production job
+downloads those same artifacts itself, and fails with a message naming the
+commit if they are not there.
+
+## The wrapper is owned by another repository
+
+`/opt/cf/deploy.sh` is not in this repository. The
+[infra repository](https://github.com/commontoolsinc/infra) generates it, in
+`ansible/playbooks/bastion.yml`, and writes it to the bastion when that
+playbook runs. Nothing here reads it, imports it, or tests it against the real
+thing.
+
+The script validates what it is given, and it takes exactly two arguments: an
+environment name it recognizes, and a 40-character commit SHA. Given anything
+else — an extra argument, an unknown environment, a revision that is not a
+full SHA — it prints its usage and exits with status 1, and the deploy job
+fails without deploying anything.
+
+This is the seam to be careful about. The staging deploy jobs run only on
+`main`, so a deploy step that no longer matches the script cannot fail on the
+pull request that introduces it. It fails on the first push to `main`
+afterwards, and then on every push after that until someone fixes it. The
+`Deploy steps call the bastion wrapper the way it accepts` case in
+[`tasks/ci-workflow.test.ts`](../../tasks/ci-workflow.test.ts) reads the
+`script:` line out of each deploy step and checks it against that contract, so
+a mismatch fails on the pull request instead.
+
+Changing the argument list therefore takes a change in each repository, in
+order: land the infra change, apply the bastion playbook so the host has the
+new script, then change the call sites here.

--- a/tasks/ci-workflow.test.ts
+++ b/tasks/ci-workflow.test.ts
@@ -50,10 +50,40 @@ function neededJobIds(job: string): string[] {
   );
 }
 
+const workflowDirectory = new URL("../.github/workflows/", import.meta.url);
+
 async function workflow(name: string): Promise<string> {
-  return await Deno.readTextFile(
-    new URL(`../.github/workflows/${name}`, import.meta.url),
+  return await Deno.readTextFile(new URL(name, workflowDirectory));
+}
+
+async function workflowNames(): Promise<string[]> {
+  const names: string[] = [];
+  for await (const entry of Deno.readDir(workflowDirectory)) {
+    if (entry.isFile && /\.ya?ml$/.test(entry.name)) names.push(entry.name);
+  }
+  return names.sort();
+}
+
+// Drops YAML comments. A `#` after whitespace ends a plain scalar, so what is
+// left on a line is the value the workflow actually carries. Applied before
+// looking for commands, so that a comment naming a command is not read as one
+// and a comment after a command is not read as part of it.
+function withoutComments(contents: string): string {
+  return contents.replaceAll(/(^|\s)#.*$/gm, "$1");
+}
+
+function deployInvocations(contents: string): string[] {
+  return [...contents.matchAll(/^ +script: (\/opt\/cf\/deploy\.sh.*)$/gm)].map(
+    (match) => match[1],
   );
+}
+
+// Splits a command the way a shell would count its words, except that a
+// `${{ ... }}` workflow expression holds spaces and still stands for one word.
+// The expression is matched to its first `}}` so that one containing a brace,
+// as `${{ format('{0}', github.sha) }}` does, still comes out as one word.
+function commandWords(command: string): string[] {
+  return [...command.matchAll(/\$\{\{.*?\}\}|\S+/g)].map((match) => match[0]);
 }
 
 function workflowTriggers(contents: string): string {
@@ -161,4 +191,58 @@ Deno.test("Dashboard publishes only from main, never from a pull request", async
       "            ${{ env.IMAGE }}:${{ github.sha }}\n" +
       "            ${{ env.IMAGE }}:latest\n",
   );
+});
+
+Deno.test("Deploy steps call the bastion wrapper the way it accepts", async () => {
+  // The bastion's /opt/cf/deploy.sh takes an environment name and a
+  // 40-character commit SHA, and nothing else. Hand it a third argument, an
+  // environment it does not know, or a revision that is not a full SHA, and it
+  // prints its usage and exits 1, failing the deploy job. That script belongs
+  // to the infra repository, so nothing else here sees it and the call sites
+  // are checked instead. docs/development/deploying.md covers the seam.
+  const environments = ["estuary", "toolshed", "rapids"];
+  // The revision has to expand to a full SHA, which is a property of what the
+  // expression reads rather than of the expression itself. `github.ref_name`
+  // would look just as much like a revision here and fail on the bastion, so
+  // the expressions whose value is a full SHA are named.
+  const revisions = ["${{ github.sha }}", "${{ steps.resolve.outputs.sha }}"];
+
+  const callers: string[] = [];
+  for (const name of await workflowNames()) {
+    const contents = withoutComments(await workflow(name));
+    const mentions = [...contents.matchAll(/\/opt\/cf\/deploy\.sh/g)].length;
+    if (mentions === 0) continue;
+    callers.push(name);
+
+    // Invocations are found by their one-line `script:` value. Counting the
+    // mentions of the script separately catches a call site written some other
+    // way, which would otherwise go unchecked.
+    const invocations = deployInvocations(contents);
+    assertEquals(
+      invocations.length,
+      mentions,
+      `${name}: every deploy.sh call belongs on a single script: line`,
+    );
+
+    for (const invocation of invocations) {
+      const args = commandWords(invocation).slice(1);
+      assertEquals(args.length, 2, `${name}: wrong arity in \`${invocation}\``);
+      assert(
+        args[0].startsWith("${{") || environments.includes(args[0]),
+        `${name}: unknown environment in \`${invocation}\``,
+      );
+      assert(
+        revisions.includes(args[1]),
+        `${name}: \`${args[1]}\` is not known to be a full SHA, in ` +
+          `\`${invocation}\``,
+      );
+    }
+  }
+
+  // Every workflow that calls the script is checked, so a new one is covered
+  // without being listed. The two that call it today are named to catch the
+  // case where the search comes back empty and the loop above does nothing.
+  for (const name of ["deno.yml", "deploy-production.yml"]) {
+    assert(callers.includes(name), `${name}: no deploy.sh call found`);
+  }
 });


### PR DESCRIPTION
Every push to main failed the "Deploy to Rapids (Staging)" job. The step opens an SSH connection to the bastion and runs /opt/cf/deploy.sh there, and the script answered with its usage text and exit status 1 rather than deploying anything.

That script belongs to the infra repository. It used to accept an optional third argument, --skip-clusterduck, which told it not to roll the new build out to the Clusterduck workers after deploying the hosts. The Rapids staging deploy passed the flag because Rapids has no Clusterduck workers behind it. Clusterduck has since been retired: its infrastructure is gone, the step that updated the workers has been removed from the script, and with it the option that suppressed that step. The script now takes exactly an environment name and a commit SHA, so what used to be an accepted flag is now an argument-count error, and the deploy fails before it starts. Both changes are correct on their own. They conflict only where the two repositories meet.

Dropping the flag restores the deploy. It cannot change what the deploy does, because the work the flag suppressed no longer exists in the script. The bastion is confirmed to be running the new script two ways: the usage text it printed is the text the script carries after the retirement, and in the same failing run the Toolshed staging deploy, which passes two arguments, succeeded.

Nothing in this repository reads that script, so a call site can drift out of step with it unnoticed. The staging deploy jobs also run only on main, so the mismatch cannot fail on the pull request that introduces it. It appears on the first push to main afterwards and repeats on every push until someone fixes it. The new case in tasks/ci-workflow.test.ts closes that gap. It searches every workflow file for a mention of the script, and for each call it finds it checks that exactly two arguments are passed, that the environment is one the script accepts unless it comes from a workflow variable, and that the revision is an expression whose value is known to be a full commit SHA. Comments are dropped before a line is read, because a hash following whitespace ends a plain scalar in YAML, so neither a comment after a command nor a comment naming the script is read as part of a call. An expression is held together as far as its first closing pair of braces, so one containing a brace stays a single word. The number of calls found is checked against the number of mentions of the script, so a call written some other way fails rather than passing unexamined.

The check was written before the fix and confirmed to fail on the third argument, naming it. It was then verified by mutating the Rapids deploy step thirteen ways. A third argument, a revision drawn from github.ref_name, an environment the script does not accept, a call moved into a block scalar, and a bad call in a workflow file the check had not been told about each fail with a message naming the cause. Doubled spaces, a tab, a trailing space, a trailing comment, and a comment naming the script all pass.

Also adds docs/development/deploying.md, which the repository had no equivalent of: which jobs deploy where, why the staging jobs wait on the binary attestation job, the wrapper's argument contract and which repository owns it, and the order a change to that contract has to happen in across the two repositories. The agent guide lists it among the runtime-development documents, so it is found before a deploy step is edited rather than after.

deflaked by Hixie's agent
Agent: Claude Opus 5, via Claude Code
NEW_COVERAGE_BASELINE
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes failing Rapids staging deploys by removing the obsolete `--skip-clusterduck` flag from the bastion wrapper call. Adds a CI check and docs to prevent future mismatches and keep deploys green.

- **Bug Fixes**
  - Update `.github/workflows/deno.yml` to call `/opt/cf/deploy.sh rapids ${{ github.sha }}` (no third arg; wrapper now takes only env and full SHA).
  - Add CI test in `tasks/ci-workflow.test.ts` to verify all `/opt/cf/deploy.sh` invocations: exactly two args, known env (or expression), and a full SHA expression; each call must be on a single `script:` line.
  - Add `docs/development/deploying.md` explaining the deploy flow and the wrapper’s contract; linked from `AGENTS.md`.

<sup>Written for commit ee218e90b08503130861b1bbe06918ad3aba3c87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

