### PR TITLE
fix(data-model): an inert plain object must be a direct `Object` instance

### DIFF
--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -1193,9 +1193,8 @@ Section 4.5.
   accepting one could only mean dropping it silently. A subclass prototype is
   live code besides — an overridden `Symbol.iterator`, say, makes iteration
   answer differently than the indices do, and freezing the array does not
-  change that. (Plain objects are treated differently on this point: see the
-  object rule below, which admits a null prototype and normalizes it on
-  reconstruction.)
+  change that. Plain objects are governed by the same principle; see the
+  object rule below.
 - May be dense or sparse
 - Elements may be `undefined` (a first-class fabric value; see Section 1.3)
 - Sparse arrays (arrays with holes) are supported; holes are distinct from
@@ -1231,7 +1230,12 @@ Section 4.5.
 > `3-json-encoding.md` for the specific JSON encoding and examples.
 
 **Objects:**
-- Plain objects only (class instances must implement the fabric protocol)
+- Direct `Object` instances only: the prototype must be `Object.prototype`
+  itself. A class instance must implement the fabric protocol, and a
+  null-prototype object causes rejection, for the reason arrays give above — a
+  prototype has no representation as object content, so accepting one could
+  only mean dropping it silently. A record therefore has exactly one shape,
+  the one the natural syntax produces
 - Keys must be strings; symbol-keyed *properties* cause rejection (this
   is distinct from symbol *values*, which are admitted per Section 1.2
   with the runtime restriction in Section 1.3)
@@ -1242,8 +1246,8 @@ Section 4.5.
   name-driven copying or serialization
 - Values must be valid fabric values; properties whose value is `undefined` are preserved
   (not omitted) — `undefined` is a first-class value, not a signal for deletion
-- No distinction between regular and null-prototype objects; reconstruction
-  produces regular plain objects
+- Reconstruction produces regular plain objects, which is the only object
+  shape a fabric value has
 
 ### 1.6 Circular References and Shared References
 
@@ -1851,8 +1855,8 @@ The system follows an **immutable-forward** design:
   boundary, not of whether type-tag reconstruction occurred.
 - **`FabricInstance`s** should ideally be frozen as well — this is the north
   star, though not yet a strict requirement.
-- **No distinction** is made between regular and null-prototype plain objects;
-  reconstruction always produces regular plain objects.
+- Reconstruction always produces regular plain objects, that being the only
+  object shape a fabric value has.
 
 This immutability guarantee enables safe sharing of reconstructed values and
 aligns with the reactive system's assumption that values don't mutate in place.
