### PR TITLE
fix(runner): report the start failure, not the cleanup it triggers

### DIFF
--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -3014,6 +3014,14 @@ export function llmDialog(
     // Abort the request if it's still pending.
     abortController?.abort("Pattern stopped");
 
+    // The cells below are assigned during the first run of this node, and a
+    // pattern can be stopped before that happens -- notably when startup
+    // fails, since the failure path cancels what it already registered. There
+    // is nothing of ours to wind down in that case, and reaching for the cells
+    // would throw from inside cleanup, replacing whatever error caused the
+    // stop.
+    if (!cellsInitialized) return;
+
     const tx = runtime.edit();
 
     // If the pending request is ours, set pending to false and clear the requestId.

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -2482,7 +2482,23 @@ export class Runner {
         // Without cleanup the piece stays registered in `this.cancels`, so
         // every later start() reports "already running" for a piece that has
         // no nodes or event handlers — events sent to it are then dropped.
-        cleanup();
+        //
+        // Cleanup runs every registered cancel, any of which may itself throw.
+        // Letting that escape would REPLACE the error being handled, so what
+        // surfaced would describe the cleanup rather than the failure that
+        // caused it — and a cancel running against half-initialized state
+        // fails in ways that look nothing like the original. Report it and
+        // rethrow what actually went wrong.
+        try {
+          cleanup();
+        } catch (cleanupError) {
+          logger.warn(
+            "start",
+            "Cleanup failed while handling a start error; reporting the " +
+              "start error, which is the one that matters.",
+            cleanupError,
+          );
+        }
         throw error;
       }
       if (!doNotUpdateOnPatternChange) {

--- a/packages/runner/test/runner.test.ts
+++ b/packages/runner/test/runner.test.ts
@@ -1339,6 +1339,51 @@ describe("setup/start", () => {
     expect(cellValue).toEqual({ output: 1 });
   });
 
+  it("reports the start failure, not a failure of the cleanup it triggers", () => {
+    // A start that fails cancels what it already registered, and a cancel can
+    // itself throw -- a builtin winding down state it had not finished
+    // building, say. Were that allowed to escape it would REPLACE the error
+    // being handled, and what surfaced would describe the cleanup rather than
+    // the failure that caused it.
+    const pattern: Pattern = {
+      argumentSchema: { type: "object", properties: {} },
+      resultSchema: {},
+      result: {},
+      nodes: [
+        {
+          // Registers a cancel that fails, then the node below fails the
+          // start, so the cancel runs against a half-built piece.
+          module: {
+            type: "raw",
+            implementation: (
+              _inputs: unknown,
+              _sendResult: unknown,
+              addCancel: (cancel: () => void) => void,
+            ) => {
+              addCancel(() => {
+                throw new Error("cleanup blew up");
+              });
+            },
+          } as unknown as Module,
+          inputs: {},
+          outputs: {},
+        },
+        {
+          // `instantiateRawNode` rejects a raw module with no implementation.
+          module: { type: "raw" } as unknown as Module,
+          inputs: {},
+          outputs: {},
+        },
+      ],
+    };
+
+    const resultCell = runtime.getCell(space, "start failure beats cleanup");
+
+    expect(() => runtime.run(undefined, pattern, {}, resultCell)).toThrow(
+      /Raw module is not a function/,
+    );
+  });
+
   it("reports a missing stream marker when a handler's $event reads undefined", async () => {
     const pattern: Pattern = {
       argumentSchema: { type: "object", properties: {} },


### PR DESCRIPTION
A start that fails cancels what it already registered, and a cancel may itself throw. `startCore` let that escape, so the cleanup error **replaced** the error being handled — what surfaced described the winding-down rather than the failure that caused it.

## How it presents

`llmDialog` registers its cancel at `llm-dialog.ts:3013`, but the cells that cancel winds down are assigned at `:3048`/`:3060`. A stop before the node's first run therefore reached for `undefined`.

Combined with the substitution above, a plain conversion rejection —

```
Not representable as a `FabricValue`: function per se (needs to have a `toJSON()` method)
```

— surfaced as:

```
Cannot read properties of undefined (reading 'withTx')
```

An error naming a member of a builtin that had nothing to do with the fault, with no stack, pointing at code that was only tidying up. Found while debugging something else; it cost hours, and the diagnosis only became possible after temporarily disabling SES error taming to recover a stack.

## The changes

Both are no-ops on the happy path.

- **`startCore`** reports a cleanup failure and rethrows the original. Cleanup still runs — skipping it would leave the piece registered in `this.cancels`, so every later `start()` reports "already running" for a piece with no nodes or event handlers.
- **`llmDialog`'s cancel** returns early when its cells were never built, using the `cellsInitialized` flag that already exists for exactly that distinction.

## The test

Pins the invariant rather than either mechanism: a pattern whose first node registers a failing cancel and whose second node fails to instantiate must report **the instantiation failure**. Verified red before the fix, where it reports `"cleanup blew up"`.

## Verification

Runner 1111/0 · full workspace all-passing · `deno task integration pattern-tests` clean · `deno fmt --check`, `deno lint`, `deno task check`, `deno task check-docs` (521 blocks), `deno task cfcheck` (423 patterns) all green · `deno.lock` untouched.

## Not included

`ensure-piece-running.ts:171` catches every error on the piece-start path and returns `false`, with its logger constructed `enabled: false` — so an error-level report there prints nothing. Same family, but making it visible is a log-policy judgment rather than a bug fix, so it is left for its own discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ANjQ4Hb5SahQxKKg8NRX3L


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix error reporting in the runner so the original start failure is surfaced instead of a cleanup exception. Also prevent `llmDialog` cancel from touching uninitialized cells, avoiding undefined-property errors.

- **Bug Fixes**
  - `startCore`: run cleanup, but catch and warn on cleanup failures; rethrow the original start error.
  - `llmDialog` cancel: return early when `cellsInitialized` is false to avoid accessing undefined cells.

<sup>Written for commit c4d5228fe76e8c9c7b451b4abf8c08b05e1ebcde. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

