### PR TITLE
fix(runner): make the asCell scope cap mean the same thing on every route

### DIFF
--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -1931,10 +1931,25 @@ export class CellImpl<T extends FabricValue>
       // scope during writes. Stamping schema scope onto this link here would
       // re-address the value to the wrong scoped instance of the container doc
       // (see CT-1623).
+      const path = [...currentLink.path, key.toString()] as string[];
+      // Remember a follow cap declared at this segment. `schema` below is
+      // replaced by the child's, so a cap on an `asCell` ancestor would
+      // otherwise vanish as soon as the path continues past it, leaving
+      // resolveLink unable to check the hop it later finds there (#5230).
+      // Recording it costs nothing on the overwhelmingly common uncapped path.
+      const cap = ContextualFlowControl.getSchemaScopeCap(childSchema);
+      const scopeCaps = cap === undefined
+        ? currentLink.scopeCaps
+        : [...(currentLink.scopeCaps ?? []), {
+          depth: path.length,
+          scope: cap,
+        }];
+
       currentLink = {
         ...currentLink,
-        path: [...currentLink.path, key.toString()] as string[],
+        path,
         schema: childSchema,
+        ...(scopeCaps !== undefined && { scopeCaps }),
       };
     }
 

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -126,7 +126,7 @@ import {
   parseLink,
   toMemorySpaceAddress,
 } from "./link-utils.ts";
