### PR TITLE
feat(runner): flip the plainResultReceipts default to on

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -30,7 +30,7 @@ was last checked against the code.
 | [`modernCellRep`](#moderncellrep) | `EXPERIMENTAL_MODERN_CELL_REP` env, or `RuntimeOptions.experimental` | off | Dan Bornstein (#3818) | graduate to always-on, then delete flag | implemented, off by default |
 | [`persistentSchedulerState`](#persistentschedulerstate) | `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE` env, or `RuntimeOptions.experimental` | off | Bernhard Seefeld (#3646) | graduate to always-on | implemented, off by default, rollout in progress |
 | [`commitPreconditions`](#commitpreconditions) | `RuntimeOptions.experimental` only (mapped `null` — programmatic rollback override — in the canonical env registry) | on | Bernhard Seefeld (#4090) | fold into base scheduler semantics, then delete flag | implemented, on by default |
-| [`plainResultReceipts`](#plainresultreceipts) | `EXPERIMENTAL_PLAIN_RESULT_RECEIPTS` env, or `RuntimeOptions.experimental` | off | Mike Salisbury (verb contract WS-C) | flip default after the invocation-protocol integration proof, then fold into receipt semantics and delete flag | implemented, off by default |
+| [`plainResultReceipts`](#plainresultreceipts) | `EXPERIMENTAL_PLAIN_RESULT_RECEIPTS` env, or `RuntimeOptions.experimental` | on | Mike Salisbury (verb contract WS-C) | fold into receipt semantics and delete flag after a bake period | implemented, on by default |
 | [`eagerSourceAnnotation`](#eagersourceannotation) | `EXPERIMENTAL_EAGER_SOURCE_ANNOTATION` env, or `RuntimeOptions.experimental` | off in production, on in shell dev builds | gideon (#4458) | permanent debug toggle, not slated for removal | implemented |
 | [`systemPatternAutoUpdate`](#systempatternautoupdate) | `EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE` env / shell build define, or `RuntimeOptions.experimental` | on in the shell (same-toolshed system sources, including all roots); off server-side | Bernhard Seefeld (#4611; shell default-on #4619) | graduate to always-on, then delete flag | implemented, on in the shell |
 | [`computedCellIds`](#computedcellids) | `EXPERIMENTAL_COMPUTED_CELL_IDS` env, or `RuntimeOptions.experimental` | on | Robin McCollum (#4659) | graduate to unconditional behavior, then delete flag | implemented, on by default |
@@ -61,9 +61,9 @@ B](#appendix-b-related-toggles-that-are-not-experimental-flags).
 These flags make up the `ExperimentalOptions` interface in
 [`packages/runner/src/runtime.ts`](../../packages/runner/src/runtime.ts). They
 are passed as `new Runtime({ experimental: { ... } })`. Each flag defaults to
-`undefined`, which means "take the built-in default". `commitPreconditions` and
-`computedCellIds` default on; the other flags in this category default off
-unless their section says otherwise.
+`undefined`, which means "take the built-in default". `commitPreconditions`,
+`plainResultReceipts`, and `computedCellIds` default on; the other flags in
+this category default off unless their section says otherwise.
 
 The mapping from environment variable to flag is defined once, canonically, as
 `EXPERIMENTAL_ENV_VARS` in
@@ -71,8 +71,9 @@ The mapping from environment variable to flag is defined once, canonically, as
 and read by `experimentalOptionsFromEnv(envReader)`. The toolshed, the CLI, and
 the background piece service all go through that one mapping, so their wirings
 cannot drift; the shell reads the same variables from its build-time defines.
-Five flags are env-reachable (`modernCellRep`, `persistentSchedulerState`,
-`eagerSourceAnnotation`, `systemPatternAutoUpdate`, `computedCellIds`);
+Six flags are env-reachable (`modernCellRep`, `persistentSchedulerState`,
+`eagerSourceAnnotation`, `plainResultReceipts`, `systemPatternAutoUpdate`,
+`computedCellIds`);
 `commitPreconditions` is deliberately mapped to `null` there, which records
 "not env-reachable" as a decision rather than an omission.
 The mapping accepts exactly `"true"` and `"false"`; any other value is ignored
@@ -141,8 +142,11 @@ propagate](#how-flags-propagate).
 ### `plainResultReceipts`
 
 - **Toggle via.** `EXPERIMENTAL_PLAIN_RESULT_RECEIPTS` env var, or
-  `RuntimeOptions.experimental.plainResultReceipts`. Env-reachable so the CLI
-  invocation-protocol work can enable it per process during integration.
+  `RuntimeOptions.experimental.plainResultReceipts`. The env mapping accepts
+  exactly `"true"` and `"false"` (the category's canonical parsing: any other
+  value — `1`, `yes`, `TRUE` — is ignored with a warning, leaving the built-in
+  default in place), so the opt-out while the flag exists is an explicit
+  `EXPERIMENTAL_PLAIN_RESULT_RECEIPTS=false`.
 - **Added by.** Mike Salisbury, verb-contract WS-C
   (`docs/plans/pattern-verb-contract-implementation.md`).
 - **Purpose.** A handler's return value containing reactives/cells projects
@@ -159,13 +163,25 @@ propagate](#how-flags-propagate).
   chaining) records a link to the mutated cell in its receipt. Receipts
   reflect what was returned. Requires `commitPreconditions` (the receipt
   write itself) to be active, which it is by default.
-- **Current default and planned end state.** Off by default. Flips on once the
-  verb-contract WS-D integration proof (caller-supplied event id → collide →
-  read back the original result, cross-process) is green; after a bake period
-  the behavior folds into base receipt semantics and the flag is deleted.
-- **Path to removal.** Delete the flag and make the projection unconditional in
-  `handleJavaScriptHandlerResult`'s receipt-only branch; update the receipt
-  content note in `docs/specs/scheduler-v2/README.md` §7.6.
+- **Current default and planned end state.** On by default. The gate the plan's
+  governing decision 2 set — the integration suite proving readback end to
+  end — was satisfied by the three-topic fixture (#5244): caller-supplied
+  event id, a dropped-response retry and a same-id replay with a different
+  payload, both reading the ORIGINAL declared result back off the receipt,
+  cross-process against an isolated toolshed. An explicit `false` (env or
+  programmatic) remains a rollback override while the flag exists. After a
+  bake period the behavior folds into base receipt semantics and the flag is
+  deleted.
+- **Status on 2026-08-03.** Implemented, on by default (default flipped after
+  #5244's proof; the receipt write's standard-flow conversion landed
+  separately in #5262). Both flag states are pinned in
+  `packages/runner/test/scheduler-event-receipts.test.ts` and
+  `packages/runner/test/declared-result-e2e.test.ts`; the flag-off cases pass
+  `plainResultReceipts: false` explicitly.
+- **Path to removal.** Let the default-on behavior soak; then delete the flag
+  and make the projection unconditional in `handleJavaScriptHandlerResult`'s
+  receipt-only branch, remove the env mapping and the explicit-off tests, and
+  update the receipt content note in `docs/specs/scheduler-v2/README.md` §7.6.
 
 ### `commitPreconditions`
 
@@ -983,7 +999,8 @@ design docs).
 The Category 1 flags are declared as the `ExperimentalOptions` interface in
 [`packages/runner/src/runtime.ts`](../../packages/runner/src/runtime.ts). The
 `Runtime` constructor merges the provided flags with the built-in defaults
-(`commitPreconditions` true, the other Category 1 flags false),
+(`commitPreconditions`, `plainResultReceipts`, and `computedCellIds` true, the
+other Category 1 flags false),
 propagates each one to its ambient control point, and then reads the effective
 state back so that `runtime.experimental.*` reflects what is actually in effect.
 

--- a/docs/plans/pattern-verb-contract-implementation.md
+++ b/docs/plans/pattern-verb-contract-implementation.md
@@ -12,6 +12,36 @@ existing thrown-handler path), while the schema-generator EMISSION of
 refusal for argument-side verbs — see the WS-C bullet for what shipped and
 Risks for the migration step landing the emission now requires.
 
+**Amended 2026-07-31 (second pass, flip staging)**: governing decision 2's
+gate is satisfied — the three-topic fixture (D4, #5244, merged) proves
+declared-result readback end to end, including the original result surviving
+a dropped-response retry and a same-id replay — and the `plainResultReceipts`
+default flip lands in #5245, approved by Berni (2026-08-03, on the measured
+fleet exposure: 40 expression-body setter verbs across 11 non-test pattern
+files begin publishing a link to the state cell they mutate) and by Mike. Env `EXPERIMENTAL_PLAIN_RESULT_RECEIPTS=false` stays the
+opt-out while the flag exists. Staging the flip surfaced a latent C4 bug,
+reachable via the env flag before any flip: the receipt-only branch wrote the
+handler's return as RAW JSON (`setRaw`), so a return carrying a live `Cell` —
+most commonly the incidental chained return of an expression-body
+`action(() => cell.set(...))`, since `set()` returns its cell — failed the
+handling on an uncloneable storage write. Per review (Berni), the fix is not
+to discard such returns but to route the receipt value through the same
+standard cell-write conversion `receipt.set(value)` applies: plain JSON
+persists as before, cell handles convert to links, and a one-line setter
+verb's receipt (and `cf piece call` result) therefore carries a link to the
+mutated cell where it used to be empty — receipts reflect what was returned.
+That fix landed separately as #5262, ahead of and independent of this flip.
+Create-only witness semantics are unchanged. One tension is recorded as
+decided, not overlooked (Berni, set explicitly and twice): receipts are
+runtime-honest, while C2's absorption rule governs DECLARATION — a concise
+completion value still declares nothing at the type layer, and with C3
+withdrawn no result schema exists to contradict — so receipts may carry
+values, including links from incidental cell returns, that no contract
+declares. Consumers must treat undeclared receipt content as advisory. The
+declared-versus-incidental distinction becomes enforceable when the
+Fabric-types stream evolution brings declared-result metadata — precisely
+the deferred-C3 gap.
+
 **Amended 2026-07-31**, C3 withdrawn in review (Berni): no result-schema
 emission for now — values flow schema-free through receipts, discovery falls
 back to prose descriptions, and the durable shape waits for the Fabric-types
@@ -66,7 +96,11 @@ Made 2026-07-24, shaping everything below:
    as its own workstream from day one, in parallel with the small wins.
 2. **Plain-return projection ships behind a flag, default-off**, per the
    `EXPERIMENTAL_OPTIONS.md` process; the default flips after the integration
-   suite proves readback end to end.
+   suite proves readback end to end. *That proof landed as the three-topic
+   fixture (D4, #5244); the flip is staged in #5245 (draft, held for the
+   explicit go from Mike and Berni), with an explicit `false` — env
+   `EXPERIMENTAL_PLAIN_RESULT_RECEIPTS=false` or programmatic — as the
+   rollback override while the flag exists.*
 3. **Continuous dogfood.** The live Estuary topics board gets `setsrc` as each
    phase lands. The compat checker gates schema breaks; every phase ends with a
    live-board acceptance pass.

--- a/docs/plans/pattern-verb-contract.md
+++ b/docs/plans/pattern-verb-contract.md
@@ -42,8 +42,9 @@ supplied rather than only when a caller passes `--invocation`;
 off `tx.handlingReceiptLink` and returns it as `invocation.result` — including
 on a receipt-exists collision, where the original handling's outcome settles
 the retry. The plain-JSON-return-into-the-receipt change exists behind the
-default-off `plainResultReceipts` option. What remains open is that flag's
-default and all of Part 1.
+`plainResultReceipts` option — default-on since the three-topic integration
+proof (#5244) satisfied governing decision 2's gate (the flip's staging is
+recorded in the implementation plan). What remains open is all of Part 1.
 
 ## Goal
 
@@ -137,9 +138,13 @@ callable layer predates:
   from `generateHandlerSchema` (`packages/runner/src/schema.ts`). So the
   address folds in the handler's binding, not the id alone. A return value
   **containing reactives or cells** is run as a result pattern into that cell
-  (`navigateTo` is the existing UI consumer); a **plain JSON return is
-  discarded** — the receipt-only branch writes `{}` unless the default-off
-  `plainResultReceipts` experimental option is set.
+  (`navigateTo` is the existing UI consumer); a **plain JSON return projects
+  into the receipt** under the `plainResultReceipts` experimental option
+  (default on — an explicit `false` restores the discard, where the
+  receipt-only branch writes `{}`). The receipt write uses the standard
+  cell-write conversion, so a bare cell return that launches nothing — e.g.
+  the chained return of an expression-body `action(() => cell.set(...))` —
+  records as a link to that cell.
 - That result cell doubles as the **exactly-once receipt**: its create is
   create-only, so a second handling of the same id — including from another
   replica against a shared server — collides, and its commit is rejected as
@@ -892,9 +897,10 @@ client retry needs.
    return into the receipt instead of `{}`, or a contract rule that results
    carry at least one reactive. The first looks right; it is the one place this
    design asks the runtime for new behaviour rather than exposure. That change
-   now exists in the same branch behind the default-off `plainResultReceipts`
-   experimental option (WS-C), so what remains open is flipping the default,
-   not the mechanism.
+   now exists behind the `plainResultReceipts` experimental option (WS-C),
+   default-on since the three-topic integration proof (#5244), so neither the
+   mechanism nor the default remains open — an explicit `false` stays the
+   rollback override while the flag exists.
 
 ## Design decisions worth recording
 

--- a/docs/specs/scheduler-v2/README.md
+++ b/docs/specs/scheduler-v2/README.md
@@ -784,11 +784,13 @@ the same `{ resultFor: cause }` cell that hosts a launched pattern when the
 handler returns one; when the handler launches nothing, the cell is simply
 the receipt. This gives handlers the same shape as computations: one
 canonical output document per unit of work, whose creation doubles as the
-exactly-once witness. A receipt-only handling writes `{}`; under the
-experimental `plainResultReceipts` flag it instead carries the handler's
-normalized return, so the verb's result is readable back by receipt address
-(`docs/development/EXPERIMENTAL_OPTIONS.md`; verb-contract plan). That value
-is written through the receipt cell's standard write conversion — plain JSON
+exactly-once witness. A receipt-only handling carries the handler's normalized
+return, so the verb's result is readable back by receipt address; the
+experimental `plainResultReceipts` flag governs that projection and defaults
+on — an explicit `false` restores the older discard-everything-to-`{}`
+behavior while the flag exists (`docs/development/EXPERIMENTAL_OPTIONS.md`;
+verb-contract plan). A value-less handler still writes `{}`. That value is
+written through the receipt cell's standard write conversion — plain JSON
 persists as-is, a live cell handle converts to a link, so a one-line setter
 verb's receipt links to the cell it mutated. The create-only witness
 semantics are unchanged either way.

--- a/packages/runner/src/runtime-presets.ts
+++ b/packages/runner/src/runtime-presets.ts
@@ -194,8 +194,9 @@ export const EXPERIMENTAL_ENV_VARS = {
   // Scheduler-v2 lineage (#4090) is default-on. Keep a programmatic rollback
   // override while the flag exists; no environment exposure is needed.
   commitPreconditions: null,
-  // Verb-contract WS-C: env-reachable so the CLI invocation-protocol work can
-  // enable it per process during the integration proof.
+  // Verb-contract WS-C: default-on since the invocation-protocol integration
+  // proof (#5244); env-reachable so a process can opt out with an explicit
+  // "false" while the flag exists.
   plainResultReceipts: "EXPERIMENTAL_PLAIN_RESULT_RECEIPTS",
   systemPatternAutoUpdate: "EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE",
   computedCellIds: "EXPERIMENTAL_COMPUTED_CELL_IDS",

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -219,9 +219,12 @@ export interface ExperimentalOptions {
    * instead of the empty `{}` witness, so a caller — or a same-id retry that
    * collides on the receipt — can read the verb's result back by receipt
    * address. Reactive-bearing returns already project via the result-pattern
-   * path; this covers plain values, which are otherwise discarded. Default
-   * off; flips after the invocation-protocol integration proof (verb
-   * contract, docs/plans/pattern-verb-contract-implementation.md WS-C/WS-D).
+   * path; this covers plain values, which are otherwise discarded. Defaults
+   * to on since the invocation-protocol integration proof (#5244's
+   * three-topic fixture; verb contract,
+   * docs/plans/pattern-verb-contract-implementation.md WS-C/WS-D). Pass
+   * `false` (or `EXPERIMENTAL_PLAIN_RESULT_RECEIPTS=false`) as a temporary
+   * rollback override while the flag exists.
    */
   plainResultReceipts?: boolean | undefined;
   /**
@@ -969,10 +972,13 @@ export class Runtime {
       }
     }
 
-    // Unlike ambient flags, computedCellIds is consumed from this Runtime's
-    // builder frame. Normalize its local default after override logging so an
-    // omitted option does not appear as an explicit `true` override.
+    // Unlike ambient flags, computedCellIds and plainResultReceipts are
+    // consumed from this Runtime instance (the builder frame and the runner's
+    // receipt-only branch respectively). Normalize their local defaults after
+    // override logging so an omitted option does not appear as an explicit
+    // `true` override.
     this.experimental.computedCellIds ??= true;
+    this.experimental.plainResultReceipts ??= true;
 
     // Propagate experimental flags to their ambient control points, then read
     // back the effective state so `experimental.*` reflects what is actually in

--- a/packages/runner/test/declared-result-e2e.test.ts
+++ b/packages/runner/test/declared-result-e2e.test.ts
@@ -1,7 +1,8 @@
 // A CTS-authored `action<Event, Result>` verb, compiled through the real
 // pipeline (`patternManager.compilePattern` → js-compiler → CTS transformers →
 // SES evaluation), delivers its returned value into the event receipt under
-// the `plainResultReceipts` experimental flag — the composition of this
+// the `plainResultReceipts` experimental flag (default-on since the flip) —
+// the composition of this
 // package's plain-return projection (scheduler-event-receipts.test.ts, which
 // exercises only the raw trusted-builder `handler`) with the api's declared-
 // result authoring surface. This is the readback half of WS-C's exit
@@ -118,9 +119,11 @@ describe("compiled CTS action<E, R> results in receipts", () => {
   let tx: IExtendedStorageTransaction;
 
   beforeEach(() => {
+    // No experimental options: this suite pins the BUILT-IN default
+    // (plainResultReceipts on). The explicitly-off case below re-creates its
+    // runtime with `plainResultReceipts: false` to pin the rollback override.
     ({ storageManager, runtime, tx } = createSchedulerTestRuntime(
       import.meta.url,
-      { experimental: { plainResultReceipts: true } },
     ));
   });
 
@@ -269,10 +272,11 @@ describe("compiled CTS action<E, R> results in receipts", () => {
     expect(writtenResolved.path).toEqual(target.path);
   });
 
-  it("discards the declared result while plainResultReceipts is off (default)", async () => {
+  it("discards the declared result while plainResultReceipts is explicitly off", async () => {
     await disposeSchedulerTestRuntime({ storageManager, runtime, tx });
     ({ storageManager, runtime, tx } = createSchedulerTestRuntime(
       import.meta.url,
+      { experimental: { plainResultReceipts: false } },
     ));
     const root = await instantiate("declared result e2e flag-off root");
     const outcomes: Outcome[] = [];

--- a/packages/runner/test/experimental-options.test.ts
+++ b/packages/runner/test/experimental-options.test.ts
@@ -37,6 +37,7 @@ describe("ExperimentalOptions", () => {
         experimental: {
           modernCellRep: false,
           commitPreconditions: false,
+          plainResultReceipts: false,
           computedCellIds: false,
         },
       });
@@ -44,6 +45,7 @@ describe("ExperimentalOptions", () => {
         modernCellRep: false,
         persistentSchedulerState: false,
         commitPreconditions: false,
+        plainResultReceipts: false,
         computedCellIds: false,
         // Read back from the ambient flag (a test seam that deliberately does
         // NOT reset on dispose — see ExperimentalOptions.eagerSourceAnnotation).
@@ -66,6 +68,7 @@ describe("ExperimentalOptions", () => {
         modernCellRep: true,
         persistentSchedulerState: false,
         commitPreconditions: true,
+        plainResultReceipts: true,
         computedCellIds: true,
         eagerSourceAnnotation: false,
       });
@@ -84,6 +87,7 @@ describe("ExperimentalOptions", () => {
         modernCellRep: false,
         persistentSchedulerState: false,
         commitPreconditions: true,
+        plainResultReceipts: true,
         computedCellIds: true,
         // Read back from the ambient flag (a test seam that deliberately does
         // NOT reset on dispose — see ExperimentalOptions.eagerSourceAnnotation).

--- a/packages/runner/test/scheduler-event-receipts.test.ts
+++ b/packages/runner/test/scheduler-event-receipts.test.ts
@@ -1236,7 +1236,12 @@ describe("scheduler event receipts", () => {
     expect(emptyReceipt.get()).toEqual({});
   });
 
-  it("discards a plain JSON return while plainResultReceipts is off (default)", async () => {
+  it("discards a plain JSON return while plainResultReceipts is explicitly off", async () => {
+    await disposeSchedulerTestRuntime({ storageManager, runtime, tx });
+    ({ storageManager, runtime, tx } = createSchedulerTestRuntime(
+      import.meta.url,
+      { experimental: { plainResultReceipts: false } },
+    ));
     const { commonfabric } = createTrustedBuilder(runtime);
     const { handler, pattern } = commonfabric;
     let handlerInvocations = 0;


### PR DESCRIPTION
## Why

Governing decision 2 flips this default "after the integration suite proves readback end to end." That proof is on main: the three-topic fixture (D4, #5244) drives a caller-supplied event id through a dropped-response retry and a same-id replay with a different payload, both reading the ORIGINAL declared result back off the receipt, cross-process.

**Approved and no longer held.** Berni signed off on 2026-08-03 — *"Writing the undeclared response into the receipt seems fine to me"* — asked against the measured fleet exposure below, and Mike gave the second half of the go the plan requires.

## What Changed

- Runtime normalizes `plainResultReceipts ??= true` beside `computedCellIds`. `EXPERIMENTAL_PLAIN_RESULT_RECEIPTS=false` (the env mapping accepts exactly `true`/`false`) or a programmatic `false` stays the rollback override while the flag exists.
- Tests that implicitly meant "flag off" now say so explicitly and are retitled; `declared-result-e2e` runs under the built-in default so it pins the flipped default itself.
- Registry (`EXPERIMENTAL_OPTIONS.md`), scheduler-v2 §7.6, the implementation plan and the design doc record the new default.

Rebuilt on current main. The earlier version of this branch sat on the pre-rebase C2/D4 lineage, where merging main produced add/add conflicts on C2's transformer files — its base had been *rewritten*, not advanced. **The diff is the flip alone, 9 files.** The receipt-write conversion that used to be bundled here shipped separately as #5262 and is on main; it was a defect under the flag as it already existed, so it had no business waiting on this decision.

## What flipping changes for callers

A verb's return value reaches its receipt by default. Per Berni's review the incidental-cell hazard was fixed at the root rather than guarded (#5262): a one-line setter verb — `action(() => cell.set(...))`, whose expression body implicitly returns the cell `set()` hands back for chaining — records a **link to the cell it mutated** where its receipt used to be empty.

**Measured scope: 40 expression-body setter verbs across 11 non-test pattern files** — `mobile-app-demo` (`openSheet`, `closeSheet`, `dismissToast`), `parking-coordinator` (cancel-edit handlers), `lot-watch` (navigation steps), `imported-calendar` / `weekly-calendar` (day/week view), plus `notes`, `router`, `agent`, and the catalog stories. None were written with results in mind; each now publishes a link to its internal state cell, readable by anyone who can read the receipt. That is what the approval covers.

Two things already decided, recorded so they are not re-litigated:

- **Undeclared receipt content is advisory.** C2's absorption rule governs DECLARATION, and with C3 withdrawn no result schema exists to contradict — so receipts may carry values, including these incidental links, that no contract declares. The distinction becomes enforceable when the Fabric-types stream evolution brings declared-result metadata; that is the deferred-C3 gap.
- **Retention is unresolved but unchanged in shape.** The receipt cell is created and create-only marked whether the flag is on or off, so the flip does not change the *number* of documents — one per handled event, as today — only their *content*. WS-E's collection story applies either way; the flip raises per-document size, not document count.

Results carrying pieces do **not** need this flip: a return containing cells travels the result-pattern projection path, which predates the flag (measured in #5263, where `addTopic` returns the created topic on any runtime while plain records need the flag). The flip's scope is precisely plain-JSON returns.

## Test plan

- **Full workspace suite green under the flipped default** — every package. This is the run that matters: the whole repo executing with results reaching receipts by default.
- `packages/runner` receipt suites green, both flag states pinned.
- The verb walkthrough (`packages/cli/integration/verbs-over-the-cli.sh`) is **23/23** under the flip. Its step 7 sets `EXPERIMENTAL_PLAIN_RESULT_RECEIPTS=false` explicitly, so it now exercises the rollback override against a default-on runtime.
- `deno fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
