### PR TITLE
fix(patterns): favorites rows require a `tag` nothing has ever written

### DIFF
--- a/packages/patterns/system/favorites-manager.tsx
+++ b/packages/patterns/system/favorites-manager.tsx
@@ -13,7 +13,7 @@ import {
 
 type Favorite = {
   cell: Writable<{ [NAME]?: string }>;
-  tag: string;
+  tag?: string;
   userTags: Writable<string[]>;
   spaceName?: string;
   // Stable key the favorite entity is addressed by (the piece's identity),

--- a/packages/patterns/system/favorites-manager.tsx
+++ b/packages/patterns/system/favorites-manager.tsx
@@ -11,9 +11,17 @@ import {
   Writable,
 } from "commonfabric";
 
+// This manager's PROJECTION of a stored favorite: only the fields it renders.
+// Naming a field it does not read costs compatibility for nothing — the row is
+// re-staged and validated against this type on every pattern swap, so a field
+// declared here must hold for every vintage in durable storage. Discovery tags
+// are the cautionary case: rows written before #4197 carry `tag` (singular),
+// rows written after carry `tags` (plural), and this manager reads neither
+// (`cf-tags` renders `item.userTags`). Declaring `tag: string` required made
+// every post-#4197 row fail validation; requiring `tags` would fail every
+// pre-#4197 row the same way. Omitting both is what accepts all of them.
 type Favorite = {
   cell: Writable<{ [NAME]?: string }>;
-  tag?: string;
   userTags: Writable<string[]>;
   spaceName?: string;
   // Stable key the favorite entity is addressed by (the piece's identity),

--- a/packages/runner/test/favorites-row-stored-shape.test.ts
+++ b/packages/runner/test/favorites-row-stored-shape.test.ts
@@ -97,10 +97,10 @@ describe("a stored favorite row instantiates in favorites-manager", () => {
     rt = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
+      // `#favorites` resolves against the identity's HOME space. `Runtime`
+      // derives that DID from the storage manager's signer, which is this
+      // space's signer, so there is nothing to pass here.
       experimental: {},
-      // `#favorites` resolves against the identity's HOME space; this runtime's
-      // space is that home space.
-      userIdentityDID: space,
     });
   });
   afterEach(async () => {
@@ -161,6 +161,7 @@ describe("a stored favorite row instantiates in favorites-manager", () => {
     // appear while already running.
     const seedTx = rt.edit();
     hostCell.withTx(seedTx).key("favorites").set([
+      // Post-#4197: discovery tags are plural, and the row is keyed by id.
       {
         cell: thingCell,
         tags: [],
@@ -169,6 +170,15 @@ describe("a stored favorite row instantiates in favorites-manager", () => {
         // property carrying `undefined` is a value of the wrong type, not an
         // omission, and the row is rejected for that instead.
         id: "favorite-1",
+      },
+      // Pre-#4197: a single `tag`, no `tags`, and no keyed `id`. Both vintages
+      // are in real storage, so a projection that requires EITHER tag field
+      // breaks one of them — this row is what keeps a future "fix" to a
+      // required `tags: string[]` from passing.
+      {
+        cell: thingCell,
+        tag: "#thing",
+        userTags: [],
       },
     ] as never);
     await seedTx.commit();
@@ -196,13 +206,19 @@ describe("a stored favorite row instantiates in favorites-manager", () => {
     expect(JSON.stringify(managerCell.getAsQueryResult()))
       .not.toContain("No favorites yet.");
 
-    // The swap. A second compilation of the same source under a fresh cause
-    // yields a distinct identity, so repointing re-stages the stored argument
-    // and validates it against the pattern's schema — the production path when
-    // the auto-update moves a running piece to new source.
+    // The swap. Identity is content-addressed, so v2 has to differ in SOURCE —
+    // a fresh transaction over identical bytes would compile to the same
+    // identity and move nothing. The difference is the pattern's name, which
+    // makes the swap positively observable below: without that, a run where
+    // the pointer move silently did nothing would pass on "no errors" alone.
     const v2Tx = rt.edit();
     const v2 = await rt.patternManager.compilePattern(
-      programOf(`${managerSource}\n// swap\n`),
+      programOf(
+        managerSource.replace(
+          `[NAME]: "Favorites Manager"`,
+          `[NAME]: "Favorites Manager v2"`,
+        ),
+      ),
       { space, tx: v2Tx },
     );
     const v2Ref = rt.patternManager.getArtifactEntryRef(v2)!;
@@ -220,6 +236,11 @@ describe("a stored favorite row instantiates in favorites-manager", () => {
     // the scheduler re-threw on every pass, and that loop starved the cell
     // reads the links depend on.
     expect(actionErrors).toEqual([]);
+    // The swap really landed: a no-op pointer move would leave the old name and
+    // make the no-errors assertion above vacuous.
+    expect(
+      (managerCell.getAsQueryResult() as Record<string, unknown>)["$NAME"],
+    ).toBe("Favorites Manager v2");
     expect(JSON.stringify(managerCell.getAsQueryResult()))
       .not.toContain("No favorites yet.");
   });

--- a/packages/runner/test/favorites-row-stored-shape.test.ts
+++ b/packages/runner/test/favorites-row-stored-shape.test.ts
@@ -1,0 +1,226 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { fromFileUrl } from "@std/path/from-file-url";
+
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+
+// A pattern that maps over durable data must accept the rows its PRODUCER
+// actually writes. Nothing checks that agreement: the row's element schema
+// comes from the consumer's own type, the rows come from a handler in another
+// pattern, and the two only meet when a stored row is re-staged.
+//
+// `favorites-manager.tsx` declared `tag: string` — required, no default — while
+// home's `addFavorite` has only ever written `{ cell, tags, userTags,
+// spaceName, id }` (`tags`, plural). Every stored favorite therefore failed the
+// row's argument validation on resume:
+//
+//   updated arguments do not match the candidate schema:
+//   element: missing required property tag
+//
+// The row never instantiated, the scheduler re-threw on every pass, and that
+// loop starved the runtime — `cell:resolveAsCell` for the row's cells stopped
+// being answered, so the links fell through to placeholder text and the tab
+// read as empty. Nothing reached the page console: the throw is inside the
+// worker runtime. One property with no producer, invisible for weeks.
+//
+// This drives the REAL shipped pattern over a row of exactly the shape
+// `addFavorite` writes, THROUGH A PATTERN SWAP. Both halves matter. Adding a
+// favorite to an already-running piece never re-stages the argument, so a
+// fresh-data test stays green against the bug — which is precisely how the
+// mismatch survived every existing test. The swap is what production does when
+// the auto-update moves a piece to new source, and it is the moment the stored
+// row meets the schema.
+
+const signer = await Identity.fromPassphrase("favorites-row-stored-shape");
+const space = signer.did();
+
+const FAVORITES_MANAGER_PATH = fromFileUrl(
+  import.meta.resolve("../../patterns/system/favorites-manager.tsx"),
+);
+
+// Stands in for home.tsx as the space's default pattern: the wish target
+// `#favorites` resolves to `<home space>.defaultPattern.favorites`, so what
+// this exposes IS what favorites-manager reads.
+const FAVORITES_HOST = [
+  "import { Default, NAME, pattern, UI, Writable } from 'commonfabric';",
+  "",
+  "type Favorite = {",
+  "  cell: Writable<{ [NAME]?: string }>;",
+  // Exactly the keys home's addFavorite stores — `tags` plural, no `tag`.
+  "  tags: string[];",
+  "  userTags: Writable<string[]>;",
+  "  spaceName?: string;",
+  "  id?: string;",
+  "};",
+  "",
+  "export default pattern<",
+  "  Record<string, never>,",
+  "  { favorites: Favorite[] | Default<[]> }",
+  ">(() => {",
+  "  const favorites = new Writable<Favorite[] | Default<[]>>([])",
+  "    .for('favorites');",
+  "  return {",
+  "    [NAME]: 'Favorites Host',",
+  "    [UI]: <div>host</div>,",
+  "    favorites,",
+  "  };",
+  "});",
+  "",
+].join("\n");
+
+// A piece for the favorite to point at, so the row holds a real cell link
+// rather than a bare object.
+const FAVORITED_PIECE = [
+  "import { NAME, pattern, UI } from 'commonfabric';",
+  "",
+  "export default pattern<Record<string, never>>(() => ({",
+  "  [NAME]: 'Favorited Thing',",
+  "  [UI]: <div>thing</div>,",
+  "}));",
+  "",
+].join("\n");
+
+const programOf = (contents: string): RuntimeProgram => ({
+  main: "/main.tsx",
+  files: [{ name: "/main.tsx", contents }],
+});
+
+describe("a stored favorite row instantiates in favorites-manager", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let rt: Runtime;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    rt = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      experimental: {},
+      // `#favorites` resolves against the identity's HOME space; this runtime's
+      // space is that home space.
+      userIdentityDID: space,
+    });
+  });
+  afterEach(async () => {
+    await rt?.dispose();
+    await storageManager?.close();
+  });
+
+  it("survives a swap carrying exactly the keys addFavorite writes", async () => {
+    const managerSource = await Deno.readTextFile(FAVORITES_MANAGER_PATH);
+    // The row's failure is a THROWN scheduler action, not a rendering
+    // difference: the map keeps the markup it produced before the swap, so the
+    // UI alone cannot tell a re-instantiated row from a stale one. The error is
+    // the assertion.
+    const actionErrors: string[] = [];
+    rt.scheduler.onError((error: unknown) =>
+      actionErrors.push(
+        String((error as { message?: string })?.message ?? error),
+      )
+    );
+
+    const tx = rt.edit();
+
+    // The space's default pattern supplies `#favorites`.
+    const host = await rt.patternManager.compilePattern(
+      programOf(FAVORITES_HOST),
+      { space, tx },
+    );
+    const hostCell = rt.getCell<Record<string, unknown>>(
+      space,
+      "favorites-host",
+      undefined,
+      tx,
+    );
+    const hostRunning = rt.run(tx, host, {}, hostCell);
+
+    // Something for the favorite to reference.
+    const thing = await rt.patternManager.compilePattern(
+      programOf(FAVORITED_PIECE),
+      { space, tx },
+    );
+    const thingCell = rt.getCell<Record<string, unknown>>(
+      space,
+      "favorited-thing",
+      undefined,
+      tx,
+    );
+    rt.run(tx, thing, {}, thingCell);
+
+    rt.getSpaceCell(space).withTx(tx).key("defaultPattern").set(
+      hostCell as never,
+    );
+    await tx.commit();
+    await hostRunning.pull();
+    await rt.idle();
+
+    // Write the row the way home's addFavorite does, then let it settle so the
+    // manager below re-stages it from durable state rather than seeing it
+    // appear while already running.
+    const seedTx = rt.edit();
+    hostCell.withTx(seedTx).key("favorites").set([
+      {
+        cell: thingCell,
+        tags: [],
+        userTags: [],
+        // `spaceName` is absent rather than explicitly undefined: an optional
+        // property carrying `undefined` is a value of the wrong type, not an
+        // omission, and the row is rejected for that instead.
+        id: "favorite-1",
+      },
+    ] as never);
+    await seedTx.commit();
+    await rt.idle();
+
+    // The REAL shipped pattern, over that stored row.
+    const managerTx = rt.edit();
+    const manager = await rt.patternManager.compilePattern(
+      programOf(managerSource),
+      { space, tx: managerTx },
+    );
+    const managerCell = rt.getCell<Record<string, unknown>>(
+      space,
+      "favorites-manager",
+      undefined,
+      managerTx,
+    );
+    const managerRunning = rt.run(managerTx, manager, {}, managerCell);
+    await managerTx.commit();
+    await managerRunning.pull();
+    await rt.idle();
+
+    // Sanity: the row is live before the swap, so a failure below is the swap's
+    // re-stage and not a mis-seeded fixture.
+    expect(JSON.stringify(managerCell.getAsQueryResult()))
+      .not.toContain("No favorites yet.");
+
+    // The swap. A second compilation of the same source under a fresh cause
+    // yields a distinct identity, so repointing re-stages the stored argument
+    // and validates it against the pattern's schema — the production path when
+    // the auto-update moves a running piece to new source.
+    const v2Tx = rt.edit();
+    const v2 = await rt.patternManager.compilePattern(
+      programOf(`${managerSource}\n// swap\n`),
+      { space, tx: v2Tx },
+    );
+    const v2Ref = rt.patternManager.getArtifactEntryRef(v2)!;
+    managerCell.withTx(v2Tx).setMetaRaw("patternIdentity", {
+      identity: v2Ref.identity,
+      symbol: v2Ref.symbol,
+    });
+    await v2Tx.commit();
+    await rt.idle();
+    await rt.runner.idlePointerMaintenance();
+    await rt.idle();
+
+    // Before the fix the swap threw out of `applySetupState` with
+    // "element: missing required property tag": the row never re-instantiated,
+    // the scheduler re-threw on every pass, and that loop starved the cell
+    // reads the links depend on.
+    expect(actionErrors).toEqual([]);
+    expect(JSON.stringify(managerCell.getAsQueryResult()))
+      .not.toContain("No favorites yet.");
+  });
+});


### PR DESCRIPTION
## Why

Home's Favorites and Profile tabs render nothing on an existing space, with a
completely clean browser console.

`favorites-manager.tsx` declared `tag: string` — required, no default — on the
element type that `favorites.map(...)` instantiates a sub-pattern from. No row
in storage satisfies it. Discovery tags moved to a client-derived plural `tags`
array in #4197, whose own description records the split: favorites created
before it carry `tag`, everything since carries `tags`. The manager reads
NEITHER — `cf-tags` renders `item.userTags`.

So every post-#4197 favorite fails the row's argument validation the moment it
is re-staged:

```
Error: updated arguments do not match the candidate schema:
       element: missing required property tag
  at Runner.validateArgument → updateAndValidateArgument → applySetupState
   → setupInternal → Runner.run → reconcile → raw:map:…
```

The row never instantiates, and the scheduler re-throws it on every pass. That
loop starves the runtime: `cell:resolveAsCell` and `cell:subscribe` for the
row's cells stop being answered and sit pending until they time out, so the
links fall through to their placeholder text and the tab reads as empty. None
of it is visible from the page — the error is raised inside the worker runtime,
so the browser console stays empty unless you call
`commonfabric.forwardWorkerConsole()` first. That silence is why one wrong
property definition read as "the tabs are broken" for weeks.

## What Changed

`tag` is **deleted** from `favorites-manager.tsx`'s `Favorite` type, not made
optional. That type is the manager's *projection* of a stored row, and every
field it names is re-validated against every vintage on each pattern swap:
requiring `tag` breaks post-#4197 rows, requiring `tags` would break pre-#4197
rows identically, and `tag?:` is merely harmless dead weight. Naming neither is
what accepts both. The reasoning is left in a comment at the type.

Plus a regression test, `packages/runner/test/favorites-row-stored-shape.test.ts`.
Three things about its shape are load-bearing:

- It drives the **real shipped** `favorites-manager.tsx`, read from disk. The
  defect was a disagreement between that file's projection and what is in
  storage; a mirrored copy of the type in the test would have drifted along with
  the bug instead of catching it.
- It seeds **both stored vintages** — a post-#4197 row (plural `tags`, keyed
  `id`) and a pre-#4197 row (singular `tag`, no `tags`, no `id`). Without the
  legacy row, "fixing" this to a required `tags: string[]` would pass while
  re-breaking every old favorite.
- It asserts through a pattern **swap**. Adding a favorite to an already-running
  piece never re-stages the argument, so a fresh-data test stays green against
  the bug — exactly how this survived every existing test. The swap is what the
  auto-update does to a running piece, and it is the moment stored rows meet the
  schema.

The assertion is on `scheduler.onError` rather than rendered output, because a
failed row leaves the markup the map produced before the swap. A name marker on
v2 is asserted too, so a pointer move that silently did nothing cannot pass on
"no errors" alone.

## Test plan

Mutation-verified in both directions against the real pattern:

| mutation | result |
|---|---|
| `tag: string` required (the shipped bug) | fails — `missing required property tag` |
| `tags: string[]` required (the plausible "fix") | fails — legacy row, `favorites: value does not match anyOf` |
| as merged | passes |

`deno fmt --check`, `deno lint`, and `deno check` clean on both files.

Reproduced end to end against `origin/main` (1513fb985) with a local two-build
harness: seed a home space (one favorite, one profile) on a pre-retirement
build, re-open the same store on main. Before: the error fires on every load and
both entries render as `Unknown Link`. After: both render their real names
(`Home #LeUGRw`, `Test Persona #1mjzzE`) with `cf-cell-link` resolving normally
— confirmed in a browser by the author.

The existing piece adopts the fix on its own through the pattern auto-update.
Instrumenting `PatternUpdater.#check` confirms the root and all four sub-pieces
fetch their advertised identity and converge; no piece surgery, no space
redeploy.

## Follow-up, not in this PR

The #5209 vintage gate cannot currently see this class: review found it reports
`2 updated cleanly with no state stranded` even with `tag` required, because the
pinned vintage holds no populated favorite row. A captured vintage carrying real
rows is what would make that gate catch the next one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
