### PR TITLE
fix(cli,runner): normalize an absent verb payload to {} and relocate the relaxation helper (D5, D6)

### DIFF
--- a/docs/plans/pattern-verb-contract-implementation.md
+++ b/docs/plans/pattern-verb-contract-implementation.md
@@ -560,7 +560,7 @@ joins WS-C. `packages/runner` (`cell.ts` send path), `packages/cli`.
   one (pre-D5, measured live: the absent call recorded "(no event)" and the
   corrected same-id retry deduplicated against it, the correction never
   applied).
-- **runner/cfc, relocate the relaxation helper (D6).**
+- ~~**runner/cfc, relocate the relaxation helper (D6).**
   `relaxDefaultedRequired` and `localRefTarget` re-implement the runtime's
   default-satisfaction rule inside `packages/cli/lib/callable.ts`, and C5
   (closed-world inputs enforced at dispatch) needs the identical relaxation
@@ -577,7 +577,22 @@ joins WS-C. `packages/runner` (`cell.ts` send path), `packages/cli`.
   `validateSchemaValue` applies but the relaxer doesn't — each a potential
   refused-but-valid call if a generated schema leans on a required property
   there); naming the boundary is the point. Pure move plus doc comment, no
-  behavior change, its own commit beside D5 so the diff reviews as such.
+  behavior change, its own commit beside D5 so the diff reviews as such.~~ —
+  **done (D6)**: both helpers moved verbatim into the validator's own module
+  (`packages/runner/src/cfc/schema-sanitization.ts`, beside
+  `validateSchemaValue`), exported from the defining module and imported
+  directly by the CLI through a new `./cfc/schema-sanitization` package
+  export — no re-export shim, nothing added to `cfc/mod.ts`. The relaxation
+  tests moved with the code
+  (`packages/runner/test/cfc-defaulted-required-relaxation.test.ts`, pinned
+  against the same relax-then-validate composition the gate applies); the
+  CLI keeps the gate tests plus one defaulted-required pin proving the gate
+  applies the relaxation. The doc comment now names the boundary: only
+  `required` is rewritten, so `additionalProperties`, `patternProperties`,
+  `minProperties` and the other constraints, `const`/`enum`, `not` /
+  `if`/`then`/`else`, and `oneOf` exclusivity are judged against the
+  original schema text — each a potential refused-but-valid call when a
+  schema leans on a defaulted property through them.
 - **Exit (Phase 2, before WS-C):** the duplicate-on-retry bug is dead on the
   live board. **Exit (Phase 4, with WS-C):** the retry returns the original
   result.

--- a/docs/plans/pattern-verb-contract-implementation.md
+++ b/docs/plans/pattern-verb-contract-implementation.md
@@ -436,11 +436,14 @@ joins WS-C. `packages/runner` (`cell.ts` send path), `packages/cli`.
   misses the event schema does not make the argument invalid: `$event` reads
   back as `undefined`, the body runs with no event, and its receipt spends the
   id while the call reports settled. Two shapes stay legal, because the runtime
-  accepts them: a call with no payload at all (`$event` is genuinely optional —
-  value-less verbs are a supported shape), and a payload omitting a property
-  that carries a `default`, which the runtime injects on read. (D5 narrows the
-  first: once it lands, an absent payload against an object-schema verb is
-  normalized to `{}` and judged like any other — see its bullet below.)
+  accepts them: a call with no payload against a verb whose schema — after
+  resolving a top-level local `$ref` — is not an object schema (`$event` is
+  genuinely optional — value-less verbs are a supported shape), and a payload
+  omitting a property that carries a `default`, which the runtime injects on
+  read. An absent payload against an object-schema verb is normalized to `{}`
+  and judged like any supplied payload (D5 — see its bullet below): refused
+  when top-level `required` survives relaxation, dispatched as `{}` — so the
+  runtime materializes defaults — when it does not.
 - **cli, phase reporting:** every output — success, failure, timeout — carries
   the furthest observed `phase`
   (`initial_sync | dispatched | committed | readback`) beside the invocation
@@ -479,7 +482,7 @@ joins WS-C. `packages/runner` (`cell.ts` send path), `packages/cli`.
   a *result* back off the receipt, because a void verb leaves none to read.
   That assertion joins when WS-C gives verbs return values — or sooner
   against `plainResultReceipts`.
-- **cli, absent-payload gate (D5) — follow-up the pre-dispatch gate's review
+- ~~**cli, absent-payload gate (D5) — follow-up the pre-dispatch gate's review
   deferred.** The pre-dispatch validator passes `input === undefined`
   unconditionally (`verbInputSchemaError`, `packages/cli/lib/callable.ts`),
   so a call that sends *nothing* against a verb whose event schema requires
@@ -535,7 +538,28 @@ joins WS-C. `packages/runner` (`cell.ts` send path), `packages/cli`.
   a provably-unsatisfiable absence is refused pre-dispatch like any other
   unfit payload. Migration note for the PR: calls that previously "settled"
   with no payload against a required-fields verb now fail locally and are
-  retryable under the same invocation id.
+  retryable under the same invocation id.~~ — **done (D5)**: the shared gate
+  (`assertVerbInputSatisfiesSchema`, both entry points) normalizes an absent
+  payload to `{}` where the schema — after `localRefTarget` resolves a
+  top-level local `$ref` — is an object schema, and dispatches exactly what
+  it judged, so an all-defaulted verb now receives a defaults-populated
+  object instead of `undefined`; the refusal reuses
+  `VerbInputValidationError` with a "no payload was supplied … send a
+  payload" detail distinct from fix-your-payload. Characterized first at
+  both entry points (the absent payload observed dispatching `undefined` on
+  unmodified code), then flipped. Measured while wiring the integration
+  mirror: a deployed stream cell's schema carries the handler's *own* event
+  schema, so it is `$ref`-rooted only when that schema is authored or
+  generated with `$defs`; flag-derivable inline-object schemas never reach
+  dispatch with an absent payload — the arg parser's requires-input check
+  (bare call) or its `{}` flag-parse (explicit `invoke`) already covers
+  them — and the gate closes the `$ref`-rooted shape, reached via explicit
+  `invoke`. `run_piece_call_retry` scenario 6 pins the property end to end
+  against a new `$ref`-rooted `recordNote` fixture verb: absent refused
+  locally, zero messages, corrected call under the SAME id records exactly
+  one (pre-D5, measured live: the absent call recorded "(no event)" and the
+  corrected same-id retry deduplicated against it, the correction never
+  applied).
 - **runner/cfc, relocate the relaxation helper (D6).**
   `relaxDefaultedRequired` and `localRefTarget` re-implement the runtime's
   default-satisfaction rule inside `packages/cli/lib/callable.ts`, and C5

--- a/docs/plans/pattern-verb-contract-implementation.md
+++ b/docs/plans/pattern-verb-contract-implementation.md
@@ -541,7 +541,12 @@ joins WS-C. `packages/runner` (`cell.ts` send path), `packages/cli`.
   retryable under the same invocation id.~~ — **done (D5)**: the shared gate
   (`assertVerbInputSatisfiesSchema`, both entry points) normalizes an absent
   payload to `{}` where the schema — after `localRefTarget` resolves a
-  top-level local `$ref` — is an object schema, and dispatches exactly what
+  top-level local `$ref` — is an object schema: directly object-shaped, or
+  an `allOf` conjunction with an object-schema branch (a conjunction with an
+  object branch IS an object schema, no branch choice involved — added on
+  review, 2026-07-31; disjunctive `anyOf`/`oneOf` roots remain out of scope
+  per this bullet's combinator boundary, since normalizing there would pick
+  among alternatives on the caller's behalf). It dispatches exactly what
   it judged, so an all-defaulted verb now receives a defaults-populated
   object instead of `undefined`; the refusal reuses
   `VerbInputValidationError` with a "no payload was supplied … send a

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -714,6 +714,44 @@ run_piece_call_retry() {
     error "The corrected retry's payload should stand, got lastMessage: $LAST_5"
   fi
 
+  # --- 6. An absent payload the verb cannot run without is refused, id intact.
+  # The mirror of scenario 5 for the second-most-likely agent mistake:
+  # forgetting the payload rather than misspelling a field. `recordNote`'s
+  # event schema sits behind a top-level local $ref, so the CLI derives no
+  # flags from it and an explicit `invoke` with no payload parses to an
+  # absent (undefined) event. Before the absent-payload gate (verb contract
+  # D5) this dispatched: the handler ran with no event, recorded
+  # "(no event)", and the receipt spent the invocation id — the corrected
+  # same-id retry then reported deduplicated with the correction never
+  # applied. Now the gate normalizes absence to {} against the resolved
+  # object schema and refuses because `required` survives relaxation, so
+  # nothing dispatches and the same id still buys the corrected call.
+  RETRY_PIECE_6=$(cf piece new --main-export $CUSTOM_EXPORT $SPACE_ARGS "$SCRIPT_DIR/pattern/fuse-exec.tsx")
+  INVOCATION_6=$(new_invocation_id)
+  set +e
+  ABSENT_OUT=$(cf piece call $SPACE_ARGS --piece "$RETRY_PIECE_6" --invocation "$INVOCATION_6" \
+    recordNote -- invoke 2>&1)
+  ABSENT_STATUS=$?
+  set -e
+  if [ "$ABSENT_STATUS" -eq 0 ]; then
+    error "An absent payload against a required-fields verb should fail, got: $ABSENT_OUT"
+  fi
+  case "$ABSENT_OUT" in
+    *'Invalid input for "recordNote"'*'no payload was supplied'*) ;;
+    *) error "An absent-payload refusal should say no payload was supplied, got: $ABSENT_OUT" ;;
+  esac
+  assert_message_count "$RETRY_PIECE_6" 0 \
+    "A refused absent-payload call must not record a message"
+
+  cf piece call $SPACE_ARGS --piece "$RETRY_PIECE_6" --invocation "$INVOCATION_6" \
+    recordNote -- --json '{"note":"corrected"}' > /dev/null
+  assert_message_count "$RETRY_PIECE_6" 1 \
+    "The refused call never spent its id, so the corrected retry should record one"
+  LAST_6=$(cf piece get $SPACE_ARGS --piece "$RETRY_PIECE_6" lastMessage)
+  if [ "$LAST_6" != '"corrected"' ]; then
+    error "The corrected retry's payload should stand, got lastMessage: $LAST_6"
+  fi
+
   echo "Successfully ran CLI piece call retry integration tests for ${API_URL}."
 }
 

--- a/packages/cli/integration/pattern/fuse-exec.tsx
+++ b/packages/cli/integration/pattern/fuse-exec.tsx
@@ -18,6 +18,10 @@ interface Input {
   messages: string[];
 }
 
