### PR TITLE
feat(cli): per-phase wall-clock timings under cf piece call --verbose (WS-D/D2)

### DIFF
--- a/docs/plans/pattern-verb-contract-implementation.md
+++ b/docs/plans/pattern-verb-contract-implementation.md
@@ -489,8 +489,15 @@ joins WS-C. `packages/runner` (`cell.ts` send path), `packages/cli`.
   (`initial_sync | dispatched | committed | readback`) beside the invocation
   id — **done (D2)** for the annotation (tracked through an `onPhase`
   callback, printed on failure exits); verbose output adds per-phase timings
-  (initial sync / dispatch / handler / commit / result sync / readback) —
-  still open. With a caller-supplied id a retry is safe in every phase, so
+  — **done**: `cf piece call --verbose` streams one wall-clock span per
+  observed phase transition to stderr (stdout stays exactly the settled
+  Invocation JSON), at the granularity the `onPhase` callback observes:
+  initial sync→dispatch, dispatch→commit acknowledgement (the handler run
+  and its commit are one span — nothing between them is observable from the
+  CLI without new runner instrumentation, and result sync is inside the
+  readback span for the same reason), receipt classification, and
+  readback→settlement; a failure exit closes the in-flight span with
+  `failed`. With a caller-supplied id a retry is safe in every phase, so
   phase is diagnosis; a derived `retrySafe` convenience flag may ride along.
 - ~~**Acknowledgement is transaction-local.** The call path awaits *this
   handling's* commit (D1's commit callback) plus receipt sync — never

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -32,6 +32,7 @@ import {
   SpaceConfig,
   stepPiece,
 } from "../lib/piece.ts";
+import type { ExecutedPieceCallable } from "../lib/piece.ts";
 import type { InvocationOutcome, InvocationPhase } from "../lib/callable.ts";
 import { renderPiece } from "../lib/piece-render.ts";
 import { parseSqliteSource } from "../lib/sqlite-source.ts";
@@ -518,6 +519,67 @@ export function pieceCallPhaseObserver(
       close(end);
     },
   };
