### PR TITLE
Take the staging shell's API host from a variable, and retire the las…

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -1421,11 +1421,35 @@ jobs:
       - name: 🔍 Verify lock file & install dependencies
         uses: ./.github/actions/deno-install
 
+      # STAGING_SHELL_API_URL names the toolshed this shell talks to, which is
+      # the host the deploy-rapids job above keeps current. It is a variable
+      # rather than a secret because it is served in plaintext inside the
+      # bundle, and because the checks below can then name it when they fail.
+      - name: 🔎 Require a staging API host
+        env:
+          API_URL: ${{ vars.STAGING_SHELL_API_URL }}
+        run: |
+          # An empty API_URL builds a shell that falls back to its own origin,
+          # which serves static assets and no API. Require a value up front, so
+          # the build never runs with nothing to point at.
+          if [ -z "$API_URL" ]; then
+            echo "::error::API_URL is empty: the STAGING_SHELL_API_URL variable is unset."
+            exit 1
+          fi
+
       - name: 🏗️ Build shell with staging API URL
         working-directory: packages/shell
-        run: deno task production
+        run: |
+          deno task production
+
+          # The build substitutes API_URL into the bundle in place of the
+          # `$API_URL` token. Confirm it landed before anything is uploaded.
+          if ! grep -rqF -e "$API_URL" dist/scripts; then
+            echo "::error::The built shell does not reference $API_URL."
+            exit 1
+          fi
         env:
-          API_URL: ${{ secrets.CLUSTERDUCK_SHELL_API_URL }}
+          API_URL: ${{ vars.STAGING_SHELL_API_URL }}
           COMMIT_SHA: ${{ github.sha }}
 
       - name: 🔑 Authenticate to Google Cloud
@@ -1446,3 +1470,18 @@ jobs:
 
           echo "📦 Staging Shell deployed"
           echo "https://staging.commontools.dev/"
+
+      - name: 🔎 Verify the published shell targets the staging API
+        env:
+          API_URL: ${{ vars.STAGING_SHELL_API_URL }}
+        run: |
+          # Read the scripts back out of the bucket, so this checks the uploaded
+          # objects rather than the local build directory. Going to the bucket
+          # rather than to the site's own URL also bypasses the CDN, which may
+          # still be serving the previous build.
+          gsutil cat "gs://staging-commontools-dev/scripts/*.js" > published-scripts.js
+          if ! grep -qF -e "$API_URL" published-scripts.js; then
+            echo "::error::The published shell does not reference $API_URL."
+            exit 1
+          fi
+          echo "Published shell targets $API_URL"

--- a/Dockerfile.toolshed
+++ b/Dockerfile.toolshed
@@ -1,9 +1,9 @@
 # Toolshed container image (M0 spike — see common-cluster docs/implementation-plan.md)
 #
 # Build context must be the labs repo ROOT (workspace imports resolve from the
-# root deno.jsonc). Modeled on clusterduck's Dockerfile.worker labs-builder
-# stage, pinned to the Deno version in mise.toml (the FROM lines below cannot
-# read it, so tasks/check-deno-pins.ts verifies they match).
+# root deno.jsonc). The builder stage is pinned to the Deno version in mise.toml
+# (the FROM lines below cannot read it, so tasks/check-deno-pins.ts verifies
+# they match).
 #
 #   docker build -f Dockerfile.toolshed --build-arg COMMIT_SHA=$(git rev-parse HEAD) \
 #     -t us-central1-docker.pkg.dev/commontools-core/containers/toolshed:m0 .

--- a/docs/development/CONFIGURATION.md
+++ b/docs/development/CONFIGURATION.md
@@ -166,7 +166,7 @@ The toolshed-embedded memory service has two modes:
 | Var | Default | Notes |
 |---|---|---|
 | `MEMORY_DIR` | `./cache/memory/` (as a `file://` URL) | **Directory mode** — one SQLite file per space. Default; backwards-compatible. |
-| `DB_PATH` | _(unset)_ | **Single-file mode** — absolute path to one SQLite database. Used for clusterduck clustering. Validated as an absolute path. |
+| `DB_PATH` | _(unset)_ | **Single-file mode** — absolute path to one SQLite database holding every space, instead of a file per space. Takes precedence over `MEMORY_DIR`. Validated as an absolute path. |
 | `MEMORY_URL` | `http://localhost:8000` | Where other components reach the memory service. |
 | `MEMORY_ACL_MODE` | `enforce` | Space ACL policy: `off`, `observe`, or `enforce`. `observe` logs ordinary access shortfalls, while malformed ACLs and fresh-space genesis violations still fail closed. |
 | `MEMORY_SERVICE_DIDS` | _(empty)_ | Comma-separated DIDs with implicit OWNER on every space. These identities may initialize ACLs but still cannot make an ordinary first write before genesis. |
