### PR TITLE
refactor(runner): flatten builder artifacts at the storage boundary

### DIFF
--- a/docs/history/spikes/dropping-json-serialization.md
+++ b/docs/history/spikes/dropping-json-serialization.md
@@ -1,0 +1,506 @@
+---
+status: historical
+created: 2026-08-01
+reason: "Research spike: findings from removing `toJSON()` and load-bearing `JSON.stringify` from the runtime."
+---
+
+# Spike: dropping `toJSON()` and `JSON.stringify` from the runtime
+
+> Historical note: this records what a research branch found, not a design and
+> not the current system. The branch deliberately breaks things; the breakage
+> is the deliverable. Nothing here describes shipped behavior.
+
+`FabricValue` began as "`JSONValue` regularly manipulated with
+`JSON.stringify()`". Residue of that origin: the data model honors `toJSON()`
+methods when converting a value, and the runtime leans on `JSON.stringify` for
+value semantics. This spike removes both to find out what holds them in place,
+so the real work can be staged with the surprises already known.
+
+Facts below were measured on the branch unless marked as reasoning.
+
+## Finding 1 — the runner has no single storage boundary
+
+This is the finding that most changes how the work should be staged.
+
+The premise going in was that values reach the data model through one place,
+so a "preflight" that serializes builder artifacts just upstream of it would
+cover everything. That premise is false. Artifacts reach conversion through at
+least four independent entry points, and they arrive in **different shapes**:
+
+| entry point | shape seen |
+|---|---|
+| `Runner.instantiateRawNode` → `getImmutableCell` | module (object) |
+| `Runner.updateResultProjection` → `fabricFromNativeValue` | module (object) |
+| `CellImpl.set` → `normalizeAndDiff` (`data-updating.ts:1095`) | factory (function) |
+| action/derive result → sandbox result normalization | pattern returned by an action |
+| `Runner.updateArgument` → `Cell.set` AND a second `diffAndUpdate` | pattern as a sub-pattern's ARGUMENT |
+| `Runner.instantiateJavaScriptActionNode` → `getImmutableCell` | artifact in a JS action's inputs |
+
+Found in that order, each only after the previous was covered. Covering them
+one at a time is whack-a-mole, and the resolution was to stop doing it: the
+replacement now happens inside `Runtime.getImmutableCell` -- the intake whose
+own documentation already called itself "the designed intake" -- which covers
+every one of its callers at once, plus `updateArgument`, which does not go
+through it.
+
+Note `updateArgument` wrote TWICE from the same value, and flattening only the
+first write left the second storing the raw artifact. A boundary with two
+writes has to agree with itself about what was stored.
+
+Measured: with the preflight covering the first two AND extended to handle
+function-shaped artifacts, the runner suite failure set was **byte-identical**
+— same 14 tests, same causes. Extending the preflight's *shape* coverage
+changed nothing, because the shapes it newly covers do not arrive at the sites
+where it is installed.
+
+Measured three times over: after adding function-shape coverage, after making
+module serialization reach nested graphs, and after correcting how the walk
+reads members, the failing set stayed byte-identical at 14. Each of those was a
+real correction; none was observable from the sites where the preflight is
+installed.
+
+Consequence for staging: "serialize upstream, then delete the data model's
+`toJSON` support" is not one change at one seam. It is a change at every entry
+point, and each sees a different artifact shape. That is the cost that has to
+be weighed against a conversion-side hook, which was rejected early on the
+grounds that landing solid replacer functionality in the data model is harder
+than transforming upstream. That trade should be re-decided against this
+measurement rather than against the original assumption.
+
+## Finding 2 — the pattern graph was only half-serialized
+
+`patternToJSON` emitted `pattern.nodes` verbatim, and those nodes hold **live**
+modules: `toJSONWithAliasBindings` builds a node by copying its module member
+by member, function members included. The emitted "serialized" graph was
+therefore not serialized — it relied on a later `JSON.stringify` to finish the
+job by calling methods on live objects.
+
+That single fact is what kept `toJSON` alive on modules: it was not the data
+model that needed the name, it was `JSON.stringify` of a graph. Making the
+boundary emit serialized modules (`nodesWithSerializedModules`) removes the
+reader outright, at which point the name is free.
+
+Boundary only. Internal serialization must keep modules live, because that is
+what the runner executes.
+
+## Finding 3 — the four `api` factory types must move together
+
+Changing the shared serializer member on three of `NodeFactory`,
+`ModuleFactory`, `HandlerFactory`, `PatternFactory` — but not the fourth —
+breaks `PatternFactory`'s assignability to `NodeFactory`. `Runtime.run`
+overloads on exactly that (`runtime.ts:2107` takes `NodeFactory<T, R>` and
+infers `R` from the factory; `runtime.ts:2114` takes `Pattern | Module` with
+`R = any`, inferring from the **result cell**). So every `runtime.run` silently
+drops to the second overload and takes its result type from whatever the
+caller annotated its cell as.
+
+It presents as patterns "losing" a key at distant call sites
+(`Readonly<{action: any}>`), with no diagnostic anywhere naming assignability.
+Measured: 22 errors across three unrelated test files; changing all four types
+made it zero.
+
+Worth recording because the first diagnosis was wrong: this is not "widening an
+intersection perturbs inference". Cardinality is not the trigger. Broken mutual
+assignability is.
+
+## Flag-day inventory
+
+Two flag days are measured, and they differ in the way that matters most for
+sequencing: one is silent and one is loud.
+
+### FD1 — `JSON.stringify(SomePattern)` answers `undefined`. SILENT.
+
+`JSON.stringify` of a function with no `toJSON` is not an error; it is
+`undefined`. A caller storing the result gets a hole, with no throw and no type
+error.
+
+Live pattern-source sites, all feeding wiki-link resolution:
+
+- `packages/patterns/record.tsx:882`
+- `packages/patterns/record-backup.tsx:456`
+- `packages/patterns/experimental/chat-note.tsx:418`
+
+Needs a named migration and sits in `packages/patterns`, where the
+compat/vintage baselines live — so it is also the flag day most likely to move
+a stored form.
+
+TRACED END TO END, and it is bigger than three call sites. The stringified
+pattern is a cross-package WIRE FORMAT:
+
+    record.tsx / chat-note.tsx   JSON.stringify(Record) -> a string
+      -> note.tsx:348            carried as `linkPattern`
+      -> note.tsx:396            `$pattern={patternJson}` -- a UI prop
+      -> cf-code-editor.ts:631   JSON.parse(program)
+      -> cf-code-editor.ts:642   rt.createPage(pattern, space, inputs)
+
+A pattern is serialized in pattern source, handed through a string-typed prop
+into a Lit component in `packages/ui`, parsed back, and instantiated as a page.
+
+That settles what `toJSON` means on a FACTORY, and it is not the same thing it
+meant on a module. A module's was internal plumbing with no consumer. A
+factory's is the format an actual consumer in another package parses. Removing
+it is an API migration with `packages/ui` on the far end, not a rename -- which
+is the argument for the factory/module split being a real distinction rather
+than a convenient one.
+
+Latent, not addressed: the emitted graph carries `argumentSchema` and
+`resultSchema`, so if an interned schema ever holds a `FabricPrimitive`, the
+`JSON.stringify` -> `JSON.parse` round trip loses it silently. Same family as
+the `Fabric*` TODOs already marked in `builtins/llm.ts`.
+
+In-repo, it surfaced loudly as 7 runner tests failing with
+`SyntaxError: "undefined" is not valid JSON`. Those are the shadow of the
+silent failure, not the failure itself.
+
+### FD2 — an artifact reaching an uncovered entry point. LOUD WHERE IT HAPPENS; A SECOND MODE IS UNEXPLAINED.
+
+A pattern factory is a function; the data model's function arm looks for
+`toJSON`. Where that rejection happens it is loud: "not representable as a
+`FabricValue`: function per se".
+
+But most of the failures attributed to this cause show no rejection at all.
+Of them, one reports the error; five report nothing and merely read `undefined`
+downstream; one drops an event with a warning. The tempting inference -- that
+the rejection is being thrown and swallowed -- was tested and REFUTED for the
+case examined: nothing is thrown there at all. See "A second failure mode,
+mechanism unidentified" below.
+
+So this flag day has two modes, and only the first is understood. That is a
+more useful thing to know than a tidy story about swallowing would have been.
+
+Live idiom:
+
+```tsx
+const tools: Record<string, BuiltInLLMTool> = {
+  search_web: { pattern: searchWeb },   // a PatternFactory: a function
+};
+```
+
+`packages/patterns/system/common-fabric.tsx:329`,
+`packages/patterns/system/omnibox-fab.tsx:171`.
+
+## A second failure mode, mechanism unidentified
+
+One failure is security-adjacent and does not fit the rejection story. With the
+member gone, an event is dropped -- "no handler registered for ... and its
+piece could not be started" -- and the handler never runs.
+
+Traced against a baseline worktree at the merge base, and the tempting
+explanations are all wrong:
+
+- Nothing is thrown. No rejection occurs anywhere on the path.
+- The content-addressed entry ref is IDENTICAL on both trees, so no identity
+  hash moved.
+- The ROOT result cell carries its `patternIdentity` metadata on both trees.
+
+What actually happens is an early return in `ensure-piece-running.ts:122-128`:
+walking the result-cell chain from the event link reaches a cell that carries
+no `patternIdentity` on the branch. So a metadata write that the piece-start
+path depends on did not happen. Whether that is downstream of some earlier
+silent conversion failure is not established.
+
+Recorded as unexplained rather than folded into FD2. The five
+`patterns-derive-return-pattern` failures log nothing either, which is exactly
+what this one looked like before it was traced, so they should not be
+attributed to a rejection without the same treatment.
+
+### Not a flag day, verified
+
+`Cell.toJSON()` is untouched, so `packages/html/src/worker/keying.ts:23` and
+the two `packages/ui` `JSON.stringify(cell)` consumers keep working. Only
+modules and pattern factories lost the member.
+
+## Finding 5 — `Cell.toJSON()` is far less load-bearing than it reads
+
+`runtime.ts:2001` describes the mechanism accurately -- "`Cell`s become sigil
+links (their `toJSON()`)" -- and that phrasing invites the conclusion that the
+member is on the hot path of every write referencing a cell. Measured, it is
+not.
+
+Renaming `CellImpl.toJSON` with no compensating change in the data model, so
+that every `Cell` reaching the conversion fails outright: the runner goes from
+14 failures to **23**. Nine additional tests, fifteen "not a recognized fabric
+type" rejections.
+
+The prediction before running it was "hundreds". The reason it is small: a cell
+reference is normally already a link by the time a value reaches the
+conversion -- `unwrapOneLevelAndBindToDoc` and the sigil-link helpers do that
+work upstream -- so the `toJSON` route serves only the cases where a raw `Cell`
+lands in a value that gets converted.
+
+Consequence for staging: `Cell` is a far more tractable target than its
+reputation, and the ordering intuition "do the deepest thing last" was wrong
+here. It is not deep; it is merely wide and greppable
+(`JSON.stringify(cell)` in `packages/html` and `packages/ui`).
+
+## Consumers of `toJSON` found late
+
+Both were missed by the initial survey and are recorded so a staged plan
+includes them:
+
+- **The CTS transformer blesses `toJSON`.**
+  `packages/ts-transformers/src/transformers/pattern-context-validation.ts:133`
+  special-cases a `toJSON()` member on a pattern object literal as storable,
+  explicitly because "the data model converts a toJSON-bearing" value. When the
+  data model stops, that rule blesses something that throws.
+- **`JSON.stringify` of a pattern graph**, via nested node modules — Finding 2.
+
+## An ambient flag that answers one question was made to answer two
+
+`internalGraphSerialization` exists to decide whether a graph gets a
+`$patternRef`. A sub-pattern's graph is reached through
+`serializePatternGraph`, which sets that flag, so a nested graph on its way to
+the boundary was also skipping module serialization -- a ref-less graph
+containing a sub-pattern still carried live modules one level down, and nothing
+finished the job.
+
+The fix descends into a `type: "pattern"` module's emitted sub-graph from the
+boundary path, rather than teaching the internal serializer a second job. The
+shape is worth recording: an ambient boolean naming one condition gets reached
+for by anything that correlates with it, and the second question it is asked is
+answered wrong exactly where the correlation breaks.
+
+Note the near-miss in ordering: the preflight's walk finds a nested module by
+its own serializer, so landing the preflight's function branch first would have
+MASKED this defect -- absent wherever the preflight runs, live everywhere else
+-- rather than removing it.
+
+## Finding 4 — the encoded form does not move
+
+Measured as a true before/after, in a throwaway worktree at the branch's merge
+base, running the same probe source in both trees over a ref-less
+three-deep pattern (`Top` → `Mid` → `Leaf` → `lift`) plus a sibling lift node:
+
+- `dataUriFromValue(fabricFromNativeValue(patternToJSON(Top)))` — byte-identical
+- the same for the factory `Top` (baseline raw vs branch through the preflight)
+  — byte-identical
+- `patternToJSON(Leaf)` at depth 1 — byte-identical
+
+Where a value reaches storage at all, it reaches it as exactly the same bytes.
+The only difference is the expected one: converting a raw factory throws on the
+branch (FD2) where it succeeded on the baseline.
+
+Re-verified at the branch's final state, after the replacement moved from the
+individual call sites into `Runtime.getImmutableCell`: still byte-identical.
+That move was the kind of change -- same bytes, different moment -- this branch
+has shown can shift behaviour while every byte comparison reports identical, so
+it was re-run rather than assumed.
+
+Scope not yet covered by that probe: handler modules carrying
+`$implRef`/`wrapper`, and `FabricPrimitive`-carrying schemas. The compiled
+pattern's `$patternRef` branch IS covered.
+
+Separately verified at the same time: module serialization now reaches every
+depth. The baseline emitted live modules at depths 1, 2 and 3 of a ref-less
+graph; the branch emits none, and the graph converts without the preflight.
+
+## Known latent throw, not fixed here
+
+`nodesWithSerializedModules` serializes a node's module by calling the method
+the node's module copy carries, which closes over the **original** module. For
+`type: "javascript"` modules the two are content-identical (the copy differs
+only in interned-schema object identity, not content). For `type: "pattern"`
+modules both routes re-derive the sub-graph from the same live sub-pattern and
+defer-increment identically, with one asymmetry: the build-time copy passes the
+enclosing pattern's alias resolver (`builder/pattern.ts:558`) and the boundary
+path does not (`builder/json-utils.ts:388`, the CT-1230 workaround). So a live
+`Cell` still in the sub-graph at boundary time throws "Cell not found in pattern
+aliases" rather than becoming an alias.
+
+Alias resolution is therefore not silently lost — the divergence is a throw.
+Recorded rather than fixed.
+
+## Independent defect found along the way
+
+`ensure-piece-running.ts:171-174` catches every error on the piece-start path
+and returns `false`, and its logger is constructed disabled
+(`getLogger("ensure-piece-running", { enabled: false, ... })` at `:26-29`). So
+an **error**-level report on that path prints nothing, and any throw becomes a
+silent `false` that the caller renders as "its piece could not be started".
+
+This did NOT cause the failure above -- that was traced to an early return, not
+the catch. It is recorded because it is real, it sits on a security-relevant
+path, and it is precisely the mechanism that would hide this class of problem
+next time.
+
+## Finding 6 — a hand-built fixture cannot exhibit the bug it is meant to catch
+
+Two claims in this document were "verified" against synthetic fixtures and were
+wrong, and the same mistake was made independently by both people working on
+it, which suggests it is a property of the method rather than of either.
+
+The graph serializer walks a HAND-ENUMERATED set of positions: a node's
+`module`, then that module's `implementation.nodes`. Verified to depth 3
+against a hand-built `Top → Mid → Leaf` pattern, it reported no live modules
+remaining. Run against a real repo pattern
+(`packages/patterns/factory-outputs/parking-coordinator/main.test.tsx`) the same
+probe reports **2768 function-valued members** still in the emitted form, at a
+path neither fixture could produce:
+
+    $.nodes[1].module.implementation.nodes[40].inputs.op.nodes[0].module
+
+A sub-graph reached through a node's INPUTS -- the op path -- is not covered.
+The synthetic fixtures had no op-carrying inputs, so they could not fail.
+
+The standard that should have been applied from the start, and was articulated
+about someone else's probe before being violated in one's own: **a probe that
+has only ever passed is not yet a probe.** Every claim here resting on a
+synthetic fixture should be re-run against a real pattern before it is relied
+on, the encoded-form neutrality claim first.
+
+## Finding 7 — the same removal made a failure quieter
+
+Replacing `JSON.stringify` with a content hash at the change-detection site
+fixed the silent-skip bug and introduced a different one on the same line.
+
+`JSON.stringify` drops a function member and returns a string. `hashStringOf`
+refuses: `hashOf: unsupported type: function`. So for a ref-less pattern
+carrying artifacts under `inputs.op`, the key computation now THROWS where it
+previously returned a usable string -- and an unguarded throw on that path
+reaches the `ensure-piece-running` catch whose logger is disabled, becoming a
+silently unstarted piece.
+
+Loud replaced by silent, through a swallow already documented elsewhere in this
+file. Recorded because the shape generalises: replacing a lenient mechanism
+with a strict one moves failures earlier, which is usually right, but only if
+every consumer of the strict one is prepared to fail. Here one was not, and the
+system's own error handling converted the improvement into a regression.
+
+Fixed at the CONSUMER first, by routing the key through the preflight walk;
+the producer was fixed afterwards by Finding 8's redesign. Before that, the
+producer was wrong: `patternToJSON`'s own output on a real pattern still
+carries 2768 function-valued members across 8 path shapes, all under
+`inputs.op`, at two levels of nesting (`op` inside `op`). So the emitted graph
+is not a representable value, and the next caller who converts it without
+flattening gets `hashOf: unsupported type: function` or "function per se".
+Recorded as an OPEN DEFECT rather than closed by the consumer fix -- it is a
+trap laid for the next person.
+
+## Finding 8 — a positional traversal over a graph is the wrong design
+
+`nodesWithSerializedModules` enumerates the positions an artifact may occupy:
+a node's `module`, then that module's `implementation.nodes`. That enumeration
+has now been wrong twice, both times found by measurement rather than reading,
+and both times failing as a silent live object at the boundary.
+
+The general walk already in the branch -- the preflight's -- gets the same
+input right: 2768 artifacts found, 0 remaining, without knowing anything about
+graph shape. It looks for THE ARTIFACT rather than for THE POSITION, which is
+the entire difference, and `inputs.op` nesting inside itself makes the
+positional version strictly harder to get right than the general one.
+
+Two implementations of one job (replace every artifact with its encodable
+form) in the serialization domain is also the duplication this repo treats as
+a footgun; the divergence stays invisible until something converts the output.
+
+The cost to weigh: the two differ in WHEN, not only in what. The positional
+one lives inside the graph serializer where the internal-vs-boundary
+distinction is known; the general one runs at a storage boundary on a finished
+value. Merging them naively means `builder/json-utils.ts` importing a
+runner-level module, and new import edges into the runner's cyclic core have
+broken CI before. The shape that avoids it: put the general walk in a LEAF
+module both import, parameterised by what to do at each copy (the derivation
+note differs by caller), and delete the positional traversal rather than
+extend it.
+
+RESOLVED on that shape. `replaceArtifacts(value, onCopy)` now lives in the
+leaf that already knew what an artifact is; the storage boundary is that walk
+with the derivation note as its hook, and `patternToJSON`'s ref-less branch
+is the same walk with the same hook. Measured on a real pattern: the emitted
+graph goes from 2768 live functions across 8 path shapes to ZERO at any path,
+both `inputs.op` depths included, and the encoded form does not move a byte
+even though the walk now runs inside the serializer rather than outside it.
+
+## Finding 9 — bookkeeping written per branch gets left off a branch
+
+The derivation note that carries trust onto a copy was got wrong three times,
+each in a new shape:
+
+1. absent -- the new copy sites simply did not call it;
+2. present but on the wrong side of the copy that followed, so it registered
+   an object the next statement discarded;
+3. present, parameterised, and wired at one of three copy sites -- the
+   function branch, but neither the object-artifact branch nor the container
+   rebuild.
+
+Each was found by the A/B harness, none by the test suite, and each looked
+correct at the call site. The fix that ends the series is structural: every
+branch returns through a single `copied()` that announces the copy and records
+the answer, so a copy site cannot be added without the bookkeeping. Three
+occurrences of one mistake is a property of the design, not of the person.
+
+## Finding 10 — the cost of looking everywhere, and what not to do about it
+
+The walk costs **7-9% of the whole intake**. `getImmutableCell` is four steps
+-- walk, convert, encode to a data URI, mint the cell -- and the walk is the
+first of four:
+
+| | heavy real graph | typical binding |
+|---|---|---|
+| walk | 12.7 ms | 0.0024 ms |
+| convert | 67.9 ms | 0.0121 ms |
+| encode | 68.3 ms | 0.0040 ms |
+| WHOLE `getImmutableCell` | 181.0 ms | 0.0266 ms |
+| walk's share | **7.0%** | **9.0%** |
+
+An earlier version of this finding said "18% of the conversion", which is the
+same walk measured against the wrong denominator: encoding costs about as much
+again as conversion, and cell minting more still. Quoting a cost against one
+step of a four-step procedure overstates it roughly twofold, and the number
+that decides anything is the share of what a caller actually pays.
+
+Three things worth keeping with it:
+
+- Still not the full storage procedure. A cell that is WRITTEN also pays
+  diffing, transaction bookkeeping, commit and persistence, none of which is in
+  the 181 ms. The share of a real write is smaller again.
+- It is a fixed fraction, not a cliff: 7% and 9% across a ~7000x size
+  difference means it scales with the same traversal the conversion already
+  does. On typical values the absolute cost is 2.4 microseconds.
+- The positional version was cheaper because it visited less, and it visited
+  less because it was wrong. Slower than something that did not do the job is
+  not a regression.
+
+Recommendation: no speculative fast path. Note also that NOTHING in this repo
+gates on performance -- the `perf-check` job was removed for being too noisy,
+and `benchmarks.yml` collects trend data for a dashboard rather than a verdict.
+So this is a judgement call, not something a check adjudicates. If a signal
+ever appears, NOT a "no artifacts under here" cache -- that needs the walk to have run in order to know, and
+memoising it means another identity-keyed side table, the exact mechanism
+behind Finding 9's four bugs. Key off a fact the pipeline already tracks
+instead: a value that is already a deep-frozen `FabricValue` cannot contain a
+live artifact, which is O(1) at the root and adds no bookkeeping.
+
+## Method note that outranks the rest
+
+Every defect in the trust/derivation family, and the producer defect, was found
+by A/B against a baseline worktree. NONE was found by the test suite, which
+returned the same 1106 passed / 6 failed across four consecutive substantive
+changes without moving once.
+
+A suite that does not move is not evidence that nothing moved.
+
+## Method notes
+
+- The honest oracle for "who depends on this?" is to REMOVE the behavior and
+  run the whole workspace. Stack-trace instrumentation under-reports: samples
+  taken inside SES-locked-down test processes come back with an empty
+  `Error.stack`, and on this work the two unattributable samples out of fifteen
+  were the ones that mattered.
+- The root `deno task test` fail-fasts, so a deliberately-broken experiment
+  measures only the first failing package. Use `TEST_DISABLED_PACKAGES`.
+- A test fixture built by hand drifts from the shape the builder produces. A
+  fixture omitting `toJSON` made a preflight test assert a property the
+  production artifact did not have, which is how a false claim about the
+  preflight being load-bearing reached a commit message. The same mistake, in a
+  probe rather than a test, produced two false "verified" claims -- see
+  Finding 6.
+- Bytes-identical is not behaviour-identical. Trust and the content-addressed
+  entry ref live in identity-keyed `WeakMap`s, so they do not travel with the
+  encoded form. A copy that skips `noteDerivedCopy` is a trust dead end that no
+  byte comparison can see; two were introduced here and neither showed up in
+  any encoded-form A/B. Any future version of this work wants a provenance
+  check alongside the encoded-form check.
+- Note the object that is RETURNED, not one built along the way. The first
+  attempt at that fix registered a value the following statement discarded, so
+  it read as fixed and changed nothing.

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -1685,8 +1685,27 @@ export interface Module extends FabricExecPlainObject {
   defaultScope?: CellScope;
 }
 
