### PR TITLE
fix(state-inspector,cli): make a rehearsal reset reach the server serving it

### DIFF
--- a/docs/development/space-clone-rehearsal.md
+++ b/docs/development/space-clone-rehearsal.md
@@ -101,9 +101,11 @@ immediately afterwards — sees the restored one. Pass two would run against pas
 one's state while `cf space verify` reported the clone pristine, which is
 exactly what the two-pass procedure exists to rule out.
 
-`cf space reset` refuses while anything still holds the working copy, so this is
-enforced rather than remembered. Restart the server (step 2) before the next
-pass.
+`cf space reset` refuses while anything still holds the working copy, so
+forgetting is loud rather than silent. Treat that as a tripwire, not a
+guarantee: it cannot stop a server that opens the store in the instant between
+the check and the restore, and no external check can. **Stopping the server is
+what makes the reset correct.** Restart it (step 2) before the next pass.
 
 ## Reading the verdict
 

--- a/docs/development/space-clone-rehearsal.md
+++ b/docs/development/space-clone-rehearsal.md
@@ -47,12 +47,26 @@ does this for you.
 ## The loop
 
 ```bash
-# 1. Clone. --from takes a path or an https URL.
+# 1. Clone. --from takes a path, or an https URL (plaintext http is refused
+#    outside loopback: a snapshot is the whole contents of the space).
 deno task cf space clone <space-did> --from <snapshot> --to ~/clones/<name>
+```
 
-# 2. Serve it — note the port offset; the clone keeps the source space's DID,
-#    so the port is what distinguishes it from production.
-MEMORY_DIR="file://$HOME/clones/<name>/" \
+`clone` prints the exact serve command and the **working database path**. Keep
+that path: every offline read below takes it explicitly, because the clone keeps
+the source space's DID and lives outside the directories `cf inspect` searches.
+Naming the space instead would resolve to whichever same-DID store discovery
+happens to find — usually this checkout's `cache/memory`, silently.
+
+```bash
+CLONE=~/clones/<name>
+DB=$CLONE/engine-v3/engine-v3/<space-did>.sqlite
+
+# 2. Serve it. The clone keeps the source space's DID, so the host and port are
+#    the ONLY things distinguishing it from production — HOST pins it to
+#    loopback (the toolshed otherwise binds 0.0.0.0, putting a second store
+#    answering to production's identity on the network).
+HOST=127.0.0.1 MEMORY_DIR="file://$CLONE/" \
   ./scripts/start-local-dev.sh --port-offset 10
 ```
 
@@ -61,20 +75,35 @@ not see it, you are pointed at something else — stop and check before writing.
 
 ```bash
 # 3. Baseline, before touching anything.
-deno task cf space verify ~/clones/<name>
-deno task cf inspect churn <space> --bucket 60      # confirm a quiet window
+deno task cf space verify $CLONE
+deno task cf inspect churn $DB --bucket 60 --until "$(date -u '+%Y-%m-%d %H:%M:%S')"
 
 # 4. Run the update against the CLONE's api-url. Children first, board last,
 #    serially — the parent's result recomputation is what storms.
 deno task cf piece setsrc … --api-url http://localhost:8010 …
 
-# 5. Judge it.
-deno task cf space verify ~/clones/<name> --expect-migration   # nonzero = baseline corrupt or entities REMOVED
-deno task cf inspect churn <space> --bucket 60 --since '<when you started>'
+# 5. Judge it. --expect-migration gates on removal, not on change.
+deno task cf space verify $CLONE --expect-migration
+deno task cf inspect churn $DB --bucket 60 \
+  --since '<when you started>' --until "$(date -u '+%Y-%m-%d %H:%M:%S')"
 
-# 6. Reset and go again.
-deno task cf space reset ~/clones/<name>
+# 6. Reset and go again. STOP THE SERVER FIRST — see below.
+./scripts/stop-local-dev.sh --port-offset 10
+deno task cf space reset $CLONE
 ```
+
+### Stop the server before resetting
+
+Not a tidiness rule. Unlinking a file does not reach a process that already has
+it open: a running toolshed keeps reading and writing the *unlinked* database
+while every new reader — including the `verify` that `cf space reset` runs
+immediately afterwards — sees the restored one. Pass two would run against pass
+one's state while `cf space verify` reported the clone pristine, which is
+exactly what the two-pass procedure exists to rule out.
+
+`cf space reset` refuses while anything still holds the working copy, so this is
+enforced rather than remembered. Restart the server (step 2) before the next
+pass.
 
 ## Reading the verdict
 
@@ -108,17 +137,66 @@ is not optional.
 - **`baseline CORRUPTED`** — the pristine snapshot no longer matches the
   manifest. Do not reset to it; re-clone.
 
+If `verify` reports entities it **could not hash** or ids it calls **ambiguous**,
+those are absent from the verdict — it is speaking for less than the whole
+store, and how much less is the number it printed.
+
 Per-entity hashes, when you need to see exactly which entities moved:
 
 ```bash
-deno task cf space fingerprint <clone>/engine-v3/engine-v3/<did>.sqlite --per-entity
+deno task cf space fingerprint $DB --per-entity
 ```
 
-To compare **authored** content directly, read each topic's *input* (argument)
-cell from the pristine and working stores and diff titles, bodies, and comment
-and link counts. That is what "durable content fingerprint unchanged" meant in
-#4997, and it is a different check from `cf space verify` — the one that
-actually answers whether the content survived.
+### Checking authored content — the step that is not optional
+
+`--expect-migration` **cannot** do this, and no whole-store hash can: overwriting
+a title is a *change*, indistinguishable from the result rewrite every successful
+migration performs. So compare the authored cells directly, pristine against
+working. They are the same fingerprint, restricted to the entities you authored:
+
+```bash
+PRISTINE=$CLONE/pristine/<space-did>.sqlite
+
+# Every entity hash on each side, generated cells excluded (--json always
+# carries the per-entity list).
+deno task cf space fingerprint $PRISTINE --json > /tmp/before.json
+deno task cf space fingerprint $DB       --json > /tmp/after.json
+
+# The entities that changed, by kind — the list `verify` only counts.
+jq -r --slurpfile b /tmp/before.json '
+  ($b[0].perEntity | map({key: (.id+" "+.scope), value: .hash}) | from_entries) as $was
+  | .perEntity[] | select($was[.id+" "+.scope] != null and $was[.id+" "+.scope] != .hash)
+  | "\(.kind)\t\(.id)"' /tmp/after.json | sort | uniq -c
+```
+
+A piece's **argument** cell holds what a human typed; its **result** and owned
+cells hold what the pattern computed. A migration rewrites the second group and
+leaves the first byte-identical, so the reading is:
+
+- `owned-cell` — expected. The migration doing its job.
+- `free-cell` — **investigate.** Argument cells are not owned by a piece and
+  land here, so a changed one is a clobber rather than a migration.
+
+Resolve which entity is a given piece's argument with:
+
+```bash
+deno task cf inspect piece $DB <piece-fid>    # prints `input:` and `result:`
+```
+
+Worked example, on a clone where one authored input was overwritten and one
+derived cell legitimately migrated:
+
+```
+$ cf space verify $CLONE --expect-migration   # exit 0 — it cannot see this
+$ …the jq above…
+   1 free-cell   of:input       ← the clobber
+   1 owned-cell  of:named       ← the migration
+```
+
+For a board of like-shaped children, the cheap version is a count and a spot
+check: every child still present, comment and link totals unchanged, and two or
+three bodies read back in full — including one with Markdown, since trimming is
+the failure that hides best.
 
 Compiler-generated internal cells are excluded by default, because a pattern
 update rotates their identities on purpose. Including them (`--include-generated`)
@@ -128,6 +206,14 @@ answers "what moved at all?", never "did content survive?".
 is the storm shape: a jump to a **sustained plateau**, not a spike. The July 2026
 incident ran at ~1,300 commits/minute for twenty minutes. A settle means the rate
 returns to baseline *and stays there*.
+
+Pass `--until` with the moment you stopped watching, as the loop above does.
+Without it the curve ends at the last write, which for a storm that has just
+stopped is its busiest bucket — so it can show a storm but never a settle. With
+it, the trailing quiet minutes are reported, and the footer prints `last commit`
+against `observed through`: the gap between them is the evidence. A mistyped
+bound is refused rather than silently matching no commits, which would otherwise
+report the window as quiet.
 
 ## Driving the migration
 
@@ -170,7 +256,16 @@ These are all failures that actually happened, not hypotheticals:
 
 ## Before going live
 
-- Two consecutive clean passes on the clone, resetting between them.
+- Two consecutive clean passes on the clone, **stopping the server, resetting,
+  and restarting between them**. A pass is clean when all four hold: `verify
+  --expect-migration` exits zero, the authored-content check above shows no
+  changed argument cells, churn settles within an observed window, and the
+  semantic acceptance checks for the specific board pass.
 - A rollback manifest written down *before* the live attempt: the pristine
   snapshot path and the exact reset command.
 - Then repeat steps 3–5 against production, with that manifest in hand.
+
+A note on what a clean pass is *not*: `cf space verify --expect-migration` exits
+zero on an untouched clone, on a half-finished migration, and on one that
+overwrote every authored title in place. It is a removal alarm, not a migration
+verdict — the other three items are what make a pass mean something.

--- a/docs/plans/topics-migration-rehearsal.md
+++ b/docs/plans/topics-migration-rehearsal.md
@@ -241,7 +241,8 @@ Stopping the server first is not tidiness: a reset unlinks the database, which
 does not reach a process that already holds it open. A running toolshed would
 keep serving pass one's state while `cf space verify` reported the clone
 pristine. `cf space reset` refuses while the store is held, so a forgotten stop
-fails loudly instead of silently invalidating the pass.
+fails loudly instead of silently invalidating the pass — but that check is a
+tripwire, not a lock. The stop is what makes the reset correct.
 
 Two consecutive clean passes before going live — see the generic runbook's
 "Before going live" for what makes a pass clean, which is more than this

--- a/docs/plans/topics-migration-rehearsal.md
+++ b/docs/plans/topics-migration-rehearsal.md
@@ -56,15 +56,29 @@ to cross-version write storms. The run is therefore *two* legacy→current
 transitions, and #4997's dangling-author and recursive-crossref fixes have to
 hold for both.
 
-Reproduce the grouping at any time with:
+Reproduce the grouping — and get the FID list itself — from the snapshot. This
+is the migration manifest: run it before pass one, check the output in, and diff
+against it before the live attempt.
 
 ```bash
-deno task cf inspect piece <space> <topic-fid>   # per piece
+# every piece in the space, with the pattern identity it currently carries
+deno task cf inspect entities $DB --kind piece --json \
+  | jq -r '.[].id' \
+  | while read -r id; do
+      deno task cf inspect piece $DB "$id" --json \
+        | jq -r '[.id, (.pattern.identity // "unresolved"), (.pattern.filename // "-")] | @tsv'
+    done | sort -k2 > topics-manifest.tsv
+
+# the 74 in scope: the board plus everything on either topic generation
+grep -E 'PB0GumS5vkDPyKAWciwh-4UtypoJwKFUXcDj3SsspHY|-85Wmyd9iwUjbpwnTYR2YolxkMUHup9WHY6YsRUDA1E|WpIRvAWL_WW45Q89ekZAlHWLObhQ16NDmQzvv_q2aI8' \
+  topics-manifest.tsv | cut -f2 | sort | uniq -c   # expect 39 / 34 / 1
 ```
 
