### PR TITLE
Remove `ID_FIELD` and its only producer

### DIFF
--- a/docs/specs/schema-generator/ts_to_json_schema_mapping.md
+++ b/docs/specs/schema-generator/ts_to_json_schema_mapping.md
@@ -604,8 +604,8 @@ The emitted key set aligns with the api's `JSONSchemaObj.ifc` member
 `writeAuthorizedBy`, `exactCopyOf`, `projection`, `observes`, and `uiContract`.
 `ownerPrincipal` and `observes` have no direct producing alias in this package
 as of this writing.
-The api type also declares `[ID]`/`[ID_FIELD]` extension keys
-(`api/index.ts`); this package never emits them (grep).
+The api type also declares an `[ID]` extension key
+(`api/index.ts`); this package never emits it (grep).
 
 ## 12. Doc Comments → `description` / `tags` / `$comment`
 

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -330,7 +330,6 @@ export interface FabricExecPlainObject
 // Runtime constants - defined by @commonfabric/runner/src/builder/types.ts
 // These are ambient declarations since the actual values are provided by the runtime environment
 export declare const ID: unique symbol;
-export declare const ID_FIELD: unique symbol;
 
 // Should be Symbol("UI") or so, but this makes repeat() use these when
 // iterating over patterns.
@@ -1590,8 +1589,8 @@ export type UnwrapCell<T> =
  * is a type utility that allows any part of type T to be wrapped in AnyCell<>,
  * and allow any part of T that is currently wrapped in AnyCell<> to be used
  * unwrapped. This is designed for use with cell method parameters, allowing
- * flexibility in how values are passed. The ID and ID_FIELD metadata symbols
- * allows controlling id generation and can only be passed to write operations.
+ * flexibility in how values are passed. The ID metadata symbol allows
+ * controlling id generation and can only be passed to write operations.
  */
 export type AnyCellWrapping<T> =
   // Handle existing AnyBrandedCell<> types, allowing unwrapping
@@ -1606,7 +1605,7 @@ export type AnyCellWrapping<T> =
     // Handle objects (excluding null)
     : T extends object ?
         | { [K in keyof T]: AnyCellWrapping<T[K]> }
-          & { [ID]?: AnyCellWrapping<JSONValue>; [ID_FIELD]?: string }
+          & { [ID]?: AnyCellWrapping<JSONValue> }
         | AnyBrandedCell<{ [K in keyof T]: AnyCellWrapping<T[K]> }>
     // Handle primitives
     : T | AnyBrandedCell<T>;
