### PR TITLE
fix(runner): read an optional property written as `undefined` as absent

### DIFF
--- a/packages/runner/src/cfc/schema-sanitization.ts
+++ b/packages/runner/src/cfc/schema-sanitization.ts
@@ -510,47 +510,36 @@ const typeMatches = (
 };
 
 /**
- * Whether `key` is an OPTIONAL property holding `undefined` — which says
- * nothing, and so is read as absent rather than as a value to measure.
+ * Whether `key` is an OPTIONAL property holding `undefined` that THIS caller
+ * has asked to read as absent rather than measure.
  *
- * JavaScript cannot tell `{ a: undefined }` from `{}` on read, and a handler
- * building an object literal out of a variable that happens to be undefined
- * writes the key without meaning to say anything by it —
- * `comments.push({ author, ... })` with no author in hand is the shape that
- * made this matter. Measuring such a key asks whether `undefined` satisfies
- * the property's declared type, which no ordinary type answers yes to, so one
- * optional field would pass when omitted and fail when written as undefined.
+ * Gated on the option, and off by default, because `undefined` is a value in
+ * this system rather than a hole: the codec stores its presence as
+ * `{"/Undefined@1": null}`, `type: "undefined"` is a type this validator
+ * supports, and `pull-materialization.test.ts` pins both halves ("does not hide
+ * present explicit undefined behind an optional alias", "retains explicit
+ * undefined at an optional derived Cell root"). A caller writing `undefined`
+ * where a number is declared has made a mistake worth rejecting while they can
+ * still see it.
  *
- * The cost of getting this wrong is not a spurious message. A stored argument
- * that fails validation refuses its pattern's every future update, and refuses
- * it identically each time — see `isStoredArgumentSchemaRefusal` in
- * `../runner.ts`, which exists because a root pinned to a version whose schema
- * cannot read its own document never opens again.
+ * The stored-argument check a pattern update runs asks a different question,
+ * which is why it opts in — see `optionalUndefinedIsAbsent`.
  *
- * REQUIRED properties are excluded, and that exclusion is load-bearing rather
- * than cautious: `type: "undefined"` is a type this validator supports, so a
- * required property of that type holds undefined legitimately and must still
- * be measured to be accepted. A required property of any OTHER type holding
- * undefined keeps failing on its type, which is the right answer by a
- * different route.
+ * REQUIRED properties are never absent under this rule, and that carve-out is
+ * load-bearing rather than cautious: a required property declared
+ * `type: "undefined"` holds undefined legitimately and must still be measured
+ * to be ACCEPTED. A required property of any other type holding undefined keeps
+ * failing on its type, which is the right answer by a different route.
  */
 const isAbsentOptional = (
   value: FabricPlainObject,
   key: string,
   requiredKeys: ReadonlySet<string>,
+  options: SchemaValidationOptions,
 ): boolean =>
+  options.optionalUndefinedIsAbsent === true &&
   (value as Record<string, unknown>)[key] === undefined &&
   !requiredKeys.has(key);
