### PR TITLE
Address system patterns by `system:` ref, and fetch only those

### DIFF
--- a/docs/specs/pattern-imports/pattern-updates.md
+++ b/docs/specs/pattern-imports/pattern-updates.md
@@ -105,9 +105,11 @@ the *destination* cell's annotations, and replication does not copy the
 `updatesAt` written in a publisher's space
 would not appear on a consumer's replicated copy. The **piece** is the reliable
 carrier: explicit source provenance travels with it. For an unstamped non-root
-piece, its verified source-doc closure supplies the authored entry path; the
-runtime persists that path on the piece only after the matching same-toolshed
-`?identity` route succeeds.
+piece, its verified source-doc closure supplies the authored entry path — but
+only a path under the patterns route is admitted, since a module's name equals
+its route only for a program compiled over HTTP. The runtime persists the
+`system:` ref that path spells, and only after the matching `?identity` route
+succeeds.
 
 ## The implemented specialized model
 
@@ -116,9 +118,11 @@ Two decisions carry the whole design:
 1. **Every updatable piece carries a `patternSource` provenance string** — the
    source it tracks for updates. (`patternSource`, *not* `source`: the latter
    is the doc-level producer annotation the server-primary work uses.) Roots
-   stamp it at URL-based creation. An unstamped non-root may recover its verified
-   authored entry filename and stamp it after that same-origin route proves it
-   implements `?identity`.
+   stamp it at creation. An unstamped non-root may recover its verified
+   authored entry filename, but only one that is itself a patterns-route path,
+   and stamps the `system:` ref for it after that route proves it implements
+   `?identity`. A filename that names no route is not a claim about a source,
+   and the piece stays unstamped.
 2. **Update = resolve `patternSource` → current identity; if it differs from
    the persisted `patternIdentity.identity`, write the new `{identity, symbol}`
    to the piece's `patternIdentity` meta.** At space open this happens before
@@ -190,10 +194,17 @@ prefix:
   (`fabric-ref-resolution.ts`: slug → piece → `patternIdentity`). A
   `cf:pattern:<hash>` ref is **frozen** (resolves to a constant → never
   updates); a bare slug **tracks**. Immutability is just a pinned ref.
-- **non-`cf:` toolshed source path** (system, e.g.
-  `/api/patterns/system/default-app.tsx`) → use `?identity` against the space's
-  host, then fetch and compile whenever the persisted artifact needs an update
-  or repair.
+- **`system:` ref** (a pattern this deployment's toolshed serves from its
+  patterns directory, addressed relative to that route, e.g.
+  `system:system/default-app.tsx` → `/api/patterns/system/default-app.tsx`) →
+  use `?identity` against the space's host, then fetch and compile whenever the
+  persisted artifact needs an update or repair. The ref is host-relative, so it
+  survives a space moving hosts; a ref that would climb out of the patterns
+  route is refused.
+- **Anything else** → no fetch. The scheme is a whitelist rather than a
+  filter, because a bare path cannot be distinguished from an authored module
+  name that merely looks like a route, and resolving such a name against the
+  host reaches whatever the site serves for an unrouted path.
 - **General source URL origins** use the discriminated active-origin and
   revision schemas defined by the piece source lifecycle spec. They must not
   overload the raw string with origin-kind-specific behavior. A fabric
@@ -210,11 +221,14 @@ be established under the ordinary consent rule. Otherwise it keeps the legacy
 locator only as inactive historical provenance and migrates the piece as
 detached. Rollout flags are not durable per-piece consent.
 
-Migration resolves a relative system path against the currently accepted
-toolshed route for the space and stores the resulting absolute web URL. If no
-accepted host can be established, migration does not invent an active origin.
-A later host remapping does not rewrite the stored URL; that requires an
-ordinary repoint.
+Migration rewrites a pre-scheme system locator — the rooted patterns-route
+path, and the absolute web URL that path resolves to under the space's own
+accepted host — into the `system:` ref naming the same file. A locator on any
+other host is left alone: re-pointing it at the local toolshed would be a
+change of source, not a change of spelling. If no accepted host can be
+established, migration does not invent an active origin. Because the ref is
+host-relative, a later host remapping needs no rewrite; changing which *file* a
+piece tracks still requires an ordinary repoint.
 
 A source-less legacy root does not gain an origin merely because it is a root.
 The specialized updater can derive an official candidate path, but ordinary
@@ -404,11 +418,12 @@ conditionally revalidate them before every update attempt.
 root with `runIt=false`, run this loop, re-resolve the cell after any metadata
 transaction, and only then start it:
 
-1. `url` = the root piece's stored `patternSource`. If it is absent, derive the
-   official candidate URL for the space, but do not treat that path as
-   provenance. A root with explicit repository provenance remains pinned.
-   `host` = `mappedHostFor(space) ?? apiUrl`. Only same-origin toolshed sources
-   participate in this v1 loop.
+1. `url` = the patterns route the root piece's stored `patternSource` ref
+   expands to. If the source is absent, derive the official candidate ref for
+   the space, but do not treat it as provenance. A root with explicit
+   repository provenance remains pinned, and so is one whose source is not a
+   `system:` ref. `host` = `mappedHostFor(space) ?? apiUrl`; the ref is
+   host-relative, so the request is same-origin by construction.
 2. `currentId` = a revalidating `GET {host}{url}?identity` for this attempt
    (`fetch` cache mode `no-cache`). A matching `ETag` may reuse the cached body
    after a `304`; the browser may not replay it without validation. An HTTP

--- a/docs/specs/pattern-imports/pattern-updates.md
+++ b/docs/specs/pattern-imports/pattern-updates.md
@@ -225,7 +225,11 @@ Migration rewrites a pre-scheme system locator — the rooted patterns-route
 path, and the absolute web URL that path resolves to under the space's own
 accepted host — into the `system:` ref naming the same file. A locator on any
 other host is left alone: re-pointing it at the local toolshed would be a
-change of source, not a change of spelling. If no accepted host can be
+change of source, not a change of spelling. A query or fragment on a legacy
+locator is dropped, since the patterns route serves a file by path and
+revalidation is the `?identity` ETag's job; the rewrite is otherwise exact, and
+a locator that cannot be spelled as a ref is left as authored rather than
+rewritten into one that would not resolve. If no accepted host can be
 established, migration does not invent an active origin. Because the ref is
 host-relative, a later host remapping needs no rewrite; changing which *file* a
 piece tracks still requires an ordinary repoint.
@@ -240,8 +244,10 @@ creates the space. In the target model, it passes that source through the same
 creation transition used for any other piece. That transition writes the first
 revision. It writes a normalized active origin only when creation also makes
 the ordinary explicit choice to accept future updates from a mutable default.
-The current implementation instead seeds a non-home root's raw `patternSource`
-from the home root's `defaultAppUrl`. Editing that template later does **not**
+The current implementation instead seeds a non-home root's `patternSource` from
+the home root's `defaultAppUrl`, canonicalized to the ref naming the same file
+so a root is born with the provenance it keeps rather than waiting on a
+migration to become followable. Editing that template later does **not**
 change an existing root. Changing that root's source is an ordinary repoint,
 edit, revert, or other lifecycle operation. Under the tentative identifier-only
 URL policy, a template stores a canonical space DID with a stable entity FID,

--- a/docs/specs/piece-source-lifecycle.md
+++ b/docs/specs/piece-source-lifecycle.md
@@ -875,12 +875,12 @@ The implementation evidence for this table is concentrated in:
 - Fabric reference parsing and resolution support content-addressed pattern
   references, explicit pins, and same-toolshed mutable references by stable
   entity or slug. Static imports pin mutable references into source.
-- System space roots carry a `patternSource` URL path when created through
-  `ensureDefaultPattern`. Roots can check that source and replace
-  `patternIdentity` before starting. Other successfully instantiated
-  same-toolshed system-source patterns are checked in the background. This is a
-  transitional implementation and migration input, not a target lifecycle
-  exception.
+- System space roots carry a `system:` `patternSource` ref when created through
+  `ensureDefaultPattern`, naming a pattern the toolshed serves relative to its
+  patterns route. Roots can check that source and replace `patternIdentity`
+  before starting. Other successfully instantiated patterns are checked in the
+  background, and only a `system:` ref is fetched. This is a transitional
+  implementation and migration input, not a target lifecycle exception.
 - Storage supports late registration of a space-to-host hint before that space
   opens. The runtime processor hydrates durable hints from the home-space site
   table. A seeded route can only be confirmed. An opened space accepts only its

--- a/packages/piece/src/manager.ts
+++ b/packages/piece/src/manager.ts
@@ -46,7 +46,7 @@ import {
 } from "../../runner/src/piece-helpers.ts";
 import { prepareSourceClosureVerification } from "../../runner/src/compilation-cache/cell-cache.ts";
 import type { PatternUpdateOutcome } from "../../runner/src/pattern-updater.ts";
