### PR TITLE
fix(data-model): refuse the property names this runtime reserves

### DIFF
--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -1246,8 +1246,34 @@ Section 4.5.
   name-driven copying or serialization
 - Values must be valid fabric values; properties whose value is `undefined` are preserved
   (not omitted) — `undefined` is a first-class value, not a signal for deletion
+- **Host restriction, not a model rule:** the property names `__proto__` and
+  `constructor` cause rejection in the JavaScript implementation. See the
+  callout below
 - Reconstruction produces regular plain objects, which is the only object
   shape a fabric value has
+
+> **Host-unsafe property names.** A fabric record's keys are strings, and the
+> model attaches no meaning to any particular one: a property name is data. Two
+> names are nonetheless refused by the JavaScript implementation, `__proto__`
+> and `constructor`.
+>
+> The reason is entirely local to that host. Records are rebuilt by name-driven
+> copying at every boundary — conversion, cloning, encoding, decoding — and in
+> JavaScript `target[key] = value` for those names does not create a property:
+> it reaches `Object.prototype`'s `__proto__` accessor, mutating the copy's
+> prototype and dropping the value, or shadows the constructor that type
+> dispatch reads. A record carrying such a name therefore cannot survive a copy
+> in this host, and the boundary refuses it rather than corrupting it in transit
+> ("death before confusion").
+>
+> This restriction belongs to the implementation, not to the model. A host that
+> does not route property assignment through a prototype chain — Rust, Swift,
+> C++, Python, and most others — has no unsafe names at all and must not adopt
+> this rule. In the JavaScript implementation it is expressed as a check
+> separate from the inertness rules, so that it can be removed as a unit if
+> those boundaries are ever rebuilt on `Object.defineProperty()` or an
+> equivalent that copies any name faithfully. An implementation in another
+> language accepts these names as ordinary keys.
 
 ### 1.6 Circular References and Shared References
 

--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -1252,28 +1252,37 @@ Section 4.5.
 - Reconstruction produces regular plain objects, which is the only object
   shape a fabric value has
 
-> **Host-unsafe property names.** A fabric record's keys are strings, and the
-> model attaches no meaning to any particular one: a property name is data. Two
-> names are nonetheless refused by the JavaScript implementation, `__proto__`
-> and `constructor`.
+> **Property names this implementation reserves.** A fabric record's keys are
+> strings, and the model attaches no meaning to any particular one: a property
+> name is data. Two names are nonetheless refused by the JavaScript
+> implementation, `__proto__` and `constructor`, for two different reasons —
+> neither of which is a limit of the language, and both of which are removable.
 >
-> The reason is entirely local to that host. Records are rebuilt by name-driven
-> copying at every boundary — conversion, cloning, encoding, decoding — and in
-> JavaScript `target[key] = value` for those names does not create a property:
-> it reaches `Object.prototype`'s `__proto__` accessor, mutating the copy's
-> prototype and dropping the value, or shadows the constructor that type
-> dispatch reads. A record carrying such a name therefore cannot survive a copy
-> in this host, and the boundary refuses it rather than corrupting it in transit
-> ("death before confusion").
+> `__proto__` cannot be rebuilt by the copying this implementation performs.
+> Records are reconstructed at each boundary — conversion, cloning, decoding —
+> by assignment (`target[key] = value`) and `Object.assign()`, and for this name
+> both reach `Object.prototype`'s accessor rather than creating a property: the
+> value is dropped, and the copy's prototype is repointed as well when that
+> value is an object or `null`. Mechanisms that carry the name faithfully do
+> exist — spread, `Object.fromEntries()`, `Object.defineProperty()`, and
+> `JSON.parse()` — so what stands in the way is the copy loops, not JavaScript.
 >
-> This restriction belongs to the implementation, not to the model. A host that
-> does not route property assignment through a prototype chain — Rust, Swift,
-> C++, Python, and most others — has no unsafe names at all and must not adopt
-> this rule. In the JavaScript implementation it is expressed as a check
-> separate from the inertness rules, so that it can be removed as a unit if
-> those boundaries are ever rebuilt on `Object.defineProperty()` or an
-> equivalent that copies any name faithfully. An implementation in another
-> language accepts these names as ordinary keys.
+> `constructor` copies faithfully. It is reserved because other boundaries in
+> this implementation already refuse it: the projection to native values drops
+> it, and `FabricError` throws on it. Admitting it here would mean accepting a
+> key that a later boundary discards without saying so.
+>
+> The boundary refuses such a record rather than corrupting it in transit
+> ("death before confusion"), and a decoder that meets one reports a
+> `ProblematicValue` rather than reconstructing something the bytes do not say.
+>
+> **This reservation belongs to the implementation, not to the model.** A host
+> that does not route property assignment through a prototype chain — Rust,
+> Swift, C++, Python, and most others — reserves no names at all and must not
+> adopt this rule. Even here it is not permanent: rebuilding the copy loops on
+> a faithful mechanism, and revisiting the boundaries that filter these names,
+> would retire it. It is expressed as a check separate from the inertness rules
+> so that it can be removed as a unit when that happens.
 
 ### 1.6 Circular References and Shared References
 

--- a/docs/specs/space-model/1-data-model.md
+++ b/docs/specs/space-model/1-data-model.md
@@ -63,6 +63,10 @@ authoritative statement of these rules.
 - Every property must be an enumerable *data* property; accessor-backed
   (getter and/or setter) and non-enumerable properties cause rejection as
   non-fabric
+- The names `__proto__` and `constructor` cause rejection in the JavaScript
+  implementation. This is a restriction of that host, which cannot copy those
+  names by assignment, rather than a rule of the model; see Section 1.5 of
+  `space-model-formal-spec/1-fabric-values.md`
 - Values must be valid fabric values
 - Reconstruction produces regular plain objects, which is the only object
   shape a fabric value has

--- a/docs/specs/space-model/1-data-model.md
+++ b/docs/specs/space-model/1-data-model.md
@@ -64,8 +64,9 @@ authoritative statement of these rules.
   (getter and/or setter) and non-enumerable properties cause rejection as
   non-fabric
 - The names `__proto__` and `constructor` cause rejection in the JavaScript
