### PR TITLE
feat(topics): every mutating verb returns what it recorded

### DIFF
--- a/packages/patterns/topics/README.md
+++ b/packages/patterns/topics/README.md
@@ -85,6 +85,7 @@ piece:
 ```bash
 cf piece call --piece <board> addTopic \
   '{"title":"...","body":"the initial living document","agentName":"Sol"}'
+# -> { "result": { "topic": … } }: the topic this call created
 cf piece get --piece <board> topics --input \
   --schema title,createdAt,lastActivityAt,commentCount
 cf piece call --piece <topic> addComment \
@@ -129,6 +130,23 @@ successful crossref row supplies the canonical Topic fid.
 Every agent-authored mutation carries `agentName`; there is no preceding “set
 current name” call. Fabric's operation history retains the authenticated human
 principal, while the stored snapshot disambiguates which agent acted.
+
+**Every mutating verb returns what it recorded.** `addTopic` returns the topic
+it created — the piece itself, so the caller addresses the new topic straight
+from the create instead of filing it and then searching the board for it.
+`addComment` and `addLink` return the appended record, `setBody` the persisted
+body plus the attribution it wrote; each carries fields the pattern resolved
+(the structured author derived from `agentName`, the write-time timestamp) that
+a caller cannot compute for itself. Counts are deliberately not returned: these
+appends are mergeable ops, so a length observed inside one handling is not a
+fact about the resulting list — read `commentCount` when you want the count.
+
+A returned value reaches the caller through the handling's receipt. A result
+carrying a piece (`addTopic`) arrives on any runtime; the plain records
+(`addComment`, `addLink`, `setBody`) additionally need `plainResultReceipts`,
+which is `EXPERIMENTAL_PLAIN_RESULT_RECEIPTS=true` until that flag's default
+flips (`docs/development/EXPERIMENTAL_OPTIONS.md`). Without it those three verbs
+still perform their write and simply report no result.
 
 `addTopic` takes the body at create (optional): a topic born with a body appears
 with it atomically — no reader observes a title-only halfway state, and no

--- a/packages/patterns/topics/main.tsx
+++ b/packages/patterns/topics/main.tsx
@@ -36,9 +36,12 @@ import Topic, {
 // Re-export the shared types for consumers and tests.
 export type {
   AddCommentEvent,
+  AddCommentResult,
   AddLinkEvent,
+  AddLinkResult,
   AgentAuthoredEvent,
   SetBodyEvent,
+  SetBodyResult,
   TopicAuthor,
   TopicComment,
   TopicInput,
@@ -70,6 +73,16 @@ export interface AddTopicEvent {
    * callers of the previous deployed schema remain valid; new callers must
    * provide a non-blank name. */
   agentName?: string;
+}
+
+export interface AddTopicResult {
+  /** The topic this call created — the piece itself, not a manufactured
+   * identifier. It reaches the caller as a link to the child, which the CLI
+   * renders as an address (`cf piece call --show-links`); the pattern does
+   * not mint fid fields of its own. A caller therefore addresses the new
+   * topic straight from the create, instead of filing it and then searching
+   * the board's crossrefs for the topic it just made. */
+  topic: TopicPiece;
 }
 
 /** One topic's place in the prose reference graph. Derived at read time from
@@ -112,7 +125,7 @@ export interface TopicsOutput {
   /** Session-local draft for the footer composer (exposed for embedding and
    * headless driving, like the chat exemplar's drafts). */
   newTitle?: PerSession<Writable<string>>;
-  addTopic: Stream<AddTopicEvent>;
+  addTopic: Stream<AddTopicEvent, AddTopicResult>;
   /** @deprecated Compatibility view for callers of the previous board. */
   myName: string;
   /** @deprecated Compatibility mutation for callers of the previous board. */
@@ -175,7 +188,9 @@ export default pattern<TopicsInput, TopicsOutput>(({ topics, myName }) => {
     profileName.trim().length > 0 && profileWish.result !== undefined
   );
 
-  const addTopic = action(({ title, body, agentName }: AddTopicEvent) => {
+  const addTopic = action<AddTopicEvent, AddTopicResult>((
+    { title, body, agentName },
+  ) => {
     const trimmed = (title ?? "").trim();
     const author = topicAuthorFromAgent(agentName ?? "");
     if (agentName !== undefined && !author) {
@@ -204,6 +219,7 @@ export default pattern<TopicsInput, TopicsOutput>(({ topics, myName }) => {
     // Mergeable append: concurrent creates from different users all land.
     topics.push(piece);
     newTitle.set("");
+    return { topic: piece };
   });
 
   const setMyName = action(({ name }: { name: string }) => {

--- a/packages/patterns/topics/topic.tsx
+++ b/packages/patterns/topics/topic.tsx
@@ -50,6 +50,37 @@ export interface SetBodyEvent extends AgentAuthoredEvent {
   body: string;
 }
 
+// ===== Verb results =====
+//
+// Each mutating verb returns exactly what it recorded, so a caller learns the
+// outcome from the call instead of following it with a verification read. The
+// records carry the fields the pattern resolved — the structured author it
+// derived from `agentName`, and the write-time timestamp — which a caller
+// cannot compute for itself. Counts are deliberately absent: every append here
+// is a mergeable op, so a length observed inside one handling is not a fact
+// about the resulting list.
+
+export interface AddCommentResult {
+  /** The comment as appended, including resolved author and `sentAt`. */
+  comment: TopicComment;
+}
+
+export interface AddLinkResult {
+  /** The link as appended, including resolved `addedBy` and `addedAt`. */
+  link: TopicLink;
+}
+
+export interface SetBodyResult {
+  /** The body as persisted — verbatim, so a caller can confirm that
+   * whitespace-sensitive Markdown survived the round trip. */
+  body: string;
+  /** Attribution written for this save. Both are absent when the caller sent
+   * no `agentName`: an unattributed save leaves the previous attribution
+   * standing rather than overwriting it. */
+  bodyUpdatedBy?: TopicAuthor;
+  bodyUpdatedAt?: number;
+}
+
 export interface TopicComment {
   /** Snapshot taken at write time (profile enrichment comes later; never gate
    * authorship on a profile wish — CT-1879). Comments carry no minted id:
@@ -130,9 +161,9 @@ export interface TopicReference {
   commentCount: number | Default<0> | undefined;
   /** Max of creation, comments, body saves, and link additions. */
   lastActivityAt: number | Default<0> | undefined;
-  addComment: Stream<AddCommentEvent>;
-  addLink: Stream<AddLinkEvent>;
-  setBody: Stream<SetBodyEvent>;
+  addComment: Stream<AddCommentEvent, AddCommentResult>;
+  addLink: Stream<AddLinkEvent, AddLinkResult>;
+  setBody: Stream<SetBodyEvent, SetBodyResult>;
 }
 
 /**
@@ -558,27 +589,34 @@ export default pattern<TopicInput, TopicOutput>(
 
     // --- Streams (external API; also usable headlessly via CLI) ---
 
-    const addComment = action(({ body: text, agentName }: AddCommentEvent) => {
-      const trimmed = (text ?? "").trim();
-      const author = topicAuthorFromAgent(agentName ?? "");
-      if (agentName !== undefined && !author) {
-        rejectMutation("addComment", "agentName must be non-blank when given");
-      }
-      if (!trimmed) rejectMutation("addComment", "body must be non-empty");
-      const legacyName = author
-        ? topicAuthorLabel(author)
-        : (myName.get() ?? "").trim() || "someone";
-      // Mergeable append: concurrent comments from different users all land.
-      comments.push({
-        author,
-        authorName: legacyName,
-        body: trimmed,
-        sentAt: Date.now(),
-      });
-    });
+    const addComment = action<AddCommentEvent, AddCommentResult>(
+      ({ body: text, agentName }) => {
+        const trimmed = (text ?? "").trim();
+        const author = topicAuthorFromAgent(agentName ?? "");
+        if (agentName !== undefined && !author) {
+          rejectMutation(
+            "addComment",
+            "agentName must be non-blank when given",
+          );
+        }
+        if (!trimmed) rejectMutation("addComment", "body must be non-empty");
+        const legacyName = author
+          ? topicAuthorLabel(author)
+          : (myName.get() ?? "").trim() || "someone";
+        const comment = {
+          author,
+          authorName: legacyName,
+          body: trimmed,
+          sentAt: Date.now(),
+        };
+        // Mergeable append: concurrent comments from different users all land.
+        comments.push(comment);
+        return { comment };
+      },
+    );
 
-    const addLink = action(
-      ({ kind, url, label, agentName }: AddLinkEvent) => {
+    const addLink = action<AddLinkEvent, AddLinkResult>(
+      ({ kind, url, label, agentName }) => {
         const trimmedUrl = (url ?? "").trim();
         const author = topicAuthorFromAgent(agentName ?? "");
         if (agentName !== undefined && !author) {
@@ -588,27 +626,37 @@ export default pattern<TopicInput, TopicOutput>(
         if (!isSafeLinkUrl(trimmedUrl)) {
           rejectMutation("addLink", "url must be http(s)");
         }
-        links.push({
+        const link = {
           kind: kind ?? "web",
           url: trimmedUrl,
           label: (label ?? "").trim() || trimmedUrl,
           addedBy: author,
           addedAt: Date.now(),
-        });
+        };
+        links.push(link);
+        return { link };
       },
     );
 
-    const setBody = action(({ body: text, agentName }: SetBodyEvent) => {
-      const author = topicAuthorFromAgent(agentName ?? "");
-      if (agentName !== undefined && !author) {
-        rejectMutation("setBody", "agentName must be non-blank when given");
-      }
-      body.set(text ?? "");
-      if (author) {
+    const setBody = action<SetBodyEvent, SetBodyResult>(
+      ({ body: text, agentName }) => {
+        const author = topicAuthorFromAgent(agentName ?? "");
+        if (agentName !== undefined && !author) {
+          rejectMutation("setBody", "agentName must be non-blank when given");
+        }
+        const persisted = text ?? "";
+        body.set(persisted);
+        if (!author) return { body: persisted };
+        const bodyUpdatedAtValue = Date.now();
         bodyUpdatedBy.set(author);
-        bodyUpdatedAt.set(Date.now());
-      }
-    });
+        bodyUpdatedAt.set(bodyUpdatedAtValue);
+        return {
+          body: persisted,
+          bodyUpdatedBy: author,
+          bodyUpdatedAt: bodyUpdatedAtValue,
+        };
+      },
+    );
 
     // --- UI-side actions (close over session drafts) ---
 

--- a/packages/patterns/topics/topics.test.tsx
+++ b/packages/patterns/topics/topics.test.tsx
@@ -20,11 +20,14 @@ import Topics, {
   type TopicReference,
 } from "./main.tsx";
 import Topic, {
+  type AddCommentResult,
+  type AddLinkResult,
   crossrefJoin,
   extractFidPayloads,
   fidPayload,
   isSafeLinkUrl,
   saveProfileBody,
+  type SetBodyResult,
   snippet,
   submitProfileComment,
   submitProfileLink,
@@ -71,15 +74,31 @@ const propValue = (value: any): unknown =>
   value && typeof value.get === "function" ? value.get() : value;
 
 // A faithful pre-authorship Topic projection: the legacy schema has no
-// `createdBy` path at all. Pushing one into a current Topic's retained
-// mentionable list exercises the mixed-version boundary that production
-// migration must preserve.
+// `createdBy` path at all, and its verbs declare no results. Pushing one into
+// a current Topic's retained mentionable list exercises the mixed-version
+// boundary that production migration must preserve.
+//
+// Its verbs carry the current declared arity because `Stream<E, R>`
+// deliberately does not satisfy `Stream<E>` and the sibling projection is one
+// contract for the whole list — verb arity is not the legacy dimension under
+// test here, the absent `createdBy` path is. A genuinely older deployed
+// sibling, whose verbs return nothing, stays valid against this same list at
+// runtime: a declared result adds nothing to the generated schema (C3
+// withdrawn — results flow schema-free through receipts), so the stored
+// schema a legacy piece is validated against is unchanged.
 const LegacyUnsignedTopic = pattern(() => {
-  const addComment = action((_event: { body: string }) => {});
-  const addLink = action(
-    (_event: { kind: TopicLinkKind; url: string; label: string }) => {},
-  );
-  const setBody = action((_event: { body: string }) => {});
+  const addComment = action<{ body: string }, AddCommentResult>((event) => ({
+    comment: { authorName: "", body: event.body, sentAt: 0 },
+  }));
+  const addLink = action<
+    { kind: TopicLinkKind; url: string; label: string },
+    AddLinkResult
+  >((event) => ({
+    link: { kind: event.kind, url: event.url, label: event.label },
+  }));
+  const setBody = action<{ body: string }, SetBodyResult>((event) => ({
+    body: event.body,
+  }));
   return {
     [NAME]: undefined,
     title: "Legacy unsigned sibling",

--- a/skills/topics/SKILL.md
+++ b/skills/topics/SKILL.md
@@ -134,9 +134,14 @@ deno task cf piece get --url "$TOPICS_BOARD_URL" crossrefs --step \
   --filter '.topic.title == "<exact title>"' --schema fid,topic.title
 ```
 