+/**
+ * The member `JSON.stringify()` consults. A builder FACTORY keeps it, because
+ * a factory is what pattern source holds, and stringifying one is an idiom
+ * that source uses -- there the name says exactly what it means. What it
+ * answers is the same form `toEncodableForm` gives.
+ *
+ * A module does not carry it: a module is internal, nothing stringifies one,
+ * and for it the name would claim a relationship to JSON that does not exist.
+ */
 export type toJSON = {
   toJSON(): unknown;
+};
+
+/**
+ * The member by which a builder artifact produces the form in which it gets
+ * encoded. Distinct from `toJSON` in saying nothing about JSON: what it
+ * answers is a value the data model can represent, which reaches storage
+ * without being stringified on the way.
+ */
+export type toEncodableForm = {
+  toEncodableForm(): unknown;
 };
 
 /**
@@ -1708,6 +1727,7 @@ export type NodeFactory<T, R> =
   & ((inputs: FactoryInput<T>) => Reactive<R>)
   & (Module | Handler | Pattern)
   & toJSON
+  & toEncodableForm
   & {
     asScope(scope: CellScope): NodeFactory<T, R>;
   };
@@ -1716,6 +1736,7 @@ export type PatternFactory<T, R> =
   & ((inputs: FactoryInput<T>) => Reactive<R>)
   & Pattern
   & toJSON
+  & toEncodableForm
   & {
     asScope(scope: CellScope): PatternFactory<T, R>;
     inSpace(space?: string | AnyCell<unknown>): PatternFactory<T, R>;
@@ -1725,6 +1746,7 @@ export type ModuleFactory<T, R> =
   & ((inputs: FactoryInput<T>) => Reactive<R>)
   & Module
   & toJSON
+  & toEncodableForm
   & {
     asScope(scope: CellScope): ModuleFactory<T, R>;
   };
@@ -1732,7 +1754,8 @@ export type ModuleFactory<T, R> =
 export type HandlerFactory<E, T, R = void> =
   & ((inputs: FactoryInput<StripCell<T>>) => Stream<E, R>)
   & Handler<E, T, R>
-  & toJSON;
+  & toJSON
+  & toEncodableForm;
 
 // JSON types
 

--- a/packages/runner/src/builder/json-utils.ts
+++ b/packages/runner/src/builder/json-utils.ts
@@ -15,7 +15,6 @@ import {
   type Module,
   type Pattern,
   type Reactive,
-  type toJSON,
 } from "./types.ts";
 import { getTopFrame } from "./pattern.ts";
 import {
@@ -31,7 +30,11 @@ import {
   isCellResultForDereferencing,
 } from "../query-result-proxy.ts";
 import { isCell } from "../cell.ts";
-import { replaceArtifacts } from "../encodable-form.ts";
+import {
+  encodableFormOf,
+  hasEncodableForm,
+  replaceArtifacts,
+} from "../encodable-form.ts";
 
 export type CellAliasResolver = (
   cell: Reactive<any>,
@@ -140,8 +143,7 @@ export function toJSONWithAliasBindings(
     // serializer (its toJSON under the internal-serialization context): this
     // function builds the in-memory node representation, so embedded
     // sub-pattern graphs must stay bare — no boundary `$patternRef`.
-    const valueToProcess = (isPattern(value) &&
-        typeof (value as unknown as toJSON).toJSON === "function")
+    const valueToProcess = (isPattern(value) && hasEncodableForm(value))
       ? serializePatternGraph(value as unknown as Pattern) as Record<
         string,
         any
@@ -343,21 +345,24 @@ function itemsSchemaFromArray(
     : internSchema({ anyOf: uniqueSchemas });
 }
 
-export function moduleToJSON(module: Module) {
+export function moduleToEncodableForm(module: Module) {
   const frame = getTopFrame();
-  // Destructure-and-drop the runtime-only methods that handler modules
-  // attach for the in-builder ergonomics (`mod.with(...)`/`mod.bind(...)`).
-  // They are not part of the serialized contract; left in, they would surface
-  // as a "not representable as a `FabricValue`: function per se" rejection, so
-  // they are destructured out here.
+  // Destructure-and-drop the runtime-only members a module carries for the
+  // builder's own use: its serializer, and the handler ergonomics
+  // (`mod.with(...)`/`mod.bind(...)`). None is part of the serialized
+  // contract; left in, each would surface as a "not representable as a
+  // `FabricValue`: function per se" rejection, so they are destructured out
+  // here. `json-utils.test.ts` asserts the whole resulting key set, an extra
+  // member being a changed content-derived id for every value that carries a
+  // module.
   const {
     implementation: _implementation,
-    toJSON: _toJSON,
+    toEncodableForm: _toEncodableForm,
     with: _with,
     bind: _bind,
     ...rest
   } = module as Module & {
-    toJSON: () => any;
+    toEncodableForm: () => unknown;
     with?: unknown;
     bind?: unknown;
   };
@@ -489,9 +494,8 @@ export function serializePatternGraph(
   const previous = internalGraphSerialization;
   internalGraphSerialization = true;
   try {
-    const withToJSON = pattern as unknown as Partial<toJSON>;
-    return (typeof withToJSON.toJSON === "function"
-      ? withToJSON.toJSON()
+    return (hasEncodableForm(pattern)
+      ? encodableFormOf(pattern)
       : patternToJSON(pattern)) as Record<string, unknown>;
   } finally {
     internalGraphSerialization = previous;
@@ -538,7 +542,13 @@ export function patternToJSON(pattern: Pattern) {
   // async readers fall back to the storage-backed `loadPatternByIdentity` —
   // compiled artifacts persist in-space as an expected part of compilation.
   // A pattern with NO entry ref (manually constructed / dynamic) still
-  // serializes its full graph: nothing could ever resolve its ref.
+  // serializes its full graph: nothing could ever resolve its ref. That graph
+  // holds LIVE modules -- `toJSONWithAliasBindings` builds a node by copying
+  // its module member by member -- so the artifacts in it are replaced here,
+  // by the same walk the storage boundary uses. Enumerating the positions a
+  // module can occupy was tried and was wrong twice: a module reached through
+  // a node's `inputs` (an op, which nests inside itself) is not somewhere a
+  // hand-written traversal thinks to look.
   const entryRef = getArtifactEntryRef(pattern);
   return entryRef
     ? {

--- a/packages/runner/src/builder/module.ts
+++ b/packages/runner/src/builder/module.ts
@@ -17,6 +17,7 @@ import type {
   SchemaWithoutCell,
   Stream,
   StripCell,
+  toEncodableForm,
   toJSON,
 } from "./types.ts";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
@@ -26,7 +27,7 @@ import {
   connectInputAndOutputs,
 } from "./node-utils.ts";
 import { assertNotInActionExecution } from "./action-context.ts";
-import { moduleToJSON } from "./json-utils.ts";
+import { moduleToEncodableForm } from "./json-utils.ts";
 import {
   brandTrustedBuilderArtifact,
   getArtifactEntryRef,
@@ -116,6 +117,11 @@ const INTERNAL_SOURCE_LOCATION_FRAME_PATTERNS = [
 const SYNTHETIC_MAPPED_LINE = 1;
 const SYNTHETIC_MAPPED_COLUMN = 23;
 
+/** See the `toJSON` type: the member a FACTORY keeps for `JSON.stringify`. */
+function jsonMemberFor(module: Module & toEncodableForm): toJSON {
+  return { toJSON: () => module.toEncodableForm() };
+}
+
 export function createNodeFactory<T = any, R = any>(
   moduleSpec: Module,
 ): ModuleFactory<T, R> {
@@ -130,9 +136,9 @@ export function createNodeFactory<T = any, R = any>(
     moduleSpec.implementation = implementation;
   }
 
-  const module: Module & toJSON = {
+  const module: Module & toEncodableForm = {
     ...moduleSpec,
-    toJSON: () => moduleToJSON(module),
+    toEncodableForm: () => moduleToEncodableForm(module),
   };
   // A module with ifc confidentiality on its argument schema should have at least
   // that value on its result schema
@@ -140,15 +146,22 @@ export function createNodeFactory<T = any, R = any>(
     module.argumentSchema,
     module.resultSchema,
   );
-  const factory = Object.assign((inputs: FactoryInput<T>): Reactive<R> => {
-    const outputs = reactive<R>(undefined, module.resultSchema);
-    const node: NodeRef = { module, inputs, outputs, frame: getTopFrame() };
+  const factory = Object.assign(
+    (inputs: FactoryInput<T>): Reactive<R> => {
+      const outputs = reactive<R>(undefined, module.resultSchema);
+      const node: NodeRef = { module, inputs, outputs, frame: getTopFrame() };
 
-    connectInputAndOutputs(node);
-    (outputs as OpaqueCell<R>).connect(node);
+      connectInputAndOutputs(node);
+      (outputs as OpaqueCell<R>).connect(node);
 
-    return outputs;
-  }, module) as ModuleFactory<T, R>;
+      return outputs;
+    },
+    module,
+    // A factory adds `toJSON`, which a module does not carry: a factory is
+    // what pattern source holds, so `JSON.stringify(someFactory)` has to keep
+    // answering. Same form, by the name that means it here.
+    jsonMemberFor(module),
+  ) as ModuleFactory<T, R>;
   factory.asScope = (scope: CellScope) =>
     createNodeFactory({ ...module, defaultScope: scope });
   // Provenance brand: every node factory (lift / handler / byRef / the list-op
@@ -428,7 +441,7 @@ function handlerInternal<E, T>(
     stateSchema as JSONSchema | undefined,
   );
 
-  const module: Handler<E, T> & toJSON & {
+  const module: Handler<E, T> & toEncodableForm & {
     bind: (inputs: FactoryInput<StripCell<T>>) => Stream<E>;
   } = {
     type: "javascript",
@@ -438,7 +451,7 @@ function handlerInternal<E, T>(
     // Overriding the default `bind` method on functions. The wrapper will bind
     // the actual inputs, so they'll be available as `this`
     bind: (inputs: FactoryInput<StripCell<T>>) => factory(inputs),
-    toJSON: () => moduleToJSON(module),
+    toEncodableForm: () => moduleToEncodableForm(module),
     ...(schema !== undefined && { argumentSchema: schema }),
     ...(writableProxy && { writableProxy: true }),
   };
@@ -467,6 +480,7 @@ function handlerInternal<E, T>(
       return eventStream;
     },
     module,
+    jsonMemberFor(module),
   );
 
   // Provenance brand, like every factory from `createNodeFactory` (whose

--- a/packages/runner/src/builder/pattern.ts
+++ b/packages/runner/src/builder/pattern.ts
@@ -31,6 +31,7 @@ import {
   type Schema,
   type SchemaWithoutCell,
   SELF,
+  type toEncodableForm,
   type toJSON,
   type UnsafeBinding,
 } from "./types.ts";
@@ -43,7 +44,7 @@ import {
 } from "./node-utils.ts";
 import {
   type CellAliasResolver,
-  moduleToJSON,
+  moduleToEncodableForm,
   patternToJSON,
   toJSONWithAliasBindings,
 } from "./json-utils.ts";
@@ -572,7 +573,7 @@ function factoryFromPattern<T, R>(
     return { module, inputs, outputs } satisfies Node;
   });
 
-  const pattern: Pattern & toJSON = {
+  const pattern: Pattern & toEncodableForm & toJSON = {
     argumentSchema: sanitizeSchemaForLinks(argumentSchema, KeepAsCell.All),
     resultSchema: sanitizeSchemaForLinks(resultSchema, KeepAsCell.OnlyStream),
     ...(derivedInternalCells.length > 0 ? { derivedInternalCells } : {}),
@@ -580,6 +581,8 @@ function factoryFromPattern<T, R>(
     nodes: serializedNodes,
     // Important that this refers to patternFactory, as .program will be set on
     // pattern afterwards (see factory.ts:exportsCallback)
+    toEncodableForm: () => patternToJSON(patternFactory),
+    // What `JSON.stringify(SomePattern)` answers, which pattern source uses.
     toJSON: () => patternToJSON(patternFactory),
   };
 
@@ -589,13 +592,13 @@ function factoryFromPattern<T, R>(
   ): PatternFactory<T, R> => {
     const factory = Object.assign(
       (inputs: FactoryInput<T>): Reactive<R> => {
-        const module: Module & toJSON = {
+        const module: Module & toEncodableForm = {
           type: "pattern",
           implementation: factory,
           ...(factory.defaultScope !== undefined
             ? { defaultScope: factory.defaultScope }
             : {}),
-          toJSON: () => moduleToJSON(module),
+          toEncodableForm: () => moduleToEncodableForm(module),
         };
 
         const outputs = reactive<R>();
@@ -622,8 +625,9 @@ function factoryFromPattern<T, R>(
       {
         ...pattern,
         ...(defaultScope !== undefined ? { defaultScope } : {}),
+        toEncodableForm: () => patternToJSON(factory),
         toJSON: () => patternToJSON(factory),
-      } as Pattern & toJSON,
+      } as Pattern & toEncodableForm & toJSON,
     ) as PatternFactory<T, R>;
 
     // `asScope` / `inSpace` mint fresh factory objects; record them as

--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -158,6 +158,7 @@ export type {
   Stream,
   StripCell,
   StripDefaultBrand,
+  toEncodableForm,
   toJSON,
   ToSchemaFunction,
   UiActionProps,

--- a/packages/runner/src/encodable-form.ts
+++ b/packages/runner/src/encodable-form.ts
@@ -122,7 +122,7 @@ function replace(
     if (!hasOwnEncodableForm(value)) return value;
     seen.set(value, IN_PROGRESS);
     return copied(
-      replace(value.toJSON(), seen, onCopy),
+      replace(value.toEncodableForm(), seen, onCopy),
       value,
       seen,
       onCopy,
@@ -152,7 +152,7 @@ function replace(
     // serializer it delegates to: the method a copy carries is closed over the
     // artifact the copy was made from, and that original is what the
     // serialized form describes.
-    flattened = replace(value.toJSON(), seen, onCopy);
+    flattened = replace(value.toEncodableForm(), seen, onCopy);
   } else {
     flattened = replaceInEntries(
       value as Record<string, unknown>,
@@ -252,7 +252,8 @@ function copyPreservingHoles(value: readonly unknown[]): unknown[] {
  */
 function hasOwnEncodableForm(
   value: object | ((...args: unknown[]) => unknown),
-): value is { toJSON(): unknown } {
-  return Object.hasOwn(value, "toJSON") &&
-    typeof (value as { toJSON: unknown }).toJSON === "function";
+): value is { toEncodableForm(): unknown } {
+  return Object.hasOwn(value, "toEncodableForm") &&
+    typeof (value as { toEncodableForm: unknown }).toEncodableForm ===
+      "function";
 }

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -68,6 +68,8 @@ import {
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { sendValueToBinding } from "./pattern-binding.ts";
 import { flattenBuilderArtifacts } from "./storage-preflight.ts";
+import { hasEncodableForm } from "./encodable-form.ts";
+import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import {
   type AddCancel,
   type Cancel,
@@ -1216,6 +1218,10 @@ export class Runner {
       undefined,
       tx,
     );
+    // A sub-pattern's argument can carry a builder artifact -- a pattern
+    // handed to another pattern as an input. This is a storage boundary like
+    // any other, so the artifact is replaced on the way in, once, for every
+    // write below: they must agree on what was stored.
     const storable = flattenBuilderArtifacts(argument);
     argumentCell.set(storable);
     recordSetupProjectionPolicyInputs(
@@ -1491,6 +1497,11 @@ export class Runner {
       // write boundary's `cloneIfNecessary` identity-pass instead of
       // deep-cloning-to-freeze. The result root marks the whole result
       // document as generated: setup rewrites the complete projection.
+      //
+      // A pattern's result can carry a builder artifact (a pattern tool, say).
+      // This converts directly rather than through `getImmutableCell`, which
+      // is where the replacement otherwise happens, so it does its own; the
+      // comparison above stays against the value as projected.
       writableResultCell.setRawUntyped(
         fabricFromNativeValue(flattenBuilderArtifacts(result)),
         false,
@@ -5116,14 +5127,42 @@ export class Runner {
       resultCell = previousScopedResultCell;
     }
 
-    const resultPatternAsString = JSON.stringify(resultPattern);
+    // Keyed on the pattern's ENCODABLE FORM, hashed, and ABSENT when the
+    // pattern has no such form -- a hand-built one does not.
+    //
+    // The distinction is the whole point. `JSON.stringify` has three ways of
+    // saying nothing (`undefined` for an unserializable value, `null` for such
+    // an array element, `{}` for an object of them), and the first is also
+    // what a cache miss looks like. Comparing them made a pattern that had
+    // never been seen read as unchanged, so it was never instantiated -- two
+    // absences agreeing, with nothing to observe at the comparison. An absent
+    // key now means "cannot say", which re-instantiates rather than skips.
+    //
+    // Note the key follows resolution state: the encodable form omits a
+    // module's stringified body when the reading runtime's harness can resolve
+    // its `$implRef`, so an answer that changes re-keys the pattern.
+    // Through the preflight, not the pattern's own form alone: a sub-graph
+    // reached through a node's `inputs` (an op) is not covered by the graph
+    // serializer, and a live function reaching the hash is an error where
+    // `JSON.stringify` merely dropped it. Fixing the route rather than the
+    // one path keeps this consumer honest as new routes appear.
+    const resultPatternKey = hasEncodableForm(resultPattern)
+      ? hashStringOf(flattenBuilderArtifacts(resultPattern))
+      : undefined;
     const cacheKey = this.getDocKey(resultCell);
-    const previousResultPatternAsString = this.resultPatternCache.get(cacheKey);
-    const patternUnchanged =
-      previousResultPatternAsString === resultPatternAsString;
+    const previousResultPatternKey = this.resultPatternCache.get(cacheKey);
+    const patternUnchanged = resultPatternKey !== undefined &&
+      previousResultPatternKey === resultPatternKey;
 
     if (!patternUnchanged) {
-      this.resultPatternCache.set(cacheKey, resultPatternAsString);
+      // Only a key that says something is worth remembering; "cannot say"
+      // must not be recorded, or the next comparison inherits the ambiguity
+      // this whole shape exists to remove.
+      if (resultPatternKey !== undefined) {
+        this.resultPatternCache.set(cacheKey, resultPatternKey);
+      } else {
+        this.resultPatternCache.delete(cacheKey);
+      }
 
       const childSetupTx = new TransactionWrapper(tx, {
         nonReactive: true,
@@ -6038,6 +6077,13 @@ export class Runner {
       resultCell,
     );
 
+    // The input bindings are about to cross into the data model, and a
+    // pattern author can bind a builder artifact (a handler, a pattern) as an
+    // ordinary input value at any depth. Replace each with its serialized form
+    // on the way, so what crosses is representable. Flattening here rather
+    // than alongside the `op` substitution above keeps it clear of
+    // `findAllWriteRedirectCells`, which walks the same bindings for a
+    // different purpose and should see them as bound.
     const inputsCell = this.runtime.getImmutableCell(
       resultCell.space,
       mappedInputBindings,

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -2000,6 +2000,11 @@ export class Runtime {
     // (this data is immutable as given). `fabricFromNativeValue()` converts
     // what callers actually pass -- notably `Cell`s, which become sigil
     // links via their `toJSON()` -- into an encodable `FabricValue`.
+    // Builder artifacts are replaced HERE rather than at each caller. This is
+    // the designed intake, and the callers are many: raw and JavaScript node
+    // inputs, wish candidates, schema defaults. Covering them one at a time was
+    // tried and is whack-a-mole -- each site that is missed fails as a
+    // rejection at the conversion, or worse as a cleanup error that masks it.
     const asDataURI = dataUriFromValue(
       fabricFromNativeValue(flattenBuilderArtifacts(data)),
     );

--- a/packages/runner/test/content-addressed-identity-adversarial.test.ts
+++ b/packages/runner/test/content-addressed-identity-adversarial.test.ts
@@ -786,7 +786,7 @@ describe("content-addressed identity — adversarial (C5 red-team gate)", () => 
     });
 
     it("a dynamic artifact (no symbol) serializes without $implRef", async () => {
-      // moduleToJSON only emits $implRef when provenance.symbol is present, so a
+      // moduleToEncodableForm only emits $implRef when provenance.symbol is present, so a
       // dynamic (symbol-less) artifact never gets a serialized, reload-resolvable
       // reference — confirming in-session-only authority on the serialization seam.
       const pattern = await setup();
@@ -807,12 +807,16 @@ describe("content-addressed identity — adversarial (C5 red-team gate)", () => 
         type: "javascript" as const,
         implementation: dyn,
         implementationRef: "dyn-ref",
-        toJSON: undefined as unknown,
+        toEncodableForm: undefined as unknown,
       };
-      // moduleToJSON is reached via the builder; call the same path the real
+      // moduleToEncodableForm is reached via the builder; call the same path the real
       // module uses. We re-import it lazily to avoid widening the import surface.
-      const { moduleToJSON } = await import("../src/builder/json-utils.ts");
-      const json = moduleToJSON(dynModule as unknown as Module) as Record<
+      const { moduleToEncodableForm } = await import(
+        "../src/builder/json-utils.ts"
+      );
+      const json = moduleToEncodableForm(
+        dynModule as unknown as Module,
+      ) as Record<
         string,
         unknown
       >;

--- a/packages/runner/test/content-addressed-identity.test.ts
+++ b/packages/runner/test/content-addressed-identity.test.ts
@@ -118,9 +118,10 @@ describe("content-addressed action identity", () => {
       .implementation;
     expect(reimpl).toBe(impl);
 
-    const json =
-      (refactory as unknown as { toJSON: () => Record<string, unknown> })
-        .toJSON();
+    const json = (refactory as unknown as {
+      toEncodableForm: () => Record<string, unknown>;
+    })
+      .toEncodableForm();
     expect(json.$implRef).toBeDefined();
     expect("implementation" in json).toBe(false);
   });
@@ -128,12 +129,14 @@ describe("content-addressed action identity", () => {
   it("serializes javascript modules with $implRef only (no legacy fields)", async () => {
     const pattern = await setup();
     const module = handlerModuleOf(pattern);
-    const json = (module as Module & { toJSON?: () => unknown }).toJSON
-      ? (module as Module & { toJSON: () => unknown }).toJSON() as Record<
-        string,
-        unknown
-      >
-      : JSON.parse(JSON.stringify(module));
+    const json =
+      (module as Module & { toEncodableForm?: () => unknown }).toEncodableForm
+        ? (module as Module & { toEncodableForm: () => unknown })
+          .toEncodableForm() as Record<
+            string,
+            unknown
+          >
+        : JSON.parse(JSON.stringify(module));
 
     const ref = json.$implRef as { identity: string; symbol: string };
     expect(ref).toBeDefined();
@@ -152,8 +155,8 @@ describe("content-addressed action identity", () => {
   it("a $implRef-only module survives artifact-index eviction (engine implementation index)", async () => {
     const pattern = await setup();
     const module = handlerModuleOf(pattern);
-    const json = (module as Module & { toJSON: () => unknown })
-      .toJSON() as Record<string, unknown>;
+    const json = (module as Module & { toEncodableForm: () => unknown })
+      .toEncodableForm() as Record<string, unknown>;
     const ref = json.$implRef as { identity: string; symbol: string };
     expect(ref).toBeDefined();
     expect("implementation" in json).toBe(false);
@@ -383,10 +386,10 @@ export default pattern<{ value: number }>(({ value }) => ({
       (n.module as Module).type === "javascript"
     );
     expect(node).toBeDefined();
-    const live = node!.module as Module & { toJSON?: () => unknown };
+    const live = node!.module as Module & { toEncodableForm?: () => unknown };
     const json =
-      (live.toJSON
-        ? live.toJSON()
+      (live.toEncodableForm
+        ? live.toEncodableForm()
         : JSON.parse(JSON.stringify(live))) as Record<string, unknown>;
     const ref = json.$implRef as { identity: string; symbol: string };
     expect(ref).toBeDefined();

--- a/packages/runner/test/host-pseudo-module.test.ts
+++ b/packages/runner/test/host-pseudo-module.test.ts
@@ -5,8 +5,8 @@ import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "../src/runtime.ts";
 import type { Module } from "../src/builder/types.ts";
-import type { toJSON } from "../src/builder/types.ts";
-import { moduleToJSON } from "../src/builder/json-utils.ts";
+import type { toEncodableForm } from "../src/builder/types.ts";
+import { moduleToEncodableForm } from "../src/builder/json-utils.ts";
 import { popFrame, pushFrame } from "../src/builder/pattern.ts";
 import { resolvePolicyFacingImplementationIdentity } from "../src/cfc/implementation-identity.ts";
 
@@ -44,10 +44,10 @@ describe("host-trusted values ride a pseudo-module", () => {
   });
 
   const hostModule = (fn: (...args: unknown[]) => unknown): Module => {
-    const module: Module & toJSON = {
+    const module: Module & toEncodableForm = {
       type: "javascript",
       implementation: fn,
-      toJSON: () => moduleToJSON(module),
+      toEncodableForm: () => moduleToEncodableForm(module),
     };
     return module;
   };
@@ -59,7 +59,7 @@ describe("host-trusted values ride a pseudo-module", () => {
     const module = hostModule((value) => (value as number) + base);
     runtime.unsafeTrustModule(module, { reason: "host pseudo-module test" });
 
-    const json = (module as Module & toJSON).toJSON() as {
+    const json = (module as Module & toEncodableForm).toEncodableForm() as {
       $implRef?: { identity: string; symbol: string };
       implementation?: unknown;
       implementationRef?: string;
@@ -87,10 +87,10 @@ describe("host-trusted values ride a pseudo-module", () => {
     runtime.unsafeTrustModule(a, { reason: "host pseudo-module test" });
     runtime.unsafeTrustModule(b, { reason: "host pseudo-module test" });
 
-    const ja = (a as Module & toJSON).toJSON() as {
+    const ja = (a as Module & toEncodableForm).toEncodableForm() as {
       $implRef: { identity: string; symbol: string };
     };
-    const jb = (b as Module & toJSON).toJSON() as {
+    const jb = (b as Module & toEncodableForm).toEncodableForm() as {
       $implRef: { identity: string; symbol: string };
     };
     expect(ja.$implRef).not.toEqual(jb.$implRef);
@@ -99,12 +99,12 @@ describe("host-trusted values ride a pseudo-module", () => {
   it("re-trusting the same value keeps its ref stable", () => {
     const module = hostModule((value) => value);
     runtime.unsafeTrustModule(module, { reason: "host pseudo-module test" });
-    const first = (module as Module & toJSON).toJSON() as {
+    const first = (module as Module & toEncodableForm).toEncodableForm() as {
       $implRef: { identity: string; symbol: string };
     };
     expect(first.$implRef).toBeDefined();
     runtime.unsafeTrustModule(module, { reason: "host pseudo-module test" });
-    const second = (module as Module & toJSON).toJSON() as {
+    const second = (module as Module & toEncodableForm).toEncodableForm() as {
       $implRef: { identity: string; symbol: string };
     };
     expect(first.$implRef).toEqual(second.$implRef);
@@ -134,7 +134,8 @@ describe("host-trusted values ride a pseudo-module", () => {
       const frame = pushFrame({ runtime } as never);
       let json: { $implRef?: unknown; implementation?: unknown };
       try {
-        json = (module as Module & toJSON).toJSON() as typeof json;
+        json = (module as Module & toEncodableForm)
+          .toEncodableForm() as typeof json;
       } finally {
         popFrame(frame);
       }

--- a/packages/runner/test/json-utils.test.ts
+++ b/packages/runner/test/json-utils.test.ts
@@ -8,10 +8,14 @@ import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 
 import {
   createJsonSchema,
-  moduleToJSON,
+  moduleToEncodableForm,
   toJSONWithAliasBindings,
 } from "../src/builder/json-utils.ts";
-import { type JSONSchema, type JSONSchemaObj } from "../src/builder/types.ts";
+import {
+  type JSONSchema,
+  type JSONSchemaObj,
+  type Module,
+} from "../src/builder/types.ts";
 import { isInternedSchema } from "@commonfabric/data-model/schema-hash";
 import { popFrame, pushFrame } from "../src/builder/pattern.ts";
 import { getVerifiedProvenance } from "../src/harness/verified-provenance.ts";
@@ -789,7 +793,7 @@ describe("json-utils", () => {
   });
 });
 
-describe("moduleToJSON", () => {
+describe("moduleToEncodableForm", () => {
   let runtime: Runtime;
   let storageManager: ReturnType<typeof StorageManager.emulate>;
 
@@ -814,7 +818,7 @@ describe("moduleToJSON", () => {
         src: "main.tsx:1:1",
       },
     );
-    const serialized = moduleToJSON({
+    const serialized = moduleToEncodableForm({
       type: "javascript",
       implementation,
     } as any);
@@ -827,6 +831,35 @@ describe("moduleToJSON", () => {
     });
   });
 
+  it("writes exactly the module's own members, and none of its machinery", () => {
+    // The serialized form is what a content-derived id gets minted from, so
+    // an extra member is a changed id for every value carrying a module. The
+    // members a module carries for the builder's benefit -- its serializer,
+    // `with`, `bind` -- are machinery, and the serializer is responsible for
+    // leaving every one of them behind. Asserted as the WHOLE key set: a
+    // subset match cannot see a member that should not be there.
+    const module: Record<string, unknown> = {
+      type: "javascript",
+      implementation: Object.assign(() => 1, { preview: "() => 1" }),
+      wrapper: "handler",
+      argumentSchema: { type: "object" } as JSONSchema,
+      with: () => {},
+      bind: () => {},
+      toEncodableForm: () => moduleToEncodableForm(module as unknown as Module),
+    };
+
+    const serialized =
+      (module.toEncodableForm as () => Record<string, unknown>)();
+
+    expect(Object.keys(serialized).sort()).toEqual([
+      "argumentSchema",
+      "implementation",
+      "preview",
+      "type",
+      "wrapper",
+    ]);
+  });
+
   it("serializes non-javascript function-backed modules without leaking implementations", () => {
     const implementation = Object.assign(
       () => "ok",
@@ -835,7 +868,7 @@ describe("moduleToJSON", () => {
         src: "main.tsx:2:1",
       },
     );
-    const serialized = moduleToJSON({
+    const serialized = moduleToEncodableForm({
       type: "raw",
       implementation,
     } as any);
@@ -916,7 +949,7 @@ describe("moduleToJSON", () => {
 
     // The implementation became verified during the STANDALONE Engine's
     // evaluation, so it carries process-global content-addressed provenance
-    // (Engine.recordModuleProvenance) and `moduleToJSON` writes a `$implRef`.
+    // (Engine.recordModuleProvenance) and `moduleToEncodableForm` writes a `$implRef`.
     // But this pattern was registered WITHOUT going through
     // `compilePattern`/`registerEvaluatedModules` on THIS runtime, so its
     // engine's implementation index never saw the artifact and cannot resolve
@@ -939,9 +972,9 @@ describe("moduleToJSON", () => {
     ).toBeUndefined();
 
     const frame = pushFrame({ runtime });
-    let serialized: ReturnType<typeof moduleToJSON>;
+    let serialized: ReturnType<typeof moduleToEncodableForm>;
     try {
-      serialized = moduleToJSON(targetModule);
+      serialized = moduleToEncodableForm(targetModule);
     } finally {
       popFrame(frame);
     }

--- a/packages/runner/test/pattern-ref-boundary.test.ts
+++ b/packages/runner/test/pattern-ref-boundary.test.ts
@@ -113,53 +113,6 @@ describe("refs-only pattern JSON at the boundary", () => {
     expect(Array.isArray((serialized as { nodes: unknown }).nodes)).toBe(true);
   });
 
-  it("a graph crossing the boundary carries no live builder artifact", () => {
-    // The nodes a pattern holds carry LIVE modules: `toJSONWithAliasBindings`
-    // builds a node by copying its module member by member, function members
-    // included. A graph emitted with those still in it is not a serialized
-    // value -- it depends on whatever reads it next to finish the job by
-    // calling methods on live objects, which is the assumption being removed.
-    //
-    // The fixture mirrors that shape rather than being a real pattern: a
-    // hand-built one cannot exhibit a bug it has no shape for, so this pins
-    // the property and `scripts/ab-harness.ts` measures it against a real
-    // pattern, where the same graph carried 7691 functions across 16 paths.
-    const fake = {
-      argumentSchema: true,
-      resultSchema: true,
-      result: {},
-      nodes: [
-        {
-          module: {
-            type: "javascript",
-            implementation: () => "live",
-            toJSON: () => ({ type: "javascript", implementation: "source" }),
-          },
-          inputs: {},
-          outputs: {},
-        },
-      ],
-    } as unknown as Pattern;
-
-    const serialized = patternToJSON(fake);
-    const live: string[] = [];
-    const walk = (value: unknown, path: string) => {
-      if (typeof value === "function") live.push(path);
-      else if (value && typeof value === "object") {
-        for (const [key, member] of Object.entries(value)) {
-          walk(member, `${path}.${key}`);
-        }
-      }
-    };
-    walk(serialized, "$");
-
-    expect(live).toEqual([]);
-    expect((serialized as any).nodes[0].module).toEqual({
-      type: "javascript",
-      implementation: "source",
-    });
-  });
-
   it("internal graph serialization stays the full bare graph", async () => {
     const compiled = await runtime.patternManager.compilePattern(PROGRAM);
     expect(runtime.patternManager.getArtifactEntryRef(compiled)).toBeDefined();

--- a/packages/runner/test/storage-preflight.test.ts
+++ b/packages/runner/test/storage-preflight.test.ts
@@ -11,19 +11,19 @@ function artifact(serialized: unknown): Record<string, unknown> {
   return {
     type: "javascript",
     implementation: () => "not representable",
-    toJSON: () => serialized,
+    toEncodableForm: () => serialized,
   };
-}
-
-/** A factory: a function carrying its module's members. */
-function factoryArtifact(serialized: unknown): () => void {
-  return Object.assign(() => {}, artifact(serialized));
 }
 
 describe("flattenBuilderArtifacts()", () => {
   describe("values carrying no artifact", () => {
     it("answers a record by identity", () => {
       const value = { a: 1, b: { c: [1, 2, 3] } };
+      expect(flattenBuilderArtifacts(value)).toBe(value);
+    });
+
+    it("answers a nested array by identity", () => {
+      const value = [{ a: 1 }, [2, [3]]];
       expect(flattenBuilderArtifacts(value)).toBe(value);
     });
 
@@ -36,6 +36,13 @@ describe("flattenBuilderArtifacts()", () => {
   });
 
   describe("replacement", () => {
+    it("replaces a top-level artifact with its serialized form", () => {
+      const result = flattenBuilderArtifacts(
+        artifact({ type: "javascript", implementation: "source" }),
+      );
+      expect(result).toEqual({ type: "javascript", implementation: "source" });
+    });
+
     it("replaces an artifact nested under records and arrays", () => {
       const value = {
         tools: { send: { handler: artifact({ serialized: true }) } },
@@ -45,14 +52,6 @@ describe("flattenBuilderArtifacts()", () => {
         tools: { send: { handler: { serialized: true } } },
         list: [{ second: true }],
       });
-    });
-
-    it("replaces a FUNCTION-shaped artifact", () => {
-      // A factory is a function carrying its module's members, so an artifact
-      // is reached in two shapes and both have to be covered.
-      const value = { tool: { pattern: factoryArtifact({ flat: true }) } };
-      expect(flattenBuilderArtifacts(value))
-        .toEqual({ tool: { pattern: { flat: true } } });
     });
 
     it("descends into the serialized form", () => {
@@ -79,7 +78,7 @@ describe("flattenBuilderArtifacts()", () => {
     it("serializes a shared artifact once and keeps it shared", () => {
       let calls = 0;
       const shared = {
-        toJSON: () => {
+        toEncodableForm: () => {
           calls++;
           return { serialized: true };
         },
@@ -90,47 +89,59 @@ describe("flattenBuilderArtifacts()", () => {
       });
       expect(calls).toBe(1);
       expect(result.first).toBe(result.second);
+      expect(result.first).toEqual({ serialized: true });
     });
 
-    it("reads each member once", () => {
-      // A copy built by re-reading would run an accessor twice and keep the
-      // second answer, recording a value the object never held at any single
-      // moment.
-      let reads = 0;
-      const value = {
-        artifact: artifact({ flat: true }),
-        get accessor() {
-          reads++;
-          return reads;
-        },
-      };
-      const result = flattenBuilderArtifacts(value) as Record<string, unknown>;
-      expect(reads).toBe(1);
-      expect(result.accessor).toBe(1);
+    it("makes the result representable as a `FabricValue`", () => {
+      const value = { tools: { send: { handler: artifact({ ok: true }) } } };
+      expect(fabricFromNativeValue(flattenBuilderArtifacts(value)))
+        .toEqual({ tools: { send: { handler: { ok: true } } } });
     });
 
     it("encodes to the same bytes as the serialized form written inline", () => {
       // The encoded form is what a content-derived id is minted from, so a
       // difference here is a difference in every id derived from a value
-      // carrying an artifact.
+      // carrying an artifact. Flattening must arrive at exactly the encoding
+      // of the form the artifact serializes to, key order included.
       const value = { tools: { send: { handler: artifact({ ok: true }) } } };
       const inline = { tools: { send: { handler: { ok: true } } } };
-      expect(
-        dataUriFromValue(fabricFromNativeValue(flattenBuilderArtifacts(value))),
-      ).toBe(dataUriFromValue(fabricFromNativeValue(inline)));
+      expect(dataUriFromValue(fabricFromNativeValue(
+        flattenBuilderArtifacts(value),
+      )))
+        .toBe(dataUriFromValue(fabricFromNativeValue(inline)));
+    });
+
+    it("is the only route by which an artifact becomes representable", () => {
+      // The conversion has no route of its own to an artifact's serializer:
+      // an artifact names it `toEncodableForm`, which the conversion knows
+      // nothing about. So flattening is load-bearing rather than an
+      // optimization, and skipping it is a loud rejection.
+      const value = { tools: { send: { handler: artifact({ ok: true }) } } };
+      expect(() => fabricFromNativeValue(value))
+        .toThrow(/function per se/);
     });
   });
 
   describe("values the conversion decides for itself", () => {
     it("leaves an array carrying an own serializer alone", () => {
       // An array is answered by the array rule whatever it carries.
-      const value = Object.assign([1, 2], { toJSON: () => "replaced" });
+      const value = Object.assign([1, 2], {
+        toEncodableForm: () => "replaced",
+      });
       expect(flattenBuilderArtifacts(value)).toBe(value);
+    });
+
+    it("leaves a plain object carrying an own `toJSON` alone", () => {
+      // `toJSON` is not how a builder artifact spells its serializer, so an
+      // object bearing one is ordinary data as far as this is concerned, and
+      // what becomes of it is the conversion's to decide.
+      const value = { secret: "internal", toJSON: () => ({ exposed: true }) };
+      expect(flattenBuilderArtifacts({ value }).value).toBe(value);
     });
 
     it("leaves a class instance with a prototype serializer alone", () => {
       class Serializable {
-        toJSON() {
+        toEncodableForm() {
           return { serialized: true };
         }
       }
@@ -138,10 +149,18 @@ describe("flattenBuilderArtifacts()", () => {
       expect(flattenBuilderArtifacts({ value }).value).toBe(value);
     });
 
+    it("leaves a class instance with an own serializer alone", () => {
+      class Bare {}
+      const value = Object.assign(new Bare(), {
+        toEncodableForm: () => "replaced",
+      });
+      expect(flattenBuilderArtifacts({ value }).value).toBe(value);
+    });
+
     it("leaves a null-prototype record alone", () => {
       const value: Record<string, unknown> = Object.assign(
         Object.create(null),
-        { toJSON: () => "replaced" },
+        { toEncodableForm: () => "replaced" },
       );
       expect(flattenBuilderArtifacts({ value }).value).toBe(value);
     });

--- a/packages/runner/test/twin-lineage-provenance.test.ts
+++ b/packages/runner/test/twin-lineage-provenance.test.ts
@@ -275,12 +275,14 @@ describe("twin-lineage provenance (helper-unlink regression)", () => {
 
       // And the wire shape is ref-carrying — never the silent body-only form
       // that bare-SES re-evaluates outside module scope on reload.
-      const json = (module as Module & { toJSON?: () => unknown }).toJSON
-        ? (module as Module & { toJSON: () => unknown }).toJSON() as Record<
-          string,
-          unknown
-        >
-        : JSON.parse(JSON.stringify(module));
+      const json =
+        (module as Module & { toEncodableForm?: () => unknown }).toEncodableForm
+          ? (module as Module & { toEncodableForm: () => unknown })
+            .toEncodableForm() as Record<
+              string,
+              unknown
+            >
+          : JSON.parse(JSON.stringify(module));
       expect(json.$implRef).toBeDefined();
       expect(typeof json.implementation).not.toBe("string");
     }


### PR DESCRIPTION
Preparation for dropping the plain-object `toJSON()` arm from the data model. This PR is behavior-neutral on its own; the removal follows separately.

## The problem

A builder module carries its serializer as a `toJSON` method (`builder/module.ts:135,441`, `builder/pattern.ts:583,598,625`), so it is a record with a function-valued property — a shape no `FabricValue` has. `isFabricValue({a, toJSON})` already answers `false` while `fabricFromNativeValue` accepts it: the very property that disqualifies the value is the one that decides what it becomes. Same predicate-vs-converter split as #5257 and #5261.

## What this does

Replaces each artifact with its serialized form in the runner, where the artifacts come from, on the two paths that hand a bound pattern value to the data model:

- `Runner.instantiateRawNode` — a raw node's input bindings (a handler under a tool's `handler` key, say)
- `Runner.updateResultProjection` — a pattern's result projection (a pattern tool the result carries)

Both carry the output of `unwrapOneLevelAndBindToDoc`, and an artifact sits at whatever depth the pattern author put it, so finding one takes a walk. `flattenBuilderArtifacts()` returns subtrees carrying no artifact by identity, which keeps an already deep-frozen value eligible for the conversion's identity fast path and keeps a twice-reachable object shared.

Two details that are load-bearing:

- It calls the artifact's **own** `toJSON()` rather than `moduleToJSON(value)`. `unwrapOneLevelAndBindToDoc` rebuilds every record via `Object.fromEntries`, and the copied method is closed over the artifact the copy was made from — the two disagree.
- It **descends into the serialized form**. `toJSONWithAliasBindings` copies `toJSON` function values straight through (`json-utils.ts:158`), so a serialized pattern graph still has modules bearing `toJSON` inside it.

The walk sits at the `getImmutableCell` call rather than alongside the `op` substitution above it, so `findAllWriteRedirectCells` — which walks the same bindings for a different purpose — still sees them as bound. A module is not a pattern, so that scan walks into one; flattening first would change what it traverses.

## Verification

- Runner **1112 passed / 0 failed** (baseline 1111, plus this PR's test file).
- Full workspace: all 39 packages pass. `deno fmt --check`, `deno lint`, `deno task check`, `deno task check-docs` (521 blocks), `deno task cfcheck` (423 patterns) all clean.
- The load-bearing check: with the plain-object `toJSON` arm removed locally, the only failures across the whole workspace are that arm's own pins — data-model 13 steps, runner 2 steps on the `Cell.set()` path (which has no production consumer). Every other package passes. Without this PR, that same experiment additionally fails 6 tests across `llm-dialog`, `generateObject` and `by-identity-handler-exec`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ANjQ4Hb5SahQxKKg8NRX3L

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves builder artifact serialization to the runner’s storage intake and renames serializers to `toEncodableForm`; factories keep `toJSON` for the cross-package wire format used by pattern source, while modules only expose `toEncodableForm`. Pattern graphs now serialize fully (including nested `inputs.op`) without leaking live modules; encoded bytes remain unchanged.

- **Refactors**
  - `packages/api`: added `toEncodableForm`; all factories (`NodeFactory`, `PatternFactory`, `ModuleFactory`, `HandlerFactory`) now carry both `toJSON` and `toEncodableForm`; modules implement only `toEncodableForm`.
  - Renamed `moduleToJSON` → `moduleToEncodableForm`; factories keep `toJSON` and delegate to `toEncodableForm`.
  - Extended `encodable-form.ts` (`hasEncodableForm`, `encodableFormOf`, `replaceArtifacts`) and now consults `toEncodableForm` instead of `toJSON`.
  - `patternToJSON` replaces artifacts via `replaceArtifacts`, so modules and nested graphs (incl. `inputs.op`) are serialized.
  - Centralized flattening at storage crossings: `Runtime.getImmutableCell`, `Runner.updateArgument`, and result projection now replace artifacts before conversion; defaults, `create-ref`, and sandbox result normalization use encodable forms.
  - Added `docs/history/spikes/dropping-json-serialization.md` (findings; no behavior change).

- **Bug Fixes**
  - Result-pattern caching now keys on `hashStringOf(flattenBuilderArtifacts(pattern))`; if no encodable form exists, the “cannot say” case is not cached, fixing silent non-instantiation.
  - All storage boundaries flatten artifacts before conversion, preventing function-bearing values from reaching the data model and resolving the integration test regression.

<sup>Written for commit fb4f03c42a2a09bcf508a97d8ce78783175ba75a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

