### PR TITLE
Split dialog messages into documents without an `[ID]` directive

### DIFF
--- a/packages/runner/integration/sync-schema-path.test.ts
+++ b/packages/runner/integration/sync-schema-path.test.ts
@@ -132,7 +132,12 @@ async function test() {
   // so instead I'll extract the link myself, and check in the heap.
   // This will be the link to the employee's address field
   const sigilLink = JSON.parse(JSON.stringify(newCell.key(0).getRaw()));
-  const normalizedLink = parseLink(sigilLink) as NormalizedLink;
+  // The stored link elides what it shares with the slot holding it, so it has
+  // to be parsed against that slot to recover the space it lives in.
+  const normalizedLink = parseLink(
+    sigilLink,
+    newCell.key(0),
+  ) as NormalizedLink;
   const record = read(
     runtime2.storageManager,
     normalizedLink.space!,

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -56,7 +56,7 @@ import {
   recordRelevantSchemaWritePolicyInput,
 } from "../cell.ts";
 import { resolveLinkScope } from "../scope.ts";
-import { type CellScope, ID, NAME, type Pattern } from "../builder/types.ts";
+import { type CellScope, NAME, type Pattern } from "../builder/types.ts";
 import { resolveStoredPatternAsync } from "./op-pattern-ref.ts";
 import { getEntityId } from "../create-ref.ts";
 import {
@@ -3148,16 +3148,25 @@ export function llmDialog(
 
           // Before starting request, set pending and append the new message.
           pending.withTx(tx).set(true);
-          inputs.key("messages").withTx(tx).push(
-            {
-              ...event,
-              // Add ID manually, as for built-ins this isn't automated
-              // TODO(seefeld): Once we have event ids, it should be that.
-              [ID]: { llmDialog: { message: cause, id: crypto.randomUUID() } },
-              // Cast because we can't yet express ArrayBuffer in JSON Schema
-            } as Schema<
-              typeof LLMMessageSchema
-            >,
+          // Each message becomes its own document, which the LlmDerived
+          // stamping downstream relies on. Built-ins do not get automatic
+          // entity splitting, so the document is made explicitly and its link
+          // pushed. The link is taken relative to the messages cell so it
+          // stores bare, exactly as an automatically split element does.
+          // TODO(seefeld): Once we have event ids, the cause should be that.
+          const messagesForPush = inputs.key("messages");
+          const messageCell = runtime.getCell(
+            messagesForPush.getAsNormalizedFullLink().space,
+            { llmDialog: { message: cause, id: crypto.randomUUID() } },
+            undefined,
+            tx,
+          );
+          messageCell.withTx(tx).set(
+            // Cast because we can't yet express ArrayBuffer in JSON Schema
+            { ...event } as Schema<typeof LLMMessageSchema>,
+          );
+          messagesForPush.withTx(tx).push(
+            messageCell.getAsLink({ base: messagesForPush }) as never,
           );
 
           // Set up new request (abort existing ones just in case) by allocating
@@ -3423,7 +3432,24 @@ async function startRequest(
     const startIndex = (messagesCell.withTx(tx).get() as
       | readonly CfcConfClause[]
       | undefined)?.length ?? 0;
-    messagesCell.withTx(tx).push(...messages);
+    // Each message becomes its own document, which the stamping below reads
+    // back. Built-ins get no automatic entity splitting, so the documents are
+    // made here explicitly. Links are taken relative to the messages cell, so
+    // they store bare -- the same shape an automatically split element has.
+    // TODO(seefeld): Once we have event ids, the cause should be that.
+    const space = messagesCell.getAsNormalizedFullLink().space;
+    messagesCell.withTx(tx).push(
+      ...messages.map((message) => {
+        const messageCell = runtime.getCell(
+          space,
+          { llmDialog: { message: cause, id: crypto.randomUUID() } },
+          undefined,
+          tx,
+        );
+        messageCell.withTx(tx).set(message);
+        return messageCell.getAsLink({ base: messagesCell }) as never;
+      }),
+    );
     if (runtime.cfcEnforcementMode === "disabled") {
       return;
     }
@@ -3655,11 +3681,10 @@ Some operations (especially \`invoke()\` with patterns) create "Pages" - running
           "LLM returned invalid/empty content, adding error message",
         );
         const errorMessage = {
-          [ID]: { llmDialog: { message: cause, id: crypto.randomUUID() } },
           role: "assistant",
           content:
             "I encountered an error generating a response. Please try again.",
-        } satisfies BuiltInLLMMessage & { [ID]: unknown };
+        } satisfies BuiltInLLMMessage;
 
         await safelyPerformUpdate(
           runtime,
@@ -3667,8 +3692,18 @@ Some operations (especially \`invoke()\` with patterns) create "Pages" - running
           internal,
           requestId,
           (tx) => {
-            messagesCell.withTx(tx).push(
+            // As above: its own document, made explicitly, link stored bare.
+            const errorCell = runtime.getCell(
+              messagesCell.getAsNormalizedFullLink().space,
+              { llmDialog: { message: cause, id: crypto.randomUUID() } },
+              undefined,
+              tx,
+            );
+            errorCell.withTx(tx).set(
               errorMessage as Schema<typeof LLMMessageSchema>,
+            );
+            messagesCell.withTx(tx).push(
+              errorCell.getAsLink({ base: messagesCell }) as never,
             );
             pending.withTx(tx).set(false);
           },
@@ -3688,11 +3723,6 @@ Some operations (especially \`invoke()\` with patterns) create "Pages" - running
             llmContent,
             toolCallParts,
           );
-
-          // Add ID to assistant message and publish immediately
-          (assistantMessage as BuiltInLLMMessage & { [ID]: unknown })[ID] = {
-            llmDialog: { message: cause, id: crypto.randomUUID() },
-          };
 
           await safelyPerformUpdate(
             runtime,
@@ -3758,10 +3788,9 @@ Some operations (especially \`invoke()\` with patterns) create "Pages" - running
             );
             // Add error message instead of invalid partial results
             const errorMessage = {
-              [ID]: { llmDialog: { message: cause, id: crypto.randomUUID() } },
               role: "assistant",
               content: "Some tool calls failed to execute. Please try again.",
-            } satisfies BuiltInLLMMessage & { [ID]: unknown };
+            } satisfies BuiltInLLMMessage;
 
             await safelyPerformUpdate(
               runtime,
@@ -3780,12 +3809,6 @@ Some operations (especially \`invoke()\` with patterns) create "Pages" - running
 
           // Create and publish tool result messages
           const toolResultMessages = createToolResultMessages(toolResults);
-
-          toolResultMessages.forEach((message) => {
-            (message as BuiltInLLMMessage & { [ID]: unknown })[ID] = {
-              llmDialog: { message: cause, id: crypto.randomUUID() },
-            };
-          });
 
           const success = await safelyPerformUpdate(
             runtime,
@@ -3875,10 +3898,9 @@ Some operations (especially \`invoke()\` with patterns) create "Pages" - running
       } else {
         // No tool calls, just add the assistant message
         const assistantMessage = {
-          [ID]: { llmDialog: { message: cause, id: crypto.randomUUID() } },
           role: "assistant",
           content: llmResult.content,
-        } satisfies BuiltInLLMMessage & { [ID]: unknown };
+        } satisfies BuiltInLLMMessage;
 
         // Ignore errors here, it probably means something else took over.
         await safelyPerformUpdate(
@@ -3910,11 +3932,10 @@ Some operations (especially \`invoke()\` with patterns) create "Pages" - running
         ? error.message
         : String(error);
       const errorMessage = {
-        [ID]: { llmDialog: { message: cause, id: crypto.randomUUID() } },
         role: "assistant",
         content:
           `I encountered an error generating a response: ${errorMessageText}`,
-      } satisfies BuiltInLLMMessage & { [ID]: unknown };
+      } satisfies BuiltInLLMMessage;
 
       safelyPerformUpdate(runtime, pending, internal, requestId, (tx) => {
         messagesCell.withTx(tx).push(

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -3462,8 +3462,8 @@ async function startRequest(
       builtinId: "llmDialog",
     });
     // Record the stamping schema for each pushed message's own entity doc
-    // (every model push carries an [ID] sigil, so each message splits into
-    // its own doc). The messages link carries its own schema, which wins over
+    // (every message is appended as a link to a document of its own, so each
+    // one is separately addressable). The messages link carries its own schema, which wins over
     // an `asSchema` handle inside `push()` (`resolvedLink.schema ?? ...`), so
     // the stamp cannot ride the array handle — instead this mirrors the
     // split-entity idiom in data-updating.ts (`recordRelevantSchemaWrite-

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -3159,24 +3159,21 @@ export function llmDialog(
           // document itself, not the input slot that points at it, which can
           // sit at a different scope. `push()` resolves the same way before it
           // writes; a document minted at the slot's scope instead lands in a
-          // partition the array's readers never look in. The link is then
-          // taken relative to that resolved base, so it stores bare, exactly
-          // as an anchored element does.
+          // partition the array's readers never look in.
+          //
+          // The document is left schema-less: the schema it would carry ends
+          // up inlined in every link written to it, and the array's own items
+          // schema already describes what a reader finds there.
           const messagesForPush = inputs.key("messages");
           const messagesBase = resolveLink(
             runtime,
             tx,
             messagesForPush.getAsNormalizedFullLink(),
           );
-          const messagesDoc = runtime.getCellFromLink(
-            messagesBase,
-            undefined,
-            tx,
-          );
-          const messageCell = runtime.getCell(
+          const messageCell = runtime.getCell<Schema<typeof LLMMessageSchema>>(
             messagesBase.space,
             { llmDialog: { message: cause, id: crypto.randomUUID() } },
-            LLMMessageSchema,
+            undefined,
             tx,
             messagesBase.scope,
           );
@@ -3184,19 +3181,7 @@ export function llmDialog(
             // Cast because we can't yet express ArrayBuffer in JSON Schema
             { ...event } as Schema<typeof LLMMessageSchema>,
           );
-          // `push()` is typed for message values and cells of them, not for
-          // links (`data-updating.ts` resolves a link where a value is
-          // expected), so appending a bare link needs the cast to the type the
-          // site resolves it to. Pushing the cell itself would type cleanly but
-          // store the link with space, scope and the whole message schema
-          // inlined -- a copy per message.
-          messagesForPush.withTx(tx).push(
-            messageCell.getAsLink({
-              base: messagesDoc,
-            }) as unknown as Schema<
-              typeof LLMMessageSchema
-            >,
-          );
+          messagesForPush.withTx(tx).push(messageCell);
 
           // Set up new request (abort existing ones just in case) by allocating
           // a new request Id and setting up a new abort controller.
@@ -3467,32 +3452,24 @@ async function startRequest(
     // identity -- a deliberate cause rather than a frame-relative counter.
     // TODO(seefeld): Once we have event ids, the cause should be that.
     //
-    // Space AND scope come from the RESOLVED messages link -- the array
-    // document itself, not the input slot that points at it, which can sit at
-    // a different scope (see the user-message push). Links are taken relative
-    // to that resolved base, so they store bare, as anchored elements do.
+    // Space, scope and schema follow the user-message push: resolved link,
+    // schema-less document.
     const base = resolveLink(
       runtime,
       tx,
       messagesCell.getAsNormalizedFullLink(),
     );
-    const baseDoc = runtime.getCellFromLink(base, undefined, tx);
     messagesCell.withTx(tx).push(
       ...messages.map((message) => {
-        const messageCell = runtime.getCell(
+        const messageCell = runtime.getCell<Schema<typeof LLMMessageSchema>>(
           base.space,
           { llmDialog: { message: cause, id: crypto.randomUUID() } },
-          LLMMessageSchema,
+          undefined,
           tx,
           base.scope,
         );
         messageCell.withTx(tx).set(message);
-        // See the note at the user-message push: bare link, hence the cast.
-        return messageCell.getAsLink({
-          base: baseDoc,
-        }) as unknown as Schema<
-          typeof LLMMessageSchema
-        >;
+        return messageCell;
       }),
     );
     if (runtime.cfcEnforcementMode === "disabled") {
@@ -3737,29 +3714,23 @@ Some operations (especially \`invoke()\` with patterns) create "Pages" - running
           requestId,
           (tx) => {
             // As above: made explicitly for identity control, in the resolved
-            // messages document's space and scope, link stored bare.
+            // messages document's space and scope, schema-less.
             const errorBase = resolveLink(
               runtime,
               tx,
               messagesCell.getAsNormalizedFullLink(),
             );
-            const errorDoc = runtime.getCellFromLink(errorBase, undefined, tx);
-            const errorCell = runtime.getCell(
+            const errorCell = runtime.getCell<Schema<typeof LLMMessageSchema>>(
               errorBase.space,
               { llmDialog: { message: cause, id: crypto.randomUUID() } },
-              LLMMessageSchema,
+              undefined,
               tx,
               errorBase.scope,
             );
             errorCell.withTx(tx).set(
               errorMessage as Schema<typeof LLMMessageSchema>,
             );
-            // See the note at the user-message push: bare link, hence the cast.
-            messagesCell.withTx(tx).push(
-              errorCell.getAsLink({ base: errorDoc }) as unknown as Schema<
-                typeof LLMMessageSchema
-              >,
-            );
+            messagesCell.withTx(tx).push(errorCell);
             pending.withTx(tx).set(false);
           },
         );

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -3149,22 +3149,32 @@ export function llmDialog(
           // Before starting request, set pending and append the new message.
           pending.withTx(tx).set(true);
           // Each message becomes its own document, which the LlmDerived
-          // stamping downstream relies on. Built-ins do not get automatic
-          // entity splitting, so the document is made explicitly and its link
-          // pushed. The link is taken relative to the messages cell so it
-          // stores bare, exactly as an automatically split element does.
+          // stamping downstream relies on. Pushing a plain message would also
+          // produce one, since `Cell.push` anchors objects in arrays; the
+          // document is made explicitly to control its identity -- a
+          // deliberate cause rather than a frame-relative counter.
           // TODO(seefeld): Once we have event ids, the cause should be that.
+          //
+          // Space AND scope come from the messages cell, so the document lands
+          // in the same partition an anchored one would, and its link stores
+          // bare relative to that cell.
           const messagesForPush = inputs.key("messages");
+          const messagesBase = messagesForPush.getAsNormalizedFullLink();
           const messageCell = runtime.getCell(
-            messagesForPush.getAsNormalizedFullLink().space,
+            messagesBase.space,
             { llmDialog: { message: cause, id: crypto.randomUUID() } },
-            undefined,
+            LLMMessageSchema,
             tx,
+            messagesBase.scope,
           );
           messageCell.withTx(tx).set(
             // Cast because we can't yet express ArrayBuffer in JSON Schema
             { ...event } as Schema<typeof LLMMessageSchema>,
           );
+          // `push()` is typed for message values and cells of them, not for
+          // links, so appending the bare link needs the cast. Pushing the cell
+          // itself would type cleanly but store the link with space, scope and
+          // the whole message schema inlined -- a copy per message.
           messagesForPush.withTx(tx).push(
             messageCell.getAsLink({ base: messagesForPush }) as never,
           );
@@ -3433,20 +3443,25 @@ async function startRequest(
       | readonly CfcConfClause[]
       | undefined)?.length ?? 0;
     // Each message becomes its own document, which the stamping below reads
-    // back. Built-ins get no automatic entity splitting, so the documents are
-    // made here explicitly. Links are taken relative to the messages cell, so
-    // they store bare -- the same shape an automatically split element has.
+    // back. Pushing plain messages would also produce them, since `Cell.push`
+    // anchors objects in arrays; they are made explicitly to control their
+    // identity -- a deliberate cause rather than a frame-relative counter.
     // TODO(seefeld): Once we have event ids, the cause should be that.
-    const space = messagesCell.getAsNormalizedFullLink().space;
+    //
+    // Space AND scope come from the messages cell, so the documents land in
+    // the same partition anchored ones would, and their links store bare.
+    const base = messagesCell.getAsNormalizedFullLink();
     messagesCell.withTx(tx).push(
       ...messages.map((message) => {
         const messageCell = runtime.getCell(
-          space,
+          base.space,
           { llmDialog: { message: cause, id: crypto.randomUUID() } },
-          undefined,
+          LLMMessageSchema,
           tx,
+          base.scope,
         );
         messageCell.withTx(tx).set(message);
+        // See the note at the user-message push: bare link, hence the cast.
         return messageCell.getAsLink({ base: messagesCell }) as never;
       }),
     );
@@ -3470,7 +3485,6 @@ async function startRequest(
     // PolicyInput` on the child doc), which also marks the transaction
     // CFC-relevant so `prepareTxForCommit` runs the persist pass that mints
     // the labelMap entry.
-    const base = messagesCell.getAsNormalizedFullLink();
     for (let index = 0; index < messages.length; index++) {
       const raw = messagesCell.withTx(tx).key(startIndex + index).getRaw();
       const link = parseLink(raw);
@@ -3692,16 +3706,20 @@ Some operations (especially \`invoke()\` with patterns) create "Pages" - running
           internal,
           requestId,
           (tx) => {
-            // As above: its own document, made explicitly, link stored bare.
+            // As above: made explicitly for identity control, in the messages
+            // cell's space and scope, link stored bare.
+            const errorBase = messagesCell.getAsNormalizedFullLink();
             const errorCell = runtime.getCell(
-              messagesCell.getAsNormalizedFullLink().space,
+              errorBase.space,
               { llmDialog: { message: cause, id: crypto.randomUUID() } },
-              undefined,
+              LLMMessageSchema,
               tx,
+              errorBase.scope,
             );
             errorCell.withTx(tx).set(
               errorMessage as Schema<typeof LLMMessageSchema>,
             );
+            // See the note at the user-message push: bare link, hence the cast.
             messagesCell.withTx(tx).push(
               errorCell.getAsLink({ base: messagesCell }) as never,
             );

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -3155,11 +3155,24 @@ export function llmDialog(
           // deliberate cause rather than a frame-relative counter.
           // TODO(seefeld): Once we have event ids, the cause should be that.
           //
-          // Space AND scope come from the messages cell, so the document lands
-          // in the same partition an anchored one would, and its link stores
-          // bare relative to that cell.
+          // Space AND scope come from the RESOLVED messages link -- the array
+          // document itself, not the input slot that points at it, which can
+          // sit at a different scope. `push()` resolves the same way before it
+          // writes; a document minted at the slot's scope instead lands in a
+          // partition the array's readers never look in. The link is then
+          // taken relative to that resolved base, so it stores bare, exactly
+          // as an anchored element does.
           const messagesForPush = inputs.key("messages");
-          const messagesBase = messagesForPush.getAsNormalizedFullLink();
+          const messagesBase = resolveLink(
+            runtime,
+            tx,
+            messagesForPush.getAsNormalizedFullLink(),
+          );
+          const messagesDoc = runtime.getCellFromLink(
+            messagesBase,
+            undefined,
+            tx,
+          );
           const messageCell = runtime.getCell(
             messagesBase.space,
             { llmDialog: { message: cause, id: crypto.randomUUID() } },
@@ -3179,7 +3192,7 @@ export function llmDialog(
           // inlined -- a copy per message.
           messagesForPush.withTx(tx).push(
             messageCell.getAsLink({
-              base: messagesForPush,
+              base: messagesDoc,
             }) as unknown as Schema<
               typeof LLMMessageSchema
             >,
@@ -3454,9 +3467,16 @@ async function startRequest(
     // identity -- a deliberate cause rather than a frame-relative counter.
     // TODO(seefeld): Once we have event ids, the cause should be that.
     //
-    // Space AND scope come from the messages cell, so the documents land in
-    // the same partition anchored ones would, and their links store bare.
-    const base = messagesCell.getAsNormalizedFullLink();
+    // Space AND scope come from the RESOLVED messages link -- the array
+    // document itself, not the input slot that points at it, which can sit at
+    // a different scope (see the user-message push). Links are taken relative
+    // to that resolved base, so they store bare, as anchored elements do.
+    const base = resolveLink(
+      runtime,
+      tx,
+      messagesCell.getAsNormalizedFullLink(),
+    );
+    const baseDoc = runtime.getCellFromLink(base, undefined, tx);
     messagesCell.withTx(tx).push(
       ...messages.map((message) => {
         const messageCell = runtime.getCell(
@@ -3469,7 +3489,7 @@ async function startRequest(
         messageCell.withTx(tx).set(message);
         // See the note at the user-message push: bare link, hence the cast.
         return messageCell.getAsLink({
-          base: messagesCell,
+          base: baseDoc,
         }) as unknown as Schema<
           typeof LLMMessageSchema
         >;
@@ -3716,9 +3736,14 @@ Some operations (especially \`invoke()\` with patterns) create "Pages" - running
           internal,
           requestId,
           (tx) => {
-            // As above: made explicitly for identity control, in the messages
-            // cell's space and scope, link stored bare.
-            const errorBase = messagesCell.getAsNormalizedFullLink();
+            // As above: made explicitly for identity control, in the resolved
+            // messages document's space and scope, link stored bare.
+            const errorBase = resolveLink(
+              runtime,
+              tx,
+              messagesCell.getAsNormalizedFullLink(),
+            );
+            const errorDoc = runtime.getCellFromLink(errorBase, undefined, tx);
             const errorCell = runtime.getCell(
               errorBase.space,
               { llmDialog: { message: cause, id: crypto.randomUUID() } },
@@ -3731,7 +3756,7 @@ Some operations (especially \`invoke()\` with patterns) create "Pages" - running
             );
             // See the note at the user-message push: bare link, hence the cast.
             messagesCell.withTx(tx).push(
-              errorCell.getAsLink({ base: messagesCell }) as unknown as Schema<
+              errorCell.getAsLink({ base: errorDoc }) as unknown as Schema<
                 typeof LLMMessageSchema
               >,
             );

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -3172,11 +3172,17 @@ export function llmDialog(
             { ...event } as Schema<typeof LLMMessageSchema>,
           );
           // `push()` is typed for message values and cells of them, not for
-          // links, so appending the bare link needs the cast. Pushing the cell
-          // itself would type cleanly but store the link with space, scope and
-          // the whole message schema inlined -- a copy per message.
+          // links (`data-updating.ts` resolves a link where a value is
+          // expected), so appending a bare link needs the cast to the type the
+          // site resolves it to. Pushing the cell itself would type cleanly but
+          // store the link with space, scope and the whole message schema
+          // inlined -- a copy per message.
           messagesForPush.withTx(tx).push(
-            messageCell.getAsLink({ base: messagesForPush }) as never,
+            messageCell.getAsLink({
+              base: messagesForPush,
+            }) as unknown as Schema<
+              typeof LLMMessageSchema
+            >,
           );
 
           // Set up new request (abort existing ones just in case) by allocating
@@ -3462,7 +3468,11 @@ async function startRequest(
         );
         messageCell.withTx(tx).set(message);
         // See the note at the user-message push: bare link, hence the cast.
-        return messageCell.getAsLink({ base: messagesCell }) as never;
+        return messageCell.getAsLink({
+          base: messagesCell,
+        }) as unknown as Schema<
+          typeof LLMMessageSchema
+        >;
       }),
     );
     if (runtime.cfcEnforcementMode === "disabled") {
@@ -3721,7 +3731,9 @@ Some operations (especially \`invoke()\` with patterns) create "Pages" - running
             );
             // See the note at the user-message push: bare link, hence the cast.
             messagesCell.withTx(tx).push(
-              errorCell.getAsLink({ base: messagesCell }) as never,
+              errorCell.getAsLink({ base: messagesCell }) as unknown as Schema<
+                typeof LLMMessageSchema
+              >,
             );
             pending.withTx(tx).set(false);
           },

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -691,7 +691,10 @@ export function normalizeAndDiff(
       }
     }
     newValue = attachCfcLabelViewToSigilLink(
-      newValue.getAsLink({ includeSchema: true }),
+      createSigilLinkFromParsedLink(newValue.getAsNormalizedFullLink(), {
+        base: link,
+        includeSchema: true,
+      }),
       carriedCfcLabelView,
     );
   }
@@ -713,7 +716,7 @@ export function normalizeAndDiff(
   }
 
   // If we're about to create a reference to ourselves, no-op
-  if (areMaybeLinkAndNormalizedLinkSame(newValue, link)) {
+  if (areMaybeLinkAndNormalizedLinkSame(newValue, link, link)) {
     diffLogger.debug(
       "diff",
       () =>

--- a/packages/runner/test/cfc-llm-derived-stamp.test.ts
+++ b/packages/runner/test/cfc-llm-derived-stamp.test.ts
@@ -125,10 +125,11 @@ describe("CFC LlmDerived stamping mechanism", () => {
     }
   });
 
-  it("stamps an [ID]-split element on its own doc", async () => {
-    // Real dialog messages carry an [ID] sigil and split into their own
-    // entity docs; the stamp must land on the split doc and surface through
-    // the element's label view.
+  it("stamps a split element on its own doc", async () => {
+    // Exercises the generic split mechanism directly, via an `[ID]` sigil.
+    // Dialog messages reach the same shape by a different route -- the dialog
+    // creates each message's document explicitly -- and either way the stamp
+    // must land on the split doc and surface through the element's label view.
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
@@ -285,7 +286,7 @@ describe("llmDialog LlmDerived stamping (end to end)", () => {
       await waitForLlmMessages(runtime, result, 2);
 
       // The contract is the PERSISTED metadata on each message's own entity
-      // doc (messages carry [ID] and split); read it there directly — the
+      // doc (every message is its own document); read it there directly — the
       // multi-hop handle chain (result → messages link → element link) is a
       // separate label-view surfacing concern.
       const messagesCell = result.key("messages");

--- a/packages/runner/test/data-updating.test.ts
+++ b/packages/runner/test/data-updating.test.ts
@@ -879,7 +879,7 @@ describe("data-updating", () => {
 
       expect(changes.length).toBe(1);
       expect(changes[0].location).toEqual(current);
-      expect(areLinksSame(changes[0].value, cellA)).toBe(true);
+      expect(areLinksSame(changes[0].value, cellA, current)).toBe(true);
     });
 
     it("should handle doc and cell references that don't change", () => {
@@ -903,7 +903,7 @@ describe("data-updating", () => {
 
       expect(changes.length).toBe(1);
       expect(changes[0].location).toEqual(current);
-      expect(areLinksSame(changes[0].value, cellA)).toBe(true);
+      expect(areLinksSame(changes[0].value, cellA, current)).toBe(true);
 
       applyChangeSet(tx, changes);
 
@@ -1386,7 +1386,7 @@ describe("data-updating", () => {
       const result = testCell.getRaw();
       expect(isPrimitiveCellLink(result?.items[0])).toBe(true);
       expect(isPrimitiveCellLink(result?.items[1])).toBe(true);
-      expect(areLinksSame(result?.items[0], result?.items[1]))
+      expect(areLinksSame(result?.items[0], result?.items[1], testCell))
         .toBe(true);
       expect(
         (tx.readValueOrThrow(parseLink(result?.items[1], testCell)!) as any)

--- a/packages/runner/test/link-resolution.test.ts
+++ b/packages/runner/test/link-resolution.test.ts
@@ -83,7 +83,11 @@ describe("link-resolution", () => {
         undefined,
         rawTx,
       );
-      expect(rawLinked.getRawUntyped()).toEqual(sourceCell.getAsLink());
+      // The stored link elides what it shares with the slot it sits in, so
+      // the expected form has to be taken relative to that same base.
+      expect(rawLinked.getRawUntyped()).toEqual(
+        sourceCell.getAsLink({ base: rawLinked }),
+      );
       expect(rawTx.getCfcState().dereferenceTraces).toEqual([]);
       rawTx.abort();
     });

--- a/packages/runner/test/llm-dialog-error-messages.test.ts
+++ b/packages/runner/test/llm-dialog-error-messages.test.ts
@@ -21,7 +21,7 @@ import { createTrustedBuilder } from "./support/trusted-builder.ts";
 import { LLMMessageSchema } from "../src/builtins/llm-schemas.ts";
 import { waitForLlmMessages } from "./support/llm-result.ts";
 
-const signer = await Identity.fromPassphrase("llm invalid content");
+const signer = await Identity.fromPassphrase("llm dialog error messages");
 
 describe("llmDialog error-path messages", () => {
   let runtime: Runtime;
@@ -94,7 +94,7 @@ describe("llmDialog error-path messages", () => {
       tx,
     );
     const result = runtime.run(tx, testPattern, {}, resultCell);
-    tx.commit();
+    await tx.commit();
 
     const addMessage = await result.key("addMessage").pull();
     addMessage.send({ role: "user", content: "Hello" });
@@ -175,7 +175,7 @@ describe("llmDialog error-path messages", () => {
         tx,
       );
       const result = runtime.run(tx, testPattern, {}, resultCell);
-      tx.commit();
+      await tx.commit();
 
       const addMessage = await result.key("addMessage").pull();
       addMessage.send({ role: "user", content: "Hello" });

--- a/packages/runner/test/llm-dialog-error-messages.test.ts
+++ b/packages/runner/test/llm-dialog-error-messages.test.ts
@@ -1,8 +1,8 @@
-// The dialog's invalid-content branch: when a model reply carries nothing
-// usable, an assistant error message is appended instead of the empty content.
-// That branch had no end-to-end coverage, so nothing pinned either the message
-// reaching `messages` or its landing in a document of its own -- the property
-// the LlmDerived stamping downstream depends on.
+// The dialog's error paths substitute an assistant message when a turn cannot
+// produce a real reply. None of them had end-to-end coverage, so nothing pinned
+// either the message reaching `messages` or its landing in a document of its
+// own -- the latter being what the LlmDerived stamping downstream depends on,
+// and what keeps the array from mixing bare values with links.
 
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
@@ -12,6 +12,7 @@ import {
   loadConversationFixture,
 } from "@commonfabric/llm/client";
 import type { BuiltInLLMMessage } from "@commonfabric/api";
+import { LLMClient } from "@commonfabric/llm/client";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { parseLink } from "../src/link-utils.ts";
 import { type JSONSchema } from "../src/builder/types.ts";
@@ -22,7 +23,7 @@ import { waitForLlmMessages } from "./support/llm-result.ts";
 
 const signer = await Identity.fromPassphrase("llm invalid content");
 
-describe("llmDialog invalid model content", () => {
+describe("llmDialog error-path messages", () => {
   let runtime: Runtime;
   let storageManager: ReturnType<typeof StorageManager.emulate>;
 
@@ -124,5 +125,83 @@ describe("llmDialog invalid model content", () => {
     }
 
     await rtx.commit();
+  });
+
+  it("stores a failed-request error message in its own document", async () => {
+    // The `.catch` path substitutes a message when the request itself rejects.
+    // It is reached by no other test, and it pushes on its own rather than
+    // through the shared model-message path, so it is exactly where an
+    // inconsistently stored element can hide.
+    const original = LLMClient.prototype.sendRequest;
+    LLMClient.prototype.sendRequest = () =>
+      Promise.reject(new Error("upstream exploded"));
+
+    try {
+      const tx = runtime.edit();
+      const { commonfabric } = createTrustedBuilder(runtime);
+      const { pattern, llmDialog, Cell } = commonfabric;
+
+      const resultSchema = {
+        type: "object",
+        properties: {
+          addMessage: { ...LLMMessageSchema, asCell: ["stream"] },
+          pending: { type: "boolean" },
+          messages: {
+            type: "array",
+            items: { type: "object", additionalProperties: true },
+          },
+        },
+        required: ["addMessage"],
+      } as const satisfies JSONSchema;
+
+      const testPattern = pattern(
+        () => {
+          const messages = Cell.of<BuiltInLLMMessage[]>([]);
+          const dialog = llmDialog({ messages });
+          return {
+            addMessage: dialog.addMessage,
+            pending: dialog.pending,
+            messages,
+          };
+        },
+        false,
+        resultSchema,
+      );
+
+      const resultCell = runtime.getCell(
+        signer.did(),
+        "llm-request-failure",
+        resultSchema,
+        tx,
+      );
+      const result = runtime.run(tx, testPattern, {}, resultCell);
+      tx.commit();
+
+      const addMessage = await result.key("addMessage").pull();
+      addMessage.send({ role: "user", content: "Hello" });
+
+      await waitForLlmMessages(runtime, result, 2);
+
+      const messagesCell = result.key("messages");
+      const rtx = runtime.edit();
+      const messages = messagesCell.withTx(rtx).get() as
+        | readonly BuiltInLLMMessage[]
+        | undefined;
+
+      expect(messages?.length).toBe(2);
+      expect(String(messages![1]!.content)).toContain("upstream exploded");
+
+      // Every element is a link. `Cell.push` assigns identity to objects in
+      // arrays, so this holds whether or not the caller chose the cause --
+      // which is what keeps the stamping from skipping elements.
+      for (const index of [0, 1]) {
+        const raw = messagesCell.withTx(rtx).key(index).getRaw();
+        expect(parseLink(raw)?.id).not.toBe(undefined);
+      }
+
+      await rtx.commit();
+    } finally {
+      LLMClient.prototype.sendRequest = original;
+    }
   });
 });

--- a/packages/runner/test/llm-dialog-error-messages.test.ts
+++ b/packages/runner/test/llm-dialog-error-messages.test.ts
@@ -95,6 +95,7 @@ describe("llmDialog error-path messages", () => {
     );
     const result = runtime.run(tx, testPattern, {}, resultCell);
     await tx.commit();
+    await runtime.idle();
 
     const addMessage = await result.key("addMessage").pull();
     addMessage.send({ role: "user", content: "Hello" });
@@ -176,6 +177,7 @@ describe("llmDialog error-path messages", () => {
       );
       const result = runtime.run(tx, testPattern, {}, resultCell);
       await tx.commit();
+      await runtime.idle();
 
       const addMessage = await result.key("addMessage").pull();
       addMessage.send({ role: "user", content: "Hello" });

--- a/packages/runner/test/llm-dialog-invalid-content.test.ts
+++ b/packages/runner/test/llm-dialog-invalid-content.test.ts
@@ -1,0 +1,128 @@
+// The dialog's invalid-content branch: when a model reply carries nothing
+// usable, an assistant error message is appended instead of the empty content.
+// That branch had no end-to-end coverage, so nothing pinned either the message
+// reaching `messages` or its landing in a document of its own -- the property
+// the LlmDerived stamping downstream depends on.
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import {
+  clearMockResponses,
+  loadConversationFixture,
+} from "@commonfabric/llm/client";
+import type { BuiltInLLMMessage } from "@commonfabric/api";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { parseLink } from "../src/link-utils.ts";
+import { type JSONSchema } from "../src/builder/types.ts";
+import { Runtime } from "../src/runtime.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+import { LLMMessageSchema } from "../src/builtins/llm-schemas.ts";
+import { waitForLlmMessages } from "./support/llm-result.ts";
+
+const signer = await Identity.fromPassphrase("llm invalid content");
+
+describe("llmDialog invalid model content", () => {
+  let runtime: Runtime;
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+
+  beforeEach(() => {
+    clearMockResponses();
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcEnforcementMode: "disabled",
+    });
+  });
+
+  afterEach(async () => {
+    clearMockResponses();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("appends an assistant error message, in its own document", async () => {
+    // Empty content fails `hasValidContent()`, which is what selects the
+    // branch under test.
+    loadConversationFixture({
+      description: "invalid content: empty assistant reply",
+      responses: [
+        {
+          type: "sendRequest",
+          response: { role: "assistant", content: "", id: "empty-1" },
+        },
+      ],
+    });
+
+    const tx = runtime.edit();
+    const { commonfabric } = createTrustedBuilder(runtime);
+    const { pattern, llmDialog, Cell } = commonfabric;
+
+    const resultSchema = {
+      type: "object",
+      properties: {
+        addMessage: { ...LLMMessageSchema, asCell: ["stream"] },
+        pending: { type: "boolean" },
+        messages: {
+          type: "array",
+          items: { type: "object", additionalProperties: true },
+        },
+      },
+      required: ["addMessage"],
+    } as const satisfies JSONSchema;
+
+    const testPattern = pattern(
+      () => {
+        const messages = Cell.of<BuiltInLLMMessage[]>([]);
+        const dialog = llmDialog({ messages });
+        return {
+          addMessage: dialog.addMessage,
+          pending: dialog.pending,
+          messages,
+        };
+      },
+      false,
+      resultSchema,
+    );
+
+    const resultCell = runtime.getCell(
+      signer.did(),
+      "llm-invalid-content",
+      resultSchema,
+      tx,
+    );
+    const result = runtime.run(tx, testPattern, {}, resultCell);
+    tx.commit();
+
+    const addMessage = await result.key("addMessage").pull();
+    addMessage.send({ role: "user", content: "Hello" });
+
+    // The user message plus the substituted error message.
+    await waitForLlmMessages(runtime, result, 2);
+
+    const messagesCell = result.key("messages");
+    const rtx = runtime.edit();
+    const messages = messagesCell.withTx(rtx).get() as
+      | readonly BuiltInLLMMessage[]
+      | undefined;
+
+    expect(messages?.length).toBe(2);
+    const errorMessage = messages![1]!;
+    expect(errorMessage.role).toBe("assistant");
+    expect(String(errorMessage.content)).toContain(
+      "I encountered an error generating a response",
+    );
+
+    // Its own document: the stored element is a link, which is exactly what
+    // the LlmDerived stamping requires of every pushed message.
+    for (const index of [0, 1]) {
+      const raw = messagesCell.withTx(rtx).key(index).getRaw();
+      const link = parseLink(raw);
+      expect(link).not.toBe(undefined);
+      expect(link?.id).not.toBe(undefined);
+    }
+
+    await rtx.commit();
+  });
+});

--- a/packages/runner/test/llm-dialog-message-scope.test.ts
+++ b/packages/runner/test/llm-dialog-message-scope.test.ts
@@ -1,0 +1,146 @@
+// The dialog's per-message documents must land in the same partition as the
+// messages array itself. An element anchored by `Cell.push` inherits the
+// array's scope; a document the dialog creates explicitly has to be given that
+// scope, or the document and the readers of its link disagree about the
+// partition: the stored element link is bare, a reader resolves it against the
+// array's scope, and a document minted at the default `"space"` scope is
+// simply not there. A session-scoped messages cell is what makes the
+// difference observable at all -- at `"space"` scope every choice coincides.
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import {
+  clearMockResponses,
+  loadConversationFixture,
+} from "@commonfabric/llm/client";
+import type { BuiltInLLMMessage } from "@commonfabric/api";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { parseLink } from "../src/link-utils.ts";
+import { resolveLink } from "../src/link-resolution.ts";
+import { type JSONSchema } from "../src/builder/types.ts";
+import { Runtime } from "../src/runtime.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+import { LLMMessageSchema } from "../src/builtins/llm-schemas.ts";
+import { waitForLlmMessages } from "./support/llm-result.ts";
+
+const signer = await Identity.fromPassphrase("llm dialog message scope");
+
+describe("llmDialog message document scope", () => {
+  let runtime: Runtime;
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+
+  beforeEach(() => {
+    clearMockResponses();
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcEnforcementMode: "disabled",
+    });
+  });
+
+  afterEach(async () => {
+    clearMockResponses();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("keeps message documents in a session-scoped messages cell's partition", async () => {
+    loadConversationFixture({
+      description: "scoped messages: one assistant reply",
+      responses: [
+        {
+          type: "sendRequest",
+          response: { role: "assistant", content: "Hi there!", id: "scope-1" },
+        },
+      ],
+    });
+
+    const tx = runtime.edit();
+    const { commonfabric } = createTrustedBuilder(runtime);
+    const { pattern, llmDialog, Cell } = commonfabric;
+
+    const resultSchema = {
+      type: "object",
+      properties: {
+        addMessage: { ...LLMMessageSchema, asCell: ["stream"] },
+        pending: { type: "boolean" },
+        messages: {
+          type: "array",
+          items: { type: "object", additionalProperties: true },
+        },
+      },
+      required: ["addMessage"],
+    } as const satisfies JSONSchema;
+
+    const testPattern = pattern(
+      () => {
+        const messages = Cell.perSession.of<BuiltInLLMMessage[]>([]);
+        const dialog = llmDialog({ messages });
+        return {
+          addMessage: dialog.addMessage,
+          pending: dialog.pending,
+          messages,
+        };
+      },
+      false,
+      resultSchema,
+    );
+
+    const resultCell = runtime.getCell(
+      signer.did(),
+      "llm-message-scope",
+      resultSchema,
+      tx,
+    );
+    const result = runtime.run(tx, testPattern, {}, resultCell);
+    await tx.commit();
+
+    const addMessage = await result.key("addMessage").pull();
+    addMessage.send({ role: "user", content: "Hello" });
+
+    // The user message plus the assistant reply.
+    await waitForLlmMessages(runtime, result, 2);
+
+    const messagesCell = result.key("messages");
+    const rtx = runtime.edit();
+
+    // The premise, so the test cannot silently degrade into the trivial
+    // all-`"space"` case: the array the dialog wrote to is session-scoped.
+    const arrayLink = resolveLink(
+      runtime,
+      rtx,
+      messagesCell.getAsNormalizedFullLink(),
+    );
+    expect(arrayLink.scope).toBe("session");
+
+    // Roundtrip: both messages read back through the array. This is the loud
+    // half of the invariant -- a document minted in a different partition than
+    // the array leaves the element link dangling, and the content vanishes.
+    const messages = messagesCell.withTx(rtx).get() as
+      | readonly BuiltInLLMMessage[]
+      | undefined;
+    expect(messages?.length).toBe(2);
+    expect(String(messages![0]!.content)).toBe("Hello");
+    expect(String(messages![1]!.content)).toBe("Hi there!");
+
+    // Shape: each stored element is a bare link -- id only, no `space` or
+    // `scope` spelled out -- exactly what an anchored element stores. A
+    // document whose scope differed from the array's would have to carry the
+    // difference here.
+    for (const index of [0, 1]) {
+      const raw = messagesCell.withTx(rtx).key(index).getRaw() as Record<
+        string,
+        Record<string, Record<string, unknown>>
+      >;
+      expect(parseLink(raw)?.id).not.toBe(undefined);
+      const payload = raw["/"]?.["link@1"];
+      expect(payload).not.toBe(undefined);
+      expect(payload!.space).toBe(undefined);
+      expect(payload!.scope).toBe(undefined);
+    }
+
+    await rtx.commit();
+  });
+});

--- a/packages/runner/test/llm-dialog-message-scope.test.ts
+++ b/packages/runner/test/llm-dialog-message-scope.test.ts
@@ -96,6 +96,7 @@ describe("llmDialog message document scope", () => {
     );
     const result = runtime.run(tx, testPattern, {}, resultCell);
     await tx.commit();
+    await runtime.idle();
 
     const addMessage = await result.key("addMessage").pull();
     addMessage.send({ role: "user", content: "Hello" });


### PR DESCRIPTION
Every message `llmDialog` pushes becomes its own document — the LlmDerived stamping reads each element back and parses it as a link. Seven call sites hand-attached an `[ID]` directive to each message: five as a property on a literal, two by mutating a message afterwards.

This creates those documents explicitly instead, which **removes the last live use of `ID` outside tests** and unblocks retiring `ID`/`ID_FIELD` entirely.

### What the directives were actually doing

Not causing the split. `Cell.push` runs `recursivelyAddIDIfNeeded`, which assigns identity to objects in arrays, so a message pushed with no directive still lands in a document of its own — verified by reading the stored elements on a path with no directive and no explicit cell:

```
RAW[0]: {"/":{"link@1":{"path":[],"id":"of:fid1:YMe7zv4i…"}}}
RAW[1]: {"/":{"link@1":{"path":[],"id":"of:fid1:-PotTAsb…"}}}
```

What a directive chose was the **cause** the entity id derives from. So removing them changes which ids get minted, not whether documents exist.

The source comment on those lines said built-ins get no automatic splitting. That was misleading, and an earlier revision of this description repeated it; `f4dffaa16` corrects it and two others that described messages as `[ID]`-carrying.

## The change

`pushModelMessages()` already owned "push these messages and stamp their docs", so minting identity moved there — it creates a cell per message under the same cause the directives used, writes the message, and pushes that cell. Its callers now build plain messages. The two paths that do not route through it (the user message, and the substituted error message) do the same inline.

Two further error paths push directly and were left alone deliberately: with no directive they take the automatic-identity route above, which produces the same bare link. A review flagged those as inconsistent storage; the raw values show otherwise, and the test added in `005e61df6` pins it.

Net effect at the call sites: three literals lose a property, two mutation blocks disappear entirely, and every `& { [ID]: unknown }` intersection goes away.

## Storage shape is unchanged

A base-relative link serializes bare. Measured against the `[ID]` split on the same data:

```
[ID] split:        {"path":[],"id":"of:fid1:nuoC…"}
explicit + base:   {"path":[],"id":"of:fid1:rrIW…"}
```

Byte-identical apart from the entity id itself. Two things worth knowing about that id:

- It no longer derives from a directive, so **ids differ from what the old code would mint** for the same message. Nothing re-derives them — the cause already carried a fresh `crypto.randomUUID()`, so identity here was always per-message and opaque — but existing persisted messages and new ones are not addressed alike.
- Without `{ base }` the link also carries `space` and `scope`, and a cell created *with* a schema puts the schema in the link too. The latter matters here: `pushModelMessages`' own comment notes the messages link's schema wins over an `asSchema` handle inside `push()`. Both are avoided — base-relative, schema-less cell.

## Testing

- Full **workspace** suite green (all packages, 218s), plus `deno fmt --check`, `deno lint`, and `deno task check-docs` (523 blocks), verified locally at `a7322e3d1`. The `runner` package alone is 1097 passed / 0 failed.
- Two error paths had **no end-to-end coverage** — nothing in the tree asserted the messages they produce. Tests for both are added here. The invalid-content one was written against the existing implementation and verified to pass there *before* the migration, so it characterizes current behavior rather than being shaped to fit the rewrite. Both pin the property this change rides on: every stored element parses as a link.

### The scope fix, now with a regression test — and a deeper root

Review found that the explicit documents defaulted to `"space"` scope while
anchored elements inherit the array's. The first fix threaded
`inputs.key("messages")`'s scope through — but that is the *input slot's*
link, which sits on the dialog's process document at `"space"` scope no matter
where the messages array actually lives. `push()` resolves the link before
writing; the explicit sites did not. Under a session-scoped messages cell the
user message's document landed in the `"space"` partition while its bare
element link resolved against `"session"`: the content was unreachable, and
the dialog stalled at `pending: true` trying to read its own transcript.

That stall is exactly the symptom that defeated the earlier attempts at a red
test — the "harness problem" was the bug itself firing. All three sites now
resolve the messages link first and mint the document at the resolved base.

The new test (`llm-dialog-message-scope.test.ts`) drives a dialog whose
pattern owns a `Cell.perSession` messages array — pattern-owned rather than
argument-injected, which sidesteps the binding questions entirely. It asserts
the resolved array is genuinely session-scoped (no vacuous pass), that both
messages read back through the array, and that each stored element is a bare
link. It is red against the slot-scope version (content lost, dialog stalled),
green with the resolved-scope version, and green against the pre-PR baseline —
the `[ID]` anchoring inherited the resolved scope by construction, so this
restores parity rather than adding behavior.

The `LlmDerived` stamping loop below `pushModelMessages()` takes the same
resolved base, so the provenance stamp records against the partition the
document actually lives in rather than the slot's.

### Pushing cells rather than links (@seefeldb)

The three sites originally pushed `cell.getAsLink(...)` behind a cast, on the
reasoning that pushing the cell inlines space, scope and schema per element.
Measured, that was 685 B per stored message against 87 B for a bare link — but
it was treating two separable costs as one, and the cast was reaching through
the very guard that keeps user-land from writing arbitrary links.

Both halves are now fixed at the source:

| | space+scope | schema | stored |
|---|---|---|---|
| push cell, before | inlined | inlined | 685 B |
| + `normalizeAndDiff` elision | elided | inlined | 600 B |
| + schema-less document | elided | absent | **87 B** |

`normalizeAndDiff()` converted a written `Cell` with no base, so the link
re-inlined what the destination slot already supplied — while the sibling
branch a hundred lines up already elided against that same `link`. Fixing it
surfaced a second latent bug of the same species: the self-reference no-op
guard also compares base-lessly, so once the link elides it stops recognizing
a cell written to its own slot, and `c.set(c)` resolves into a cycle. Four test
assertions needed a base they were missing, plus one in
`packages/runner/integration/` that CI caught and the workspace `deno task test`
does not cover — the package integration suites run under a separate task.

The invariant this establishes: **a stored link is only meaningful together with
the slot it was read from.** Parsing one without its base is a bug even where it
currently works. The two base-less `parseLink()` sites left in `src`
(`llm-dialog.ts` stamping, `sqlite-builtins.ts` per-row labels) are safe only
because they fall back to `link.space ?? base.space`.

Schema is not affected by elision, so the documents are also created
schema-less — a document's schema is inlined into every link written to it, and
the array's own items schema already describes what a reader finds. Typing stays
at the call site via `runtime.getCell<Schema<typeof LLMMessageSchema>>`.

Result: `push(messageCell)`, no casts, and the same 87 B on disk.

## Reviewing

Six commits, each test in its own. The invalid-content test lands before the `[ID]` removal and was verified green there first, so it characterizes existing behavior rather than being shaped to fit the rewrite. The failed-request test follows the removal. The scope test lands with its fix — it cannot be staged separately, since it is red without it.

The reviewer question I would most value a second opinion on: whether minting per-message identity inside `pushModelMessages()` is the right home for it, versus keeping it at the call sites. It reads better to me — the function that pushes and stamps is now also the one that mints — but it does mean callers can no longer choose a cause.

There is a `TODO(seefeld)` on the original lines about event ids eventually supplying the cause; that intent is preserved, just relocated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJwf3YGTzF42U7WBdAq4Pf

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split `llmDialog` messages into their own documents without `[ID]`. Identity is minted after resolving the `messages` link, and we now push message cells directly; storage stays as bare, base-relative links and per-message docs are schema-less.

- **Refactors**
  - Removed all `[ID]` usage; identity minting is done inline when pushing one cell per message using the resolved `messages` link.
  - Per-message docs are schema-less; the array’s items schema defines shape.
  - `normalizeAndDiff()` elides cell-valued writes against the slot, enabling bare links and removing casts/extra base cells.

- **Bug Fixes**
  - Mint docs and stamp in the resolved array’s space/scope; added a session-scope regression test.
  - Fixed self-reference no-op guard in `normalizeAndDiff()` to handle elided bases; updated tests to compare links relative to the slot and stabilized with `runtime.idle()`.
  - In `integration/sync-schema-path`, parse stored links against the slot that holds them to recover `space`.

<sup>Written for commit 65bf6f044ab2cdbfbb30b8a2f23ef4dcb47d93fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

