### PR TITLE
docs: prefer narrow cross-pattern contracts

### DIFF
--- a/docs/common/ai/pattern-critique-guide.md
+++ b/docs/common/ai/pattern-critique-guide.md
@@ -266,6 +266,38 @@ See `docs/common/patterns/multi-user-patterns.md#presenting-identity` and `docs/
   resolved string/number is the actual defect, and `cf check` would reject the
   handler-state type mismatch if the binding were unresolved.
 
+### 17. Cross-Pattern Data Contracts
+
+Review types used to read externally owned data: linked pieces, wish results,
+registry entries, cells passed between independently evolving patterns, and
+similar boundaries. A schema is a runtime projection and capability contract,
+not just a TypeScript annotation. The consumer should name only the fields it
+reads and the writable/stream capabilities it actually uses.
+
+| Violation | Fix |
+|-----------|-----|
+| another pattern's full `FooInput` or `FooOutput` is imported, aliased, or extended to type external data even though only a subset is used | declare a consumer-owned structural type containing exactly the fields and capabilities used |
+| `Pick<FooOutput, ...>` / `Omit<FooOutput, ...>` is used merely to avoid spelling the consumer contract | write the minimal local shape so unrelated producer type changes do not become consumer migrations |
+| a consumer projection names fields it never reads, including `[UI]`, unrelated state, or mutation streams | remove them; undeclared fields are intentionally outside this relationship |
+| a consumer requests `Writable<>`, `Cell<>`, or a stream it does not mutate, bind, or send | use the plain readable field type or omit the capability |
+| a producer's advertised reusable model contains its full pattern state or grows whenever one consumer needs another field | keep/export a shallow role model for the stable shared semantics; let specialized consumers own additional local projections |
+
+This duplication is intentional. Narrow schemas avoid traversing unrelated
+linked data, reduce validation failures across durable-data vintages, avoid
+exporting excess write capabilities, and let patterns migrate independently.
+See
+`docs/common/patterns/composition.md#keep-external-data-contracts-narrow`.
+
+Do not flag a genuinely shared protocol (for example, a stream event or enum),
+a cohesive domain model co-owned by one pattern family, a test intentionally
+checking the complete public result, or a wrapper whose stated purpose is to
+forward the complete contract. If the consumer demonstrably uses every field
+and capability, the full contract may be honest.
+
+Severity is `minor` when the only current effect is unnecessary coupling.
+Raise it to `major` when the oversized contract causes extra traversal,
+validation/migration failure, or excess write capability.
+
 ## Output Format
 
 The review should be emitted as a structured checklist with explicit pass/fail

--- a/docs/common/ai/pattern-critique-guide.md
+++ b/docs/common/ai/pattern-critique-guide.md
@@ -270,33 +270,38 @@ See `docs/common/patterns/multi-user-patterns.md#presenting-identity` and `docs/
 
 Review types used to read externally owned data: linked pieces, wish results,
 registry entries, cells passed between independently evolving patterns, and
-similar boundaries. A schema is a runtime projection and capability contract,
-not just a TypeScript annotation. The consumer should name only the fields it
-reads and the writable/stream capabilities it actually uses.
+similar boundaries. A schema is a runtime projection and binding contract, not
+just a TypeScript annotation. The consumer should name only the fields it reads
+and the live-cell/stream bindings it actually uses.
 
 | Violation | Fix |
 |-----------|-----|
-| another pattern's full `FooInput` or `FooOutput` is imported, aliased, or extended to type external data even though only a subset is used | declare a consumer-owned structural type containing exactly the fields and capabilities used |
+| another pattern's full `FooInput` or `FooOutput` is imported, aliased, or extended to type external data even though only a subset is used | declare a consumer-owned structural type containing exactly the fields and bindings used |
 | `Pick<FooOutput, ...>` / `Omit<FooOutput, ...>` is used merely to avoid spelling the consumer contract | write the minimal local shape so unrelated producer type changes do not become consumer migrations |
 | a consumer projection names fields it never reads, including `[UI]`, unrelated state, or mutation streams | remove them; undeclared fields are intentionally outside this relationship |
-| a consumer requests `Writable<>`, `Cell<>`, or a stream it does not mutate, bind, or send | use the plain readable field type or omit the capability |
+| a consumer requests a branded live cell (`Writable<>` / `Cell<>`) or stream when it needs only a projected value or does not use the stream | use the plain field type or omit the stream; `Writable<>` and `Cell<>` are equivalent aliases, not different authority levels |
 | a producer's advertised reusable model contains its full pattern state or grows whenever one consumer needs another field | keep/export a shallow role model for the stable shared semantics; let specialized consumers own additional local projections |
 
 This duplication is intentional. Narrow schemas avoid traversing unrelated
 linked data, reduce validation failures across durable-data vintages, avoid
-exporting excess write capabilities, and let patterns migrate independently.
-See
+unnecessary live-cell and stream bindings, and let patterns migrate
+independently. An extra required field whose value is unavailable or
+incompatible invalidates its object; when that object is an array element, one
+invalid element voids the entire array read. See
+`packages/runner/test/traverse-required-links.test.ts` and
 `docs/common/patterns/composition.md#keep-external-data-contracts-narrow`.
 
 Do not flag a genuinely shared protocol (for example, a stream event or enum),
 a cohesive domain model co-owned by one pattern family, a test intentionally
 checking the complete public result, or a wrapper whose stated purpose is to
 forward the complete contract. If the consumer demonstrably uses every field
