### PR TITLE
feat(cli): add computed transforms to cf piece get

### DIFF
--- a/docs/plans/pattern-verb-contract.md
+++ b/docs/plans/pattern-verb-contract.md
@@ -364,15 +364,13 @@ board topic). Until that lands, board-level routing
 (`addComment {topicFid, body}`) is the documented workaround — pragmatic, not
 the target shape.
 
-Two client affordances surfaced in review (2026-07-28) and are deferred,
-blocking nothing: `cf piece get` could grow flags that let an agent control
-how much data a read returns when exploring the fabric interactively — a
-`--schema` override reading through a narrower schema (the runtime's
-`asSchema`; the CLI already narrows its own internal reads this way, e.g.
-the `asSchema` narrowing in `packages/cli/lib/piece-render.ts`), and a limit on the number of records
-returned from a large array. Adjacent CLI work for when board scale demands it,
-recorded here so the deferral is deliberate; neither is an ask on any
-workstream in the implementation plan.
+`cf piece get` lets an agent control how much data an exploratory read returns:
+`--filter` narrows array membership and `--schema` projects fields through the
+runtime's `asSchema` read path. Both execute through computed pattern nodes so
+their CFC behavior matches pattern expressions. A limit on the number of
+records returned from a large array remains deferred, blocking nothing. It is
+adjacent CLI work for when board scale demands it, not an ask on any workstream
+in this implementation plan.
 
 **A set of verbs wants to be a structural interface, and the machinery for that
 already exists.** Schemas are the type system, so a verb set is a schema

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -131,8 +131,8 @@ cf piece get --piece ID items \
 `--filter` is jq-inspired rather than a full jq interpreter. It applies only to
 arrays and accepts value paths (`.status`, `.author.name`, `.["display-name"]`,
 `.tags[-1]`), JSON literals, `==`, `!=`, `<`, `<=`, `>`, `>=`, `and`, `or`,
-`not`, and parentheses. The predicate must produce a boolean. Filtering happens
-before schema projection.
+`not`, and parentheses. Like jq, only `false` and `null` are falsey, so a
+missing path simply does not match. Filtering happens before schema projection.
 
 `--schema` accepts one of three forms:
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -132,7 +132,8 @@ cf piece get --piece ID items \
 arrays and accepts value paths (`.status`, `.author.name`, `.["display-name"]`,
 `.tags[-1]`), JSON literals, `==`, `!=`, `<`, `<=`, `>`, `>=`, `and`, `or`,
 `not`, and parentheses. Like jq, only `false` and `null` are falsey, so a
-missing path simply does not match. Filtering happens before schema projection.
+missing path simply does not match. A stored `undefined` is treated like a
+missing value and is also falsey. Filtering happens before schema projection.
 
 `--schema` accepts one of three forms:
 
@@ -145,7 +146,10 @@ Schema describes the complete returned value, so a schema combined with
 `--filter` must have an array root. Object `properties` are a whitelist by
 default; use `"additionalProperties": true` to retain unspecified properties.
 Projection schemas support structural `properties`, `items`, and scalar leaf
-schemas. Schema combinators and references are rejected.
+schemas. In an array-item projection, a scalar leaf whose declared type does not
+match the stored value is omitted by the runtime rather than reported as an
+error; prefer `true` leaves unless that type filtering is intentional. Schema
+combinators and references are rejected.
 
 Both transforms run as a short-lived computed pattern in the caller's session.
 The runtime's list filter/map builtins therefore handle CFC exactly as authored

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -116,6 +116,45 @@ standard error and continues searching that piece and the rest of the space.
 - The launcher spawns the child CLI with `deno run --quiet` so Deno's own
   warnings (npm "Ignored build scripts" banner) never reach users.
 
+### Transforming `piece get` output
+
+`piece get` can filter an array before it reaches stdout and project the result
+to a smaller shape:
+
+```bash
+cf piece get --piece ID items --filter '.status == "open"'
+cf piece get --piece ID items \
+  --filter '.status == "open" and .score >= 10' \
+  --schema id,title,author.name
+```
+
+`--filter` is jq-inspired rather than a full jq interpreter. It applies only to
+arrays and accepts value paths (`.status`, `.author.name`, `.["display-name"]`,
+`.tags[-1]`), JSON literals, `==`, `!=`, `<`, `<=`, `>`, `>=`, `and`, `or`,
+`not`, and parentheses. The predicate must produce a boolean. Filtering happens
+before schema projection.
+
+`--schema` accepts one of three forms:
+
+- a comma-separated field projection such as `id,title,author.name`;
+- an inline JSON Schema object;
+- `@path/to/schema.json`.
+
+For an array result, the concise form describes each item. An inline/file JSON
+Schema describes the complete returned value, so a schema combined with
+`--filter` must have an array root. Object `properties` are a whitelist by
+default; use `"additionalProperties": true` to retain unspecified properties.
+Projection schemas support structural `properties`, `items`, and scalar leaf
+schemas. Schema combinators and references are rejected.
+
+Both transforms run as a short-lived computed pattern in the caller's session.
+The runtime's list filter/map builtins therefore handle CFC exactly as authored
+pattern expressions do: predicate observations label array membership,
+projection reads propagate labels, and filtered elements retain their source
+links. The source cell's schema remains authoritative for Common Fabric
+metadata. A caller cannot introduce or override `ifc`, `asCell`, `scope`, or
+`default` through `--schema`.
+
 ## Built Binary
 
 `deno task build-binaries cf` compiles the CLI to `dist/cf` — fully

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -44,6 +44,11 @@ import { UI } from "@commonfabric/runner";
 import ports from "@commonfabric/ports" with { type: "json" };
 import type { PiecePatternRef } from "@commonfabric/piece/ops";
 import { reservesStdoutForCommandOutput } from "../lib/json-output.ts";
+import {
+  parsePieceGetFilter,
+  parsePieceGetProjection,
+  PieceGetTransformError,
+} from "../lib/piece-get-transform.ts";
 
 // Hint system: print helpful next-step suggestions after operations
 let quietMode = false;
