### PR TITLE
docs(plans): record the measured absent-event default behavior in D5

### DIFF
--- a/docs/plans/pattern-verb-contract-implementation.md
+++ b/docs/plans/pattern-verb-contract-implementation.md
@@ -9,7 +9,10 @@ as work proceeds: check off exit criteria, record scope changes.
 without) and D6 (the default-relaxation helper moves next to the runner's
 validator so C5 shares it instead of re-implementing it), and WS-E records
 that pre-dispatch refusals must join the `VerbError` code taxonomy when codes
-reach the invocation surface, so agents branch on one signal.
+reach the invocation surface, so agents branch on one signal. Later the same
+day, D5's open question was measured (see its bullet): absent events bypass
+default materialization entirely, narrowing D5's remaining choice to
+refuse-on-unrelaxed-`required` versus normalize-absent-to-`{}`.
 
 **Amended 2026-07-28**, context only — no scope or decision changed: Risks
 names #5059 (`cf piece setsrc --check`) as the candidate preflight for the
@@ -417,9 +420,19 @@ joins WS-C. `packages/runner` (`cell.ts` send path), `packages/cli`.
   silent. Characterize first: a CLI unit test pins that an absent payload
   currently dispatches against a required-fields schema, then flips to
   assert refusal — the same order the gate's runner characterization took.
-  One question settles by experiment, not assumption: when `required` names
-  only defaulted properties and nothing is sent, what does `$event` read
-  back as — the answer belongs in a code comment. Plumbing reuses
+  The question this bullet once left to experiment is now measured
+  (2026-07-30, scratch runner test on the gate's branch, recorded on
+  #5147): defaults materialize only for a **present** object payload —
+  `SchemaObjectTraverser.traverseObjectWithSchema` fills each missing
+  defaulted property before checking `required` — while a wholly absent
+  event bypasses the object branch entirely, so the handler sees
+  `undefined` and the receipt still spends the id even when every required
+  property carries a default. Relaxation is therefore honest for present
+  payloads and the wrong lens for the absence decision: an all-defaulted
+  `required` list does not make absence deliverable. D5 settles, at the
+  top of its PR, whether that corner refuses on **unrelaxed** `required`
+  or normalizes an absent payload to `{}` so defaults engage; the measured
+  behavior belongs in the helper's doc comment either way. Plumbing reuses
   `VerbInputValidationError` with a detail that says no payload was supplied
   and names the missing requirement ("send a payload" must read differently
   from "fix your payload"); both entry points (piece call and mounted exec)


### PR DESCRIPTION
## Why

D5's bullet left one question to be settled by experiment: what a handler sees when `required` names only defaulted properties and nothing is sent. It is now measured (scratch runner test on #5147's branch; evidence and test source recorded on that PR): defaults materialize only for a present object payload — `traverseObjectWithSchema` fills missing defaulted properties before the `required` check — while a wholly absent event bypasses default materialization entirely, so the handler sees `undefined` and the receipt still spends the invocation id. The plan should carry the measured answer rather than the open question: relaxation is honest for present payloads and the wrong lens for the absence decision. Follow-up to #5219; arc: #5147, #5087, #5089, #5118.

## What Changed

Docs only: D5's bullet replaces its settle-by-experiment sentence with the measured behavior and narrows the remaining choice (refuse on unrelaxed `required` versus normalize absent to `{}`, settled at the top of the D5 PR); the 2026-07-30 amendment note gains a sentence pointing at it.

## Test plan

`deno fmt --check`, `deno lint`, `deno task check-docs` (523 blocks) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented the measured D5 behavior for absent events: defaults only apply when a payload object is present; with no payload, handlers see `undefined` and the invocation ID is still spent. Replaced the open question with this result, narrowed the remaining decision to refusing on unrelaxed `required` vs normalizing absence to `{}`, and added an amendment note pointing to it.

<sup>Written for commit 9cd18579a3abe77f33b5c34a4d6f20465151fbb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