-  implementation. This is a restriction of that host, which cannot copy those
-  names by assignment, rather than a rule of the model; see Section 1.5 of
+  implementation. This is a reservation of that implementation — one name its
+  copy loops cannot rebuild, one that its other boundaries already refuse —
+  rather than a rule of the model; see Section 1.5 of
   `space-model-formal-spec/1-fabric-values.md`
 - Values must be valid fabric values
 - Reconstruction produces regular plain objects, which is the only object

--- a/packages/data-model/src/codec-json/JsonEncodingContext.ts
+++ b/packages/data-model/src/codec-json/JsonEncodingContext.ts
@@ -1,4 +1,4 @@
-import { isPlainObject } from "@commonfabric/utils/types";
+import { isPlainObject, isUnsafeObjectKey } from "@commonfabric/utils/types";
 import { utf8SortedKeysOf } from "@commonfabric/utils/utf8";
 
 import { FabricSpecialObject, type FabricValue } from "@/interface.ts";
@@ -360,6 +360,15 @@ export class JsonEncodingContext implements SerializationContext<string> {
         const inner = rawState as Record<string, JsonWireValue>;
         const result: Record<string, FabricValue> = {};
         for (const [key, val] of Object.entries(inner)) {
+          // Same reservation as the plain-object arm below: the assignment
+          // cannot rebuild these names.
+          if (isUnsafeObjectKey(key)) {
+            return new ProblematicValue(
+              key,
+              inner as unknown as FabricValue,
+              `object contains a key this runtime reserves: "${key}"`,
+            ) as unknown as FabricValue;
+          }
           result[key] = this.#decodeValue(val, context, registry);
         }
         return Object.freeze(result);
@@ -461,6 +470,18 @@ export class JsonEncodingContext implements SerializationContext<string> {
           key.slice(1),
           data as unknown as FabricValue,
           `object contains reserved /-prefixed key: "${key}"`,
+        ) as unknown as FabricValue;
+      }
+      // A name this runtime reserves cannot be rebuilt by the assignment
+      // below: `__proto__` would repoint the result's prototype instead of
+      // becoming a property. Such a record cannot have been written by this
+      // implementation, whose write path refuses it, so report it rather than
+      // decoding something the bytes do not say.
+      if (isUnsafeObjectKey(key)) {
+        return new ProblematicValue(
+          key,
+          data as unknown as FabricValue,
+          `object contains a key this runtime reserves: "${key}"`,
         ) as unknown as FabricValue;
       }
       result[key] = this.#decodeValue(val, context, registry);

--- a/packages/data-model/src/codec-json/JsonEncodingContext.ts
+++ b/packages/data-model/src/codec-json/JsonEncodingContext.ts
@@ -365,9 +365,9 @@ export class JsonEncodingContext implements SerializationContext<string> {
           if (isUnsafeObjectKey(key)) {
             return new ProblematicValue(
               key,
-              inner as unknown as FabricValue,
+              inner,
               `object contains a key this runtime reserves: "${key}"`,
-            ) as unknown as FabricValue;
+            );
           }
           result[key] = this.#decodeValue(val, context, registry);
         }
@@ -384,9 +384,9 @@ export class JsonEncodingContext implements SerializationContext<string> {
       if (tag === "") {
         return new ProblematicValue(
           tag,
-          state as unknown as FabricValue,
+          state,
           `object has bare "/" key`,
-        ) as unknown as FabricValue;
+        );
       }
 
       // Registry-based (tag lookup) dispatch
@@ -408,9 +408,9 @@ export class JsonEncodingContext implements SerializationContext<string> {
             return deepFreeze(
               new ProblematicValue(
                 tag,
-                state as unknown as FabricValue,
+                state,
                 e instanceof Error ? e.message : String(e),
-              ) as unknown as FabricValue,
+              ),
             );
           }
         }
@@ -468,9 +468,9 @@ export class JsonEncodingContext implements SerializationContext<string> {
       if (key.startsWith("/")) {
         return new ProblematicValue(
           key.slice(1),
-          data as unknown as FabricValue,
+          data,
           `object contains reserved /-prefixed key: "${key}"`,
-        ) as unknown as FabricValue;
+        );
       }
       // A name this runtime reserves cannot be rebuilt by the assignment
       // below: `__proto__` would repoint the result's prototype instead of
@@ -480,9 +480,9 @@ export class JsonEncodingContext implements SerializationContext<string> {
       if (isUnsafeObjectKey(key)) {
         return new ProblematicValue(
           key,
-          data as unknown as FabricValue,
+          data,
           `object contains a key this runtime reserves: "${key}"`,
-        ) as unknown as FabricValue;
+        );
       }
       result[key] = this.#decodeValue(val, context, registry);
     }

--- a/packages/data-model/src/interface.ts
+++ b/packages/data-model/src/interface.ts
@@ -179,10 +179,13 @@ export interface FabricArray extends ReadonlyArray<FabricValue> {}
 /**
  * Object/record of fabric values.
  *
- * Note: `.__proto__` and `constructor()` properties are not currently guarded
- * against at the type level or at runtime in clone/conversion internals.
- * If prototype pollution becomes a concern, add boundary validation where
- * values enter the fabric system (e.g., `fabricFromNativeValue()`).
+ * The names `__proto__` and `constructor` are refused at the boundaries where
+ * values enter or leave storage, so no `FabricPlainObject` carries one. The
+ * type cannot say as much -- a string index signature admits every string --
+ * so the guarantee is the boundary's, not TypeScript's. Note the internal copy
+ * loops are unguarded and rely on it: they rebuild records by assignment,
+ * which for `__proto__` would repoint the copy's prototype rather than
+ * creating a property.
  */
 export interface FabricPlainObject
   extends Readonly<Record<string, FabricValue>> {}

--- a/packages/data-model/src/native-conversion.ts
+++ b/packages/data-model/src/native-conversion.ts
@@ -290,14 +290,15 @@ export function shallowFabricFromNativeValue(
             "inert plain object",
         );
       }
