### PR TITLE
feat(utils): make the structural shape checks type predicates

### DIFF
--- a/packages/data-model/src/codec-json/JsonEncodingContext.ts
+++ b/packages/data-model/src/codec-json/JsonEncodingContext.ts
@@ -178,11 +178,8 @@ export class JsonEncodingContext implements SerializationContext<string> {
     }
 
     // `isEncodedInstance()` guaranteed a single-property object, so this
-    // destructures that one entry. (`isPlainObject()` is not a type guard, so
-    // narrow explicitly for the type-checker.)
-    const [key, value] = Object.entries(
-      data as Record<string, JsonWireValue>,
-    )[0]!;
+    // destructures that one entry.
+    const [key, value] = Object.entries(data)[0]!;
     return { tag: key.slice(1), state: value };
   }
 

--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -163,9 +163,8 @@ export function isFabricValue(value: unknown): value is FabricValue {
       // see `unsafeObjectKeyIn()`.
       if (!isInertPlainObject(item)) return false;
       if (unsafeObjectKeyIn(item) !== undefined) return false;
-      const record = item as Record<string, unknown>;
-      for (const key of Object.keys(record)) {
-        if (!check(record[key])) return false;
+      for (const key of Object.keys(item)) {
+        if (!check(item[key])) return false;
       }
       return true;
     } else {

--- a/packages/utils/src/arrays.ts
+++ b/packages/utils/src/arrays.ts
@@ -173,8 +173,7 @@ export function isArrayWithOnlyIndexProperties(array: unknown): boolean {
  * means inertness was not established, which is weaker than its negation, and
  * `false`-branch narrowing is subtraction, which cannot express that. Hence the
  * overload pair, which keeps a caller already holding an array type out of the
- * subtraction and preserves its element type and `readonly`-ness; the header of
- * the `types` module gives the full account.
+ * subtraction; the header of the `types` module gives the full account.
  *
  * @param array The value to check.
  * @returns `true` if the array is an inert array, `false` otherwise.

--- a/packages/utils/src/arrays.ts
+++ b/packages/utils/src/arrays.ts
@@ -103,9 +103,23 @@ export function isArrayIndexPropertyName(name: string): boolean {
  * regards to what `Proxy`s actually do), _and_ by making this assumption, this
  * function avoids having to inspect _every_ key.
  *
+ * This is a structural predicate, so it narrows in one direction only, and is
+ * overloaded accordingly; the header of the `types` module gives the full
+ * account. The short of it: a `false` result reports that index-only-ness could
+ * not be established, which is weaker than the negation, and TypeScript's
+ * `false`-branch narrowing is subtraction and so cannot express the difference.
+ * The first overload keeps callers who already hold an array type out of that
+ * subtraction entirely.
+ *
  * @param array The value to check.
  * @returns `true` if the array has only index properties, `false` otherwise.
  */
+export function isArrayWithOnlyIndexProperties(
+  array: readonly unknown[],
+): boolean;
+export function isArrayWithOnlyIndexProperties(
+  array: unknown,
+): array is readonly unknown[];
 export function isArrayWithOnlyIndexProperties(array: unknown): boolean {
   // `Array.isArray()` sees through a `Proxy` to its target, so a proxied array
   // is still recognized as one here.
@@ -151,9 +165,22 @@ export function isArrayWithOnlyIndexProperties(array: unknown): boolean {
  * question forwards to the target, and a trap that answers otherwise is the
  * proxy's own bug to own.
  *
+ * Inertness is a property of the array at the moment of the check, not of its
+ * type: an index can be redefined as an accessor, or a named property added, at
+ * any later point. So this predicate narrows only to `readonly unknown[]` --
+ * true of the value forever after -- and never to anything asserting the
+ * inertness itself, and it narrows in one direction only. A `false` result
+ * means inertness was not established, which is weaker than its negation, and
+ * `false`-branch narrowing is subtraction, which cannot express that. Hence the
+ * overload pair, which keeps a caller already holding an array type out of the
+ * subtraction and preserves its element type and `readonly`-ness; the header of
+ * the `types` module gives the full account.
+ *
  * @param array The value to check.
  * @returns `true` if the array is an inert array, `false` otherwise.
  */
+export function isInertArray(array: readonly unknown[]): boolean;
+export function isInertArray(array: unknown): array is readonly unknown[];
 export function isInertArray(array: unknown): boolean {
   // `Array.isArray()` sees through a `Proxy` to its target, so a proxied array
   // is still recognized as one here, and -- absent a `getPrototypeOf()` trap --

--- a/packages/utils/src/objects.ts
+++ b/packages/utils/src/objects.ts
@@ -2,6 +2,8 @@
  * Pure utility functions for checking the property-key shape of plain objects.
  */
 
+import type { ReadonlyRecord } from "./types.ts";
+
 /**
  * Indicates whether the given value is an *inert* plain object -- a direct
  * instance of `Object`, every own property an enumerable
@@ -30,10 +32,23 @@
  * throwing no matter what it is handed. A `Proxy` is the one exception, and
  * unavoidably so, since it can throw from its own traps.
  *
+ * Inertness is a property of the object at the moment of the check, not of its
+ * type: a property can be redefined as an accessor, or a symbol-keyed one
+ * added, at any later point. So this predicate narrows only to
+ * `ReadonlyRecord` -- true of the value forever after -- and never to anything
+ * asserting the inertness itself, and it narrows in one direction only. A
+ * `false` result means inertness was not established, which is weaker than its
+ * negation, and `false`-branch narrowing is subtraction, which cannot express
+ * that. Hence the overload pair, which keeps a caller already holding a record
+ * type out of the subtraction; the header of the `types` module gives the full
+ * account.
+ *
  * @param value The value to check.
  * @returns `true` if the value is a plain object all of whose own properties
  *   are enumerable string-keyed data properties, `false` otherwise.
  */
+export function isInertPlainObject(value: ReadonlyRecord): boolean;
+export function isInertPlainObject(value: unknown): value is ReadonlyRecord;
 export function isInertPlainObject(
   value: unknown,
 ): boolean {

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -1,4 +1,39 @@
 /**
+ * Type predicates over the general shape of a value.
+ *
+ * The predicates here come in two kinds, and the difference is visible at the
+ * call site. One kind tests an exact `typeof` class -- `isString()`,
+ * `isNumber()`, `isFunction()` -- and says everything there is to say about the
+ * value, so its `false` branch is exactly as trustworthy as its `true` branch.
+ *
+ * The other kind is *structural*: `isPlainObject()` and `isPlainContainer()`
+ * here, and `isInertArray()`, `isArrayWithOnlyIndexProperties()`, and
+ * `isInertPlainObject()` in the sibling `arrays` and `objects` modules. Each of
+ * those checks strictly more than the type it narrows to can express, and
+ * deliberately so: each narrows to the weakest type that stays true however the
+ * value is treated afterwards, never to the property it actually checks. A
+ * prototype can be reassigned and a property redefined, so "is `Object`-rooted"
+ * or "is inert" describes an instant rather than a type, and a narrowed type
+ * that claimed it would go on claiming it after it stopped being so.
+ *
+ * A structural predicate is therefore *one-directional*: its `false` branch
+ * means "not established", not "the negation holds". TypeScript cannot be told
+ * this, because narrowing a `false` branch is subtraction and the language has
+ * no negated types. Left to itself it would subtract the narrowed type from the
+ * declared one, so a caller already holding a type at least as specific as what
+ * the predicate narrows to would find the `false` branch reduced to `never` --
+ * a value the check rejected, for a reason the type system never recorded.
+ *
+ * Each structural predicate heads this off with a pair of overloads. A caller
+ * who already knows the broad shape gets a plain `boolean`, keeping both
+ * branches intact along with whatever element or property types it came in
+ * with; a caller holding `unknown` or `object`, who has no such type to lose,
+ * gets the narrowing. The first overload is also what keeps a `readonly`
+ * declaration from being silently widened, since narrowing intersects and would
+ * otherwise hand back a mutable view of a frozen value.
+ */
+
+/**
  * Predicate for narrowing a mutable string-keyed record type.
  * @param value - The value to check
  * @returns True if the value is a record object
@@ -96,9 +131,16 @@ export function isFiniteNumber(value: unknown): boolean {
  * null-prototype object answers `true` here and `false` there, and both
  * answers are right for their own question.
  *
+ * This is a structural predicate, so it narrows in one direction only, and is
+ * overloaded accordingly; see the module header for what that means and why.
+ * In particular, a `false` result says the value is not `Object`-rooted right
+ * now, which is not the same as any statement about its type.
+ *
  * @param value - The value to check
  * @returns True if the value is a plain object
  */
+export function isPlainObject(value: ReadonlyRecord): boolean;
+export function isPlainObject(value: unknown): value is ReadonlyRecord;
 export function isPlainObject(value: unknown): boolean {
   if (value === null || typeof value !== "object") return false;
   const proto = Object.getPrototypeOf(value);
@@ -113,12 +155,21 @@ export function isPlainObject(value: unknown): boolean {
  * uniformly. Non-plain class instances (`Date`, `Map`, `Set`, `Error`,
  * user-defined classes, ...) deliberately do not qualify.
  *
+ * This is a structural predicate, so it narrows in one direction only, and is
+ * overloaded accordingly; see the module header. Unlike its neighbours it
+ * narrows to a *mutable* pair of types, because its callers are the ones that
+ * go on to write through the result.
+ *
  * @param value - The value to check
  * @returns True if the value is a plain object or an array
  */
 export function isPlainContainer(
+  value: ReadonlyRecord | readonly unknown[],
+): boolean;
+export function isPlainContainer(
   value: unknown,
-): value is Record<string, unknown> | unknown[] {
+): value is Record<string, unknown> | unknown[];
+export function isPlainContainer(value: unknown): boolean {
   return Array.isArray(value) || isPlainObject(value);
 }
 

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -18,8 +18,8 @@
  *
  * The narrowed types are read-only for the same reason. A frozen value is the
  * ordinary case here, and a predicate narrowing to a mutable `unknown[]` would
- * hand a caller holding `unknown` a writable view of one -- narrowing replaces
- * such a declared type outright rather than intersecting with it.
+ * hand a caller holding `unknown` a writable view of one, there being no
+ * `readonly` on the declared type for the result to inherit.
  * `isPlainContainer()` is the deliberate exception on both counts: it narrows
  * to mutable types, which claim more than it checks, because its callers are
  * the ones that go on to write through the result. The residual hazard is its
@@ -39,10 +39,13 @@
  * branches; a caller holding `unknown` or `object`, who has no such type to
  * lose, gets the narrowing. Keeping the `false` branch usable is the whole of
  * what the first overload buys, and the only reason it is there. It is not what
- * protects a `readonly` declaration -- the read-only narrowed types do that
- * unaided, since narrowing a declared type that is already read-only
- * intersects with it rather than replacing it, which also preserves the element
- * and property types the caller arrived with.
+ * protects a `readonly` declaration; the read-only narrow targets do that
+ * unaided. A declared type that is already read-only is assignable to such a
+ * target, so narrowing keeps it exactly as it was -- element and property types
+ * included -- and it goes on rejecting writes. Against a *mutable* target it
+ * would not be assignable, and TypeScript would intersect the two instead: the
+ * resulting `readonly number[] & unknown[]` accepts writes, which is how a
+ * mutable target launders `readonly` away.
  */
 
 /**

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -16,6 +16,16 @@
  * or "is inert" describes an instant rather than a type, and a narrowed type
  * that claimed it would go on claiming it after it stopped being so.
  *
+ * The narrowed types are read-only for the same reason. A frozen value is the
+ * ordinary case here, and a predicate narrowing to a mutable `unknown[]` would
+ * hand a caller holding `unknown` a writable view of one -- narrowing replaces
+ * such a declared type outright rather than intersecting with it.
+ * `isPlainContainer()` is the deliberate exception on both counts: it narrows
+ * to mutable types, which claim more than it checks, because its callers are
+ * the ones that go on to write through the result. The residual hazard is its
+ * own: a caller passing `unknown` gets a writable view of what may be a frozen
+ * container, with nothing at compile time to say so.
+ *
  * A structural predicate is therefore *one-directional*: its `false` branch
  * means "not established", not "the negation holds". TypeScript cannot be told
  * this, because narrowing a `false` branch is subtraction and the language has
@@ -25,12 +35,14 @@
  * a value the check rejected, for a reason the type system never recorded.
  *
  * Each structural predicate heads this off with a pair of overloads. A caller
- * who already knows the broad shape gets a plain `boolean`, keeping both
- * branches intact along with whatever element or property types it came in
- * with; a caller holding `unknown` or `object`, who has no such type to lose,
- * gets the narrowing. The first overload is also what keeps a `readonly`
- * declaration from being silently widened, since narrowing intersects and would
- * otherwise hand back a mutable view of a frozen value.
+ * who already knows the broad shape gets a plain `boolean` and keeps both
+ * branches; a caller holding `unknown` or `object`, who has no such type to
+ * lose, gets the narrowing. Keeping the `false` branch usable is the whole of
+ * what the first overload buys, and the only reason it is there. It is not what
+ * protects a `readonly` declaration -- the read-only narrowed types do that
+ * unaided, since narrowing a declared type that is already read-only
+ * intersects with it rather than replacing it, which also preserves the element
+ * and property types the caller arrived with.
  */
 
 /**

--- a/packages/utils/test/narrowing.test.ts
+++ b/packages/utils/test/narrowing.test.ts
@@ -5,7 +5,11 @@ import {
   isInertArray,
 } from "@commonfabric/utils/arrays";
 import { isInertPlainObject } from "@commonfabric/utils/objects";
-import { isPlainObject, type ReadonlyRecord } from "@commonfabric/utils/types";
+import {
+  isPlainContainer,
+  isPlainObject,
+  type ReadonlyRecord,
+} from "@commonfabric/utils/types";
 
 /**
  * The narrowing contract of the structural predicates, as described in the
@@ -74,6 +78,19 @@ describe("structural predicate narrowing", () => {
       expect(array[0]!.toFixed(1)).toBe("1.0");
     });
 
+    it("keeps a `readonly`-declared array usable after a `false` result", () => {
+      const backing: number[] = [1, 2, 3];
+      Object.defineProperty(backing, 1, { get: () => 2 });
+      const array: readonly number[] = backing;
+
+      if (isInertArray(array)) {
+        throw new Error("Expected an accessor-backed index to be rejected.");
+      }
+
+      // Still `readonly number[]`, not `never`.
+      expect(array[0]!.toFixed(1)).toBe("1.0");
+    });
+
     it("keeps a record usable after a `false` result", () => {
       const record: Record<string, unknown> = Object.create(null);
       record.a = 1;
@@ -82,8 +99,10 @@ describe("structural predicate narrowing", () => {
         throw new Error("Expected a null-prototype object to be rejected.");
       }
 
-      // `record` is still `Record<string, unknown>` here, not `never`.
-      expect(Object.keys(record)).toEqual(["a"]);
+      // `record` is still `Record<string, unknown>` here, not `never`. It has
+      // to be a property access: `Object.keys()` and index access both accept
+      // `never` without complaint, and so would pass even had it collapsed.
+      expect(record.a).toBe(1);
     });
 
     it("keeps a record usable after a `false` result from `isPlainObject()`", () => {
@@ -96,27 +115,32 @@ describe("structural predicate narrowing", () => {
         throw new Error("Expected a non-`Object`-rooted value to be rejected.");
       }
 
-      expect(Object.keys(record)).toEqual([]);
+      // Again a property access, for the reason given just above. The value
+      // comes from the prototype, which is exactly what disqualified it.
+      expect(record.inherited).toBe(1);
+    });
+
+    it("keeps a container usable after a `false` result", () => {
+      const container: ReadonlyRecord = new Date() as unknown as ReadonlyRecord;
+
+      if (isPlainContainer(container)) {
+        throw new Error("Expected a class instance to be rejected.");
+      }
+
+      expect(container.nope).toBe(undefined);
     });
   });
 
-  describe("never hands back a mutable view of a `readonly` value", () => {
-    // These assert assignability rather than performing a write: the values are
+  describe("narrows to a read-only type, so a frozen value stays frozen", () => {
+    // This guards the choice of narrowed *type*, not the overload pair: a
+    // `readonly`-declared caller keeps its `readonly` either way, because
+    // narrowing intersects with such a type rather than replacing it. It is the
+    // caller passing `unknown` -- who has no `readonly` of their own -- that a
+    // mutable narrow target would hand a writable view of a frozen value.
+    //
+    // It asserts assignability rather than performing a write: the value is
     // frozen, so an actual assignment would throw at runtime under module
     // strict mode and prove nothing about the type.
-
-    it("preserves `readonly` on a value that arrived `readonly`", () => {
-      const frozen: readonly number[] = Object.freeze([1, 2, 3]);
-
-      if (!isInertArray(frozen)) {
-        throw new Error("Expected a frozen array to be inert.");
-      }
-
-      // @ts-expect-error `readonly` survives the check; it is not widened.
-      const _widened: number[] = frozen;
-
-      expect(frozen[0]).toBe(1);
-    });
 
     it("narrows `unknown` to a read-only array, not a mutable one", () => {
       const value: unknown = Object.freeze([1]);

--- a/packages/utils/test/narrowing.test.ts
+++ b/packages/utils/test/narrowing.test.ts
@@ -1,0 +1,134 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  isArrayWithOnlyIndexProperties,
+  isInertArray,
+} from "@commonfabric/utils/arrays";
+import { isInertPlainObject } from "@commonfabric/utils/objects";
+import { isPlainObject, type ReadonlyRecord } from "@commonfabric/utils/types";
+
+/**
+ * The narrowing contract of the structural predicates, as described in the
+ * header of the `types` module. These are compile-time assertions: the `test`
+ * task runs with `--no-check`, so it is `deno task check` that enforces them.
+ * The runtime bodies exist so the assertions sit on values that a reader can
+ * see are of the stated kind, and so the file is not silently inert.
+ */
+describe("structural predicate narrowing", () => {
+  describe("narrows an `unknown` caller, which has nothing to lose", () => {
+    it("narrows `unknown` to an array", () => {
+      const value: unknown = [1, 2, 3];
+
+      if (isInertArray(value)) {
+        // Reachable only if `value` narrowed; no cast in sight.
+        expect(value.length).toBe(3);
+      } else {
+        throw new Error("Expected an inert array.");
+      }
+    });
+
+    it("narrows `unknown` to a record", () => {
+      const value: unknown = { a: 1 };
+
+      if (isInertPlainObject(value)) {
+        expect(Object.keys(value)).toEqual(["a"]);
+      } else {
+        throw new Error("Expected an inert plain object.");
+      }
+    });
+
+    it("narrows `unknown` for the weaker two predicates as well", () => {
+      const array: unknown = [1];
+      const object: unknown = { a: 1 };
+
+      if (isArrayWithOnlyIndexProperties(array)) {
+        expect(array.length).toBe(1);
+      } else {
+        throw new Error("Expected an index-only array.");
+      }
+
+      if (isPlainObject(object)) {
+        expect(Object.keys(object)).toEqual(["a"]);
+      } else {
+        throw new Error("Expected a plain object.");
+      }
+    });
+  });
+
+  describe("leaves the `false` branch usable for a caller that already knows the shape", () => {
+    // The point of the overload pair. Were these predicates declared with the
+    // narrowing signature alone, `false`-branch subtraction would reduce each
+    // of these values to `never`, on the strength of a rejection whose reason
+    // the type system never recorded.
+
+    it("keeps an array usable after a `false` result", () => {
+      const array: number[] = [1, 2, 3];
+      Object.defineProperty(array, 1, { get: () => 2 });
+
+      if (isInertArray(array)) {
+        throw new Error("Expected an accessor-backed index to be rejected.");
+      }
+
+      // `array` is still `number[]` here, not `never`.
+      expect(array.length).toBe(3);
+      expect(array[0]!.toFixed(1)).toBe("1.0");
+    });
+
+    it("keeps a record usable after a `false` result", () => {
+      const record: Record<string, unknown> = Object.create(null);
+      record.a = 1;
+
+      if (isInertPlainObject(record)) {
+        throw new Error("Expected a null-prototype object to be rejected.");
+      }
+
+      // `record` is still `Record<string, unknown>` here, not `never`.
+      expect(Object.keys(record)).toEqual(["a"]);
+    });
+
+    it("keeps a record usable after a `false` result from `isPlainObject()`", () => {
+      // A record-typed value that is not `Object`-rooted. TypeScript has no way
+      // to say that about a type, which is precisely why the `false` branch has
+      // to stay usable.
+      const record: ReadonlyRecord = Object.create({ inherited: 1 });
+
+      if (isPlainObject(record)) {
+        throw new Error("Expected a non-`Object`-rooted value to be rejected.");
+      }
+
+      expect(Object.keys(record)).toEqual([]);
+    });
+  });
+
+  describe("never hands back a mutable view of a `readonly` value", () => {
+    // These assert assignability rather than performing a write: the values are
+    // frozen, so an actual assignment would throw at runtime under module
+    // strict mode and prove nothing about the type.
+
+    it("preserves `readonly` on a value that arrived `readonly`", () => {
+      const frozen: readonly number[] = Object.freeze([1, 2, 3]);
+
+      if (!isInertArray(frozen)) {
+        throw new Error("Expected a frozen array to be inert.");
+      }
+
+      // @ts-expect-error `readonly` survives the check; it is not widened.
+      const _widened: number[] = frozen;
+
+      expect(frozen[0]).toBe(1);
+    });
+
+    it("narrows `unknown` to a read-only array, not a mutable one", () => {
+      const value: unknown = Object.freeze([1]);
+
+      if (!isInertArray(value)) {
+        throw new Error("Expected a frozen array to be inert.");
+      }
+
+      // @ts-expect-error The narrowed type confers read access, not write.
+      const _widened: unknown[] = value;
+
+      expect(value[0]).toBe(1);
+    });
+  });
+});

--- a/packages/utils/test/narrowing.test.ts
+++ b/packages/utils/test/narrowing.test.ts
@@ -57,6 +57,18 @@ describe("structural predicate narrowing", () => {
         throw new Error("Expected a plain object.");
       }
     });
+
+    it("narrows `unknown` for `isPlainContainer()`", () => {
+      // This one narrowed before it was overloaded, so it is the only predicate
+      // here whose existing narrowing could have been *lost* rather than gained.
+      const value: unknown = { a: 1 };
+
+      if (isPlainContainer(value)) {
+        expect(Object.keys(value)).toEqual(["a"]);
+      } else {
+        throw new Error("Expected a plain container.");
+      }
+    });
   });
 
   describe("leaves the `false` branch usable for a caller that already knows the shape", () => {
@@ -88,6 +100,20 @@ describe("structural predicate narrowing", () => {
       }
 
       // Still `readonly number[]`, not `never`.
+      expect(array[0]!.toFixed(1)).toBe("1.0");
+    });
+
+    it("keeps an array usable after a `false` result from `isArrayWithOnlyIndexProperties()`", () => {
+      // This predicate got the overload pair for family consistency rather than
+      // to fix a call site, which makes it the likeliest of the five to have the
+      // pair "simplified away" later. Hence a guard of its own.
+      const array: number[] = [1, 2, 3];
+      Object.defineProperty(array, "named", { value: 1, enumerable: true });
+
+      if (isArrayWithOnlyIndexProperties(array)) {
+        throw new Error("Expected a named property to be rejected.");
+      }
+
       expect(array[0]!.toFixed(1)).toBe("1.0");
     });
 
@@ -153,6 +179,64 @@ describe("structural predicate narrowing", () => {
       const _widened: unknown[] = value;
 
       expect(value[0]).toBe(1);
+    });
+
+    it("narrows `unknown` to a read-only record, not a mutable one", () => {
+      const value: unknown = Object.freeze({ a: 1 });
+
+      if (!isInertPlainObject(value)) {
+        throw new Error("Expected a frozen plain object to be inert.");
+      }
+
+      // A read-only *index signature* is not caught by assignability the way a
+      // `readonly` array is -- `ReadonlyRecord` assigns happily to
+      // `Record<string, unknown>`. Only a write catches it, so the assertion
+      // lives in a function that is never called, the value being frozen.
+      const _assertReadOnly = () => {
+        // @ts-expect-error The narrowed type confers read access, not write.
+        value.a = 2;
+      };
+
+      expect(value.a).toBe(1);
+    });
+
+    it("narrows `unknown` to a read-only record for `isPlainObject()` too", () => {
+      const value: unknown = Object.freeze({ a: 1 });
+
+      if (!isPlainObject(value)) {
+        throw new Error(
+          "Expected a frozen plain object to be `Object`-rooted.",
+        );
+      }
+
+      const _assertReadOnly = () => {
+        // @ts-expect-error The narrowed type confers read access, not write.
+        value.a = 2;
+      };
+
+      expect(value.a).toBe(1);
+    });
+  });
+
+  describe("narrows `isPlainContainer()` to a mutable type, deliberately", () => {
+    it("keeps the container writable, as `value-clone.ts` requires", () => {
+      // The one exception to the read-only rule above, and the one place where
+      // a well-meaning tidy-up would do real damage: `value-clone.ts` writes
+      // through this result. Should the narrowed type ever go read-only, the
+      // write below stops compiling -- which is the point.
+      //
+      // It has to be the record arm. Reaching the array arm means going through
+      // `Array.isArray()`, whose signature narrows to `any[]` and so launders
+      // any `readonly` away, leaving nothing for this to detect.
+      const value: unknown = { a: 1 };
+
+      if (!isPlainContainer(value) || Array.isArray(value)) {
+        throw new Error("Expected a plain-object container.");
+      }
+
+      value.a = 2;
+
+      expect(value.a).toBe(2);
     });
   });
 });

--- a/packages/utils/test/narrowing.test.ts
+++ b/packages/utils/test/narrowing.test.ts
@@ -58,6 +58,25 @@ describe("structural predicate narrowing", () => {
       }
     });
 
+    it("narrows an `object`-typed caller too", () => {
+      // `object` is assignable to neither narrow target, so it selects the
+      // narrowing overload rather than the first one. That is what lets
+      // `data-model`'s `type-check.ts` walk a value typed `object` with no cast,
+      // and the module header claims it in as many words.
+      const record: object = { a: 1 };
+      const array: object = [1];
+
+      if (!isInertPlainObject(record)) {
+        throw new Error("Expected an inert plain object.");
+      }
+      expect(Object.keys(record)).toEqual(["a"]);
+
+      if (!isInertArray(array)) {
+        throw new Error("Expected an inert array.");
+      }
+      expect(array.length).toBe(1);
+    });
+
     it("narrows `unknown` for `isPlainContainer()`", () => {
       // This one narrowed before it was overloaded, so it is the only predicate
       // here whose existing narrowing could have been *lost* rather than gained.


### PR DESCRIPTION
## What

`isInertArray()`, `isInertPlainObject()`, `isPlainObject()`, and
`isArrayWithOnlyIndexProperties()` answered `boolean`, leaving every caller to
cast its way back to a usable type. They now narrow. `isPlainContainer()`
already narrowed, and picks up the same overload treatment.

## What each narrows to, and why it isn't stronger

Each narrows to the weakest type that stays true however the value is treated
afterwards — `readonly unknown[]` and `ReadonlyRecord` — and never to the
property it actually checks.

Inertness is an observation about an instant, not a fact about a type: an index
can be redefined as an accessor, or a symbol key added, at any later point. A
branded `InertArray` would go on asserting inertness after the value stopped
being inert, with no check that could ever catch it. The weak structural claims
survive anything that happens to the value later.

## Why overloads rather than a bare predicate

`false`-branch narrowing is subtraction, and TypeScript has no negated types.
A single predicate signature would reduce the `false` branch to `never` for any
caller already holding a type as specific as the narrowed one — on the strength
of a rejection whose reason the type system never recorded. Measured, with the
bare signature:

```ts
declare const rec: Record<string, unknown>;
if (!isInertPlainObject(rec)) {
  const x: never = rec;   // compiles — but a record can be null-prototype,
}                         // symbol-keyed, or accessor-backed, all rejected
```

The overload pair heads this off. A caller who already knows the broad shape
gets a plain `boolean` and keeps both branches, along with the element and
property types it arrived with; a caller holding `unknown` or `object`, which
has nothing to lose in the `false` branch, gets the narrowing.

Keeping the `false` branch usable is the *whole* of what the first overload
buys. Measured against bare single-signature equivalents using the shipped
narrow targets, a `readonly`-declared caller keeps both its `readonly` and its
element type with no overload at all.

## Why the narrow targets are read-only

That is a separate mechanism, and it does the real work. Revealing the narrowed
type directly:

- `readonly number[]` narrowed by `a is readonly unknown[]` stays exactly
  `readonly number[]` — the declared type is already assignable to the target,
  so narrowing keeps it as it was, and it goes on rejecting writes.
- Narrowed by a *mutable* `a is unknown[]`, it becomes
  `readonly number[] & unknown[]` — an actual intersection — and `frozen[0] = 99`
  compiles.

So intersection is what happens in the mutable case, and is precisely how
`readonly` gets laundered away. The exposure is the caller passing `unknown`,
who has no `readonly` of their own for the result to inherit, and who in this
repo is very often holding a deep-frozen value.

`isPlainContainer()` is the deliberate exception on both counts: it narrows to
*mutable* types — which therefore claim more than it checks — because its
callers (`value-clone.ts`) write through the result. Its residual hazard is
stated in the module header: a caller passing `unknown` gets a writable view of
a possibly frozen container with nothing at compile time to say so.

## Notes

- The rationale lives once in the header of the `types` module; the individual
  doc comments state the hazard briefly and point at it.
- `type-check.ts` loses a now-redundant `as Record<string, unknown>` cast, and
  `JsonEncodingContext.unwrapTag()` loses another along with a comment that
  asserted `isPlainObject()` is *not* a type guard — false as of this branch. No
  other call site needed a change: all 21 consumer files across `cli`, `fuse`,
  `memory`, `pure-json`, `runner`, `schema-generator`, `state-inspector`, and
  `data-model` type-check unchanged. Several further casts in `data-model` are
  now redundant too; they are left alone as a separate sweep, since only the one
  above carried a comment this branch falsifies.
- `packages/utils` runs its suite with `--no-check`, so `narrowing.test.ts` is
  enforced by `deno task check` (which covers `packages/utils`) rather than by
  the suite. Its runtime bodies keep it from being silently inert.
- Every `false`-branch assertion in `narrowing.test.ts` is verified to *fail*
  when compiled against a bare single-signature equivalent, and the `readonly`
  assertion to fail against a mutable narrow target. This matters more than it
  might sound: `Object.keys()` and index access both accept `never` without
  complaint, so an assertion written either of those ways passes against the
  very signature it exists to rule out. Property access is what catches it.

## Verification

`deno fmt --check`, `deno lint`, `deno task check`, `deno task check-docs`, and
the full workspace `deno task test` all pass. `data-model` is not on
`tasks/check.sh`'s path list, so it was type-checked explicitly as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XVfNoL2iqhNckYT3Z2SH4y
