### PR TITLE
fix(runner): abandon a remove-by-value that does not explain the array

### DIFF
--- a/docs/development/keyed-collection-writes.md
+++ b/docs/development/keyed-collection-writes.md
@@ -64,7 +64,11 @@ mergeable ops plus plain entity edits:
   same field resolves last-writer-wins; edits to different records never interact.
 - **Delete** — `array.removeByValue(array.elementById(key))`. `removeByValue`
   matches the membership entry by link and is idempotent, so concurrent deletes of
-  distinct keys merge.
+  distinct keys merge. It stays mergeable as long as the removals are the
+  transaction's only change to *that array* — editing a keyed element writes the
+  entity document, so it does not count, but rewriting the list in the same
+  handler falls the path back to a whole-array diff (see
+  `mergeable-collection-writes.md`).
 
 The lunch poll derives a vote's key as `JSON.stringify([voterName, optionId])`
 and an option's key as its generated `id`; castVote, clearMyVote, and the

--- a/docs/development/mergeable-collection-writes.md
+++ b/docs/development/mergeable-collection-writes.md
@@ -239,7 +239,10 @@ applies:
   matches the durable element exactly. Because it identifies what to remove by
   value rather than by position, concurrent removes of distinct entries merge
   instead of clobbering through a whole-array rewrite. Suppression drops the
-  whole subtree at the array path that the local positional removal produced.
+  whole subtree at the array path that the local positional removal produced,
+  which makes the op the commit's only carrier for that array — so it is emitted
+  only when it fully accounts for the local value (see the removal-check bullet
+  below).
 
 `add-unique` and `remove-by-value` compare by stored-value content equality. For
 an element that is a separate entity, that stored value is a link, so the
@@ -287,7 +290,7 @@ first, since the op carries only the delta.
   merge-friendliness (it commits as a value diff, so it can false-conflict under
   contention) rather than being silently corrupted. Read that as a description of
   the poisoned path, not as a closed-class guarantee for every op — see "Known
-  gaps" at the end of this section for two shapes that still commit a value the
+  gaps" at the end of this section for a shape that still commits a value the
   writer never saw. The rule is that every whole-value write poisons the ops it
   covers, so the sites to keep in step are every path that performs one:
   `Cell.set`, `Cell.setRawUntyped`, the query-result proxy's in-place mutators,
@@ -361,24 +364,41 @@ first, since the op carries only the delta.
   guarantee should not rest on that coincidence: nothing obliges a reshape to
   read what it overwrites.
 
+- **A `removeByValue` that does not account for the whole local array falls back
+  too.** Its suppression is `subtree: true` — the array path and everything under
+  it — so unlike a tail op it leaves *nothing* to carry the array, not even the
+  per-index candidates. That is a stronger claim, and it is checked against the
+  whole value rather than a prefix: applying the recorded removals to the base
+  array (every occurrence of each value, exactly as the store applies the wire
+  op) must reproduce the working array. The comparison is `valueEqual`, so hole
+  layout counts too. Anything else the transaction changed on that array breaks
+  the equality and abandons the intent, and the whole-array diff commits the
+  local value instead.
+
+  Two ordinary shapes need it, and neither is caught earlier. An element edit —
+  the "edit one row and delete another in the same handler" shape — writes
+  *beneath* the array and so deliberately does not poison the intent, yet the
+  subtree suppression discards its per-index candidate; a tail op survives that
+  composition, a removal cannot. And a whole-value `set` landing *before* the
+  removal (at this path or at a parent) has no intent to poison yet. In both
+  cases the store would otherwise apply the removals to an untouched base and
+  drop everything else, while the writing session's own value shows the change.
+
+  A transaction that creates the array and removes from it in one go has no base
+  array to check against, and abandons for that reason: the removals say nothing
+  about the elements the transaction created, so with the diff suppressed the
+  entity would never be written at all.
+
+  A removal that is the transaction's only change to the array — including
+  alongside a write to a *sibling* field, which is not that array — reproduces
+  the working array exactly and keeps its op, so concurrent removals of distinct
+  entries still merge.
+
 ### Known gaps
 
