### PR TITLE
Document the `false` argument-schema footgun on `pattern()`

### DIFF
--- a/packages/runner/src/builder/pattern.ts
+++ b/packages/runner/src/builder/pattern.ts
@@ -77,7 +77,13 @@ import { hardenVerifiedFunction } from "../sandbox/function-hardening.ts";
 /** Declare a pattern
  *
  * @param fn A function that creates the pattern graph
- * @param argumentSchema An optional JSONSchema for the pattern inputs
+ * @param argumentSchema An optional JSONSchema for the pattern inputs. A
+ *   pattern that takes no inputs may pass `false` (the JSON Schema that
+ *   matches nothing) -- but do not copy that shape into a pattern that does
+ *   take inputs: a `false` argument schema silently drops every argument
+ *   supplied at run time, so each input reads as `undefined` with no error.
+ *   A pattern with inputs needs a real argument schema here (the position
+ *   cannot be skipped when a `resultSchema` is also passed).
  * @param resultSchema An optional JSONSchema for the pattern outputs
  *
  * @returns A pattern node factory that also serializes as pattern.


### PR DESCRIPTION
`pattern(fn, false, resultSchema)` is a correct and common shape for a pattern that takes no inputs — `false` is the JSON Schema that matches nothing. Copying that shape into a pattern that *does* take inputs produces a silent failure: every argument supplied through `runtime.run()` is dropped by the schema, and each input reads as `undefined` with no error anywhere.

This cost four debugging rounds during the PR #5208 test work before it was diagnosed, and the behavior was not written down anywhere in the tree. This puts the warning in the one place a pattern author reliably looks: the JSDoc on `pattern()`'s `argumentSchema` parameter, where editor hover surfaces it at the call site.

Comment-only change; full workspace suite run at this branch state: all tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VEMbFKHAMQ5h71AD5uFj8


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a JSDoc warning on `pattern()`’s `argumentSchema` to explain that using `false` on patterns with inputs silently drops all args (inputs read as `undefined` with no error).

Docs-only change in `packages/runner/src/builder/pattern.ts`; clarifies that input-taking patterns must provide a real argument schema and that this position can’t be skipped when a `resultSchema` is passed.

<sup>Written for commit 420ee8f175047b208d17f5894d0c9a4d81a61316. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

