### PR TITLE
Pin the `[toCell]` annotated-value write-back round trip

### DIFF
--- a/packages/runner/test/schema-links.test.ts
+++ b/packages/runner/test/schema-links.test.ts
@@ -10,6 +10,7 @@ import { createCell, isCell } from "../src/cell.ts";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { type JSONSchema } from "../src/builder/types.ts";
 import { diffAndUpdate } from "../src/data-updating.ts";
+import { parseLink } from "../src/link-utils.ts";
 import { Runtime } from "../src/runtime.ts";
 import { dataUriFromValueWithResolvedLinks } from "../src/data-uri.ts";
 import { areLinksSame } from "../src/link-utils.ts";
@@ -228,6 +229,77 @@ describe("Schema - Link Resolution", () => {
       expect(links[0].id).not.toBe(links[1].id);
       expect(links[1].id).not.toBe(links[2].id);
       expect(links[0].id).not.toBe(links[2].id);
+    });
+
+    it("stores annotated values back as links, with [toCell] stripped", () => {
+      // `.get()` results carry a non-enumerable `[toCell]` symbol -- on plain
+      // OBJECTS as well as arrays. Written back into storage, such a value
+      // must become a link to its source (the annotation is the way back),
+      // never reaching conversion with the symbol attached: conversion
+      // rejects non-inert objects loudly, so a leak here would throw.
+      const schema = {
+        type: "object",
+        properties: {
+          items: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                name: { type: "string" },
+                value: { type: "number" },
+              },
+            },
+          },
+        },
+      } as const satisfies JSONSchema;
+      const source = runtime.getCell(
+        space,
+        "annotated-write-back-source",
+        schema,
+        tx,
+      );
+      source.set({ items: [{ name: "Ada", value: 1 }] });
+
+      const item = source.key("items").key(0).get();
+      const items = source.key("items").get();
+      expect(typeof (item as any)[toCell]).toBe("function");
+      expect(typeof (items as any)[toCell]).toBe("function");
+
+      const dest = runtime.getCell<{ single: unknown; list: unknown }>(
+        space,
+        "annotated-write-back-dest",
+        undefined,
+        tx,
+      );
+      dest.set({ single: item, list: items });
+
+      // Both the annotated object and the annotated array land as links to
+      // their source locations...
+      const raw = dest.getRaw() as { single: unknown; list: unknown };
+      const singleLink = parseLink(raw.single, dest);
+      expect(singleLink?.path).toEqual(["items", "0"]);
+      const listLink = parseLink(raw.list, dest);
+      expect(listLink?.path).toEqual(["items"]);
+
+      // ...no symbol survives anywhere in the stored tree...
+      const assertNoSymbolKeys = (value: unknown): void => {
+        if (value === null || typeof value !== "object") return;
+        for (const key of Reflect.ownKeys(value)) {
+          expect(typeof key).toBe("string");
+          assertNoSymbolKeys(
+            (value as Record<string, unknown>)[key as string],
+          );
+        }
+      };
+      assertNoSymbolKeys(raw);
+
+      // ...and reads through the links yield the source values.
+      const view = dest.get() as {
+        single: { name: string };
+        list: { value: number }[];
+      };
+      expect(view.single.name).toBe("Ada");
+      expect(view.list[0].value).toBe(1);
     });
 
     it("should create URIs for plain objects not marked asCell", () => {


### PR DESCRIPTION
Follow-up to #5247, pinning a guarantee that was verified during that work but whose test didn't land with it.

Writing a `[toCell]`-annotated query result into another cell must store a **link back to the source**, not a copy, and the stored raw data must carry no symbol keys. The mechanism: the diff walk's `BRANCH_QUERY_RESULT` case converts the annotated value to a link to its source *before* strict conversion ever sees it — so the annotation (a non-enumerable symbol) never reaches storage. This was definitively known to work for arrays; the test pins the plain-object side too, plus the no-symbol-keys guarantee over everything stored:

- gets an annotated object (`source.key("items").key(0).get()`) and an annotated array, writes both into a destination cell;
- asserts the stored values are links back to the source paths (`["items", "0"]` and `["items"]`);
- walks the destination's stored raw data asserting no symbol keys anywhere;
- reads the values back through the links.

Test-only change; no runtime code touched.

## Verification

Repo-wide `deno task check`, `fmt --check`, `lint` clean; full runner suite green at this head (and the same content previously passed the full gate battery including `check-docs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VEMbFKHAMQ5h71AD5uFj8


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a test that pins `[toCell]` annotated-value write‑back: writing an annotated object or array into another cell stores a link back to its source (not a copy) and persists no symbol keys. The test verifies link paths and read-back for both cases; no runtime code changed.

<sup>Written for commit 5d817024dfcf02e032b54b74733cfd5c13fb27c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