-Two shapes still commit a value the writer never saw. Both are measured, both
-predate the tail-op checks above, and neither is caught by them. Treat this list
-as the honest boundary of "falls back rather than corrupts".
-
-- **`removeByValue` alongside any other change to the same array.** Its
-  suppression is `subtree: true` — the whole array path and everything under it —
-  and unlike the tail ops it has no commit-time check that the local value is
-  still what the op describes. So any other local change to that array is
-  swallowed. Measured, from a durable `["a","b","c"]`: `key(0).set("A")` then
-  `removeByValue("c")` gives a local `["A","b"]` and a durable `["a","b"]` — the
-  edit is gone; the reverse order loses it too; and `set(["p","q"])` then
-  `removeByValue("p")` gives a local `["q"]` against a durable `["a","b","c"]` —
-  the whole `set` vanishes. The first of these is the ordinary "edit one row and
-  delete another in the same handler" shape. Note that the deliberate decision
-  *not* to poison beneath a write is what lets it through: an element edit writes
-  beneath the array, so it leaves the `removeByValue` intent alive.
+One shape still commits a value the writer never saw. It is measured, it predates
+the commit-time checks above, and it is not caught by them. Treat this as the
+honest boundary of "falls back rather than corrupts".
 
 - **Nested arrays where one tail op's payload contains another's target.** Push a
   new array onto an outer array, then push into that inner array: the outer

--- a/docs/development/patch-operations.md
+++ b/docs/development/patch-operations.md
@@ -63,10 +63,11 @@ Take `Cell.increment(2)`:
 3. **Commit** — at commit the intent becomes wire ops plus the diff-suppression
    they imply (`buildMergeableIntent`), and the whole-value diff for the paths the
    op covers is dropped. The op travels in `ClientCommit.operations`. A builder
-   that finds its intent no longer describes the local value — a tail op whose
-   base length no longer matches its prefix, because the transaction also
-   reshaped the array before the op or at a parent path — instead *abandons* it,
-   and the commit poisons the path as above.
+   that finds its intent no longer describes the local value instead *abandons*
+   it, and the commit poisons the path as above: a tail op whose prefix no longer
+   matches its base, or a `remove-by-value` whose removals applied to the base do
+   not reproduce the working array — both meaning the transaction also changed
+   that array outside the op, before it or at a parent path.
 4. **Apply** — the durable store applies the op against live state
    (`packages/memory/v2/patch.ts`, `patchOpDescriptors[op].apply`).
 5. **React** — the store computes which paths the op touched so stale reads

--- a/packages/runner/src/storage/mergeable-ops.ts
+++ b/packages/runner/src/storage/mergeable-ops.ts
@@ -1,4 +1,5 @@
 import type { FabricValue } from "@commonfabric/api";
+import { valueEqual } from "@commonfabric/data-model/fabric-value";
 import type { PatchOp } from "@commonfabric/memory/v2";
 import { encodePointer } from "../../../memory/v2/path.ts";
 
@@ -221,6 +222,70 @@ const buildTailOp = (
   };
 };
 