-or read `patternIdentity` from each topic document directly — the board's
-`topics` input holds wrapper cells, so follow each wrapper's `result` link one
-hop to reach the piece that carries `patternIdentity`.
+The count check is the point: the space holds 319 pieces across 150 identities,
+so "did I migrate the right 74?" is a question the manifest answers and a
+hand-copied list does not. It is also the rollback record — the second column is
+the source id to `setsrc` back to, which the Going-live section requires be
+captured before starting.
 
 **Upgrading to:** `packages/patterns/topics/{topic,main}.tsx` at current `main`
 (#4997's legacy-safety fixes plus #4991's body-at-create and thrown
@@ -93,16 +107,25 @@ a sustained plateau rather than a burst.
 
 ## Open decisions — resolve before running
 
-1. **Starting state.** The Risks section says rehearse **old→populate→new**.
-   A clone of today's board is already mid-state: 73 legacy-schema topics under
-   a pre-rework board. Options: (a) migrate the clone as-is, which rehearses the
-   *actual* transition that will happen live; (b) build a synthetic old→new
-   sequence in a scratch space, which tests the transition in isolation but not
-   against real data. **(a) is what #4997's rehearsal did** and what the tooling
-   is built for. Confirm this reading before running.
+1. ~~**Starting state.**~~ **Resolved: (a), migrate a clone of the current
+   production snapshot as-is.** The Risks section says rehearse
+   **old→populate→new**, but a clone of today's board is already mid-state: 73
+   legacy-schema topics under a pre-rework board. Migrating it rehearses the
+   *actual* transition that will happen live, which is what a rehearsal is for;
+   it is what #4997's rehearsal did and what the tooling is built for. A
+   synthetic old→populate→new sequence in a scratch space is worth having as
+   compatibility coverage, but it cannot substitute — it tests the transition in
+   isolation and not against real data, and the failures this migration is
+   guarding against (two live generations, results read by a parent) are
+   properties of the real store.
 2. ~~**Which pattern revision** to `setsrc`.~~ **Resolved 2026-07-29: latest
    `main`.** It is the transition that will actually happen, and #4997's
    legacy-safety fixes are what make the legacy→current jump survivable.
+   **Pin the SHA at pass one and reuse it** for pass two and the live run
+   (`git rev-parse HEAD`, recorded beside the manifest). "Latest `main`" moves,
+   and two passes against different sources are not two passes of the same
+   rehearsal — the whole point of resetting between them is that the only thing
+   varying is the attempt.
 3. **Whether one clean pass is enough.** The generic runbook asks for two
    consecutive clean passes; a 1.0 GB clone makes each attempt ~15 s of clone
    plus the migration itself. Cheap enough to keep the bar at two.
@@ -114,12 +137,28 @@ Clone and serve per the generic runbook. Then:
 ### Baseline
 
 ```bash
-deno task cf space verify <clone>                    # record fingerprint + counts
-deno task cf inspect churn <did> --bucket 60         # confirm a quiet window
+CLONE=~/clones/topics
+DB=$CLONE/engine-v3/engine-v3/did:key:z6MkjcdxtxTiUWkPkPffhs8ENkCcJjuRCQPpJFb2xyzwHqEk.sqlite
+
+deno task cf space verify $CLONE                     # record fingerprint + counts
+deno task cf inspect churn $DB --bucket 60 \
+  --until "$(date -u '+%Y-%m-%d %H:%M:%S')"          # confirm a quiet window
 ```
 
+The churn read takes the clone's **database path**, not the DID: the clone lives
+outside the directories `cf inspect` searches, and naming the space would
+resolve to whichever same-DID store discovery finds — usually this checkout's
+`cache/memory`, silently. `--until` is what makes a quiet window observable
+rather than assumed (generic runbook, "Reading the verdict").
+
 Record: topic count (expect 73), comment and link totals, the content
-fingerprint, and `max(seq)`.
+fingerprint, and `max(seq)`. The first two come from the baseline fingerprint
+dump the generic runbook's authored-content check already produces:
+
+```bash
+deno task cf space fingerprint $CLONE/pristine/<did>.sqlite --json > /tmp/before.json
+jq '[.perEntity[] | .kind] | group_by(.) | map({(.[0]): length}) | add' /tmp/before.json
+```
 
 ### Migrate — children first, board last, serially
 
@@ -149,9 +188,18 @@ run, and the verification below is the only thing that is.
 ### Verify
 
 ```bash
-deno task cf space verify <clone>                    # nonzero exit if content moved
-deno task cf inspect churn <did> --bucket 60 --since '<start>'
+# --expect-migration is REQUIRED here: without it, verify is strict and exits
+# nonzero on any change at all — which every successful migration is, because
+# each piece's result value is rewritten.
+deno task cf space verify $CLONE --expect-migration
+deno task cf inspect churn $DB --bucket 60 \
+  --since '<start>' --until "$(date -u '+%Y-%m-%d %H:%M:%S')"
 ```
+
+Then the authored-content check from the generic runbook ("Checking authored
+content — the step that is not optional"). It is not optional here either:
+`--expect-migration` gates on removal, and overwriting a topic body is a change,
+so this run's own gate cannot see the failure mode that matters most.
 
 Then the acceptance items from the implementation plan's live checklist, which
 `cf space verify` cannot cover because they are semantic:
@@ -174,17 +222,44 @@ Then the acceptance items from the implementation plan's live checklist, which
   half-migration on its own: leaving generation B behind changes no authored
   content, so the fingerprint is unmoved and the counts merely grow.
 
-`cf space verify` reporting `content unchanged` while commit counts grow is the
-expected result: a migration writes, and generated cells are excluded from the
-fingerprint precisely because they rotate.
+The expected `cf space verify` result is **`content CHANGED` with `removed 0`**,
+and the per-kind tally confined to pieces and their derived cells. Generated
+cells are excluded from the fingerprint because they rotate, but *results* are
+not — and a schema update rewrites every piece's result — so `content unchanged`
+after this migration would mean the migration did not land, not that it landed
+cleanly.
 
 ### Reset and repeat
 
 ```bash
-deno task cf space reset <clone>
+./scripts/stop-local-dev.sh --port-offset 10     # required, see below
+deno task cf space reset $CLONE
+# then restart per the generic runbook's step 2 before the next pass
 ```
 
-Two consecutive clean passes before going live.
+Stopping the server first is not tidiness: a reset unlinks the database, which
+does not reach a process that already holds it open. A running toolshed would
+keep serving pass one's state while `cf space verify` reported the clone
+pristine. `cf space reset` refuses while the store is held, so a forgotten stop
+fails loudly instead of silently invalidating the pass.
+
+Two consecutive clean passes before going live — see the generic runbook's
+"Before going live" for what makes a pass clean, which is more than this
+command's exit code.
+
+### If the run stops partway
+
+Resource exhaustion wedged the server in the first real rehearsal, and it will
+happen again on a 1 GB store. The migration is durable: already-migrated pieces
+stay migrated. To resume, re-read which pieces still carry an old identity and
+continue from there rather than restarting the pass:
+
+```bash
+deno task cf inspect piece $DB <topic-fid>     # `pattern:` line carries the identity
+```
+
+Only start a fresh pass (stop, reset, restart) if you cannot account for every
+piece — a pass whose midpoint is unknown is not one of the two clean passes.
 
 ## Going live
 

--- a/packages/cli/commands/inspect.ts
+++ b/packages/cli/commands/inspect.ts
@@ -684,8 +684,18 @@ export const inspect = new Command()
   .option("--bucket <seconds:number>", "Bucket width in seconds.", {
     default: 60,
   })
-  .option("--since <time:string>", "Lower bound on commit time (inclusive).")
-  .option("--until <time:string>", "Upper bound on commit time (exclusive).")
+  .option(
+    "--since <time:string>",
+    "Lower bound on commit time (inclusive). Also widens the curve to cover " +
+      "the whole window asked for.",
+  )
+  .option(
+    "--until <time:string>",
+    "Upper bound on commit time (exclusive). This is the observation " +
+      "boundary: pass the moment you stopped watching and the trailing quiet " +
+      "buckets are reported, which is what shows a storm SETTLED rather than " +
+      "merely ended at the last write.",
+  )
   .option("--top <n:number>", "Entities to attribute the peak bucket to.", {
     default: 10,
   })
@@ -721,7 +731,13 @@ export const inspect = new Command()
               `revisions over ${report.buckets.length} × ${report.bucketSeconds}s` +
               `\npeak ${report.peak.start}: ${
                 commitsPerMinute(report.peak, report.bucketSeconds).toFixed(1)
-              } commits/min`,
+              } commits/min` +
+              // Where writing stopped, against where watching stopped. A curve
+              // that merely ran out of data ends on its last write; one that
+              // was observed through a quiet period ends after it. Only the
+              // second is evidence of a settle, and they render identically
+              // without both numbers.
+              `\nlast commit ${report.lastCommit}, observed through ${report.to}`,
           );
           for (const e of report.peakEntities) {
             console.log(

--- a/packages/cli/commands/space.ts
+++ b/packages/cli/commands/space.ts
@@ -25,6 +25,7 @@ import {
   resetClone,
   resolveSpace,
   verifyClone,
+  type VerifyResult,
 } from "@commonfabric/state-inspector";
 import { contentFingerprint } from "@commonfabric/state-inspector";
 import { hasJsonArgument } from "../lib/json-output.ts";
@@ -86,6 +87,42 @@ function assertConfidentialTransport(url: string): void {
 }
 
 /**
+ * How many redirects to follow. A cycle guard, not a retry budget: each hop is
+ * a different URL, and a server that keeps redirecting is misconfigured rather
+ * than slow.
+ */
+const MAX_REDIRECTS = 5;
+
+/**
+ * `fetch`, checking the transport of EVERY hop.
+ *
+ * `fetch` follows redirects itself and reports only the final response, so
+ * validating the URL an operator typed proves nothing about where the bytes
+ * came from: an https URL that 302s to plaintext http would put the whole space
+ * on the wire in the clear, having passed the check. Following by hand is the
+ * only way the refusal can cover the request that actually carries the body.
+ */
+async function fetchFollowingRedirects(url: string): Promise<Response> {
+  let current = url;
+  for (let hop = 0;; hop++) {
+    assertConfidentialTransport(current);
+    const response = await fetch(current, { redirect: "manual" });
+    const location = response.headers.get("location");
+    const redirected = response.status >= 300 && response.status < 400 &&
+      location !== null;
+    if (!redirected) return response;
+    await response.body?.cancel();
+    if (hop === MAX_REDIRECTS) {
+      throw new Error(
+        `could not download ${url}: more than ${MAX_REDIRECTS} redirects.`,
+      );
+    }
+    // Resolve against the current URL: a `Location` may be relative.
+    current = new URL(location, current).toString();
+  }
+}
+
+/**
  * Download a remote snapshot to a temp file so `--from` can take a URL.
  *
  * Returns the staging directory alongside the path so the caller can remove it:
@@ -101,8 +138,7 @@ function assertConfidentialTransport(url: string): void {
 async function fetchSnapshot(
   url: string,
 ): Promise<{ path: string; stagingDir: string }> {
-  assertConfidentialTransport(url);
-  const response = await fetch(url);
+  const response = await fetchFollowingRedirects(url);
   if (!response.ok || response.body === null) {
     await response.body?.cancel();
     throw new Error(`could not download ${url}: HTTP ${response.status}`);
@@ -156,6 +192,38 @@ function uncertaintyNote(
     );
   }
   return notes.map((n) => `${indent}⚠ ${n}\n`).join("");
+}
+
+/**
+ * The uncertainty lines for a verify, covering BOTH sides of the comparison.
+ *
+ * Reporting only the working copy's counts would hide the case the diff is
+ * least able to see. An entity excluded from the BASELINE is absent from the
+ * "before" side, so if it is still excluded now the diff cannot compare it at
+ * all and a change to it is silent — that blind spot belongs to the baseline
+ * and does not show up in a working-copy count. An older clone that never
+ * recorded the numbers is the same situation with the size unknown, which is a
+ * weaker claim than zero and must not render as zero.
+ */
+function verifyUncertaintyNote(u: VerifyResult["uncertainty"]): string {
+  const working = uncertaintyNote(
+    u.unhashable.working,
+    u.ambiguous.working,
+    "",
+  );
+  const { unhashable, ambiguous } = u;
+  if (unhashable.manifest === null || ambiguous.manifest === null) {
+    return working +
+      `⚠ this clone predates uncertainty recording, so how much its BASELINE ` +
+      `excluded is unknown; re-clone for a verdict that can say\n`;
+  }
+  const baseline = uncertaintyNote(unhashable.manifest, ambiguous.manifest, "");
+  if (baseline === "") return working;
+  return working +
+    baseline.replace(
+      /^⚠ /gm,
+      "⚠ in the BASELINE: ",
+    );
 }
 
 export const space = new Command()
@@ -287,11 +355,7 @@ export const space = new Command()
           `content    ${fingerprint.match ? "unchanged" : "CHANGED"}\n` +
           `commits    ${counts.manifest.commits} → ${counts.working.commits}\n` +
           `revisions  ${counts.manifest.revisions} → ${counts.working.revisions}\n` +
-          uncertaintyNote(
-            result.uncertainty.unhashable.working,
-            result.uncertainty.ambiguous.working,
-            "",
-          ) +
+          verifyUncertaintyNote(result.uncertainty) +
           `\n` +
           (!result.baselineIntact
             ? "BASELINE CORRUPTED — the pristine snapshot no longer matches the " +

--- a/packages/cli/commands/space.ts
+++ b/packages/cli/commands/space.ts
@@ -64,28 +64,99 @@ function fromFileUrl(url: string): string {
 }
 
 /**
+ * Reject a snapshot URL that would put a whole space on the wire in the clear.
+ *
+ * A snapshot is the entire contents of a space — the same confidentiality
+ * judgement that keeps the dump endpoint hard-off in production — so plaintext
+ * transport is refused rather than merely discouraged in the help text.
+ * Loopback is the exception: it never leaves the machine, and the tests serve
+ * fixtures over it.
+ */
+function assertConfidentialTransport(url: string): void {
+  const parsed = new URL(url);
+  if (parsed.protocol === "https:") return;
+  const loopback = parsed.hostname === "127.0.0.1" ||
+    parsed.hostname === "::1" || parsed.hostname === "localhost";
+  if (parsed.protocol === "http:" && loopback) return;
+  throw new ValidationError(
+    `refusing to download a snapshot over ${parsed.protocol}//: a whole-space ` +
+      `snapshot is the entire contents of the space. Use https, or copy the ` +
+      `file down yourself and pass a path.`,
+  );
+}
+
+/**
  * Download a remote snapshot to a temp file so `--from` can take a URL.
  *
  * Returns the staging directory alongside the path so the caller can remove it:
  * a real snapshot is gigabytes, and leaving one per invocation in the system
  * temp directory would be a quiet disk leak.
+ *
+ * Cleanup on the failure paths belongs HERE, not with the caller: once this
+ * function throws it has never returned the directory, so no caller can be
+ * holding a handle to remove. A stream that dies mid-download — the likeliest
+ * failure at gigabyte scale, and the one a non-2xx check cannot catch — would
+ * otherwise strand a partial file the size of however much arrived.
  */
 async function fetchSnapshot(
   url: string,
 ): Promise<{ path: string; stagingDir: string }> {
+  assertConfidentialTransport(url);
   const response = await fetch(url);
   if (!response.ok || response.body === null) {
+    await response.body?.cancel();
     throw new Error(`could not download ${url}: HTTP ${response.status}`);
   }
   const stagingDir = await Deno.makeTempDir({ prefix: "cf-space-clone-" });
   const path = `${stagingDir}/snapshot.sqlite`;
-  using file = await Deno.open(path, { write: true, create: true });
-  await response.body.pipeTo(file.writable);
+  try {
+    const file = await Deno.open(path, { write: true, create: true });
+    // `pipeTo` closes the destination on success and aborts it on failure, so
+    // the handle needs no separate disposal — and must not be given one, since
+    // closing an already-closed file is itself an error.
+    await response.body.pipeTo(file.writable);
+  } catch (error) {
+    await Deno.remove(stagingDir, { recursive: true }).catch(() => {});
+    throw error;
+  }
   return { path, stagingDir };
 }
 
 const bytes = (n: number): string =>
   n >= 1e9 ? `${(n / 1e9).toFixed(2)} GB` : `${(n / 1e6).toFixed(1)} MB`;
