### PR TITLE
fix(cli,runner): tear down the runtime that writes a vintage fixture

### DIFF
--- a/docs/plans/pattern-update-state-continuity.md
+++ b/docs/plans/pattern-update-state-continuity.md
@@ -243,18 +243,6 @@ Things this stage settled that the plan had wrong or open:
   materialize could snapshot a space missing the very state the tier replays.
   Downstream cases would go red, but several layers from the cause. It is now
   `editWithRetry` with the result asserted.
-- The runtime that WRITES a fixture is torn down before the snapshot, and that
-  takes a `dispose({ closeStorage: false })` to express: the store belongs to
-  the capture, which needs it open to flush, so the runner cannot use a plain
-  `dispose()`. What it buys over the per-step `idle()`/`synced()` is the
-  background work that lives OUTSIDE the scheduler — `patternUpdater`'s source
-  checks and the runner's pointer-commit roll-forwards, which no settle covers.
-  Measured on both required fixtures: quiescing the writer at the snapshot point
-  runs no further scheduler action and adds no commit, so this is the contract
-  made structural rather than a bug fixed. It matters because the alternative is
-  a snapshot whose completeness depends on which of two runtimes won a race, and
-  the tier's whole claim is that a fixture holds a state the pattern reached.
-
 On `setPattern` versus `PatternUpdater`: the replay drives the updater's path,
 because that is what the field actually runs. The difference is the whole
 reason this regime is CI-only — `cf piece setsrc` calls
@@ -550,6 +538,35 @@ recapture again.
 Gate: a vintage contains data a change can strand, so stage 5's value
 comparison has something to compare, and every change is checked against every
 world ever captured.
+
+Things this stage settled that the plan had wrong or open:
+
+- The runtime that WRITES a fixture is torn down before the snapshot, which
+  takes a `dispose({ closeStorage: false })` to express — the store is the
+  capture's, and a callee must not tear down what its caller is still using.
+  What the teardown buys over the per-step `idle()`/`synced()` is the work that
+  lives OUTSIDE the scheduler: `patternUpdater`'s source checks, the runner's
+  pointer-commit roll-forwards, and in-flight async builtin work, none of which
+  a settle covers. Measured on both required fixtures: quiescing the writer at
+  the snapshot point runs no further scheduler action and adds no commit, so
+  this is the contract made structural, not a bug fixed. It matters because the
+  alternative is a snapshot whose completeness depends on which of two runtimes
+  won a race, and the tier's whole claim is that a fixture holds a state the
+  pattern reached.
+- A kept store keeps RECORDING, so that path also drains in-flight async
+  builtin work first — `settled()` is the only barrier that waits for a fetch /
+  llm call or a sqlite RPC and its writeback, and it runs before anything is
+  cancelled so a writeback's cascade is not cut midway. Without it a capture
+  whose pattern uses an async builtin could snapshot a partial result.
+- Closing the caller's store would NOT have broken this capture, and that is not
+  a reason to do it. Measured: forcing `closeStorage: true` still produced a
+  byte-for-byte equivalent fixture, because `close()` destroys the manager's
+  providers and rotates its session id rather than latching it shut, and the
+  harness owns the memory server the manager re-provisions against. Under
+  `StorageManager.emulate`, which owns its own server, the same close strands
+  every later write. So the survivability of a close depends on ownership the
+  callee cannot see, which is the argument for handing the decision back rather
+  than for relying on the recovery.
 
 **The cycle — DECIDED.** Per change:
 

--- a/docs/plans/pattern-update-state-continuity.md
+++ b/docs/plans/pattern-update-state-continuity.md
@@ -557,16 +557,26 @@ Things this stage settled that the plan had wrong or open:
   builtin work first — `settled()` is the only barrier that waits for a fetch /
   llm call or a sqlite RPC and its writeback, and it runs before anything is
   cancelled so a writeback's cascade is not cut midway. Without it a capture
-  whose pattern uses an async builtin could snapshot a partial result.
+  whose pattern uses an async builtin could snapshot a partial result. The
+  drain is UNCAPPED: `settled()`'s default gives up after 50 rounds and returns
+  with work outstanding, no throw and no signal, which is the same hole one
+  layer down. Measured over 60 generations of chained tracked work — a capped
+  drain returns at generation 50 while the chain keeps writing.
 - Closing the caller's store would NOT have broken this capture, and that is not
   a reason to do it. Measured: forcing `closeStorage: true` still produced a
-  byte-for-byte equivalent fixture, because `close()` destroys the manager's
-  providers and rotates its session id rather than latching it shut, and the
-  harness owns the memory server the manager re-provisions against. Under
+  logically identical fixture — same commit / revision / doc counts and the same
+  op multiset once entity ids are masked. But the reason it survived is narrower
+  than it looks. `close()` destroys the manager's providers and rotates its
+  session id rather than latching it shut, so what a later write does depends on
+  circumstance: a write to a doc the replica never saw lands, a retrying writer
+  recovers, and a bare `commit()` to a doc the replica already knew fails its
+  stale-read precondition and loses the write. The capture came through because
+  `writeVintageManifest` uses `editWithRetry` on a doc nothing had touched —
+  both favourable conditions at once — not because closing is benign. Under
   `StorageManager.emulate`, which owns its own server, the same close strands
-  every later write. So the survivability of a close depends on ownership the
-  callee cannot see, which is the argument for handing the decision back rather
-  than for relying on the recovery.
+  everything. Which case a caller lands in turns on ownership the callee cannot
+  see, which is the argument for handing the decision back rather than for
+  relying on the recovery.
 
 **The cycle — DECIDED.** Per change:
 

--- a/docs/plans/pattern-update-state-continuity.md
+++ b/docs/plans/pattern-update-state-continuity.md
@@ -243,6 +243,17 @@ Things this stage settled that the plan had wrong or open:
   materialize could snapshot a space missing the very state the tier replays.
   Downstream cases would go red, but several layers from the cause. It is now
   `editWithRetry` with the result asserted.
+- The runtime that WRITES a fixture is torn down before the snapshot, and that
+  takes a `dispose({ closeStorage: false })` to express: the store belongs to
+  the capture, which needs it open to flush, so the runner cannot use a plain
+  `dispose()`. What it buys over the per-step `idle()`/`synced()` is the
+  background work that lives OUTSIDE the scheduler — `patternUpdater`'s source
+  checks and the runner's pointer-commit roll-forwards, which no settle covers.
+  Measured on both required fixtures: quiescing the writer at the snapshot point
+  runs no further scheduler action and adds no commit, so this is the contract
+  made structural rather than a bug fixed. It matters because the alternative is
+  a snapshot whose completeness depends on which of two runtimes won a race, and
+  the tier's whole claim is that a fixture holds a state the pattern reached.
 
 On `setPattern` versus `PatternUpdater`: the replay drives the updater's path,
 because that is what the field actually runs. The difference is the whole

