### PR TITLE
docs(patterns): extract a live pattern-update-testing spec, archive the plan

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -152,7 +152,7 @@ jobs:
       # that now exits 1 naming the key. Emptiness is judged per leaf, so
       # partial loss counts too.
       #
-      # The limit worth knowing (docs/plans/pattern-update-state-continuity.md):
+      # The limit worth knowing (docs/specs/pattern-update-testing.md):
       # a value that merely CHANGED is warned about rather than failed on,
       # because a replay recomputes as well as reads. So a moved key whose new
       # slot the pattern SEEDS reads back non-empty and only warns. The same

--- a/docs/development/TESTING.md
+++ b/docs/development/TESTING.md
@@ -169,6 +169,11 @@ run directory.
   call the LLM, including the test-environment guard and conversation fixtures.
 - [UI_TESTING.md](UI_TESTING.md) — testing shadow DOM components in browser
   integration tests.
+- [../specs/pattern-update-testing.md](../specs/pattern-update-testing.md) —
+  the two CI gates standing between an incompatible pattern and every piece
+  running it: contract compatibility (`deno task pattern-compat`) and state
+  continuity (`deno task pattern-vintage`), what each proves, and what an
+  author does to add a pattern to the fixture set.
 - [../common/workflows/pattern-testing.md](../common/workflows/pattern-testing.md)
   — writing and running pattern tests with `cf test`. The agent-oriented version
   is [../common/ai/pattern-testing-guide.md](../common/ai/pattern-testing-guide.md),

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -130,6 +130,11 @@ One line per archived document; each document's header carries the fuller
 - [2026-03-17-ct-exec-fuse-callables.md](plans/2026-03-17-ct-exec-fuse-callables.md)
   and [its test plan](plans/2026-03-17-ct-exec-fuse-callables-test-plan.md) —
   `cf exec` and mounted callable files.
+- [pattern-update-state-continuity.md](plans/pattern-update-state-continuity.md)
+  — the Tier 2 state-continuity gate: capture and replay machinery,
+  test-populated vintages, and value comparison, executed 2026-07/08. Records
+  the measurements that decided the design, including the ones that reversed
+  it (raw beats gzipped storage; a cross-DID restore reads fine).
 - [assertion-diagnostics.md](plans/assertion-diagnostics.md) — power-assert
   operand reporting for pattern-test assertions, with the compile-time
   constraints that shaped it, executed 2026-07.

--- a/docs/history/plans/pattern-update-open-argument-investigation.md
+++ b/docs/history/plans/pattern-update-open-argument-investigation.md
@@ -3,7 +3,7 @@ status: historical
 created: 2026-07-30
 archived: 2026-07-30
 reason: "Investigation record: why the open-argument update class went unvalidated, and the correction of an earlier measurement that pointed at the wrong mechanism."
-superseded-by: docs/plans/pattern-update-state-continuity.md
+superseded-by: docs/specs/pattern-update-testing.md
 ---
 
 # Open-argument update validation: what was actually broken
@@ -11,7 +11,7 @@ superseded-by: docs/plans/pattern-update-state-continuity.md
 A record of one investigation, kept because its conclusion reversed a
 measurement this repository had already written down as fact. The behaviour it
 describes has since changed; read
-[`docs/plans/pattern-update-state-continuity.md`](../../plans/pattern-update-state-continuity.md)
+[`docs/specs/pattern-update-testing.md`](../../specs/pattern-update-testing.md)
 for the current system.
 
 ## The gap

--- a/docs/history/plans/pattern-update-state-continuity.md
+++ b/docs/history/plans/pattern-update-state-continuity.md
@@ -1,3 +1,11 @@
+---
+status: historical
+created: 2026-07-29
+archived: 2026-08-01
+reason: "Executed plan; stages 1-4 and stage 5's value comparison shipped. The live description of the resulting gates is docs/specs/pattern-update-testing.md."
+superseded-by: docs/specs/pattern-update-testing.md
+---
+
 # Pattern update state continuity (Tier 2)
 
 Status: In progress. Stages 1–4 are complete and the tier is now a REAL GATE:
@@ -69,7 +77,7 @@ land or the plan is abandoned, archive this document under
 `home.tsx`, `default-app.tsx`, and the profile patterns auto-update: the runtime
 resolves a source pointer to a current identity and swaps the pattern in place
 onto the same result cell. The specification is
