### PR TITLE
dashboard: report cloud spend as money paid, over days the export has…

### DIFF
--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -183,7 +183,7 @@ surveillance tool.
 | production | synthetic HTTP check of the production server: `/_health` on `PROD_URL`'s origin, which answers only while the server is really serving. Defaults to estuary, the production toolshed. Estuary is on the tailnet, so a dashboard without direct tailnet access can route this check through `PROD_PROXY` or point `PROD_URL` at another truthful health source | `PROD_URL`, `PROD_PROXY` (optional) |
 | common.tools | synthetic HTTP check of the public site | `COMMON_TOOLS_URL` (optional; defaults to `https://common.tools`) |
 | prod errors | SigNoz trace error rate for one service (errored spans / all spans): last-12h headline, with a per-hour sparkline over the retained trace history (~2 weeks) and the last-12h slice that feeds the headline highlighted. Scoped to `PROD_SERVICE` — the same SigNoz holds staging and one-off perf runs, whose rates are not production's. Gray (not red) when SigNoz is unreachable. Pops out to the SigNoz logs explorer | `SIGNOZ_URL`, `SIGNOZ_API_KEY`; optional `PROD_SERVICE`, `SIGNOZ_UI_URL` for the pop-out |
-| cloud spend | BigQuery billing export, projected to month-end from the available part of a 14-day daily-cost window early in the month. The header shows actual MTD spend. The highlighted part of the 45-day chart shows the days used for the estimate | `GCP_BILLING_TABLE` (+ Workload Identity, or `GCP_SA_KEY` locally), optional `GCP_DAILY_BUDGET` |
+| cloud spend | BigQuery billing export, after credits, projected to month-end from the available part of a 14-day daily-cost window early in the month. The header shows actual MTD spend. The highlighted part of the 45-day chart shows the days used for the estimate | `GCP_BILLING_TABLE` (+ Workload Identity, or `GCP_SA_KEY` locally), optional `GCP_DAILY_BUDGET` |
 | ci spend | GitHub Actions and Blacksmith billing, projected to month-end in USD. Each configured source gets a line in the shared 45-day chart and an MTD label. The header shows combined MTD spend. A source that cannot be read shows `$???`, while the headline remains a lower bound from the sources that did respond | either or both of `GH_TOKEN` (with org billing read) and `BLACKSMITH_API_TOKEN`; optional `GH_BILLING_ORG`, `BLACKSMITH_ORG`, `CI_MONTHLY_BUDGET` |
 | benchmarks | a scale-invariant index of benchmark performance on `benchmarks.yml` main runs, trended over ~45 days (each run vs the last, geometric mean of per-benchmark changes, so every benchmark weighs the same): red when the most recent run failed or produced no valid data (the main signal), orange only on a broad across-the-board rise. Adding or removing a benchmark is a non-event. Drills through to the per-benchmark history | `GH_TOKEN` |
 | performance history → `/bench?view=runtime` | runtime benchmark trends, labs or loom CI duration history, and a detailed CI run Gantt. Historical views support windows from 1 through 45 days, date axes, and duration sorting. CI includes end-to-end workflow time, every job, and slowest-shard group lines | `GH_TOKEN` |
@@ -316,13 +316,36 @@ dataset.
 6. For local development instead, grant those two roles to a service account,
    download a key for it, and set `GCP_SA_KEY` to the file's contents.
 
-The tile sums the raw `cost` column, i.e. total spend across every project tied
-to the exported billing account, gross of credits. It shows the estimated
-full-month spend as its headline and the actual month-to-date value in the
-header. The estimate uses every settled day in the current month. During the
-first half of the month, it fills that rate window from the prior month's tail
-until it covers 14 days or reaches the first available billing day. The chart
-shows up to 45 complete UTC days and highlights the part used for the estimate.
+The tile covers every project tied to the exported billing account. Its figures
+are money that account actually pays: the export's `cost` column plus the credits
+the same rows carry, which are negative amounts. Every kind of credit counts —
+promotional credits, committed- and sustained-use discounts, and the free tier —
+because none of them is money the account pays. The credit is not a figure the
+tile reports on its own; it is simply absent from the spend, in the same way that
+the usage GitHub's plan includes is absent from the ci-spend figures.
+
+It shows the estimated full-month spend as its headline and the actual
+month-to-date value in the header. The estimate uses every settled day in the
+current month. During the first half of the month, it fills that rate window from
+the prior month's tail until it covers 14 days or reaches the first available
+billing day. The chart shows up to 45 finished UTC days and highlights the part
+used for the estimate.
+
+A day is finished when the export has stopped adding to it, which the tile reads
+from the export's own progress: a day counts as finished once a later day's usage
+has been written since that day was last written to. This matters because the
+export lands a day's usage in batches and goes on adding to a day well into the
+following one, so a day it has not finished holds only part of that day's cost.
+Such a day belongs in the month-to-date total, where it is a running figure, and
+not in the rate behind the projection or at the end of the chart, where it would
+read as spend falling away. When the export has finished no day for more than
+four days the tile goes gray and says how far behind it is, rather than
+projecting a month from stale history.
+
+A promotional credit is finite, so the spend the tile reports rises when a grant
+runs out even though nothing about the usage changed. How much of a grant is left
+is not in the billing export: Google publishes it only in the console's billing
+credits page.
 
 ### `OPENAI_ADMIN_KEY`
 