--- a/docs/specs/PATTERN_TESTING_SPEC.md
+++ b/docs/specs/PATTERN_TESTING_SPEC.md
@@ -275,7 +275,10 @@ async function runTestPattern(testPath: string, options: TestOptions): Promise<T
     storageManager,
     apiUrl: new URL(import.meta.url)
   });
-  const engine = new Engine(runtime);
+  // The runtime's OWN harness, never a second Engine: verified-load
+  // registration, source maps and module hashes live on the engine that
+  // evaluates the bundle, and splitting them breaks CFC verified bindings.
+  const engine = runtime.harness;
 
   // 2. Compile and run the test pattern
   const program = await engine.resolve(

--- a/docs/specs/PATTERN_TESTING_SPEC.md
+++ b/docs/specs/PATTERN_TESTING_SPEC.md
@@ -364,9 +364,9 @@ async function runTestPattern(testPath: string, options: TestOptions): Promise<T
     }
   }
 
-  // 6. Cleanup
-  engine.dispose();
-  await storageManager.close();
+  // 6. Cleanup. `dispose()` also closes the storage manager; a caller that
+  // supplied its own passes `{ closeStorage: false }` and closes it itself.
+  await runtime.dispose();
 
   return { results, path: testPath };
 }

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -1930,6 +1930,12 @@ export async function runTestPattern(
     // it wrote — so it is RAISED, not logged. A capture refused is recoverable;
     // a fixture silently missing state is the failure this whole path exists to
     // prevent.
+    //
+    // Losing the race ABANDONS the dispose rather than cancelling it: `settled()`
+    // takes no abort signal, so the drain runs on in the background and the
+    // steps after it never happen. Acceptable because the only path that can
+    // reach it has already failed — the capture is refused and its temp store
+    // and server are torn down by `captureVintage`'s own `finally`.
     const runnerOwnsStorage = options.storageHost === undefined;
     const teardown = withPhase(
       ["runTestPattern", "cleanup", "runtimeDispose"],

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -1980,7 +1980,20 @@ export async function runTests(
   for (const testPath of paths) {
     console.log(`\n${basename(testPath)}`);
 
-    const result = await runTestPattern(testPath, options);
+    // `runTestPattern` RAISES a teardown that did not complete, which is the
+    // right contract for a direct caller — the vintage capture is about to read
+    // what the run wrote, so it must refuse rather than snapshot. A multi-file
+    // run is the other case: one wedged file is a failure of that file, not a
+    // reason the remaining ones go unreported. Counted and skipped past, so the
+    // exit code is still non-zero.
+    let result: TestRunResult;
+    try {
+      result = await runTestPattern(testPath, options);
+    } catch (error) {
+      totalFailed++;
+      console.log(`  ✗ ${formatError(error)}`);
+      continue;
+    }
     allResults.push(result);
 
     if (result.error) {

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -364,6 +364,10 @@ export interface TestRunnerOptions {
    * The caller OWNS the lifecycle: the runner will not close this storage
    * manager, because the snapshot happens after the run and needs the store
    * open to flush through `synced()`.
+   *
+   * The RUNTIME is still torn down (`dispose({ closeStorage: false })`), which
+   * is what makes reading the store afterwards a statement about the state the
+   * run reached: the runtime that wrote it can no longer commit into it.
    */
   storageHost?: {
     identity: Identity;
@@ -1896,17 +1900,24 @@ export async function runTestPattern(
     // 6. Cleanup
     continuousUiCancel?.();
     continuousUiCancel = undefined;
-    await withPhase(["runTestPattern", "cleanup", "engineDispose"], () => {
-      engine.dispose();
-    });
-    // A caller-supplied store is the CALLER's to close: the vintage capture
-    // snapshots after this returns and needs the store open to flush.
-    if (options.storageHost === undefined) {
-      await withPhase(
-        ["runTestPattern", "cleanup", "storageClose"],
-        () => storageManager.close(),
-      );
-    }
+    // Tear the whole runtime down, not just its engine. What that buys beyond
+    // `engine.dispose()` is that the runtime STOPS WRITING: `runner.stopAll()`,
+    // `patternUpdater.dispose()` and the pointer-commit settle stop and drain
+    // the background work that lives OUTSIDE the scheduler, so no per-step
+    // `idle()`/`synced()` covers it. That matters most for a caller-supplied
+    // store, which outlives this call and gets READ afterwards — the vintage
+    // capture snapshots it — because a snapshot taken while the writer can
+    // still commit records whatever happened to have landed by then rather
+    // than the state the run reached.
+    //
+    // `closeStorage` is what makes disposing possible here at all: a
+    // caller-supplied store is the CALLER's to close, and the capture needs it
+    // open to flush the snapshot through `synced()`.
+    await withPhase(
+      ["runTestPattern", "cleanup", "runtimeDispose"],
+      () =>
+        runtime.dispose({ closeStorage: options.storageHost === undefined }),
+    );
   }
 }
 

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -362,12 +362,14 @@ export interface TestRunnerOptions {
    * fixture instead of a bare materialized root.
    *
    * The caller OWNS the lifecycle: the runner will not close this storage
-   * manager, because the snapshot happens after the run and needs the store
-   * open to flush through `synced()`.
+   * manager, because a callee must not tear down a resource its caller is
+   * still using — the snapshot happens after the run returns.
    *
    * The RUNTIME is still torn down (`dispose({ closeStorage: false })`), which
    * is what makes reading the store afterwards a statement about the state the
-   * run reached: the runtime that wrote it can no longer commit into it.
+   * run reached: the runtime that wrote it can no longer commit into it. A
+   * teardown that does not complete is RAISED on this path rather than logged,
+   * since the caller would otherwise read a store whose writer never stopped.
    */
   storageHost?: {
     identity: Identity;
@@ -1898,26 +1900,54 @@ export async function runTestPattern(
       });
     }
     // 6. Cleanup
+    // The run is over, so pattern-code output during teardown is no longer the
+    // test's behavior. This matters more than it used to: `engine.dispose()`
+    // was the FIRST cleanup step and killed the SES runtime immediately, while
+    // `Runtime.dispose()` reaches `harness.dispose()` only at the end — so the
+    // drain below now runs with pattern code still able to log. Both capture
+    // lists are returned BY REFERENCE, so a late push would still fail the run.
+    consoleCaptureActive = false;
     continuousUiCancel?.();
     continuousUiCancel = undefined;
-    // Tear the whole runtime down, not just its engine. What that buys beyond
-    // `engine.dispose()` is that the runtime STOPS WRITING: `runner.stopAll()`,
-    // `patternUpdater.dispose()` and the pointer-commit settle stop and drain
-    // the background work that lives OUTSIDE the scheduler, so no per-step
-    // `idle()`/`synced()` covers it. That matters most for a caller-supplied
-    // store, which outlives this call and gets READ afterwards — the vintage
-    // capture snapshots it — because a snapshot taken while the writer can
-    // still commit records whatever happened to have landed by then rather
-    // than the state the run reached.
+    // Tear the whole runtime down, not just its engine: that is what stops it
+    // WRITING (`Runtime.dispose`'s JSDoc has the mechanism). It matters here
+    // because a caller-supplied store outlives this call and gets READ — the
+    // vintage capture snapshots it — so a runtime still able to commit would
+    // make the snapshot a race rather than a record. `closeStorage` keeps that
+    // store the CALLER's to close.
     //
-    // `closeStorage` is what makes disposing possible here at all: a
-    // caller-supplied store is the CALLER's to close, and the capture needs it
-    // open to flush the snapshot through `synced()`.
-    await withPhase(
+    // Bounded the same way every other await in this function is (the step
+    // settles at `settleRuntime`), and for the same reason: a pattern under
+    // test is untrusted code that may never quiesce, and `scheduler.idle()` —
+    // which `dispose()` awaits — never resolves for a system that genuinely
+    // never settles. Unbounded, one such pattern turns "this file reports a
+    // timeout" into "`cf test` hangs with no output", since `runTests` has no
+    // per-file guard. Firing early is safe here in a way it is not elsewhere:
+    // it only skips the rest of a teardown in a process that is moving on.
+    //
+    // Except when the caller supplied the store. There an incomplete teardown
+    // means the writer was NOT quiesced, and the caller is about to read what
+    // it wrote — so it is RAISED, not logged. A capture refused is recoverable;
+    // a fixture silently missing state is the failure this whole path exists to
+    // prevent.
+    const runnerOwnsStorage = options.storageHost === undefined;
+    const teardown = withPhase(
       ["runTestPattern", "cleanup", "runtimeDispose"],
       () =>
-        runtime.dispose({ closeStorage: options.storageHost === undefined }),
+        Promise.race([
+          runtime.dispose({ closeStorage: runnerOwnsStorage }),
+          timeout(TIMEOUT, `Runtime teardown timed out after ${TIMEOUT}ms`),
+        ]),
     );
+    if (runnerOwnsStorage) {
+      await teardown.catch((error) => {
+        console.error(
+          `[cf test] teardown failed for ${testPath}: ${formatError(error)}`,
+        );
+      });
+    } else {
+      await teardown;
+    }
   }
 }
 

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -1939,15 +1939,16 @@ export async function runTestPattern(
           timeout(TIMEOUT, `Runtime teardown timed out after ${TIMEOUT}ms`),
         ]),
     );
-    if (runnerOwnsStorage) {
-      await teardown.catch((error) => {
-        console.error(
-          `[cf test] teardown failed for ${testPath}: ${formatError(error)}`,
-        );
-      });
-    } else {
-      await teardown;
-    }
+    await teardown.catch((error) => {
+      // Reported either way. Raising from a `finally` DISCARDS the result this
+      // function was about to return — the catch above already turned a failing
+      // run into one — so without this line a test that fails its assertions
+      // AND wedges teardown would report only the wedge.
+      console.error(
+        `[cf test] teardown failed for ${testPath}: ${formatError(error)}`,
+      );
+      if (!runnerOwnsStorage) throw error;
+    });
   }
 }
 

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -368,8 +368,8 @@ export interface TestRunnerOptions {
    * The RUNTIME is still torn down (`dispose({ closeStorage: false })`), which
    * is what makes reading the store afterwards a statement about the state the
    * run reached: the runtime that wrote it can no longer commit into it. A
-   * teardown that does not complete is RAISED on this path rather than logged,
-   * since the caller would otherwise read a store whose writer never stopped.
+   * teardown that does not complete is RAISED, so a caller never reads a store
+   * whose writer never stopped.
    */
   storageHost?: {
     identity: Identity;
@@ -1925,35 +1925,36 @@ export async function runTestPattern(
     // per-file guard. Firing early is safe here in a way it is not elsewhere:
     // it only skips the rest of a teardown in a process that is moving on.
     //
-    // Except when the caller supplied the store. There an incomplete teardown
-    // means the writer was NOT quiesced, and the caller is about to read what
-    // it wrote — so it is RAISED, not logged. A capture refused is recoverable;
-    // a fixture silently missing state is the failure this whole path exists to
-    // prevent.
+    // A teardown that does not complete is RAISED, on both paths. It says the
+    // runtime never quiesced, which is a fact about the pattern under test —
+    // reporting it only to stderr would let `cf test` exit 0 on a run whose
+    // writer was still going, and a caller that supplied its own store is worse
+    // off still, since it is about to read what that writer wrote. Raising also
+    // keeps the pre-existing contract: `storageManager.close()` used to sit here
+    // unguarded, so a failing teardown already failed the file.
     //
-    // Losing the race ABANDONS the dispose rather than cancelling it: `settled()`
-    // takes no abort signal, so the drain runs on in the background and the
-    // steps after it never happen. Acceptable because the only path that can
-    // reach it has already failed — the capture is refused and its temp store
-    // and server are torn down by `captureVintage`'s own `finally`.
-    const runnerOwnsStorage = options.storageHost === undefined;
+    // Logged BEFORE it is raised because throwing from a `finally` discards the
+    // result this function was about to return, including any step failures.
+    // The exit code is right either way; the log is what keeps the diagnosis.
+    //
+    // Losing the race ABANDONS the dispose rather than cancelling it:
+    // `settled()` takes no abort signal, so the drain runs on in the background
+    // and the steps after it never happen. Acceptable because the only path
+    // that reaches it has already failed, and a capture's temp store and server
+    // are torn down by `captureVintage`'s own `finally`.
     const teardown = withPhase(
       ["runTestPattern", "cleanup", "runtimeDispose"],
       () =>
         Promise.race([
-          runtime.dispose({ closeStorage: runnerOwnsStorage }),
+          runtime.dispose({ closeStorage: options.storageHost === undefined }),
           timeout(TIMEOUT, `Runtime teardown timed out after ${TIMEOUT}ms`),
         ]),
     );
     await teardown.catch((error) => {
-      // Reported either way. Raising from a `finally` DISCARDS the result this
-      // function was about to return — the catch above already turned a failing
-      // run into one — so without this line a test that fails its assertions
-      // AND wedges teardown would report only the wedge.
       console.error(
         `[cf test] teardown failed for ${testPath}: ${formatError(error)}`,
       );
-      if (!runnerOwnsStorage) throw error;
+      throw error;
     });
   }
 }

--- a/packages/cli/test/fixtures/storage-host/counter.test.tsx
+++ b/packages/cli/test/fixtures/storage-host/counter.test.tsx
@@ -1,0 +1,21 @@
+/**
+ * Fixture for the caller-supplied storage host. Writes durable state through a
+ * real handler, so a caller reading the store after the run has something the
+ * pattern actually reached to find — which is the whole point of the option
+ * (the pattern-vintage capture snapshots the store afterwards).
+ */
+import { action, computed, pattern, Writable } from "commonfabric";
+
+export default pattern(() => {
+  const count = new Writable(0).for("count");
+  const bump = action(() => count.set(count.get() + 1));
+
+  return {
+    count,
+    tests: [
+      { action: bump },
+      { action: bump },
+      { assertion: computed(() => count.get() === 2) },
+    ],
+  };
+});

--- a/packages/cli/test/test-runner-storage-host.test.ts
+++ b/packages/cli/test/test-runner-storage-host.test.ts
@@ -79,5 +79,37 @@ describe(
       // The caller owns the close, which is the other half of the contract.
       await reader.dispose();
     });
+
+    it("RAISES a teardown that does not complete", async () => {
+      // The other half of "the store is the caller's": the caller is about to
+      // read what this run wrote, so a teardown that did not finish must not be
+      // reported as a completed run. `captureVintage` turns the throw into a
+      // refused capture rather than a fixture silently missing state.
+      //
+      // Driven by a store whose `synced()` always rejects, which is what the
+      // teardown drain awaits. The run itself fails too — that is fine and not
+      // what this pins; the claim is that the failure REACHES the caller rather
+      // than being logged and swallowed.
+      const identity = await Identity.fromPassphrase("cli storage host raise");
+      const wedged = StorageManager.emulate({ as: identity });
+      // Patched on the INSTANCE, not through a Proxy: the manager reads private
+      // class fields, and a Proxy receiver makes `#telemetry` throw before the
+      // wedge under test is ever reached.
+      (wedged as { synced: () => Promise<void> }).synced = () =>
+        Promise.reject(new Error("wedged store"));
+
+      await expect(
+        runTestPattern(resolve(FIXTURES, "counter.test.tsx"), {
+          root: FIXTURES,
+          storageHost: {
+            identity,
+            storageManager: wedged,
+            resultCause: RESULT_CAUSE,
+          },
+        }),
+      ).rejects.toThrow("wedged store");
+
+      await wedged.close();
+    });
   },
 );