@@ -3087,7 +3091,10 @@ export function fabricFromNativeValue(
 > array rule of Section 1.5, rather than being rejected as some unrecognized
 > class or routed elsewhere by something the array carries. Fallback paths
 > handle exotic Error subclasses (via `Error.isError()`), null-prototype
-> objects, and objects with `toJSON()` methods.
+> objects, and objects with `toJSON()` methods. Tagging a null-prototype
+> object `"Object"` classifies more broadly than the type admits, for the same
+> reason the array tag does: it is what lets the object rule of Section 1.5
+> reject the value by name rather than as some unrecognized class.
 
 > **Implementation: centralized shallow-clone utility.** The conversion
 > functions use a centralized `cloneIfNecessary()` utility (in

--- a/docs/specs/space-model/1-data-model.md
+++ b/docs/specs/space-model/1-data-model.md
@@ -57,14 +57,15 @@ authoritative statement of these rules.
 
 #### Objects
 
-- Plain objects only (no class instances)
+- Direct `Object` instances only: the prototype must be `Object.prototype`
+  itself, so class instances and null-prototype objects alike cause rejection
 - Keys must be strings; symbol keys cause rejection as non-fabric
 - Every property must be an enumerable *data* property; accessor-backed
   (getter and/or setter) and non-enumerable properties cause rejection as
   non-fabric
 - Values must be valid fabric values
-- No distinction between regular and null-prototype objects; reconstruction
-  produces regular plain objects
+- Reconstruction produces regular plain objects, which is the only object
+  shape a fabric value has
 
 ### Special Values
 
@@ -459,8 +460,8 @@ The system aims for an **immutable-forward** design:
 - **Plain objects and arrays** are frozen (`Object.freeze()`) upon reconstruction
 - **`FabricInstance`s** should ideally be frozen as well — this is the north
   star, though not yet a strict requirement
-- **No distinction** is made between regular and null-prototype plain objects;
-  reconstruction always produces regular plain objects
+- Reconstruction always produces regular plain objects, that being the only
+  object shape a fabric value has
 
 This immutability guarantee enables safe sharing of reconstructed values and
 aligns with the reactive system's assumption that values don't mutate in place.

--- a/packages/data-model/src/native-conversion.ts
+++ b/packages/data-model/src/native-conversion.ts
@@ -118,9 +118,10 @@ export function shallowCleanArray(
  * the rejection happen ("death before confusion").
  *
  * The result is always `Object.prototype`-based, so a null-prototype input
- * comes back with an ordinary prototype. That is not a loss here: the fabric
- * model draws no distinction between the two, and reconstruction produces
- * ordinary plain objects either way.
+ * comes back with an ordinary prototype. That re-rooting is the point for such
+ * an input: a fabric record has exactly one shape, so this is how a caller
+ * holding a null-prototype object says it means to shed the prototype rather
+ * than have the conversion functions refuse the value.
  *
  * @param value The object to clean.
  * @param frozen Whether to freeze the result. Defaults to `true`.
@@ -538,10 +539,9 @@ function fabricFromNativeValueInternal(
     result = resultArray;
   } else {
     // Recurse into object properties. Preserve `undefined`-valued properties.
-    // Use `Object.create()` to preserve null prototypes (`Object.fromEntries()`
-    // always produces `Object.prototype`-backed results).
-    const proto = Object.getPrototypeOf(value);
-    const obj = Object.create(proto) as Record<string, FabricValue>;
+    // The result is `Object.prototype`-rooted, which is the shape a fabric
+    // record has and the only one an accepted input can carry.
+    const obj = {} as Record<string, FabricValue>;
     for (const [key, val] of Object.entries(value)) {
       obj[key] = fabricFromNativeValueInternal(
         val,

--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -200,6 +200,14 @@ export function isFabricObjectOrArray(
  * which are representable as a `FabricPlainObject`. Unlike a bare `isRecord()` check,
  * it preserves the value type — `FabricPlainObject`'s string index of `FabricValue`
  * keeps an indexed value typed as a `FabricValue`.
+ *
+ * This asks a shape question -- "may I read this by property name?" -- of a
+ * value the type already says is a `FabricValue`, and a null-prototype object
+ * answers yes as readily as any other record. That makes it deliberately
+ * looser than membership: a `FabricPlainObject` is `Object.prototype`-rooted,
+ * so `isFabricValue()` refuses the null-prototype object this accepts. The
+ * looseness costs nothing, the input being out of contract either way, and it
+ * keeps callers holding un-validated values from losing a reader they can use.
  */
 export function isFabricPlainObject(
   value: FabricValue,

--- a/packages/data-model/src/value-clone.ts
+++ b/packages/data-model/src/value-clone.ts
@@ -216,9 +216,12 @@ export function cloneHelper(
       if (canReturnAsIs(value)) return value;
       const obj = value as object;
       if (deep) seen = trackForCircularity(obj, seen);
-      // Preserve null prototypes (e.g. `Object.create(null)`).
-      const proto = Object.getPrototypeOf(obj);
-      const copy = Object.create(proto) as Record<string, FabricValue>;
+      // A clone is built in the shape a fabric record has, the same way the
+      // array case above builds a fresh `Array`. Valid input is already
+      // `Object.prototype`-rooted, so this changes nothing for it; input that
+      // reached here carrying some other prototype leaves canonical rather
+      // than propagating a shape no fabric value has.
+      const copy = {} as Record<string, FabricValue>;
       if (deep) {
         for (const [key, val] of Object.entries(obj)) {
           copy[key] = cloneHelper(

--- a/packages/data-model/test/cloneIfNecessary.test.ts
+++ b/packages/data-model/test/cloneIfNecessary.test.ts
@@ -1,7 +1,11 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
-import { cloneIfNecessary, type CloneOptions } from "@/fabric-value.ts";
+import {
+  cloneIfNecessary,
+  type CloneOptions,
+  isFabricValue,
+} from "@/fabric-value.ts";
 import type { FabricValue } from "@/fabric-value.ts";
 import { isDeepFrozen, isDeepFrozenFabricValue } from "@/deep-freeze.ts";
 import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
@@ -304,54 +308,59 @@ describe("cloneIfNecessary", () => {
     });
   });
 
-  describe(`\`null\` prototype preservation`, () => {
-    it("preserves `null` prototype on objects", () => {
-      const value = Object.create(null) as Record<string, unknown>;
-      value.a = 1;
-      value.b = "two";
-      const result = cloneIfNecessary(
-        value as FabricValue,
-      ) as Record<string, unknown>;
-      expect(Object.getPrototypeOf(result)).toBe(null);
-      expect(result.a).toBe(1);
-      expect(result.b).toBe("two");
-      expect(Object.isFrozen(result)).toBe(true);
+  describe(`\`null\` prototype canonicalization`, () => {
+    // A null-prototype object is not a `FabricValue`, so none can arrive here
+    // by any validating route. Should one reach this function anyway, the
+    // clone leaves in the shape a fabric record has -- the same canonicalizing
+    // answer the array case gives an `Array` subclass -- rather than
+    // propagating a shape the model has no representation for.
+    function nullProto(
+      fields: Record<string, unknown>,
+    ): Record<string, unknown> {
+      return Object.assign(
+        Object.create(null) as Record<string, unknown>,
+        fields,
+      );
+    }
+
+    for (
+      const [label, opts] of [
+        ["deep and frozen", undefined],
+        ["deep and unfrozen", { frozen: false }],
+        ["shallow and frozen", { deep: false }],
+        ["shallow and unfrozen", { frozen: false, deep: false }],
+      ] as const
+    ) {
+      it(`re-roots a null-prototype object, ${label}`, () => {
+        const value = nullProto({ a: 1, b: "two" });
+        const result = cloneIfNecessary(
+          value as FabricValue,
+          opts as CloneOptions | undefined,
+        ) as Record<string, unknown>;
+
+        expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+        expect(result.a).toBe(1);
+        expect(result.b).toBe("two");
+        expect(Object.isFrozen(result)).toBe(opts?.frozen !== false);
+      });
+    }
+
+    it("re-roots a nested null-prototype object on a deep clone", () => {
+      const value = { child: nullProto({ v: 42 }) };
+      const result = cloneIfNecessary(value as FabricValue) as {
+        child: Record<string, unknown>;
+      };
+
+      expect(Object.getPrototypeOf(result.child)).toBe(Object.prototype);
+      expect(result.child.v).toBe(42);
     });
 
-    it("preserves `null` prototype when `frozen=false`", () => {
-      const value = Object.create(null) as Record<string, unknown>;
-      value.x = 42;
-      const result = cloneIfNecessary(
-        value as FabricValue,
-        { frozen: false },
-      ) as Record<string, unknown>;
-      expect(Object.getPrototypeOf(result)).toBe(null);
-      expect(result.x).toBe(42);
-      expect(Object.isFrozen(result)).toBe(false);
-    });
-
-    it("preserves `null` prototype on shallow clone", () => {
-      const value = Object.create(null) as Record<string, unknown>;
-      value.a = 1;
-      const result = cloneIfNecessary(
-        value as FabricValue,
-        { deep: false },
-      ) as Record<string, unknown>;
-      expect(Object.getPrototypeOf(result)).toBe(null);
-      expect(result.a).toBe(1);
-      expect(Object.isFrozen(result)).toBe(true);
-    });
-
-    it("preserves `null` prototype on shallow clone when `frozen=false`", () => {
-      const value = Object.create(null) as Record<string, unknown>;
-      value.b = 2;
-      const result = cloneIfNecessary(
-        value as FabricValue,
-        { frozen: false, deep: false },
-      ) as Record<string, unknown>;
-      expect(Object.getPrototypeOf(result)).toBe(null);
-      expect(result.b).toBe(2);
-      expect(Object.isFrozen(result)).toBe(false);
+    it("produces a value `isFabricValue()` accepts", () => {
+      // The point of canonicalizing: what comes out is a member of the type,
+      // where the input was not.
+      const value = nullProto({ a: 1 });
+      expect(isFabricValue(value)).toBe(false);
+      expect(isFabricValue(cloneIfNecessary(value as FabricValue))).toBe(true);
     });
   });
 

--- a/packages/data-model/test/native-conversion.test.ts
+++ b/packages/data-model/test/native-conversion.test.ts
@@ -998,29 +998,21 @@ describe("native-conversion", () => {
         expect(result).toBe(mutable); // identity -- no copy needed
       });
 
-      it("preserves `null` prototype on objects when `freeze=true`", () => {
+      it("throws for a null-prototype object, frozen or not", () => {
+        // A record has one shape in this system, and a prototype is not part
+        // of what a value says as data -- it would not survive the first
+        // encoding boundary. Rejecting says so, where accepting would mean
+        // carrying a distinction that quietly stops existing.
         const obj = Object.create(null) as Record<string, unknown>;
         obj.a = 1;
-        const result = shallowFabricFromNativeValue(obj, true) as Record<
-          string,
-          unknown
-        >;
-        expect(Object.getPrototypeOf(result)).toBe(null);
-        expect(Object.isFrozen(result)).toBe(true);
-        expect(result.a).toBe(1);
-      });
+        expect(() => shallowFabricFromNativeValue(obj, true)).toThrow(
+          "Not representable as a `FabricValue`: object that is not an inert plain object",
+        );
 
-      it("preserves `null` prototype on objects when `freeze=false`", () => {
-        const obj = Object.create(null) as Record<string, unknown>;
-        obj.b = 2;
         Object.freeze(obj);
-        const result = shallowFabricFromNativeValue(obj, false) as Record<
-          string,
-          unknown
-        >;
-        expect(Object.getPrototypeOf(result)).toBe(null);
-        expect(Object.isFrozen(result)).toBe(false);
-        expect(result.b).toBe(2);
+        expect(() => shallowFabricFromNativeValue(obj, false)).toThrow(
+          "Not representable as a `FabricValue`: object that is not an inert plain object",
+        );
       });
 
       it("converts native `Uint8Array` to `FabricBytes`", () => {
@@ -1873,25 +1865,20 @@ describe("native-conversion", () => {
         expect(Object.isFrozen(obj)).toBe(false);
       });
 
-      it("preserves `null` prototype on top-level object", () => {
+      it("throws for a null-prototype object at the top level", () => {
         const obj = Object.create(null) as Record<string, unknown>;
         obj.x = 1;
-        const result = fabricFromNativeValue(obj) as Record<string, unknown>;
-        expect(Object.getPrototypeOf(result)).toBe(null);
-        expect(Object.isFrozen(result)).toBe(true);
-        expect(result.x).toBe(1);
+        expect(() => fabricFromNativeValue(obj)).toThrow(
+          "Not representable as a `FabricValue`: object that is not an inert plain object",
+        );
       });
 
-      it("preserves `null` prototype on nested object", () => {
+      it("throws for a null-prototype object nested in the graph", () => {
         const inner = Object.create(null) as Record<string, unknown>;
         inner.val = 42;
-        const outer = { nested: inner };
-        const result = fabricFromNativeValue(outer) as Record<
-          string,
-          Record<string, unknown>
-        >;
-        expect(Object.getPrototypeOf(result.nested)).toBe(null);
-        expect(result.nested!.val).toBe(42);
+        expect(() => fabricFromNativeValue({ nested: inner })).toThrow(
+          "Not representable as a `FabricValue`: object that is not an inert plain object",
+        );
       });
     });
   });

--- a/packages/data-model/test/type-check.test.ts
+++ b/packages/data-model/test/type-check.test.ts
@@ -66,12 +66,6 @@ describe("type-check", () => {
         expect(isFabricValueLayer({ nested: { object: true } })).toBe(true);
       });
 
-      it("returns `true` for a null-prototype object", () => {
-        const obj = Object.create(null) as Record<string, unknown>;
-        obj.a = 1;
-        expect(isFabricValueLayer(obj)).toBe(true);
-      });
-
       it("returns `true` for a dense array", () => {
         expect(isFabricValueLayer([])).toBe(true);
         expect(isFabricValueLayer([1, 2, 3])).toBe(true);
@@ -151,7 +145,17 @@ describe("type-check", () => {
       it("returns `true` for an object whose keys are all enumerable strings", () => {
         expect(isFabricValueLayer({ a: 1, b: 2 })).toBe(true);
         expect(isFabricValueLayer({})).toBe(true);
-        expect(isFabricValueLayer(Object.create(null))).toBe(true);
+      });
+
+      it("returns `false` for a null-prototype object", () => {
+        // A record has one shape here: `Object.prototype`-rooted. A prototype
+        // is not part of what a value says as data and would not survive
+        // encoding, so a value carrying a different one is refused rather than
+        // accepted and quietly changed.
+        const obj = Object.create(null) as Record<string, unknown>;
+        obj.a = 1;
+        expect(isFabricValueLayer(obj)).toBe(false);
+        expect(isFabricValueLayer(Object.create(null))).toBe(false);
       });
     });
 
@@ -284,10 +288,12 @@ describe("type-check", () => {
         expect(isFabricValue({ nested: { deeply: { value: 1 } } })).toBe(true);
       });
 
-      it("returns `true` for a null-prototype object", () => {
+      it("returns `false` for a null-prototype object, at any depth", () => {
         const obj = Object.create(null) as Record<string, unknown>;
         obj.a = 1;
-        expect(isFabricValue(obj)).toBe(true);
+        expect(isFabricValue(obj)).toBe(false);
+        expect(isFabricValue({ nested: obj })).toBe(false);
+        expect(isFabricValue([obj])).toBe(false);
       });
 
       it("returns `false` for an object with a symbol-keyed property", () => {

--- a/packages/runner/src/sandbox/plain-data.ts
+++ b/packages/runner/src/sandbox/plain-data.ts
@@ -296,9 +296,11 @@ function freezeObject(
   path: string,
   converted: WeakMap<object, ModuleSafeValue>,
 ): ModuleSafeRecord {
-  const result = Object.create(
-    Object.getPrototypeOf(value),
-  ) as ModuleSafeRecord;
+  // A record leaves here in the one shape a fabric value has. `assertPlainData`
+  // admits a null-prototype object, that being an ordinary way to build a
+  // dictionary, and this is where it becomes canonical -- so what a pattern
+  // receives stays inside `FabricValue`, which a null-prototype record is not.
+  const result = {} as ModuleSafeRecord;
   converted.set(value, result as ModuleSafeValue);
 
   copyOwnProperties(value, result, path, converted);

--- a/packages/runner/src/sandbox/result-normalization.ts
+++ b/packages/runner/src/sandbox/result-normalization.ts
@@ -233,6 +233,11 @@ function prepareActionResultValidation(
   const existing = prepared.get(value);
   if (existing !== undefined) return existing;
 
+  // Copying the prototype is safe because this runs on the output of
+  // `adaptSandboxResult()`, which has already re-rooted every record -- so the
+  // prototype in hand is `Object.prototype`. Anything that ran this pass
+  // first, on a value straight from the sandbox, would propagate a prototype
+  // no fabric record has.
   const valueIsArray = Array.isArray(value);
   const copy: unknown[] | Record<string, unknown> = valueIsArray
     ? new Array((value as unknown[]).length)

--- a/packages/runner/src/sandbox/result-normalization.ts
+++ b/packages/runner/src/sandbox/result-normalization.ts
@@ -181,12 +181,16 @@ function adaptSandboxResult(
   const existing = adapted.get(value);
   if (existing !== undefined) return existing;
 
+  // This boundary answers in canonical shapes: a fresh `Array` for anything
+  // array-shaped, and an `Object.prototype`-rooted record for anything else.
+  // A prototype is not part of what a value says as data, and a fabric value
+  // has exactly one shape for a record, so a pattern that builds a result with
+  // `Object.create(null)` or `Object.groupBy()` has it re-rooted here rather
+  // than carried across only to be rejected downstream.
   const valueIsArray = Array.isArray(value);
   const copy: unknown[] | Record<string, unknown> = valueIsArray
     ? new Array((value as unknown[]).length)
-    : Object.create(
-      Object.getPrototypeOf(value) === null ? null : Object.prototype,
-    );
+    : {};
   adapted.set(value, copy);
 
   for (const [key, child] of Object.entries(value)) {

--- a/packages/runner/test/action-result-validation.test.ts
+++ b/packages/runner/test/action-result-validation.test.ts
@@ -94,6 +94,27 @@ describe("normalizeSandboxResult", () => {
     expect(value.first).not.toBe(shared);
   });
 
+  it("re-roots a bare null-prototype record, nested included", () => {
+    // `Object.create(null)` is an ordinary way to build a dictionary, and a
+    // pattern may return one. This boundary is a canonicalizing copy, so it
+    // leaves in the one shape a fabric record has, rather than being carried
+    // across intact and refused later by the conversion functions.
+    const inner = Object.create(null) as Record<string, unknown>;
+    inner.v = 42;
+    const outer = Object.create(null) as Record<string, unknown>;
+    outer.child = inner;
+    outer.a = 1;
+
+    const normalized = normalizeSandboxResult(outer);
+    const value = normalized.value as Record<string, unknown>;
+
+    expect(Object.getPrototypeOf(value)).toBe(Object.prototype);
+    expect(value.a).toBe(1);
+    const child = value.child as Record<string, unknown>;
+    expect(Object.getPrototypeOf(child)).toBe(Object.prototype);
+    expect(child.v).toBe(42);
+  });
+
   it("rejects custom instances with null-rooted prototypes", () => {
     class NullRooted {
       value = 1;

--- a/packages/runner/test/plain-data.test.ts
+++ b/packages/runner/test/plain-data.test.ts
@@ -110,6 +110,25 @@ describe("plain-data sandbox helper", () => {
     );
   });
 
+  it("re-roots a null-prototype record in the snapshot", () => {
+    // Validation admits one, a null-prototype object being an ordinary way to
+    // build a dictionary. The snapshot is where it becomes canonical, so what
+    // reaches a pattern stays inside `FabricValue`, which a null-prototype
+    // record is not.
+    const inner = Object.create(null) as Record<string, unknown>;
+    inner.v = 42;
+    const source = Object.create(null) as Record<string, unknown>;
+    source.child = inner;
+
+    const result = freezeVerifiedPlainData(source) as Record<string, unknown>;
+
+    expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+    const child = result.child as Record<string, unknown>;
+    expect(Object.getPrototypeOf(child)).toBe(Object.prototype);
+    expect(child.v).toBe(42);
+    expect(Object.isFrozen(result)).toBe(true);
+  });
+
   it("rejects values whose own property descriptors disappear", () => {
     const source = new Proxy({}, {
       ownKeys: () => ["ghost"],

--- a/packages/utils/src/objects.ts
+++ b/packages/utils/src/objects.ts
@@ -3,8 +3,8 @@
  */
 
 /**
- * Indicates whether the given value is an *inert* plain object -- prototype
- * `Object.prototype` or `null`, every own property an enumerable
+ * Indicates whether the given value is an *inert* plain object -- a direct
+ * instance of `Object`, every own property an enumerable
  * string-keyed *data* property -- which is what "plain object" means in this
  * system. Symbol keys and non-enumerable string keys cause rejection,
  * whether or not they carry data, because neither has any representation as
@@ -14,6 +14,16 @@
  * enumerable string, because it makes the object non-inert: an accessor is
  * live code, a read of which executes it and can answer differently every
  * time -- and freezing the object does not change that.
+ *
+ * "Direct instance" means the prototype is `Object.prototype` exactly, so a
+ * null-prototype object is rejected along with every class instance. A
+ * prototype is not part of what an object says as data: it has no
+ * representation in any encoding, so a record that crosses a storage boundary
+ * comes back `Object.prototype`-rooted whatever it went in as. Accepting a
+ * null-prototype object would therefore mean carrying a distinction that
+ * exists only in memory and stops existing at the first boundary. A caller
+ * holding one and meaning to shed it can say so with
+ * `shallowCleanPlainObject()`, which rebuilds the record `Object`-rooted.
  *
  * Anything that isn't a plain object is rejected, class instances and arrays
  * included, which also makes this function total: it answers rather than
@@ -31,8 +41,7 @@ export function isInertPlainObject(
     return false;
   }
 
-  const proto = Object.getPrototypeOf(value);
-  if (!((proto === Object.prototype) || (proto === null))) {
+  if (Object.getPrototypeOf(value) !== Object.prototype) {
     return false;
   }
 

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -86,7 +86,16 @@ export function isFiniteNumber(value: unknown): boolean {
 }
 
 /**
- * Check whether a value is a plain object.
+ * Check whether a value is a plain object: prototype `Object.prototype` or
+ * `null`, with no constraint on its properties.
+ *
+ * This is the shape question -- "may I read this by property name?" -- and is
+ * deliberately looser than what the data model admits as a record. For that,
+ * see `isInertPlainObject()`, which requires a direct `Object` instance whose
+ * every own property is an enumerable string-keyed data property. A
+ * null-prototype object answers `true` here and `false` there, and both
+ * answers are right for their own question.
+ *
  * @param value - The value to check
  * @returns True if the value is a plain object
  */

--- a/packages/utils/test/objects.test.ts
+++ b/packages/utils/test/objects.test.ts
@@ -14,12 +14,6 @@ describe("objects", () => {
           .toBe(true);
       });
 
-      it("accepts a null-prototype object", () => {
-        const obj = Object.create(null) as Record<string, unknown>;
-        obj.a = 1;
-        expect(isInertPlainObject(obj)).toBe(true);
-      });
-
       it("accepts a key whose value is `undefined`", () => {
         // A present key holding `undefined` is still an enumerable string key.
         expect(isInertPlainObject({ a: undefined }))
@@ -161,6 +155,18 @@ describe("objects", () => {
         const fake = Object.create(Array.prototype) as Record<string, unknown>;
         fake.a = 1;
         expect(isInertPlainObject(fake)).toBe(false);
+      });
+
+      it("rejects a null-prototype object", () => {
+        // A record has one shape here, the one the natural syntax produces. A
+        // prototype has no representation in any encoding, so accepting this
+        // would mean carrying a distinction that stops existing at the first
+        // storage boundary. `shallowCleanPlainObject()` is how a caller says
+        // it means to shed one.
+        const obj = Object.create(null) as Record<string, unknown>;
+        obj.a = 1;
+        expect(isInertPlainObject(obj)).toBe(false);
+        expect(isInertPlainObject(Object.create(null))).toBe(false);
       });
 
       it("answers rather than throwing for `null` and `undefined`", () => {


### PR DESCRIPTION
`isInertPlainObject()` now requires the prototype to be `Object.prototype`
itself, so a null-prototype object is no longer a `FabricValue`. This is the
object-side counterpart to #5257, and it lets both container rules rest on one
principle.

## Why

A prototype is not part of what an object says as data. The value model
already says so in three places — two records differing only in prototype are
`valueEqual`, hash identically, and encode to identical bytes:

```
valueEqual(nullProtoObj, {a: 1})        true
hashBytesOf(nullProto) == hash({a:1})   true
jsonFromValue(nullProto)                fvj1:{"a":1}   — byte-identical
valueFromJson(...)  proto               Object.prototype
```

But conversion *preserved* the null prototype, on the clone path and through
the deep-frozen identity short-circuit alike. So the distinction existed in
memory and stopped existing at the first storage boundary — the same
preserve-here / normalize-there fork that #5257 retired for arrays.

Rejecting says so, where accepting could only mean changing the value quietly.
It also leaves a record with exactly one shape: the one the natural syntax
produces. `Object.create(null)` has real advantages, but the world is not
going to write it everywhere, and this system is not going to carry it across
an encoding boundary — so accepting it buys a distinction nothing downstream
can honor.

A caller holding one and meaning to shed it says so explicitly with
`shallowCleanPlainObject()`, which rebuilds the record `Object`-rooted. That is
the same reject-with-an-explicit-normalizer shape the array rule uses.

## Patterns keep their idioms

`adaptSandboxResult()` (`runner/src/sandbox/result-normalization.ts`) now
re-roots to `{}` instead of preserving a null prototype. That boundary was
already a canonicalizing copy — it rebuilds anything array-shaped into a fresh
`new Array(len)` — so a pattern returning `Object.create(null)` has it
normalized there, rather than carried across only to be rejected downstream
with an error naming inertness instead of the prototype it just went to the
trouble of keeping. (`Object.groupBy()` is not reachable from pattern source:
`groupBy` is absent from the pattern typings, so calling it fails type-check.
`Object.create(null)` is the real case this covers.)

## Cost: twelve tests, zero production sites

Nothing in the repo produces a null-prototype object that reaches the fabric.
The four `Object.create(null)` sites are `js-compiler`'s internal `fsWrite`
map, `cf-harness`'s credential store (a JSON file), `integration/page.ts`'s
console stub, and `deno-web-test`'s browser-harness `Deno` stub. Dynamic
producers come back clean too: zero `Object.groupBy` / `Map.groupBy` calls
(and `groupBy` is absent from the pattern typings, so pattern source calling
it fails type-check), the four regexes with named capture groups all discard
`.groups` after reading a string out of it, and `Object.fromEntries`,
`structuredClone`, and `JSON.parse` all produce `Object.prototype`-rooted
results. Every object construction on a decode path is `{}`,
`Object.fromEntries`, or `JSON.parse` — there is no `Object.create` in
`packages/memory` source at all — so this is a tightening rather than a fix
for a live bug.

The entire cost was tests that pinned the old rule:

| suite | tests |
| --- | --- |
| `data-model/test/cloneIfNecessary.test.ts` | 4 (now 6, asserting canonicalization) |
| `data-model/test/native-conversion.test.ts` | 4 (now 3; the frozen/unfrozen pair merged) |
| `data-model/test/type-check.test.ts` | 3 |
| `utils/test/objects.test.ts` | 1 |

Each asserted acceptance or preservation directly; none broke because it
*used* such an object.

## Where the rule reaches

Validation is not the only place a record gets built, so three walkers that
built one in whatever shape they were handed now build the canonical shape:

- **`cloneHelper()`** builds `{}` rather than `Object.create(getPrototypeOf)`,
  matching its own array arm, which canonicalizes an indirect array into a
  fresh `Array`. No change for valid input; a canonical result for input that
  arrived without validation.
- **`freezeVerifiedPlainData()`** re-roots in the snapshot. This one is bound
  into the pattern surface as `__cf_data` and `schema`, so it was handing
  patterns hardened records outside `FabricValue` — which the sandboxing
  spec's "recursively inert subset of `FabricValue`" claim forbids.
  Validation still admits a null-prototype input; the snapshot is where it
  becomes canonical.
- **`fabricFromNativeValueInternal()`** had the same `Object.create()` call,
  unreachable now that conversion rejects such input before reaching it.

One place still copies a prototype rather than canonicalizing:
`prepareActionResultValidation()`. That is correct only because
`normalizeSandboxResult()` runs `adaptSandboxResult()` first, so every record
it sees is already `Object.prototype`-rooted — an ordering dependency nothing
about the call announced, now stated where the copy happens.

What deliberately did *not* change:

- **Type-tag dispatch** still tags a null-prototype object `Object`, so the
  object rule rejects it by name rather than as some unrecognized class —
  exactly as it tags an indirect array `Array`.
- **`isFabricPlainObject()`** still accepts one, and now documents why. It asks
  whether a value may be read by property name, of something the type already
  claims is a `FabricValue`, and several runner call sites narrow un-validated
  values through it via `as FabricValue`. Membership is `isFabricValue()`'s
  question; the two differ on purpose. (All ~11 call sites checked: the
  schema-defaults merge writes through a spread, so its output is canonical
  regardless.)

## Spec

Section 1.5's object rule now leads with the direct-instance requirement, and
all four "no distinction between regular and null-prototype objects" passages
are gone — two in the formal spec, and two in `docs/specs/space-model/1-data-model.md`,
which carried them verbatim while citing the formal spec as authoritative.

#5257's array bullet had to note that plain objects were treated differently
on this point; that parenthetical becomes "governed by the same principle."

## Verification

`deno fmt --check`, `deno lint`, `deno task check`, `deno task check-docs`, and
the full workspace suite green at 223.3s on the branch head. `deno.lock` clean.