+interface RecordNoteEvent {
+  note: string;
+}
+
 interface Output {
   [NAME]: string;
   lastMessage: string;
@@ -25,6 +29,7 @@ interface Output {
   legacyCount: number;
   messages: string[];
   recordMessage: Stream<{ message: string }>;
+  recordNote: Stream<RecordNoteEvent>;
   legacyWrite: Stream<Record<string, never>>;
   search: PatternToolResult<{ source: string }>;
 }
@@ -63,6 +68,37 @@ const recordMessage = handler(
     state.lastMessage.set(message);
     state.messageCount.set(state.messageCount.get() + 1);
     state.messages.push(message);
+  },
+);
+
+// The event schema sits behind a top-level local $ref, deliberately: the
+// deployed stream schema then has no top-level `properties`, so a bare
+// `cf piece call <piece> recordNote` parses to an absent (`undefined`)
+// payload instead of schema-derived flags — the deployed shape the
+// absent-payload gate (verb contract D5) exists for. `recordMessage` keeps
+// the inline form so the fixture carries one verb of each shape.
+const recordNote = handler(
+  {
+    $ref: "#/$defs/RecordNoteEvent",
+    $defs: {
+      RecordNoteEvent: {
+        type: "object",
+        properties: {
+          note: { type: "string" },
+        },
+        required: ["note"],
+      },
+    },
+  } as const,
+  model,
+  (event, state) => {
+    // Tolerates a missing event on purpose: if an absent payload ever reaches
+    // dispatch again, the handling records "(no event)" instead of throwing,
+    // so the retry test observes the silent id-spend as data.
+    const note = (event as RecordNoteEvent | undefined)?.note ?? "(no event)";
+    state.lastMessage.set(note);
+    state.messageCount.set(state.messageCount.get() + 1);
+    state.messages.push(note);
   },
 );
 