--- a/packages/cli/test/test-runner-storage-host.test.ts
+++ b/packages/cli/test/test-runner-storage-host.test.ts
@@ -21,7 +21,7 @@ import { resolve } from "@std/path";
 import { Identity } from "@commonfabric/identity";
 import { Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { runTestPattern } from "../lib/test-runner.ts";
+import { runTestPattern, runTests } from "../lib/test-runner.ts";
 
 const FIXTURES = resolve(import.meta.dirname!, "fixtures/storage-host");
 
@@ -108,6 +108,27 @@ describe(
           },
         }),
       ).rejects.toThrow("wedged store");
+
+      await wedged.close();
+    });
+
+    it("counts a raised teardown per file and keeps the run going", async () => {
+      // The raise is right for a DIRECT caller and wrong for a multi-file run:
+      // one wedged file must not take the remaining files' results with it.
+      // Two paths, both wedged — a `failed` of 2 is what says the loop got past
+      // the first one rather than aborting on it.
+      const identity = await Identity.fromPassphrase("cli storage host suite");
+      const wedged = StorageManager.emulate({ as: identity });
+      (wedged as { synced: () => Promise<void> }).synced = () =>
+        Promise.reject(new Error("wedged store"));
+      const fixture = resolve(FIXTURES, "counter.test.tsx");
+
+      const { failed } = await runTests([fixture, fixture], {
+        root: FIXTURES,
+        storageHost: { identity, storageManager: wedged },
+      });
+
+      expect(failed).toBe(2);
 
       await wedged.close();
     });

