### PR TITLE
refactor(piece): drop the narrow read's hand-rolled asCell traversal

### DIFF
--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -4,7 +4,6 @@ import { caseFold } from "unicode-case-folding";
 import { loadIdentity } from "./identity.ts";
 import {
   Cell,
-  cellAtPath,
   entityIdFrom,
   experimentalOptionsFromEnv,
   formatFabricRef,
@@ -2194,7 +2193,7 @@ export async function getCellValue(
       await piece.getCell().pull();
       const rootCell =
         await (options.input ? piece.input.getCell() : piece.result.getCell());
-      const targetCell = cellAtPath(rootCell, path);
+      const targetCell = rootCell.key(...path);
       await targetCell.pull();
       await manager.synced();
       await manager.runtime.idle();

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -1,7 +1,6 @@
 import {
   applyPieceSourceTransition,
   Cell,
-  cellAtPath,
   type CellPath,
   cellWithScopedLinkRequiredsRelaxed,
   ContextualFlowControl,
@@ -35,8 +34,7 @@ import {
   sanitizeSchemaForLinks,
   schemaAcceptsOpaqueCellValue,
 } from "@commonfabric/runner";
-import type { CellKind, JSONSchemaObj, LinkScope } from "@commonfabric/api";
-import { SchemaObjectTraverser } from "@commonfabric/runner/traverse";
+import type { CellKind, LinkScope } from "@commonfabric/api";
 import {
   cfcSchemaChildRoot,
   resolveCfcSchemaRefRoot,
@@ -798,34 +796,6 @@ export function consumeOuterCellContract(
     payloadSchema: entries.length === 1
       ? payloadSchema
       : { ...payloadSchema, asCell: entries.slice(1) },
-  };
-}
-
-function schemaHasAsCell(
-  schema: JSONSchema | undefined,
-): schema is JSONSchemaObj {
-  return SchemaObjectTraverser.hasAsCell(schema);
-}
-
-/**
- * Consume one uniform asCell layer, including across anyOf/oneOf branches.
- * This is the compound-schema counterpart to runner/schema.ts's filterAsCell;
- * keep their top-level wrapper semantics aligned.
- */
-function consumeAsCellProjectionSchema(schema: JSONSchemaObj): JSONSchema {
-  if (ContextualFlowControl.getAsCellValues(schema).length > 0) {
-    return consumeOuterCellContract(schema).payloadSchema;
-  }
-  const anyOf = schema.anyOf?.every(schemaHasAsCell)
-    ? schema.anyOf.map(consumeAsCellProjectionSchema)
-    : schema.anyOf;
-  const oneOf = schema.oneOf?.every(schemaHasAsCell)
-    ? schema.oneOf.map(consumeAsCellProjectionSchema)
-    : schema.oneOf;
-  return {
-    ...schema,
-    ...(anyOf !== undefined && { anyOf }),
-    ...(oneOf !== undefined && { oneOf }),
   };
 }
 
@@ -2290,51 +2260,33 @@ class PiecePropIo implements PieceCellIo {
     // started by pull() sends its path plus narrowed schema to Memory v2, so
     // this avoids traversing unrelated linked fields (an input can contain a
     // broad authoring graph even when the caller asks for one small durable
-    // field). Traverse one segment at a time so an intermediate asCell value
-    // can re-root the remaining path, matching resolveCellPath.
-    return await this.#getAtPath(targetCell, targetCell, path, 0);
-  }
-
-  async #getAtPath(
-    targetCell: Cell<unknown>,
-    parentCell: Cell<unknown>,
-    path: CellPath,
-    index: number,
-  ): Promise<unknown> {
-    const selectedCell = cellAtPath(parentCell, [path[index]]);
-    const isLast = index === path.length - 1;
-    const selectedSchema = selectedCell.schema;
-    const isAsCellProjection = schemaHasAsCell(selectedSchema);
-    // Ordinary inline ancestors need no read: extending their schema/path
-    // keeps the final query as narrow as possible. An asCell ancestor must
-    // be materialized so the rest of the path can move to its handle.
-    if (!isLast && !isAsCellProjection) {
-      return await this.#getAtPath(targetCell, selectedCell, path, index + 1);
-    }
-
+    // field). No per-segment asCell handling is needed: key() walks the schema
+    // (so an asCell ancestor's `properties` keep narrowing the query) and link
+    // resolution follows the stored link at that segment during the read. Only
+    // a TERMINAL asCell needs unwrapping, because that is the one place the
+    // projection hands back a handle instead of a value.
+    const selectedCell = targetCell.key(...path);
     await selectedCell.pull();
-    if (isAsCellProjection) {
-      // An asCell projection materializes even an explicit `undefined` as
-      // a Cell, so inspect the stored slot before resolving the handle.
-      // Falling back preserves the root read's absent-vs-undefined rules.
+    // Relax `required` for scoped links that this session cannot materialize,
+    // at the selected subtree rather than the root — same boundary as
+    // #getFromRoot, see schemaWithScopedLinkRequiredsRelaxed.
+    const selected = cellWithScopedLinkRequiredsRelaxed(selectedCell).get();
+    if (isCell(selected)) {
+      // An asCell projection materializes even an absent or explicitly
+      // undefined slot as a Cell, so inspect the stored slot before reading
+      // through the handle. Falling back preserves the root read's
+      // absent-vs-undefined rules and its missing-path diagnostics.
       if (selectedCell.getRaw() === undefined) {
         return await this.#getFromRoot(targetCell, path);
       }
-      const handle = selectedCell.resolveAsCell().asSchema(
-        consumeAsCellProjectionSchema(selectedSchema),
-      );
-      if (isLast) {
-        const readableHandle = cellWithScopedLinkRequiredsRelaxed(handle);
-        await readableHandle.pull();
-        return readableHandle.get();
-      }
-      return await this.#getAtPath(targetCell, handle, path, index + 1);
+      const handle = cellWithScopedLinkRequiredsRelaxed(selected);
+      await handle.pull();
+      return handle.get();
     }
-    const selected = cellWithScopedLinkRequiredsRelaxed(selectedCell).get();
     if (selected === undefined) {
       return await this.#getFromRoot(targetCell, path);
     }
-    return isCell(selected) ? await selected.pull() : selected;
+    return selected;
   }
 
   async #getFromRoot(targetCell: Cell<unknown>, path: CellPath) {
@@ -2382,7 +2334,7 @@ class PiecePropIo implements PieceCellIo {
       committedTargetCell = targetCell;
 
       // Build the path with transaction context
-      const txCell = cellAtPath(targetCell.withTx(tx), path ?? []);
+      const txCell = targetCell.withTx(tx).key(...(path ?? []));
 
       const writePath = path ?? [];
       const writeTargetDiffers = (

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -34,7 +34,8 @@ import {
   sanitizeSchemaForLinks,
   schemaAcceptsOpaqueCellValue,
 } from "@commonfabric/runner";
-import type { CellKind, LinkScope } from "@commonfabric/api";
+import type { CellKind, JSONSchemaObj, LinkScope } from "@commonfabric/api";
+import { SchemaObjectTraverser } from "@commonfabric/runner/traverse";
 import {
   cfcSchemaChildRoot,
   resolveCfcSchemaRefRoot,
@@ -796,6 +797,34 @@ export function consumeOuterCellContract(
     payloadSchema: entries.length === 1
       ? payloadSchema
       : { ...payloadSchema, asCell: entries.slice(1) },
+  };
+}
+
+function schemaHasAsCell(
+  schema: JSONSchema | undefined,
+): schema is JSONSchemaObj {
+  return SchemaObjectTraverser.hasAsCell(schema);
+}
+
+/**
+ * Consume one uniform asCell layer, including across anyOf/oneOf branches.
+ * This is the compound-schema counterpart to runner/schema.ts's filterAsCell;
+ * keep their top-level wrapper semantics aligned.
+ */
+function consumeAsCellProjectionSchema(schema: JSONSchemaObj): JSONSchema {
+  if (ContextualFlowControl.getAsCellValues(schema).length > 0) {
+    return consumeOuterCellContract(schema).payloadSchema;
+  }
+  const anyOf = schema.anyOf?.every(schemaHasAsCell)
+    ? schema.anyOf.map(consumeAsCellProjectionSchema)
+    : schema.anyOf;
+  const oneOf = schema.oneOf?.every(schemaHasAsCell)
+    ? schema.oneOf.map(consumeAsCellProjectionSchema)
+    : schema.oneOf;
+  return {
+    ...schema,
+    ...(anyOf !== undefined && { anyOf }),
+    ...(oneOf !== undefined && { oneOf }),
   };
 }
 
@@ -2260,33 +2289,41 @@ class PiecePropIo implements PieceCellIo {
     // started by pull() sends its path plus narrowed schema to Memory v2, so
     // this avoids traversing unrelated linked fields (an input can contain a
     // broad authoring graph even when the caller asks for one small durable
-    // field). No per-segment asCell handling is needed: key() walks the schema
-    // (so an asCell ancestor's `properties` keep narrowing the query) and link
-    // resolution follows the stored link at that segment during the read. Only
-    // a TERMINAL asCell needs unwrapping, because that is the one place the
-    // projection hands back a handle instead of a value.
+    // field). No per-segment asCell handling is needed on the way down: key()
+    // walks the schema (so an asCell ancestor's `properties` keep narrowing the
+    // query) and link resolution follows the stored link at that segment during
+    // the read. A TERMINAL asCell still needs unwrapping, because that is the
+    // one place the projection hands back a handle instead of a value.
     const selectedCell = targetCell.key(...path);
     await selectedCell.pull();
+    const selectedSchema = selectedCell.schema;
+    if (schemaHasAsCell(selectedSchema)) {
+      // An asCell projection materializes even an absent or explicitly
+      // undefined slot as a Cell, so inspect the stored slot before resolving
+      // the handle. Falling back preserves the root read's absent-vs-undefined
+      // rules and its missing-path diagnostics.
+      if (selectedCell.getRaw() === undefined) {
+        return await this.#getFromRoot(targetCell, path);
+      }
+      // resolveAsCell() applies the asCell descriptor's scope cap. The Cell the
+      // projection hands back from get() does NOT, and neither does a key()
+      // chain that continues past the handle — see #5230. Route through
+      // resolveAsCell() so a capped handle stays capped at this boundary.
+      const handle = selectedCell.resolveAsCell().asSchema(
+        consumeAsCellProjectionSchema(selectedSchema),
+      );
+      const readableHandle = cellWithScopedLinkRequiredsRelaxed(handle);
+      await readableHandle.pull();
+      return readableHandle.get();
+    }
     // Relax `required` for scoped links that this session cannot materialize,
     // at the selected subtree rather than the root — same boundary as
     // #getFromRoot, see schemaWithScopedLinkRequiredsRelaxed.
     const selected = cellWithScopedLinkRequiredsRelaxed(selectedCell).get();
-    if (isCell(selected)) {
-      // An asCell projection materializes even an absent or explicitly
-      // undefined slot as a Cell, so inspect the stored slot before reading
-      // through the handle. Falling back preserves the root read's
-      // absent-vs-undefined rules and its missing-path diagnostics.
-      if (selectedCell.getRaw() === undefined) {
-        return await this.#getFromRoot(targetCell, path);
-      }
-      const handle = cellWithScopedLinkRequiredsRelaxed(selected);
-      await handle.pull();
-      return handle.get();
-    }
     if (selected === undefined) {
       return await this.#getFromRoot(targetCell, path);
     }
-    return selected;
+    return isCell(selected) ? await selected.pull() : selected;
   }
 
   async #getFromRoot(targetCell: Cell<unknown>, path: CellPath) {

--- a/packages/piece/test/pull-materialization.test.ts
+++ b/packages/piece/test/pull-materialization.test.ts
@@ -7266,4 +7266,98 @@ describe("piece cold-replica slot read (two replicas, one server)", () => {
       await readerStorage.close();
     }
   });
+
+  // The narrow read reaches a path below an asCell slot with a plain `key()`
+  // chain, letting link resolution follow the handle mid-path rather than
+  // dereferencing it by hand. This pins the two properties that choice has to
+  // keep: the terminal handle still applies the scoped-link relaxation (so a
+  // scoped child voids only itself, not its whole object), and a path THROUGH
+  // the handle still lands on the right document.
+  it("relaxes a scoped link below an asCell handle, at and through it", async () => {
+    const sectionSchema = {
+      type: "object",
+      properties: {
+        label: { type: "string" },
+        inner: {
+          type: "object",
+          properties: {
+            plain: { type: "string" },
+            scoped: { type: "string" },
+          },
+          required: ["plain", "scoped"],
+        },
+      },
+      required: ["label"],
+    } as const satisfies JSONSchema;
+    const tx = writerRuntime.edit();
+    const scoped = writerRuntime.getCell<string>(
+      writerManager.getSpace(),
+      "handle-scoped-" + crypto.randomUUID(),
+      { type: "string" },
+      tx,
+      "session",
+    );
+    scoped.set("writer-only");
+    const section = writerRuntime.getCell(
+      writerManager.getSpace(),
+      "handle-section-" + crypto.randomUUID(),
+      sectionSchema,
+      tx,
+    );
+    section.set({
+      label: "hello",
+      inner: { plain: "visible", scoped },
+    } as never);
+    const commit = await tx.commit();
+    expect(commit.error).toBeUndefined();
+
+    const piece = await writerManager.runPersistent(
+      trustPattern(writerRuntime, {
+        argumentSchema: {
+          type: "object",
+          properties: { handle: { ...sectionSchema, asCell: ["cell"] } },
+          required: ["handle"],
+        },
+        resultSchema: { type: "object", properties: {} },
+        result: {},
+        nodes: [],
+      }),
+      { handle: section },
+      undefined,
+      { start: true },
+    );
+    await writerManager.synced();
+
+    const readerStorage = SharedServerStorageManager.connectTo(server, {
+      as: signer,
+    });
+    const readerRuntime = new Runtime({
+      apiUrl: new URL("http://localhost:9999"),
+      storageManager: readerStorage,
+    });
+    const readerSession = await createSession({ identity: signer, spaceName });
+    const readerManager = new PieceManager(readerSession, readerRuntime);
+    try {
+      await readerManager.synced();
+      const readerPieces = new PiecesController(readerManager);
+      const readerPiece = await readerPieces.get(
+        entityRefToString(piece.entityId),
+        false,
+      );
+
+      // Terminal asCell: the handle is unwrapped and read through the same
+      // relaxation the root read uses, so `inner` survives without `scoped`.
+      expect(await readerPiece.input.get(["handle"])).toEqual({
+        label: "hello",
+        inner: { plain: "visible" },
+      });
+      // Through the asCell: link resolution follows the handle mid-path.
+      expect(await readerPiece.input.get(["handle", "label"])).toBe("hello");
+      expect(await readerPiece.input.get(["handle", "inner", "plain"]))
+        .toBe("visible");
+    } finally {
+      await readerRuntime.dispose();
+      await readerStorage.close();
+    }
+  });
 });

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -253,7 +253,6 @@ export { schemaToTypeString } from "./schema-format.ts";
 export type { SchemaFormatOptions } from "./schema-format.ts";
 export { ACLManager } from "./acl-manager.ts";
 export {
-  cellAtPath,
   cellEntityIdString,
   type CellPath,
   cellWithScopedLinkRequiredsRelaxed,

--- a/packages/runner/src/piece-helpers.ts
+++ b/packages/runner/src/piece-helpers.ts
@@ -34,20 +34,6 @@ export function parseCellPath(path: string): CellPath {
   });
 }
 
-/** Return the Cell view at `path` without reading or dereferencing it. */
-export function cellAtPath<T>(
-  cell: Cell<T>,
-  path: CellPath,
-): Cell<unknown> {
-  let currentCell = cell as Cell<unknown>;
-  for (const segment of path) {
-    currentCell = currentCell.key(
-      segment as keyof unknown,
-    ) as Cell<unknown>;
-  }
-  return currentCell;
-}
-
 export function resolveCellPath<T>(
   cell: Cell<T>,
   path: CellPath,


### PR DESCRIPTION
## Why

Follow-up to #5222, addressing the two review comments left on it after it landed.

#5222's actual fix is 25 lines and carries the entire win it measured (`comments --input` 89.1s → 15.4s). The other seven commits were review response, and two cubic P2s in that stream asked for a per-segment traversal that dereferences an intermediate `asCell` by hand and consumes `anyOf`/`oneOf` asCell wrappers. That machinery is not needed:

- `Cell.key()` walks the schema, so an `asCell` ancestor's `properties` keep narrowing the query, and `resolveLink` follows the stored link at that segment during the read.
- Only a **terminal** `asCell` hands back a handle instead of a value — that is the one case that needs unwrapping, and #5222's first commit already did it in two lines.

Evidence: reverting `#getAtPath` to a plain `key(...path)` chain leaves all 368 piece steps green, **including the two tests #5222 added to prove the traversal** — `re-roots a narrow path through an intermediate asCell` and `re-roots through compound intermediate asCell schemas`. Nothing in the suite distinguishes the hand-rolled version from link resolution doing its job.

Bisecting the same way isolates the review feedback that *was* load-bearing. Against #5222's first commit exactly three tests fail:

- `a fresh replica preserves visible nested input beside a scoped link` — the scoped-link relaxation at the narrow cell
- `preserves missing-path diagnostics for an absent asCell slot`
- `preserves explicit undefined for an asCell slot` — the `getRaw() === undefined` pre-check

Both fixes are kept here, in six lines instead of a recursive method plus two schema helpers.

`cellAtPath` goes too. `Cell.key(...keys)` has always been variadic, so the helper was a new exported symbol on `@commonfabric/runner` that did nothing `key()` did not — verified identical link, schema, and value, including through an `asCell` ancestor.

## What changed

- `PiecePropIo.get` — `#getAtPath` recursion collapses to one `key(...path)` chain, `pull`, terminal-handle unwrap, root fallback.
- The terminal `asCell` branch is unchanged from #5222 and still routes through `resolveAsCell()`. It has to: `resolveAsCell()` applies the `asCell` descriptor's scope cap and the Cell returned by the value projection does not, so reading the handle off the projection leaks a capped value. `schemaHasAsCell` and `consumeAsCellProjectionSchema` stay for that branch.
- Deleted `cellAtPath` and its `packages/runner/src/index.ts` export; the two call sites use `key(...path)`.
- **New test** — `relaxes a scoped link below an asCell handle, at and through it`. This closes the one gap the simplification opens: letting link resolution follow the handle mid-path means the asCell entry's scope follow-cap is no longer applied by hand. The test reads a session-scoped link nested under an `asCell` handle from a genuine second replica, at the handle and through it.

No test from #5222 was deleted or weakened. Net −40 lines of source, +94 of test.

## Scope caps

Codex flagged that dropping the traversal would let `input.get(["handle","field"])` return a value the schema blocks. Measured against merged #5222 (`b68db3b35`), that read returns the capped value **on `main` too** — the path-through case was never capped, so it is not a regression here. The traversal only ran when a segment's own schema carried the `asCell`, by which point `key()` had already dropped the cap.

It did surface a real one: an earlier revision of this PR read the terminal handle off the value projection and so leaked the capped `["handle"]` case that `main` blocks. Fixed in `35581f014`; a probe now matches `main` on all three read shapes (pathless root, at-handle, through-handle).

The inconsistency underneath is filed as **#5230** — `key()` past an `asCell` drops the descriptor, and the value projection never consults the cap, so three routes to the same handle give two answers. That is a runner-level property affecting every `key()` user across an `asCell` boundary, so it is deliberately not point-fixed here; this PR stays behavior-identical to `main`.

## Test plan

- `deno fmt` / `deno lint` / `deno check` on all changed files — clean
- `packages/piece` — 31 tests / **369** steps (was 368; the new test is the +1)
- `packages/runner` — `scoped-link-whole-object-read`, `cell-as-cell`, `cell-core`, `cell-links`, `ascell-link-read-through-conflict` — 14 tests / 139 steps
- `packages/cli` — `piece-cell-operations`, `piece`, `piece-verbs`, `piece-integration` — 72 steps
- `packages/fuse` — `cell-bridge` — 87 tests (FUSE is the other caller that reads with a path: `result.get(["$FS"])`, `result.get(["$FS","content"])`)
- **Fix-revert check on the new test**: dropping `cellWithScopedLinkRequiredsRelaxed` from the terminal handle makes it fail; restoring it makes it pass. The narrow-read behavior is not restated by any other test, which is how #5222's asCell traversal shipped unfalsified in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies narrow piece path reads by dropping the hand-rolled asCell traversal and using `Cell.key(...path)`. Terminal asCell reads now go through `resolveAsCell()` so scope caps apply, while keeping scoped-link relaxation and root fallback; adds a test covering reads at and through the handle.

- **Refactors**
  - Use `key(...path)` in `PiecePropIo.get`; unwrap terminal asCell via `resolveAsCell()` + `cellWithScopedLinkRequiredsRelaxed`.
  - Remove `cellAtPath` and its export from `@commonfabric/runner`; update CLI and write path code to use `key(...path)`.

- **Bug Fixes**
  - Preserve root fallback and missing-path diagnostics for absent or explicitly `undefined` asCell slots.
  - Enforce asCell scope cap on terminal handle reads; relax scoped-link requireds at that boundary.
  - New test verifies relaxing a scoped link below an asCell handle and reading both at and through it across replicas.

<sup>Written for commit 35581f014a933b41fa3d66ba97b26abe6f025171. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