+
+/**
+ * The line that says how much of the store the fingerprint could not speak for.
+ *
+ * Printed only when there is something to say, but never suppressed when there
+ * is: a verdict computed over an unknown fraction of a space reads exactly like
+ * one computed over all of it, and this is the only place that difference
+ * becomes visible to an operator.
+ */
+function uncertaintyNote(
+  unhashable: number | null | undefined,
+  ambiguous: number | null | undefined,
+  indent: string,
+): string {
+  const notes: string[] = [];
+  if (unhashable) {
+    notes.push(
+      `${unhashable} entit${
+        unhashable === 1 ? "y" : "ies"
+      } could not be hashed and ` +
+        `${unhashable === 1 ? "is" : "are"} absent from this verdict`,
+    );
+  }
+  if (ambiguous) {
+    notes.push(
+      `${ambiguous} id(s) generated in one manifest and named in another, ` +
+        `counted as generated — a change to ${
+          ambiguous === 1 ? "it" : "them"
+        } would not show`,
+    );
+  }
+  return notes.map((n) => `${indent}⚠ ${n}\n`).join("");
+}
 
 export const space = new Command()
   .name("space")
@@ -164,10 +235,22 @@ export const space = new Command()
           `  content    ${manifest.fingerprint.hash}\n` +
           `             ${manifest.fingerprint.entities} entities fingerprinted, ` +
           `${manifest.fingerprint.excludedGenerated} generated cells excluded\n` +
+          uncertaintyNote(
+            manifest.fingerprint.unhashable,
+            manifest.fingerprint.ambiguous,
+            "             ",
+          ) +
           `  working    ${paths.workingPath}\n\n` +
-          `serve it (NOT the live store — note the port offset):\n` +
-          `  MEMORY_DIR="file://${targetDir}/" ./scripts/start-local-dev.sh --port-offset 10\n\n` +
-          `then, per attempt:\n` +
+          // HOST is pinned to loopback: the toolshed defaults to 0.0.0.0, and a
+          // clone keeps the source space's DID, so a clone bound to every
+          // interface is a second store answering to production's identity on
+          // the network. The port offset separates it from a local production
+          // server; only the host binding keeps it off the network entirely.
+          `serve it (NOT the live store — note the host and port):\n` +
+          `  HOST=127.0.0.1 MEMORY_DIR="file://${targetDir}/" ` +
+          `./scripts/start-local-dev.sh --port-offset 10\n\n` +
+          `then, per attempt (stop the server before resetting — a reset ` +
+          `cannot reach a process that already holds the store open):\n` +
           `  cf space verify ${targetDir}\n` +
           `  cf space reset  ${targetDir}`,
       );
@@ -203,7 +286,13 @@ export const space = new Command()
           `added      ${diff.added}\n` +
           `content    ${fingerprint.match ? "unchanged" : "CHANGED"}\n` +
           `commits    ${counts.manifest.commits} → ${counts.working.commits}\n` +
-          `revisions  ${counts.manifest.revisions} → ${counts.working.revisions}\n\n` +
+          `revisions  ${counts.manifest.revisions} → ${counts.working.revisions}\n` +
+          uncertaintyNote(
+            result.uncertainty.unhashable.working,
+            result.uncertainty.ambiguous.working,
+            "",
+          ) +
+          `\n` +
           (!result.baselineIntact
             ? "BASELINE CORRUPTED — the pristine snapshot no longer matches the " +
               "manifest; do not reset to it."

--- a/packages/cli/test/inspect-churn.test.ts
+++ b/packages/cli/test/inspect-churn.test.ts
@@ -113,6 +113,48 @@ describe("cf inspect churn", () => {
     });
   });
 