-import { isCellScope, normalizeCellScope } from "./scope.ts";
+import { isCellScope, narrowerScopeCap, normalizeCellScope } from "./scope.ts";
 import type {
   ChangeGroup,
   IExtendedStorageTransaction,
@@ -1923,8 +1923,18 @@ export class CellImpl<T extends FabricValue>
     const recordCap = (depth: number, schema: JSONSchema | undefined) => {
       const cap = ContextualFlowControl.getSchemaScopeCap(schema);
       if (cap === undefined) return;
-      // A repeated key() over the same prefix re-derives the same caps.
-      if (scopeCaps?.some((entry) => entry.depth === depth)) return;
+      // A repeated key() over the same prefix re-derives the same depth, and
+      // asSchema() can re-declare one with a DIFFERENT cap. Keep the narrower:
+      // skipping on depth alone would let a looser recorded cap shadow a
+      // tighter one the caller just asked for.
+      const existing = scopeCaps?.find((entry) => entry.depth === depth);
+      if (existing !== undefined) {
+        if (narrowerScopeCap(cap, existing.scope) === existing.scope) return;
+        scopeCaps = scopeCaps!.map((entry) =>
+          entry.depth === depth ? { depth, scope: cap } : entry
+        );
+        return;
+      }
       scopeCaps = [...(scopeCaps ?? []), { depth, scope: cap }];
     };
     // Seed with the cap declared at the address we start from: it governs a

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -1921,7 +1921,13 @@ export class CellImpl<T extends FabricValue>
     // continues past it (#5230). Costs nothing on the uncapped path.
     let scopeCaps = currentLink.scopeCaps;
     const recordCap = (depth: number, schema: JSONSchema | undefined) => {
-      const cap = ContextualFlowControl.getSchemaScopeCap(schema);
+      // getSchemaScopeCap is the long-standing path-resolution precedence;
+      // the compound lookup adds anyOf/oneOf-wrapped asCell caps it cannot
+      // see. Taking the narrower is additive: it can only tighten.
+      const cap = narrowerScopeCap(
+        ContextualFlowControl.getSchemaScopeCap(schema),
+        ContextualFlowControl.getAsCellFollowScopeCap(schema),
+      );
       if (cap === undefined) return;
       // A repeated key() over the same prefix re-derives the same depth, and
       // asSchema() can re-declare one with a DIFFERENT cap. Keep the narrower:

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -1915,6 +1915,23 @@ export class CellImpl<T extends FabricValue>
     let childSchema: JSONSchema | undefined;
     const childPath = keys.map((key) => key.toString());
 
+    // Follow caps this walk narrows past, so resolveLink can still check a hop
+    // it later finds at an ancestor. `schema` only ever describes the leaf, so
+    // a cap on an `asCell` ancestor otherwise vanishes the moment the path
+    // continues past it (#5230). Costs nothing on the uncapped path.
+    let scopeCaps = currentLink.scopeCaps;
+    const recordCap = (depth: number, schema: JSONSchema | undefined) => {
+      const cap = ContextualFlowControl.getSchemaScopeCap(schema);
+      if (cap === undefined) return;
+      // A repeated key() over the same prefix re-derives the same caps.
+      if (scopeCaps?.some((entry) => entry.depth === depth)) return;
+      scopeCaps = [...(scopeCaps ?? []), { depth, scope: cap }];
+    };
+    // Seed with the cap declared at the address we start from: it governs a
+    // link stored AT this address, which the first appended segment already
+    // puts beyond the reach of the leaf schema.
+    if (keys.length > 0) recordCap(currentLink.path.length, currentLink.schema);
+
     for (const key of keys) {
       // Get child schema if we have one
       childSchema = currentLink.schema
@@ -1932,18 +1949,7 @@ export class CellImpl<T extends FabricValue>
       // re-address the value to the wrong scoped instance of the container doc
       // (see CT-1623).
       const path = [...currentLink.path, key.toString()] as string[];
-      // Remember a follow cap declared at this segment. `schema` below is
-      // replaced by the child's, so a cap on an `asCell` ancestor would
-      // otherwise vanish as soon as the path continues past it, leaving
-      // resolveLink unable to check the hop it later finds there (#5230).
-      // Recording it costs nothing on the overwhelmingly common uncapped path.
-      const cap = ContextualFlowControl.getSchemaScopeCap(childSchema);
-      const scopeCaps = cap === undefined
-        ? currentLink.scopeCaps
-        : [...(currentLink.scopeCaps ?? []), {
-          depth: path.length,
-          scope: cap,
-        }];
+      recordCap(path.length, childSchema);
 
       currentLink = {
         ...currentLink,

--- a/packages/runner/src/cfc.ts
+++ b/packages/runner/src/cfc.ts
@@ -9,7 +9,7 @@ import type {
   JSONSchema,
   SchemaScope,
 } from "./builder/types.ts";
-import { isSchemaScope } from "./scope.ts";
+import { isSchemaScope, narrowerScopeCap } from "./scope.ts";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { uniqueCfcAtoms } from "./cfc/observation.ts";
 import {
@@ -780,5 +780,42 @@ export class ContextualFlowControl {
     if (isSchemaScope(entryScope)) return entryScope;
     if (isSchemaScope(schema.scope)) return schema.scope;
     return undefined;
+  }
+
+  /**
+   * The follow cap declared by an `asCell` ENTRY, looking through `anyOf` /
+   * `oneOf` wrappers.
+   *
+   * Two differences from {@link getSchemaScopeCap}, both deliberate:
+   *
+   * - No `schema.scope` fallback. Authors write `scope` on a node to say "this
+   *   value lives at that scope"; reading it as a follow cap at a handle
+   *   boundary invents a restriction nobody asked for.
+   * - It descends into `anyOf`/`oneOf`. A cap wrapped in a compound schema —
+   *   `{anyOf: [{...asCell: [{kind:"cell", scope:"space"}]}, {type:"null"}]}`
+   *   — is a real shape here, and reading only the top level made it a
+   *   one-line cap bypass. Branches that declare no `asCell` at all (a `null`
+   *   alternative) are not handles and are skipped; among those that do, the
+   *   NARROWEST wins, since the runtime value may be any of them.
+   */
+  static getAsCellFollowScopeCap(
+    schema: JSONSchema | undefined,
+  ): SchemaScope | undefined {
+    if (!isRecord(schema)) return undefined;
+    const entryScope = ContextualFlowControl.getAsCellScope(
+      ContextualFlowControl.getAsCellValues(schema).at(0),
+    );
+    if (isSchemaScope(entryScope)) return entryScope;
+    let cap: SchemaScope | undefined;
+    for (const branches of [schema.anyOf, schema.oneOf]) {
+      if (!Array.isArray(branches)) continue;
+      for (const branch of branches) {
+        const branchCap = ContextualFlowControl.getAsCellFollowScopeCap(
+          branch as JSONSchema,
+        );
+        cap = narrowerScopeCap(cap, branchCap);
+      }
+    }
+    return cap;
   }
 }

--- a/packages/runner/src/link-resolution.ts
+++ b/packages/runner/src/link-resolution.ts
@@ -11,6 +11,7 @@ import {
   type CellLink,
   type NormalizedFullLink,
   parseLink,
+  type ScopeCapAtDepth,
   toMemorySpaceAddress,
 } from "./link-utils.ts";
 import type {
@@ -21,7 +22,7 @@ import { linkResolutionProbe } from "./storage/reactivity-log.ts";
 import { ContextualFlowControl } from "./cfc.ts";
 import type { Runtime } from "./runtime.ts";
 import type { CfcAddress } from "./cfc/types.ts";
-import { canFollowScopedLink, scopeRank } from "./scope.ts";
+import { canFollowScopedLink, narrowerScopeCap } from "./scope.ts";
 import type { SchemaScope } from "./builder/types.ts";
 
 const logger = getLogger("link-resolution");
@@ -94,16 +95,25 @@ const recordDereferenceHop = (
 // recorded caps at all. Keeping it as a floor means this change can only block
 // more than before, never less.
 //
-// NOTE: no test reaches this floor — every shape tried either records a cap or
-// fails to resolve for unrelated reasons. It is here as a conservatism, not as
-// behavior anything depends on, so treat it as unproven rather than pinned.
-const narrowerCap = (
-  a: SchemaScope | undefined,
-  b: SchemaScope | undefined,
-): SchemaScope | undefined => {
-  if (a === undefined || a === "any") return b;
-  if (b === undefined || b === "any") return a;
-  return scopeRank(a) <= scopeRank(b) ? a : b;
+// This floor is load-bearing, not just belt-and-braces: a link assembled
+// directly (`runtime.getCellFromLink` with a multi-segment path) has no
+// recorded caps at all, and removing the floor lets such a read follow a
+// narrower link that main blocks. Pinned by a test.
+/**
+ * Shift recorded caps onto a link's target after a hop consumed `consumed`
+ * leading segments. Caps at or below the hop are dropped (already enforced);
+ * the rest move by `shift` so their depths still address the same segments.
+ */
+const rebaseScopeCaps = (
+  caps: readonly ScopeCapAtDepth[] | undefined,
+  consumed: number,
+  shift: number,
+): readonly ScopeCapAtDepth[] | undefined => {
+  if (caps === undefined) return undefined;
+  const moved = caps
+    .filter((cap) => cap.depth > consumed)
+    .map((cap) => ({ depth: cap.depth + shift, scope: cap.scope }));
+  return moved.length > 0 ? moved : undefined;
 };
 
 const schemaScopeForLinkAtDepth = (
@@ -112,7 +122,7 @@ const schemaScopeForLinkAtDepth = (
 ): SchemaScope | undefined => {
   const leafCap = ContextualFlowControl.getSchemaScopeCap(link.schema);
   if (depth >= link.path.length) return leafCap;
-  return narrowerCap(
+  return narrowerScopeCap(
     link.scopeCaps?.find((cap) => cap.depth === depth)?.scope,
     leafCap,
   );
@@ -126,11 +136,16 @@ const schemaScopeForLinkAtDepth = (
  */
 export const undefinedDataLink = (
   link: NormalizedFullLink,
-): NormalizedFullLink => ({
-  ...link,
-  id: dataUriFromValueWithResolvedLinks(undefined, link),
-  path: [],
-});
+): NormalizedFullLink => {
+  // `path` is rebased to [], so any recorded cap depths now address segments
+  // of a different document. Drop them rather than leave them misaligned.
+  const { scopeCaps: _dropped, ...rest } = link;
+  return {
+    ...rest,
+    id: dataUriFromValueWithResolvedLinks(undefined, link),
+    path: [],
+  };
+};
 
 const canFollowLinkHop = (
   source: NormalizedFullLink,
@@ -351,13 +366,28 @@ export function resolveLink(
       recordDereferenceHop(tx, nextHop);
       const nextLink = nextHop.link;
       const crossSpace = nextLink.space !== link.space;
+      // The hop consumed `nextHop.depth` of our path and re-rooted the rest
+      // under the target. Caps recorded for the consumed prefix have done
+      // their job; caps for the REMAINING segments still have to travel, or a
+      // capped handle below an already-followed link goes unchecked -- the
+      // shape you get whenever a cell's root value is a link. `nextHop.link`
+      // comes from `parseLink` and carries no caps of its own, so rebasing is
+      // just a shift onto the target's path.
+      const carriedCaps = rebaseScopeCaps(
+        link.scopeCaps,
+        nextHop.depth,
+        nextHop.link.path.length - (link.path.length - nextHop.depth),
+      );
       if (nextLink.schema === undefined && link.schema !== undefined) {
         link = {
           ...nextLink,
           schema: link.schema,
+          ...(carriedCaps !== undefined && { scopeCaps: carriedCaps }),
         };
       } else {
-        link = nextLink;
+        link = carriedCaps === undefined
+          ? nextLink
+          : { ...nextLink, scopeCaps: carriedCaps };
       }
       // Force fetching data from the server when the local replica cannot
       // serve the hop target: crossing spaces (the origin server never pushes

--- a/packages/runner/src/link-resolution.ts
+++ b/packages/runner/src/link-resolution.ts
@@ -120,7 +120,14 @@ const schemaScopeForLinkAtDepth = (
   link: NormalizedFullLink,
   depth: number,
 ): SchemaScope | undefined => {
-  const leafCap = ContextualFlowControl.getSchemaScopeCap(link.schema);
+  // getSchemaScopeCap only reads the top level, so a cap wrapped in
+  // anyOf/oneOf is invisible to it. A mixed compound (`[<capped handle>,
+  // {type:"null"}]`) never mints a handle at all -- the link is simply
+  // followed -- so this is the only place that shape can be caught.
+  const leafCap = narrowerScopeCap(
+    ContextualFlowControl.getSchemaScopeCap(link.schema),
+    ContextualFlowControl.getAsCellFollowScopeCap(link.schema),
+  );
   if (depth >= link.path.length) return leafCap;
   return narrowerScopeCap(
     link.scopeCaps?.find((cap) => cap.depth === depth)?.scope,
@@ -376,7 +383,10 @@ export function resolveLink(
       const carriedCaps = rebaseScopeCaps(
         link.scopeCaps,
         nextHop.depth,
-        nextHop.link.path.length - (link.path.length - nextHop.depth),
+        // A cap at old depth k lands at (target base length) + (k - depth).
+        // target base length = nextHop.link.path.length - (path.length - depth),
+        // so the shift reduces to target-path length minus our own.
+        nextHop.link.path.length - link.path.length,
       );
       if (nextLink.schema === undefined && link.schema !== undefined) {
         link = {

--- a/packages/runner/src/link-resolution.ts
+++ b/packages/runner/src/link-resolution.ts
@@ -21,7 +21,7 @@ import { linkResolutionProbe } from "./storage/reactivity-log.ts";
 import { ContextualFlowControl } from "./cfc.ts";
 import type { Runtime } from "./runtime.ts";
 import type { CfcAddress } from "./cfc/types.ts";
-import { canFollowScopedLink } from "./scope.ts";
+import { canFollowScopedLink, scopeRank } from "./scope.ts";
 import type { SchemaScope } from "./builder/types.ts";
 
 const logger = getLogger("link-resolution");
@@ -85,16 +85,37 @@ const recordDereferenceHop = (
 // full path. A hop found at an ancestor is governed by whatever that ancestor's
 // schema declared, which `key()` recorded in `scopeCaps` on its way down —
 // narrowing had already replaced the declaring schema by the time we get here
-// (#5230). Fall back to the leaf schema when nothing was recorded, which is
-// both the pre-existing behavior and correct for a full-path hop.
+// (#5230).
+//
+// For an ancestor hop we take the NARROWER of the recorded cap and the leaf's.
+// The leaf cap is not really the right authority there — it describes a
+// different address — but applying it to ancestor hops is what this resolver
+// has always done, and a link that never passed through `key()` carries no
+// recorded caps at all. Keeping it as a floor means this change can only block
+// more than before, never less.
+//
+// NOTE: no test reaches this floor — every shape tried either records a cap or
+// fails to resolve for unrelated reasons. It is here as a conservatism, not as
+// behavior anything depends on, so treat it as unproven rather than pinned.
+const narrowerCap = (
+  a: SchemaScope | undefined,
+  b: SchemaScope | undefined,
+): SchemaScope | undefined => {
+  if (a === undefined || a === "any") return b;
+  if (b === undefined || b === "any") return a;
+  return scopeRank(a) <= scopeRank(b) ? a : b;
+};
+
 const schemaScopeForLinkAtDepth = (
   link: NormalizedFullLink,
   depth: number,
 ): SchemaScope | undefined => {
-  if (depth >= link.path.length) {
-    return ContextualFlowControl.getSchemaScopeCap(link.schema);
-  }
-  return link.scopeCaps?.find((cap) => cap.depth === depth)?.scope;
+  const leafCap = ContextualFlowControl.getSchemaScopeCap(link.schema);
+  if (depth >= link.path.length) return leafCap;
+  return narrowerCap(
+    link.scopeCaps?.find((cap) => cap.depth === depth)?.scope,
+    leafCap,
+  );
 };
 
 /**

--- a/packages/runner/src/link-resolution.ts
+++ b/packages/runner/src/link-resolution.ts
@@ -44,6 +44,13 @@ type LinkHop = {
   link: NormalizedFullLink;
   source: NormalizedFullLink;
   kind: "value" | "write-redirect";
+  /**
+   * How many of the resolving link's path segments the stored link sits under.
+   * Equal to `link.path.length` for a hop found at the full path, and shorter
+   * when the hop was discovered at an ancestor — which is the case that has to
+   * consult `scopeCaps` rather than the leaf schema.
+   */
+  depth: number;
 };
 
 const cfcAddressFromLink = (link: NormalizedFullLink): CfcAddress => ({
@@ -73,12 +80,32 @@ const recordDereferenceHop = (
 // follow (see ContextualFlowControl.getSchemaScopeCap for the precedence). This
 // caps *which* link scopes may be followed; it must never be copied onto the
 // followed link itself.
-const schemaScopeForLink = (
+//
+// `link.schema` describes the LEAF, so it only answers for a hop found at the
+// full path. A hop found at an ancestor is governed by whatever that ancestor's
+// schema declared, which `key()` recorded in `scopeCaps` on its way down —
+// narrowing had already replaced the declaring schema by the time we get here
+// (#5230). Fall back to the leaf schema when nothing was recorded, which is
+// both the pre-existing behavior and correct for a full-path hop.
+const schemaScopeForLinkAtDepth = (
   link: NormalizedFullLink,
-): SchemaScope | undefined =>
-  ContextualFlowControl.getSchemaScopeCap(link.schema);
+  depth: number,
+): SchemaScope | undefined => {
+  if (depth >= link.path.length) {
+    return ContextualFlowControl.getSchemaScopeCap(link.schema);
+  }
+  return link.scopeCaps?.find((cap) => cap.depth === depth)?.scope;
+};
 
-const undefinedDataLink = (link: NormalizedFullLink): NormalizedFullLink => ({
+/**
+ * The link a blocked or dead-ended chain resolves to: undefined-data in place.
+ * Exported so every site that decides a link may not be followed produces the
+ * same shape — notably the asCell boundaries, which build a handle instead of
+ * following and so never reach the check below (#5230).
+ */
+export const undefinedDataLink = (
+  link: NormalizedFullLink,
+): NormalizedFullLink => ({
   ...link,
   id: dataUriFromValueWithResolvedLinks(undefined, link),
   path: [],
@@ -86,8 +113,12 @@ const undefinedDataLink = (link: NormalizedFullLink): NormalizedFullLink => ({
 
 const canFollowLinkHop = (
   source: NormalizedFullLink,
-  target: NormalizedFullLink,
-): boolean => canFollowScopedLink(schemaScopeForLink(source), target.scope);
+  hop: LinkHop,
+): boolean =>
+  canFollowScopedLink(
+    schemaScopeForLinkAtDepth(source, hop.depth),
+    hop.link.scope,
+  );
 
 /**
  * Resolves a document path with support for links inside documents.
@@ -192,6 +223,7 @@ export function resolveLink(
         link: nextLink,
         source: { ...link, path: [...link.path] },
         kind: hopKindForLink(nextLink),
+        depth: link.path.length,
       };
     } else if (sigilProbe.error?.name === "NotFoundError") {
       const lastValid = (sigilProbe.error as INotFoundError).path.slice(); // [] => doc missing
@@ -230,6 +262,7 @@ export function resolveLink(
               link: nextLink,
               source: { ...link, path: [...lastValid] },
               kind: hopKindForLink(nextLink),
+              depth: lastValid.length,
             };
           }
         }
@@ -255,11 +288,11 @@ export function resolveLink(
     }
 
     if (nextHop !== undefined) {
-      if (!canFollowLinkHop(link, nextHop.link)) {
+      if (!canFollowLinkHop(link, nextHop)) {
         // Blocked narrower-scope follow during link resolution — resolves to
         // undefined silently. Warn (not info) so the drop is observable; see
         // the matching site in traverse.ts followPointer (CT-1642).
-        const schemaScope = schemaScopeForLink(link);
+        const schemaScope = schemaScopeForLinkAtDepth(link, nextHop.depth);
         logger.warn("scope: blocked narrower link follow", () => [
           `a "${schemaScope}"-scoped read cannot follow a ` +
           `"${nextHop.link.scope}"-scoped link, so it resolves to undefined. ` +

--- a/packages/runner/src/link-types.ts
+++ b/packages/runner/src/link-types.ts
@@ -71,6 +71,16 @@ export type NormalizedLink = {
    * Read-side only: this is never serialized into a sigil link, never part of
    * link identity (`areNormalizedLinksSame`), and must never be stamped onto a
    * followed link's own scope (CT-1623).
+   *
+   * Caps are MONOTONIC across `asSchema()`: reinterpreting an address can
+   * tighten a cap (the next `key()` merges the narrower of the two) but never
+   * lift one. Clearing them on `asSchema` looks tempting — it is a sibling
+   * with a different schema, so carrying provenance from the discarded one
+   * reads as surprising — but it would turn every `asSchema`-based read
+   * helper into a cap bypass. `cellWithScopedLinkRequiredsRelaxed`, the piece
+   * read boundary itself, ends in `cell.asSchema(relaxed)`; the ancestor caps
+   * a narrowed cell carries exist nowhere else, so dropping them there would
+   * silently lift the caps that boundary is supposed to enforce.
    */
   scopeCaps?: readonly ScopeCapAtDepth[];
 };

--- a/packages/runner/src/link-types.ts
+++ b/packages/runner/src/link-types.ts
@@ -4,6 +4,7 @@ import {
   type CellScope,
   type JSONSchema,
   type LinkScope,
+  type SchemaScope,
 } from "./builder/types.ts";
 import { type MemorySpace } from "./cell.ts";
 import {
@@ -39,6 +40,17 @@ function parseScopedIdSegment(idSegment: string): {
 }
 
 /**
+ * A follow cap declared by the schema at `depth` path segments from this
+ * link's root, remembered because narrowing past that segment drops the
+ * declaring schema. See {@link NormalizedLink.scopeCaps}.
+ */
+export type ScopeCapAtDepth = {
+  /** Number of leading `path` segments the declaring schema addresses. */
+  depth: number;
+  scope: SchemaScope;
+};
+
+/**
  * Normalized link structure returned by parsers
  */
 export type NormalizedLink = {
@@ -48,6 +60,19 @@ export type NormalizedLink = {
   scope?: LinkScope;
   schema?: JSONSchema;
   overwrite?: "redirect"; // "this" gets normalized away to undefined
+  /**
+   * Follow caps declared by schemas ABOVE this link's leaf, ascending by
+   * depth. `schema` only describes the leaf, so a cap declared mid-path — an
+   * `asCell` entry's `scope` on an ancestor — is otherwise lost the moment
+   * `key()` narrows past it, and `resolveLink` has nothing to check when it
+   * discovers the stored link at that ancestor. Populated by `Cell.key()`,
+   * which is the one place that walks the schema segment by segment.
+   *
+   * Read-side only: this is never serialized into a sigil link, never part of
+   * link identity (`areNormalizedLinksSame`), and must never be stamped onto a
+   * followed link's own scope (CT-1623).
+   */
+  scopeCaps?: readonly ScopeCapAtDepth[];
 };
 
 /**

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -22,9 +22,14 @@ import {
   schemaWithProperties,
 } from "@commonfabric/data-model/schema-utils";
 import { createCell, isCell } from "./cell.ts";
+import { canFollowScopedLink } from "./scope.ts";
 import { forEachSubschema } from "./schema-walk.ts";
 import { arrayMatchesPositionally } from "./schema-match.ts";
-import { readMaybeLink, resolveLink } from "./link-resolution.ts";
+import {
+  readMaybeLink,
+  resolveLink,
+  undefinedDataLink,
+} from "./link-resolution.ts";
 import { type IExtendedStorageTransaction } from "./storage/interface.ts";
 import { getTransactionForChildCells } from "./storage/extended-storage-transaction.ts";
 import { type Runtime } from "./runtime.ts";
@@ -1080,8 +1085,23 @@ export function validateAndTransform(
   if (SchemaObjectTraverser.hasAsCell(effectiveSchema)) {
     // We check for a link value, since we will follow links one step in get
     // We've already followed all the writeRedirect links above.
-    const next = readMaybeLink(tx, link);
+    let next = readMaybeLink(tx, link);
     if (next !== undefined) {
+      // An asCell schema turns this link into a handle instead of following
+      // it, so resolveLink's cap check never sees this hop. Apply it here too,
+      // or reading THROUGH the handle escapes the cap the schema declared
+      // (#5230).
+      const schemaScope = ContextualFlowControl.getSchemaScopeCap(
+        effectiveSchema,
+      );
+      if (!canFollowScopedLink(schemaScope, next.scope)) {
+        logger.warn(
+          `blocked narrower-scope asCell handle: a "${schemaScope}"-scoped ` +
+            `read cannot hold a "${next.scope}"-scoped link, so the handle ` +
+            `reads as undefined.`,
+        );
+        next = undefinedDataLink(next);
+      }
       cfcLabelView = mergeCfcLabelViews([
         cfcLabelView,
         cfcLabelViewForDereference(

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -1085,7 +1085,7 @@ export function validateAndTransform(
   if (SchemaObjectTraverser.hasAsCell(effectiveSchema)) {
     // We check for a link value, since we will follow links one step in get
     // We've already followed all the writeRedirect links above.
-    let next = readMaybeLink(tx, link);
+    const next = readMaybeLink(tx, link);
     if (next !== undefined) {
       // An asCell schema turns this link into a handle instead of following
       // it, so resolveLink's cap check never sees this hop. Apply it here too,
@@ -1100,7 +1100,17 @@ export function validateAndTransform(
             `read cannot hold a "${next.scope}"-scoped link, so the handle ` +
             `reads as undefined.`,
         );
-        next = undefinedDataLink(next);
+        // Exactly the shape resolveLink produces for a blocked follow:
+        // undefined-data in the SOURCE's place, keeping the reader's own space
+        // and scope, and no dereference recorded for a hop we refused to take.
+        // Keeping `effectiveSchema` preserves the asCell marker, so the caller
+        // still gets a handle -- one that reads as undefined.
+        const blocked = {
+          ...undefinedDataLink(link),
+          schema: effectiveSchema!,
+        };
+        objectCreator.setBase(blocked, cfcLabelView);
+        return objectCreator.createObject(blocked, undefined);
       }
       cfcLabelView = mergeCfcLabelViews([
         cfcLabelView,

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -4,7 +4,7 @@ import { getLogger } from "@commonfabric/utils/logger";
 import { isReadonlyRecord, isRecord } from "@commonfabric/utils/types";
 import { storedCfcMetadataAppliesToPath } from "./cfc/metadata.ts";
 import { ContextualFlowControl } from "./cfc.ts";
-import { type JSONSchema } from "./builder/types.ts";
+import { type JSONSchema, type SchemaScope } from "./builder/types.ts";
 import type { JSONSchemaObj, JSONValue } from "@commonfabric/api";
 import {
   cloneIfNecessary,
@@ -22,7 +22,7 @@ import {
   schemaWithProperties,
 } from "@commonfabric/data-model/schema-utils";
 import { createCell, isCell } from "./cell.ts";
-import { canFollowScopedLink, isSchemaScope } from "./scope.ts";
+import { canFollowScopedLink } from "./scope.ts";
 import { forEachSubschema } from "./schema-walk.ts";
 import { arrayMatchesPositionally } from "./schema-match.ts";
 import {
@@ -140,6 +140,26 @@ const asCellCompoundCandidates = (
     compoundAsCellCandidatesCache.set(schema, candidates);
   }
   return candidates;
+};
+
+/**
+ * The link a handle gets when its target is narrower than the cap its schema
+ * declares: undefined-data in place, the same shape resolveLink hands back for
+ * a blocked follow. It is still a Cell -- so a `required` container is not
+ * voided -- it reads as undefined, and it is not writable, because a data URI
+ * is a read-only address.
+ */
+const blockedHandleLink = (
+  link: NormalizedFullLink,
+  cap: SchemaScope | undefined,
+): NormalizedFullLink => {
+  logger.warn(
+    `blocked narrower-scope asCell handle: a "${cap}"-scoped read cannot ` +
+      `hold a "${link.scope}"-scoped link, so the handle reads as undefined. ` +
+      `Declare the handle's asCell scope at least as narrow as the value it ` +
+      `points at.`,
+  );
+  return undefinedDataLink(link);
 };
 
 const asCellCompoundSchemaForValue = (
@@ -1091,30 +1111,6 @@ export function validateAndTransform(
       // it, so resolveLink's cap check never sees this hop. Apply it here too,
       // or reading THROUGH the handle escapes the cap the schema declared
       // (#5230).
-      // Only the asCell entry's own scope, not getSchemaScopeCap's
-      // `schema.scope` fallback — see asCellEntryScopeCap in traverse.ts.
-      const entryScope = ContextualFlowControl.getAsCellScope(
-        ContextualFlowControl.getAsCellValues(effectiveSchema).at(0),
-      );
-      const schemaScope = isSchemaScope(entryScope) ? entryScope : undefined;
-      if (!canFollowScopedLink(schemaScope, next.scope)) {
-        logger.warn(
-          `blocked narrower-scope asCell handle: a "${schemaScope}"-scoped ` +
-            `read cannot hold a "${next.scope}"-scoped link, so the handle ` +
-            `reads as undefined.`,
-        );
-        // Exactly the shape resolveLink produces for a blocked follow:
-        // undefined-data in the SOURCE's place, keeping the reader's own space
-        // and scope, and no dereference recorded for a hop we refused to take.
-        // Keeping `effectiveSchema` preserves the asCell marker, so the caller
-        // still gets a handle -- one that reads as undefined.
-        const blocked = {
-          ...undefinedDataLink(link),
-          schema: effectiveSchema!,
-        };
-        objectCreator.setBase(blocked, cfcLabelView);
-        return objectCreator.createObject(blocked, undefined);
-      }
       cfcLabelView = mergeCfcLabelViews([
         cfcLabelView,
         cfcLabelViewForDereference(
@@ -1376,15 +1372,25 @@ class TransformObjectCreator
         if (cellKind === undefined) {
           return undefined;
         }
-        // TODO(@ubik2): deal with anyOf/oneOf with asCell/asStream
         // This is a read/materialization path: keep the link's own
         // storage-resolved scope. The asCell entry scope is honored as a
         // follow cap during link resolution, never copied onto the link here
         // (doing so would re-address the value to a different scoped instance).
+        //
+        // Minting a handle is the one place a link is NOT followed, so
+        // resolveLink's cap check never sees this hop -- and the holder reads
+        // through the handle later, which is exactly the follow the cap bounds
+        // (#5230). Every route that produces a handle lands here, including
+        // the compound anyOf/oneOf shape `getSchemaScopeCap` cannot see, so
+        // this is the one place the check belongs.
+        const followCap = ContextualFlowControl.getAsCellFollowScopeCap(schema);
+        const handleLink = canFollowScopedLink(followCap, link.scope)
+          ? link
+          : blockedHandleLink(link, followCap);
         return createCell(
           this.runtime,
           {
-            ...link,
+            ...handleLink,
             schema: unwrapAsCellSchema(schema as JSONSchemaObj),
           },
           getTransactionForChildCells(this.tx),

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -22,7 +22,7 @@ import {
   schemaWithProperties,
 } from "@commonfabric/data-model/schema-utils";
 import { createCell, isCell } from "./cell.ts";
-import { canFollowScopedLink } from "./scope.ts";
+import { canFollowScopedLink, isSchemaScope } from "./scope.ts";
 import { forEachSubschema } from "./schema-walk.ts";
 import { arrayMatchesPositionally } from "./schema-match.ts";
 import {
@@ -1091,9 +1091,12 @@ export function validateAndTransform(
       // it, so resolveLink's cap check never sees this hop. Apply it here too,
       // or reading THROUGH the handle escapes the cap the schema declared
       // (#5230).
-      const schemaScope = ContextualFlowControl.getSchemaScopeCap(
-        effectiveSchema,
+      // Only the asCell entry's own scope, not getSchemaScopeCap's
+      // `schema.scope` fallback — see asCellEntryScopeCap in traverse.ts.
+      const entryScope = ContextualFlowControl.getAsCellScope(
+        ContextualFlowControl.getAsCellValues(effectiveSchema).at(0),
       );
+      const schemaScope = isSchemaScope(entryScope) ? entryScope : undefined;
       if (!canFollowScopedLink(schemaScope, next.scope)) {
         logger.warn(
           `blocked narrower-scope asCell handle: a "${schemaScope}"-scoped ` +

--- a/packages/runner/src/scope.ts
+++ b/packages/runner/src/scope.ts
@@ -113,6 +113,19 @@ export function scopeRank(scope: CellScope): number {
   return scopeRankByValue[scope];
 }
 
+/**
+ * The narrower (more restrictive) of two schema follow caps. `undefined` and
+ * `"any"` mean "no cap", so they lose to any real one.
+ */
+export function narrowerScopeCap(
+  a: SchemaScope | undefined,
+  b: SchemaScope | undefined,
+): SchemaScope | undefined {
+  if (a === undefined || a === "any") return b;
+  if (b === undefined || b === "any") return a;
+  return scopeRank(a) <= scopeRank(b) ? a : b;
+}
+
 export function narrowestScope(
   scopes: Iterable<CellScope | undefined>,
 ): CellScope {

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -44,7 +44,7 @@ import type {
 } from "./builder/types.ts";
 import { dataUriFromValueWithResolvedLinks } from "./data-uri.ts";
 import { addressKey, NormalizedFullLink, parseLink } from "./link-utils.ts";
-import { canFollowScopedLink } from "./scope.ts";
+import { canFollowScopedLink, isSchemaScope } from "./scope.ts";
 import type {
   Activity,
   CommitError,
@@ -4011,6 +4011,9 @@ export class SchemaObjectTraverser<V extends FabricValue>
       // work as expected. Handle boolean items values for element schema
       // let createdDataURI = false;
       // const maybeLink = parseLink(item, arrayLink);
+      // curDoc is advanced past the element's link below, so remember where
+      // the element itself lives for a blocked handle's address.
+      const elementSource = curDoc.address;
       if (isSigilLink(item)) {
         if (this.traverseCells) {
           const alreadyTracked = this.isLinkedDocumentCovered(
@@ -4153,9 +4156,13 @@ export class SchemaObjectTraverser<V extends FabricValue>
         // to the child cell and observe it when the target materializes.
         const isLink = isSigilLink(curDoc.value);
         if (isLink) this.tx.read(curDoc.address, READ_FOR_SCHEDULING);
-        const cellLink = isLink
-          ? getNextCellLink(curDoc, curSelector.schema!)
-          : getNormalizedLink(curDoc.address, curSelector.schema);
+        const cellLink = cappedHandleLink(
+          isLink
+            ? getNextCellLink(curDoc, curSelector.schema!)
+            : getNormalizedLink(curDoc.address, curSelector.schema),
+          curSelector.schema,
+          elementSource,
+        );
         const val = this.objectCreator.createObject(cellLink, undefined);
         arrayObj[index] = val;
       } else {
@@ -4264,7 +4271,11 @@ export class SchemaObjectTraverser<V extends FabricValue>
         // link and do not descend/read nested properties from this value here.
         // If we have a value instead of a link, create a link to the value
         // We don't traverse and validate, since this is an asCell boundary.
-        const cellLink = getNormalizedLink(propAddress, propSchema);
+        const cellLink = cappedHandleLink(
+          getNormalizedLink(propAddress, propSchema),
+          propSchema,
+          propAddress,
+        );
         const val = this.objectCreator.createObject(cellLink, undefined);
         filteredObj[propKey] = val;
       } else {
@@ -4379,7 +4390,11 @@ export class SchemaObjectTraverser<V extends FabricValue>
     // This means we don't follow any redirects
     const asCellValues = ContextualFlowControl.getAsCellValues(schema);
     if (ContextualFlowControl.getAsCellKind(asCellValues.at(0)) === "opaque") {
-      const cellLink = getNextCellLink(doc, schema);
+      const cellLink = cappedHandleLink(
+        getNextCellLink(doc, schema),
+        schema,
+        doc.address,
+      );
       return { ok: this.objectCreator.createObject(cellLink, undefined) };
     }
 
@@ -4461,7 +4476,11 @@ export class SchemaObjectTraverser<V extends FabricValue>
       if (isSigilLink(redirDoc.value)) {
         this.tx.read(redirDoc.address, READ_FOR_SCHEDULING);
       }
-      const cellLink = getNextCellLink(redirDoc, combinedSchema);
+      const cellLink = cappedHandleLink(
+        getNextCellLink(redirDoc, combinedSchema),
+        combinedSchema,
+        redirDoc.address,
+      );
       logger.debug(
         "traverse",
         () => ["Next cell link:", {
@@ -4823,6 +4842,59 @@ function _mergeAnyOfBranchSchemasUncached(
  * @returns a normalized full link which will have the address and schema
  *   information that we should use for the cell.
  */
+/**
+ * The follow cap an `asCell` ENTRY declares, and only that.
+ *
+ * Deliberately NOT getSchemaScopeCap: that falls back to the schema's own
+ * `scope`, which authors also write to mean "this value lives at that scope".
+ * Honouring the fallback here would invent a follow cap nobody asked for on
+ * any node carrying both `asCell` and `scope`. Path resolution keeps using
+ * getSchemaScopeCap, which is what it has always done.
+ */
+const asCellEntryScopeCap = (
+  schema: JSONSchema | undefined,
+): SchemaScope | undefined => {
+  const entryScope = ContextualFlowControl.getAsCellScope(
+    ContextualFlowControl.getAsCellValues(schema).at(0),
+  );
+  return isSchemaScope(entryScope) ? entryScope : undefined;
+};
+
+/**
+ * Gate a handle about to be built at an `asCell` boundary.
+ *
+ * A boundary is the one place a link becomes a handle INSTEAD of being
+ * followed, so followPointer's cap check never runs for it -- and the holder
+ * reads through that handle later, which is exactly the follow the cap was
+ * meant to bound (#5230). Checking the finished handle link covers every way
+ * the boundary is reached, including an array element whose link the traversal
+ * has already stepped past.
+ *
+ * A blocked handle resolves to undefined-data at `source`, matching what
+ * resolveLink hands back for a blocked follow: it still IS a Cell (so a
+ * `required` container is not voided), it reads as undefined, and it is not
+ * writable -- a data URI is a read-only address.
+ */
+function cappedHandleLink(
+  handleLink: NormalizedFullLink,
+  schema: JSONSchema | undefined,
+  source: IMemorySpaceValueAddress,
+): NormalizedFullLink {
+  const schemaScope = asCellEntryScopeCap(schema);
+  if (canFollowScopedLink(schemaScope, handleLink.scope)) return handleLink;
+  logger.warn("traverse", () => [
+    `blocked narrower-scope asCell handle: a "${schemaScope}"-scoped read ` +
+    `cannot hold a "${handleLink.scope}"-scoped link, so the handle reads ` +
+    `as undefined. Declare the handle's asCell scope at least as narrow as ` +
+    `the value it points at.`,
+    { schemaScope, linkScope: handleLink.scope, target: handleLink },
+  ]);
+  return {
+    ...undefinedDataLink(getNormalizedLink(source, schema)),
+    ...(handleLink.schema !== undefined && { schema: handleLink.schema }),
+  };
+}
+
 function getNextCellLink(
   doc: IMemorySpaceValueAttestation,
   schema: JSONSchema,
@@ -4832,30 +4904,6 @@ function getNextCellLink(
   // that location, so we effectively follow one more link if available.
   const lastLink = parseLink(doc.value, doc.address);
   if (lastLink !== undefined) {
-    // An asCell boundary is the one place a link is turned into a handle
-    // instead of being followed, so followPointer's cap check never runs for
-    // it. Apply the same rule here, or the cap means nothing to anyone who
-    // reads THROUGH the handle (#5230). Resolve to undefined-data, matching
-    // what resolveLink hands back for a blocked follow, so the three routes to
-    // a capped handle agree.
-    const schemaScope = schemaFollowScopeCap(schema);
-    if (!canFollowScopedLink(schemaScope, lastLink.scope)) {
-      logger.warn("traverse", () => [
-        `blocked narrower-scope asCell handle: a "${schemaScope}"-scoped ` +
-        `read cannot hold a "${lastLink.scope}"-scoped link, so the handle ` +
-        `reads as undefined. Declare the handle's asCell scope at least as ` +
-        `narrow as the value it points at.`,
-        { schemaScope, linkScope: lastLink.scope, target: lastLink },
-      ]);
-      // Undefined-data in the SOURCE's place, matching resolveLink and the
-      // asCell path in schema.ts so a blocked handle has ONE identity however
-      // it was reached. `schema` keeps the asCell marker, so the caller still
-      // gets a handle -- one that reads as undefined.
-      return {
-        ...undefinedDataLink(getNormalizedLink(doc.address, schema)),
-        schema,
-      };
-    }
     // The link may not have the asCell flags, so pull that from itemSchema
     return {
       ...lastLink,

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -44,7 +44,7 @@ import type {
 } from "./builder/types.ts";
 import { dataUriFromValueWithResolvedLinks } from "./data-uri.ts";
 import { addressKey, NormalizedFullLink, parseLink } from "./link-utils.ts";
-import { canFollowScopedLink, isSchemaScope } from "./scope.ts";
+import { canFollowScopedLink } from "./scope.ts";
 import type {
   Activity,
   CommitError,
@@ -74,7 +74,7 @@ import {
   isWriteRedirectLink,
   type ValuePath,
 } from "./link-types.ts";
-import { type LastNode, undefinedDataLink } from "./link-resolution.ts";
+import type { LastNode } from "./link-resolution.ts";
 import type { IAttestation, IMemoryAddress } from "./storage/interface.ts";
 import { linkRefFrom } from "@commonfabric/data-model/cell-rep";
 import { type CellLinkRefPayload, SigilLink } from "./sigil-types.ts";
@@ -4011,9 +4011,6 @@ export class SchemaObjectTraverser<V extends FabricValue>
       // work as expected. Handle boolean items values for element schema
       // let createdDataURI = false;
       // const maybeLink = parseLink(item, arrayLink);
-      // curDoc is advanced past the element's link below, so remember where
-      // the element itself lives for a blocked handle's address.
-      const elementSource = curDoc.address;
       if (isSigilLink(item)) {
         if (this.traverseCells) {
           const alreadyTracked = this.isLinkedDocumentCovered(
@@ -4156,13 +4153,9 @@ export class SchemaObjectTraverser<V extends FabricValue>
         // to the child cell and observe it when the target materializes.
         const isLink = isSigilLink(curDoc.value);
         if (isLink) this.tx.read(curDoc.address, READ_FOR_SCHEDULING);
-        const cellLink = cappedHandleLink(
-          isLink
-            ? getNextCellLink(curDoc, curSelector.schema!)
-            : getNormalizedLink(curDoc.address, curSelector.schema),
-          curSelector.schema,
-          elementSource,
-        );
+        const cellLink = isLink
+          ? getNextCellLink(curDoc, curSelector.schema!)
+          : getNormalizedLink(curDoc.address, curSelector.schema);
         const val = this.objectCreator.createObject(cellLink, undefined);
         arrayObj[index] = val;
       } else {
@@ -4271,11 +4264,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
         // link and do not descend/read nested properties from this value here.
         // If we have a value instead of a link, create a link to the value
         // We don't traverse and validate, since this is an asCell boundary.
-        const cellLink = cappedHandleLink(
-          getNormalizedLink(propAddress, propSchema),
-          propSchema,
-          propAddress,
-        );
+        const cellLink = getNormalizedLink(propAddress, propSchema);
         const val = this.objectCreator.createObject(cellLink, undefined);
         filteredObj[propKey] = val;
       } else {
@@ -4390,11 +4379,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
     // This means we don't follow any redirects
     const asCellValues = ContextualFlowControl.getAsCellValues(schema);
     if (ContextualFlowControl.getAsCellKind(asCellValues.at(0)) === "opaque") {
-      const cellLink = cappedHandleLink(
-        getNextCellLink(doc, schema),
-        schema,
-        doc.address,
-      );
+      const cellLink = getNextCellLink(doc, schema);
       return { ok: this.objectCreator.createObject(cellLink, undefined) };
     }
 
@@ -4476,11 +4461,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
       if (isSigilLink(redirDoc.value)) {
         this.tx.read(redirDoc.address, READ_FOR_SCHEDULING);
       }
-      const cellLink = cappedHandleLink(
-        getNextCellLink(redirDoc, combinedSchema),
-        combinedSchema,
-        redirDoc.address,
-      );
+      const cellLink = getNextCellLink(redirDoc, combinedSchema);
       logger.debug(
         "traverse",
         () => ["Next cell link:", {
@@ -4842,59 +4823,6 @@ function _mergeAnyOfBranchSchemasUncached(
  * @returns a normalized full link which will have the address and schema
  *   information that we should use for the cell.
  */
-/**
- * The follow cap an `asCell` ENTRY declares, and only that.
- *
- * Deliberately NOT getSchemaScopeCap: that falls back to the schema's own
- * `scope`, which authors also write to mean "this value lives at that scope".
- * Honouring the fallback here would invent a follow cap nobody asked for on
- * any node carrying both `asCell` and `scope`. Path resolution keeps using
- * getSchemaScopeCap, which is what it has always done.
- */
-const asCellEntryScopeCap = (
-  schema: JSONSchema | undefined,
-): SchemaScope | undefined => {
-  const entryScope = ContextualFlowControl.getAsCellScope(
-    ContextualFlowControl.getAsCellValues(schema).at(0),
-  );
-  return isSchemaScope(entryScope) ? entryScope : undefined;
-};
-
-/**
- * Gate a handle about to be built at an `asCell` boundary.
- *
- * A boundary is the one place a link becomes a handle INSTEAD of being
- * followed, so followPointer's cap check never runs for it -- and the holder
- * reads through that handle later, which is exactly the follow the cap was
- * meant to bound (#5230). Checking the finished handle link covers every way
- * the boundary is reached, including an array element whose link the traversal
- * has already stepped past.
- *
- * A blocked handle resolves to undefined-data at `source`, matching what
- * resolveLink hands back for a blocked follow: it still IS a Cell (so a
- * `required` container is not voided), it reads as undefined, and it is not
- * writable -- a data URI is a read-only address.
- */
-function cappedHandleLink(
-  handleLink: NormalizedFullLink,
-  schema: JSONSchema | undefined,
-  source: IMemorySpaceValueAddress,
-): NormalizedFullLink {
-  const schemaScope = asCellEntryScopeCap(schema);
-  if (canFollowScopedLink(schemaScope, handleLink.scope)) return handleLink;
-  logger.warn("traverse", () => [
-    `blocked narrower-scope asCell handle: a "${schemaScope}"-scoped read ` +
-    `cannot hold a "${handleLink.scope}"-scoped link, so the handle reads ` +
-    `as undefined. Declare the handle's asCell scope at least as narrow as ` +
-    `the value it points at.`,
-    { schemaScope, linkScope: handleLink.scope, target: handleLink },
-  ]);
-  return {
-    ...undefinedDataLink(getNormalizedLink(source, schema)),
-    ...(handleLink.schema !== undefined && { schema: handleLink.schema }),
-  };
-}
-
 function getNextCellLink(
   doc: IMemorySpaceValueAttestation,
   schema: JSONSchema,

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -74,7 +74,7 @@ import {
   isWriteRedirectLink,
   type ValuePath,
 } from "./link-types.ts";
-import type { LastNode } from "./link-resolution.ts";
+import { type LastNode, undefinedDataLink } from "./link-resolution.ts";
 import type { IAttestation, IMemoryAddress } from "./storage/interface.ts";
 import { linkRefFrom } from "@commonfabric/data-model/cell-rep";
 import { type CellLinkRefPayload, SigilLink } from "./sigil-types.ts";
@@ -4832,6 +4832,26 @@ function getNextCellLink(
   // that location, so we effectively follow one more link if available.
   const lastLink = parseLink(doc.value, doc.address);
   if (lastLink !== undefined) {
+    // An asCell boundary is the one place a link is turned into a handle
+    // instead of being followed, so followPointer's cap check never runs for
+    // it. Apply the same rule here, or the cap means nothing to anyone who
+    // reads THROUGH the handle (#5230). Resolve to undefined-data, matching
+    // what resolveLink hands back for a blocked follow, so the three routes to
+    // a capped handle agree.
+    const schemaScope = schemaFollowScopeCap(schema);
+    if (!canFollowScopedLink(schemaScope, lastLink.scope)) {
+      logger.warn("traverse", () => [
+        `blocked narrower-scope asCell handle: a "${schemaScope}"-scoped ` +
+        `read cannot hold a "${lastLink.scope}"-scoped link, so the handle ` +
+        `reads as undefined. Declare the handle's asCell scope at least as ` +
+        `narrow as the value it points at.`,
+        { schemaScope, linkScope: lastLink.scope, target: lastLink },
+      ]);
+      return {
+        ...undefinedDataLink(lastLink),
+        schema: combineSchema(schema, lastLink.schema ?? true),
+      };
+    }
     // The link may not have the asCell flags, so pull that from itemSchema
     return {
       ...lastLink,

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -4847,9 +4847,13 @@ function getNextCellLink(
         `narrow as the value it points at.`,
         { schemaScope, linkScope: lastLink.scope, target: lastLink },
       ]);
+      // Undefined-data in the SOURCE's place, matching resolveLink and the
+      // asCell path in schema.ts so a blocked handle has ONE identity however
+      // it was reached. `schema` keeps the asCell marker, so the caller still
+      // gets a handle -- one that reads as undefined.
       return {
-        ...undefinedDataLink(lastLink),
-        schema: combineSchema(schema, lastLink.schema ?? true),
+        ...undefinedDataLink(getNormalizedLink(doc.address, schema)),
+        schema,
       };
     }
     // The link may not have the asCell flags, so pull that from itemSchema

--- a/packages/runner/test/ascell-scope-cap.test.ts
+++ b/packages/runner/test/ascell-scope-cap.test.ts
@@ -1,0 +1,178 @@
+// An `asCell` entry's `scope` is a follow cap: it bounds which link scopes a
+// read arriving through that schema may follow (ContextualFlowControl
+// .getSchemaScopeCap). It is what lets a space-scoped list require that every
+// handle in it points somewhere every reader in the space can resolve.
+//
+// The cap has to mean the same thing however the handle is reached. These tests
+// pin the three routes to one answer:
+//
+//   1. the value projection            -- cell.key("handle").get()
+//   2. a key() chain past the handle   -- cell.key("handle", "field").get()
+//   3. an explicit dereference         -- cell.key("handle").resolveAsCell()
+//
+// Before #5230 only (3) consulted the cap: (1) never checked it, and (2) lost
+// it because key() narrows through getSchemaAtPath, which drops the ancestor's
+// asCell entry, leaving resolveLink's schemaScopeForLink() with nothing to
+// check one hop later.
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { isCell } from "../src/cell.ts";
+import { ContextualFlowControl } from "../src/cfc.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { JSONSchema, SchemaScope } from "../src/builder/types.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+
+const signer = await Identity.fromPassphrase("ascell scope cap");
+const space = signer.did();
+
+const innerSchema = {
+  type: "object",
+  properties: { field: { type: "string" } },
+  required: ["field"],
+} as const satisfies JSONSchema;
+
+describe("asCell scope cap", () => {
+  let runtime: Runtime;
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let tx: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    tx = runtime.edit();
+  });
+
+  afterEach(async () => {
+    await tx.commit();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  /**
+   * Build `{ handle: <link to a cell in `targetScope`> }` where `handle`'s
+   * asCell entry declares `cap`, and return the three routes to the handle.
+   */
+  const build = (
+    label: string,
+    cap: SchemaScope | undefined,
+    targetScope: "space" | "user" | "session",
+  ) => {
+    const inner = runtime.getCell(
+      space,
+      `cap-inner-${label}`,
+      innerSchema,
+      tx,
+      targetScope,
+    );
+    inner.set({ field: "secret" });
+
+    const outer = runtime.getCell(
+      space,
+      `cap-outer-${label}`,
+      {
+        type: "object",
+        properties: {
+          handle: {
+            ...innerSchema,
+            asCell: cap === undefined
+              ? ["cell"]
+              : [{ kind: "cell", scope: cap }],
+          },
+        },
+        required: ["handle"],
+      } as JSONSchema,
+      tx,
+    );
+    outer.set({ handle: inner } as never);
+
+    const projected = outer.key("handle").get();
+    return {
+      outer,
+      // 1. value projection: the Cell the asCell slot materializes to
+      projection: isCell(projected)
+        ? (projected as { get(): unknown }).get()
+        : projected,
+      // 2. key() chain continuing past the handle
+      through: outer.key("handle", "field").get(),
+      // 3. explicit dereference
+      dereferenced: outer.key("handle").resolveAsCell().key("field").get(),
+    };
+  };
+
+  it("blocks every route when the cap is narrower than the link", () => {
+    // handle caps follows at `space`; the stored link is session-scoped.
+    const r = build("blocked", "space", "session");
+    expect(r.dereferenced).toBeUndefined();
+    expect(r.through).toBeUndefined();
+    expect(r.projection).toBeUndefined();
+  });
+
+  it("allows every route when the cap admits the link's scope", () => {
+    // A session cap is permissive: it admits space, user and session links.
+    const r = build("permitted", "session", "session");
+    expect(r.dereferenced).toBe("secret");
+    expect(r.through).toBe("secret");
+    expect(r.projection).toEqual({ field: "secret" });
+  });
+
+  it("allows every route when no cap is declared", () => {
+    const r = build("uncapped", undefined, "session");
+    expect(r.dereferenced).toBe("secret");
+    expect(r.through).toBe("secret");
+    expect(r.projection).toEqual({ field: "secret" });
+  });
+
+  it("allows every route when the link is no narrower than the cap", () => {
+    const r = build("same-scope", "space", "space");
+    expect(r.dereferenced).toBe("secret");
+    expect(r.through).toBe("secret");
+    expect(r.projection).toEqual({ field: "secret" });
+  });
+
+  it("keeps the cap reachable after key() narrows past the handle", () => {
+    const inner = runtime.getCell(
+      space,
+      "cap-schema-inner",
+      innerSchema,
+      tx,
+      "session",
+    );
+    inner.set({ field: "secret" });
+    const outer = runtime.getCell(
+      space,
+      "cap-schema-outer",
+      {
+        type: "object",
+        properties: {
+          handle: {
+            ...innerSchema,
+            asCell: [{ kind: "cell", scope: "space" }],
+          },
+        },
+        required: ["handle"],
+      } as JSONSchema,
+      tx,
+    );
+    outer.set({ handle: inner } as never);
+
+    // The cap is visible on the handle itself...
+    expect(
+      ContextualFlowControl.getSchemaScopeCap(outer.key("handle").schema),
+    ).toBe("space");
+    // ...and the leaf schema below it legitimately carries no cap of its own,
+    // so the link has to remember the one declared at depth 1.
+    expect(
+      ContextualFlowControl.getSchemaScopeCap(
+        outer.key("handle", "field").schema,
+      ),
+    ).toBeUndefined();
+    expect(
+      outer.key("handle", "field").getAsNormalizedFullLink().scopeCaps,
+    ).toEqual([{ depth: 1, scope: "space" }]);
+  });
+});

--- a/packages/runner/test/ascell-scope-cap.test.ts
+++ b/packages/runner/test/ascell-scope-cap.test.ts
@@ -101,6 +101,14 @@ describe("asCell scope cap", () => {
       through: outer.key("handle", "field").get(),
       // 3. explicit dereference
       dereferenced: outer.key("handle").resolveAsCell().key("field").get(),
+      // 4. the handle reached as a PROPERTY of a whole-object read. This goes
+      //    through SchemaObjectTraverser rather than validateAndTransform's
+      //    top-level asCell path, and builds the handle in getNextCellLink.
+      whole: (() => {
+        const parent = (outer.get() ?? {}) as { handle?: unknown };
+        const handle = parent.handle;
+        return isCell(handle) ? (handle as { get(): unknown }).get() : handle;
+      })(),
     };
   };
 
@@ -110,6 +118,7 @@ describe("asCell scope cap", () => {
     expect(r.dereferenced).toBeUndefined();
     expect(r.through).toBeUndefined();
     expect(r.projection).toBeUndefined();
+    expect(r.whole).toBeUndefined();
   });
 
   it("allows every route when the cap admits the link's scope", () => {
@@ -118,6 +127,7 @@ describe("asCell scope cap", () => {
     expect(r.dereferenced).toBe("secret");
     expect(r.through).toBe("secret");
     expect(r.projection).toEqual({ field: "secret" });
+    expect(r.whole).toEqual({ field: "secret" });
   });
 
   it("allows every route when no cap is declared", () => {
@@ -125,6 +135,7 @@ describe("asCell scope cap", () => {
     expect(r.dereferenced).toBe("secret");
     expect(r.through).toBe("secret");
     expect(r.projection).toEqual({ field: "secret" });
+    expect(r.whole).toEqual({ field: "secret" });
   });
 
   it("allows every route when the link is no narrower than the cap", () => {
@@ -132,6 +143,7 @@ describe("asCell scope cap", () => {
     expect(r.dereferenced).toBe("secret");
     expect(r.through).toBe("secret");
     expect(r.projection).toEqual({ field: "secret" });
+    expect(r.whole).toEqual({ field: "secret" });
   });
 
   it("keeps the cap reachable after key() narrows past the handle", () => {
@@ -174,5 +186,65 @@ describe("asCell scope cap", () => {
     expect(
       outer.key("handle", "field").getAsNormalizedFullLink().scopeCaps,
     ).toEqual([{ depth: 1, scope: "space" }]);
+  });
+
+  it("records the cap declared at the address key() starts from", () => {
+    // `outer.key("handle").key("field")` reaches the same leaf as
+    // `outer.key("handle", "field")`, but the cap on `handle` is now declared
+    // by the schema of the cell key() is CALLED ON rather than by a child
+    // schema the loop walks to. Without seeding from the starting link, that
+    // cap is never recorded and the chained form leaks where the varargs form
+    // blocks.
+    const r = build("chained", "space", "session");
+    const handle = r.outer.key("handle");
+    expect(handle.key("field").getAsNormalizedFullLink().scopeCaps)
+      .toEqual([{ depth: 1, scope: "space" }]);
+    expect(handle.key("field").get()).toBeUndefined();
+  });
+
+  it("records a cap declared at the root of a link key() never walked", () => {
+    // A cell whose OWN value is a link, reinterpreted through a capped schema:
+    // nothing recorded the cap, because key() was never called above this
+    // address. The first key() has to seed from the link it starts at, or the
+    // hop resolveLink finds at depth 0 is checked against the leaf schema —
+    // which has no cap — and the session-scoped target leaks.
+    const inner = runtime.getCell(
+      space,
+      "root-cap-inner",
+      innerSchema,
+      tx,
+      "session",
+    );
+    inner.set({ field: "secret" });
+    const holder = runtime.getCell(space, "root-cap-holder", undefined, tx);
+    holder.set(inner as never);
+
+    const capped = holder.asSchema(
+      {
+        ...innerSchema,
+        asCell: [{ kind: "cell", scope: "space" }],
+      } as JSONSchema,
+    );
+    expect(capped.key("field").getAsNormalizedFullLink().scopeCaps)
+      .toEqual([{ depth: 0, scope: "space" }]);
+    expect(capped.key("field").get()).toBeUndefined();
+  });
+
+  it("keeps caps across asSchema, so reinterpreting cannot lift one", () => {
+    // asSchema() makes a sibling at the SAME address with a different schema.
+    // The recorded caps describe how this address was reached, which that
+    // reinterpretation does not change — and dropping them would turn
+    // asSchema() into a way to read past any cap. Read-boundary helpers like
+    // cellWithScopedLinkRequiredsRelaxed are asSchema calls, so they have to
+    // carry the caps through too.
+    const r = build("as-schema", "space", "session");
+    const uncapped = {
+      ...innerSchema,
+      asCell: ["cell"],
+    } as JSONSchema;
+    const reinterpreted = r.outer.key("handle").asSchema(uncapped);
+    expect(reinterpreted.getAsNormalizedFullLink().scopeCaps)
+      .toEqual([{ depth: 1, scope: "space" }]);
+    expect(reinterpreted.key("field").get()).toBeUndefined();
   });
 });

--- a/packages/runner/test/ascell-scope-cap.test.ts
+++ b/packages/runner/test/ascell-scope-cap.test.ts
@@ -189,12 +189,10 @@ describe("asCell scope cap", () => {
   });
 
   it("records the cap declared at the address key() starts from", () => {
-    // `outer.key("handle").key("field")` reaches the same leaf as
-    // `outer.key("handle", "field")`, but the cap on `handle` is now declared
-    // by the schema of the cell key() is CALLED ON rather than by a child
-    // schema the loop walks to. Without seeding from the starting link, that
-    // cap is never recorded and the chained form leaks where the varargs form
-    // blocks.
+    // The chained form must reach the same answer as the varargs form. This
+    // one does NOT depend on the seed -- `outer.key("handle")` already
+    // recorded depth 1 in its own loop, and the chained call inherits it. The
+    // seed is what the next test covers.
     const r = build("chained", "space", "session");
     const handle = r.outer.key("handle");
     expect(handle.key("field").getAsNormalizedFullLink().scopeCaps)
@@ -246,5 +244,203 @@ describe("asCell scope cap", () => {
     expect(reinterpreted.getAsNormalizedFullLink().scopeCaps)
       .toEqual([{ depth: 1, scope: "space" }]);
     expect(reinterpreted.key("field").get()).toBeUndefined();
+  });
+});
+
+// Shapes the first round of this change missed, each found by adversarial
+// review rather than by the tests above.
+describe("asCell scope cap, harder shapes", () => {
+  let runtime: Runtime;
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let tx: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    tx = runtime.edit();
+  });
+
+  afterEach(async () => {
+    await tx.commit();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  const sessionInner = (cause: string) => {
+    const inner = runtime.getCell(space, cause, innerSchema, tx, "session");
+    inner.set({ field: "secret" });
+    return inner;
+  };
+
+  it("caps an array element handle", () => {
+    // The motivating shape: a space-scoped list whose element handles must
+    // point somewhere every reader in the space can resolve. Array elements
+    // reach the boundary with the element's link already stepped past, so the
+    // handle is built from the target address rather than from a sigil.
+    const inner = sessionInner("arr-inner");
+    const outer = runtime.getCell(
+      space,
+      "arr-outer",
+      {
+        type: "object",
+        properties: {
+          items: {
+            type: "array",
+            items: {
+              ...innerSchema,
+              asCell: [{ kind: "cell", scope: "space" }],
+            },
+          },
+        },
+        required: ["items"],
+      } as JSONSchema,
+      tx,
+    );
+    outer.set({ items: [inner] } as never);
+
+    const readHandle = (v: unknown) =>
+      isCell(v) ? (v as { get(): unknown }).get() : v;
+
+    const viaKey = outer.key("items").get() as unknown[];
+    expect(readHandle(viaKey[0])).toBeUndefined();
+    const viaWhole = (outer.get() as { items: unknown[] }).items;
+    expect(readHandle(viaWhole[0])).toBeUndefined();
+    expect(readHandle(outer.key("items", "0").get())).toBeUndefined();
+  });
+
+  it("caps a handle below a link the resolver already followed", () => {
+    // `outer`'s own value is a link to `mid`, so resolution consumes a hop
+    // before it ever reaches the capped handle. Caps recorded for the
+    // remaining segments have to travel across that hop.
+    const inner = sessionInner("hop-inner");
+    const mid = runtime.getCell(space, "hop-mid", undefined, tx);
+    mid.set({ handle: inner } as never);
+    const outer = runtime.getCell(space, "hop-outer", undefined, tx);
+    outer.set(mid as never);
+
+    const capped = outer.asSchema(
+      {
+        type: "object",
+        properties: {
+          handle: {
+            ...innerSchema,
+            asCell: [{ kind: "cell", scope: "space" }],
+          },
+        },
+        required: ["handle"],
+      } as JSONSchema,
+    );
+    expect(capped.key("handle", "field").get()).toBeUndefined();
+    const projected = capped.key("handle").get();
+    expect(
+      isCell(projected) ? (projected as { get(): unknown }).get() : projected,
+    )
+      .toBeUndefined();
+  });
+
+  it("lets asSchema tighten a cap it cannot loosen", () => {
+    // A looser cap recorded at a depth must not shadow a tighter one declared
+    // for the same depth by a later asSchema().
+    const inner = sessionInner("tighten-inner");
+    const outer = runtime.getCell(
+      space,
+      "tighten-outer",
+      {
+        type: "object",
+        properties: {
+          handle: {
+            ...innerSchema,
+            asCell: [{ kind: "cell", scope: "session" }],
+          },
+        },
+        required: ["handle"],
+      } as JSONSchema,
+      tx,
+    );
+    outer.set({ handle: inner } as never);
+
+    // The permissive cap reads through, as it should.
+    expect(outer.key("handle", "field").get()).toBe("secret");
+    // Re-declaring it tighter blocks, on both routes.
+    const tightened = outer.key("handle").asSchema(
+      {
+        ...innerSchema,
+        asCell: [{ kind: "cell", scope: "space" }],
+      } as JSONSchema,
+    );
+    expect(tightened.key("field").get()).toBeUndefined();
+  });
+
+  it("applies the leaf cap to an ancestor hop of a directly-built link", () => {
+    // A link assembled without key() carries no recorded caps, so only the
+    // leaf-schema floor in schemaScopeForLinkAtDepth can answer for a hop
+    // found at an ancestor. Removing that floor lets this read through.
+    const inner = sessionInner("floor-inner");
+    const holder = runtime.getCell(space, "floor-holder", undefined, tx);
+    holder.set({ a: inner } as never);
+    const base = holder.getAsNormalizedFullLink();
+    const atLeaf = (schema: JSONSchema) =>
+      runtime.getCellFromLink({ ...base, path: ["a", "field"] }, schema, tx);
+
+    // Control: with no cap anywhere the ancestor hop is followed.
+    expect(atLeaf({ type: "string" } as JSONSchema).get()).toBe("secret");
+    const capped = atLeaf({ type: "string", scope: "space" } as JSONSchema);
+    expect(capped.getAsNormalizedFullLink().scopeCaps).toBeUndefined();
+    expect(capped.get()).toBeUndefined();
+  });
+
+  it("does not invent a cap from `scope` beside an uncapped asCell", () => {
+    // `scope` on a node also means "this value lives at that scope". Only the
+    // asCell entry's own scope is a follow cap at a handle boundary.
+    const inner = sessionInner("noinvent-inner");
+    const outer = runtime.getCell(
+      space,
+      "noinvent-outer",
+      {
+        type: "object",
+        properties: {
+          handle: { ...innerSchema, asCell: ["cell"], scope: "space" },
+        },
+        required: ["handle"],
+      } as JSONSchema,
+      tx,
+    );
+    outer.set({ handle: inner } as never);
+    const projected = outer.key("handle").get();
+    expect(
+      isCell(projected) ? (projected as { get(): unknown }).get() : projected,
+    )
+      .toEqual({ field: "secret" });
+  });
+
+  it("refuses writes through a blocked handle", () => {
+    const inner = sessionInner("write-inner");
+    const outer = runtime.getCell(
+      space,
+      "write-outer",
+      {
+        type: "object",
+        properties: {
+          handle: {
+            ...innerSchema,
+            asCell: [{ kind: "cell", scope: "space" }],
+          },
+        },
+        required: ["handle"],
+      } as JSONSchema,
+      tx,
+    );
+    outer.set({ handle: inner } as never);
+
+    const blocked = outer.key("handle").get();
+    expect(isCell(blocked)).toBe(true);
+    expect(() =>
+      (blocked as { set(v: unknown): void }).set({ field: "hacked" })
+    )
+      .toThrow();
+    expect(inner.get()).toEqual({ field: "secret" });
   });
 });

--- a/packages/runner/test/ascell-scope-cap.test.ts
+++ b/packages/runner/test/ascell-scope-cap.test.ts
@@ -444,3 +444,139 @@ describe("asCell scope cap, harder shapes", () => {
     expect(inner.get()).toEqual({ field: "secret" });
   });
 });
+
+describe("asCell scope cap, positional and compound", () => {
+  let runtime: Runtime;
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let tx: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    tx = runtime.edit();
+  });
+
+  afterEach(async () => {
+    await tx.commit();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  const scopedInner = (cause: string, scope: "space" | "user" | "session") => {
+    const inner = runtime.getCell(space, cause, innerSchema, tx, scope);
+    inner.set({ field: "secret" });
+    return inner;
+  };
+
+  it("caps a handle below a NON-ROOT ancestor link", () => {
+    // The rebase across a hop shifts recorded cap depths onto the target's
+    // path. With the ancestor link at the root (depth 0) the shift is 0 either
+    // way, so an off-by-depth error hides. Here the link sits at `wrap`
+    // (depth 1) and the cap at `wrap/handle` (depth 2), so a wrong shift files
+    // the cap under a depth the hop never asks about and the read leaks.
+    const inner = scopedInner("nonroot-inner", "session");
+    const mid = runtime.getCell(space, "nonroot-mid", undefined, tx);
+    mid.set({ handle: inner } as never);
+    const outer = runtime.getCell(space, "nonroot-outer", undefined, tx);
+    outer.set({ wrap: mid } as never);
+
+    const capped = outer.asSchema(
+      {
+        type: "object",
+        properties: {
+          wrap: {
+            type: "object",
+            properties: {
+              handle: {
+                ...innerSchema,
+                asCell: [{ kind: "cell", scope: "space" }],
+              },
+            },
+            required: ["handle"],
+          },
+        },
+        required: ["wrap"],
+      } as JSONSchema,
+    );
+    expect(capped.key("wrap", "handle", "field").get()).toBeUndefined();
+  });
+
+  it("enforces a cap wrapped in anyOf on every route", () => {
+    // `{anyOf: [<capped handle>, {type:"null"}]}` is a real shape here.
+    // Reading only the top level for an asCell entry made it a cap bypass.
+    const inner = scopedInner("anyof-inner", "session");
+    const outer = runtime.getCell(
+      space,
+      "anyof-outer",
+      {
+        type: "object",
+        properties: {
+          handle: {
+            anyOf: [
+              { ...innerSchema, asCell: [{ kind: "cell", scope: "space" }] },
+              { type: "null" },
+            ],
+          },
+        },
+        required: ["handle"],
+      } as JSONSchema,
+      tx,
+    );
+    outer.set({ handle: inner } as never);
+
+    expect(outer.key("handle", "field").get()).toBeUndefined();
+    const projected = outer.key("handle").get();
+    expect(
+      isCell(projected) ? (projected as { get(): unknown }).get() : projected,
+    ).toBeUndefined();
+  });
+
+  it("keeps caps positional: a narrow cap below does not block a wide hop", () => {
+    // Why scopeCaps records a DEPTH rather than collapsing to one cap.
+    // `myProfile` is capped at `user` and legitimately holds a user-scoped
+    // link; the `profile` inside it is capped at `space`. Each cap governs the
+    // hop at its OWN position. Collapsing to the narrowest (`space`) would
+    // block the user-scoped hop at `myProfile`, which is exactly the shape
+    // pattern-scope.test.ts builds.
+    const profile = scopedInner("pos-profile", "space");
+    const myProfile = runtime.getCell(
+      space,
+      "pos-myprofile",
+      undefined,
+      tx,
+      "user",
+    );
+    myProfile.set({ profile } as never);
+    const root = runtime.getCell(space, "pos-root", undefined, tx);
+    root.set({ myProfile } as never);
+
+    const capped = root.asSchema(
+      {
+        type: "object",
+        properties: {
+          myProfile: {
+            type: "object",
+            properties: {
+              profile: {
+                ...innerSchema,
+                asCell: [{ kind: "cell", scope: "space" }],
+              },
+            },
+            required: ["profile"],
+            asCell: [{ kind: "cell", scope: "user" }],
+          },
+        },
+        required: ["myProfile"],
+      } as JSONSchema,
+    );
+
+    // The user-scoped hop at `myProfile` is permitted by ITS cap...
+    const handle = capped.key("myProfile").get();
+    expect(isCell(handle)).toBe(true);
+    // ...and the space-scoped profile below it reads through.
+    expect(capped.key("myProfile", "profile", "field").get()).toBe("secret");
+  });
+});


### PR DESCRIPTION
## Why

Closes #5230.

An `asCell` entry's `scope` is a follow cap — it bounds which link scopes a read arriving through that schema may follow. It is what lets a space-scoped list require that every handle in it points somewhere every reader in the space can resolve (`packages/runner/test/pattern-scope.test.ts` builds exactly that: `authorProfile` capped at `space` inside a space-scoped `messages` array).

Only one of the three routes to a handle enforced it. For one cell, one schema, one stored link:

```
cell.key("handle").get().get()      -> {"field":"secret"}   cap ignored
cell.key("handle", "field").get()   -> "secret"             cap ignored
cell.key("handle").resolveAsCell()  -> Undefined@1          cap honored
```

So whether a capped handle held depended on which materialization a caller happened to reach for, and callers pick between them for reasons that have nothing to do with scope. `PiecePropIo.get` is the live example: it blocks `["handle"]` and leaks `["handle","field"]`, purely because those two paths route differently.

## What changed

Two independent gaps.

**1. `key()` past the handle dropped the declaring schema.** Narrowing goes through `getSchemaAtPath`, which walks the `asCell` schema's `properties` and returns the leaf (`{"type":"string"}`), so `resolveLink`'s `schemaScopeForLink` had nothing to check one hop later:

```
getSchemaScopeCap(outer.key("handle").schema)         -> "space"
getSchemaScopeCap(outer.key("handle","field").schema) -> undefined
```

`key()` now records a cap it narrows past on the link (`scopeCaps: [{depth, scope}]`), and `resolveLink` consults the cap declared at the depth where it actually *finds* the hop rather than the leaf's. `scopeCaps` is read-side only: never serialized into a sigil link (`createSigilLinkFromParsedLink` builds field by field), never part of link identity (`areNormalizedLinksSame` compares id/space/scope/path), and never stamped onto a followed link's own scope — CT-1623 stays intact.

**2. The value projection never consulted the cap at all.** An `asCell` boundary is the one place a link is turned into a handle *instead of* being followed, so `followPointer`'s check never runs for it. Both boundary sites — the traverser's `getNextCellLink` and `validateAndTransform`'s top-level `asCell` path — now apply the same rule and resolve to undefined-data. `undefinedDataLink` is exported from `link-resolution.ts` so all three routes produce the same shape by construction.

## Test plan

New `packages/runner/test/ascell-scope-cap.test.ts` pins all three routes to one answer across four schema shapes. The three permissive cases (cap admits the link, no cap declared, link no narrower than the cap) already passed before the fix and are here as regression guards — the risk in this change is over-blocking, not under-blocking. A fifth test pins the `scopeCaps` plumbing directly.

- `deno fmt` / `deno lint` / `deno check` on all changed files — clean
- **`packages/runner` — 1103 passed / 5752 steps / 0 failed**, via the package's own task (`--preload=test/clock-preload.ts`; without the clock preload the suite has 108 pre-existing timing failures on unmodified `main` too, so that run is not a baseline)
- `packages/piece` — 31 tests / 368 steps
- `packages/patterns` — 66 tests / 32 steps
- `packages/fuse` — 347 tests
- `packages/cli` piece tests — 72 steps

## Follow-up

This unblocks removing the `resolveAsCell` routing that #5229 had to keep in `PiecePropIo.get`: with the cap enforced on the projection, the plain `key()` + projection read blocks a capped handle on its own. Verified against this branch — `["handle"]` returns `undefined` and `["handle","field"]` is blocked. One wrinkle to settle there: the blocked through-path currently falls through to the root read and surfaces as `Cannot access path "handle/field" - property "field" not found` rather than `undefined`, so the piece layer reports a blocked read as a missing one. Worth deciding deliberately rather than inheriting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces `asCell` scope caps on every route (projection, `key()` through-paths, deref, whole-object/array traversal) so capped handles behave the same everywhere and resolve to a unified undefined-data shape when blocked (fixes #5230). Also handles caps inside `anyOf`/`oneOf` and corrects cap rebasing across already-followed hops.

- Bug Fixes
  - Track caps via `scopeCaps`: seed from the starting address, correctly rebase across followed hops (fixed shift off-by-depth), keep the narrower cap when re-declared via `asSchema`, and preserve across `asSchema`. Read-only: not serialized, not part of identity, never stamped onto followed links.
  - Resolve using the cap at the hop’s depth: combine the asCell follow cap (including caps wrapped in `anyOf`/`oneOf`, narrowest wins) with the leaf’s; for ancestor hops use the narrower of the recorded cap and the leaf cap, keeping the leaf cap as a floor when no recorded caps exist.
  - Enforce the same cap check at all asCell boundaries at a single handle-mint site (projection, whole-object reads, arrays, redirects). Consult only the entry’s own asCell scope (ignore `schema.scope`), return `undefinedDataLink` (which drops `scopeCaps`) and skip deref logging when blocked; writes through blocked handles are refused.
  - Add tests for arrays, `anyOf`/`oneOf` compounds (null branches ignored; narrowest cap wins), cross-hop rebasing at non-root depth, positional caps, `asSchema` tightening, leaf-cap floor, no invented cap from `scope`, blocked writes, and all access routes.
  - Document the monotonic-cap rule on `scopeCaps`: caps persist across `asSchema` (cannot be lifted), with rationale added inline.

<sup>Written for commit 57a0ba79d23d33bde2e3556c17e92e7e79a2a612. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