--- a/packages/cli/test/test-runner-storage-host.test.ts
+++ b/packages/cli/test/test-runner-storage-host.test.ts
@@ -5,8 +5,15 @@
  *
  * The caller this exists for is the pattern-vintage capture
  * (`tasks/pattern-vintage-run.ts`), which snapshots the store afterwards — so
- * "the store survives and holds what the pattern reached" is the contract, and
- * it is checked here rather than only through the gate that consumes it.
+ * the seam is checked here rather than only through the gate that consumes it.
+ *
+ * The read below goes through the SAME manager, so what it pins is "still open
+ * and its state still reachable through it", not durability: a regression that
+ * stopped flushing at teardown would leave this green. That is the right scope
+ * — the capture's own `snapshot()` does `idle()` + `synced()` before copying
+ * the file, so durability-at-return was never this seam's job. Durability is
+ * witnessed through an independent manager in
+ * `packages/runner/test/runtime-dispose-keep-storage.test.ts`.
  */
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";

--- a/packages/cli/test/test-runner-storage-host.test.ts
+++ b/packages/cli/test/test-runner-storage-host.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Guard for `TestRunnerOptions.storageHost`: the runner runs against a
+ * caller-supplied identity and store, records what the run instantiates, and
+ * leaves that store OPEN and readable once the run returns.
+ *
+ * The caller this exists for is the pattern-vintage capture
+ * (`tasks/pattern-vintage-run.ts`), which snapshots the store afterwards — so
+ * "the store survives and holds what the pattern reached" is the contract, and
+ * it is checked here rather than only through the gate that consumes it.
+ */
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { resolve } from "@std/path";
+import { Identity } from "@commonfabric/identity";
+import { Runtime } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { runTestPattern } from "../lib/test-runner.ts";
+
+const FIXTURES = resolve(import.meta.dirname!, "fixtures/storage-host");
+
+/** Pinned, because an id that differs every run cannot be addressed again. */
+const RESULT_CAUSE = { cliStorageHost: "counter" };
+
+const SCHEMA = {
+  type: "object",
+  properties: { count: { type: "number" } },
+} as const;
+
+describe(
+  "runTestPattern with a caller-supplied storage host",
+  { sanitizeOps: false, sanitizeResources: false },
+  () => {
+    it("leaves the store readable, holding what the run wrote", async () => {
+      const identity = await Identity.fromPassphrase("cli storage host test");
+      const storageManager = StorageManager.emulate({ as: identity });
+      const instantiated: string[] = [];
+
+      const result = await runTestPattern(
+        resolve(FIXTURES, "counter.test.tsx"),
+        {
+          root: FIXTURES,
+          storageHost: {
+            identity,
+            storageManager,
+            resultCause: RESULT_CAUSE,
+            onPatternInstantiated: (i) => instantiated.push(i.identity),
+          },
+        },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.results.filter((r) => !r.passed && !r.skipped)).toEqual([]);
+      // The observer is how the capture learns what to replay later; a run that
+      // recorded nothing would produce a fixture with no update targets.
+      expect(instantiated.length).toBeGreaterThan(0);
+
+      // The runner tore its own runtime down but did NOT close this manager, so
+      // a fresh runtime over it reads the state the handlers wrote — two bumps,
+      // durable, addressable by the cause the caller pinned.
+      const reader = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager,
+      });
+      const root = reader.getCell<{ count: number }>(
+        identity.did(),
+        RESULT_CAUSE,
+        SCHEMA,
+      );
+      await root.sync();
+      expect(root.get()?.count).toBe(2);
+
+      // The caller owns the close, which is the other half of the contract.
+      await reader.dispose();
+    });
+  },
+);

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -1309,8 +1309,20 @@ export class Runtime {
    * Any unawaited tx.commit() calls will be canceled when
    * storageManager.close() tears down storage sessions. Callers
    * should await all pending commits before calling dispose().
+   *
+   * `closeStorage: false` leaves the storage manager OPEN for a caller that
+   * OWNS it and is still using it — a second runtime sharing the same store, or
+   * one that reads the store after this runtime is done writing to it. Every
+   * other step still runs, which is the point: quiescing the WRITER is what
+   * makes a subsequent read of the store a statement about a state this runtime
+   * actually reached. `idle()` and `synced()` cannot substitute, because they
+   * say nothing about the background work that only teardown stops —
+   * `patternUpdater`'s source checks and the runner's pointer-commit
+   * roll-forwards both live outside the scheduler and can still commit.
    */
-  async dispose(): Promise<void> {
+  async dispose(
+    { closeStorage = true }: { closeStorage?: boolean } = {},
+  ): Promise<void> {
     // Abort any pending (not-yet-started) queued jobs so they don't start
     // after storage is torn down.
     for (const queue of this.queues.values()) {
@@ -1339,7 +1351,7 @@ export class Runtime {
     this.moduleRegistry.clear();
 
     // Cancel all storage operations
-    await this.storageManager.close();
+    if (closeStorage) await this.storageManager.close();
 
     // Wait for any pending operations
     await this.scheduler.idle();

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -1322,12 +1322,14 @@ export class Runtime {
    * path also drains in-flight async builtin work first; see below.
    *
    * It is about OWNERSHIP, not survivability. `close()` destroys the manager's
-   * providers and rotates its session id rather than latching it shut, so how
-   * badly closing hurts depends on who owns the server behind it: a manager
-   * over a caller-held server re-provisions and later writes still land, while
-   * `StorageManager.emulate` owns its own server and closing strands them (both
-   * measured). Recovering in one configuration is not a contract, so a callee
-   * hands the decision back rather than relying on it.
+   * providers and rotates its session id rather than latching it shut, so what
+   * a later write does is a matter of circumstance rather than contract — all
+   * measured: over a caller-held server, a write to a doc the replica never saw
+   * lands, a retrying writer (`editWithRetry`) recovers, and a bare `commit()`
+   * to a doc the replica already knew fails its stale-read precondition and
+   * LOSES the write; over `StorageManager.emulate`, which owns its server,
+   * closing strands everything. A callee cannot see which of those its caller
+   * is in, so it hands the decision back rather than betting on the recovery.
    *
    * Passing `false` makes closing the CALLER's job — nothing else will. Note
    * `await using` / `[Symbol.asyncDispose]` always takes the closing path.
@@ -1355,10 +1357,15 @@ export class Runtime {
     // leaving the store holding part of a result — which is worse than either
     // extreme for a reader trying to learn what state this runtime reached.
     //
-    // This is an unbounded wait, deliberately: a bound would report the runtime
-    // quiesced while it was still working, which is the one answer a caller
-    // reading the store afterwards cannot recover from.
-    if (!closeStorage) await this.settled();
+    // UNCAPPED, deliberately. `settled()`'s default 50 rounds falls out of the
+    // loop and returns — silently, with work still outstanding — which is
+    // exactly the hole this drain exists to close, one layer down. Measured: 60
+    // generations of chained tracked work, and a capped drain returned at
+    // generation 50 while the chain kept running and writing. `settledFor`'s
+    // JSDoc gives the reason a cap is wrong for this question and why removing
+    // it cannot spin: every round awaits real promises, so a runtime that keeps
+    // working keeps the barrier open rather than busy-looping.
+    if (!closeStorage) await this.settled(Infinity);
     // Abort any pending (not-yet-started) queued jobs so they don't start
     // after storage is torn down.
     for (const queue of this.queues.values()) {

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -1318,11 +1318,47 @@ export class Runtime {
    * actually reached. `idle()` and `synced()` cannot substitute, because they
    * say nothing about the background work that only teardown stops —
    * `patternUpdater`'s source checks and the runner's pointer-commit
-   * roll-forwards both live outside the scheduler and can still commit.
+   * roll-forwards both live outside the scheduler and can still commit. That
+   * path also drains in-flight async builtin work first; see below.
+   *
+   * It is about OWNERSHIP, not survivability. `close()` destroys the manager's
+   * providers and rotates its session id rather than latching it shut, so how
+   * badly closing hurts depends on who owns the server behind it: a manager
+   * over a caller-held server re-provisions and later writes still land, while
+   * `StorageManager.emulate` owns its own server and closing strands them (both
+   * measured). Recovering in one configuration is not a contract, so a callee
+   * hands the decision back rather than relying on it.
+   *
+   * Passing `false` makes closing the CALLER's job — nothing else will. Note
+   * `await using` / `[Symbol.asyncDispose]` always takes the closing path.
+   *
+   * Either way this resets the PROCESS-GLOBAL experimental config to defaults
+   * (`resetModernCellRepConfig` and friends). Under a non-default flag that is
+   * visible to a second runtime still running against the same store, which is
+   * exactly the caller this option serves — so set the flags per process, not
+   * per runtime, if two of them must agree.
    */
   async dispose(
     { closeStorage = true }: { closeStorage?: boolean } = {},
   ): Promise<void> {
+    // A kept store keeps RECORDING, so this path drains what could still write
+    // into it. In-flight async builtin work is that shape: a fetch / llm call or
+    // a sqlite RPC runs from a post-commit outbox flush and writes its result
+    // back when it lands, and `trackAsyncWork` exists because neither `idle()`
+    // nor `synced()` waits for it. `settled()` is the barrier that does. The
+    // closing path skips it because a caller who let the store close has no
+    // reader left to mislead, and waiting on the network in every teardown is a
+    // real cost; here the caller is about to read what this runtime wrote.
+    //
+    // BEFORE the cancellation below, not after: `stopAll()` and
+    // `scheduler.dispose()` would cut a writeback's reactive cascade midway,
+    // leaving the store holding part of a result — which is worse than either
+    // extreme for a reader trying to learn what state this runtime reached.
+    //
+    // This is an unbounded wait, deliberately: a bound would report the runtime
+    // quiesced while it was still working, which is the one answer a caller
+    // reading the store afterwards cannot recover from.
+    if (!closeStorage) await this.settled();
     // Abort any pending (not-yet-started) queued jobs so they don't start
     // after storage is torn down.
     for (const queue of this.queues.values()) {

--- a/packages/runner/test/runtime-dispose-keep-storage.test.ts
+++ b/packages/runner/test/runtime-dispose-keep-storage.test.ts
@@ -1,0 +1,125 @@
+/**
+ * `dispose({ closeStorage: false })`: tear the runtime down, leave the store.
+ *
+ * The shape this exists for is one store with two runtimes, where one of them
+ * populates the store and something else READS the store afterwards — the
+ * pattern-vintage capture runs a pattern's own tests against a file-backed
+ * space and then snapshots the file (`tasks/pattern-vintage-run.ts`).
+ *
+ * Without this option the writing runtime cannot be disposed at all, because
+ * `dispose()` closes the storage manager and that manager belongs to the
+ * caller. Leaving it undisposed is not equivalent: `runner.stopAll()`,
+ * `patternUpdater.dispose()` and the pointer-commit settle stop and drain
+ * background work that lives OUTSIDE the scheduler, so no amount of `idle()` or
+ * `synced()` substitutes for them — a reader would be sampling a store its
+ * writer can still commit into.
+ */
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+
+const signer = await Identity.fromPassphrase("runtime dispose keep storage");
+const space = signer.did();
+
+const SCHEMA = {
+  type: "object",
+  properties: { value: { type: "number" } },
+} as const;
+
+describe("runtime.dispose({ closeStorage })", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+  });
+
+  afterEach(async () => {
+    // Idempotent: the closing case below has already closed it.
+    await storageManager?.close().catch(() => {});
+  });
+
+  it("leaves a caller-owned store usable by another runtime", async () => {
+    const writer = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    const reader = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+
+    const writeTx = writer.edit();
+    writer.getCell<{ value: number }>(
+      space,
+      "dispose-keep-storage",
+      SCHEMA,
+      writeTx,
+    ).set({ value: 7 });
+    await writeTx.commit();
+    await writer.idle();
+    await storageManager.synced();
+
+    await writer.dispose({ closeStorage: false });
+
+    // The store outlived the writer's teardown: still readable…
+    const cell = reader.getCell<{ value: number }>(
+      space,
+      "dispose-keep-storage",
+      SCHEMA,
+    );
+    await cell.sync();
+    expect(cell.get()).toEqual({ value: 7 });
+
+    // …and still WRITABLE, which is the stronger claim: a manager whose
+    // sessions had been torn down would reject this rather than return a value
+    // it already had cached.
+    const readerTx = reader.edit();
+    cell.withTx(readerTx).set({ value: 8 });
+    await readerTx.commit();
+    await reader.idle();
+    await storageManager.synced();
+    expect(cell.get()).toEqual({ value: 8 });
+
+    await reader.dispose({ closeStorage: false });
+  });
+
+  it("closes the store by default", async () => {
+    const writer = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    const reader = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+
+    const writeTx = writer.edit();
+    writer.getCell<{ value: number }>(space, "dispose-closes", SCHEMA, writeTx)
+      .set({ value: 7 });
+    await writeTx.commit();
+    await writer.idle();
+    await storageManager.synced();
+
+    await writer.dispose();
+
+    // The paired assertion, same sequence as above: without it `closeStorage`
+    // could be ignored in BOTH directions and the case above would still pass.
+    //
+    // A closed manager fails QUIETLY, which is the hazard worth pinning. The
+    // sync resolves and the commit below reports no error — they just reach
+    // nothing. So a caller that hands its store to something that closes it
+    // gets a store that reads empty rather than an exception saying why.
+    const cell = reader.getCell<{ value: number }>(
+      space,
+      "dispose-closes",
+      SCHEMA,
+    );
+    await cell.sync();
+    expect(cell.get()).toBeUndefined();
+
+    await reader.dispose({ closeStorage: false });
+  });
+});

--- a/packages/runner/test/runtime-dispose-keep-storage.test.ts
+++ b/packages/runner/test/runtime-dispose-keep-storage.test.ts
@@ -219,4 +219,40 @@ describe("runtime.dispose({ closeStorage })", () => {
     await held.synced();
     expect(await witnessed("dispose-drains")).toEqual({ value: 42 });
   });
+
+  it("drains work that CHAINS past settled()'s default round cap", async () => {
+    // One generation of tracked work is drained by a capped barrier too, so the
+    // case above cannot see the cap. `settled()`'s default gives up after 50
+    // rounds and returns with work outstanding — no throw, no signal — so a
+    // drain that inherited it would re-open the hole for exactly the shape a
+    // capture is likely to hit: an llm dialog with tool calls, or a fetch chain,
+    // where each result registers the next piece of work.
+    const GENERATIONS = 60;
+    const writer = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: held,
+    });
+
+    let reached = 0;
+    // Each generation registers the NEXT one and does not await it. That is
+    // what costs a round: `settled()` awaits the set it snapshotted, and finds
+    // a fresh entry waiting when it comes back. A chain whose head promise
+    // transitively awaits the whole tail drains in ONE round instead and would
+    // pass under the cap — measured, on the first version of this case.
+    const spawn = () => {
+      const work = new Promise<void>((resolve) => setTimeout(resolve, 0))
+        .then(() => {
+          reached++;
+          if (reached < GENERATIONS) spawn();
+        });
+      writer.trackAsyncWork(work);
+    };
+    spawn();
+
+    await writer.dispose({ closeStorage: false });
+
+    // Verified by mutation: with `settled()` left at its default cap this reads
+    // 50, and the chain is still running after dispose returned.
+    expect(reached).toBe(GENERATIONS);
+  });
 });

--- a/packages/runner/test/runtime-dispose-keep-storage.test.ts
+++ b/packages/runner/test/runtime-dispose-keep-storage.test.ts
@@ -6,20 +6,38 @@
  * pattern-vintage capture runs a pattern's own tests against a file-backed
  * space and then snapshots the file (`tasks/pattern-vintage-run.ts`).
  *
- * Without this option the writing runtime cannot be disposed at all, because
- * `dispose()` closes the storage manager and that manager belongs to the
- * caller. Leaving it undisposed is not equivalent: `runner.stopAll()`,
- * `patternUpdater.dispose()` and the pointer-commit settle stop and drain
- * background work that lives OUTSIDE the scheduler, so no amount of `idle()` or
- * `synced()` substitutes for them — a reader would be sampling a store its
- * writer can still commit into.
+ * The reason is OWNERSHIP, not breakage: a callee must not tear down a resource
+ * its caller owns. Whether closing is survivable varies with who owns the
+ * server behind the manager — `StorageManager.emulate` owns its own, so closing
+ * it strands every later write, while a manager over a caller-held server
+ * silently re-provisions and the writes land (both measured). "It recovered in
+ * this configuration" is not a contract, so what is pinned here is the call
+ * itself: `close()` happens on the default path and does not happen on this
+ * one, and the store stays usable across the teardown.
+ *
+ * TWO storage managers over ONE in-process server, not two runtimes over one
+ * manager. A replica belongs to its StorageManager, so two runtimes sharing one
+ * read the same local heap and a read-back would pass against a store nothing
+ * reached. Every claim here is about what reached the durable store, so the
+ * reader sits behind a manager of its own.
  */
 
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
-import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import type { MemorySpace, Signer } from "@commonfabric/memory/interface";
+import * as MemoryV2Client from "@commonfabric/memory/v2/client";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import {
+  type Options,
+  type SessionFactory,
+  StorageManager,
+} from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
+import {
+  TEST_MEMORY_SERVER_AUTH,
+  testPrincipalSessionOpenAuthFactory,
+} from "./memory-v2-test-utils.ts";
 
 const signer = await Identity.fromPassphrase("runtime dispose keep storage");
 const space = signer.did();
@@ -29,97 +47,176 @@ const SCHEMA = {
   properties: { value: { type: "number" } },
 } as const;
 
+class LoopbackSessionFactory implements SessionFactory {
+  constructor(private readonly server: MemoryV2Server.Server) {}
+  async create(id: string, signer?: Signer) {
+    const client = await MemoryV2Client.connect({
+      transport: MemoryV2Client.loopback(this.server),
+    });
+    const session = await client.mount(
+      id as MemorySpace,
+      {},
+      testPrincipalSessionOpenAuthFactory(signer),
+    );
+    return { client, session };
+  }
+}
+
+/**
+ * Counts `close()` calls, so "the runner closed my store" is asserted directly
+ * rather than through a downstream symptom whose visibility depends on who owns
+ * the server.
+ */
+class CountingStorageManager extends StorageManager {
+  closeCount = 0;
+  static over(server: MemoryV2Server.Server): CountingStorageManager {
+    return new CountingStorageManager(
+      { as: signer, memoryHost: new URL("memory://") } as Options,
+      new LoopbackSessionFactory(server),
+    );
+  }
+  override close(): Promise<void> {
+    this.closeCount++;
+    return super.close();
+  }
+}
+
 describe("runtime.dispose({ closeStorage })", () => {
-  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let server: MemoryV2Server.Server;
+  /** The store under test — handed to a runtime that does not own it. */
+  let held: CountingStorageManager;
+  /** An independent view of the same durable state, for witnessing writes. */
+  let witness: CountingStorageManager;
+  let witnessRuntime: Runtime;
 
-  beforeEach(() => {
-    storageManager = StorageManager.emulate({ as: signer });
-  });
-
-  afterEach(async () => {
-    // Idempotent: the closing case below has already closed it.
-    await storageManager?.close().catch(() => {});
-  });
-
-  it("leaves a caller-owned store usable by another runtime", async () => {
-    const writer = new Runtime({
-      apiUrl: new URL(import.meta.url),
-      storageManager,
-    });
-    const reader = new Runtime({
-      apiUrl: new URL(import.meta.url),
-      storageManager,
-    });
-
-    const writeTx = writer.edit();
-    writer.getCell<{ value: number }>(
+  /** What the durable store holds for `cause`, read through `witness`. */
+  const witnessed = async (cause: string) => {
+    const cell = witnessRuntime.getCell<{ value: number }>(
       space,
-      "dispose-keep-storage",
-      SCHEMA,
-      writeTx,
-    ).set({ value: 7 });
-    await writeTx.commit();
-    await writer.idle();
-    await storageManager.synced();
-
-    await writer.dispose({ closeStorage: false });
-
-    // The store outlived the writer's teardown: still readable…
-    const cell = reader.getCell<{ value: number }>(
-      space,
-      "dispose-keep-storage",
+      cause,
       SCHEMA,
     );
     await cell.sync();
-    expect(cell.get()).toEqual({ value: 7 });
+    return cell.get();
+  };
 
-    // …and still WRITABLE, which is the stronger claim: a manager whose
-    // sessions had been torn down would reject this rather than return a value
-    // it already had cached.
-    const readerTx = reader.edit();
-    cell.withTx(readerTx).set({ value: 8 });
-    await readerTx.commit();
-    await reader.idle();
-    await storageManager.synced();
-    expect(cell.get()).toEqual({ value: 8 });
+  const write = async (runtime: Runtime, cause: string, value: number) => {
+    const tx = runtime.edit();
+    runtime.getCell<{ value: number }>(space, cause, SCHEMA, tx).set({ value });
+    await tx.commit();
+    await runtime.idle();
+  };
 
-    await reader.dispose({ closeStorage: false });
+  beforeEach(() => {
+    server = new MemoryV2Server.Server({
+      authorizeSessionOpen(message) {
+        const principal = (message.authorization as { principal?: unknown })
+          ?.principal;
+        return typeof principal === "string" ? principal : undefined;
+      },
+      sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
+    });
+    held = CountingStorageManager.over(server);
+    witness = CountingStorageManager.over(server);
+    witnessRuntime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: witness,
+    });
+  });
+
+  afterEach(async () => {
+    await witnessRuntime.dispose();
+    // Raised, not swallowed: `close()` is idempotent (measured — a double close
+    // does not throw), so a rejection here is a real teardown failure.
+    await held.close();
+    await server.close();
+  });
+
+  it("leaves a caller-owned store alone and usable", async () => {
+    const writer = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: held,
+    });
+    await write(writer, "dispose-keep-storage", 7);
+    await held.synced();
+
+    await writer.dispose({ closeStorage: false });
+
+    expect(held.closeCount).toBe(0);
+    expect(await witnessed("dispose-keep-storage")).toEqual({ value: 7 });
+
+    // Still ACCEPTS writes — the capture's actual next move, which writes its
+    // manifest through this same manager after the run returns. Witnessed
+    // rather than read back locally, because the manager's own replica serves
+    // a value back whether or not it reached the store.
+    const second = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: held,
+    });
+    await write(second, "dispose-keep-storage-after", 8);
+    await held.synced();
+    expect(await witnessed("dispose-keep-storage-after")).toEqual({ value: 8 });
+
+    await second.dispose({ closeStorage: false });
   });
 
   it("closes the store by default", async () => {
     const writer = new Runtime({
       apiUrl: new URL(import.meta.url),
-      storageManager,
+      storageManager: held,
     });
-    const reader = new Runtime({
-      apiUrl: new URL(import.meta.url),
-      storageManager,
-    });
-
-    const writeTx = writer.edit();
-    writer.getCell<{ value: number }>(space, "dispose-closes", SCHEMA, writeTx)
-      .set({ value: 7 });
-    await writeTx.commit();
-    await writer.idle();
-    await storageManager.synced();
+    await write(writer, "dispose-closes", 7);
+    await held.synced();
 
     await writer.dispose();
 
-    // The paired assertion, same sequence as above: without it `closeStorage`
-    // could be ignored in BOTH directions and the case above would still pass.
-    //
-    // A closed manager fails QUIETLY, which is the hazard worth pinning. The
-    // sync resolves and the commit below reports no error — they just reach
-    // nothing. So a caller that hands its store to something that closes it
-    // gets a store that reads empty rather than an exception saying why.
-    const cell = reader.getCell<{ value: number }>(
-      space,
-      "dispose-closes",
-      SCHEMA,
-    );
-    await cell.sync();
-    expect(cell.get()).toBeUndefined();
+    // The paired assertion: without it `closeStorage` could be ignored in BOTH
+    // directions and the case above would still pass.
+    expect(held.closeCount).toBe(1);
+    // What was already durable survives — closing is not a rollback.
+    expect(await witnessed("dispose-closes")).toEqual({ value: 7 });
+  });
 
-    await reader.dispose({ closeStorage: false });
+  it("drains in-flight async builtin work before tearing down", async () => {
+    // The hole this closes: a fetch / llm call or a sqlite RPC runs from a
+    // post-commit outbox flush and writes its result back when it lands, and
+    // `trackAsyncWork` exists precisely because `idle()` and `synced()` do not
+    // wait for it. A store the caller keeps records that late writeback — after
+    // `dispose()` claimed the runtime was done, and possibly after the caller
+    // read the store.
+    const writer = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: held,
+    });
+
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const order: string[] = [];
+    const work = gate.then(async () => {
+      await write(writer, "dispose-drains", 42);
+      order.push("work");
+    });
+    writer.trackAsyncWork(work);
+
+    const disposing = writer.dispose({ closeStorage: false })
+      .then(() => order.push("dispose"));
+
+    // A yield, not a timeout: `gate` cannot resolve until this test resolves
+    // it, so no number of further turns changes the answer — a dispose that
+    // drains is blocked forever, and one that does not has nothing left to
+    // await (measured: a no-work dispose completes within one macrotask turn).
+    // Verified by mutation: removing the drain reds this assertion, 10 of 10.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(order).toEqual([]);
+
+    release();
+    await disposing;
+    // The writeback lands BEFORE dispose returns, so a caller that reads the
+    // store afterwards sees the state this runtime actually reached.
+    expect(order).toEqual(["work", "dispose"]);
+    await held.synced();
+    expect(await witnessed("dispose-drains")).toEqual({ value: 42 });
   });
 });