@@ -157,13 +162,14 @@ export function localPatternEntry(
 
 /**
  * A `piece get` failure caused by a data condition rather than bad arguments:
- * a path that doesn't resolve, or a result schema that can't project the
- * stored data (PieceResultProjectionError). Reported as a plain error on
- * stderr with exit 1, never as a Cliffy ValidationError (which would dump the
- * usage screen and read as an arg-parse failure).
+ * a path that doesn't resolve, a result schema that can't project stored data,
+ * or a filter/projection that doesn't fit the selected value. Reported as a
+ * plain error on stderr with exit 1, never as a Cliffy ValidationError (which
+ * would dump the usage screen and read as an arg-parse failure).
  */
 export function isPieceGetDataError(error: unknown): error is Error {
   return error instanceof PieceResultProjectionError ||
+    error instanceof PieceGetTransformError ||
     (error instanceof Error &&
       error.message.startsWith("Cannot access path"));
 }
@@ -172,16 +178,20 @@ export function isPieceGetDataError(error: unknown): error is Error {
  * Build the stderr report for a `piece get` failure. Returns null when the
  * error is not a data error (the caller should rethrow). `message` is the
  * one-line error; `hint` is an optional next-step tip. A projection error
- * already carries its own `--step` guidance, and an input-mode read has
- * nothing more to suggest — only a result-mode unresolved path gets the
- * `--input` tip.
+ * already carries its own `--step` guidance, transform errors stand alone,
+ * and an input-mode read has nothing more to suggest — only a result-mode
+ * unresolved path gets the `--input` tip.
  */
 export function pieceGetDataErrorReport(
   error: unknown,
   opts: { input?: boolean; piece?: string },
 ): { message: string; hint?: string } | null {
   if (!isPieceGetDataError(error)) return null;
-  if (error instanceof PieceResultProjectionError || opts.input) {
+  if (
+    error instanceof PieceResultProjectionError ||
+    error instanceof PieceGetTransformError ||
+    opts.input
+  ) {
     return { message: error.message };
   }
   return {
@@ -1073,6 +1083,18 @@ PATH FORMAT: Use forward slashes and numeric indices for arrays.
     cliText(`cf piece get ${EX_ID} ${EX_COMP_PIECE} --step`),
     `Start, recompute, and get the result in one CLI session.`,
   )
+  .example(
+    cliText(
+      `cf piece get ${EX_ID} ${EX_COMP_PIECE} items --filter '.status == "open"'`,
+    ),
+    "Return only matching items from an array.",
+  )
+  .example(
+    cliText(
+      `cf piece get ${EX_ID} ${EX_COMP_PIECE} items --schema id,title`,
+    ),
+    "Project each returned item to selected fields.",
+  )
   .option("-c,--piece <piece:string>", "The target piece ID.")
   .option("--input", "Read from the piece's input cell instead of result cell")
   .option(
@@ -1083,6 +1105,14 @@ PATH FORMAT: Use forward slashes and numeric indices for arrays.
     "--json",
     "Select JSON output explicitly. This command always outputs JSON.",
   )
+  .option(
+    "--filter <predicate:string>",
+    "Filter an array with a jq-inspired predicate",
+  )
+  .option(
+    "--schema <schema:string>",
+    "Project output with comma-separated fields, inline JSON Schema, or @file",
+  )
   .arguments("[path:string]")
   .action(async (options, pathString) => {
     setQuietMode(!!options.quiet);
@@ -1092,9 +1122,18 @@ PATH FORMAT: Use forward slashes and numeric indices for arrays.
     };
     const pathSegments = pathString ? parseCellPath(pathString) : [];
     try {
+      const filter = options.filter === undefined
+        ? undefined
+        : parsePieceGetFilter(options.filter);
+      const projection = options.schema === undefined
+        ? undefined
+        : await parsePieceGetProjection(options.schema);
       const value = await getCellValue(pieceConfig, pathSegments, {
         input: options.input,
         step: options.step,
+        ...(filter !== undefined || projection !== undefined
+          ? { transform: { filter, projection } }
+          : {}),
       });
       render(value, { json: true });
     } catch (error) {

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -47,6 +47,7 @@ import { reservesStdoutForCommandOutput } from "../lib/json-output.ts";
 import {
   parsePieceGetFilter,
   parsePieceGetProjection,
+  type PieceGetTransform,
   PieceGetTransformError,
 } from "../lib/piece-get-transform.ts";
 
@@ -73,6 +74,21 @@ export function normalizeApiUrl(apiUrl: string): string {
   normalized.hash = "";
   const href = normalized.toString();
   return basePath ? href : href.slice(0, -1);
+}
+
+export async function parsePieceGetTransformOptions(options: {
+  filter?: string;
+  schema?: string;
+}): Promise<PieceGetTransform | undefined> {
+  const filter = options.filter === undefined
+    ? undefined
+    : parsePieceGetFilter(options.filter);
+  const projection = options.schema === undefined
+    ? undefined
+    : await parsePieceGetProjection(options.schema);
+  return filter === undefined && projection === undefined
+    ? undefined
+    : { filter, projection };
 }
 
 function summarizeForDisplay(value: unknown): unknown {
@@ -1122,18 +1138,11 @@ PATH FORMAT: Use forward slashes and numeric indices for arrays.
     };
     const pathSegments = pathString ? parseCellPath(pathString) : [];
     try {
-      const filter = options.filter === undefined
-        ? undefined
-        : parsePieceGetFilter(options.filter);
-      const projection = options.schema === undefined
-        ? undefined
-        : await parsePieceGetProjection(options.schema);
+      const transform = await parsePieceGetTransformOptions(options);
       const value = await getCellValue(pieceConfig, pathSegments, {
         input: options.input,
         step: options.step,
-        ...(filter !== undefined || projection !== undefined
-          ? { transform: { filter, projection } }
-          : {}),
+        ...(transform === undefined ? {} : { transform }),
       });
       render(value, { json: true });
     } catch (error) {

--- a/packages/cli/lib/piece-get-transform.ts
+++ b/packages/cli/lib/piece-get-transform.ts
@@ -1,0 +1,1247 @@
+import type { Cell } from "@commonfabric/api";
+import {
+  ContextualFlowControl,
+  createBuilder,
+  deepEqual,
+  type JSONSchema,
+  type MemorySpace,
+  type Runtime,
+} from "@commonfabric/runner";
+import { isRecord } from "@commonfabric/utils/types";
+import { runtimeErrorLog } from "./callable.ts";
+
+type PredicateComparisonOperator = "==" | "!=" | "<" | "<=" | ">" | ">=";
+
+export type PieceGetPredicate =
+  | { kind: "literal"; value: string | number | boolean | null }
+  | { kind: "path"; path: Array<string | number> }
+  | { kind: "not"; value: PieceGetPredicate }
+  | {
+    kind: "boolean";
+    operator: "and" | "or";
+    left: PieceGetPredicate;
+    right: PieceGetPredicate;
+  }
+  | {
+    kind: "comparison";
+    operator: PredicateComparisonOperator;
+    left: PieceGetPredicate;
+    right: PieceGetPredicate;
+  };
+
+export interface ParsedPieceGetFilter {
+  source: string;
+  predicate: PieceGetPredicate;
+  paths: Array<Array<string | number>>;
+}
+
+export interface PieceGetProjection {
+  source: string;
+  schema: JSONSchema;
+  kind: "concise" | "json";
+}
+
+export interface PieceGetTransform {
+  filter?: ParsedPieceGetFilter;
+  projection?: PieceGetProjection;
+}
+
+export class PieceGetTransformError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "PieceGetTransformError";
+  }
+}
+
+type TokenKind =
+  | "dot"
+  | "left-bracket"
+  | "right-bracket"
+  | "left-paren"
+  | "right-paren"
+  | "operator"
+  | "identifier"
+  | "string"
+  | "number"
+  | "eof";
+
+interface Token {
+  kind: TokenKind;
+  value?: string | number;
+  position: number;
+}
+
+function expressionError(source: string, position: number, message: string) {
+  return new PieceGetTransformError(
+    `Invalid --filter predicate at column ${position + 1}: ${message}\n` +
+      `  ${source}`,
+  );
+}
+
+function tokenizePredicate(source: string): Token[] {
+  const result: Token[] = [];
+  let position = 0;
+
+  while (position < source.length) {
+    const char = source[position];
+    if (/\s/.test(char)) {
+      position++;
+      continue;
+    }
+    const punctuation: Partial<Record<string, TokenKind>> = {
+      ".": "dot",
+      "[": "left-bracket",
+      "]": "right-bracket",
+      "(": "left-paren",
+      ")": "right-paren",
+    };
+    const punctuationKind = punctuation[char];
+    if (punctuationKind !== undefined) {
+      result.push({ kind: punctuationKind, position });
+      position++;
+      continue;
+    }
+
+    const operator = source.slice(position).match(/^(==|!=|<=|>=|<|>)/)?.[0];
+    if (operator !== undefined) {
+      result.push({ kind: "operator", value: operator, position });
+      position += operator.length;
+      continue;
+    }
+
+    if (char === '"') {
+      let end = position + 1;
+      let escaped = false;
+      for (; end < source.length; end++) {
+        const candidate = source[end];
+        if (!escaped && candidate === '"') break;
+        if (!escaped && candidate === "\\") {
+          escaped = true;
+        } else {
+          escaped = false;
+        }
+      }
+      if (end >= source.length) {
+        throw expressionError(source, position, "unterminated string literal");
+      }
+      const literal = source.slice(position, end + 1);
+      let value: string;
+      try {
+        value = JSON.parse(literal);
+      } catch {
+        throw expressionError(source, position, "invalid string literal");
+      }
+      result.push({ kind: "string", value, position });
+      position = end + 1;
+      continue;
+    }
+
+    const number = source.slice(position).match(
+      /^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/,
+    )?.[0];
+    if (number !== undefined) {
+      result.push({ kind: "number", value: Number(number), position });
+      position += number.length;
+      continue;
+    }
+
+    const identifier = source.slice(position).match(
+      /^[A-Za-z_$][A-Za-z0-9_$-]*/,
+    )?.[0];
+    if (identifier !== undefined) {
+      result.push({ kind: "identifier", value: identifier, position });
+      position += identifier.length;
+      continue;
+    }
+
+    throw expressionError(
+      source,
+      position,
+      `unexpected character ${JSON.stringify(char)}`,
+    );
+  }
+
+  result.push({ kind: "eof", position: source.length });
+  return result;
+}
+
+class PredicateParser {
+  #index = 0;
+
+  constructor(
+    private readonly source: string,
+    private readonly tokens: Token[],
+  ) {}
+
+  parse(): PieceGetPredicate {
+    const result = this.#parseOr();
+    const trailing = this.#peek();
+    if (trailing.kind !== "eof") {
+      throw expressionError(
+        this.source,
+        trailing.position,
+        "unexpected trailing input",
+      );
+    }
+    return result;
+  }
+
+  #peek(): Token {
+    return this.tokens[this.#index];
+  }
+
+  #take(): Token {
+    return this.tokens[this.#index++];
+  }
+
+  #takeKind(kind: TokenKind, message: string): Token {
+    const token = this.#peek();
+    if (token.kind !== kind) {
+      throw expressionError(this.source, token.position, message);
+    }
+    return this.#take();
+  }
+
+  #takeKeyword(keyword: string): boolean {
+    const token = this.#peek();
+    if (token.kind === "identifier" && token.value === keyword) {
+      this.#take();
+      return true;
+    }
+    return false;
+  }
+
+  #parseOr(): PieceGetPredicate {
+    let left = this.#parseAnd();
+    while (this.#takeKeyword("or")) {
+      left = {
+        kind: "boolean",
+        operator: "or",
+        left,
+        right: this.#parseAnd(),
+      };
+    }
+    return left;
+  }
+
+  #parseAnd(): PieceGetPredicate {
+    let left = this.#parseComparison();
+    while (this.#takeKeyword("and")) {
+      left = {
+        kind: "boolean",
+        operator: "and",
+        left,
+        right: this.#parseComparison(),
+      };
+    }
+    return left;
+  }
+
+  #parseComparison(): PieceGetPredicate {
+    const left = this.#parseUnary();
+    const token = this.#peek();
+    if (token.kind !== "operator") return left;
+    this.#take();
+    return {
+      kind: "comparison",
+      operator: token.value as PredicateComparisonOperator,
+      left,
+      right: this.#parseUnary(),
+    };
+  }
+
+  #parseUnary(): PieceGetPredicate {
+    if (this.#takeKeyword("not")) {
+      return { kind: "not", value: this.#parseUnary() };
+    }
+    return this.#parsePrimary();
+  }
+
+  #parsePrimary(): PieceGetPredicate {
+    const token = this.#peek();
+    if (token.kind === "left-paren") {
+      this.#take();
+      const result = this.#parseOr();
+      this.#takeKind("right-paren", 'expected ")"');
+      return result;
+    }
+    if (token.kind === "dot") return this.#parsePath();
+    if (token.kind === "string" || token.kind === "number") {
+      this.#take();
+      return {
+        kind: "literal",
+        value: token.value as string | number,
+      };
+    }
+    if (token.kind === "identifier") {
+      const literal = token.value === "true"
+        ? true
+        : token.value === "false"
+        ? false
+        : token.value === "null"
+        ? null
+        : undefined;
+      if (literal !== undefined || token.value === "null") {
+        this.#take();
+        return { kind: "literal", value: literal ?? null };
+      }
+    }
+    throw expressionError(
+      this.source,
+      token.position,
+      "expected a path, literal, or parenthesized expression",
+    );
+  }
+
+  #parsePath(): PieceGetPredicate {
+    this.#take();
+    const path: Array<string | number> = [];
+    const first = this.#peek();
+    if (first.kind === "identifier") {
+      path.push(String(this.#take().value));
+    }
+
+    while (true) {
+      const token = this.#peek();
+      if (token.kind === "dot") {
+        this.#take();
+        path.push(
+          String(
+            this.#takeKind(
+              "identifier",
+              "expected a property name after dot",
+            ).value,
+          ),
+        );
+        continue;
+      }
+      if (token.kind === "left-bracket") {
+        this.#take();
+        const segment = this.#peek();
+        if (segment.kind !== "string" && segment.kind !== "number") {
+          throw expressionError(
+            this.source,
+            segment.position,
+            "expected a string or number inside brackets",
+          );
+        }
+        this.#take();
+        path.push(segment.value as string | number);
+        this.#takeKind("right-bracket", 'expected "]"');
+        continue;
+      }
+      break;
+    }
+    return { kind: "path", path };
+  }
+}
+
+function collectPredicatePaths(
+  predicate: PieceGetPredicate,
+  result: Array<Array<string | number>>,
+): void {
+  switch (predicate.kind) {
+    case "path":
+      result.push(predicate.path);
+      break;
+    case "not":
+      collectPredicatePaths(predicate.value, result);
+      break;
+    case "boolean":
+    case "comparison":
+      collectPredicatePaths(predicate.left, result);
+      collectPredicatePaths(predicate.right, result);
+      break;
+    case "literal":
+      break;
+  }
+}
+
+export function parsePieceGetFilter(source: string): ParsedPieceGetFilter {
+  if (source.trim().length === 0) {
+    throw new PieceGetTransformError("--filter predicate must not be empty");
+  }
+  const predicate = new PredicateParser(
+    source,
+    tokenizePredicate(source),
+  ).parse();
+  const paths: Array<Array<string | number>> = [];
+  collectPredicatePaths(predicate, paths);
+  return { source, predicate, paths };
+}
+
+function valueAtPredicatePath(
+  value: unknown,
+  path: Array<string | number>,
+): unknown {
+  let current = value;
+  for (const segment of path) {
+    if (current === null || current === undefined) return null;
+    if (Array.isArray(current) && typeof segment === "number") {
+      const index = segment < 0 ? current.length + segment : segment;
+      current = index >= 0 && index < current.length ? current[index] : null;
+      continue;
+    }
+    if (
+      typeof current === "object" && !Array.isArray(current) &&
+      typeof segment === "string"
+    ) {
+      current = Object.hasOwn(current, segment)
+        ? (current as Record<string, unknown>)[segment]
+        : null;
+      continue;
+    }
+    return null;
+  }
+  return current;
+}
+
+function requireBoolean(value: unknown, context: string): boolean {
+  if (typeof value !== "boolean") {
+    throw new PieceGetTransformError(
+      `--filter ${context} must evaluate to a boolean, got ${
+        value === null ? "null" : typeof value
+      }`,
+    );
+  }
+  return value;
+}
+
+function comparePredicateValues(
+  operator: PredicateComparisonOperator,
+  left: unknown,
+  right: unknown,
+): boolean {
+  if (operator === "==") return deepEqual(left, right);
+  if (operator === "!=") return !deepEqual(left, right);
+  if (
+    (typeof left !== "number" || typeof right !== "number") &&
+    (typeof left !== "string" || typeof right !== "string")
+  ) {
+    throw new PieceGetTransformError(
+      `--filter ${operator} requires two numbers or two strings`,
+    );
+  }
+  switch (operator) {
+    case "<":
+      return left < right;
+    case "<=":
+      return left <= right;
+    case ">":
+      return left > right;
+    case ">=":
+      return left >= right;
+  }
+}
+
+export function evaluatePieceGetPredicate(
+  predicate: PieceGetPredicate,
+  value: unknown,
+): boolean {
+  const evaluate = (node: PieceGetPredicate): unknown => {
+    switch (node.kind) {
+      case "literal":
+        return node.value;
+      case "path":
+        return valueAtPredicatePath(value, node.path);
+      case "not":
+        return !requireBoolean(evaluate(node.value), '"not" operand');
+      case "boolean": {
+        const left = requireBoolean(
+          evaluate(node.left),
+          `"${node.operator}" left operand`,
+        );
+        if (node.operator === "and") {
+          return left &&
+            requireBoolean(evaluate(node.right), '"and" right operand');
+        }
+        return left ||
+          requireBoolean(evaluate(node.right), '"or" right operand');
+      }
+      case "comparison":
+        return comparePredicateValues(
+          node.operator,
+          evaluate(node.left),
+          evaluate(node.right),
+        );
+    }
+  };
+  return requireBoolean(evaluate(predicate), "predicate");
+}
+
+const FORBIDDEN_PROJECTION_KEYS = new Set([
+  "asCell",
+  "default",
+  "ifc",
+  "scope",
+]);
+const UNSUPPORTED_PROJECTION_KEYS = new Set([
+  "$ref",
+  "$defs",
+  "definitions",
+  "allOf",
+  "anyOf",
+  "oneOf",
+  "not",
+  "if",
+  "then",
+  "else",
+  "dependentSchemas",
+  "contains",
+  "patternProperties",
+  "prefixItems",
+  "propertyNames",
+  "contentSchema",
+]);
+
+function normalizeProjectionSchema(
+  schema: unknown,
+  path = "<root>",
+): JSONSchema {
+  if (schema === true) return true;
+  if (schema === false) {
+    throw new PieceGetTransformError(
+      `Invalid --schema at ${path}: false cannot project a value`,
+    );
+  }
+  if (!isRecord(schema)) {
+    throw new PieceGetTransformError(
+      `Invalid --schema at ${path}: expected a JSON Schema object`,
+    );
+  }
+  for (const key of Object.keys(schema)) {
+    if (FORBIDDEN_PROJECTION_KEYS.has(key)) {
+      throw new PieceGetTransformError(
+        `Invalid --schema at ${path}: "${key}" is controlled by the source ` +
+          "schema and cannot be supplied by a projection",
+      );
+    }
+    if (UNSUPPORTED_PROJECTION_KEYS.has(key)) {
+      throw new PieceGetTransformError(
+        `Invalid --schema at ${path}: "${key}" is not supported by projection schemas`,
+      );
+    }
+  }
+
+  const result: Record<string, unknown> = { ...schema };
+  if (schema.properties !== undefined) {
+    if (!isRecord(schema.properties)) {
+      throw new PieceGetTransformError(
+        `Invalid --schema at ${path}: "properties" must be an object`,
+      );
+    }
+    result.properties = Object.fromEntries(
+      Object.entries(schema.properties).map(([key, child]) => [
+        key,
+        normalizeProjectionSchema(child, `${path}.${key}`),
+      ]),
+    );
+    if (schema.additionalProperties === undefined) {
+      result.additionalProperties = false;
+    }
+  }
+  if (
+    schema.additionalProperties !== undefined &&
+    typeof schema.additionalProperties !== "boolean"
+  ) {
+    result.additionalProperties = normalizeProjectionSchema(
+      schema.additionalProperties,
+      `${path}.*`,
+    );
+  }
+  if (schema.items !== undefined) {
+    result.items = normalizeProjectionSchema(schema.items, `${path}[]`);
+  }
+  return result as JSONSchema;
+}
+
+function conciseProjectionSchema(source: string): JSONSchema {
+  const paths = source.split(",").map((part) => part.trim());
+  if (paths.some((path) => path.length === 0)) {
+    throw new PieceGetTransformError(
+      "Invalid --schema concise projection: expected comma-separated field paths",
+    );
+  }
+  const root: Record<string, unknown> = {};
+  for (const path of paths) {
+    const segments = path.split(".");
+    if (
+      segments.some((segment) => !/^[A-Za-z_$][A-Za-z0-9_$-]*$/.test(segment))
+    ) {
+      throw new PieceGetTransformError(
+        `Invalid --schema field path ${JSON.stringify(path)}`,
+      );
+    }
+    let node = root;
+    for (let index = 0; index < segments.length; index++) {
+      const segment = segments[index];
+      if (index === segments.length - 1) {
+        node[segment] = true;
+        continue;
+      }
+      const existing = node[segment];
+      if (existing === true) continue;
+      if (!isRecord(existing)) {
+        node[segment] = {};
+      }
+      node = node[segment] as Record<string, unknown>;
+    }
+  }
+
+  const toSchema = (node: Record<string, unknown>): JSONSchema => ({
+    type: "object",
+    properties: Object.fromEntries(
+      Object.entries(node).map(([key, value]) => [
+        key,
+        value === true ? true : toSchema(value as Record<string, unknown>),
+      ]),
+    ),
+    additionalProperties: false,
+  });
+  return toSchema(root);
+}
+
+export interface ProjectionParseDependencies {
+  readTextFile?: (path: string) => Promise<string>;
+}
+
+export async function parsePieceGetProjection(
+  source: string,
+  deps: ProjectionParseDependencies = {},
+): Promise<PieceGetProjection> {
+  const trimmed = source.trim();
+  if (trimmed.length === 0) {
+    throw new PieceGetTransformError("--schema must not be empty");
+  }
+
+  if (trimmed.startsWith("@")) {
+    const path = trimmed.slice(1);
+    if (path.length === 0) {
+      throw new PieceGetTransformError(
+        "--schema @file requires a file path",
+      );
+    }
+    let contents: string;
+    try {
+      contents = await (deps.readTextFile ?? Deno.readTextFile)(path);
+    } catch (error) {
+      throw new PieceGetTransformError(
+        `Could not read --schema file "${path}": ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        { cause: error },
+      );
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(contents);
+    } catch (error) {
+      throw new PieceGetTransformError(
+        `Invalid JSON in --schema file "${path}": ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        { cause: error },
+      );
+    }
+    return {
+      source,
+      schema: normalizeProjectionSchema(parsed),
+      kind: "json",
+    };
+  }
+
+  if (trimmed.startsWith("{") || trimmed === "true" || trimmed === "false") {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch (error) {
+      throw new PieceGetTransformError(
+        `Invalid JSON passed to --schema: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        { cause: error },
+      );
+    }
+    return {
+      source,
+      schema: normalizeProjectionSchema(parsed),
+      kind: "json",
+    };
+  }
+
+  return {
+    source,
+    schema: conciseProjectionSchema(trimmed),
+    kind: "concise",
+  };
+}
+
+function schemaTypes(schema: JSONSchema | undefined): string[] {
+  if (!isRecord(schema)) return [];
+  return Array.isArray(schema.type)
+    ? schema.type.filter((value): value is string => typeof value === "string")
+    : typeof schema.type === "string"
+    ? [schema.type]
+    : [];
+}
+
+function schemaIsArray(schema: JSONSchema | undefined): boolean {
+  return schemaTypes(schema).includes("array");
+}
+
+function schemaAtArrayItem(
+  cfc: ContextualFlowControl,
+  schema: JSONSchema | undefined,
+): JSONSchema | undefined {
+  if (schema === undefined) return undefined;
+  const item = cfc.schemaAtPath(schema, ["0"]);
+  return item === false ? undefined : item;
+}
+
+function dereferencedElementSchema(
+  schema: JSONSchema | undefined,
+): JSONSchema {
+  if (!isRecord(schema) || schema.asCell === undefined) {
+    return schema ?? true;
+  }
+  const { asCell: _asCell, ...dereferenced } = schema;
+  return Object.keys(dereferenced).length === 0 ? true : dereferenced;
+}
+
+function filteredOutputSchema(
+  sourceSchema: JSONSchema | undefined,
+  sourceItemSchema: JSONSchema | undefined,
+): JSONSchema {
+  if (!isRecord(sourceSchema)) {
+    return { type: "array", items: true };
+  }
+  const { items: _items, prefixItems: _prefixItems, ...metadata } =
+    sourceSchema;
+  return {
+    ...metadata,
+    type: "array",
+    items: dereferencedElementSchema(sourceItemSchema),
+  };
+}
+
+function projectionMask(schema: JSONSchema): JSONSchema {
+  if (schema === true) return true;
+  if (!isRecord(schema)) return true;
+  if (schema.additionalProperties === true) return true;
+  if (schema.type === "array" || schema.items !== undefined) {
+    return {
+      type: "array",
+      items: schema.items === undefined ? true : projectionMask(schema.items),
+    };
+  }
+  if (schema.type === "object" || schema.properties !== undefined) {
+    return {
+      type: "object",
+      properties: Object.fromEntries(
+        Object.entries(schema.properties ?? {}).map(([key, child]) => [
+          key,
+          projectionMask(child),
+        ]),
+      ),
+      additionalProperties: false,
+    };
+  }
+  return true;
+}
+
+function maskFromPaths(paths: Array<Array<string | number>>): JSONSchema {
+  if (paths.some((path) => path.length === 0)) return true;
+  const build = (
+    remaining: Array<Array<string | number>>,
+  ): JSONSchema => {
+    if (remaining.some((path) => path.length === 0)) return true;
+    const strings = new Map<string, Array<Array<string | number>>>();
+    const numbers = new Map<number, Array<Array<string | number>>>();
+    for (const path of remaining) {
+      const [head, ...tail] = path;
+      const target = typeof head === "number" ? numbers : strings;
+      const key = head as never;
+      const entries = target.get(key) ?? [];
+      entries.push(tail);
+      target.set(key, entries);
+    }
+    if (strings.size > 0 && numbers.size > 0) return true;
+    if (numbers.size > 0) {
+      const max = Math.max(...numbers.keys());
+      if (max < 0 || max > 100) return true;
+      const prefixItems = Array.from(
+        { length: max + 1 },
+        (_, index) => {
+          const children = numbers.get(index);
+          return children === undefined ? true : build(children);
+        },
+      );
+      return { type: "array", prefixItems };
+    }
+    return {
+      type: "object",
+      properties: Object.fromEntries(
+        [...strings].map(([key, children]) => [key, build(children)]),
+      ),
+      additionalProperties: false,
+    };
+  };
+  return paths.length === 0 ? true : build(paths);
+}
+
+function mergeMasks(left: JSONSchema, right: JSONSchema): JSONSchema {
+  if (left === true || right === true) return true;
+  if (!isRecord(left) || !isRecord(right)) return true;
+  if (
+    (left.type === "array" || left.items !== undefined) &&
+    (right.type === "array" || right.items !== undefined)
+  ) {
+    return {
+      type: "array",
+      items: mergeMasks(left.items ?? true, right.items ?? true),
+    };
+  }
+  if (
+    (left.type === "object" || left.properties !== undefined) &&
+    (right.type === "object" || right.properties !== undefined)
+  ) {
+    const properties: Record<string, JSONSchema> = {};
+    for (
+      const key of new Set([
+        ...Object.keys(left.properties ?? {}),
+        ...Object.keys(right.properties ?? {}),
+      ])
+    ) {
+      const leftChild = left.properties?.[key];
+      const rightChild = right.properties?.[key];
+      properties[key] = leftChild === undefined
+        ? rightChild!
+        : rightChild === undefined
+        ? leftChild
+        : mergeMasks(leftChild, rightChild);
+    }
+    return { type: "object", properties, additionalProperties: false };
+  }
+  return true;
+}
+
+function selectSourceSchema(
+  cfc: ContextualFlowControl,
+  source: JSONSchema | undefined,
+  mask: JSONSchema,
+): JSONSchema {
+  if (source === undefined || source === true) return mask;
+  if (source === false || mask === true || !isRecord(mask)) {
+    return source;
+  }
+  if (!isRecord(source)) return source;
+  if (
+    source.$ref !== undefined || source.anyOf !== undefined ||
+    source.oneOf !== undefined || source.allOf !== undefined
+  ) {
+    return source;
+  }
+
+  if (mask.type === "array" || mask.items !== undefined) {
+    if (!schemaIsArray(source)) return source;
+    const sourceItem = schemaAtArrayItem(cfc, source);
+    const { items: _items, prefixItems: _prefixItems, ...metadata } = source;
+    return {
+      ...metadata,
+      type: "array",
+      items: selectSourceSchema(cfc, sourceItem, mask.items ?? true),
+    };
+  }
+
+  if (mask.type === "object" || mask.properties !== undefined) {
+    if (
+      !schemaTypes(source).includes("object") &&
+      source.properties === undefined
+    ) {
+      return source;
+    }
+    const {
+      properties: _properties,
+      required,
+      additionalProperties: _additionalProperties,
+      patternProperties: _patternProperties,
+      ...metadata
+    } = source;
+    const requested = mask.properties ?? {};
+    const properties: Record<string, JSONSchema> = {};
+    for (const [key, childMask] of Object.entries(requested)) {
+      const child = cfc.schemaAtPath(source, [key]);
+      properties[key] = selectSourceSchema(
+        cfc,
+        child === false ? undefined : child,
+        childMask,
+      );
+    }
+    const selectedRequired = required?.filter((key) => key in properties);
+    return {
+      ...metadata,
+      type: "object",
+      properties,
+      ...(selectedRequired?.length ? { required: selectedRequired } : {}),
+      additionalProperties: false,
+    };
+  }
+  return source;
+}
+
+function projectValue(
+  value: unknown,
+  schema: JSONSchema,
+  path = "<root>",
+): unknown {
+  if (schema === true) return value;
+  if (!isRecord(schema)) {
+    throw new PieceGetTransformError(
+      `Cannot project ${path}: unsupported schema`,
+    );
+  }
+  if (schema.type === "array" || schema.items !== undefined) {
+    if (!Array.isArray(value)) {
+      throw new PieceGetTransformError(
+        `Cannot apply --schema at ${path}: expected an array`,
+      );
+    }
+    const itemSchema = schema.items ?? true;
+    return value.map((item, index) =>
+      projectValue(item, itemSchema, `${path}[${index}]`)
+    );
+  }
+  if (schema.type === "object" || schema.properties !== undefined) {
+    if (!isRecord(value)) {
+      throw new PieceGetTransformError(
+        `Cannot apply --schema at ${path}: expected an object`,
+      );
+    }
+    const result: Record<string, unknown> = {};
+    const properties = schema.properties ?? {};
+    for (const [key, childSchema] of Object.entries(properties)) {
+      if (Object.hasOwn(value, key)) {
+        result[key] = projectValue(value[key], childSchema, `${path}.${key}`);
+      } else if (schema.required?.includes(key)) {
+        throw new PieceGetTransformError(
+          `Cannot apply --schema at ${path}: required property "${key}" is missing`,
+        );
+      }
+    }
+    if (
+      schema.additionalProperties === true ||
+      isRecord(schema.additionalProperties)
+    ) {
+      for (const [key, child] of Object.entries(value)) {
+        if (key in properties) continue;
+        if (schema.additionalProperties === true) {
+          result[key] = child;
+        } else {
+          result[key] = projectValue(
+            child,
+            schema.additionalProperties,
+            `${path}.${key}`,
+          );
+        }
+      }
+    }
+    return result;
+  }
+  return value;
+}
+
+interface ResolvedProjection {
+  outputSchema: JSONSchema;
+  projectsArrayItems: boolean;
+  itemSchema?: JSONSchema;
+}
+
+function resolveProjection(
+  projection: PieceGetProjection | undefined,
+  sourceIsArray: boolean,
+  hasFilter: boolean,
+): ResolvedProjection | undefined {
+  if (projection === undefined) return undefined;
+  if (projection.kind === "concise") {
+    const projectsArrayItems = hasFilter || sourceIsArray;
+    return projectsArrayItems
+      ? {
+        outputSchema: { type: "array", items: projection.schema },
+        projectsArrayItems: true,
+        itemSchema: projection.schema,
+      }
+      : {
+        outputSchema: projection.schema,
+        projectsArrayItems: false,
+      };
+  }
+  if (hasFilter && !schemaIsArray(projection.schema)) {
+    throw new PieceGetTransformError(
+      "When --filter is used, a JSON --schema must describe the returned " +
+        'array (for example {"type":"array","items":{...}}).',
+    );
+  }
+  const projectsArrayItems = schemaIsArray(projection.schema);
+  return {
+    outputSchema: projection.schema,
+    projectsArrayItems,
+    ...(projectsArrayItems
+      ? {
+        itemSchema: isRecord(projection.schema)
+          ? projection.schema.items ?? true
+          : true,
+      }
+      : {}),
+  };
+}
+
+export interface DerivePieceGetDependencies {
+  onResultCell?: (cell: Cell<unknown>) => void;
+}
+
+/**
+ * Apply a piece-get filter/projection through an actual runtime pattern graph.
+ *
+ * The filter uses the runner's list builtin, so predicate observations taint
+ * collection membership exactly as they do in authored patterns. Array
+ * projection uses the map builtin for pointwise labels. Object/scalar
+ * projection uses a lift. Caller schemas are structural only; authoritative
+ * CFC metadata comes from the selected source cell's schema and dynamic label
+ * view.
+ */
+export async function derivePieceGetValue(
+  runtime: Runtime,
+  space: MemorySpace,
+  sourceCell: Cell<unknown>,
+  transform: PieceGetTransform,
+  deps: DerivePieceGetDependencies = {},
+): Promise<unknown> {
+  if (transform.filter === undefined && transform.projection === undefined) {
+    return await sourceCell.pull();
+  }
+
+  const cfc = new ContextualFlowControl();
+  const sourceValue = await sourceCell.pull();
+  const sourceSchema = sourceCell.schema;
+  if (transform.filter !== undefined && !Array.isArray(sourceValue)) {
+    throw new PieceGetTransformError(
+      "--filter can only be applied to an array",
+    );
+  }
+  const projection = resolveProjection(
+    transform.projection,
+    Array.isArray(sourceValue),
+    transform.filter !== undefined,
+  );
+  const sourceItemSchema = schemaAtArrayItem(cfc, sourceSchema);
+  const predicateItemMask = transform.filter === undefined
+    ? undefined
+    : maskFromPaths(transform.filter.paths);
+  const projectionMaskSchema = projection === undefined
+    ? undefined
+    : projectionMask(projection.outputSchema);
+  const projectionItemMask = projection?.projectsArrayItems
+    ? projectionMask(projection.itemSchema ?? true)
+    : undefined;
+
+  let sourceMask: JSONSchema = true;
+  if (transform.filter !== undefined && projection === undefined) {
+    // Filtering returns original elements. Keep their complete source schema
+    // on the links that survive, while the predicate pattern below narrows the
+    // actual predicate reads.
+    sourceMask = true;
+  } else if (transform.filter !== undefined) {
+    sourceMask = {
+      type: "array",
+      items: mergeMasks(
+        predicateItemMask ?? true,
+        projectionItemMask ?? true,
+      ),
+    };
+  } else if (projectionMaskSchema !== undefined) {
+    sourceMask = projectionMaskSchema;
+  }
+  const sourceReadSchema = selectSourceSchema(cfc, sourceSchema, sourceMask);
+
+  const { commonfabric } = createBuilder({
+    unsafeHostTrust: runtime.createUnsafeHostTrust({
+      reason: "cf piece get filter/schema computed projection",
+    }),
+  });
+  const { lift, pattern } = commonfabric;
+  const paramsSchema: JSONSchema = {
+    type: "object",
+    additionalProperties: true,
+  };
+
+  let predicatePattern: ReturnType<typeof pattern> | undefined;
+  if (transform.filter !== undefined) {
+    const elementSchema = selectSourceSchema(
+      cfc,
+      sourceItemSchema,
+      predicateItemMask ?? true,
+    );
+    const argumentSchema: JSONSchema = {
+      type: "object",
+      properties: {
+        element: dereferencedElementSchema(elementSchema),
+        params: paramsSchema,
+      },
+      required: ["element", "params"],
+      additionalProperties: false,
+    };
+    const predicateModule = lift(
+      ({ element, params }: {
+        element: unknown;
+        params: { predicate: PieceGetPredicate };
+      }) => evaluatePieceGetPredicate(params.predicate, element),
+      argumentSchema,
+      { type: "boolean" },
+    );
+    predicatePattern = pattern(
+      ({ element, params }: any) => predicateModule({ element, params }),
+      argumentSchema,
+      { type: "boolean" },
+    );
+  }
+
+  let itemProjectionPattern: ReturnType<typeof pattern> | undefined;
+  if (projection?.projectsArrayItems) {
+    const itemSchema = projection.itemSchema ?? true;
+    const elementSchema = selectSourceSchema(
+      cfc,
+      sourceItemSchema,
+      projectionItemMask ?? true,
+    );
+    const argumentSchema: JSONSchema = {
+      type: "object",
+      properties: {
+        element: dereferencedElementSchema(elementSchema),
+        params: paramsSchema,
+      },
+      required: ["element", "params"],
+      additionalProperties: false,
+    };
+    const projectionModule = lift(
+      ({ element, params }: {
+        element: unknown;
+        params: { schema: JSONSchema };
+      }) => projectValue(element, params.schema),
+      argumentSchema,
+      itemSchema,
+    );
+    itemProjectionPattern = pattern(
+      ({ element, params }: any) => projectionModule({ element, params }),
+      argumentSchema,
+      itemSchema,
+    );
+  }
+
+  const directProjectionArgumentSchema: JSONSchema = {
+    type: "object",
+    properties: {
+      value: sourceReadSchema,
+      params: paramsSchema,
+    },
+    required: ["value", "params"],
+    additionalProperties: false,
+  };
+  const directProjectionModule = projection !== undefined &&
+      !projection.projectsArrayItems
+    ? lift(
+      ({ value, params }: {
+        value: unknown;
+        params: { schema: JSONSchema };
+      }) => projectValue(value, params.schema),
+      directProjectionArgumentSchema,
+      projection.outputSchema,
+    )
+    : undefined;
+
+  const outputSchema: JSONSchema = projection?.outputSchema ??
+    (transform.filter !== undefined
+      ? filteredOutputSchema(sourceSchema, sourceItemSchema)
+      : sourceSchema ?? true);
+  const mainArgumentSchema: JSONSchema = {
+    type: "object",
+    properties: { value: sourceReadSchema },
+    required: ["value"],
+    additionalProperties: false,
+  };
+  const mainResultSchema: JSONSchema = {
+    type: "object",
+    properties: { value: outputSchema },
+    required: ["value"],
+    additionalProperties: false,
+  };
+  const mainPattern = pattern(
+    ({ value }: any) => {
+      let result: any = value;
+      if (predicatePattern !== undefined) {
+        result = result.filterWithPattern(predicatePattern as any, {
+          predicate: transform.filter!.predicate,
+        });
+      }
+      if (itemProjectionPattern !== undefined) {
+        result = result.mapWithPattern(itemProjectionPattern as any, {
+          schema: projection!.itemSchema ?? true,
+        });
+      } else if (directProjectionModule !== undefined) {
+        result = directProjectionModule({
+          value: result,
+          params: { schema: projection!.outputSchema },
+        });
+      }
+      return { value: result };
+    },
+    mainArgumentSchema,
+    mainResultSchema,
+  );
+
+  const tx = runtime.edit();
+  const resultCell = runtime.getCell(
+    space,
+    {
+      pieceGetTransform: {
+        source: sourceCell.getAsNormalizedFullLink(),
+        filter: transform.filter?.source,
+        schema: transform.projection?.source,
+      },
+    },
+    mainResultSchema,
+    tx,
+    "session",
+  );
+  const errors = runtimeErrorLog(runtime);
+  const errorCountBefore = errors.length;
+  const result = runtime.run(
+    tx,
+    mainPattern,
+    { value: sourceCell },
+    resultCell,
+  );
+  try {
+    runtime.prepareTxForCommit(tx);
+    const committed = await tx.commit();
+    if (committed.error !== undefined) {
+      throw new PieceGetTransformError(
+        `Could not apply piece get transform: ${committed.error}`,
+      );
+    }
+    await result.pull();
+    await runtime.idle();
+    await runtime.storageManager.synced();
+    await result.pull();
+    await runtime.idle();
+    const recorded = errors.slice(errorCountBefore).at(-1);
+    if (recorded !== undefined) {
+      throw new PieceGetTransformError(
+        `Could not apply piece get transform: ${recorded.message}`,
+      );
+    }
+    deps.onResultCell?.(result as Cell<unknown>);
+    return result.key("value").get();
+  } finally {
+    runtime.runner.stop(resultCell);
+  }
+}

--- a/packages/cli/lib/piece-get-transform.ts
+++ b/packages/cli/lib/piece-get-transform.ts
@@ -396,15 +396,8 @@ function valueAtPredicatePath(
   return current;
 }
 
-function requireBoolean(value: unknown, context: string): boolean {
-  if (typeof value !== "boolean") {
-    throw new PieceGetTransformError(
-      `--filter ${context} must evaluate to a boolean, got ${
-        value === null ? "null" : typeof value
-      }`,
-    );
-  }
-  return value;
+function predicateTruthiness(value: unknown): boolean {
+  return value !== false && value !== null;
 }
 
 function comparePredicateValues(
@@ -445,18 +438,13 @@ export function evaluatePieceGetPredicate(
       case "path":
         return valueAtPredicatePath(value, node.path);
       case "not":
-        return !requireBoolean(evaluate(node.value), '"not" operand');
+        return !predicateTruthiness(evaluate(node.value));
       case "boolean": {
-        const left = requireBoolean(
-          evaluate(node.left),
-          `"${node.operator}" left operand`,
-        );
+        const left = predicateTruthiness(evaluate(node.left));
         if (node.operator === "and") {
-          return left &&
-            requireBoolean(evaluate(node.right), '"and" right operand');
+          return left && predicateTruthiness(evaluate(node.right));
         }
-        return left ||
-          requireBoolean(evaluate(node.right), '"or" right operand');
+        return left || predicateTruthiness(evaluate(node.right));
       }
       case "comparison":
         return comparePredicateValues(
@@ -466,7 +454,7 @@ export function evaluatePieceGetPredicate(
         );
     }
   };
-  return requireBoolean(evaluate(predicate), "predicate");
+  return predicateTruthiness(evaluate(predicate));
 }
 
 const FORBIDDEN_PROJECTION_KEYS = new Set([
@@ -504,7 +492,7 @@ function normalizeProjectionSchema(
       `Invalid --schema at ${path}: false cannot project a value`,
     );
   }
-  if (!isRecord(schema)) {
+  if (!isRecord(schema) || Array.isArray(schema)) {
     throw new PieceGetTransformError(
       `Invalid --schema at ${path}: expected a JSON Schema object`,
     );
@@ -525,7 +513,7 @@ function normalizeProjectionSchema(
 
   const result: Record<string, unknown> = { ...schema };
   if (schema.properties !== undefined) {
-    if (!isRecord(schema.properties)) {
+    if (!isRecord(schema.properties) || Array.isArray(schema.properties)) {
       throw new PieceGetTransformError(
         `Invalid --schema at ${path}: "properties" must be an object`,
       );
@@ -539,6 +527,11 @@ function normalizeProjectionSchema(
     if (schema.additionalProperties === undefined) {
       result.additionalProperties = false;
     }
+  } else if (
+    schemaTypes(schema as JSONSchema).includes("object") &&
+    schema.additionalProperties === undefined
+  ) {
+    result.additionalProperties = true;
   }
   if (
     schema.additionalProperties !== undefined &&
@@ -580,7 +573,7 @@ function conciseProjectionSchema(source: string): JSONSchema {
         continue;
       }
       const existing = node[segment];
-      if (existing === true) continue;
+      if (existing === true) break;
       if (!isRecord(existing)) {
         node[segment] = {};
       }
@@ -724,21 +717,42 @@ function filteredOutputSchema(
   };
 }
 
-function projectionMask(schema: JSONSchema): JSONSchema {
+type ObjectProjectionMask = {
+  type: "object";
+  properties: Record<string, ProjectionMask>;
+  additionalProperties: false;
+};
+type ProjectionMask =
+  | true
+  | { type: "array"; items: ProjectionMask }
+  | ObjectProjectionMask;
+type PredicateMask = true | ObjectProjectionMask;
+
+function projectionMask(schema: JSONSchema): ProjectionMask {
   if (schema === true) return true;
-  if (!isRecord(schema)) return true;
-  if (schema.additionalProperties === true) return true;
-  if (schema.type === "array" || schema.items !== undefined) {
+  // `normalizeProjectionSchema()` rejects false schemas before this point.
+  const objectSchema = schema as Exclude<JSONSchema, boolean>;
+  if (
+    objectSchema.additionalProperties === true ||
+    isRecord(objectSchema.additionalProperties)
+  ) {
+    return true;
+  }
+  if (objectSchema.type === "array" || objectSchema.items !== undefined) {
     return {
       type: "array",
-      items: schema.items === undefined ? true : projectionMask(schema.items),
+      items: objectSchema.items === undefined
+        ? true
+        : projectionMask(objectSchema.items),
     };
   }
-  if (schema.type === "object" || schema.properties !== undefined) {
+  if (
+    objectSchema.type === "object" || objectSchema.properties !== undefined
+  ) {
     return {
       type: "object",
       properties: Object.fromEntries(
-        Object.entries(schema.properties ?? {}).map(([key, child]) => [
+        Object.entries(objectSchema.properties ?? {}).map(([key, child]) => [
           key,
           projectionMask(child),
         ]),
@@ -749,34 +763,22 @@ function projectionMask(schema: JSONSchema): JSONSchema {
   return true;
 }
 
-function maskFromPaths(paths: Array<Array<string | number>>): JSONSchema {
+function maskFromPaths(
+  paths: Array<Array<string | number>>,
+): PredicateMask {
   if (paths.some((path) => path.length === 0)) return true;
   const build = (
     remaining: Array<Array<string | number>>,
-  ): JSONSchema => {
+  ): PredicateMask => {
     if (remaining.some((path) => path.length === 0)) return true;
+    if (remaining.some(([head]) => typeof head === "number")) return true;
     const strings = new Map<string, Array<Array<string | number>>>();
-    const numbers = new Map<number, Array<Array<string | number>>>();
     for (const path of remaining) {
       const [head, ...tail] = path;
-      const target = typeof head === "number" ? numbers : strings;
-      const key = head as never;
-      const entries = target.get(key) ?? [];
+      const key = head as string;
+      const entries = strings.get(key) ?? [];
       entries.push(tail);
-      target.set(key, entries);
-    }
-    if (strings.size > 0 && numbers.size > 0) return true;
-    if (numbers.size > 0) {
-      const max = Math.max(...numbers.keys());
-      if (max < 0 || max > 100) return true;
-      const prefixItems = Array.from(
-        { length: max + 1 },
-        (_, index) => {
-          const children = numbers.get(index);
-          return children === undefined ? true : build(children);
-        },
-      );
-      return { type: "array", prefixItems };
+      strings.set(key, entries);
     }
     return {
       type: "object",
@@ -789,52 +791,39 @@ function maskFromPaths(paths: Array<Array<string | number>>): JSONSchema {
   return paths.length === 0 ? true : build(paths);
 }
 
-function mergeMasks(left: JSONSchema, right: JSONSchema): JSONSchema {
+function mergeMasks(
+  left: PredicateMask,
+  right: ProjectionMask,
+): ProjectionMask {
   if (left === true || right === true) return true;
-  if (!isRecord(left) || !isRecord(right)) return true;
-  if (
-    (left.type === "array" || left.items !== undefined) &&
-    (right.type === "array" || right.items !== undefined)
+  if (right.type !== "object") return true;
+  const properties: Record<string, ProjectionMask> = {};
+  for (
+    const key of new Set([
+      ...Object.keys(left.properties),
+      ...Object.keys(right.properties),
+    ])
   ) {
-    return {
-      type: "array",
-      items: mergeMasks(left.items ?? true, right.items ?? true),
-    };
+    const leftChild = left.properties[key];
+    const rightChild = right.properties[key];
+    properties[key] = leftChild === undefined
+      ? rightChild!
+      : rightChild === undefined
+      ? leftChild
+      : mergeMasks(leftChild as PredicateMask, rightChild);
   }
-  if (
-    (left.type === "object" || left.properties !== undefined) &&
-    (right.type === "object" || right.properties !== undefined)
-  ) {
-    const properties: Record<string, JSONSchema> = {};
-    for (
-      const key of new Set([
-        ...Object.keys(left.properties ?? {}),
-        ...Object.keys(right.properties ?? {}),
-      ])
-    ) {
-      const leftChild = left.properties?.[key];
-      const rightChild = right.properties?.[key];
-      properties[key] = leftChild === undefined
-        ? rightChild!
-        : rightChild === undefined
-        ? leftChild
-        : mergeMasks(leftChild, rightChild);
-    }
-    return { type: "object", properties, additionalProperties: false };
-  }
-  return true;
+  return { type: "object", properties, additionalProperties: false };
 }
 
 function selectSourceSchema(
   cfc: ContextualFlowControl,
   source: JSONSchema | undefined,
-  mask: JSONSchema,
+  mask: ProjectionMask,
 ): JSONSchema {
   if (source === undefined || source === true) return mask;
   if (source === false || mask === true || !isRecord(mask)) {
     return source;
   }
-  if (!isRecord(source)) return source;
   if (
     source.$ref !== undefined || source.anyOf !== undefined ||
     source.oneOf !== undefined || source.allOf !== undefined
@@ -842,112 +831,47 @@ function selectSourceSchema(
     return source;
   }
 
-  if (mask.type === "array" || mask.items !== undefined) {
+  if (mask.type === "array") {
     if (!schemaIsArray(source)) return source;
     const sourceItem = schemaAtArrayItem(cfc, source);
     const { items: _items, prefixItems: _prefixItems, ...metadata } = source;
     return {
       ...metadata,
       type: "array",
-      items: selectSourceSchema(cfc, sourceItem, mask.items ?? true),
+      items: selectSourceSchema(cfc, sourceItem, mask.items),
     };
   }
 
-  if (mask.type === "object" || mask.properties !== undefined) {
-    if (
-      !schemaTypes(source).includes("object") &&
-      source.properties === undefined
-    ) {
-      return source;
-    }
-    const {
-      properties: _properties,
-      required,
-      additionalProperties: _additionalProperties,
-      patternProperties: _patternProperties,
-      ...metadata
-    } = source;
-    const requested = mask.properties ?? {};
-    const properties: Record<string, JSONSchema> = {};
-    for (const [key, childMask] of Object.entries(requested)) {
-      const child = cfc.schemaAtPath(source, [key]);
-      properties[key] = selectSourceSchema(
-        cfc,
-        child === false ? undefined : child,
-        childMask,
-      );
-    }
-    const selectedRequired = required?.filter((key) => key in properties);
-    return {
-      ...metadata,
-      type: "object",
-      properties,
-      ...(selectedRequired?.length ? { required: selectedRequired } : {}),
-      additionalProperties: false,
-    };
+  if (
+    !schemaTypes(source).includes("object") &&
+    source.properties === undefined
+  ) {
+    return source;
   }
-  return source;
-}
-
-function projectValue(
-  value: unknown,
-  schema: JSONSchema,
-  path = "<root>",
-): unknown {
-  if (schema === true) return value;
-  if (!isRecord(schema)) {
-    throw new PieceGetTransformError(
-      `Cannot project ${path}: unsupported schema`,
+  const {
+    properties: _properties,
+    required,
+    additionalProperties: _additionalProperties,
+    patternProperties: _patternProperties,
+    ...metadata
+  } = source;
+  const properties: Record<string, JSONSchema> = {};
+  for (const [key, childMask] of Object.entries(mask.properties)) {
+    const child = cfc.schemaAtPath(source, [key]);
+    properties[key] = selectSourceSchema(
+      cfc,
+      child === false ? undefined : child,
+      childMask,
     );
   }
-  if (schema.type === "array" || schema.items !== undefined) {
-    if (!Array.isArray(value)) {
-      throw new PieceGetTransformError(
-        `Cannot apply --schema at ${path}: expected an array`,
-      );
-    }
-    const itemSchema = schema.items ?? true;
-    return value.map((item, index) =>
-      projectValue(item, itemSchema, `${path}[${index}]`)
-    );
-  }
-  if (schema.type === "object" || schema.properties !== undefined) {
-    if (!isRecord(value)) {
-      throw new PieceGetTransformError(
-        `Cannot apply --schema at ${path}: expected an object`,
-      );
-    }
-    const result: Record<string, unknown> = {};
-    const properties = schema.properties ?? {};
-    for (const [key, childSchema] of Object.entries(properties)) {
-      if (Object.hasOwn(value, key)) {
-        result[key] = projectValue(value[key], childSchema, `${path}.${key}`);
-      } else if (schema.required?.includes(key)) {
-        throw new PieceGetTransformError(
-          `Cannot apply --schema at ${path}: required property "${key}" is missing`,
-        );
-      }
-    }
-    if (
-      schema.additionalProperties === true ||
-      isRecord(schema.additionalProperties)
-    ) {
-      for (const [key, child] of Object.entries(value)) {
-        if (key in properties) continue;
-        if (schema.additionalProperties === true) {
-          result[key] = child;
-        } else {
-          result[key] = projectValue(
-            child,
-            schema.additionalProperties,
-            `${path}.${key}`,
-          );
-        }
-      }
-    }
-    return result;
-  }
-  return value;
+  const selectedRequired = required?.filter((key) => key in properties);
+  return {
+    ...metadata,
+    type: "object",
+    properties,
+    ...(selectedRequired?.length ? { required: selectedRequired } : {}),
+    additionalProperties: false,
+  };
 }
 
 interface ResolvedProjection {
@@ -959,11 +883,10 @@ interface ResolvedProjection {
 function resolveProjection(
   projection: PieceGetProjection | undefined,
   sourceIsArray: boolean,
-  hasFilter: boolean,
 ): ResolvedProjection | undefined {
   if (projection === undefined) return undefined;
   if (projection.kind === "concise") {
-    const projectsArrayItems = hasFilter || sourceIsArray;
+    const projectsArrayItems = sourceIsArray;
     return projectsArrayItems
       ? {
         outputSchema: { type: "array", items: projection.schema },
@@ -975,21 +898,25 @@ function resolveProjection(
         projectsArrayItems: false,
       };
   }
-  if (hasFilter && !schemaIsArray(projection.schema)) {
+  const projectsArrayItems = schemaIsArray(projection.schema);
+  if (
+    projection.schema !== true &&
+    sourceIsArray !== projectsArrayItems
+  ) {
     throw new PieceGetTransformError(
-      "When --filter is used, a JSON --schema must describe the returned " +
-        'array (for example {"type":"array","items":{...}}).',
+      sourceIsArray
+        ? "A JSON --schema for an array value must describe the returned " +
+          'array (for example {"type":"array","items":{...}}).'
+        : "An array-rooted JSON --schema can only be applied to an array value.",
     );
   }
-  const projectsArrayItems = schemaIsArray(projection.schema);
   return {
     outputSchema: projection.schema,
     projectsArrayItems,
     ...(projectsArrayItems
       ? {
-        itemSchema: isRecord(projection.schema)
-          ? projection.schema.items ?? true
-          : true,
+        itemSchema: (projection.schema as Exclude<JSONSchema, boolean>).items ??
+          true,
       }
       : {}),
   };
@@ -1005,9 +932,10 @@ export interface DerivePieceGetDependencies {
  * The filter uses the runner's list builtin, so predicate observations taint
  * collection membership exactly as they do in authored patterns. Array
  * projection uses the map builtin for pointwise labels. Object/scalar
- * projection uses a lift. Caller schemas are structural only; authoritative
- * CFC metadata comes from the selected source cell's schema and dynamic label
- * view.
+ * projection uses a lift. Projection nodes are identities over runtime
+ * `asSchema` reads: the source-derived read schema performs the structural
+ * projection while preserving authoritative source CFC metadata. Caller
+ * schemas describe output shape only and cannot replace source metadata.
  */
 export async function derivePieceGetValue(
   runtime: Runtime,
@@ -1031,7 +959,6 @@ export async function derivePieceGetValue(
   const projection = resolveProjection(
     transform.projection,
     Array.isArray(sourceValue),
-    transform.filter !== undefined,
   );
   const sourceItemSchema = schemaAtArrayItem(cfc, sourceSchema);
   const predicateItemMask = transform.filter === undefined
@@ -1041,10 +968,10 @@ export async function derivePieceGetValue(
     ? undefined
     : projectionMask(projection.outputSchema);
   const projectionItemMask = projection?.projectsArrayItems
-    ? projectionMask(projection.itemSchema ?? true)
+    ? projectionMask(projection.itemSchema!)
     : undefined;
 
-  let sourceMask: JSONSchema = true;
+  let sourceMask: ProjectionMask = true;
   if (transform.filter !== undefined && projection === undefined) {
     // Filtering returns original elements. Keep their complete source schema
     // on the links that survive, while the predicate pattern below narrows the
@@ -1054,8 +981,8 @@ export async function derivePieceGetValue(
     sourceMask = {
       type: "array",
       items: mergeMasks(
-        predicateItemMask ?? true,
-        projectionItemMask ?? true,
+        predicateItemMask!,
+        projectionItemMask!,
       ),
     };
   } else if (projectionMaskSchema !== undefined) {
@@ -1079,7 +1006,7 @@ export async function derivePieceGetValue(
     const elementSchema = selectSourceSchema(
       cfc,
       sourceItemSchema,
-      predicateItemMask ?? true,
+      predicateItemMask!,
     );
     const argumentSchema: JSONSchema = {
       type: "object",
@@ -1107,31 +1034,27 @@ export async function derivePieceGetValue(
 
   let itemProjectionPattern: ReturnType<typeof pattern> | undefined;
   if (projection?.projectsArrayItems) {
-    const itemSchema = projection.itemSchema ?? true;
+    const itemSchema = projection.itemSchema!;
     const elementSchema = selectSourceSchema(
       cfc,
       sourceItemSchema,
-      projectionItemMask ?? true,
+      projectionItemMask!,
     );
     const argumentSchema: JSONSchema = {
       type: "object",
       properties: {
         element: dereferencedElementSchema(elementSchema),
-        params: paramsSchema,
       },
-      required: ["element", "params"],
+      required: ["element"],
       additionalProperties: false,
     };
     const projectionModule = lift(
-      ({ element, params }: {
-        element: unknown;
-        params: { schema: JSONSchema };
-      }) => projectValue(element, params.schema),
+      ({ element }: { element: unknown }) => element,
       argumentSchema,
       itemSchema,
     );
     itemProjectionPattern = pattern(
-      ({ element, params }: any) => projectionModule({ element, params }),
+      ({ element }: any) => projectionModule({ element }),
       argumentSchema,
       itemSchema,
     );
@@ -1141,27 +1064,21 @@ export async function derivePieceGetValue(
     type: "object",
     properties: {
       value: sourceReadSchema,
-      params: paramsSchema,
     },
-    required: ["value", "params"],
+    required: ["value"],
     additionalProperties: false,
   };
   const directProjectionModule = projection !== undefined &&
       !projection.projectsArrayItems
     ? lift(
-      ({ value, params }: {
-        value: unknown;
-        params: { schema: JSONSchema };
-      }) => projectValue(value, params.schema),
+      ({ value }: { value: unknown }) => value,
       directProjectionArgumentSchema,
       projection.outputSchema,
     )
     : undefined;
 
   const outputSchema: JSONSchema = projection?.outputSchema ??
-    (transform.filter !== undefined
-      ? filteredOutputSchema(sourceSchema, sourceItemSchema)
-      : sourceSchema ?? true);
+    filteredOutputSchema(sourceSchema, sourceItemSchema);
   const mainArgumentSchema: JSONSchema = {
     type: "object",
     properties: { value: sourceReadSchema },
@@ -1183,14 +1100,9 @@ export async function derivePieceGetValue(
         });
       }
       if (itemProjectionPattern !== undefined) {
-        result = result.mapWithPattern(itemProjectionPattern as any, {
-          schema: projection!.itemSchema ?? true,
-        });
+        result = result.mapWithPattern(itemProjectionPattern as any, {});
       } else if (directProjectionModule !== undefined) {
-        result = directProjectionModule({
-          value: result,
-          params: { schema: projection!.outputSchema },
-        });
+        result = directProjectionModule({ value: result });
       }
       return { value: result };
     },
@@ -1217,7 +1129,7 @@ export async function derivePieceGetValue(
   const result = runtime.run(
     tx,
     mainPattern,
-    { value: sourceCell },
+    { value: sourceCell.asSchema(sourceReadSchema) },
     resultCell,
   );
   try {

--- a/packages/cli/lib/piece-get-transform.ts
+++ b/packages/cli/lib/piece-get-transform.ts
@@ -397,7 +397,7 @@ function valueAtPredicatePath(
 }
 
 function predicateTruthiness(value: unknown): boolean {
-  return value !== false && value !== null;
+  return value !== false && value != null;
 }
 
 function comparePredicateValues(
@@ -717,16 +717,22 @@ function filteredOutputSchema(
   };
 }
 
-type ObjectProjectionMask = {
+interface ObjectMask<Child> {
   type: "object";
-  properties: Record<string, ProjectionMask>;
+  properties: Record<string, Child>;
   additionalProperties: false;
-};
+}
+interface ArrayProjectionMask {
+  type: "array";
+  items: ProjectionMask;
+}
+interface ObjectProjectionMask extends ObjectMask<ProjectionMask> {}
 type ProjectionMask =
   | true
-  | { type: "array"; items: ProjectionMask }
+  | ArrayProjectionMask
   | ObjectProjectionMask;
-type PredicateMask = true | ObjectProjectionMask;
+interface ObjectPredicateMask extends ObjectMask<PredicateMask> {}
+type PredicateMask = true | ObjectPredicateMask;
 
 function projectionMask(schema: JSONSchema): ProjectionMask {
   if (schema === true) return true;
@@ -810,7 +816,7 @@ function mergeMasks(
       ? rightChild!
       : rightChild === undefined
       ? leftChild
-      : mergeMasks(leftChild as PredicateMask, rightChild);
+      : mergeMasks(leftChild, rightChild);
   }
   return { type: "object", properties, additionalProperties: false };
 }

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -2206,9 +2206,39 @@ export async function getCellValue(
       await manager.synced();
     }
 
+    const prop = options.input ? "input" : "result";
+    if (options.transform !== undefined) {
+      const rootCell = await piece[prop].getCell();
+      const targetCell = rootCell.key(...path);
+      let transformed: unknown;
+      try {
+        transformed = await (deps.derivePieceGetValue ?? derivePieceGetValue)(
+          manager.runtime,
+          manager.getSpace(),
+          targetCell,
+          options.transform,
+        );
+      } catch (error) {
+        if (
+          !options.input && error instanceof Error &&
+          error.message.startsWith("Cannot access path") &&
+          await resultProjectionFailedAtPath(piece, path)
+        ) {
+          throw new PieceResultProjectionError(path, shouldStep);
+        }
+        throw error;
+      }
+      if (
+        !options.input && transformed === undefined &&
+        await resultProjectionFailedAtPath(piece, path)
+      ) {
+        throw new PieceResultProjectionError(path, shouldStep);
+      }
+      return transformed;
+    }
+
     let value: unknown;
     try {
-      const prop = options.input ? "input" : "result";
       value = await timeCliPhase(
         `getCellValue.${prop}.get`,
         () => piece[prop].get(path),
@@ -2229,18 +2259,6 @@ export async function getCellValue(
       await resultProjectionFailedAtPath(piece, path)
     ) {
       throw new PieceResultProjectionError(path, shouldStep);
-    }
-
-    if (options.transform !== undefined) {
-      const prop = options.input ? "input" : "result";
-      const rootCell = await piece[prop].getCell();
-      const targetCell = rootCell.key(...path);
-      return await (deps.derivePieceGetValue ?? derivePieceGetValue)(
-        manager.runtime,
-        manager.getSpace(),
-        targetCell,
-        options.transform,
-      );
     }
 
     return value;

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -72,6 +72,10 @@ import {
 import { cliCommand } from "./cli-name.ts";
 import { deriveDiskHandleId } from "./sqlite-source.ts";
 import { stderrConsoleHandler } from "./json-output.ts";
+import {
+  derivePieceGetValue,
+  type PieceGetTransform,
+} from "./piece-get-transform.ts";
 
 export interface EntryConfig {
   mainPath: string;
@@ -107,6 +111,7 @@ export interface SetPiecePatternOptions {
 export interface GetCellValueOptions {
   input?: boolean;
   step?: boolean;
+  transform?: PieceGetTransform;
 }
 
 export class PieceResultProjectionError extends Error {
@@ -194,6 +199,7 @@ interface PieceOperationDependencies extends PieceResolutionDeps {
     source: "input data" | "result data" | "metadata",
     error: unknown,
   ) => void;
+  derivePieceGetValue?: typeof derivePieceGetValue;
 }
 
 const CLI_TRACE_TIMINGS = Deno.env.get("CF_CLI_TRACE_TIMINGS") === "1";
@@ -2223,6 +2229,18 @@ export async function getCellValue(
       await resultProjectionFailedAtPath(piece, path)
     ) {
       throw new PieceResultProjectionError(path, shouldStep);
+    }
+
+    if (options.transform !== undefined) {
+      const prop = options.input ? "input" : "result";
+      const rootCell = await piece[prop].getCell();
+      const targetCell = rootCell.key(...path);
+      return await (deps.derivePieceGetValue ?? derivePieceGetValue)(
+        manager.runtime,
+        manager.getSpace(),
+        targetCell,
+        options.transform,
+      );
     }
 
     return value;

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -24,6 +24,7 @@ import {
   verbInputErrorReport,
 } from "../commands/piece.ts";
 import { LinkValidationError } from "../lib/piece.ts";
+import { PieceGetTransformError } from "../lib/piece-get-transform.ts";
 
 describe("executePieceCallable", () => {
   it("preserves plain-text mode while resolving a callable", async () => {
@@ -1608,6 +1609,19 @@ describe("piece get data errors", () => {
     // the generic --input tip (a different remedy).
     expect(report?.message).toMatch(/schema could not resolve/);
     expect(report?.message).toMatch(/--step/);
+    expect(report?.hint).toBeUndefined();
+  });
+
+  it("reports transform failures without an unrelated --input hint", () => {
+    const transformError = new PieceGetTransformError(
+      "--filter can only be applied to an array",
+    );
+    expect(isPieceGetDataError(transformError)).toBe(true);
+    const report = pieceGetDataErrorReport(transformError, {
+      input: false,
+      piece: "fid1:piece-123",
+    });
+    expect(report?.message).toBe("--filter can only be applied to an array");
     expect(report?.hint).toBeUndefined();
   });
 });

--- a/packages/cli/test/piece-get-transform.test.ts
+++ b/packages/cli/test/piece-get-transform.test.ts
@@ -21,12 +21,17 @@ describe("cf piece get transforms", () => {
 
   beforeEach(() => {
     storageManager = StorageManager.emulate({ as: signer });
+    const runtimeErrors: Array<{ message: string }> = [];
     runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
       cfcEnforcementMode: "observe",
       cfcFlowLabels: "persist",
+      errorHandlers: [
+        (error) => runtimeErrors.push({ message: error.message }),
+      ],
     });
+    (runtime as any)[Symbol.for("cf.cli.runtimeErrorLog")] = runtimeErrors;
   });
 
   afterEach(async () => {
@@ -65,10 +70,112 @@ describe("cf piece get transforms", () => {
     })).toBe(true);
   });
 
-  it("rejects non-boolean predicates", () => {
-    const parsed = parsePieceGetFilter(".name");
-    expect(() => evaluatePieceGetPredicate(parsed.predicate, { name: "Ada" }))
-      .toThrow(PieceGetTransformError);
+  it("uses jq truthiness for predicate values and missing paths", () => {
+    const value = {
+      name: "Ada",
+      zero: 0,
+      empty: "",
+      disabled: false,
+      nil: null,
+    };
+    for (
+      const source of [
+        ".name",
+        ".zero",
+        ".empty",
+        "not .missing",
+        "false or true",
+        ".disabled == false",
+      ]
+    ) {
+      expect(evaluatePieceGetPredicate(
+        parsePieceGetFilter(source).predicate,
+        value,
+      )).toBe(true);
+    }
+    for (const source of [".disabled", ".nil", ".missing"]) {
+      expect(evaluatePieceGetPredicate(
+        parsePieceGetFilter(source).predicate,
+        value,
+      )).toBe(false);
+    }
+  });
+
+  it("returns null for missing, incompatible, and out-of-range paths", () => {
+    const value = {
+      nil: null,
+      name: "Ada",
+      tags: ["first"],
+    };
+    for (
+      const source of [
+        ".nil.child",
+        ".name.child",
+        ".tags.name",
+        ".tags[3]",
+        ".tags[-3]",
+      ]
+    ) {
+      expect(evaluatePieceGetPredicate(
+        parsePieceGetFilter(source).predicate,
+        value,
+      )).toBe(false);
+    }
+    expect(evaluatePieceGetPredicate(
+      parsePieceGetFilter(".tags[0]").predicate,
+      value,
+    )).toBe(true);
+  });
+
+  it("compares strings, numbers, and structured equality", () => {
+    const value = {
+      score: 10,
+      name: "Grace",
+      tags: ["a", "b"],
+    };
+    for (
+      const source of [
+        ".score < 11",
+        ".score <= 10",
+        ".score > 9",
+        ".score >= 10",
+        '.name < "H"',
+        '.tags == .["tags"]',
+        ".tags != null",
+      ]
+    ) {
+      expect(evaluatePieceGetPredicate(
+        parsePieceGetFilter(source).predicate,
+        value,
+      )).toBe(true);
+    }
+    expect(() =>
+      evaluatePieceGetPredicate(
+        parsePieceGetFilter(".score > true").predicate,
+        value,
+      )
+    ).toThrow("--filter > requires two numbers or two strings");
+  });
+
+  it("reports invalid predicate syntax", () => {
+    for (
+      const source of [
+        "",
+        "#",
+        '"unterminated',
+        '"\\x"',
+        "(",
+        ".name)",
+        ".name.",
+        ".name[true]",
+        '.name["key"',
+        "unknown",
+      ]
+    ) {
+      expect(() => parsePieceGetFilter(source)).toThrow(
+        PieceGetTransformError,
+      );
+    }
   });
 
   it("parses concise, inline, and file projection schemas", async () => {
@@ -111,15 +218,116 @@ describe("cf piece get transforms", () => {
         additionalProperties: false,
       },
     });
+
+    const path = await Deno.makeTempFile({ suffix: ".json" });
+    try {
+      await Deno.writeTextFile(path, '{"type":"object"}');
+      expect((await parsePieceGetProjection(`@${path}`)).schema).toEqual({
+        type: "object",
+        additionalProperties: true,
+      });
+    } finally {
+      await Deno.remove(path);
+    }
+  });
+
+  it("collapses overlapping concise paths without exposing siblings", async () => {
+    for (const source of ["author,author.name", "author.name,author"]) {
+      expect((await parsePieceGetProjection(source)).schema).toEqual({
+        type: "object",
+        properties: { author: true },
+        additionalProperties: false,
+      });
+    }
+  });
+
+  it("validates projection schema roots and nested schema objects", async () => {
+    await expect(parsePieceGetProjection("")).rejects.toThrow(
+      "--schema must not be empty",
+    );
+    await expect(parsePieceGetProjection("@")).rejects.toThrow(
+      "--schema @file requires a file path",
+    );
+    await expect(parsePieceGetProjection("@missing.json", {
+      readTextFile: () => Promise.reject(new Error("gone")),
+    })).rejects.toThrow('Could not read --schema file "missing.json": gone');
+    await expect(parsePieceGetProjection("@bad.json", {
+      readTextFile: () => Promise.resolve("{"),
+    })).rejects.toThrow('Invalid JSON in --schema file "bad.json"');
+    await expect(parsePieceGetProjection("@array.json", {
+      readTextFile: () => Promise.resolve("[]"),
+    })).rejects.toThrow("expected a JSON Schema object");
+    await expect(parsePieceGetProjection("{")).rejects.toThrow(
+      "Invalid JSON passed to --schema",
+    );
+    await expect(parsePieceGetProjection("false")).rejects.toThrow(
+      "false cannot project a value",
+    );
+    await expect(parsePieceGetProjection(
+      '{"type":"object","properties":[]}',
+    )).rejects.toThrow('"properties" must be an object');
+    await expect(parsePieceGetProjection("a,,b")).rejects.toThrow(
+      "expected comma-separated field paths",
+    );
+    await expect(parsePieceGetProjection("a.0")).rejects.toThrow(
+      "Invalid --schema field path",
+    );
+  });
+
+  it("normalizes identity and additional-property projection schemas", async () => {
+    expect((await parsePieceGetProjection('{"type":"object"}')).schema)
+      .toEqual({
+        type: "object",
+        additionalProperties: true,
+      });
+    expect(
+      (await parsePieceGetProjection(
+        '{"type":"object","additionalProperties":{"type":"string"}}',
+      )).schema,
+    ).toEqual({
+      type: "object",
+      additionalProperties: { type: "string" },
+    });
+    expect((await parsePieceGetProjection("true")).schema).toBe(true);
   });
 
   it("does not let caller projection schemas forge CFC metadata", async () => {
-    await expect(parsePieceGetProjection(
-      '{"type":"string","ifc":{"confidentiality":["fake"]}}',
-    )).rejects.toThrow(PieceGetTransformError);
-    await expect(parsePieceGetProjection(
-      '{"type":"object","properties":{"secret":{"asCell":["cell"]}}}',
-    )).rejects.toThrow(PieceGetTransformError);
+    for (const key of ["asCell", "default", "ifc", "scope"]) {
+      await expect(parsePieceGetProjection(JSON.stringify({
+        type: "object",
+        properties: {
+          secret: { type: "string", [key]: key === "asCell" ? ["cell"] : {} },
+        },
+      }))).rejects.toThrow(PieceGetTransformError);
+    }
+  });
+
+  it("rejects unsupported projection composition keywords", async () => {
+    for (
+      const key of [
+        "$ref",
+        "$defs",
+        "definitions",
+        "allOf",
+        "anyOf",
+        "oneOf",
+        "not",
+        "if",
+        "then",
+        "else",
+        "dependentSchemas",
+        "contains",
+        "patternProperties",
+        "prefixItems",
+        "propertyNames",
+        "contentSchema",
+      ]
+    ) {
+      await expect(parsePieceGetProjection(JSON.stringify({
+        type: "object",
+        [key]: {},
+      }))).rejects.toThrow(`"${key}" is not supported`);
+    }
   });
 
   it("filters and projects arrays through the runtime pattern graph", async () => {
@@ -158,6 +366,264 @@ describe("cf piece get transforms", () => {
     ]);
   });
 
+  it("does not leak nested siblings from overlapping concise paths", async () => {
+    const tx = runtime.edit();
+    const source = runtime.getCell(
+      space,
+      "overlap-projection-source",
+      {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            author: {
+              type: "object",
+              properties: {
+                name: { type: "string" },
+                privateEmail: { type: "string" },
+              },
+            },
+            ignored: { type: "string" },
+          },
+        },
+      },
+      tx,
+    );
+    source.set([{
+      author: { name: "Ada", privateEmail: "ada@example.com" },
+      ignored: "hidden",
+    }]);
+    expect((await tx.commit()).ok).toBeDefined();
+
+    const result = await derivePieceGetValue(runtime, space, source, {
+      projection: await parsePieceGetProjection(
+        "author.name,author.name.first",
+      ),
+    });
+
+    expect(result).toEqual([{ author: { name: "Ada" } }]);
+  });
+
+  it("supports direct projection and identity object schemas", async () => {
+    const tx = runtime.edit();
+    const source = runtime.getCell(
+      space,
+      "object-projection-source",
+      {
+        type: "object",
+        properties: {
+          id: { type: "number" },
+          title: { type: "string" },
+        },
+        required: ["id", "title"],
+      },
+      tx,
+    );
+    source.set({ id: 1, title: "Visible" });
+    expect((await tx.commit()).ok).toBeDefined();
+
+    expect(
+      await derivePieceGetValue(runtime, space, source, {
+        projection: await parsePieceGetProjection("id"),
+      }),
+    ).toEqual({ id: 1 });
+    expect(
+      await derivePieceGetValue(runtime, space, source, {
+        projection: await parsePieceGetProjection("missing"),
+      }),
+    ).toEqual({});
+    expect(
+      await derivePieceGetValue(runtime, space, source, {
+        projection: await parsePieceGetProjection('{"type":"object"}'),
+      }),
+    ).toEqual({ id: 1, title: "Visible" });
+    expect(await derivePieceGetValue(runtime, space, source, {})).toEqual({
+      id: 1,
+      title: "Visible",
+    });
+  });
+
+  it("handles schema-less filters and identity projection schemas", async () => {
+    const tx = runtime.edit();
+    const schemaLess = runtime.getCell(
+      space,
+      "schema-less-filter-source",
+      undefined,
+      tx,
+    );
+    schemaLess.set([1, 2]);
+    const nestedArrays = runtime.getCell(
+      space,
+      "nested-array-filter-source",
+      {
+        type: "array",
+        items: { type: "array", items: { type: "number" } },
+      },
+      tx,
+    );
+    nestedArrays.set([[1], []]);
+    const scalar = runtime.getCell(
+      space,
+      "scalar-projection-source",
+      { type: "string" },
+      tx,
+    );
+    scalar.set("visible");
+    const permissiveArray = runtime.getCell(
+      space,
+      "permissive-array-projection-source",
+      {},
+      tx,
+    );
+    permissiveArray.set([{ id: 1, hidden: true }]);
+    const composedObject = runtime.getCell(
+      space,
+      "composed-object-projection-source",
+      {
+        anyOf: [{
+          type: "object",
+          properties: { id: { type: "number" } },
+        }],
+      },
+      tx,
+    );
+    composedObject.set({ id: 2 });
+    expect((await tx.commit()).ok).toBeDefined();
+
+    expect(
+      await derivePieceGetValue(runtime, space, schemaLess, {
+        filter: parsePieceGetFilter("true"),
+      }),
+    ).toEqual([1, 2]);
+    expect(
+      await derivePieceGetValue(runtime, space, schemaLess, {
+        filter: parsePieceGetFilter("."),
+      }),
+    ).toEqual([1, 2]);
+    expect(
+      await derivePieceGetValue(runtime, space, nestedArrays, {
+        filter: parsePieceGetFilter(".[0]"),
+      }),
+    ).toEqual([[1]]);
+    expect(
+      await derivePieceGetValue(runtime, space, nestedArrays, {
+        filter: parsePieceGetFilter(".length"),
+        projection: await parsePieceGetProjection(
+          '{"type":"array","items":{"type":"array","items":true}}',
+        ),
+      }),
+    ).toEqual([]);
+    expect(
+      await derivePieceGetValue(runtime, space, schemaLess, {
+        projection: await parsePieceGetProjection("true"),
+      }),
+    ).toEqual([1, 2]);
+    expect(
+      await derivePieceGetValue(runtime, space, schemaLess, {
+        projection: await parsePieceGetProjection('{"type":"array"}'),
+      }),
+    ).toEqual([1, 2]);
+    expect(
+      await derivePieceGetValue(runtime, space, schemaLess, {
+        projection: await parsePieceGetProjection(
+          '{"type":["array","null"],"items":true}',
+        ),
+      }),
+    ).toEqual([1, 2]);
+    expect(
+      await derivePieceGetValue(runtime, space, scalar, {
+        projection: await parsePieceGetProjection('{"type":"string"}'),
+      }),
+    ).toBe("visible");
+    expect(
+      await derivePieceGetValue(runtime, space, permissiveArray, {
+        projection: await parsePieceGetProjection("id"),
+      }),
+    ).toEqual([{ id: 1 }]);
+    expect(
+      await derivePieceGetValue(runtime, space, composedObject, {
+        projection: await parsePieceGetProjection("id"),
+      }),
+    ).toEqual({ id: 2 });
+  });
+
+  it("supports an explicitly closed object projection", async () => {
+    const tx = runtime.edit();
+    const source = runtime.getCell(
+      space,
+      "closed-object-projection-source",
+      {
+        type: "object",
+        properties: { hidden: { type: "string" } },
+      },
+      tx,
+    );
+    source.set({ hidden: "not returned" });
+    expect((await tx.commit()).ok).toBeDefined();
+
+    expect(
+      await derivePieceGetValue(runtime, space, source, {
+        projection: await parsePieceGetProjection(
+          '{"type":"object","additionalProperties":false}',
+        ),
+      }),
+    ).toEqual({});
+  });
+
+  it("rejects JSON projection roots that mismatch the selected value", async () => {
+    const tx = runtime.edit();
+    const arraySource = runtime.getCell(
+      space,
+      "array-schema-mismatch-source",
+      { type: "array", items: { type: "object" } },
+      tx,
+    );
+    arraySource.set([{ id: 1 }]);
+    const objectSource = runtime.getCell(
+      space,
+      "object-schema-mismatch-source",
+      { type: "object" },
+      tx,
+    );
+    objectSource.set({ id: 1 });
+    expect((await tx.commit()).ok).toBeDefined();
+
+    await expect(derivePieceGetValue(runtime, space, arraySource, {
+      projection: await parsePieceGetProjection('{"type":"object"}'),
+    })).rejects.toThrow("must describe the returned array");
+    await expect(derivePieceGetValue(runtime, space, objectSource, {
+      projection: await parsePieceGetProjection(
+        '{"type":"array","items":true}',
+      ),
+    })).rejects.toThrow(
+      "can only be applied to an array value",
+    );
+  });
+
+  it("treats a missing filter path as a non-match", async () => {
+    const tx = runtime.edit();
+    const source = runtime.getCell(
+      space,
+      "missing-filter-path-source",
+      {
+        type: "array",
+        items: {
+          type: "object",
+          properties: { id: { type: "number" } },
+        },
+      },
+      tx,
+    );
+    source.set([{ id: 1 }, { id: 2 }]);
+    expect((await tx.commit()).ok).toBeDefined();
+
+    expect(
+      await derivePieceGetValue(runtime, space, source, {
+        filter: parsePieceGetFilter(".missing"),
+      }),
+    ).toEqual([]);
+  });
+
   it("rejects --filter for non-array sources", async () => {
     const tx = runtime.edit();
     const source = runtime.getCell(
@@ -172,6 +638,60 @@ describe("cf piece get transforms", () => {
     await expect(derivePieceGetValue(runtime, space, source, {
       filter: parsePieceGetFilter(".id == 1"),
     })).rejects.toThrow("--filter can only be applied to an array");
+  });
+
+  it("reports runtime predicate failures as transform errors", async () => {
+    const tx = runtime.edit();
+    const source = runtime.getCell(
+      space,
+      "predicate-runtime-error-source",
+      {
+        type: "array",
+        items: {
+          type: "object",
+          properties: { score: { type: "boolean" } },
+        },
+      },
+      tx,
+    );
+    source.set([{ score: true }]);
+    expect((await tx.commit()).ok).toBeDefined();
+
+    await expect(derivePieceGetValue(runtime, space, source, {
+      filter: parsePieceGetFilter(".score > 1"),
+    })).rejects.toThrow("Could not apply piece get transform");
+  });
+
+  it("reports transform transaction commit failures", async () => {
+    const setup = runtime.edit();
+    const source = runtime.getCell(
+      space,
+      "transform-commit-error-source",
+      {
+        type: "object",
+        properties: { id: { type: "number" } },
+      },
+      setup,
+    );
+    source.set({ id: 1 });
+    expect((await setup.commit()).ok).toBeDefined();
+
+    const originalEdit = runtime.edit.bind(runtime);
+    (runtime as any).edit = () => {
+      const tx = originalEdit();
+      (tx as any).commit = () =>
+        Promise.resolve({ error: "forced commit failure" });
+      return tx;
+    };
+    try {
+      await expect(derivePieceGetValue(runtime, space, source, {
+        projection: await parsePieceGetProjection("id"),
+      })).rejects.toThrow(
+        "Could not apply piece get transform: forced commit failure",
+      );
+    } finally {
+      (runtime as any).edit = originalEdit;
+    }
   });
 
   it("carries predicate labels on filtered membership like a pattern", async () => {

--- a/packages/cli/test/piece-get-transform.test.ts
+++ b/packages/cli/test/piece-get-transform.test.ts
@@ -77,6 +77,7 @@ describe("cf piece get transforms", () => {
       empty: "",
       disabled: false,
       nil: null,
+      unset: undefined,
     };
     for (
       const source of [
@@ -93,7 +94,7 @@ describe("cf piece get transforms", () => {
         value,
       )).toBe(true);
     }
-    for (const source of [".disabled", ".nil", ".missing"]) {
+    for (const source of [".disabled", ".nil", ".unset", ".missing"]) {
       expect(evaluatePieceGetPredicate(
         parsePieceGetFilter(source).predicate,
         value,
@@ -363,6 +364,17 @@ describe("cf piece get transforms", () => {
     expect(result).toEqual([
       { id: 1, title: "First" },
       { id: 3, title: "Third" },
+    ]);
+    expect(
+      await derivePieceGetValue(runtime, space, source, {
+        projection: await parsePieceGetProjection(
+          '{"type":"array","items":{"type":"object","properties":{"id":{"type":"string"},"title":true}}}',
+        ),
+      }),
+    ).toEqual([
+      { title: "First" },
+      { title: "Second" },
+      { title: "Third" },
     ]);
   });
 

--- a/packages/cli/test/piece-get-transform.test.ts
+++ b/packages/cli/test/piece-get-transform.test.ts
@@ -1,0 +1,336 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import type { FabricValue } from "@commonfabric/data-model/interface";
+import { Identity } from "@commonfabric/identity";
+import { type Cell, Runtime } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import {
+  derivePieceGetValue,
+  evaluatePieceGetPredicate,
+  parsePieceGetFilter,
+  parsePieceGetProjection,
+  PieceGetTransformError,
+} from "../lib/piece-get-transform.ts";
+
+const signer = await Identity.fromPassphrase("cf-piece-get-transform");
+const space = signer.did();
+
+describe("cf piece get transforms", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "observe",
+      cfcFlowLabels: "persist",
+    });
+  });
+
+  afterEach(async () => {
+    await runtime.dispose();
+    await storageManager.close();
+  });
+
+  it("parses and evaluates jq-inspired predicates", () => {
+    const parsed = parsePieceGetFilter(
+      '.status == "open" and (.score >= 10 or .priority == true)',
+    );
+    expect(parsed.paths).toEqual([
+      ["status"],
+      ["score"],
+      ["priority"],
+    ]);
+    expect(evaluatePieceGetPredicate(parsed.predicate, {
+      status: "open",
+      score: 12,
+      priority: false,
+    })).toBe(true);
+    expect(evaluatePieceGetPredicate(parsed.predicate, {
+      status: "closed",
+      score: 12,
+      priority: true,
+    })).toBe(false);
+  });
+
+  it("supports bracket paths, negative indices, and not", () => {
+    const parsed = parsePieceGetFilter(
+      'not .disabled and .["tags"][-1] == "current"',
+    );
+    expect(evaluatePieceGetPredicate(parsed.predicate, {
+      disabled: false,
+      tags: ["old", "current"],
+    })).toBe(true);
+  });
+
+  it("rejects non-boolean predicates", () => {
+    const parsed = parsePieceGetFilter(".name");
+    expect(() => evaluatePieceGetPredicate(parsed.predicate, { name: "Ada" }))
+      .toThrow(PieceGetTransformError);
+  });
+
+  it("parses concise, inline, and file projection schemas", async () => {
+    const concise = await parsePieceGetProjection("id,author.name");
+    expect(concise.kind).toBe("concise");
+    expect(concise.schema).toEqual({
+      type: "object",
+      properties: {
+        id: true,
+        author: {
+          type: "object",
+          properties: { name: true },
+          additionalProperties: false,
+        },
+      },
+      additionalProperties: false,
+    });
+
+    const inline = await parsePieceGetProjection(
+      '{"type":"object","properties":{"title":{"type":"string"}}}',
+    );
+    expect(inline.schema).toEqual({
+      type: "object",
+      properties: { title: { type: "string" } },
+      additionalProperties: false,
+    });
+
+    const fromFile = await parsePieceGetProjection("@projection.json", {
+      readTextFile: () =>
+        Promise.resolve(
+          '{"type":"array","items":{"type":"object","properties":{"id":true}}}',
+        ),
+    });
+    expect(fromFile.kind).toBe("json");
+    expect(fromFile.schema).toEqual({
+      type: "array",
+      items: {
+        type: "object",
+        properties: { id: true },
+        additionalProperties: false,
+      },
+    });
+  });
+
+  it("does not let caller projection schemas forge CFC metadata", async () => {
+    await expect(parsePieceGetProjection(
+      '{"type":"string","ifc":{"confidentiality":["fake"]}}',
+    )).rejects.toThrow(PieceGetTransformError);
+    await expect(parsePieceGetProjection(
+      '{"type":"object","properties":{"secret":{"asCell":["cell"]}}}',
+    )).rejects.toThrow(PieceGetTransformError);
+  });
+
+  it("filters and projects arrays through the runtime pattern graph", async () => {
+    const tx = runtime.edit();
+    const source = runtime.getCell(
+      space,
+      "plain-transform-source",
+      {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            id: { type: "number" },
+            title: { type: "string" },
+            status: { type: "string" },
+          },
+        },
+      },
+      tx,
+    );
+    source.set([
+      { id: 1, title: "First", status: "open" },
+      { id: 2, title: "Second", status: "closed" },
+      { id: 3, title: "Third", status: "open" },
+    ]);
+    expect((await tx.commit()).ok).toBeDefined();
+
+    const result = await derivePieceGetValue(runtime, space, source, {
+      filter: parsePieceGetFilter('.status == "open"'),
+      projection: await parsePieceGetProjection("id,title"),
+    });
+
+    expect(result).toEqual([
+      { id: 1, title: "First" },
+      { id: 3, title: "Third" },
+    ]);
+  });
+
+  it("rejects --filter for non-array sources", async () => {
+    const tx = runtime.edit();
+    const source = runtime.getCell(
+      space,
+      "object-filter-source",
+      { type: "object", properties: { id: { type: "number" } } },
+      tx,
+    );
+    source.set({ id: 1 });
+    expect((await tx.commit()).ok).toBeDefined();
+
+    await expect(derivePieceGetValue(runtime, space, source, {
+      filter: parsePieceGetFilter(".id == 1"),
+    })).rejects.toThrow("--filter can only be applied to an array");
+  });
+
+  it("carries predicate labels on filtered membership like a pattern", async () => {
+    await seedLabeledDoc(runtime, "filter-element-a", {
+      id: 1,
+      status: "open",
+    }, "alice-secret");
+    await seedLabeledDoc(runtime, "filter-element-b", {
+      id: 2,
+      status: "closed",
+    }, "bob-secret");
+
+    const setup = runtime.edit();
+    const elementA = runtime.getCell(
+      space,
+      "filter-element-a",
+      undefined,
+      setup,
+    );
+    const elementB = runtime.getCell(
+      space,
+      "filter-element-b",
+      undefined,
+      setup,
+    );
+    const source = runtime.getCell(
+      space,
+      "labeled-filter-source",
+      { type: "array", items: { asCell: ["cell"] } },
+      setup,
+    );
+    source.set([elementA, elementB]);
+    expect((await setup.commit()).ok).toBeDefined();
+    const sourceRead = runtime.getCell(
+      space,
+      "labeled-filter-source",
+      { type: "array", items: { asCell: ["cell"] } },
+    );
+
+    let resultCell: Cell<unknown> | undefined;
+    const result = await derivePieceGetValue(runtime, space, sourceRead, {
+      filter: parsePieceGetFilter('.status == "open"'),
+    }, {
+      onResultCell: (cell) => resultCell = cell,
+    });
+    expect(result).toEqual([{ id: 1, status: "open" }]);
+
+    const probeTx = runtime.edit();
+    const kept = resultCell!.key("value").withTx(probeTx).get() as unknown[];
+    const probe = runtime.getCell(
+      space,
+      "filter-membership-probe",
+      undefined,
+      probeTx,
+    );
+    probe.set({ count: kept.length });
+    probeTx.prepareCfc();
+    expect((await probeTx.commit()).ok).toBeDefined();
+
+    const labels = derivedConfidentiality(
+      probe.getAsNormalizedFullLink().id,
+    );
+    expect(labels).toContain("alice-secret");
+    expect(labels).toContain("bob-secret");
+  });
+
+  it("derives projected field labels from source CFC metadata", async () => {
+    const setup = runtime.edit();
+    const source = runtime.getCell(
+      space,
+      "static-label-projection-source",
+      {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            id: {
+              type: "number",
+              ifc: { confidentiality: ["source-secret"] },
+            },
+            ignored: { type: "string" },
+          },
+        },
+      },
+      setup,
+    );
+    source.set([{ id: 7, ignored: "not returned" }]);
+    expect((await setup.commit()).ok).toBeDefined();
+
+    let resultCell: Cell<unknown> | undefined;
+    const result = await derivePieceGetValue(runtime, space, source, {
+      projection: await parsePieceGetProjection("id"),
+    }, {
+      onResultCell: (cell) => resultCell = cell,
+    });
+    expect(result).toEqual([{ id: 7 }]);
+
+    const probeTx = runtime.edit();
+    const projectedId = resultCell!.key("value").key(0).key("id").withTx(
+      probeTx,
+    ).get();
+    const probe = runtime.getCell(
+      space,
+      "projection-label-probe",
+      undefined,
+      probeTx,
+    );
+    probe.set({ projectedId });
+    probeTx.prepareCfc();
+    expect((await probeTx.commit()).ok).toBeDefined();
+
+    expect(derivedConfidentiality(
+      probe.getAsNormalizedFullLink().id,
+    )).toContain("source-secret");
+  });
+
+  async function seedLabeledDoc(
+    targetRuntime: Runtime,
+    cause: string,
+    value: FabricValue,
+    atom: string,
+  ): Promise<void> {
+    const seed = targetRuntime.edit();
+    const cell = targetRuntime.getCell(space, cause, undefined, seed);
+    const id = cell.getAsNormalizedFullLink().id;
+    seed.writeOrThrow({
+      space,
+      scope: "space",
+      id,
+      path: [],
+    }, {
+      value,
+      cfc: {
+        version: 1,
+        schemaHash: "seed-schema",
+        labelMap: {
+          version: 1,
+          entries: [{
+            path: [],
+            label: { confidentiality: [atom] },
+          }],
+        },
+      },
+    });
+    expect((await seed.commit()).ok).toBeDefined();
+  }
+
+  function derivedConfidentiality(id: string): string[] {
+    type StoredEntry = {
+      origin?: string;
+      label: { confidentiality?: string[] };
+    };
+    const replica = storageManager.open(space).replica as unknown as {
+      getDocument(
+        id: string,
+      ): { cfc?: { labelMap?: { entries: StoredEntry[] } } } | undefined;
+    };
+    return replica.getDocument(id)?.cfc?.labelMap?.entries
+      ?.filter((entry) => entry.origin === "derived")
+      .flatMap((entry) => entry.label.confidentiality ?? []) ?? [];
+  }
+});

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -43,12 +43,16 @@ import {
   localPatternEntry,
   normalizeApiUrl,
   parseLink,
+  parsePieceGetTransformOptions,
   parsePieceOptions,
   parseSpaceOptions,
   piece,
   setPieceSourceFromCommand,
 } from "../commands/piece.ts";
-import { parsePieceGetFilter } from "../lib/piece-get-transform.ts";
+import {
+  parsePieceGetFilter,
+  PieceGetTransformError,
+} from "../lib/piece-get-transform.ts";
 
 const API_URL = "https://cf.dev";
 const SPACE = "common-knowledge";
@@ -555,6 +559,42 @@ describe("cli piece parsing", () => {
     expect(getFlags).toContain("--schema");
   });
 
+  it("parses piece get transform options", async () => {
+    expect(await parsePieceGetTransformOptions({})).toBeUndefined();
+
+    const filterOnly = await parsePieceGetTransformOptions({
+      filter: ".active",
+    });
+    expect(filterOnly?.filter?.source).toBe(".active");
+    expect(filterOnly?.projection).toBeUndefined();
+
+    const schemaOnly = await parsePieceGetTransformOptions({
+      schema: "id,name",
+    });
+    expect(schemaOnly?.filter).toBeUndefined();
+    expect(schemaOnly?.projection?.source).toBe("id,name");
+
+    const both = await parsePieceGetTransformOptions({
+      filter: ".active",
+      schema: "id",
+    });
+    expect(both?.filter?.source).toBe(".active");
+    expect(both?.projection?.source).toBe("id");
+  });
+
+  it("passes parsed transforms through the piece get command action", async () => {
+    const { code, stderr } = await cf(
+      "piece get " +
+        "--identity ./definitely-missing-piece-get-review.key " +
+        "--api-url https://cf.dev --space common-knowledge " +
+        `--piece ${PIECE} --filter .active --schema id`,
+    );
+    expect(code).toBe(1);
+    expect(stderr.join("\n")).toContain(
+      "definitely-missing-piece-get-review.key",
+    );
+  });
+
   it("applies get transforms to the selected path cell", async () => {
     const targetCell = { marker: "selected-path-cell" };
     const rootCell = {
@@ -568,7 +608,9 @@ describe("cli piece parsing", () => {
         Promise.resolve({
           input: { get: () => Promise.resolve(undefined) },
           result: {
-            get: () => Promise.resolve([{ id: 1 }, { id: 2 }]),
+            get: () => {
+              throw new Error("transform reads must not materialize result");
+            },
             getCell: () => Promise.resolve(rootCell),
           },
         }),
@@ -598,6 +640,90 @@ describe("cli piece parsing", () => {
     );
 
     expect(value).toEqual([{ id: 2 }]);
+  });
+
+  it("preserves transform errors that are not result projection failures", async () => {
+    const transformError = new PieceGetTransformError("invalid transform");
+    const targetCell = {};
+    const rootCell = { key: () => targetCell };
+    const controller = {
+      get: () =>
+        Promise.resolve({
+          result: { getCell: () => Promise.resolve(rootCell) },
+        }),
+    };
+
+    await expect(getCellValue(
+      { apiUrl: API_URL, space: SPACE, identity: ID, piece: PIECE },
+      [],
+      { transform: { filter: parsePieceGetFilter(".active") } },
+      {
+        loadManager: () =>
+          Promise.resolve({
+            runtime: {},
+            getSpace: () => "did:key:test-space",
+          } as any),
+        resolvePieceAddress: (_manager, id) => Promise.resolve(id),
+        createController: () => controller as any,
+        derivePieceGetValue: () => Promise.reject(transformError),
+      },
+    )).rejects.toBe(transformError);
+  });
+
+  it("reports projection failures encountered during transformed reads", async () => {
+    const targetCell = {
+      schema: { type: "number" },
+      getRaw: () => ({ "/": "missing-session-count" }),
+    };
+    const rootCell = {
+      schema: {
+        type: "object",
+        properties: { count: { type: "number" } },
+        required: ["count"],
+      },
+      key: () => targetCell,
+    };
+    const controller = {
+      get: () =>
+        Promise.resolve({
+          result: { getCell: () => Promise.resolve(rootCell) },
+        }),
+    };
+    const deps = {
+      loadManager: () =>
+        Promise.resolve({
+          runtime: {},
+          getSpace: () => "did:key:test-space",
+        } as any),
+      resolvePieceAddress: (_manager: any, id: string) => Promise.resolve(id),
+      createController: () => controller as any,
+    };
+    const options = {
+      transform: { filter: parsePieceGetFilter(".active") },
+    };
+
+    await expect(getCellValue(
+      { apiUrl: API_URL, space: SPACE, identity: ID, piece: PIECE },
+      ["count"],
+      options,
+      {
+        ...deps,
+        derivePieceGetValue: () =>
+          Promise.reject(
+            new Error('Cannot access path "count" - property not found'),
+          ),
+      },
+    )).rejects.toThrow(PieceResultProjectionError);
+
+    await expect(getCellValue(
+      { apiUrl: API_URL, space: SPACE, identity: ID, piece: PIECE },
+      ["count"],
+      options,
+      {
+        ...deps,
+        derivePieceGetValue: () => Promise.resolve(undefined),
+      },
+    )).rejects.toThrow(PieceResultProjectionError);
   });
 
   it("steps, reads, syncs, and stops in one get operation", async () => {

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -48,6 +48,7 @@ import {
   piece,
   setPieceSourceFromCommand,
 } from "../commands/piece.ts";
+import { parsePieceGetFilter } from "../lib/piece-get-transform.ts";
 
 const API_URL = "https://cf.dev";
 const SPACE = "common-knowledge";
@@ -545,11 +546,58 @@ describe("cli piece parsing", () => {
     );
   });
 
-  it("offers a one-session step option for piece result reads", () => {
+  it("offers computed transforms for piece reads", () => {
     const getFlags = piece.getCommand("get")!.getOptions().flatMap((option) =>
       option.flags
     );
     expect(getFlags).toContain("--step");
+    expect(getFlags).toContain("--filter");
+    expect(getFlags).toContain("--schema");
+  });
+
+  it("applies get transforms to the selected path cell", async () => {
+    const targetCell = { marker: "selected-path-cell" };
+    const rootCell = {
+      key: (...path: Array<string | number>) => {
+        expect(path).toEqual(["items"]);
+        return targetCell;
+      },
+    };
+    const controller = {
+      get: () =>
+        Promise.resolve({
+          input: { get: () => Promise.resolve(undefined) },
+          result: {
+            get: () => Promise.resolve([{ id: 1 }, { id: 2 }]),
+            getCell: () => Promise.resolve(rootCell),
+          },
+        }),
+    };
+    const manager = {
+      runtime: { marker: "runtime" },
+      getSpace: () => "did:key:test-space",
+    };
+    const filter = parsePieceGetFilter(".id == 2");
+
+    const value = await getCellValue(
+      { apiUrl: API_URL, space: SPACE, identity: ID, piece: PIECE },
+      ["items"],
+      { transform: { filter } },
+      {
+        loadManager: () => Promise.resolve(manager as any),
+        resolvePieceAddress: (_manager, id) => Promise.resolve(id),
+        createController: () => controller as any,
+        derivePieceGetValue: (runtime, space, source, transform) => {
+          expect(runtime).toBe(manager.runtime as any);
+          expect(space).toBe("did:key:test-space");
+          expect(source).toBe(targetCell as any);
+          expect(transform.filter).toBe(filter);
+          return Promise.resolve([{ id: 2 }]);
+        },
+      },
+    );
+
+    expect(value).toEqual([{ id: 2 }]);
   });
 
   it("steps, reads, syncs, and stops in one get operation", async () => {

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -227,12 +227,12 @@ echo '{"name": "John"}' | deno task cf piece set ... user
 `piece get` and `wish` always print JSON. Both accept a redundant `--json` so
 callers can request the format explicitly.
 
-`piece get --filter` accepts a jq-inspired boolean predicate over array items:
-paths, JSON literals, comparisons, `and`/`or`/`not`, and parentheses. It is not
-general jq and rejects non-array inputs. `--schema` projects output from a
-comma-separated field list, an inline JSON Schema, or `@schema.json`; concise
-fields apply per item for arrays, while JSON Schema describes the whole output.
-The two flags compose as filter-then-project. Both run through runtime
+`piece get --filter` accepts a jq-inspired predicate over array items: paths,
+JSON literals, comparisons, `and`/`or`/`not`, and parentheses. Only `false` and
+`null` are falsey, and non-array inputs are rejected. `--schema` projects output
+from a comma-separated field list, an inline JSON Schema, or `@schema.json`;
+concise fields apply per item for arrays, while JSON Schema describes the whole
+output. The two flags compose as filter-then-project. Both run through runtime
 filter/map/lift nodes, so CFC behavior is the same as a computed pattern
 expression. Source schema metadata is authoritative; projection schemas cannot
 supply `ifc`, `asCell`, `scope`, or `default`. See `packages/cli/README.md` for

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -229,14 +229,17 @@ callers can request the format explicitly.
 
 `piece get --filter` accepts a jq-inspired predicate over array items: paths,
 JSON literals, comparisons, `and`/`or`/`not`, and parentheses. Only `false` and
-`null` are falsey, and non-array inputs are rejected. `--schema` projects output
-from a comma-separated field list, an inline JSON Schema, or `@schema.json`;
-concise fields apply per item for arrays, while JSON Schema describes the whole
-output. The two flags compose as filter-then-project. Both run through runtime
-filter/map/lift nodes, so CFC behavior is the same as a computed pattern
-expression. Source schema metadata is authoritative; projection schemas cannot
-supply `ifc`, `asCell`, `scope`, or `default`. See `packages/cli/README.md` for
-the exact syntax and supported schema subset.
+`null` are falsey; stored `undefined` is treated like a missing value and is
+also falsey. Non-array inputs are rejected. `--schema` projects output from a
+comma-separated field list, an inline JSON Schema, or `@schema.json`; concise
+fields apply per item for arrays, while JSON Schema describes the whole output.
+In an array-item projection, a typed scalar leaf that does not match stored data
+is omitted rather than reported as an error; prefer `true` leaves unless type
+filtering is intentional. The two flags compose as filter-then-project. Both run
+through runtime filter/map/lift nodes, so CFC behavior is the same as a computed
+pattern expression. Source schema metadata is authoritative; projection schemas
+cannot supply `ifc`, `asCell`, `scope`, or `default`. See
+`packages/cli/README.md` for the exact syntax and supported schema subset.
 
 For `piece call`, options before the callable name configure `piece call`.
 Arguments after the callable name configure the invoked handler or tool. The

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -132,6 +132,8 @@ See `docs/development/EXPERIMENTAL_OPTIONS.md` for available flags.
 | Update existing    | `deno task cf piece setsrc pattern.tsx --root . --repository REPO --piece ID -i key -a url -s space` |
 | Inspect state      | `deno task cf piece inspect --piece ID ...`                                                          |
 | Get field          | `deno task cf piece get --piece ID fieldPath ...`                                                    |
+| Filter array       | `deno task cf piece get --piece ID items --filter '.active == true' ...`                             |
+| Project fields     | `deno task cf piece get --piece ID items --schema id,title ...`                                      |
 | Step + get         | `deno task cf piece get --piece ID fieldPath --step ...`                                             |
 | Set field          | `echo '{"data":...}' \| deno task cf piece set --piece ID path ...`                                  |
 | Call handler       | `deno task cf piece call --piece ID handlerName ...`                                                 |
@@ -224,6 +226,17 @@ echo '{"name": "John"}' | deno task cf piece set ... user
 
 `piece get` and `wish` always print JSON. Both accept a redundant `--json` so
 callers can request the format explicitly.
+
+`piece get --filter` accepts a jq-inspired boolean predicate over array items:
+paths, JSON literals, comparisons, `and`/`or`/`not`, and parentheses. It is not
+general jq and rejects non-array inputs. `--schema` projects output from a
+comma-separated field list, an inline JSON Schema, or `@schema.json`; concise
+fields apply per item for arrays, while JSON Schema describes the whole output.
+The two flags compose as filter-then-project. Both run through runtime
+filter/map/lift nodes, so CFC behavior is the same as a computed pattern
+expression. Source schema metadata is authoritative; projection schemas cannot
+supply `ifc`, `asCell`, `scope`, or `default`. See `packages/cli/README.md` for
+the exact syntax and supported schema subset.
 
 For `piece call`, options before the callable name configure `piece call`.
 Arguments after the callable name configure the invoked handler or tool. The


### PR DESCRIPTION
## Summary

- add `cf piece get --filter <predicate>` with a jq-inspired, array-only predicate language
- add `cf piece get --schema <schema>` with concise fields, inline JSON Schema, and `@file` forms
- compose filtering before projection to reduce JSON returned to callers
- run both transforms through session-scoped runtime filter/map/lift nodes

## CFC semantics

The transform graph uses the same list builtins and computed nodes as authored patterns. Predicate observations label filtered membership, projected reads propagate source labels, and filtered elements retain their source links. Caller projection schemas cannot introduce or override `ifc`, `asCell`, `scope`, or `default` metadata.

## Validation

- targeted CLI and transform suites: 138 steps passed
- CFC regressions cover secret-dependent membership and projected-field propagation
- `deno lint` passed repository-wide
- `deno task check-docs` passed
- `deno task check-skill-facts` passed
- full CLI suite: 1,650 passed; two unrelated existing color-mode assertions failed
- all touched files pass `deno fmt --check`; repository-wide formatting still reports 23 unrelated existing files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds computed transforms to `cf piece get` with jq-style array filtering and schema-based projection to cut down JSON output and keep CFC labels consistent. This update clarifies projection behavior (array roots, property whitelists, and scalar leaf handling) and improves transform error reporting.

- **New Features**
  - `--filter <predicate>`: jq-inspired predicates over arrays with paths (dot/bracket, negative indices), JSON literals, `== != < <= > >=`, `and or not`, and parentheses. Only `false`, `null`, and missing/`undefined` values are falsey; non-array inputs are rejected.
  - `--schema <schema>`: project with `id,title,author.name`, inline JSON Schema, or `@file`. Concise fields apply per array item; JSON Schema describes the whole output and for arrays must have an array root. Object `properties` act as a whitelist by default (use `"additionalProperties": true` to keep others). Typed scalar leaves that don’t match stored values are omitted, not errors. Combinators and `$ref` are rejected, and callers cannot set `ifc`, `asCell`, `scope`, or `default`.
  - Composes as filter-then-project and runs through session-scoped filter/map/lift nodes so predicate labels carry membership, projected reads propagate labels, and filtered elements retain source links. Clear data-error reporting via `PieceGetTransformError`; CLI help, docs, and tests added.

<sup>Written for commit e112468045653e3df6a3bcd042813f789212ba44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