@@ -119,6 +155,7 @@ export const customPatternExport = pattern<Input, Output>(
       legacyCount: cell.legacyCount,
       messages: cell.messages,
       recordMessage: recordMessage(cell),
+      recordNote: recordNote(cell),
       legacyWrite: legacyWrite(cell),
       search: patternTool(searchTool, {
         source: "bound-source",

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -279,6 +279,14 @@ function localRefTarget(
  * without the caller supplying it. Validating against the unrelaxed schema
  * would reject payloads the verb would have accepted.
  *
+ * This is honest only for a payload that is PRESENT (measured 2026-07-30,
+ * recorded on #5147): `SchemaObjectTraverser.traverseObjectWithSchema` (runner
+ * `traverse.ts`) fills each missing defaulted property of a present object
+ * before checking `required`, while a wholly absent event bypasses the object
+ * branch entirely — the handler sees `undefined` and no default is ever
+ * conjured. An absent payload is therefore normalized to `{}` before this
+ * relaxation is consulted (`normalizeAbsentVerbPayload`), never excused by it.
+ *
  * `seen` both memoizes and breaks reference cycles: the relaxed copy is
  * registered before its children are filled in, so a schema that reaches
  * itself resolves to the copy already under construction.
@@ -355,6 +363,40 @@ function relaxDefaultedRequired(
 }
 
 /**
+ * Normalize an absent payload to `{}` where the verb's event schema — after
+ * resolving a top-level local `$ref` (a stream's schema is often
+ * `{ $ref: "#/$defs/X", asCell: ["stream"], $defs: {...} }`) — is an object
+ * schema. Everything else passes through untouched: schema `undefined` /
+ * `true`, boolean `false` (an absent payload must pass; a supplied one is
+ * already refused), non-object schemas, and an unresolvable `$ref` (fail-open
+ * on uncertainty — refuse only on proof).
+ *
+ * Why `{}` rather than refusing absence outright (settled 2026-07-30,
+ * measured on #5147): the runtime materializes a property's `default` only
+ * for a PRESENT object payload — a wholly absent event bypasses default
+ * materialization entirely, the handler sees `undefined`, and the receipt
+ * still spends the invocation id. Normalizing lets absence flow through the
+ * same gate as any payload: `{}` fails the relaxed schema exactly when
+ * top-level `required` survives `relaxDefaultedRequired` (refusal, id never
+ * spent), and dispatching `{}` where every required property carries a
+ * default makes the runtime fill those defaults in — where an absent event
+ * would have delivered nothing.
+ */
+export function normalizeAbsentVerbPayload(
+  input: unknown,
+  schema: JSONSchema | undefined,
+): unknown {
+  if (input !== undefined) return input;
+  if (!isSchemaObject(schema)) return input;
+  const target = localRefTarget(schema, schema);
+  if (!isSchemaObject(target)) return input;
+  if (target.type !== "object" && !isSchemaObject(target.properties)) {
+    return input;
+  }
+  return {};
+}
+
+/**
  * Reject a payload that cannot satisfy the verb's event schema, before it is
  * sent.
  *
@@ -367,10 +409,11 @@ function relaxDefaultedRequired(
  * key: an id that was never dispatched is still spendable by the corrected
  * retry.
  *
- * A verb invoked with no payload at all is left alone. `$event` is genuinely
- * optional in the generated handler schema — value-less verbs are a supported
- * shape — so the rule is that a payload which *was* supplied must fit, not
- * that every verb must be given one.
+ * An absent payload reaches this function only after
+ * `normalizeAbsentVerbPayload`: against an object schema it arrives as `{}`
+ * and is judged like any supplied payload; against everything else it stays
+ * `undefined` and passes — `$event` is genuinely optional in the generated
+ * handler schema, and value-less verbs are a supported shape.
  */
 export function verbInputSchemaError(
   input: unknown,
@@ -384,15 +427,30 @@ export function verbInputSchemaError(
   );
 }
 
+/**
+ * The shared pre-dispatch gate. Returns the input to dispatch — the caller's
+ * own payload, or `{}` when an absent payload was normalized against an
+ * object schema — and throws `VerbInputValidationError` when that input
+ * cannot satisfy the schema. The absent-payload refusal says so explicitly:
+ * "send a payload" has to read differently from "fix your payload".
+ */
 function assertVerbInputSatisfiesSchema(
   verb: string,
   input: unknown,
   schema: JSONSchema | undefined,
-): void {
-  const detail = verbInputSchemaError(input, schema);
+): unknown {
+  const normalized = normalizeAbsentVerbPayload(input, schema);
+  const detail = verbInputSchemaError(normalized, schema);
   if (detail !== undefined) {
-    throw new VerbInputValidationError(verb, detail);
+    throw new VerbInputValidationError(
+      verb,
+      input === undefined
+        ? `no payload was supplied, and this verb cannot run without one ` +
+          `(${detail}) — send a payload`
+        : detail,
+    );
   }
+  return normalized;
 }
 
 function cloneWithoutBoundToolKeys(
@@ -522,8 +580,10 @@ export async function executeResolvedCallable(
     const send = resolved.callableCell.send;
     if (typeof send === "function") {
       // Before anything is dispatched, and so before the invocation id can be
-      // spent on a handling that would run with no event.
-      assertVerbInputSatisfiesSchema(
+      // spent on a handling that would run with no event. An absent payload
+      // is normalized to `{}` against an object schema (D5), so what goes out
+      // is what the gate judged.
+      const dispatchInput = assertVerbInputSatisfiesSchema(
         resolved.cellKey,
         input,
         resolved.callableCell.schema,
@@ -537,7 +597,7 @@ export async function executeResolvedCallable(
           try {
             send.call(
               resolved.callableCell,
-              input,
+              dispatchInput,
               resolve,
               invocationId !== undefined
                 ? { eventId: invocationId }

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -285,7 +285,7 @@ export function normalizeAbsentVerbPayload(
  * boundary the D5 rule records (refuse or normalize only on proof) — the
  * plan's D5 bullet names disjunctive roots out of scope.
  */
-function schemaIsObjectShaped(
+export function schemaIsObjectShaped(
   target: JSONSchema,
   root: JSONSchema,
 ): boolean {

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -1,5 +1,9 @@
 import type { CellScope, JSONSchema } from "@commonfabric/api";
-import { validateSchemaValue } from "@commonfabric/runner/cfc";
+import {
+  localRefTarget,
+  relaxDefaultedRequired,
+  validateSchemaValue,
+} from "@commonfabric/runner/cfc/schema-sanitization";
 import {
   type CallableKind,
   classifyCallableEntry,
@@ -233,134 +237,10 @@ export class VerbInputValidationError extends Error {
   }
 }
 
-/**
- * Follow local `#/$defs/...` / `#/definitions/...` references to the schema
- * they name, so a `default` behind one is still seen. Chains are followed to
- * their end; anything unresolvable (a remote ref, a missing entry, a cycle)
- * yields the last schema reached rather than failing.
- */
-function localRefTarget(
-  schema: JSONSchema,
-  root: JSONSchema,
-): JSONSchema {
-  let current = schema;
-  const visited = new Set<object>();
-  while (isSchemaObject(current)) {
-    const ref = current.$ref;
-    if (typeof ref !== "string" || !isSchemaObject(root)) return current;
-    if (visited.has(current)) return current;
-    visited.add(current);
-    // `$defs` only, deliberately — NOT `definitions`. Hoisting emits `$defs`
-    // and `#/$defs/...` (schema-generator AGENTS.md: "anything that says
-    // `definitions` is out of date"), so a `definitions` ref is one the
-    // runtime cannot resolve either. Following it here would relax a required
-    // field on the strength of a default that never gets injected, letting an
-    // invalid payload through and spending its invocation id on a handling
-    // that receives no event — the exact failure this gate exists to stop.
-    // Unresolvable refs keep the field required, so the call is refused before
-    // dispatch and the id survives.
-    const match = /^#\/\$defs\/(.+)$/.exec(ref);
-    if (!match) return current;
-    const pool = (root as Record<string, unknown>).$defs;
-    if (!isSchemaObject(pool as JSONSchema)) return current;
-    const target = (pool as Record<string, JSONSchema>)[match[1]];
-    if (target === undefined) return current;
-    current = target;
-  }
-  return current;
-}
-
-/**
- * A copy of `schema` whose `required` lists omit properties that carry their
- * own `default`.
- *
- * The runtime injects a property's default when the payload leaves it out (the
- * schema read path in runner `schema.ts`), so such a property is satisfiable
- * without the caller supplying it. Validating against the unrelaxed schema
- * would reject payloads the verb would have accepted.
- *
- * This is honest only for a payload that is PRESENT (measured 2026-07-30,
- * recorded on #5147): `SchemaObjectTraverser.traverseObjectWithSchema` (runner
- * `traverse.ts`) fills each missing defaulted property of a present object
- * before checking `required`, while a wholly absent event bypasses the object
- * branch entirely — the handler sees `undefined` and no default is ever
- * conjured. An absent payload is therefore normalized to `{}` before this
- * relaxation is consulted (`normalizeAbsentVerbPayload`), never excused by it.
- *
- * `seen` both memoizes and breaks reference cycles: the relaxed copy is
- * registered before its children are filled in, so a schema that reaches
- * itself resolves to the copy already under construction.
- */
-function relaxDefaultedRequired(
-  schema: JSONSchema,
-  root: JSONSchema,
-  seen: Map<object, JSONSchema>,
-): JSONSchema {
-  if (!isSchemaObject(schema)) return schema;
-  const cached = seen.get(schema);
-  if (cached !== undefined) return cached;
-
-  const relaxed: Record<string, unknown> = { ...schema };
-  seen.set(schema, relaxed as JSONSchema);
-
-  const properties = schema.properties;
-  if (isSchemaObject(properties)) {
-    const defaulted = new Set<string>();
-    const next: Record<string, JSONSchema> = {};
-    for (
-      const [key, propSchema] of Object.entries(
-        properties as Record<string, JSONSchema>,
-      )
-    ) {
-      const target = localRefTarget(propSchema, root);
-      if (isSchemaObject(target) && target.default !== undefined) {
-        defaulted.add(key);
-      }
-      next[key] = relaxDefaultedRequired(propSchema, root, seen);
-    }
-    relaxed.properties = next;
-    if (Array.isArray(schema.required)) {
-      relaxed.required = (schema.required as string[]).filter(
-        (key) => !defaulted.has(key),
-      );
-    }
-  }
-
-  // `items` is a single schema here; the validator rejects the tuple form
-  // outright ("schema must be an object or boolean").
-  if (schema.items !== undefined) {
-    relaxed.items = relaxDefaultedRequired(
-      schema.items as JSONSchema,
-      root,
-      seen,
-    );
-  }
-
-  const fields = schema as Record<string, unknown>;
-  for (const combinator of ["anyOf", "oneOf", "allOf"]) {
-    const branches = fields[combinator];
-    if (Array.isArray(branches)) {
-      relaxed[combinator] = (branches as JSONSchema[]).map((entry) =>
-        relaxDefaultedRequired(entry, root, seen)
-      );
-    }
-  }
-
-  for (const pool of ["$defs", "definitions"]) {
-    const defs = fields[pool];
-    if (isSchemaObject(defs as JSONSchema)) {
-      const next: Record<string, JSONSchema> = {};
-      for (
-        const [key, entry] of Object.entries(defs as Record<string, JSONSchema>)
-      ) {
-        next[key] = relaxDefaultedRequired(entry, root, seen);
-      }
-      relaxed[pool] = next;
-    }
-  }
-
-  return relaxed as JSONSchema;
-}
+// `localRefTarget` and `relaxDefaultedRequired` live beside the runtime's
+// own validator (`@commonfabric/runner/cfc/schema-sanitization`), so this
+// gate and the server-side closed-world enforcement (C5) share one
+// implementation of "what does a default satisfy" instead of drifting apart.
 
 /**
  * Normalize an absent payload to `{}` where the verb's event schema — after

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -246,10 +246,12 @@ export class VerbInputValidationError extends Error {
  * Normalize an absent payload to `{}` where the verb's event schema — after
  * resolving a top-level local `$ref` (a stream's schema is often
  * `{ $ref: "#/$defs/X", asCell: ["stream"], $defs: {...} }`) — is an object
- * schema. Everything else passes through untouched: schema `undefined` /
- * `true`, boolean `false` (an absent payload must pass; a supplied one is
- * already refused), non-object schemas, and an unresolvable `$ref` (fail-open
- * on uncertainty — refuse only on proof).
+ * schema: directly object-shaped, or an `allOf` conjunction with an
+ * object-schema branch (see `schemaIsObjectShaped`; `anyOf`/`oneOf` roots
+ * stay untouched). Everything else passes through untouched: schema
+ * `undefined` / `true`, boolean `false` (an absent payload must pass; a
+ * supplied one is already refused), non-object schemas, and an unresolvable
+ * `$ref` (fail-open on uncertainty — refuse only on proof).
  *
  * Why `{}` rather than refusing absence outright (settled 2026-07-30,
  * measured on #5147): the runtime materializes a property's `default` only
@@ -270,10 +272,35 @@ export function normalizeAbsentVerbPayload(
   if (!isSchemaObject(schema)) return input;
   const target = localRefTarget(schema, schema);
   if (!isSchemaObject(target)) return input;
-  if (target.type !== "object" && !isSchemaObject(target.properties)) {
-    return input;
-  }
+  if (!schemaIsObjectShaped(target, schema)) return input;
   return {};
+}
+
+/**
+ * Whether a resolved event schema describes an object payload — directly, or
+ * as an `allOf` conjunction with an object-schema branch (a conjunction that
+ * includes an object schema IS an object schema, no branch choice involved).
+ * `anyOf`/`oneOf` roots deliberately return false: normalizing `{}` there
+ * would pick among alternatives on the caller's behalf, the combinator
+ * boundary the D5 rule records (refuse or normalize only on proof) — the
+ * plan's D5 bullet names disjunctive roots out of scope.
+ */
+function schemaIsObjectShaped(
+  target: JSONSchema,
+  root: JSONSchema,
+): boolean {
+  if (!isSchemaObject(target)) return false;
+  if (target.type === "object" || isSchemaObject(target.properties)) {
+    return true;
+  }
+  if (Array.isArray(target.allOf)) {
+    return target.allOf.some((branch) => {
+      const resolved = localRefTarget(branch, root);
+      return isSchemaObject(resolved) &&
+        (resolved.type === "object" || isSchemaObject(resolved.properties));
+    });
+  }
+  return false;
 }
 
 /**

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -2534,6 +2534,57 @@ describe("mounted callable resolution and execution", () => {
     expect(harness.tracker.handlerWrites).toEqual([]);
   });
 
+  // Characterized first (pre-D5, observed passing on unmodified code with
+  // the dispatch assertion): a mounted handler invoked with nothing at all
+  // dispatched `undefined` when its event schema sat behind a top-level
+  // local $ref the arg parser derives no flags from. The gate now normalizes
+  // absence to `{}` against the resolved object schema and refuses when
+  // `required` survives relaxation — nothing dispatches, so an invocation id
+  // would never have been spent.
+  it("refuses an absent payload for a mounted handler that cannot run without one", async () => {
+    const mountpoint = join(tmpDir, "mount");
+    const filePath = await createMountedFile(mountpoint, {
+      relativePath: "home/pieces/notes-2/result/add.handler",
+      pieceId: "of:piece-123",
+    });
+    const harness = createExecHarness({
+      callableKind: "handler",
+      cellProp: "result",
+      cellKey: "add",
+      pieceId: "of:piece-123",
+      inputSchema: {
+        $ref: "#/$defs/AddEvent",
+        asCell: ["stream"],
+        $defs: {
+          AddEvent: {
+            type: "object",
+            properties: { query: { type: "string" } },
+            required: ["query"],
+          },
+        },
+      } as JSONSchema,
+    });
+
+    await writeLiveMountState(stateDir, mountpoint);
+
+    await expect(
+      executeMountedCallableFile(
+        filePath,
+        [],
+        {
+          stateDir,
+          loadManager: () => Promise.resolve(harness.manager),
+          loadPiece: () => Promise.resolve(harness.piece),
+          isStdinTerminal: () => true,
+        },
+      ),
+    ).rejects.toThrow(
+      /Invalid input for "add": no payload was supplied.*query.*send a payload/,
+    );
+
+    expect(harness.tracker.handlerWrites).toEqual([]);
+  });
+
   it("returns machine-readable schema details for --help --json", async () => {
     const mountpoint = join(tmpDir, "mount");
     const filePath = await createMountedFile(mountpoint, {

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -1951,6 +1951,17 @@ describe("normalizeAbsentVerbPayload", () => {
     } as JSONSchema)).toBeUndefined();
   });
 
+  // A boolean definition is a resolvable target that still proves nothing
+  // about the event being an object — absence passes through, like any other
+  // non-object target.
+  it("leaves absence alone when the top-level $ref names a boolean def", () => {
+    expect(normalizeAbsentVerbPayload(undefined, {
+      $ref: "#/$defs/Anything",
+      asCell: ["stream"],
+      $defs: { Anything: true },
+    } as JSONSchema)).toBeUndefined();
+  });
+
   // The schema-less handler-input shape (`{ asCell: ["stream"] }` with no
   // type and no properties) is not an object schema; `{}` means nothing
   // there.

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -1962,6 +1962,47 @@ describe("normalizeAbsentVerbPayload", () => {
     } as JSONSchema)).toBeUndefined();
   });
 
+  // An allOf conjunction with an object-schema branch IS an object schema —
+  // no branch choice is involved, so `{}` is exactly as meaningful as for a
+  // direct object root, and the gate then judges it the same way (refused
+  // when non-defaulted required survives relaxation, dispatched with defaults
+  // engaging when it does not).
+  it("normalizes absence to {} against an allOf of object schemas", () => {
+    expect(normalizeAbsentVerbPayload(undefined, {
+      allOf: [
+        {
+          type: "object",
+          properties: { mode: { type: "string", default: "fast" } },
+          required: ["mode"],
+        },
+      ],
+    } as unknown as JSONSchema)).toEqual({});
+  });
+
+  it("normalizes absence through an allOf branch behind a $ref", () => {
+    expect(normalizeAbsentVerbPayload(undefined, {
+      allOf: [{ $ref: "#/$defs/Base" }],
+      $defs: {
+        Base: {
+          type: "object",
+          properties: { mode: { type: "string", default: "fast" } },
+        },
+      },
+    } as unknown as JSONSchema)).toEqual({});
+  });
+
+  // Disjunctive roots stay out of scope (the D5 rule's recorded combinator
+  // boundary): normalizing `{}` against anyOf/oneOf would pick among
+  // alternatives on the caller's behalf.
+  it("leaves absence alone against anyOf/oneOf roots", () => {
+    expect(normalizeAbsentVerbPayload(undefined, {
+      anyOf: [{ type: "object", properties: {} }],
+    } as unknown as JSONSchema)).toBeUndefined();
+    expect(normalizeAbsentVerbPayload(undefined, {
+      oneOf: [{ type: "object", properties: {} }],
+    } as unknown as JSONSchema)).toBeUndefined();
+  });
+
   // The schema-less handler-input shape (`{ asCell: ["stream"] }` with no
   // type and no properties) is not an object schema; `{}` means nothing
   // there.

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -1851,147 +1851,17 @@ describe("verbInputSchemaError", () => {
   });
 
   // The runtime injects a property's default when the payload omits it, so
-  // requiring it here would refuse a call the verb would have accepted.
+  // requiring it here would refuse a call the verb would have accepted. This
+  // pins that the gate APPLIES the relaxation; the relaxation's own semantics
+  // ($ref chains, combinators, cycles, the `definitions` refusal) are pinned
+  // where the helpers live (runner `cfc-defaulted-required-relaxation.test.ts`
+  // — verb contract D6).
   it("treats a defaulted property as satisfied when omitted", () => {
     expect(verbInputSchemaError({}, {
       type: "object",
       properties: { mode: { type: "string", default: "fast" } },
       required: ["mode"],
     })).toBeUndefined();
-  });
-
-  it("treats a defaulted property as satisfied when nested", () => {
-    expect(verbInputSchemaError({ opts: {} }, {
-      type: "object",
-      properties: {
-        opts: {
-          type: "object",
-          properties: { mode: { type: "string", default: "fast" } },
-          required: ["mode"],
-        },
-      },
-      required: ["opts"],
-    })).toBeUndefined();
-  });
-
-  it("treats a defaulted property as satisfied behind a $ref", () => {
-    expect(verbInputSchemaError({}, {
-      type: "object",
-      properties: { mode: { $ref: "#/$defs/Mode" } },
-      required: ["mode"],
-      $defs: { Mode: { type: "string", default: "fast" } },
-    })).toBeUndefined();
-  });
-
-  it("follows a $ref chain to find the default", () => {
-    expect(verbInputSchemaError({}, {
-      type: "object",
-      properties: { mode: { $ref: "#/$defs/Mode" } },
-      required: ["mode"],
-      $defs: {
-        Mode: { $ref: "#/$defs/RealMode" },
-        RealMode: { type: "string", default: "fast" },
-      },
-    })).toBeUndefined();
-  });
-
-  it("relaxes a defaulted property inside array items", () => {
-    expect(verbInputSchemaError([{}], {
-      type: "array",
-      items: {
-        type: "object",
-        properties: { mode: { type: "string", default: "fast" } },
-        required: ["mode"],
-      },
-    })).toBeUndefined();
-  });
-
-  it("relaxes a defaulted property inside a combinator branch", () => {
-    expect(verbInputSchemaError({}, {
-      anyOf: [
-        {
-          type: "object",
-          properties: { mode: { type: "string", default: "fast" } },
-          required: ["mode"],
-        },
-      ],
-    } as JSONSchema)).toBeUndefined();
-  });
-
-  // A reference that names nothing local cannot be followed to a default.
-  // Relaxation leaves it exactly as written rather than guessing.
-  it("leaves a non-local $ref untouched", () => {
-    expect(verbInputSchemaError({ mode: "x" }, {
-      type: "object",
-      properties: { mode: { $ref: "https://example.com/Mode" } },
-    } as JSONSchema)).toMatch(/cannot resolve schema reference/);
-  });
-
-  // Hoisting emits `$defs`; a `definitions` ref is one the runtime cannot
-  // resolve either. Relaxing on a default behind one would admit a payload the
-  // verb then receives as an absent event, spending the invocation id.
-  it("does not relax on a default behind a #/definitions ref", () => {
-    expect(verbInputSchemaError({}, {
-      type: "object",
-      properties: { mode: { $ref: "#/definitions/Mode" } },
-      required: ["mode"],
-      definitions: { Mode: { type: "string", default: "fast" } },
-    } as unknown as JSONSchema)).toMatch(/mode/);
-  });
-
-  it("leaves a $ref naming a missing definition untouched", () => {
-    expect(verbInputSchemaError({ mode: "x" }, {
-      type: "object",
-      properties: { mode: { $ref: "#/$defs/Absent" } },
-      $defs: { Present: { type: "string" } },
-    } as JSONSchema)).toMatch(/cannot resolve schema reference/);
-  });
-
-  it("ignores a malformed $defs pool instead of indexing it", () => {
-    expect(verbInputSchemaError({ mode: "x" }, {
-      type: "object",
-      properties: { mode: { $ref: "#/$defs/Mode" } },
-      $defs: null,
-    } as unknown as JSONSchema)).toMatch(/cannot resolve schema reference/);
-  });
-
-  it("handles a $ref whose target is a boolean schema", () => {
-    expect(verbInputSchemaError({ mode: "x" }, {
-      type: "object",
-      properties: { mode: { $ref: "#/$defs/Anything" } },
-      $defs: { Anything: true },
-    } as JSONSchema)).toBeUndefined();
-  });
-
-  it("passes a boolean property schema through unchanged", () => {
-    expect(verbInputSchemaError({ mode: "x" }, {
-      type: "object",
-      properties: { mode: true },
-    } as JSONSchema)).toBeUndefined();
-  });
-
-  // A ref cycle names no schema to check against. Relaxation walks it without
-  // looping and hands it on unchanged; the validator is what reports it.
-  it("terminates on a $ref cycle instead of looping", () => {
-    expect(verbInputSchemaError({ mode: "x" }, {
-      type: "object",
-      properties: { mode: { $ref: "#/$defs/A" } },
-      $defs: {
-        A: { $ref: "#/$defs/B" },
-        B: { $ref: "#/$defs/A" },
-      },
-    })).toMatch(/cannot resolve schema reference/);
-  });
-
-  it("still rejects a non-defaulted sibling of a defaulted property", () => {
-    expect(verbInputSchemaError({}, {
-      type: "object",
-      properties: {
-        mode: { type: "string", default: "fast" },
-        target: { type: "string" },
-      },
-      required: ["mode", "target"],
-    })).toMatch(/target/);
   });
 
   it("accepts asCell fields given either a plain value or a link", () => {
@@ -2013,17 +1883,6 @@ describe("verbInputSchemaError", () => {
         schema,
       ),
     ).toBeUndefined();
-  });
-
-  it("terminates on a self-referential schema", () => {
-    const cyclic: Record<string, unknown> = {
-      type: "object",
-      properties: { name: { type: "string" } },
-      required: ["name"],
-    };
-    (cyclic.properties as Record<string, unknown>).child = cyclic;
-    expect(verbInputSchemaError({ name: "a" }, cyclic as JSONSchema))
-      .toBeUndefined();
   });
 });
 

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -4,6 +4,7 @@ import type { JSONSchema } from "@commonfabric/api";
 import {
   CF_RUNTIME_ERROR_LOG,
   normalizeAbsentVerbPayload,
+  runtimeErrorLog,
   verbInputSchemaError,
   VerbInputValidationError,
 } from "../lib/callable.ts";
@@ -2079,5 +2080,24 @@ describe("reportVerbInputErrorOrRethrow", () => {
 
     expect(printed).toEqual([]);
     expect(exited).toEqual([]);
+  });
+});
+
+describe("runtimeErrorLog", () => {
+  // Pinned directly rather than left to incidental coverage: which execution
+  // paths hand this a non-object runtime varies by run and sharding, and the
+  // coverage gate has flagged the resulting phantom deltas on unrelated PRs.
+  it("returns [] for non-object runtimes and runtimes without a log", () => {
+    expect(runtimeErrorLog(undefined)).toEqual([]);
+    expect(runtimeErrorLog("not a runtime")).toEqual([]);
+    expect(runtimeErrorLog({})).toEqual([]);
+    expect(runtimeErrorLog({ [CF_RUNTIME_ERROR_LOG]: "not an array" }))
+      .toEqual([]);
+  });
+
+  it("returns the recorded log when present", () => {
+    const records = [{ message: "boom" }];
+    expect(runtimeErrorLog({ [CF_RUNTIME_ERROR_LOG]: records }))
+      .toEqual(records);
   });
 });

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -5,6 +5,7 @@ import {
   CF_RUNTIME_ERROR_LOG,
   normalizeAbsentVerbPayload,
   runtimeErrorLog,
+  schemaIsObjectShaped,
   verbInputSchemaError,
   VerbInputValidationError,
 } from "../lib/callable.ts";
@@ -2099,5 +2100,33 @@ describe("runtimeErrorLog", () => {
     const records = [{ message: "boom" }];
     expect(runtimeErrorLog({ [CF_RUNTIME_ERROR_LOG]: records }))
       .toEqual(records);
+  });
+});
+
+describe("schemaIsObjectShaped", () => {
+  // Pinned directly: the gate's caller pre-filters non-object roots, so the
+  // defensive boolean-target guard is unreachable through it, and the
+  // combinator boundary this function encodes (allOf conjunctions count,
+  // disjunctions never) deserves its own record.
+  it("rejects boolean schemas and accepts object shapes", () => {
+    expect(schemaIsObjectShaped(true, true)).toBe(false);
+    expect(schemaIsObjectShaped(false, false)).toBe(false);
+    expect(schemaIsObjectShaped({ type: "object" }, {})).toBe(true);
+    expect(schemaIsObjectShaped({ properties: { a: {} } }, {})).toBe(true);
+  });
+
+  it("counts allOf conjunctions with an object branch, never disjunctions", () => {
+    expect(schemaIsObjectShaped(
+      { allOf: [{ type: "string" }, { type: "object" }] },
+      {},
+    )).toBe(true);
+    expect(schemaIsObjectShaped(
+      { anyOf: [{ type: "object" }] },
+      {},
+    )).toBe(false);
+    expect(schemaIsObjectShaped(
+      { oneOf: [{ type: "object" }] },
+      {},
+    )).toBe(false);
   });
 });

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -3,6 +3,7 @@ import { expect } from "@std/expect";
 import type { JSONSchema } from "@commonfabric/api";
 import {
   CF_RUNTIME_ERROR_LOG,
+  normalizeAbsentVerbPayload,
   verbInputSchemaError,
   VerbInputValidationError,
 } from "../lib/callable.ts";
@@ -183,6 +184,112 @@ describe("executePieceCallable", () => {
     // receipt burns the id while the call reports settled.
     expect(harness.tracker.handlerWrites).toEqual([]);
     expect(harness.tracker.sendOptions).toEqual([]);
+  });
+
+  // Characterized first (pre-D5, observed passing on unmodified code): this
+  // exact call dispatched — the handler ran with `$event === undefined` and
+  // its receipt spent the invocation id. The schema below is the deployed
+  // shape absence reaches dispatch through: a top-level local $ref with the
+  // stream marker, which the arg parser cannot derive flags from, so a bare
+  // call parses to `input === undefined`.
+  it("refuses an absent payload against a verb that provably cannot run without one", async () => {
+    const harness = createPieceCallableHarness({
+      callableKind: "handler",
+      cellKey: "recordMessage",
+      inputSchema: {
+        $ref: "#/$defs/RecordMessageEvent",
+        asCell: ["stream"],
+        $defs: {
+          RecordMessageEvent: {
+            type: "object",
+            properties: {
+              message: { type: "string" },
+            },
+            required: ["message"],
+          },
+        },
+      } as JSONSchema,
+    });
+
+    await expect(
+      executePieceCallable(
+        {
+          apiUrl: "http://localhost:8000",
+          identity: "/tmp/test-identity.pem",
+          piece: "fid1:piece-123",
+          space: "home",
+        },
+        "recordMessage",
+        [],
+        {
+          loadManager: () => Promise.resolve(harness.manager),
+          loadPiece: () => Promise.resolve(harness.piece),
+          isStdinTerminal: () => true,
+          invocationId: "inv-absent-retry",
+        },
+      ),
+    ).rejects.toThrow(
+      /Invalid input for "recordMessage": no payload was supplied.*message.*send a payload/,
+    );
+
+    // Nothing reached the stream, so the invocation id was never spent — the
+    // retry that actually sends a payload can still use it.
+    expect(harness.tracker.handlerWrites).toEqual([]);
+    expect(harness.tracker.sendOptions).toEqual([]);
+  });
+
+  it("normalizes an absent payload to {} so an all-defaulted verb receives its defaults", async () => {
+    const harness = createPieceCallableHarness({
+      callableKind: "handler",
+      cellKey: "refreshFeed",
+      inputSchema: {
+        $ref: "#/$defs/RefreshEvent",
+        asCell: ["stream"],
+        $defs: {
+          RefreshEvent: {
+            type: "object",
+            properties: {
+              mode: { type: "string", default: "fast" },
+              limit: { type: "number", default: 10 },
+            },
+            required: ["mode", "limit"],
+          },
+        },
+      } as JSONSchema,
+      receiptValue: {},
+    });
+
+    const result = await executePieceCallable(
+      {
+        apiUrl: "http://localhost:8000",
+        identity: "/tmp/test-identity.pem",
+        piece: "fid1:piece-123",
+        space: "home",
+      },
+      "refreshFeed",
+      [],
+      {
+        loadManager: () => Promise.resolve(harness.manager),
+        loadPiece: () => Promise.resolve(harness.piece),
+        isStdinTerminal: () => true,
+        invocationId: "inv-defaulted",
+      },
+    );
+
+    // `{}` goes out instead of nothing: the runtime materializes defaults for
+    // a PRESENT object payload only, so this is the difference between the
+    // handler seeing `{ mode: "fast", limit: 10 }` and seeing `undefined`.
+    expect(harness.tracker.handlerWrites).toEqual([
+      {
+        cellProp: "result",
+        path: ["refreshFeed"],
+        value: {},
+      },
+    ]);
+    expect(result.invocation).toEqual({
+      id: "inv-defaulted",
+      status: "settled",
+    });
   });
 
   it("runs tools from schema-derived flags and returns JSON output", async () => {
@@ -1917,6 +2024,81 @@ describe("verbInputSchemaError", () => {
     (cyclic.properties as Record<string, unknown>).child = cyclic;
     expect(verbInputSchemaError({ name: "a" }, cyclic as JSONSchema))
       .toBeUndefined();
+  });
+});
+
+describe("normalizeAbsentVerbPayload", () => {
+  it("normalizes absence to {} against a plain object schema", () => {
+    expect(normalizeAbsentVerbPayload(undefined, {
+      type: "object",
+      properties: { message: { type: "string" } },
+      required: ["message"],
+    })).toEqual({});
+  });
+
+  it("normalizes absence to {} through a top-level local $ref", () => {
+    expect(normalizeAbsentVerbPayload(undefined, {
+      $ref: "#/$defs/Event",
+      asCell: ["stream"],
+      $defs: {
+        Event: {
+          type: "object",
+          properties: { message: { type: "string" } },
+          required: ["message"],
+        },
+      },
+    } as JSONSchema)).toEqual({});
+  });
+
+  it("leaves a supplied payload untouched, object schema or not", () => {
+    const payload = { message: "milk" };
+    expect(normalizeAbsentVerbPayload(payload, {
+      type: "object",
+      properties: { message: { type: "string" } },
+    })).toBe(payload);
+    expect(normalizeAbsentVerbPayload("text", { type: "string" })).toBe(
+      "text",
+    );
+  });
+
+  it("leaves absence alone when the verb declares no schema", () => {
+    expect(normalizeAbsentVerbPayload(undefined, undefined)).toBeUndefined();
+    expect(normalizeAbsentVerbPayload(undefined, true)).toBeUndefined();
+  });
+
+  // An absent payload must keep passing a `false` schema — a supplied one is
+  // already refused by the validator ("schema rejects all values"), and
+  // normalizing here would convert every call into that refusal.
+  it("leaves absence alone against a boolean false schema", () => {
+    expect(normalizeAbsentVerbPayload(undefined, false)).toBeUndefined();
+  });
+
+  it("leaves absence alone against a non-object schema", () => {
+    expect(normalizeAbsentVerbPayload(undefined, { type: "string" }))
+      .toBeUndefined();
+    expect(normalizeAbsentVerbPayload(undefined, {
+      type: "array",
+      items: { type: "string" },
+    })).toBeUndefined();
+  });
+
+  // Refuse only on proof: a $ref nobody can resolve proves nothing about the
+  // event being an object, so absence keeps today's pass-through behavior.
+  it("leaves absence alone when the top-level $ref cannot be resolved", () => {
+    expect(normalizeAbsentVerbPayload(undefined, {
+      $ref: "#/$defs/Absent",
+      asCell: ["stream"],
+      $defs: { Present: { type: "object" } },
+    } as JSONSchema)).toBeUndefined();
+  });
+
+  // The schema-less handler-input shape (`{ asCell: ["stream"] }` with no
+  // type and no properties) is not an object schema; `{}` means nothing
+  // there.
+  it("leaves absence alone against a schema-less stream marker", () => {
+    expect(normalizeAbsentVerbPayload(undefined, {
+      asCell: ["stream"],
+    } as JSONSchema)).toBeUndefined();
   });
 });
 

--- a/packages/runner/deno.jsonc
+++ b/packages/runner/deno.jsonc
@@ -35,6 +35,7 @@
     "./toolshed-http-auth": "./src/toolshed-http-auth.ts",
     "./cfc": "./src/cfc/mod.ts",
     "./cfc/label-view-core": "./src/cfc/label-view-core.ts",
-    "./cfc/migration-reason": "./src/cfc/migration-reason.ts"
+    "./cfc/migration-reason": "./src/cfc/migration-reason.ts",
+    "./cfc/schema-sanitization": "./src/cfc/schema-sanitization.ts"
   }
 }

--- a/packages/runner/src/cfc/schema-sanitization.ts
+++ b/packages/runner/src/cfc/schema-sanitization.ts
@@ -1345,7 +1345,21 @@ export function localRefTarget(
  *
  * `seen` both memoizes and breaks reference cycles: the relaxed copy is
  * registered before its children are filled in, so a schema that reaches
- * itself resolves to the copy already under construction.
+ * itself resolves to the copy already under construction. The memo is keyed
+ * by schema object identity alone — cycle-breaking requires registering
+ * before the scope of every reaching path is known — so a schema OBJECT
+ * shared verbatim across two different definition scopes relaxes in the
+ * scope that reaches it first. Generated schemas do not share fragment
+ * objects across scopes, so this stays theoretical.
+ *
+ * Scope discipline: a subtree that declares its own `$defs` opens a new
+ * local-ref scope (`cfcSchemaChildRoot`) — the same per-hop root tracking
+ * `localRefTarget` applies. Every ref consulted for a `default` and every
+ * recursion below resolves in the CURRENT schema's scope, so a property
+ * `$ref` beneath a nested object's own `$defs` finds that pool, not the
+ * document root's (which may not name the definition — or worse, name a
+ * decoy without the default, leaving the property required and refusing a
+ * payload the runtime materializes).
  */
 export function relaxDefaultedRequired(
   schema: JSONSchema,
@@ -1359,6 +1373,8 @@ export function relaxDefaultedRequired(
   const relaxed: Record<string, unknown> = { ...schema };
   seen.set(schema, relaxed as JSONSchema);
 
+  const scopeRoot = cfcSchemaChildRoot(schema, root);
+
   const properties = schema.properties;
   if (isSchemaObject(properties)) {
     const defaulted = new Set<string>();
@@ -1368,11 +1384,27 @@ export function relaxDefaultedRequired(
         properties as Record<string, JSONSchema>,
       )
     ) {
-      const target = localRefTarget(propSchema, root);
-      if (isSchemaObject(target) && target.default !== undefined) {
+      const target = localRefTarget(propSchema, scopeRoot);
+      // A property counts as defaulted only when the runtime would inject
+      // its default on read: a `default` on the property schema itself is
+      // read directly (ref-site siblings included — the default-injection
+      // read in runner `schema.ts` consults `propSchema.default` without
+      // resolving the ref), and a `default` on a fully RESOLVED chain end is
+      // materialized through the resolved view. A default stranded on an
+      // unresolvable chain's last reachable wrapper is neither: the runtime
+      // cannot resolve past it, so crediting it would admit `{}` and spend
+      // the invocation id on a handling missing the field. An unresolvable
+      // chain keeps the field required (fail-closed), matching
+      // `localRefTarget`'s contract for the gates.
+      const chainEndResolved = isSchemaObject(target) &&
+        typeof target.$ref !== "string";
+      if (
+        (isSchemaObject(propSchema) && propSchema.default !== undefined) ||
+        (chainEndResolved && target.default !== undefined)
+      ) {
         defaulted.add(key);
       }
-      next[key] = relaxDefaultedRequired(propSchema, root, seen);
+      next[key] = relaxDefaultedRequired(propSchema, scopeRoot, seen);
     }
     relaxed.properties = next;
     if (Array.isArray(schema.required)) {
@@ -1382,13 +1414,20 @@ export function relaxDefaultedRequired(
     }
   }
 
-  // `items` is a single schema here; the validator rejects the tuple form
-  // outright ("schema must be an object or boolean").
+  // `items` is a single schema here; the validator rejects the legacy tuple
+  // form of `items` outright ("schema must be an object or boolean"). Tuples
+  // are `prefixItems`, whose slot schemas get the same treatment — a present
+  // tuple-slot object is materialized like any present object.
   if (schema.items !== undefined) {
     relaxed.items = relaxDefaultedRequired(
       schema.items as JSONSchema,
-      root,
+      scopeRoot,
       seen,
+    );
+  }
+  if (Array.isArray(schema.prefixItems)) {
+    relaxed.prefixItems = (schema.prefixItems as JSONSchema[]).map((entry) =>
+      relaxDefaultedRequired(entry, scopeRoot, seen)
     );
   }
 
@@ -1397,7 +1436,7 @@ export function relaxDefaultedRequired(
     const branches = fields[combinator];
     if (Array.isArray(branches)) {
       relaxed[combinator] = (branches as JSONSchema[]).map((entry) =>
-        relaxDefaultedRequired(entry, root, seen)
+        relaxDefaultedRequired(entry, scopeRoot, seen)
       );
     }
   }
@@ -1409,7 +1448,7 @@ export function relaxDefaultedRequired(
       for (
         const [key, entry] of Object.entries(defs as Record<string, JSONSchema>)
       ) {
-        next[key] = relaxDefaultedRequired(entry, root, seen);
+        next[key] = relaxDefaultedRequired(entry, scopeRoot, seen);
       }
       relaxed[pool] = next;
     }

--- a/packages/runner/src/cfc/schema-sanitization.ts
+++ b/packages/runner/src/cfc/schema-sanitization.ts
@@ -19,6 +19,7 @@ import {
 import { uniqueCfcAtoms } from "./observation.ts";
 import {
   cfcSchemaChildRoot,
+  isEmbeddedCfcSchemaRef,
   resolveCfcSchemaRef,
   resolveCfcSchemaRefRoot,
   resolveCfcSchemaRefs,
@@ -1267,38 +1268,47 @@ const isSchemaObject = (
   typeof schema === "object" && schema !== null && !Array.isArray(schema);
 
 /**
- * Follow local `#/$defs/...` / `#/definitions/...` references to the schema
- * they name, so a `default` behind one is still seen. Chains are followed to
- * their end; anything unresolvable (a remote ref, a missing entry, a cycle)
- * yields the last schema reached rather than failing.
+ * Follow `$ref` chains to the schema they name, so a `default` behind one is
+ * still seen. Resolution is the canonical resolver's, not a private pointer
+ * parser: each hop goes through `resolveCfcSchemaRef` (which decodes JSON
+ * Pointer escapes, so `#/$defs/A~1B` names the `"A/B"` definition, and
+ * resolves the embedded-schema URIs) against the scope `cfcSchemaChildRoot`
+ * assigns — a subtree with its own `$defs` opens a new scope, exactly the
+ * root tracking `resolveCfcSchemaRefRoot` applies. A hand-rolled regex here
+ * previously disagreed with that resolver on escaped names and nested
+ * scopes, so this gate refused payloads the runtime's own materialization
+ * accepts.
+ *
+ * Chains are followed to their end; anything the canonical resolver does not
+ * resolve (a remote non-embedded ref, a `definitions` pointer — hoisting
+ * emits `$defs` only, so the runtime cannot resolve those either — a missing
+ * entry, a cycle) yields the last schema reached rather than failing. For
+ * the gates built on this, unresolvable keeps the field required, so the
+ * call is refused and the invocation id survives for a corrected retry.
  */
 export function localRefTarget(
   schema: JSONSchema,
   root: JSONSchema,
 ): JSONSchema {
   let current = schema;
-  const visited = new Set<object>();
-  while (isSchemaObject(current)) {
+  let currentRoot = cfcSchemaChildRoot(schema, root);
+  const seenRefs = new Map<JSONSchema, Set<string>>();
+  while (isSchemaObject(current) && typeof current.$ref === "string") {
     const ref = current.$ref;
-    if (typeof ref !== "string" || !isSchemaObject(root)) return current;
-    if (visited.has(current)) return current;
-    visited.add(current);
-    // `$defs` only, deliberately — NOT `definitions`. Hoisting emits `$defs`
-    // and `#/$defs/...` (schema-generator AGENTS.md: "anything that says
-    // `definitions` is out of date"), so a `definitions` ref is one the
-    // runtime cannot resolve either. Following it here would relax a required
-    // field on the strength of a default that never gets injected, letting an
-    // invalid payload through and spending its invocation id on a handling
-    // that receives no event — the exact failure the pre-dispatch gate exists
-    // to stop. Unresolvable refs keep the field required, so the call is
-    // refused before dispatch and the id survives.
-    const match = /^#\/\$defs\/(.+)$/.exec(ref);
-    if (!match) return current;
-    const pool = (root as Record<string, unknown>).$defs;
-    if (!isSchemaObject(pool as JSONSchema)) return current;
-    const target = (pool as Record<string, JSONSchema>)[match[1]];
-    if (target === undefined) return current;
-    current = target;
+    let refsForRoot = seenRefs.get(currentRoot);
+    if (refsForRoot?.has(ref)) return current;
+    if (!refsForRoot) {
+      refsForRoot = new Set();
+      seenRefs.set(currentRoot, refsForRoot);
+    }
+    refsForRoot.add(ref);
+    const next = resolveCfcSchemaRef(currentRoot, ref);
+    if (next === undefined) return current;
+    currentRoot = cfcSchemaChildRoot(
+      next,
+      isEmbeddedCfcSchemaRef(ref) ? next : currentRoot,
+    );
+    current = next;
   }
   return current;
 }

--- a/packages/runner/src/cfc/schema-sanitization.ts
+++ b/packages/runner/src/cfc/schema-sanitization.ts
@@ -1261,6 +1261,153 @@ const unmarkSchemaValueActive = (
   );
 };
 
+const isSchemaObject = (
+  schema: JSONSchema | undefined,
+): schema is Record<string, unknown> =>
+  typeof schema === "object" && schema !== null && !Array.isArray(schema);
+
+/**
+ * Follow local `#/$defs/...` / `#/definitions/...` references to the schema
+ * they name, so a `default` behind one is still seen. Chains are followed to
+ * their end; anything unresolvable (a remote ref, a missing entry, a cycle)
+ * yields the last schema reached rather than failing.
+ */
+export function localRefTarget(
+  schema: JSONSchema,
+  root: JSONSchema,
+): JSONSchema {
+  let current = schema;
+  const visited = new Set<object>();
+  while (isSchemaObject(current)) {
+    const ref = current.$ref;
+    if (typeof ref !== "string" || !isSchemaObject(root)) return current;
+    if (visited.has(current)) return current;
+    visited.add(current);
+    // `$defs` only, deliberately — NOT `definitions`. Hoisting emits `$defs`
+    // and `#/$defs/...` (schema-generator AGENTS.md: "anything that says
+    // `definitions` is out of date"), so a `definitions` ref is one the
+    // runtime cannot resolve either. Following it here would relax a required
+    // field on the strength of a default that never gets injected, letting an
+    // invalid payload through and spending its invocation id on a handling
+    // that receives no event — the exact failure the pre-dispatch gate exists
+    // to stop. Unresolvable refs keep the field required, so the call is
+    // refused before dispatch and the id survives.
+    const match = /^#\/\$defs\/(.+)$/.exec(ref);
+    if (!match) return current;
+    const pool = (root as Record<string, unknown>).$defs;
+    if (!isSchemaObject(pool as JSONSchema)) return current;
+    const target = (pool as Record<string, JSONSchema>)[match[1]];
+    if (target === undefined) return current;
+    current = target;
+  }
+  return current;
+}
+
+/**
+ * A copy of `schema` whose `required` lists omit properties that carry their
+ * own `default`.
+ *
+ * The runtime injects a property's default when the payload leaves it out (the
+ * schema read path in runner `schema.ts`), so such a property is satisfiable
+ * without the caller supplying it. Validating against the unrelaxed schema
+ * would reject payloads the verb would have accepted.
+ *
+ * This is honest only for a payload that is PRESENT (measured 2026-07-30,
+ * recorded on #5147): `SchemaObjectTraverser.traverseObjectWithSchema` (runner
+ * `traverse.ts`) fills each missing defaulted property of a present object
+ * before checking `required`, while a wholly absent event bypasses the object
+ * branch entirely — the handler sees `undefined` and no default is ever
+ * conjured. The CLI's absent-payload gate therefore normalizes an absent
+ * payload to `{}` before consulting this relaxation; absence is never excused
+ * by it.
+ *
+ * What this relaxation does NOT check — the boundary, named so nobody assumes
+ * it: only `required` lists are rewritten. Every other validation
+ * `validateSchemaValue` applies runs against the original schema text —
+ * `additionalProperties`, `patternProperties`, `minProperties` and the other
+ * object/array/string/number constraints, `const`/`enum`, `not` and
+ * `if`/`then`/`else`, and `oneOf` exclusivity. None of them is re-judged as
+ * if the runtime's defaults had already been filled in, so a schema that
+ * leans on a defaulted property through one of them (say `minProperties: 1`
+ * over a single all-defaulted property, or an `if` conditioned on it) can
+ * refuse a payload the runtime would have completed from defaults — a
+ * refused-but-valid call, the conservative side of this gate.
+ *
+ * `seen` both memoizes and breaks reference cycles: the relaxed copy is
+ * registered before its children are filled in, so a schema that reaches
+ * itself resolves to the copy already under construction.
+ */
+export function relaxDefaultedRequired(
+  schema: JSONSchema,
+  root: JSONSchema,
+  seen: Map<object, JSONSchema>,
+): JSONSchema {
+  if (!isSchemaObject(schema)) return schema;
+  const cached = seen.get(schema);
+  if (cached !== undefined) return cached;
+
+  const relaxed: Record<string, unknown> = { ...schema };
+  seen.set(schema, relaxed as JSONSchema);
+
+  const properties = schema.properties;
+  if (isSchemaObject(properties)) {
+    const defaulted = new Set<string>();
+    const next: Record<string, JSONSchema> = {};
+    for (
+      const [key, propSchema] of Object.entries(
+        properties as Record<string, JSONSchema>,
+      )
+    ) {
+      const target = localRefTarget(propSchema, root);
+      if (isSchemaObject(target) && target.default !== undefined) {
+        defaulted.add(key);
+      }
+      next[key] = relaxDefaultedRequired(propSchema, root, seen);
+    }
+    relaxed.properties = next;
+    if (Array.isArray(schema.required)) {
+      relaxed.required = (schema.required as string[]).filter(
+        (key) => !defaulted.has(key),
+      );
+    }
+  }
+
+  // `items` is a single schema here; the validator rejects the tuple form
+  // outright ("schema must be an object or boolean").
+  if (schema.items !== undefined) {
+    relaxed.items = relaxDefaultedRequired(
+      schema.items as JSONSchema,
+      root,
+      seen,
+    );
+  }
+
+  const fields = schema as Record<string, unknown>;
+  for (const combinator of ["anyOf", "oneOf", "allOf"]) {
+    const branches = fields[combinator];
+    if (Array.isArray(branches)) {
+      relaxed[combinator] = (branches as JSONSchema[]).map((entry) =>
+        relaxDefaultedRequired(entry, root, seen)
+      );
+    }
+  }
+
+  for (const pool of ["$defs", "definitions"]) {
+    const defs = fields[pool];
+    if (isSchemaObject(defs as JSONSchema)) {
+      const next: Record<string, JSONSchema> = {};
+      for (
+        const [key, entry] of Object.entries(defs as Record<string, JSONSchema>)
+      ) {
+        next[key] = relaxDefaultedRequired(entry, root, seen);
+      }
+      relaxed[pool] = next;
+    }
+  }
+
+  return relaxed as JSONSchema;
+}
+
 export const validateSchemaValue = (
   schema: JSONSchema,
   value: unknown,

--- a/packages/runner/test/cfc-defaulted-required-relaxation.test.ts
+++ b/packages/runner/test/cfc-defaulted-required-relaxation.test.ts
@@ -1,0 +1,195 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import type { JSONSchema } from "../src/builder/types.ts";
+import {
+  localRefTarget,
+  relaxDefaultedRequired,
+  validateSchemaValue,
+} from "../src/cfc/schema-sanitization.ts";
+
+/** The composition the CLI's pre-dispatch verb gate applies to a present
+ * payload (`verbInputSchemaError`, `packages/cli/lib/callable.ts`), and the
+ * one C5's server-side closed-world enforcement shares: validate against the
+ * schema with defaulted properties relaxed out of `required`. These tests
+ * moved here with the helpers (verb contract D6) because they pin the
+ * relaxation semantics, not the CLI's refusal behavior. */
+const relaxedValidationError = (
+  input: unknown,
+  schema: JSONSchema,
+): string | undefined =>
+  validateSchemaValue(relaxDefaultedRequired(schema, schema, new Map()), input);
+
+describe("relaxDefaultedRequired", () => {
+  // The runtime injects a property's default when a present payload omits it,
+  // so requiring it here would refuse a call the verb would have accepted.
+  it("treats a defaulted property as satisfied when omitted", () => {
+    expect(relaxedValidationError({}, {
+      type: "object",
+      properties: { mode: { type: "string", default: "fast" } },
+      required: ["mode"],
+    })).toBeUndefined();
+  });
+
+  it("treats a defaulted property as satisfied when nested", () => {
+    expect(relaxedValidationError({ opts: {} }, {
+      type: "object",
+      properties: {
+        opts: {
+          type: "object",
+          properties: { mode: { type: "string", default: "fast" } },
+          required: ["mode"],
+        },
+      },
+      required: ["opts"],
+    })).toBeUndefined();
+  });
+
+  it("treats a defaulted property as satisfied behind a $ref", () => {
+    expect(relaxedValidationError({}, {
+      type: "object",
+      properties: { mode: { $ref: "#/$defs/Mode" } },
+      required: ["mode"],
+      $defs: { Mode: { type: "string", default: "fast" } },
+    })).toBeUndefined();
+  });
+
+  it("follows a $ref chain to find the default", () => {
+    expect(relaxedValidationError({}, {
+      type: "object",
+      properties: { mode: { $ref: "#/$defs/Mode" } },
+      required: ["mode"],
+      $defs: {
+        Mode: { $ref: "#/$defs/RealMode" },
+        RealMode: { type: "string", default: "fast" },
+      },
+    })).toBeUndefined();
+  });
+
+  it("relaxes a defaulted property inside array items", () => {
+    expect(relaxedValidationError([{}], {
+      type: "array",
+      items: {
+        type: "object",
+        properties: { mode: { type: "string", default: "fast" } },
+        required: ["mode"],
+      },
+    })).toBeUndefined();
+  });
+
+  it("relaxes a defaulted property inside a combinator branch", () => {
+    expect(relaxedValidationError({}, {
+      anyOf: [
+        {
+          type: "object",
+          properties: { mode: { type: "string", default: "fast" } },
+          required: ["mode"],
+        },
+      ],
+    } as JSONSchema)).toBeUndefined();
+  });
+
+  // A reference that names nothing local cannot be followed to a default.
+  // Relaxation leaves it exactly as written rather than guessing.
+  it("leaves a non-local $ref untouched", () => {
+    expect(relaxedValidationError({ mode: "x" }, {
+      type: "object",
+      properties: { mode: { $ref: "https://example.com/Mode" } },
+    } as JSONSchema)).toMatch(/cannot resolve schema reference/);
+  });
+
+  // Hoisting emits `$defs`; a `definitions` ref is one the runtime cannot
+  // resolve either. Relaxing on a default behind one would admit a payload the
+  // verb then receives as an absent event, spending the invocation id.
+  it("does not relax on a default behind a #/definitions ref", () => {
+    expect(relaxedValidationError({}, {
+      type: "object",
+      properties: { mode: { $ref: "#/definitions/Mode" } },
+      required: ["mode"],
+      definitions: { Mode: { type: "string", default: "fast" } },
+    } as unknown as JSONSchema)).toMatch(/mode/);
+  });
+
+  it("leaves a $ref naming a missing definition untouched", () => {
+    expect(relaxedValidationError({ mode: "x" }, {
+      type: "object",
+      properties: { mode: { $ref: "#/$defs/Absent" } },
+      $defs: { Present: { type: "string" } },
+    } as JSONSchema)).toMatch(/cannot resolve schema reference/);
+  });
+
+  it("ignores a malformed $defs pool instead of indexing it", () => {
+    expect(relaxedValidationError({ mode: "x" }, {
+      type: "object",
+      properties: { mode: { $ref: "#/$defs/Mode" } },
+      $defs: null,
+    } as unknown as JSONSchema)).toMatch(/cannot resolve schema reference/);
+  });
+
+  it("handles a $ref whose target is a boolean schema", () => {
+    expect(relaxedValidationError({ mode: "x" }, {
+      type: "object",
+      properties: { mode: { $ref: "#/$defs/Anything" } },
+      $defs: { Anything: true },
+    } as JSONSchema)).toBeUndefined();
+  });
+
+  it("passes a boolean property schema through unchanged", () => {
+    expect(relaxedValidationError({ mode: "x" }, {
+      type: "object",
+      properties: { mode: true },
+    } as JSONSchema)).toBeUndefined();
+  });
+
+  // A ref cycle names no schema to check against. Relaxation walks it without
+  // looping and hands it on unchanged; the validator is what reports it.
+  it("terminates on a $ref cycle instead of looping", () => {
+    expect(relaxedValidationError({ mode: "x" }, {
+      type: "object",
+      properties: { mode: { $ref: "#/$defs/A" } },
+      $defs: {
+        A: { $ref: "#/$defs/B" },
+        B: { $ref: "#/$defs/A" },
+      },
+    })).toMatch(/cannot resolve schema reference/);
+  });
+
+  it("still rejects a non-defaulted sibling of a defaulted property", () => {
+    expect(relaxedValidationError({}, {
+      type: "object",
+      properties: {
+        mode: { type: "string", default: "fast" },
+        target: { type: "string" },
+      },
+      required: ["mode", "target"],
+    })).toMatch(/target/);
+  });
+
+  it("terminates on a self-referential schema", () => {
+    const cyclic: Record<string, unknown> = {
+      type: "object",
+      properties: { name: { type: "string" } },
+      required: ["name"],
+    };
+    (cyclic.properties as Record<string, unknown>).child = cyclic;
+    expect(relaxedValidationError({ name: "a" }, cyclic as JSONSchema))
+      .toBeUndefined();
+  });
+});
+
+describe("localRefTarget", () => {
+  it("resolves a top-level local $ref to the schema it names", () => {
+    const target = { type: "object", properties: {} } as const;
+    expect(localRefTarget(
+      { $ref: "#/$defs/Event" } as JSONSchema,
+      { $ref: "#/$defs/Event", $defs: { Event: target } } as JSONSchema,
+    )).toEqual(target);
+  });
+
+  it("returns the last reachable schema when a ref cannot be resolved", () => {
+    const unresolvable = { $ref: "#/$defs/Absent" } as JSONSchema;
+    expect(localRefTarget(
+      unresolvable,
+      { $defs: { Present: { type: "string" } } } as JSONSchema,
+    )).toBe(unresolvable);
+  });
+});

--- a/packages/runner/test/cfc-defaulted-required-relaxation.test.ts
+++ b/packages/runner/test/cfc-defaulted-required-relaxation.test.ts
@@ -53,6 +53,48 @@ describe("relaxDefaultedRequired", () => {
     })).toBeUndefined();
   });
 
+  // Resolution is the canonical resolver's, JSON Pointer escapes included:
+  // `#/$defs/A~1B` names the `"A/B"` definition. The previous hand-rolled
+  // regex indexed `$defs` by the UNDECODED text, missed the default, left
+  // `mode` required, and both gates refused `{}` even though runtime
+  // materialization accepts it and supplies the default (review repro on the
+  // D5/D6 PR).
+  it("relaxes a default behind a JSON-Pointer-escaped name (A~1B names A/B)", () => {
+    expect(relaxedValidationError({}, {
+      type: "object",
+      properties: { mode: { $ref: "#/$defs/A~1B" } },
+      required: ["mode"],
+      $defs: { "A/B": { type: "string", default: "fast" } },
+    })).toBeUndefined();
+  });
+
+  it("relaxes a default behind a ~0 escape (A~0B names A~B)", () => {
+    expect(relaxedValidationError({}, {
+      type: "object",
+      properties: { mode: { $ref: "#/$defs/A~0B" } },
+      required: ["mode"],
+      $defs: { "A~B": { type: "string", default: "fast" } },
+    })).toBeUndefined();
+  });
+
+  // A subtree that declares its own `$defs` opens a new local-ref scope
+  // (`cfcSchemaChildRoot`), so its refs must resolve against ITS definitions,
+  // not the document root's. The outer decoy definition carries no default:
+  // resolving in the wrong scope leaves `mode` required and refuses `{}`.
+  it("relaxes a default the subtree's own $defs scope provides", () => {
+    expect(relaxedValidationError({}, {
+      type: "object",
+      properties: {
+        mode: {
+          $ref: "#/$defs/Mode",
+          $defs: { Mode: { type: "string", default: "fast" } },
+        },
+      },
+      required: ["mode"],
+      $defs: { Mode: { type: "number" } },
+    })).toBeUndefined();
+  });
+
   it("follows a $ref chain to find the default", () => {
     expect(relaxedValidationError({}, {
       type: "object",
@@ -191,5 +233,24 @@ describe("localRefTarget", () => {
       unresolvable,
       { $defs: { Present: { type: "string" } } } as JSONSchema,
     )).toBe(unresolvable);
+  });
+
+  it("decodes JSON Pointer escapes exactly like the canonical resolver", () => {
+    const target = { type: "string", default: "fast" } as const;
+    expect(localRefTarget(
+      { $ref: "#/$defs/A~1B" } as JSONSchema,
+      { $defs: { "A/B": target } } as JSONSchema,
+    )).toEqual(target);
+  });
+
+  it("resolves inside the scope a subtree's own $defs opens", () => {
+    const inner = { type: "string", default: "fast" } as const;
+    expect(localRefTarget(
+      {
+        $ref: "#/$defs/Mode",
+        $defs: { Mode: inner },
+      } as JSONSchema,
+      { $defs: { Mode: { type: "number" } } } as JSONSchema,
+    )).toEqual(inner);
   });
 });

--- a/packages/runner/test/cfc-defaulted-required-relaxation.test.ts
+++ b/packages/runner/test/cfc-defaulted-required-relaxation.test.ts
@@ -95,6 +95,46 @@ describe("relaxDefaultedRequired", () => {
     })).toBeUndefined();
   });
 
+  // The recursion threads each level's own scope (`cfcSchemaChildRoot`), so
+  // a property `$ref` beneath a NESTED object's own `$defs` resolves against
+  // that pool. Passing the outer root at every level — the previous behavior
+  // — missed the nested pool's default, left `mode` required, and the gate
+  // refused `{ opts: {} }` ("opts: missing required property mode") for a
+  // payload runtime materialization accepts and defaults (review repro on
+  // the D5/D6 PR).
+  it("relaxes a defaulted-required behind a nested object's own $defs", () => {
+    expect(relaxedValidationError({ opts: {} }, {
+      type: "object",
+      properties: {
+        opts: {
+          type: "object",
+          properties: { mode: { $ref: "#/$defs/Mode" } },
+          required: ["mode"],
+          $defs: { Mode: { type: "string", default: "fast" } },
+        },
+      },
+      required: ["opts"],
+    })).toBeUndefined();
+  });
+
+  it("resolves a nested scope's ref in its own pool, not a decoy outer one", () => {
+    expect(relaxedValidationError({ opts: {} }, {
+      type: "object",
+      properties: {
+        opts: {
+          type: "object",
+          properties: { mode: { $ref: "#/$defs/Mode" } },
+          required: ["mode"],
+          $defs: { Mode: { type: "string", default: "fast" } },
+        },
+      },
+      required: ["opts"],
+      // Same name in the document root, WITHOUT a default: resolving in the
+      // wrong scope would keep `mode` required and refuse the payload.
+      $defs: { Mode: { type: "number" } },
+    })).toBeUndefined();
+  });
+
   it("follows a $ref chain to find the default", () => {
     expect(relaxedValidationError({}, {
       type: "object",
@@ -116,6 +156,48 @@ describe("relaxDefaultedRequired", () => {
         required: ["mode"],
       },
     })).toBeUndefined();
+  });
+
+  // Tuple slots are ordinary present objects to the runtime's default
+  // materialization, so their schemas get the same relaxation as `items`.
+  it("relaxes a defaulted property inside a prefixItems slot", () => {
+    expect(relaxedValidationError([{}], {
+      type: "array",
+      prefixItems: [{
+        type: "object",
+        properties: { mode: { type: "string", default: "fast" } },
+        required: ["mode"],
+      }],
+    } as unknown as JSONSchema)).toBeUndefined();
+  });
+
+  // The runtime's default-injection read consults the property schema's own
+  // `default` directly, without resolving the ref — so a ref-site sibling
+  // default satisfies the property even when the referenced definition
+  // carries none.
+  it("relaxes on a ref-site sibling default", () => {
+    expect(relaxedValidationError({}, {
+      type: "object",
+      properties: { mode: { $ref: "#/$defs/Mode", default: "fast" } },
+      required: ["mode"],
+      $defs: { Mode: { type: "string" } },
+    })).toBeUndefined();
+  });
+
+  // The inverse boundary: a default stranded on an UNRESOLVABLE chain's last
+  // reachable wrapper is one the runtime never injects — the property schema
+  // itself has no default, and the chain cannot resolve to a view carrying
+  // one. Crediting it would admit `{}` and spend the invocation id on a
+  // handling missing the field; unresolvable keeps the field required.
+  it("does not relax on a default stranded mid-way through a broken chain", () => {
+    expect(relaxedValidationError({}, {
+      type: "object",
+      properties: { mode: { $ref: "#/$defs/A" } },
+      required: ["mode"],
+      $defs: {
+        A: { $ref: "#/$defs/Missing", default: "fast" },
+      },
+    } as unknown as JSONSchema)).toMatch(/mode/);
   });
 
   it("relaxes a defaulted property inside a combinator branch", () => {


### PR DESCRIPTION
## Why

The pre-dispatch verb gate (#5147) passes `input === undefined` unconditionally, so a call that sends *nothing* against a verb whose event schema requires fields still dispatches: the handler runs with `$event === undefined` and the handling's receipt silently spends the invocation id. That is the same failure class the gate closed for typo'd payloads, reached by the second-most-likely agent mistake — forgetting the payload rather than misspelling a field. Reproduced live against a local toolshed before the fix: an absent `recordNote -- invoke` recorded `"(no event)"` and the corrected retry under the same invocation id reported `deduplicated: true` — the correction was never applied.

The measured ground truth (the "Measured: what a handler sees" comment on #5147) is why normalization — not outright refusal of absence — is the fix: the runtime materializes a property's `default` only for a **present** object payload, before the `required` check; a wholly absent event bypasses default materialization entirely. Relaxation is therefore the wrong lens for the absence decision — an all-defaulted `required` list does not make absence deliverable. The plan settled the rule (Berni, 2026-07-30, recorded in `docs/plans/pattern-verb-contract-implementation.md`): **normalize an absent payload to `{}`** where the verb's schema is an object schema, so absence flows through the same gate as any payload — refused exactly when top-level `required` survives `relaxDefaultedRequired`, and dispatched as `{}` (so the runtime fills defaults in) when it does not.

D6 rides along in its own commit because the review of #5147 named the residual risk: `relaxDefaultedRequired` and `localRefTarget` re-implemented the runtime's default-satisfaction rule inside the CLI, and C5 (closed-world verb inputs enforced at dispatch) needs the identical relaxation server-side. Two copies of "what does a default satisfy" is how the CLI and the runtime drift apart, so the helpers move next to `validateSchemaValue`.

Prior PRs in this arc: #5087, #5089, #5118, and the gate itself, #5147.

**Characterized first**, the same order #5147's runner characterization took: a unit test at each entry point pinned that an absent payload *dispatches* against a required-fields schema — both observed passing on unmodified code (`handlerWrites` recording `value: undefined`, the invocation id attached) — and then flipped to assert refusal with the implementation. The end-to-end behavior was characterized the same way against a live local toolshed before and after the change.

## What Changed

**Commit 1 — D5 (behavior change), `packages/cli`:**

- `normalizeAbsentVerbPayload` (new, `lib/callable.ts`): an absent payload is normalized to `{}` when the verb's schema — after resolving a top-level local `$ref` via `localRefTarget` — is an object schema. Everything else keeps today's absent-passes behavior: schema `undefined` / `true`, boolean `false`, non-object schemas, the schema-less stream marker, and an unresolvable `$ref` (fail-open on uncertainty — refuse only on proof).
- The shared gate (`assertVerbInputSatisfiesSchema`, the call site both entry points — piece call and mounted exec — flow through) now returns the input it judged, and that is what dispatches: an all-defaulted verb receives a defaults-populated object instead of `undefined`.
- The refusal reuses `VerbInputValidationError` with a distinct detail — `no payload was supplied, and this verb cannot run without one (missing required property …) — send a payload` — so "send a payload" reads differently from "fix your payload". The id is never spent; the corrected retry can reuse it.
- Unit tests: absent vs required-fields object schema refused at **both** entry points (id not spent); absent vs all-defaulted-required schema dispatches `{}`; absent vs boolean `false` / no schema / `true` / non-object / unresolvable-`$ref` passes untouched.
- Integration: `run_piece_call_retry` gains scenario 6, the mirror of #5147's scenario 5 — absent payload refused locally, zero messages recorded, corrected call under the **same** invocation id records exactly one. It runs against a new `$ref`-rooted `recordNote` fixture verb, because that is the deployed shape absence actually reaches dispatch through: a stream cell's schema carries the handler's own event schema, and flag-derivable inline-object schemas are already stopped earlier by the arg parser (requires-input check on a bare call, `{}` flag-parse under explicit `invoke`).
- Plan doc: the struck pre-dispatch bullet's "Two shapes stay legal…" wording narrowed to the shipped behavior; the D5 bullet struck with a **done (D5)** note.

**Commit 2 — D6 (pure move, no behavior change), `packages/runner` + `packages/cli`:**

- `relaxDefaultedRequired` and `localRefTarget` moved verbatim into `packages/runner/src/cfc/schema-sanitization.ts`, beside `validateSchemaValue`. Exported from the defining module; the CLI imports directly from it via a new `./cfc/schema-sanitization` package export — no re-export shim, nothing added to `cfc/mod.ts`.
- The ~15 relaxation unit tests moved with the code (`packages/runner/test/cfc-defaulted-required-relaxation.test.ts`), written against the same relax-then-validate composition the gate applies. The CLI keeps the tests that exercise the gate (refusal at both entry points, id not spent) plus one defaulted-required pin proving the gate applies the relaxation.
- The helper's doc comment now names its boundary — what relaxation does **not** check: only `required` lists are rewritten, so `additionalProperties`, `patternProperties`, `minProperties` and the other constraints, `const`/`enum`, `not` / `if`/`then`/`else`, and `oneOf` exclusivity are judged against the original schema text — each a potential refused-but-valid call when a schema leans on a defaulted property through them.
- Plan doc: D6 bullet struck with a **done (D6)** note.

## Test plan

- `packages/cli`: full suite green — **123 passed (179 steps), 0 failed** (run after each commit).
- `packages/runner`: full suite green — **1106 passed (5783 steps), 0 failed** (includes the 17 moved/added relaxation steps in `cfc-defaulted-required-relaxation.test.ts`).
- Characterization order: the absent-payload dispatch tests were observed **passing on unmodified code** at both entry points before the implementation flipped them to refusal.
- Integration: the `piece-call` section (`run_piece_call` + `run_piece_call_retry`, scenario 6 included) **ran locally** against an isolated toolshed on port 8987, green both after the D5 commit and after the D6 commit. The pre-D5 failure mode was also reproduced live on the same setup (absent call recorded `"(no event)"`, same-id retry deduplicated) before the gate refused it.
- Repo-wide `deno fmt --check`, `deno lint`, and `deno task check-docs` green.

## Migration note

Calls that previously "settled" with no payload against a required-fields verb now **fail locally** (exit 1, `Invalid input for "<verb>": no payload was supplied…`) and are **retryable under the same invocation id** — the id is no longer silently spent on a handling that ran with no event. Verbs whose required properties all carry defaults now deliver a defaults-populated `{}` to the handler instead of `undefined`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize absent verb payloads to `{}` at the CLI pre-dispatch gate when the event schema is object-shaped (direct object or `allOf` with an object) so defaults materialize and invocation ids aren’t silently spent. Move and harden schema helpers into `@commonfabric/runner/cfc/schema-sanitization` to match runtime ref resolution and default behavior; add tight coverage pins.

- **Bug Fixes**
  - Absent payloads normalize to `{}` after resolving a top-level local `$ref`; validation then refuses with “no payload was supplied … send a payload” if relaxed `required` still fails, or dispatches `{}` so defaults engage. Id is not spent on refusal.
  - Pass-through unchanged for schema `undefined`/`true`, boolean `false`, non-object schemas, schema-less stream markers, and unresolvable top-level `$ref`. `anyOf`/`oneOf` roots stay out of scope; `allOf` with any object branch counts as object-shaped.
  - Integration adds retry scenario 6 against a `$ref`-rooted `recordNote` verb: absent refused, zero messages; corrected call under the same id records one. Mounted exec mirrors the refusal.

- **Refactors**
  - Moved `relaxDefaultedRequired` and `localRefTarget` to `@commonfabric/runner/cfc/schema-sanitization`; CLI imports from there via a new `./cfc/schema-sanitization` export.
  - `localRefTarget` now uses the canonical resolver (JSON Pointer escapes, nested `$defs` scopes) and returns the last reachable schema for unresolvable refs.
  - Relaxation is scope-aware per subtree, honors ref-site sibling `default`, only credits a chain-end `default` when the `$ref` chain fully resolves, and relaxes tuple slot schemas in `prefixItems`.
  - Tests: moved relaxation suite to runner; CLI keeps gate behavior tests plus a pin proving relaxation is applied. Exported/pinned `schemaIsObjectShaped` (allOf counts, disjunctions do not) and pinned `runtimeErrorLog` early returns to stabilize coverage.

<sup>Written for commit 609b9758526c394879fa7c40a5ea3549b132df03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