-[`docs/specs/pattern-imports/pattern-updates.md`](../specs/pattern-imports/pattern-updates.md),
+[`docs/specs/pattern-imports/pattern-updates.md`](../../specs/pattern-imports/pattern-updates.md),
 and it already names this tier as required work — "CI and golden replay tests
 must exercise representative prior state and verify that the proposed source
 still reads and preserves it".
@@ -150,7 +158,7 @@ Measured on branch `tier2`, not assumed:
 | Every case discriminates — each goes red under a mutation of the thing it claims to test | measured by mutation: dropping `expectedPatternIdentity` reds the rejection case; no-oping the snapshot restore reds **five of six** (the sixth takes no snapshot); undoing `.for('itemList')` reds the storage-move case; giving the argument candidate a COMPATIBLE type reds the argument case |
 | A stranded-data assertion needs its control in the SAME case | measured: with the restore no-oped, the storage-move case alone stayed GREEN — `items === []` is also what an unrestored fixture reads. It now replays the vintage over the same snapshot first, and the argument case carries the same control for the same reason |
 | Tier 1 **defers** the open-argument evolution class to a runtime guard, and that guard now fires on both update routes | over an open argument object, a candidate naming a new optional field of any type is waved through (`schema-compatibility.ts`, "Open objects remain evolvable…") on the ground that the runner validates the piece's merged durable arguments. Measured on both routes: the hot-swap refused it already; the roll-forward materialize now does too, with `updated arguments do not match the candidate schema: count: value does not match type number`, and the captured bytes survive the refusal. Guarded in `packages/runner/test/pattern-update-argument-validation.test.ts` (both routes, plus the cold-link control) and replayed from a captured vintage in `state-continuity.test.ts` |
-| The `{ unresolvedLinkRaw }` leniency draws the link/plain line by itself | measured: `overlayUnresolvedLinkPlaceholders` substitutes the opaque placeholder only where the *raw* value at that slot is a cell link that materialized to nothing, so a plain wrong-typed value reaches `validateSchemaValue` and is rejected, under both write shapes (argument supplied at `run()`, and argument written through the root's `argument` meta the way the capture does). Validating an update strictly therefore costs nothing in CT-1917 deferral, and needs no change to this path. An investigation record of a superseded reading of this mechanism is in [`docs/history/plans/pattern-update-open-argument-investigation.md`](../history/plans/pattern-update-open-argument-investigation.md) |
+| The `{ unresolvedLinkRaw }` leniency draws the link/plain line by itself | measured: `overlayUnresolvedLinkPlaceholders` substitutes the opaque placeholder only where the *raw* value at that slot is a cell link that materialized to nothing, so a plain wrong-typed value reaches `validateSchemaValue` and is rejected, under both write shapes (argument supplied at `run()`, and argument written through the root's `argument` meta the way the capture does). Validating an update strictly therefore costs nothing in CT-1917 deferral, and needs no change to this path. An investigation record of a superseded reading of this mechanism is in [`docs/history/plans/pattern-update-open-argument-investigation.md`](pattern-update-open-argument-investigation.md) |
 | A repair path cannot tell an update from a replay by the pattern POINTER | the roll-forward materialize commits the candidate's identity and then calls `runSynced` (`pieces-controller.ts`), and `PatternUpdater`'s instantiated mode moves the pointer with no setup at all, leaving a root that boots through the cold-start setup repair. Both reach setup with the pointer already naming the pattern being installed, so `samePattern` is true for what is an update. `patternSetupIdentity` — stamped only once setup has staged an identity's schema, arguments, internal cells and result projection — is the signal that survives, and `PatternUpdater` already used it for the same purpose (`setupNeedsRepair`). Now read in `setupInternal` via `storedSetupMarker`, which returns `"matches" | "other" | "absent"` — three states rather than a boolean, because an absent marker is not evidence that the running graph is this pattern and must not be read as one. The routes that hand setup a pattern the pointer does not name yet (`PatternUpdater`'s default-root apply, `cf piece setsrc`) were recognized as changes already, which is why they validated before this change |
 | An ABSENT setup marker still skips the re-stage, and that currently covers most roots | deliberate, and the residual: a root written before the marker existed cannot be told from a pending update, and re-staging every such root would validate and rewrite defaults over arguments no update is touching. The window is one setup wide per root and needs a pre-stamped pointer, so an ordinary identity change (`samePattern` false) validates regardless. What the arithmetic understates: `patternSetupIdentity` was introduced 2026-07-24, so a root written before then is exempt for its first repair-route update — and aged roots are exactly the population likeliest to hold an argument a new schema cannot read. This tier does NOT cover them: a capture runs setup through the current runner, so a captured vintage is always marked. The exemption is pinned as a decision in `pattern-update-argument-validation.test.ts` (marker stripped, update admitted, marker written on the way through so the exemption closes behind itself) |
 | Re-staging widens the repair transaction's conflict set | the re-stage reads the stored argument and `validateArgument` materializes it, and `ignoreReadForScheduling` suppresses scheduling only — it is not `ignoreReadForCommit` — so both reads join the commit's conflict set on paths that previously did neither. Accepted rather than closed, with the mitigation stated narrowly: the `runSynced` callers reach `applySetupState` inside an `editWithRetry`, so a conflict retries rather than failing the repair, and `runSynced` pre-syncs the cells it is about to set up — but `swapToPattern` uses a bare `edit()`, and the marker read itself sits in `setupInternal` and so joins every setup's conflict set, including a caller-managed transaction that does not retry. The nested-piece repair opts out of the re-stage entirely, so it adds neither read. Not reproduced; recorded because the internal-cell code one screen up avoids exactly this hazard for its own probe read |
@@ -186,7 +194,7 @@ restoring is a file copy. A JSON dump would need a re-writer that reconstructs
 docs, causes, and links — and getting causes wrong silently produces a fixture
 that is not the state that was captured. Restore is same-DID; re-keying is an
 unbounded migration that destroys the fidelity the fixture exists to buy (see
-[`space-clone-rehearsal.md`](space-clone-rehearsal.md)).
+[`space-clone-rehearsal.md`](../../plans/space-clone-rehearsal.md)).
 
 **Every capture lives in git. DECIDED — this reverses the original split.**
 Auto captures were to live in CI artifacts because "at ~1.5 MB a floor,
