### PR TITLE
refactor(api,runner): Handler/HandlerFactory type parameters go event-first

### DIFF
--- a/docs/plans/pattern-verb-contract-implementation.md
+++ b/docs/plans/pattern-verb-contract-implementation.md
@@ -195,7 +195,12 @@ Size L (~1–2 weeks). No dependencies; starts immediately.
   Verb-shaped type parameters read one way throughout: **`E`** the event,
   **`R`** the declared result, **`T`** the handler's bound state where there
   is one. `Handler`/`HandlerFactory`'s second parameter was spelled `R` while
-  it meant the event.
+  it meant the event. The order is uniform too (#5161, settled after C1
+  landed): `Handler`/`HandlerFactory` are event-first — `Handler<E, T, R>`,
+  `HandlerFactory<E, T, R>` — so the tuple reads identically at the type, the
+  `handler()`/`action()` call, and the produced `Stream<E, R>`. Positional
+  annotations were flipped repo-wide in the same change; the compiler
+  enumerates any stragglers.
 
   **A result is opt-in by explicit type argument — `action<E, R>(...)` —
   never inferred.** A concise arrow body's completion value is whatever its

--- a/docs/specs/pattern-construction/node-factory-shipping.md
+++ b/docs/specs/pattern-construction/node-factory-shipping.md
@@ -165,7 +165,7 @@ The same applies to modules and handlers:
 interface FactoryInputs {
   value: string;
   transform: ModuleFactory<{ value: string }, { length: number }>;
-  select: HandlerFactory<{ source: string }, { id: string }>;
+  select: HandlerFactory<{ id: string }, { source: string }>;
 }
 
 const useFactories = pattern<FactoryInputs>(({

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -1698,11 +1698,12 @@ export type toJSON = {
  * declares back to a caller (`void` for the value-less majority), and **`T`**
  * is the handler's bound state, present only where there is one.
  *
- * `Handler`'s second parameter was spelled `R` before a result existed; it has
- * always been the event type, so it is `E` now and `R` means one thing
- * everywhere. Type parameters are positional — no caller changes.
+ * `Handler` and `HandlerFactory` take them event-first — `Handler<E, T, R>` —
+ * the same order `handler()`'s own type parameters and `Stream<E, R>` read,
+ * so one tuple means the same thing at the declaration, the builder call, and
+ * the produced stream (#5161).
  */
-export type Handler<T = any, E = any, R = void> = Module & {
+export type Handler<E = any, T = any, R = void> = Module & {
   with: (inputs: FactoryInput<StripCell<T>>) => Stream<E, R>;
 };
 
@@ -1731,9 +1732,9 @@ export type ModuleFactory<T, R> =
     asScope(scope: CellScope): ModuleFactory<T, R>;
   };
 
-export type HandlerFactory<T, E, R = void> =
+export type HandlerFactory<E, T, R = void> =
   & ((inputs: FactoryInput<StripCell<T>>) => Stream<E, R>)
-  & Handler<T, E, R>
+  & Handler<E, T, R>
   & toJSON;
 
 // JSON types
@@ -2434,17 +2435,17 @@ export interface HandlerFunction {
     eventSchema: JSONSchema,
     stateSchema: JSONSchema,
     handler: (event: E, props: HandlerState<T>) => any,
-  ): HandlerFactory<T, E>;
+  ): HandlerFactory<E, T>;
 
   // Without schemas
   <E, T>(
     handler: (event: E, props: T) => any,
     options: { proxy: true },
-  ): HandlerFactory<T, E>;
+  ): HandlerFactory<E, T>;
 
   <E, T>(
     handler: (event: E, props: HandlerState<T>) => any,
-  ): HandlerFactory<T, E>;
+  ): HandlerFactory<E, T>;
 
   // Declared results, reached only by naming all three type arguments —
   // `ActionFunction`'s explicit-only rule, for the same reason: the `=> any`
@@ -2454,16 +2455,16 @@ export interface HandlerFunction {
     eventSchema: JSONSchema,
     stateSchema: JSONSchema,
     handler: (event: E, props: HandlerState<T>) => R,
-  ): HandlerFactory<T, E, R>;
+  ): HandlerFactory<E, T, R>;
 
   <E, T, R>(
     handler: (event: E, props: T) => R,
     options: { proxy: true },
-  ): HandlerFactory<T, E, R>;
+  ): HandlerFactory<E, T, R>;
 
   <E, T, R>(
     handler: (event: E, props: HandlerState<T>) => R,
-  ): HandlerFactory<T, E, R>;
+  ): HandlerFactory<E, T, R>;
 }
 
 /**

--- a/packages/api/schema.ts
+++ b/packages/api/schema.ts
@@ -422,7 +422,7 @@ declare module "commonfabric" {
       eventSchema: E,
       stateSchema: T,
       handler: (event: Schema<E>, props: Schema<T>) => any,
-    ): HandlerFactory<SchemaWithoutCell<T>, SchemaWithoutCell<E>>;
+    ): HandlerFactory<SchemaWithoutCell<E>, SchemaWithoutCell<T>>;
   }
 
   // Augment WishFunction with schema-based overloads

--- a/packages/api/test/factory-input-types.test.ts
+++ b/packages/api/test/factory-input-types.test.ts
@@ -73,7 +73,7 @@ const _roomBinding: MustBeTrue<
 
 const _handlerFactory: MustBeTrue<
   AssertAssignable<
-    HandlerFactory<HandlerState, void>,
+    HandlerFactory<void, HandlerState>,
     (inputs: HandlerBinding) => unknown
   >
 > = true;

--- a/packages/api/test/handler-function-surface.test.ts
+++ b/packages/api/test/handler-function-surface.test.ts
@@ -42,7 +42,7 @@ export function _handlerFunctionSurfaceProbe() {
     { proxy: true },
   );
   type _ConciseHasNoResult = MustBeTrue<
-    Same<typeof concise, HandlerFactory<BoundState, string>>
+    Same<typeof concise, HandlerFactory<string, BoundState>>
   >;
 
   // A result is reachable from a pattern, and only by naming all three type
@@ -51,7 +51,7 @@ export function _handlerFunctionSurfaceProbe() {
     (_event, _props) => ({ topic: { fid: "topic-1" } }),
   );
   type _DeclaredCarriesResult = MustBeTrue<
-    Same<typeof declared, HandlerFactory<BoundState, AddTopic, TopicRef>>
+    Same<typeof declared, HandlerFactory<AddTopic, BoundState, TopicRef>>
   >;
 
   const declaredProxy = handler<AddTopic, BoundState, TopicRef>(
@@ -59,7 +59,7 @@ export function _handlerFunctionSurfaceProbe() {
     { proxy: true },
   );
   type _ProxyCarriesResult = MustBeTrue<
-    Same<typeof declaredProxy, HandlerFactory<BoundState, AddTopic, TopicRef>>
+    Same<typeof declaredProxy, HandlerFactory<AddTopic, BoundState, TopicRef>>
   >;
 
   const declaredWithSchemas = handler<AddTopic, BoundState, TopicRef>(
@@ -70,7 +70,7 @@ export function _handlerFunctionSurfaceProbe() {
   type _SchemaFormCarriesResult = MustBeTrue<
     Same<
       typeof declaredWithSchemas,
-      HandlerFactory<BoundState, AddTopic, TopicRef>
+      HandlerFactory<AddTopic, BoundState, TopicRef>
     >
   >;
 

--- a/packages/runner/src/builder/module.ts
+++ b/packages/runner/src/builder/module.ts
@@ -397,7 +397,7 @@ function handlerInternal<E, T>(
     | undefined,
   stateSchema?: JSONSchema | { proxy: true },
   handler?: (event: E, props: T) => any,
-): HandlerFactory<T, E> {
+): HandlerFactory<E, T> {
   let writableProxy = false;
   if (typeof eventSchema === "function") {
     if (
@@ -428,7 +428,7 @@ function handlerInternal<E, T>(
     stateSchema as JSONSchema | undefined,
   );
 
-  const module: Handler<T, E> & toJSON & {
+  const module: Handler<E, T> & toJSON & {
     bind: (inputs: FactoryInput<StripCell<T>>) => Stream<E>;
   } = {
     type: "javascript",
@@ -487,19 +487,19 @@ export function handler<
   eventSchema: E,
   stateSchema: T,
   handler: (event: Schema<E>, props: Schema<T>) => any,
-): HandlerFactory<SchemaWithoutCell<T>, SchemaWithoutCell<E>>;
+): HandlerFactory<SchemaWithoutCell<E>, SchemaWithoutCell<T>>;
 export function handler<E, T>(
   eventSchema: JSONSchema,
   stateSchema: JSONSchema,
   handler: (event: E, props: T) => any,
-): HandlerFactory<T, E>;
+): HandlerFactory<E, T>;
 export function handler<E, T>(
   handler: (Event: E, props: T) => any,
   options: { proxy: true },
-): HandlerFactory<T, E>;
+): HandlerFactory<E, T>;
 export function handler<E, T>(
   handler: (event: E, props: T) => any,
-): HandlerFactory<T, E>;
+): HandlerFactory<E, T>;
 // Declared results, reached only by naming all three type arguments — the
 // same explicit-only rule as `action`'s result overload, mirrored here and in
 // api's `HandlerFunction` (both halves are hand-maintained; an overload
@@ -510,14 +510,14 @@ export function handler<E, T, R>(
   eventSchema: JSONSchema,
   stateSchema: JSONSchema,
   handler: (event: E, props: T) => R,
-): HandlerFactory<T, E, R>;
+): HandlerFactory<E, T, R>;
 export function handler<E, T, R>(
   handler: (event: E, props: T) => R,
   options: { proxy: true },
-): HandlerFactory<T, E, R>;
+): HandlerFactory<E, T, R>;
 export function handler<E, T, R>(
   handler: (event: E, props: T) => R,
-): HandlerFactory<T, E, R>;
+): HandlerFactory<E, T, R>;
 export function handler<E, T, R = void>(
   eventSchema:
     | JSONSchema
@@ -525,10 +525,10 @@ export function handler<E, T, R = void>(
     | undefined,
   stateSchema?: JSONSchema | { proxy: true },
   handler?: (event: E, props: T) => any,
-): HandlerFactory<T, E, R> {
+): HandlerFactory<E, T, R> {
   return handlerInternal(eventSchema, stateSchema, handler) as HandlerFactory<
-    T,
     E,
+    T,
     R
   >;
 }

--- a/packages/runner/test/factory-input-types.test.ts
+++ b/packages/runner/test/factory-input-types.test.ts
@@ -69,7 +69,7 @@ const _roomBinding: MustBeTrue<
 
 const _handlerFactory: MustBeTrue<
   AssertAssignable<
-    HandlerFactory<HandlerState, void>,
+    HandlerFactory<void, HandlerState>,
     (inputs: HandlerBinding) => unknown
   >
 > = true;

--- a/packages/runner/test/handler-overload-types.test.ts
+++ b/packages/runner/test/handler-overload-types.test.ts
@@ -51,7 +51,7 @@ export function _handlerOverloadTypeProbe() {
     (id: string, state: BoundState) => state.selected.set(id),
   );
   type _ConciseHasNoResult = MustBeTrue<
-    Same<typeof concise, HandlerFactory<BoundState, string>>
+    Same<typeof concise, HandlerFactory<string, BoundState>>
   >;
 
   // A result is opt-in, and only by naming all three type arguments — on each
@@ -60,7 +60,7 @@ export function _handlerOverloadTypeProbe() {
     (_event, _state) => ({ id: "topic-1" }),
   );
   type _DeclaredCarriesResult = MustBeTrue<
-    Same<typeof declared, HandlerFactory<BoundState, AddTopic, TopicRef>>
+    Same<typeof declared, HandlerFactory<AddTopic, BoundState, TopicRef>>
   >;
 
   const declaredProxy = handler<AddTopic, BoundState, TopicRef>(
@@ -68,7 +68,7 @@ export function _handlerOverloadTypeProbe() {
     { proxy: true },
   );
   type _ProxyCarriesResult = MustBeTrue<
-    Same<typeof declaredProxy, HandlerFactory<BoundState, AddTopic, TopicRef>>
+    Same<typeof declaredProxy, HandlerFactory<AddTopic, BoundState, TopicRef>>
   >;
 
   const declaredWithSchemas = handler<AddTopic, BoundState, TopicRef>(
@@ -79,7 +79,7 @@ export function _handlerOverloadTypeProbe() {
   type _SchemaFormCarriesResult = MustBeTrue<
     Same<
       typeof declaredWithSchemas,
-      HandlerFactory<BoundState, AddTopic, TopicRef>
+      HandlerFactory<AddTopic, BoundState, TopicRef>
     >
   >;
 
@@ -87,7 +87,7 @@ export function _handlerOverloadTypeProbe() {
   // dropped declaration is a compile error at the assignment rather than a
   // silent erasure.
   type _DeclaredIsNotResultLess = MustBeTrue<
-    Same<typeof declared, HandlerFactory<BoundState, AddTopic>> extends true
+    Same<typeof declared, HandlerFactory<AddTopic, BoundState>> extends true
       ? false
       : true
   >;

--- a/packages/ts-transformers/test/fixtures/closures/map-conditional-inline-handler-send.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-conditional-inline-handler-send.expected.jsx
@@ -68,7 +68,7 @@ const castVote = handler({
     ]);
 });
 const __cfLift_1 = __cfHelpers.lift<{
-    castVote: __cfHelpers.HandlerFactory<{ votes: __cfHelpers.Cell<VoteEvent[]>; }, VoteEvent, void>;
+    castVote: __cfHelpers.HandlerFactory<VoteEvent, { votes: __cfHelpers.Cell<VoteEvent[]>; }, void>;
     state: {
         votes: VoteEvent[];
     };

--- a/packages/ts-transformers/test/fixtures/handler-schema/stream-declared-result.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/stream-declared-result.expected.jsx
@@ -118,7 +118,7 @@ export default pattern(() => {
 // Verifies: a declared result on Stream's second parameter survives the
 //   transformer and still satisfies the pattern's own Output annotation.
 //   `action` is the sole result-authoring surface — `handler()` produces
-//   HandlerFactory<T, E, void>, so the same shape written with `handler` does
+//   HandlerFactory<E, T, void>, so the same shape written with `handler` does
 //   not compile. C2 lowers the returned value; C3 emits the result schema.
 //   Until both land, a returning verb transforms exactly like a value-less
 //   one, and this golden is the baseline they move.

--- a/packages/ts-transformers/test/fixtures/handler-schema/stream-declared-result.input.tsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/stream-declared-result.input.tsx
@@ -42,7 +42,7 @@ export default pattern<Record<string, never>, Verbs>(() => {
 // Verifies: a declared result on Stream's second parameter survives the
 //   transformer and still satisfies the pattern's own Output annotation.
 //   `action` is the sole result-authoring surface — `handler()` produces
-//   HandlerFactory<T, E, void>, so the same shape written with `handler` does
+//   HandlerFactory<E, T, void>, so the same shape written with `handler` does
 //   not compile. C2 lowers the returned value; C3 emits the result schema.
 //   Until both land, a returning verb transforms exactly like a value-less
 //   one, and this golden is the baseline they move.


### PR DESCRIPTION
## Why

Closes #5161. `handler<E, T, R>(...)` returned `HandlerFactory<T, E, R>` — the same three-name tuple in two different orders on consecutive lines, in both hand-maintained halves of the surface. Two parameters made that a quirk; C1 (#5170) adding the third made it a standing invitation to transpose, and the exposure is at its floor right now: ~36 positional annotation sites, all in-repo, none in pattern code (patterns write `Stream<E, R>` and infer the factory). C2/C3 build on these types next, so this is the cheapest moment the flip will ever have. Direction (event-first, option 1 of #5161) confirmed by Mike after the C1 review round.

## What Changed

`Handler<E, T, R>` and `HandlerFactory<E, T, R>` — event, state, result — matching the order `handler()`'s and `action()`'s own type parameters and `Stream<E, R>` already read. Pure positional reorder, no runtime change, parameter meanings and names untouched. Every annotation site flipped in the same commit (api overloads and schema.ts, builder module.ts, the four type-guard test files, one spec-doc example); the two transformer goldens regenerated via `UPDATE_GOLDENS`; the naming-convention doc comment on `Handler` now records the order; the plan's naming bullet records the decision.

## Test plan

- `deno task check` (workspace): zero TS errors across 432 paths — the compiler enumerates every positional site, so a missed one cannot survive this
- `packages/api`: 25 passed · `packages/schema-generator`: 55 passed · `packages/ts-transformers`: 1118 passed (goldens regenerated) · runner type-guard/E2E files: 5 passed
- `deno fmt --check`, `deno lint`, `deno task check-docs` (520 blocks): clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reordered `Handler` and `HandlerFactory` generics to be event-first, so they read `Handler<E, T, R>` and `HandlerFactory<E, T, R>` in the same order as `handler()`, `action()`, and `Stream<E, R>`. This is a types-only change with no runtime impact.

- **Refactors**
  - Updated types and overloads in `packages/api` and `packages/runner` to return event-first factories.
  - Flipped all in-repo annotations, tests, and transformer goldens; refreshed docs to note the new order.
  - Adjusted schema augmentation to return `HandlerFactory<SchemaWithoutCell<E>, SchemaWithoutCell<T>>`.

- **Migration**
  - If you annotate generics explicitly, switch to event-first: `Handler<E, T, R>` and `HandlerFactory<E, T, R>`.
  - Update annotations like `HandlerFactory<MyEvent, MyState, Result>` (was `HandlerFactory<MyState, MyEvent, Result>`).

<sup>Written for commit fbc4f4421d33c6204506dbb53267322467b853e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