@@ -1686,7 +1685,6 @@ export interface JSONObject extends Readonly<Record<string, JSONValue>> {}
 // removed before sending to storage.
 export interface IDFields {
   readonly [ID]?: unknown;
-  readonly [ID_FIELD]?: unknown;
 }
 
 /**
@@ -1792,7 +1790,6 @@ export type JSONSchemaObj = {
 
   // Common Fabric extensions
   readonly [ID]?: unknown;
-  readonly [ID_FIELD]?: unknown;
   readonly scope?: SchemaScope;
   // Discovery hashtags from the doc comment (lowercased, without the leading
   // `#`). Populated by the schema generator; mirrors the description text.

--- a/packages/runner/src/builder/factory.ts
+++ b/packages/runner/src/builder/factory.ts
@@ -16,7 +16,6 @@ import {
   CHIP_UI,
   FS,
   ID,
-  ID_FIELD,
   NAME,
   schema as schemaIdentity,
   SELF,
@@ -274,7 +273,6 @@ export const createBuilder = (options: CreateBuilderOptions = {}): {
 
     // Constants
     ID,
-    ID_FIELD,
     SELF,
     TYPE,
     NAME,

--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -37,7 +37,6 @@ import type {
   HandlerFunction,
   HFunction,
   ID as IDSymbol,
-  ID_FIELD as IDFieldSymbol,
   IfElseFunction,
   InspectConfLabelFunction,
   JSONSchema,
@@ -79,9 +78,6 @@ import { type Runtime } from "../runtime.ts";
 
 // Define runtime constants here - actual runtime values
 export const ID: typeof IDSymbol = Symbol("ID, unique to the context") as any;
-export const ID_FIELD: typeof IDFieldSymbol = Symbol(
-  "ID_FIELD, name of sibling that contains id",
-) as any;
 
 // Should be Symbol("UI") or so, but this makes repeat() use these when
 // iterating over patterns.
@@ -431,7 +427,6 @@ export interface BuilderFunctionsAndConstants {
 
   // Constants
   ID: typeof ID;
-  ID_FIELD: typeof ID_FIELD;
   SELF: typeof SELF;
   TYPE: typeof TYPE;
   NAME: typeof NAME;

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -57,7 +57,6 @@ import {
   type HKT,
   type ICell,
   ID,
-  ID_FIELD,
   type IDFields,
   isStreamValue,
   type IsThisObject,
@@ -3066,22 +3065,22 @@ export function recursivelyAddIDIfNeeded<T>(
     return value;
   }
 
-  // A plain object may still be carrying an `[ID]` or `[ID_FIELD]` directive
-  // here -- either author-supplied or added by the array walk below -- and those
-  // are instructions for `diffAndUpdate()`, not content, so the conversion
+  // A plain object may still be carrying an `[ID]` directive here -- either
+  // author-supplied or added by the array walk below -- and it is an
+  // instruction for `diffAndUpdate()`, not content, so the conversion
   // functions rightly refuse to store an object bearing one. Such an object is
   // walked directly instead; the walk rebuilds it either way, and the directive
   // survives to the consumer that strips it.
   // Known gap, deliberately left: the bypass is unconditional, so an object
-  // carrying a directive AND some other symbol or non-enumerable key keeps its
-  // other key out of the key check too, and the record walk below then drops it
-  // silently (it rebuilds from `Object.entries()` and copies back only `ID` and
-  // `ID_FIELD`). That drop predates the key check rather than being introduced
-  // by this bypass, and it goes away with the directives themselves. Should they
+  // carrying the directive AND some other symbol or non-enumerable key keeps
+  // its other key out of the key check too, and the record walk below then
+  // drops it silently (it rebuilds from `Object.entries()` and copies back
+  // only `ID`). That drop predates the key check rather than being introduced
+  // by this bypass, and it goes away with the directive itself. Should it
   // outlive this comment, close it by requiring everything other than the
-  // directives to satisfy `isPlainObjectWithOnlyEnumerableStringKeys()`.
+  // directive to satisfy `isPlainObjectWithOnlyEnumerableStringKeys()`.
   const carriesIdDirective = isPlainObject(value) &&
-    ((ID in (value as object)) || (ID_FIELD in (value as object)));
+    (ID in (value as object));
 
   // Convert value to fabric form. This handles:
   // - Primitives (e.g., pass -0/NaN/Infinity/bigint through, reject unique
@@ -3188,17 +3187,11 @@ export function recursivelyAddIDIfNeeded<T>(
       result[key] = next;
     });
 
-    // Copy supported symbols from the original value. Symbols are not
+    // Copy the `ID` directive from the original value. Symbols are not
     // enumerable via `Object.entries()` and are not preserved by the
     // shallow fabric conversion.
-    if (isRecord(value)) {
-      const valueRecord = value as Record<string, unknown>;
-      [ID, ID_FIELD].forEach((symbol) => {
-        const key = symbol as keyof IDFields;
-        if (key in valueRecord) {
-          result[key] = (valueRecord as IDFields)[key];
-        }
-      });
+    if (isRecord(value) && ID in value) {
+      result[ID] = (value as IDFields)[ID];
     }
 
     if (!changed) {

--- a/packages/runner/src/cfc.ts
+++ b/packages/runner/src/cfc.ts
@@ -727,8 +727,8 @@ export class ContextualFlowControl {
     return cfcSchemaIsTrue(schema);
   }
 
-  // We don't need to check ID and ID_FIELD, since they won't be included
-  // in Object.keys return values.
+  // We don't need to check ID, since it won't be included in Object.keys
+  // return values.
   static isInternalSchemaKey(key: string): boolean {
     return cfcSchemaIsInternalKey(key);
   }

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -1,4 +1,4 @@
-import { isObject, isRecord, type Mutable } from "@commonfabric/utils/types";
+import { isObject, isRecord } from "@commonfabric/utils/types";
 import type { CfcConfClause } from "./cfc/clause.ts";
 import type { CfcAtom } from "@commonfabric/api/cfc";
 import { forEachSubschema } from "./schema-walk.ts";
@@ -12,13 +12,8 @@ import {
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { getLogger } from "@commonfabric/utils/logger";
-import {
-  type CellScope,
-  ID,
-  ID_FIELD,
-  type JSONSchema,
-} from "./builder/types.ts";
-import type { IDFields, JSONSchemaObj } from "@commonfabric/api";
+import { type CellScope, ID, type JSONSchema } from "./builder/types.ts";
+import type { JSONSchemaObj } from "@commonfabric/api";
 import { ContextualFlowControl } from "./cfc.ts";
 import { isCellScope, scopeRank } from "./scope.ts";
 import { createRef } from "./create-ref.ts";
@@ -505,71 +500,6 @@ export function normalizeAndDiff(
         seen,
       ),
     ];
-  }
-
-  // ID_FIELD redirects to an existing field and we do something like DOM
-  // diffing with it: We look at sibling entries and their value for that field,
-  // and if we find a match, we reuse that document. Otherwise we create a new
-  // one, but with a random id. It's random as opposed to causal like ID below,
-  // because we don't want to recycle a document that was removed and added
-  // back, we want to assume removing and adding with the same id is
-  // semantically a new item (in fact we otherwise run into compare-and-swap
-  // transaction errors).
-  const idFieldValue = newValue as FabricPlainObject & { [ID_FIELD]?: string };
-  if (isRecord(newValue) && idFieldValue[ID_FIELD] !== undefined) {
-    diffLogger.debug(
-      "diff",
-      () => `[BRANCH_ID_FIELD] Processing ID_FIELD redirect at path=${pathStr}`,
-    );
-    const { [ID_FIELD]: fieldName, ...rest } = idFieldValue as
-      & { [ID_FIELD]: string }
-      & FabricPlainObject;
-    const id = idFieldValue[fieldName];
-    if (link.path.length > 1) {
-      const parent = tx.readValueOrThrow({
-        ...link,
-        path: link.path.slice(0, -1),
-      }, options);
-      if (Array.isArray(parent)) {
-        const base = runtime.getCellFromLink(link, undefined, tx);
-        for (const v of parent) {
-          if (isCellLink(v)) {
-            const sibling = parseLink(v, base);
-            const siblingId = tx.readValueOrThrow({
-              ...sibling,
-              path: [...sibling.path, fieldName as string],
-            }, options);
-            if (siblingId === id) {
-              // We found a sibling with the same id, so ...
-              return [
-                // ... reuse the existing document
-                ...normalizeAndDiff(
-                  runtime,
-                  tx,
-                  link,
-                  v,
-                  context,
-                  options,
-                  seen,
-                ),
-                // ... and update it to the new value
-                ...normalizeAndDiff(
-                  runtime,
-                  tx,
-                  sibling,
-                  rest,
-                  context,
-                  options,
-                  seen,
-                ),
-              ];
-            }
-          }
-        }
-      }
-    }
-    // Fallback: A random id. Below this will create a new entity.
-    newValue = { [ID]: crypto.randomUUID(), ...rest };
   }
 
   // Unwrap proxies and handle special types
@@ -1580,40 +1510,6 @@ export function applyChangeSet(
       change.delete ? { delete: true } : undefined,
     );
   }
-}
-
-/**
- * Translates `id` that React likes to create to our `ID` property, making sure
- * in any given object it is never used twice.
- *
- * This mostly makes sense in a context where we ship entire JSON documents back
- * and forth and can't express graphs, i.e. two places referring to the same
- * underlying entity.
- *
- * We'll want to revisit once iframes become more sophisticated in what they can
- * express, e.g. we could have the inner shim do some of this work instead.
- */
-export function addCommonIDfromObjectID(
-  obj: unknown,
-  fieldName: string = "id",
-): void {
-  function traverse(obj: unknown): void {
-    if (isRecord(obj) && fieldName in obj) {
-      (obj as Mutable<IDFields>)[ID_FIELD] = fieldName;
-    }
-
-    // TODO(danfuzz): Latent — this is a public entry point (re-exported,
-    // "entire JSON documents" from iframes) walking `obj: unknown` with no
-    // `FabricSpecialObject` guard (only `isCell`/`isPrimitiveCellLink`). A
-    // caller can't be proven to pass only plain JSON, so if a `FabricPrimitive`/
-    // `FabricInstance` ever reaches here it is mishandled (primitive decomposed,
-    // instance walked by internal slots). Mark against that.
-    if (isRecord(obj) && !isCell(obj) && !isPrimitiveCellLink(obj)) {
-      Object.values(obj).forEach((v) => traverse(v));
-    }
-  }
-
-  traverse(obj);
 }
 
 /**

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -100,7 +100,6 @@ export {
   type PatternCoverageSpan,
   writePatternCoverageLcov,
 } from "./pattern-coverage.ts";
-export { addCommonIDfromObjectID } from "./data-updating.ts";
 export {
   type BlindStructuralTarget,
   isRendererInputTx,
@@ -182,7 +181,6 @@ export {
   type FsProjection,
   type HandlerFactory,
   ID,
-  ID_FIELD,
   isModule,
   isPattern,
   isReactive,

--- a/packages/runner/test/cell-as-cell.test.ts
+++ b/packages/runner/test/cell-as-cell.test.ts
@@ -12,7 +12,6 @@ import { ID, JSONSchema } from "../src/builder/types.ts";
 import { popFrame, pushFrame } from "../src/builder/pattern.ts";
 import { Runtime } from "../src/runtime.ts";
 import { txToReactivityLog } from "../src/scheduler.ts";
-import { addCommonIDfromObjectID } from "../src/data-updating.ts";
 import { isPrimitiveCellLink, parseLink } from "../src/link-utils.ts";
 import { areNormalizedLinksSame } from "../src/link-utils.ts";
 import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
@@ -1245,7 +1244,6 @@ describe("asCell with schema", () => {
       },
     ];
     const initialDataCopy = JSON.parse(JSON.stringify(initialData));
-    addCommonIDfromObjectID(initialDataCopy);
 
     const frame1 = pushFrame({
       generatedIdCounter: 0,
@@ -1270,7 +1268,6 @@ describe("asCell with schema", () => {
     const linkFromContext1 = parseLink(testCell.getRaw()[0], testCell)!;
 
     const returnedData = JSON.parse(JSON.stringify(testCell.get()));
-    addCommonIDfromObjectID(returnedData);
 
     const frame2 = pushFrame({
       generatedIdCounter: 0,

--- a/packages/runner/test/cell-core.test.ts
+++ b/packages/runner/test/cell-core.test.ts
@@ -68,6 +68,30 @@ describe("Cell", () => {
     expect(c.get()).toBe(10);
   });
 
+  it("delegates unrecognized symbol reads on a reactive proxy to the target", () => {
+    const c = runtime.getCell<{ a: number }>(
+      space,
+      "reactive proxy delegates unrecognized symbols",
+      undefined,
+      tx,
+    );
+    c.set({ a: 1 });
+
+    // String and number properties become nested cells, and a handful of
+    // well-known symbols get bespoke answers -- but any other symbol falls
+    // through to the proxied target itself, rather than being treated as
+    // data navigation.
+    const marked = Object.assign(() => undefined, {
+      [Symbol.for("cf.test.marker")]: "on-target",
+    });
+    const proxy = c.getAsReactiveProxy(marked) as unknown as Record<
+      symbol,
+      unknown
+    >;
+    expect(proxy[Symbol.for("cf.test.marker")]).toBe("on-target");
+    expect(proxy[Symbol.for("cf.test.absent")]).toBe(undefined);
+  });
+
   it("should update cell value using send", () => {
     const c = runtime.getCell<number>(
       space,

--- a/packages/runner/test/data-updating.test.ts
+++ b/packages/runner/test/data-updating.test.ts
@@ -1,8 +1,7 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { ID, ID_FIELD, JSONSchema } from "../src/builder/types.ts";
+import { ID, JSONSchema } from "../src/builder/types.ts";
 import {
-  addCommonIDfromObjectID,
   applyChangeSet,
   type ChangeSet,
   compactChangeSet,
@@ -744,67 +743,6 @@ describe("data-updating", () => {
         .toEqual("Second Value");
     });
 
-    it("should handle ID_FIELD redirects and reuse existing documents", () => {
-      const testCell = runtime.getCell<any>(
-        space,
-        "should handle ID_FIELD redirects",
-        undefined,
-        tx,
-      );
-      testCell.set({ items: [] });
-
-      // Create an initial item
-      const data = { id: "item1", name: "First Item" };
-      addCommonIDfromObjectID(data);
-      diffAndUpdate(
-        runtime,
-        tx,
-        testCell.key("items").key(0).getAsNormalizedFullLink(),
-        data,
-        "test ID_FIELD redirects",
-      );
-
-      const initialLink = testCell.getRaw().items[0];
-
-      // Update with another item using ID_FIELD to point to the 'id' field
-      const newValue = {
-        items: [
-          { id: "item0", name: "New Item" },
-          { id: "item1", name: "Updated Item" },
-        ],
-      };
-      addCommonIDfromObjectID(newValue);
-
-      diffAndUpdate(
-        runtime,
-        tx,
-        testCell.getAsNormalizedFullLink(),
-        newValue,
-        "test ID_FIELD redirects",
-      );
-
-      // Verify that the second item reused the existing document
-      expect(isPrimitiveCellLink(testCell.getRaw().items[0])).toBe(true);
-      expect(isPrimitiveCellLink(testCell.getRaw().items[1])).toBe(true);
-      expect(areLinksSame(testCell.getRaw().items[1], initialLink)).toBe(true);
-      expect(
-        (tx.readValueOrThrow(
-          parseLink(testCell.getRaw().items[1], testCell)!,
-        ) as any)
-          .name,
-      )
-        .toEqual(
-          "Updated Item",
-        );
-      expect(
-        (tx.readValueOrThrow(
-          parseLink(testCell.getRaw().items[0], testCell)!,
-        ) as any)
-          .name,
-      )
-        .toEqual("New Item");
-    });
-
     it("should treat different properties as different ID namespaces", () => {
       const testCell = runtime.getCell<any>(
         space,
@@ -1344,55 +1282,6 @@ describe("data-updating", () => {
       );
       expect(setChange).toBeDefined();
       expect(setChange!.value).toBe(2);
-    });
-  });
-
-  describe("addCommonIDfromObjectID", () => {
-    it("should handle arrays", () => {
-      const obj = { items: [{ id: "item1", name: "First Item" }] };
-      addCommonIDfromObjectID(obj);
-      expect((obj.items[0] as any)[ID_FIELD]).toBe("id");
-    });
-
-    it("should reuse items", () => {
-      const itemCell = runtime.getCell<{ id: string; name: string }>(
-        space,
-        "addCommonIDfromObjectID reuse items",
-        undefined,
-        tx,
-      );
-      itemCell.set({ id: "item1", name: "Original Item" });
-
-      const testCell = runtime.getCell<{ items: any[] }>(
-        space,
-        "addCommonIDfromObjectID arrays",
-        undefined,
-        tx,
-      );
-      testCell.setRaw({ items: [itemCell.getAsLink()] });
-
-      const data = {
-        items: [{ id: "item1", name: "New Item" }, itemCell],
-      };
-      addCommonIDfromObjectID(data);
-      diffAndUpdate(
-        runtime,
-        tx,
-        testCell.getAsNormalizedFullLink(),
-        data,
-        "addCommonIDfromObjectID reuse items",
-      );
-
-      const result = testCell.getRaw();
-      expect(isPrimitiveCellLink(result?.items[0])).toBe(true);
-      expect(isPrimitiveCellLink(result?.items[1])).toBe(true);
-      expect(areLinksSame(result?.items[0], result?.items[1], testCell))
-        .toBe(true);
-      expect(
-        (tx.readValueOrThrow(parseLink(result?.items[1], testCell)!) as any)
-          .name,
-      )
-        .toBe("New Item");
     });
   });
 


### PR DESCRIPTION
First step of retiring the write-directive symbols (`ID` + `ID_FIELD`), which is what blocks tightening the runtime's `FabricPlainObject` recognition: the directives are the one sanctioned way a symbol-keyed plain object flows through the write path, so the tightening cannot be honest while they exist.

## What `ID_FIELD` was

A write-time annotation naming a sibling property to derive list-item identity from. `normalizeAndDiff()` matched that field's value against existing sibling documents and reused the match (DOM-diff style), falling back to a fresh random id.

## Why it can simply go

Its only producer in the tree was `addCommonIDfromObjectID()` — the bridge that stamped `id`-bearing objects when whole JSON documents were shipped in from iframes. That regime no longer exists; the bridge had zero callers outside its own tests, and no pattern, package, or transformer references `ID_FIELD` anywhere.

## What's removed

- `data-updating.ts`: the `BRANCH_ID_FIELD` interpreter branch and `addCommonIDfromObjectID()`.
- `@commonfabric/api`: the `ID_FIELD` symbol declaration and its slots in `AnyCellWrapping`, `IDFields`, and the JSONSchema extension keys.
- Builder surface: the runtime symbol (`builder/types.ts`), the pattern-author exposure (`factory.ts`, `CommonFabricTypes`), and the runner index exports.
- `cell.ts`: the `ID_FIELD` half of the directive carry-through in the write walk (the known-gap comment there narrows accordingly).
- One spec line in `ts_to_json_schema_mapping.md` updated to match the api surface.

## Tests

Mechanism tests (`ID_FIELD` redirect reuse, `addCommonIDfromObjectID`) are deleted with the mechanism — dead coverage once the branch is gone. The cell-as-cell "ids update when context changes" test kept its guard by dropping the bridge calls: plain array anchoring under a frame provides the same document splitting, and that behavior — not the directive — is what the test pins.

## Verification

Repo-wide grep sweep clean (no `ID_FIELD`/`addCommonIDfromObjectID` outside `docs/history/` and the defunct `patterns/deprecated`). `deno task check` green, `packages/api` checked directly, repo-wide `deno fmt --check` + `deno lint` clean, `deno task check-docs` 523/523, runner suite 1099 passed / 0 failed, full workspace suite green at this commit.

## What follows

`ID` remains, with its three internal producers (all funneling through `recursivelyAddIDIfNeeded`). Internalizing it — anchoring array objects directly inside the diff so no symbol-keyed plain object crosses the write path at all — is the next, separate PR; removing the `ID` public surface is the one after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VEMbFKHAMQ5h71AD5uFj8

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the `ID_FIELD` write directive and its only producer `addCommonIDfromObjectID`, simplifying the write path and enabling tighter `FabricPlainObject` checks. Also pins reactive proxy behavior so unknown symbol reads delegate to the target.

- **Refactors**
  - Removed `ID_FIELD` handling from `normalizeAndDiff()` and the carry-through in `cell.ts`; deleted `addCommonIDfromObjectID()` and runner exports.
  - Dropped `ID_FIELD` from `@commonfabric/api` (`AnyCellWrapping`, `IDFields`, `JSONSchemaObj`) and from builder/runtime constants and exports.
  - Updated schema docs to reference only `[ID]`.
  - Added a unit test pinning that reactive proxies delegate unrecognized symbol reads to the target.

- **Migration**
  - Remove any use of `addCommonIDfromObjectID()` and `[ID_FIELD]`.
  - If you depended on ID-field-based reuse, pass `[ID]` directly or use stable links; no `JSONSchema` key for `ID_FIELD` remains.

<sup>Written for commit 217dd4f5b45dea10c227348f373235ef2e831c69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

