### PR TITLE
Memoize the cycle walk; note the special-object elision dependency

### DIFF
--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -2987,6 +2987,10 @@ function maybeConvertArrayPathToDataURILink(
  */
 function containsCycle(value: unknown): boolean {
   const ancestors = new Set<object>();
+  // Nodes already walked to completion without finding a cycle. Without this
+  // memo the walk is exponential on shared acyclic references (a diamond per
+  // level doubles the work), and candidate values are user-controlled.
+  const completed = new Set<object>();
   const walk = (node: unknown): boolean => {
     if (
       node === null || typeof node !== "object" || isCell(node) ||
@@ -2994,6 +2998,7 @@ function containsCycle(value: unknown): boolean {
     ) {
       return false;
     }
+    if (completed.has(node)) return false;
     if (ancestors.has(node)) return true;
     ancestors.add(node);
     const values = Array.isArray(node) ? node : Object.values(node);
@@ -3001,6 +3006,7 @@ function containsCycle(value: unknown): boolean {
       if (walk(child)) return true;
     }
     ancestors.delete(node);
+    completed.add(node);
     return false;
   };
   return walk(value);

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -1157,6 +1157,12 @@ export function normalizeAndDiff(
   // shallowly normalized -- its nested contents (Cells, native objects) are
   // converted later in the recursion, so a deep comparison would inspect
   // values whose canonical form does not exist yet.
+  //
+  // Atomic fabric objects are excluded from this guard: an untouched
+  // special-object prefix element re-emits its identical stored instance
+  // from the instance branch below, and the mergeable invariant for those
+  // elements rests on the write layer eliding that identical write from the
+  // journal rather than on this guard.
   if (
     state.nextAnchorId !== undefined &&
     isArrayElement &&

--- a/packages/runner/test/data-updating.test.ts
+++ b/packages/runner/test/data-updating.test.ts
@@ -1624,6 +1624,36 @@ describe("data-updating", () => {
       }
     });
 
+    it("framed addUnique handles a deeply shared acyclic candidate", () => {
+      // A diamond-shaped candidate (each level's object shared by two
+      // parents) is acyclic but has exponentially many paths. The cycle
+      // check must memoize completed nodes -- candidate values are
+      // user-controlled, and without the memo this walk (not the write)
+      // would hang the handler. This test simply completing is the guard.
+      const frame = pushFrame({
+        generatedIdCounter: 0,
+        cause: "addUnique shared dag",
+        reactives: new Set(),
+      });
+      try {
+        const cell = runtime.getCell<unknown[]>(
+          space,
+          "addUnique shared dag",
+          undefined,
+          tx,
+        );
+        cell.set([]);
+        let node: Record<string, unknown> = { leaf: true };
+        for (let i = 0; i < 30; i++) {
+          node = { a: node, b: node };
+        }
+        cell.addUnique(node);
+        expect((cell.getRaw() as unknown[]).length).toBe(1);
+      } finally {
+        popFrame(frame);
+      }
+    });
+
     it("framed addUnique accepts a new self-referential candidate", () => {
       // A cyclic candidate can never equal a stored element -- stored fabric
       // values are acyclic (cycles persist as links) -- so the dedup must


### PR DESCRIPTION
Follow-up to #5221, carrying the round-10 review's findings — these fixes were staged when that PR merged, so they ride separately.

**`containsCycle()` memoization.** The cycle walk (added in #5221 for `addUnique`'s dedup) tracked ancestors but never memoized completed nodes, making it exponential on shared acyclic references: a diamond-shaped candidate measured ~2s at depth 24, ~4× per two levels — and candidate values are user-controlled, so a framed `addUnique` with a ~30-object shared DAG would hang the handler. A `completed` set makes the walk linear. The regression test drives a depth-30 diamond through the public `addUnique` path (7ms fixed; simply completing is the guard — a reintroduced exponential blow-up hangs the test loudly).

**Elision-dependency disclosure.** The review verified end-to-end (two-session durable probe) that an untouched `FabricSpecialObject` prefix element re-emits its identical stored instance and the write layer elides it from the journal — so the mergeable below-tail invariant holds for those elements via elision rather than the untouched-element guard. The anchoring comment now states that dependency; the cheap in-branch hardening (`Object.is` no-op in the instance branch) remains an open follow-up.

Verification: targeted suites green, repo-wide `deno fmt --check`/`deno lint` clean, `deno check` clean on touched files, full workspace suite green at this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VEMbFKHAMQ5h71AD5uFj8


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Memoized the `containsCycle()` walk to make `addUnique` dedup linear on shared acyclic inputs and prevent handler hangs. Also clarifies the dependency on write-layer elision for untouched special-object prefix elements.

- **Bug Fixes**
  - Added a `completed` set to `containsCycle()` so shared DAGs don’t cause exponential work; added a regression test using a depth-30 diamond via `addUnique`.
  - Documented in `normalizeAndDiff()` that identical `FabricSpecialObject` instances are re-emitted and elided by the write layer, not by the untouched-element guard.

<sup>Written for commit e0b38765f63a85a39176cd62dd533adb406f2266. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

