### PR TITLE
fix(runner): write a receipt through the cell's standard write flow

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -148,11 +148,17 @@ propagate](#how-flags-propagate).
 - **Purpose.** A handler's return value containing reactives/cells projects
   into its per-event receipt cell via the result-pattern path, but a **plain
   JSON return is discarded** — the receipt-only branch writes `{}`. Under this
-  flag the receipt carries the (already-normalized) plain return instead, so a
+  flag the receipt carries the (already-normalized) return instead, so a
   caller — or a same-id retry that collides on the create-only receipt — can
   read the verb's result back by receipt address. `{}` remains the shape for
-  value-less handlers. Requires `commitPreconditions` (the receipt write
-  itself) to be active, which it is by default.
+  value-less handlers. The value goes through the receipt cell's standard
+  write flow (`set` → `diffAndUpdate`), the same conversion any cell write
+  gets: plain JSON persists as-is and a live `Cell` handle converts to a
+  link — so a one-line setter verb (`action(() => cell.set(...))`, whose
+  expression body implicitly returns the cell `set()` hands back for
+  chaining) records a link to the mutated cell in its receipt. Receipts
+  reflect what was returned. Requires `commitPreconditions` (the receipt
+  write itself) to be active, which it is by default.
 - **Current default and planned end state.** Off by default. Flips on once the
   verb-contract WS-D integration proof (caller-supplied event id → collide →
   read back the original result, cross-process) is green; after a bake period

--- a/docs/specs/scheduler-v2/README.md
+++ b/docs/specs/scheduler-v2/README.md
@@ -786,9 +786,12 @@ the receipt. This gives handlers the same shape as computations: one
 canonical output document per unit of work, whose creation doubles as the
 exactly-once witness. A receipt-only handling writes `{}`; under the
 experimental `plainResultReceipts` flag it instead carries the handler's
-normalized plain JSON return, so the verb's result is readable back by
-receipt address (`docs/development/EXPERIMENTAL_OPTIONS.md`; verb-contract
-plan) — the create-only witness semantics are unchanged either way.
+normalized return, so the verb's result is readable back by receipt address
+(`docs/development/EXPERIMENTAL_OPTIONS.md`; verb-contract plan). That value
+is written through the receipt cell's standard write conversion — plain JSON
+persists as-is, a live cell handle converts to a link, so a one-line setter
+verb's receipt links to the cell it mutated. The create-only witness
+semantics are unchanged either way.
 
 For an inline, non-navigation handler result, an `inSpace` child does not move
 that canonical handler-result wrapper into the child space. The result/receipt

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -4858,16 +4858,26 @@ export class Runner {
         // Receipt-only handling (spec scheduler-v2 §7.6): nothing was
         // launched, but the result cell is still created — its create is the
         // exactly-once witness for this event id. Under plainResultReceipts
-        // the witness also carries the handler's (already-normalized) plain
-        // JSON return, so a caller — or a same-id retry colliding on the
-        // receipt — reads the verb's result back by receipt address (verb
-        // contract Part 2). `{}` remains the value-less shape either way.
+        // the witness also carries the handler's (already-normalized) return,
+        // so a caller — or a same-id retry colliding on the receipt — reads
+        // the verb's result back by receipt address (verb contract Part 2).
+        // `{}` remains the value-less shape either way.
+        //
+        // The value goes through the receipt cell's STANDARD write flow
+        // (`set` → diffAndUpdate), the same conversion any cell write gets:
+        // plain JSON persists as-is and a live Cell handle converts to a
+        // link. That matters because incidental cell returns are a sanctioned
+        // idiom — `set()` returns its cell for chaining, so an
+        // expression-body `action(() => cell.set(...))` returns the mutated
+        // cell — and a raw write here fails the whole handling on such a
+        // value with an uncloneable-live-object storage error instead of
+        // recording what was returned.
         const receiptValue =
           this.runtime.experimental.plainResultReceipts === true &&
             result !== undefined
             ? result
             : {};
-        receiptCell.withTx(tx).setRaw(receiptValue);
+        receiptCell.withTx(tx).set(receiptValue);
         tx.markCreateOnly?.(receiptCell.getAsNormalizedFullLink());
       }
       return result;

--- a/packages/runner/test/declared-result-e2e.test.ts
+++ b/packages/runner/test/declared-result-e2e.test.ts
@@ -7,6 +7,13 @@
 // result authoring surface. This is the readback half of WS-C's exit
 // criterion, pinned at the runner in addition to the end-to-end fixture
 // (pattern-verb-contract-implementation.md, D4).
+//
+// The incidental-cell-return case pins the receipt write's conversion: `set()`
+// returns its cell for chaining, so an expression-body
+// `action(() => cell.set(...))` returns a live Cell. The receipt write goes
+// through the cell's standard write flow, so that return is recorded as a LINK
+// to the mutated cell — receipts reflect what was returned (a raw write fails
+// the whole handling on the live object instead).
 import {
   afterEach,
   beforeEach,
@@ -24,6 +31,8 @@ import type {
   SchedulerTestStorageManager,
 } from "./scheduler-test-utils.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
+import { parseLink } from "../src/link-utils.ts";
+import { resolveLink } from "../src/link-resolution.ts";
 
 // One verb declared with `action<Event, Result>` whose body returns a value
 // derived from the event (provably from that dispatch), and one value-less
@@ -47,6 +56,7 @@ const DECLARED_RESULT_PROGRAM: RuntimeProgram = {
       "interface Verbs {",
       "  addTopic: Stream<AddTopic, AddTopicResult>;",
       "  touch: Stream<AddTopic>;",
+      "  bump: Stream<AddTopic>;",
       "  count: number;",
       "}",
       "",
@@ -62,7 +72,12 @@ const DECLARED_RESULT_PROGRAM: RuntimeProgram = {
       "    count.set(count.get() + 1);",
       "  });",
       "",
-      "  return { addTopic, touch, count };",
+      "  // Expression body: implicitly returns `count.set(...)`'s chained",
+      "  // cell — the incidental cell return the standard receipt write",
+      "  // conversion records as a link to the mutated cell.",
+      "  const bump = action((_event: AddTopic) => count.set(count.get() + 1));",
+      "",
+      "  return { addTopic, touch, bump, count };",
       "});",
     ].join("\n"),
   }],
@@ -121,6 +136,7 @@ describe("compiled CTS action<E, R> results in receipts", () => {
     const rootCell = runtime.getCell<{
       addTopic: unknown;
       touch: unknown;
+      bump: unknown;
       count: number;
     }>(
       space,
@@ -207,6 +223,50 @@ describe("compiled CTS action<E, R> results in receipts", () => {
 
     // The two receipts are distinct documents.
     expect(outcomes[0].receiptLink!.id).not.toBe(outcomes[1].receiptLink!.id);
+  });
+
+  it("projects an incidental cell return (chained set) as a link to the mutated cell", async () => {
+    const root = await instantiate("incidental cell return root");
+    const outcomes: Outcome[] = [];
+
+    dispatch(
+      root.key("bump") as Cell<unknown>,
+      { title: "incidental" },
+      "evt:declared-result:3:bump",
+      outcomes,
+    );
+    await waitForSchedulerCondition(
+      runtime,
+      () => outcomes.length === 1,
+      "incidental-cell-return event did not settle",
+    );
+    await runtime.scheduler.idleWithPendingCommits();
+
+    // The handling commits — the chained cell return must not fail the
+    // action ("Cannot clone: CellImpl", the raw-write bug) — and the body
+    // ran.
+    expect(outcomes[0].status).toBe("done");
+    expect(await root.key("count").pull()).toBe(1);
+
+    // The receipt went through the standard cell-write conversion, so it
+    // carries a LINK to the returned cell. Assert by identity, not shape:
+    // resolve both the stored link and the pattern's own `count` cell
+    // through the same link machinery and compare addresses.
+    const receipt = runtime.getCellFromLink<unknown>(
+      outcomes[0].receiptLink!,
+    );
+    await receipt.pull();
+    const written = parseLink(receipt.getRaw(), receipt);
+    expect(written).toBeDefined();
+    const writtenResolved = resolveLink(runtime, runtime.readTx(), written!);
+    const target = resolveLink(
+      runtime,
+      runtime.readTx(),
+      (root.key("count") as Cell<number>).getAsNormalizedFullLink(),
+    );
+    expect(writtenResolved.space).toBe(target.space);
+    expect(writtenResolved.id).toBe(target.id);
+    expect(writtenResolved.path).toEqual(target.path);
   });
 
   it("discards the declared result while plainResultReceipts is off (default)", async () => {


### PR DESCRIPTION
## Why

A receipt-only handling wrote the handler's return with `setRaw`, so a return carrying a live `Cell` failed the **whole handling** with `Cannot clone: CellImpl` instead of recording what was returned.

This is reachable today, without any default change: `EXPERIMENTAL_PLAIN_RESULT_RECEIPTS=true` is enough. And the value that trips it is a sanctioned idiom, not an authoring mistake — `set()` returns its cell for chaining, so an expression-body `action(() => cell.set(...))` returns the mutated cell.

This is the fix Berni prescribed in the #5245 review, **extracted so it can land on its own**. #5245 currently carries it bundled with the default flip, which means a bug fix is gated behind a policy decision. They are separable: this is a defect under the flag as it exists today; the flip is a decision about that flag's default. Landing this first also makes the flip safe to evaluate on its own merits — the naive flip's central failure was exactly this bug.

## What Changed

- **`packages/runner/src/runner.ts`** — the receipt value goes through the cell's standard write flow (`set` → `diffAndUpdate`), the same conversion any cell write gets. Plain JSON persists exactly as before; a live cell handle converts to a link, so a one-line setter verb's receipt carries a link to the cell it mutated where it used to fail. Create-only witness semantics are unchanged, and `{}` remains the value-less shape.
- **`declared-result-e2e.test.ts`** — a compiled `action(() => count.set(...))` verb whose receipt is asserted to be a link to `count`, compared by **resolved address rather than shape** (both the stored link and the pattern's own cell go through the same link machinery).
- **Docs** — the `plainResultReceipts` registry entry and scheduler-v2 §7.6's receipt note describe the conversion. The flag's default is untouched by this PR.

## The default path changes too — read this before merging

Framing this as a flag-gated fix would undersell it. `receiptValue` is `{}` when
`plainResultReceipts` is off, and that `{}` now goes through `set` →
`diffAndUpdate` rather than a raw write. **Every receipt-only handling on every
deployment takes the new path**, not only flag-on runs. What that exposes, and
why it is still safe:

- **The create-only witness holds.** `scheduler-event-receipts.test.ts:196`
  ("deduplicates redelivered events by create-only receipt") runs in the default
  flag state and passes. That is the property idempotency rests on: had `set`
  short-circuited and skipped the write, dedup would break. It does not. The D3
  CLI integration retry scenarios confirm the same across processes.
- **No schema to trip over.** The receipt cell is created with an `undefined`
  schema (`getCell(space, { resultFor: cause }, undefined, tx)`), so `set`'s
  validation path has nothing to enforce or reject.
- **Cost.** `set` does strictly more work than `setRaw` — conversion plus
  diffing — on a per-handled-event path. For `{}` that is trivial, but it is a
  hot path and the change is real.

## Test plan

- New test verified **red first** on the unfixed code: `Cannot clone: CellImpl`, the exact production failure.
- `packages/runner` receipt suites green; repo-wide `deno task test` green (329s, all packages).
- `deno fmt --check`, `deno lint`, `deno task check-docs` (521 blocks) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Write receipt values through the cell’s standard write flow to prevent crashes when a handler returns a live `Cell`. JSON receipts are unchanged; live cells are stored as links.

- **Bug Fixes**
  - In `packages/runner/src/runner.ts`, receipt writes now use `set` (→ `diffAndUpdate`) instead of `setRaw` for both `{}` (flag off) and the normalized return when `EXPERIMENTAL_PLAIN_RESULT_RECEIPTS=true`: plain JSON persists, a `Cell` converts to a link, and create-only witness semantics are unchanged.
  - Expanded e2e test (`packages/runner/test/declared-result-e2e.test.ts`) with a compiled `action(() => count.set(...))` verb (`bump`) and an assertion that the receipt links to `count` by resolved address; reproduced the prior failure (“Cannot clone: CellImpl”) red-first.
  - Updated docs (`docs/development/EXPERIMENTAL_OPTIONS.md`, `docs/specs/scheduler-v2/README.md`) to describe the standard write conversion; the flag’s default is unchanged.

<sup>Written for commit 864691f2997fc9373fb246ebc8b54ea6a62b0230. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