@@ -882,9 +890,9 @@ Three further limits, all measured, all in the gate as shipped:
 
 ## References
 
-- [`docs/specs/pattern-imports/pattern-updates.md`](../specs/pattern-imports/pattern-updates.md)
+- [`docs/specs/pattern-imports/pattern-updates.md`](../../specs/pattern-imports/pattern-updates.md)
   — the updater this tier guards, and the § that requires this work
-- [`space-clone-rehearsal.md`](space-clone-rehearsal.md) — same-DID reasoning
+- [`space-clone-rehearsal.md`](../../plans/space-clone-rehearsal.md) — same-DID reasoning
   and the rehearsal practice this shares mechanics with
 - `packages/piece/test/check-update-default-pattern.test.ts` — the update path
   driven with inline sources; stage 2 drives it from a captured vintage instead

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -26,8 +26,6 @@ a record: archive it to `docs/history/plans/` following the procedure in
   optional CI adoption and further fixture hardening.
 - [Inverting the physics of trust](inverting-the-physics-of-trust.md) explains
   the runtime's trust model and the work that follows from it.
-  sequences the replay tier that proves an updated pattern can still read the
-  state its predecessor wrote.
 - [Pattern verb contract implementation](pattern-verb-contract-implementation.md)
   sequences the implementation of the
   [pattern verb contract](pattern-verb-contract.md).

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -26,7 +26,6 @@ a record: archive it to `docs/history/plans/` following the procedure in
   optional CI adoption and further fixture hardening.
 - [Inverting the physics of trust](inverting-the-physics-of-trust.md) explains
   the runtime's trust model and the work that follows from it.
-- [Pattern update state continuity](pattern-update-state-continuity.md)
   sequences the replay tier that proves an updated pattern can still read the
   state its predecessor wrote.
 - [Pattern verb contract implementation](pattern-verb-contract-implementation.md)

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -21,6 +21,7 @@ decision is reversed or superseded).
 ### Pattern construction and authoring
 
 - [Pattern testing](PATTERN_TESTING_SPEC.md)
+- [Pattern update testing](pattern-update-testing.md)
 - [Pattern construction](pattern-construction/README.md)
 - [Pattern imports](pattern-imports/README.md)
 - [TypeScript transformer](ts-transformer/README.md)

