### PR TITLE
test(cli): D4 — three-topic end-to-end fixture (integration half)

### DIFF
--- a/docs/plans/pattern-verb-contract-implementation.md
+++ b/docs/plans/pattern-verb-contract-implementation.md
@@ -804,7 +804,13 @@ change that alters them.
   directly, standing in for the live pass's fid rendering; the
   dropped-response retry — and a same-id replay with a different payload —
   must read the ORIGINAL result back off the receipt (the assertion D3 left
-  open). Results flow schema-free per the C3 deferral: the value path is
+  open). The drop is deterministic, not a recorded race branch: the call
+  runs with a test-only per-phase stderr announcement
+  (`CF_TEST_ANNOUNCE_INVOCATION_PHASES`, off by default) and is killed only
+  after a blocking pipe read sees `phase: committed`, so the
+  commit-then-lost-response window is a property of the mechanism and the
+  dedup-with-original-result path is asserted unconditionally, every run.
+  Results flow schema-free per the C3 deferral: the value path is
   what the fixture proves, and no assertion reads a result schema from the
   durable store. Command counts, payload sizes, and per-command wall-clock
   print as `[d4-baseline]` lines (per-phase timings await #5233's

--- a/docs/plans/pattern-verb-contract-implementation.md
+++ b/docs/plans/pattern-verb-contract-implementation.md
@@ -524,11 +524,13 @@ joins WS-C. `packages/runner` (`cell.ts` send path), `packages/cli`.
   without racing a clock; a `--message` that differs on the retry proves the
   settled outcome stands rather than being overwritten. Each scenario spawns
   a fresh `cf` process, so the fresh-process case is the default rather than
-  a special one. One half of the third scenario is not covered yet: the
+  a special one. ~~One half of the third scenario is not covered yet: the
   collision is asserted through `deduplicated` and exit 0, but not by reading
-  a *result* back off the receipt, because a void verb leaves none to read.
-  That assertion joins when WS-C gives verbs return values — or sooner
-  against `plainResultReceipts`.
+  a *result* back off the receipt, because a void verb leaves none to
+  read.~~ — closed by D4's integration fixture (`run_three_topic_fixture`,
+  same file): a settled create replayed under its id, with a different
+  payload, must report `deduplicated` AND carry the ORIGINAL declared
+  result, read back off the receipt under `plainResultReceipts`.
 - ~~**cli, absent-payload gate (D5) — follow-up the pre-dispatch gate's review
   deferred.** The pre-dispatch validator passes `input === undefined`
   unconditionally (`verbInputSchemaError`, `packages/cli/lib/callable.ts`),
@@ -782,7 +784,7 @@ change that alters them.
   plumbing, collision, reclassification, and readback against an isolated
   toolshed.
 - **End-to-end fixture (D4, Phase 4):** the three-topic graph from the live
-  session, run as an integration test and as the live pass — create an
+  session, run ~~as an integration test~~ and as the live pass — create an
   umbrella with body (returns its child reference); create two children whose
   bodies reference it; revise the umbrella to reference both; deliberately
   drop one create response and retry with the same invocation id. Verify
@@ -791,6 +793,24 @@ change that alters them.
   to the acting agent. Record command
   count, payload sizes, per-phase timings, and cold/warm durations — the
   baseline the session-mode decision (Non-goals) reads.
