### PR TITLE
fix(runner): bound the caches that grow with everything a session tou…

### DIFF
--- a/docs/history/development/performance/2026-07-unbounded-runtime-caches.md
+++ b/docs/history/development/performance/2026-07-unbounded-runtime-caches.md
@@ -1,0 +1,96 @@
+---
+status: historical
+created: 2026-07-29
+archived: 2026-07-29
+reason: "Audit of the runtime caches with no bound a long session can reach, and the measurement of bounding them."
+---
+
+# Unbounded runtime caches, July 2026
+
+## What this found
+
+Four caches in the runtime grew with the number of distinct things a session
+had ever handled, rather than with the number it was working on. A view that
+pages forward through a long list reaches every one of them: each page brings
+a fresh set of element results, action instances, and rendered values, and
+none of those keys is ever revisited.
+
+Two of the four had no bound at all. The other two had a bound that could not
+be reached before the memory was gone.
+
+| Cache                                         | Bound before          | Cost of one entry             |
+| --------------------------------------------- | --------------------- | ----------------------------- |
+| `dataURISyncCache` (`runner/src/storage/v2.ts`) | 10,000 entries       | a whole data URI as the key, plus a `Cell` |
+| `stringRepCache` (`data-model/src/value-hash.ts`) | 50,000 entries      | the hashed string as the key  |
+| `Scheduler.actionStats` (`runner/src/scheduler/timing.ts`) | none        | an action id and five numbers  |
+| `Runner.locallyPrepared/StoppedResults` (`runner/src/runner.ts`) | none  | a result key and a pattern key |
+
+The two counted bounds were the dangerous ones, because in both cases the
+entry count says nothing about the cost. A data URI carries its whole value in
+its id, so a rendered UI tree gives a key tens of kilobytes long, and 10,000 of
+those is hundreds of megabytes before the cache notices it is full. The same
+holds for the string hasher: whole documents and inlined data URIs reach it,
+and the cache holds each one alive by its key.
+
+`dataURISyncCache` had a second problem. Its value was the `Cell` the first
+caller happened to pass, which kept that cell's transaction, that
+transaction's runtime, and every value the transaction had read alive for as
+long as the entry survived. It was also process-wide, so a second storage
+manager could take a hit populated by the first and skip a pull its own
+replica needed.
+
+## Measurement
+
+`packages/runner/test/window-retention-probe.ts` walks a projection window
+forward over a long list, showing a position it has never shown on each move,
+and reports the heap after a forced collection.
+
+```
+deno run -A --v8-flags=--expose-gc \
+  packages/runner/test/window-retention-probe.ts index 24 2000 walk
+```
+
+|                            | before   | after    |
+| -------------------------- | -------- | -------- |
+| at rest, before the walk   | 93.9 MB  | 87.6 MB  |
+| after 24 forward moves     | 171.9 MB | 163.0 MB |
+
+The same walk with 20,000-byte rows and 12 moves goes from 99.5 MB to 142.1 MB
+before, and 93.4 MB to 134.6 MB after.
+
+So on this workload the fixes are worth about 5% of the retained heap, most of
+it a lower floor rather than a lower slope. That is the honest figure for a
+projection whose elements are plain documents. It understates what the same
+fixes are worth to a view that renders its rows, because the probe's patterns
+return fields rather than markup and so produce almost no inlined data URIs —
+and the data-URI memo was both the largest entry and the one holding a live
+cell.
+
+The value of bounding these is not mainly the megabytes on any one run. It is
+that none of the four had a ceiling a long session could not walk past.
+
+## What is still unbounded
+
+Two things remain, both visible by reading the code rather than by measuring.
+
+`SpaceReplica` keeps a `DocumentRecord` for every document it has ever loaded
+and drops them only when the session resets. Nothing tells it a document is no
+longer wanted: the replica tracks sinks, but reactivity reaches the runtime
+through the space-wide storage subscription instead, so the sink map stays
+empty and carries no interest signal.
+
+The memory v2 protocol cannot shrink a watch set from the client. `client.ts`
+only ever calls `watchAddSync`, and accumulates `#watchSpecs` for the session's
+lifetime. `session.watch.set` exists in the protocol and could replace a set,
+but nothing drives it.
+
+Together those mean a long-lived tab keeps every document it has read and stays
+subscribed to all of them. The freeze, sorted-key, and value-hash caches in
+`data-model` and `utils` are keyed on those documents, so they grow in step —
+and the `WeakMap` and `WeakSet` tables behind them do not shrink once grown, so
+a transient peak costs the tab for the rest of its life.
+
+Releasing documents needs per-document interest tracking threaded from the
+cells down to the replica, a watch-set shrink built on `session.watch.set`, and
+a decision about what a read of a released document does. That is a design
+change across the runner and memory packages, not a cache bound.

--- a/packages/data-model/src/value-hash.ts
+++ b/packages/data-model/src/value-hash.ts
@@ -121,9 +121,17 @@ const CANONICAL_NAN_BYTES = new Uint8Array([
   0x00,
 ]);
 
-/** LRU cache for string representations. */
+/**
+ * LRU cache for string representations. The entry count suits the short,
+ * repeated strings this mostly sees — property names, ids, tags. The byte
+ * budget covers the rest: values reach this hasher as whole documents and
+ * inlined data URIs that run to tens of kilobytes each, and 50,000 of those
+ * held by their key alone would be gigabytes.
+ */
 const stringRepCache = new LRUCache<string, Uint8Array>({
   capacity: 50_000,
+  weigh: (key, value) => key.length * 2 + value.length + 64,
+  maxWeight: 8 * 1024 * 1024,
 });
 
 /** Prepopulated cache of encoded small-length numbers. */

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -13,6 +13,7 @@ import { hashOf } from "@commonfabric/data-model/value-hash";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { getLogger } from "@commonfabric/utils/logger";
 import { isRecord } from "@commonfabric/utils/types";