--- a/docs/specs/pattern-update-testing.md
+++ b/docs/specs/pattern-update-testing.md
@@ -1,0 +1,330 @@
+# Pattern update testing
+
+Two CI gates stand between an incompatible pattern and every piece running it.
+This document specifies what each one proves, what it deliberately does not,
+and what an author does to participate.
+
+## Why the gates exist
+
+The automatic pattern updater performs **no structural check at all**. `cf
+piece setsrc` refuses an incompatible replacement by calling
+`assertPatternSchemasBackwardCompatible`, but the automatic path compiles the
+new source, verifies the entry identity, and applies it. So CI is the only
+thing standing between an incompatible pattern and a running piece, and a bad
+update does not throw — it leaves a piece that can no longer materialize.
+
+The two gates guard different halves of the same risk:
+
+| | Gate | CI job | What it proves |
+| --- | --- | --- | --- |
+| Tier 1 | `deno task pattern-compat` | Pattern Update Compatibility | The **contract** a pattern declares can still be applied over every contract it has declared before |
+| Tier 2 | `deno task pattern-vintage` | Pattern Update State Continuity | A real **document** written by an older version is still readable, and its data survives |
+
+Tier 1 is a statement about schemas. Tier 2 proves the stronger thing schemas
+cannot say. Neither subsumes the other: a contract can stay compatible while
+the data goes unreachable, and a fixture can only cover patterns some test
+actually instantiates.
+
+## Tier 1 — contract compatibility
+
+Compiles **every** authored pattern under `packages/patterns/`, derives its
+argument and result schemas, and proves the current contract can be applied
+over every contract recorded for it under `packages/patterns/baselines/`.
+There is no opt-in: a pattern is covered by existing.
+
+Baselines are **append-only**, enforced mechanically by
+`tasks/check-baselines-append-only.ts` (CI job: Pattern Baselines
+Append-Only). An author-run `--update` that could remove a baseline could
+remove the very one that would have caught a break.
+
+### Findings and their remedies
+
+- **`contract <hash> is not recorded`** — the pattern's contract changed and
+  the new one has no baseline. Run `deno task pattern-compat --update` and
+  commit the recorded baseline. Routine.
+- **`cannot be applied over baseline <label>`** — the change would break
+  pieces running an older version. This **cannot be recorded away**:
+  `--update` records only when "not recorded" is the *sole* finding, so an
+  incompatible contract is never written to a baseline. The remedy is to
+  change the pattern, usually by giving a new required field a `Default<>`.
+
+  This is deliberate. An incompatible contract cannot merge, so it never
+  ships; recording it would force a later corrected contract to prove itself
+  against a version that only ever existed in a failed CI run, with no way to
+  remove it.
+- **`<role> schema is not valid on its own terms`** — the schema fails
+  definition validation independently of any baseline.
+- **`has N baseline(s) but yields no contract now`** — a file that used to be
+  a pattern no longer exports one. Every piece tracking that path is pinned to
+  its current pattern **forever**: the updater's identity probe fails and
+  nothing surfaces on the piece. Restore the pattern, or delete its baseline
+  directory to record the retirement deliberately.
+- **`newly fails to evaluate`** — a pattern that cannot evaluate gets no
+  contract, so no baseline, so no check, forever. Fix it, or add it to
+  `tasks/pattern-compat-unevaluable.ts` with a reason. That allowlist can only
+  shrink: a listed pattern that evaluates again must leave the list, or its
+  exemption outlives the breakage it was granted for.
+
+An already-recorded contract is not re-validated. It was proved when recorded
+and has not changed since, and both the definition validator and the subset
+proof blow up combinatorially on some real schemas — so the steady state, where
+no contract changed, costs nothing beyond the compile.
+
+## Tier 2 — state continuity
+
+Replays committed SQLite stores — real state, written through a pattern's own
+handlers by running its own tests — under today's pattern source.
+
+### What a green run asserts
+
+Per fixture:
+
+- the vintage **restored**: its manifest contains the identity the filename
+  records, checked before anything is applied;
+- today's source **resolves and compiles** for every recorded instantiation;
+- the fixture actually **holds** each recorded root, checked per target before
+  anything is applied to it;
+- the setup commit carrying the artifact onto that root is **not refused** and
+  completes;
+- the root then **reads as something** rather than nothing;
+- every value the vintage held is **still readable** afterwards.
+
+The restore and per-root controls are not ceremony. An empty or truncated
+store presents as a fresh space, today's source materializes onto a fresh space
+happily, and without those controls every remaining check passes while nothing
+has been replayed. A root can also be absent while the fixture is otherwise
+good — recorded in a space that did not travel, in a companion store that
+restored empty, or at a cell id nothing ever wrote.
+
+Across the run, `isClean` additionally requires a positive number of fixtures
+replayed, a positive number of candidates, and a positive number of upgrade
+targets. A run that examined nothing is a failure, not a pass. A `beforeunload`
+guard turns "the process ended without reaching a verdict" into exit 1 — a
+pattern that does not compile and a corrupt fixture both reject a promise
+nobody awaits while the promise the replay awaits never settles.
+
+### The class this catches that Tier 1 cannot
+
+Move where a field is stored — `.for("journal")` becomes `.for("journalMoved")`
+— and the declared contract does not change by a byte, while every document
+written under the old name goes unreachable. Nothing throws. Measured on the
+real `home.tsx`, that exits 1 naming the key and showing what was there.
+
+Emptiness is judged **per leaf at any depth**, so partial loss counts: two of
+three rows disappearing is a finding, not a warning. Judged only at the top, a
+`.for()` list would fail solely when it emptied entirely.
+
+### What it compares, and what it excludes
+
+The comparison reads the vintage under the root's **own stored schema**, so it
+sees the data as the version that wrote it did, and compares only keys that
+were present before — an update may legitimately *add* a field, which is what
+`Default<>` is for.
+
+That schema is relaxed at its `unknown` positions first, on both sides: a
+schema-driven read resolves nothing there, so a key an index signature covers
+would otherwise arrive as `undefined` however much state it holds,
+indistinguishable from a key the document does not hold.
+
+It compares **state, not renderings**. `$UI` and its variants are recomputed by
+the setup and a stored rendering never matches a fresh one, so comparing them
+would red every pattern edit while saying nothing about data. Every other key
+is compared, `$NAME` included. Excluding those names is not sufficient on its
+own — a `map`-body hoist is a recorded instantiation whose whole result is a
+vnode under no `$UI` — so a rendering is also recognised by shape, wherever it
+sits.
+
+What a root holds at a cell or stream position is compared as the **document it
+points at**, so a field that moved to a different document is still a finding.
+
+### Findings are graded
+
+A replay recomputes as well as reads, so a derived value the vintage never
+pulled on can resolve to something better this time. A value that merely
+**changed** is reported with `console.warn` and does not fail; a non-empty
+value that went **empty** does fail.
+
+The limit this buys, pinned by name in `tasks/pattern-vintage-run.test.ts`: a
+moved `.for()` key whose new slot the pattern *seeds* reads back non-empty and
+only warns. The same move into a slot that stays empty fails. Weighting a key
+by whether it is backed by an `of:` document rather than a `computed:` one is
+the candidate for closing that gap.
+
+## Fixture layout
+
+```
+packages/piece/test/vintages/<test key>/<tier>/<iso>-<identity>.sqlite
+packages/piece/test/vintages/<test key>/<tier>/<iso>-<identity>.sqlite.spaces/<did>.sqlite
+```
+
+- **`<test key>`** is the path under `packages/patterns/` of the **test** that
+  produced the fixture. Keyed by test rather than by pattern because a test
+  need not be named after what it drives, and one fixture routinely covers
+  several patterns.
+- **`<identity>`** is provenance, not an address: it records which version
+  wrote the state. Nothing looks a fixture up by it — the replay enumerates the
+  directory and replays everything it finds. A gate that selected fixtures by
+  identity would silently cover nothing the moment naming drifted; enumeration
+  cannot.
+- **`<iso>`** is a capture timestamp, with `:` substituted so the name is legal
+  on Windows and still sorts chronologically. Retention sorts on this field.
+- The **`.sqlite.spaces/`** directory carries the run's other spaces. A capture
+  that instantiates a pattern via `Factory.inSpace(...)` writes a second store,
+  and a fixture holding only the first would record roots whose state it does
+  not have. It is part of the fixture, not a fixture itself, so
+  `parseVintagePath` declines everything inside one.
+
+The tree is deliberately **not** under `packages/patterns/`.
+`tasks/build-binaries.ts` passes that whole directory to `deno compile
+--include`, which is recursive over non-source files, so fixtures would ship
+inside the toolshed binary; and `PatternsServer` serves the same directory by
+path, so they would be fetchable from any deployment.
+
+Fixtures are stored **raw**, not compressed. A store is mostly slack and gzips
+15–48x, so pre-compressing looks free — but it defeats git's *delta*
+compression, which is the mechanism that makes accumulating vintages cheap. Two
+raw captures of `home.tsx` cost 232.86 KiB packed against 232.50 KiB for one; two
+gzipped ones cost between +21 KiB and the entire second file depending on the
+compression level.
+
+### The two tiers
+
+- **`pinned/`** — never pruned, and the only tier that credits coverage.
+- **`auto/`** — generations captured automatically, pruned to the newest
+  `AUTO_GENERATIONS_KEPT` (4) per test key.
+
+An auto generation credits no coverage by design: it is regenerable and pruned
+by count, so letting one satisfy the coverage requirement would let retention
+delete a pattern's only evidence while the gate still read green.
+
+Accumulating generations is what makes the gate get *stronger* over time rather
+than merely staying green. One pinned vintage proves today's source can read
+one old world; a run of generations proves it can read every world the pattern
+has passed through. That is affordable because git deltas adjacent generations
+to roughly 9 KiB, while each costs a few MB of working-tree disk in every
+clone — which is what the retention bound exists for. It bounds **checkouts**,
+not history.
+
+## Commands
+
+```
+deno task pattern-vintage                                  # replay every fixture (what CI runs)
+deno task pattern-vintage --update topics/topics.test.tsx  # capture a first pinned fixture
+deno task pattern-vintage --capture-changed                # capture a generation where due
+deno task pattern-vintage --pin topics/topics.test.tsx     # promote the newest generation
+```
+
+`--update` and `--pin` name a **test** path, never a pattern path: a fixture is
+produced by running a test and covers whatever that test instantiates.
+`system/home.tsx` names no test and captures nothing.
+
+There is no bare `--update` and no list of what CI replays. Every fixture under
+the vintages tree is replayed by the plain command, so committing a captured
+fixture is the whole of adding one. A default seed set would only ever serve a
+*missing* fixture, which is exactly when nothing on disk knows which test covers
+the pattern.
+
+`--capture-changed` captures for every test key whose fixtures have all fallen
+behind today's source. The trigger needs no new measurement: the replay already
+computes `changed` per target, so a fixture replaying with `changed === 0` **is**
+the current generation, and once no fixture for a key reports zero the next is
+due. A fixture with no targets proved nothing and a failed fixture is the gate's
+own red, so neither counts as evidence of currency.
+
+Unrecognised flags are rejected. An unknown flag matches no command, so the run
+would otherwise fall through to the plain gate, replay everything and exit 0 —
+reporting the tree healthy to someone who asked for something else.
+
+**Neither `--capture-changed` nor `--pin` runs in CI.** CI runs the plain gate,
+which only reads the tree. Both writing commands land fixtures in the working
+tree to be committed and reviewed like any other change; a gate that wrote its
+own evidence would be grading its own homework.
+
+## Invariants
+
+- **A test pattern creates stores; it is never an upgrade target.** The replay
+  path refuses a program whose entry resolves to a `*.test.tsx`. A
+  test-populated store puts the *test* pattern at the top with the pattern
+  under test as a nested instance, so applying the test pattern makes the gate
+  weaker. Enforced mechanically rather than by comment, with its own case in
+  `tasks/pattern-vintage-run.test.ts`: prose was already the plan's wording
+  when the shortcut got taken anyway.
+- **Capture only ever adds.** No command overwrites or deletes an existing
+  fixture, in either tier. Deleting one is a deliberate act visible in a diff.
+  Unlike Tier 1's baselines there is no mechanical checker here, so this rests
+  on the commands' refusal plus review — a deliberate choice to operate on
+  trust.
+- **Retention cannot reach a pinned vintage.** `autoGenerationsToPrune` filters
+  the tier *before* it sorts or slices, so no ordering of the later steps can
+  name a pinned fixture, and `removeVintages` refuses one again at the point of
+  deletion. A deep vintage cannot be recaptured — the pattern that wrote it no
+  longer exists in runnable form — and a pruner is invoked by people doing
+  something else.
+- **Promotion never overwrites.** `git mv` refuses a destination file that
+  exists, but moves a *directory* into an existing directory of the same name
+  rather than refusing, so both the primary file and the companion directory
+  are checked. The check is conditional on there being a source companion,
+  which is what lets a re-run of `--pin` finish an interrupted promotion.
+- **Each capture gets a fresh store.** Vintages are independent snapshots of
+  one version's world, never one database migrated forward: a carried-forward
+  lineage would already be shaped by every migration since, and would no longer
+  be state written by a version that knew nothing about today's.
+- **Required patterns come from the runtime's own constants.**
+  `HOME_PATTERN_SOURCE` and `DEFAULT_APP_PATTERN_SOURCE` derive the set CI
+  insists on, so the gate cannot drift from what actually auto-updates. A
+  constant that stops deriving a key stops the run rather than emptying the
+  requirement.
+
+## Adding a pattern to Tier 2
+
+```
+deno task pattern-vintage --update <path to the test that drives it>
+```
+
+Commit the `.sqlite` file it writes. Capture refuses if the test fails — the
+fixture would record a state the pattern never legitimately reaches — or if the
+run made no assertions, since the fixture would hold no state. It also refuses
+a run that instantiated no upgradable pattern, or one whose roots cannot be
+mapped back to a file, because a capture the gate accepts must be a replay it
+accepts.
+
+## Limits
+
+Named rather than implied, because a gate's uncovered edges are part of its
+specification:
+
+- **Migration coverage is not built.** When a memory-engine schema change
+  lands, the affected captures should be *promoted* to pinned rather than
+  recaptured — a dump regenerated after a migration proves nothing, since the
+  pre-migration state is the artifact. The selection rule differs from
+  everything else here: the trigger is a memory change rather than a pattern
+  change, and it wants breadth across *shapes* rather than depth per pattern.
+- **A changed value only warns.** See "Findings are graded" above.
+- **Whether a fixture rots is unresolved.** The by-identity load keys its
+  compile cache on a runtime version and falls back to recompiling the stored
+  source closure on a miss, which reintroduces "old source must still compile
+  under today's API". Whether a pinned vintage stays replayable across a
+  runtime bump, or whether the fallback needs pinning too, is not settled.
+- **The open-argument residual.** The class is validated on every update route,
+  but a root carrying no `patternSetupIdentity` marker at all still skips the
+  re-stage, because absence cannot be told from a pending update. The window is
+  one setup wide per root; closing it means deciding what a root with no marker
+  and an unreadable argument should do at boot.
+- **Cross-space fixtures are synthetic.** Every committed fixture is
+  single-space. `tasks/pattern-vintage-run.test.ts` is the whole of the
+  coverage for companion stores, and deliberately so: it can break a child on
+  purpose, which a pinned fixture cannot.
+- **Restore exercises the migration chain.** `snapshotSpaceStore` runs no
+  migrations, but reopening an old store does. That is a feature — evidence
+  that memory migrations preserve old spaces — but it means a red fixture can
+  be a migration bug rather than a pattern bug. Worth knowing when triaging.
+
+## References
+
+- [`pattern-imports/pattern-updates.md`](pattern-imports/pattern-updates.md) —
+  the updater these gates guard, and the section requiring this work
+- [`../development/space-clone-rehearsal.md`](../development/space-clone-rehearsal.md)
+  — rehearsing a pattern update against a clone of a real space
+- [`../history/plans/pattern-update-state-continuity.md`](../history/plans/pattern-update-state-continuity.md)
+  — the executed plan: the measurements that decided this design, including the
+  ones that reversed it