-
-/**
- * The keys `value` says something at, for the checks that range over UNDECLARED
- * keys. Nothing undeclared can be required, so {@link isAbsentOptional}'s
- * carve-out cannot apply and plain undefined-is-absent holds.
- */
-const definedKeys = (value: FabricPlainObject): string[] =>
-  Object.keys(value).filter((key) =>
-    (value as Record<string, unknown>)[key] !== undefined
-  );
 
 const schemaValueEqual = (left: unknown, right: unknown): boolean => {
   try {
@@ -1122,6 +1111,7 @@ interface SchemaValidationOptions {
     schema: JSONSchema,
     fullSchema: JSONSchema,
   ) => boolean;
+  optionalUndefinedIsAbsent?: boolean;
 }
 
 export interface SchemaValueValidationOptions {
@@ -1135,6 +1125,32 @@ export interface SchemaValueValidationOptions {
     schema: JSONSchema,
     fullSchema: JSONSchema,
   ) => boolean;
+  /**
+   * Read an OPTIONAL property whose value is `undefined` as absent instead of
+   * measuring it against the property's declared type.
+   *
+   * OFF by default, and deliberately: `undefined` is a value here, not a hole.
+   * The codec stores its presence (`{"/Undefined@1": null}`),
+   * `type: "undefined"` is a type this validator supports, and a caller writing
+   * `undefined` where a number is declared has made a mistake worth rejecting
+   * while they can still see it -- `pull-materialization.test.ts` pins that with
+   * "does not hide present explicit undefined behind an optional alias" and
+   * "retains explicit undefined at an optional derived Cell root".
+   *
+   * ON for one caller: the STORED-ARGUMENT check a pattern update runs. That
+   * asks a different question -- "can this version read the document already
+   * there" -- and answers it with a refusal that is PERMANENT
+   * (`isStoredArgumentSchemaRefusal` in `../runner.ts`: the same identity
+   * refuses identically, so a root pinned to a version whose schema cannot read
+   * its own document never opens again). A key holding `undefined` carries no
+   * data, and a handler mints one without meaning to: measured,
+   * `packages/patterns/topics/topic.tsx` does `comments.push({ author, ... })`
+   * with no author whenever `addComment` gets no `agentName`, and
+   * `lunch-poll/main.tsx` does the same with `imageUrl`. Refusing those
+   * documents forever is the wrong trade; rejecting a bad write now is the
+   * right one.
+   */
+  optionalUndefinedIsAbsent?: boolean;
 }
 
 const SANITIZATION_VALIDATION: SchemaValidationOptions = {
@@ -1318,12 +1334,29 @@ const validateAgainstSchemaInternal = (
     }
 
     if (Array.isArray(schema.allOf)) {
+      // `optionalUndefinedIsAbsent` is dropped for the branches. It decides
+      // "optional" from the `required` array on the node doing the check, and
+      // `allOf` is precisely the combinator that can put `required` on one node
+      // and `properties` on another — `{allOf: [{required: ["x"]}, {properties:
+      // {x: {type: "string"}}}]}` would then see `x` as optional in the branch
+      // that types it and skip the check, accepting `{x: undefined}` against a
+      // required string. Measured, and reported by review on #5251.
+      //
+      // Dropped rather than plumbed: requiredness would have to be accumulated
+      // conjunctively down the recursion, and nothing needs it. The generator
+      // emits no `allOf` at all (zero occurrences in `packages/schema-generator`
+      // and in every committed pattern baseline), so no pattern argument schema
+      // — the only place this option is enabled — can reach the branch. Strict
+      // is the safe direction for a shape that does not occur.
+      const branchOptions = options.optionalUndefinedIsAbsent === true
+        ? { ...options, optionalUndefinedIsAbsent: false }
+        : options;
       for (const branch of schema.allOf) {
         const failure = validateAgainstSchemaInternal(
           branch,
           value,
           schemaRoot,
-          options,
+          branchOptions,
           context,
         );
         if (failure !== undefined) return failure;
@@ -1423,7 +1456,7 @@ const validateAgainstSchemaInternal = (
       for (const [key, child] of Object.entries(schema.properties ?? {})) {
         if (
           Object.hasOwn(value, key) &&
-          !isAbsentOptional(value, key, requiredKeys)
+          !isAbsentOptional(value, key, requiredKeys, options)
         ) {
           const failure = validateAgainstSchemaInternal(
             child,
@@ -1446,7 +1479,7 @@ const validateAgainstSchemaInternal = (
             new RegExp(pattern)
           )
           : [];
-        const extra = definedKeys(value).find((key) =>
+        const extra = Object.keys(value).find((key) =>
           !known.has(key) && !patterns.some((pattern) => pattern.test(key))
         );
         if (extra !== undefined) {
@@ -1459,7 +1492,7 @@ const validateAgainstSchemaInternal = (
             new RegExp(pattern)
           )
           : [];
-        for (const key of definedKeys(value)) {
+        for (const key of Object.keys(value)) {
           if (
             !known.has(key) && !patterns.some((pattern) => pattern.test(key))
           ) {

--- a/packages/runner/src/cfc/schema-sanitization.ts
+++ b/packages/runner/src/cfc/schema-sanitization.ts
@@ -509,6 +509,49 @@ const typeMatches = (
   }
 };
 
+/**
+ * Whether `key` is an OPTIONAL property holding `undefined` — which says
+ * nothing, and so is read as absent rather than as a value to measure.
+ *
+ * JavaScript cannot tell `{ a: undefined }` from `{}` on read, and a handler
+ * building an object literal out of a variable that happens to be undefined
+ * writes the key without meaning to say anything by it —
+ * `comments.push({ author, ... })` with no author in hand is the shape that
+ * made this matter. Measuring such a key asks whether `undefined` satisfies
+ * the property's declared type, which no ordinary type answers yes to, so one
+ * optional field would pass when omitted and fail when written as undefined.
+ *
+ * The cost of getting this wrong is not a spurious message. A stored argument
+ * that fails validation refuses its pattern's every future update, and refuses
+ * it identically each time — see `isStoredArgumentSchemaRefusal` in
+ * `../runner.ts`, which exists because a root pinned to a version whose schema
+ * cannot read its own document never opens again.
+ *
+ * REQUIRED properties are excluded, and that exclusion is load-bearing rather
+ * than cautious: `type: "undefined"` is a type this validator supports, so a
+ * required property of that type holds undefined legitimately and must still
+ * be measured to be accepted. A required property of any OTHER type holding
+ * undefined keeps failing on its type, which is the right answer by a
+ * different route.
+ */
+const isAbsentOptional = (
+  value: FabricPlainObject,
+  key: string,
+  requiredKeys: ReadonlySet<string>,
+): boolean =>
+  (value as Record<string, unknown>)[key] === undefined &&
+  !requiredKeys.has(key);
+
+/**
+ * The keys `value` says something at, for the checks that range over UNDECLARED
+ * keys. Nothing undeclared can be required, so {@link isAbsentOptional}'s
+ * carve-out cannot apply and plain undefined-is-absent holds.
+ */
+const definedKeys = (value: FabricPlainObject): string[] =>
+  Object.keys(value).filter((key) =>
+    (value as Record<string, unknown>)[key] !== undefined
+  );
+
 const schemaValueEqual = (left: unknown, right: unknown): boolean => {
   try {
     return valueEqual(left as FabricValue, right as FabricValue);
@@ -1366,13 +1409,22 @@ const validateAgainstSchemaInternal = (
     }
 
     if (isFabricPlainObjectValue(value)) {
-      for (const key of schema.required ?? []) {
+      const requiredKeys = new Set(schema.required ?? []);
+      // REQUIRED keeps asking only whether the key is there. A schema may
+      // declare `type: "undefined"`, and a required property of that type
+      // holds undefined legitimately — so whether undefined belongs at a key
+      // is the property schema's question, answered just below, not this
+      // loop's.
+      for (const key of requiredKeys) {
         if (!Object.hasOwn(value, key)) {
           return mismatch(`missing required property ${key}`);
         }
       }
       for (const [key, child] of Object.entries(schema.properties ?? {})) {
-        if (Object.hasOwn(value, key)) {
+        if (
+          Object.hasOwn(value, key) &&
+          !isAbsentOptional(value, key, requiredKeys)
+        ) {
           const failure = validateAgainstSchemaInternal(
             child,
             value[key],
@@ -1394,7 +1446,7 @@ const validateAgainstSchemaInternal = (
             new RegExp(pattern)
           )
           : [];
-        const extra = Object.keys(value).find((key) =>
+        const extra = definedKeys(value).find((key) =>
           !known.has(key) && !patterns.some((pattern) => pattern.test(key))
         );
         if (extra !== undefined) {
@@ -1407,7 +1459,7 @@ const validateAgainstSchemaInternal = (
             new RegExp(pattern)
           )
           : [];
-        for (const key of Object.keys(value)) {
+        for (const key of definedKeys(value)) {
           if (
             !known.has(key) && !patterns.some((pattern) => pattern.test(key))
           ) {

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1283,7 +1283,23 @@ export class Runner {
       argumentSchema,
       validationArgument,
       argumentSchema,
-      { acceptOpaqueValue: acceptsOpaqueCellOrUnresolvedLink },
+      {
+        acceptOpaqueValue: acceptsOpaqueCellOrUnresolvedLink,
+        // An OPTIONAL key holding `undefined` carries no data, and a handler
+        // mints one without meaning to: `comments.push({ author, ... })` with
+        // no author in hand writes the key, and the codec stores that presence.
+        // Measuring it here asks whether `undefined` satisfies the property's
+        // declared type, which nothing ordinary answers yes to — and THIS
+        // refusal is permanent, because the same identity refuses identically
+        // (see `isStoredArgumentSchemaRefusal`). A pattern would be unable to
+        // update documents it wrote itself. Measured on `topics/topic.tsx`
+        // (`author`) and `lunch-poll/main.tsx` (`imageUrl`).
+        //
+        // Scoped to THIS caller rather than made the validator's rule: writing
+        // `undefined` where a number is declared is still a mistake worth
+        // rejecting at a result write, while the caller can still see it.
+        optionalUndefinedIsAbsent: true,
+      },
     );
     if (validationFailure !== undefined) {
       throw new Error(

--- a/packages/runner/test/cfc-schema-sanitization.test.ts
+++ b/packages/runner/test/cfc-schema-sanitization.test.ts
@@ -313,20 +313,23 @@ describe("cfc schema sanitization", () => {
     }, ["ok"])).toBeUndefined();
   });
 
-  it("treats an optional property holding undefined as absent", () => {
-    // A handler that builds `{ author, ... }` from a variable that happens to
-    // be undefined writes the KEY, and the codec stores that presence
-    // faithfully. Validating it as a value then measures `undefined` against
-    // the property's declared type, which no JSON Schema type matches — so the
-    // same optional field passes when omitted and fails when written as
-    // undefined, though JS cannot tell the two apart on read.
+  it("reads an optional property holding undefined as absent ONLY on request", () => {
+    // `undefined` is a value in this system, not a hole: the codec stores its
+    // presence as `{"/Undefined@1": null}` and `type: "undefined"` is a type
+    // this validator supports. So measuring it is the DEFAULT, and
+    // `pull-materialization.test.ts` pins both halves of that contract with
+    // "does not hide present explicit undefined behind an optional alias" and
+    // "retains explicit undefined at an optional derived Cell root".
     //
-    // Measured consequence: `packages/patterns/topics/topic.tsx` pushes
+    // One caller opts out: the stored-argument check a pattern update runs.
+    // Its refusal is PERMANENT — see `isStoredArgumentSchemaRefusal` in
+    // runner.ts, the same identity refuses identically — and a handler mints
+    // the shape without meaning to. Measured: `topics/topic.tsx` pushes
     // `{ author, ... }` from `addComment` whenever no `agentName` is supplied,
-    // and the resulting document REFUSES its own pattern's next update with
-    // `comments: 0: author: value does not match type object`. A refusal here
-    // is permanent — see `isStoredArgumentSchemaRefusal` in runner.ts: the same
-    // identity refuses identically, so the root never opens again.
+    // so the document REFUSED its own pattern's next update with
+    // `comments: 0: author: value does not match type object`;
+    // `lunch-poll/main.tsx` did the same through `imageUrl`.
+    const lenient = { optionalUndefinedIsAbsent: true } as const;
     const optionalObject = {
       type: "object",
       properties: {
@@ -334,48 +337,122 @@ describe("cfc schema sanitization", () => {
         body: { type: "string" },
       },
     } as const satisfies JSONSchema;
-    expect(validateAgainstSchema(optionalObject, { body: "old" }))
+
+    // Omitted is fine either way — the control that says the cases below are
+    // about PRESENCE of undefined, not about the key being optional.
+    expect(validateSchemaValue(optionalObject, { body: "old" }))
       .toBeUndefined();
     expect(
-      validateAgainstSchema(optionalObject, { author: undefined, body: "old" }),
+      validateSchemaValue(optionalObject, { body: "old" }, undefined, lenient),
     )
       .toBeUndefined();
 
-    // The same rule inside an array, which is where the topics document holds
-    // it: an element's optional field, present and undefined.
-    expect(validateAgainstSchema({
-      type: "array",
-      items: optionalObject,
-    }, [{ author: undefined, body: "old" }])).toBeUndefined();
+    // Default: measured, and it fails. Opted in: absent.
+    const present = { author: undefined, body: "old" };
+    expect(validateSchemaValue(optionalObject, present))
+      .toBe("author: value does not match type object");
+    expect(validateSchemaValue(optionalObject, present, undefined, lenient))
+      .toBeUndefined();
 
-    // Loosening stops at OPTIONAL, and required properties are still measured.
-    // A required object holding undefined keeps failing on its type.
-    expect(validateAgainstSchema({
-      type: "object",
-      properties: { author: { type: "object" } },
-      required: ["author"],
-    }, { author: undefined })).toBe("author: value does not match type object");
+    // The same, inside an array — where the topics document actually holds it.
+    const inArray = { type: "array", items: optionalObject } as const;
+    const rows = [{ author: undefined, body: "old" }];
+    expect(validateSchemaValue(inArray, rows))
+      .toBe("0: author: value does not match type object");
+    expect(validateSchemaValue(inArray, rows, undefined, lenient))
+      .toBeUndefined();
 
-    // Why required is measured rather than read as absent: `type: "undefined"`
-    // is a type this validator supports, so a REQUIRED property of that type
-    // holds undefined legitimately. Reading undefined as absence everywhere
-    // reports this as a missing property — caught by `runner.test.ts`'s
-    // "preserves explicit undefined while combining union defaults", which
-    // validates a defaults object built from exactly this schema shape.
-    expect(validateAgainstSchema({
-      type: "object",
-      properties: { x: { type: "undefined" } },
-      required: ["x"],
-    }, { x: undefined })).toBeUndefined();
+    // The opt-in stops at OPTIONAL. A required object holding undefined keeps
+    // failing on its type even when asked to be lenient.
+    expect(validateSchemaValue(
+      {
+        type: "object",
+        properties: { author: { type: "object" } },
+        required: ["author"],
+      },
+      { author: undefined },
+      undefined,
+      lenient,
+    ))
+      .toBe("author: value does not match type object");
 
-    // An UNDECLARED key holding undefined is absent too — nothing undeclared
-    // can be required, so the carve-out above cannot apply. Without this a
-    // closed schema refuses an object that says nothing at the extra key.
-    expect(validateAgainstSchema({
+    // Why required is measured rather than read as absent: a REQUIRED property
+    // declared `type: "undefined"` holds undefined legitimately and must still
+    // be ACCEPTED. Reading undefined as absence everywhere reports this as a
+    // missing property — caught by `runner.test.ts`'s "preserves explicit
+    // undefined while combining union defaults", which validates a defaults
+    // object built from exactly this shape.
+    expect(validateSchemaValue(
+      {
+        type: "object",
+        properties: { x: { type: "undefined" } },
+        required: ["x"],
+      },
+      { x: undefined },
+      undefined,
+      lenient,
+    )).toBeUndefined();
+
+    // The opt-in reaches DECLARED properties only. An undeclared key is still
+    // measured, opt-in or not: `required` may name a key that `properties`
+    // does not, so skipping undefined-valued keys in the additional-property
+    // scans let a required-but-undeclared one bypass both
+    // `additionalProperties: false` and an `additionalProperties` subschema
+    // (reported by review on #5251). Nothing measured needed that leniency —
+    // `topic.tsx`'s `author` and `lunch-poll`'s `imageUrl` are both declared.
+    const closed = {
       type: "object",
       properties: { body: { type: "string" } },
       additionalProperties: false,
-    }, { body: "old", extra: undefined })).toBeUndefined();
+    } as const;
+    const withExtra = { body: "old", extra: undefined };
+    expect(validateSchemaValue(closed, withExtra))
+      .toBe("additional property extra");
+    expect(validateSchemaValue(closed, withExtra, undefined, lenient))
+      .toBe("additional property extra");
+    expect(validateSchemaValue(
+      {
+        type: "object",
+        properties: {},
+        required: ["x"],
+        additionalProperties: false,
+      },
+      { x: undefined },
+      undefined,
+      lenient,
+    )).toBe("additional property x");
+  });
+
+  it("drops the undefined-is-absent opt-in inside allOf branches", () => {
+    // `optionalUndefinedIsAbsent` decides "optional" from the `required` array
+    // on the node doing the check, and `allOf` is the combinator that can put
+    // `required` on one node and `properties` on another. Without dropping it
+    // for the branches, the branch that TYPES `x` sees no `required` and skips
+    // the check, accepting `{x: undefined}` against a required string
+    // (reported by review on #5251).
+    //
+    // Dropped rather than plumbed: nothing needs it. `packages/schema-generator`
+    // emits no `allOf` at all and no committed pattern baseline contains one,
+    // so a pattern argument schema — the only place the opt-in is enabled —
+    // cannot reach this branch. Strict is the safe direction for a shape that
+    // does not occur.
+    const split = {
+      allOf: [
+        { required: ["x"] },
+        { properties: { x: { type: "string" } } },
+      ],
+    } as const satisfies JSONSchema;
+    const lenient = { optionalUndefinedIsAbsent: true } as const;
+
+    expect(validateSchemaValue(split, { x: undefined }))
+      .toBe("x: value does not match type string");
+    expect(validateSchemaValue(split, { x: undefined }, undefined, lenient))
+      .toBe("x: value does not match type string");
+    // The control: the branch is still doing its ordinary work either way.
+    expect(validateSchemaValue(split, { x: 1 }, undefined, lenient))
+      .toBe("x: value does not match type string");
+    expect(validateSchemaValue(split, { x: "ok" }, undefined, lenient))
+      .toBeUndefined();
   });
 
   it("strictly validates Common Fabric values for schema migrations", () => {

--- a/packages/runner/test/cfc-schema-sanitization.test.ts
+++ b/packages/runner/test/cfc-schema-sanitization.test.ts
@@ -313,6 +313,71 @@ describe("cfc schema sanitization", () => {
     }, ["ok"])).toBeUndefined();
   });
 
+  it("treats an optional property holding undefined as absent", () => {
+    // A handler that builds `{ author, ... }` from a variable that happens to
+    // be undefined writes the KEY, and the codec stores that presence
+    // faithfully. Validating it as a value then measures `undefined` against
+    // the property's declared type, which no JSON Schema type matches — so the
+    // same optional field passes when omitted and fails when written as
+    // undefined, though JS cannot tell the two apart on read.
+    //
+    // Measured consequence: `packages/patterns/topics/topic.tsx` pushes
+    // `{ author, ... }` from `addComment` whenever no `agentName` is supplied,
+    // and the resulting document REFUSES its own pattern's next update with
+    // `comments: 0: author: value does not match type object`. A refusal here
+    // is permanent — see `isStoredArgumentSchemaRefusal` in runner.ts: the same
+    // identity refuses identically, so the root never opens again.
+    const optionalObject = {
+      type: "object",
+      properties: {
+        author: { type: "object", properties: { name: { type: "string" } } },
+        body: { type: "string" },
+      },
+    } as const satisfies JSONSchema;
+    expect(validateAgainstSchema(optionalObject, { body: "old" }))
+      .toBeUndefined();
+    expect(
+      validateAgainstSchema(optionalObject, { author: undefined, body: "old" }),
+    )
+      .toBeUndefined();
+
+    // The same rule inside an array, which is where the topics document holds
+    // it: an element's optional field, present and undefined.
+    expect(validateAgainstSchema({
+      type: "array",
+      items: optionalObject,
+    }, [{ author: undefined, body: "old" }])).toBeUndefined();
+
+    // Loosening stops at OPTIONAL, and required properties are still measured.
+    // A required object holding undefined keeps failing on its type.
+    expect(validateAgainstSchema({
+      type: "object",
+      properties: { author: { type: "object" } },
+      required: ["author"],
+    }, { author: undefined })).toBe("author: value does not match type object");
+
+    // Why required is measured rather than read as absent: `type: "undefined"`
+    // is a type this validator supports, so a REQUIRED property of that type
+    // holds undefined legitimately. Reading undefined as absence everywhere
+    // reports this as a missing property — caught by `runner.test.ts`'s
+    // "preserves explicit undefined while combining union defaults", which
+    // validates a defaults object built from exactly this schema shape.
+    expect(validateAgainstSchema({
+      type: "object",
+      properties: { x: { type: "undefined" } },
+      required: ["x"],
+    }, { x: undefined })).toBeUndefined();
+
+    // An UNDECLARED key holding undefined is absent too — nothing undeclared
+    // can be required, so the carve-out above cannot apply. Without this a
+    // closed schema refuses an object that says nothing at the extra key.
+    expect(validateAgainstSchema({
+      type: "object",
+      properties: { body: { type: "string" } },
+      additionalProperties: false,
+    }, { body: "old", extra: undefined })).toBeUndefined();
+  });
+
   it("strictly validates Common Fabric values for schema migrations", () => {
     expect(validateSchemaValue({ type: "undefined" }, undefined))
       .toBeUndefined();

--- a/packages/runner/test/pattern-update-argument-validation.test.ts
+++ b/packages/runner/test/pattern-update-argument-validation.test.ts
@@ -235,6 +235,65 @@ describe("pattern update validates the stored argument", () => {
     ).toBe(vintageIdentity);
   });
 
+  it("accepts an optional property a handler stored as undefined", async () => {
+    // The shape a real deployed pattern writes. `packages/patterns/topics/
+    // topic.tsx`'s `addComment` builds `comments.push({ author, ... })` from a
+    // variable that is undefined whenever no `agentName` was supplied, so the
+    // KEY lands with no value under it, and the codec stores that presence.
+    //
+    // JavaScript cannot tell `{ author: undefined }` from `{}` on read, so the
+    // pattern has not said anything different by writing it — but validating
+    // the key as a value asks whether `undefined` is an object, which nothing
+    // answers yes to. Measured on the committed topics vintage before this was
+    // fixed: `comments: 0: author: value does not match type object`, refusing
+    // the update of a document the pattern itself had written. The refusal is
+    // permanent (see the roll-forward case above), so this is a piece that
+    // never opens again rather than one that logs and recovers.
+    const stored = {
+      comments: [{ author: undefined, authorName: "Old Agent", body: "old" }],
+    };
+    const { cell } = await setupVintage(
+      openArgument("v1"),
+      stored,
+      "optional-undefined-property",
+    );
+
+    // The premise, checked rather than assumed: if the codec dropped the key on
+    // the way to storage there would be nothing here to validate, and this
+    // case would pass without ever exercising the rule it exists for.
+    const storedLink = getMetaLink(cell, "argument")!;
+    const storedRaw = rt.getCellFromLink(storedLink).getRaw() as {
+      comments: Record<string, unknown>[];
+    };
+    expect(
+      Object.hasOwn(storedRaw.comments[0], "author"),
+      "the stored argument does not carry `author` at all, so this case no " +
+        "longer reaches the present-but-undefined rule it was written for",
+    ).toBe(true);
+    expect(storedRaw.comments[0].author).toBeUndefined();
+
+    const { error, thrown } = await rollForward(
+      cell,
+      programOf([
+        "import { pattern } from 'commonfabric';",
+        "interface Author { kind: string; name: string }",
+        "interface Comment { author?: Author; authorName?: string; body?: string }",
+        "interface Args { comments?: Comment[]; [key: string]: any }",
+        "export default pattern<Args, { marker: string }>(() => {",
+        '  return { marker: "v2" };',
+        "});",
+        "",
+      ].join("\n")),
+    );
+
+    expect(
+      error,
+      "a property the pattern wrote as undefined was measured against its " +
+        "declared type, so the update the pattern's own data provoked is refused",
+    ).toBeUndefined();
+    expect(isStoredArgumentSchemaRefusal(thrown)).toBe(false);
+  });
+
   it("lets a MARKERLESS root through, and marks it on the way", async () => {
     // The deliberate exemption, pinned so it is a decision rather than an
     // assumption. `storedSetupMarker` reports an absent `patternSetupIdentity`


### PR DESCRIPTION
## The bug

A handler that builds an object literal from a variable that happens to be undefined writes the KEY, and the codec stores that presence faithfully. Validating it as a value then asks whether `undefined` satisfies the property's declared type — which no ordinary type answers yes to.

So the same optional field **passed when omitted and failed when written as `undefined`**, a distinction JavaScript cannot make on read.

## Why it matters

`packages/patterns/topics/topic.tsx` does exactly that:

```ts
const author = topicAuthorFromAgent(agentName ?? "");  // undefined when no agentName
comments.push({ author, authorName: legacyName, body: trimmed, sentAt: Date.now() });
```

The stored comment carries `author` as `{"/Undefined@1": null}` — present, undefined. Its own pattern's next update was then **refused**:

```
updated arguments do not match the candidate schema: comments: 0: author: value does not match type object
```

That refusal is permanent. `isStoredArgumentSchemaRefusal` exists precisely because "a root pinned to a version whose schema cannot read its own document never opens again". The runtime was writing data its own updater would not accept, and **any** pattern doing `push({ optionalField, ... })` mints one.

## The fix

An **optional** property holding `undefined` is absent. Three sites, all asking "is this property present": the `properties` loop and both `additionalProperties` scans.

### What is deliberately NOT changed

- **`required`.** `type: "undefined"` is a type this validator supports, so a required property of that type holds `undefined` legitimately and must still be measured. My first attempt applied the rule to all eight presence checks; `runner.test.ts` → *"preserves explicit undefined while combining union defaults"* caught it, validating a defaults object of exactly that shape. A required property of any other type holding `undefined` keeps failing on its type — right answer by a different route.
- **`min/maxProperties`, `dependentRequired`, `dependentSchemas`, `propertyNames`.** Counting and dependency semantics where "present" is genuinely ambiguous for a required-undefined, and none were measured.
- **Array indices.** The five `Object.hasOwn(value, index)` checks distinguish a sparse hole from a present element; `[undefined]` genuinely differs from `[]` — it has a length.

## Verification

- Red→green confirmed **both directions**: source reverted with the new tests kept → both fail; fix restored → both pass.
- Full runner suite **1100 passed / 0 failed**.
- On the Tier 2 vintage gate against the committed topics fixture, `updated cleanly` went **32 → 33** and the refusal disappeared.

Two tests: the validator rule (including the `type: "undefined"` carve-out and the undeclared-key case) and an end-to-end roll-forward built on the real topics shape, with an explicit premise assertion that the codec actually stored the key — otherwise it would pass without exercising anything.

Found by the Tier 2 vintage gate on its first genuine exercise against topics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in validator mode used only during stored-argument checks to treat optional properties written as `undefined` as absent. This avoids permanent update refusals (e.g., `{ author: undefined }` in comments) without changing default validation.

- **Bug Fixes**
  - Introduced `optionalUndefinedIsAbsent`; enabled only in stored-argument validation in `packages/runner/src/runner.ts`. Default validator stays strict (`undefined` is a value).
  - Applies only to declared optional properties (including array items); required keys are still measured. `type: "undefined"` when required remains valid; required non-undefined types with `undefined` still fail.
  - Keeps strict `additionalProperties`; undeclared keys set to `undefined` still error. Drops the option inside `allOf` branches to avoid skipping requiredness.
  - Added unit and end-to-end tests for default vs opt-in behavior, array cases, `allOf` handling, and a topics/lunch-poll stored-argument acceptance case.

<sup>Written for commit c7e02bc0f55add806e239e7b541c6c061cd77c42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

