### PR TITLE
docs(plans): verb-result design corrections and decisions

### DIFF
--- a/docs/plans/pattern-verb-contract-implementation.md
+++ b/docs/plans/pattern-verb-contract-implementation.md
@@ -130,6 +130,30 @@ Size L (~1–2 weeks). No dependencies; starts immediately.
 `packages/api`, `packages/ts-transformers`, `packages/schema-generator`,
 `packages/runner`.
 
+- **Results: every published name is permanent, at every depth.** Schema
+  compatibility checks results as candidate ⊆ previous, and "results may
+  narrow freely" governs *values*, never *named fields*. Measured against
+  `assertPatternSchemasBackwardCompatible`:
+
+  | change | verdict |
+  | --- | --- |
+  | remove a named field, any depth | rejected |
+  | add a **required** field, any depth | rejected unless it has a default |
+  | add an **optional** field, any depth | allowed |
+  | narrow a value type, any depth | allowed |
+
+  Nesting a result under one key confers nothing — the removed-field check
+  recurses, so a nested removal is rejected on a nested path exactly as a flat
+  one is. So the rule to author against is: publish as few names as the verb
+  can live with, and make every later addition optional. The design doc's
+  matching paragraph is corrected the same way.
+- **`action` is the sole result-authoring surface.** `handler()` produces
+  `HandlerFactory<T, E, void>`, so a returning verb written with `handler`
+  does not compile against a `Stream<E, R>` annotation. Deliberate: `action`
+  is the CTS-native surface a pattern author writes, `handler` the lower-level
+  escape hatch, and threading `R` through both would double a hand-maintained
+  mirror that already drifts. C2's returning-body error must point authors at
+  `action` rather than merely rejecting the body.
 - **api:** `action` overloads accept a return type (today both overloads type
   the callback `=> void` — the `action()` overloads in
   `packages/runner/src/builder/module.ts`); `Stream<T, R = void>`
@@ -200,6 +224,26 @@ Size L (~1–2 weeks). No dependencies; starts immediately.
   ignored — design rule 1): emit `additionalProperties: false` for event
   payloads, confirm the runner enforces it at dispatch, and record the rule
   in the mapping spec.
+
+  **A value-less verb wants `{ type: "object", properties: {} }`, not the
+  generic `void` sentinel**, which lowers to `{ asCell: ["opaque"] }` — a
+  *wrapper* claim ("the result is an opaque cell") rather than a statement
+  that there is no result, and it would hand readback a cell to resolve. The
+  empty object describes the value the runtime actually writes, since a
+  value-less handling's receipt is `{}`; it satisfies rule 3's "a verb that
+  produces nothing says so"; and leaving `additionalProperties` **undefined**
+  keeps it open, because the compat checker reads `additionalProperties ??
+  true`. Emitting `false` there would freeze a verb as value-less forever.
+  Deliberately the opposite of verb *inputs*, which close so an undeclared
+  field is a rejection.
+
+  **`AsStream` stays single-slot**, so `Stream.for<Event, Result>()` cannot
+  construct a result-carrying stream. Acceptable because verbs come from
+  `action`/`handler` and streams are leaves. If it ever bites, the cost is
+  bounded: `AsStream` has three non-test uses, and widening is four defaulted
+  edits — `_B` on `HKT` (implementors inherit it), `Apply<F, A, B = void>`,
+  `<T, R = void>` on `CellTypeConstructor`'s `new`/`of`/`for`, and `AsStream`'s
+  two-slot projection. Every step carries a default, so no call site moves.
 - **Which signal marks a verb — checked, and C3 is not exposed to it.** An
   earlier revision of this bullet warned that "stream/handler properties" is
   not one predicate, because `Cell.isStream` accepts three independent signals
@@ -247,6 +291,13 @@ Size L (~1–2 weeks). No dependencies; starts immediately.
 - **Exit:** a CTS pattern declares a verb returning `AddTopicResult`; the
   result schema appears in the durable schema; under the flag, both plain and
   reactive returns are readable in the receipt cell.
+- **The reactive half of that exit needs no new machinery** (Berni,
+  2026-07-29): `await cell.pull()` on the receipt already ensures the pattern
+  on that cell, if there is one, has run. The readback the CLI performs is
+  therefore the same call for a plain return and a launched one, and the
+  difference stays inside `pull()`. Recorded rather than assumed — the claim
+  is the architect's about his own machinery, and this plan has not yet
+  exercised a reactive return end to end.
 
 ### WS-D — invocation plumbing
 
@@ -268,6 +319,15 @@ joins WS-C. `packages/runner` (`cell.ts` send path), `packages/cli`.
   ends in the stream link. The binding is a content hash over the caller's key
   plus the whole link, not a delimited join: the caller's half is opaque, so
   concatenation would let a chosen id shift the separator.