--- a/docs/specs/pattern-update-testing.md
+++ b/docs/specs/pattern-update-testing.md
@@ -235,10 +235,12 @@ Unrecognised flags are rejected. An unknown flag matches no command, so the run
 would otherwise fall through to the plain gate, replay everything and exit 0 —
 reporting the tree healthy to someone who asked for something else.
 
-**Neither `--capture-changed` nor `--pin` runs in CI.** CI runs the plain gate,
-which only reads the tree. Both writing commands land fixtures in the working
-tree to be committed and reviewed like any other change; a gate that wrote its
-own evidence would be grading its own homework.
+**No writing command runs in CI**, and there are three of them: `--update`
+captures a first pinned fixture, `--capture-changed` captures a generation, and
+`--pin` promotes one. CI runs only the plain gate, which reads the tree and
+never writes to it. All three land fixtures in the working tree to be committed
+and reviewed like any other change; a gate that wrote its own evidence would be
+grading its own homework.
 
 ## Invariants
 

--- a/tasks/pattern-vintage.ts
+++ b/tasks/pattern-vintage.ts
@@ -42,7 +42,7 @@
  * doc is still a finding.
  *
  *   deno task pattern-vintage                                  # replay; fail on a stranded fixture
- *   deno task pattern-vintage --update topics/topics.test.tsx  # pin one
+ *   deno task pattern-vintage --update topics/topics.test.tsx  # first pinned fixture
  *   deno task pattern-vintage --capture-changed                # capture a generation where due
  *   deno task pattern-vintage --pin topics/topics.test.tsx     # promote the newest generation
  *
