### PR TITLE
feat(memory,runner): patch-op accepts carry the post-apply document; confirmPending promotes to server truth (CT-1926)

### DIFF
--- a/docs/specs/memory-v2/03-commit-model.md
+++ b/docs/specs/memory-v2/03-commit-model.md
@@ -566,6 +566,17 @@ When a commit is rejected:
 
 The client library SHOULD support automatic retry with a bounded retry count.
 
+When a commit is ACCEPTED, the response's patch revisions carry the
+document's post-commit state (04-protocol.md §4.3.1, CT-1926). The client
+promotes its confirmed mirror from that value when it differs from its own
+locally-extrapolated result — the accept can outrun the batched fan-out
+carrying the foreign writes the patch was applied on top of, and promoting
+a local extrapolation in that window mints a confirmed (seq, value) pair
+the server never had, whose stamp then feeds dishonest staleness bases into
+later reads. When the response value matches the local extrapolation (the
+steady state), the client keeps its local promotion so the materialized
+value's identity survives confirmation.
+
 ## 3.13 Mapping from Current Implementation
 
 | v1 Concept                            | v2 Concept                                        | Notes                                                         |

--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -485,6 +485,20 @@ type TransactResult =
   | { error: AuthorizationError };
 ```
 
+Revision payloads in the accept response: a `set` revision carries its
+document payload, a `delete` revision is identity-only, and a `patch`
+revision carries `document` — the document's POST-COMMIT state (the same
+state on every patch revision of a doc in the commit, revision-order
+independent; replayed accepts recover it as of the replayed commit's seq,
+not the current head). This lets the client promote its confirmed mirror
+from the value the server actually computed instead of extrapolating its
+own patch onto a possibly-stale local base — the inline verdict can outrun
+the batched novelty fan-out carrying the foreign writes the patch was
+applied on top of (CT-1926). The field is additive: clients fall back to
+local extrapolation when a server omits it, and promote the response value
+only when it differs from that extrapolation (preserving materialized-value
+identity across confirmation in the steady state).
+
 Path conventions on the wire:
 
 - `ClientCommit` reads and writes use full document paths.

--- a/packages/memory/test/v2-accept-postapply-doc-test.ts
+++ b/packages/memory/test/v2-accept-postapply-doc-test.ts
@@ -1,0 +1,223 @@
+// CT-1926: patch-op accept responses carry the document's post-commit state.
+//
+// The client's `confirmPending` promotes its confirmed mirror from this value
+// instead of extrapolating its own patch onto a possibly-stale local base —
+// the inline accept can outrun the batched fan-out carrying the foreign
+// writes the patch was applied on top of, and a locally-extrapolated
+// promotion mints a (seq, value) pair the server never had, feeding
+// dishonest staleness bases into later reads. `set` revisions keep carrying
+// their own payload; `delete` stays identity-only. Replayed accepts recover
+// the same document via a seq-pinned read, so a replay observed after later
+// commits landed still reports the state as of the replayed commit.
+
+import { assertEquals } from "@std/assert";
+import { toFileUrl } from "@std/path";
+import { applyCommit, close, type Engine, open } from "../v2/engine.ts";
+import { type EntityDocument } from "../v2.ts";
+
+const createEngine = async (): Promise<{ engine: Engine; path: string }> => {
+  const path = await Deno.makeTempFile({ suffix: ".sqlite" });
+  const engine = await open({ url: toFileUrl(path) });
+  return { engine, path };
+};
+
+const invocationFor = (
+  localSeq: number,
+  extra: Record<string, unknown> = {},
+) => ({
+  iss: "did:key:alice",
+  aud: "did:key:service",
+  cmd: "/memory/transact",
+  sub: "did:key:space",
+  args: { localSeq, ...extra },
+});
+
+const authorization = {
+  signature: "sig:alice",
+  access: { "proof:1": {} },
+};
+
+const toEntityDocument = (
+  value: unknown,
+): EntityDocument => ({ value } as EntityDocument);
+
+Deno.test("memory v2 engine: a patch accept carries the post-apply document, including foreign writes the client has not seen", async () => {
+  const { engine, path } = await createEngine();
+  try {
+    // Foreign winner establishes the container the client's mirror lacks.
+    applyCommit(engine, {
+      sessionId: "session:other",
+      invocation: invocationFor(1, { actor: "other" }),
+      authorization,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "entity:list",
+          value: toEntityDocument({ items: ["a", "b"] }),
+        }],
+      },
+    });
+
+    // The session's blind append is applied against the winner's container.
+    const applied = applyCommit(engine, {
+      sessionId: "session:1",
+      invocation: invocationFor(1),
+      authorization,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "patch",
+          id: "entity:list",
+          patches: [{ op: "add", path: "/value/items/-", value: "X" }],
+        }],
+      },
+    });
+
+    assertEquals(applied.revisions.length, 1);
+    assertEquals(applied.revisions[0].op, "patch");
+    // The response tells the client what the doc actually became — the
+    // winner's items plus the append — not just the patch it already knew.
+    assertEquals(
+      applied.revisions[0].document,
+      toEntityDocument({ items: ["a", "b", "X"] }),
+    );
+  } finally {
+    close(engine);
+    await Deno.remove(path).catch(() => {});
+  }
+});
+
+Deno.test("memory v2 engine: set and delete revisions keep their shapes; multi-patch docs report the final state on every revision", async () => {
+  const { engine, path } = await createEngine();
+  try {
+    applyCommit(engine, {
+      sessionId: "session:1",
+      invocation: invocationFor(1),
+      authorization,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "entity:doc",
+          value: toEntityDocument({ x: 1 }),
+        }],
+      },
+    });
+
+    // One commit, two patches on the same doc plus a set and a delete on
+    // others: every patch revision carries the doc's FINAL post-commit
+    // state (revision-order independent), the set echoes its payload, the
+    // delete stays identity-only.
+    const applied = applyCommit(engine, {
+      sessionId: "session:1",
+      invocation: invocationFor(2),
+      authorization,
+      commit: {
+        localSeq: 2,
+        reads: { confirmed: [], pending: [] },
+        operations: [
+          {
+            op: "patch",
+            id: "entity:doc",
+            patches: [{ op: "replace", path: "/value/x", value: 2 }],
+          },
+          {
+            op: "patch",
+            id: "entity:doc",
+            patches: [{ op: "add", path: "/value/y", value: 3 }],
+          },
+          {
+            op: "set",
+            id: "entity:fresh",
+            value: toEntityDocument({ ok: true }),
+          },
+          { op: "delete", id: "entity:gone" },
+        ],
+      },
+    });
+
+    const final = toEntityDocument({ x: 2, y: 3 });
+    assertEquals(applied.revisions[0].document, final);
+    assertEquals(applied.revisions[1].document, final);
+    assertEquals(
+      applied.revisions[2].document,
+      toEntityDocument({ ok: true }),
+    );
+    assertEquals(applied.revisions[3].document, undefined);
+  } finally {
+    close(engine);
+    await Deno.remove(path).catch(() => {});
+  }
+});
+
+Deno.test("memory v2 engine: a replayed patch accept reports the state as of ITS commit, not the head", async () => {
+  const { engine, path } = await createEngine();
+  try {
+    applyCommit(engine, {
+      sessionId: "session:other",
+      invocation: invocationFor(1, { actor: "other" }),
+      authorization,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "entity:list",
+          value: toEntityDocument({ items: ["a"] }),
+        }],
+      },
+    });
+    const original = {
+      sessionId: "session:1",
+      invocation: invocationFor(1),
+      authorization,
+      commit: {
+        localSeq: 1,
+        reads: {
+          confirmed: [] as never[],
+          pending: [] as never[],
+        },
+        operations: [{
+          op: "patch" as const,
+          id: "entity:list",
+          patches: [{
+            op: "add" as const,
+            path: "/value/items/-",
+            value: "X",
+          }],
+        }],
+      },
+    };
+    applyCommit(engine, original);
+    // A later foreign write advances the doc past the replayed commit.
+    applyCommit(engine, {
+      sessionId: "session:other",
+      invocation: invocationFor(2, { actor: "other" }),
+      authorization,
+      commit: {
+        localSeq: 2,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "patch",
+          id: "entity:list",
+          patches: [{ op: "add", path: "/value/items/-", value: "later" }],
+        }],
+      },
+    });
+
+    // Replay (same session, same localSeq, same payload): the seq-pinned
+    // recovery reports ["a","X"], not the current head ["a","X","later"].
+    const replayed = applyCommit(engine, original);
+    assertEquals(
+      replayed.revisions[0].document,
+      toEntityDocument({ items: ["a", "X"] }),
+    );
+  } finally {
+    close(engine);
+    await Deno.remove(path).catch(() => {});
+  }
+});

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -5232,6 +5232,7 @@ const applyCommitTransaction = (
   validateStoredSyncSchemaRefs(engine, branch, revisions, original);
 
   engine.statements.updateBranchHead.run({ branch, seq });
+  attachPostApplyDocuments(engine, branch, revisions, seq);
   materializeSnapshots(engine, branch, revisions);
 
   const changedSchedulerWrites = space
@@ -6211,6 +6212,27 @@ const selectCommitRevisions = (
   const rows = engine.statements.selectCommitRevisions.all({
     commit_seq: commitSeq,
   }) as RevisionRow[];
+  // Replayed accepts carry the same post-apply document a fresh accept does
+  // (CT-1926): recovered with a seq-pinned read, so a replay observed after
+  // LATER commits landed still reports the state as of THIS commit.
+  const postApply = new Map<string, EntityDocument | undefined>();
+  const postApplyDocument = (
+    row: RevisionRow,
+  ): EntityDocument | undefined => {
+    const key = revisionKey(row.branch, row.id, row.scope_key);
+    if (!postApply.has(key)) {
+      postApply.set(
+        key,
+        readStateForScopeKey(engine, {
+          id: row.id,
+          scopeKey: row.scope_key,
+          branch: row.branch,
+          seq: row.commit_seq,
+        })?.document ?? undefined,
+      );
+    }
+    return postApply.get(key);
+  };
   return rows.map((row) => {
     const base = {
       id: row.id,
@@ -6229,13 +6251,60 @@ const selectCommitRevisions = (
       } satisfies AppliedRevision;
     }
     if (row.op === "patch") {
+      const document = postApplyDocument(row);
       return {
         ...base,
         patches: decodeStoredPatchList(row.data),
+        ...(document !== undefined ? { document } : {}),
       } satisfies AppliedRevision;
     }
     return base as AppliedRevision;
   });
+};
+
+/**
+ * Populates `document` on every PATCH revision with the document's
+ * post-commit state (CT-1926). The client promotes its confirmed mirror
+ * from this value instead of extrapolating its own patch onto a possibly
+ * stale local base: the inline accept can outrun the batched fan-out
+ * carrying the foreign writes the patch was applied on top of, and a
+ * locally-extrapolated promotion then mints a (seq, value) pair the server
+ * never had — feeding dishonest staleness bases into later reads. `set`
+ * revisions already carry their payload; `delete` stays identity-only. The
+ * SAME post-commit state is attached to every patch revision of a doc in
+ * this commit (revision-order independent), and the field is additive: old
+ * clients ignore it, new clients fall back to local extrapolation when a
+ * pre-CT-1926 server omits it.
+ */
+const attachPostApplyDocuments = (
+  engine: Engine,
+  branch: BranchName,
+  revisions: AppliedRevision[],
+  seq: number,
+): void => {
+  const states = new Map<string, EntityDocument | undefined>();
+  for (const revision of revisions) {
+    if (revision.op !== "patch") {
+      continue;
+    }
+    const scopeKey = revision.scopeKey ?? DEFAULT_SCOPE_KEY;
+    const key = revisionKey(branch, revision.id, scopeKey);
+    if (!states.has(key)) {
+      states.set(
+        key,
+        readStateForScopeKey(engine, {
+          id: revision.id,
+          scopeKey,
+          branch,
+          seq,
+        })?.document ?? undefined,
+      );
+    }
+    const document = states.get(key);
+    if (document !== undefined) {
+      revision.document = document;
+    }
+  }
 };
 
 const materializeSnapshots = (

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -2,6 +2,7 @@ import {
   cloneIfNecessary,
   cloneWithoutValueAtPath,
   cloneWithValueAtPath,
+  valueEqual,
 } from "@commonfabric/data-model/fabric-value";
 import type { FabricValue, SchemaPathSelector } from "@commonfabric/api";
 import type { Entity } from "@commonfabric/memory/interface";
@@ -3964,6 +3965,24 @@ class SpaceReplica implements ISpaceReplica {
         { id: operation.id, scope: operation.scope },
       ]),
     );
+    // Server truth per doc (CT-1926): accept revisions carry the doc's
+    // post-commit state — `document` on set/patch revisions, absence of a
+    // value on a final delete. Revisions arrive in op order, so last wins;
+    // a patch revision WITHOUT `document` is a pre-CT-1926 server, and it
+    // also invalidates any earlier op's value for the doc (a partial view
+    // must not be promoted as the post-commit state) — those docs fall back
+    // to the local extrapolation below.
+    const serverTruth = new Map<string, EntityDocument | undefined>();
+    for (const revision of applied.revisions) {
+      const key = docKey(revision.id as URI, revision.scope);
+      if (revision.op === "delete") {
+        serverTruth.set(key, undefined);
+      } else if (revision.document !== undefined) {
+        serverTruth.set(key, revision.document);
+      } else {
+        serverTruth.delete(key);
+      }
+    }
     for (const { id, scope } of keys.values()) {
       const record = this.record(id, scope);
       const pendingIndexes = record.pending.flatMap((entry, index) =>
@@ -3982,6 +4001,7 @@ class SpaceReplica implements ISpaceReplica {
       let promoted: ConfirmedVersion | undefined;
       let reusedSuffix: PendingMaterializedPrefix[] | undefined;
 
+      const key = docKey(id, scope);
       if (record.confirmed.seq < applied.seq) {
         if (firstPendingIndex === 0) {
           const prefix = materializedVersionThroughPending(
@@ -4007,6 +4027,22 @@ class SpaceReplica implements ISpaceReplica {
               scope,
             }),
           );
+        }
+        // CT-1926: when the accept carried the doc's post-commit state and
+        // it DIFFERS from the local extrapolation, the mirror was stale (a
+        // foreign write raced the fan-out) — promote the server truth and
+        // drop the cached materializations; the identity change is real.
+        // When they MATCH — the steady state — keep the local promotion, so
+        // the materialized value's identity survives confirmation (pinned
+        // by "confirming the head pending write promotes the cached
+        // materialization": identity churn on every accept would ripple
+        // into shallow change detection).
+        if (promoted !== undefined && serverTruth.has(key)) {
+          const truth = serverTruth.get(key);
+          if (!valueEqual(promoted.value, truth)) {
+            promoted = confirmedVersion(applied.seq, truth);
+            reusedSuffix = undefined;
+          }
         }
       }
 

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -165,6 +165,9 @@ const localSeqTop = (read: { localSeq: number | number[] }): number =>
 
 class ScriptedServerModel {
   connectionCount = 0;
+  /** Simulate a pre-CT-1926 server: accept revisions omit the post-apply
+   * document, so the client must fall back to local extrapolation. */
+  omitPostApplyDocuments = false;
   transactLocalSeqs: number[] = [];
   readonly confirmed = new Map<URI, DocState>();
   readonly applied = new Map<number, AppliedRecord>();
@@ -362,7 +365,7 @@ class ScriptedServerModel {
         opIndex: index,
         commitSeq: seq,
         op: operation.op,
-        ...(operation.op === "delete" ? {} : {
+        ...(operation.op === "delete" || this.omitPostApplyDocuments ? {} : {
           document: {
             value: clone(this.confirmed.get(operation.id as URI)?.value),
           },
@@ -2101,6 +2104,45 @@ Deno.test("memory v2 stacked commits: confirmation promotes the server's post-ap
     // fan-out eventually corrected it — the CT-1872 convergence wrinkle.
     expectVisible(harness, {
       A: valueFor("foreign", { extra: true, note: "local-edit" }),
+    });
+  } finally {
+    await harness.close();
+  }
+});
+
+Deno.test("memory v2 stacked commits: a pre-CT-1926 accept without a post-apply document falls back to local extrapolation", async () => {
+  const harness = await createHarness();
+  harness.model.omitPostApplyDocuments = true;
+  try {
+    await seedAccepted(harness, DOCS.A, valueFor("base"));
+
+    // Same foreign interleave as the CT-1926 promotion test, but the accept
+    // carries no post-apply document (old server). The client keeps today's
+    // extrapolation: confirmed misses the foreign fields until fan-out
+    // corrects it — the documented pre-CT-1926 residue, NOT silent
+    // breakage.
+    const patchLocalSeq = 2;
+    harness.model.setOutcome(patchLocalSeq, {
+      kind: "accept",
+      remoteInterleave: {
+        label: "foreign-replace",
+        operations: [{
+          op: "set",
+          id: DOCS.A,
+          value: valueFor("foreign", { extra: true }),
+        }],
+      },
+    });
+    const patch = beginPatch(
+      harness,
+      DOCS.A,
+      [{ op: "add", path: "/value/note", value: "local-edit" }],
+      valueFor("base", { note: "local-edit" }),
+    );
+    await assertResultOk(patch);
+
+    expectVisible(harness, {
+      A: valueFor("base", { note: "local-edit" }),
     });
   } finally {
     await harness.close();

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -342,33 +342,37 @@ class ScriptedServerModel {
     const touched = commit.operations.flatMap((operation) =>
       touchedWritesForOperation(operation)
     );
-    const revisions = commit.operations
-      .filter((operation) => operation.op !== "sqlite")
-      .map((operation, index) => ({
-        id: operation.id,
-        branch: "",
-        seq: this.serverSeq + 1,
-        opIndex: index,
-        commitSeq: this.serverSeq + 1,
-        op: operation.op,
-      }));
-    const applied = {
-      seq: ++this.serverSeq,
-      branch: "",
-      revisions,
-    } as AppliedCommit;
-
+    const seq = ++this.serverSeq;
     for (const operation of commit.operations) {
       if (operation.op === "sqlite") continue;
       const next = applyOperation(
         operation,
         this.confirmed.get(operation.id as URI)?.value,
       );
-      this.confirmed.set(operation.id as URI, {
-        seq: applied.seq,
-        value: next,
-      });
+      this.confirmed.set(operation.id as URI, { seq, value: next });
     }
+    // Post-commit state per revision, as a CT-1926 server attaches it:
+    // envelope-wrapped document for set/patch, identity-only for delete.
+    const revisions = commit.operations
+      .filter((operation) => operation.op !== "sqlite")
+      .map((operation, index) => ({
+        id: operation.id,
+        branch: "",
+        seq,
+        opIndex: index,
+        commitSeq: seq,
+        op: operation.op,
+        ...(operation.op === "delete" ? {} : {
+          document: {
+            value: clone(this.confirmed.get(operation.id as URI)?.value),
+          },
+        }),
+      }));
+    const applied = {
+      seq,
+      branch: "",
+      revisions,
+    } as AppliedCommit;
 
     this.applied.set(commit.localSeq, {
       localSeq: commit.localSeq,
@@ -2054,6 +2058,50 @@ Deno.test("memory v2 stacked commits: divergent basis overrides survive pending-
       ],
     );
     await assertResultOk(c2.promise);
+  } finally {
+    await harness.close();
+  }
+});
+
+Deno.test("memory v2 stacked commits: confirmation promotes the server's post-apply value over a stale local mirror (CT-1926)", async () => {
+  const harness = await createHarness();
+  try {
+    await seedAccepted(harness, DOCS.A, valueFor("base"));
+
+    // A foreign whole-doc replacement interleaves server-side just before
+    // the patch's accept; its fan-out frame is never delivered (the
+    // scripted transport sends no sync). The patch is blind, so the server
+    // accepts it ON TOP of the foreign value.
+    // beginPatch bypasses the harness dispatch counter: on the wire it is
+    // localSeq 2 (seed = 1).
+    const patchLocalSeq = 2;
+    harness.model.setOutcome(patchLocalSeq, {
+      kind: "accept",
+      remoteInterleave: {
+        label: "foreign-replace",
+        operations: [{
+          op: "set",
+          id: DOCS.A,
+          value: valueFor("foreign", { extra: true }),
+        }],
+      },
+    });
+    const patch = beginPatch(
+      harness,
+      DOCS.A,
+      [{ op: "add", path: "/value/note", value: "local-edit" }],
+      valueFor("base", { note: "local-edit" }),
+    );
+    await assertResultOk(patch);
+
+    // The accept's post-apply document is what the server actually computed:
+    // the foreign replacement plus the local leaf. Pre-CT-1926 the client
+    // extrapolated its patch onto the stale "base" mirror instead, minting a
+    // confirmed state the server never had (no foreign fields) until the
+    // fan-out eventually corrected it — the CT-1872 convergence wrinkle.
+    expectVisible(harness, {
+      A: valueFor("foreign", { extra: true, note: "local-edit" }),
+    });
   } finally {
     await harness.close();
   }


### PR DESCRIPTION
## Why

The client's `confirmPending` promotes an accepted commit by applying its local pending patch onto the local confirmed mirror — which can be stale for that doc, because the inline accept systematically outruns the batched novelty fan-out carrying the foreign writes the patch was applied on top of (verified structural: 5ms refresh timer + drain-wait that yields to inbound traffic, widest under load). The promotion then mints a confirmed `(seq, value)` pair the server never had, and that stamp feeds later reads' staleness bases (`pushCommitRead` emits `record.confirmed.seq` as confirmed `seq` / pending `basisSeq`) — an honest client producing INV-1 missed-write observations that no current checker can see, since engine, naive model, and oracle all replay the claimed basis. This is the CT-1872 "unpinned convergence" wrinkle plus its sharper dishonest-basis consequence. CT-1926 has the full design discussion; the ordering-side complement is CT-1927.

## What

**Engine** (f3eca4b93): every `patch` revision in an accept response now carries `document` — the doc's POST-COMMIT state, recovered via the canonical seq-pinned read right after the head update (`attachPostApplyDocuments`; the same state on every patch revision of a doc, revision-order independent). `selectCommitRevisions` recovers it for replays at THE REPLAYED COMMIT's seq, not head (safe under snapshot retention: reconstruction falls back to the last durable `set` row + patch fold). `set` keeps its payload; `delete` stays identity-only. Zero server.ts changes (the server returns `AppliedCommit` verbatim) and no other consumer of `AppliedRevision.document` exists (fan-out runs off `markSpaceDirty`).

**Client** (b1dc40af0): `confirmPending` reads the accept's revisions (last revision per doc wins; a patch revision without `document` — pre-CT-1926 server — also invalidates earlier same-doc values, so partial views never promote). The rule, refined during implementation by an existing pin: compute the local promotion as before, compare with the canonical `valueEqual` —

- **equal (steady state)** → keep the local promotion and its materialization cache, so the visible value's IDENTITY survives confirmation (pinned by "confirming the head pending write promotes the cached materialization"; identity churn on every accept would ripple into shallow change detection);
- **different (a foreign write raced the fan-out)** → promote the server truth and drop the cache — the identity change is real.

Identity changes iff the value does. This is not the rejected hash-optimistic design: no wire hashes, no held commits, no new client state — both values are in hand and the comparison is local.

**Tests**: three engine tests (post-apply includes unseen foreign writes; shape preservation across set/delete/multi-patch; seq-pinned replay vs head); scripted server model attaches documents like the real engine; convergence regression (foreign whole-doc replacement interleaves before a blind patch's accept, no sync delivered → confirmed equals server truth INCLUDING the foreign fields — the CT-1872 convergence property, closed for the accept path); old-server fallback regression (`omitPostApplyDocuments`: extrapolation preserved, the documented residue).

**Docs**: 04-protocol §4.3.1 (response revision payloads), 03-commit-model §3.12 (accept-side promotion rule).

## Rollout

Additive field, no negotiation (same pattern as `basisSeq`): old clients ignore it; new clients fall back to extrapolation against old servers. Under CT-1927 (flush-before-verdict + frame-time retirement) the value becomes a guarded no-op for watched docs; it stays load-bearing for unwatched docs, pre-CT-1927 servers, and rollout skew — attached unconditionally on purpose.

## Verification

- `packages/memory`: 459/459 (three new engine tests included)
- `packages/runner`: 1101/1101 — including the new convergence + fallback regressions AND the pre-existing identity-stability pin that forced the valueEqual refinement
- `deno task check` green (runner package + root), `check-docs` 523 blocks, fmt/lint clean
- Self-review (cf-review) verified the three least-trusted spots: `valueEqual` undefined handling (`Object.is` fast path), replay reconstruction under snapshot retention (falls back to durable `set` + fold — cost, not error), reconstruction cost bounded by `DEFAULT_SNAPSHOT_INTERVAL = 10` patches

## Notes for review

- Originally stacked on #5110 (CT-1910), which merged 2026-07-29 with history preserved — this PR is exactly the three CT-1926 commits.
- Known added cost: one bounded document reconstruction per patch-written doc per accept (the server previously never materialized per commit; snapshots are interval-gated). If it ever profiles, the natural reuse is feeding `materializeSnapshots` from the same reconstruction.
- CFC read-authority checkpoint from the ticket (write-only shapes should not receive other writers' content in the response) remains a server-layer review item — the engine attaches unconditionally today, matching the existing behavior of `set` payload echo and query access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accept responses now include the post-commit document for patch ops, and the client promotes confirmed state from that server value when it differs from local extrapolation. This fulfills CT-1926 and prevents confirming states the server never had.

- **New Features**
  - `packages/memory`: Each patch revision in an accept carries `document` (the post-commit state), recovered via a seq-pinned read; `set` keeps its payload and `delete` stays identity-only. The field is additive, so old clients ignore it and replays return the state as of the replayed commit.
  - `packages/runner`: `confirmPending` compares the local promotion with the response’s `document`. If equal, it keeps the local identity; if different, it promotes the server value and drops the cache. Falls back to local extrapolation when a server omits `document` (pre-CT-1926).

<sup>Written for commit 9c8018c8500039b8a2fc22191c329e984ae417c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