### PR DESCRIPTION
Reported as a suspected (mechanism-read, not reproduced) finding in review of #5196. Three review rounds later it has grown a second, real bug and three corrections to my own claims — details below.

## The reported gap

`runTestPattern` disposed only its `engine`, never the `Runtime` it built. It arguably could not: `Runtime.dispose()` closes the storage manager, and under the vintage capture that manager belongs to the caller. So for the runtime that actually **wrote** a fixture, `runner.stopAll()`, `patternUpdater.dispose()`, the pointer-commit settle and `scheduler.idle()` never ran — while `snapshot()`'s own `idle()`/`synced()` ran on the *other* runtime, the one that wrote nothing.

**Does it produce bad fixtures? Measured: no.** Probed at the snapshot point — snapshot, quiesce the writing runtime, snapshot again — for both required patterns:

| pattern | pendingPointerCommits | pendingWatcherLoads | scheduler runCount | before → after |
|---|---|---|---|---|
| `system/home.tsx` | 0 | 0 | 15 → 15 | 15 commits / 96 rev / 89 docs, unchanged |
| `system/default-app.tsx` | 0 | 0 | 124 → 124 | 92 / 270 / 187, unchanged |

Nothing outside the scheduler was armed, and the last step's settle had already drained the scheduler. The contract held by luck. This makes it structural.