+
+  The alternative — a client-side helper that derives the receipt cell rather
+  than receiving its address — was raised again in review (Berni, 2026-07-29)
+  as an equal option. It is not equal, for a reason worth keeping written
+  down: **the receipt is not derivable from the event id alone.** Its cause is
+  the handler's bound closure *plus* the event id, as this document already
+  states. A helper would have to reconstruct `$ctx` from the callable cell at
+  every call site — the client-side reconstruction the callback route exists
+  to avoid, and the same fact that makes caller-key scoping necessary.
 - ~~**cli:** `--invocation <id>` on `piece call` (UUID minted and printed by
   default, including when the wait times out); after commit, sync and read the
   receipt (a cold plain read returns `undefined` — sync first); reclassify
@@ -379,11 +439,29 @@ Size M, mostly parallel. `packages/cli`, `skills/cf`.
   everything per the decided semantics; handler result schemas appear once
   WS-C lands, tier filtering with the marker, later. The 2026-07-24 amendment is absorbed: the listing carries the
   deployed pattern's source identity (skew detection).
-- Generic identity annotation for data reads and callable results. Start with
-  an exploration form such as `--include-ids` that annotates points where the
-  backing identity changes; evaluate a narrower path-selected form if broad
-  output is too noisy. Patterns return child references and never manufacture
-  their own fid fields for this purpose.
+- Generic identity annotation for data reads and callable results
+  (`--show-links` / `--include-ids`). Patterns return child references and
+  never manufacture their own fid fields for this purpose. Two shapes were
+  weighed (Berni, 2026-07-29): an inline `"@ID": { doc?, path?, space?,
+  scope? }` wherever the doc id or scope changes, versus provenance beside the
+  value as a `{ "/path": <link> }` dictionary.
+
+  **Take the second.** Berni's own objection settles it: inline cannot
+  annotate a **scalar**, and a scalar can be its own doc, so the format needs
+  a special case exactly where results are simplest — and an irregular format
+  costs an agent more than a verbose one. A second reason follows from the
+  result rule above: an inline `@ID` inside a schema-described result is
+  either undeclared (the tolerated-but-undeclared shape rule 1 exists to kill)
+  or declared, and then permanent at every path it appears, for provenance
+  metadata.
+
+  Not a new format either — the llm-dialog tool path already returns the link
+  as a sibling of the value, never inside it. Placement is a `links` field on
+  the Invocation JSON rather than a second stdout block: `resultRef` is
+  already recorded as advisory until the invocation protocol carries it there,
+  and Invocation is required to be authored open-world precisely so protocol
+  fields can be added later. Cost is bounded by emitting links only for paths
+  that have them, and only when asked.
 - **Read-path guard:** `cf piece get` on a path that resolves to a verb returns
   the stream's serialization rather than redirecting. The llm-dialog `read`
   tool already rejects this case with the right message — "Path resolves to a

--- a/docs/plans/pattern-verb-contract.md
+++ b/docs/plans/pattern-verb-contract.md
@@ -641,14 +641,27 @@ compared for exact equality, so a field cannot change
 between data and verb across a deploy. Verb names and their verb-ness are
 therefore already a contract with teeth, before this document adds any rule.
 
-The practical consequence for verb results: return the value inside an
-envelope under a single key rather than spreading it across top-level fields.
-Every top-level name published is permanent; a value nested under one key
-leaves only that key permanent and everything beneath it free to narrow. The
-llm-dialog tool path already returns exactly this shape from both of its
-branches — an `@resultLocation` link, the value, and its schema together (both
-`"@resultLocation"` sites in `handleInvoke`,
-`packages/runner/src/builtins/llm-dialog.ts`).
+The practical consequence for verb results: **every name a result publishes is
+permanent regardless of depth, and every later addition must be optional.**
+
+An earlier revision of this paragraph advised nesting the value under a single
+key so that "only that key is permanent and everything beneath it is free to
+narrow". Measured against `assertPatternSchemasBackwardCompatible`, that is not
+what the checker does. The removed-field check recurses, so a nested removal is
+rejected on a nested path (`result.topic.title: existing result field was
+removed`) exactly as a flat one is. Adding a **required** field is rejected at
+any depth unless it carries a default; adding an **optional** one is allowed at
+any depth; narrowing a *value* type is allowed at any depth. Nesting changes
+none of it.
+
+"Results may narrow freely" is therefore true of values and never of names,
+which is the distinction the earlier wording blurred. Publish as few names as
+the verb can live with, and make every later addition optional. An envelope
+remains a reasonable readability choice — the llm-dialog tool path returns a
+single-key shape from both of its branches, an `@resultLocation` link, the
+value, and its schema together (both `"@resultLocation"` sites in
+`handleInvoke`, `packages/runner/src/builtins/llm-dialog.ts`) — just not for
+the evolution reason previously given.
 
 ### Authoring
 


