### PR TITLE
feat(cli): refuse a piece get path that lands on a verb (WS-F read-path guard)

### DIFF
--- a/docs/plans/pattern-verb-contract-implementation.md
+++ b/docs/plans/pattern-verb-contract-implementation.md
@@ -642,12 +642,18 @@ Size M, mostly parallel. `packages/cli`, `skills/cf`.
   and Invocation is required to be authored open-world precisely so protocol
   fields can be added later. Cost is bounded by emitting links only for paths
   that have them, and only when asked.
-- **Read-path guard:** `cf piece get` on a path that resolves to a verb returns
-  the stream's serialization rather than redirecting. The llm-dialog `read`
-  tool already rejects this case with the right message — "Path resolves to a
-  handler; use invoke() instead" — and the CLI read path
-  (`packages/cli/lib/piece.ts`, `getCellValue`) has no equivalent check. Cheap,
-  and it saves an agent a wasted turn.
+- ~~**Read-path guard:** `cf piece get` on a path that resolves to a verb
+  returns the stream's serialization rather than redirecting. The llm-dialog
+  `read` tool already rejects this case with the right message — "Path
+  resolves to a handler; use invoke() instead" — and the CLI read path
+  (`packages/cli/lib/piece.ts`, `getCellValue`) has no equivalent check.
+  Cheap, and it saves an agent a wasted turn.~~ — **done**: `getCellValue`
+  classifies the read path's last segment with the same classification
+  `cf piece call` resolves through — ordinary detection plus the
+  forced-stream probe — and a path landing ON a verb (handler or tool)
+  refuses with "Path resolves to a verb; use 'cf piece call …' instead.",
+  reported as a `piece get` data error (one line on stderr, exit 1). Parent
+  objects and plain data paths read as before.
 - `--await` / `--no-wait` and the caller-controlled wait bound — with WS-D.
 - Skill updates ride each surface (`skills/cf`, `skills/topics`): the handle
   lookup and verification read leave the documented workflow when Phase 4

--- a/docs/plans/pattern-verb-contract-implementation.md
+++ b/docs/plans/pattern-verb-contract-implementation.md
@@ -648,12 +648,17 @@ Size M, mostly parallel. `packages/cli`, `skills/cf`.
   resolves to a handler; use invoke() instead" — and the CLI read path
   (`packages/cli/lib/piece.ts`, `getCellValue`) has no equivalent check.
   Cheap, and it saves an agent a wasted turn.~~ — **done**: `getCellValue`