## What this changes

`Runtime.dispose({ closeStorage })` — `false` leaves a caller-owned store open; every other teardown step still runs. `runTestPattern` now disposes its runtime, which also closes a plain leak: the `Runtime` was never disposed on *any* path, including ordinary `cf test`.

**The keep-open path drains in-flight async builtin work first.** Codex caught that `#pendingAsyncWork` — a fetch / llm call or sqlite RPC and its writeback — is awaited only by `settled()`, never by `idle()`, so a store the caller keeps would record a write issued after `dispose()` returned. Drained before anything is cancelled, or `stopAll()` cuts a writeback's cascade midway and leaves a partial result.

**Uncapped, and that took a second pass to get right.** `settled()`'s default `maxRounds = 50` falls out of its loop and *returns* — no throw, no signal — with work outstanding, which was the same hole one layer down. Measured over 60 generations of chained tracked work: a capped drain returned at generation 50 while the chain kept writing. Now `settled(Infinity)`, which cannot spin for the reason `settledFor`'s JSDoc already documents.

Teardown is bounded in `runTestPattern` the way every other await there already is — `dispose()` awaits `scheduler.idle()`, which never resolves for a system that genuinely never settles, and unbounded that turns one non-settling pattern from "this file reports a timeout" into "`cf test` hangs with no output". Raised rather than logged when the caller supplied the store.