@@ -78,10 +78,11 @@
  * store to ~9 KiB — and bounded where it is not, since each one also costs
  * 3.5 MiB of working-tree disk in every clone.
  *
- * Neither command runs in CI. CI runs the plain gate, which only ever READS
- * the tree. Capture and promotion write fixtures, and a gate that wrote its own
- * evidence would be grading its own homework; both land in the working tree to
- * be committed and reviewed like any other change.
+ * NO writing command runs in CI, and there are three: `--update`,
+ * `--capture-changed` and `--pin`. CI runs the plain gate, which only ever
+ * READS the tree. A gate that wrote its own evidence would be grading its own
+ * homework, so all three land in the working tree to be committed and reviewed
+ * like any other change.
  *
  * `--capture-changed` refuses to capture onto a red tree, which is also what
  * removes the need for a rule about capturing mid-edit: a generation is a


### PR DESCRIPTION
Follow-up to #5260. The Tier 2 plan has been executed, so under `docs/README.md` it stops being live documentation — but the plan *was* the only description of the resulting system, and `docs/specs/README.md` is explicit that **"a spec that remains the best description of the shipped subsystem"** stays live. So the durable half is extracted rather than archived along with the rest.

## New: `docs/specs/pattern-update-testing.md`

Covers **both** gates, since neither was documented outside its task file:

- **Tier 1** (`deno task pattern-compat`) — what it proves, and each of its five findings with the remedy that fits. Including the one that matters most: `cannot be applied over baseline` **cannot be recorded away**, because `--update` records only when "not recorded" is the sole finding. The obvious instinct on any baseline failure is "re-record the baseline", and here that silently does nothing while the run stays red.
- **Tier 2** (`deno task pattern-vintage`) — precisely what a green run asserts per fixture, what it compares, what it excludes and why, the fixture layout, the two tiers, the commands, and the invariants that hold it up.

The **Limits** section is deliberate: a gate's uncovered edges are part of its specification. Migration coverage, the changed-value warning, fixture rot, the open-argument residual, and the synthetic cross-space coverage are named rather than left implied. That is also where the remaining stage-5 work is recoverable from, without keeping a near-empty plan alive to hold two checkboxes.

## Archived: `docs/history/plans/pattern-update-state-continuity.md`

Moved with the metadata header and a `superseded-by`. **Body frozen** — the only edits are the five relative links that broke on the move, which is what `docs/history/README.md` permits (verified by diffing the archived body against the original: nothing else changed).

It keeps the value the spec should not carry — the measurements that decided the design, including the ones that *reversed* it: raw storage beats gzipped because gzip defeats git's delta compression, and a cross-DID restore reads fine after all.