@@ -389,7 +389,6 @@ shell expansion to forward extra `deno test` flags (e.g. `--filter`).
 |---|---|
 | `dev` | Build against the cloud toolshed at `toolshed.saga-castor.ts.net`. Use this for shell-only work. |
 | `dev-local` | Build against `http://localhost:$TOOLSHED_PORT`. **Use this for local dev** — `dev` points at the cloud backend. |
-| `dev-clusterduck` | Build against the clusterduck instance (`localhost:7001`). |
 | `build` / `production` | Optimized build (`production` sets `PRODUCTION=1`). |
 | `serve` | Serve pre-built `dist/` on `0.0.0.0:9099`. |
 | `test`, `integration` | Test suites. |

--- a/docs/development/deploying.md
+++ b/docs/development/deploying.md
@@ -1,10 +1,11 @@
 # Deploying a commit
 
-A commit reaches a host by way of the bastion. The deploy jobs in CI open an
-SSH connection to the bastion and run one command there, `/opt/cf/deploy.sh`,
-passing the environment to deploy and the commit to deploy to it. That script
-does the rest: it deploys the binaries that CI already built and uploaded for
-that commit.
+A commit reaches a server host by way of the bastion. The deploy jobs in CI
+open an SSH connection to the bastion and run one command there,
+`/opt/cf/deploy.sh`, passing the environment to deploy and the commit to deploy
+to it. That script does the rest: it deploys the binaries that CI already built
+and uploaded for that commit. The shell is a static site rather than a server,
+and reaches its bucket another way; "The staging shell" below covers it.
 
 Three jobs do this:
 
@@ -51,3 +52,29 @@ a mismatch fails on the pull request instead.
 Changing the argument list therefore takes a change in each repository, in
 order: land the infra change, apply the bastion playbook so the host has the
 new script, then change the call sites here.
+
+## The staging shell
+
+The `deploy-shell-staging` job in `.github/workflows/deno.yml` publishes the
+shell on every push to `main`. It does not touch the bastion: it builds
+`packages/shell` and copies the result into the `staging-commontools-dev`
+bucket, which is served at <https://staging.commontools.dev/>. Each build also
+lands under `builds/<commit>/` so a page that is already open keeps the exact
+module graph it started with.
+
+The shell has to be told which toolshed to talk to, because it is served from a
+different origin than the API it calls. The `STAGING_SHELL_API_URL` variable
+carries that host, and the build substitutes it into the bundle. It is a
+variable rather than a secret: the value ends up in a bundle that anyone can
+read, so hiding it from review buys nothing and costs the ability to see what
+staging points at. The host it names is the one `deploy-rapids` keeps current.
+
+Publishing is not the same as working, and this job cannot tell the difference
+by uploading alone — it makes no request to the API it just configured. So it
+checks three things instead. An unset variable fails the job before the build,
+because a shell built with no API host falls back to its own origin, and that
+origin serves static assets and no API. The built bundle must then contain the
+host that was passed in. Finally the scripts are read back out of the bucket
+and checked again, so a green job means the objects being served name the host
+they should. That last read goes to the bucket rather than to the site's
+address, because the CDN may still be serving the previous build.

--- a/packages/shell/deno.jsonc
+++ b/packages/shell/deno.jsonc
@@ -7,7 +7,6 @@
     "serve": "deno run -A ../felt/cli.ts serve .",
     "dev": "deno task clean && API_URL=https://toolshed.saga-castor.ts.net deno run -A ../felt/cli.ts dev .",
     "dev-local": "deno task clean && API_URL=http://localhost:$TOOLSHED_PORT deno run -A ../felt/cli.ts dev .",
-    "dev-clusterduck": "deno task clean && API_URL='http://localhost:7001' deno run -A ../felt/cli.ts dev .",
     "integration": "LOG_LEVEL=warn deno test -A $INTEGRATION_TEST_FLAGS ./integration/*.test.ts",
     // --no-check: this package is type-checked by `deno task check` (tasks/check.sh).
     "test": "deno test --no-check --allow-net=127.0.0.1 --allow-read --allow-write --allow-run --allow-env test/*.test.ts"