-      // A host restriction rather than a model one, so it says so rather than
-      // blaming inertness: such an object IS inert, and a runtime that does
-      // not route assignment through a prototype chain would take it happily.
+      // A restriction of this implementation rather than of the model, so it
+      // says so rather than blaming inertness: such an object IS inert, and a
+      // runtime that does not route property assignment through a prototype
+      // chain reserves no names at all.
       const unsafeKey = unsafeObjectKeyIn(value as object);
       if (unsafeKey !== undefined) {
         throw new Error(
           "Not representable as a `FabricValue`: object with a property name " +
-            `this JavaScript host cannot carry (\`${unsafeKey}\`)`,
+            `this runtime reserves (\`${unsafeKey}\`)`,
         );
       }
       // Plain objects: delegate frozenness handling to `cloneHelper()`.

--- a/packages/data-model/src/native-conversion.ts
+++ b/packages/data-model/src/native-conversion.ts
@@ -2,6 +2,7 @@ import {
   isInstance,
   isRecord,
   isUnsafeObjectKey,
+  unsafeObjectKeyIn,
 } from "@commonfabric/utils/types";
 import { isInertPlainObject } from "@commonfabric/utils/objects";
 import {
@@ -287,6 +288,16 @@ export function shallowFabricFromNativeValue(
         throw new Error(
           "Not representable as a `FabricValue`: object that is not an " +
             "inert plain object",
+        );
+      }
+      // A host restriction rather than a model one, so it says so rather than
+      // blaming inertness: such an object IS inert, and a runtime that does
+      // not route assignment through a prototype chain would take it happily.
+      const unsafeKey = unsafeObjectKeyIn(value as object);
+      if (unsafeKey !== undefined) {
+        throw new Error(
+          "Not representable as a `FabricValue`: object with a property name " +
+            `this JavaScript host cannot carry (\`${unsafeKey}\`)`,
         );
       }
       // Plain objects: delegate frozenness handling to `cloneHelper()`.
@@ -702,7 +713,10 @@ function isFabricCompatibleInternal(
       // Plain objects -- check the key shape, then all property values
       // recursively. A symbol key or a non-enumerable string key has no fabric
       // representation, just as an array's non-index properties do not.
-      if (!isInertPlainObject(value)) {
+      if (
+        !isInertPlainObject(value) ||
+        (unsafeObjectKeyIn(value) !== undefined)
+      ) {
         seen.delete(value);
         return false;
       }

--- a/packages/data-model/src/native-type-tags.ts
+++ b/packages/data-model/src/native-type-tags.ts
@@ -169,9 +169,17 @@ export function tagFromNativeValue(value: unknown): NativeTag | null {
     return NATIVE_TAGS.Array;
   }
 
-  // Guard: null-prototype objects or exotic objects may not have a function
-  // constructor.
-  const ctor = value.constructor;
+  // The constructor is read from the PROTOTYPE, not from the value. What is
+  // being asked is which class the value is an instance of, and that is a fact
+  // about its prototype; an own `constructor` property is ordinary data that
+  // happens to share the name, and must not decide the value's type. Reading
+  // it off the value would let `{constructor: Error}` -- a plain record --
+  // answer `Error` and be silently rebuilt as one.
+  //
+  // Guard: a null-prototype object has no constructor to find, and an exotic
+  // one may not have a callable one.
+  const proto = Object.getPrototypeOf(value);
+  const ctor = proto === null ? undefined : proto.constructor;
   let tag: NativeTag | null = null;
 
   if (typeof ctor === "function") {
@@ -198,12 +206,11 @@ export function tagFromNativeValue(value: unknown): NativeTag | null {
     // `FabricInstance` values (object-like protocol types).
     if (value instanceof FabricInstance) return NATIVE_TAGS.FabricInstance;
 
-    // Plain objects whose constructor was unusable: a null prototype, or an
-    // own `constructor` property shadowing the real one with something that
-    // is not a class. Both are answered `Object` so the object rule decides
-    // them by name, the same way an indirect array is answered `Array`.
-    const proto = Object.getPrototypeOf(value);
-    if (proto === null || proto === Object.prototype) tag = NATIVE_TAGS.Object;
+    // Null-prototype objects (`Object.create(null)`), which have no
+    // constructor to have been recognized. Answered `Object` so the object
+    // rule decides them by name, the same way an indirect array is answered
+    // `Array`.
+    if (proto === null) tag = NATIVE_TAGS.Object;
   }
 
   // For `Object` and still-null tags: a per-instance `toJSON()` method

--- a/packages/data-model/src/native-type-tags.ts
+++ b/packages/data-model/src/native-type-tags.ts
@@ -198,9 +198,12 @@ export function tagFromNativeValue(value: unknown): NativeTag | null {
     // `FabricInstance` values (object-like protocol types).
     if (value instanceof FabricInstance) return NATIVE_TAGS.FabricInstance;
 
-    // Null-prototype objects (`Object.create(null)`).
+    // Plain objects whose constructor was unusable: a null prototype, or an
+    // own `constructor` property shadowing the real one with something that
+    // is not a class. Both are answered `Object` so the object rule decides
+    // them by name, the same way an indirect array is answered `Array`.
     const proto = Object.getPrototypeOf(value);
-    if (proto === null) tag = NATIVE_TAGS.Object;
+    if (proto === null || proto === Object.prototype) tag = NATIVE_TAGS.Object;
   }
 
   // For `Object` and still-null tags: a per-instance `toJSON()` method

--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -52,8 +52,8 @@ export function isFabricValueLayer(
       // `FabricSpecialObject`, handled above). `FabricPlainObject` is keyed by
       // `string`, so a symbol key has no representation either, and neither
       // does a non-enumerable string key; an accessor-backed property is live
-      // code rather than inert data. The host-unsafe names are a separate
-      // question from inertness -- see `unsafeObjectKeyIn()`.
+      // code rather than inert data. The names this runtime reserves are a
+      // separate question from inertness -- see `unsafeObjectKeyIn()`.
       return isInertPlainObject(value) &&
         (unsafeObjectKeyIn(value) === undefined);
     }
@@ -159,8 +159,8 @@ export function isFabricValue(value: unknown): value is FabricValue {
       // Symbol-keyed and non-enumerable string-keyed properties have no fabric
       // representation, the same as an array's non-index properties; an
       // accessor-backed property is live code rather than inert data. The
-      // host-unsafe names are a separate question from inertness -- see
-      // `unsafeObjectKeyIn()`.
+      // names this runtime reserves are a separate question from inertness --
+      // see `unsafeObjectKeyIn()`.
       if (!isInertPlainObject(item)) return false;
       if (unsafeObjectKeyIn(item) !== undefined) return false;
       const record = item as Record<string, unknown>;

--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -1,6 +1,6 @@
 import { isInertArray } from "@commonfabric/utils/arrays";
 import { isInertPlainObject } from "@commonfabric/utils/objects";
-import { isPlainObject } from "@commonfabric/utils/types";
+import { isPlainObject, unsafeObjectKeyIn } from "@commonfabric/utils/types";
 
 import {
   type FabricPlainObject,
@@ -52,8 +52,10 @@ export function isFabricValueLayer(
       // `FabricSpecialObject`, handled above). `FabricPlainObject` is keyed by
       // `string`, so a symbol key has no representation either, and neither
       // does a non-enumerable string key; an accessor-backed property is live
-      // code rather than inert data.
-      return isInertPlainObject(value);
+      // code rather than inert data. The host-unsafe names are a separate
+      // question from inertness -- see `unsafeObjectKeyIn()`.
+      return isInertPlainObject(value) &&
+        (unsafeObjectKeyIn(value) === undefined);
     }
 
     case "symbol": {
@@ -156,8 +158,11 @@ export function isFabricValue(value: unknown): value is FabricValue {
     } else if (isPlainObject(item)) {
       // Symbol-keyed and non-enumerable string-keyed properties have no fabric
       // representation, the same as an array's non-index properties; an
-      // accessor-backed property is live code rather than inert data.
+      // accessor-backed property is live code rather than inert data. The
+      // host-unsafe names are a separate question from inertness -- see
+      // `unsafeObjectKeyIn()`.
       if (!isInertPlainObject(item)) return false;
+      if (unsafeObjectKeyIn(item) !== undefined) return false;
       const record = item as Record<string, unknown>;
       for (const key of Object.keys(record)) {
         if (!check(record[key])) return false;

--- a/packages/data-model/test/codec-json/JsonEncodingContext.test.ts
+++ b/packages/data-model/test/codec-json/JsonEncodingContext.test.ts
@@ -851,6 +851,91 @@ describe("JsonEncodingContext", () => {
         expect(result["/x"]!["/quote"]).toBe("inner");
       });
     });
+
+    describe("property names this runtime reserves", () => {
+      it("produces a `ProblematicValue` for a reserved key", () => {
+        // The decoder is a boundary where external bytes enter, and the
+        // assignment it rebuilds records with cannot create these names: in a
+        // realm that keeps the `__proto__` accessor, the key would be lost and
+        // the result's prototype repointed to whatever the bytes carried.
+        // Nothing this implementation writes can contain one, so bytes that do
+        // are reported rather than reconstructed.
+        //
+        // The keys are computed on purpose: in an object literal a bare or
+        // quoted `__proto__:` sets the prototype instead of creating a
+        // property, so a literal cannot express this wire shape at all.
+        // `JSON.parse()`, which is how such bytes actually arrive, does create
+        // the own property.
+        expect(fromWireFormat({ ["__proto__"]: { hostile: true }, a: 1 }))
+          .toBeInstanceOf(ProblematicValue);
+        expect(fromWireFormat({ ["constructor"]: "c" }))
+          .toBeInstanceOf(ProblematicValue);
+      });
+
+      it("produces a `ProblematicValue` for a reserved key nested in the graph", () => {
+        const result = fromWireFormat({
+          nested: { ["__proto__"]: 1 },
+        }) as Record<string, unknown>;
+        expect(result.nested).toBeInstanceOf(ProblematicValue);
+        expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+      });
+
+      it("produces a `ProblematicValue` for a reserved key inside `/object`", () => {
+        expect(fromWireFormat({ "/object": { ["__proto__"]: 1 } }))
+          .toBeInstanceOf(ProblematicValue);
+      });
+
+      it("leaves `Object.prototype` untouched where the accessor is standard", () => {
+        // The refusal above is checked in Deno, which replaces
+        // `Object.prototype.__proto__` with a setter that defines an own
+        // property -- so a decoder that assigned the key would look correct
+        // here no matter what. This installs the standard accessor, which is
+        // what browsers have and what this code also runs under, and pins the
+        // outcome the refusal exists to produce: nothing reconstructed, and no
+        // prototype repointed.
+        const saved = Object.getOwnPropertyDescriptor(
+          Object.prototype,
+          "__proto__",
+        );
+        try {
+          Object.defineProperty(Object.prototype, "__proto__", {
+            configurable: true,
+            get(this: object) {
+              return Object.getPrototypeOf(this);
+            },
+            set(this: object, v: unknown) {
+              // Spec-faithful: a no-op unless the value is an object or `null`.
+              if ((typeof v === "object") || (typeof v === "function")) {
+                Object.setPrototypeOf(this, v as object | null);
+              }
+            },
+          });
+
+          const hostile = { hostile: true };
+          expect(fromWireFormat({ ["__proto__"]: hostile, a: 1 }))
+            .toBeInstanceOf(ProblematicValue);
+
+          const nested = fromWireFormat({
+            deep: { ["__proto__"]: hostile },
+          }) as Record<string, unknown>;
+          expect(nested.deep).toBeInstanceOf(ProblematicValue);
+          expect(Object.getPrototypeOf(nested)).toBe(Object.prototype);
+
+          // The payload reached nobody: not the decoded records, and not the
+          // shared prototype every object in the process answers through.
+          expect(
+            (Object.prototype as Record<string, unknown>).hostile,
+          ).toBe(undefined);
+          expect(({} as Record<string, unknown>).hostile).toBe(undefined);
+        } finally {
+          if (saved === undefined) {
+            delete (Object.prototype as Record<string, unknown>)["__proto__"];
+          } else {
+            Object.defineProperty(Object.prototype, "__proto__", saved);
+          }
+        }
+      });
+    });
   });
 
   describe("/quote handling", () => {

--- a/packages/data-model/test/native-conversion.test.ts
+++ b/packages/data-model/test/native-conversion.test.ts
@@ -812,6 +812,42 @@ describe("native-conversion", () => {
 
     // `-0`, `NaN`, `+Infinity`, and `-Infinity` are valid `FabricValue`
     // members and pass through unchanged.
+    describe("property names this runtime reserves", () => {
+      // A restriction of this runtime rather than of the data model: such an
+      // object is perfectly inert, and its keys are strings like any other.
+      // `__proto__` is refused because the assignment that rebuilds records
+      // cannot create it, `constructor` because other boundaries here already
+      // drop or refuse it.
+      it("throws for `__proto__`, naming it as the cause", () => {
+        expect(() => fabricFromNativeValue({ ["__proto__"]: 1, a: 2 })).toThrow(
+          "Not representable as a `FabricValue`: object with a property name " +
+            "this runtime reserves (`__proto__`)",
+        );
+      });
+
+      it("throws for `constructor`, naming it as the cause", () => {
+        // Type dispatch reads the constructor from the prototype, so an own
+        // `constructor` property no longer decides the value's type: it
+        // reaches the object rule and is named, rather than failing as some
+        // unrecognized type or being rebuilt as whatever class it held.
+        expect(() => fabricFromNativeValue({ ["constructor"]: "c" })).toThrow(
+          "Not representable as a `FabricValue`: object with a property name " +
+            "this runtime reserves (`constructor`)",
+        );
+        expect(() => fabricFromNativeValue({ ["constructor"]: Error })).toThrow(
+          "this runtime reserves (`constructor`)",
+        );
+      });
+
+      it("throws for a reserved name nested in the graph", () => {
+        expect(() => fabricFromNativeValue({ a: { ["__proto__"]: 1 } }))
+          .toThrow("this runtime reserves (`__proto__`)");
+        expect(() => fabricFromNativeValue([{ ["__proto__"]: 1 }])).toThrow(
+          "this runtime reserves (`__proto__`)",
+        );
+      });
+    });
+
     describe("special numbers", () => {
       it("passes `NaN` through", () => {
         expect(Number.isNaN(shallowFabricFromNativeValue(NaN))).toBe(true);
@@ -1865,37 +1901,6 @@ describe("native-conversion", () => {
         expect(Object.isFrozen(obj)).toBe(false);
       });
 
-      it("throws for a host-unsafe property name, naming the cause", () => {
-        // The message says "this JavaScript host" rather than blaming
-        // inertness, because such an object is inert: what it violates is a
-        // restriction of the runtime, not of the data model.
-        expect(() => fabricFromNativeValue({ ["__proto__"]: 1, a: 2 })).toThrow(
-          "Not representable as a `FabricValue`: object with a property name " +
-            "this JavaScript host cannot carry (`__proto__`)",
-        );
-      });
-
-      it("throws for a `constructor` property, reaching the object rule", () => {
-        // Type-tag dispatch reads `value.constructor`, which such an object
-        // shadows with a non-class. It answers `Object` on the prototype
-        // instead, so the value is rejected by name rather than as some
-        // unrecognized type.
-        expect(() => fabricFromNativeValue({ ["constructor"]: "c" })).toThrow(
-          "Not representable as a `FabricValue`: object with a property name " +
-            "this JavaScript host cannot carry (`constructor`)",
-        );
-      });
-
-      it("throws for a host-unsafe name nested in the graph", () => {
-        expect(() => fabricFromNativeValue({ a: { ["__proto__"]: 1 } }))
-          .toThrow(
-            "this JavaScript host cannot carry (`__proto__`)",
-          );
-        expect(() => fabricFromNativeValue([{ ["__proto__"]: 1 }])).toThrow(
-          "this JavaScript host cannot carry (`__proto__`)",
-        );
-      });
-
       it("throws for a null-prototype object at the top level", () => {
         const obj = Object.create(null) as Record<string, unknown>;
         obj.x = 1;
@@ -2094,7 +2099,7 @@ describe("native-conversion", () => {
         expect(isFabricCompatible({ data: sub })).toBe(false);
       });
 
-      it("rejects a host-unsafe property name", () => {
+      it("returns `false` for a property name this runtime reserves", () => {
         expect(isFabricCompatible({ ["__proto__"]: 1 })).toBe(false);
         expect(isFabricCompatible({ ["constructor"]: 1 })).toBe(false);
         expect(isFabricCompatible({ nested: { ["__proto__"]: 1 } })).toBe(

--- a/packages/data-model/test/native-conversion.test.ts
+++ b/packages/data-model/test/native-conversion.test.ts
@@ -1865,6 +1865,37 @@ describe("native-conversion", () => {
         expect(Object.isFrozen(obj)).toBe(false);
       });
 
+      it("throws for a host-unsafe property name, naming the cause", () => {
+        // The message says "this JavaScript host" rather than blaming
+        // inertness, because such an object is inert: what it violates is a
+        // restriction of the runtime, not of the data model.
+        expect(() => fabricFromNativeValue({ ["__proto__"]: 1, a: 2 })).toThrow(
+          "Not representable as a `FabricValue`: object with a property name " +
+            "this JavaScript host cannot carry (`__proto__`)",
+        );
+      });
+
+      it("throws for a `constructor` property, reaching the object rule", () => {
+        // Type-tag dispatch reads `value.constructor`, which such an object
+        // shadows with a non-class. It answers `Object` on the prototype
+        // instead, so the value is rejected by name rather than as some
+        // unrecognized type.
+        expect(() => fabricFromNativeValue({ ["constructor"]: "c" })).toThrow(
+          "Not representable as a `FabricValue`: object with a property name " +
+            "this JavaScript host cannot carry (`constructor`)",
+        );
+      });
+
+      it("throws for a host-unsafe name nested in the graph", () => {
+        expect(() => fabricFromNativeValue({ a: { ["__proto__"]: 1 } }))
+          .toThrow(
+            "this JavaScript host cannot carry (`__proto__`)",
+          );
+        expect(() => fabricFromNativeValue([{ ["__proto__"]: 1 }])).toThrow(
+          "this JavaScript host cannot carry (`__proto__`)",
+        );
+      });
+
       it("throws for a null-prototype object at the top level", () => {
         const obj = Object.create(null) as Record<string, unknown>;
         obj.x = 1;
@@ -2061,6 +2092,14 @@ describe("native-conversion", () => {
         sub.push(1, 2);
         expect(isFabricCompatible(sub)).toBe(false);
         expect(isFabricCompatible({ data: sub })).toBe(false);
+      });
+
+      it("rejects a host-unsafe property name", () => {
+        expect(isFabricCompatible({ ["__proto__"]: 1 })).toBe(false);
+        expect(isFabricCompatible({ ["constructor"]: 1 })).toBe(false);
+        expect(isFabricCompatible({ nested: { ["__proto__"]: 1 } })).toBe(
+          false,
+        );
       });
 
       it("rejects an array whose prototype was severed", () => {

--- a/packages/data-model/test/type-check.test.ts
+++ b/packages/data-model/test/type-check.test.ts
@@ -147,6 +147,15 @@ describe("type-check", () => {
         expect(isFabricValueLayer({})).toBe(true);
       });
 
+      it("returns `false` for a host-unsafe property name", () => {
+        // Not a statement about the data model: such an object is perfectly
+        // inert, and a runtime that does not route assignment through a
+        // prototype chain would carry it fine. It is refused because in this
+        // host the name cannot survive the copy that every boundary performs.
+        expect(isFabricValueLayer({ ["__proto__"]: 1, other: 2 })).toBe(false);
+        expect(isFabricValueLayer({ ["constructor"]: 1 })).toBe(false);
+      });
+
       it("returns `false` for a null-prototype object", () => {
         // A record has one shape here: `Object.prototype`-rooted. A prototype
         // is not part of what a value says as data and would not survive
@@ -286,6 +295,14 @@ describe("type-check", () => {
         expect(isFabricValue({})).toBe(true);
         expect(isFabricValue({ a: 1, b: "two", c: null })).toBe(true);
         expect(isFabricValue({ nested: { deeply: { value: 1 } } })).toBe(true);
+      });
+
+      it("returns `false` for a host-unsafe property name, at any depth", () => {
+        const unsafe = { ["__proto__"]: 1 };
+        expect(isFabricValue(unsafe)).toBe(false);
+        expect(isFabricValue({ nested: unsafe })).toBe(false);
+        expect(isFabricValue([unsafe])).toBe(false);
+        expect(isFabricValue({ ["constructor"]: 1 })).toBe(false);
       });
 
       it("returns `false` for a null-prototype object, at any depth", () => {

--- a/packages/data-model/test/type-check.test.ts
+++ b/packages/data-model/test/type-check.test.ts
@@ -147,7 +147,7 @@ describe("type-check", () => {
         expect(isFabricValueLayer({})).toBe(true);
       });
 
-      it("returns `false` for a host-unsafe property name", () => {
+      it("returns `false` for a property name this runtime reserves", () => {
         // Not a statement about the data model: such an object is perfectly
         // inert, and a runtime that does not route assignment through a
         // prototype chain would carry it fine. It is refused because in this
@@ -297,7 +297,7 @@ describe("type-check", () => {
         expect(isFabricValue({ nested: { deeply: { value: 1 } } })).toBe(true);
       });
 
-      it("returns `false` for a host-unsafe property name, at any depth", () => {
+      it("returns `false` for a reserved property name, at any depth", () => {
         const unsafe = { ["__proto__"]: 1 };
         expect(isFabricValue(unsafe)).toBe(false);
         expect(isFabricValue({ nested: unsafe })).toBe(false);

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -168,3 +168,32 @@ const UNSAFE_OBJECT_KEYS = new Set(["__proto__", "constructor"]);
 export function isUnsafeObjectKey(key: string): boolean {
   return UNSAFE_OBJECT_KEYS.has(key);
 }
+
+/**
+ * Returns the host-unsafe own property name the given object carries, if any.
+ *
+ * This asks about the JavaScript host, not about the data model. A property
+ * name is data like any other, and a runtime that does not route property
+ * assignment through a prototype chain -- which is most of them -- has no
+ * unsafe names at all. What makes these two names unusable *here* is that
+ * name-driven copying (`target[key] = value`), which is how records are
+ * rebuilt at every boundary, does not create the property: it reaches
+ * `Object.prototype`'s `__proto__` accessor instead, mutating the copy's
+ * prototype and dropping the value. So a record carrying one cannot survive
+ * a copy in this host, whatever the model says about it.
+ *
+ * The check is two `Object.hasOwn()` calls rather than a key walk, so it costs
+ * nothing per property and can sit on a hot validation path.
+ *
+ * @param value The object to check.
+ * @returns The offending property name, or `undefined` if there is none.
+ */
+export function unsafeObjectKeyIn(value: object): string | undefined {
+  for (const key of UNSAFE_OBJECT_KEYS) {
+    if (Object.hasOwn(value, key)) {
+      return key;
+    }
+  }
+
+  return undefined;
+}

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -170,17 +170,30 @@ export function isUnsafeObjectKey(key: string): boolean {
 }
 
 /**
- * Returns the host-unsafe own property name the given object carries, if any.
+ * Returns the reserved own property name the given object carries, if any.
  *
- * This asks about the JavaScript host, not about the data model. A property
- * name is data like any other, and a runtime that does not route property
- * assignment through a prototype chain -- which is most of them -- has no
- * unsafe names at all. What makes these two names unusable *here* is that
- * name-driven copying (`target[key] = value`), which is how records are
- * rebuilt at every boundary, does not create the property: it reaches
- * `Object.prototype`'s `__proto__` accessor instead, mutating the copy's
- * prototype and dropping the value. So a record carrying one cannot survive
- * a copy in this host, whatever the model says about it.
+ * This asks about this implementation, not about the data model. A property
+ * name is data like any other, and an implementation on a host that does not
+ * route property assignment through a prototype chain -- which is most of them
+ * -- would reserve no names at all. The two here are refused for two different
+ * local reasons, and neither is a limit of the language:
+ *
+ * * `__proto__` cannot be rebuilt by the copying this system actually does.
+ *   Records are reconstructed by assignment (`target[key] = value`) and
+ *   `Object.assign()`, and for this name both reach `Object.prototype`'s
+ *   accessor instead of creating a property: the value is dropped, and the
+ *   copy's prototype is repointed as well when that value is an object or
+ *   `null`. Faithful mechanisms do exist -- spread, `Object.fromEntries()`,
+ *   `Object.defineProperty()`, and `JSON.parse()` all carry the name -- so
+ *   what stands in the way is the copy loops, not JavaScript.
+ * * `constructor` copies faithfully. It is reserved because other boundaries
+ *   in this implementation already refuse it: the projection to native values
+ *   drops it, and `FabricError` throws on it. Accepting it here would mean
+ *   admitting a key that a later boundary discards without saying so.
+ *
+ * Both are therefore removable, by rebuilding the copy loops on a faithful
+ * mechanism and revisiting the boundaries that filter these names. Until then
+ * the reservation is what keeps a record from being corrupted in transit.
  *
  * The check is two `Object.hasOwn()` calls rather than a key walk, so it costs
  * nothing per property and can sit on a hot validation path.

--- a/packages/utils/test/types.test.ts
+++ b/packages/utils/test/types.test.ts
@@ -14,6 +14,7 @@ import {
   isString,
   isUnsafeObjectKey,
   Mutable,
+  unsafeObjectKeyIn,
 } from "@commonfabric/utils/types";
 
 type ImmutableObj<T> = {
@@ -411,6 +412,73 @@ describe("types", () => {
             "isUnsafeObjectKey() is now open to prototype pollution.",
         );
         throw e;
+      }
+    });
+  });
+
+  describe("unsafeObjectKeyIn", () => {
+    it("finds an unsafe own key", () => {
+      const withProto = { other: 1 } as Record<string, unknown>;
+      Object.defineProperty(withProto, "__proto__", {
+        value: 1,
+        enumerable: true,
+        writable: true,
+        configurable: true,
+      });
+      expect(unsafeObjectKeyIn(withProto)).toBe("__proto__");
+      expect(unsafeObjectKeyIn({ ["constructor"]: 1 })).toBe("constructor");
+    });
+
+    it("returns `undefined` for ordinary objects", () => {
+      expect(unsafeObjectKeyIn({})).toBe(undefined);
+      expect(unsafeObjectKeyIn({ a: 1, prototype: 2, toString: 3 })).toBe(
+        undefined,
+      );
+    });
+
+    it("ignores an inherited unsafe name", () => {
+      // Every object inherits `constructor`, and most inherit `__proto__`.
+      // Only an OWN property is the value's own data, and only that can fail
+      // to survive a copy.
+      expect(unsafeObjectKeyIn(Object.create({ constructor: 1 }))).toBe(
+        undefined,
+      );
+    });
+
+    it("pins the host behavior the restriction exists for", () => {
+      // The companion to the `__proto__`-is-inert test above, from the other
+      // side. Deno neutralises the accessor, so a copy loop there is safe and
+      // no test can see the hazard. A realm that keeps the accessor -- every
+      // browser, and this repo ships `data-model` to browsers -- loses the
+      // property and mutates the copy instead. That is what makes these names
+      // uncarryable HERE, and the day no realm behaves this way is the day the
+      // restriction can go.
+      const saved = Object.getOwnPropertyDescriptor(
+        Object.prototype,
+        "__proto__",
+      );
+      try {
+        Object.defineProperty(Object.prototype, "__proto__", {
+          configurable: true,
+          get(this: object) {
+            return Object.getPrototypeOf(this);
+          },
+          set(this: object, v: object | null) {
+            Object.setPrototypeOf(this, v);
+          },
+        });
+
+        const copy: Record<string, unknown> = {};
+        copy["__proto__"] = { marker: true };
+
+        expect(Object.hasOwn(copy, "__proto__")).toBe(false);
+        expect(Object.getPrototypeOf(copy)).not.toBe(Object.prototype);
+      } finally {
+        if (saved === undefined) {
+          delete (Object.prototype as Record<string, unknown>)["__proto__"];
+        } else {
+          Object.defineProperty(Object.prototype, "__proto__", saved);
+        }
       }
     });
   });

--- a/packages/utils/test/types.test.ts
+++ b/packages/utils/test/types.test.ts
@@ -417,7 +417,7 @@ describe("types", () => {
   });
 
   describe("unsafeObjectKeyIn", () => {
-    it("finds an unsafe own key", () => {
+    it("returns the offending name for a reserved own key", () => {
       const withProto = { other: 1 } as Record<string, unknown>;
       Object.defineProperty(withProto, "__proto__", {
         value: 1,
@@ -436,7 +436,7 @@ describe("types", () => {
       );
     });
 
-    it("ignores an inherited unsafe name", () => {
+    it("returns `undefined` for an inherited reserved name", () => {
       // Every object inherits `constructor`, and most inherit `__proto__`.
       // Only an OWN property is the value's own data, and only that can fail
       // to survive a copy.
@@ -445,7 +445,7 @@ describe("types", () => {
       );
     });
 
-    it("pins the host behavior the restriction exists for", () => {
+    it("is needed because assignment loses the key where the accessor is standard", () => {
       // The companion to the `__proto__`-is-inert test above, from the other
       // side. Deno neutralises the accessor, so a copy loop there is safe and
       // no test can see the hazard. A realm that keeps the accessor -- every
@@ -463,8 +463,14 @@ describe("types", () => {
           get(this: object) {
             return Object.getPrototypeOf(this);
           },
-          set(this: object, v: object | null) {
-            Object.setPrototypeOf(this, v);
+          set(this: object, v: unknown) {
+            // Spec-faithful: the setter is a no-op unless the value is an
+            // object or `null`. A primitive-valued `__proto__` assignment
+            // silently does nothing at all -- the key is still lost, but the
+            // prototype is untouched.
+            if ((typeof v === "object") || (typeof v === "function")) {
+              Object.setPrototypeOf(this, v as object | null);
+            }
           },
         });
 
@@ -473,6 +479,13 @@ describe("types", () => {
 
         expect(Object.hasOwn(copy, "__proto__")).toBe(false);
         expect(Object.getPrototypeOf(copy)).not.toBe(Object.prototype);
+
+        // A primitive value loses the key without touching the prototype:
+        // the same data loss, a quieter failure.
+        const primitive: Record<string, unknown> = {};
+        primitive["__proto__"] = "payload";
+        expect(Object.hasOwn(primitive, "__proto__")).toBe(false);
+        expect(Object.getPrototypeOf(primitive)).toBe(Object.prototype);
       } finally {
         if (saved === undefined) {
           delete (Object.prototype as Record<string, unknown>)["__proto__"];


### PR DESCRIPTION
A record keyed `__proto__` satisfied every rule the data model has, and was then
corrupted by the machinery meant to carry it. Both the write path and the
decoder now refuse that name and `constructor`, loudly, instead of mangling them
in transit.

Found by the cubic bot on #5261, which reported it as caused by that PR. It was
not — the behavior is identical on `main` well before it.

## The bug

Records are rebuilt by name-driven copying at every boundary — conversion,
cloning, decoding. In JavaScript, `target[key] = value` for `__proto__` does not
create a property: it reaches `Object.prototype`'s accessor. Measured in a realm
that keeps that accessor:

```
input {["__proto__"]: "payload", other: 1}   isFabricValue: true
fabricFromNativeValue  ->  own keys: other   proto MUTATED   isFabricValue(result): FALSE
cloneIfNecessary       ->  own keys: other   proto MUTATED
valueFromJson          ->  own keys: a       proto MUTATED   <- decode side, no validation at all
```

The conversion functions returned something their own membership check rejects,
and the decoder reconstructed a polluted object from stored bytes.

**Why nothing caught it.** Deno replaces `Object.prototype.__proto__` with a
setter that defines an own property, so assignment there behaves and every test
passes. Browsers keep the standard accessor, and `data-model` ships to browsers.
The worst case was cross-environment: the server stores the key fine, and a
browser decoding that record gets a polluted object.

## The fix

Both names are refused, at the write path and at the decoder, via a new
`unsafeObjectKeyIn()` — a neighbour to the `isUnsafeObjectKey()` this project
already applies at five other boundaries, sharing its key set. Two
`Object.hasOwn()` calls, no key walk, so it sits on the hot validation path for
free. The decoder reports a `ProblematicValue`, matching how it already handles
reserved `/`-prefixed keys in the same function.

**Two names, two unrelated reasons** — and the docs say which is which, because
they have different removal conditions:

- **`__proto__`** cannot be rebuilt by the copying this runtime performs. Its
  loops use assignment and `Object.assign()`, both of which reach the accessor.
  Faithful mechanisms exist — spread, `Object.fromEntries()`,
  `Object.defineProperty()`, `JSON.parse()` — so what stands in the way is the
  copy loops, not JavaScript.
- **`constructor` copies faithfully.** It is reserved because other boundaries
  here already refuse it: the projection to native values drops it, and
  `FabricError` throws on it. Admitting it would mean accepting a key that a
  later boundary discards without saying so.

## Type dispatch reads the constructor from the prototype

`tagFromNativeValue()` read `value.constructor`, so an own `constructor`
property decided the value's type. That is what made a `constructor` key fail,
and it was doing worse than failing:

| value | before | now |
| --- | --- | --- |
| `{constructor: Error}` | **silently rebuilt as `FabricError`** | rejected by name |
| `{constructor: Uint8Array}` | **silently rebuilt as `FabricBytes`** | rejected by name |
| `{constructor: Date}` | throws "Date with extra enumerable properties" | rejected by name |
| `{constructor: "c"}` | throws "not a recognized fabric type" | rejected by name |

Asking which class a value is an instance of is a question about its prototype;
an own `constructor` is ordinary data that happens to share the name. Dispatch
now reads it from the prototype, which fixes the root rather than compensating
for it. Verified across 27 shapes: exactly those five `{constructor: <class>}`
cases differ from the previous behavior, and nothing else moves.

## This is a restriction of this runtime, not of the model

A property name is data. An implementation on a host that does not route
property assignment through a prototype chain — Rust, Swift, C++, Python — would
reserve no names at all, and §1.5 says so, along with what removal would take
here. The check is composed at the chokepoints rather than folded into
`isInertPlainObject()`, so it can be deleted as a unit rather than extracted
from a model predicate. The message names the runtime rather than blaming
inertness, which such an object does not violate:

```
Not representable as a `FabricValue`: object with a property name
this runtime reserves (`__proto__`)
```

## Tests

`utils/test/types.test.ts` already pinned that Deno neutralises `__proto__`,
with a comment warning whoever rolls a Deno version that changes it. This adds
the mirror image: a spec-faithful accessor is installed, and the test pins that
assignment there loses the property — including the quieter primitive-valued
case, where the key vanishes and the prototype is untouched. That is the fact
the whole restriction rests on, and the day no realm behaves that way is the day
it can go.

Plus rejection coverage at each predicate, each conversion entry point, and the
decoder — top level, nested, inside an array, and through the `/object` arm.

One trap worth knowing, which bit these tests first: in an object *literal*,
even a quoted `"__proto__":` sets the prototype rather than creating an own
property. Only a computed key expresses the shape at all. `JSON.parse()`, which
is how such bytes actually arrive, does create the own property.

## Alternative considered

Making the copy loops `__proto__`-safe instead, keeping the names legal.
Rejected after finding that five existing boundaries already treat them as
not-carried — one by throwing — so "legal key" would have meant reversing those
deliberate conventions across ~15 sites, and would still have left the decoder
needing a decision. Worth revisiting together with them if the long-term goal of
universally-legal property names is taken up in earnest; the docs are written so
that remains a tractable task rather than reading as a language limitation.

## Also in here

Every `as unknown as FabricValue` in `JsonEncodingContext.ts` turned out to
assert something the type system already knew — `ProblematicValue` is a
`FabricValue`, and the wire values passed to it as `state` are assignable
outright. Eight dead casts, four of them written by this branch by copying the
shape of the `/`-prefixed arm beside them. `as X` at least fails when it is
wrong; `as unknown as X` disables the check, so a stale one can outlive its
reason silently — which is what happened.

The same pattern appears in the `[DEEP_FREEZE]` of `ProblematicValue`,
`UnknownValue`, `FabricError`, and `FabricLink`, and removing it from the first
compiles clean. Left for a follow-up, being outside the files this change
otherwise touches.

## Verification

`deno fmt --check`, `deno lint`, `deno task check`, `deno task check-docs`, and
the full workspace suite green at 224.3s on the branch head. `deno.lock` clean. No existing test pinned acceptance
of either name.
