### PR TITLE
fix(piece): narrow path reads before pulling

### DIFF
--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -2205,9 +2205,11 @@ export async function getCellValue(
 
     let value: unknown;
     try {
-      value = options.input
-        ? await piece.input.get(path)
-        : await piece.result.get(path);
+      const prop = options.input ? "input" : "result";
+      value = await timeCliPhase(
+        `getCellValue.${prop}.get`,
+        () => piece[prop].get(path),
+      );
     } catch (error) {
       if (
         !options.input && error instanceof Error &&

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -4,6 +4,7 @@ import { caseFold } from "unicode-case-folding";
 import { loadIdentity } from "./identity.ts";
 import {
   Cell,
+  cellAtPath,
   entityIdFrom,
   experimentalOptionsFromEnv,
   formatFabricRef,
@@ -2193,10 +2194,7 @@ export async function getCellValue(
       await piece.getCell().pull();
       const rootCell =
         await (options.input ? piece.input.getCell() : piece.result.getCell());
-      let targetCell = rootCell;
-      for (const segment of path) {
-        targetCell = targetCell.key(segment as keyof unknown) as Cell<unknown>;
-      }
+      const targetCell = cellAtPath(rootCell, path);
       await targetCell.pull();
       await manager.synced();
       await manager.runtime.idle();

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -2275,22 +2275,22 @@ class PiecePropIo implements PieceCellIo {
 
         await selectedCell.pull();
         const selected = cellWithScopedLinkRequiredsRelaxed(selectedCell).get();
-        if (selected === undefined) break;
-        if (isCell(selected)) {
-          if (isLast) {
-            return await selected.pull();
-          }
-          selectedCell = selected;
-        } else if (isLast) {
-          return selected;
-        } else {
-          break;
+        if (selected === undefined) {
+          return await this.#getFromRoot(targetCell, path);
         }
+        if (isLast) {
+          return isCell(selected) ? await selected.pull() : selected;
+        }
+        if (!isCell(selected)) return await this.#getFromRoot(targetCell, path);
+        selectedCell = selected;
       }
-      // Preserve the existing missing-path diagnostics and the distinction
-      // between an absent field and a schema-valid undefined value. This slow
-      // fallback is reached only when the narrow projection produced no value.
     }
+    return await this.#getFromRoot(targetCell, path ?? []);
+  }
+
+  async #getFromRoot(targetCell: Cell<unknown>, path: CellPath) {
+    // Preserve the existing missing-path diagnostics and the distinction
+    // between an absent field and a schema-valid undefined value.
     await targetCell.pull();
     // Terminal read boundary: relax `required` for properties whose stored
     // value links into a scope this session may not be able to materialize
@@ -2300,7 +2300,7 @@ class PiecePropIo implements PieceCellIo {
     // #4746-compatible rationale.
     return resolveCellPath(
       cellWithScopedLinkRequiredsRelaxed(targetCell),
-      path ?? [],
+      path,
     );
   }
 

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -36,6 +36,7 @@ import {
   schemaAcceptsOpaqueCellValue,
 } from "@commonfabric/runner";
 import type { CellKind, LinkScope } from "@commonfabric/api";
+import { SchemaObjectTraverser } from "@commonfabric/runner/traverse";
 import {
   cfcSchemaChildRoot,
   resolveCfcSchemaRefRoot,
@@ -2265,24 +2266,26 @@ class PiecePropIo implements PieceCellIo {
       for (const [index, segment] of path.entries()) {
         selectedCell = cellAtPath(selectedCell, [segment]);
         const isLast = index === path.length - 1;
-        const isAsCellProjection = ContextualFlowControl.getAsCellValues(
+        const isAsCellProjection = SchemaObjectTraverser.hasAsCell(
           selectedCell.schema,
-        ).length > 0;
+        );
         // Ordinary inline ancestors need no read: extending their schema/path
         // keeps the final query as narrow as possible. An asCell ancestor must
         // be materialized so the rest of the path can move to its handle.
         if (!isLast && !isAsCellProjection) continue;
 
         await selectedCell.pull();
+        if (isAsCellProjection) {
+          const handle = selectedCell.resolveAsCell();
+          if (isLast) return await handle.pull();
+          selectedCell = handle;
+          continue;
+        }
         const selected = cellWithScopedLinkRequiredsRelaxed(selectedCell).get();
         if (selected === undefined) {
           return await this.#getFromRoot(targetCell, path);
         }
-        if (isLast) {
-          return isCell(selected) ? await selected.pull() : selected;
-        }
-        if (!isCell(selected)) return await this.#getFromRoot(targetCell, path);
-        selectedCell = selected;
+        return isCell(selected) ? await selected.pull() : selected;
       }
     }
     return await this.#getFromRoot(targetCell, path ?? []);

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -2295,12 +2295,19 @@ class PiecePropIo implements PieceCellIo {
 
         await selectedCell.pull();
         if (isAsCellProjection) {
+          // An asCell projection materializes even an explicit `undefined` as
+          // a Cell, so inspect the stored slot before resolving the handle.
+          // Falling back preserves the root read's absent-vs-undefined rules.
+          if (selectedCell.getRaw() === undefined) {
+            return await this.#getFromRoot(targetCell, path);
+          }
           const handle = selectedCell.resolveAsCell().asSchema(
             consumeAsCellProjectionSchema(selectedCell.schema!),
           );
-          await handle.pull();
           if (isLast) {
-            return cellWithScopedLinkRequiredsRelaxed(handle).get();
+            const readableHandle = cellWithScopedLinkRequiredsRelaxed(handle);
+            await readableHandle.pull();
+            return readableHandle.get();
           }
           selectedCell = handle;
           continue;

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -2253,6 +2253,31 @@ class PiecePropIo implements PieceCellIo {
 
   async get(path?: CellPath) {
     const targetCell = await this.#getTargetCell();
+    if (path?.length) {
+      // Pull the requested cell, not the whole input/result root. The sync
+      // started by pull() sends its path plus narrowed schema to Memory v2, so
+      // this avoids traversing unrelated linked fields (an input can contain a
+      // broad authoring graph even when the caller asks for one small durable
+      // field). A terminal asCell value is the selected field's handle; pull
+      // that handle to materialize its value without widening back to root.
+      let selectedCell = targetCell;
+      for (const segment of path) {
+        selectedCell = selectedCell.key(
+          segment as keyof unknown,
+        ) as Cell<unknown>;
+      }
+      await selectedCell.pull();
+      const selected = selectedCell.get();
+      if (isCell(selected)) {
+        return await selected.pull();
+      }
+      if (selected !== undefined) {
+        return selected;
+      }
+      // Preserve the existing missing-path diagnostics and the distinction
+      // between an absent field and a schema-valid undefined value. This slow
+      // fallback is reached only when the narrow projection produced no value.
+    }
     await targetCell.pull();
     // Terminal read boundary: relax `required` for properties whose stored
     // value links into a scope this session may not be able to materialize

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -801,6 +801,25 @@ export function consumeOuterCellContract(
   };
 }
 
+/** Consume one uniform asCell layer, including across anyOf/oneOf branches. */
+function consumeAsCellProjectionSchema(schema: JSONSchema): JSONSchema {
+  if (typeof schema !== "object" || schema === null) return schema;
+  if (ContextualFlowControl.getAsCellValues(schema).length > 0) {
+    return consumeOuterCellContract(schema).payloadSchema;
+  }
+  const anyOf = schema.anyOf?.every(SchemaObjectTraverser.hasAsCell)
+    ? schema.anyOf.map(consumeAsCellProjectionSchema)
+    : schema.anyOf;
+  const oneOf = schema.oneOf?.every(SchemaObjectTraverser.hasAsCell)
+    ? schema.oneOf.map(consumeAsCellProjectionSchema)
+    : schema.oneOf;
+  return {
+    ...schema,
+    ...(anyOf !== undefined && { anyOf }),
+    ...(oneOf !== undefined && { oneOf }),
+  };
+}
+
 function outerCellShapesMatch(
   left: OuterCellShape,
   right: OuterCellShape,
@@ -2276,8 +2295,13 @@ class PiecePropIo implements PieceCellIo {
 
         await selectedCell.pull();
         if (isAsCellProjection) {
-          const handle = selectedCell.resolveAsCell();
-          if (isLast) return await handle.pull();
+          const handle = selectedCell.resolveAsCell().asSchema(
+            consumeAsCellProjectionSchema(selectedCell.schema!),
+          );
+          await handle.pull();
+          if (isLast) {
+            return cellWithScopedLinkRequiredsRelaxed(handle).get();
+          }
           selectedCell = handle;
           continue;
         }

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -1,6 +1,7 @@
 import {
   applyPieceSourceTransition,
   Cell,
+  cellAtPath,
   type CellPath,
   cellWithScopedLinkRequiredsRelaxed,
   ContextualFlowControl,
@@ -2258,21 +2259,33 @@ class PiecePropIo implements PieceCellIo {
       // started by pull() sends its path plus narrowed schema to Memory v2, so
       // this avoids traversing unrelated linked fields (an input can contain a
       // broad authoring graph even when the caller asks for one small durable
-      // field). A terminal asCell value is the selected field's handle; pull
-      // that handle to materialize its value without widening back to root.
+      // field). Traverse one segment at a time so an intermediate asCell value
+      // can re-root the remaining path, matching resolveCellPath.
       let selectedCell = targetCell;
-      for (const segment of path) {
-        selectedCell = selectedCell.key(
-          segment as keyof unknown,
-        ) as Cell<unknown>;
-      }
-      await selectedCell.pull();
-      const selected = selectedCell.get();
-      if (isCell(selected)) {
-        return await selected.pull();
-      }
-      if (selected !== undefined) {
-        return selected;
+      for (const [index, segment] of path.entries()) {
+        selectedCell = cellAtPath(selectedCell, [segment]);
+        const isLast = index === path.length - 1;
+        const isAsCellProjection = ContextualFlowControl.getAsCellValues(
+          selectedCell.schema,
+        ).length > 0;
+        // Ordinary inline ancestors need no read: extending their schema/path
+        // keeps the final query as narrow as possible. An asCell ancestor must
+        // be materialized so the rest of the path can move to its handle.
+        if (!isLast && !isAsCellProjection) continue;
+
+        await selectedCell.pull();
+        const selected = cellWithScopedLinkRequiredsRelaxed(selectedCell).get();
+        if (selected === undefined) break;
+        if (isCell(selected)) {
+          if (isLast) {
+            return await selected.pull();
+          }
+          selectedCell = selected;
+        } else if (isLast) {
+          return selected;
+        } else {
+          break;
+        }
       }
       // Preserve the existing missing-path diagnostics and the distinction
       // between an absent field and a schema-valid undefined value. This slow
@@ -2320,10 +2333,7 @@ class PiecePropIo implements PieceCellIo {
       committedTargetCell = targetCell;
 
       // Build the path with transaction context
-      let txCell = targetCell.withTx(tx);
-      for (const segment of (path ?? [])) {
-        txCell = txCell.key(segment as keyof unknown) as Cell<unknown>;
-      }
+      const txCell = cellAtPath(targetCell.withTx(tx), path ?? []);
 
       const writePath = path ?? [];
       const writeTargetDiffers = (

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -801,13 +801,17 @@ export function consumeOuterCellContract(
   };
 }
 
-/** Consume one uniform asCell layer, including across anyOf/oneOf branches. */
 function schemaHasAsCell(
   schema: JSONSchema | undefined,
 ): schema is JSONSchemaObj {
   return SchemaObjectTraverser.hasAsCell(schema);
 }
 
+/**
+ * Consume one uniform asCell layer, including across anyOf/oneOf branches.
+ * This is the compound-schema counterpart to runner/schema.ts's filterAsCell;
+ * keep their top-level wrapper semantics aligned.
+ */
 function consumeAsCellProjectionSchema(schema: JSONSchemaObj): JSONSchema {
   if (ContextualFlowControl.getAsCellValues(schema).length > 0) {
     return consumeOuterCellContract(schema).payloadSchema;

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -35,7 +35,7 @@ import {
   sanitizeSchemaForLinks,
   schemaAcceptsOpaqueCellValue,
 } from "@commonfabric/runner";
-import type { CellKind, LinkScope } from "@commonfabric/api";
+import type { CellKind, JSONSchemaObj, LinkScope } from "@commonfabric/api";
 import { SchemaObjectTraverser } from "@commonfabric/runner/traverse";
 import {
   cfcSchemaChildRoot,
@@ -802,15 +802,20 @@ export function consumeOuterCellContract(
 }
 
 /** Consume one uniform asCell layer, including across anyOf/oneOf branches. */
-function consumeAsCellProjectionSchema(schema: JSONSchema): JSONSchema {
-  if (typeof schema !== "object" || schema === null) return schema;
+function schemaHasAsCell(
+  schema: JSONSchema | undefined,
+): schema is JSONSchemaObj {
+  return SchemaObjectTraverser.hasAsCell(schema);
+}
+
+function consumeAsCellProjectionSchema(schema: JSONSchemaObj): JSONSchema {
   if (ContextualFlowControl.getAsCellValues(schema).length > 0) {
     return consumeOuterCellContract(schema).payloadSchema;
   }
-  const anyOf = schema.anyOf?.every(SchemaObjectTraverser.hasAsCell)
+  const anyOf = schema.anyOf?.every(schemaHasAsCell)
     ? schema.anyOf.map(consumeAsCellProjectionSchema)
     : schema.anyOf;
-  const oneOf = schema.oneOf?.every(SchemaObjectTraverser.hasAsCell)
+  const oneOf = schema.oneOf?.every(schemaHasAsCell)
     ? schema.oneOf.map(consumeAsCellProjectionSchema)
     : schema.oneOf;
   return {
@@ -2274,52 +2279,58 @@ class PiecePropIo implements PieceCellIo {
 
   async get(path?: CellPath) {
     const targetCell = await this.#getTargetCell();
-    if (path?.length) {
-      // Pull the requested cell, not the whole input/result root. The sync
-      // started by pull() sends its path plus narrowed schema to Memory v2, so
-      // this avoids traversing unrelated linked fields (an input can contain a
-      // broad authoring graph even when the caller asks for one small durable
-      // field). Traverse one segment at a time so an intermediate asCell value
-      // can re-root the remaining path, matching resolveCellPath.
-      let selectedCell = targetCell;
-      for (const [index, segment] of path.entries()) {
-        selectedCell = cellAtPath(selectedCell, [segment]);
-        const isLast = index === path.length - 1;
-        const isAsCellProjection = SchemaObjectTraverser.hasAsCell(
-          selectedCell.schema,
-        );
-        // Ordinary inline ancestors need no read: extending their schema/path
-        // keeps the final query as narrow as possible. An asCell ancestor must
-        // be materialized so the rest of the path can move to its handle.
-        if (!isLast && !isAsCellProjection) continue;
-
-        await selectedCell.pull();
-        if (isAsCellProjection) {
-          // An asCell projection materializes even an explicit `undefined` as
-          // a Cell, so inspect the stored slot before resolving the handle.
-          // Falling back preserves the root read's absent-vs-undefined rules.
-          if (selectedCell.getRaw() === undefined) {
-            return await this.#getFromRoot(targetCell, path);
-          }
-          const handle = selectedCell.resolveAsCell().asSchema(
-            consumeAsCellProjectionSchema(selectedCell.schema!),
-          );
-          if (isLast) {
-            const readableHandle = cellWithScopedLinkRequiredsRelaxed(handle);
-            await readableHandle.pull();
-            return readableHandle.get();
-          }
-          selectedCell = handle;
-          continue;
-        }
-        const selected = cellWithScopedLinkRequiredsRelaxed(selectedCell).get();
-        if (selected === undefined) {
-          return await this.#getFromRoot(targetCell, path);
-        }
-        return isCell(selected) ? await selected.pull() : selected;
-      }
+    if (!path?.length) {
+      return await this.#getFromRoot(targetCell, []);
     }
-    return await this.#getFromRoot(targetCell, path ?? []);
+    // Pull the requested cell, not the whole input/result root. The sync
+    // started by pull() sends its path plus narrowed schema to Memory v2, so
+    // this avoids traversing unrelated linked fields (an input can contain a
+    // broad authoring graph even when the caller asks for one small durable
+    // field). Traverse one segment at a time so an intermediate asCell value
+    // can re-root the remaining path, matching resolveCellPath.
+    return await this.#getAtPath(targetCell, targetCell, path, 0);
+  }
+
+  async #getAtPath(
+    targetCell: Cell<unknown>,
+    parentCell: Cell<unknown>,
+    path: CellPath,
+    index: number,
+  ): Promise<unknown> {
+    const selectedCell = cellAtPath(parentCell, [path[index]]);
+    const isLast = index === path.length - 1;
+    const selectedSchema = selectedCell.schema;
+    const isAsCellProjection = schemaHasAsCell(selectedSchema);
+    // Ordinary inline ancestors need no read: extending their schema/path
+    // keeps the final query as narrow as possible. An asCell ancestor must
+    // be materialized so the rest of the path can move to its handle.
+    if (!isLast && !isAsCellProjection) {
+      return await this.#getAtPath(targetCell, selectedCell, path, index + 1);
+    }
+
+    await selectedCell.pull();
+    if (isAsCellProjection) {
+      // An asCell projection materializes even an explicit `undefined` as
+      // a Cell, so inspect the stored slot before resolving the handle.
+      // Falling back preserves the root read's absent-vs-undefined rules.
+      if (selectedCell.getRaw() === undefined) {
+        return await this.#getFromRoot(targetCell, path);
+      }
+      const handle = selectedCell.resolveAsCell().asSchema(
+        consumeAsCellProjectionSchema(selectedSchema),
+      );
+      if (isLast) {
+        const readableHandle = cellWithScopedLinkRequiredsRelaxed(handle);
+        await readableHandle.pull();
+        return readableHandle.get();
+      }
+      return await this.#getAtPath(targetCell, handle, path, index + 1);
+    }
+    const selected = cellWithScopedLinkRequiredsRelaxed(selectedCell).get();
+    if (selected === undefined) {
+      return await this.#getFromRoot(targetCell, path);
+    }
+    return isCell(selected) ? await selected.pull() : selected;
   }
 
   async #getFromRoot(targetCell: Cell<unknown>, path: CellPath) {

--- a/packages/piece/test/pull-materialization.test.ts
+++ b/packages/piece/test/pull-materialization.test.ts
@@ -1976,6 +1976,62 @@ describe("piece pull materialization", () => {
     });
   });
 
+  it("preserves missing-path diagnostics for an absent asCell slot", async () => {
+    const piece = await manager.runPersistent(
+      trustPattern(runtime, {
+        argumentSchema: {
+          type: "object",
+          properties: {
+            handle: { type: "number", asCell: ["cell"] },
+          },
+        },
+        resultSchema: { type: "object", properties: {} },
+        result: {},
+        nodes: [],
+      }),
+      {},
+      undefined,
+      { start: true },
+    );
+    const controller = new PieceController(manager, piece);
+
+    await withInputRootPullSpy(manager, piece, async (rootPulls) => {
+      await expect(controller.input.get(["handle"])).rejects.toThrow(
+        'Cannot access path "handle" - property "handle" not found',
+      );
+      expect(rootPulls()).toBe(1);
+    });
+  });
+
+  it("preserves explicit undefined for an asCell slot", async () => {
+    const piece = await manager.runPersistent(
+      trustPattern(runtime, {
+        argumentSchema: {
+          type: "object",
+          properties: {
+            handle: {
+              anyOf: [{ type: "number" }, { type: "undefined" }],
+              asCell: ["cell"],
+            },
+          },
+          required: ["handle"],
+        },
+        resultSchema: { type: "object", properties: {} },
+        result: {},
+        nodes: [],
+      }),
+      { handle: undefined },
+      undefined,
+      { start: true },
+    );
+    const controller = new PieceController(manager, piece);
+
+    await withInputRootPullSpy(manager, piece, async (rootPulls) => {
+      expect(await controller.input.get(["handle"])).toBeUndefined();
+      expect(rootPulls()).toBe(1);
+    });
+  });
+
   it("materializes piece results before setInput returns", async () => {
     const piece = await manager.runPersistent(
       trustPattern(runtime, doublePattern()),

--- a/packages/piece/test/pull-materialization.test.ts
+++ b/packages/piece/test/pull-materialization.test.ts
@@ -3,6 +3,7 @@ import { expect } from "@std/expect";
 import type { FabricValue } from "@commonfabric/data-model/interface";
 import { createSession, Identity } from "@commonfabric/identity";
 import {
+  type Cell,
   getPatternIdentityRef,
   getPatternRepository,
   getPieceSourceRevisions,
@@ -446,6 +447,29 @@ function trustPattern(runtime: Runtime, pattern: Pattern): Pattern {
   return runtime.unsafeTrustPattern(pattern, {
     reason: "piece pull materialization test fixture",
   });
+}
+
+async function withInputRootPullSpy<T>(
+  manager: PieceManager,
+  piece: Cell<unknown>,
+  action: (rootPulls: () => number) => Promise<T>,
+): Promise<T> {
+  const inputRoot = manager.getArgument(piece);
+  const originalGetArgument = manager.getArgument.bind(manager);
+  const originalPull = inputRoot.pull.bind(inputRoot);
+  let pullCount = 0;
+  manager.getArgument = (() => inputRoot) as typeof manager.getArgument;
+  inputRoot.pull = () => {
+    pullCount++;
+    return originalPull();
+  };
+
+  try {
+    return await action(() => pullCount);
+  } finally {
+    manager.getArgument = originalGetArgument;
+    inputRoot.pull = originalPull;
+  }
 }
 
 // Two-replica harness: a server that several emulated replicas can share, so a
@@ -1730,26 +1754,13 @@ describe("piece pull materialization", () => {
       { start: true },
     );
     const controller = new PieceController(manager, piece);
-    const inputRoot = manager.getArgument(piece);
-    const originalGetArgument = manager.getArgument.bind(manager);
-    const originalPull = inputRoot.pull.bind(inputRoot);
-    let rootPulls = 0;
-    manager.getArgument = (() => inputRoot) as typeof manager.getArgument;
-    inputRoot.pull = () => {
-      rootPulls++;
-      return originalPull();
-    };
-
-    try {
+    await withInputRootPullSpy(manager, piece, async (rootPulls) => {
       expect(await controller.input.get(["input"])).toBe(5);
-      expect(rootPulls).toBe(0);
+      expect(rootPulls()).toBe(0);
 
       expect(await controller.input.get()).toEqual({ input: 5 });
-      expect(rootPulls).toBe(1);
-    } finally {
-      manager.getArgument = originalGetArgument;
-      inputRoot.pull = originalPull;
-    }
+      expect(rootPulls()).toBe(1);
+    });
   });
 
   it("pulls a selected asCell value without pulling the input root", async () => {
@@ -1786,23 +1797,137 @@ describe("piece pull materialization", () => {
       { start: true },
     );
     const controller = new PieceController(manager, targetPiece);
-    const inputRoot = manager.getArgument(targetPiece);
-    const originalGetArgument = manager.getArgument.bind(manager);
-    const originalPull = inputRoot.pull.bind(inputRoot);
-    let rootPulls = 0;
-    manager.getArgument = (() => inputRoot) as typeof manager.getArgument;
-    inputRoot.pull = () => {
-      rootPulls++;
-      return originalPull();
-    };
-
-    try {
+    await withInputRootPullSpy(manager, targetPiece, async (rootPulls) => {
       expect(await controller.input.get(["handle"])).toBe(7);
-      expect(rootPulls).toBe(0);
-    } finally {
-      manager.getArgument = originalGetArgument;
-      inputRoot.pull = originalPull;
-    }
+      expect(rootPulls()).toBe(0);
+    });
+  });
+
+  it("narrows a multi-segment input path without pulling the root", async () => {
+    const piece = await manager.runPersistent(
+      trustPattern(runtime, {
+        argumentSchema: {
+          type: "object",
+          properties: {
+            section: {
+              type: "object",
+              properties: { value: { type: "number" } },
+              required: ["value"],
+            },
+          },
+          required: ["section"],
+        },
+        resultSchema: { type: "object", properties: {} },
+        result: {},
+        nodes: [],
+      }),
+      { section: { value: 7 } },
+      undefined,
+      { start: true },
+    );
+    const controller = new PieceController(manager, piece);
+
+    await withInputRootPullSpy(manager, piece, async (rootPulls) => {
+      expect(await controller.input.get(["section", "value"])).toBe(7);
+      expect(rootPulls()).toBe(0);
+    });
+  });
+
+  it("re-roots a narrow path through an intermediate asCell", async () => {
+    const sourcePiece = await manager.runPersistent(
+      trustPattern(runtime, {
+        argumentSchema: { type: "object", properties: {} },
+        resultSchema: {
+          type: "object",
+          properties: {
+            details: {
+              type: "object",
+              properties: { value: { type: "number" } },
+              required: ["value"],
+            },
+          },
+          required: ["details"],
+        },
+        result: { details: { value: 7 } },
+        nodes: [],
+      }),
+      {},
+      undefined,
+      { start: true },
+    );
+    const targetPiece = await manager.runPersistent(
+      trustPattern(runtime, {
+        argumentSchema: {
+          type: "object",
+          properties: {
+            handle: {
+              type: "object",
+              properties: { value: { type: "number" } },
+              required: ["value"],
+              asCell: ["cell"],
+            },
+          },
+          required: ["handle"],
+        },
+        resultSchema: { type: "object", properties: {} },
+        result: {},
+        nodes: [],
+      }),
+      { handle: sourcePiece.key("details") },
+      undefined,
+      { start: true },
+    );
+    const controller = new PieceController(manager, targetPiece);
+
+    await withInputRootPullSpy(manager, targetPiece, async (rootPulls) => {
+      expect(await controller.input.get(["handle", "value"])).toBe(7);
+      expect(rootPulls()).toBe(0);
+    });
+  });
+
+  it("preserves missing-path diagnostics through the narrow fallback", async () => {
+    const piece = await manager.runPersistent(
+      trustPattern(runtime, doublePattern()),
+      { input: 5 },
+      undefined,
+      { start: true },
+    );
+    const controller = new PieceController(manager, piece);
+
+    await withInputRootPullSpy(manager, piece, async (rootPulls) => {
+      await expect(controller.input.get(["missing"])).rejects.toThrow(
+        'Cannot access path "missing" - property "missing" not found',
+      );
+      expect(rootPulls()).toBe(1);
+    });
+  });
+
+  it("preserves schema-valid undefined through the narrow fallback", async () => {
+    const piece = await manager.runPersistent(
+      trustPattern(runtime, {
+        argumentSchema: {
+          type: "object",
+          properties: {
+            value: {
+              anyOf: [{ type: "number" }, { type: "undefined" }],
+            },
+          },
+          required: ["value"],
+        },
+        resultSchema: { type: "object", properties: {} },
+        result: {},
+        nodes: [],
+      }),
+      { value: undefined },
+      undefined,
+      { start: true },
+    );
+    const controller = new PieceController(manager, piece);
+
+    await withInputRootPullSpy(manager, piece, async (rootPulls) => {
+      expect(await controller.input.get(["value"])).toBeUndefined();
+      expect(rootPulls()).toBe(1);
+    });
   });
 
   it("materializes piece results before setInput returns", async () => {
@@ -6957,6 +7082,83 @@ describe("piece cold-replica slot read (two replicas, one server)", () => {
       // that threw "piece missing argument cell" pre-fix, so exercise it first.
       expect(await piece.input.get(["input"])).toBe(5);
       expect(await piece.result.get(["output"])).toBe(10);
+    } finally {
+      await readerRuntime.dispose();
+      await readerStorage.close();
+    }
+  });
+
+  it("a fresh replica preserves visible nested input beside a scoped link", async () => {
+    const sectionSchema = {
+      type: "object",
+      properties: {
+        label: { type: "string" },
+        inner: {
+          type: "object",
+          properties: {
+            plain: { type: "string" },
+            scoped: { type: "string" },
+          },
+          required: ["plain", "scoped"],
+        },
+      },
+      required: ["label"],
+    } as const satisfies JSONSchema;
+    const tx = writerRuntime.edit();
+    const scoped = writerRuntime.getCell<string>(
+      writerManager.getSpace(),
+      "nested-scoped-" + crypto.randomUUID(),
+      { type: "string" },
+      tx,
+      "session",
+    );
+    scoped.set("writer-only");
+    const commit = await tx.commit();
+    expect(commit.error).toBeUndefined();
+
+    const piece = await writerManager.runPersistent(
+      trustPattern(writerRuntime, {
+        argumentSchema: {
+          type: "object",
+          properties: { section: sectionSchema },
+          required: ["section"],
+        },
+        resultSchema: { type: "object", properties: {} },
+        result: {},
+        nodes: [],
+      }),
+      {
+        section: {
+          label: "hello",
+          inner: { plain: "visible", scoped },
+        },
+      },
+      undefined,
+      { start: true },
+    );
+    await writerManager.synced();
+
+    const readerStorage = SharedServerStorageManager.connectTo(server, {
+      as: signer,
+    });
+    const readerRuntime = new Runtime({
+      apiUrl: new URL("http://localhost:9999"),
+      storageManager: readerStorage,
+    });
+    const readerSession = await createSession({ identity: signer, spaceName });
+    const readerManager = new PieceManager(readerSession, readerRuntime);
+    try {
+      await readerManager.synced();
+      const readerPieces = new PiecesController(readerManager);
+      const readerPiece = await readerPieces.get(
+        entityRefToString(piece.entityId),
+        false,
+      );
+
+      expect(await readerPiece.input.get(["section"])).toEqual({
+        label: "hello",
+        inner: { plain: "visible" },
+      });
     } finally {
       await readerRuntime.dispose();
       await readerStorage.close();

--- a/packages/piece/test/pull-materialization.test.ts
+++ b/packages/piece/test/pull-materialization.test.ts
@@ -1722,6 +1722,89 @@ describe("piece pull materialization", () => {
     expect(await controller.result.get(["output"])).toBe(14);
   });
 
+  it("does not pull the input root for a selected path", async () => {
+    const piece = await manager.runPersistent(
+      trustPattern(runtime, doublePattern()),
+      { input: 5 },
+      undefined,
+      { start: true },
+    );
+    const controller = new PieceController(manager, piece);
+    const inputRoot = manager.getArgument(piece);
+    const originalGetArgument = manager.getArgument.bind(manager);
+    const originalPull = inputRoot.pull.bind(inputRoot);
+    let rootPulls = 0;
+    manager.getArgument = (() => inputRoot) as typeof manager.getArgument;
+    inputRoot.pull = () => {
+      rootPulls++;
+      return originalPull();
+    };
+
+    try {
+      expect(await controller.input.get(["input"])).toBe(5);
+      expect(rootPulls).toBe(0);
+
+      expect(await controller.input.get()).toEqual({ input: 5 });
+      expect(rootPulls).toBe(1);
+    } finally {
+      manager.getArgument = originalGetArgument;
+      inputRoot.pull = originalPull;
+    }
+  });
+
+  it("pulls a selected asCell value without pulling the input root", async () => {
+    const sourcePiece = await manager.runPersistent(
+      trustPattern(runtime, {
+        argumentSchema: { type: "object", properties: {} },
+        resultSchema: {
+          type: "object",
+          properties: { value: { type: "number" } },
+          required: ["value"],
+        },
+        result: { value: 7 },
+        nodes: [],
+      }),
+      {},
+      undefined,
+      { start: true },
+    );
+    const targetPiece = await manager.runPersistent(
+      trustPattern(runtime, {
+        argumentSchema: {
+          type: "object",
+          properties: {
+            handle: { type: "number", asCell: ["cell"] },
+          },
+          required: ["handle"],
+        },
+        resultSchema: { type: "object", properties: {} },
+        result: {},
+        nodes: [],
+      }),
+      { handle: sourcePiece.key("value") },
+      undefined,
+      { start: true },
+    );
+    const controller = new PieceController(manager, targetPiece);
+    const inputRoot = manager.getArgument(targetPiece);
+    const originalGetArgument = manager.getArgument.bind(manager);
+    const originalPull = inputRoot.pull.bind(inputRoot);
+    let rootPulls = 0;
+    manager.getArgument = (() => inputRoot) as typeof manager.getArgument;
+    inputRoot.pull = () => {
+      rootPulls++;
+      return originalPull();
+    };
+
+    try {
+      expect(await controller.input.get(["handle"])).toBe(7);
+      expect(rootPulls).toBe(0);
+    } finally {
+      manager.getArgument = originalGetArgument;
+      inputRoot.pull = originalPull;
+    }
+  });
+
   it("materializes piece results before setInput returns", async () => {
     const piece = await manager.runPersistent(
       trustPattern(runtime, doublePattern()),

--- a/packages/piece/test/pull-materialization.test.ts
+++ b/packages/piece/test/pull-materialization.test.ts
@@ -1885,6 +1885,52 @@ describe("piece pull materialization", () => {
     });
   });
 
+  it("re-roots through compound intermediate asCell schemas", async () => {
+    const detailsSchema = {
+      type: "object",
+      properties: {
+        kind: { const: "number" },
+        value: { type: "number" },
+      },
+      required: ["kind", "value"],
+    } as const satisfies JSONSchema;
+    const compoundCellSchema = {
+      anyOf: [
+        { ...detailsSchema, asCell: ["cell"] },
+        {
+          type: "object",
+          properties: {
+            kind: { const: "text" },
+            value: { type: "string" },
+          },
+          required: ["kind", "value"],
+          asCell: ["cell"],
+        },
+      ],
+    } as const satisfies JSONSchema;
+    const targetPiece = await manager.runPersistent(
+      trustPattern(runtime, {
+        argumentSchema: {
+          type: "object",
+          properties: { handle: compoundCellSchema },
+          required: ["handle"],
+        },
+        resultSchema: { type: "object", properties: {} },
+        result: {},
+        nodes: [],
+      }),
+      { handle: { kind: "number", value: 7 } },
+      undefined,
+      { start: true },
+    );
+    const controller = new PieceController(manager, targetPiece);
+
+    await withInputRootPullSpy(manager, targetPiece, async (rootPulls) => {
+      expect(await controller.input.get(["handle", "value"])).toBe(7);
+      expect(rootPulls()).toBe(0);
+    });
+  });
+
   it("preserves missing-path diagnostics through the narrow fallback", async () => {
     const piece = await manager.runPersistent(
       trustPattern(runtime, doublePattern()),

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -253,6 +253,7 @@ export { schemaToTypeString } from "./schema-format.ts";
 export type { SchemaFormatOptions } from "./schema-format.ts";
 export { ACLManager } from "./acl-manager.ts";
 export {
+  cellAtPath,
   cellEntityIdString,
   type CellPath,
   cellWithScopedLinkRequiredsRelaxed,

--- a/packages/runner/src/piece-helpers.ts
+++ b/packages/runner/src/piece-helpers.ts
@@ -34,6 +34,20 @@ export function parseCellPath(path: string): CellPath {
   });
 }
 
+/** Return the Cell view at `path` without reading or dereferencing it. */
+export function cellAtPath<T>(
+  cell: Cell<T>,
+  path: CellPath,
+): Cell<unknown> {
+  let currentCell = cell as Cell<unknown>;
+  for (const segment of path) {
+    currentCell = currentCell.key(
+      segment as keyof unknown,
+    ) as Cell<unknown>;
+  }
+  return currentCell;
+}
+
 export function resolveCellPath<T>(
   cell: Cell<T>,
   path: CellPath,
@@ -102,8 +116,9 @@ export function cellEntityIdString(cell: Cell<unknown>): string | undefined {
  * ENTIRE object (`traverseObjectWithSchema`'s required check) — so a path-less
  * piece read returns `undefined` while every child-path read works. Per the
  * #4746 contract, partial visibility must be expressed in the schema rather
- * than special-cased in the traverser; this helper is the piece read boundary
- * doing exactly that, driven by the stored links' own declared scopes.
+ * than special-cased in the traverser; piece reads apply this helper at both
+ * the root and a selected subtree boundary, driven by the stored links' own
+ * declared scopes.
  *
  * Also relaxed: a property whose chain resolution is SCOPE-BLOCKED (a schema
  * scope cap forbade following a narrower link, CT-1642) — the member is just
@@ -240,10 +255,11 @@ export function schemaWithScopedLinkRequiredsRelaxed(
 }
 
 /**
- * Return `cell` re-schema'd for a terminal whole-object read: `required`
- * entries that point at narrower-scoped stored links are relaxed via
- * {@link schemaWithScopedLinkRequiredsRelaxed}. Returns the cell unchanged
- * when it carries no schema, the raw value is unreadable, or nothing needed
+ * Return `cell` re-schema'd for a terminal object read, whether it is the piece
+ * root or a selected subtree: `required` entries that point at
+ * narrower-scoped stored links are relaxed via
+ * {@link schemaWithScopedLinkRequiredsRelaxed}. Returns the cell unchanged when
+ * it carries no schema, the raw value is unreadable, or nothing needed
  * relaxing.
  */
 export function cellWithScopedLinkRequiredsRelaxed<T>(

--- a/packages/runner/test/scoped-link-whole-object-read.test.ts
+++ b/packages/runner/test/scoped-link-whole-object-read.test.ts
@@ -36,8 +36,8 @@ import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
 // The fix lives at the piece read boundary:
 // schemaWithScopedLinkRequiredsRelaxed derives a projection schema whose
 // `required` no longer claims properties stored as narrower-scoped links,
-// and PiecePropIo.get reads through it — expressing partial visibility in
-// the schema, exactly as #4746 prescribes.
+// and PiecePropIo.get reads both roots and selected subtrees through it —
+// expressing partial visibility in the schema, exactly as #4746 prescribes.
 class SharedServerStorageManager extends EmulatedStorageManager {
   static connectTo(
     server: MemoryV2Server.Server,


### PR DESCRIPTION
## Summary

- pull the requested input/result child cell before materializing the property root
- re-root through intermediate `asCell` handles and pull terminal handles
- preserve scoped-link partial visibility at the selected subtree boundary
- preserve pathless reads and the existing missing-path/`undefined` fallback behavior
- add an explicit CLI timing phase around the input/result value read

## Context

This is a follow-up to #5195. The usage instrumentation added there showed that
the slow Topics benchmark was not spending its time in the model or failing to
use the prompt cache. It was spending about 89 seconds in:

```sh
cf piece get --url <topic-url> comments --input
```

`PiecePropIo.get(path)` previously pulled the complete input/result root and
only then resolved `path`. For the deployed Topic pattern, the input root also
contains `mentionable`, which links to the board-wide Topic graph. Asking for
the two-element `comments` field therefore traversed that unrelated authoring
graph.

The equivalent result read was already fast because the result does not expose
that same broad input-only graph. Input remains the correct durable read for
Topics; this change makes the requested input path determine what is pulled.

## Safety

The narrowed path uses the existing `Cell.pull()` and schema/path selection
machinery. It does not introduce a new query protocol.

- pathless reads still pull the whole root
- selected scalar/object/array paths return directly after their narrow pull
- intermediate `asCell` values re-root the remaining path, matching
  `resolveCellPath`; terminal handles are pulled directly after consuming one
  outer capability layer, including uniform `anyOf`/`oneOf` wrappers
- selected subtrees use the same scoped-link relaxation as whole-root reads
- an unresolved narrow value falls back to the previous root-pull path, keeping
  existing missing-path diagnostics and schema-valid `undefined` behavior

This PR does not change model caching, add `piece get` filtering/projection
flags, or change FUSE hydration.

## Measurements

Same read-only three-command CF harness workload, `gpt-5.6-terra`,
`openai-codex`, low reasoning, CFC disabled, and Docker `runc`:

| Measurement | Before (`49d9a7dd`) | This branch (`0649bcb3`) |
| --- | ---: | ---: |
| End-to-end harness duration | 102.6 s | 25.8 s |
| `comments --input` tool call | 89.1 s | 15.4 s |
| Total tokens | 19,483 | 19,743 |
| Cached input tokens | 7,168 | 7,168 |

The tool call is about 5.8x faster and the complete workload about 4x faster.
Token usage is essentially unchanged, which is expected: the returned comments
and four-turn transcript are still approximately the same size.

An additional direct host trace reported `getCellValue.input.get` at 26 ms and
completed in 8.75 seconds including CLI startup/synchronization. Its 12,917-byte
JSON output was byte-identical to the pre-change captured output.

## Validation

- `deno fmt --check` for all changed files
- `deno check` for all changed files
- `packages/piece`: 31 tests / 368 steps passed
- focused coverage for multi-segment paths, direct and compound-schema
  intermediate `asCell` re-rooting, ordinary and `asCell` missing-path /
  explicit-`undefined` fallback, and a fresh-replica scoped link nested below
  an optional object
- exact `core-piece-links` CLI integration shard against freshly built
  `toolshed` and `cf` binaries, including the invented-piece link case
- `packages/cli`: 1,645 tests / 394 steps passed; two color-output assertions
  fail identically on unchanged `main`
- real Estuary `comments --input` read
- full CF harness benchmark described above