--- a/packages/toolshed/env.ts
+++ b/packages/toolshed/env.ts
@@ -134,7 +134,7 @@ export const EnvSchema = z.object({
   //  - MEMORY_DIR is used by toolshed to access sqlite files for common-memory
   //    (directory mode - default, backwards compatible)
   //  - DB_PATH is an optional absolute path to a single SQLite database file
-  //    (single-file mode - for clusterduck clustering)
+  //    holding every space (single-file mode - takes precedence over MEMORY_DIR)
   //  - MEMORY_URL is used by toolshed to connect to memory endpoint
   // ===========================================================================
   MEMORY_DIR: z.string().default(


### PR DESCRIPTION
…t Clusterduck references

The host the staging shell talks to is now a repository variable, `STAGING_SHELL_API_URL`, rather than a secret. It was never a secret. It is a hostname compiled into a JavaScript bundle that is served publicly, so anyone who loads the staging site can read it. Holding it as a secret bought no confidentiality, and it cost visibility: the value could not be seen in review or found by searching the repository, and it went on naming a decommissioned host across every push to main without anyone noticing. It also lets the checks described below name the host they expected and the host they found, which a masked secret would have printed as three asterisks. The variable is read by a job that declares the `ci` environment, so it resolves whether it is defined on that environment or on the repository.

That job could not have reported the problem, because it could not fail. It builds the shell with an API host, copies the result into a bucket, and makes no request to the API it just configured. Uploading is all it verified, so it reported success while publishing a shell pointed at a host that had been torn down.

Three checks now stand between the configured host and a published bundle. An empty value fails the job before the build runs, because a shell built with no API host falls back to its own origin, and that origin serves static assets and no API. After the build, the bundle must contain the host that was passed in, which catches a break in the token substitution the build performs. After the upload, the scripts are read back out of the bucket and checked again, so a green job means the objects now being served name the host they should. That last read goes to the bucket rather than to the site's own address, because the CDN may still be serving the previous build.

`docs/development/deploying.md` gains a section for this job. It described how a commit reaches a server host through the bastion, and the shell reaches a bucket instead, so the one deploy the document did not cover was the one whose target had been invisible. The section records where the API host comes from, why it is a variable, and what the three checks establish.

The rest of this change removes what the Clusterduck decommission left behind. That platform is retired and its infrastructure is gone, but references to it survived here, and they split two ways.

The shell package carried a `dev-clusterduck` task that built the shell against a Clusterduck router on a local port. Nothing listens there any more, so the task and the row documenting it are both removed.

The others were descriptions rather than behavior. Single-file memory mode, selected by `DB_PATH`, was described as existing "for clusterduck clustering". The capability is very much alive: the toolshed container image uses it to warm its startup path, the memory package implements the store layout for it, and the command line interface and state inspector both read it. Only the description was tied to the retired platform, so the environment variable reference and the matching comment in the toolshed environment schema now say what the mode does. It is one SQLite database holding every space, and it takes precedence over the per-space directory. The toolshed Dockerfile's note that its builder stage was modeled on Clusterduck's worker Dockerfile pointed at a file that no longer exists, and described where the stage came from rather than what it does, so that clause is gone and the surviving sentence keeps the substantive part about the Deno version pin.

A comment in the workflow records where the variable's value has to point, which is the same toolshed the rapids deploy job keeps current, rather than restating the hostname. Restating it would be one more copy to fall out of date, which is the failure this whole change is about.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the staging shell to read its API host from the `STAGING_SHELL_API_URL` repository variable and add CI checks to block bad builds. Also remove the last Clusterduck references and update docs.

- **New Features**
  - Read the API host from `STAGING_SHELL_API_URL` (repo or `ci` environment); not a secret since it ships in the bundle.
  - CI now fails if the URL is empty, missing from built scripts, or missing in the uploaded scripts read from the bucket (bypasses CDN).

- **Refactors**
  - Retired Clusterduck references: removed the `dev-clusterduck` task in `packages/shell/deno.jsonc` and related docs; trimmed outdated notes in `Dockerfile.toolshed`.
  - Clarified single-file memory mode: `DB_PATH` is one SQLite DB for all spaces and takes precedence over `MEMORY_DIR` (`packages/toolshed/env.ts`, `docs/development/CONFIGURATION.md`).
  - Added a “Staging shell” section to `docs/development/deploying.md` explaining the variable and the three checks, plus a workflow comment noting the host should point to the same toolshed `deploy-rapids` updates.

<sup>Written for commit a12a9ec8b660fc436332f39135397a24de5bd270. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