-  classifies the read path's last segment with the same classification
-  `cf piece call` resolves through — ordinary detection plus the
-  forced-stream probe — and a path landing ON a verb (handler or tool)
-  refuses with "Path resolves to a verb; use 'cf piece call …' instead.",
-  reported as a `piece get` data error (one line on stderr, exit 1). Parent
-  objects and plain data paths read as before.
+  refuses only on the two definite stored signals — the link-derived schema
+  answers as a stream, or the value reads as the `{$stream: true}` sentinel —
+  reported as a `piece get` data error (one line on stderr, exit 1). A root
+  verb redirects at `cf piece call`; a nested verb is not root-callable, so
+  it points at reading the parent object or `cf piece verbs` instead. The
+  guard never consults the forced-stream probe: the probe stays with the
+  dispatcher and the listing, where over-inclusion is an extra row or a call
+  the caller asked for, but the cast's stream schema survives link resolution
+  for inline values, so a read guard built on it would refuse plain data
+  outputs. Reads fail open; tool bindings read as data (the llm-dialog read
+  tool reads them too); parent objects and plain data paths read as before.
 - `--await` / `--no-wait` and the caller-controlled wait bound — with WS-D.
 - Skill updates ride each surface (`skills/cf`, `skills/topics`): the handle
   lookup and verification read leave the documented workflow when Phase 4

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -19,6 +19,7 @@ import {
   newPiece,
   PieceConfig,
   PieceResultProjectionError,
+  PieceVerbReadError,
   recreateSpaceRootPattern,
   removePiece,
   resetHomePattern,
@@ -178,14 +179,18 @@ export function localPatternEntry(
 
 /**
  * A `piece get` failure caused by a data condition rather than bad arguments:
- * a path that doesn't resolve, a result schema that can't project stored data,
- * or a filter/projection that doesn't fit the selected value. Reported as a
- * plain error on stderr with exit 1, never as a Cliffy ValidationError (which
- * would dump the usage screen and read as an arg-parse failure).
+ * a path that doesn't resolve, a result schema that can't project stored data
+ * (PieceResultProjectionError), a filter/projection that doesn't fit the
+ * selected value (PieceGetTransformError), or a path that lands on a verb
+ * (PieceVerbReadError — the read-path guard's redirect at `cf piece call`).
+ * Reported as a plain error on stderr with exit 1, never as a Cliffy
+ * ValidationError (which would dump the usage screen and read as an arg-parse
+ * failure).
  */
 export function isPieceGetDataError(error: unknown): error is Error {
   return error instanceof PieceResultProjectionError ||
     error instanceof PieceGetTransformError ||
+    error instanceof PieceVerbReadError ||
     (error instanceof Error &&
       error.message.startsWith("Cannot access path"));
 }
@@ -195,7 +200,8 @@ export function isPieceGetDataError(error: unknown): error is Error {
  * error is not a data error (the caller should rethrow). `message` is the
  * one-line error; `hint` is an optional next-step tip. A projection error
  * already carries its own `--step` guidance, transform errors stand alone,
- * and an input-mode read has nothing more to suggest — only a result-mode
+ * a verb refusal already carries its `cf piece call` redirect, and an
+ * input-mode read has nothing more to suggest — only a result-mode
  * unresolved path gets the `--input` tip.
  */
 export function pieceGetDataErrorReport(
@@ -206,6 +212,7 @@ export function pieceGetDataErrorReport(
   if (
     error instanceof PieceResultProjectionError ||
     error instanceof PieceGetTransformError ||
+    error instanceof PieceVerbReadError ||
     opts.input
   ) {
     return { message: error.message };

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -48,7 +48,7 @@ import { getCarriedCfcLabelView } from "@commonfabric/runner/cfc";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { isPlainObject, isRecord } from "@commonfabric/utils/types";
 import { pinProgramFabricImports, renderPinRewrite } from "./fabric-deps.ts";
-import { isHandlerCell } from "../../fuse/callables.ts";
+import { isHandlerCell, isStreamValue } from "../../fuse/callables.ts";
 import { throwOnSpaceAuthorizationError } from "./utils.ts";
 import {
   callableCommandSpec,
@@ -117,13 +117,21 @@ export interface GetCellValueOptions {
 
 /** A `cf piece get` path that lands ON a verb. Reading a verb returns the
  * stream's serialization — never what the caller wanted — so the read refuses
- * and redirects to the dispatcher instead, mirroring the llm-dialog read
- * tool's "Path resolves to a handler; use invoke() instead." (verb contract
- * WS-F, read-path guard). */
+ * and redirects instead, mirroring the llm-dialog read tool's "Path resolves
+ * to a handler; use invoke() instead." (verb contract WS-F, read-path guard).
+ * `callable` is whether `cf piece call <verb>` actually resolves the verb —
+ * the dispatcher resolves root-level names only — so the refusal never
+ * suggests a command that would fail: a nested verb points at reading the
+ * parent object or the root-level verbs listing instead. */
 export class PieceVerbReadError extends Error {
-  constructor(verb: string, piece: string) {
+  constructor(verb: string, piece: string, callable: boolean) {
     super(
-      `Path resolves to a verb; use 'cf piece call --piece ${piece} ${verb}' instead.`,
+      callable
+        ? `Path resolves to a verb; use 'cf piece call --piece ${piece} ${verb}' instead.`
+        : `Path resolves to a verb that is not directly callable: verbs are ` +
+          `invoked at the piece's root surface. Read the parent object ` +
+          `instead, or list the callable verbs with ` +
+          `'cf piece verbs --piece ${piece}'.`,
     );
     this.name = "PieceVerbReadError";
   }
@@ -1359,7 +1367,12 @@ async function tryResolvePieceCallableAt(
  * of `cf piece call` (tryResolvePieceHandler) — a handler whose stored schema
  * lost the stream marker still answers this cast — shared with the listing's
  * fallback probe and the read-path guard so all three classify identically.
- * Returns the proven stream cell, or null. */
+ * Only meaningful at the piece cell, where every attribute is a
+ * schema-carrying link or a genuine handler: for inline values and
+ * schema-less links the cast schema itself survives resolution and
+ * `Cell.isStream`'s schema branch answers "stream" from it, so probing
+ * arbitrary cells would report plain data as handlers. Returns the proven
+ * stream cell, or null. */
 function probeForcedStreamCell(cell: any, name: string): any | null {
   if (
     typeof cell !== "object" || cell === null ||
@@ -2199,49 +2212,57 @@ export function formatViewTree(view: unknown): string {
   return format(view, "", true);
 }
 
+/** A read path's last segment classified as a verb: the name, and whether
+ * `cf piece call <name>` actually resolves it (root-level names only). */
+interface ReadPathVerb {
+  verb: string;
+  callable: boolean;
+}
+
 /**
- * True when a `cf piece get` path lands ON a verb: the same classification
- * `cf piece call` resolves through — `detectCallableKind` on the link-derived
- * cell (tryResolvePieceCallableAt), then the forced-stream probe
- * (tryResolvePieceHandler) — applied at the read path's last segment, so the
- * read guard and the dispatcher can never disagree about what is callable.
- * A classification failure is not a verb: the guard must never break a plain
- * data read.
+ * Classify a `cf piece get` path whose last segment CERTAINLY lands on a
+ * verb. The guard refuses only on the two definite stored signals: the
+ * link-derived schema answers as a stream (`isHandlerCell` on the
+ * `asSchemaFromLinks` cell — that schema comes from stored links, never from
+ * a caller-supplied cast), or the stored value reads as the
+ * `{$stream: true}` sentinel. It NEVER refuses on the forced-stream probe:
+ * the probe is deliberately permissive for the dispatcher and the listing —
+ * over-inclusion there is an extra listing row or a call the caller asked
+ * for — but the cast's stream schema survives link resolution for inline
+ * values and schema-less links (`resolveLink` keeps the caller's schema and
+ * `Cell.isStream`'s schema branch answers from it), so a read guard built on
+ * it would refuse plain data outputs. Reads fail open: a classification
+ * failure, an uncertain shape, or a tool binding (readable data, exactly as
+ * the llm-dialog read tool treats it) all read normally.
+ *
+ * `callable` is true only for root-level names — the dispatcher's resolution
+ * paths all start at a root — so the refusal message can redirect honestly.
  */
-async function readPathLandsOnVerb(
+async function classifyReadPathVerb(
   piece: any,
   prop: "input" | "result",
   path: readonly (string | number)[],
-): Promise<boolean> {
+): Promise<ReadPathVerb | null> {
   const name = path.at(-1);
   // Verbs are named properties; a path-less read is the parent-object read,
   // which stays readable even when the object carries verbs.
-  if (typeof name !== "string") return false;
+  if (typeof name !== "string") return null;
   try {
     const rootCell = await piece[prop].getCell();
     const parentCell = path.length > 1
       ? rootCell.key(...path.slice(0, -1))
       : rootCell;
-    const callableCell = parentCell.key(name).asSchemaFromLinks?.();
+    const child = parentCell.key(name);
+    const derived = child.asSchemaFromLinks?.() ?? child;
     if (
-      callableCell &&
-      detectCallableKind(
-        getCallableValue(parentCell.get?.(), name),
-        callableCell,
-      )
+      isStreamValue(getCallableValue(parentCell.get?.(), name)) ||
+      isHandlerCell(derived)
     ) {
-      return true;
+      return { verb: name, callable: path.length === 1 };
     }
-    // Root-level result names dispatch through the piece cell's forced stream
-    // cast (result is the identity on the piece cell — see
-    // tryResolvePieceHandler); nested names and input-side names get the same
-    // probe on their own parent.
-    const probeTarget = prop === "result" && path.length === 1
-      ? piece.getCell?.() ?? parentCell
-      : parentCell;
-    return probeForcedStreamCell(probeTarget, name) !== null;
+    return null;
   } catch {
-    return false;
+    return null;
   }
 }
 
@@ -2352,10 +2373,15 @@ export async function getCellValue(
 
     // Read-path guard (verb contract WS-F): a path that lands ON a verb would
     // return the stream's serialization — never what a caller wants — so it
-    // refuses and redirects to `cf piece call`. Classified after the read so
-    // the piece's links and schema are materialized locally.
-    if (await readPathLandsOnVerb(piece, prop, path)) {
-      throw new PieceVerbReadError(String(path.at(-1)), resolvedConfig.piece);
+    // refuses and redirects. Classified after the read so the piece's links
+    // and schema are materialized locally.
+    const verb = await classifyReadPathVerb(piece, prop, path);
+    if (verb) {
+      throw new PieceVerbReadError(
+        verb.verb,
+        resolvedConfig.piece,
+        verb.callable,
+      );
     }
 
     return value;

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -115,6 +115,20 @@ export interface GetCellValueOptions {
   transform?: PieceGetTransform;
 }
 
+/** A `cf piece get` path that lands ON a verb. Reading a verb returns the
+ * stream's serialization — never what the caller wanted — so the read refuses
+ * and redirects to the dispatcher instead, mirroring the llm-dialog read
+ * tool's "Path resolves to a handler; use invoke() instead." (verb contract
+ * WS-F, read-path guard). */
+export class PieceVerbReadError extends Error {
+  constructor(verb: string, piece: string) {
+    super(
+      `Path resolves to a verb; use 'cf piece call --piece ${piece} ${verb}' instead.`,
+    );
+    this.name = "PieceVerbReadError";
+  }
+}
+
 export class PieceResultProjectionError extends Error {
   constructor(path: readonly (string | number)[], stepped: boolean) {
     const location = path.length === 0 ? "<root>" : path.join("/");
@@ -1340,6 +1354,30 @@ async function tryResolvePieceCallableAt(
   };
 }
 
+/** The forced-stream probe: cast `name` on `cell` to a stream and ask the
+ * runtime whether it answers as a handler. This is the third resolution path
+ * of `cf piece call` (tryResolvePieceHandler) — a handler whose stored schema
+ * lost the stream marker still answers this cast — shared with the listing's
+ * fallback probe and the read-path guard so all three classify identically.
+ * Returns the proven stream cell, or null. */
+function probeForcedStreamCell(cell: any, name: string): any | null {
+  if (
+    typeof cell !== "object" || cell === null ||
+    typeof cell.asSchema !== "function"
+  ) {
+    return null;
+  }
+  const streamRoot = cell.asSchema({
+    type: "object",
+    properties: {
+      [name]: { asCell: ["stream"] },
+    },
+    required: [name],
+  });
+  const streamCell = streamRoot.key(name);
+  return isHandlerCell(streamCell) ? streamCell : null;
+}
+
 async function tryResolvePieceHandler(
   piece: any,
   manager: any,
@@ -1351,15 +1389,8 @@ async function tryResolvePieceHandler(
     return null;
   }
 
-  const streamRoot = pieceCell.asSchema({
-    type: "object",
-    properties: {
-      [callableName]: { asCell: ["stream"] },
-    },
-    required: [callableName],
-  });
-  const streamCell = streamRoot.key(callableName);
-  if (!isHandlerCell(streamCell)) {
+  const streamCell = probeForcedStreamCell(pieceCell, callableName);
+  if (!streamCell) {
     return null;
   }
 
@@ -1624,12 +1655,7 @@ export async function listPieceCallables(
     }
     for (const name of rejected) {
       if (listings.has(name)) continue;
-      const streamRoot = pieceCell.asSchema({
-        type: "object",
-        properties: { [name]: { asCell: ["stream"] } },
-        required: [name],
-      });
-      if (!isHandlerCell(streamRoot.key(name))) continue;
+      if (!probeForcedStreamCell(pieceCell, name)) continue;
       const callableCell = resultRoot.key(name).asSchemaFromLinks();
       const spec = callableCommandSpec(callableCell, "handler");
       listings.set(name, {
@@ -2173,6 +2199,52 @@ export function formatViewTree(view: unknown): string {
   return format(view, "", true);
 }
 
+/**
+ * True when a `cf piece get` path lands ON a verb: the same classification
+ * `cf piece call` resolves through — `detectCallableKind` on the link-derived
+ * cell (tryResolvePieceCallableAt), then the forced-stream probe
+ * (tryResolvePieceHandler) — applied at the read path's last segment, so the
+ * read guard and the dispatcher can never disagree about what is callable.
+ * A classification failure is not a verb: the guard must never break a plain
+ * data read.
+ */
+async function readPathLandsOnVerb(
+  piece: any,
+  prop: "input" | "result",
+  path: readonly (string | number)[],
+): Promise<boolean> {
+  const name = path.at(-1);
+  // Verbs are named properties; a path-less read is the parent-object read,
+  // which stays readable even when the object carries verbs.
+  if (typeof name !== "string") return false;
+  try {
+    const rootCell = await piece[prop].getCell();
+    const parentCell = path.length > 1
+      ? rootCell.key(...path.slice(0, -1))
+      : rootCell;
+    const callableCell = parentCell.key(name).asSchemaFromLinks?.();
+    if (
+      callableCell &&
+      detectCallableKind(
+        getCallableValue(parentCell.get?.(), name),
+        callableCell,
+      )
+    ) {
+      return true;
+    }
+    // Root-level result names dispatch through the piece cell's forced stream
+    // cast (result is the identity on the piece cell — see
+    // tryResolvePieceHandler); nested names and input-side names get the same
+    // probe on their own parent.
+    const probeTarget = prop === "result" && path.length === 1
+      ? piece.getCell?.() ?? parentCell
+      : parentCell;
+    return probeForcedStreamCell(probeTarget, name) !== null;
+  } catch {
+    return false;
+  }
+}
+
 export async function getCellValue(
   config: PieceConfig,
   path: (string | number)[],
@@ -2229,6 +2301,12 @@ export async function getCellValue(
         }
         throw error;
       }
+      // Read-path guard (verb contract WS-F): the transform path returns
+      // early, so it needs the same verb refusal the plain read applies
+      // below — a verb read through a transform is the same mistake.
+      if (await readPathLandsOnVerb(piece, prop, path)) {
+        throw new PieceVerbReadError(String(path.at(-1)), resolvedConfig.piece);
+      }
       const sourceWasAbsent = typeof targetCell.getRaw === "function" &&
         targetCell.getRaw() === undefined;
       if (
@@ -2270,6 +2348,14 @@ export async function getCellValue(
       await resultProjectionFailedAtPath(piece, path)
     ) {
       throw new PieceResultProjectionError(path, shouldStep);
+    }
+
+    // Read-path guard (verb contract WS-F): a path that lands ON a verb would
+    // return the stream's serialization — never what a caller wants — so it
+    // refuses and redirects to `cf piece call`. Classified after the read so
+    // the piece's links and schema are materialized locally.
+    if (await readPathLandsOnVerb(piece, prop, path)) {
+      throw new PieceVerbReadError(String(path.at(-1)), resolvedConfig.piece);
     }
 
     return value;

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -2325,8 +2325,13 @@ export async function getCellValue(
       // Read-path guard (verb contract WS-F): the transform path returns
       // early, so it needs the same verb refusal the plain read applies
       // below — a verb read through a transform is the same mistake.
-      if (await readPathLandsOnVerb(piece, prop, path)) {
-        throw new PieceVerbReadError(String(path.at(-1)), resolvedConfig.piece);
+      const transformPathVerb = await classifyReadPathVerb(piece, prop, path);
+      if (transformPathVerb) {
+        throw new PieceVerbReadError(
+          transformPathVerb.verb,
+          resolvedConfig.piece,
+          transformPathVerb.callable,
+        );
       }
       const sourceWasAbsent = typeof targetCell.getRaw === "function" &&
         targetCell.getRaw() === undefined;

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -9,6 +9,7 @@ import {
 import {
   executePieceCallable,
   PieceResultProjectionError,
+  PieceVerbReadError,
 } from "../lib/piece.ts";
 import {
   exitWithDataError,
@@ -1623,6 +1624,40 @@ describe("piece get data errors", () => {
     });
     expect(report?.message).toBe("--filter can only be applied to an array");
     expect(report?.hint).toBeUndefined();
+  });
+
+  it("refuses a path that lands on a verb with the call redirect and exit 1", () => {
+    const verbError = new PieceVerbReadError("addTopic", "fid1:piece-123");
+    expect(isPieceGetDataError(verbError)).toBe(true);
+    const report = pieceGetDataErrorReport(verbError, {
+      input: false,
+      piece: "fid1:piece-123",
+    });
+    // The message IS the redirect — mirroring the llm-dialog read tool's
+    // "Path resolves to a handler; use invoke() instead." — so no extra hint
+    // rides along (the --input tip would be a wrong remedy for a verb).
+    expect(report?.message).toBe(
+      "Path resolves to a verb; use 'cf piece call --piece fid1:piece-123 addTopic' instead.",
+    );
+    expect(report?.hint).toBeUndefined();
+
+    // Threaded through the shared data-error exit: stderr message, exit 1.
+    const printed: string[] = [];
+    const exited: number[] = [];
+    expect(() =>
+      exitWithDataError(report!, {
+        printError: (m) => printed.push(m),
+        printHint: () => {},
+        exit: (code: number): never => {
+          exited.push(code);
+          throw new Error("exit-sentinel");
+        },
+      })
+    ).toThrow("exit-sentinel");
+    expect(printed).toEqual([
+      "Path resolves to a verb; use 'cf piece call --piece fid1:piece-123 addTopic' instead.",
+    ]);
+    expect(exited).toEqual([1]);
   });
 });
 

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -1627,7 +1627,11 @@ describe("piece get data errors", () => {
   });
 
   it("refuses a path that lands on a verb with the call redirect and exit 1", () => {
-    const verbError = new PieceVerbReadError("addTopic", "fid1:piece-123");
+    const verbError = new PieceVerbReadError(
+      "addTopic",
+      "fid1:piece-123",
+      true,
+    );
     expect(isPieceGetDataError(verbError)).toBe(true);
     const report = pieceGetDataErrorReport(verbError, {
       input: false,
@@ -1640,6 +1644,20 @@ describe("piece get data errors", () => {
       "Path resolves to a verb; use 'cf piece call --piece fid1:piece-123 addTopic' instead.",
     );
     expect(report?.hint).toBeUndefined();
+
+    // A nested verb is not root-callable, so its report must not suggest a
+    // command that would fail — it redirects at the parent read and the
+    // verbs listing instead, still hint-free.
+    const nestedReport = pieceGetDataErrorReport(
+      new PieceVerbReadError("removeItem", "fid1:piece-123", false),
+      { input: false, piece: "fid1:piece-123" },
+    );
+    expect(nestedReport?.message).toMatch(/not directly callable/);
+    expect(nestedReport?.message).toMatch(
+      /cf piece verbs --piece fid1:piece-123/,
+    );
+    expect(nestedReport?.message).not.toContain("cf piece call");
+    expect(nestedReport?.hint).toBeUndefined();
 
     // Threaded through the shared data-error exit: stderr message, exit 1.
     const printed: string[] = [];

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -28,6 +28,68 @@ import { LinkValidationError } from "../lib/piece.ts";
 import { PieceGetTransformError } from "../lib/piece-get-transform.ts";
 
 describe("executePieceCallable", () => {
+  it("reports not-found when the piece cell has no schema-cast surface", async () => {
+    // The forced-stream probe's type guard: a piece cell without asSchema
+    // cannot take the cast, so the third resolution path answers null and
+    // the resolver reports not-found instead of crashing on the probe.
+    const emptyChild: Record<string, unknown> = {
+      schema: undefined,
+      get: () => undefined,
+      getRaw: () => undefined,
+    };
+    emptyChild.key = () => emptyChild;
+    emptyChild.asSchemaFromLinks = () => emptyChild;
+    const emptyRoot = {
+      schema: undefined,
+      get: () => ({}),
+      getRaw: () => ({}),
+      key: () => emptyChild,
+      asSchemaFromLinks: () => emptyChild,
+    };
+    const piece = {
+      result: { getCell: () => Promise.resolve(emptyRoot) },
+      input: { getCell: () => Promise.resolve(emptyRoot) },
+      getCell: () => ({}),
+    };
+    await expect(
+      executePieceCallable(
+        {
+          apiUrl: "http://localhost:8000",
+          identity: "/tmp/test-identity.pem",
+          piece: "fid1:piece-123",
+          space: "home",
+        },
+        "missing",
+        [],
+        {
+          loadManager: () =>
+            Promise.resolve({ getSpace: () => "home" } as never),
+          loadPiece: () => Promise.resolve(piece as never),
+        },
+      ),
+    ).rejects.toThrow('Callable "missing" not found');
+
+    // A piece exposing no cell at all skips the probe the same way.
+    const { getCell: _getCell, ...pieceWithoutCell } = piece;
+    await expect(
+      executePieceCallable(
+        {
+          apiUrl: "http://localhost:8000",
+          identity: "/tmp/test-identity.pem",
+          piece: "fid1:piece-123",
+          space: "home",
+        },
+        "missing",
+        [],
+        {
+          loadManager: () =>
+            Promise.resolve({ getSpace: () => "home" } as never),
+          loadPiece: () => Promise.resolve(pieceWithoutCell as never),
+        },
+      ),
+    ).rejects.toThrow('Callable "missing" not found');
+  });
+
   it("preserves plain-text mode while resolving a callable", async () => {
     const harness = createPieceCallableHarness({
       callableKind: "handler",

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -24,6 +24,7 @@ import {
   listPieces,
   newPiece,
   PieceResultProjectionError,
+  PieceVerbReadError,
   recreateSpaceRootPattern,
   resolveLinkEndpointAddress,
   resolvePieceConfig,
@@ -873,6 +874,9 @@ describe("cli piece parsing", () => {
       "runtime.idle",
       "manager.synced",
       "result.get",
+      // The read-path guard classifies the read path after the value read
+      // (verb contract WS-F), descending to the same key once more.
+      "result.key:value",
       `stop:${PIECE}`,
     ]);
   });
@@ -1003,6 +1007,135 @@ describe("cli piece parsing", () => {
         createController: () => controller as any,
       },
     )).resolves.toBeUndefined();
+  });
+
+  describe("read-path guard (verb contract WS-F)", () => {
+    /** Minimal cell double for the guard's classification walk: value
+     * access, key() descent, and asSchemaFromLinks identity — the same
+     * surface piece-verbs.test.ts doubles for listPieceCallables. */
+    function guardCell(value: unknown): {
+      get: () => unknown;
+      getRaw: () => unknown;
+      asSchemaFromLinks: () => unknown;
+      key: (...segments: (string | number)[]) => unknown;
+    } {
+      const self = {
+        get: () => value,
+        getRaw: () => value,
+        asSchemaFromLinks: () => self,
+        key: (...segments: (string | number)[]) => {
+          let child: unknown = value;
+          for (const segment of segments) {
+            child = typeof child === "object" && child !== null
+              ? (child as Record<string | number, unknown>)[segment]
+              : undefined;
+          }
+          return guardCell(child);
+        },
+      };
+      return self;
+    }
+
+    const readPath = (value: unknown, path: (string | number)[]): unknown =>
+      path.reduce(
+        (current: unknown, segment) =>
+          typeof current === "object" && current !== null
+            ? (current as Record<string | number, unknown>)[segment]
+            : undefined,
+        value,
+      );
+
+    const RESULT_VALUE = {
+      title: "Groceries",
+      addItem: { $stream: true },
+      nested: {
+        list: ["milk"],
+        removeItem: { $stream: true },
+      },
+      search: {
+        pattern: { argumentSchema: { type: "object" } },
+        extraParams: {},
+      },
+    };
+
+    const guardDeps = (piece: unknown) => ({
+      loadManager: () => Promise.resolve({} as never),
+      resolvePieceAddress: (_manager: unknown, id: string) =>
+        Promise.resolve(id),
+      createController: () => ({ get: () => Promise.resolve(piece) }) as never,
+    });
+
+    const guardPiece = (resultValue: unknown, pieceCell?: unknown) => ({
+      input: {
+        get: () => Promise.resolve(undefined),
+        getCell: () => Promise.resolve(guardCell(undefined)),
+      },
+      result: {
+        get: (path: (string | number)[]) =>
+          Promise.resolve(readPath(resultValue, path)),
+        getCell: () => Promise.resolve(guardCell(resultValue)),
+      },
+      ...(pieceCell ? { getCell: () => pieceCell } : {}),
+    });
+
+    const config = {
+      apiUrl: API_URL,
+      space: SPACE,
+      identity: ID,
+      piece: PIECE,
+    };
+
+    it("refuses a path that lands on a verb, pointing at cf piece call", async () => {
+      const deps = guardDeps(guardPiece(RESULT_VALUE));
+      const error = await getCellValue(config, ["addItem"], {}, deps)
+        .catch((error) => error);
+      expect(error).toBeInstanceOf(PieceVerbReadError);
+      expect((error as Error).message).toBe(
+        `Path resolves to a verb; use 'cf piece call --piece ${PIECE} addItem' instead.`,
+      );
+
+      // The same guard covers a verb nested below the result root, and a
+      // tool-shaped verb — both are callable, so both redirect.
+      await expect(getCellValue(config, ["nested", "removeItem"], {}, deps))
+        .rejects.toThrow(PieceVerbReadError);
+      await expect(getCellValue(config, ["search"], {}, deps))
+        .rejects.toThrow(PieceVerbReadError);
+    });
+
+    it("refuses a verb only reachable through the forced-stream probe", async () => {
+      // Ordinary detection sees a plain object; only the forced stream cast
+      // on the piece cell — cf piece call's third resolution path — proves
+      // it is a handler. The guard must agree with the dispatcher.
+      const pieceCell = {
+        asSchema: () => ({
+          key: (name: string) => ({ isStream: () => name === "hiddenPing" }),
+        }),
+      };
+      const deps = guardDeps(
+        guardPiece({ hiddenPing: {}, count: 3 }, pieceCell),
+      );
+      await expect(getCellValue(config, ["hiddenPing"], {}, deps))
+        .rejects.toThrow(/use 'cf piece call/);
+      // A data sibling on the same piece still reads: the probe answers for
+      // the one name, not the whole piece.
+      await expect(getCellValue(config, ["count"], {}, deps)).resolves.toBe(3);
+    });
+
+    it("still reads plain data paths and a verb's parent object", async () => {
+      const deps = guardDeps(guardPiece(RESULT_VALUE));
+      await expect(getCellValue(config, ["title"], {}, deps)).resolves.toBe(
+        "Groceries",
+      );
+      await expect(getCellValue(config, ["nested", "list"], {}, deps))
+        .resolves.toEqual(["milk"]);
+      // Only the path that lands ON the verb refuses: its parent object —
+      // named or the path-less full result — keeps reading, verbs included.
+      await expect(getCellValue(config, ["nested"], {}, deps)).resolves
+        .toEqual(RESULT_VALUE.nested);
+      await expect(getCellValue(config, [], {}, deps)).resolves.toEqual(
+        RESULT_VALUE,
+      );
+    });
   });
 
   it("rejects repository metadata when resetting the home pattern", async () => {

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -979,6 +979,31 @@ describe("cli piece parsing", () => {
     )).rejects.toThrow(PieceResultProjectionError);
   });
 
+  it("rethrows a read failure that is not a path/projection condition", async () => {
+    const controller = {
+      get: () =>
+        Promise.resolve({
+          input: { get: () => Promise.resolve(undefined) },
+          result: {
+            get: () => Promise.reject(new Error("network unreachable")),
+            getCell: () =>
+              Promise.resolve({ schema: undefined, getRaw: () => undefined }),
+          },
+        }),
+    };
+
+    await expect(getCellValue(
+      { apiUrl: API_URL, space: SPACE, identity: ID, piece: PIECE },
+      ["count"],
+      {},
+      {
+        loadManager: () => Promise.resolve({} as any),
+        resolvePieceAddress: (_manager, id) => Promise.resolve(id),
+        createController: () => controller as any,
+      },
+    )).rejects.toThrow("network unreachable");
+  });
+
   it("preserves schema-valid undefined over present raw data", async () => {
     const rawCell = {
       schema: {
@@ -1183,6 +1208,30 @@ describe("cli piece parsing", () => {
       await expect(getCellValue(config, ["lastMessage"], {}, deps))
         .resolves.toEqual({ text: "hi" });
       await expect(getCellValue(config, ["count"], {}, deps)).resolves.toBe(3);
+    });
+
+    it("fails open when classification itself fails", async () => {
+      // A cell surface that throws during the guard's walk must never turn
+      // a successful read into a refusal: the guard swallows the failure
+      // and the value wins.
+      const throwingRoot = {
+        get: () => ({ field: "ok" }),
+        key: () => {
+          throw new Error("no traversal surface");
+        },
+      };
+      const piece = {
+        input: {
+          get: () => Promise.resolve(undefined),
+          getCell: () => Promise.resolve(guardCell(undefined)),
+        },
+        result: {
+          get: () => Promise.resolve("ok"),
+          getCell: () => Promise.resolve(throwingRoot),
+        },
+      };
+      await expect(getCellValue(config, ["field"], {}, guardDeps(piece)))
+        .resolves.toBe("ok");
     });
 
     it("still reads plain data, tool bindings, and a verb's parent object", async () => {

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -1012,17 +1012,26 @@ describe("cli piece parsing", () => {
   describe("read-path guard (verb contract WS-F)", () => {
     /** Minimal cell double for the guard's classification walk: value
      * access, key() descent, and asSchemaFromLinks identity — the same
-     * surface piece-verbs.test.ts doubles for listPieceCallables. */
+     * surface piece-verbs.test.ts doubles for listPieceCallables. Its
+     * asSchema models the real forced-cast semantics: the cast schema
+     * survives resolution for inline values and schema-less links, so a
+     * forced probe answers "stream" for ANY name. The guard is certain-only
+     * and must never consult that cast — the data reads below go through
+     * this double to pin it. */
     function guardCell(value: unknown): {
       get: () => unknown;
       getRaw: () => unknown;
       asSchemaFromLinks: () => unknown;
+      asSchema: (schema: unknown) => unknown;
       key: (...segments: (string | number)[]) => unknown;
     } {
       const self = {
         get: () => value,
         getRaw: () => value,
         asSchemaFromLinks: () => self,
+        asSchema: (_schema: unknown) => ({
+          key: (_name: string) => ({ isStream: () => true }),
+        }),
         key: (...segments: (string | number)[]) => {
           let child: unknown = value;
           for (const segment of segments) {
@@ -1065,10 +1074,15 @@ describe("cli piece parsing", () => {
       createController: () => ({ get: () => Promise.resolve(piece) }) as never,
     });
 
-    const guardPiece = (resultValue: unknown, pieceCell?: unknown) => ({
+    const guardPiece = (
+      resultValue: unknown,
+      pieceCell?: unknown,
+      inputValue?: unknown,
+    ) => ({
       input: {
-        get: () => Promise.resolve(undefined),
-        getCell: () => Promise.resolve(guardCell(undefined)),
+        get: (path: (string | number)[]) =>
+          Promise.resolve(readPath(inputValue, path)),
+        getCell: () => Promise.resolve(guardCell(inputValue)),
       },
       result: {
         get: (path: (string | number)[]) =>
@@ -1085,7 +1099,7 @@ describe("cli piece parsing", () => {
       piece: PIECE,
     };
 
-    it("refuses a path that lands on a verb, pointing at cf piece call", async () => {
+    it("refuses a root verb path, pointing at cf piece call", async () => {
       const deps = guardDeps(guardPiece(RESULT_VALUE));
       const error = await getCellValue(config, ["addItem"], {}, deps)
         .catch((error) => error);
@@ -1094,40 +1108,99 @@ describe("cli piece parsing", () => {
         `Path resolves to a verb; use 'cf piece call --piece ${PIECE} addItem' instead.`,
       );
 
-      // The same guard covers a verb nested below the result root, and a
-      // tool-shaped verb — both are callable, so both redirect.
-      await expect(getCellValue(config, ["nested", "removeItem"], {}, deps))
-        .rejects.toThrow(PieceVerbReadError);
-      await expect(getCellValue(config, ["search"], {}, deps))
-        .rejects.toThrow(PieceVerbReadError);
+      // A root verb on the input cell redirects the same way: the dispatcher
+      // resolves result root then input root, so it is callable by name.
+      const inputDeps = guardDeps(
+        guardPiece(undefined, undefined, { setup: { $stream: true } }),
+      );
+      await expect(
+        getCellValue(config, ["setup"], { input: true }, inputDeps),
+      ).rejects.toThrow(/use 'cf piece call/);
     });
 
-    it("refuses a verb only reachable through the forced-stream probe", async () => {
-      // Ordinary detection sees a plain object; only the forced stream cast
-      // on the piece cell — cf piece call's third resolution path — proves
-      // it is a handler. The guard must agree with the dispatcher.
+    it("refuses on the stored schema marker even when the value reads empty", async () => {
+      // The second definite signal: the link-derived schema answers as a
+      // stream while the read value is an empty object (the marker survives
+      // in stored links even when the serialization is bare).
+      const rootCell = {
+        get: () => ({ notify: {} }),
+        key: (name: string) => ({
+          asSchemaFromLinks: () => ({ isStream: () => name === "notify" }),
+        }),
+      };
+      const piece = {
+        input: {
+          get: () => Promise.resolve(undefined),
+          getCell: () => Promise.resolve(guardCell(undefined)),
+        },
+        result: {
+          get: () => Promise.resolve({}),
+          getCell: () => Promise.resolve(rootCell),
+        },
+      };
+      await expect(getCellValue(config, ["notify"], {}, guardDeps(piece)))
+        .rejects.toThrow(/use 'cf piece call/);
+    });
+
+    it("refuses a nested verb path without suggesting an uncallable command", async () => {
+      // `cf piece call` resolves root-level names only, so `cf piece call
+      // removeItem` would fail — the refusal must not suggest it. It says
+      // why the read refused and where to go instead.
+      const deps = guardDeps(guardPiece(RESULT_VALUE));
+      const error = await getCellValue(
+        config,
+        ["nested", "removeItem"],
+        {},
+        deps,
+      ).catch((error) => error);
+      expect(error).toBeInstanceOf(PieceVerbReadError);
+      expect((error as Error).message).toBe(
+        "Path resolves to a verb that is not directly callable: verbs are " +
+          "invoked at the piece's root surface. Read the parent object " +
+          "instead, or list the callable verbs with " +
+          `'cf piece verbs --piece ${PIECE}'.`,
+      );
+      expect((error as Error).message).not.toContain("cf piece call");
+    });
+
+    it("reads a probe-classifiable but marker-less output (fails open)", async () => {
+      // The CTS integration shape: a plain data output the forced-stream
+      // probe would classify as callable (the cast schema survives
+      // resolution, so the probe answers "stream" for it), with no stored
+      // marker and no sentinel. The dispatcher and the listing may
+      // over-include it — a read guard must not: the read succeeds.
       const pieceCell = {
         asSchema: () => ({
-          key: (name: string) => ({ isStream: () => name === "hiddenPing" }),
+          key: (_name: string) => ({ isStream: () => true }),
         }),
       };
       const deps = guardDeps(
-        guardPiece({ hiddenPing: {}, count: 3 }, pieceCell),
+        guardPiece(
+          { lastMessage: { text: "hi" }, count: 3 },
+          pieceCell,
+        ),
       );
-      await expect(getCellValue(config, ["hiddenPing"], {}, deps))
-        .rejects.toThrow(/use 'cf piece call/);
-      // A data sibling on the same piece still reads: the probe answers for
-      // the one name, not the whole piece.
+      await expect(getCellValue(config, ["lastMessage"], {}, deps))
+        .resolves.toEqual({ text: "hi" });
       await expect(getCellValue(config, ["count"], {}, deps)).resolves.toBe(3);
     });
 
-    it("still reads plain data paths and a verb's parent object", async () => {
-      const deps = guardDeps(guardPiece(RESULT_VALUE));
+    it("still reads plain data, tool bindings, and a verb's parent object", async () => {
+      const deps = guardDeps(
+        guardPiece(RESULT_VALUE, undefined, { config: { retries: 2 } }),
+      );
       await expect(getCellValue(config, ["title"], {}, deps)).resolves.toBe(
         "Groceries",
       );
       await expect(getCellValue(config, ["nested", "list"], {}, deps))
         .resolves.toEqual(["milk"]);
+      await expect(
+        getCellValue(config, ["config"], { input: true }, deps),
+      ).resolves.toEqual({ retries: 2 });
+      // A tool binding reads as data — the llm-dialog read tool reads tools
+      // too; only streams have a serialization no reader wants.
+      await expect(getCellValue(config, ["search"], {}, deps)).resolves
+        .toEqual(RESULT_VALUE.search);
       // Only the path that lands ON the verb refuses: its parent object —
       // named or the path-less full result — keeps reading, verbs included.
       await expect(getCellValue(config, ["nested"], {}, deps)).resolves

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -65,9 +65,11 @@ what this looks like when it bites.
 - A `piece get` path that doesn't resolve is a data error: one-line message on
   stderr, exit 1 (no usage screen). A `piece link` that fails validation
   (missing source/target piece or path) reports the same way. So does a
-  `piece get` path that lands on a verb (handler or tool): reading a verb
-  refuses and points at `cf piece call` — read data, call verbs. The verb's
-  parent object still reads.
+  `piece get` path that lands on a handler verb: reading a stream refuses — read
+  data, call verbs. A root verb's refusal points at `cf piece call`; a nested
+  verb is not directly callable, so it points at reading the parent object or
+  `cf piece verbs`. The verb's parent object still reads, and tool bindings read
+  as data.
 
 ## Environment Setup
 

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -64,7 +64,10 @@ what this looks like when it bites.
   argument, or schema-derived flags after `--`. Empty stdin fails loudly.
 - A `piece get` path that doesn't resolve is a data error: one-line message on
   stderr, exit 1 (no usage screen). A `piece link` that fails validation
-  (missing source/target piece or path) reports the same way.
+  (missing source/target piece or path) reports the same way. So does a
+  `piece get` path that lands on a verb (handler or tool): reading a verb
+  refuses and points at `cf piece call` — read data, call verbs. The verb's
+  parent object still reads.
 
 ## Environment Setup
 


### PR DESCRIPTION
## Why

Part of the pattern-verb-contract arc (WS-F, plan: `docs/plans/pattern-verb-contract-implementation.md`; design PR #4968).

`cf piece get` on a path that resolves to a verb currently returns the stream's serialization (`{"$stream": true}`) instead of redirecting — never what the caller wanted, and it costs an agent a wasted turn before it discovers it should have called the verb. The llm-dialog `read` tool already rejects this case ("Path resolves to a handler; use invoke() instead."); this gives the CLI read path the equivalent guard, pointing at `cf piece call`.

## What Changed

- `packages/cli/lib/piece.ts`
  - `getCellValue` now classifies the read path's last segment after the value read (so links/schema are materialized) and refuses with the new `PieceVerbReadError`: `Path resolves to a verb; use 'cf piece call --piece <piece> <verb>' instead.`
  - The classification is the one `cf piece call` resolves through, not a second one: `detectCallableKind` on the link-derived cell (as in `tryResolvePieceCallableAt`), then the forced-stream probe. The probe is extracted into a shared `probeForcedStreamCell` helper now used by all three sites — `tryResolvePieceHandler`, the `listPieceCallables` fallback, and the read guard — so the dispatcher, the listing, and the guard can never disagree about what is callable.
  - Only the path that lands ON a verb refuses. A verb's parent object (named or the path-less full result) and plain data paths read as before, and a classification failure is treated as "not a verb" so the guard can never break a plain read.
- `packages/cli/commands/piece.ts`: `PieceVerbReadError` reports as a `piece get` data error — one-line message on stderr, exit 1, no usage screen, no `--input` tip (the redirect is the remedy).
- Docs riding: the plan's WS-F read-path guard bullet is struck as done; `skills/cf/SKILL.md`'s output-conventions section records the new refusal.

## Test plan

- `packages/cli/test/piece.test.ts`: refuses a path landing on a verb (root, nested, and tool-shaped), refuses a verb only reachable through the forced-stream probe while its data sibling still reads, and keeps reading plain data paths and a verb's parent object.
- `packages/cli/test/piece-call.test.ts`: `PieceVerbReadError` classifies as a data error, reports message-only (the message IS the redirect), and exits 1 through the shared data-error exit.
- `cd packages/cli && deno task test` green; repo-wide `deno fmt --check`, `deno lint`, `deno task check-docs`, `deno task check-skill-facts` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`cf piece get` now refuses paths that land on a verb using certain-only detection. Root verbs redirect to `cf piece call`; nested verbs explain they’re not directly callable and point to reading the parent object or `cf piece verbs`.

- **New Features**
  - Added a read-path guard in `packages/cli/lib/piece.ts` that refuses only on stored signals: the link-derived schema answers as a stream or the value is `{$stream: true}`. The guard never uses the forced-stream probe and classifies after the read (applies to plain reads and transforms).

- **Refactors**
  - Extracted `probeForcedStreamCell` and reused in `tryResolvePieceHandler` and `listPieceCallables` (not in the guard) to keep dispatcher and listing classification consistent.
  - Updated `packages/cli/commands/piece.ts` to treat `PieceVerbReadError` as a `piece get` data error (message-only, exit 1). Tests cover fail-open classification, the probe’s type guard, non-data read failures passing through, and a getCell-less piece resolution. Docs updated to mark WS-F read-path guard as done and describe both refusal messages.

<sup>Written for commit 0ce346ab3cae789cdde91dc54f75df7d0cba84f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