+
+  **The integration half is done** — `run_three_topic_fixture` in
+  `packages/cli/integration/integration.sh` (the piece-call shard, its own
+  space, `EXPERIMENTAL_PLAIN_RESULT_RECEIPTS=true` on every call), driving a
+  declared-result fixture pattern
+  (`packages/cli/integration/pattern/topic-graph.tsx`) against an isolated
+  toolshed. References adapt to that setting: a create returns
+  `{ id, path }` and the test opens the canonical child by that path
+  directly, standing in for the live pass's fid rendering; the
+  dropped-response retry — and a same-id replay with a different payload —
+  must read the ORIGINAL result back off the receipt (the assertion D3 left
+  open). Results flow schema-free per the C3 deferral: the value path is
+  what the fixture proves, and no assertion reads a result schema from the
+  durable store. Command counts, payload sizes, and per-command wall-clock
+  print as `[d4-baseline]` lines (per-phase timings await #5233's
+  `--verbose`). **The live pass stays open**, gated on the write-storm
+  machinery (Risks): until that gate clears, no live-board run has happened
+  and D4 is not done.
 - **Live acceptance checklist**, per phase, against the Estuary board — a
   scenario per phase (six-call filing shrinking to five in Phase 1, a
   deliberate duplicate retry in Phase 2, a returned handle in Phase 4), and

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -458,17 +458,31 @@ export function resolveInvocationId(
  * still holds the exact id to retry with, and the retry deduplicates instead
  * of executing a second time. Announcing once matters: a caller scraping
  * stderr for its id should not have to decide which of several to trust.
+ *
+ * `announcePhases` is a test-harness hook (reached via the
+ * `CF_TEST_ANNOUNCE_INVOCATION_PHASES` env var at the call site): every phase
+ * advance is additionally announced as `invocation: <id> phase: <phase>` —
+ * the shape failure exits already print. Integration scenarios that must act
+ * inside a specific window block on a phase line instead of racing a clock:
+ * the dropped-response fixture kills its call only after reading
+ * `phase: committed`, which the observer emits only once the handling's
+ * durable commit has been acknowledged. Off by default, so normal output is
+ * byte-identical with the hook absent.
  */
 export function invocationPhaseReporter(
   invocationId: string,
   onAdvance: (phase: InvocationPhase) => void,
   announce: (message: string) => void = console.error,
+  announcePhases = false,
 ): (phase: InvocationPhase) => void {
   let announced = false;
   return (next) => {
     if (next === "dispatched" && !announced) {
       announced = true;
       announce(`invocation: ${invocationId}`);
+    }
+    if (announcePhases) {
+      announce(`invocation: ${invocationId} phase: ${next}`);
     }
     onAdvance(next);
   };
@@ -1462,6 +1476,8 @@ after --. Handlers interpret piped input when no input argument is present.`,
           onPhase: invocationPhaseReporter(
             invocationId,
             observer.onPhase,
+            undefined,
+            Boolean(Deno.env.get("CF_TEST_ANNOUNCE_INVOCATION_PHASES")),
           ),
         },
       ).catch((error) =>

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -823,9 +823,14 @@ run_three_topic_fixture() {
   CHILD_A_PATH=$(echo "$CHILD_A_JSON" | jq -re '.result.topic.path')
 
   # --- 3. Child B's response is deliberately dropped. -----------------------
-  # Killed after dispatch, triggered by the CLI's own `invocation:`
-  # announcement through a blocking pipe read (D3's mechanism) — lands in the
-  # window without racing a clock. The caller is left holding only the id.
+  # The commit-then-lost-response window is entered deterministically, not by
+  # racing a clock: the call runs with the CLI's test-only phase
+  # announcements on (CF_TEST_ANNOUNCE_INVOCATION_PHASES — stderr lines of
+  # the form `invocation: <id> phase: <phase>`, emitted only under that env
+  # var), and a blocking pipe read waits for `phase: committed`, which the
+  # CLI prints only once the handling's durable commit is acknowledged and
+  # before the response is consumed. Only then is the process killed, so
+  # commit-before-kill is a property of the mechanism, not of the schedule.
   INV_CHILD_B=$(new_invocation_id)
   CHILD_B_PAYLOAD=$(jq -cn --arg u "$UMBRELLA_ID" \
     '{title: "Child B", body: ("Extends " + $u + "."), agentName: "fable-d4",
@@ -837,32 +842,33 @@ run_three_topic_fixture() {
   # the kill) goes to a separate file so the baseline's command count is
   # exact rather than ±1 on the kill race.
   CF_CLI_INTEGRATION_TIMINGS_FILE="$D4_TIMINGS.killed" \
+  CF_TEST_ANNOUNCE_INVOCATION_PHASES=1 \
     cf piece call $SPACE_ARGS --piece "$TOPIC_PIECE_ID" --invocation "$INV_CHILD_B" \
     createTopic -- --json "$CHILD_B_PAYLOAD" > /dev/null 2> "$ANNOUNCE_FIFO" &
   CALL_PID=$!
   set -e
-  ANNOUNCED=""
+  COMMIT_ANNOUNCED=""
   while IFS= read -r line; do
     case "$line" in
-      *"invocation: $INV_CHILD_B"*)
-        ANNOUNCED="yes"
+      *"invocation: $INV_CHILD_B phase: committed"*)
+        COMMIT_ANNOUNCED="yes"
         break
         ;;
     esac
   done < "$ANNOUNCE_FIFO"
   kill_process_tree "$CALL_PID"
   rm -f "$ANNOUNCE_FIFO"
-  if [ -z "$ANNOUNCED" ]; then
-    error "cf piece call should announce its invocation id at dispatch"
+  if [ -z "$COMMIT_ANNOUNCED" ]; then
+    error "The dropped call must reach its committed phase before the kill; the phase announcement never arrived"
   fi
 
-  # Whether the killed call got its commit in is genuinely racy; both
-  # outcomes are correct but exercise different machinery, so record which
-  # one ran (D3's convention). Committed → the retry MUST collide; not
-  # committed → the retry applies cleanly and its own handling is the
-  # original.
-  TOPICS_BEFORE_RETRY=$(cf piece get $SPACE_ARGS --piece "$TOPIC_PIECE_ID" topics 2>/dev/null | jq 'length')
-  echo "dropped-response: topics committed before kill = $TOPICS_BEFORE_RETRY"
+  # The kill landed only after the durable commit, so the create MUST be
+  # visible — a hard assertion, not a recorded race branch. If the kill ever
+  # lands pre-commit, the scenario fails here.
+  TOPICS_AFTER_KILL=$(cf piece get $SPACE_ARGS --piece "$TOPIC_PIECE_ID" topics 2>/dev/null | jq 'length')
+  if [ "$TOPICS_AFTER_KILL" != "3" ]; then
+    error "The dropped create committed before the kill, so three topics must exist, got: $TOPICS_AFTER_KILL"
+  fi
 
   set +e
   CHILD_B_JSON=$(cf piece call $SPACE_ARGS --piece "$TOPIC_PIECE_ID" \
@@ -872,14 +878,12 @@ run_three_topic_fixture() {
   if [ "$CHILD_B_STATUS" -ne 0 ]; then
     error "Retrying the dropped create under the same id should exit 0, got $CHILD_B_STATUS"
   fi
-  if [ "$TOPICS_BEFORE_RETRY" = "3" ]; then
-    echo "$CHILD_B_JSON" | jq -e '.deduplicated == true' > /dev/null ||
-      error "The dropped create had committed, so its retry must deduplicate, got: $CHILD_B_JSON"
-  elif echo "$CHILD_B_JSON" | jq -e '.deduplicated == true' > /dev/null; then
-    error "The dropped create never committed, so its retry must not deduplicate, got: $CHILD_B_JSON"
-  fi
-  # Either way the retry's Invocation JSON carries the settled handling's
-  # result — the readback the caller acts on after losing a response.
+  # The commit provably preceded the kill, so the retry MUST collide on the
+  # create-only receipt and settle as the ORIGINAL handling — every run.
+  echo "$CHILD_B_JSON" | jq -e '.deduplicated == true' > /dev/null ||
+    error "The dropped create had committed, so its retry must deduplicate, got: $CHILD_B_JSON"
+  # The retry's Invocation JSON carries the settled handling's result — the
+  # readback the caller acts on after losing a response.
   CHILD_B_ID=$(echo "$CHILD_B_JSON" | jq -re '.result.topic.id') ||
     error "The dropped create's retry should read the result back, got: $CHILD_B_JSON"
   CHILD_B_PATH=$(echo "$CHILD_B_JSON" | jq -re '.result.topic.path')

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -755,6 +755,237 @@ run_piece_call_retry() {
   echo "Successfully ran CLI piece call retry integration tests for ${API_URL}."
 }
 
+# The three-topic end-to-end fixture (verb contract D4, integration half):
+# the graph from the live session, run against an isolated toolshed. An
+# umbrella topic and two children are created through verbs that DECLARE
+# results (the C1 authoring surface); every settled call's Invocation JSON
+# must carry the result read back off the handling's receipt (C4's
+# plainResultReceipts + D2). Results flow schema-free (the C3 deferral):
+# the value path is the whole proof, and nothing here reads a result schema
+# from the durable store. The retry of a deliberately dropped response must
+# read the ORIGINAL result (the assertion D3 could not make with void
+# verbs). The live-board half of D4 stays open, gated on the write-storm
+# machinery (plan: Risks).
+run_three_topic_fixture() {
+  setup_space
+
+  echo "Testing the three-topic end-to-end fixture (declared verb results)..."
+
+  # Result readback is the point of this fixture, so the plain-return
+  # projection is on for every call. The handler executes in the CLI's own
+  # runtime, which reads the flag from the environment; the registry accepts
+  # exactly "true"/"false" (EXPERIMENTAL_OPTIONS.md).
+  export EXPERIMENTAL_PLAIN_RESULT_RECEIPTS=true
+
+  # Per-command wall-clock baseline (the plan's session-mode decision reads
+  # these numbers). Reuses the harness's own timing wrapper; per-phase
+  # --verbose timings (#5233) are not on this branch, so wall-clock around
+  # each command is the honest measure.
+  local saved_timings="${CF_CLI_INTEGRATION_TIMINGS:-}"
+  local saved_timings_file="${CF_CLI_INTEGRATION_TIMINGS_FILE:-}"
+  D4_TIMINGS=$(mktemp)
+  export CF_CLI_INTEGRATION_TIMINGS=1
+  export CF_CLI_INTEGRATION_TIMINGS_FILE="$D4_TIMINGS"
+
+  TOPIC_PIECE_ID=$(cf piece new $SPACE_ARGS "$SCRIPT_DIR/pattern/topic-graph.tsx")
+  echo "Created topic-graph piece: $TOPIC_PIECE_ID"
+
+  # --- 1. Create the umbrella; its declared result is the child reference. --
+  INV_UMBRELLA=$(new_invocation_id)
+  UMBRELLA_PAYLOAD='{"title":"Umbrella","body":"Tracks the D4 fixture family.","agentName":"fable-d4"}'
+  UMBRELLA_JSON=$(cf piece call $SPACE_ARGS --piece "$TOPIC_PIECE_ID" \
+    --invocation "$INV_UMBRELLA" createTopic -- --json "$UMBRELLA_PAYLOAD" 2>/dev/null)
+  echo "$UMBRELLA_JSON" | jq -e --arg id "$INV_UMBRELLA" \
+    '.invocation == $id and .status == "settled"' > /dev/null ||
+    error "The umbrella create should settle under the caller's id, got: $UMBRELLA_JSON"
+  UMBRELLA_ID=$(echo "$UMBRELLA_JSON" | jq -re '.result.topic.id') ||
+    error "The umbrella create's Invocation JSON should carry its declared result, got: $UMBRELLA_JSON"
+  UMBRELLA_PATH=$(echo "$UMBRELLA_JSON" | jq -re '.result.topic.path')
+  # The returned reference addresses the canonical child directly — no list
+  # scan, no correlation by index.
+  UMBRELLA_ENTRY=$(cf piece get $SPACE_ARGS --piece "$TOPIC_PIECE_ID" "$UMBRELLA_PATH")
+  echo "$UMBRELLA_ENTRY" | jq -e --arg id "$UMBRELLA_ID" \
+    '.id == $id and .title == "Umbrella" and
+     .body == "Tracks the D4 fixture family." and .createdBy == "fable-d4"' > /dev/null ||
+    error "The umbrella's returned reference should open the canonical child, got: $UMBRELLA_ENTRY"
+
+  # --- 2. Child A references the umbrella BY ITS RETURNED ID. ---------------
+  # The umbrella id below came off the result readback, so the reference
+  # graph is built from returned references, never from prior knowledge.
+  INV_CHILD_A=$(new_invocation_id)
+  CHILD_A_PAYLOAD=$(jq -cn --arg u "$UMBRELLA_ID" \
+    '{title: "Child A", body: ("Refines " + $u + "."), agentName: "fable-d4",
+      references: [$u]}')
+  CHILD_A_JSON=$(cf piece call $SPACE_ARGS --piece "$TOPIC_PIECE_ID" \
+    --invocation "$INV_CHILD_A" createTopic -- --json "$CHILD_A_PAYLOAD" 2>/dev/null)
+  CHILD_A_ID=$(echo "$CHILD_A_JSON" | jq -re '.result.topic.id') ||
+    error "Child A's Invocation JSON should carry its declared result, got: $CHILD_A_JSON"
+  CHILD_A_PATH=$(echo "$CHILD_A_JSON" | jq -re '.result.topic.path')
+
+  # --- 3. Child B's response is deliberately dropped. -----------------------
+  # Killed after dispatch, triggered by the CLI's own `invocation:`
+  # announcement through a blocking pipe read (D3's mechanism) — lands in the
+  # window without racing a clock. The caller is left holding only the id.
+  INV_CHILD_B=$(new_invocation_id)
+  CHILD_B_PAYLOAD=$(jq -cn --arg u "$UMBRELLA_ID" \
+    '{title: "Child B", body: ("Extends " + $u + "."), agentName: "fable-d4",
+      references: [$u]}')
+  ANNOUNCE_FIFO=$(mktemp -u)
+  mkfifo "$ANNOUNCE_FIFO"
+  set +e
+  # The killed dispatch's timing line (written only if its wrapper survives
+  # the kill) goes to a separate file so the baseline's command count is
+  # exact rather than ±1 on the kill race.
+  CF_CLI_INTEGRATION_TIMINGS_FILE="$D4_TIMINGS.killed" \
+    cf piece call $SPACE_ARGS --piece "$TOPIC_PIECE_ID" --invocation "$INV_CHILD_B" \
+    createTopic -- --json "$CHILD_B_PAYLOAD" > /dev/null 2> "$ANNOUNCE_FIFO" &
+  CALL_PID=$!
+  set -e
+  ANNOUNCED=""
+  while IFS= read -r line; do
+    case "$line" in
+      *"invocation: $INV_CHILD_B"*)
+        ANNOUNCED="yes"
+        break
+        ;;
+    esac
+  done < "$ANNOUNCE_FIFO"
+  kill_process_tree "$CALL_PID"
+  rm -f "$ANNOUNCE_FIFO"
+  if [ -z "$ANNOUNCED" ]; then
+    error "cf piece call should announce its invocation id at dispatch"
+  fi
+
+  # Whether the killed call got its commit in is genuinely racy; both
+  # outcomes are correct but exercise different machinery, so record which
+  # one ran (D3's convention). Committed → the retry MUST collide; not
+  # committed → the retry applies cleanly and its own handling is the
+  # original.
+  TOPICS_BEFORE_RETRY=$(cf piece get $SPACE_ARGS --piece "$TOPIC_PIECE_ID" topics 2>/dev/null | jq 'length')
+  echo "dropped-response: topics committed before kill = $TOPICS_BEFORE_RETRY"
+
+  set +e
+  CHILD_B_JSON=$(cf piece call $SPACE_ARGS --piece "$TOPIC_PIECE_ID" \
+    --invocation "$INV_CHILD_B" createTopic -- --json "$CHILD_B_PAYLOAD" 2>/dev/null)
+  CHILD_B_STATUS=$?
+  set -e
+  if [ "$CHILD_B_STATUS" -ne 0 ]; then
+    error "Retrying the dropped create under the same id should exit 0, got $CHILD_B_STATUS"
+  fi
+  if [ "$TOPICS_BEFORE_RETRY" = "3" ]; then
+    echo "$CHILD_B_JSON" | jq -e '.deduplicated == true' > /dev/null ||
+      error "The dropped create had committed, so its retry must deduplicate, got: $CHILD_B_JSON"
+  elif echo "$CHILD_B_JSON" | jq -e '.deduplicated == true' > /dev/null; then
+    error "The dropped create never committed, so its retry must not deduplicate, got: $CHILD_B_JSON"
+  fi
+  # Either way the retry's Invocation JSON carries the settled handling's
+  # result — the readback the caller acts on after losing a response.
+  CHILD_B_ID=$(echo "$CHILD_B_JSON" | jq -re '.result.topic.id') ||
+    error "The dropped create's retry should read the result back, got: $CHILD_B_JSON"
+  CHILD_B_PATH=$(echo "$CHILD_B_JSON" | jq -re '.result.topic.path')
+
+  # --- 4. The settled id replayed with a DIFFERENT payload. -----------------
+  # The assertion D3 left open (its verbs were void): the collision on the
+  # create-only receipt must hand back the ORIGINAL handling's result — not
+  # silence, and not anything derived from the imposter payload.
+  IMPOSTER_PAYLOAD='{"title":"Child B imposter","body":"Must not exist.","agentName":"impostor"}'
+  set +e
+  REPLAY_JSON=$(cf piece call $SPACE_ARGS --piece "$TOPIC_PIECE_ID" \
+    --invocation "$INV_CHILD_B" createTopic -- --json "$IMPOSTER_PAYLOAD" 2>/dev/null)
+  REPLAY_STATUS=$?
+  set -e
+  if [ "$REPLAY_STATUS" -ne 0 ]; then
+    error "A same-id replay should exit 0, got $REPLAY_STATUS"
+  fi
+  echo "$REPLAY_JSON" | jq -e '.deduplicated == true' > /dev/null ||
+    error "A same-id replay should deduplicate, got: $REPLAY_JSON"
+  assert_json_eq \
+    "$(echo "$REPLAY_JSON" | jq '.result')" \
+    "$(echo "$CHILD_B_JSON" | jq '.result')" \
+    "The replay must read the ORIGINAL result back, got: $REPLAY_JSON (original: $CHILD_B_JSON)"
+
+  # --- 5. Revise the umbrella to reference both children. -------------------
+  INV_REVISE=$(new_invocation_id)
+  REVISE_PAYLOAD=$(jq -cn --arg u "$UMBRELLA_ID" --arg a "$CHILD_A_ID" --arg b "$CHILD_B_ID" \
+    '{id: $u, body: ("Umbrella over " + $a + " and " + $b + "."),
+      agentName: "fable-d4-editor", references: [$a, $b]}')
+  REVISE_JSON=$(cf piece call $SPACE_ARGS --piece "$TOPIC_PIECE_ID" \
+    --invocation "$INV_REVISE" reviseBody -- --json "$REVISE_PAYLOAD" 2>/dev/null)
+  echo "$REVISE_JSON" | jq -e --arg id "$UMBRELLA_ID" --arg path "$UMBRELLA_PATH" \
+    '.status == "settled" and .result.topic.id == $id and .result.topic.path == $path' > /dev/null ||
+    error "reviseBody should return the umbrella's own reference, got: $REVISE_JSON"
+
+  # --- 6. Exactly three topics; references, reciprocals, attribution. -------
+  # One step so the derived views (topicCount, referencedBy) recompute from
+  # the committed writes: acknowledgement is transaction-local (D2), so the
+  # calls above deliberately never waited for derived recomputation.
+  cf piece step $SPACE_ARGS --piece "$TOPIC_PIECE_ID"
+
+  COUNT=$(cf piece get $SPACE_ARGS --piece "$TOPIC_PIECE_ID" topicCount)
+  if [ "$COUNT" != "3" ]; then
+    error "Exactly three topics should exist, got topicCount: $COUNT"
+  fi
+  TOPICS_LEN=$(cf piece get $SPACE_ARGS --piece "$TOPIC_PIECE_ID" topics | jq 'length')
+  if [ "$TOPICS_LEN" != "3" ]; then
+    error "Exactly three topics should exist, got topics length: $TOPICS_LEN"
+  fi
+
+  # Each returned reference opens its canonical child: revised body and both
+  # attributions on the umbrella; create-time state and the umbrella edge on
+  # each child. Child B must be the dropped create's payload — the imposter
+  # payload must not have applied.
+  UMBRELLA_FINAL=$(cf piece get $SPACE_ARGS --piece "$TOPIC_PIECE_ID" "$UMBRELLA_PATH")
+  echo "$UMBRELLA_FINAL" | jq -e \
+    --arg id "$UMBRELLA_ID" --arg a "$CHILD_A_ID" --arg b "$CHILD_B_ID" \
+    '.id == $id and .createdBy == "fable-d4" and .bodyUpdatedBy == "fable-d4-editor" and
+     .body == ("Umbrella over " + $a + " and " + $b + ".") and
+     .references == [$a, $b]' > /dev/null ||
+    error "The revised umbrella should carry both child references and revision attribution, got: $UMBRELLA_FINAL"
+  CHILD_A_FINAL=$(cf piece get $SPACE_ARGS --piece "$TOPIC_PIECE_ID" "$CHILD_A_PATH")
+  echo "$CHILD_A_FINAL" | jq -e --arg id "$CHILD_A_ID" --arg u "$UMBRELLA_ID" \
+    '.id == $id and .title == "Child A" and .createdBy == "fable-d4" and
+     .bodyUpdatedBy == "" and .references == [$u]' > /dev/null ||
+    error "Child A's returned reference should open the canonical child, got: $CHILD_A_FINAL"
+  CHILD_B_FINAL=$(cf piece get $SPACE_ARGS --piece "$TOPIC_PIECE_ID" "$CHILD_B_PATH")
+  echo "$CHILD_B_FINAL" | jq -e --arg id "$CHILD_B_ID" --arg u "$UMBRELLA_ID" \
+    '.id == $id and .title == "Child B" and .createdBy == "fable-d4" and
+     .references == [$u]' > /dev/null ||
+    error "Child B's returned reference should open the dropped create's canonical child, got: $CHILD_B_FINAL"
+
+  # The reciprocal derived references (this fixture's crossrefs analogue):
+  # children point up at the umbrella, the revised umbrella points down at
+  # both children, derived — never persisted.
+  RECIPROCAL=$(cf piece get $SPACE_ARGS --piece "$TOPIC_PIECE_ID" referencedBy)
+  echo "$RECIPROCAL" | jq -e \
+    --arg u "$UMBRELLA_ID" --arg a "$CHILD_A_ID" --arg b "$CHILD_B_ID" \
+    '.[$u] == [$a, $b] and .[$a] == [$u] and .[$b] == [$u]' > /dev/null ||
+    error "Reciprocal derived references should link umbrella and children both ways, got: $RECIPROCAL"
+
+  # --- Baseline the plan's session-mode decision reads. ---------------------
+  echo "[d4-baseline] payload bytes:" \
+    "umbrella=$(printf %s "$UMBRELLA_PAYLOAD" | wc -c | tr -d ' ')" \
+    "child-a=$(printf %s "$CHILD_A_PAYLOAD" | wc -c | tr -d ' ')" \
+    "child-b=$(printf %s "$CHILD_B_PAYLOAD" | wc -c | tr -d ' ')" \
+    "revise=$(printf %s "$REVISE_PAYLOAD" | wc -c | tr -d ' ')"
+  echo "[d4-baseline] cf commands (excluding the killed dispatch): $(wc -l < "$D4_TIMINGS" | tr -d ' ')"
+  sed 's/^/[d4-baseline] /' "$D4_TIMINGS"
+  rm -f "$D4_TIMINGS" "$D4_TIMINGS.killed"
+
+  if [ -n "$saved_timings" ]; then
+    export CF_CLI_INTEGRATION_TIMINGS="$saved_timings"
+  else
+    unset CF_CLI_INTEGRATION_TIMINGS
+  fi
+  if [ -n "$saved_timings_file" ]; then
+    export CF_CLI_INTEGRATION_TIMINGS_FILE="$saved_timings_file"
+  else
+    unset CF_CLI_INTEGRATION_TIMINGS_FILE
+  fi
+  unset EXPERIMENTAL_PLAIN_RESULT_RECEIPTS
+
+  echo "Successfully ran the three-topic end-to-end fixture for ${API_URL}/${SPACE}/${TOPIC_PIECE_ID}."
+}
+
 run_wish() {
   setup_space
 
@@ -789,6 +1020,7 @@ case "$SECTION" in
     run_piece_links
     run_piece_call
     run_piece_call_retry
+    run_three_topic_fixture
     run_wish
     ;;
   piece-basics)
@@ -804,9 +1036,13 @@ case "$SECTION" in
   piece-call)
     run_piece_call
     run_piece_call_retry
+    run_three_topic_fixture
     ;;
   piece-call-retry)
     run_piece_call_retry
+    ;;
+  three-topic)
+    run_three_topic_fixture
     ;;
   wish)
     run_wish

--- a/packages/cli/integration/pattern/topic-graph.tsx
+++ b/packages/cli/integration/pattern/topic-graph.tsx
@@ -87,7 +87,10 @@ export default pattern<TopicGraphInput, TopicGraphOutput>(({ topics }) => {
         throw new Error("createTopic: agentName must be non-blank");
       }
       const list = topics.get() ?? [];
-      const id = `topic-${list.length + 1}`;
+      // Captured before the push so the derivation cannot depend on whether
+      // `list` is a live view or a snapshot of the cell's value.
+      const index = list.length;
+      const id = `topic-${index + 1}`;
       topics.push({
         id,
         title: trimmed,
@@ -96,7 +99,7 @@ export default pattern<TopicGraphInput, TopicGraphOutput>(({ topics }) => {
         bodyUpdatedBy: "",
         references: references ?? [],
       });
-      return { topic: { id, path: `topics/${list.length}` } };
+      return { topic: { id, path: `topics/${index}` } };
     },
   );
 

--- a/packages/cli/integration/pattern/topic-graph.tsx
+++ b/packages/cli/integration/pattern/topic-graph.tsx
@@ -1,0 +1,146 @@
+import {
+  action,
+  computed,
+  type Default,
+  NAME,
+  pattern,
+  type Stream,
+  type Writable,
+} from "commonfabric";
+
+/** One topic on the board. Plain data rather than a sub-piece: this fixture
+ * proves the invocation protocol end to end (verb contract D4, integration
+ * half), and a path into this piece's own result tree is the reference shape
+ * the CLI can resolve against an isolated toolshed — the live board's
+ * fid-rendering half of D4 stays open. */
+interface TopicEntry {
+  id: string;
+  title: string;
+  body: string;
+  /** Attribution, interim `agentName` style (verb contract decision 5). */
+  createdBy: string;
+  /** "" until the body is revised. */
+  bodyUpdatedBy: string;
+  /** Ids of sibling topics this topic's body references. */
+  references: string[];
+}
+
+interface CreateTopicEvent {
+  title: string;
+  /** The topic's initial body, part of the create's atomic unit. */
+  body: string;
+  agentName: string;
+  /** Ids the body references, recorded as explicit edges. */
+  references?: string[];
+}
+
+interface ReviseBodyEvent {
+  id: string;
+  body: string;
+  agentName: string;
+  references: string[];
+}
+
+/** The created (or revised) child's reference: its minted id plus the path
+ * that opens the canonical child on this piece's result — decision 6:
+ * patterns return references, clients render identity. */
+interface TopicRef {
+  id: string;
+  path: string;
+}
+
+interface CreateTopicResult {
+  topic: TopicRef;
+}
+
+interface ReviseBodyResult {
+  topic: TopicRef;
+}
+
+interface TopicGraphInput {
+  topics?: Writable<TopicEntry[] | Default<[]>>;
+}
+
+interface TopicGraphOutput {
+  [NAME]: string;
+  topics: TopicEntry[];
+  topicCount: number;
+  /** Reciprocal edges, derived at read time and never persisted — topic id →
+   * ids of the topics whose `references` name it (this fixture's analogue of
+   * the topics board's crossrefs). */
+  referencedBy: Record<string, string[]>;
+  createTopic: Stream<CreateTopicEvent, CreateTopicResult>;
+  reviseBody: Stream<ReviseBodyEvent, ReviseBodyResult>;
+}
+
+/** A topics-like board whose verbs DECLARE results (verb contract C1
+ * surface): `createTopic` returns the created child's reference and
+ * `reviseBody` returns the revised topic's. Results flow schema-free
+ * through the handling's receipt (the C3 deferral), where `cf piece call`
+ * reads them back under `plainResultReceipts`. */
+export default pattern<TopicGraphInput, TopicGraphOutput>(({ topics }) => {
+  const createTopic = action<CreateTopicEvent, CreateTopicResult>(
+    ({ title, body, agentName, references }) => {
+      const trimmed = (title ?? "").trim();
+      if (!trimmed) throw new Error("createTopic: title must be non-empty");
+      if (!(agentName ?? "").trim()) {
+        throw new Error("createTopic: agentName must be non-blank");
+      }
+      const list = topics.get() ?? [];
+      const id = `topic-${list.length + 1}`;
+      topics.push({
+        id,
+        title: trimmed,
+        body,
+        createdBy: agentName,
+        bodyUpdatedBy: "",
+        references: references ?? [],
+      });
+      return { topic: { id, path: `topics/${list.length}` } };
+    },
+  );
+
+  const reviseBody = action<ReviseBodyEvent, ReviseBodyResult>(
+    ({ id, body, agentName, references }) => {
+      if (!(agentName ?? "").trim()) {
+        throw new Error("reviseBody: agentName must be non-blank");
+      }
+      const list = topics.get() ?? [];
+      const index = list.findIndex((entry) => entry?.id === id);
+      if (index < 0) {
+        throw new Error(`reviseBody: no topic with id "${id}"`);
+      }
+      const entry = topics.key(index);
+      entry.key("body").set(body);
+      entry.key("bodyUpdatedBy").set(agentName);
+      entry.key("references").set(references);
+      return { topic: { id, path: `topics/${index}` } };
+    },
+  );
+
+  const topicCount = computed(() => (topics.get() ?? []).length);
+
+  const referencedBy = computed(() => {
+    const list = topics.get() ?? [];
+    const edges: Record<string, string[]> = {};
+    for (const entry of list) {
+      if (entry) edges[entry.id] = [];
+    }
+    for (const entry of list) {
+      if (!entry) continue;
+      for (const ref of entry.references ?? []) {
+        (edges[ref] ??= []).push(entry.id);
+      }
+    }
+    return edges;
+  });
+
+  return {
+    [NAME]: computed(() => `Topic graph (${(topics.get() ?? []).length})`),
+    topics,
+    topicCount,
+    referencedBy,
+    createTopic,
+    reviseBody,
+  };
+});

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -1763,6 +1763,52 @@ describe("piece call stdin payloads", () => {
     expect(rethrowLines).toEqual([]);
   });
 
+  it("announces per-phase lines only under the test hook", () => {
+    // Disabled (the default): no phase lines — normal output stays exactly
+    // the single dispatch announcement.
+    const silent: string[] = [];
+    const off = invocationPhaseReporter(
+      "inv-10",
+      () => {},
+      (m) => silent.push(m),
+    );
+    off("initial_sync");
+    off("dispatched");
+    off("committed");
+    expect(silent).toEqual(["invocation: inv-10"]);
+
+    // Enabled: every advance also carries `invocation: <id> phase: <phase>`,
+    // the shape failure exits already print. The `committed` line is the one
+    // the dropped-response fixture blocks on before killing its call — it
+    // must appear at committed, and not before.
+    const announced: string[] = [];
+    const seen: string[] = [];
+    const on = invocationPhaseReporter(
+      "inv-11",
+      (p) => seen.push(p),
+      (m) => announced.push(m),
+      true,
+    );
+    on("initial_sync");
+    expect(announced).toEqual(["invocation: inv-11 phase: initial_sync"]);
+    on("dispatched");
+    on("committed");
+    on("readback");
+    expect(announced).toEqual([
+      "invocation: inv-11 phase: initial_sync",
+      "invocation: inv-11",
+      "invocation: inv-11 phase: dispatched",
+      "invocation: inv-11 phase: committed",
+      "invocation: inv-11 phase: readback",
+    ]);
+    expect(seen).toEqual([
+      "initial_sync",
+      "dispatched",
+      "committed",
+      "readback",
+    ]);
+  });
+
   it("shapes the settled Invocation JSON an agent parses", () => {
     expect(invocationJson({ id: "inv-1", status: "settled" })).toEqual({
       invocation: "inv-1",


### PR DESCRIPTION
## Why

The verb-contract plan ([pattern-verb-contract-implementation.md](../blob/main/docs/plans/pattern-verb-contract-implementation.md)) makes the three-topic fixture (D4) the end-to-end criterion for Phase 4: until one scenario proves declared results all the way through — authoring surface (C1) → receipt projection (C4) → Invocation JSON readback (D2) — the pieces are only proven in isolation. **C3 (result-schema emission) was withdrawn in review** (Berni, recorded in the base branch's plan amendment): results flow schema-free through receipts, discovery falls back to prose descriptions, and the durable shape waits for the Fabric-types stream evolution. This fixture is the value-path proof that deferral leans on — the receipt readback works end to end with no result schema anywhere.

The specific gap this closes beyond D3: the receipt-exists collision was asserted via `deduplicated` and exit 0, but never by reading a *result* back — a void verb left none to read. An agent that loses a response needs the retry to hand back the ORIGINAL result, and nothing asserted that.

Stacked on **`feat/c2-verb-return-guard`** (C2, #5234; C3's deferral is recorded there). Prior PRs in the series: #5234 (C2), #5240 (C3 — withdrawn).

## What Changed

- **`packages/cli/integration/pattern/topic-graph.tsx`** — a topics-like fixture pattern whose verbs declare results with the C1 surface: `createTopic: Stream<CreateTopicEvent, CreateTopicResult>` returns the created child's `{ id, path }` reference; `reviseBody` returns the revised topic's. Reciprocal references (`referencedBy`) derive at read time, attribution rides `createdBy`/`bodyUpdatedBy`.
- **`run_three_topic_fixture`** in `packages/cli/integration/integration.sh` (piece-call shard, own space, `EXPERIMENTAL_PLAIN_RESULT_RECEIPTS=true` on every call): create umbrella → read its reference off the Invocation JSON → create two children referencing it *by the read-back id* → deliberately drop one create's response (killed after dispatch, triggered by the CLI's own `invocation:` announcement through a blocking pipe read — no clocks, D3's mechanism) → retry under the SAME id → replay the settled id with an imposter payload → revise the umbrella to reference both children. Verifies: every returned reference opens the canonical child directly by path; the dropped-response retry and the imposter replay both read the ORIGINAL result back; exactly three topics; reciprocal derived references; attribution. All waits event-driven; each `cf` call is a fresh process.
- **Plan edits riding:** D4's integration half struck (live pass explicitly open, gated on the write-storm machinery); D3's uncovered-half sentence closed.

Per the C3 withdrawal, this PR contains **no schema-keyword machinery**: no `result` keyword assertions, no `cf piece verbs` changes — the scenario proves value-path readback only.

## Measured baseline (isolated toolshed, source-run CLI, macOS)

The numbers the plan's session-mode decision (Non-goals) reads. Latest full run on this base; per-phase timings await #5233's `--verbose`, so these are wall-clock per command (the harness's own `[cf-timing]` wrapper).

| step | wall-clock |
| --- | --- |
| `piece new` (deploy, incl. CTS compile) | 3042 ms |
| `createTopic` umbrella (first call in space) | 987 ms |
| `createTopic` child A | 823 ms |
| `createTopic` child B dispatch (killed) + retry | 804 ms |
| same-id imposter replay (dedup + original readback) | 1080 ms |
| `reviseBody` | 940 ms |
| `piece step` | 999 ms |
| `piece get` reads (8×) | 524–831 ms |

- Commands: **15** `cf` invocations per scenario (+1 killed dispatch, logged separately so the count is exact).
- Payload sizes: umbrella **82 B**, child A **93 B**, child B **93 B**, revise **125 B**.
- Cold/warm: locally flat — every call is a fresh process at ~0.5–1.1 s; the deploy dominates (3.0 s warm cache, 5.5 s cold observed on earlier runs). The 20–80 s/mutation the plan records from the live board does not reproduce against an isolated toolshed, which bounds how much of that cost is fresh-runtime tax versus live-board sync/recomputation tax — the split the session-mode decision needs.
- In every local run so far the killed dispatch had committed before the kill (topics = 3 at retry), so the retry exercised the deduplicate-and-read-back branch; the scenario records the branch taken either way, and the imposter replay asserts the original-result readback deterministically regardless of the race.

## Test plan

- `run_three_topic_fixture` green against an isolated toolshed on this base — exit 0 (and previously green as the full `piece-call` shard on the pre-rework branch).
- `packages/cli` unit suite: 123 passed (179 steps), 0 failed.
- Repo-wide `deno fmt --check`, `deno lint`, `deno task check-docs` (520 blocks) — clean.
- CI note: the piece-call shard grows by ~15 commands (~1–2 min at CI speeds) within its 10-minute budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)