### PR TITLE
Rename `isPlainObjectWithOnlyEnumerableStringKeys()` to `isInertPlainObject()`

### DIFF
--- a/packages/data-model/src/native-conversion.ts
+++ b/packages/data-model/src/native-conversion.ts
@@ -3,7 +3,7 @@ import {
   isRecord,
   isUnsafeObjectKey,
 } from "@commonfabric/utils/types";
-import { isPlainObjectWithOnlyEnumerableStringKeys } from "@commonfabric/utils/objects";
+import { isInertPlainObject } from "@commonfabric/utils/objects";
 import {
   isArrayIndexPropertyName,
   isInertArray,
@@ -106,7 +106,7 @@ export function shallowCleanArray(
 /**
  * Returns a shallow clone of the given object carrying nothing but its
  * enumerable string-keyed properties, that is, one which satisfies
- * `isPlainObjectWithOnlyEnumerableStringKeys()`. Values are copied by reference
+ * `isInertPlainObject()`. Values are copied by reference
  * without themselves being converted or validated, this being a shallow
  * operation.
  *
@@ -278,7 +278,7 @@ export function shallowFabricFromNativeValue(
       // outright rather than dropping or flattening it on the way through
       // ("death before confusion"), matching how an array's non-index
       // properties are treated.
-      if (!isPlainObjectWithOnlyEnumerableStringKeys(value)) {
+      if (!isInertPlainObject(value)) {
         throw new Error(
           "Not representable as a `FabricValue`: object that is not an " +
             "inert plain object",
@@ -697,7 +697,7 @@ function isFabricCompatibleInternal(
       // Plain objects -- check the key shape, then all property values
       // recursively. A symbol key or a non-enumerable string key has no fabric
       // representation, just as an array's non-index properties do not.
-      if (!isPlainObjectWithOnlyEnumerableStringKeys(value)) {
+      if (!isInertPlainObject(value)) {
         seen.delete(value);
         return false;
       }

--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -1,5 +1,5 @@
 import { isInertArray } from "@commonfabric/utils/arrays";
-import { isPlainObjectWithOnlyEnumerableStringKeys } from "@commonfabric/utils/objects";
+import { isInertPlainObject } from "@commonfabric/utils/objects";
 import { isPlainObject } from "@commonfabric/utils/types";
 
 import {
@@ -51,7 +51,7 @@ export function isFabricValueLayer(
       // `string`, so a symbol key has no representation either, and neither
       // does a non-enumerable string key; an accessor-backed property is live
       // code rather than inert data.
-      return isPlainObjectWithOnlyEnumerableStringKeys(value);
+      return isInertPlainObject(value);
     }
 
     case "symbol": {
@@ -152,7 +152,7 @@ export function isFabricValue(value: unknown): value is FabricValue {
       // Symbol-keyed and non-enumerable string-keyed properties have no fabric
       // representation, the same as an array's non-index properties; an
       // accessor-backed property is live code rather than inert data.
-      if (!isPlainObjectWithOnlyEnumerableStringKeys(item)) return false;
+      if (!isInertPlainObject(item)) return false;
       const record = item as Record<string, unknown>;
       for (const key of Object.keys(record)) {
         if (!check(record[key])) return false;

--- a/packages/data-model/test/native-conversion.test.ts
+++ b/packages/data-model/test/native-conversion.test.ts
@@ -24,7 +24,7 @@ import {
   shallowFabricFromNativeValue,
 } from "@/native-conversion.ts";
 import { isArrayWithOnlyIndexProperties } from "@commonfabric/utils/arrays";
-import { isPlainObjectWithOnlyEnumerableStringKeys } from "@commonfabric/utils/objects";
+import { isInertPlainObject } from "@commonfabric/utils/objects";
 import { FrozenMap, FrozenSet } from "@/frozen-builtins.ts";
 import { UnknownValue } from "@/fabric-instances/UnknownValue.ts";
 import { ProblematicValue } from "@/fabric-instances/ProblematicValue.ts";
@@ -2022,7 +2022,7 @@ describe("native-conversion", () => {
 
       const result = shallowCleanPlainObject(obj) as Record<string, unknown>;
 
-      expect(isPlainObjectWithOnlyEnumerableStringKeys(result)).toBe(true);
+      expect(isInertPlainObject(result)).toBe(true);
       expect(result).toEqual({ a: 1 });
     });
 

--- a/packages/utils/src/objects.ts
+++ b/packages/utils/src/objects.ts
@@ -24,7 +24,7 @@
  * @returns `true` if the value is a plain object all of whose own properties
  *   are enumerable string-keyed data properties, `false` otherwise.
  */
-export function isPlainObjectWithOnlyEnumerableStringKeys(
+export function isInertPlainObject(
   value: unknown,
 ): boolean {
   if ((value === null) || (typeof value !== "object")) {

--- a/packages/utils/test/objects.test.ts
+++ b/packages/utils/test/objects.test.ts
@@ -1,41 +1,41 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { isPlainObjectWithOnlyEnumerableStringKeys } from "@commonfabric/utils/objects";
+import { isInertPlainObject } from "@commonfabric/utils/objects";
 
 describe("objects", () => {
-  describe("isPlainObjectWithOnlyEnumerableStringKeys()", () => {
+  describe("isInertPlainObject()", () => {
     describe("returns `true` for a plain object with only enumerable string keys", () => {
       it("accepts an empty object", () => {
-        expect(isPlainObjectWithOnlyEnumerableStringKeys({})).toBe(true);
+        expect(isInertPlainObject({})).toBe(true);
       });
 
       it("accepts an object with string-keyed values", () => {
-        expect(isPlainObjectWithOnlyEnumerableStringKeys({ a: 1, b: "two" }))
+        expect(isInertPlainObject({ a: 1, b: "two" }))
           .toBe(true);
       });
 
       it("accepts a null-prototype object", () => {
         const obj = Object.create(null) as Record<string, unknown>;
         obj.a = 1;
-        expect(isPlainObjectWithOnlyEnumerableStringKeys(obj)).toBe(true);
+        expect(isInertPlainObject(obj)).toBe(true);
       });
 
       it("accepts a key whose value is `undefined`", () => {
         // A present key holding `undefined` is still an enumerable string key.
-        expect(isPlainObjectWithOnlyEnumerableStringKeys({ a: undefined }))
+        expect(isInertPlainObject({ a: undefined }))
           .toBe(true);
       });
 
       it("accepts an index-shaped string key", () => {
         // Unlike an array, an object has no notion of an index key; `"0"` is
         // just a string name here.
-        expect(isPlainObjectWithOnlyEnumerableStringKeys({ 0: "a", 1: "b" }))
+        expect(isInertPlainObject({ 0: "a", 1: "b" }))
           .toBe(true);
       });
 
       it("accepts a frozen object", () => {
         expect(
-          isPlainObjectWithOnlyEnumerableStringKeys(Object.freeze({ a: 1 })),
+          isInertPlainObject(Object.freeze({ a: 1 })),
         )
           .toBe(true);
       });
@@ -45,7 +45,7 @@ describe("objects", () => {
       it("rejects an enumerable symbol-keyed property", () => {
         const obj = { a: 1 } as Record<string | symbol, unknown>;
         obj[Symbol("s")] = 2;
-        expect(isPlainObjectWithOnlyEnumerableStringKeys(obj)).toBe(false);
+        expect(isInertPlainObject(obj)).toBe(false);
       });
 
       it("rejects a non-enumerable symbol-keyed property", () => {
@@ -54,7 +54,7 @@ describe("objects", () => {
           value: 2,
           enumerable: false,
         });
-        expect(isPlainObjectWithOnlyEnumerableStringKeys(obj)).toBe(false);
+        expect(isInertPlainObject(obj)).toBe(false);
       });
 
       it("rejects a registry-interned symbol-keyed property", () => {
@@ -62,19 +62,19 @@ describe("objects", () => {
         // *name*.
         const obj = { a: 1 } as Record<string | symbol, unknown>;
         obj[Symbol.for("s")] = 2;
-        expect(isPlainObjectWithOnlyEnumerableStringKeys(obj)).toBe(false);
+        expect(isInertPlainObject(obj)).toBe(false);
       });
 
       it("rejects a well-known symbol-keyed property", () => {
         const obj = { a: 1 } as Record<string | symbol, unknown>;
         obj[Symbol.toStringTag] = "Nope";
-        expect(isPlainObjectWithOnlyEnumerableStringKeys(obj)).toBe(false);
+        expect(isInertPlainObject(obj)).toBe(false);
       });
 
       it("rejects a non-enumerable string-keyed property", () => {
         const obj = { a: 1 };
         Object.defineProperty(obj, "hidden", { value: 2, enumerable: false });
-        expect(isPlainObjectWithOnlyEnumerableStringKeys(obj)).toBe(false);
+        expect(isInertPlainObject(obj)).toBe(false);
       });
 
       it("rejects a non-enumerable string key whose value is `undefined`", () => {
@@ -84,7 +84,7 @@ describe("objects", () => {
           value: undefined,
           enumerable: false,
         });
-        expect(isPlainObjectWithOnlyEnumerableStringKeys(obj)).toBe(false);
+        expect(isInertPlainObject(obj)).toBe(false);
       });
 
       it("rejects an accessor property, enumerable or not", () => {
@@ -100,16 +100,16 @@ describe("objects", () => {
         // disqualifying regardless of its key's visibility: it is live code,
         // not data. This pins that the check covers data-versus-accessor in
         // addition to key visibility.
-        expect(isPlainObjectWithOnlyEnumerableStringKeys(enumerable)).toBe(
+        expect(isInertPlainObject(enumerable)).toBe(
           false,
         );
-        expect(isPlainObjectWithOnlyEnumerableStringKeys(hidden)).toBe(false);
+        expect(isInertPlainObject(hidden)).toBe(false);
       });
 
       it("rejects a setter-only property", () => {
         const obj = { a: 1 };
         Object.defineProperty(obj, "s", { set: () => {}, enumerable: true });
-        expect(isPlainObjectWithOnlyEnumerableStringKeys(obj)).toBe(false);
+        expect(isInertPlainObject(obj)).toBe(false);
       });
 
       it("rejects a getter/setter pair", () => {
@@ -119,68 +119,68 @@ describe("objects", () => {
           set: () => {},
           enumerable: true,
         });
-        expect(isPlainObjectWithOnlyEnumerableStringKeys(obj)).toBe(false);
+        expect(isInertPlainObject(obj)).toBe(false);
       });
 
       it("rejects a frozen object with a getter", () => {
         // Freezing does not make an accessor inert: reads still execute it.
         const obj = { a: 1 };
         Object.defineProperty(obj, "g", { get: () => 2, enumerable: true });
-        expect(isPlainObjectWithOnlyEnumerableStringKeys(Object.freeze(obj)))
+        expect(isInertPlainObject(Object.freeze(obj)))
           .toBe(false);
       });
     });
 
     describe("returns `false` for anything that is not a plain object", () => {
       it("rejects an array, empty or not", () => {
-        expect(isPlainObjectWithOnlyEnumerableStringKeys([])).toBe(false);
-        expect(isPlainObjectWithOnlyEnumerableStringKeys([1, 2])).toBe(false);
+        expect(isInertPlainObject([])).toBe(false);
+        expect(isInertPlainObject([1, 2])).toBe(false);
       });
 
       it("rejects a class instance", () => {
         class Thing {
           a = 1;
         }
-        expect(isPlainObjectWithOnlyEnumerableStringKeys(new Thing()))
+        expect(isInertPlainObject(new Thing()))
           .toBe(false);
       });
 
       it("rejects built-in instances", () => {
-        expect(isPlainObjectWithOnlyEnumerableStringKeys(new Date())).toBe(
+        expect(isInertPlainObject(new Date())).toBe(
           false,
         );
-        expect(isPlainObjectWithOnlyEnumerableStringKeys(new Map())).toBe(
+        expect(isInertPlainObject(new Map())).toBe(
           false,
         );
-        expect(isPlainObjectWithOnlyEnumerableStringKeys(/re/)).toBe(false);
-        expect(isPlainObjectWithOnlyEnumerableStringKeys(new Uint8Array([1])))
+        expect(isInertPlainObject(/re/)).toBe(false);
+        expect(isInertPlainObject(new Uint8Array([1])))
           .toBe(false);
       });
 
       it("rejects an object whose prototype is `Array.prototype`", () => {
         const fake = Object.create(Array.prototype) as Record<string, unknown>;
         fake.a = 1;
-        expect(isPlainObjectWithOnlyEnumerableStringKeys(fake)).toBe(false);
+        expect(isInertPlainObject(fake)).toBe(false);
       });
 
       it("answers rather than throwing for `null` and `undefined`", () => {
-        expect(isPlainObjectWithOnlyEnumerableStringKeys(null)).toBe(false);
-        expect(isPlainObjectWithOnlyEnumerableStringKeys(undefined)).toBe(
+        expect(isInertPlainObject(null)).toBe(false);
+        expect(isInertPlainObject(undefined)).toBe(
           false,
         );
       });
 
       it("answers rather than throwing for primitives", () => {
-        expect(isPlainObjectWithOnlyEnumerableStringKeys("abc")).toBe(false);
-        expect(isPlainObjectWithOnlyEnumerableStringKeys(42)).toBe(false);
-        expect(isPlainObjectWithOnlyEnumerableStringKeys(true)).toBe(false);
-        expect(isPlainObjectWithOnlyEnumerableStringKeys(1n)).toBe(false);
-        expect(isPlainObjectWithOnlyEnumerableStringKeys(Symbol("s")))
+        expect(isInertPlainObject("abc")).toBe(false);
+        expect(isInertPlainObject(42)).toBe(false);
+        expect(isInertPlainObject(true)).toBe(false);
+        expect(isInertPlainObject(1n)).toBe(false);
+        expect(isInertPlainObject(Symbol("s")))
           .toBe(false);
       });
 
       it("rejects a function", () => {
-        expect(isPlainObjectWithOnlyEnumerableStringKeys(() => 1)).toBe(false);
+        expect(isInertPlainObject(() => 1)).toBe(false);
       });
     });
 
@@ -188,13 +188,13 @@ describe("objects", () => {
       // `Object.getPrototypeOf` and the key traps forward to the target, so a
       // pass-through proxy over a plain object is judged on the target.
       expect(
-        isPlainObjectWithOnlyEnumerableStringKeys(new Proxy({ a: 1 }, {})),
+        isInertPlainObject(new Proxy({ a: 1 }, {})),
       ).toBe(true);
 
       const withSymbol = { a: 1 } as Record<string | symbol, unknown>;
       withSymbol[Symbol("s")] = 2;
       expect(
-        isPlainObjectWithOnlyEnumerableStringKeys(new Proxy(withSymbol, {})),
+        isInertPlainObject(new Proxy(withSymbol, {})),
       ).toBe(false);
     });
   });


### PR DESCRIPTION
Follow-on to #5250: the object predicate joins the `isInert*` naming. The old name described the check by enumerating its mechanics and still managed to omit one of them (data-property-ness); the new name says what the predicate decides -- inertness is what "plain object" means in this system (#5247) -- and matches its array companion `isInertArray()`.

Pure rename, no behavior change: all 47 occurrences across the five files that reference it (utils src + test, data-model `type-check.ts` / `native-conversion.ts` + test). No string-literal or documentation references exist.

## Verification

Repo-wide `deno task check`, `check-docs` (521/521), `fmt --check`, `lint` clean; full workspace suite green at this head ("All tests passing!"), including utils (92 passed / 571 steps) and data-model (47 passed / 2178 steps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VEMbFKHAMQ5h71AD5uFj8

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed isPlainObjectWithOnlyEnumerableStringKeys() to isInertPlainObject() to match the `isInert*` naming and better reflect intent. No behavior changes; updated references across utils, data-model, and tests.

- **Migration**
  - Replace isPlainObjectWithOnlyEnumerableStringKeys with isInertPlainObject in imports/usages from `@commonfabric/utils/objects`.

<sup>Written for commit b78f73d500074c249da888480c4bf3e8d19848ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

