### PR TITLE
fix(data-model): an array is answered by the array rule, and nothing else

### DIFF
--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -1183,6 +1183,12 @@ Section 4.5.
 ### 1.5 Recursive Containers
 
 **Arrays:**
+- Direct `Array` instances only: the prototype must be `Array.prototype`
+  itself. An `Array` subclass instance, an array whose prototype has been
+  severed or replaced, and an array from another realm all cause rejection,
+  because a prototype is live code rather than an inert value — an overridden
+  `Symbol.iterator`, say, makes iteration answer differently than the indices
+  do — and no prototype has any representation as array content
 - May be dense or sparse
 - Elements may be `undefined` (a first-class fabric value; see Section 1.3)
 - Sparse arrays (arrays with holes) are supported; holes are distinct from
@@ -3063,9 +3069,12 @@ export function fabricFromNativeValue(
 > `"Date"`, `"RegExp"`, `"Array"`, `"Object"`, `"Primitive"`,
 > `"FabricInstance"`). The conversion function then switches on the tag to
 > route to the appropriate wrapping logic. Fallback paths handle exotic Error
-> subclasses (via `Error.isError()`), cross-realm arrays (via
-> `Array.isArray()`), null-prototype objects, and objects with `toJSON()`
-> methods.
+> subclasses (via `Error.isError()`), arrays whose constructor is unreachable
+> or foreign (via `Array.isArray()`), null-prototype objects, and objects with
+> `toJSON()` methods. Dispatch classifies more broadly than the type admits:
+> tagging a subclass instance or a cross-realm array as `"Array"` is what lets
+> the array rule of Section 1.5 reject it by name, rather than as some
+> unrecognized class.
 
 > **Implementation: centralized shallow-clone utility.** The conversion
 > functions use a centralized `cloneIfNecessary()` utility (in

--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -1186,9 +1186,13 @@ Section 4.5.
 - Direct `Array` instances only: the prototype must be `Array.prototype`
   itself. An `Array` subclass instance, an array whose prototype has been
   severed or replaced, and an array from another realm all cause rejection,
-  because a prototype is live code rather than an inert value — an overridden
-  `Symbol.iterator`, say, makes iteration answer differently than the indices
-  do — and no prototype has any representation as array content
+  because an array's prototype has no representation as array content, so
+  accepting one could only mean dropping it silently. A subclass prototype is
+  live code besides — an overridden `Symbol.iterator`, say, makes iteration
+  answer differently than the indices do, and freezing the array does not
+  change that. (Plain objects are treated differently on this point: see the
+  object rule below, which admits a null prototype and normalizes it on
+  reconstruction.)
 - May be dense or sparse
 - Elements may be `undefined` (a first-class fabric value; see Section 1.3)
 - Sparse arrays (arrays with holes) are supported; holes are distinct from
@@ -2907,7 +2911,10 @@ boundary-only serialization and the three-layer architecture:
 > **`toJSON()` compatibility and migration.** The conversion functions and their
 > variants currently honor `toJSON()` methods on objects that have them — if an
 > object has a `toJSON()` method and does not implement `FabricInstance`, the
-> conversion functions call `toJSON()` and process the result. This preserves
+> conversion functions call `toJSON()` and process the result. Arrays are
+> outside this: an array is answered by the array rule of Section 1.5 whatever
+> it carries, and `toJSON` is a named own property, which that rule rejects.
+> This preserves
 > backward compatibility with existing code. However, `toJSON()` support is
 > **marked for removal**: it eagerly converts to JSON-compatible shapes, which
 > is incompatible with late serialization. Implementors should migrate to the
@@ -3068,13 +3075,14 @@ export function fabricFromNativeValue(
 > single constructor lookup that returns a tag string (e.g., `"Error"`,
 > `"Date"`, `"RegExp"`, `"Array"`, `"Object"`, `"Primitive"`,
 > `"FabricInstance"`). The conversion function then switches on the tag to
-> route to the appropriate wrapping logic. Fallback paths handle exotic Error
-> subclasses (via `Error.isError()`), arrays whose constructor is unreachable
-> or foreign (via `Array.isArray()`), null-prototype objects, and objects with
-> `toJSON()` methods. Dispatch classifies more broadly than the type admits:
-> tagging a subclass instance or a cross-realm array as `"Array"` is what lets
-> the array rule of Section 1.5 reject it by name, rather than as some
-> unrecognized class.
+> route to the appropriate wrapping logic. An array is the exception to the
+> constructor lookup: `Array.isArray()` is consulted first and answers
+> `"Array"` unconditionally, so a subclass instance, a severed-prototype array,
+> and a cross-realm array all reach array handling and are answered by the
+> array rule of Section 1.5, rather than being rejected as some unrecognized
+> class or routed elsewhere by something the array carries. Fallback paths
+> handle exotic Error subclasses (via `Error.isError()`), null-prototype
+> objects, and objects with `toJSON()` methods.
 
 > **Implementation: centralized shallow-clone utility.** The conversion
 > functions use a centralized `cloneIfNecessary()` utility (in

--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -189,7 +189,10 @@ member of `FabricValue`.
 > **Legacy: `{ toJSON(): unknown }` variant.** The `toJSON()` arm of
 > `FabricNativeObject` represents objects that provide a `toJSON()` method.
 > The conversion functions call `toJSON()` and process the
-> result (Section 8.2). This variant is **legacy and marked for removal** —
+> result (Section 8.2). Arrays are excluded: an array is decided by the array
+> rule of Section 1.5 whatever it carries, so one bearing a `toJSON` method is
+> rejected rather than converted. This variant is **legacy and marked for
+> removal** —
 > callers should migrate to the fabric protocol
 > (`FabricInstance` + `[CODEC]`). See Section 7.1 for migration guidance.
 
@@ -2913,8 +2916,10 @@ boundary-only serialization and the three-layer architecture:
 > object has a `toJSON()` method and does not implement `FabricInstance`, the
 > conversion functions call `toJSON()` and process the result. Arrays are
 > outside this: an array is answered by the array rule of Section 1.5 whatever
-> it carries, and `toJSON` is a named own property, which that rule rejects.
-> This preserves
+> it carries. An own `toJSON` is a named key, which that rule rejects; an
+> inherited one is not array content, and honoring it would mean a single
+> assignment to `Array.prototype.toJSON` could route every array in the process
+> through it. This preserves
 > backward compatibility with existing code. However, `toJSON()` support is
 > **marked for removal**: it eagerly converts to JSON-compatible shapes, which
 > is incompatible with late serialization. Implementors should migrate to the
@@ -3212,8 +3217,10 @@ if the value is:
   string). Unique symbols return `false`; see the Section 1.3 callout.
 - A `FabricInstance` (including the native object wrapper classes)
 - A `FabricNativeObject` (`Error`, `Map`, `Set`, `Date`, `RegExp`,
-  `Uint8Array`, or an object with a `toJSON()` method — legacy)
-- An array where every present element satisfies `isFabricCompatible()`
+  `Uint8Array`, or a non-array object with a `toJSON()` method — legacy)
+- An array where every present element satisfies `isFabricCompatible()`, and
+  which the array rule of Section 1.5 accepts — a `toJSON` method does not
+  make an otherwise-rejected array compatible
 - A plain object where every value satisfies `isFabricCompatible()`
 
 It returns `false` for unsupported types (`WeakMap`, `Promise`, DOM nodes,

--- a/docs/specs/sparse-array-preservation.md
+++ b/docs/specs/sparse-array-preservation.md
@@ -105,21 +105,28 @@ Read path:   storage → traverseDAG → normalizeAndDiff → builtins (map, etc
 These layers handle sparse arrays correctly and are less likely to regress
 because their sparse support was part of the original design:
 
-- **`packages/data-model/native-conversion.ts`** — `shallowFabricFromNativeValue` and
-  `fabricFromNativeValue` use `i in arr` checks.
-- **`packages/memory/serialization.ts`** — Encodes holes as run-length-encoded
-  `/hole` entries; decodes them back to true holes via `new Array(len)`.
-- **`packages/data-model/value-hash.ts`** — Handles holes in hash computation.
+- **`packages/data-model/src/native-conversion.ts`** —
+  `shallowFabricFromNativeValue` and `fabricFromNativeValue` use `i in arr`
+  checks. An array returned from a `toJSON()` method gets the same care: the
+  result goes through `cloneHelper()`, which rebuilds it with
+  `new Array(length)` and copies only the indices that are present.
+- **`packages/data-model/src/codec-json/JsonEncodingContext.ts`** — Encodes a
+  run of holes as a single hole-tagged count; decoding rebuilds them as true
+  holes.
+- **`packages/data-model/src/value-hash.ts`** — Feeds holes to the hash
+  directly, coalescing each run into one hole entry.
 
-### Value validation (`packages/data-model/fabric-value.ts`)
+### Value validation (`packages/data-model/src/type-check.ts`)
 
-`isFabricArray` accepts sparse arrays — holes are valid fabric structure. It
-uses `for` + `i in` because it needs early return.
+`isFabricValueLayer()` and `isFabricValue()` accept sparse arrays — holes are
+valid fabric structure. `isFabricValue()` uses `for` + `i in` because it needs
+early return, skipping holes rather than validating them as values.
 
 ### v2-transaction write path (`packages/runner/src/storage/v2-transaction.ts`)
 
 The hot write path (since PR #3704) goes through `applyMutablePathWrite`,
-which calls `cloneForMutation` (in `value-clone.ts`) to shallow-thaw the
+which calls `cloneForMutation` (in
+`packages/data-model/src/value-clone.ts`) to shallow-thaw the
 spine and then mutates the leaf parent in place. `cloneForMutation`'s
 shallow-thaw step uses `cloneIfNecessary({ frozen: false, deep: false })`
 on each spine container, which for arrays preserves sparseness: it
@@ -207,14 +214,13 @@ changes reactively:
 - **Hole becomes value:** A new pattern run is created (or reused from
   `elementRuns` if the identity key matches a previous run).
 
-### Hashing boundary (`packages/memory/reference.ts`)
+### Hashing boundary (`packages/data-model/src/value-hash.ts`)
 
-The merkle-reference library cannot hash sparse array holes (it throws
-`TypeError: Unknown type undefined`). The `wrappedNodeBuilder.toTree` wrapper
-detects sparse arrays and densifies them (holes → `null`) before passing to the
-default node builder. This only affects hash computation — the actual data in
-storage remains sparse. The modern hash path (`value-hash.ts`) handles
-holes natively and does not need this workaround.
+Holes are hashed as themselves. `feedArray()` walks the array by index and,
+on reaching an absent one, coalesces the whole run of consecutive holes into a
+single hole entry carrying its length. A hole is therefore distinct from a
+`null` or an `undefined` element in the hash, exactly as it is in storage, so
+two arrays that differ only in sparseness hash differently.
 
 ## Writing new code that handles arrays
 
@@ -250,9 +256,9 @@ Test coverage verifies sparse preservation at each layer:
   the full Cell write path (which lands in `applyMutablePathWrite`) preserve
   holes; the helper's `cloneForMutation` + leaf-mutation steps round-trip
   sparseness.
-- **`packages/runner/test/cell.test.ts`** — Writing a sparse array to a cell and
-  reading it back preserves holes; `push` onto a sparse array preserves existing
-  holes.
+- **`packages/runner/test/array-push-mergeable.test.ts`** — `push` onto a
+  sparse array preserves the existing holes, including when the cell had no
+  prior value and when a concurrent edit touches a hole.
 - **`packages/runner/test/traverse.test.ts`** — Sparse array roundtrip through
   `traverse` preserves holes (both `traverseDAG` and schema-driven
   `traverseArrayWithSchema` paths).
@@ -266,10 +272,3 @@ Test coverage verifies sparse preservation at each layer:
 These tests use the `in` operator to assert true sparseness (`1 in result`
 should be `false`), not just value equality. A regression that densifies arrays
 will fail these assertions.
-
-## Known limitations
-
-- **`data-model/native-conversion.ts` `HasToJSON` path:**
-  `Object.freeze([...converted])` in the `HasToJSON` case would densify a sparse
-  array returned from `toJSON()`. This is an edge case — `toJSON()` rarely
-  returns sparse arrays.

--- a/packages/data-model/src/interface.ts
+++ b/packages/data-model/src/interface.ts
@@ -229,6 +229,12 @@ export type MutableFabricValueLayer =
  * `isFabricCompatible()` type predicate
  * (`value is FabricValue | FabricNativeObject`) remains sound.
  *
+ * Arrays are the exception the arm cannot state structurally: an array is
+ * decided by the array rule whatever it carries, so one bearing a `toJSON`
+ * method is rejected rather than converted, even though it satisfies this
+ * arm's shape. A type cannot say "any object with `toJSON()` except an
+ * array", so the carve-out lives here in prose.
+ *
  * Note: `bigint` is NOT included here -- it is a primitive (like `undefined`)
  * and belongs directly in `FabricValue` without wrapping.
  */

--- a/packages/data-model/src/native-conversion.ts
+++ b/packages/data-model/src/native-conversion.ts
@@ -299,7 +299,8 @@ export function shallowFabricFromNativeValue(
     }
 
     case NATIVE_TAGS.HasToJSON: {
-      // Objects (or arrays/class instances) with a `toJSON()` method.
+      // Objects (or class instances) with a `toJSON()` method. Arrays never
+      // reach here: they are tagged `Array` whatever they carry.
       // Call `toJSON()` and validate the result.
       const converted = (value as { toJSON: () => unknown }).toJSON();
       if (!isFabricValueLayer(converted)) {

--- a/packages/data-model/src/native-conversion.ts
+++ b/packages/data-model/src/native-conversion.ts
@@ -41,7 +41,8 @@ function rejectExtraProperties(value: object, typeName: string): void {
 /**
  * Returns a shallow clone of the given array carrying nothing but its
  * enumerable index properties and `length`, that is, one which satisfies
- * `isInertArray()`. Holes are preserved as holes, and
+ * `isInertArray()` -- a direct `Array` instance, whatever the given array's
+ * prototype. Holes are preserved as holes, and
  * elements are copied by reference without themselves being converted or
  * validated, this being a shallow operation.
  *
@@ -249,11 +250,14 @@ export function shallowFabricFromNativeValue(
     }
 
     case NATIVE_TAGS.Array: {
-      // An array in this system is INERT: it may only carry numeric index
-      // properties, each a data property. A named or symbol-keyed property
-      // has no fabric representation, and an accessor-backed index is live
-      // code rather than inert data; reject any of them outright rather than
-      // silently dropping or flattening ("death before confusion").
+      // An array in this system is INERT: a direct `Array` instance, which
+      // may only carry numeric index properties, each a data property. A named
+      // or symbol-keyed property has no fabric representation, and an
+      // accessor-backed index is live code rather than inert data -- as is the
+      // prototype of an `Array` subclass instance, which can make iteration
+      // answer differently than the indices say. Reject any of them outright
+      // rather than silently dropping or flattening ("death before
+      // confusion").
       if (!isInertArray(value)) {
         throw new Error(
           "Not representable as a `FabricValue`: array that is not an " +
@@ -663,8 +667,8 @@ function isFabricCompatibleInternal(
       seen.add(value);
 
       if (Array.isArray(value)) {
-        // Check array structure (no non-index properties, no
-        // accessor-backed indices).
+        // Check array structure (a direct `Array` instance, no non-index
+        // properties, no accessor-backed indices).
         if (!isInertArray(value)) {
           seen.delete(value);
           return false;

--- a/packages/data-model/src/native-type-tags.ts
+++ b/packages/data-model/src/native-type-tags.ts
@@ -135,14 +135,23 @@ export function tagFromNativeClass(
  * value is a recognized convertible native instance, or `null` otherwise.
  * Non-object types (`null`, `undefined`, primitives) return `Primitive`.
  *
- * Dispatches via the value's constructor (O(1) switch in `tagFromNativeClass`,
- * which matches `Error` subclasses via `prototype instanceof Error`). Falls
- * back to native error detection and `Array.isArray()` for values whose
- * constructor is unreachable -- a severed prototype, or another realm -- and
- * to a prototype check for null-prototype objects.
+ * An array answers `Array` before anything else is consulted, `toJSON()`
+ * included. `Array.isArray()` is realm-agnostic and sees through both a
+ * subclass and a severed prototype, so every array-shaped value reaches array
+ * handling and is answered by the array rule, which alone decides what an
+ * array may be. Nothing an array carries can route it elsewhere: a `toJSON()`
+ * method is a named own property, which that rule rejects anyway, so honoring
+ * it here would mean converting a value by the very property that disqualifies
+ * it.
  *
- * For tags that have pass-through handling (`Object`, `Array`) or no dedicated
- * handler (`null`), a per-instance `hasToJSON()` check upgrades the tag to
+ * Otherwise dispatches via the value's constructor (O(1) switch in
+ * `tagFromNativeClass`, which matches `Error` subclasses via
+ * `prototype instanceof Error`), falling back to native error detection for
+ * values whose constructor is unreachable -- a severed prototype, or another
+ * realm -- and to a prototype check for null-prototype objects.
+ *
+ * For tags that have pass-through handling (`Object`) or no dedicated handler
+ * (`null`), a per-instance `hasToJSON()` check upgrades the tag to
  * `HasToJSON`. Dedicated types (`Error`, `Date`, `Map`, etc.) and `HasToJSON` from
  * `tagFromNativeClass()` are returned as-is.
  */
@@ -150,6 +159,12 @@ export function tagFromNativeValue(value: unknown): NativeTag | null {
   if (value === null || typeof value !== "object") {
     return NATIVE_TAGS.Primitive;
   }
+
+  // Arrays first, and unconditionally: see above.
+  if (Array.isArray(value)) {
+    return NATIVE_TAGS.Array;
+  }
+
   // Guard: null-prototype objects or exotic objects may not have a function
   // constructor.
   const ctor = value.constructor;
@@ -162,9 +177,7 @@ export function tagFromNativeValue(value: unknown): NativeTag | null {
   // `tagFromNativeClass()` handles dedicated types (`Error`, `Date`, `Map`, etc.) and
   // returns `HasToJSON` for classes whose prototype has `toJSON()`. For those,
   // return immediately -- no instance-level override needed.
-  if (
-    tag !== null && tag !== NATIVE_TAGS.Object && tag !== NATIVE_TAGS.Array
-  ) {
+  if (tag !== null && tag !== NATIVE_TAGS.Object) {
     return tag;
   }
 
@@ -179,20 +192,15 @@ export function tagFromNativeValue(value: unknown): NativeTag | null {
     // `FabricInstance` values (object-like protocol types).
     if (value instanceof FabricInstance) return NATIVE_TAGS.FabricInstance;
 
-    // Cross-realm arrays may have a different constructor.
-    if (Array.isArray(value)) tag = NATIVE_TAGS.Array;
-
     // Null-prototype objects (`Object.create(null)`).
-    if (tag === null) {
-      const proto = Object.getPrototypeOf(value);
-      if (proto === null) tag = NATIVE_TAGS.Object;
-    }
+    const proto = Object.getPrototypeOf(value);
+    if (proto === null) tag = NATIVE_TAGS.Object;
   }
 
-  // For `Object`, `Array`, and still-null tags: a per-instance `toJSON()` method
+  // For `Object` and still-null tags: a per-instance `toJSON()` method
   // overrides to `HasToJSON`. This catches plain objects with `toJSON()` as an own
-  // property, arrays with `toJSON()` added, and unrecognized class instances
-  // whose prototype wasn't caught by `tagFromNativeClass()`.
+  // property, and unrecognized class instances whose prototype wasn't caught by
+  // `tagFromNativeClass()`.
   if (hasToJSON(value)) return NATIVE_TAGS.HasToJSON;
 
   return tag;

--- a/packages/data-model/src/native-type-tags.ts
+++ b/packages/data-model/src/native-type-tags.ts
@@ -137,12 +137,16 @@ export function tagFromNativeClass(
  *
  * An array answers `Array` before anything else is consulted, `toJSON()`
  * included. `Array.isArray()` is realm-agnostic and sees through both a
- * subclass and a severed prototype, so every array-shaped value reaches array
- * handling and is answered by the array rule, which alone decides what an
- * array may be. Nothing an array carries can route it elsewhere: a `toJSON()`
- * method is a named own property, which that rule rejects anyway, so honoring
- * it here would mean converting a value by the very property that disqualifies
- * it.
+ * subclass and a severed prototype, so every array reaches array handling and
+ * is answered by the array rule, which alone decides what an array may be.
+ *
+ * A `toJSON()` method reaches an array by one of two routes, and neither may
+ * decide its fate. As an own property it is a named key, which the array rule
+ * rejects -- so honoring it would convert a value by the very property that
+ * disqualifies it. Inherited, it is not array content at all: `hasToJSON()`
+ * answers on `in`, so a single `Array.prototype.toJSON` assignment anywhere in
+ * the process would otherwise route *every* array in the system through it.
+ * Answering `Array` up front is what makes arrays immune to that.
  *
  * Otherwise dispatches via the value's constructor (O(1) switch in
  * `tagFromNativeClass`, which matches `Error` subclasses via
@@ -177,7 +181,9 @@ export function tagFromNativeValue(value: unknown): NativeTag | null {
   // `tagFromNativeClass()` handles dedicated types (`Error`, `Date`, `Map`, etc.) and
   // returns `HasToJSON` for classes whose prototype has `toJSON()`. For those,
   // return immediately -- no instance-level override needed.
-  if (tag !== null && tag !== NATIVE_TAGS.Object) {
+  if (
+    tag !== null && tag !== NATIVE_TAGS.Object && tag !== NATIVE_TAGS.Array
+  ) {
     return tag;
   }
 

--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -16,7 +16,8 @@ import { BaseFabricPrimitive } from "./fabric-primitives/BaseFabricPrimitive.ts"
  * `FabricSpecialObject`s (both `FabricInstance` and `FabricPrimitive`),
  * `undefined`, and arrays with `undefined` elements or sparse holes
  * -- in addition to the base fabric types (`null`, `boolean`, `number`,
- * `string`, plain objects, dense arrays).
+ * `string`, plain objects, dense arrays). An array must be a direct `Array`
+ * instance; a subclass instance is not a fabric value.
  *
  * This function is a TypeScript type guard for `FabricValueLayer`.
  */
@@ -43,7 +44,8 @@ export function isFabricValueLayer(
       if (Array.isArray(value)) {
         // Arrays with `undefined` elements and sparse holes are accepted, but
         // not arrays carrying named or symbol-keyed properties, nor an
-        // accessor-backed index (live code rather than inert data).
+        // accessor-backed index, nor an indirect instance such as an `Array`
+        // subclass (all live code rather than inert data).
         return isInertArray(value);
       }
       // Plain objects are accepted; class instances are not (except
@@ -73,13 +75,15 @@ export function isFabricValueLayer(
  * Returns `true` for any scalar (`null`, `undefined`, `boolean`, `number`
  * -- including `-0`, `NaN`, and `±Infinity` -- `string`, `bigint`, and
  * registry-interned (`Symbol.for(...)`) symbols), any `FabricInstance` or
- * `FabricPrimitive`, an array of `FabricValue`s with no named or symbol-keyed
- * properties, `length` aside (sparse holes allowed), or a plain object whose
- * values are all
+ * `FabricPrimitive`, a direct `Array` instance holding `FabricValue`s with no
+ * named or symbol-keyed properties, `length` aside (sparse holes allowed), or
+ * a plain object whose values are all
  * `FabricValue`s. Returns `false` for a `function` or a unique (uninterned)
  * symbol -- whether the value itself or reached anywhere within it -- for an
  * accessor-backed (getter/setter) property anywhere, plain-object keyed or
- * array-indexed alike, which makes its container non-inert, and for any
+ * array-indexed alike, which makes its container non-inert, for an `Array`
+ * subclass instance or other indirectly-rooted array, whose prototype is live
+ * code the same way an accessor is, and for any
  * other class instance (`Date`, `Map`, ...) not representable as a
  * `FabricValue`. Handles circular references.
  *
@@ -141,7 +145,8 @@ export function isFabricValue(value: unknown): value is FabricValue {
     } else if (Array.isArray(item)) {
       // Arrays with named (non-index) or symbol-keyed properties have no
       // fabric representation; an accessor-backed index is live code rather
-      // than inert data.
+      // than inert data, as is the prototype of an indirect instance such as
+      // an `Array` subclass.
       if (!isInertArray(item)) return false;
       for (let i = 0; i < item.length; i++) {
         if (!(i in item)) continue; // sparse hole

--- a/packages/data-model/test/cloneIfNecessary.test.ts
+++ b/packages/data-model/test/cloneIfNecessary.test.ts
@@ -385,6 +385,51 @@ describe("cloneIfNecessary", () => {
     });
   });
 
+  describe(`indirect \`Array\` instances`, () => {
+    // An `Array` subclass is not a `FabricValue`, so the deep-frozen identity
+    // optimization must not answer for one: returning it as-is would carry a
+    // live prototype into stored state, where an overridden `Symbol.iterator`
+    // answers content that the indices never show.
+    class Smuggler extends Array<unknown> {
+      override *[Symbol.iterator](): Generator<unknown> {
+        yield "smuggled";
+      }
+    }
+
+    function frozenSmuggler(): unknown[] {
+      const result = new Smuggler();
+      result.push("benign");
+      Object.freeze(result);
+      return result;
+    }
+
+    it("does not report a frozen subclass instance as deep-frozen", () => {
+      // This is what turns off the identity optimization below.
+      expect(isDeepFrozenFabricValue(frozenSmuggler() as FabricValue))
+        .toBe(false);
+    });
+
+    it("deep-clones a frozen subclass instance into a direct `Array`", () => {
+      const value = frozenSmuggler();
+      const result = cloneIfNecessary(value as FabricValue) as unknown[];
+
+      expect(result).not.toBe(value);
+      expect(Object.getPrototypeOf(result)).toBe(Array.prototype);
+      expect([...result]).toEqual(["benign"]);
+      expect(Object.isFrozen(result)).toBe(true);
+    });
+
+    it("deep-clones a nested frozen subclass instance", () => {
+      const value = { data: frozenSmuggler() };
+      const result = cloneIfNecessary(value as FabricValue) as {
+        data: unknown[];
+      };
+
+      expect(Object.getPrototypeOf(result.data)).toBe(Array.prototype);
+      expect([...result.data]).toEqual(["benign"]);
+    });
+  });
+
   describe(`circular reference detection`, () => {
     it("throws on direct circular object reference", () => {
       const obj = {} as Record<string, unknown>;

--- a/packages/data-model/test/native-conversion.test.ts
+++ b/packages/data-model/test/native-conversion.test.ts
@@ -720,10 +720,14 @@ describe("native-conversion", () => {
         expect(result).toEqual({ exposed: true });
       });
 
-      it("converts arrays with `toJSON()`", () => {
+      it("throws for arrays with `toJSON()`", () => {
+        // An array is answered by the array rule whatever it carries, and that
+        // rule rejects the named own property `toJSON` is.
         const arr = [1, 2, 3] as unknown[] & { toJSON?: () => unknown };
         arr.toJSON = () => "custom array";
-        expect(shallowFabricFromNativeValue(arr)).toBe("custom array");
+        expect(() => shallowFabricFromNativeValue(arr)).toThrow(
+          "Not representable as a `FabricValue`: array that is not an inert array",
+        );
       });
 
       it("throws if `toJSON()` returns a non-fabric value", () => {
@@ -1675,6 +1679,28 @@ describe("native-conversion", () => {
         const severed: unknown[] = [1, 2];
         Object.setPrototypeOf(severed, null);
         expect(() => fabricFromNativeValue(severed)).toThrow(
+          "Not representable as a `FabricValue`: array that is not an inert array",
+        );
+      });
+
+      it("throws for a subclass instance carrying `toJSON()`", () => {
+        // No property an array carries can route it away from the array rule,
+        // on the prototype or as an own key.
+        class ProtoJson extends Array<unknown> {
+          toJSON(): unknown[] {
+            return [7, 8];
+          }
+        }
+        const protoJson = new ProtoJson();
+        protoJson.push(1);
+        expect(() => fabricFromNativeValue(protoJson)).toThrow(
+          "Not representable as a `FabricValue`: array that is not an inert array",
+        );
+
+        const ownJson = new (class extends Array<unknown> {})();
+        ownJson.push(1);
+        (ownJson as unknown as Record<string, unknown>).toJSON = () => [9];
+        expect(() => fabricFromNativeValue(ownJson)).toThrow(
           "Not representable as a `FabricValue`: array that is not an inert array",
         );
       });

--- a/packages/data-model/test/native-conversion.test.ts
+++ b/packages/data-model/test/native-conversion.test.ts
@@ -1631,6 +1631,55 @@ describe("native-conversion", () => {
       });
     });
 
+    describe("throws for indirect `Array` instances", () => {
+      it("throws for an `Array` subclass instance", () => {
+        class Sub extends Array {}
+        const sub = new Sub();
+        sub.push(1, 2);
+        expect(() => fabricFromNativeValue(sub)).toThrow(
+          "Not representable as a `FabricValue`: array that is not an inert array",
+        );
+      });
+
+      it("throws for a nested `Array` subclass instance", () => {
+        class Sub extends Array {}
+        const sub = new Sub();
+        sub.push(1, 2);
+        expect(() => fabricFromNativeValue({ data: sub })).toThrow(
+          "Not representable as a `FabricValue`: array that is not an inert array",
+        );
+      });
+
+      it("throws even for an already-frozen subclass instance", () => {
+        // The case the deep-frozen identity short-circuit would otherwise wave
+        // through unconverted, prototype and all: iteration answers content
+        // that the indices never show, and freezing the instance does nothing
+        // about the prototype that does it.
+        class Smuggler extends Array {
+          override *[Symbol.iterator](): Generator<unknown> {
+            yield "smuggled";
+          }
+        }
+        const smuggler = new Smuggler();
+        smuggler.push("benign");
+        Object.freeze(smuggler);
+
+        expect([...smuggler]).toEqual(["smuggled"]);
+        expect(smuggler[0]).toBe("benign");
+        expect(() => fabricFromNativeValue(smuggler)).toThrow(
+          "Not representable as a `FabricValue`: array that is not an inert array",
+        );
+      });
+
+      it("throws for an array whose prototype was severed", () => {
+        const severed: unknown[] = [1, 2];
+        Object.setPrototypeOf(severed, null);
+        expect(() => fabricFromNativeValue(severed)).toThrow(
+          "Not representable as a `FabricValue`: array that is not an inert array",
+        );
+      });
+    });
+
     // `-0`, `NaN`, `+Infinity`, and `-Infinity` are valid `FabricValue`
     // members and pass through unchanged.
     describe("special numbers", () => {
@@ -1990,6 +2039,22 @@ describe("native-conversion", () => {
       const arr = [1, 2, 3] as number[] & { extra?: string };
       arr.extra = "nope";
       expect(isFabricCompatible(arr)).toBe(false);
+    });
+
+    describe("indirect `Array` instances", () => {
+      it("rejects an `Array` subclass instance", () => {
+        class Sub extends Array {}
+        const sub = new Sub();
+        sub.push(1, 2);
+        expect(isFabricCompatible(sub)).toBe(false);
+        expect(isFabricCompatible({ data: sub })).toBe(false);
+      });
+
+      it("rejects an array whose prototype was severed", () => {
+        const severed: unknown[] = [1, 2];
+        Object.setPrototypeOf(severed, null);
+        expect(isFabricCompatible(severed)).toBe(false);
+      });
     });
 
     it("rejects an object with a symbol-keyed property", () => {

--- a/packages/data-model/test/native-type-tags.test.ts
+++ b/packages/data-model/test/native-type-tags.test.ts
@@ -129,12 +129,28 @@ describe("native-type-tags", () => {
 
     it("returns `Array` tag for arrays with `toJSON()`", () => {
       // An array answers `Array` whatever it carries, so the array rule is
-      // what decides its fate. A `toJSON()` method is a named own property,
-      // which that rule rejects, so routing the value by it would convert an
-      // array by the very property that disqualifies it.
+      // what decides its fate. Here `toJSON` is a named own key, which that
+      // rule rejects, so routing the value by it would convert an array by the
+      // very property that disqualifies it.
       const arr = [1, 2, 3] as unknown[] & { toJSON?: () => unknown };
       arr.toJSON = () => "custom array";
       expect(tagFromNativeValue(arr)).toBe(NATIVE_TAGS.Array);
+    });
+
+    it("returns `Array` tag despite an inherited `toJSON()`", () => {
+      // The other route in, and the one that makes answering `Array` up front
+      // matter: `hasToJSON()` answers on `in`, so were an inherited `toJSON`
+      // consulted, one assignment to `Array.prototype` would route every array
+      // in the process through it.
+      const proto = Array.prototype as unknown as Record<string, unknown>;
+      try {
+        proto.toJSON = () => "hijacked";
+        const arr = [1, 2];
+        expect(Object.hasOwn(arr, "toJSON")).toBe(false);
+        expect(tagFromNativeValue(arr)).toBe(NATIVE_TAGS.Array);
+      } finally {
+        delete proto.toJSON;
+      }
     });
 
     it("returns `Array` tag for an `Array` subclass carrying `toJSON()`", () => {

--- a/packages/data-model/test/native-type-tags.test.ts
+++ b/packages/data-model/test/native-type-tags.test.ts
@@ -127,10 +127,23 @@ describe("native-type-tags", () => {
       expect(tagFromNativeValue(obj)).toBe(NATIVE_TAGS.HasToJSON);
     });
 
-    it("returns `HasToJSON` tag for arrays with `toJSON()`", () => {
+    it("returns `Array` tag for arrays with `toJSON()`", () => {
+      // An array answers `Array` whatever it carries, so the array rule is
+      // what decides its fate. A `toJSON()` method is a named own property,
+      // which that rule rejects, so routing the value by it would convert an
+      // array by the very property that disqualifies it.
       const arr = [1, 2, 3] as unknown[] & { toJSON?: () => unknown };
       arr.toJSON = () => "custom array";
-      expect(tagFromNativeValue(arr)).toBe(NATIVE_TAGS.HasToJSON);
+      expect(tagFromNativeValue(arr)).toBe(NATIVE_TAGS.Array);
+    });
+
+    it("returns `Array` tag for an `Array` subclass carrying `toJSON()`", () => {
+      class ProtoJson extends Array {
+        toJSON(): unknown[] {
+          return [7, 8];
+        }
+      }
+      expect(tagFromNativeValue(new ProtoJson())).toBe(NATIVE_TAGS.Array);
     });
 
     it("returns `HasToJSON` tag for class instances with `toJSON()`", () => {

--- a/packages/data-model/test/type-check.test.ts
+++ b/packages/data-model/test/type-check.test.ts
@@ -187,6 +187,22 @@ describe("type-check", () => {
         expect(isFabricValueLayer(arr)).toBe(false);
       });
 
+      it("returns `false` for an `Array` subclass instance", () => {
+        // A subclass prototype is live code just as an accessor is, and
+        // freezing the instance does not change that.
+        class Sub extends Array {}
+        const sub = new Sub();
+        sub.push(1, 2);
+        expect(isFabricValueLayer(sub)).toBe(false);
+        expect(isFabricValueLayer(Object.freeze(sub))).toBe(false);
+      });
+
+      it("returns `false` for an array whose prototype was severed", () => {
+        const severed: unknown[] = [1, 2];
+        Object.setPrototypeOf(severed, null);
+        expect(isFabricValueLayer(severed)).toBe(false);
+      });
+
       it("returns `false` for a sparse array with extra named properties", () => {
         // Length 3, hole at index 1, plus a named property "foo": still
         // `false` because the named property isn't a valid array index.
@@ -428,6 +444,24 @@ describe("type-check", () => {
         const arr = [1, 2];
         (arr as unknown as Record<symbol, unknown>)[Symbol.for("extra")] = 42;
         expect(isFabricValue({ data: arr })).toBe(false);
+      });
+
+      it("returns `false` for an indirect `Array` instance, at any depth", () => {
+        // A subclass prototype is live code no matter the container: an
+        // overridden `Symbol.iterator` makes iteration answer content the
+        // indices never show, and freezing does not reach the prototype.
+        class Sub extends Array {}
+        const top = new Sub();
+        top.push(1, 2);
+        expect(isFabricValue(top)).toBe(false);
+        expect(isFabricValue(Object.freeze(top))).toBe(false);
+        expect(isFabricValue({ data: top })).toBe(false);
+        expect(isFabricValue([1, [top]])).toBe(false);
+
+        const severed: unknown[] = [3, 4];
+        Object.setPrototypeOf(severed, null);
+        expect(isFabricValue(severed)).toBe(false);
+        expect(isFabricValue({ data: severed })).toBe(false);
       });
 
       it("returns `false` for a unique (uninterned) symbol", () => {

--- a/packages/runner/test/cell-core.test.ts
+++ b/packages/runner/test/cell-core.test.ts
@@ -310,20 +310,22 @@ describe("Cell", () => {
     expect(result.length).toBe(4);
   });
 
-  it("should call toJSON() on arrays with toJSON method during set", () => {
+  it("should reject arrays carrying a toJSON method during set", () => {
     const c = runtime.getCell<unknown>(
       space,
-      "should call toJSON() on arrays with toJSON method during set",
+      "should reject arrays carrying a toJSON method during set",
       undefined,
       tx,
     );
     const arrWithToJSON = [1, 2, 3] as unknown[] & { toJSON?: () => unknown };
     arrWithToJSON.toJSON = () => "custom-array-value";
-    c.set({ arr: arrWithToJSON });
 
-    const result = c.get() as { arr: unknown } | undefined;
-    // toJSON() should have been called
-    expect(result?.arr).toBe("custom-array-value");
+    // An array is answered by the array rule whatever it carries, and `toJSON`
+    // is a named own property, which that rule rejects. Converting by it would
+    // mean storing an array by the very property that disqualifies it.
+    expect(() => c.set({ arr: arrWithToJSON })).toThrow(
+      "Not representable as a `FabricValue`: array that is not an inert array",
+    );
   });
 
   it("should create a proxy for the cell", () => {

--- a/packages/utils/src/arrays.bench.ts
+++ b/packages/utils/src/arrays.bench.ts
@@ -24,8 +24,8 @@
  *    `ownKeys` trap plus a `getOwnPropertyDescriptor` trap per key to filter
  *    for enumerability, where `Reflect.ownKeys()` fires exactly one trap. The
  *    runtime proxies heavily, so the proxied figure is not a curiosity. For
- *    `isInertArray()` a proxy also pays one `getOwnPropertyDescriptor` trap
- *    per index.
+ *    `isInertArray()` a proxy also pays one `getPrototypeOf` trap for the
+ *    directness check, plus one `getOwnPropertyDescriptor` trap per index.
  *
  * 3. **The inert/index-only spread itself.** Per-index
  *    `Object.getOwnPropertyDescriptor()` allocates a descriptor object per

--- a/packages/utils/src/arrays.ts
+++ b/packages/utils/src/arrays.ts
@@ -85,9 +85,9 @@ export function isArrayIndexPropertyName(name: string): boolean {
  *
  * A `Proxy` is the exception, and unavoidably so: it can throw from its own
  * traps, and such an error propagates rather than being reported as `false`.
- * A revoked proxy fails the array test itself, and a live one can throw from
- * `ownKeys()`. Reporting `false` there would mean reading "this is not an
- * index-only array" into what is actually a failure to find out.
+ * A revoked proxy makes `Array.isArray()` itself throw, and a live one can
+ * throw from `ownKeys()`. Reporting `false` there would mean reading "this is
+ * not an index-only array" into what is actually a failure to find out.
  *
  * **Note:** This function relies on the given array producing `Reflect.ownKeys()`
  * output which agrees with the JavaScript spec with regards to key ordering,

--- a/packages/utils/src/arrays.ts
+++ b/packages/utils/src/arrays.ts
@@ -121,9 +121,10 @@ export function isArrayWithOnlyIndexProperties(array: unknown): boolean {
 }
 
 /**
- * Indicates whether the given array is an _inert_ array: every own property an
- * array index holding a _data_ property, `length` aside -- which is what a
- * well-formed array means in this system. Beyond the index-only requirement of
+ * Indicates whether the given array is an _inert_ array: a direct instance of
+ * `Array`, every own property of which is an array index holding a _data_
+ * property, `length` aside -- which is what a well-formed array means in this
+ * system. Beyond the index-only requirement of
  * {@link isArrayWithOnlyIndexProperties} (which this check subsumes; there is
  * no need to call both), an accessor-backed (getter and/or setter) index
  * causes rejection, because it makes the array non-inert: an accessor is live
@@ -133,16 +134,36 @@ export function isArrayWithOnlyIndexProperties(array: unknown): boolean {
  * enumeration-driven copying, so an index's enumerability has no bearing on
  * the array's inertness.
  *
+ * "Direct instance" means the prototype is `Array.prototype` exactly. An
+ * `Array` subclass instance is rejected, because its prototype is live code
+ * just as much as an accessor is: an overridden `Symbol.iterator` (or `at()`,
+ * or `values()`) makes iteration answer differently than the indices say, and
+ * again freezing changes nothing. An array whose prototype has been severed
+ * (`null`) is rejected too, as is an array from another realm, whose prototype
+ * is a different `Array.prototype` carrying whatever that realm did to it.
+ * None of those prototypes are part of what an array says as data, so
+ * accepting one would mean carrying an alien prototype along in defiance of
+ * the type, or silently dropping it.
+ *
  * The array-recognition, `Proxy`, and key-ordering caveats described on
- * {@link isArrayWithOnlyIndexProperties} apply here as well.
+ * {@link isArrayWithOnlyIndexProperties} apply here as well. A `Proxy` over a
+ * direct `Array` passes: absent a `getPrototypeOf()` trap, the prototype
+ * question forwards to the target, and a trap that answers otherwise is the
+ * proxy's own bug to own.
  *
  * @param array The value to check.
  * @returns `true` if the array is an inert array, `false` otherwise.
  */
 export function isInertArray(array: unknown): boolean {
   // `Array.isArray()` sees through a `Proxy` to its target, so a proxied array
-  // is still recognized as one here.
-  if (!Array.isArray(array)) {
+  // is still recognized as one here, and -- absent a `getPrototypeOf()` trap --
+  // answers its target's prototype as well. `Array.isArray()` is deliberately
+  // realm-agnostic, so the prototype comparison is what makes this the local
+  // `Array` and not merely something array-shaped.
+  if (
+    !Array.isArray(array) ||
+    (Object.getPrototypeOf(array) !== Array.prototype)
+  ) {
     return false;
   }
 

--- a/packages/utils/test/arrays.test.ts
+++ b/packages/utils/test/arrays.test.ts
@@ -352,8 +352,9 @@ describe("arrays", () => {
 
     describe("`Proxy` handling", () => {
       it("accepts a pass-through proxy over an inert array", () => {
-        // `Array.isArray()` sees through to the target, so a proxied inert
-        // array is still recognized as one.
+        // `Array.isArray()` sees through to the target, and the prototype
+        // question forwards to it as well, so a proxied inert array is still
+        // recognized as one.
         expect(isInertArray(new Proxy([1, 2, 3], {}))).toBe(true);
       });
 
@@ -412,6 +413,57 @@ describe("arrays", () => {
           configurable: true,
         });
         expect(isInertArray(arr)).toBe(false);
+      });
+    });
+
+    describe("returns `false` for indirect `Array` instances", () => {
+      it("rejects an `Array` subclass instance", () => {
+        class Sub extends Array {}
+        const sub = new Sub();
+        sub.push(1, 2);
+
+        // Index-only and data-backed, so only the prototype separates it from
+        // an inert array.
+        expect(isArrayWithOnlyIndexProperties(sub)).toBe(true);
+        expect(isInertArray(sub)).toBe(false);
+      });
+
+      it("rejects a subclass instance whose prototype rewrites iteration", () => {
+        // The concrete hazard the prototype requirement addresses: iteration
+        // and index reads answer different content, and freezing the instance
+        // does not touch the prototype that does it.
+        class Smuggler extends Array {
+          override *[Symbol.iterator](): Generator<unknown> {
+            yield "smuggled";
+          }
+        }
+        const smuggler = new Smuggler();
+        smuggler.push("benign");
+        Object.freeze(smuggler);
+
+        expect([...smuggler]).toEqual(["smuggled"]);
+        expect(smuggler[0]).toBe("benign");
+        expect(isInertArray(smuggler)).toBe(false);
+      });
+
+      it("rejects an array whose prototype was severed", () => {
+        const severed: unknown[] = [1, 2];
+        Object.setPrototypeOf(severed, null);
+        expect(isInertArray(severed)).toBe(false);
+      });
+
+      it("rejects an array reparented onto another prototype", () => {
+        const reparented: unknown[] = [1, 2];
+        Object.setPrototypeOf(reparented, Object.prototype);
+        expect(isInertArray(reparented)).toBe(false);
+      });
+
+      it("rejects a proxy that answers a non-`Array` prototype", () => {
+        // `Array.isArray()` sees the array target, so the prototype answer is
+        // the only thing that can catch this one.
+        const lying = new Proxy([1, 2], { getPrototypeOf: () => null });
+        expect(Array.isArray(lying)).toBe(true);
+        expect(isInertArray(lying)).toBe(false);
       });
     });
   });


### PR DESCRIPTION
An array is now answered by the array rule and nothing else: `isInertArray()`
requires the prototype to be `Array.prototype` itself, and type-tag dispatch
routes every `Array.isArray()` value to the array rule whatever the value
carries.

## Why

A prototype is live code the same way an accessor-backed index is, which the
inertness rule already rejects. An overridden `Symbol.iterator` makes iteration
answer content that the indices never show, and freezing the instance does
nothing about the prototype that does it:

```
class Smuggler extends Array { *[Symbol.iterator]() { yield "smuggled"; } }
const s = new Smuggler(); s.push("benign"); Object.freeze(s);

[...s]  // ["smuggled"]
s[0]    // "benign"
```

Such a value reached stored state intact. `cloneHelper()`'s deep-frozen
identity short-circuit returns an already-frozen value as-is, prototype and
all, while the same array unfrozen was copied into a genuine `Array` — so what
got stored depended on the frozenness of what was handed in. Rejection retires
that fork, and matches how the object side treats a non-inert plain object.

`Array.isArray()` is deliberately realm-agnostic and sees straight through a
subclass, so the prototype comparison is what makes the check say "an `Array`,
per se".

## The `toJSON()` escape, closed

`tagFromNativeValue()` now answers `Array` for any `Array.isArray()` value,
unconditionally and ahead of the constructor lookup, so nothing an array
carries can route it elsewhere:

| value | before | now |
| --- | --- | --- |
| subclass, `toJSON()` on prototype | `[7,8]` | throws |
| subclass, own `toJSON()` | `[9]` | throws |
| direct array, own `toJSON()` | `"custom array"` | throws |
| severed-prototype array | throws | throws |

A `toJSON` reaches an array by one of two routes, and neither may decide its
fate:

- **As an own property** it is a named key, which the array rule rejects — so
  honoring it would convert an array by the very property that disqualifies
  it.
- **Inherited**, it is not array content at all. `hasToJSON()` answers on
  `in`, so without this carve-out a single assignment to
  `Array.prototype.toJSON` would route *every array in the process* through
  it — and no array rule would object, the method being nobody's own key.
  Answering `Array` up front is what makes arrays immune to that. There is a
  test for it.

Neither reason depends on what becomes of `toJSON()` support, which is
separately marked for removal (`native-conversion.ts`'s TODO and spec §7.1).

Non-arrays are untouched: the early `Array.isArray()` answer covers every
actual array, so the constructor switch's `Array` tag still falls through to
the `toJSON` upgrade for things like `Object.create(Array.prototype)`. That
keeps `isFabricCompatible()` and the conversion functions agreeing on every
shape — including the one they already disagreed on before this PR, where
`isFabricCompatible()` answered `false` for an array-plus-`toJSON()` that
`fabricFromNativeValue()` happily converted.

`hashOf()` and `cloneIfNecessary()` now treat an array bearing `toJSON`
exactly as they treat an array bearing any other named own property — same
hash, and the key dropped on clone. That is alignment with how every other
named property has always been handled, not a new behavior for arrays.

## Cross-realm

Rejecting a foreign array narrows `Array.isArray()`, so every realm boundary in
the repo was checked. None of them hands the fabric a foreign array:

- **SES compartments share the host realm's intrinsics.** Measured with this
  repo's `ses@^2.2.0` after `lockdown()`: an array evaluated inside a
  compartment has `proto === Array.prototype`, as does one from `JSON.parse`
  inside it, `harden([1,2])`, and `.map()`. Pattern code is not a source of
  foreign arrays.
- **Workers and the iframe sandbox** communicate via `postMessage` /
  structured clone, so arrays are rebuilt in the receiving realm.
- No `node:vm`, `ShadowRealm`, or other realm construction exists in
  `packages/`.

## Scope

`isInertArray()`'s four call sites — `isFabricValueLayer()`, `isFabricValue()`,
`fabricFromNativeValue()`, and `isFabricCompatible()` — needed no change, and
the rejection message already speaks of an array that is not an inert array.

`isArrayWithOnlyIndexProperties()` is untouched. It has no production callers
(`query-result-proxy.ts:574` names it in a comment, documenting the key-order
invariant it reads); it stays as the cheaper key-shape predicate, and remains a
strict subset of what inertness rejects.

A `Proxy` over a direct `Array` still passes: absent a `getPrototypeOf()` trap
the prototype question forwards to the target, and no such trap exists in
`packages/` production code. A trap that answers otherwise is the proxy's own
bug to own, per the best-effort proxy stance, and there is a test for it.

## Behavior change

Host code that hands the fabric an exotic array now gets a throw where an
unfrozen one used to be silently normalized into a genuine `Array`. No
`extends Array` producer exists in the repo outside tests.

Sandbox egress is unaffected and still normalizes: `adaptSandboxResult()`
(`runner/src/sandbox/result-normalization.ts`) copies any `Array.isArray()`
container into a fresh `new Array(len)` before validation ever runs, so an
`Array` subclass returned from a pattern is laundered rather than rejected —
and its smuggled iteration content is discarded, not carried. Whether that
boundary should reject instead is a separate question.

## Known follow-ups, not addressed here

Two production sites still route arrays through `toJSON()`, so the principle
is not yet universal. Both throw downstream anyway, since the value itself is
no longer storable:

- `runner/src/create-ref.ts:99` — `isRecord()` is true for arrays, so an
  array's entity ID is still derived from its `toJSON()` result.
- `runner/src/builder/reactive.ts:88` — `defaultForValue()` calls
  `toJSON.call(value)` for any object, arrays included.

## Cost

One `Object.getPrototypeOf()` against an already-present `Reflect.ownKeys()`
and per-index descriptor walk. For a proxied array it is one added trap, noted
in the bench header.

## Verification

`deno fmt --check`, `deno lint`, `deno task check`, `deno task check-docs`, and
the full workspace suite. `deno.lock` clean.