## References repointed

- `docs/plans/README.md` — entry dropped
- `.github/workflows/deno.yml` — comment now cites the spec
- the sibling historical investigation's `superseded-by` and body link
- indexed from `docs/specs/README.md`, linked from the `docs/development/TESTING.md` hub

## Verification

`deno task check-docs` (521 blocks) and `deno task check-skill-facts` pass; `deno fmt --check` clean. Every relative link in the new and moved documents resolves, checked programmatically rather than by eye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a live spec for pattern update testing that documents both CI gates (contract compatibility and state continuity). Archived the executed Tier 2 plan and updated references across docs and CI.

- **New Features**
  - Added `docs/specs/pattern-update-testing.md` covering Tier 1 (`deno task pattern-compat`) findings and remedies, and Tier 2 (`deno task pattern-vintage`) assertions, comparisons, fixture layout, commands, invariants, and named limits.

- **Refactors**
  - Archived the Tier 2 plan to `docs/history/plans/pattern-update-state-continuity.md` with metadata and `superseded-by`; body preserved aside from fixed relative links.
  - Repointed references in `docs/specs/README.md`, `docs/development/TESTING.md`, `.github/workflows/deno.yml`, `docs/plans/README.md`, and the related investigation’s `superseded-by`.
  - Verified `deno task check-docs`, `deno fmt --check`, and link resolution.

<sup>Written for commit 57778431048a2424ed3ba9b106ce4799db92d59b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