+  it("shows a settle by reporting the quiet through --until", async () => {
+    // Without an observation boundary the curve ends at the last write, which
+    // for a storm that has just stopped is its busiest bucket — so it can show
+    // a storm but never show one settling. The footer's two timestamps are what
+    // make the gap between "stopped writing" and "stopped watching" readable.
+    await withStore(STORM, async (path) => {
+      const bare = text((await cf(`inspect churn ${path}`)).stdout);
+      expect(bare).toContain("over 3 × 60s");
+      expect(bare).toContain(
+        "last commit 2026-07-22 10:02:00, observed through 2026-07-22 10:02:00",
+      );
+
+      const observed = await cf(
+        `inspect churn ${path} --until "2026-07-22 10:06:00"`,
+      );
+      expect(observed.code).toBe(0);
+      const output = text(observed.stdout);
+      expect(output).toContain("over 6 × 60s");
+      // Writing stopped four minutes before watching did, and the totals did
+      // not move — the trailing buckets are quiet, not new activity.
+      expect(output).toContain(
+        "last commit 2026-07-22 10:02:00, observed through 2026-07-22 10:05:00",
+      );
+      expect(output).toContain("42 commits / 52 revisions");
+    });
+  });
+
+  it("refuses a window that would report as quiet rather than as wrong", async () => {
+    await withStore(STORM, async (path) => {
+      const unreadable = await cf(`inspect churn ${path} --since yesterday`);
+      expect(unreadable.code).not.toBe(0);
+      expect(text(unreadable.stderr)).toContain("not a time SQLite can read");
+
+      const backwards = await cf(
+        `inspect churn ${path} --since "2026-07-22 11:00:00" ` +
+          `--until "2026-07-22 10:00:00"`,
+      );
+      expect(backwards.code).not.toBe(0);
+      expect(text(backwards.stderr)).toContain("is not before");
+    });
+  });
+
   it("emits machine-readable JSON", async () => {
     await withStore(STORM, async (path) => {
       const result = await cf(`inspect churn ${path} --json --top 1`);

--- a/packages/cli/test/space.test.ts
+++ b/packages/cli/test/space.test.ts
@@ -325,6 +325,69 @@ describe("cf space", () => {
     });
   });
 
+  it("refuses a redirect that downgrades to plaintext http", async () => {
+    // Validating only the URL an operator typed proves nothing about where the
+    // bytes came from: `fetch` follows redirects itself and reports only the
+    // final response, so a permitted origin that 302s elsewhere would carry the
+    // whole space over the redirected transport, having passed the check.
+    await withFixture(async ({ clone }) => {
+      const server = Deno.serve(
+        { hostname: "127.0.0.1", port: 0, onListen: () => {} },
+        () =>
+          new Response(null, {
+            status: 302,
+            headers: { location: "http://example.com/snapshot.sqlite" },
+          }),
+      );
+      const url = `http://127.0.0.1:${server.addr.port}/snapshot.sqlite`;
+      try {
+        const result = await cf(
+          `space clone ${SPACE} --from ${url} --to ${clone}`,
+        );
+        expect(result.code).not.toBe(0);
+        expect(text(result.stderr)).toContain("refusing to download");
+      } finally {
+        await server.shutdown();
+      }
+    });
+  });
+
+  it("follows a permitted redirect and clones what it lands on", async () => {
+    // The other half: refusing the downgrade must not refuse redirects as
+    // such, or `--from <s3-url>` — the whole reason the flag takes a URL —
+    // stops working the first time a bucket redirects.
+    await withFixture(async ({ snapshot, clone }) => {
+      const body = await Deno.readFile(snapshot);
+      const target = Deno.serve(
+        { hostname: "127.0.0.1", port: 0, onListen: () => {} },
+        () => new Response(body),
+      );
+      const redirector = Deno.serve(
+        { hostname: "127.0.0.1", port: 0, onListen: () => {} },
+        () =>
+          new Response(null, {
+            status: 302,
+            // Relative, so this also pins that a bare `Location` resolves
+            // against the URL it came from rather than being taken verbatim.
+            headers: {
+              location: `http://127.0.0.1:${target.addr.port}/s.sqlite`,
+            },
+          }),
+      );
+      try {
+        const result = await cf(
+          `space clone ${SPACE} ` +
+            `--from http://127.0.0.1:${redirector.addr.port}/go --to ${clone}`,
+        );
+        expect(result.code).toBe(0);
+        expect((await cf(`space verify ${clone}`)).code).toBe(0);
+      } finally {
+        await redirector.shutdown();
+        await target.shutdown();
+      }
+    });
+  });
+
   it("refuses to pull a whole-space snapshot over plaintext http", async () => {
     // A snapshot is the entire contents of a space — the same confidentiality
     // judgement that keeps the dump endpoint off in production. Loopback is
@@ -335,6 +398,107 @@ describe("cf space", () => {
       );
       expect(result.code).not.toBe(0);
       expect(text(result.stderr)).toContain("refusing to download");
+    });
+  });
+
+  it("accepts https and fails on the network, not on the transport check", async () => {
+    // The guard must let the transport it exists to require actually through.
+    // Nothing listens on this port, so the request fails at connect — the point
+    // is that it got as far as connecting.
+    await withFixture(async ({ clone }) => {
+      const result = await cf(
+        `space clone ${SPACE} --from https://127.0.0.1:9/s.sqlite --to ${clone}`,
+      );
+      expect(result.code).not.toBe(0);
+      expect(text(result.stderr)).not.toContain("refusing to download");
+    });
+  });
+
+  it("gives up on a redirect loop instead of following it forever", async () => {
+    await withFixture(async ({ clone }) => {
+      let hops = 0;
+      const server = Deno.serve(
+        { hostname: "127.0.0.1", port: 0, onListen: () => {} },
+        (request) => {
+          hops++;
+          return new Response(null, {
+            status: 302,
+            headers: { location: new URL(request.url).pathname + "x" },
+          });
+        },
+      );
+      try {
+        const result = await cf(
+          `space clone ${SPACE} ` +
+            `--from http://127.0.0.1:${server.addr.port}/go --to ${clone}`,
+        );
+        expect(result.code).not.toBe(0);
+        expect(text(result.stderr)).toContain("redirects");
+        // Bounded, and bounded by the hop limit rather than by exhaustion.
+        expect(hops).toBeLessThanOrEqual(6);
+      } finally {
+        await server.shutdown();
+      }
+    });
+  });
+
+  it("warns that an ambiguous id could hide a change to it", async () => {
+    // An id one manifest calls generated and another calls named is counted as
+    // generated and excluded, so a change to it never reaches the verdict.
+    // Nothing gates on this, which makes saying it the whole protection.
+    await withFixture(async ({ snapshot, clone }) => {
+      await cf(`space clone ${SPACE} --from ${snapshot} --to ${clone}`);
+      const manifestPath = `${clone}/clone.json`;
+      const manifest = JSON.parse(await Deno.readTextFile(manifestPath));
+      manifest.fingerprint.ambiguous = 1;
+      await Deno.writeTextFile(manifestPath, JSON.stringify(manifest));
+
+      const result = await cf(`space verify ${clone}`);
+      expect(result.code).toBe(0);
+      expect(text(result.stdout)).toContain("would not show");
+    });
+  });
+
+  it("says so when a clone cannot report what its BASELINE excluded", async () => {
+    // An entity excluded from the baseline is absent from the "before" side, so
+    // if it is still excluded now the diff cannot compare it at all and a change
+    // to it is silent. That blind spot belongs to the baseline and never shows
+    // up in a working-copy count — and on a clone predating the recording its
+    // size is unknown, which is a weaker claim than zero and must not render as
+    // zero.
+    await withFixture(async ({ snapshot, clone }) => {
+      await cf(`space clone ${SPACE} --from ${snapshot} --to ${clone}`);
+
+      const manifestPath = `${clone}/clone.json`;
+      const manifest = JSON.parse(await Deno.readTextFile(manifestPath));
+      expect(manifest.fingerprint.unhashable).toBe(0);
+      delete manifest.fingerprint.unhashable;
+      delete manifest.fingerprint.ambiguous;
+      await Deno.writeTextFile(manifestPath, JSON.stringify(manifest));
+
+      const result = await cf(`space verify ${clone}`);
+      expect(result.code).toBe(0);
+      expect(text(result.stdout)).toContain("predates uncertainty recording");
+    });
+  });
+
+  it("reports uncertainty the BASELINE carried, not just the working copy", async () => {
+    await withFixture(async ({ snapshot, clone }) => {
+      await cf(`space clone ${SPACE} --from ${snapshot} --to ${clone}`);
+
+      // Stand in for a baseline that excluded entities: the working copy is
+      // untouched, so nothing on the "after" side would mention them.
+      const manifestPath = `${clone}/clone.json`;
+      const manifest = JSON.parse(await Deno.readTextFile(manifestPath));
+      manifest.fingerprint.unhashable = 2;
+      await Deno.writeTextFile(manifestPath, JSON.stringify(manifest));
+
+      const result = await cf(`space verify ${clone}`);
+      expect(result.code).toBe(0);
+      const out = text(result.stdout);
+      expect(out).toContain("content    unchanged");
+      expect(out).toContain("in the BASELINE");
+      expect(out).toContain("2 entities could not be hashed");
     });
   });
 

--- a/packages/cli/test/space.test.ts
+++ b/packages/cli/test/space.test.ts
@@ -15,6 +15,21 @@ import { cf, withEnv } from "./utils.ts";
 /** `CliResult` streams are line arrays; join before substring assertions. */
 const text = (lines: string[]): string => lines.join("\n");
 
+/**
+ * Staging directories `--from <url>` may have created, by name.
+ *
+ * Callers compare a before/after set rather than asserting the system temp
+ * directory holds none: it is shared, so an unrelated leftover would fail that
+ * spuriously and forever.
+ */
+async function stagingDirs(): Promise<Set<string>> {
+  const found = new Set<string>();
+  for await (const entry of Deno.readDir(Deno.env.get("TMPDIR") ?? "/tmp")) {
+    if (entry.name.startsWith("cf-space-clone-")) found.add(entry.name);
+  }
+  return found;
+}
+
 const SPACE = "did:key:z6MkCliCloneTest";
 const SESSION = "session:did:key:zSpaceAAAA:11111111-2222-3333";
 const MODULE_IDENTITY = "pf1v3J_M5Nep7cq-Uh8EYG0ZQaE217FfDfcjbwGdjVI";
@@ -242,18 +257,6 @@ describe("cf space", () => {
     // snapshot across operators. A real snapshot is gigabytes, so the staging
     // copy must not survive the command.
     await withFixture(async ({ snapshot, clone }) => {
-      // Compare staging directories before and after rather than asserting the
-      // system temp directory holds none: it is shared, so an unrelated
-      // leftover would fail this spuriously and forever.
-      const stagingDirs = async (): Promise<Set<string>> => {
-        const found = new Set<string>();
-        for await (
-          const entry of Deno.readDir(Deno.env.get("TMPDIR") ?? "/tmp")
-        ) {
-          if (entry.name.startsWith("cf-space-clone-")) found.add(entry.name);
-        }
-        return found;
-      };
       const before = await stagingDirs();
 
       const body = await Deno.readFile(snapshot);
@@ -277,6 +280,61 @@ describe("cf space", () => {
       const after = await stagingDirs();
       const leaked = [...after].filter((name) => !before.has(name));
       expect(leaked).toEqual([]);
+    });
+  });
+
+  it("cleans up staging when the download dies mid-stream", async () => {
+    // The failure a status check cannot catch: headers say 200, then the
+    // connection drops. At the gigabyte scale `--from <url>` exists for, the
+    // partial file stranded in the system temp directory is however much
+    // arrived — so cleanup has to live where the failure does, not with a
+    // caller that never received a directory to clean.
+    await withFixture(async ({ snapshot, clone }) => {
+      const before = await stagingDirs();
+
+      const body = await Deno.readFile(snapshot);
+      const server = Deno.serve(
+        { hostname: "127.0.0.1", port: 0, onListen: () => {} },
+        () =>
+          // Promise a full-length body and deliver a prefix, so the truncation
+          // surfaces on the CLIENT as a short read. Erroring the stream instead
+          // would work too, but the server-side abort prints a stack trace into
+          // every run of this suite.
+          new Response(
+            new ReadableStream({
+              start(controller) {
+                controller.enqueue(body.slice(0, 512));
+                controller.close();
+              },
+            }),
+            { headers: { "content-length": String(body.length) } },
+          ),
+      );
+      const url = `http://127.0.0.1:${server.addr.port}/snapshot.sqlite`;
+      try {
+        const result = await cf(
+          `space clone ${SPACE} --from ${url} --to ${clone}`,
+        );
+        expect(result.code).not.toBe(0);
+      } finally {
+        await server.shutdown();
+      }
+
+      const leaked = [...await stagingDirs()].filter((n) => !before.has(n));
+      expect(leaked).toEqual([]);
+    });
+  });
+
+  it("refuses to pull a whole-space snapshot over plaintext http", async () => {
+    // A snapshot is the entire contents of a space — the same confidentiality
+    // judgement that keeps the dump endpoint off in production. Loopback is
+    // exempt (it never leaves the machine) and the tests above rely on that.
+    await withFixture(async ({ clone }) => {
+      const result = await cf(
+        `space clone ${SPACE} --from http://example.com/s.sqlite --to ${clone}`,
+      );
+      expect(result.code).not.toBe(0);
+      expect(text(result.stderr)).toContain("refusing to download");
     });
   });
 

--- a/packages/state-inspector/churn.ts
+++ b/packages/state-inspector/churn.ts
@@ -126,6 +126,16 @@ export function commitChurn(
   // it would be used for. Refuse instead.
   const sinceEpoch = parseStoreTime(db, "since", options.since);
   const untilEpoch = parseStoreTime(db, "until", options.until);
+  // Same failure with two readable bounds: an empty or backwards interval also
+  // matches no commits, and also renders as a quiet window rather than as the
+  // mistake it is. `until` is exclusive, so equal bounds are empty too.
+  if (sinceEpoch !== null && untilEpoch !== null && sinceEpoch >= untilEpoch) {
+    throw new Error(
+      `--since ${JSON.stringify(options.since)} is not before --until ` +
+        `${JSON.stringify(options.until)}, so the window is empty — which ` +
+        `would report as a quiet space rather than as a bad window.`,
+    );
+  }
 
   // `strftime('%s', …)` yields NULL for a value it cannot parse as a time, which
   // is how untimed rows are separated from real zero-activity buckets. It also

--- a/packages/state-inspector/churn.ts
+++ b/packages/state-inspector/churn.ts
@@ -41,11 +41,28 @@ export interface ChurnEntity {
 export interface ChurnReport {
   bucketSeconds: number;
   branch: string;
-  /** First and last bucket start actually observed (null on an empty window). */
+  /** First and last bucket start the curve covers (null on an empty window). */
   from: string | null;
   to: string | null;
+  /**
+   * Start of the last bucket that actually holds a commit (null when none do).
+   *
+   * Distinguishes the two shapes a flat tail can have: a curve that ran out of
+   * data at its last write, and a window that was genuinely observed through to
+   * its end and stayed quiet. Only the second is evidence of a settle, and
+   * without this they render identically.
+   */
+  lastCommit: string | null;
   totals: { commits: number; revisions: number };
-  /** Contiguous, zero-filled from `from` to `to` so gaps read as quiet. */
+  /**
+   * Contiguous, zero-filled from `from` to `to` so gaps read as quiet.
+   *
+   * Extends to cover an explicit `since`/`until` even where no commit landed:
+   * "the rate returned to baseline and STAYED there" is a claim about a period
+   * of time, and a curve that stops at its own last write can never show it —
+   * it ends on a busy bucket by construction, exactly when a storm has just
+   * stopped.
+   */
   buckets: ChurnBucket[];
   /** The busiest bucket by commits, or null when the window is empty. */
   peak: ChurnBucket | null;
@@ -63,9 +80,20 @@ export interface ChurnOptions {
   branch?: string;
   /** Bucket width in seconds. Default 60. */
   bucketSeconds?: number;
-  /** Lower bound on `commit.created_at`, inclusive. `YYYY-MM-DD HH:MM:SS` or ISO. */
+  /**
+   * Lower bound on `commit.created_at`, inclusive. `YYYY-MM-DD HH:MM:SS` or ISO.
+   *
+   * Also widens the curve: the buckets cover the whole window asked for, not
+   * just the part of it that happened to contain writes.
+   */
   since?: string;
-  /** Upper bound on `commit.created_at`, exclusive. */
+  /**
+   * Upper bound on `commit.created_at`, exclusive.
+   *
+   * This is the observation boundary as well as a filter — pass the moment you
+   * stopped watching (`now`, after a migration) and the trailing quiet buckets
+   * are reported instead of implied.
+   */
   until?: string;
   /** How many entities to attribute the peak bucket to. Default 10. */
   top?: number;
@@ -90,6 +118,15 @@ export function commitChurn(
   }
 
   const db = space.db;
+  // A bound SQLite cannot read as a time compares as NULL, so it matches NO
+  // rows — and the report then says "no timed commits in window", which is
+  // indistinguishable from a genuinely quiet space. The runbook has operators
+  // typing `--since '<when you started>'` by hand to confirm a settle, so a
+  // mistyped bound reporting silence is a false all-clear on exactly the check
+  // it would be used for. Refuse instead.
+  const sinceEpoch = parseStoreTime(db, "since", options.since);
+  const untilEpoch = parseStoreTime(db, "until", options.until);
+
   // `strftime('%s', …)` yields NULL for a value it cannot parse as a time, which
   // is how untimed rows are separated from real zero-activity buckets. It also
   // yields TEXT, and SQLite sorts every INTEGER before every TEXT — so each
@@ -141,6 +178,7 @@ export function commitChurn(
       branch,
       from: null,
       to: null,
+      lastCommit: null,
       totals: { commits: 0, revisions: 0 },
       buckets: [],
       peak: null,
@@ -149,8 +187,21 @@ export function commitChurn(
     };
   }
 
-  const first = rows[0].bucket;
-  const last = rows[rows.length - 1].bucket;
+  // Widen to the requested window before measuring the span, so the bucket cap
+  // is applied to what will actually be materialized.
+  const bucketOf = (epoch: number) =>
+    Math.floor(epoch / bucketSeconds) * bucketSeconds;
+  // `until` is exclusive, so the last bucket the window touches is the one
+  // holding the instant before it — otherwise an `until` landing exactly on a
+  // boundary would materialize a bucket the filter excluded, reporting a zero
+  // that is an artifact rather than an observation.
+  const first = sinceEpoch === null
+    ? rows[0].bucket
+    : Math.min(rows[0].bucket, bucketOf(sinceEpoch));
+  const lastObserved = rows[rows.length - 1].bucket;
+  const last = untilEpoch === null
+    ? lastObserved
+    : Math.max(lastObserved, bucketOf(untilEpoch - 1));
   const span = (last - first) / bucketSeconds + 1;
   if (span > MAX_BUCKETS) {
     throw new Error(
@@ -193,6 +244,7 @@ export function commitChurn(
     branch,
     from: buckets[0].start,
     to: buckets[buckets.length - 1].start,
+    lastCommit: epochToStoreTime(db, lastObserved),
     totals,
     buckets,
     peak,
@@ -249,6 +301,32 @@ function epochToStoreTime(db: SpaceDb["db"], epoch: number): string {
   return db
     .prepare(`SELECT datetime(:e, 'unixepoch') t`)
     .get<{ t: string }>({ e: epoch })!.t;
+}
+
+/**
+ * A window bound as an epoch second, parsed by SQLite itself so the curve's
+ * edges and the SQL filter can never disagree about what a timestamp means.
+ *
+ * Null only for an absent bound. A bound that is present but unreadable throws:
+ * see the refusal note in `commitChurn`.
+ */
+function parseStoreTime(
+  db: SpaceDb["db"],
+  option: string,
+  text: string | undefined,
+): number | null {
+  if (text === undefined) return null;
+  const epoch = db
+    .prepare(`SELECT CAST(strftime('%s', :t) AS INTEGER) e`)
+    .get<{ e: number | null }>({ t: text })?.e ?? null;
+  if (epoch === null) {
+    throw new Error(
+      `--${option} ${JSON.stringify(text)} is not a time SQLite can read. ` +
+        `Use 'YYYY-MM-DD HH:MM:SS' (UTC) or an ISO timestamp — left as is it ` +
+        `would match no commits and report the window as quiet.`,
+    );
+  }
+  return epoch;
 }
 
 /** Commits per minute for a bucket — the unit the incident record speaks in. */

--- a/packages/state-inspector/clone.ts
+++ b/packages/state-inspector/clone.ts
@@ -24,6 +24,11 @@
 // serves the clone as a live space under the SAME DID.
 
 import * as Path from "@std/path";
+// The only read-WRITE database handle in this package, and it opens nothing:
+// `assertNotInUse` takes a lock to ask whether a server is still holding the
+// working copy. `db.ts` stays read-only by contract, so the probe lives here
+// with the rest of the code that legitimately writes to a clone.
+import { Database } from "@db/sqlite";
 import {
   resolveMemoryEngineStoreRootUrl,
   resolveSpaceStoreUrl,
@@ -35,6 +40,7 @@ import {
   contentFingerprint,
   diffFingerprints,
   type FingerprintReport,
+  type ScopedEntity,
 } from "./fingerprint.ts";
 
 /** Filenames the layout depends on. */
@@ -82,8 +88,23 @@ export interface CloneManifest {
     entities: number;
     maxSeq: number;
   };
-  /** Content fingerprint at clone time, generated cells excluded. */
-  fingerprint: { hash: string; entities: number; excludedGenerated: number };
+  /**
+   * Content fingerprint at clone time, generated cells excluded.
+   *
+   * `unhashable` and `ambiguous` record what the baseline fingerprint could NOT
+   * speak for. Both are absent from the roll-up by construction, so a verdict
+   * computed from the hash alone rests on however much evidence happened to
+   * exist — and without recording the number here, nobody could tell whether
+   * that was all of it. Optional: clones taken before these were recorded
+   * report them as unknown rather than as zero.
+   */
+  fingerprint: {
+    hash: string;
+    entities: number;
+    excludedGenerated: number;
+    unhashable?: number;
+    ambiguous?: number;
+  };
 }
 
 export interface CreateCloneOptions {
@@ -200,6 +221,8 @@ export async function createClone(
       hash: fingerprint.hash,
       entities: fingerprint.entities,
       excludedGenerated: fingerprint.excludedGenerated,
+      unhashable: fingerprint.unhashable.length,
+      ambiguous: fingerprint.ambiguous.length,
     },
   };
 
@@ -232,10 +255,19 @@ export async function createClone(
  * Deletes the `-wal`/`-shm` companions the engine creates on open. Leaving them
  * behind would let a checkpoint replay part of the discarded attempt over the
  * fresh copy — a reset that silently isn't one.
+ *
+ * REFUSES while a server still has the working copy open, because unlinking a
+ * file does not disturb a process that already holds it: the server keeps
+ * reading and writing the unlinked inode while every new reader — including the
+ * `verify` this function's caller runs next — sees the restored one. Pass two of
+ * a rehearsal would then run against pass one's state while `cf space verify`
+ * reported the clone pristine, which is the failure mode the whole two-pass
+ * procedure exists to rule out.
  */
 export async function resetClone(dir: string): Promise<CloneManifest> {
   const manifest = await readManifest(dir);
   const paths = clonePaths(await canonicalPath(dir), manifest.space);
+  await assertNotInUse(paths.workingPath);
   // The companions are absent on a clone no engine has opened yet — the normal
   // case at the start of a rehearsal — so their absence is not an error, while
   // any OTHER failure must surface rather than leave a half-reset clone.
@@ -245,6 +277,54 @@ export async function resetClone(dir: string): Promise<CloneManifest> {
   }
   await Deno.copyFile(paths.pristinePath, paths.workingPath);
   return manifest;
+}
+
+/**
+ * Refuse if any process still holds the working copy open.
+ *
+ * The probe is the hazard itself rather than a proxy for it: take SQLite's
+ * exclusive lock, which in WAL mode cannot be granted while another connection
+ * has the shared-memory index mapped. A PID or lease file would have to be
+ * written by the server, kept in step with it, and disbelieved when stale; this
+ * asks the operating system the actual question and needs no bookkeeping. It
+ * also gives the right answer in the case a marker would get wrong: a toolshed
+ * that is running but has never opened THIS space's engine holds nothing, and
+ * resetting under it is safe because it will open the restored file when it
+ * first reads.
+ *
+ * Locking is the only signal the binding exposes — its errors carry a message
+ * and nothing else — so the two outcomes are separated by message. Anything
+ * that is not a lock conflict means the working copy could not be opened as a
+ * database at all, and that is precisely when a reset is the remedy rather than
+ * the risk, so it proceeds.
+ */
+async function assertNotInUse(workingPath: string): Promise<void> {
+  // Nothing to hold open, and `Database` would otherwise create an empty file
+  // just to probe it. The copy below restores it either way.
+  if (!(await pathExists(workingPath))) return;
+  let db: Database;
+  try {
+    db = new Database(workingPath, { create: false });
+  } catch {
+    return; // unopenable — reset is the fix, not the hazard
+  }
+  try {
+    db.exec("PRAGMA locking_mode=EXCLUSIVE");
+    db.exec("BEGIN IMMEDIATE");
+    db.exec("ROLLBACK");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!/database (is|table is) locked/i.test(message)) return;
+    throw new Error(
+      `refusing to reset ${workingPath}: another process still has it open ` +
+        `(${message}). Unlinking it would not reach that process — it would ` +
+        `keep serving the discarded attempt while verify reported the clone ` +
+        `pristine. Stop the server first (scripts/stop-local-dev.sh ` +
+        `--port-offset 10), reset, then start it again.`,
+    );
+  } finally {
+    db.close();
+  }
 }
 
 export interface VerifyResult {
@@ -303,6 +383,32 @@ export interface VerifyResult {
     /** Counts per entity kind, so "74 pieces" reads differently from "74 cells". */
     changedByKind: Record<string, number>;
     removedByKind: Record<string, number>;
+  };
+  /**
+   * How much of the store the fingerprint could not speak for, on each side.
+   *
+   * Neither verdict above is computed from these, and that is deliberate rather
+   * than an omission — but a verdict that silently rests on partial evidence is
+   * indistinguishable from one that rests on all of it, so the number is
+   * reported wherever the verdict is.
+   *
+   * The two behave differently, and only one is already covered:
+   *
+   *   * `unhashable` — an entity that BECOMES unhashable drops out of the
+   *     working fingerprint entirely, so the diff already counts it as
+   *     `removed` and both verdicts already fail. The gap the count closes is
+   *     the entity unhashable on BOTH sides: invisible to the diff, so a change
+   *     to it is silent, and the only way to know is that the number is nonzero.
+   *   * `ambiguous` — an id one manifest calls generated and another calls
+   *     named is counted as generated and excluded, which can hide a real
+   *     change to authored content. Nothing gates on it, so the count is the
+   *     whole signal.
+   *
+   * `manifest` is null on clones taken before these were recorded.
+   */
+  uncertainty: {
+    unhashable: { manifest: number | null; working: number };
+    ambiguous: { manifest: number | null; working: number };
   };
 }
 
@@ -380,27 +486,26 @@ export async function verifyClone(dir: string): Promise<VerifyResult> {
   }
 
   const d = diffFingerprints(before, fingerprint);
-  // `diffFingerprints` keys by id AND scope, because one id can hold a shared
-  // space value plus per-user/per-session overrides that are genuinely
-  // different entities. Keying these lookups by id alone would let the last
-  // scope win and misclassify the tally — exactly the precision ("74 pieces vs
-  // 73 cells") the diff exists to provide. `diff` reports bare ids, so a
-  // by-id-only fallback keeps a lookup working when scopes disagree.
+  // Keyed by id AND scope throughout: one id can hold a shared space value plus
+  // per-user/per-session overrides that are genuinely different entities, and a
+  // by-id lookup would let the last scope win and misclassify the tally —
+  // exactly the precision ("74 pieces vs 73 cells") the diff exists to provide.
+  // `diffFingerprints` reports the address it compared by, so there is nothing
+  // left to guess at here.
   const kindIndex = (rows: FingerprintReport["perEntity"]) => {
-    const byIdAndScope = new Map<string, string>();
-    const byId = new Map<string, string>();
-    for (const e of rows) {
-      byIdAndScope.set(`${e.id} ${e.scope}`, e.kind);
-      byId.set(e.id, e.kind);
-    }
-    return (id: string) => byIdAndScope.get(id) ?? byId.get(id) ?? "unknown";
+    const byAddress = new Map(rows.map((e) => [`${e.id} ${e.scope}`, e.kind]));
+    return (at: ScopedEntity) =>
+      byAddress.get(`${at.id} ${at.scope}`) ?? "unknown";
   };
   const kindOf = kindIndex(fingerprint.perEntity);
   const kindWas = kindIndex(before.perEntity);
-  const tally = (ids: string[], lookup: (id: string) => string) => {
+  const tally = (
+    entities: ScopedEntity[],
+    lookup: (at: ScopedEntity) => string,
+  ) => {
     const out: Record<string, number> = {};
-    for (const id of ids) {
-      const k = lookup(id);
+    for (const at of entities) {
+      const k = lookup(at);
       out[k] = (out[k] ?? 0) + 1;
     }
     return out;
@@ -426,6 +531,16 @@ export async function verifyClone(dir: string): Promise<VerifyResult> {
       excludedGenerated: fingerprint.excludedGenerated,
     },
     diff: delta,
+    uncertainty: {
+      unhashable: {
+        manifest: manifest.fingerprint.unhashable ?? null,
+        working: fingerprint.unhashable.length,
+      },
+      ambiguous: {
+        manifest: manifest.fingerprint.ambiguous ?? null,
+        working: fingerprint.ambiguous.length,
+      },
+    },
   };
 }
 

--- a/packages/state-inspector/clone.ts
+++ b/packages/state-inspector/clone.ts
@@ -263,6 +263,16 @@ export async function createClone(
  * a rehearsal would then run against pass one's state while `cf space verify`
  * reported the clone pristine, which is the failure mode the whole two-pass
  * procedure exists to rule out.
+ *
+ * That check is a TRIPWIRE, not mutual exclusion. It catches the case that
+ * actually happens — an operator who forgot to stop a toolshed that is already
+ * serving the clone — and cannot prevent one that opens the store in the
+ * instant between the probe and the unlink. No external check can: a process
+ * that opens a SQLite file takes no lock in doing so, so there is no state to
+ * hold against it, and holding our own lock across the unlink would be worse
+ * (the probe connection would then rewrite `-wal`/`-shm` beside the freshly
+ * restored copy on close). Stopping the server is what makes a reset correct;
+ * this makes forgetting to loud rather than silent.
  */
 export async function resetClone(dir: string): Promise<CloneManifest> {
   const manifest = await readManifest(dir);
@@ -280,7 +290,10 @@ export async function resetClone(dir: string): Promise<CloneManifest> {
 }
 
 /**
- * Refuse if any process still holds the working copy open.
+ * Refuse if any process still holds the working copy open, as of now.
+ *
+ * "As of now" is the honest scope — see the tripwire note on {@link resetClone}
+ * for why nothing stronger is available from outside the server.
  *
  * The probe is the hazard itself rather than a proxy for it: take SQLite's
  * exclusive lock, which in WAL mode cannot be granted while another connection

--- a/packages/state-inspector/fingerprint.ts
+++ b/packages/state-inspector/fingerprint.ts
@@ -23,7 +23,7 @@ import { hashOf } from "@commonfabric/data-model/value-hash";
 import { utf8Compare } from "@commonfabric/utils/utf8";
 import type { SpaceDb } from "./db.ts";
 import { type EntityModel, listEntityModels } from "./model.ts";
-import { reconstructDocument } from "./reconstruct.ts";
+import { type EntityAddress, reconstructDocument } from "./reconstruct.ts";
 import { listScopes } from "./scopes.ts";
 
 /**
@@ -256,11 +256,27 @@ export function contentFingerprint(
   };
 }
 
+/**
+ * An {@link EntityAddress} whose scope is known — which, for a diff, it always
+ * is.
+ *
+ * An id is NOT unique on its own: one id can hold a shared space value plus
+ * per-user/per-session overrides that are genuinely different entities. So the
+ * diff reports the pair it compared by. Returning a bare id forced every caller
+ * to re-associate it with a scope by guessing — a lookup that silently lets the
+ * last scope win, misclassifying exactly the per-kind precision ("74 pieces vs
+ * 73 cells") the diff exists to provide.
+ *
+ * Being an `EntityAddress` is the useful part: what a diff entry is FOR is
+ * looking the entity up, and this hands straight to `reconstructDocument`.
+ */
+export type ScopedEntity = EntityAddress & { scope: string };
+
 export interface FingerprintDiff {
   equal: boolean;
-  added: string[];
-  removed: string[];
-  changed: string[];
+  added: ScopedEntity[];
+  removed: ScopedEntity[];
+  changed: ScopedEntity[];
 }
 
 /**
@@ -275,20 +291,26 @@ export function diffFingerprints(
   const a = new Map(before.perEntity.map((e) => [key(e), e]));
   const b = new Map(after.perEntity.map((e) => [key(e), e]));
 
-  const added: string[] = [];
-  const removed: string[] = [];
-  const changed: string[] = [];
+  const added: ScopedEntity[] = [];
+  const removed: ScopedEntity[] = [];
+  const changed: ScopedEntity[] = [];
+  const at = (e: EntityFingerprint): ScopedEntity => ({
+    id: e.id,
+    scope: e.scope,
+  });
 
-  for (const [k, e] of b) if (!a.has(k)) added.push(e.id);
+  for (const [k, e] of b) if (!a.has(k)) added.push(at(e));
   for (const [k, e] of a) {
     const other = b.get(k);
-    if (other === undefined) removed.push(e.id);
-    else if (other.hash !== e.hash) changed.push(e.id);
+    if (other === undefined) removed.push(at(e));
+    else if (other.hash !== e.hash) changed.push(at(e));
   }
 
-  added.sort(utf8Compare);
-  removed.sort(utf8Compare);
-  changed.sort(utf8Compare);
+  const byAddress = (x: ScopedEntity, y: ScopedEntity) =>
+    x.id === y.id ? utf8Compare(x.scope, y.scope) : utf8Compare(x.id, y.id);
+  added.sort(byAddress);
+  removed.sort(byAddress);
+  changed.sort(byAddress);
   return {
     equal: added.length === 0 && removed.length === 0 && changed.length === 0,
     added,

--- a/packages/state-inspector/test/churn.test.ts
+++ b/packages/state-inspector/test/churn.test.ts
@@ -253,6 +253,38 @@ Deno.test("a window bound SQLite cannot read is refused, not treated as quiet", 
   });
 });
 
+Deno.test("an empty or backwards window is refused, not reported as quiet", () => {
+  // Two perfectly readable bounds in the wrong order match no commits and hit
+  // the same false all-clear as an unparseable one. `until` is exclusive, so
+  // equal bounds are empty too.
+  withStore((commit) => {
+    commit("2026-07-22 10:00:00", ["of:topic"]);
+  }, (space) => {
+    for (
+      const [since, until] of [
+        ["2026-07-22 11:00:00", "2026-07-22 10:00:00"], // backwards
+        ["2026-07-22 10:00:00", "2026-07-22 10:00:00"], // empty
+      ]
+    ) {
+      assertThrows(
+        () => commitChurn(space, { bucketSeconds: 60, since, until }),
+        Error,
+        "is not before",
+      );
+    }
+    // A window that IS ordered still works, including one holding no commits —
+    // that is a real observation, not a mistake.
+    assertEquals(
+      commitChurn(space, {
+        bucketSeconds: 60,
+        since: "2026-07-22 12:00:00",
+        until: "2026-07-22 13:00:00",
+      }).totals.commits,
+      0,
+    );
+  });
+});
+
 Deno.test("a commit with no revisions still counts as a commit", () => {
   // LEFT JOIN, not JOIN: an empty commit is real activity and a fan-out over
   // revisions must not inflate the commit count either.

--- a/packages/state-inspector/test/churn.test.ts
+++ b/packages/state-inspector/test/churn.test.ts
@@ -176,6 +176,83 @@ Deno.test("--since / --until bound the window, inclusive/exclusive", () => {
   });
 });
 
+Deno.test("the curve covers the window asked for, not just its writes", () => {
+  // "The rate returns to baseline AND STAYS THERE" is the runbook's settle
+  // condition, and a curve that stops at its own last write can never show it:
+  // a storm that has just stopped ends on its busiest bucket by construction.
+  // `until` is the observation boundary — pass the moment you stopped watching
+  // and the trailing quiet is reported rather than left to be assumed.
+  withStore((commit) => {
+    commit("2026-07-22 10:00:00", ["of:topic"]);
+    for (let i = 0; i < 50; i++) commit("2026-07-22 10:01:00", ["of:storm"]);
+  }, (space) => {
+    const bare = commitChurn(space, { bucketSeconds: 60 });
+    assertEquals(
+      bare.buckets.map((b) => b.commits),
+      [1, 50],
+      "unbounded, the curve ends on the storm and proves nothing about after",
+    );
+
+    const observed = commitChurn(space, {
+      bucketSeconds: 60,
+      until: "2026-07-22 10:05:00",
+    });
+    assertEquals(
+      observed.buckets.map((b) => b.commits),
+      [1, 50, 0, 0, 0],
+      "the quiet minutes through the boundary are reported, not implied",
+    );
+    // `until` is exclusive, so 10:05 itself is not materialized — a zero there
+    // would be an artifact of the bound rather than an observation.
+    assertEquals(observed.to, "2026-07-22 10:04:00");
+    // ...and the settle is legible: writes stopped well before we stopped
+    // watching. That comparison is impossible without both numbers.
+    assertEquals(observed.lastCommit, "2026-07-22 10:01:00");
+    assertEquals(observed.totals, bare.totals, "widening adds no writes");
+
+    // `since` widens the leading edge the same way, so a baseline observation
+    // shows the quiet it is claiming.
+    const before = commitChurn(space, {
+      bucketSeconds: 60,
+      since: "2026-07-22 09:58:00",
+    });
+    assertEquals(before.buckets.map((b) => b.commits), [0, 0, 1, 50]);
+    assertEquals(before.from, "2026-07-22 09:58:00");
+  });
+});
+
+Deno.test("a window bound SQLite cannot read is refused, not treated as quiet", () => {
+  // An unreadable bound compares as NULL and therefore matches NO commits, so
+  // the report would say "no timed commits in window" — indistinguishable from
+  // a genuinely quiet space. That is a false all-clear on the one check this
+  // command exists to support, and the runbook has operators typing these
+  // bounds by hand.
+  withStore((commit) => {
+    commit("2026-07-22 10:00:00", ["of:topic"]);
+  }, (space) => {
+    for (const bound of ["since", "until"] as const) {
+      const error = assertThrows(
+        () => commitChurn(space, { bucketSeconds: 60, [bound]: "yesterday" }),
+        Error,
+        `--${bound}`,
+      );
+      assert(
+        /report the window as quiet/.test(error.message),
+        `the message must say what silently goes wrong, got: ${error.message}`,
+      );
+    }
+    // A readable bound still works, so the check is not just refusing anything
+    // unusual: an ISO timestamp is accepted alongside the store's own format.
+    assertEquals(
+      commitChurn(space, {
+        bucketSeconds: 60,
+        since: "2026-07-22T09:00:00Z",
+      }).totals.commits,
+      1,
+    );
+  });
+});
+
 Deno.test("a commit with no revisions still counts as a commit", () => {
   // LEFT JOIN, not JOIN: an empty commit is real activity and a fan-out over
   // revisions must not inflate the commit count either.

--- a/packages/state-inspector/test/clone.test.ts
+++ b/packages/state-inspector/test/clone.test.ts
@@ -314,6 +314,33 @@ Deno.test("reset refuses while a server still holds the working copy", async () 
   });
 });
 
+Deno.test("reset restores a working copy that was deleted outright", async () => {
+  // Nothing to hold open, and nothing to unlink. The probe must not treat an
+  // absent file as a reason to fail — and must not create one just to ask.
+  await withDirs(async ({ source, clone }) => {
+    await createClone({ source, space: SPACE, targetDir: clone, now: NOW });
+    await Deno.remove(clonePaths(clone, SPACE).workingPath);
+
+    await resetClone(clone);
+    assert((await verifyClone(clone)).ok, "restored from pristine");
+  });
+});
+
+Deno.test("reset works when the working path cannot be opened at all", async () => {
+  // The probe fails at open rather than at lock — a different branch from a
+  // file that opens and turns out not to be a database, and the same verdict:
+  // whatever is in the way, restoring from pristine is the remedy.
+  await withDirs(async ({ source, clone }) => {
+    await createClone({ source, space: SPACE, targetDir: clone, now: NOW });
+    const paths = clonePaths(clone, SPACE);
+    await Deno.remove(paths.workingPath);
+    await Deno.mkdir(paths.workingPath);
+
+    await resetClone(clone);
+    assert((await verifyClone(clone)).ok, "restored from pristine");
+  });
+});
+
 Deno.test("reset still works on a working copy that is not a database", async () => {
   // The mirror image of the guard above: a probe that refuses whenever it
   // cannot take the lock would refuse hardest on a corrupt working copy, which

--- a/packages/state-inspector/test/clone.test.ts
+++ b/packages/state-inspector/test/clone.test.ts
@@ -276,6 +276,58 @@ Deno.test("reset discards the attempt, including WAL companions", async () => {
   });
 });
 
+Deno.test("reset refuses while a server still holds the working copy", async () => {
+  // The defect this pins: unlinking a file does not reach a process that
+  // already has it open. A toolshed keeps reading and writing the unlinked
+  // inode while every NEW reader — including the verify that `cf space reset`
+  // runs immediately afterwards — sees the restored one, so the reset reports
+  // success while pass two runs against pass one's state. Every other reset
+  // test in this file closes its connection first, which is exactly the case
+  // that cannot catch this.
+  await withDirs(async ({ source, clone }) => {
+    await createClone({ source, space: SPACE, targetDir: clone, now: NOW });
+    const paths = clonePaths(clone, SPACE);
+
+    // Stand in for the served store: WAL, and still open.
+    const server = new Database(paths.workingPath);
+    server.exec("PRAGMA journal_mode = WAL");
+    server.prepare(`SELECT count(*) FROM "commit"`).get();
+    try {
+      const error = await assertRejects(
+        () => resetClone(clone),
+        Error,
+        "still has it open",
+      );
+      assert(
+        /stop the server/i.test(error.message),
+        `the message must say what to do, got: ${error.message}`,
+      );
+    } finally {
+      server.close();
+    }
+
+    // And the refusal is not a permanent lockout: once the holder is gone the
+    // same reset succeeds. A guard that could not be cleared would push
+    // operators straight back to `rm -rf`.
+    await resetClone(clone);
+    assert((await verifyClone(clone)).ok, "reset works once the server stops");
+  });
+});
+
+Deno.test("reset still works on a working copy that is not a database", async () => {
+  // The mirror image of the guard above: a probe that refuses whenever it
+  // cannot take the lock would refuse hardest on a corrupt working copy, which
+  // is precisely when a reset is the remedy rather than the risk.
+  await withDirs(async ({ source, clone }) => {
+    await createClone({ source, space: SPACE, targetDir: clone, now: NOW });
+    const paths = clonePaths(clone, SPACE);
+    await Deno.writeTextFile(paths.workingPath, "not a database at all");
+
+    await resetClone(clone);
+    assert((await verifyClone(clone)).ok, "restored from pristine");
+  });
+});
+
 Deno.test("verify reports a corrupted baseline rather than trusting it", async () => {
   await withDirs(async ({ source, clone }) => {
     await createClone({ source, space: SPACE, targetDir: clone, now: NOW });
@@ -414,11 +466,27 @@ Deno.test("the per-kind tally respects scope, not just id", async () => {
     ).run(seq, JSON.stringify({ value: "per-user override" }), seq);
     db.close();
 
+    // Also CHANGE the space-scope row of the same id, so the tally has to
+    // classify a real entry rather than an empty map. Without this the
+    // assertions below pass no matter how the kind lookup behaves.
+    mutate(clonePaths(clone, SPACE).workingPath, [[
+      "of:named",
+      { value: "named-v2", result: link("of:piece") },
+    ]]);
+
     const v = await verifyClone(clone);
     assertEquals(v.diff.removed, 0);
     assertEquals(v.diff.added, 1, "the per-user entity is new, not a rewrite");
-    // Classified as its own kind rather than inheriting the space-scope row's.
-    assertEquals(Object.values(v.diff.removedByKind).length, 0);
+    assertEquals(v.diff.changed, 1, "the space-scope row of the same id moved");
+    // The point of the test: `of:named` exists at two scopes, and the changed
+    // one must be classified from ITS OWN row. A by-id lookup would let
+    // whichever scope enumerated last supply the kind for both.
+    assertEquals(
+      v.diff.changedByKind,
+      { "owned-cell": 1 },
+      "classified from the changed entity's own (id, scope), not by id alone",
+    );
+    assertEquals(v.diff.removedByKind, {});
   });
 });
 

--- a/packages/state-inspector/test/fingerprint.test.ts
+++ b/packages/state-inspector/test/fingerprint.test.ts
@@ -223,8 +223,10 @@ Deno.test("diff names what moved, not merely that something did", () => {
 
   const d = diffFingerprints(before!, after!);
   assert(!d.equal);
-  assertEquals(d.changed, ["of:named"]);
-  assertEquals(d.added, ["of:newcomer"]);
+  // Addresses, not bare ids: an id is not unique across scopes, so the diff
+  // reports the (id, scope) pair it actually compared by.
+  assertEquals(d.changed, [{ id: "of:named", scope: "space" }]);
+  assertEquals(d.added, [{ id: "of:newcomer", scope: "space" }]);
   assertEquals(d.removed, []);
 
   assert(
@@ -236,8 +238,8 @@ Deno.test("diff names what moved, not merely that something did", () => {
   // entity is the failure this must catch, and it reads as `removed`, never as
   // a bare "the fingerprints differ".
   const reverse = diffFingerprints(after!, before!);
-  assertEquals(reverse.removed, ["of:newcomer"]);
-  assertEquals(reverse.changed, ["of:named"]);
+  assertEquals(reverse.removed, [{ id: "of:newcomer", scope: "space" }]);
+  assertEquals(reverse.changed, [{ id: "of:named", scope: "space" }]);
   assertEquals(reverse.added, []);
 });
 

--- a/skills/state-inspector/SKILL.md
+++ b/skills/state-inspector/SKILL.md
@@ -158,7 +158,8 @@ fixed recipe. The recurring debugging questions and where they resolve:
   because overwriting authored content is a change rather than a removal. Stop
   the server before `reset`: unlinking the database does not reach a process
   holding it open, so `reset` refuses rather than let a served clone keep
-  serving the discarded attempt. Full procedure:
+  serving the discarded attempt — a tripwire for a forgotten stop, not a
+  substitute for it. Full procedure:
   `docs/development/space-clone-rehearsal.md`.
   `cf space fingerprint <space>` runs the content check alone against any store.
   Compiler-generated internal cells are excluded by default: a pattern update

--- a/skills/state-inspector/SKILL.md
+++ b/skills/state-inspector/SKILL.md
@@ -142,14 +142,24 @@ fixed recipe. The recurring debugging questions and where they resolve:
   burst from the same writes spread over a week — churn is the shape-in-time
   view: a storm starting, and a settle completing. Use it before and after a
   `setsrc` on a populated space; `--bucket`/`--since`/`--until` frame the
-  window. It reports rates and never judges them — what counts as "settled" is
-  yours to decide.
+  window. Pass `--until` with the moment you stopped watching: the curve then
+  covers the window you asked about rather than ending at the last write, which
+  is the difference between showing a storm and showing it SETTLE. It reports
+  rates and never judges them — what counts as "settled" is yours to decide.
 - _"Did a migration preserve this space's content?"_ → `cf space` (a sibling
   command, not `inspect` — a clone exists to be written to, so it lives outside
   inspect's read-only contract). `cf space clone <did> --from <snapshot> --to
-  <dir>` builds a writable rehearsal copy plus a manifest; `verify` reports
-  whether durable content still matches the baseline (exiting nonzero when it
-  does not) and `reset` restores it for the next attempt.
+  <dir>` builds a writable rehearsal copy plus a manifest; `verify` reports what
+  moved against that baseline and `reset` restores it for the next attempt.
+  Two things decide whether a rehearsal means anything, and both are easy to get
+  wrong: `verify` is strict by default (any change exits nonzero, right for an
+  untouched clone, wrong after a migration — pass `--expect-migration`, which
+  gates on entities REMOVED instead), and it cannot see a clobber either way,
+  because overwriting authored content is a change rather than a removal. Stop
+  the server before `reset`: unlinking the database does not reach a process
+  holding it open, so `reset` refuses rather than let a served clone keep
+  serving the discarded attempt. Full procedure:
+  `docs/development/space-clone-rehearsal.md`.
   `cf space fingerprint <space>` runs the content check alone against any store.
   Compiler-generated internal cells are excluded by default: a pattern update
   rotates their identities on purpose, so counting them would change the


### PR DESCRIPTION
## Why

`cf space reset` cannot reset a clone a server is currently serving, and says
it did.

`resetClone` unlinks the working database, its `-wal` and `-shm`, then copies
the pristine bytes back under the same pathname. Unlinking a file does not
reach a process that already holds it. A running toolshed caches its engine
per space (`#engines`, `packages/memory/v2/server.ts:887`, cleared only on
close), so it keeps reading and writing the *unlinked* inode while every new
reader sees the restored one — including the `verify` that `cf space reset`
runs immediately afterwards, which then prints "content matches baseline".

Reproduced:

```
{"verifier": ["baseline"], "server": ["pass1"]}
```

The runbook starts a toolshed at step 2, migrates at step 4, and resets at
step 6 without ever stopping it, then asks for "two consecutive clean passes,
resetting between them". So pass two could run against pass one's state under
a green verdict — the exact failure the two-pass procedure exists to rule out.
That invalidates the blessed practice before it is used on a populated space.

The rest of this PR closes the gaps that make a rehearsal *gate* mean less
than it appears to: evidence the tool had but never showed, a settle condition
the churn curve structurally could not demonstrate, and a check the runbook
called "not optional" while supplying no command for it.

Follows #5168, #5157, #5153, #5150, #5140, #5122, #5081, #5079, #5009.

## What Changed

**The reset guard.** `resetClone` refuses while anything still holds the
working copy. The probe takes SQLite's exclusive lock — which in WAL mode
cannot be granted while another connection has the shared-memory index mapped
— rather than a PID or lease file. That asks the OS the actual question,
needs no bookkeeping that can go stale, and stays correct in the case a marker
gets wrong: a toolshed that is running but has never opened *this* space's
engine holds nothing, and resetting under it is safe. A working copy that
cannot be opened as a database still resets, since that is precisely when a
reset is the remedy rather than the risk.

**Churn can now show a settle.** Zero-filling stopped at the last observed
commit, so a storm that has just stopped ends on its busiest bucket and the
curve can never show "returned to baseline *and stayed there*". `--until` now
widens the curve to the window asked about instead of only filtering it, and
the report carries `lastCommit` against `to` — where writing stopped versus
where watching stopped. Rather than add the flag a review proposed, this gives
the existing bound the meaning it already implied.

Separately: a bound SQLite cannot parse compares as NULL and therefore matched
*no* commits, reporting "no timed commits in window" — indistinguishable from
a genuinely quiet space, and a false all-clear on the one check the command
exists to support. It is now refused.

**Uncertainty is visible.** `unhashable` and `ambiguous` entities are absent
from the fingerprint by construction, and neither `verify` nor the manifest
mentioned them, so a verdict resting on partial evidence read exactly like one
resting on all of it. Both are now recorded at clone time and printed by
`clone` and `verify`. Neither gates — documented, with the reason each behaves
the way it does.

**`diffFingerprints` returns `(id, scope)`.** It keyed by both internally and
returned bare ids, forcing `clone.ts` into a by-id fallback that lets the last
scope win. The type narrows the existing `EntityAddress` rather than
duplicating it, so an entry hands straight to `reconstructDocument`.

**Snapshot download.** Plaintext `http` is refused outside loopback (docs said
https; the code took `/^https?:\/\//`), and staging cleanup moved inside
`fetchSnapshot` — it is called outside the caller's `try`, so a stream dying
mid-download stranded a partial file at the gigabyte scale the flag exists for.

**Docs.** Stop/reset/restart ordering in both runbooks; `HOST=127.0.0.1` in
the printed serve line (the toolshed defaults to `0.0.0.0`, and a clone keeps
production's DID); offline reads take the clone's database path, since
`~/clones` is not a discovery root and naming the space resolves to whichever
same-DID store discovery finds; a deterministic FID/identity manifest
replacing a circular instruction; and the authored-content check now has
commands and a worked example. `docs/plans/topics-migration-rehearsal.md`
claimed a successful migration leaves the fingerprint unchanged and omitted
`--expect-migration` — both contradicted shipped behavior.

**Not done:** the protected-authored-state baseline. `--expect-migration`
gates on removal and discloses that prominently; making it a migration verdict
is a design change, not a bug fix. Instead the runbook now states plainly that
a clean pass is four things, only one of which is this exit code.

## Test plan

`deno test packages/state-inspector/test/` (90 passed), `packages/cli`
`space.test.ts` (18 steps), `inspect-churn.test.ts`, `main-command.test.ts`;
`deno fmt --check`, `deno lint`, `deno task check-docs` (523 blocks),
`deno task check-skill-facts`.

New tests, each pinned to a defect rather than to the implementation:

- reset refuses while a connection is held, and succeeds once it is released
  (every pre-existing reset test closed its connection first, which is the
  case that cannot catch this);
- reset still works on a working copy that is not a database;
- staging is cleaned when the download dies mid-stream (the existing 404 test
  throws *before* `makeTempDir`, so the leak path was untested);
- plaintext http is refused;
- the curve covers the window asked for, and an unreadable bound is refused;
- the per-kind scope test now asserts the changed entity's kind. The previous
  version asserted only that `removedByKind` was empty while `removed` was 0
  — vacuous. I verified the rewrite fails against a by-id lookup.

Verified by hand through the real CLI against a seeded clone: the reset
refusal and its recovery, the uncertainty line, the `--expect-migration`
verdict, and the authored-content pipeline — which surfaced a clobbered input
as `free-cell of:input` on a clone where `verify --expect-migration` exited 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents silent bad rehearsals by refusing `cf space reset` while a server holds the clone’s DB (tripwire, not a lock), makes churn settles observable, and surfaces fingerprint uncertainty on both baseline and working. Secures snapshot downloads by validating every redirect hop and bounding loops.

- **New Features**
  - `cf space reset` guards via a SQLite exclusive lock and proceeds if the working copy isn’t a database.
  - Churn: `--until` widens the curve to the full window; footer shows `last commit …, observed through …`.
  - Fingerprints: `cf space clone`/`verify` now show `unhashable` and `ambiguous` counts for both baseline and working; `diffFingerprints` returns `(id, scope)` for precise tallies; serve hint binds `HOST=127.0.0.1`.

- **Bug Fixes**
  - Churn bounds: unreadable or backwards/empty `--since/--until` are rejected instead of silently matching no commits.
  - Snapshot fetch: refuse plaintext `http` off loopback, validate transport on every redirect hop, follow permitted redirects (relative too) with a hop cap, and clean staging if a stream dies mid-download.
  - Docs: clarified stop/reset/restart ordering, exact DB-path usage for offline reads, and a worked authored-content check with commands.

<sup>Written for commit f4894260e9cf542c9fbaa0403976e5dea1c97e88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