-and capability, the full contract may be honest.
+and binding, the full contract may be honest. Also do not flag `[UI]` on a
+sub-pattern's own output type: it is required for rendering that sub-pattern in
+another pattern.
 
 Severity is `minor` when the only current effect is unnecessary coupling.
 Raise it to `major` when the oversized contract causes extra traversal,
-validation/migration failure, or excess write capability.
+validation, or migration failure.
 
 ## Output Format
 

--- a/docs/common/ai/pattern-development-guide.md
+++ b/docs/common/ai/pattern-development-guide.md
@@ -353,6 +353,15 @@ match exactly. There is no automatic name mapping. `chartData` and
 Coordinate naming across related patterns before implementation. Mismatched
 field names create silent friction later and are easy to miss during assembly.
 
+Keep the receiving side's data contract as narrow as its actual reads and
+writes. Pattern schemas select and validate runtime data and carry cell/stream
+capabilities, so importing a producer's full `Input` or `Output` type can fetch,
+bind, and migration-couple much more than the relationship needs. Prefer a
+consumer-owned structural type containing only the required fields. When
+several independent consumers share a genuine role, have the producer export a
+shallow role model rather than its full pattern schema. See
+`docs/common/patterns/composition.md#keep-external-data-contracts-narrow`.
+
 ## Workflow Guidance
 
 The common operating rhythm is:

--- a/docs/common/ai/pattern-development-guide.md
+++ b/docs/common/ai/pattern-development-guide.md
@@ -354,12 +354,12 @@ Coordinate naming across related patterns before implementation. Mismatched
 field names create silent friction later and are easy to miss during assembly.
 
 Keep the receiving side's data contract as narrow as its actual reads and
-writes. Pattern schemas select and validate runtime data and carry cell/stream
-capabilities, so importing a producer's full `Input` or `Output` type can fetch,
-bind, and migration-couple much more than the relationship needs. Prefer a
-consumer-owned structural type containing only the required fields. When
-several independent consumers share a genuine role, have the producer export a
-shallow role model rather than its full pattern schema. See
+writes. Pattern schemas select and validate runtime data and preserve requested
+live-cell/stream bindings, so importing a producer's full `Input` or `Output`
+type can fetch, bind, and migration-couple much more than the relationship
+needs. Prefer a consumer-owned structural type containing only the required
+fields. When several independent consumers share a genuine role, have the
+producer export a shallow role model rather than its full pattern schema. See
 `docs/common/patterns/composition.md#keep-external-data-contracts-narrow`.
 
 ## Workflow Guidance

