### PR TITLE
Reject accessor-backed properties from fabric plain objects

### DIFF
--- a/packages/data-model/src/native-conversion.ts
+++ b/packages/data-model/src/native-conversion.ts
@@ -3,7 +3,10 @@ import {
   isRecord,
   isUnsafeObjectKey,
 } from "@commonfabric/utils/types";
-import { isPlainObjectWithOnlyEnumerableStringKeys } from "@commonfabric/utils/objects";
+import {
+  hasOnlyOwnDataProperties,
+  isPlainObjectWithOnlyEnumerableStringKeys,
+} from "@commonfabric/utils/objects";
 import {
   isArrayIndexPropertyName,
   isArrayWithOnlyIndexProperties,
@@ -263,13 +266,19 @@ export function shallowFabricFromNativeValue(
 
     case NATIVE_TAGS.Object: {
       // `FabricPlainObject` is keyed by `string`, so a symbol key has no fabric
-      // representation, and neither does a non-enumerable string key. Reject
-      // either outright rather than dropping it on the way through ("death
-      // before confusion"), matching how an array's non-index properties are
-      // treated.
+      // representation, and neither does a non-enumerable string key; an
+      // accessor-backed property is live code rather than inert data. Reject
+      // any of them outright rather than dropping or flattening it on the way
+      // through ("death before confusion"), matching how an array's non-index
+      // properties are treated.
       if (!isPlainObjectWithOnlyEnumerableStringKeys(value)) {
         throw new Error(
           "Cannot store object with non-string-keyed properties",
+        );
+      }
+      if (!hasOnlyOwnDataProperties(value as object)) {
+        throw new Error(
+          "Cannot store object with accessor-backed properties",
         );
       }
       // Plain objects: delegate frozenness handling to `cloneHelper()`.

--- a/packages/data-model/src/native-conversion.ts
+++ b/packages/data-model/src/native-conversion.ts
@@ -3,10 +3,7 @@ import {
   isRecord,
   isUnsafeObjectKey,
 } from "@commonfabric/utils/types";
-import {
-  hasOnlyOwnDataProperties,
-  isPlainObjectWithOnlyEnumerableStringKeys,
-} from "@commonfabric/utils/objects";
+import { isPlainObjectWithOnlyEnumerableStringKeys } from "@commonfabric/utils/objects";
 import {
   isArrayIndexPropertyName,
   isArrayWithOnlyIndexProperties,
@@ -265,20 +262,16 @@ export function shallowFabricFromNativeValue(
     }
 
     case NATIVE_TAGS.Object: {
-      // `FabricPlainObject` is keyed by `string`, so a symbol key has no fabric
-      // representation, and neither does a non-enumerable string key; an
-      // accessor-backed property is live code rather than inert data. Reject
-      // any of them outright rather than dropping or flattening it on the way
-      // through ("death before confusion"), matching how an array's non-index
+      // A plain object in this system is INERT: `FabricPlainObject` is keyed
+      // by `string`, so a symbol key has no fabric representation, and
+      // neither does a non-enumerable string key; an accessor-backed
+      // property is live code rather than inert data. Reject any of them
+      // outright rather than dropping or flattening it on the way through
+      // ("death before confusion"), matching how an array's non-index
       // properties are treated.
       if (!isPlainObjectWithOnlyEnumerableStringKeys(value)) {
         throw new Error(
-          "Cannot store object with non-string-keyed properties",
-        );
-      }
-      if (!hasOnlyOwnDataProperties(value as object)) {
-        throw new Error(
-          "Cannot store object with accessor-backed properties",
+          "Cannot store object that is not an inert plain object",
         );
       }
       // Plain objects: delegate frozenness handling to `cloneHelper()`.

--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -1,8 +1,5 @@
 import { isArrayWithOnlyIndexProperties } from "@commonfabric/utils/arrays";
-import {
-  hasOnlyOwnDataProperties,
-  isPlainObjectWithOnlyEnumerableStringKeys,
-} from "@commonfabric/utils/objects";
+import { isPlainObjectWithOnlyEnumerableStringKeys } from "@commonfabric/utils/objects";
 import { isPlainObject } from "@commonfabric/utils/types";
 
 import {
@@ -53,8 +50,7 @@ export function isFabricValueLayer(
       // `string`, so a symbol key has no representation either, and neither
       // does a non-enumerable string key; an accessor-backed property is live
       // code rather than inert data.
-      return isPlainObjectWithOnlyEnumerableStringKeys(value) &&
-        hasOnlyOwnDataProperties(value);
+      return isPlainObjectWithOnlyEnumerableStringKeys(value);
     }
 
     case "symbol": {
@@ -80,10 +76,11 @@ export function isFabricValueLayer(
  * properties, `length` aside (sparse holes allowed), or a plain object whose
  * values are all
  * `FabricValue`s. Returns `false` for a `function` or a unique (uninterned)
- * symbol -- whether the value itself or reached anywhere within it -- for an
- * accessor-backed (getter/setter) property anywhere, which is live code
- * rather than inert data, and for any other class instance (`Date`, `Map`,
- * ...) not representable as a `FabricValue`. Handles circular references.
+ * symbol -- whether the value itself or reached anywhere within it -- for a
+ * plain object carrying an accessor-backed (getter/setter) property, which
+ * makes it non-inert (an accessor-backed array INDEX is a known gap, not yet
+ * rejected), and for any other class instance (`Date`, `Map`, ...) not
+ * representable as a `FabricValue`. Handles circular references.
  *
  * This is a *membership* check, not a frozen-ness check: a structurally-valid
  * but unfrozen object or array is still a `FabricValue`. For the deep-frozen
@@ -154,7 +151,6 @@ export function isFabricValue(value: unknown): value is FabricValue {
       // representation, the same as an array's non-index properties; an
       // accessor-backed property is live code rather than inert data.
       if (!isPlainObjectWithOnlyEnumerableStringKeys(item)) return false;
-      if (!hasOnlyOwnDataProperties(item)) return false;
       const record = item as Record<string, unknown>;
       for (const key of Object.keys(record)) {
         if (!check(record[key])) return false;

--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -1,5 +1,8 @@
 import { isArrayWithOnlyIndexProperties } from "@commonfabric/utils/arrays";
-import { isPlainObjectWithOnlyEnumerableStringKeys } from "@commonfabric/utils/objects";
+import {
+  hasOnlyOwnDataProperties,
+  isPlainObjectWithOnlyEnumerableStringKeys,
+} from "@commonfabric/utils/objects";
 import { isPlainObject } from "@commonfabric/utils/types";
 
 import {
@@ -48,8 +51,10 @@ export function isFabricValueLayer(
       // Plain objects are accepted; class instances are not (except
       // `FabricSpecialObject`, handled above). `FabricPlainObject` is keyed by
       // `string`, so a symbol key has no representation either, and neither
-      // does a non-enumerable string key.
-      return isPlainObjectWithOnlyEnumerableStringKeys(value);
+      // does a non-enumerable string key; an accessor-backed property is live
+      // code rather than inert data.
+      return isPlainObjectWithOnlyEnumerableStringKeys(value) &&
+        hasOnlyOwnDataProperties(value);
     }
 
     case "symbol": {
@@ -75,9 +80,10 @@ export function isFabricValueLayer(
  * properties, `length` aside (sparse holes allowed), or a plain object whose
  * values are all
  * `FabricValue`s. Returns `false` for a `function` or a unique (uninterned)
- * symbol -- whether the value itself or reached anywhere within it -- and for
- * any other class instance (`Date`, `Map`, ...) not representable as a
- * `FabricValue`. Handles circular references.
+ * symbol -- whether the value itself or reached anywhere within it -- for an
+ * accessor-backed (getter/setter) property anywhere, which is live code
+ * rather than inert data, and for any other class instance (`Date`, `Map`,
+ * ...) not representable as a `FabricValue`. Handles circular references.
  *
  * This is a *membership* check, not a frozen-ness check: a structurally-valid
  * but unfrozen object or array is still a `FabricValue`. For the deep-frozen
@@ -145,8 +151,10 @@ export function isFabricValue(value: unknown): value is FabricValue {
       return true;
     } else if (isPlainObject(item)) {
       // Symbol-keyed and non-enumerable string-keyed properties have no fabric
-      // representation, the same as an array's non-index properties.
+      // representation, the same as an array's non-index properties; an
+      // accessor-backed property is live code rather than inert data.
       if (!isPlainObjectWithOnlyEnumerableStringKeys(item)) return false;
+      if (!hasOnlyOwnDataProperties(item)) return false;
       const record = item as Record<string, unknown>;
       for (const key of Object.keys(record)) {
         if (!check(record[key])) return false;

--- a/packages/data-model/test/deep-freeze.test.ts
+++ b/packages/data-model/test/deep-freeze.test.ts
@@ -403,6 +403,26 @@ describe("deep-freeze", () => {
     });
   });
 
+  describe("`isDeepFrozenFabricValue()` accessor properties", () => {
+    it("returns `false` for a frozen object with a getter", () => {
+      // Freezing an object does not make an accessor inert: a read still
+      // executes it and can answer differently every time. Such an object
+      // must not be granted the deep-frozen-fabric-value trust level.
+      const obj = { a: 1 };
+      Object.defineProperty(obj, "g", { get: () => 2, enumerable: true });
+      Object.freeze(obj);
+      expect(isDeepFrozenFabricValue(obj)).toBe(false);
+    });
+
+    it("returns `false` for a frozen tree with a getter-bearing record inside", () => {
+      const inner = { b: 3 };
+      Object.defineProperty(inner, "g", { get: () => 4, enumerable: true });
+      Object.freeze(inner);
+      const tree = Object.freeze({ data: inner });
+      expect(isDeepFrozenFabricValue(tree)).toBe(false);
+    });
+  });
+
   describe("`isDeepFrozenFabricValue()` symbols", () => {
     // Only registry-interned symbols are `FabricValue`s; unique (uninterned)
     // symbols are not portable across realms and are rejected, consistent with

--- a/packages/data-model/test/native-conversion.test.ts
+++ b/packages/data-model/test/native-conversion.test.ts
@@ -1545,7 +1545,7 @@ describe("native-conversion", () => {
         const obj = { a: 1 } as Record<string | symbol, unknown>;
         obj[Symbol("s")] = 2;
         expect(() => fabricFromNativeValue(obj)).toThrow(
-          "Cannot store object with non-string-keyed properties",
+          "Cannot store object that is not an inert plain object",
         );
       });
 
@@ -1553,7 +1553,7 @@ describe("native-conversion", () => {
         const obj = { a: 1 };
         Object.defineProperty(obj, "hidden", { value: 2, enumerable: false });
         expect(() => fabricFromNativeValue(obj)).toThrow(
-          "Cannot store object with non-string-keyed properties",
+          "Cannot store object that is not an inert plain object",
         );
       });
 
@@ -1561,7 +1561,7 @@ describe("native-conversion", () => {
         const inner = { a: 1 } as Record<string | symbol, unknown>;
         inner[Symbol("s")] = 2;
         expect(() => fabricFromNativeValue([inner])).toThrow(
-          "Cannot store object with non-string-keyed properties",
+          "Cannot store object that is not an inert plain object",
         );
       });
 

--- a/packages/data-model/test/type-check.test.ts
+++ b/packages/data-model/test/type-check.test.ts
@@ -133,6 +133,21 @@ describe("type-check", () => {
         expect(isFabricValueLayer(obj)).toBe(false);
       });
 
+      it("returns `false` for an accessor-backed property", () => {
+        // An accessor is live code, not inert data: a read executes it and
+        // can answer differently every time. Freezing does not change that.
+        const obj = { a: 1 };
+        Object.defineProperty(obj, "g", { get: () => 2, enumerable: true });
+        expect(isFabricValueLayer(obj)).toBe(false);
+        expect(isFabricValueLayer(Object.freeze(obj))).toBe(false);
+      });
+
+      it("returns `false` for a setter-only property", () => {
+        const obj = { a: 1 };
+        Object.defineProperty(obj, "s", { set: () => {}, enumerable: true });
+        expect(isFabricValueLayer(obj)).toBe(false);
+      });
+
       it("returns `true` for an object whose keys are all enumerable strings", () => {
         expect(isFabricValueLayer({ a: 1, b: 2 })).toBe(true);
         expect(isFabricValueLayer({})).toBe(true);
@@ -332,6 +347,20 @@ describe("type-check", () => {
       it("returns `false` for a non-fabric class instance nested in the graph", () => {
         expect(isFabricValue({ a: 1, d: new Date() })).toBe(false);
         expect(isFabricValue([1, [2, new Map()]])).toBe(false);
+      });
+
+      it("returns `false` for an accessor-backed property, at any depth", () => {
+        // An accessor is live code, not inert data: a read executes it and
+        // can answer differently every time. Freezing does not change that.
+        const top = { a: 1 };
+        Object.defineProperty(top, "g", { get: () => 2, enumerable: true });
+        expect(isFabricValue(top)).toBe(false);
+        expect(isFabricValue(Object.freeze(top))).toBe(false);
+
+        const inner = { b: 3 };
+        Object.defineProperty(inner, "g", { get: () => 4, enumerable: true });
+        expect(isFabricValue({ outer: inner })).toBe(false);
+        expect(isFabricValue([1, [inner]])).toBe(false);
       });
 
       it("returns `false` for an array with enumerable named (non-index) properties", () => {

--- a/packages/utils/src/objects.ts
+++ b/packages/utils/src/objects.ts
@@ -3,12 +3,17 @@
  */
 
 /**
- * Indicates whether the given value is a plain object -- prototype
- * `Object.prototype` or `null` -- every one of whose own properties has an
- * enumerable string key. Symbol keys and non-enumerable string keys both cause
- * rejection, whether or not they carry data, because neither has any
- * representation as a property *name*: neither survives serialization, nor a
- * name-driven copy such as `Object.entries()` round-tripping.
+ * Indicates whether the given value is an *inert* plain object -- prototype
+ * `Object.prototype` or `null`, every own property an enumerable
+ * string-keyed *data* property -- which is what "plain object" means in this
+ * system. Symbol keys and non-enumerable string keys cause rejection,
+ * whether or not they carry data, because neither has any representation as
+ * a property *name*: neither survives serialization, nor a name-driven copy
+ * such as `Object.entries()` round-tripping. An accessor-backed (getter
+ * and/or setter) property also causes rejection, even when its key is an
+ * enumerable string, because it makes the object non-inert: an accessor is
+ * live code, a read of which executes it and can answer differently every
+ * time -- and freezing the object does not change that.
  *
  * Anything that isn't a plain object is rejected, class instances and arrays
  * included, which also makes this function total: it answers rather than
@@ -16,8 +21,8 @@
  * unavoidably so, since it can throw from its own traps.
  *
  * @param value The value to check.
- * @returns `true` if the value is a plain object all of whose own keys are
- *   enumerable strings, `false` otherwise.
+ * @returns `true` if the value is a plain object all of whose own properties
+ *   are enumerable string-keyed data properties, `false` otherwise.
  */
 export function isPlainObjectWithOnlyEnumerableStringKeys(
   value: unknown,
@@ -31,34 +36,20 @@ export function isPlainObjectWithOnlyEnumerableStringKeys(
     return false;
   }
 
-  // `Reflect.ownKeys()` yields every own string and symbol key regardless of
-  // enumerability, while `Object.keys()` yields exactly the enumerable string
-  // ones, so the former is always a superset of the latter. Equal counts across
-  // a superset relation therefore means the two agree key for key -- no symbol
-  // key and no non-enumerable string key anywhere.
-  return Reflect.ownKeys(value).length === Object.keys(value).length;
-}
-
-/**
- * Indicates whether every own property of the given object is a *data*
- * property -- as opposed to an accessor (getter and/or setter). An accessor
- * is live code rather than inert data: a read executes it and can answer
- * differently every time, and freezing the object does not change that.
- *
- * This is purely a descriptor-shape check; it says nothing about the keys'
- * visibility or type. Pair it with
- * `isPlainObjectWithOnlyEnumerableStringKeys()` when both dimensions matter.
- *
- * @param value The object to check.
- * @returns `true` if every own property is a data property, `false`
- *   otherwise.
- */
-export function hasOnlyOwnDataProperties(value: object): boolean {
+  // A single pass over the own keys checks all three requirements: each key
+  // must be a string (`Reflect.ownKeys()` yields symbol keys too, which a
+  // count-based comparison would need a second key walk to exclude), and its
+  // descriptor must be enumerable and carry `value` (an accessor answers
+  // `get` / `set` instead).
   for (const key of Reflect.ownKeys(value)) {
+    if (typeof key !== "string") {
+      return false;
+    }
     const descriptor = Object.getOwnPropertyDescriptor(value, key)!;
-    if (!("value" in descriptor)) {
+    if (!descriptor.enumerable || !("value" in descriptor)) {
       return false;
     }
   }
+
   return true;
 }

--- a/packages/utils/src/objects.ts
+++ b/packages/utils/src/objects.ts
@@ -38,3 +38,27 @@ export function isPlainObjectWithOnlyEnumerableStringKeys(
   // key and no non-enumerable string key anywhere.
   return Reflect.ownKeys(value).length === Object.keys(value).length;
 }
+
+/**
+ * Indicates whether every own property of the given object is a *data*
+ * property -- as opposed to an accessor (getter and/or setter). An accessor
+ * is live code rather than inert data: a read executes it and can answer
+ * differently every time, and freezing the object does not change that.
+ *
+ * This is purely a descriptor-shape check; it says nothing about the keys'
+ * visibility or type. Pair it with
+ * `isPlainObjectWithOnlyEnumerableStringKeys()` when both dimensions matter.
+ *
+ * @param value The object to check.
+ * @returns `true` if every own property is a data property, `false`
+ *   otherwise.
+ */
+export function hasOnlyOwnDataProperties(value: object): boolean {
+  for (const key of Reflect.ownKeys(value)) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key)!;
+    if (!("value" in descriptor)) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/packages/utils/test/objects.test.ts
+++ b/packages/utils/test/objects.test.ts
@@ -1,6 +1,9 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { isPlainObjectWithOnlyEnumerableStringKeys } from "@commonfabric/utils/objects";
+import {
+  hasOnlyOwnDataProperties,
+  isPlainObjectWithOnlyEnumerableStringKeys,
+} from "@commonfabric/utils/objects";
 
 describe("objects", () => {
   describe("isPlainObjectWithOnlyEnumerableStringKeys()", () => {
@@ -171,6 +174,51 @@ describe("objects", () => {
       expect(
         isPlainObjectWithOnlyEnumerableStringKeys(new Proxy(withSymbol, {})),
       ).toBe(false);
+    });
+  });
+
+  describe("hasOnlyOwnDataProperties()", () => {
+    it("accepts an object with only data properties", () => {
+      expect(hasOnlyOwnDataProperties({})).toBe(true);
+      expect(hasOnlyOwnDataProperties({ a: 1, b: "two" })).toBe(true);
+      expect(hasOnlyOwnDataProperties(Object.freeze({ a: 1 }))).toBe(true);
+    });
+
+    it("accepts non-enumerable and symbol-keyed data properties", () => {
+      // Descriptor shape only; key visibility and type are out of scope.
+      const obj = { a: 1 } as Record<string | symbol, unknown>;
+      Object.defineProperty(obj, "hidden", { value: 2, enumerable: false });
+      obj[Symbol("s")] = 3;
+      expect(hasOnlyOwnDataProperties(obj)).toBe(true);
+    });
+
+    it("accepts an array of data elements", () => {
+      expect(hasOnlyOwnDataProperties([1, 2, 3])).toBe(true);
+    });
+
+    it("rejects an enumerable getter", () => {
+      const obj = { a: 1 };
+      Object.defineProperty(obj, "g", { get: () => 2, enumerable: true });
+      expect(hasOnlyOwnDataProperties(obj)).toBe(false);
+    });
+
+    it("rejects a non-enumerable getter", () => {
+      const obj = { a: 1 };
+      Object.defineProperty(obj, "g", { get: () => 2, enumerable: false });
+      expect(hasOnlyOwnDataProperties(obj)).toBe(false);
+    });
+
+    it("rejects a setter-only property", () => {
+      const obj = { a: 1 };
+      Object.defineProperty(obj, "s", { set: () => {}, enumerable: true });
+      expect(hasOnlyOwnDataProperties(obj)).toBe(false);
+    });
+
+    it("rejects a frozen object with a getter", () => {
+      // Freezing does not make an accessor inert: reads still execute it.
+      const obj = { a: 1 };
+      Object.defineProperty(obj, "g", { get: () => 2, enumerable: true });
+      expect(hasOnlyOwnDataProperties(Object.freeze(obj))).toBe(false);
     });
   });
 });

--- a/packages/utils/test/objects.test.ts
+++ b/packages/utils/test/objects.test.ts
@@ -1,9 +1,6 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import {
-  hasOnlyOwnDataProperties,
-  isPlainObjectWithOnlyEnumerableStringKeys,
-} from "@commonfabric/utils/objects";
+import { isPlainObjectWithOnlyEnumerableStringKeys } from "@commonfabric/utils/objects";
 
 describe("objects", () => {
   describe("isPlainObjectWithOnlyEnumerableStringKeys()", () => {
@@ -99,13 +96,38 @@ describe("objects", () => {
         const hidden = {};
         Object.defineProperty(hidden, "g", { get: () => 1, enumerable: false });
 
-        // An enumerable accessor is a string key and passes; a non-enumerable
-        // one does not. This pins that the check is about key visibility rather
-        // than about data-versus-accessor.
+        // A "plain object" in this system is an INERT one, so an accessor is
+        // disqualifying regardless of its key's visibility: it is live code,
+        // not data. This pins that the check covers data-versus-accessor in
+        // addition to key visibility.
         expect(isPlainObjectWithOnlyEnumerableStringKeys(enumerable)).toBe(
-          true,
+          false,
         );
         expect(isPlainObjectWithOnlyEnumerableStringKeys(hidden)).toBe(false);
+      });
+
+      it("rejects a setter-only property", () => {
+        const obj = { a: 1 };
+        Object.defineProperty(obj, "s", { set: () => {}, enumerable: true });
+        expect(isPlainObjectWithOnlyEnumerableStringKeys(obj)).toBe(false);
+      });
+
+      it("rejects a getter/setter pair", () => {
+        const obj = { a: 1 };
+        Object.defineProperty(obj, "gs", {
+          get: () => 2,
+          set: () => {},
+          enumerable: true,
+        });
+        expect(isPlainObjectWithOnlyEnumerableStringKeys(obj)).toBe(false);
+      });
+
+      it("rejects a frozen object with a getter", () => {
+        // Freezing does not make an accessor inert: reads still execute it.
+        const obj = { a: 1 };
+        Object.defineProperty(obj, "g", { get: () => 2, enumerable: true });
+        expect(isPlainObjectWithOnlyEnumerableStringKeys(Object.freeze(obj)))
+          .toBe(false);
       });
     });
 
@@ -174,51 +196,6 @@ describe("objects", () => {
       expect(
         isPlainObjectWithOnlyEnumerableStringKeys(new Proxy(withSymbol, {})),
       ).toBe(false);
-    });
-  });
-
-  describe("hasOnlyOwnDataProperties()", () => {
-    it("accepts an object with only data properties", () => {
-      expect(hasOnlyOwnDataProperties({})).toBe(true);
-      expect(hasOnlyOwnDataProperties({ a: 1, b: "two" })).toBe(true);
-      expect(hasOnlyOwnDataProperties(Object.freeze({ a: 1 }))).toBe(true);
-    });
-
-    it("accepts non-enumerable and symbol-keyed data properties", () => {
-      // Descriptor shape only; key visibility and type are out of scope.
-      const obj = { a: 1 } as Record<string | symbol, unknown>;
-      Object.defineProperty(obj, "hidden", { value: 2, enumerable: false });
-      obj[Symbol("s")] = 3;
-      expect(hasOnlyOwnDataProperties(obj)).toBe(true);
-    });
-
-    it("accepts an array of data elements", () => {
-      expect(hasOnlyOwnDataProperties([1, 2, 3])).toBe(true);
-    });
-
-    it("rejects an enumerable getter", () => {
-      const obj = { a: 1 };
-      Object.defineProperty(obj, "g", { get: () => 2, enumerable: true });
-      expect(hasOnlyOwnDataProperties(obj)).toBe(false);
-    });
-
-    it("rejects a non-enumerable getter", () => {
-      const obj = { a: 1 };
-      Object.defineProperty(obj, "g", { get: () => 2, enumerable: false });
-      expect(hasOnlyOwnDataProperties(obj)).toBe(false);
-    });
-
-    it("rejects a setter-only property", () => {
-      const obj = { a: 1 };
-      Object.defineProperty(obj, "s", { set: () => {}, enumerable: true });
-      expect(hasOnlyOwnDataProperties(obj)).toBe(false);
-    });
-
-    it("rejects a frozen object with a getter", () => {
-      // Freezing does not make an accessor inert: reads still execute it.
-      const obj = { a: 1 };
-      Object.defineProperty(obj, "g", { get: () => 2, enumerable: true });
-      expect(hasOnlyOwnDataProperties(Object.freeze(obj))).toBe(false);
     });
   });
 });


### PR DESCRIPTION
The `FabricPlainObject` tightening the directive retirement (#5208 → #5242) existed to unblock: with no sanctioned symbol-carriers left, fabric membership can be strict about what a plain object is — and the probe-driven survey found the one remaining hole is **accessor-backed properties**.

## The gap, empirically

An enumerable string-keyed getter (or setter) passed every fabric membership check as inert record data:

| shape | `isFabricValue` | `isFabricValueLayer` | `isDeepFrozenFabricValue` |
|---|---|---|---|
| symbol key | ✅ rejected | ✅ rejected | ✅ rejected |
| non-enumerable key | ✅ rejected | ✅ rejected | ✅ rejected |
| **enumerable getter** | ❌ passed | ❌ passed | ❌ **frozen variant passed** |
| **setter-only** | ❌ passed | ❌ passed | — |

The frozen-getter row is the sharp edge: an object whose reads execute arbitrary code — able to answer differently every time, `Object.freeze` notwithstanding — was granted the system's strongest trust level. The shallow conversion likewise accepted such objects and silently flattened the accessor to its momentary value.

## The fix: "plain object" means *inert* plain object

By design decision in review discussion: inertness is constitutive of what "plain object" means in this system, so the data-property requirement lives *inside* `isPlainObjectWithOnlyEnumerableStringKeys()` rather than composed on top. The predicate's own test previously pinned a key-visibility-only scope; that pin is deliberately superseded and now pins the inert semantics. The check is a **single pass** — one `Reflect.ownKeys()` walk whose per-key descriptor covers string-ness, enumerability, and data-ness at once, replacing the old two-key-walk count comparison. All three fabric chokepoint sites (`isFabricValueLayer()`, `isFabricValue()`'s plain-object arm, and `shallowFabricFromNativeValue()`'s object case) get the strictness through the one predicate; the conversion throws `Cannot store object that is not an inert plain object` instead of silently flattening.

(An earlier revision of this branch composed a separate `hasOnlyOwnDataProperties()` helper to preserve the visibility-only pin; the redefinition made that indirection — and its second key walk — unnecessary, and the helper is gone.)

## Measured cost

Fused single-pass predicate: ~82ns for a 3-key record (vs ~62ns before — the irreducible descriptor cost) and **~2.8µs at 100 keys, back at the previous count-trick's ~2.7µs** while verifying strictly more. Full runner suite (the heaviest consumer): 1104 passed / 0 failed with zero call-site changes — nothing in the tree writes accessor-bearing objects.

## Deliberately out of scope, queued next

The `isFabricValue()` doc scopes its accessor claim to plain-object properties accordingly (cubic's catch on the first revision). An accessor-backed array **index** still passes (`isArrayWithOnlyIndexProperties` is a last-key peek; a naive descriptor walk there measured **5.4×** on the small-array hot case). That gap is real, disclosed, and queued as the immediate follow-up. Its design is open: the inert-by-definition principle argues for fusing into the array predicate as done here for objects, but the naive cost says the implementation (or its placement) needs its own treatment.

## Verification

Repo-wide `deno task check`, `check-docs` (521/521), `fmt --check`, `lint` all clean; utils 92/0, data-model 47/0, runner 1104/0 (all re-run at the fused head), full workspace suite green at this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VEMbFKHAMQ5h71AD5uFj8