-import { deriveSystemPatternUrl } from "./system-pattern-url.ts";
+import { deriveSystemPatternSource } from "./system-pattern-url.ts";
 ensureNotRenderThread();
 
 const PRIVILEGED_PIECE_LIST_SCHEMA = internSchema({
@@ -277,7 +277,7 @@ export class PieceManager {
         const root = await this.get(defaultPattern, false, nameSchema);
         outcome = await this.runtime.patternUpdater.checkDefaultPattern(
           root,
-          deriveSystemPatternUrl(this.space, this.runtime),
+          deriveSystemPatternSource(this.space, this.runtime),
         );
       } catch {
         throw error;

--- a/packages/piece/src/ops/piece-origin.ts
+++ b/packages/piece/src/ops/piece-origin.ts
@@ -17,6 +17,7 @@ import {
   type MemorySpace,
   NAME,
   parseFabricRef,
+  resolveSystemPatternSource,
   type Runtime,
   type RuntimeProgram,
 } from "@commonfabric/runner";
@@ -227,9 +228,9 @@ function fabricHostScheme(host: string): "http:" | "https:" {
 /**
  * Classify a recorded source string as an origin.
  *
- * A toolshed-relative path — the legacy shape system roots are stamped with —
- * resolves against the host accepted for `space`, so the origin that leaves
- * this function is always absolute. An unusable string throws rather than
+ * A `system:` ref, and the toolshed-relative path that is the legacy shape
+ * system roots were stamped with, both resolve against the host accepted for
+ * `space`, so the origin that leaves this function is always absolute. An unusable string throws rather than
  * becoming a silently inert origin.
  */
 export function classifyOrigin(
@@ -263,6 +264,17 @@ export function classifyOrigin(
         ? "fabric-piece"
         : "fabric-pattern",
     };
+  }
+
+  // A `system:` ref names a pattern this deployment's toolshed serves; it
+  // classifies as the web origin it resolves to, keeping the ref itself as the
+  // recorded form so the panel shows what the piece actually stores.
+  const systemRoute = resolveSystemPatternSource(source);
+  if (systemRoute !== undefined) {
+    return webOrigin(
+      new URL(systemRoute, runtime.hostForSpace(space)),
+      source,
+    );
   }
 
   if (source.startsWith("/")) {

--- a/packages/piece/src/ops/piece-origin.ts
+++ b/packages/piece/src/ops/piece-origin.ts
@@ -230,8 +230,8 @@ function fabricHostScheme(host: string): "http:" | "https:" {
  *
  * A `system:` ref, and the toolshed-relative path that is the legacy shape
  * system roots were stamped with, both resolve against the host accepted for
- * `space`, so the origin that leaves this function is always absolute. An unusable string throws rather than
- * becoming a silently inert origin.
+ * `space`, so the origin that leaves this function is always absolute. An
+ * unusable string throws rather than becoming a silently inert origin.
  */
 export function classifyOrigin(
   runtime: Runtime,

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -36,15 +36,21 @@ import { homeSchema } from "@commonfabric/home-schemas";
 const PIECE_TRACE_TIMINGS = typeof Deno !== "undefined" &&
   Deno.env.get("CF_CLI_TRACE_TIMINGS") === "1";
 
-// System space-root pattern URLs and their derivation live in
-// ../system-pattern-url.ts (shared with PieceManager's default-root
-// heal-on-load-failure retry); re-exported here for existing importers.
+// System space-root pattern refs, their derivation, and the source→URL
+// resolution live in ../system-pattern-url.ts (shared with PieceManager's
+// default-root heal-on-load-failure retry); re-exported here for existing
+// importers.
 import {
-  DEFAULT_APP_PATTERN_URL,
-  deriveSystemPatternUrl,
-  HOME_PATTERN_URL,
+  DEFAULT_APP_PATTERN_SOURCE,
+  deriveSystemPatternSource,
+  HOME_PATTERN_SOURCE,
+  patternSourceUrl,
 } from "../system-pattern-url.ts";
-export { DEFAULT_APP_PATTERN_URL, deriveSystemPatternUrl, HOME_PATTERN_URL };
+export {
+  DEFAULT_APP_PATTERN_SOURCE,
+  deriveSystemPatternSource,
+  HOME_PATTERN_SOURCE,
+};
 
 // Default roots have a stronger update policy than ordinary pieces: an
 // existing root is reconciled before start, while a new root is compiled from
@@ -341,13 +347,13 @@ export class PiecesController<T = unknown> {
     const isHomeSpace =
       this.#manager.getSpace() === this.#manager.runtime.userIdentityDID;
 
-    let patternConfig: { name: string; urlPath: string; cause: string };
+    let patternConfig: { name: string; source: string; cause: string };
     let pattern;
 
     if (options?.customProgram) {
       patternConfig = {
         name: isHomeSpace ? "Home" : "DefaultPieceList",
-        urlPath: "custom",
+        source: "custom",
         cause: isHomeSpace
           ? `home-pattern-${Date.now()}`
           : `space-root-${Date.now()}`,
@@ -360,20 +366,20 @@ export class PiecesController<T = unknown> {
       if (isHomeSpace) {
         patternConfig = {
           name: "Home",
-          urlPath: HOME_PATTERN_URL,
+          source: HOME_PATTERN_SOURCE,
           cause: `home-pattern-${Date.now()}`,
         };
       } else {
         const customUrl = await this.getDefaultAppUrlFromHome();
         patternConfig = {
           name: "DefaultPieceList",
-          urlPath: customUrl || DEFAULT_APP_PATTERN_URL,
+          source: customUrl || DEFAULT_APP_PATTERN_SOURCE,
           cause: `space-root-${Date.now()}`,
         };
       }
 
-      const patternUrl = new URL(
-        patternConfig.urlPath,
+      const patternUrl = patternSourceUrl(
+        patternConfig.source,
         this.#manager.runtime.apiUrl,
       );
 
@@ -420,7 +426,7 @@ export class PiecesController<T = unknown> {
       // setPatternRepository below, so a custom root without a repository
       // intentionally stays unstamped.
       if (options?.customProgram === undefined) {
-        setPatternSource(pieceCell, tx, patternConfig.urlPath);
+        setPatternSource(pieceCell, tx, patternConfig.source);
       }
 
       if (options?.repository !== undefined) {
@@ -481,12 +487,12 @@ export class PiecesController<T = unknown> {
     const isHomeSpace =
       this.#manager.getSpace() === this.#manager.runtime.userIdentityDID;
 
-    let patternConfig: { name: string; urlPath: string; cause: string };
+    let patternConfig: { name: string; source: string; cause: string };
 
     if (isHomeSpace) {
       patternConfig = {
         name: "Home",
-        urlPath: HOME_PATTERN_URL,
+        source: HOME_PATTERN_SOURCE,
         cause: "home-pattern",
       };
     } else {
@@ -496,13 +502,13 @@ export class PiecesController<T = unknown> {
       );
       patternConfig = {
         name: "DefaultPieceList",
-        urlPath: customUrl || DEFAULT_APP_PATTERN_URL,
+        source: customUrl || DEFAULT_APP_PATTERN_SOURCE,
         cause: "space-root",
       };
     }
 
-    const patternUrl = new URL(
-      patternConfig.urlPath,
+    const patternUrl = patternSourceUrl(
+      patternConfig.source,
       this.#manager.runtime.apiUrl,
     );
 
@@ -568,7 +574,7 @@ export class PiecesController<T = unknown> {
 
           // Stamp the provenance the piece tracks for updates (the source it
           // was born from) — the same transaction, one extra meta write.
-          setPatternSource(pieceCell, tx, patternConfig.urlPath);
+          setPatternSource(pieceCell, tx, patternConfig.source);
 
           // Link as default pattern within same transaction
           defaultPatternCell.set(pieceCell.withTx(tx));
@@ -808,7 +814,7 @@ export class PiecesController<T = unknown> {
     const space = this.#manager.getSpace();
     // Reuse the canonical official-URL derivation (home.tsx for the home DID,
     // default-app.tsx otherwise) — never hard-code home here.
-    const officialUrlPath = deriveSystemPatternUrl(space, runtime);
+    const officialUrlPath = deriveSystemPatternSource(space, runtime);
     const msg = (error: unknown) =>
       error instanceof Error ? error.message : String(error);
     // Name the check that actually refused. Two signals escalate to this heal —
@@ -839,7 +845,10 @@ export class PiecesController<T = unknown> {
     // could roll forward onto the WRONG host's system pattern. `hostForSpace`
     // is the same `mappedHostFor(space) ?? apiUrl` resolution PatternUpdater
     // uses for its own roll-forward.
-    const officialUrl = new URL(officialUrlPath, runtime.hostForSpace(space));
+    const officialUrl = patternSourceUrl(
+      officialUrlPath,
+      runtime.hostForSpace(space),
+    );
     let officialPattern;
     let officialRef;
     try {
@@ -1036,7 +1045,7 @@ export class PiecesController<T = unknown> {
       if (!root) return "current";
       return await runtime.patternUpdater.checkDefaultPattern(
         root,
-        deriveSystemPatternUrl(space, runtime),
+        deriveSystemPatternSource(space, runtime),
       );
     } catch (error) {
       pieceUpdateLogger.warn("root-resolution-failed", () => [

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -9,6 +9,7 @@ import {
   isStoredArgumentSchemaRefusal,
   type JSONSchema,
   type ModuleByteCache,
+  normalizePatternSource,
   type PatternCoverageCollector,
   type PatternUpdateOutcome,
   type PieceSourceTransition,
@@ -287,7 +288,14 @@ export class PiecesController<T = unknown> {
   }
 
   /**
-   * Read the default app URL from the home space's configuration.
+   * Read the configured default app source from the home space.
+   *
+   * The value is authored as a URL and canonicalized to the ref that names the
+   * same file, so a root is born with the provenance it will keep. Stamping the
+   * authored spelling instead would leave every new root waiting on a migration
+   * to become followable — and on a deployment with the update flag off, waiting
+   * forever. A locator naming no pattern route is returned as authored.
+   *
    * Returns empty string if not configured or if home space is not accessible.
    */
   private async getDefaultAppUrlFromHome(): Promise<string> {
@@ -304,7 +312,9 @@ export class PiecesController<T = unknown> {
           homeSpaceCell.key("defaultPattern")
             .asSchema(homeSchema).key("defaultAppUrl").get(),
       );
-      return typeof url === "string" ? url.trim() : "";
+      return typeof url === "string"
+        ? normalizePatternSource(url.trim(), this.#manager.runtime.apiUrl)
+        : "";
     } catch (error) {
       console.warn("Failed to read defaultAppUrl from home space:", error);
       return "";

--- a/packages/piece/src/system-pattern-url.ts
+++ b/packages/piece/src/system-pattern-url.ts
@@ -6,8 +6,8 @@ import {
 } from "@commonfabric/runner";
 
 // System space-root patterns, served as raw TSX by the toolshed patterns route
-// and addressed by `system:` ref (see the runner's pattern-source.ts for why
-// the scheme, rather than the route path it expands to, is what a piece
+// and addressed by `system:` ref (the runner's pattern-source-scheme.ts has
+// why the scheme, rather than the route path it expands to, is what a piece
 // stores). Shared by PiecesController (boot-path reconciliation) and
 // PieceManager (the default-root heal-on-load-failure retry) — a home of its
 // own so the manager does not import the controller that wraps it.

--- a/packages/piece/src/system-pattern-url.ts
+++ b/packages/piece/src/system-pattern-url.ts
@@ -1,25 +1,43 @@
 import type { MemorySpace } from "@commonfabric/runner";
 import type { Runtime } from "@commonfabric/runner";
+import {
+  resolveSystemPatternSource,
+  systemPatternSource,
+} from "@commonfabric/runner";
 
-// System space-root patterns, served as raw TSX by the toolshed patterns route.
-// Shared by PiecesController (boot-path reconciliation) and PieceManager (the
-// default-root heal-on-load-failure retry) — a home of its own so the manager
-// does not import the controller that wraps it.
-export const HOME_PATTERN_URL = "/api/patterns/system/home.tsx";
-export const DEFAULT_APP_PATTERN_URL = "/api/patterns/system/default-app.tsx";
+// System space-root patterns, served as raw TSX by the toolshed patterns route
+// and addressed by `system:` ref (see the runner's pattern-source.ts for why
+// the scheme, rather than the route path it expands to, is what a piece
+// stores). Shared by PiecesController (boot-path reconciliation) and
+// PieceManager (the default-root heal-on-load-failure retry) — a home of its
+// own so the manager does not import the controller that wraps it.
+export const HOME_PATTERN_SOURCE = systemPatternSource("system/home.tsx");
+export const DEFAULT_APP_PATTERN_SOURCE = systemPatternSource(
+  "system/default-app.tsx",
+);
 
 /**
- * The official system space-root pattern URL for a space type — the home DID
+ * The official system space-root pattern ref for a space type — the home DID
  * gets home.tsx, every other space gets the default app. This derivation only
  * selects the identity to check; it never proves that a sourceless root tracks
- * that URL. Exact equality with the official content identity supplies
+ * that ref. Exact equality with the official content identity supplies
  * that proof at the check site.
  */
-export function deriveSystemPatternUrl(
+export function deriveSystemPatternSource(
   space: MemorySpace,
   runtime: Runtime,
 ): string {
   return space === runtime.userIdentityDID
-    ? HOME_PATTERN_URL
-    : DEFAULT_APP_PATTERN_URL;
+    ? HOME_PATTERN_SOURCE
+    : DEFAULT_APP_PATTERN_SOURCE;
+}
+
+/**
+ * Resolve a stored pattern source to the URL to fetch it from, against `base`.
+ * A `system:` ref expands to its patterns route; anything else (a custom
+ * `defaultAppUrl`) is resolved as the URL it already is. The caller chooses the
+ * base, because which host serves a space is its decision to make.
+ */
+export function patternSourceUrl(source: string, base: string | URL): URL {
+  return new URL(resolveSystemPatternSource(source) ?? source, base);
 }

--- a/packages/piece/test/check-update-default-pattern.test.ts
+++ b/packages/piece/test/check-update-default-pattern.test.ts
@@ -8,6 +8,7 @@ import {
   getPieceSourceRevisions,
   parseLink,
   resolveEntryIdentity,
+  resolveSystemPatternSource,
   Runtime,
 } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
@@ -17,10 +18,18 @@ import { HttpProgramResolver } from "@commonfabric/js-compiler/program";
 import { FabricLink } from "@commonfabric/data-model/fabric-instances";
 import { PieceManager } from "../src/manager.ts";
 import {
-  DEFAULT_APP_PATTERN_URL,
-  HOME_PATTERN_URL,
+  DEFAULT_APP_PATTERN_SOURCE,
+  HOME_PATTERN_SOURCE,
   PiecesController,
 } from "../src/ops/pieces-controller.ts";
+
+// The routes those refs resolve to. A system pattern is still SERVED at, and
+// its modules still NAMED by, the route path; the `system:` ref is what a
+// piece stores as provenance.
+const DEFAULT_APP_PATTERN_PATH = resolveSystemPatternSource(
+  DEFAULT_APP_PATTERN_SOURCE,
+)!;
+const HOME_PATTERN_PATH = resolveSystemPatternSource(HOME_PATTERN_SOURCE)!;
 
 const signer = await Identity.fromPassphrase("check update default pattern");
 
@@ -123,17 +132,12 @@ const IMPORTED_MODULE_URL = "/api/patterns/system/update-marker.ts";
 // A same-host custom-app path, as home config would supply via
 // `defaultAppUrl` (a published custom app, NOT a system pattern).
 const CUSTOM_APP_URL = "/api/patterns/custom/my-app.tsx";
-const TEST_TOOLSHED_URL = "http://toolshed.test";
-
-function absoluteSourceUrl(path: string): string {
-  return new URL(path, TEST_TOOLSHED_URL).href;
-}
 
 /** Content identity a toolshed would serve for `source`. */
 function identityForSource(
   source: string,
   imports: Record<string, string> = {},
-  entry = DEFAULT_APP_PATTERN_URL,
+  entry = DEFAULT_APP_PATTERN_PATH,
 ): Promise<string> {
   return resolveEntryIdentity(
     entry,
@@ -193,8 +197,8 @@ function installFetchStub(): StubControls {
     });
 
     if (
-      url.pathname === DEFAULT_APP_PATTERN_URL ||
-      url.pathname === HOME_PATTERN_URL
+      url.pathname === DEFAULT_APP_PATTERN_PATH ||
+      url.pathname === HOME_PATTERN_PATH
     ) {
       if (url.searchParams.has("identity")) {
         identityFetchCount++;
@@ -438,11 +442,11 @@ describe("checkAndUpdateDefaultPattern", () => {
     ).toEqual([
       {
         operation: "baseline",
-        origin: absoluteSourceUrl(DEFAULT_APP_PATTERN_URL),
+        origin: DEFAULT_APP_PATTERN_SOURCE,
       },
       {
         operation: "origin-update",
-        origin: absoluteSourceUrl(DEFAULT_APP_PATTERN_URL),
+        origin: DEFAULT_APP_PATTERN_SOURCE,
       },
     ]);
   });
@@ -476,8 +480,8 @@ describe("checkAndUpdateDefaultPattern", () => {
     stub.setSource(SOURCE_V2);
     const currentPattern = await runtime.patternManager.compilePattern(
       {
-        main: DEFAULT_APP_PATTERN_URL,
-        files: [{ name: DEFAULT_APP_PATTERN_URL, contents: SOURCE_V2 }],
+        main: DEFAULT_APP_PATTERN_PATH,
+        files: [{ name: DEFAULT_APP_PATTERN_PATH, contents: SOURCE_V2 }],
       },
       { space: manager.getSpace() },
     );
@@ -533,9 +537,9 @@ describe("checkAndUpdateDefaultPattern", () => {
     stub.setSource(argumentSourceV2);
     const currentPattern = await runtime.patternManager.compilePattern(
       {
-        main: DEFAULT_APP_PATTERN_URL,
+        main: DEFAULT_APP_PATTERN_PATH,
         files: [{
-          name: DEFAULT_APP_PATTERN_URL,
+          name: DEFAULT_APP_PATTERN_PATH,
           contents: argumentSourceV2,
         }],
       },
@@ -603,9 +607,9 @@ describe("checkAndUpdateDefaultPattern", () => {
 
     const alternatePattern = await runtime.patternManager.compilePattern(
       {
-        main: DEFAULT_APP_PATTERN_URL,
+        main: DEFAULT_APP_PATTERN_PATH,
         mainExport: "alternate",
-        files: [{ name: DEFAULT_APP_PATTERN_URL, contents: source }],
+        files: [{ name: DEFAULT_APP_PATTERN_PATH, contents: source }],
       },
       { space: manager.getSpace() },
     );
@@ -1050,12 +1054,12 @@ describe("checkAndUpdateDefaultPattern", () => {
       }),
     ).toEqual([
       {
-        path: DEFAULT_APP_PATTERN_URL,
+        path: DEFAULT_APP_PATTERN_PATH,
         identity: true,
         cache: "no-cache",
       },
       {
-        path: DEFAULT_APP_PATTERN_URL,
+        path: DEFAULT_APP_PATTERN_PATH,
         identity: false,
         cache: "no-cache",
       },
@@ -1164,7 +1168,7 @@ describe("checkAndUpdateDefaultPattern", () => {
 
     const root = (await manager.getDefaultPattern(false))!;
     expect(getPatternSource(root)).toBe(
-      absoluteSourceUrl(DEFAULT_APP_PATTERN_URL),
+      DEFAULT_APP_PATTERN_SOURCE,
     );
     expect(getPatternIdentityRef(root)?.identity).toBe(
       await identityForSource(SOURCE_V1),
@@ -1229,7 +1233,9 @@ describe("checkAndUpdateDefaultPattern", () => {
         "repaired-provenance",
       );
       expect(stub.sourceFetches()).toBe(sourceFetchesBefore + 1);
-      expect(getPatternSource(piece.getCell())).toBe(DEFAULT_APP_PATTERN_URL);
+      expect(getPatternSource(piece.getCell())).toBe(
+        DEFAULT_APP_PATTERN_SOURCE,
+      );
     } finally {
       runtime.patternManager.loadPatternByIdentity = originalLoad;
     }
@@ -1380,8 +1386,8 @@ describe("checkAndUpdateDefaultPattern", () => {
     await setup({ systemPatternAutoUpdate: true });
     const piece = await controller.recreateDefaultPattern({
       customProgram: {
-        main: DEFAULT_APP_PATTERN_URL,
-        files: [{ name: DEFAULT_APP_PATTERN_URL, contents: SOURCE_V1 }],
+        main: DEFAULT_APP_PATTERN_PATH,
+        files: [{ name: DEFAULT_APP_PATTERN_PATH, contents: SOURCE_V1 }],
       },
     });
     const oldRef = getPatternIdentityRef(piece.getCell())!;
@@ -1413,7 +1419,7 @@ describe("checkAndUpdateDefaultPattern", () => {
 
       const unchanged = (await manager.getDefaultPattern(false))!;
       expect(getPatternIdentityRef(unchanged)).toEqual(oldRef);
-      expect(getPatternSource(unchanged)).toBe(DEFAULT_APP_PATTERN_URL);
+      expect(getPatternSource(unchanged)).toBe(DEFAULT_APP_PATTERN_SOURCE);
       expect(stub.identityFetches()).toBe(1);
     } finally {
       runtime.patternManager.compilePattern = originalCompile;
@@ -1512,8 +1518,10 @@ describe("checkAndUpdateDefaultPattern", () => {
     const root = (await manager.getDefaultPattern(false))!;
     expect(JSON.stringify(root.getAsLink())).toBe(rootLinkBefore);
     const idV2 = getPatternIdentityRef(root)?.identity;
-    // The home root compiles at HOME_PATTERN_URL — identity includes the entry.
-    expect(idV2).toBe(await identityForSource(SOURCE_V2, {}, HOME_PATTERN_URL));
+    // The home root compiles at HOME_PATTERN_PATH — identity includes the entry.
+    expect(idV2).toBe(
+      await identityForSource(SOURCE_V2, {}, HOME_PATTERN_PATH),
+    );
     expect(idV2).not.toBe(idV1);
   });
 
@@ -1573,10 +1581,10 @@ describe("checkAndUpdateDefaultPattern", () => {
 
     const after = (await manager.getDefaultPattern(false))!;
     expect(getPatternIdentityRef(after)?.identity).toBe(
-      await identityForSource(SOURCE_V2, {}, HOME_PATTERN_URL),
+      await identityForSource(SOURCE_V2, {}, HOME_PATTERN_PATH),
     );
     // Provenance back-filled: the root now tracks the official URL.
-    expect(getPatternSource(after)).toBe(absoluteSourceUrl(HOME_PATTERN_URL));
+    expect(getPatternSource(after)).toBe(HOME_PATTERN_SOURCE);
     // The displaced ref is the only record of the replaced sourceless root.
     const displaced = (after as unknown as {
       getMetaRaw: (key: string) => unknown;
@@ -1625,7 +1633,7 @@ describe("checkAndUpdateDefaultPattern", () => {
     const after = (await manager.getDefaultPattern(true))!;
     await runtime.idle();
     expect(getPatternIdentityRef(after)?.identity).toBe(
-      await identityForSource(SOURCE_V3_HANDLER, {}, HOME_PATTERN_URL),
+      await identityForSource(SOURCE_V3_HANDLER, {}, HOME_PATTERN_PATH),
     );
     expect(after.key("count").get()).toBe(0);
   });
@@ -1700,7 +1708,7 @@ describe("checkAndUpdateDefaultPattern", () => {
     // Re-resolve: the controller's cell is a pre-heal transaction view.
     const after = (await manager.getDefaultPattern(false))!;
     expect(getPatternIdentityRef(after)?.identity).toBe(
-      await identityForSource(SOURCE_V3_HANDLER, {}, HOME_PATTERN_URL),
+      await identityForSource(SOURCE_V3_HANDLER, {}, HOME_PATTERN_PATH),
     );
     // Functional pin: the pattern body ran its setup (count materialized)…
     expect(after.key("count").get()).toBe(0);
@@ -1734,7 +1742,7 @@ describe("checkAndUpdateDefaultPattern", () => {
     const targetId = await identityForSource(
       SOURCE_V3_HANDLER,
       {},
-      HOME_PATTERN_URL,
+      HOME_PATTERN_PATH,
     );
     // Model the already-committed swap: identity points at the CURRENT
     // official pattern, doc still set up for SOURCE_V1 (marker-less for V3).
@@ -1787,7 +1795,7 @@ describe("checkAndUpdateDefaultPattern", () => {
     //    to it (sourceless) — the pre-fix required-favorites home.tsx.
     stub.setSource(SOURCE_HOME_OLD_REQUIRED);
     const oldResolved = await runtime.harness.resolve(
-      new HttpProgramResolver(new URL(HOME_PATTERN_URL, runtime.apiUrl).href),
+      new HttpProgramResolver(new URL(HOME_PATTERN_PATH, runtime.apiUrl).href),
     );
     const oldPattern = await runtime.patternManager.compilePattern(
       { ...oldResolved, mainExport: "default" },
@@ -1817,7 +1825,7 @@ describe("checkAndUpdateDefaultPattern", () => {
     //    compiled THIS source, not a stale-cached one.
     stub.setSource(SOURCE_HOME_OFFICIAL_DEFAULTED);
     const officialResolved = await runtime.harness.resolve(
-      new HttpProgramResolver(new URL(HOME_PATTERN_URL, runtime.apiUrl).href),
+      new HttpProgramResolver(new URL(HOME_PATTERN_PATH, runtime.apiUrl).href),
     );
     const officialPattern = await runtime.patternManager.compilePattern(
       { ...officialResolved, mainExport: "default" },
@@ -1874,7 +1882,7 @@ describe("checkAndUpdateDefaultPattern", () => {
     const after = (await manager.getDefaultPattern(false))!;
     // Rolled forward to the official identity, official provenance stamped…
     expect(getPatternIdentityRef(after)?.identity).toBe(officialId);
-    expect(getPatternSource(after)).toBe(absoluteSourceUrl(HOME_PATTERN_URL));
+    expect(getPatternSource(after)).toBe(HOME_PATTERN_SOURCE);
     // …recording the displaced pinned pattern for recovery.
     const displaced = (after as unknown as {
       getMetaRaw: (k: string) => unknown;
@@ -1897,7 +1905,8 @@ describe("checkAndUpdateDefaultPattern", () => {
     // pin is the whole point, so a cache-stale compile would defeat it.
     const homeSourceFetches = stub.requestedFetches().filter((f) => {
       const u = new URL(f.href);
-      return u.pathname === HOME_PATTERN_URL && !u.searchParams.has("identity");
+      return u.pathname === HOME_PATTERN_PATH &&
+        !u.searchParams.has("identity");
     });
     expect(homeSourceFetches.some((f) => f.cache === "no-cache")).toBe(true);
   });
@@ -1921,7 +1930,7 @@ describe("checkAndUpdateDefaultPattern", () => {
 
     stub.setSource(SOURCE_HOME_OLD_REQUIRED);
     const oldResolved = await runtime.harness.resolve(
-      new HttpProgramResolver(new URL(HOME_PATTERN_URL, runtime.apiUrl).href),
+      new HttpProgramResolver(new URL(HOME_PATTERN_PATH, runtime.apiUrl).href),
     );
     const oldPattern = await runtime.patternManager.compilePattern(
       { ...oldResolved, mainExport: "default" },
@@ -1940,7 +1949,7 @@ describe("checkAndUpdateDefaultPattern", () => {
     // the heal does, so `officialId` is exactly the roll-forward's target.
     stub.setSource(SOURCE_HOME_OFFICIAL_DEFAULTED);
     const officialResolved = await runtime.harness.resolve(
-      new HttpProgramResolver(new URL(HOME_PATTERN_URL, runtime.apiUrl).href),
+      new HttpProgramResolver(new URL(HOME_PATTERN_PATH, runtime.apiUrl).href),
     );
     const officialPattern = await runtime.patternManager.compilePattern(
       { ...officialResolved, mainExport: "default" },
@@ -2112,7 +2121,7 @@ describe("checkAndUpdateDefaultPattern", () => {
     // A distinct, loadable identity for the "concurrent heal" to install.
     stub.setSource(SOURCE_V3_HANDLER);
     const otherResolved = await runtime.harness.resolve(
-      new HttpProgramResolver(new URL(HOME_PATTERN_URL, runtime.apiUrl).href),
+      new HttpProgramResolver(new URL(HOME_PATTERN_PATH, runtime.apiUrl).href),
     );
     const otherPattern = await runtime.patternManager.compilePattern(
       { ...otherResolved, mainExport: "default" },
@@ -2231,7 +2240,7 @@ describe("checkAndUpdateDefaultPattern", () => {
     await manager.stopPiece(root);
     stub.setSource(SOURCE_HOME_OFFICIAL_DEFAULTED);
     const officialResolved = await runtime.harness.resolve(
-      new HttpProgramResolver(new URL(HOME_PATTERN_URL, runtime.apiUrl).href),
+      new HttpProgramResolver(new URL(HOME_PATTERN_PATH, runtime.apiUrl).href),
     );
     const officialPattern = await runtime.patternManager.compilePattern(
       { ...officialResolved, mainExport: "default" },
@@ -2286,7 +2295,7 @@ describe("checkAndUpdateDefaultPattern", () => {
     // they share one identity and differ only by symbol.
     stub.setSource(SOURCE_HOME_TWO_EXPORT);
     const resolved = await runtime.harness.resolve(
-      new HttpProgramResolver(new URL(HOME_PATTERN_URL, runtime.apiUrl).href),
+      new HttpProgramResolver(new URL(HOME_PATTERN_PATH, runtime.apiUrl).href),
     );
     const legacyPattern = await runtime.patternManager.compilePattern(
       { ...resolved, mainExport: "legacyHome" },
@@ -2456,8 +2465,8 @@ describe("checkAndUpdateDefaultPattern", () => {
     stub.setSource(SOURCE_V3_HANDLER);
     const currentPattern = await runtime.patternManager.compilePattern(
       {
-        main: HOME_PATTERN_URL,
-        files: [{ name: HOME_PATTERN_URL, contents: SOURCE_V3_HANDLER }],
+        main: HOME_PATTERN_PATH,
+        files: [{ name: HOME_PATTERN_PATH, contents: SOURCE_V3_HANDLER }],
       },
       { space: manager.getSpace() },
     );
@@ -2494,7 +2503,7 @@ describe("checkAndUpdateDefaultPattern", () => {
     await runtime.idle();
     const after = (await manager.getDefaultPattern(false))!;
     expect(getPatternIdentityRef(after)?.identity).toBe(
-      await identityForSource(SOURCE_V3_HANDLER, {}, HOME_PATTERN_URL),
+      await identityForSource(SOURCE_V3_HANDLER, {}, HOME_PATTERN_PATH),
     );
     expect(after.key("count").get()).toBe(0);
     (after.key("bump") as unknown as { send: (e: unknown) => void }).send({});
@@ -2522,7 +2531,7 @@ describe("checkAndUpdateDefaultPattern", () => {
     const targetId = await identityForSource(
       SOURCE_V3_HANDLER,
       {},
-      HOME_PATTERN_URL,
+      HOME_PATTERN_PATH,
     );
     const { error } = await runtime.editWithRetry((tx) => {
       root.withTx(tx).setMetaRaw("patternIdentity", {
@@ -2624,7 +2633,7 @@ describe("checkAndUpdateDefaultPattern", () => {
       await identityForSource(SOURCE_V2),
     );
     expect(getPatternSource(after)).toBe(
-      absoluteSourceUrl(DEFAULT_APP_PATTERN_URL),
+      DEFAULT_APP_PATTERN_SOURCE,
     );
     const displaced = (after as unknown as {
       getMetaRaw: (key: string) => unknown;
@@ -2694,7 +2703,7 @@ describe("checkAndUpdateDefaultPattern", () => {
       await setup({ systemPatternAutoUpdate: true });
       await controller.recreateDefaultPattern();
       const root = (await manager.getDefaultPattern(false))!;
-      expect(getPatternSource(root)).toBe(DEFAULT_APP_PATTERN_URL);
+      expect(getPatternSource(root)).toBe(DEFAULT_APP_PATTERN_SOURCE);
 
       // The stamp is the point: it makes the recreated root eligible for
       // auto-update. A newer toolshed identity must roll it forward instead
@@ -2747,9 +2756,9 @@ describe("checkAndUpdateDefaultPattern", () => {
       expect(await controller.checkAndUpdateDefaultPattern()).toBe("updated");
       await runtime.idle();
       const updated = (await manager.getDefaultPattern(false))!;
-      expect(getPatternSource(updated)).toBe(
-        absoluteSourceUrl(CUSTOM_APP_URL),
-      );
+      // The check re-stamps the configured route path in its canonical `system:`
+      // spelling — the same migration any pre-scheme provenance gets.
+      expect(getPatternSource(updated)).toBe("system:custom/my-app.tsx");
       expect(getPatternIdentityRef(updated)?.identity).toBe(
         await identityForSource(customV2, {}, CUSTOM_APP_URL),
       );
@@ -2760,7 +2769,7 @@ describe("checkAndUpdateDefaultPattern", () => {
 
       await controller.recreateDefaultPattern();
       const root = (await manager.getDefaultPattern(false))!;
-      expect(getPatternSource(root)).toBe(HOME_PATTERN_URL);
+      expect(getPatternSource(root)).toBe(HOME_PATTERN_SOURCE);
     });
   });
 });

--- a/packages/piece/test/check-update-default-pattern.test.ts
+++ b/packages/piece/test/check-update-default-pattern.test.ts
@@ -132,6 +132,8 @@ const IMPORTED_MODULE_URL = "/api/patterns/system/update-marker.ts";
 // A same-host custom-app path, as home config would supply via
 // `defaultAppUrl` (a published custom app, NOT a system pattern).
 const CUSTOM_APP_URL = "/api/patterns/custom/my-app.tsx";
+// What a root configured with that URL stores: the ref naming the same file.
+const CUSTOM_APP_SOURCE = "system:custom/my-app.tsx";
 
 /** Content identity a toolshed would serve for `source`. */
 function identityForSource(
@@ -2740,9 +2742,11 @@ describe("checkAndUpdateDefaultPattern", () => {
       stub.setCustomSource(customV1);
       await controller.recreateDefaultPattern();
       const root = (await manager.getDefaultPattern(false))!;
-      // patternSource freezes the exact source selected at birth — the
-      // configured custom path, not the default-app fallback.
-      expect(getPatternSource(root)).toBe(CUSTOM_APP_URL);
+      // patternSource freezes the source selected at birth — the configured
+      // custom app, not the default-app fallback. The authored URL is
+      // canonicalized to the ref naming the same file, so the root is born
+      // with the provenance it keeps rather than waiting on a migration.
+      expect(getPatternSource(root)).toBe(CUSTOM_APP_SOURCE);
       expect(getPatternIdentityRef(root)?.identity).toBe(
         await identityForSource(customV1, {}, CUSTOM_APP_URL),
       );
@@ -2756,9 +2760,7 @@ describe("checkAndUpdateDefaultPattern", () => {
       expect(await controller.checkAndUpdateDefaultPattern()).toBe("updated");
       await runtime.idle();
       const updated = (await manager.getDefaultPattern(false))!;
-      // The check re-stamps the configured route path in its canonical `system:`
-      // spelling — the same migration any pre-scheme provenance gets.
-      expect(getPatternSource(updated)).toBe("system:custom/my-app.tsx");
+      expect(getPatternSource(updated)).toBe(CUSTOM_APP_SOURCE);
       expect(getPatternIdentityRef(updated)?.identity).toBe(
         await identityForSource(customV2, {}, CUSTOM_APP_URL),
       );

--- a/packages/piece/test/default-app-golden-replay.test.ts
+++ b/packages/piece/test/default-app-golden-replay.test.ts
@@ -4,6 +4,7 @@ import {
   getPatternIdentityRef,
   isLink,
   resolveEntryIdentity,
+  resolveSystemPatternSource,
   Runtime,
 } from "@commonfabric/runner";
 import {
@@ -13,9 +14,15 @@ import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import { createSession, Identity } from "@commonfabric/identity";
 import { PieceManager } from "../src/manager.ts";
 import {
-  DEFAULT_APP_PATTERN_URL,
+  DEFAULT_APP_PATTERN_SOURCE,
   PiecesController,
 } from "../src/ops/pieces-controller.ts";
+
+// The route that ref expands to — what the toolshed serves, and what the
+// worker names the module by when it compiles the pattern over HTTP.
+const DEFAULT_APP_PATTERN_PATH = resolveSystemPatternSource(
+  DEFAULT_APP_PATTERN_SOURCE,
+)!;
 
 // Golden replay for non-home root state across an in-place update.
 //
@@ -108,9 +115,9 @@ const SEEDED_PIECES = ["note:groceries", "note:standup", "notebook:trip"];
 /** Content identity a toolshed would serve for `source`. */
 function identityForSource(source: string): Promise<string> {
   return resolveEntryIdentity(
-    DEFAULT_APP_PATTERN_URL,
+    DEFAULT_APP_PATTERN_PATH,
     (name) =>
-      name === DEFAULT_APP_PATTERN_URL
+      name === DEFAULT_APP_PATTERN_PATH
         ? Promise.resolve(source)
         : Promise.reject(new Error(`not found: ${name}`)),
   );
@@ -133,7 +140,7 @@ function installFetchStub(): StubControls {
       : input.url;
     const url = new URL(href);
 
-    if (url.pathname === DEFAULT_APP_PATTERN_URL) {
+    if (url.pathname === DEFAULT_APP_PATTERN_PATH) {
       if (url.searchParams.has("identity")) {
         return new Response(await identityForSource(source), {
           headers: { "content-type": "text/plain" },
@@ -392,8 +399,8 @@ describe("default-app golden replay (state survives an in-place roll-forward)", 
     stub.setSource(ROOT_V2);
     const currentPattern = await runtime.patternManager.compilePattern(
       {
-        main: DEFAULT_APP_PATTERN_URL,
-        files: [{ name: DEFAULT_APP_PATTERN_URL, contents: ROOT_V2 }],
+        main: DEFAULT_APP_PATTERN_PATH,
+        files: [{ name: DEFAULT_APP_PATTERN_PATH, contents: ROOT_V2 }],
       },
       { space: manager.getSpace() },
     );

--- a/packages/piece/test/home-golden-replay.test.ts
+++ b/packages/piece/test/home-golden-replay.test.ts
@@ -3,15 +3,22 @@ import { expect } from "@std/expect";
 import {
   getPatternIdentityRef,
   resolveEntryIdentity,
+  resolveSystemPatternSource,
   Runtime,
 } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { createSession, Identity } from "@commonfabric/identity";
 import { PieceManager } from "../src/manager.ts";
 import {
-  HOME_PATTERN_URL,
+  HOME_PATTERN_SOURCE,
   PiecesController,
 } from "../src/ops/pieces-controller.ts";
+
+// The route that ref expands to — what the toolshed serves, and what the
+// worker names the module by when it compiles the pattern over HTTP.
+const HOME_PATTERN_PATH = resolveSystemPatternSource(
+  HOME_PATTERN_SOURCE,
+)!;
 
 // Golden replay for the HOME root — the higher-stakes sibling of
 // default-app-golden-replay.test.ts.
@@ -82,9 +89,9 @@ const SEEDED_COUNTS =
 /** Content identity a toolshed would serve for `source`. */
 function identityForSource(source: string): Promise<string> {
   return resolveEntryIdentity(
-    HOME_PATTERN_URL, // /api/patterns/system/home.tsx
+    HOME_PATTERN_PATH, // /api/patterns/system/home.tsx
     (name) =>
-      name === HOME_PATTERN_URL
+      name === HOME_PATTERN_PATH
         ? Promise.resolve(source)
         : Promise.reject(new Error(`not found: ${name}`)),
   );
@@ -107,7 +114,7 @@ function installFetchStub(): StubControls {
       : input.url;
     const url = new URL(href);
 
-    if (url.pathname === HOME_PATTERN_URL) {
+    if (url.pathname === HOME_PATTERN_PATH) {
       if (url.searchParams.has("identity")) {
         return new Response(await identityForSource(source), {
           headers: { "content-type": "text/plain" },
@@ -146,7 +153,7 @@ describe("home golden replay (durable home state survives an in-place roll-forwa
     });
     // A HOME session: space === the user's identity DID, which is what flips
     // `isHomeSpace` on inside the controller (ensureDefaultPattern + the update
-    // gate) so the home branch — cause "home-pattern", provenance HOME_PATTERN_URL
+    // gate) so the home branch — cause "home-pattern", provenance HOME_PATTERN_PATH
     // — is exercised.
     const session = await createSession({
       identity: signer,

--- a/packages/piece/test/pattern-source-provenance.test.ts
+++ b/packages/piece/test/pattern-source-provenance.test.ts
@@ -3,17 +3,24 @@ import { expect } from "@std/expect";
 import {
   getPatternIdentityRef,
   getPatternSource,
+  resolveSystemPatternSource,
   Runtime,
 } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { createSession, Identity } from "@commonfabric/identity";
 import { PieceManager } from "../src/manager.ts";
 import {
-  DEFAULT_APP_PATTERN_URL,
-  deriveSystemPatternUrl,
-  HOME_PATTERN_URL,
+  DEFAULT_APP_PATTERN_SOURCE,
+  deriveSystemPatternSource,
+  HOME_PATTERN_SOURCE,
   PiecesController,
 } from "../src/ops/pieces-controller.ts";
+
+// The route the ref expands to: still what the module is NAMED, because the
+// worker compiles this pattern over HTTP.
+const DEFAULT_APP_PATTERN_PATH = resolveSystemPatternSource(
+  DEFAULT_APP_PATTERN_SOURCE,
+)!;
 
 const signer = await Identity.fromPassphrase("pattern source provenance");
 
@@ -56,16 +63,16 @@ function installFetchStub(
   };
 }
 
-describe("deriveSystemPatternUrl", () => {
+describe("deriveSystemPatternSource", () => {
   it("returns home.tsx for the home space, default-app.tsx otherwise", () => {
     const runtime = {
       userIdentityDID: "did:key:home",
     } as unknown as Runtime;
-    expect(deriveSystemPatternUrl("did:key:home" as never, runtime)).toBe(
-      HOME_PATTERN_URL,
+    expect(deriveSystemPatternSource("did:key:home" as never, runtime)).toBe(
+      HOME_PATTERN_SOURCE,
     );
-    expect(deriveSystemPatternUrl("did:key:other" as never, runtime)).toBe(
-      DEFAULT_APP_PATTERN_URL,
+    expect(deriveSystemPatternSource("did:key:other" as never, runtime)).toBe(
+      DEFAULT_APP_PATTERN_SOURCE,
     );
   });
 });
@@ -103,17 +110,17 @@ describe("ensureDefaultPattern stamps patternSource", () => {
     restoreFetch();
   });
 
-  it("stamps the default-app source path on a non-home root", async () => {
+  it("stamps the default-app source ref on a non-home root", async () => {
     const piece = await controller.ensureDefaultPattern();
     const source = getPatternSource(piece.getCell());
-    expect(source).toBe(DEFAULT_APP_PATTERN_URL);
+    expect(source).toBe(DEFAULT_APP_PATTERN_SOURCE);
     const identityRef = getPatternIdentityRef(piece.getCell())!;
     expect(await piece.getPatternRef()).toEqual({
       ...identityRef,
       source: {
         ref: `cf:pattern:${identityRef.identity}`,
-        entry: DEFAULT_APP_PATTERN_URL,
-        origin: DEFAULT_APP_PATTERN_URL,
+        entry: DEFAULT_APP_PATTERN_PATH,
+        origin: DEFAULT_APP_PATTERN_SOURCE,
       },
     });
   });

--- a/packages/piece/test/piece-origin.test.ts
+++ b/packages/piece/test/piece-origin.test.ts
@@ -7,15 +7,21 @@ import {
   getPieceSourceSnapshot,
   type MemorySpace,
   preparePieceSourceTransitionBaseline,
+  resolveSystemPatternSource,
   Runtime,
 } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { createSession, Identity } from "@commonfabric/identity";
 import { PieceManager } from "../src/manager.ts";
 import {
-  DEFAULT_APP_PATTERN_URL,
+  DEFAULT_APP_PATTERN_SOURCE,
   PiecesController,
 } from "../src/ops/pieces-controller.ts";
+
+// The route that ref resolves to.
+const DEFAULT_APP_PATTERN_PATH = resolveSystemPatternSource(
+  DEFAULT_APP_PATTERN_SOURCE,
+)!;
 import {
   classifyOrigin,
   PieceOriginError,
@@ -490,7 +496,7 @@ describe("reading a piece's source state", () => {
 
   beforeEach(async () => {
     restoreFetch = installFetchStub({
-      [DEFAULT_APP_PATTERN_URL]: DEFAULT_APP_SOURCE,
+      [DEFAULT_APP_PATTERN_PATH]: DEFAULT_APP_SOURCE,
     });
     storageManager = StorageManager.emulate({ as: signer });
     runtime = new Runtime({
@@ -536,16 +542,16 @@ describe("reading a piece's source state", () => {
     });
   });
 
-  it("reports a space root's stamped path as an absolute web origin", async () => {
+  it("reports a space root's stamped ref as an absolute web origin", async () => {
     const root = await controller.ensureDefaultPattern();
 
     const state = await readPieceSourceState(runtime, root.getCell());
-    // The root is stamped with a toolshed-relative path; the origin that comes
-    // back is absolute, with the recorded form kept alongside it.
+    // The root is stamped with a `system:` ref; the origin that comes back is
+    // the absolute route it resolves to, with the ref kept alongside it.
     expect(state.origin).toEqual({
-      url: `http://toolshed.test${DEFAULT_APP_PATTERN_URL}`,
+      url: `http://toolshed.test${DEFAULT_APP_PATTERN_PATH}`,
       kind: "web",
-      recorded: DEFAULT_APP_PATTERN_URL,
+      recorded: DEFAULT_APP_PATTERN_SOURCE,
     });
     expect(state.files.length).toBeGreaterThan(0);
     expect(state.files[0].name).toBe(state.entry);
@@ -570,16 +576,16 @@ describe("reading a piece's source state", () => {
       baseline,
       timestamp: 42,
       operation: "origin-update",
-      origin: DEFAULT_APP_PATTERN_URL,
+      origin: DEFAULT_APP_PATTERN_PATH,
       expected,
     });
     await tx.commit();
 
     const state = await readPieceSourceState(runtime, cell);
     expect(state.origin).toEqual({
-      url: `http://toolshed.test${DEFAULT_APP_PATTERN_URL}`,
+      url: `http://toolshed.test${DEFAULT_APP_PATTERN_PATH}`,
       kind: "web",
-      recorded: DEFAULT_APP_PATTERN_URL,
+      recorded: DEFAULT_APP_PATTERN_PATH,
     });
     expect(state.history.at(-1)?.origin).toEqual(state.origin);
   });

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -122,6 +122,14 @@ export {
 } from "./link-utils.ts";
 export * from "./pattern-manager.ts";
 export {
+  normalizePatternSource,
+  PATTERNS_ROUTE_PREFIX,
+  resolveSystemPatternSource,
+  SYSTEM_PATTERN_SOURCE_SCHEME,
+  systemPatternSource,
+  systemPatternSourceForModuleName,
+} from "./pattern-source-scheme.ts";
+export {
   type PatternUpdateOutcome,
   PatternUpdater,
 } from "./pattern-updater.ts";

--- a/packages/runner/src/pattern-source-scheme.ts
+++ b/packages/runner/src/pattern-source-scheme.ts
@@ -1,0 +1,139 @@
+/**
+ * The `patternSource` grammar: a piece's provenance string, dispatched by its
+ * scheme.
+ *
+ * - `cf:…` — a published fabric ref, resolved by the fabric chase
+ *   (`fabric-ref-resolution.ts`).
+ * - `system:<path>` — a pattern this deployment's toolshed serves from its
+ *   patterns directory, addressed RELATIVE to that route:
+ *   `system:system/default-app.tsx` → `/api/patterns/system/default-app.tsx`.
+ *
+ * Why a scheme rather than the bare route path it expands to. The updater's
+ * rule has to be a whitelist, because the alternative — "any same-origin path
+ * may be fetched" — cannot distinguish a route from an author-controlled module
+ * filename that merely looks like one. A pattern deployed from a local file
+ * tree names its modules by their path under the compile root (`/main.tsx`,
+ * `/participant-identity-card.tsx`); treating such a name as a URL fetched the
+ * shell's SPA fallback, which answers 200 with HTML for any unrouted path, and
+ * then compiled that HTML as TSX. Requiring an explicit scheme means provenance
+ * has to be *claimed* at deploy time, and everything else is skipped.
+ *
+ * The ref is also deliberately host-relative. A space that moves hosts keeps
+ * working, and the host stays out of the identity — the same reason `cf:` refs
+ * are stored in their canonical host-less form.
+ */
+
+/** The scheme naming a pattern served by this deployment's patterns route. */
+export const SYSTEM_PATTERN_SOURCE_SCHEME = "system:";
+
+/**
+ * The URL prefix the toolshed serves its patterns directory under. A pattern's
+ * content identity folds in each module's authored path, and the worker names
+ * modules by their URL pathname, so this prefix is part of the identity
+ * contract — not merely a routing detail.
+ */
+export const PATTERNS_ROUTE_PREFIX = "/api/patterns/";
+
+// Resolution only needs a syntactic base: the caller re-resolves the returned
+// path against the host that actually serves the space.
+const RESOLUTION_BASE = "https://pattern-source.invalid/";
+
+/** The `system:` ref addressing `path` under the patterns route. */
+export function systemPatternSource(path: string): string {
+  return SYSTEM_PATTERN_SOURCE_SCHEME + path;
+}
+
+/**
+ * The route path a `system:` ref addresses, or `undefined` for anything that is
+ * not a well-formed one — a `cf:` ref, a bare path, an absolute URL, a module
+ * filename. Callers resolve the result against the space's host.
+ *
+ * A ref may not climb out of the patterns route: `..` segments are normalized
+ * before the prefix is re-checked, and a query or fragment is refused outright
+ * (`?identity` is the updater's to add, not the ref's to carry).
+ */
+export function resolveSystemPatternSource(
+  source: string,
+): string | undefined {
+  if (!source.startsWith(SYSTEM_PATTERN_SOURCE_SCHEME)) return undefined;
+  const path = source.slice(SYSTEM_PATTERN_SOURCE_SCHEME.length);
+  if (path.length === 0 || path.startsWith("/")) return undefined;
+  if (path.includes("?") || path.includes("#")) return undefined;
+  let resolved: URL;
+  try {
+    resolved = new URL(PATTERNS_ROUTE_PREFIX + path, RESOLUTION_BASE);
+  } catch {
+    return undefined;
+  }
+  if (resolved.origin !== new URL(RESOLUTION_BASE).origin) return undefined;
+  if (!resolved.pathname.startsWith(PATTERNS_ROUTE_PREFIX)) return undefined;
+  return resolved.pathname;
+}
+
+/**
+ * The `system:` ref a compiled module name spells, or `undefined` when the name
+ * says nothing about a route.
+ *
+ * A module's name is a URL pathname only for a program the worker compiled over
+ * HTTP, where `HttpProgramResolver` names every module by its pathname. A
+ * program compiled from a file tree names each module by its path under the
+ * compile root instead — `/main.tsx`, `/participant-identity-card.tsx` — and
+ * such a name is not a claim about anything the host serves. Admitting only
+ * patterns-route names keeps recovered provenance to the one representation
+ * where a name and a route are the same string.
+ */
+export function systemPatternSourceForModuleName(
+  name: string,
+): string | undefined {
+  if (!name.startsWith(PATTERNS_ROUTE_PREFIX)) return undefined;
+  const source = systemPatternSource(name.slice(PATTERNS_ROUTE_PREFIX.length));
+  return resolveSystemPatternSource(source) === undefined ? undefined : source;
+}
+
+/**
+ * Rewrite a pre-scheme provenance string into its `system:` ref, leaving
+ * everything else untouched.
+ *
+ * Two legacy spellings are in the wild. Roots stamped by PiecesController
+ * carry the rooted route path (`/api/patterns/system/home.tsx`), and any piece
+ * whose source transition has been recorded since carries the absolute href
+ * that `normalizePieceSourceOrigin` rewrote that path into against the space's
+ * host. The absolute form is only rewritten when it names the space's own host,
+ * so a ref pointing somewhere else — which the pre-scheme updater refused to
+ * follow as cross-origin — is not silently repointed at the local host.
+ *
+ * The updater re-stamps a piece it finds in a legacy spelling, so a piece
+ * migrates on its next successful check.
+ *
+ * TODO(seefeldb) 2026-08-31: once a round of updates has re-stamped the
+ * deployed pieces, delete this and require the scheme at the read sites.
+ */
+export function normalizePatternSource(
+  source: string,
+  host?: string | URL,
+): string {
+  const path = legacyPatternsRoutePath(source, host);
+  return path === undefined ? source : systemPatternSource(path);
+}
+
+function legacyPatternsRoutePath(
+  source: string,
+  host: string | URL | undefined,
+): string | undefined {
+  if (source.startsWith(PATTERNS_ROUTE_PREFIX)) {
+    return source.slice(PATTERNS_ROUTE_PREFIX.length);
+  }
+  if (host === undefined) return undefined;
+  let url: URL;
+  let hostUrl: URL;
+  try {
+    url = new URL(source);
+    hostUrl = new URL(host);
+  } catch {
+    return undefined;
+  }
+  if (url.origin !== hostUrl.origin) return undefined;
+  if (!url.pathname.startsWith(PATTERNS_ROUTE_PREFIX)) return undefined;
+  if (url.search.length > 0 || url.hash.length > 0) return undefined;
+  return url.pathname.slice(PATTERNS_ROUTE_PREFIX.length);
+}

--- a/packages/runner/src/pattern-source-scheme.ts
+++ b/packages/runner/src/pattern-source-scheme.ts
@@ -48,9 +48,9 @@ export function systemPatternSource(path: string): string {
  * not a well-formed one — a `cf:` ref, a bare path, an absolute URL, a module
  * filename. Callers resolve the result against the space's host.
  *
- * A ref may not climb out of the patterns route: `..` segments are normalized
- * before the prefix is re-checked, and a query or fragment is refused outright
- * (`?identity` is the updater's to add, not the ref's to carry).
+ * A ref may not climb out of the patterns route, and a query or fragment is
+ * refused outright (`?identity` is the updater's to add, not the ref's to
+ * carry).
  */
 export function resolveSystemPatternSource(
   source: string,
@@ -61,11 +61,33 @@ export function resolveSystemPatternSource(
   if (path.includes("?") || path.includes("#")) return undefined;
   // Resolving a `/`-rooted path against a fixed base neither throws nor can
   // reach another origin, whatever the ref holds — the prefix is prepended, so
-  // even `//evil.example/x` is just a path. What it CAN do is climb: `..`
-  // segments are normalized here, and the prefix is re-checked afterwards.
+  // even `//evil.example/x` is just a path. What it CAN do is climb, so `..`
+  // segments are normalized here and the prefix is re-checked afterwards.
   const resolved = new URL(PATTERNS_ROUTE_PREFIX + path, RESOLUTION_BASE);
-  if (!resolved.pathname.startsWith(PATTERNS_ROUTE_PREFIX)) return undefined;
+  if (!staysInPatternsRoute(resolved.pathname)) return undefined;
   return resolved.pathname;
+}
+
+/**
+ * Whether a resolved pathname still addresses a file under the patterns route.
+ *
+ * The URL parser normalizes `..` but never decodes `%2f`, so `..%2f..%2fx`
+ * survives normalization as a single opaque segment and passes a bare prefix
+ * check. The server rejects that before it reads a file, but the layer belongs
+ * here too: `systemPatternSourceForModuleName` is fed author-controlled strings.
+ * Decoding is checked separately because a malformed escape throws.
+ */
+function staysInPatternsRoute(pathname: string): boolean {
+  if (!pathname.startsWith(PATTERNS_ROUTE_PREFIX)) return false;
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(pathname);
+  } catch {
+    return false;
+  }
+  // The prefix itself survives decoding — it was matched literally above — so
+  // only what follows it can climb.
+  return !decoded.split("/").includes("..");
 }
 
 /**
@@ -92,46 +114,60 @@ export function systemPatternSourceForModuleName(
  * Rewrite a pre-scheme provenance string into its `system:` ref, leaving
  * everything else untouched.
  *
- * Two legacy spellings are in the wild. Roots stamped by PiecesController
- * carry the rooted route path (`/api/patterns/system/home.tsx`), and any piece
- * whose source transition has been recorded since carries the absolute href
- * that `normalizePieceSourceOrigin` rewrote that path into against the space's
- * host. The absolute form is only rewritten when it names the space's own host,
- * so a ref pointing somewhere else — which the pre-scheme updater refused to
- * follow as cross-origin — is not silently repointed at the local host.
+ * Two legacy spellings are in the wild: the rooted route path
+ * (`/api/patterns/system/home.tsx`), and the absolute href that
+ * `normalizePieceSourceOrigin` rewrites that path into against the space's
+ * host once a source transition records it. The absolute form is rewritten only
+ * when it names the space's own host, so a locator pointing somewhere else is
+ * not silently re-pointed at the local toolshed — that would be a change of
+ * source, not of spelling.
  *
- * The updater re-stamps a piece it finds in a legacy spelling, so a piece
- * migrates on its next successful check.
+ * A query or fragment on a legacy locator is dropped: it selects nothing on the
+ * patterns route, which serves a file by path, and revalidation is the
+ * `?identity` ETag's job. Keeping it would leave the piece with a locator no
+ * ref can spell, and therefore one nothing would ever follow again.
  *
- * TODO(seefeldb) 2026-08-31: once a round of updates has re-stamped the
- * deployed pieces, delete this and require the scheme at the read sites.
+ * The result either resolves as a ref or is the input unchanged; nothing here
+ * can mint a ref the resolver rejects.
+ *
+ * TODO(seefeldb) 2026-08-31: revisit — do NOT delete on sight. Removal needs
+ * two things this change does not do. Durable pre-existing provenance has to be
+ * migrated, which only happens on a successful check and therefore never on a
+ * deployment running with `systemPatternAutoUpdate` off. And
+ * `isLegacyPieceRegistryRoot` reads this to recognise a root that tracks the
+ * official default app, on a path with no flag gate at all.
  */
 export function normalizePatternSource(
   source: string,
   host?: string | URL,
 ): string {
   const path = legacyPatternsRoutePath(source, host);
-  return path === undefined ? source : systemPatternSource(path);
+  if (path === undefined) return source;
+  const ref = systemPatternSource(path);
+  return resolveSystemPatternSource(ref) === undefined ? source : ref;
 }
 
 function legacyPatternsRoutePath(
   source: string,
   host: string | URL | undefined,
 ): string | undefined {
-  if (source.startsWith(PATTERNS_ROUTE_PREFIX)) {
-    return source.slice(PATTERNS_ROUTE_PREFIX.length);
-  }
-  if (host === undefined) return undefined;
+  // Both spellings are read as URLs so they get one set of checks: a rooted
+  // path against a syntactic base, an absolute locator against the space's own
+  // host. Reading only the rooted form as a string let `..`, a query, and a
+  // fragment through, each of which spells a ref that cannot resolve.
   let url: URL;
-  let hostUrl: URL;
-  try {
-    url = new URL(source);
-    hostUrl = new URL(host);
-  } catch {
-    return undefined;
+  if (source.startsWith("/")) {
+    url = new URL(source, RESOLUTION_BASE);
+  } else {
+    if (host === undefined) return undefined;
+    try {
+      url = new URL(source);
+      if (url.origin !== new URL(host).origin) return undefined;
+    } catch {
+      return undefined;
+    }
   }
-  if (url.origin !== hostUrl.origin) return undefined;
-  if (!url.pathname.startsWith(PATTERNS_ROUTE_PREFIX)) return undefined;
-  if (url.search.length > 0 || url.hash.length > 0) return undefined;
-  return url.pathname.slice(PATTERNS_ROUTE_PREFIX.length);
+  if (!staysInPatternsRoute(url.pathname)) return undefined;
+  const path = url.pathname.slice(PATTERNS_ROUTE_PREFIX.length);
+  return path.length === 0 ? undefined : path;
 }

--- a/packages/runner/src/pattern-source-scheme.ts
+++ b/packages/runner/src/pattern-source-scheme.ts
@@ -158,6 +158,11 @@ function legacyPatternsRoutePath(
   let url: URL;
   if (source.startsWith("/")) {
     url = new URL(source, RESOLUTION_BASE);
+    // A leading `/` is not proof of a path: `//host/x` and `/\host/x` both
+    // introduce an authority, and their pathname alone looks like a local
+    // route. Re-pointing such a locator at this toolshed would change which
+    // host a piece follows, which is a change of source, not of spelling.
+    if (url.origin !== new URL(RESOLUTION_BASE).origin) return undefined;
   } else {
     if (host === undefined) return undefined;
     try {

--- a/packages/runner/src/pattern-source-scheme.ts
+++ b/packages/runner/src/pattern-source-scheme.ts
@@ -59,13 +59,11 @@ export function resolveSystemPatternSource(
   const path = source.slice(SYSTEM_PATTERN_SOURCE_SCHEME.length);
   if (path.length === 0 || path.startsWith("/")) return undefined;
   if (path.includes("?") || path.includes("#")) return undefined;
-  let resolved: URL;
-  try {
-    resolved = new URL(PATTERNS_ROUTE_PREFIX + path, RESOLUTION_BASE);
-  } catch {
-    return undefined;
-  }
-  if (resolved.origin !== new URL(RESOLUTION_BASE).origin) return undefined;
+  // Resolving a `/`-rooted path against a fixed base neither throws nor can
+  // reach another origin, whatever the ref holds — the prefix is prepended, so
+  // even `//evil.example/x` is just a path. What it CAN do is climb: `..`
+  // segments are normalized here, and the prefix is re-checked afterwards.
+  const resolved = new URL(PATTERNS_ROUTE_PREFIX + path, RESOLUTION_BASE);
   if (!resolved.pathname.startsWith(PATTERNS_ROUTE_PREFIX)) return undefined;
   return resolved.pathname;
 }

--- a/packages/runner/src/pattern-updater.ts
+++ b/packages/runner/src/pattern-updater.ts
@@ -14,6 +14,11 @@ import {
   preparePieceSourceTransitionBaseline,
 } from "./runner.ts";
 import type { Pattern } from "./builder/types.ts";
+import {
+  normalizePatternSource,
+  resolveSystemPatternSource,
+  systemPatternSourceForModuleName,
+} from "./pattern-source-scheme.ts";
 import type { Runtime } from "./runtime.ts";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 
@@ -169,31 +174,53 @@ export class PatternUpdater {
       const sourceSnapshot = getPieceSourceSnapshot(resultCell)!;
       if (storedRepository !== undefined) return "current";
 
-      let source = storedSource;
+      const host = runtime.mappedHostFor(space) ?? runtime.apiUrl.href;
+      let source = storedSource === undefined
+        ? undefined
+        : normalizePatternSource(storedSource, host);
       if (source === undefined) {
         // A lifecycle revision with no active origin is an intentional detach.
         // Only a history-free legacy piece may have provenance reconstructed.
         if (sourceSnapshot.revisionId !== null) return "current";
         if (mode.kind === "default-root") {
-          source = mode.officialSource;
+          // Callers may still name the official root by its route path; the
+          // same legacy rewrite applies, so the repair below stamps the ref.
+          source = normalizePatternSource(mode.officialSource, host);
         }
         if (mode.kind === "instantiated") {
           // A sourceless default root remains under the stricter, awaited root
           // policy. In particular, do not turn an author-controlled filename
           // into provenance and bypass its legacy/custom-root admission rules.
+          //
+          // Reconstruction is limited to an entry document whose name is itself
+          // a patterns-route pathname, which is the only case where the name
+          // says where the source came from. A program deployed from a file
+          // tree names its entry for the compile root instead
+          // (`/participant-identity-card.tsx`); resolving that against the host
+          // fetched the shell's SPA fallback — 200, with HTML, for any unrouted
+          // path — and then compiled the HTML as TSX.
           const program = await runtime.patternManager
             .getPatternSourceProgramByIdentity(runningRef.identity, space);
-          source = program?.main;
+          source = program === undefined
+            ? undefined
+            : systemPatternSourceForModuleName(program.main);
         }
         if (source === undefined) return "current";
       }
 
-      // Published `cf:` refs have a different resolver. This pass is exactly
-      // for same-toolshed HTTP sources whose route implements `?identity`.
-      if (source.startsWith("cf:")) return "current";
-      const host = runtime.mappedHostFor(space) ?? runtime.apiUrl.href;
-      const target = new URL(source, host);
-      if (target.origin !== new URL(host).origin) return "current";
+      // Only a `system:` ref names something this pass can fetch. A `cf:` ref
+      // has its own resolver, and everything else is provenance this pass has
+      // no route for.
+      const routePath = resolveSystemPatternSource(source);
+      if (routePath === undefined) return "current";
+      // A piece still carrying a pre-scheme spelling is re-stamped in its
+      // canonical form by the repair below, so it migrates on this check.
+      const legacyProvenance = storedSource !== undefined &&
+        storedSource !== source;
+      // Host-relative by construction, so there is no cross-origin case left
+      // to refuse: the ref addresses the patterns route of whichever host
+      // serves this space.
+      const target = new URL(routePath, host);
       const baseline = await preparePieceSourceTransitionBaseline(
         runtime,
         resultCell,
@@ -238,6 +265,8 @@ export class PatternUpdater {
       const repairProvenance = async (
         transitionBaseline: PieceSourceTransitionBaseline = baseline,
       ): Promise<PatternUpdateOutcome> => {
+        // A legacy re-stamp keeps `origin-update`: the origin field does
+        // change, even though it names the same route in a new spelling.
         const transition = sourceTransition(
           storedSource === undefined ? "follow" : "origin-update",
           source,
@@ -336,7 +365,7 @@ export class PatternUpdater {
           mode.kind === "instantiated" &&
           baseline.kind === "retain"
         ) {
-          return storedSource === undefined
+          return storedSource === undefined || legacyProvenance
             ? await repairProvenance()
             : "current";
         }
@@ -357,7 +386,7 @@ export class PatternUpdater {
             !setupNeedsRepair &&
             baseline.kind !== "unavailable"
           ) {
-            return storedSource === undefined
+            return storedSource === undefined || legacyProvenance
               ? await repairProvenance()
               : "current";
           }
@@ -402,7 +431,7 @@ export class PatternUpdater {
         entryRef.identity === runningRef.identity &&
         entryRef.symbol === runningRef.symbol
       ) {
-        return storedSource === undefined ||
+        return storedSource === undefined || legacyProvenance ||
             baseline.kind === "unavailable"
           ? await repairProvenance(transitionBaseline)
           : "current";

--- a/packages/runner/src/pattern-updater.ts
+++ b/packages/runner/src/pattern-updater.ts
@@ -183,8 +183,10 @@ export class PatternUpdater {
         // Only a history-free legacy piece may have provenance reconstructed.
         if (sourceSnapshot.revisionId !== null) return "current";
         if (mode.kind === "default-root") {
-          // Callers may still name the official root by its route path; the
-          // same legacy rewrite applies, so the repair below stamps the ref.
+          // `checkDefaultPattern` is exported, and a caller outside this
+          // package may still name the official root by its route path. The
+          // same rewrite applies, so the repair below stamps the ref either
+          // way rather than refusing a caller that spells it the old way.
           source = normalizePatternSource(mode.officialSource, host);
         }
         if (mode.kind === "instantiated") {

--- a/packages/runner/src/piece-helpers.ts
+++ b/packages/runner/src/piece-helpers.ts
@@ -9,6 +9,10 @@ import { getLogger } from "../../utils/src/logger.ts";
 import { type Cell, isCell, isStream } from "./cell.ts";
 import { isSigilLink } from "./link-types.ts";
 import { parseLink } from "./link-utils.ts";
+import {
+  normalizePatternSource,
+  systemPatternSource,
+} from "./pattern-source-scheme.ts";
 import { resolveLink } from "./link-resolution.ts";
 import { DEFAULT_CELL_SCOPE, scopeRank } from "./scope.ts";
 import type { IExtendedStorageTransaction } from "./storage/interface.ts";
@@ -285,7 +289,9 @@ export function getResultCellWithSourceSchema<T = unknown>(
   return cell;
 }
 
-const DEFAULT_APP_PATTERN_SOURCE = "/api/patterns/system/default-app.tsx";
+const DEFAULT_APP_PATTERN_SOURCE = systemPatternSource(
+  "system/default-app.tsx",
+);
 
 /**
  * Identifies a persisted default-app-shaped root that still exposes its piece
@@ -302,7 +308,14 @@ export function isLegacyPieceRegistryRoot(
     typeof patternIdentity.identity !== "string" ||
     typeof patternIdentity.symbol !== "string" ||
     (patternSource !== undefined &&
-      patternSource !== DEFAULT_APP_PATTERN_SOURCE)
+      (typeof patternSource !== "string" ||
+        // Compare in canonical form: a root that tracks the official default
+        // app is the same root whether it was stamped with the `system:` ref
+        // or with either pre-scheme spelling of that route.
+        normalizePatternSource(
+            patternSource,
+            root.runtime.hostForSpace(root.space),
+          ) !== DEFAULT_APP_PATTERN_SOURCE))
   ) {
     return false;
   }

--- a/packages/runner/test/pattern-auto-update.test.ts
+++ b/packages/runner/test/pattern-auto-update.test.ts
@@ -657,6 +657,15 @@ describe("lazy system-pattern auto-update", () => {
 
     expect(getPatternIdentityRef(piece)).toEqual(originalRef);
     expect(getPatternSource(piece)).toBe(PARENT_SOURCE);
+    // Re-spelling the origin is an origin change to the history, which is the
+    // accepted cost of migrating in place: the pair below is what a reader of
+    // the source panel sees once, per piece, and never again. Pinned here so
+    // it stays a decision rather than a side effect.
+    expect(getPieceSourceRevisions(piece).map((entry) => entry.operation))
+      .toEqual(["baseline", "origin-update"]);
+    // Both revisions name the same file, so the migration moves no source.
+    const origins = getPieceSourceRevisions(piece).map((entry) => entry.origin);
+    expect(origins).toEqual([legacyOrigin, PARENT_SOURCE]);
   });
 
   it("repairs an active legacy origin whose retained source probe failed", async () => {

--- a/packages/runner/test/pattern-auto-update.test.ts
+++ b/packages/runner/test/pattern-auto-update.test.ts
@@ -14,10 +14,14 @@ import {
   type RuntimeProgram,
   setPatternRepository,
   setPatternSource,
+  systemPatternSource,
 } from "../src/index.ts";
 
 const signer = await Identity.fromPassphrase("lazy system pattern updates");
 const PARENT_PATH = "/api/patterns/system/lazy-update-parent.tsx";
+// The `system:` ref that route path spells — what a checked piece is stamped
+// with, whichever legacy spelling it started from.
+const PARENT_SOURCE = systemPatternSource("system/lazy-update-parent.tsx");
 const SOURCE_PATH = "/api/patterns/system/lazy-update-test.tsx";
 const SYMBOL = "TrackedPattern";
 
@@ -52,6 +56,22 @@ function parentProgram(contents: string): RuntimeProgram {
       name: PARENT_PATH,
       contents: parentSource,
     }, { name: SOURCE_PATH, contents }],
+  };
+}
+
+// A program named the way `cf piece new` names one deployed from a file tree:
+// every module by its path under the compile root, so the entry says nothing
+// about what the host serves.
+const FILE_TREE_PATH = "/main.tsx";
+
+function fileTreeProgram(contents: string): RuntimeProgram {
+  return {
+    main: FILE_TREE_PATH,
+    mainExport: SYMBOL,
+    files: [
+      { name: FILE_TREE_PATH, contents: parentSource },
+      { name: "/lazy-update-test.tsx", contents },
+    ],
   };
 }
 
@@ -200,9 +220,7 @@ describe("lazy system-pattern auto-update", () => {
     identityGate.resolve();
     await runtime.patternUpdater.idle();
     expect(identityFetches).toBe(1);
-    expect(getPatternSource(piece)).toBe(
-      new URL(PARENT_PATH, runtime.apiUrl).href,
-    );
+    expect(getPatternSource(piece)).toBe(PARENT_SOURCE);
   });
 
   it("does not schedule a generic check for an explicitly handled root", async () => {
@@ -528,9 +546,7 @@ describe("lazy system-pattern auto-update", () => {
       identity: v2Identity,
       symbol: SYMBOL,
     });
-    expect(getPatternSource(piece)).toBe(
-      new URL(PARENT_PATH, runtime.apiUrl).href,
-    );
+    expect(getPatternSource(piece)).toBe(PARENT_SOURCE);
     expect(requested).toContainEqual({
       href: `http://toolshed.test${PARENT_PATH}?identity=`,
       cache: "no-cache",
@@ -571,10 +587,76 @@ describe("lazy system-pattern auto-update", () => {
     await runtime.patternUpdater.idle();
 
     expect(getPatternIdentityRef(piece)).toEqual(originalRef);
-    expect(getPatternSource(piece)).toBe(
-      new URL(PARENT_PATH, runtime.apiUrl).href,
-    );
+    expect(getPatternSource(piece)).toBe(PARENT_SOURCE);
     expect(sourceFetches).toBe(0);
+  });
+
+  it("does not fetch an entry filename that names no route", async () => {
+    let fetches = 0;
+    createRuntime(() => {
+      fetches++;
+      return Promise.resolve(new Response("unexpected"));
+    });
+    const space = signer.did();
+    const pattern = await runtime.patternManager.compilePattern(
+      fileTreeProgram(source("v1")),
+      { space },
+    );
+    const piece = runtime.getCell<{ marker?: string }>(
+      space,
+      `file-tree-${crypto.randomUUID()}`,
+    );
+    await runtime.setup(undefined, pattern, {}, piece);
+    const recovered = await runtime.patternManager
+      .getPatternSourceProgramByIdentity(
+        getPatternIdentityRef(piece)!.identity,
+        space,
+      );
+    // The precondition this guards: a program deployed from a file tree names
+    // its entry for the compile root, not for any route. Resolving that name
+    // against the host reached the shell's SPA fallback, which answers 200 with
+    // HTML for an unrouted path, and the HTML was then compiled as TSX.
+    expect(recovered?.main).toBe(FILE_TREE_PATH);
+
+    runtime.patternUpdater.schedule(piece);
+    await runtime.patternUpdater.idle();
+
+    expect(fetches).toBe(0);
+    expect(getPatternSource(piece)).toBeUndefined();
+  });
+
+  it("re-stamps a legacy absolute origin as a system ref", async () => {
+    const v1Identity = await identityFor(source("v1"));
+    const piece = await preparePiece((input) => {
+      const href = input instanceof Request
+        ? input.url
+        : input instanceof URL
+        ? input.href
+        : input;
+      const url = new URL(href);
+      if (url.pathname !== PARENT_PATH) {
+        return Promise.resolve(new Response("not found", { status: 404 }));
+      }
+      return Promise.resolve(
+        url.searchParams.has("identity")
+          ? new Response(v1Identity)
+          : new Response(parentSource),
+      );
+    });
+    // The spelling a piece carries once a source transition recorded its route
+    // path against the space's host.
+    const legacyOrigin = new URL(PARENT_PATH, runtime.apiUrl).href;
+    const stamped = await runtime.editWithRetry((tx) => {
+      setPatternSource(piece, tx, legacyOrigin);
+    });
+    expect(stamped.error).toBeUndefined();
+    const originalRef = getPatternIdentityRef(piece);
+
+    runtime.patternUpdater.schedule(piece);
+    await runtime.patternUpdater.idle();
+
+    expect(getPatternIdentityRef(piece)).toEqual(originalRef);
+    expect(getPatternSource(piece)).toBe(PARENT_SOURCE);
   });
 
   it("repairs an active legacy origin whose retained source probe failed", async () => {
@@ -627,9 +709,7 @@ describe("lazy system-pattern auto-update", () => {
     expect(sourceFetches).toBeGreaterThan(0);
     expect(getPieceSourceRevisions(piece).map((entry) => entry.operation))
       .toEqual(["baseline", "origin-update"]);
-    expect(getPatternSource(piece)).toBe(
-      new URL(PARENT_PATH, runtime.apiUrl).href,
-    );
+    expect(getPatternSource(piece)).toBe(PARENT_SOURCE);
   });
 
   it("rejects an unattended update that changes the piece contract", async () => {

--- a/packages/runner/test/pattern-source-scheme.test.ts
+++ b/packages/runner/test/pattern-source-scheme.test.ts
@@ -81,6 +81,9 @@ describe("normalizePatternSource", () => {
     expect(
       normalizePatternSource("http://elsewhere.test/api/patterns/x.tsx", HOST),
     ).toBe("http://elsewhere.test/api/patterns/x.tsx");
+    // This host, but not the patterns route: nothing to rewrite it into.
+    expect(normalizePatternSource(`${HOST}/api/other/thing.tsx`, HOST))
+      .toBe(`${HOST}/api/other/thing.tsx`);
     // With no host there is nothing to compare against.
     expect(normalizePatternSource(`${HOST}/api/patterns/system/home.tsx`))
       .toBe(`${HOST}/api/patterns/system/home.tsx`);

--- a/packages/runner/test/pattern-source-scheme.test.ts
+++ b/packages/runner/test/pattern-source-scheme.test.ts
@@ -43,6 +43,15 @@ describe("resolveSystemPatternSource", () => {
     expect(resolveSystemPatternSource("system:../secrets.tsx")).toBeUndefined();
     expect(resolveSystemPatternSource("system:system/../../etc/passwd"))
       .toBeUndefined();
+    // The URL parser normalizes `%2e%2e` into a double-dot segment, but never
+    // decodes `%2f`, so an encoded separator survives normalization as one
+    // opaque segment and passes a bare prefix check.
+    expect(resolveSystemPatternSource("system:%2e%2e/%2e%2e/x.tsx"))
+      .toBeUndefined();
+    expect(resolveSystemPatternSource("system:..%2f..%2fetc/passwd"))
+      .toBeUndefined();
+    // A malformed escape cannot be decoded, so it cannot be cleared either.
+    expect(resolveSystemPatternSource("system:%")).toBeUndefined();
     // Climbing back in is fine — it still addresses the route.
     expect(resolveSystemPatternSource("system:system/../system/home.tsx"))
       .toBe("/api/patterns/system/home.tsx");
@@ -89,6 +98,61 @@ describe("normalizePatternSource", () => {
       .toBe(`${HOST}/api/patterns/system/home.tsx`);
   });
 
+  it("drops a query or fragment rather than minting an unusable ref", () => {
+    // The patterns route serves a file by path, so neither selects anything;
+    // keeping either would spell a ref the resolver rejects, leaving the piece
+    // with provenance nothing would follow again.
+    expect(normalizePatternSource("/api/patterns/custom/my-app.tsx?v=2", HOST))
+      .toBe("system:custom/my-app.tsx");
+    expect(normalizePatternSource(`${HOST}/api/patterns/x.tsx#frag`, HOST))
+      .toBe("system:x.tsx");
+  });
+
+  it("refuses a legacy locator that does not address a file on the route", () => {
+    // Climbing, an empty path, and a doubled separator each spell a ref that
+    // cannot resolve, so the locator is left as authored instead.
+    for (
+      const source of [
+        "/api/patterns/../../etc/passwd",
+        "/api/patterns/",
+        "/api/patterns//x.tsx",
+        "/api/patterns/..%2f..%2fx.tsx",
+      ]
+    ) {
+      expect(normalizePatternSource(source, HOST)).toBe(source);
+    }
+  });
+
+  it("never returns a rewrite its own resolver would reject", () => {
+    // The invariant the two functions have to keep between them: whatever
+    // normalization hands back is either the input or a usable ref.
+    for (
+      const source of [
+        "/api/patterns/system/home.tsx",
+        "/api/patterns/x?v=2",
+        "/api/patterns/x#f",
+        "/api/patterns/",
+        "/api/patterns//x",
+        "/api/patterns/../..",
+        "/api/patterns/..%2fx",
+        "/api/patterns/%",
+        "/main.tsx",
+        "/",
+        `${HOST}/api/patterns/system/home.tsx`,
+        `${HOST}/api/patterns/`,
+        `${HOST}/api/other/x.tsx`,
+        "http://elsewhere.test/api/patterns/x.tsx",
+        "cf:published-pattern",
+        "system:system/home.tsx",
+        "",
+      ]
+    ) {
+      const normalized = normalizePatternSource(source, HOST);
+      if (normalized === source) continue;
+      expect(resolveSystemPatternSource(normalized)).toBeDefined();
+    }
+  });
+
   it("leaves everything else exactly as it found it", () => {
     for (
       const source of [
@@ -96,7 +160,7 @@ describe("normalizePatternSource", () => {
         "system:system/home.tsx",
         "/main.tsx",
         "/api/other/thing.tsx",
-        `${HOST}/api/patterns/system/home.tsx?v=2`,
+        `${HOST}/api/other/thing.tsx`,
         "not an origin",
       ]
     ) {

--- a/packages/runner/test/pattern-source-scheme.test.ts
+++ b/packages/runner/test/pattern-source-scheme.test.ts
@@ -1,0 +1,103 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  normalizePatternSource,
+  resolveSystemPatternSource,
+  systemPatternSource,
+  systemPatternSourceForModuleName,
+} from "../src/pattern-source-scheme.ts";
+
+const HOST = "http://toolshed.test";
+
+describe("resolveSystemPatternSource", () => {
+  it("expands a ref to its patterns route", () => {
+    expect(
+      resolveSystemPatternSource(systemPatternSource("lunch-poll/main.tsx")),
+    ).toBe("/api/patterns/lunch-poll/main.tsx");
+    expect(resolveSystemPatternSource("system:system/default-app.tsx"))
+      .toBe("/api/patterns/system/default-app.tsx");
+  });
+
+  it("refuses everything that is not a well-formed ref", () => {
+    // The whitelist is the point. Each of these either did produce a fetch
+    // under the old "any same-origin path" rule, or would under a looser one.
+    for (
+      const source of [
+        "cf:published-pattern",
+        "/api/patterns/system/home.tsx", // the pre-scheme spelling, unrewritten
+        "/participant-identity-card.tsx", // a file-tree module name
+        "/main.tsx",
+        "http://toolshed.test/api/patterns/system/home.tsx",
+        "system:", // no path
+        "system:/leading-slash.tsx",
+        "system:main.tsx?identity=", // the updater adds the query, not the ref
+        "system:main.tsx#frag",
+        "",
+      ]
+    ) {
+      expect(resolveSystemPatternSource(source)).toBeUndefined();
+    }
+  });
+
+  it("refuses a ref that climbs out of the patterns route", () => {
+    expect(resolveSystemPatternSource("system:../secrets.tsx")).toBeUndefined();
+    expect(resolveSystemPatternSource("system:system/../../etc/passwd"))
+      .toBeUndefined();
+    // Climbing back in is fine — it still addresses the route.
+    expect(resolveSystemPatternSource("system:system/../system/home.tsx"))
+      .toBe("/api/patterns/system/home.tsx");
+  });
+});
+
+describe("systemPatternSourceForModuleName", () => {
+  it("accepts a patterns-route module name", () => {
+    expect(systemPatternSourceForModuleName("/api/patterns/system/home.tsx"))
+      .toBe("system:system/home.tsx");
+  });
+
+  it("refuses a name that says nothing about a route", () => {
+    // How a program deployed from a file tree names its modules — the case
+    // this guard exists for.
+    expect(systemPatternSourceForModuleName("/participant-identity-card.tsx"))
+      .toBeUndefined();
+    expect(systemPatternSourceForModuleName("/main.tsx")).toBeUndefined();
+    expect(systemPatternSourceForModuleName("main.tsx")).toBeUndefined();
+  });
+});
+
+describe("normalizePatternSource", () => {
+  it("rewrites the rooted route path a system root was stamped with", () => {
+    expect(normalizePatternSource("/api/patterns/system/home.tsx"))
+      .toBe("system:system/home.tsx");
+    expect(normalizePatternSource("/api/patterns/custom/my-app.tsx", HOST))
+      .toBe("system:custom/my-app.tsx");
+  });
+
+  it("rewrites the absolute form only for the space's own host", () => {
+    expect(
+      normalizePatternSource(`${HOST}/api/patterns/system/home.tsx`, HOST),
+    ).toBe("system:system/home.tsx");
+    // Another host's route is not this host's to re-point at.
+    expect(
+      normalizePatternSource("http://elsewhere.test/api/patterns/x.tsx", HOST),
+    ).toBe("http://elsewhere.test/api/patterns/x.tsx");
+    // With no host there is nothing to compare against.
+    expect(normalizePatternSource(`${HOST}/api/patterns/system/home.tsx`))
+      .toBe(`${HOST}/api/patterns/system/home.tsx`);
+  });
+
+  it("leaves everything else exactly as it found it", () => {
+    for (
+      const source of [
+        "cf:published-pattern",
+        "system:system/home.tsx",
+        "/main.tsx",
+        "/api/other/thing.tsx",
+        `${HOST}/api/patterns/system/home.tsx?v=2`,
+        "not an origin",
+      ]
+    ) {
+      expect(normalizePatternSource(source, HOST)).toBe(source);
+    }
+  });
+});

--- a/packages/runner/test/pattern-source-scheme.test.ts
+++ b/packages/runner/test/pattern-source-scheme.test.ts
@@ -108,6 +108,20 @@ describe("normalizePatternSource", () => {
       .toBe("system:x.tsx");
   });
 
+  it("refuses a legacy locator that names another host", () => {
+    // Each of these has a local-looking pathname but an authority of its own,
+    // so rewriting it would move the piece onto this toolshed's copy.
+    for (
+      const source of [
+        "//elsewhere.test/api/patterns/x.tsx",
+        "/\\elsewhere.test/api/patterns/x.tsx",
+        "http://elsewhere.test/api/patterns/x.tsx",
+      ]
+    ) {
+      expect(normalizePatternSource(source, HOST)).toBe(source);
+    }
+  });
+
   it("refuses a legacy locator that does not address a file on the route", () => {
     // Climbing, an empty path, and a doubled separator each spell a ref that
     // cannot resolve, so the locator is left as authored instead.

--- a/packages/runner/test/piece-helpers.test.ts
+++ b/packages/runner/test/piece-helpers.test.ts
@@ -4,6 +4,7 @@ import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import {
   getResultCellWithSourceSchema,
+  isLegacyPieceRegistryRoot,
   parseCellPath,
   resolveCellPath,
 } from "../src/piece-helpers.ts";
@@ -271,5 +272,87 @@ describe("getResultCellWithSourceSchema", () => {
     const annotated = getResultCellWithSourceSchema(explicitCell);
 
     assertEquals(annotated.getAsNormalizedFullLink().schema, explicitSchema);
+  });
+});
+
+describe("isLegacyPieceRegistryRoot", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+
+  const HOST = "http://toolshed.test";
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({ apiUrl: new URL(HOST), storageManager });
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  // A root in the shape the predicate looks for: the retired `allPieces` field
+  // with its `addPiece` stream, and no `pieceRegistry`.
+  async function legacyShapedRoot(patternSource?: unknown) {
+    const root = runtime.getCell<Record<string, unknown>>(
+      space,
+      `legacy-registry-root-${crypto.randomUUID()}`,
+    );
+    const { error } = await runtime.editWithRetry((tx) => {
+      const withTx = root.withTx(tx);
+      withTx.set({
+        allPieces: [],
+        addPiece: { $stream: true },
+      } as unknown as Record<string, unknown>);
+      withTx.setMetaRaw("patternIdentity", {
+        identity: "fid1:whatever",
+        symbol: "default",
+      });
+      if (patternSource !== undefined) {
+        withTx.setMetaRaw("patternSource", patternSource as never);
+      }
+    });
+    assertEquals(error, undefined);
+    return root;
+  }
+
+  it("accepts every spelling of the official default-app source", async () => {
+    // The three that name the same file: the ref a root is stamped with today,
+    // the rooted route path, and the absolute href a recorded source
+    // transition rewrites that path into against the space's own host.
+    for (
+      const source of [
+        undefined,
+        "system:system/default-app.tsx",
+        "/api/patterns/system/default-app.tsx",
+        `${HOST}/api/patterns/system/default-app.tsx`,
+      ]
+    ) {
+      assertEquals(
+        isLegacyPieceRegistryRoot(await legacyShapedRoot(source)),
+        true,
+        `expected ${String(source)} to qualify`,
+      );
+    }
+  });
+
+  it("refuses a root tracking anything else", async () => {
+    // Another host's copy is a different source, not another spelling — and a
+    // custom pattern is exactly what the predicate exists to exclude.
+    for (
+      const source of [
+        "system:custom/my-app.tsx",
+        "/api/patterns/custom/my-app.tsx",
+        "http://elsewhere.test/api/patterns/system/default-app.tsx",
+        "cf:published-pattern",
+        42,
+      ]
+    ) {
+      assertEquals(
+        isLegacyPieceRegistryRoot(await legacyShapedRoot(source)),
+        false,
+        `expected ${String(source)} to be refused`,
+      );
+    }
   });
 });

--- a/packages/toolshed/routes/patterns/patterns-server.ts
+++ b/packages/toolshed/routes/patterns/patterns-server.ts
@@ -1,13 +1,17 @@
 import { decode } from "@commonfabric/utils/encoding";
 import { join } from "@std/path/join";
 import { toFileUrl } from "@std/path/to-file-url";
-import { resolveEntryIdentity } from "@commonfabric/runner";
+import {
+  PATTERNS_ROUTE_PREFIX,
+  resolveEntryIdentity,
+} from "@commonfabric/runner";
 
-// The URL prefix this route serves patterns under. A pattern's content identity
-// folds in each module's authored path, and the worker names modules by their
-// URL pathname (HttpProgramResolver), so the identity must be computed over
-// pathname-prefixed names to equal the worker's stored patternIdentity.
-const PATTERNS_ROUTE_PREFIX = "/api/patterns/";
+// The prefix this route serves patterns under is the runner's constant, not
+// this route's own. A pattern's content identity folds in each module's
+// authored path, and the worker names modules by their URL pathname
+// (HttpProgramResolver), so the identity must be computed over
+// pathname-prefixed names to equal the worker's stored patternIdentity — and
+// the same prefix is what a `system:` provenance ref expands to.
 
 /**
  * Simple helper for serving pattern files from the patterns directory.

--- a/tasks/pattern-vintage-lib.test.ts
+++ b/tasks/pattern-vintage-lib.test.ts
@@ -231,6 +231,18 @@ describe("coverage", () => {
     expect(requiredPatternKeys(["/api/meta", ""])).toEqual([]);
   });
 
+  it("derives keys from the `system:` refs the runtime actually holds", () => {
+    expect(requiredPatternKeys([
+      "system:system/home.tsx",
+      "system:system/default-app.tsx",
+    ])).toEqual(["system/default-app.tsx", "system/home.tsx"]);
+    // A source naming no route is not silently dropped from the required set:
+    // it stays unmapped, and the caller refuses to run on it.
+    expect(unmappedPatternUrls(["system:system/home.tsx"])).toEqual([]);
+    expect(unmappedPatternUrls(["system:", "cf:published"]))
+      .toEqual(["system:", "cf:published"]);
+  });
+
   it("names a URL the derivation could not map, rather than dropping it", () => {
     // The dangerous shape: reroute the patterns endpoint and every required
     // key derives to nothing, leaving a gate that insists on nothing while

--- a/tasks/pattern-vintage-lib.ts
+++ b/tasks/pattern-vintage-lib.ts
@@ -69,6 +69,7 @@
  */
 
 import { VINTAGE_SPACES_SUFFIX } from "../packages/piece/test/vintage-layout.ts";
+import { resolveSystemPatternSource } from "@commonfabric/runner";
 
 /** Root of the committed fixture tree. See the note above on why it is here. */
 export const VINTAGES_DIR = "packages/piece/test/vintages";
@@ -243,11 +244,24 @@ export function coveredPatternKeys(
  */
 const PATTERN_ROUTE_MARKER = "/patterns/";
 
+/**
+ * The route a system pattern source names.
+ *
+ * The runtime's constants are `system:` refs, addressed relative to the
+ * patterns route; the gate maps routes to fixture keys. A source that names no
+ * route is handed back unchanged, so it reaches the unmapped check below rather
+ * than disappearing from the required set.
+ */
+function patternRoute(source: string): string {
+  return resolveSystemPatternSource(source) ?? source;
+}
+
 export function requiredPatternKeys(
   systemPatternUrls: readonly string[],
 ): string[] {
   const keys: string[] = [];
-  for (const url of systemPatternUrls) {
+  for (const source of systemPatternUrls) {
+    const url = patternRoute(source);
     const at = url.indexOf(PATTERN_ROUTE_MARKER);
     if (at === -1) continue;
     keys.push(url.slice(at + PATTERN_ROUTE_MARKER.length));
@@ -267,7 +281,9 @@ export function requiredPatternKeys(
 export function unmappedPatternUrls(
   systemPatternUrls: readonly string[],
 ): string[] {
-  return systemPatternUrls.filter((url) => !url.includes(PATTERN_ROUTE_MARKER));
+  return systemPatternUrls.filter((source) =>
+    !patternRoute(source).includes(PATTERN_ROUTE_MARKER)
+  );
 }
 
 /** Required patterns with no pinned vintage. */

--- a/tasks/pattern-vintage.ts
+++ b/tasks/pattern-vintage.ts
@@ -67,7 +67,6 @@
 
 import { fromFileUrl } from "@std/path/from-file-url";
 import { Identity } from "@commonfabric/identity";
-import { resolveSystemPatternSource } from "@commonfabric/runner";
 import {
   DEFAULT_APP_PATTERN_SOURCE,
   HOME_PATTERN_SOURCE,
@@ -122,12 +121,7 @@ async function main() {
   // cannot drift from what actually auto-updates. A constant that stops
   // deriving a key would leave the gate requiring nothing, so that is checked
   // rather than absorbed.
-  // The constants are `system:` refs; the gate maps ROUTES to fixture keys, so
-  // each is expanded here. A ref that stops resolving to a route falls through
-  // unexpanded and trips the unmapped check below — the drift the check exists
-  // for, rather than a key that silently disappears.
-  const systemUrls = [HOME_PATTERN_SOURCE, DEFAULT_APP_PATTERN_SOURCE]
-    .map((source) => resolveSystemPatternSource(source) ?? source);
+  const systemUrls = [HOME_PATTERN_SOURCE, DEFAULT_APP_PATTERN_SOURCE];
   const unmapped = unmappedPatternUrls(systemUrls);
   if (unmapped.length > 0) {
     console.error(reportUnmappedUrls(unmapped));

--- a/tasks/pattern-vintage.ts
+++ b/tasks/pattern-vintage.ts
@@ -67,9 +67,10 @@
 
 import { fromFileUrl } from "@std/path/from-file-url";
 import { Identity } from "@commonfabric/identity";
+import { resolveSystemPatternSource } from "@commonfabric/runner";
 import {
-  DEFAULT_APP_PATTERN_URL,
-  HOME_PATTERN_URL,
+  DEFAULT_APP_PATTERN_SOURCE,
+  HOME_PATTERN_SOURCE,
 } from "../packages/piece/src/system-pattern-url.ts";
 import {
   armVerdictGuard,
@@ -121,7 +122,12 @@ async function main() {
   // cannot drift from what actually auto-updates. A constant that stops
   // deriving a key would leave the gate requiring nothing, so that is checked
   // rather than absorbed.
-  const systemUrls = [HOME_PATTERN_URL, DEFAULT_APP_PATTERN_URL];
+  // The constants are `system:` refs; the gate maps ROUTES to fixture keys, so
+  // each is expanded here. A ref that stops resolving to a route falls through
+  // unexpanded and trips the unmapped check below — the drift the check exists
+  // for, rather than a key that silently disappears.
+  const systemUrls = [HOME_PATTERN_SOURCE, DEFAULT_APP_PATTERN_SOURCE]
+    .map((source) => resolveSystemPatternSource(source) ?? source);
   const unmapped = unmappedPatternUrls(systemUrls);
   if (unmapped.length > 0) {
     console.error(reportUnmappedUrls(unmapped));


### PR DESCRIPTION
## Why

Opening a piece in a `lunch-poll` space logged a TypeScript compile failure against the user's own pattern:

```
[WARN][runner.pattern-update] check-failed pattern update check failed
[ERROR] ';' expected.
1 | import { __cfHelpers } from "commonfabric";
2 | <!DOCTYPE html>
```

The updater was compiling the shell's `index.html` as TSX.

A piece with no stored provenance had it reconstructed from the entry document's authored module filename, then resolved against the host as if it were a URL. That name is a URL pathname only for a program the worker compiled over HTTP; a program deployed from a file tree names its modules by their path under the compile root. The `lunch-poll` piece was deployed with `--root` at the pattern directory, so its modules are `/main.tsx`, `/participant-identity-card.tsx`, …, and the check requested `https://<host>/participant-identity-card.tsx`. Nothing routes that path, the SPA fallback answers 200 with HTML, the body was accepted as an advertised identity because it was non-empty, and the page was downloaded and compiled. Every open of that piece produced the noise above.

`pieces-controller` already declines to stamp the `"custom"` placeholder for exactly this reason — *"stamping the placeholder would poison URL resolution — it would resolve relative to the host."* The invariant was stated; the reconstruction path went around it.

The fix makes provenance say what it means instead of leaving the updater to infer it. `system:<path>` names a pattern this deployment's toolshed serves from its patterns directory, relative to that route, and a fetch happens only for provenance that is one. A bare path cannot be distinguished from a module filename that merely looks like a route, so a whitelist is the only rule that holds.

The scheme keeps the host out of provenance as a side benefit: `system:system/home.tsx` survives a space moving hosts, where the absolute href a recorded source transition produced does not — the same reason `cf:` refs are stored host-less.

## What changed

- **`runner/src/pattern-source-scheme.ts`** (new) — the grammar: expansion to the patterns route, the traversal guard, the admission rule for recovered module names, and the legacy rewrite. `PATTERNS_ROUTE_PREFIX` lives here now, and `patterns-server.ts` imports it rather than keeping its own copy.
- **`pattern-updater.ts`** — resolves provenance through the scheme and returns `current` for anything else, which subsumes the old `cf:` check and the cross-origin refusal. Reconstruction from a recovered module name is kept, but only for a name that is itself a patterns-route pathname.
- **System roots** are stamped `system:system/home.tsx` / `system:system/default-app.tsx`. The constants are renamed `*_PATTERN_SOURCE`, since they are no longer URLs, and `patternSourceUrl()` resolves a stored source at the fetch sites.
- **The configured `defaultAppUrl` is canonicalized when read**, so a root is born with the provenance it keeps. Stamping the authored spelling would leave every new root waiting on a migration to become followable — and on a deployment running with the update flag off, waiting forever.
- **`classifyOrigin`** classifies a `system:` ref as the web origin it resolves to, keeping the ref as the recorded form, so the source panel still shows a system root's URL.
- **`isLegacyPieceRegistryRoot`** compares provenance in canonical form, so a root that tracks the official default app is recognized whichever spelling it carries.
- **Migration** — the rooted route path and the absolute href on the space's own host are rewritten on read and re-stamped on the next successful check. A locator on another host is left alone: re-pointing it here would be a change of source, not of spelling. Normalization can never return a rewrite its own resolver would reject.
- **Live specs updated**: `docs/specs/pattern-imports/pattern-updates.md`, `docs/specs/piece-source-lifecycle.md`.

## Security

The traversal guard decodes before checking. The URL parser normalizes `%2e%2e` into a double-dot segment but never decodes `%2f`, so `..%2f..%2fx` survived normalization as one opaque segment and passed a bare prefix check. The server rejects that independently, but the layer belongs here too, since `systemPatternSourceForModuleName` is the entry point fed author-controlled strings.

A leading `/` is also not proof of a path: `//host/x` and `/\host/x` both parse with an authority of their own and a pathname that looks like a local route. Both are refused rather than rewritten onto this toolshed.

## Test plan

- Unit coverage for the scheme: expansion, encoded and plain traversal, malformed escapes, hidden authorities, the filenames it must refuse, both legacy rewrites, and a table asserting the invariant that normalization returns either its input or a ref that resolves. The file is at 100% line coverage.
- New updater case asserting a file-tree-named entry produces **no** fetch. Verified it fails against the unmodified updater — the request goes out — and passes here.
- New updater case for the absolute-href legacy spelling, pinning both the re-stamp and the two history revisions it produces, so the migration's churn is a decision rather than a side effect.
- A test table for `isLegacyPieceRegistryRoot`, which had none and now depends on canonical comparison.
- `packages/piece` green (31 files, 369 steps). `packages/runner` shows 108 failures identical on a clean checkout of the base commit (time/entropy gate, memory-v2 races); the added cases pass. Repo typecheck, lint, format, and the pattern-vintage gate all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)