## Three corrections to claims I made along the way

Recorded because the PR's value is partly in the measurements, and these were wrong:

1. **"A closed StorageManager fails quiet"** — true only for `StorageManager.emulate`, which owns its server. `close()` destroys providers and rotates the session id rather than latching shut.
2. **"The capture needs the store open to flush"** (pre-existing comment) — false. Forcing `closeStorage: true` produced a logically identical fixture. The reason to leave the store alone is **ownership**, not breakage.
3. **Why that experiment passed** — narrower than it looked. Over a caller-held server a post-close write lands only if the doc is one the replica never saw, *or* the writer retries; a bare `commit()` to a known doc fails its stale-read precondition and loses the write. `writeVintageManifest` uses `editWithRetry` on a fresh doc — both favourable conditions at once.

## Tests

`packages/runner/test/runtime-dispose-keep-storage.test.ts` — two storage managers over one in-process server, because two runtimes sharing one manager share its replica and a read-back passes against a store nothing reached. Four cases, each verified red under its own mutation and green under the others: ignore `closeStorage` toward closing, ignore it toward keeping, remove the drain, cap the drain (reds with exactly `50` vs `60`).

`packages/cli/test/test-runner-storage-host.test.ts` — first direct test of the `storageHost` seam: run a fixture against an injected store, then read what the handlers wrote. Reds when the runner closes the caller's store.

## Verification

- `deno task integration pattern-tests` 120/120 · `packages/runner` 1096 pass · `packages/piece` 31 pass
- `deno task pattern-vintage` exit 0 · `tasks/pattern-vintage-run.test.ts` green
- Both required fixtures re-captured after every change: logically identical to pre-change (home 18 commits / 137 rev / 130 docs)
- `deno fmt --check`, `deno lint` clean

Captures are **not** byte- or entity-id-reproducible (random causes give ~30 of 130 doc ids fresh each run; counts are stable) — mask ids and compare the op multiset.

Pre-existing, unrelated: `packages/cli` `view-commitmsg.test.ts` "realGit: accepts an amend that reproduces the same commit object" fails on a clean stashed tree too — environmental (git version).

Follow-up filed separately: ~10 runner tests hand-roll `scheduler.dispose()` to quiesce a runtime without closing a shared store, two of them with comments documenting the limitation this PR removes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)