+type RemoveIntent = Extract<MergeableOpIntent, { op: "remove-by-value" }>;
+
+// The array the store will hold once the intent's removals have been applied to
+// `base`, mirroring how the wire op applies (`removeByValueAtPath` in
+// `@commonfabric/memory/v2/patch`): every occurrence of each value goes, in the
+// order the values were recorded.
+const withRemovalsApplied = (
+  base: readonly FabricValue[],
+  values: readonly FabricValue[],
+): FabricValue[] => {
+  const result = base.slice() as FabricValue[];
+  for (const value of values) {
+    for (let index = result.length - 1; index >= 0; index -= 1) {
+      if (valueEqual(result[index], value)) {
+        result.splice(index, 1);
+      }
+    }
+  }
+  return result;
+};
+
+// A remove-by-value rebuilds the array's membership by value, so it suppresses
+// the whole subtree the local removal produced (a positional splice/shrink)
+// rather than a tail slice. Nothing at or under the array path survives that, so
+// the op is the commit's ONLY carrier for this array — a stronger claim than a
+// tail op's, which leaves the prefix's per-index candidates alive. It may make
+// that claim only when it fully explains the local value: the working array has
+// to be exactly the base with the removed values taken out.
+//
+// Anything else the transaction changed on the same array — an element edit, a
+// whole-value `set` at this path or at a parent — otherwise loses the candidate
+// that would have carried it and is silently discarded, while the writing
+// session's own value shows the change. Neither shape is caught earlier: an
+// element edit writes BENEATH the array and so deliberately does not poison the
+// intent, and a `set` landing before the op has no intent to poison yet. When
+// the check fails, abandon the intent and let the whole-array diff commit the
+// local value.
+const buildRemoveByValue = (
+  intent: RemoveIntent,
+  ctx: MergeableBuildContext,
+): MergeableBuildResult => {
+  const array = ctx.workingArray;
+  const base = ctx.initialArray;
+  // With no base array the transaction materialized the array itself, so there
+  // is nothing to check the removals against — and the subtree suppression would
+  // drop the creation whole, writing nothing at all.
+  if (!array || !ctx.hadInitialArray || !base) {
+    return { ops: [], suppress: [], abandon: true };
+  }
+  // `valueEqual` compares arrays by canonical content hash, so this also holds
+  // the op to the base's hole layout rather than flattening it away.
+  if (!valueEqual(withRemovalsApplied(base, intent.values), array)) {
+    return { ops: [], suppress: [], abandon: true };
+  }
+  return {
+    ops: intent.values.map((value) => ({
+      op: "remove-by-value",
+      path: encodePointer(intent.path),
+      value,
+    })),
+    suppress: [{ path: intent.path, subtree: true }],
+  };
+};
+
 const mergeableOpDescriptors: Record<MergeableWireOp, MergeableOpDescriptor> = {
   append: descriptor<AppendIntent, AppendDelta>({
     op: "append",
@@ -277,16 +342,7 @@ const mergeableOpDescriptors: Record<MergeableWireOp, MergeableOpDescriptor> = {
         delta.value,
       ],
     }),
-    // The op rebuilds the array's membership by value; suppress the whole subtree
-    // the local removal produced (a positional splice/shrink).
-    build: (intent) => ({
-      ops: intent.values.map((value) => ({
-        op: "remove-by-value",
-        path: encodePointer(intent.path),
-        value,
-      })),
-      suppress: [{ path: intent.path, subtree: true }],
-    }),
+    build: buildRemoveByValue,
   }),
 };
 

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -1112,8 +1112,11 @@ export class V2StorageTransaction implements IStorageTransaction {
   // and leaves a write to a sibling field alone.
   //
   // A path carrying no intent yet is left alone — but that is not a statement
-  // that a reshape before an op is harmless. It is caught later instead, by the
-  // tail builder's own prefix check at commit (see ./mergeable-ops.ts).
+  // that a reshape before an op is harmless. It is caught later instead, by each
+  // builder's own check at commit that its intent still describes the local
+  // value (see ./mergeable-ops.ts). The same goes for an element edit, which is
+  // beneath the array and so passes through here untouched: harmless to a tail
+  // op, fatal to a remove-by-value, and the builders are what tell them apart.
   poisonMergeableOp(address: IMemorySpaceAddress): void {
     // Only ever called right after a write on this transaction, so the tx is
     // editable — no editable() re-check. The write also made the address's
@@ -2634,12 +2637,12 @@ export class V2StorageTransaction implements IStorageTransaction {
   // supply each intent the working/initial array state its builder needs.
   //
   // A builder can also abandon its intent — the recorded op no longer describes
-  // the transaction's local value (see `buildTailOp`). Abandoning must poison the
-  // path here rather than just skip the op, because a surviving intent still
-  // narrows the op's reads out of the commit's conflict set (v2.ts) and would
-  // hand the replacing whole-value diff a read set it has not earned. This runs
-  // inside getNativeCommit, which precedes that narrowing, so both sides see the
-  // same intents.
+  // the transaction's local value (see `buildTailOp` / `buildRemoveByValue`).
+  // Abandoning must poison the path here rather than just skip the op, because a
+  // surviving intent still narrows the op's reads out of the commit's conflict
+  // set (v2.ts) and would hand the replacing whole-value diff a read set it has
+  // not earned. This runs inside getNativeCommit, which precedes that narrowing,
+  // so both sides see the same intents.
   private buildMergeableOps(
     doc: WritableDocumentEntry,
   ): { ops: PatchOp[]; suppress: OpSuppression[] } {

--- a/packages/runner/test/array-push-mergeable.test.ts
+++ b/packages/runner/test/array-push-mergeable.test.ts
@@ -1449,6 +1449,287 @@ describe("mergeable array appends", () => {
     }
   });
 
+  // The ordinary "edit one row and delete another in the same handler" shape. A
+  // remove-by-value suppresses the array path AND everything under it, so the
+  // edit's per-index candidate has no surviving carrier: without the builder's
+  // own commit-time check the store applies the removal to the untouched base
+  // and the edit is gone, while the writing session's local value shows it. The
+  // edit writes BENEATH the array, so it deliberately does not poison the
+  // intent — the check at build is the only thing that can catch this.
+  it("an element edit before a removeByValue survives the removal", async () => {
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage1,
+    });
+    try {
+      const tx0 = rt1.edit();
+      rt1.getCell<string[]>(space, CAUSE, stringListSchema, tx0).set([
+        "a",
+        "b",
+        "c",
+      ]);
+      await tx0.commit();
+      await rt1.storageManager.synced();
+
+      const tx1 = rt1.edit();
+      const cell = rt1.getCell<string[]>(space, CAUSE, stringListSchema, tx1);
+      cell.key(0).set("A");
+      cell.removeByValue("c");
+      expect(cell.get()).toEqual(["A", "b"]);
+      await tx1.commit();
+      await rt1.storageManager.synced();
+
+      expect(await readDurable(server)).toEqual(["A", "b"]);
+    } finally {
+      await rt1.dispose();
+    }
+  });
+
+  // The same composition in the other order. Recording the op first does not
+  // help: the edit still lands beneath the array and leaves the intent alive, so
+  // the suppression discards it just the same.
+  it("an element edit after a removeByValue survives the removal", async () => {
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage1,
+    });
+    try {
+      const tx0 = rt1.edit();
+      rt1.getCell<string[]>(space, CAUSE, stringListSchema, tx0).set([
+        "a",
+        "b",
+        "c",
+      ]);
+      await tx0.commit();
+      await rt1.storageManager.synced();
+
+      const tx1 = rt1.edit();
+      const cell = rt1.getCell<string[]>(space, CAUSE, stringListSchema, tx1);
+      cell.removeByValue("c");
+      cell.key(0).set("A");
+      expect(cell.get()).toEqual(["A", "b"]);
+      await tx1.commit();
+      await rt1.storageManager.synced();
+
+      expect(await readDurable(server)).toEqual(["A", "b"]);
+    } finally {
+      await rt1.dispose();
+    }
+  });
+
+  // A whole-array set BEFORE the removal: no intent exists yet for the set's
+  // write to poison, so the op is recorded against an array the transaction had
+  // already replaced. Its suppression then discards the set's entire diff and
+  // only the removals reach the store, leaving the durable list untouched apart
+  // from them.
+  it("a whole-array set before a removeByValue commits the set array", async () => {
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage1,
+    });
+    try {
+      const tx0 = rt1.edit();
+      rt1.getCell<string[]>(space, CAUSE, stringListSchema, tx0).set([
+        "a",
+        "b",
+        "c",
+      ]);
+      await tx0.commit();
+      await rt1.storageManager.synced();
+
+      const tx1 = rt1.edit();
+      const cell = rt1.getCell<string[]>(space, CAUSE, stringListSchema, tx1);
+      cell.set(["p", "q"]);
+      cell.removeByValue("p");
+      expect(cell.get()).toEqual(["q"]);
+      await tx1.commit();
+      await rt1.storageManager.synced();
+
+      expect(await readDurable(server)).toEqual(["q"]);
+    } finally {
+      await rt1.dispose();
+    }
+  });
+
+  // Creating the array and removing from it in one transaction: there is no base
+  // array for the op to describe at all. The removals alone say nothing about
+  // the elements the transaction created, and the subtree suppression discards
+  // the diff that carries them — so without the fallback the entity is never
+  // written and the durable value stays absent.
+  it("a removeByValue on an array the transaction created commits the array", async () => {
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage1,
+    });
+    const CREATED_CAUSE = "created-then-removed-list";
+    try {
+      const tx1 = rt1.edit();
+      const cell = rt1.getCell<string[]>(
+        space,
+        CREATED_CAUSE,
+        stringListSchema,
+        tx1,
+      );
+      cell.set(["p", "q"]);
+      cell.removeByValue("p");
+      expect(cell.get()).toEqual(["q"]);
+      await tx1.commit();
+      await rt1.storageManager.synced();
+
+      const storage = SharedServerStorageManager.connectTo(server, {
+        as: signer,
+      });
+      const rt2 = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager: storage,
+      });
+      try {
+        const readBack = rt2.getCell<string[]>(
+          space,
+          CREATED_CAUSE,
+          stringListSchema,
+        );
+        await readBack.sync();
+        await readBack.pull();
+        expect(readBack.get()).toEqual(["q"]);
+      } finally {
+        await rt2.dispose();
+        await storage.close();
+      }
+    } finally {
+      await rt1.dispose();
+    }
+  });
+
+  // The same reshape reached from a PARENT path — a `set` on the enclosing
+  // object, landing before the op, so neither the write-time poison (nothing
+  // recorded yet) nor a check scoped to the array's own path would see it.
+  it("a parent-object set before a nested removeByValue commits the set list", async () => {
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage1,
+    });
+    const holderSchema = {
+      type: "object",
+      properties: { rows: stringListSchema },
+      // deno-lint-ignore no-explicit-any
+    } as any;
+    const HOLDER_CAUSE = "nested-remove-holder";
+    try {
+      const tx0 = rt1.edit();
+      rt1.getCell(space, HOLDER_CAUSE, holderSchema, tx0).set({
+        rows: ["a", "b", "c"],
+      });
+      await tx0.commit();
+      await rt1.storageManager.synced();
+
+      const tx1 = rt1.edit();
+      const holder = rt1.getCell(space, HOLDER_CAUSE, holderSchema, tx1);
+      holder.set({ rows: ["p", "q"] });
+      holder.key("rows").removeByValue("p");
+      expect(holder.get()).toEqual({ rows: ["q"] });
+      await tx1.commit();
+      await rt1.storageManager.synced();
+
+      const storage = SharedServerStorageManager.connectTo(server, {
+        as: signer,
+      });
+      const rt2 = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager: storage,
+      });
+      try {
+        const cell = rt2.getCell(space, HOLDER_CAUSE, holderSchema);
+        await cell.sync();
+        await cell.pull();
+        expect(cell.get()).toEqual({ rows: ["q"] });
+      } finally {
+        await rt2.dispose();
+        await storage.close();
+      }
+    } finally {
+      await rt1.dispose();
+    }
+  });
+
+  // The fallback is scoped: a removal that IS the transaction's only change to
+  // the array stays mergeable, so two sessions removing distinct elements
+  // against the same base still merge. Without this the fix would trade one
+  // silent loss for the clobbering the mergeable op exists to prevent. (The
+  // sibling test above removes concurrently from a shared base; this one pins
+  // that a same-transaction change to a DIFFERENT array leaves the removal
+  // mergeable.)
+  it("a removeByValue stays mergeable when the other change is to a sibling field", async () => {
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage1,
+    });
+    const rt2 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage2,
+    });
+    const holderSchema = {
+      type: "object",
+      properties: { rows: stringListSchema, title: { type: "string" } },
+      // deno-lint-ignore no-explicit-any
+    } as any;
+    const HOLDER_CAUSE = "sibling-remove-holder";
+    const readHolder = async () => {
+      const storage = SharedServerStorageManager.connectTo(server, {
+        as: signer,
+      });
+      const rt = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager: storage,
+      });
+      try {
+        const cell = rt.getCell(space, HOLDER_CAUSE, holderSchema);
+        await cell.sync();
+        await cell.pull();
+        return cell.get();
+      } finally {
+        await rt.dispose();
+        await storage.close();
+      }
+    };
+    try {
+      const tx0 = rt1.edit();
+      rt1.getCell(space, HOLDER_CAUSE, holderSchema, tx0).set({
+        rows: ["a", "b", "c"],
+        title: "before",
+      });
+      await tx0.commit();
+      await rt1.storageManager.synced();
+
+      const cell2 = rt2.getCell(space, HOLDER_CAUSE, holderSchema);
+      await cell2.sync();
+      await cell2.pull();
+
+      // Session 1 removes "a".
+      const txA = rt1.edit();
+      rt1.getCell(space, HOLDER_CAUSE, holderSchema, txA)
+        .key("rows").removeByValue("a");
+      await txA.commit();
+      await rt1.storageManager.synced();
+
+      // Session 2, still at the pre-removal basis, removes a different element
+      // and edits an unrelated field. The sibling write does not touch the
+      // array, so the removal stays mergeable and both removals land.
+      const txB = rt2.edit();
+      const holderB = rt2.getCell(space, HOLDER_CAUSE, holderSchema, txB);
+      holderB.key("rows").removeByValue("c");
+      holderB.key("title").set("after");
+      const result = await txB.commit();
+      await rt2.storageManager.synced();
+
+      expect(result.error).toBeUndefined();
+      expect(await readHolder()).toEqual({ rows: ["b"], title: "after" });
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  });
+
   // A zero increment is a programming no-op and is rejected.
   it("increment(0) throws", async () => {
     const rt1 = new Runtime({

--- a/packages/runner/test/mergeable-op-registry.test.ts
+++ b/packages/runner/test/mergeable-op-registry.test.ts
@@ -210,3 +210,90 @@ describe("mergeable tail-op build guards", () => {
     ).toEqual({ ops: [], suppress: [], abandon: true });
   });
 });
+
+// A remove-by-value suppresses the array path AND its whole subtree, so unlike a
+// tail op it leaves the commit no other carrier for that array. It may therefore
+// be emitted only when it fully explains the local value: the working array must
+// be exactly the base with the removed values taken out. Anything else the
+// transaction changed on that array would otherwise be silently discarded.
+describe("mergeable remove-by-value build guards", () => {
+  const removeIntent = (...values: string[]) =>
+    ({ op: "remove-by-value", path: ["value"], values }) as const;
+
+  const ctx = (
+    workingArray: FabricValue[] | undefined,
+    initialArray?: FabricValue[],
+  ) => ({
+    workingArray,
+    hadInitialArray: initialArray !== undefined,
+    hadInitialValue: initialArray !== undefined,
+    initialArray,
+  });
+
+  it("emits one wire op per removed value and suppresses the subtree", () => {
+    expect(
+      buildMergeableIntent(removeIntent("a", "c"), ctx(["b"], ["a", "b", "c"])),
+    ).toEqual({
+      ops: [
+        { op: "remove-by-value", path: "/value", value: "a" },
+        { op: "remove-by-value", path: "/value", value: "c" },
+      ],
+      suppress: [{ path: ["value"], subtree: true }],
+    });
+  });
+
+  // Every occurrence of a removed value goes, matching how the store applies the
+  // wire op — so a base holding duplicates still lines up with the local value
+  // and keeps its op.
+  it("accounts for every occurrence of a removed value", () => {
+    expect(
+      buildMergeableIntent(removeIntent("a"), ctx(["b"], ["a", "b", "a"])).ops
+        .length,
+    ).toBe(1);
+  });
+
+  // An element edit alongside the removal: the working array is the base minus
+  // "c" but with index 0 rewritten, which the removals alone cannot produce.
+  it("abandons the intent when the working array holds an edited element", () => {
+    expect(
+      buildMergeableIntent(removeIntent("c"), ctx(["A", "b"], ["a", "b", "c"])),
+    ).toEqual({ ops: [], suppress: [], abandon: true });
+  });
+
+  // A whole-array set alongside the removal: neither the surviving element nor
+  // the disappearance of the base's members is expressed by the removals.
+  it("abandons the intent when the array was replaced wholesale", () => {
+    expect(
+      buildMergeableIntent(removeIntent("p"), ctx(["q"], ["a", "b", "c"])),
+    ).toEqual({ ops: [], suppress: [], abandon: true });
+  });
+
+  // Hole layout is part of "explains the local value": the base's hole at index
+  // 1 was filled, which the removals do not express and no surviving candidate
+  // carries. `valueEqual` compares by canonical content hash, which keeps a hole
+  // distinct from a value (and from a stored `undefined`) rather than flattening
+  // the distinction the way a length check would.
+  it("abandons the intent when a hole in the base was filled", () => {
+    const base: FabricValue[] = ["a", , "c"] as FabricValue[];
+    expect(
+      buildMergeableIntent(removeIntent("c"), ctx(["a", "b"], base)),
+    ).toEqual({ ops: [], suppress: [], abandon: true });
+  });
+
+  // No base array to check against — the transaction materialized the array
+  // itself — so the op cannot be shown to explain the local value, and its
+  // subtree suppression would drop the creation entirely.
+  it("abandons the intent when there was no base array", () => {
+    expect(
+      buildMergeableIntent(removeIntent("p"), ctx(["q"])),
+    ).toEqual({ ops: [], suppress: [], abandon: true });
+  });
+
+  // The op path holds no array at commit (overwritten with a scalar, or gone),
+  // so there is no local value for the removals to describe.
+  it("abandons the intent when there is no working array", () => {
+    expect(
+      buildMergeableIntent(removeIntent("a"), ctx(undefined, ["a", "b"])),
+    ).toEqual({ ops: [], suppress: [], abandon: true });
+  });
+});


### PR DESCRIPTION
Sibling of #5216, same family: a mergeable op's diff-suppression silently discarded whatever else the transaction changed on that array.

## The bug

`removeByValue` suppresses `subtree: true` — the array path and everything under it — so unlike a tail op it leaves the commit *nothing* to carry that array, not even the per-index candidates. It made that stronger claim with no commit-time check that it held, so every diff candidate for the array was dropped and only the removals were sent.

Measured from a durable `["a","b","c"]`, asserting from a fresh session:

| Handler | Local value | Durable value |
| --- | --- | --- |
| `key(0).set("A")` then `removeByValue("c")` | `["A","b"]` | `["a","b"]` — edit lost |
| `removeByValue("c")` then `key(0).set("A")` | `["A","b"]` | `["a","b"]` — edit lost |
| `set(["p","q"])` then `removeByValue("p")` | `["q"]` | `["a","b","c"]` — whole `set` lost |

The first is the ordinary "edit one row and delete another in the same handler" shape.

Neither is caught earlier. `poisonMergeableOp` fires at the moment of a write, so it only sees a reshape landing *after* an op at *exactly* the op's path. An element edit writes *beneath* the array and is deliberately left alone — that is what lets an edit compose with a `push` — and a `set` landing before the removal has no intent to poison yet.

## The fix

`buildRemoveByValue` applies the recorded removals to the base array — every occurrence of each value, mirroring the store's `removeByValueAtPath` — and requires the result to equal the working array. Otherwise it abandons the intent, so `buildMergeableOps` deletes and poisons the path and the whole-array diff commits the local value.

The comparison is `valueEqual`, so hole layout counts alongside length and element values. A length-only check would pass the element-edit case above.

No base array (the transaction created it) also abandons: nothing to validate against, and the subtree suppression would otherwise drop the creation whole, writing nothing at all.

A removal that is the transaction's only change to the array — including alongside a write to a *sibling* field — reproduces the working array exactly and keeps its op, so concurrent removals of distinct entries still merge.

## Tests

Six durable tests in `array-push-mergeable.test.ts`, asserted through the existing `readDurable` helper: the writer's own optimistic value is *correct* in this bug, so `cell.get()` proves nothing. Plus a "stays mergeable alongside a sibling-field write" guard so the fix cannot be read as killing the merge, and seven builder-level guards in `mergeable-op-registry.test.ts`.

All six durable tests confirmed red before the fix. Mutation-tested — four mutations, each redding only its own guard:

| Mutation | Reds |
| --- | --- |
| Drop the check entirely | all 6 durable + 5 abandon guards |
| Compare lengths, not values | both element-edit tests + the edited-element and hole-fill guards |
| Remove one occurrence per value | the every-occurrence guard only |
| Use the working array as base | the create-and-remove test + the no-base guard |

## Docs

`removeByValue` leaves **Known gaps** in `mergeable-collection-writes.md` (the nested-array shape remains, and is still documented as an open gap), replaced by a bullet describing the check. Pointers updated in `patch-operations.md` and `keyed-collection-writes.md`.

## Verification

`packages/runner` 1103 passed / 0 failed; `packages/memory` 456 passed / 0 failed; repo-wide `deno fmt --check` and `deno lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes silent data loss when `removeByValue` suppresses an array subtree and drops other changes to the same array. The builder now validates that removals fully explain the local array and falls back to a whole-array diff when they do not.

- **Bug Fixes**
  - Added commit-time validation in `buildRemoveByValue`: apply recorded removals to the base array and compare to the working array with `valueEqual` from `@commonfabric/data-model/fabric-value`; if mismatched or no base exists, abandon the op and poison the path so the whole-array diff commits the local value.
  - Keeps removal mergeable when it’s the only change to that array; sibling-field edits compose; concurrent removals of distinct entries still merge.
  - Updated docs to describe the check and narrow “Known gaps”; added durable and builder tests for element edits, whole-array sets, parent writes, creation+removal, duplicates, and hole layout.

<sup>Written for commit ca32d8c963547281110c8e68e7cf14b04508ee4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