+}
+
+/**
+ * The success tail of `cf piece call`, extracted from the command action so
+ * it is unit-coverable — command action bodies never execute under the unit
+ * suite, the same convention that keeps `cf test` out of its action body
+ * (docs/development/COVERAGE.md). Help output returns BEFORE the observer
+ * finishes: no invocation ran, so there is no span to close.
+ */
+export function renderPieceCallOutcome(
+  observer: { finish: (end?: "settled" | "failed") => void },
+  result: ExecutedPieceCallable,
+  callableName: string,
+  piece: string,
+  deps: {
+    render?: (text: string) => void;
+    hint?: (text: string, prefix?: boolean) => void;
+    printError?: (text: string) => void;
+  } = {},
+): void {
+  const renderOut = deps.render ?? render;
+  const hintOut = deps.hint ?? hint;
+  const printError = deps.printError ?? console.error;
+  if (result.helpText) {
+    renderOut(result.helpText);
+    return;
+  }
+  observer.finish();
+  if (result.outputText) {
+    renderOut(result.outputText);
+    if (result.resultRef) {
+      // stderr, so stdout stays exactly the tool's JSON result. Routed
+      // through hint() DELIBERATELY: under --quiet the ref is suppressed —
+      // it is advisory until the invocation protocol carries it in the
+      // stdout Invocation JSON (verb contract WS-D), and --quiet callers
+      // asked for the bare result.
+      const ref = result.resultRef;
+      hintOut(
+        `Tool result cell: ${ref.id} (space ${ref.space}, scope ${ref.scope})`,
+        false,
+      );
+    }
+    return;
+  }
+  const nextSteps = cliText(`NEXT STEPS:
+  → Verify state:  cf piece get --piece ${piece} <path> ...
+  → Full inspect:  cf piece inspect --piece ${piece} ...`);
+  if (result.invocation) {
+    // The machine surface for a handler invocation: stdout carries the
+    // settled Invocation JSON, prose stays on stderr via hint().
+    renderOut(JSON.stringify(invocationJson(result.invocation), null, 2));
+    hintOut(nextSteps);
+    return;
+  }
+  const confirmation = `Called handler "${callableName}" on piece ${piece}`;
+  if (result.parsed.usedJsonInput) {
+    printError(confirmation);
+  } else {
+    renderOut(confirmation);
+  }
+  hintOut(nextSteps);
 }
 
 /**
@@ -1410,46 +1472,7 @@ after --. Handlers interpret piped input when no input argument is present.`,
           observer,
         )
       );
-      if (result.helpText) {
-        render(result.helpText);
-        return;
-      }
-      observer.finish();
-      if (result.outputText) {
-        render(result.outputText);
-        if (result.resultRef) {
-          // stderr, so stdout stays exactly the tool's JSON result. Routed
-          // through hint() DELIBERATELY: under --quiet the ref is suppressed —
-          // it is advisory until the invocation protocol carries it in the
-          // stdout Invocation JSON (verb contract WS-D), and --quiet callers
-          // asked for the bare result.
-          const ref = result.resultRef;
-          hint(
-            `Tool result cell: ${ref.id} (space ${ref.space}, scope ${ref.scope})`,
-            false,
-          );
-        }
-        return;
-      }
-      if (result.invocation) {
-        // The machine surface for a handler invocation: stdout carries the
-        // settled Invocation JSON, prose stays on stderr via hint().
-        render(JSON.stringify(invocationJson(result.invocation), null, 2));
-        hint(cliText(`NEXT STEPS:
-  → Verify state:  cf piece get --piece ${pieceConfig.piece} <path> ...
-  → Full inspect:  cf piece inspect --piece ${pieceConfig.piece} ...`));
-        return;
-      }
-      const confirmation =
-        `Called handler "${callableName}" on piece ${pieceConfig.piece}`;
-      if (result.parsed.usedJsonInput) {
-        console.error(confirmation);
-      } else {
-        render(confirmation);
-      }
-      hint(cliText(`NEXT STEPS:
-  → Verify state:  cf piece get --piece ${pieceConfig.piece} <path> ...
-  → Full inspect:  cf piece inspect --piece ${pieceConfig.piece} ...`));
+      renderPieceCallOutcome(observer, result, callableName, pieceConfig.piece);
     } catch (error) {
       exitPieceCallFailure(observer, error, invocationId, phase);
     }

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -429,6 +429,53 @@ export function invocationPhaseReporter(
 }
 
 /**
+ * Phase observer for `cf piece call`: always advances the furthest-phase
+ * tracker the failure report prints; under --verbose it also streams one
+ * wall-clock span per observed phase transition (verb contract WS-D, phase
+ * timings). Spans are bounded by the phases the `onPhase` callback already
+ * observes — initial sync up to dispatch, the dispatched handler run up to
+ * its transaction-local commit acknowledgement, the receipt classification,
+ * and the receipt readback up to settlement — because those boundaries are
+ * what the invocation actually reports; nothing new is instrumented inside
+ * the runner. Every line goes to stderr so stdout stays exactly the settled
+ * Invocation JSON an agent parses, and lines stream as transitions happen so
+ * a failure exit keeps every span observed before the failure — `finish`
+ * closes the in-flight span with the outcome that ended it.
+ */
+export function pieceCallPhaseObserver(
+  verbose: boolean,
+  onAdvance: (phase: InvocationPhase) => void,
+  emit: (line: string) => void = console.error,
+  now: () => number = () => performance.now(),
+): {
+  onPhase: (phase: InvocationPhase) => void;
+  finish: (end?: "settled" | "failed") => void;
+} {
+  if (!verbose) {
+    return { onPhase: onAdvance, finish: () => {} };
+  }
+  let current: InvocationPhase = "initial_sync";
+  let spanStart = now();
+  let finished = false;
+  const close = (next: string) => {
+    emit(`timing: ${current} → ${next} ${(now() - spanStart).toFixed(1)}ms`);
+  };
+  return {
+    onPhase: (next) => {
+      close(next);
+      current = next;
+      spanStart = now();
+      onAdvance(next);
+    },
+    finish: (end = "settled") => {
+      if (finished) return;
+      finished = true;
+      close(end);
+    },
+  };
+}
+
+/**
  * Shape a settled handler invocation for stdout. This is the wire contract an
  * agent parses, so the optional keys are load-bearing: `deduplicated` appears
  * only when the call collided on an existing receipt, and `result` only when
@@ -1275,11 +1322,20 @@ after --. Handlers interpret piped input when no input argument is present.`,
       "outcome — but the handler body does re-run, so effects outside the " +
       "transaction repeat. Minted automatically when omitted.",
   )
+  .option(
+    "--verbose",
+    "Print per-phase wall-clock timings to stderr (before the callable " +
+      "name). stdout still carries only the command output.",
+  )
   .stopEarly()
   .arguments("<callable:string> [tail...:string]")
   .action(async function (options, callableName, ...tail) {
     const invocationId = resolveInvocationId(options.invocation);
     let phase: InvocationPhase = "initial_sync";
+    const observer = pieceCallPhaseObserver(
+      !!options.verbose,
+      (next) => phase = next,
+    );
     try {
       setQuietMode(!!options.quiet);
       const invocation = pieceCallInvocation(
@@ -1298,7 +1354,7 @@ after --. Handlers interpret piped input when no input argument is present.`,
           invocationId,
           onPhase: invocationPhaseReporter(
             invocationId,
-            (next) => phase = next,
+            observer.onPhase,
           ),
         },
       ).catch((error) =>
@@ -1308,6 +1364,7 @@ after --. Handlers interpret piped input when no input argument is present.`,
         render(result.helpText);
         return;
       }
+      observer.finish();
       if (result.outputText) {
         render(result.outputText);
         if (result.resultRef) {
@@ -1349,6 +1406,7 @@ after --. Handlers interpret piped input when no input argument is present.`,
       }
       const message = error instanceof Error ? error.message : String(error);
       console.error(message);
+      observer.finish("failed");
       // Where the invocation stopped decides retry semantics: anything at or
       // past "dispatched" retries SAFELY ONLY with this same id (same-id
       // retries deduplicate; a fresh id would re-execute).

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -294,15 +294,60 @@ export function exitWithDataError(
  * action body only ever runs under Cliffy, so anything written there is
  * unreachable from a unit test. The `deps` seam is `exitWithDataError`'s,
  * threaded so a test can observe the report without a real process exit.
+ *
+ * `observer` is the call's phase observer: this exit bypasses the action's
+ * catch (it terminates the process from inside the promise chain), so the
+ * verbose in-flight span must be closed HERE — otherwise a pre-dispatch
+ * payload rejection under --verbose would leave the initial_sync span
+ * dangling with no failure timing. A rethrown error is closed by the
+ * action's own failure exit instead.
  */
 export function reportVerbInputErrorOrRethrow(
   error: unknown,
   piece: string | undefined,
   deps?: Parameters<typeof exitWithDataError>[1],
+  observer?: { finish: (end?: "settled" | "failed") => void },
 ): never {
   const report = verbInputErrorReport(error, { piece: piece ?? "<piece>" });
-  if (report) exitWithDataError(report, deps);
+  if (report) {
+    observer?.finish("failed");
+    exitWithDataError(report, deps);
+  }
   throw error;
+}
+
+/**
+ * The failure exit for `cf piece call`: closes the verbose in-flight span as
+ * `failed` (idempotent — a span already closed elsewhere stays closed),
+ * rethrows Cliffy validation errors so usage failures still render the usage
+ * screen — with their span closed first — and reports everything else as the
+ * failure message plus the invocation id beside the furthest observed phase,
+ * the retry key, before exiting 1. A named export rather than catch-block
+ * prose because the action body only runs under Cliffy and is unreachable
+ * from a unit test; the seams let a test observe the exact exit contract.
+ */
+export function exitPieceCallFailure(
+  observer: { finish: (end?: "settled" | "failed") => void },
+  error: unknown,
+  invocationId: string,
+  phase: InvocationPhase,
+  deps?: {
+    printError?: (message: string) => void;
+    exit?: (code: number) => never;
+  },
+): never {
+  observer.finish("failed");
+  if (error instanceof ValidationError) {
+    throw error;
+  }
+  const printError = deps?.printError ?? console.error;
+  const exit = deps?.exit ?? Deno.exit;
+  printError(error instanceof Error ? error.message : String(error));
+  // Where the invocation stopped decides retry semantics: anything at or
+  // past "dispatched" retries SAFELY ONLY with this same id (same-id
+  // retries deduplicate; a fresh id would re-execute).
+  printError(`invocation: ${invocationId} phase: ${phase}`);
+  return exit(1);
 }
 
 export function pieceCallRawArgs(
@@ -1358,7 +1403,12 @@ after --. Handlers interpret piped input when no input argument is present.`,
           ),
         },
       ).catch((error) =>
-        reportVerbInputErrorOrRethrow(error, pieceConfig.piece)
+        reportVerbInputErrorOrRethrow(
+          error,
+          pieceConfig.piece,
+          undefined,
+          observer,
+        )
       );
       if (result.helpText) {
         render(result.helpText);
@@ -1401,17 +1451,7 @@ after --. Handlers interpret piped input when no input argument is present.`,
   → Verify state:  cf piece get --piece ${pieceConfig.piece} <path> ...
   → Full inspect:  cf piece inspect --piece ${pieceConfig.piece} ...`));
     } catch (error) {
-      if (error instanceof ValidationError) {
-        throw error;
-      }
-      const message = error instanceof Error ? error.message : String(error);
-      console.error(message);
-      observer.finish("failed");
-      // Where the invocation stopped decides retry semantics: anything at or
-      // past "dispatched" retries SAFELY ONLY with this same id (same-id
-      // retries deduplicate; a fresh id would re-execute).
-      console.error(`invocation: ${invocationId} phase: ${phase}`);
-      Deno.exit(1);
+      exitPieceCallFailure(observer, error, invocationId, phase);
     }
   })
   /* piece verbs */

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -14,7 +14,9 @@ import {
   PieceResultProjectionError,
   PieceVerbReadError,
 } from "../lib/piece.ts";
+import { ValidationError } from "@cliffy/command";
 import {
+  exitPieceCallFailure,
   exitWithDataError,
   invocationJson,
   invocationPhaseReporter,
@@ -1630,6 +1632,132 @@ describe("piece call stdin payloads", () => {
     expect(stderrLines[0]).toMatch(/^timing: initial_sync → dispatched \d/);
     expect(stderrLines[1]).toMatch(/^timing: dispatched → settled \d/);
     expect(stdoutLines).toEqual([]);
+  });
+
+  it("closes the verbose span on the failure exit and reports the retry key", () => {
+    const lines: string[] = [];
+    const printed: string[] = [];
+    const exited: number[] = [];
+    let t = 3000;
+    const observer = pieceCallPhaseObserver(
+      true,
+      () => {},
+      (line) => lines.push(line),
+      () => t,
+    );
+    t = 3020;
+    observer.onPhase("dispatched");
+    t = 3050;
+    expect(() =>
+      exitPieceCallFailure(
+        observer,
+        new Error("send blew up"),
+        "inv-7",
+        "dispatched",
+        {
+          printError: (message) => printed.push(message),
+          exit: (code): never => {
+            exited.push(code);
+            throw new Error("exit-sentinel");
+          },
+        },
+      )
+    ).toThrow("exit-sentinel");
+    expect(lines).toEqual([
+      "timing: initial_sync → dispatched 20.0ms",
+      "timing: dispatched → failed 30.0ms",
+    ]);
+    expect(printed).toEqual([
+      "send blew up",
+      "invocation: inv-7 phase: dispatched",
+    ]);
+    expect(exited).toEqual([1]);
+  });
+
+  it("closes the verbose span before rethrowing a usage error", () => {
+    // A Cliffy ValidationError renders the usage screen upstream — but the
+    // in-flight span must still close as failed first, so malformed
+    // input/options leave a complete timing stream.
+    const lines: string[] = [];
+    const printed: string[] = [];
+    const observer = pieceCallPhaseObserver(
+      true,
+      () => {},
+      (line) => lines.push(line),
+      () => 0,
+    );
+    expect(() =>
+      exitPieceCallFailure(
+        observer,
+        new ValidationError("bad flags"),
+        "inv-8",
+        "initial_sync",
+        {
+          printError: (message) => printed.push(message),
+          exit: (): never => {
+            throw new Error("exit-sentinel");
+          },
+        },
+      )
+    ).toThrow(ValidationError);
+    expect(lines).toEqual(["timing: initial_sync → failed 0.0ms"]);
+    // The usage error reports through Cliffy, not the failure printer.
+    expect(printed).toEqual([]);
+  });
+
+  it("closes the verbose span on the pre-dispatch payload-rejection exit", () => {
+    // reportVerbInputErrorOrRethrow terminates the process from inside the
+    // promise chain, bypassing the action's catch — without the observer
+    // threading, --verbose would leave the initial_sync span dangling.
+    const lines: string[] = [];
+    const printed: string[] = [];
+    const exited: number[] = [];
+    let t = 4000;
+    const observer = pieceCallPhaseObserver(
+      true,
+      () => {},
+      (line) => lines.push(line),
+      () => t,
+    );
+    t = 4012;
+    expect(() =>
+      reportVerbInputErrorOrRethrow(
+        new VerbInputValidationError("addTopic", "missing required title"),
+        "fid1:piece-123",
+        {
+          printError: (message) => printed.push(message),
+          printHint: () => {},
+          exit: (code): never => {
+            exited.push(code);
+            throw new Error("exit-sentinel");
+          },
+        },
+        observer,
+      )
+    ).toThrow("exit-sentinel");
+    expect(lines).toEqual(["timing: initial_sync → failed 12.0ms"]);
+    expect(printed).toHaveLength(1);
+    expect(printed[0]).toMatch(/Invalid input for "addTopic"/);
+    expect(exited).toEqual([1]);
+
+    // A rethrown (non-payload) error leaves the span open: the action's own
+    // failure exit closes it later, so nothing may be emitted here.
+    const rethrowLines: string[] = [];
+    const rethrowObserver = pieceCallPhaseObserver(
+      true,
+      () => {},
+      (line) => rethrowLines.push(line),
+      () => 0,
+    );
+    expect(() =>
+      reportVerbInputErrorOrRethrow(
+        new Error("network unreachable"),
+        "fid1:piece-123",
+        undefined,
+        rethrowObserver,
+      )
+    ).toThrow("network unreachable");
+    expect(rethrowLines).toEqual([]);
   });
 
   it("shapes the settled Invocation JSON an agent parses", () => {

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -20,6 +20,7 @@ import {
   invocationPhaseReporter,
   isPieceGetDataError,
   pieceCallInvocation,
+  pieceCallPhaseObserver,
   pieceCallRawArgs,
   pieceGetDataErrorReport,
   pieceLinkDataErrorReport,
@@ -1538,6 +1539,97 @@ describe("piece call stdin payloads", () => {
       "dispatched",
       "readback",
     ]);
+  });
+
+  it("streams one wall-clock span per observed phase to stderr under --verbose", () => {
+    const lines: string[] = [];
+    const seen: string[] = [];
+    let t = 1000;
+    const observer = pieceCallPhaseObserver(
+      true,
+      (phase) => seen.push(phase),
+      (line) => lines.push(line),
+      () => t,
+    );
+    t = 1012.5;
+    observer.onPhase("dispatched");
+    t = 1093.5;
+    observer.onPhase("committed");
+    t = 1094.5;
+    observer.onPhase("readback");
+    t = 1100;
+    observer.finish();
+    // A second finish must not double-close the settled span.
+    observer.finish();
+    expect(lines).toEqual([
+      "timing: initial_sync → dispatched 12.5ms",
+      "timing: dispatched → committed 81.0ms",
+      "timing: committed → readback 1.0ms",
+      "timing: readback → settled 5.5ms",
+    ]);
+    // The furthest-phase tracker still advances for the failure report.
+    expect(seen).toEqual(["dispatched", "committed", "readback"]);
+  });
+
+  it("closes the in-flight span with the failure that ended it", () => {
+    const lines: string[] = [];
+    let t = 2000;
+    const observer = pieceCallPhaseObserver(
+      true,
+      () => {},
+      (line) => lines.push(line),
+      () => t,
+    );
+    t = 2010;
+    observer.onPhase("dispatched");
+    t = 2500;
+    observer.finish("failed");
+    // Lines stream per transition, so the spans observed before the failure
+    // are already out; the failure only closes the one in flight.
+    expect(lines).toEqual([
+      "timing: initial_sync → dispatched 10.0ms",
+      "timing: dispatched → failed 490.0ms",
+    ]);
+  });
+
+  it("emits no timing lines without --verbose while phases still advance", () => {
+    const lines: string[] = [];
+    const seen: string[] = [];
+    const observer = pieceCallPhaseObserver(
+      false,
+      (phase) => seen.push(phase),
+      (line) => lines.push(line),
+    );
+    observer.onPhase("dispatched");
+    observer.onPhase("committed");
+    observer.finish();
+    expect(lines).toEqual([]);
+    expect(seen).toEqual(["dispatched", "committed"]);
+  });
+
+  it("defaults to console.error — stdout stays exactly the command output", () => {
+    const stderrLines: string[] = [];
+    const stdoutLines: string[] = [];
+    const originalError = console.error;
+    const originalLog = console.log;
+    console.error = (...args: unknown[]) => {
+      stderrLines.push(args.join(" "));
+    };
+    console.log = (...args: unknown[]) => {
+      stdoutLines.push(args.join(" "));
+    };
+    try {
+      const observer = pieceCallPhaseObserver(true, () => {});
+      observer.onPhase("dispatched");
+      observer.finish();
+    } finally {
+      console.error = originalError;
+      console.log = originalLog;
+    }
+    expect(stderrLines).toHaveLength(2);
+    expect(stderrLines[0]).toMatch(/^timing: initial_sync → dispatched \d/);
+    expect(stderrLines[1]).toMatch(/^timing: dispatched → settled \d/);
+    expect(stdoutLines).toEqual([]);
   });
 
   it("shapes the settled Invocation JSON an agent parses", () => {

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -1,4 +1,5 @@
 import { describe, it } from "@std/testing/bdd";
+import { assertEquals, assertStringIncludes } from "@std/assert";
 import { expect } from "@std/expect";
 import type { JSONSchema } from "@commonfabric/api";
 import {
@@ -14,6 +15,7 @@ import {
   PieceResultProjectionError,
   PieceVerbReadError,
 } from "../lib/piece.ts";
+import type { ExecutedPieceCallable } from "../lib/piece.ts";
 import { ValidationError } from "@cliffy/command";
 import {
   exitPieceCallFailure,
@@ -26,6 +28,7 @@ import {
   pieceCallRawArgs,
   pieceGetDataErrorReport,
   pieceLinkDataErrorReport,
+  renderPieceCallOutcome,
   reportVerbInputErrorOrRethrow,
   resolveInvocationId,
   verbInputErrorReport,
@@ -2463,5 +2466,109 @@ describe("schemaIsObjectShaped", () => {
       { oneOf: [{ type: "object" }] },
       {},
     )).toBe(false);
+  });
+});
+
+describe("renderPieceCallOutcome", () => {
+  const observerRecorder = () => {
+    const finishes: (string | undefined)[] = [];
+    return {
+      observer: { finish: (end?: "settled" | "failed") => finishes.push(end) },
+      finishes,
+    };
+  };
+  const sinkRecorder = () => {
+    const rendered: string[] = [];
+    const hinted: string[] = [];
+    const errored: string[] = [];
+    return {
+      deps: {
+        render: (t: string) => rendered.push(t),
+        hint: (t: string) => hinted.push(t),
+        printError: (t: string) => errored.push(t),
+      },
+      rendered,
+      hinted,
+      errored,
+    };
+  };
+  const base = { parsed: { usedJsonInput: false }, resolved: {} };
+
+  it("help output returns before the observer finishes", () => {
+    const { observer, finishes } = observerRecorder();
+    const { deps, rendered } = sinkRecorder();
+    renderPieceCallOutcome(
+      observer,
+      { ...base, helpText: "usage" } as ExecutedPieceCallable,
+      "addTopic",
+      "fid1:piece",
+      deps,
+    );
+    assertEquals(rendered, ["usage"]);
+    assertEquals(finishes.length, 0);
+  });
+
+  it("tool output finishes the span and hints the result ref", () => {
+    const { observer, finishes } = observerRecorder();
+    const { deps, rendered, hinted } = sinkRecorder();
+    renderPieceCallOutcome(
+      observer,
+      {
+        ...base,
+        outputText: "{}",
+        resultRef: { id: "of:x", space: "did:key:s", scope: "space" },
+      } as ExecutedPieceCallable,
+      "tool",
+      "fid1:piece",
+      deps,
+    );
+    assertEquals(finishes, [undefined]);
+    assertEquals(rendered, ["{}"]);
+    assertEquals(hinted.length, 1);
+    assertStringIncludes(hinted[0], "of:x");
+  });
+
+  it("handler invocations render the Invocation JSON with next steps", () => {
+    const { observer, finishes } = observerRecorder();
+    const { deps, rendered, hinted } = sinkRecorder();
+    renderPieceCallOutcome(
+      observer,
+      {
+        ...base,
+        invocation: { id: "inv-1", status: "settled" },
+      } as unknown as ExecutedPieceCallable,
+      "addTopic",
+      "fid1:piece",
+      deps,
+    );
+    assertEquals(finishes, [undefined]);
+    assertEquals(JSON.parse(rendered[0]).invocation, "inv-1");
+    assertStringIncludes(hinted[0], "NEXT STEPS");
+  });
+
+  it("confirmations route to stderr under JSON input, stdout otherwise", () => {
+    const jsonCase = observerRecorder();
+    const jsonSinks = sinkRecorder();
+    renderPieceCallOutcome(
+      jsonCase.observer,
+      { ...base, parsed: { usedJsonInput: true } } as ExecutedPieceCallable,
+      "addTopic",
+      "fid1:piece",
+      jsonSinks.deps,
+    );
+    assertEquals(jsonSinks.errored.length, 1);
+    assertEquals(jsonSinks.rendered.length, 0);
+
+    const plainCase = observerRecorder();
+    const plainSinks = sinkRecorder();
+    renderPieceCallOutcome(
+      plainCase.observer,
+      { ...base } as ExecutedPieceCallable,
+      "addTopic",
+      "fid1:piece",
+      plainSinks.deps,
+    );
+    assertEquals(plainSinks.errored.length, 0);
+    assertStringIncludes(plainSinks.rendered[0], 'Called handler "addTopic"');
   });
 });

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -791,6 +791,13 @@ describe("cli piece parsing", () => {
     )).resolves.toBeUndefined();
   });
 
+  it("offers per-phase timing output for piece call", () => {
+    const callFlags = piece.getCommand("call")!.getOptions().flatMap((option) =>
+      option.flags
+    );
+    expect(callFlags).toContain("--verbose");
+  });
+
   it("steps, reads, syncs, and stops in one get operation", async () => {
     const order: string[] = [];
     const controller = {


### PR DESCRIPTION
## Why

Part of the pattern-verb-contract arc (WS-D / D2, plan: `docs/plans/pattern-verb-contract-implementation.md`; design PR #4968). The D2 phase annotation already landed — every failure exit prints the furthest observed phase (`initial_sync | dispatched | committed | readback`) beside the invocation id, threaded through an `onPhase` callback. The bullet's remaining "still open" clause was per-phase timings under verbose output: when a call is slow, the phase alone says where it stopped but not where the time went.

## What Changed

- `packages/cli/commands/piece.ts`
  - New `--verbose` flag on `cf piece call` (a piece-call option, before the callable name, like `--invocation`).
  - New `pieceCallPhaseObserver`: always advances the furthest-phase tracker the failure report prints; under `--verbose` it also streams one wall-clock span per observed phase transition to stderr — `timing: initial_sync → dispatched 12.5ms` — as the transition happens, so a failure exit keeps every span observed before the failure and closes the in-flight span with `failed`. stdout stays exactly the settled Invocation JSON.
- Docs riding: the plan's WS-D "cli, phase reporting" bullet's verbose-timings clause is marked done with the observed granularity recorded.

**Granularity note (deviation from the plan's sub-phase list):** the plan lists "initial sync / dispatch / handler / commit / result sync / readback". The `onPhase` callback observes four boundaries (`dispatched` fires just before the send, `committed` on the transaction-local commit acknowledgement, `readback` before the receipt pull), so the spans reported are: initial sync→dispatch, dispatch→commit acknowledgement (the handler run and its commit are one span — nothing between them is observable from the CLI without new instrumentation deep in the runner), receipt classification (committed→readback), and readback→settlement (result sync is inside it, same reason). Timings are recorded at the phase transitions the CLI actually observes rather than inventing new runner instrumentation; the plan bullet now says exactly this.

## Test plan

- `packages/cli/test/piece-call.test.ts` (`pieceCallPhaseObserver`): with a fake clock, the verbose path emits one exact span line per observed phase plus the settled close (idempotent finish); a failure closes the in-flight span with `failed`; non-verbose emits no lines while the phase tracker still advances; the default emitter writes through `console.error` and nothing reaches `console.log` (stdout unchanged).
- `packages/cli/test/piece.test.ts`: `cf piece call` offers `--verbose`.
- `cd packages/cli && deno task test` green; repo-wide `deno fmt --check`, `deno lint`, `deno task check-docs` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-phase wall-clock timings to `cf piece call --verbose` and close the in-flight span on every exit (success, payload errors, and usage errors). Helps diagnose slow calls; stdout stays the settled Invocation JSON.

- **New Features**
  - `--verbose` streams timing lines like `timing: initial_sync → dispatched 12.5ms` to stderr as phases change; stdout remains only the settled Invocation JSON.
  - Granularity: initial_sync→dispatched, dispatched→committed, committed→readback, readback→settled. Failures close the current span with `failed`. Plan WS‑D timings marked done at this granularity.
  - `pieceCallPhaseObserver` emits timings and tracks the furthest phase; failures close spans via `reportVerbInputErrorOrRethrow` and `exitPieceCallFailure`, which also prints the error plus `invocation id` and `phase` before exit 1.

- **Refactors**
  - Extract the success path into `renderPieceCallOutcome` so `observer.finish()` and output routing are unit-covered.
  - Centralize failure handling in `exitPieceCallFailure` to close spans and rethrow usage errors; no change to user output.

<sup>Written for commit 60dae2186733192edaf4c7a8f7724e36a6d27bec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