### PR DESCRIPTION
## Why

`main`'s design doc currently gives advice I measured to be wrong, and several decisions from this week's review exist only in conversation. This lands the corrections and decisions on their own, so the design record is right while the implementation PRs (#5147, #5170) are reviewed separately.

Docs only. Everything here is true against `main` today — nothing waits on unmerged code, and no "done" marker rides along.

## What Changed

### A correction `main` needs

The design doc advises returning a result inside an envelope "so only that key is permanent and everything beneath it is free to narrow." Measured against `assertPatternSchemasBackwardCompatible`, nesting confers **nothing** — the removed-field check recurses, so a nested removal is rejected on a nested path (`result.topic.title: existing result field was removed`) exactly as a flat one is.

| change | verdict |
| --- | --- |
| remove a named field, any depth | rejected |
| add a **required** field, any depth | rejected unless it has a default |
| add an **optional** field, any depth | allowed |
| narrow a value type, any depth | allowed |

So "results may narrow freely" is true of *values* and never of *names*. The rule to author against is: publish as few names as the verb can live with, and make every later addition optional. An envelope stays a reasonable readability choice — just not for the evolution reason given. Corrected in both docs.

### Decisions recorded

- **`action` is the sole result-authoring surface.** `handler()` produces `HandlerFactory<T, E, void>`, so a returning verb written with `handler` does not compile against a `Stream<E, R>` annotation. C2's returning-body error must point authors at `action` rather than merely rejecting the body.
- **A value-less verb's result schema is `{type: "object", properties: {}}`**, not the `void` sentinel's `{asCell: ["opaque"]}` — a *wrapper* claim, which would hand readback a cell to resolve. Left open (`additionalProperties` undefined) so a verb can gain a result later; `false` would freeze it value-less permanently. Deliberately the opposite of verb *inputs*, which close so an undeclared field is a rejection.
- **`AsStream` stays single-slot**, with the widening cost written down: three non-test uses, four defaulted edits, no call site moves.

### From the design review (Berni, 2026-07-29)

- **`pull()` covers the reactive half of WS-C's exit.** `await cell.pull()` on the receipt already ensures the pattern on it has run, so a plain return and a launched one are the same call from the caller's side. Recorded as his claim about his own machinery, **not** as verified — no reactive return has been exercised end to end.
- **The receipt is not derivable from the event id alone.** Its cause is the handler's bound closure *plus* the event id, so a client-side helper is not an equal alternative to receiving the address on the commit callback. This is the same fact that makes caller-key scoping necessary.
- **`--show-links` puts provenance beside the value**, not inline `@ID`. Inline cannot annotate a scalar, and a scalar can be its own doc; and an inline key inside a schema-described result is either undeclared (the shape rule 1 exists to kill) or permanent at every path it appears. Not a new format — llm-dialog already returns the link as a sibling of the value. Placement is a `links` field on the Invocation JSON, which is authored open-world for exactly this kind of extension.

## Test plan

- `deno task check-docs plans` — passes.
- `docs/` is fmt-excluded; added prose hand-wrapped at 80 columns (verified no added line exceeds it).
- The evolution table is measured, not inferred: each row was run against `assertPatternSchemasBackwardCompatible` with flat and enveloped result schemas before being written down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects verb-result evolution guidance and records recent review decisions so the design docs reflect current `main` behavior. Docs only.

- **Docs Corrections**
  - Result field names are permanent at any depth; nesting under an envelope does not relax compatibility. Publish few names and make later additions optional. Removing fields is rejected; adding required fields is rejected unless defaulted; adding optional fields is allowed; narrowing value types is allowed.
  - `action` is the sole result-authoring surface. `handler()` remains `HandlerFactory<T, E, void>`; a returning body should be directed to `action`.

- **Recorded Decisions**
  - Value-less result schema is `{ type: "object", properties: {} }` with `additionalProperties` unset, not the `void` sentinel `{ asCell: ["opaque"] }`.
  - `AsStream` stays single-slot; widening cost is documented.
  - Reactive returns: `pull()` on the receipt covers the reactive exit; the receipt address is not derivable from the event id alone, so keep the commit-callback address.
  - `--show-links` reports provenance beside the value via an Invocation `links` field, not inline `@ID`.

<sup>Written for commit a1769dcd5f600d1113584f4f2cd78a37ae82e0d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