--- a/docs/common/concepts/reactivity.md
+++ b/docs/common/concepts/reactivity.md
@@ -107,13 +107,18 @@ interface CounterOutput {
 declared interface by name (`pattern<Input, Output>` produces a
 `PatternFactory<…, Output>`), a non-exported `Output` interface fails
 compilation with "Default export of the module has or is using private name
-'Output'". The result type is your public contract — export it:
+'Output'". The result type is the factory's public return contract — export it:
 
 ```tsx
 // Shown for illustration only.
 export interface CounterOutput { /* ... */ }
 export default pattern<CounterInput, CounterOutput>(/* ... */);
 ```
+
+This TypeScript visibility requirement does not make the full output type the
+right input schema for every external consumer. A consumer that needs only a
+subset should normally declare its own narrow structural projection; see
+[Keep External Data Contracts Narrow](../patterns/composition.md#keep-external-data-contracts-narrow).
 
 Consumers see exactly what the author returned — the factory's result type is
 not stripped. A consumer that receives `Writable<GameState>` reads current

--- a/docs/common/patterns/composition.md
+++ b/docs/common/patterns/composition.md
@@ -69,6 +69,49 @@ Both patterns receive the same `items` cell - changes sync automatically.
 - **Pattern Composition**: Multiple views in one UI, reusable components
 - **Linked Pieces**: Independent deployments that communicate
 
+## Keep External Data Contracts Narrow
+
+A pattern schema is a runtime projection and capability contract, not only a
+TypeScript annotation. When a pattern receives externally owned data through a
+link, wish result, registry entry, or other cell, declare only the fields it
+reads and only the write or stream capabilities it uses. Extra fields can make
+the runtime traverse more linked data, make otherwise compatible stored values
+fail validation, and couple the consumer to unrelated producer migrations.
+
+The consumer normally owns this structural type:
+
+```typescript
+// Shown at module scope.
+type NotePreview = {
+  title?: string;
+  summary?: string;
+};
+
+interface PreviewInput {
+  note: NotePreview;
+}
+```
+
+Do not import another pattern's entire `FooInput` or `FooOutput`, or derive a
+`Pick`/`Omit` from it, merely because it contains the needed fields. Spelling
+the minimal local shape is intentional duplication: the producer can evolve
+unrelated state, UI, and mutation streams without changing this consumer's
+contract.
+
+When a producer intentionally supports a stable role used by several
+independent consumers, export a shallow model for that role, such as a
+`MentionablePiece` or `SummarizablePiece`, rather than asking consumers to
+reuse its full input or output schema. Keep that model limited to the role's
+semantic core. A consumer with extra needs should usually extend its own local
+projection instead of widening the shared model for everyone.
+
+Reusing a shared type is still appropriate when it is itself the intended
+protocol: for example, a stream event, an enum, or a cohesive domain model
+co-owned by one pattern family. A wrapper that deliberately forwards a complete
+contract may also use that complete contract. The test is whether every named
+field and capability belongs to the relationship, not whether centralizing the
+type removes duplicate TypeScript.
+
 ## Merging Complex Objects from Pattern Inputs
 
 Pattern inputs are cellified — they become cell proxies, not plain objects. You **cannot** spread a pattern input directly into an object literal, because the spread operates on the proxy's own properties (which are empty) rather than the underlying value.

--- a/docs/common/patterns/composition.md
+++ b/docs/common/patterns/composition.md
@@ -71,12 +71,15 @@ Both patterns receive the same `items` cell - changes sync automatically.
 
 ## Keep External Data Contracts Narrow
 
-A pattern schema is a runtime projection and capability contract, not only a
+A pattern schema is a runtime projection and binding contract, not only a
 TypeScript annotation. When a pattern receives externally owned data through a
 link, wish result, registry entry, or other cell, declare only the fields it
-reads and only the write or stream capabilities it uses. Extra fields can make
-the runtime traverse more linked data, make otherwise compatible stored values
-fail validation, and couple the consumer to unrelated producer migrations.
+reads and only the live-cell or stream bindings it uses. Extra optional fields
+can make the runtime traverse more linked data. An extra required field whose
+value is absent or incompatible and whose schema does not accept `undefined`
+invalidates the containing object; if that object is an array element, one
+invalid element voids the entire array read. See
+`packages/runner/test/traverse-required-links.test.ts`.
 
 The consumer normally owns this structural type:
 
@@ -98,12 +101,27 @@ the minimal local shape is intentional duplication: the producer can evolve
 unrelated state, UI, and mutation streams without changing this consumer's
 contract.
 
+An output type must be exported so TypeScript can name the default pattern
+factory's return contract. That visibility requirement is not an invitation for
+external consumers to reuse the whole type as their input schema.
+
+`Writable<T>` and `Cell<T>` are the same cell type and runtime interface;
+choosing between those names does not grant or restrict authority. The
+meaningful consumer-side choice is branded versus plain: a branded result
+projection preserves a live cell binding, while a plain field projects its
+reactive value. Request the brand only when the relationship needs cell
+identity or the cell API. See
+[Reactivity and Write Access](../concepts/reactivity.md#results-mirror-the-rule-writable-in-a-result-type-grants-write-access)
+and [Writable](../concepts/types-and-schemas/writable.md).
+
 When a producer intentionally supports a stable role used by several
 independent consumers, export a shallow model for that role, such as a
 `MentionablePiece` or `SummarizablePiece`, rather than asking consumers to
 reuse its full input or output schema. Keep that model limited to the role's
 semantic core. A consumer with extra needs should usually extend its own local
-projection instead of widening the shared model for everyone.
+projection instead of widening the shared model for everyone. For a concrete
+example, see `MentionablePiece` in
+`packages/patterns/system/backlinks-index.tsx`.
 
 Reusing a shared type is still appropriate when it is itself the intended
 protocol: for example, a stream event, an enum, or a cohesive domain model

--- a/skills/pattern-critic/SKILL.md
+++ b/skills/pattern-critic/SKILL.md
@@ -43,14 +43,15 @@ Warnings summary line, never Failed.
   `docs/common/patterns/multi-user-patterns.md#presenting-identity`
   (critique-guide category 16).
 
-- **Oversized cross-pattern contracts:** for every imported pattern
-  `Input`/`Output` type used to describe linked, wished, registered, or
-  otherwise external data, compare the declared shape with the fields and
-  capabilities the consumer actually uses. Prefer a consumer-owned minimal
-  structural type, or a producer-exported shallow role model, over the full
-  pattern schema and over `Pick`/`Omit` coupling. Extra schema fields cause
-  extra traversal, validation/migration coupling, and possibly excess write
-  authority; report them under critique-guide category 17.
+- **Oversized cross-pattern contracts:** for every type describing linked,
+  wished, registered, or otherwise external data — imported or declared inline —
+  compare the declared shape with the fields and bindings the consumer actually
+  uses. Prefer a consumer-owned minimal structural type, or a producer-exported
+  shallow role model, over the full pattern schema and over `Pick`/`Omit`
+  coupling. Extra schema fields cause extra traversal and validation/migration
+  coupling; unnecessary `Writable<>`/`Cell<>` brands preserve a live-cell
+  binding but do not grant runtime authority. Report these under critique-guide
+  category 17.
 
 Then use the detailed references already maintained in the repo for:
 

--- a/skills/pattern-critic/SKILL.md
+++ b/skills/pattern-critic/SKILL.md
@@ -43,10 +43,20 @@ Warnings summary line, never Failed.
   `docs/common/patterns/multi-user-patterns.md#presenting-identity`
   (critique-guide category 16).
 
+- **Oversized cross-pattern contracts:** for every imported pattern
+  `Input`/`Output` type used to describe linked, wished, registered, or
+  otherwise external data, compare the declared shape with the fields and
+  capabilities the consumer actually uses. Prefer a consumer-owned minimal
+  structural type, or a producer-exported shallow role model, over the full
+  pattern schema and over `Pick`/`Omit` coupling. Extra schema fields cause
+  extra traversal, validation/migration coupling, and possibly excess write
+  authority; report them under critique-guide category 17.
+
 Then use the detailed references already maintained in the repo for:
 
 - `docs/development/debugging/README.md`
 - `docs/development/debugging/gotchas/`
+- `docs/common/patterns/composition.md`
 - `docs/common/components/COMPONENTS.md`
 - `docs/common/patterns/multi-user-patterns.md`
 - `docs/common/patterns/ui-cookbook.md`


### PR DESCRIPTION
## Summary

- document consumer-owned minimal schemas for external pattern data
- add narrow-contract guidance to the pattern development prompt
- add cross-pattern data contracts as pattern-critic category 17
- distinguish shallow shared role models from full Input/Output reuse

## Validation

- deno fmt --check
- deno lint
- deno task check-docs
- deno task check-skill-facts
- pattern-critic skill metadata validation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented narrow cross-pattern data contracts and updated the pattern-critic to flag oversized external schemas and unnecessary bindings. This reduces coupling, extra traversal, and validation/migration failures.

- **New Features**
  - Added pattern-critic category 17 with clear violations/fixes, exceptions (shared protocols, sub-pattern `"[UI]"`), and severity guidance; updated `skills/pattern-critic/SKILL.md` references.
  - Expanded composition and development guides with a new “Keep External Data Contracts Narrow” section and examples; prefer consumer-owned minimal schemas and shallow role models over full `Input`/`Output` or `Pick`/`Omit` reuse.
  - Clarified external binding contracts in reactivity docs: exporting an `Output` is for factory visibility, not a mandate for consumers; `Writable<>` and `Cell<>` are equivalent aliases—brands preserve live-cell bindings but do not grant authority.

<sup>Written for commit 26c549629178e12f0e1da936bc9111216ae27af6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