-Find the new topic's canonical fid in `crossrefs` before applying further
-changes. All handler arguments are JSON; encode multiline Markdown rather than
-passing an unescaped string.
+`addTopic` returns the topic it created, so a board running this source hands
+back the new topic on the call itself. The board's deployed pattern can be older
+than this source, and an older `addTopic` returns nothing; `crossrefs` above
+remains the path that works either way, and `cf piece verbs` reports the
+deployed pattern's source identity when you need to know which you are talking
+to. Find the new topic's canonical fid before applying further changes. All
+handler arguments are JSON; encode multiline Markdown rather than passing an
+unescaped string.
 
 ```bash
 deno task cf piece call --url "$TOPIC_URL" setBody \
@@ -147,6 +152,13 @@ deno task cf piece call --url "$TOPIC_URL" addLink \
   '{"kind":"pr","url":"<PR URL>","label":"<PR label>","agentName":"<agent name>"}'
 deno task cf piece get --url "$TOPIC_URL" commentCount --step
 ```
+
+Each of these three returns the record it wrote — the appended comment or link,
+or the persisted body plus its attribution — which spares the verification read
+above. That result rides `plainResultReceipts`
+(`EXPERIMENTAL_PLAIN_RESULT_RECEIPTS=true` until the flag's default flips); the
+write happens either way, so treat an absent result as "not enabled here", never
+as "the mutation did not land".
 
 The body is the living big-picture document. Replace it in place with the full
 revised body so a reader sees the current state without replaying the thread,


### PR DESCRIPTION
## Why

The verb-contract plan's Phase 3 says "topics verbs return values." The machinery landed — C1's `Stream<E, R>` (#5170), C4's receipt projection, D1–D3's invocation protocol, and #5244's end-to-end proof — but **the topics board itself was never converted**, and no issue in the plan's breakdown covers it. `addTopic` was still `Stream<AddTopicEvent>`, returning nothing.

The cost is paid on every headless file. Creating a topic took two calls to learn one fact: file it, then search the board's `crossrefs` for the topic you just made — a lookup that is a guess the moment two agents file concurrently. The same shape repeated below: `addComment`, `addLink`, and `setBody` each wrote a record the caller could not see without a follow-up read.

This is also the missing step between the merged arc and *demonstrating* it: calling pattern verbs over the CLI and getting real values back, piece references included, on the pieces the team actually uses.

Prior PRs in the series: #5170 (C1), #5147, #5244 (D4), #5262 (receipt write conversion).

## What Changed

Each mutating verb declares a result with the C1 surface and returns what it wrote:

- **`addTopic` → `{ topic }`** — the created piece itself. The pattern mints no fid of its own (decision 6: patterns return references, clients render identity); it reaches the caller as a link to the child, which `cf piece call --show-links` (F2, #5243) renders as an address.
- **`addComment` → `{ comment }`**, **`addLink` → `{ link }`** — the appended record, carrying the structured author the pattern derived from `agentName` and the write-time timestamp. Neither is computable by the caller.
- **`setBody` → `{ body, bodyUpdatedBy?, bodyUpdatedAt? }`** — the persisted body (so a caller can confirm whitespace-sensitive Markdown survived) plus the attribution written; both absent when the save was unattributed.

**No counts are returned.** These appends are mergeable ops, so a length observed inside one handling is not a fact about the resulting list. `commentCount` stays the honest way to ask.

Docs riding the change: `packages/patterns/topics/README.md` and `skills/topics/SKILL.md`, both of which previously instructed the lookup this replaces.

## The compat story

**The durable schema does not change.** `cf check --pattern-json` is byte-identical across this change apart from the compiled module's own `$implRef.identity` — all 30 differing lines are that hash. A declared result adds nothing to the generated schema (C3 withdrawn: results flow schema-free through receipts), so the compat checker has nothing to refuse and every existing caller stays valid.

## Measured, against an isolated toolshed

This source deployed to a fresh board, driven with `cf piece call`:

| verb | returns | flag off | flag on |
| --- | --- | --- | --- |
| `addTopic` | the created topic piece | **works** | works |
| `addComment` / `addLink` / `setBody` | the written record | `null` | works |

`addTopic` returns on **any** runtime — a return carrying cells goes through the result-pattern projection path, not the receipt-only branch `plainResultReceipts` gates. The three plain records need `EXPERIMENTAL_PLAIN_RESULT_RECEIPTS=true`; with it off the write still lands and the result reads `null`. Both the README and the skill say so explicitly, so an absent result is never mistaken for a mutation that did not happen.

Example (flag on):

```json
{ "status": "settled",
  "result": { "comment": { "author": { "kind": "agent", "name": "Opus" },
                           "authorName": "Opus (agent)",
                           "body": "A comment whose record comes back from the call.",
                           "sentAt": 1785559228000 } } }
```

## A note on the legacy fixture

`topics.test.tsx`'s legacy sibling gains the declared arity. `Stream<E, R>` deliberately does not satisfy `Stream<E>` (`packages/api/index.ts`), and the sibling projection is one contract for the whole list, so a value-less fixture no longer satisfies `TopicReference`. Verb arity is not the legacy dimension that fixture tests — the absent `createdBy` path is — and a genuinely older *deployed* sibling stays valid against this same list at runtime, because the stored schema it is validated against did not change. Double-casting is banned by the pattern language, which is the right answer here: it forced the question rather than letting it be silenced.

## Test plan

- `topics.test.tsx`, `topics-rejections.test.tsx`, `multi-user.test.tsx`: **50 passed, 0 failed**.
- End-to-end against a local toolshed: deploy → `addTopic` → address the returned topic → `addComment` / `setBody` / `addLink`, each result inspected; repeated with the flag off to pin the degradation.
- Schema equivalence verified by diffing `cf check --pattern-json` before and after.
- Repo-wide `deno fmt --check`, `deno lint`, `deno task check-docs` (521 blocks), `deno task check-skill-facts` (34 docs) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make all Topics mutating verbs return the record they wrote so callers can use results directly and skip follow-up reads. Improves CLI/headless flows without changing the durable schema.

- **New Features**
  - `addTopic` → `{ topic }` (the created piece).
  - `addComment` → `{ comment }`, `addLink` → `{ link }`, `setBody` → `{ body, bodyUpdatedBy?, bodyUpdatedAt? }`.
  - Streams now declare result types in the public surface (`Stream<Event, Result>`; `AddTopicResult`, `AddCommentResult`, `AddLinkResult`, `SetBodyResult` exported).
  - Counts are not returned; use `commentCount`.
  - Results flow via receipts: `addTopic` returns on any runtime; the others require `EXPERIMENTAL_PLAIN_RESULT_RECEIPTS=true`.

- **Migration**
  - Schema is unchanged; existing callers remain valid.
  - With the flag off, `addComment`/`addLink`/`setBody` still write but return `null`; `addTopic` always returns.
  - Some deployed boards may be older and return nothing; fall back to reading `crossrefs`. Docs updated in `packages/patterns/topics/README.md` and `skills/topics/SKILL.md`.

<sup>Written for commit e2b847ead6ff7d1a725d77d8eb5d5de56f265a72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