--- a/packages/dashboard/tiles/gcp-spend.test.ts
+++ b/packages/dashboard/tiles/gcp-spend.test.ts
@@ -66,10 +66,18 @@ const bigQueryStub = (rows: (string | null)[][]) => (url: string): Response =>
 const DAY = 86_400_000;
 const TABLE = "billing-proj.billing.gcp_billing_export_v1_XXXX";
 
+// One row per day, in the shape the query returns: the day, its cost before
+// credits, the credit that came off it (negative, as the export records it), and
+// the seconds-epoch time the export last added to that day. These fixtures export
+// each day eight hours in, so every day but the newest has a later day written
+// after it, which is what marks a day finished.
+const exportedAt = (day: string) => (Date.parse(`${day}T08:00:00Z`) / 1000);
+
 function dailyRows(
   first: string,
   last: string,
   amount: (day: string) => number,
+  credit: (day: string) => number = () => 0,
 ): string[][] {
   const rows: string[][] = [];
   for (
@@ -78,16 +86,24 @@ function dailyRows(
     time += DAY
   ) {
     const day = new Date(time).toISOString().slice(0, 10);
-    rows.push([day, String(amount(day))]);
+    rows.push([
+      day,
+      String(amount(day)),
+      String(credit(day)),
+      String(exportedAt(day)),
+    ]);
   }
   return rows;
 }
 
-const earlyMonthRows = () =>
+// Through to today, which the export is still writing: the newest finished day
+// is 2026-01-09, and today's own partial cost is $5.
+const earlyMonthRows = (credit: (day: string) => number = () => 0) =>
   dailyRows(
     "2025-11-26",
-    "2026-01-09",
-    (day) => day.startsWith("2026-01") ? 20 : 10,
+    "2026-01-10",
+    (day) => day === "2026-01-10" ? 5 : day.startsWith("2026-01") ? 20 : 10,
+    credit,
   );
 
 Deno.test(
@@ -105,7 +121,7 @@ Deno.test(
   "cloud spend: an unsafe table id is refused before any query",
   async () => {
     const { result, calls } = await withFetch(
-      bigQueryStub([["2026-01-09", "10"]]),
+      bigQueryStub([["2026-01-09", "10", "0"]]),
       () =>
         gcpSpend.collect(
           ctx({
@@ -134,13 +150,14 @@ Deno.test(
         ),
     );
 
-    // Nine complete January days at $20 plus five December days at $10 form
-    // the 14-day rate: $230 / 14 * 31 = about $509.
+    // Nine finished January days at $20 plus five December days at $10 form
+    // the 14-day rate: $230 / 14 * 31 = about $509. Today's $5 is in the
+    // month-to-date total and out of the rate.
     assertEquals(result.status, "good");
     assertEquals(result.value, "~$509/mo");
     assertEquals(
       result.aside,
-      '<span class="hmtd">$180 MTD</span>',
+      '<span class="hmtd">$185 MTD</span>',
     );
     assertEquals(result.sub, "billing account spend");
     assertEquals(result.duration, 45 * DAY);
@@ -161,6 +178,10 @@ Deno.test(
     );
     const sql = JSON.parse(query.body).query as string;
     assertStringIncludes(sql, "SUM(cost)");
+    assertStringIncludes(
+      sql,
+      "SUM((SELECT SUM(credit.amount) FROM UNNEST(credits) AS credit))",
+    );
     assertStringIncludes(sql, `\`${TABLE}\``);
     assertStringIncludes(sql, "INTERVAL 45 DAY");
     assertStringIncludes(
@@ -168,6 +189,44 @@ Deno.test(
       "DATE(usage_start_time) <= CURRENT_DATE()",
     );
     assertStringIncludes(sql, "GROUP BY day ORDER BY day");
+  },
+);
+
+Deno.test(
+  "cloud spend: credits come off every figure the tile reports",
+  async () => {
+    // A quarter off every day: $20 days cost $15, $10 days cost $7.50, and
+    // today's $5 so far costs $3.75. The tile reports only those amounts.
+    const { result } = await withFetch(
+      bigQueryStub(
+        earlyMonthRows((day) =>
+          day === "2026-01-10" ? -1.25 : day.startsWith("2026-01") ? -5 : -2.5
+        ),
+      ),
+      () =>
+        gcpSpend.collect(
+          ctx({
+            GCP_BILLING_TABLE: TABLE,
+            GCP_DAILY_BUDGET: "17",
+          }),
+        ),
+    );
+
+    // The same 14-day window, after credits: nine January days at $15 plus five
+    // December days at $7.50 is $172.50 / 14 * 31 = about $382.
+    assertEquals(result.value, "~$382/mo");
+    assertEquals(
+      result.aside,
+      '<span class="hmtd">$139 MTD</span>',
+    );
+    assertEquals(result.sub, "billing account spend");
+    // One line, for what the account pays. The credit is not a figure the tile
+    // reports, so nothing on it names or charts the cost before credits.
+    const polylines = [
+      ...(result.extra ?? "").matchAll(/<polyline points="([^"]+)"/g),
+    ];
+    assertEquals(polylines.length, 2);
+    assert(!(result.extra ?? "").includes("$185"));
   },
 );
 
@@ -204,7 +263,7 @@ Deno.test(
             "2025-12-31",
             () => 10,
           ),
-          ["2026-01-01", "7"],
+          ["2026-01-01", "7", "0", String(exportedAt("2026-01-01"))],
         ],
       ),
       () => gcpSpend.collect(ctx({ GCP_BILLING_TABLE: TABLE })),
@@ -230,14 +289,16 @@ Deno.test(
   "cloud spend: a short export history does not invent earlier zero-cost days",
   async () => {
     const { result } = await withFetch(
-      bigQueryStub([["2026-01-09", "20"]]),
+      bigQueryStub(dailyRows("2026-01-09", "2026-01-10", () => 20)),
       () => gcpSpend.collect(ctx({ GCP_BILLING_TABLE: TABLE })),
     );
 
+    // One finished day at $20 rates the month; today's $20 so far is only part
+    // of the month-to-date total, and one day is too few to chart.
     assertEquals(result.value, "~$620/mo");
     assertEquals(
       result.aside,
-      '<span class="hmtd">$20 MTD</span>',
+      '<span class="hmtd">$40 MTD</span>',
     );
     assertEquals(result.duration, 0);
     assertEquals(result.extra, "");
@@ -258,13 +319,11 @@ Deno.test(
 );
 
 Deno.test(
-  "cloud spend: a missing last complete day means billing data has not arrived",
+  "cloud spend: a single exported day is one the export has not finished",
   async () => {
+    // Nothing later has been written, so the export may still be adding to it.
     const { result } = await withFetch(
-      bigQueryStub([
-        ["2026-01-08", "20"],
-        ["2026-01-10", "5"],
-      ]),
+      bigQueryStub(dailyRows("2026-01-09", "2026-01-09", () => 20)),
       () => gcpSpend.collect(ctx({ GCP_BILLING_TABLE: TABLE })),
     );
     assertEquals(result.status, "unknown");
@@ -274,15 +333,57 @@ Deno.test(
 );
 
 Deno.test(
+  "cloud spend: days the export is still adding to stay out of the rate",
+  async () => {
+    const { result } = await withFetch(
+      bigQueryStub([
+        ...dailyRows("2026-01-01", "2026-01-07", () => 20),
+        // The export's newest write touched both of these days, so it has
+        // finished neither, and each holds part of a day's cost so far.
+        ["2026-01-08", "5", "0", String(exportedAt("2026-01-10"))],
+        ["2026-01-09", "5", "0", String(exportedAt("2026-01-10"))],
+      ]),
+      () => gcpSpend.collect(ctx({ GCP_BILLING_TABLE: TABLE })),
+    );
+
+    // Seven finished days at $20 rate the month at $620. Rating the two
+    // part-days as well would put it near $517.
+    assertEquals(result.value, "~$620/mo");
+    assertEquals(
+      result.aside,
+      '<span class="hmtd">$150 MTD</span>',
+    );
+    assertEquals(result.duration, 7 * DAY);
+  },
+);
+
+Deno.test(
+  "cloud spend: an export that has finished nothing for days is gray",
+  async () => {
+    const { result } = await withFetch(
+      bigQueryStub(dailyRows("2026-01-01", "2026-01-03", () => 20)),
+      () => gcpSpend.collect(ctx({ GCP_BILLING_TABLE: TABLE })),
+    );
+    assertEquals(result.status, "unknown");
+    assertEquals(result.value, "—");
+    assertEquals(result.sub, "billing export 8 days behind");
+  },
+);
+
+Deno.test(
   "cloud spend: malformed history is gray and never becomes a figure",
   async () => {
     for (
       const rows of [
-        [["2026-01-09", "not-a-number"]],
-        [["not-a-day", "10"]],
-        [["2026-99-99", "10"]],
-        [["2026-01-11", "10"]],
-        [["2026-01-09", null]],
+        [["2026-01-09", "not-a-number", "0", "1767000000"]],
+        [["not-a-day", "10", "0", "1767000000"]],
+        [["2026-99-99", "10", "0", "1767000000"]],
+        [["2026-01-11", "10", "0", "1767000000"]],
+        [["2026-01-09", null, "0", "1767000000"]],
+        [["2026-01-09", "10", "not-a-number", "1767000000"]],
+        [["2026-01-09", "10", null, "1767000000"]],
+        [["2026-01-09", "10", "0", "not-a-number"]],
+        [["2026-01-09", "10", "0", null]],
       ] as (string | null)[][][]
     ) {
       const { result } = await withFetch(

--- a/packages/dashboard/tiles/gcp-spend.ts
+++ b/packages/dashboard/tiles/gcp-spend.ts
@@ -1,26 +1,46 @@
 // cloud spend: month-to-date GCP cost from a BigQuery billing export, projected
-// to a full-month total. The daily series covers up to 45 complete UTC days.
-// The rate window is highlighted. Early in the month it reaches into available
-// prior-month history, up to a 14-day total. Today's partial cost contributes
-// only to the month-to-date total.
+// to a full-month total. Every figure is money the account actually pays: the
+// cost of its usage after the credits that come off it. The daily series covers
+// up to 45 finished UTC days. The rate window is highlighted. Early in the month
+// it reaches into available prior-month history, up to a 14-day total. Cost from
+// a day the export is still writing contributes only to the month-to-date total.
+//
+// The export lands a day's usage in batches, and goes on adding to a day well
+// into the following one, so a day it has not finished reads as a fall in spend
+// and would drag down any rate measured over it. A day counts as finished once
+// the export has written a later day's usage since it last wrote that day's,
+// because the export works forward through usage and does not return to a day it
+// has left behind. The chart and the rate window both end at the newest finished
+// day, and an export that has finished no day in several days grays the tile
+// rather than projecting from stale history.
 //
 // The tile uses the BigQuery REST API, without bq or gcloud. It authenticates as
 // the workload's service account in GKE, or with GCP_SA_KEY locally. That account
 // needs BigQuery Job User on the query project and Data Viewer on the dataset.
 import type { Tile, TileView } from "../types.ts";
 import { bigQuery } from "../gcp.ts";
-import { budgetStatus, readBudget, usd } from "../lib.ts";
+import { budgetStatus, daysLabel, readBudget, usd } from "../lib.ts";
 import { DAY_MS, SPEND_HISTORY_DAYS, spendChart, summarizeDailySpend } from "../spend.ts";
 
 const GCP_COLOR = "#4285f4";
-const GCP_LAG_DAYS = 1;
+// How far behind the newest finished day may fall before the tile stops
+// reporting. The export normally finishes a day within a day or two of it
+// ending, so this much silence is a broken export rather than a slow one.
+const MAX_EXPORT_LAG_DAYS = 4;
 
-// Daily gross cost for the trailing complete UTC days and today. Grouping in
-// BigQuery keeps the response small even when the export has many rows per
-// service.
+// Daily cost, credit, and export progress for the trailing UTC days and today.
+// A usage row carries its credits as a repeated field of negative amounts,
+// covering promotions, committed- and sustained-use discounts, and the free tier,
+// so what the account pays for that row is the two added together. The latest
+// export_time of a day's rows is when the export last added to that day.
+// Grouping in BigQuery keeps the response small even when the export has many
+// rows per service.
 const sqlFor = (table: string) =>
   `SELECT FORMAT_DATE('%F', DATE(usage_start_time)) AS day, ` +
-  `SUM(cost) AS cost FROM \`${table}\` ` +
+  `SUM(cost) AS cost, ` +
+  `IFNULL(SUM((SELECT SUM(credit.amount) FROM UNNEST(credits) AS credit)), 0) ` +
+  `AS credits, UNIX_SECONDS(MAX(export_time)) AS exported ` +
+  `FROM \`${table}\` ` +
   `WHERE DATE(usage_start_time) >= ` +
   `DATE_SUB(CURRENT_DATE(), INTERVAL ${SPEND_HISTORY_DAYS} DAY) ` +
   `AND DATE(usage_start_time) <= CURRENT_DATE() ` +
@@ -37,10 +57,21 @@ function dayTime(day: string): number | null {
   return new Date(parsed).toISOString().slice(0, 10) === day ? parsed : null;
 }
 
+function amount(cell: string | undefined): number {
+  const raw = cell ?? "";
+  return raw.trim() === "" ? NaN : Number(raw);
+}
+
+interface DailyCost {
+  paid: number; // cost after credits
+  exported: number; // when the export last added to this day, in seconds
+}
+
 interface DailyCostHistory {
-  complete: Map<string, number>;
-  actualMtd: number;
+  paid: Map<string, number>; // finished days, cost after credits
+  paidMtd: number; // this month so far, unfinished days included
   availableSince: string;
+  lagDays: number; // days from the newest finished day to today
 }
 
 function dailyCosts(
@@ -52,45 +83,60 @@ function dailyCosts(
     now.getUTCMonth(),
     now.getUTCDate(),
   );
-  const last = today - DAY_MS;
   const first = today - SPEND_HISTORY_DAYS * DAY_MS;
-  const parsed = new Map<string, number>();
+  const parsed = new Map<string, DailyCost>();
   let oldest = today;
   for (const row of rows) {
     const day = row[0] ?? "";
     const time = dayTime(day);
-    const raw = row[1] ?? "";
-    const cost = raw.trim() === "" ? NaN : Number(raw);
+    const cost = amount(row[1]);
+    const credit = amount(row[2]);
+    const exported = amount(row[3]);
     if (
       time === null ||
       time < first ||
       time > today ||
-      !Number.isFinite(cost)
+      !Number.isFinite(cost) ||
+      !Number.isFinite(credit) ||
+      !Number.isFinite(exported)
     ) {
       throw new Error("billing history has an unexpected shape");
     }
-    parsed.set(day, cost);
+    parsed.set(day, { paid: cost + credit, exported });
     oldest = Math.min(oldest, time);
   }
 
-  const lastDay = new Date(last).toISOString().slice(0, 10);
-  if (!parsed.has(lastDay)) return null;
+  // The newest day the export has finished with: walking back from the newest
+  // day, the first one the export stopped adding to before it wrote a later day.
+  const days = [...parsed.keys()].sort();
+  let laterExport = -Infinity;
+  let last: number | undefined;
+  for (let index = days.length - 1; index >= 0; index--) {
+    const exported = parsed.get(days[index])!.exported;
+    if (exported < laterExport) {
+      last = dayTime(days[index])!;
+      break;
+    }
+    laterExport = Math.max(laterExport, exported);
+  }
+  if (last === undefined) return null;
 
-  // Missing dates after the first exported date are real quiet days once the
-  // query's one-day billing lag has elapsed.
-  const complete = new Map<string, number>();
+  // Missing dates after the first exported date are real quiet days: the export
+  // has moved past them, so there was nothing to bill.
+  const paid = new Map<string, number>();
   for (let time = oldest; time <= last; time += DAY_MS) {
     const day = new Date(time).toISOString().slice(0, 10);
-    complete.set(day, parsed.get(day) ?? 0);
+    paid.set(day, parsed.get(day)?.paid ?? 0);
   }
   const monthPrefix = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}-`;
-  const actualMtd = [...parsed]
+  const paidMtd = [...parsed]
     .filter(([day]) => day.startsWith(monthPrefix))
-    .reduce((sum, [, cost]) => sum + cost, 0);
+    .reduce((sum, [, cost]) => sum + cost.paid, 0);
   return {
-    complete,
-    actualMtd,
+    paid,
+    paidMtd,
     availableSince: new Date(oldest).toISOString().slice(0, 10),
+    lagDays: (today - last) / DAY_MS,
   };
 }
 
@@ -152,12 +198,23 @@ export const gcpSpend: Tile = {
         sub: "no billing data yet",
       };
     }
+    if (history.lagDays > MAX_EXPORT_LAG_DAYS) {
+      return {
+        label,
+        status: "unknown",
+        value: "—",
+        sub: `billing export ${daysLabel(history.lagDays)} behind`,
+      };
+    }
 
+    // The rate window stops at the newest finished day, which the export leaves
+    // this many days back, so the days it is still writing are left out of the
+    // rate rather than counted as days that spent nothing.
     const summary = summarizeDailySpend(
-      history.complete,
+      history.paid,
       now,
       {
-        lagDays: GCP_LAG_DAYS,
+        lagDays: history.lagDays,
         availableSince: history.availableSince,
       },
     );
@@ -168,7 +225,7 @@ export const gcpSpend: Tile = {
     const monthlyBudget = dailyBudget * daysInMonth;
     const status = budgetStatus(summary.projected, monthlyBudget);
     const chart = spendChart(
-      [{ spend: { byDay: history.complete }, color: GCP_COLOR }],
+      [{ spend: { byDay: history.paid }, color: GCP_COLOR }],
       now,
       status,
       summary.estimateDays,
@@ -178,7 +235,7 @@ export const gcpSpend: Tile = {
       label,
       status,
       value: `~${usd(summary.projected)}/mo`,
-      aside: `<span class="hmtd">${usd(history.actualMtd)} MTD</span>`,
+      aside: `<span class="hmtd">${usd(history.paidMtd)} MTD</span>`,
       sub: "billing account spend",
       extra: chart.chart,
       duration: chart.duration,


### PR DESCRIPTION
… finished

The cloud-spend tile summed the billing export's `cost` column, which is the price of the usage before anything comes off it. The billing account earns credits — a promotional grant, plus committed- and sustained-use discounts and the free tier — and none of that is money anyone pays, so every figure on the tile overstated the bill by whatever the credits covered. On the production export that is around a fifth of the total, and the promotional part arrives as a lump each month that covers several days of usage outright, so the overstatement was neither small nor steady.

A usage row carries its credits as a repeated field of negative amounts, so the amount actually paid for that row is the cost and the credits added together. The query now sums both per day, and the headline, the month-to-date total in the header, the rate behind the projection, and the chart are all money paid. Nothing on the tile reports the credit itself: a spend tile answers how much money left the account, and a credit belongs in the arithmetic behind that answer rather than as a figure of its own.

The tile also treated yesterday as a complete day, which the export does not deliver. It lands usage in batches and goes on adding to a day well into the following one: a day is around two thirds written when it ends and only settles about noon the next day. So for most of every UTC day the chart ended on a point a third to a half below the real figure, and the projection was rated over that part-day too. The query now also reads the latest export_time of each day's rows, which is when the export last added to that day. A day counts as finished once a later day's usage has been written since that day was last written to, because the export works forward through usage and does not come back to a day it has left behind. The chart and the rate window end at the newest finished day, and how far back that day sits becomes the lag the shared spend summary uses, so the days still being written stay out of the rate instead of counting as days that spent nothing.

An export that has finished no day for more than four days now grays the tile and says how far behind it is. That replaces a check that refused to report at all unless yesterday had rows, which made a single missing day look the same as an export that had stopped.

A promotional grant is finite, so the reported spend will rise when one runs out even though the usage has not changed. How much of a grant is left is not in the billing export; Google publishes it only in the console's billing credits page.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Report GCP cloud spend as actual money paid (cost after credits) and base projections on finished export days for accurate month-to-date and forecasts.

- **New Features**
  - Sum `cost` plus per-row credits; headline, MTD, projection, and chart are net of promotional, committed-use, sustained-use, and free-tier credits. Credits are not shown as a separate line.
  - Use `export_time` to include only finished days in the chart and projection; MTD still includes in-progress days. Early month backfills the 14‑day rate window from the prior month when needed.
  - Gray the tile and show “billing export N days behind” if no day has finished in >4 days, replacing the previous “yesterday must have rows” check.
  - Updated `README` and tests to reflect the new behavior.

<sup>Written for commit f6779eb203080d4089e89f8bb5036c115282baac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