+import { BoundedKeyMap } from "@commonfabric/utils/cache";
 import { PatternManager } from "./pattern-manager.ts";
 import { rendererVDOMSchema } from "./schemas.ts";
 import { forEachSubschema } from "./schema-walk.ts";
@@ -147,6 +148,13 @@ const sourceLocationLogger = getLogger("runner.source-location", {
   level: "warn",
   logCountEvery: 0,
 });
+
+/**
+ * How many prepared/stopped result shortcuts one runner keeps. Sized well
+ * above any plausible number of simultaneously live pieces, so the bound is
+ * reached only by a pattern churning through results it will not revisit.
+ */
+const RESULT_SHORTCUT_LIMIT = 4096;
 
 const EAGER_RESULT_BUILTIN_REFS = new Set([
   "fetchBinary",
@@ -857,14 +865,20 @@ export class Runner {
   // so tests can synchronize deterministically under the frozen-clock
   // preload, where wall-clock polling cannot observe this work.
   private pendingWatcherPatternLoads = new Set<Promise<unknown>>();
-  private locallyPreparedResults = new Map<
+  // Both maps record that this runner prepared or stopped a result, so a later
+  // start of the same result can reuse the cells it already assembled instead
+  // of re-syncing dependencies and rehydrating a snapshot. They are shortcuts:
+  // a missing entry costs a slower start, never a wrong one. They are bounded
+  // for that reason — a result key names one result document, and a pattern
+  // that keeps starting and stopping children adds keys it will never revisit.
+  private locallyPreparedResults = new BoundedKeyMap<
     `${MemorySpace}/${CellScope}/${URI}`,
     string
-  >();
-  private locallyStoppedResults = new Map<
+  >(RESULT_SHORTCUT_LIMIT);
+  private locallyStoppedResults = new BoundedKeyMap<
     `${MemorySpace}/${CellScope}/${URI}`,
     string
-  >();
+  >(RESULT_SHORTCUT_LIMIT);
   // Successful event-result starts that are still live in this runner. This is
   // intentionally local and bounded by live starts: it lets a sequential
   // redelivery avoid re-materializing an already-won result before the

--- a/packages/runner/src/scheduler/constants.ts
+++ b/packages/runner/src/scheduler/constants.ts
@@ -65,3 +65,14 @@ export const AUTO_DEBOUNCE_DELAY_MS = 100;
 // (observed: CI's slow runners quantized second-navigation boots to ~10s and
 // starved a 30s UI-commit wait; see lunch-poll-vote integration failure).
 export const INITIAL_RUN_SYNC_HOLD_TIMEOUT_MS = 2_000;
+
+/**
+ * Action-timing stats entries kept before the least recently run is dropped.
+ * An action id names one action INSTANCE, not one piece of source, so a
+ * pattern that keeps creating actions — a list projecting a window that moves
+ * over a long list makes a fresh set every time the window moves — adds ids
+ * without ever reusing them. Auto debounce and the scheduler graph read these,
+ * and both concern actions that are still running, so the least recently run
+ * entry is the one to lose.
+ */
+export const MAX_ACTION_STATS = 20_000;

--- a/packages/runner/src/scheduler/facade.ts
+++ b/packages/runner/src/scheduler/facade.ts
@@ -1,3 +1,4 @@
+import { BoundedKeyMap } from "@commonfabric/utils/cache";
 import { getLogger } from "@commonfabric/utils/logger";
 import type { Cancel } from "../cancel.ts";
 import { getTopFrame } from "../builder/pattern.ts";
@@ -35,6 +36,7 @@ import type {
 import {
   CONVERGENCE_IDLE_HOLD_MAX_BACKOFF_PASSES,
   INITIAL_RUN_SYNC_HOLD_TIMEOUT_MS,
+  MAX_ACTION_STATS,
   MAX_SETTLE_STATS_HISTORY,
 } from "./constants.ts";
 import {
@@ -440,7 +442,9 @@ export class Scheduler {
 
   // Compute time tracking for auto-debounce and diagnostics
   // Keyed by action ID (source location) to persist stats across action recreation
-  private actionStats = new Map<string, ActionStats>();
+  private actionStats = new BoundedKeyMap<string, ActionStats>(
+    MAX_ACTION_STATS,
+  );
   private actionTimingState: ActionTimingState = {
     actionStats: this.actionStats,
     getActionId: (action) => this.getActionId(action),

--- a/packages/runner/src/scheduler/timing.ts
+++ b/packages/runner/src/scheduler/timing.ts
@@ -1,8 +1,9 @@
+import { BoundedKeyMap } from "@commonfabric/utils/cache";
 import type { ActionStats } from "../telemetry.ts";
 import type { Action } from "./types.ts";
 
 export interface ActionTimingState {
-  readonly actionStats: Map<string, ActionStats>;
+  readonly actionStats: BoundedKeyMap<string, ActionStats>;
   readonly getActionId: (action: Action) => string;
 }
 
@@ -20,15 +21,18 @@ export function recordActionTime(
     existing.averageTime = existing.totalTime / existing.runCount;
     existing.lastRunTime = elapsed;
     existing.lastRunTimestamp = now;
-  } else {
-    state.actionStats.set(actionId, {
-      runCount: 1,
-      totalTime: elapsed,
-      averageTime: elapsed,
-      lastRunTime: elapsed,
-      lastRunTimestamp: now,
-    });
+    // Setting it again moves it to the young end, so the map ages entries by
+    // when their action last ran.
+    state.actionStats.set(actionId, existing);
+    return;
   }
+  state.actionStats.set(actionId, {
+    runCount: 1,
+    totalTime: elapsed,
+    averageTime: elapsed,
+    lastRunTime: elapsed,
+    lastRunTimestamp: now,
+  });
 }
 
 export function getActionStats(

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -47,6 +47,7 @@ import {
   touchedPointerPaths,
 } from "../../../memory/v2/patch.ts";
 import type { AppliedCommit } from "@commonfabric/memory/v2/engine";
+import { BoundedKeyMap } from "@commonfabric/utils/cache";
 import { getLogger } from "@commonfabric/utils/logger";
 import {
   isObject,
@@ -242,7 +243,31 @@ function conflictAdmissionMode(): ConflictAdmissionMode {
     return "off";
   }
 }
-const dataURISyncCache = new Map<string, Promise<Cell<any>>>();
+/**
+ * Identity of one data-URI pull: the URI, the schema it was read against, the
+ * path into it, and where it lives.
+ *
+ * The result is a hash rather than those parts joined together. A data URI
+ * carries its whole value in its id, so the id is the one part that varies
+ * without bound — a rendered UI tree reaches tens of kilobytes — and a cache
+ * keyed on it directly would cost that much per entry.
+ */
+export function dataURISyncKey(identity: {
+  id: string;
+  schema: JSONSchema | undefined;
+  path: readonly string[];
+  space: MemorySpace;
+  scope: CellScope | undefined;
+}): string {
+  return hashStringOf([
+    identity.id,
+    identity.schema ? hashStringOf(identity.schema) : "",
+    [...identity.path],
+    identity.space,
+    normalizeCellScope(identity.scope),
+  ]);
+}
+
 const DOCUMENT_MIME = "application/json" as const;
 const UNCACHED_TRANSACTION_VALUE = Symbol("uncachedTransactionValue");
 
@@ -850,6 +875,13 @@ export class StorageManager implements IStorageManager {
   // absent targets (dangling links, deleted docs) from churning the
   // cross-space convergence loop on every read.
   #docPullKicks = new Set<string>();
+  // Data URIs whose linked targets this manager has already pulled, keyed by a
+  // hash of the URI, schema, path, space, and scope. Per manager rather than
+  // per process: a hit skips the pull, and a manager that inherited another
+  // manager's hit would leave its own replica without those documents.
+  #dataURISyncs = new BoundedKeyMap<string, Promise<void>>(
+    DATA_URI_SYNC_CACHE_MAX,
+  );
   // In-flight commits, registered synchronously by the transaction layer at
   // commit() entry (see IStorageManager.trackPendingCommit). This is the
   // write-durability barrier: distinct from #crossSpacePromises, which also
@@ -1108,6 +1140,7 @@ export class StorageManager implements IStorageManager {
       [...this.#providers.values()].map((provider) => provider.destroy()),
     );
     this.#providers.clear();
+    this.#dataURISyncs.clear();
     this.#sessionId = crypto.randomUUID();
   }
 
@@ -1119,6 +1152,7 @@ export class StorageManager implements IStorageManager {
       [...this.#providers.values()].map((provider) => provider.destroyNow()),
     );
     this.#providers.clear();
+    this.#dataURISyncs.clear();
     this.#sessionId = crypto.randomUUID();
   }
 
@@ -1461,47 +1495,40 @@ export class StorageManager implements IStorageManager {
       .finally(() => this.resolveCrossSpace(resolve));
   }
 
-  private syncDataURICell<T>(
+  private async syncDataURICell<T>(
     cell: Cell<T>,
     space: MemorySpace,
     id: string,
     schema: JSONSchema | undefined,
     scope: CellScope | undefined,
   ): Promise<Cell<T>> {
-    const pathStr = JSON.stringify(cell.path);
-    const schemaStr = schema ? hashStringOf(schema) : "";
-    const cacheKey = `${id}|${schemaStr}|${pathStr}|${space}|${
-      normalizeCellScope(scope)
-    }`;
-    const existing = dataURISyncCache.get(cacheKey);
-    if (existing) {
-      return existing as Promise<Cell<T>>;
-    }
-    const promise = this.syncDataURICellUncached(
-      cell,
-      space,
+    const cacheKey = dataURISyncKey({
       id,
       schema,
+      path: cell.path.map(String),
+      space,
       scope,
-    );
-    if (dataURISyncCache.size >= DATA_URI_SYNC_CACHE_MAX) {
-      dataURISyncCache.clear();
+    });
+    let work = this.#dataURISyncs.get(cacheKey);
+    if (work === undefined) {
+      work = this.syncDataURILinkTargets(cell, space, id, schema, scope);
+      this.#dataURISyncs.set(cacheKey, work);
     }
-    dataURISyncCache.set(cacheKey, promise);
-    return promise;
+    await work;
+    return cell;
   }
 
-  private async syncDataURICellUncached<T>(
+  private async syncDataURILinkTargets<T>(
     cell: Cell<T>,
     space: MemorySpace,
     id: string,
     schema: JSONSchema | undefined,
     scope: CellScope | undefined,
-  ): Promise<Cell<T>> {
+  ): Promise<void> {
     let value: unknown = valueFromDataUri(id);
     for (const segment of [...cell.path.map(String)]) {
       if (!isRecord(value) && !Array.isArray(value)) {
-        return cell;
+        return;
       }
       value = (value as Record<string, unknown>)[segment];
     }
@@ -1524,7 +1551,6 @@ export class StorageManager implements IStorageManager {
     if (promises.length > 0) {
       await Promise.all(promises);
     }
-    return cell;
   }
 
   private collectLinkedCellSyncs(

--- a/packages/runner/test/data-uri-sync.test.ts
+++ b/packages/runner/test/data-uri-sync.test.ts
@@ -6,6 +6,7 @@ import { Runtime } from "../src/runtime.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 import { dataUriFromValueWithResolvedLinks } from "../src/data-uri.ts";
 import { LINK_V1_TAG } from "../src/sigil-types.ts";
+import { dataURISyncKey } from "../src/storage/v2.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
@@ -324,5 +325,146 @@ describe("data URI sync", () => {
     await dataCell.sync();
 
     expect(syncedIds).toContain(linkedId);
+  });
+
+  it("sync stops walking when the path leaves the data URI's containers", async () => {
+    const linkedCell = runtime.getCell(
+      space,
+      "unreachable-target",
+      undefined,
+      tx,
+    );
+    linkedCell.set("never pulled");
+    const linkedId = linkedCell.getAsNormalizedFullLink().id;
+
+    // The link sits beside the path, not under it. Walking ["count", "deeper"]
+    // steps onto a number, which holds no further segments, so the walk gives
+    // up before it ever reaches the link.
+    const dataURI = dataUriFromValueWithResolvedLinks({
+      count: 42,
+      ref: { "/": { [LINK_V1_TAG]: { id: linkedId, path: [] } } },
+    });
+    const dataCell = runtime.getCellFromEntityId(
+      space,
+      dataURI,
+      ["count", "deeper"],
+      undefined,
+      tx,
+    );
+
+    const provider = storageManager.open(space);
+    const originalSync = provider.sync.bind(provider);
+    const syncedIds: string[] = [];
+    // deno-lint-ignore no-explicit-any
+    provider.sync = (id: any, selector?: any, scope?: any) => {
+      syncedIds.push(id);
+      return originalSync(id, selector, scope);
+    };
+
+    expect(await dataCell.sync()).toBe(dataCell);
+    expect(syncedIds).toEqual([]);
+  });
+
+  it("sync on a data: URI cell resolves to the cell it was called on", async () => {
+    const dataURI = dataUriFromValueWithResolvedLinks({ simple: "value" });
+    const cell = runtime.getCellFromEntityId(
+      space,
+      dataURI,
+      [],
+      undefined,
+      tx,
+    );
+
+    expect(await cell.sync()).toBe(cell);
+    // The second call takes the memoized path. It must still hand back this
+    // caller's cell: another cell would carry another transaction, and holding
+    // one in the memo would keep that transaction and everything it read alive.
+    expect(await cell.sync()).toBe(cell);
+
+    const second = runtime.getCellFromEntityId(
+      space,
+      dataURI,
+      [],
+      undefined,
+      tx,
+    );
+    expect(await second.sync()).toBe(second);
+  });
+
+  it("does not carry a data: URI sync across storage managers", async () => {
+    const linkedCell = runtime.getCell(space, "cross-manager", undefined, tx);
+    linkedCell.set({ value: "target data" });
+    const linkedId = linkedCell.getAsNormalizedFullLink().id;
+    const dataURI = dataUriFromValueWithResolvedLinks({
+      ref: { "/": { [LINK_V1_TAG]: { id: linkedId, path: [] } } },
+    });
+
+    await runtime.getCellFromEntityId(space, dataURI, [], undefined, tx).sync();
+
+    // A second manager has its own providers and its own session. It must pull
+    // the link target itself rather than inherit the first manager's work.
+    const otherStorageManager = StorageManager.emulate({ as: signer });
+    const otherRuntime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: otherStorageManager,
+    });
+    const otherTx = otherRuntime.edit();
+    try {
+      const provider = otherStorageManager.open(space);
+      const originalSync = provider.sync.bind(provider);
+      const syncedIds: string[] = [];
+      // deno-lint-ignore no-explicit-any
+      provider.sync = (id: any, selector?: any, scope?: any) => {
+        syncedIds.push(id);
+        return originalSync(id, selector, scope);
+      };
+
+      await otherRuntime
+        .getCellFromEntityId(space, dataURI, [], undefined, otherTx)
+        .sync();
+
+      expect(syncedIds).toContain(linkedId);
+    } finally {
+      await otherTx.commit();
+      await otherRuntime.dispose();
+      await otherStorageManager.close();
+    }
+  });
+});
+
+describe("data URI sync memo key", () => {
+  const identity = {
+    id: "data:application/json,{}",
+    schema: undefined,
+    path: [] as readonly string[],
+    space,
+    scope: undefined,
+  };
+
+  it("costs the same however large the data URI is", () => {
+    const small = dataURISyncKey(identity);
+    const huge = dataURISyncKey({
+      ...identity,
+      id: `data:application/json,${"x".repeat(200_000)}`,
+    });
+    expect(huge.length).toBe(small.length);
+    expect(huge).not.toBe(small);
+  });
+
+  it("separates entries that differ in any part of their identity", () => {
+    const base = dataURISyncKey(identity);
+    const keys = [
+      base,
+      dataURISyncKey({ ...identity, id: 'data:application/json,{"a":1}' }),
+      dataURISyncKey({ ...identity, schema: { type: "string" } }),
+      dataURISyncKey({ ...identity, path: ["value"] }),
+      dataURISyncKey({ ...identity, scope: "user" }),
+    ];
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it("gives one identity one key", () => {
+    expect(dataURISyncKey({ ...identity, path: ["a", "b"] }))
+      .toBe(dataURISyncKey({ ...identity, path: ["a", "b"] }));
   });
 });

--- a/packages/runner/test/scheduler-timing.test.ts
+++ b/packages/runner/test/scheduler-timing.test.ts
@@ -17,6 +17,48 @@ import type {
   IExtendedStorageTransaction,
   SchedulerTestStorageManager,
 } from "./scheduler-test-utils.ts";
+import { BoundedKeyMap } from "@commonfabric/utils/cache";
+import type { ActionStats } from "../src/telemetry.ts";
+import { getActionStats, recordActionTime } from "../src/scheduler/timing.ts";
+
+describe("action timing stats", () => {
+  // Each action instance gets its own id, so a pattern that keeps creating
+  // actions — a list projecting a window that moves — would otherwise add a
+  // stats entry per instance for the life of the runtime.
+  const stateFor = (actionStats: BoundedKeyMap<string, ActionStats>) => ({
+    actionStats,
+    getActionId: (action: Action) => (action as { id?: string }).id ?? "?",
+  });
+  const actionWithId = (id: string) =>
+    Object.assign(() => {}, { id }) as unknown as Action;
+
+  it("bounds the stats map and drops the least recently run entry", () => {
+    const actionStats = new BoundedKeyMap<string, ActionStats>(20_000);
+    const state = stateFor(actionStats);
+    for (let index = 0; index < 25_000; index++) {
+      recordActionTime(state, actionWithId(`action-${index}`), 1, index);
+    }
+    expect(actionStats.size).toBeLessThanOrEqual(20_000);
+    expect(getActionStats(state, "action-0")).toBeUndefined();
+    expect(getActionStats(state, "action-24999")).toBeDefined();
+  });
+
+  it("keeps an action that keeps running", () => {
+    const actionStats = new BoundedKeyMap<string, ActionStats>(20_000);
+    const state = stateFor(actionStats);
+    const survivor = actionWithId("survivor");
+    recordActionTime(state, survivor, 1, 0);
+    for (let index = 0; index < 25_000; index++) {
+      recordActionTime(state, actionWithId(`action-${index}`), 1, index + 1);
+      if (index % 100 === 0) {
+        recordActionTime(state, survivor, 1, index + 1);
+      }
+    }
+    const stats = getActionStats(state, survivor);
+    expect(stats).toBeDefined();
+    expect(stats!.runCount).toBe(251);
+  });
+});
 
 describe("debounce and throttling", () => {
   let storageManager: SchedulerTestStorageManager;

--- a/packages/runner/test/window-retention-probe.ts
+++ b/packages/runner/test/window-retention-probe.ts
@@ -1,7 +1,15 @@
-// Retained heap while a list projects a window that moves back and forth.
+// Retained heap while a list projects a window over a long list.
 //
 //   deno run -A --v8-flags=--expose-gc \
-//     packages/runner/test/window-retention-probe.ts [shape] [moves]
+//     packages/runner/test/window-retention-probe.ts [shape] [moves] \
+//     [rowBytes] [walk]
+//
+// Two movement patterns, selected by the fourth argument:
+//   toggle (default) — the window alternates between two positions, so every
+//                      move re-shows rows the run has already shown
+//   walk             — the window steps forward, so every move shows a
+//                      position the run has never shown, the way a reader
+//                      pages forward through a long list
 //
 // Shapes select what the projection does with each element:
 //   inline   — elements are plain values, the element pattern returns fields
@@ -9,6 +17,9 @@
 //   cells    — elements are stable child cells, projected the same way
 //   opaque   — elements are stable child cells, and the nested pattern takes
 //              one of them as an opaque cell input
+//   index    — rows live in their own documents, linked from an index
+//              document, each carrying rowBytes of filler and an opaque
+//              manifest the row does not read
 //
 // The heap is reported after a forced collection, so the figures are reachable
 // memory rather than uncollected garbage.
@@ -154,8 +165,10 @@ export default pattern<
 
 const shape = Deno.args[0] ?? "child";
 const moves = Number(Deno.args[1] ?? 10);
-const rowCount = WINDOW_SIZE * 4;
 const rowBytes = Number(Deno.args[2] ?? 100);
+const walk = Deno.args[3] === "walk";
+// A walk needs a position per move, plus the two the warm-up visits.
+const rowCount = walk ? WINDOW_SIZE * (moves + 2) : WINDOW_SIZE * 4;
 const source = PROGRAMS[shape];
 if (source === undefined) {
   throw new Error(`unknown shape ${shape}; try ${Object.keys(PROGRAMS)}`);
@@ -251,13 +264,18 @@ try {
   await moveWindow(0);
 
   const baseline = heapMb();
-  console.log(`shape=${shape} rows=${rowCount} window=${WINDOW_SIZE}`);
+  console.log(
+    `shape=${shape} rows=${rowCount} window=${WINDOW_SIZE} ` +
+      `moves=${moves} ${walk ? "walk" : "toggle"}`,
+  );
   console.log(
     `after the window has visited both positions: ${baseline.toFixed(1)} MB`,
   );
   for (let move = 0; move < moves; move++) {
-    await moveWindow(move % 2 === 0 ? WINDOW_SIZE : 0);
-    if (move % 2 === 1) {
+    await moveWindow(
+      walk ? (move + 2) * WINDOW_SIZE : move % 2 === 0 ? WINDOW_SIZE : 0,
+    );
+    if (walk || move % 2 === 1) {
       const heap = heapMb();
       console.log(
         `after ${move + 1} more moves: ${heap.toFixed(1)} MB ` +

--- a/packages/utils/src/cache.bench.ts
+++ b/packages/utils/src/cache.bench.ts
@@ -1,10 +1,15 @@
-import { Cache, CacheOptions, LRUCache, LRUCacheNaive } from "./cache.ts";
+import {
+  Cache,
+  LRUCache,
+  LRUCacheNaive,
+  WeightedCacheOptions,
+} from "./cache.ts";
 
 const CACHE_SIZE = 1000;
 const OPERATIONS = 10000;
 
 function createCache<K, V>(
-  Ctor: new (options: CacheOptions) => Cache<K, V>,
+  Ctor: new (options: WeightedCacheOptions<K, V>) => Cache<K, V>,
 ): Cache<K, V> {
   return new Ctor({ capacity: CACHE_SIZE });
 }

--- a/packages/utils/src/cache.ts
+++ b/packages/utils/src/cache.ts
@@ -2,6 +2,16 @@ export interface CacheOptions {
   capacity?: number;
 }
 
+export interface WeightedCacheOptions<K, V> extends CacheOptions {
+  /**
+   * Cost of one entry, in whatever unit `maxWeight` is expressed in. Supply
+   * both to bound a cache whose entries vary in size — an entry count alone
+   * bounds how many things a cache holds, not how much memory they take.
+   */
+  weigh?: (key: K, value: V) => number;
+  maxWeight?: number;
+}
+
 export interface Cache<K, V> {
   readonly size: number;
   has(key: K): boolean;
@@ -9,6 +19,86 @@ export interface Cache<K, V> {
   put(key: K, value: V): void;
   delete(key: K): boolean;
   clear(): void;
+}
+
+/**
+ * A Map that drops its oldest key once it holds `limit` of them. Insertion
+ * order is the eviction order, and re-setting a key refreshes its place, so
+ * what goes first is whatever has gone longest without being written.
+ *
+ * The point of the Map-shaped surface is that an unbounded `Map` field becomes
+ * bounded by changing only its declaration. Reach for this where the entries
+ * are hints — a value whose loss costs a slower path, never a wrong answer —
+ * and where the keys keep arriving: one per instance of something the program
+ * creates and discards, rather than one per fixed thing it knows about.
+ */
+export class BoundedKeyMap<K, V> implements ReadonlyMap<K, V> {
+  readonly #entries = new Map<K, V>();
+  readonly #limit: number;
+
+  constructor(limit: number) {
+    this.#limit = Math.max(limit, 1);
+  }
+
+  get size(): number {
+    return this.#entries.size;
+  }
+
+  has(key: K): boolean {
+    return this.#entries.has(key);
+  }
+
+  get(key: K): V | undefined {
+    return this.#entries.get(key);
+  }
+
+  set(key: K, value: V): void {
+    this.#entries.delete(key);
+    // Keys come out in insertion order, so this drops the oldest first, and
+    // stops as soon as the new entry has somewhere to go.
+    for (const oldest of this.#entries.keys()) {
+      if (this.#entries.size < this.#limit) break;
+      this.#entries.delete(oldest);
+    }
+    this.#entries.set(key, value);
+  }
+
+  delete(key: K): boolean {
+    return this.#entries.delete(key);
+  }
+
+  clear(): void {
+    this.#entries.clear();
+  }
+
+  // The read side is the standard ReadonlyMap surface, so a consumer that only
+  // reads takes `ReadonlyMap` and accepts either this or a plain Map. Every
+  // traversal runs oldest first, which is the order entries are dropped in.
+
+  entries(): MapIterator<[K, V]> {
+    return this.#entries.entries();
+  }
+
+  keys(): MapIterator<K> {
+    return this.#entries.keys();
+  }
+
+  values(): MapIterator<V> {
+    return this.#entries.values();
+  }
+
+  forEach(
+    callback: (value: V, key: K, map: ReadonlyMap<K, V>) => void,
+    thisArg?: unknown,
+  ): void {
+    for (const [key, value] of this.#entries) {
+      callback.call(thisArg, value, key, this);
+    }
+  }
+
+  [Symbol.iterator](): MapIterator<[K, V]> {
+    return this.#entries.entries();
+  }
 }
 
 export class LRUCacheNaive<K, V> implements Cache<K, V> {
@@ -63,6 +153,7 @@ export class LRUCacheNaive<K, V> implements Cache<K, V> {
 interface LRUNode<K, V> {
   key: K;
   value: V;
+  weight: number;
   prev: LRUNode<K, V> | null;
   next: LRUNode<K, V> | null;
 }
@@ -72,13 +163,26 @@ export class LRUCache<K, V> implements Cache<K, V> {
   #head: LRUNode<K, V> | null = null;
   #tail: LRUNode<K, V> | null = null;
   #capacity: number;
+  // Declared as an explicit `| undefined` rather than an optional field, so
+  // assigning the caller's optional `weigh` stays legal for the packages that
+  // compile with exactOptionalPropertyTypes.
+  #weigh: ((key: K, value: V) => number) | undefined;
+  #maxWeight: number;
+  #weight = 0;
 
-  constructor(options: CacheOptions = {}) {
+  constructor(options: WeightedCacheOptions<K, V> = {}) {
     this.#capacity = Math.max(options.capacity ?? 1000, 1);
+    this.#weigh = options.weigh;
+    this.#maxWeight = options.maxWeight ?? Infinity;
   }
 
   get size(): number {
     return this.#map.size;
+  }
+
+  /** Total weight of the entries currently held, per the `weigh` option. */
+  get weight(): number {
+    return this.#weight;
   }
 
   has(key: K): boolean {
@@ -95,10 +199,14 @@ export class LRUCache<K, V> implements Cache<K, V> {
   }
 
   put(key: K, value: V): void {
+    const weight = this.#weigh?.(key, value) ?? 0;
     const existingNode = this.#map.get(key);
     if (existingNode !== undefined) {
+      this.#weight += weight - existingNode.weight;
       existingNode.value = value;
+      existingNode.weight = weight;
       this.#moveToTail(existingNode);
+      this.#evictToFit();
       return;
     }
 
@@ -106,9 +214,11 @@ export class LRUCache<K, V> implements Cache<K, V> {
       this.#evictHead();
     }
 
-    const node: LRUNode<K, V> = { key, value, prev: null, next: null };
+    const node: LRUNode<K, V> = { key, value, weight, prev: null, next: null };
     this.#map.set(key, node);
     this.#addToTail(node);
+    this.#weight += weight;
+    this.#evictToFit();
   }
 
   delete(key: K): boolean {
@@ -118,6 +228,7 @@ export class LRUCache<K, V> implements Cache<K, V> {
     }
     this.#map.delete(key);
     this.#removeNode(node);
+    this.#weight -= node.weight;
     return true;
   }
 
@@ -125,6 +236,16 @@ export class LRUCache<K, V> implements Cache<K, V> {
     this.#map.clear();
     this.#head = null;
     this.#tail = null;
+    this.#weight = 0;
+  }
+
+  // Evict from the least-recently-used end until the weight budget is met.
+  // The most recent entry stays even when it alone exceeds the budget, so a
+  // single oversized value cannot leave the cache empty on every put.
+  #evictToFit(): void {
+    while (this.#weight > this.#maxWeight && this.#map.size > 1) {
+      this.#evictHead();
+    }
   }
 
   #removeNode(node: LRUNode<K, V>): void {
@@ -168,5 +289,6 @@ export class LRUCache<K, V> implements Cache<K, V> {
     const node = this.#head;
     this.#map.delete(node.key);
     this.#removeNode(node);
+    this.#weight -= node.weight;
   }
 }

--- a/packages/utils/test/cache.test.ts
+++ b/packages/utils/test/cache.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { LRUCache } from "@commonfabric/utils/cache";
+import { BoundedKeyMap, LRUCache } from "@commonfabric/utils/cache";
 
 describe("LRUCache", () => {
   describe("basic operations", () => {
@@ -170,5 +170,154 @@ describe("LRUCache", () => {
       expect(cache.has("c")).toBe(true);
       expect(cache.has("d")).toBe(true);
     });
+  });
+  describe("weight budget", () => {
+    const weighByValue = { weigh: (_key: string, value: number) => value };
+
+    it("evicts the least recently used entry until the budget is met", () => {
+      const cache = new LRUCache<string, number>({
+        capacity: 100,
+        maxWeight: 10,
+        ...weighByValue,
+      });
+      cache.put("a", 4);
+      cache.put("b", 4);
+      expect(cache.weight).toBe(8);
+      cache.get("a");
+      cache.put("c", 4);
+      expect(cache.has("b")).toBe(false);
+      expect(cache.has("a")).toBe(true);
+      expect(cache.has("c")).toBe(true);
+      expect(cache.weight).toBe(8);
+    });
+
+    it("keeps a single entry that alone exceeds the budget", () => {
+      const cache = new LRUCache<string, number>({
+        capacity: 100,
+        maxWeight: 10,
+        ...weighByValue,
+      });
+      cache.put("huge", 1000);
+      expect(cache.get("huge")).toBe(1000);
+      expect(cache.size).toBe(1);
+      cache.put("small", 1);
+      expect(cache.has("huge")).toBe(false);
+      expect(cache.get("small")).toBe(1);
+    });
+
+    it("tracks weight through replacement, delete, and clear", () => {
+      const cache = new LRUCache<string, number>({
+        capacity: 100,
+        maxWeight: 100,
+        ...weighByValue,
+      });
+      cache.put("a", 5);
+      cache.put("a", 7);
+      expect(cache.size).toBe(1);
+      expect(cache.weight).toBe(7);
+      cache.put("b", 3);
+      cache.delete("a");
+      expect(cache.weight).toBe(3);
+      cache.clear();
+      expect(cache.weight).toBe(0);
+    });
+
+    it("still honors the entry count when no budget is set", () => {
+      const cache = new LRUCache<string, number>({ capacity: 2 });
+      cache.put("a", 1);
+      cache.put("b", 2);
+      cache.put("c", 3);
+      expect(cache.has("a")).toBe(false);
+      expect(cache.weight).toBe(0);
+    });
+  });
+});
+
+describe("BoundedKeyMap", () => {
+  it("reads back what it stored", () => {
+    const map = new BoundedKeyMap<string, number>(10);
+    map.set("a", 1);
+    expect(map.get("a")).toBe(1);
+    expect(map.has("a")).toBe(true);
+    expect(map.has("b")).toBe(false);
+    expect(map.get("b")).toBeUndefined();
+    expect(map.size).toBe(1);
+  });
+
+  it("drops the oldest key once it is full", () => {
+    const map = new BoundedKeyMap<string, number>(3);
+    for (const key of ["a", "b", "c", "d"]) map.set(key, 1);
+    expect(map.size).toBe(3);
+    expect(map.has("a")).toBe(false);
+    expect(map.has("d")).toBe(true);
+  });
+
+  it("stays bounded however many distinct keys arrive", () => {
+    const map = new BoundedKeyMap<number, number>(64);
+    for (let key = 0; key < 100_000; key++) map.set(key, key);
+    expect(map.size).toBe(64);
+    expect(map.get(99_999)).toBe(99_999);
+    expect(map.has(0)).toBe(false);
+  });
+
+  it("keeps a key that is written again", () => {
+    const map = new BoundedKeyMap<string, number>(4);
+    map.set("keep", 0);
+    for (let round = 0; round < 100; round++) {
+      map.set(`churn-${round}`, round);
+      map.set("keep", round);
+    }
+    expect(map.get("keep")).toBe(99);
+  });
+
+  it("does not keep a key that is only ever read", () => {
+    // Reads are free: eviction order tracks writes alone, so a hot reader with
+    // no writer still ages out. Callers that need read-recency want an LRU.
+    const map = new BoundedKeyMap<string, number>(4);
+    map.set("read-only", 7);
+    for (let round = 0; round < 100; round++) {
+      map.get("read-only");
+      map.set(`churn-${round}`, round);
+    }
+    expect(map.has("read-only")).toBe(false);
+  });
+
+  it("forgets a deleted key and everything on clear", () => {
+    const map = new BoundedKeyMap<string, number>(10);
+    map.set("a", 1);
+    map.set("b", 2);
+    expect(map.delete("a")).toBe(true);
+    expect(map.delete("a")).toBe(false);
+    expect(map.size).toBe(1);
+    map.clear();
+    expect(map.size).toBe(0);
+    expect(map.has("b")).toBe(false);
+  });
+
+  it("reads like a ReadonlyMap, oldest entry first", () => {
+    const map = new BoundedKeyMap<string, number>(10);
+    map.set("a", 1);
+    map.set("b", 2);
+    expect([...map]).toEqual([["a", 1], ["b", 2]]);
+    expect([...map.entries()]).toEqual([["a", 1], ["b", 2]]);
+    expect([...map.keys()]).toEqual(["a", "b"]);
+    expect([...map.values()]).toEqual([1, 2]);
+    const seen: Array<[string, number]> = [];
+    map.forEach((value, key) => seen.push([key, value]));
+    expect(seen).toEqual([["a", 1], ["b", 2]]);
+    // Re-setting a key moves it to the young end, so traversal order tracks
+    // writes rather than first sight.
+    map.set("a", 3);
+    expect([...map.keys()]).toEqual(["b", "a"]);
+    const readonlyView: ReadonlyMap<string, number> = map;
+    expect(readonlyView.get("a")).toBe(3);
+  });
+
+  it("holds one entry when given a nonsensical limit", () => {
+    const map = new BoundedKeyMap<string, number>(0);
+    map.set("a", 1);
+    map.set("b", 2);
+    expect(map.size).toBe(1);
+    expect(map.get("b")).toBe(2);
   });
 });


### PR DESCRIPTION
…ches

Four runtime caches grew with the number of distinct things a session had ever handled rather than the number it was working on. A view that pages forward through a long list reaches all four: every move of the projection window brings a fresh set of element results, action instances, and rendered values, and none of those keys is ever revisited.

Two had no bound at all. The scheduler's action-timing stats are keyed by action id, which names an action INSTANCE and not a piece of source, and the runner's prepared and stopped result shortcuts are keyed by result document. Bound both, evicting whatever has gone longest without being written. Both are hints — auto debounce and a faster start path — so an evicted entry costs a slower path, never a wrong result. The Map-shaped bounded map they now use lives in utils beside the LRU cache, since making an unbounded Map field bounded should be a change to its declaration alone.

The other two had a bound counted in entries, which says nothing about what they cost. The data-URI sync memo held 10,000 entries keyed by the data URI itself; a data URI carries its whole value in its id, so a rendered UI tree gives a key tens of kilobytes long and the cache is hundreds of megabytes before it notices it is full. Key it by a hash instead, which also makes the key derivation a small pure function with its own tests. That memo also stored the Cell its first caller passed, keeping that cell's transaction, the transaction's runtime, and every value the transaction read alive for as long as the entry survived; it now stores the pull work and returns the caller's own cell. And it was process-wide, so a second storage manager could take a hit populated by the first and skip a pull its own replica needed — it now belongs to the manager.

The string-representation cache in the value hasher had the same shape: 50,000 entries whatever their size, holding each hashed string alive by its key, with whole documents and inlined data URIs passing through it. Give the LRU cache an optional weight budget and use it here, keeping the entry count for the short repeated strings it mostly sees.

Add a forward-walking mode to the window retention probe. It only toggled between two positions, which re-shows rows the run has already shown and so misses this entirely; walking forward shows a position the run has never shown on every move. Walking 24 positions over 520 rows, the heap goes from 93.9 MB at rest and 171.9 MB at the end to 87.6 MB and 163.0 MB — about 5%, most of it a lower floor rather than a lower slope. That understates what the same fixes are worth to a view that renders its rows, because the probe's patterns return fields rather than markup and so produce almost no inlined data URIs. The point is not the megabytes on one run: it is that none of the four had a ceiling a long session could not walk past.

docs/history records the audit, the measurement, and the two things that remain unbounded — the space replica keeps every document it has ever loaded, and the memory protocol has no way for a client to shrink a watch set — neither of which is a cache bound.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound four runtime caches to prevent unbounded growth during long sessions and paging. Adds weight-aware LRU and safer, per-manager data-URI memoization, reducing retained heap by ~5% in the probe.

- **Bug Fixes**
  - Bounded `Scheduler.actionStats` to 20,000 entries; drops least-recently-run.
  - Bounded runner result shortcuts (`locallyPreparedResults`, `locallyStoppedResults`) to 4,096 via `BoundedKeyMap`.
  - Reworked data: URI sync memo: per `StorageManager`, keyed by `dataURISyncKey` (hash of URI+schema+path+space+scope); memoizes pull work and returns the caller’s cell.
  - Capped `stringRepCache` in `@commonfabric/data-model/value-hash` by weight using `LRUCache` with `weigh` and `maxWeight = 8MB`.

- **Refactors**
  - Added `BoundedKeyMap` and weight budget support to `LRUCache` in `@commonfabric/utils/cache`.
  - Added forward-walk mode to the window retention probe; documented results and remaining unbounded areas.
  - Expanded tests for cache bounds, data-URI keying, cross-manager behavior, and weighted LRU.

<sup>Written for commit d220c352947afc0824f27147fdb74d42193cd659. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

