### PR TITLE
refactor: remove unnecessary casts to `FabricValue` and friends

### DIFF
--- a/packages/data-model/src/cell-rep.ts
+++ b/packages/data-model/src/cell-rep.ts
@@ -261,7 +261,7 @@ function assertWireLinkRefPayloadShape(
   if (!isPlainObject(value)) {
     throw new Error("Cell-link wire payload must be a plain object.");
   }
-  for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+  for (const [key, val] of Object.entries(value)) {
     if (isUnsafeObjectKey(key)) {
       throw new Error(`Cell-link wire payload has a forbidden key: "${key}".`);
     }

--- a/packages/data-model/src/codec-json/JsonEncodingContext.ts
+++ b/packages/data-model/src/codec-json/JsonEncodingContext.ts
@@ -268,7 +268,7 @@ export class JsonEncodingContext implements SerializationContext<string> {
           result.push(this.wrapTag(CODEC_META_TAGS.hole, count));
         } else {
           result.push(
-            this.#encodeValue(value[i] as FabricValue, seen, registry),
+            this.#encodeValue(value[i], seen, registry),
           );
           i++;
         }
@@ -349,7 +349,7 @@ export class JsonEncodingContext implements SerializationContext<string> {
 
       // `CODEC_META_TAGS.quote` literal handling (Section 5.6).
       if (tag === CODEC_META_TAGS.quote) {
-        return rawState as FabricValue;
+        return rawState;
       }
 
       // `CODEC_META_TAGS.object` unwrapping (Section 5.6).

--- a/packages/data-model/src/fabric-instances/FabricError.ts
+++ b/packages/data-model/src/fabric-instances/FabricError.ts
@@ -247,7 +247,7 @@ export class FabricError extends FabricNativeWrapper<Error>
     for (const value of this.#extras.values()) {
       subFreeze(value);
     }
-    return Object.freeze(this) as unknown as FabricValue;
+    return Object.freeze(this);
   }
 
   /**
@@ -371,7 +371,7 @@ export class FabricError extends FabricNativeWrapper<Error>
         for (const [key, val] of value.extraEntries()) {
           state[key] = val;
         }
-        return state as FabricValue;
+        return state;
       }
 
       /** @inheritDoc */

--- a/packages/data-model/src/fabric-instances/FabricLink.ts
+++ b/packages/data-model/src/fabric-instances/FabricLink.ts
@@ -75,7 +75,7 @@ export class FabricLink extends BaseFabricInstance implements ApiFabricLink {
     subFreeze: (value: FabricValue) => FabricValue,
   ): FabricValue {
     subFreeze(this.#payload);
-    return Object.freeze(this) as unknown as FabricValue;
+    return Object.freeze(this);
   }
 
   /**

--- a/packages/data-model/src/fabric-instances/ProblematicValue.ts
+++ b/packages/data-model/src/fabric-instances/ProblematicValue.ts
@@ -47,7 +47,7 @@ export class ProblematicValue extends ExplicitTagValue {
     subFreeze: (value: FabricValue) => FabricValue,
   ): FabricValue {
     subFreeze(this.state);
-    return Object.freeze(this) as unknown as FabricValue;
+    return Object.freeze(this);
   }
 
   /**

--- a/packages/data-model/src/fabric-instances/UnknownValue.ts
+++ b/packages/data-model/src/fabric-instances/UnknownValue.ts
@@ -32,7 +32,7 @@ export class UnknownValue extends ExplicitTagValue {
     subFreeze: (value: FabricValue) => FabricValue,
   ): FabricValue {
     subFreeze(this.state);
-    return Object.freeze(this) as unknown as FabricValue;
+    return Object.freeze(this);
   }
 
   /**

--- a/packages/data-model/src/fabric-primitives/FabricHash.ts
+++ b/packages/data-model/src/fabric-primitives/FabricHash.ts
@@ -153,7 +153,7 @@ export class FabricHash extends BaseFabricPrimitive implements ApiFabricHash {
             `Hash: expected object state, got ${typeof state}`,
           );
         }
-        const { tag, hash } = state as Record<string, unknown>;
+        const { tag, hash } = state;
         if (typeof tag !== "string" || typeof hash !== "string") {
           return new ProblematicValue(
             typeTag,

--- a/packages/data-model/src/fabric-primitives/FabricRegExp.ts
+++ b/packages/data-model/src/fabric-primitives/FabricRegExp.ts
@@ -165,10 +165,9 @@ export class FabricRegExp extends BaseFabricPrimitive
         // `RegExp`); other flavors are stored faithfully and may carry
         // arbitrary `source`/`flags`. So a malformed non-`es2025` wire object
         // is accepted as-is rather than becoming a `ProblematicValue`.
-        const s = state as Record<string, unknown>;
-        const flavor = (s.flavor as string) ?? DEFAULT_FLAVOR;
-        const source = (s.source as string) ?? "";
-        const flags = (s.flags as string) ?? "";
+        const flavor = (state.flavor as string) ?? DEFAULT_FLAVOR;
+        const source = (state.source as string) ?? "";
+        const flags = (state.flags as string) ?? "";
         try {
           return new FabricRegExp(flavor, source, flags);
         } catch (e) {

--- a/packages/data-model/src/native-conversion.ts
+++ b/packages/data-model/src/native-conversion.ts
@@ -102,7 +102,7 @@ export function shallowCleanArray(
     Object.freeze(result);
   }
 
-  return result as FabricValueLayer;
+  return result;
 }
 
 /**
@@ -141,7 +141,7 @@ export function shallowCleanPlainObject(
     Object.freeze(result);
   }
 
-  return result as FabricValueLayer;
+  return result;
 }
 
 /**
@@ -273,7 +273,7 @@ export function shallowFabricFromNativeValue(
         false,
         false,
         null,
-      ) as FabricValueLayer;
+      );
     }
 
     case NATIVE_TAGS.Object: {
@@ -308,7 +308,7 @@ export function shallowFabricFromNativeValue(
         false,
         false,
         null,
-      ) as FabricValueLayer;
+      );
     }
 
     case NATIVE_TAGS.HasToJSON: {
@@ -328,7 +328,7 @@ export function shallowFabricFromNativeValue(
         false,
         false,
         null,
-      ) as FabricValueLayer;
+      );
     }
 
     case NATIVE_TAGS.FabricInstance: {
@@ -341,7 +341,7 @@ export function shallowFabricFromNativeValue(
         false,
         false,
         null,
-      ) as FabricValueLayer;
+      );
     }
 
     // deno-lint-ignore no-fallthrough

--- a/packages/data-model/src/schema-utils.ts
+++ b/packages/data-model/src/schema-utils.ts
@@ -185,7 +185,7 @@ export function schemaWithProperties(
   // freezing the `schema`/`overrides` inputs in place -- so the subsequent
   // `toDeepFrozenSchema(result, true)` only has to seal the (owned) top.
   const result = shallowMutableClone(
-    { ...schema, ...overrides } as FabricValue,
+    { ...schema, ...overrides },
   ) as JSONSchemaObj;
   return isInternedSchema(schema)
     ? internSchema(result)

--- a/packages/data-model/src/value-clone.ts
+++ b/packages/data-model/src/value-clone.ts
@@ -225,7 +225,7 @@ export function cloneHelper(
       if (deep) {
         for (const [key, val] of Object.entries(obj)) {
           copy[key] = cloneHelper(
-            val as FabricValue,
+            val,
             frozen,
             deep,
             force,
@@ -539,7 +539,7 @@ export function cloneForMutation<T extends FabricValue>(
     // `FabricInstance`s this is a `cloneIfNecessary(_, { frozen: false,
     // deep: false, force })` call; under `force: false` and an
     // already-mutable input it short-circuits to identity.
-    const thawed = cloneIfNecessary(next as FabricValue, cloneOpts);
+    const thawed = cloneIfNecessary(next, cloneOpts);
     if (thawed !== next) {
       (current as Record<string, FabricValue>)[key] = thawed;
     }

--- a/packages/data-model/src/value-clone.ts
+++ b/packages/data-model/src/value-clone.ts
@@ -691,7 +691,7 @@ export function cloneWithoutValueAtPath(
   );
   const lastKey = path[path.length - 1]!;
   if (Array.isArray(pathValue)) {
-    (pathValue as FabricValue[]).splice(Number(lastKey), 1);
+    pathValue.splice(Number(lastKey), 1);
   } else {
     delete (pathValue as Record<string, FabricValue>)[lastKey];
   }

--- a/packages/data-model/test/cloneForMutation.test.ts
+++ b/packages/data-model/test/cloneForMutation.test.ts
@@ -10,7 +10,7 @@ import { FabricError } from "@/fabric-instances/FabricError.ts";
 describe("cloneForMutation", () => {
   describe("empty path", () => {
     it("returns the root as mutable, plus identical `pathValue`", () => {
-      const root = Object.freeze({ a: 1, b: 2 }) as FabricValue;
+      const root = Object.freeze({ a: 1, b: 2 });
       const { value, pathValue } = cloneForMutation(root, []);
 
       expect(value).not.toBe(root);
@@ -20,7 +20,7 @@ describe("cloneForMutation", () => {
     });
 
     it("returns input identity when already mutable + `force=false`", () => {
-      const root = { a: 1 } as FabricValue;
+      const root = { a: 1 };
       const { value, pathValue } = cloneForMutation(root, [], {
         force: false,
       });
@@ -32,7 +32,7 @@ describe("cloneForMutation", () => {
       // Default `force` is true, matching `cloneIfNecessary`'s default
       // when `frozen: false`. Even with mutable input, the result is a
       // fresh copy.
-      const root = { a: 1 } as FabricValue;
+      const root = { a: 1 };
       const { value, pathValue } = cloneForMutation(root, []);
       expect(value).not.toBe(root);
       expect(pathValue).toBe(value);
@@ -41,7 +41,7 @@ describe("cloneForMutation", () => {
     });
 
     it("always shallow-clones the root when `force=true`", () => {
-      const root = { a: 1 } as FabricValue;
+      const root = { a: 1 };
       const { value, pathValue } = cloneForMutation(root, [], {
         force: true,
       });
@@ -55,7 +55,7 @@ describe("cloneForMutation", () => {
       const err = FabricError.fromNativeError(new Error("test"));
       Object.freeze(err);
       const { value, pathValue } = cloneForMutation(
-        err as unknown as FabricValue,
+        err,
         [],
       );
       expect(value).not.toBe(err);
@@ -77,7 +77,7 @@ describe("cloneForMutation", () => {
       const root = Object.freeze({
         a: inner,
         b: sibling,
-      }) as FabricValue;
+      });
 
       const { value, pathValue } = cloneForMutation(root, ["a"]);
 
@@ -98,7 +98,7 @@ describe("cloneForMutation", () => {
       const noteB = Object.freeze({ title: "second" });
       const root = Object.freeze({
         notes: Object.freeze([noteA, noteB]),
-      }) as FabricValue;
+      });
 
       const { value, pathValue } = cloneForMutation(root, ["notes"]);
 
@@ -118,7 +118,7 @@ describe("cloneForMutation", () => {
 
     it("returns input root identity when already mutable + `force=false`", () => {
       const inner = { x: 1 };
-      const root = { a: inner } as FabricValue;
+      const root = { a: inner };
 
       const { value, pathValue } = cloneForMutation(root, ["a"], {
         force: false,
@@ -133,7 +133,7 @@ describe("cloneForMutation", () => {
     it("does not touch a mutable input on default options", () => {
       // Default `force` is true: input is left alone even when mutable.
       const inner = { x: 1 };
-      const root = { a: inner } as FabricValue;
+      const root = { a: inner };
 
       const { value, pathValue } = cloneForMutation(root, ["a"]);
 
@@ -144,7 +144,7 @@ describe("cloneForMutation", () => {
 
     it("always copies the root and leaf when `force=true`", () => {
       const inner = { x: 1 };
-      const root = { a: inner } as FabricValue;
+      const root = { a: inner };
 
       const { value, pathValue } = cloneForMutation(root, ["a"], {
         force: true,
@@ -171,7 +171,7 @@ describe("cloneForMutation", () => {
       const b = Object.freeze({ c, b2 });
       const a2 = Object.freeze({ off: "spine-a" });
       const a = Object.freeze({ b, a2 });
-      const root = Object.freeze({ a, a2 }) as FabricValue;
+      const root = Object.freeze({ a, a2 });
 
       const { value, pathValue } = cloneForMutation(root, ["a", "b", "c"]);
 
@@ -214,7 +214,7 @@ describe("cloneForMutation", () => {
       const target = Object.freeze({ leaf: true });
       const otherNote = Object.freeze({ leaf: false });
       const notes = Object.freeze([otherNote, target]);
-      const root = Object.freeze({ notes }) as FabricValue;
+      const root = Object.freeze({ notes });
 
       const { value, pathValue } = cloneForMutation(
         root,
@@ -240,7 +240,7 @@ describe("cloneForMutation", () => {
       expect(isDeepFrozen(sibling)).toBe(true);
 
       const target = Object.freeze({ leaf: true });
-      const root = deepFreeze({ a: target, b: sibling }) as FabricValue;
+      const root = deepFreeze({ a: target, b: sibling });
 
       const { value } = cloneForMutation(root, ["a"]);
 
@@ -256,7 +256,7 @@ describe("cloneForMutation", () => {
     it("clones via `shallowClone(false)`, not as a plain object", () => {
       const err = FabricError.fromNativeError(new Error("boom"));
       Object.freeze(err);
-      const root = Object.freeze({ payload: err }) as FabricValue;
+      const root = Object.freeze({ payload: err });
 
       const { value, pathValue } = cloneForMutation(root, ["payload"]);
 
@@ -277,7 +277,7 @@ describe("cloneForMutation", () => {
   describe("mutation through pathValue", () => {
     it("supports array push without touching the input", () => {
       const notes = Object.freeze([{ id: 1 }, { id: 2 }]);
-      const root = Object.freeze({ notes }) as FabricValue;
+      const root = Object.freeze({ notes });
 
       const { value, pathValue } = cloneForMutation(root, ["notes"]);
 
@@ -297,7 +297,7 @@ describe("cloneForMutation", () => {
       const root = Object.freeze({
         keep: 1,
         drop: 2,
-      }) as FabricValue;
+      });
 
       const { value, pathValue } = cloneForMutation(root, []);
 
@@ -312,7 +312,7 @@ describe("cloneForMutation", () => {
       const root = { inner };
 
       const { value, pathValue } = cloneForMutation(
-        root as unknown as FabricValue,
+        root,
         ["inner"],
         { force: true },
       );
@@ -330,7 +330,7 @@ describe("cloneForMutation", () => {
 
   describe("createMissing", () => {
     it("creates a missing intermediate object", () => {
-      const root = Object.freeze({ a: { existing: 1 } }) as FabricValue;
+      const root = Object.freeze({ a: { existing: 1 } });
       const { value, pathValue } = cloneForMutation(
         root,
         ["a", "new"],
@@ -351,7 +351,7 @@ describe("cloneForMutation", () => {
     });
 
     it("creates a missing intermediate array (numeric next key)", () => {
-      const root = Object.freeze({ a: {} }) as FabricValue;
+      const root = Object.freeze({ a: {} });
       const { value, pathValue } = cloneForMutation(
         root,
         ["a", "items"],
@@ -368,7 +368,7 @@ describe("cloneForMutation", () => {
     });
 
     it("treats `-` as the JSON-Pointer array append marker", () => {
-      const root = Object.freeze({}) as FabricValue;
+      const root = Object.freeze({});
       const { value: _v, pathValue } = cloneForMutation(
         root,
         ["items"],
@@ -378,7 +378,7 @@ describe("cloneForMutation", () => {
     });
 
     it("defaults to an object when `nextKeyAfterPath` is omitted", () => {
-      const root = Object.freeze({}) as FabricValue;
+      const root = Object.freeze({});
       const { pathValue } = cloneForMutation(
         root,
         ["new"],
@@ -401,7 +401,7 @@ describe("cloneForMutation", () => {
       //   "title" -> object.
       // - path[2]="title" -> the leaf, nextKeyAfterPath="" -> object
       //   if missing.
-      const root = Object.freeze({}) as FabricValue;
+      const root = Object.freeze({});
       const { value, pathValue } = cloneForMutation(
         root,
         ["notes", "0", "title"],
@@ -424,7 +424,7 @@ describe("cloneForMutation", () => {
       const existingNotes = Object.freeze([{ kept: 1 }]);
       const root = Object.freeze({
         notes: existingNotes,
-      }) as FabricValue;
+      });
       const { value, pathValue } = cloneForMutation(
         root,
         ["notes", "0", "newKey"],
@@ -446,7 +446,7 @@ describe("cloneForMutation", () => {
       // same as the default.
       const root = Object.freeze({
         a: Object.freeze({ b: Object.freeze({ c: 42 }) }),
-      }) as FabricValue;
+      });
       const { pathValue } = cloneForMutation(
         root,
         ["a", "b"],
@@ -459,7 +459,7 @@ describe("cloneForMutation", () => {
       // If `createMissing: true` but every step exists AND `force:
       // false` AND input is already mutable, identity is preserved.
       const inner = { existing: 1 };
-      const root = { a: inner } as FabricValue;
+      const root = { a: inner };
       const { value, pathValue } = cloneForMutation(
         root,
         ["a"],
@@ -472,7 +472,7 @@ describe("cloneForMutation", () => {
     it("respects `force=true` on the spine-thaw even when creating", () => {
       // When force=true (default), already-mutable spine containers
       // are still copied. `createMissing` doesn't change that.
-      const root = { existing: 1 } as FabricValue;
+      const root = { existing: 1 };
       const { value, pathValue } = cloneForMutation(
         root,
         ["new"],
@@ -490,7 +490,7 @@ describe("cloneForMutation", () => {
 
   describe("CloneForMutationError", () => {
     it("uses kind `missing-segment` for a missing intermediate", () => {
-      const root = Object.freeze({ a: { b: 1 } }) as FabricValue;
+      const root = Object.freeze({ a: { b: 1 } });
       try {
         cloneForMutation(root, ["a", "nonesuch", "more"]);
         throw new Error("expected throw");
@@ -504,7 +504,7 @@ describe("cloneForMutation", () => {
     });
 
     it("uses kind `non-container-descent` for primitive in path", () => {
-      const root = Object.freeze({ x: 42 }) as FabricValue;
+      const root = Object.freeze({ x: 42 });
       try {
         cloneForMutation(root, ["x", "anything"]);
         throw new Error("expected throw");
@@ -518,7 +518,7 @@ describe("cloneForMutation", () => {
     });
 
     it("uses kind `non-mutable-leaf` for a primitive leaf", () => {
-      const root = Object.freeze({ x: 42 }) as FabricValue;
+      const root = Object.freeze({ x: 42 });
       try {
         cloneForMutation(root, ["x"]);
         throw new Error("expected throw");
@@ -533,7 +533,7 @@ describe("cloneForMutation", () => {
 
     it("uses kind `non-mutable-root` for empty path with bad root", () => {
       try {
-        cloneForMutation(42 as FabricValue, []);
+        cloneForMutation(42, []);
         throw new Error("expected throw");
       } catch (e) {
         expect(e).toBeInstanceOf(CloneForMutationError);
@@ -546,7 +546,7 @@ describe("cloneForMutation", () => {
 
     it("uses kind `non-container-root` for non-empty path with bad root", () => {
       try {
-        cloneForMutation(42 as FabricValue, ["x"]);
+        cloneForMutation(42, ["x"]);
         throw new Error("expected throw");
       } catch (e) {
         expect(e).toBeInstanceOf(CloneForMutationError);
@@ -559,7 +559,7 @@ describe("cloneForMutation", () => {
 
     it("sets `error.name` to `CloneForMutationError`", () => {
       try {
-        cloneForMutation(42 as FabricValue, []);
+        cloneForMutation(42, []);
         throw new Error("expected throw");
       } catch (e) {
         expect((e as Error).name).toBe("CloneForMutationError");
@@ -569,7 +569,7 @@ describe("cloneForMutation", () => {
 
   describe("errors", () => {
     it("throws on a missing path segment", () => {
-      const root = Object.freeze({ a: { b: 1 } }) as FabricValue;
+      const root = Object.freeze({ a: { b: 1 } });
       expect(() => cloneForMutation(root, ["a", "nonesuch"]))
         .toThrow("missing path segment");
     });
@@ -577,20 +577,20 @@ describe("cloneForMutation", () => {
     it("throws on a missing array index", () => {
       const root = Object.freeze({
         notes: Object.freeze([1, 2, 3]),
-      }) as FabricValue;
+      });
       expect(() => cloneForMutation(root, ["notes", "10"]))
         .toThrow("missing path segment");
     });
 
     it("throws when descending through a primitive", () => {
-      const root = Object.freeze({ x: 42 }) as FabricValue;
+      const root = Object.freeze({ x: 42 });
       expect(() => cloneForMutation(root, ["x", "anything"]))
         .toThrow("cannot descend into");
     });
 
     it("throws when descending through a `FabricInstance`", () => {
       const err = FabricError.fromNativeError(new Error("inside"));
-      const root = Object.freeze({ err }) as FabricValue;
+      const root = Object.freeze({ err });
       // `path = ["err", "something"]` tries to descend INTO the
       // FabricInstance, which isn't supported.
       expect(() => cloneForMutation(root, ["err", "message"])).toThrow(
@@ -601,14 +601,14 @@ describe("cloneForMutation", () => {
     it("throws when descending through a `FabricPrimitive`", () => {
       const epoch = new FabricEpochNsec(123n);
       const root = Object.freeze({
-        epoch: epoch as unknown as FabricValue,
-      }) as FabricValue;
+        epoch: epoch,
+      });
       expect(() => cloneForMutation(root, ["epoch", "anything"]))
         .toThrow("cannot descend into");
     });
 
     it("throws when the leaf is a primitive (not mutable)", () => {
-      const root = Object.freeze({ x: 42 }) as FabricValue;
+      const root = Object.freeze({ x: 42 });
       expect(() => cloneForMutation(root, ["x"]))
         .toThrow("cannot mutate");
     });
@@ -616,19 +616,19 @@ describe("cloneForMutation", () => {
     it("throws when the leaf is a `FabricPrimitive` (not mutable)", () => {
       const epoch = new FabricEpochNsec(123n);
       const root = Object.freeze({
-        epoch: epoch as unknown as FabricValue,
-      }) as FabricValue;
+        epoch: epoch,
+      });
       expect(() => cloneForMutation(root, ["epoch"]))
         .toThrow("cannot mutate");
     });
 
     it("throws on empty-path against a non-mutable root", () => {
-      expect(() => cloneForMutation(42 as FabricValue, []))
+      expect(() => cloneForMutation(42, []))
         .toThrow("cannot mutate");
     });
 
     it("throws on non-empty path against a non-container root", () => {
-      expect(() => cloneForMutation(42 as FabricValue, ["x"]))
+      expect(() => cloneForMutation(42, ["x"]))
         .toThrow("cannot descend into");
     });
 
@@ -636,7 +636,7 @@ describe("cloneForMutation", () => {
       // A FabricInstance is OK at the leaf but not as the root of a
       // non-empty path (we don't descend into FabricInstance internals).
       const err = FabricError.fromNativeError(new Error("test"));
-      expect(() => cloneForMutation(err as unknown as FabricValue, ["x"]))
+      expect(() => cloneForMutation(err, ["x"]))
         .toThrow("cannot descend into");
     });
   });

--- a/packages/data-model/test/cloneForMutation.test.ts
+++ b/packages/data-model/test/cloneForMutation.test.ts
@@ -62,7 +62,7 @@ describe("cloneForMutation", () => {
       expect(Object.isFrozen(value)).toBe(false);
       expect(pathValue).toBe(value);
       // `[SHALLOW_UNFROZEN_CLONE]` preserves the FabricValue-shaped state.
-      const cloned = value as unknown as FabricError;
+      const cloned = value;
       expect(cloned.type).toBe(err.type);
       expect(cloned.name).toBe(err.name);
       expect(cloned.message).toBe(err.message);

--- a/packages/data-model/test/cloneForMutation.test.ts
+++ b/packages/data-model/test/cloneForMutation.test.ts
@@ -2,7 +2,6 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
 import { cloneForMutation, CloneForMutationError } from "@/fabric-value.ts";
-import type { FabricValue } from "@/fabric-value.ts";
 import { deepFreeze, isDeepFrozen } from "@/deep-freeze.ts";
 import { FabricEpochNsec } from "@/fabric-primitives/FabricEpochNsec.ts";
 import { FabricError } from "@/fabric-instances/FabricError.ts";

--- a/packages/data-model/test/cloneIfNecessary.test.ts
+++ b/packages/data-model/test/cloneIfNecessary.test.ts
@@ -23,13 +23,13 @@ import { FabricPrimitive, FabricSpecialObject } from "@/interface.ts";
 describe("cloneIfNecessary", () => {
   describe(`error cases`, () => {
     it("throws for `frozen=true`, `force=true`", () => {
-      const value = { a: 1 } as FabricValue;
+      const value = { a: 1 };
       expect(() => cloneIfNecessary(value, { frozen: true, force: true }))
         .toThrow("frozen: true, force: true");
     });
 
     it("throws for `frozen=false`, `force=false`, `deep=true`", () => {
-      const value = { a: 1 } as FabricValue;
+      const value = { a: 1 };
       expect(() => cloneIfNecessary(value, { frozen: false, force: false }))
         .toThrow("frozen: false, force: false, deep: true");
     });
@@ -37,19 +37,19 @@ describe("cloneIfNecessary", () => {
 
   describe(`default options`, () => {
     it("passes through primitives unchanged", () => {
-      expect(cloneIfNecessary(42 as FabricValue)).toBe(42);
-      expect(cloneIfNecessary("hello" as FabricValue)).toBe("hello");
+      expect(cloneIfNecessary(42)).toBe(42);
+      expect(cloneIfNecessary("hello")).toBe("hello");
       expect(cloneIfNecessary(null)).toBe(null);
-      expect(cloneIfNecessary(true as FabricValue)).toBe(true);
+      expect(cloneIfNecessary(true)).toBe(true);
       expect(cloneIfNecessary(undefined)).toBe(undefined);
     });
 
     it("passes through bigint unchanged", () => {
-      expect(cloneIfNecessary(42n as FabricValue)).toBe(42n);
+      expect(cloneIfNecessary(42n)).toBe(42n);
     });
 
     it("returns a frozen copy of an unfrozen object", () => {
-      const value = { a: 1, b: "two" } as FabricValue;
+      const value = { a: 1, b: "two" };
       const result = cloneIfNecessary(value);
       expect(result).toEqual({ a: 1, b: "two" });
       expect(result).not.toBe(value);
@@ -57,7 +57,7 @@ describe("cloneIfNecessary", () => {
     });
 
     it("returns a frozen copy of an unfrozen array", () => {
-      const value = [1, 2, 3] as FabricValue;
+      const value = [1, 2, 3];
       const result = cloneIfNecessary(value);
       expect(result).toEqual([1, 2, 3]);
       expect(result).not.toBe(value);
@@ -65,7 +65,7 @@ describe("cloneIfNecessary", () => {
     });
 
     it("deep-freezes nested structures", () => {
-      const value = { a: { b: [1, 2] } } as FabricValue;
+      const value = { a: { b: [1, 2] } };
       const result = cloneIfNecessary(value) as Record<string, unknown>;
       expect(Object.isFrozen(result)).toBe(true);
       expect(Object.isFrozen(result.a)).toBe(true);
@@ -75,7 +75,7 @@ describe("cloneIfNecessary", () => {
 
     it("returns already-deep-frozen value as-is (identity optimization)", () => {
       const inner = Object.freeze([1, 2]);
-      const value = Object.freeze({ a: inner }) as FabricValue;
+      const value = Object.freeze({ a: inner });
       const result = cloneIfNecessary(value);
       expect(result).toBe(value); // identity -- no clone needed
     });
@@ -84,7 +84,7 @@ describe("cloneIfNecessary", () => {
       // `frozenChild` is a deep-frozen subtree.
       const frozenChild = Object.freeze({ x: Object.freeze([1, 2]) });
       // `value` is NOT frozen (unfrozen parent), so it must be cloned.
-      const value = { a: frozenChild, b: "mutable" } as FabricValue;
+      const value = { a: frozenChild, b: "mutable" };
       const result = cloneIfNecessary(value) as Record<string, unknown>;
       // The outer object is a new frozen clone.
       expect(result).not.toBe(value);
@@ -97,7 +97,7 @@ describe("cloneIfNecessary", () => {
 
   describe(`\`frozen=false\`, deep clone`, () => {
     it("returns a mutable copy of a frozen object", () => {
-      const value = Object.freeze({ a: 1, b: "two" }) as FabricValue;
+      const value = Object.freeze({ a: 1, b: "two" });
       const result = cloneIfNecessary(value, { frozen: false });
       expect(result).toEqual({ a: 1, b: "two" });
       expect(result).not.toBe(value);
@@ -105,7 +105,7 @@ describe("cloneIfNecessary", () => {
     });
 
     it("returns a mutable array copy", () => {
-      const value = Object.freeze([1, 2, 3]) as FabricValue;
+      const value = Object.freeze([1, 2, 3]);
       const result = cloneIfNecessary(value, { frozen: false });
       expect(result).toEqual([1, 2, 3]);
       expect(result).not.toBe(value);
@@ -114,7 +114,7 @@ describe("cloneIfNecessary", () => {
 
     it("clones already-mutable values (`force=true` default)", () => {
       const inner = { x: 1 };
-      const value = { a: inner, b: [2, 3] } as FabricValue;
+      const value = { a: inner, b: [2, 3] };
       const result = cloneIfNecessary(value, { frozen: false }) as Record<
         string,
         unknown
@@ -132,7 +132,7 @@ describe("cloneIfNecessary", () => {
       const inner = Object.freeze([1, 2]);
       const value = Object.freeze({
         a: Object.freeze({ b: inner }),
-      }) as FabricValue;
+      });
       const result = cloneIfNecessary(value, { frozen: false }) as Record<
         string,
         unknown
@@ -147,7 +147,7 @@ describe("cloneIfNecessary", () => {
   describe(`shallow clone`, () => {
     it("shallow-clones an unfrozen object to frozen", () => {
       const inner = { x: 1 };
-      const value = { a: inner } as FabricValue;
+      const value = { a: inner };
       const result = cloneIfNecessary(value, { deep: false }) as Record<
         string,
         unknown
@@ -159,13 +159,13 @@ describe("cloneIfNecessary", () => {
     });
 
     it("returns already-frozen object as-is (shallow, `force=false`)", () => {
-      const value = Object.freeze({ a: 1 }) as FabricValue;
+      const value = Object.freeze({ a: 1 });
       const result = cloneIfNecessary(value, { deep: false });
       expect(result).toBe(value);
     });
 
     it("shallow-clones frozen object to mutable (`deep=false`, `frozen=false`)", () => {
-      const value = Object.freeze({ a: 1, b: "two" }) as FabricValue;
+      const value = Object.freeze({ a: 1, b: "two" });
       const result = cloneIfNecessary(value, {
         deep: false,
         frozen: false,
@@ -176,7 +176,7 @@ describe("cloneIfNecessary", () => {
     });
 
     it("force-copies mutable object (shallow, `frozen=false`, `force=true`)", () => {
-      const value = { a: 1 } as FabricValue;
+      const value = { a: 1 };
       const result = cloneIfNecessary(value, {
         deep: false,
         frozen: false,
@@ -187,7 +187,7 @@ describe("cloneIfNecessary", () => {
     });
 
     it("returns mutable as-is (shallow, `frozen=false`, `force=false`)", () => {
-      const value = { a: 1 } as FabricValue;
+      const value = { a: 1 };
       const result = cloneIfNecessary(value, {
         deep: false,
         frozen: false,
@@ -197,7 +197,7 @@ describe("cloneIfNecessary", () => {
     });
 
     it("thaws frozen value (shallow, `frozen=false`, `force=false`)", () => {
-      const value = Object.freeze({ a: 1 }) as FabricValue;
+      const value = Object.freeze({ a: 1 });
       const result = cloneIfNecessary(value, {
         deep: false,
         frozen: false,
@@ -240,7 +240,7 @@ describe("cloneIfNecessary", () => {
       const error = FabricError.fromNativeError(new Error("test"));
       Object.freeze(error);
       const result = cloneIfNecessary(
-        error as unknown as FabricValue,
+        error,
         { frozen: false },
       );
       expect(result).toBeInstanceOf(FabricError);
@@ -254,7 +254,7 @@ describe("cloneIfNecessary", () => {
       // nested deep-frozen FabricError is returned by identity.
       const error = FabricError.fromNativeError(new Error("nested"));
       Object.freeze(error);
-      const value = { err: error, x: 42 } as FabricValue;
+      const value = { err: error, x: 42 };
       const result = cloneIfNecessary(value) as Record<string, unknown>;
       expect(result).not.toBe(value);
       expect(Object.isFrozen(result)).toBe(true);
@@ -268,7 +268,7 @@ describe("cloneIfNecessary", () => {
       // Shallow clone of a container shares the nested instance by
       // reference -- it is never traversed or rebuilt.
       const error = FabricError.fromNativeError(new Error("nested"));
-      const value = { err: error, x: 42 } as FabricValue;
+      const value = { err: error, x: 42 };
       const result = cloneIfNecessary(value, { deep: false }) as Record<
         string,
         unknown
@@ -282,7 +282,7 @@ describe("cloneIfNecessary", () => {
 
   describe(`\`undefined\` preservation`, () => {
     it("preserves `undefined` in objects", () => {
-      const value = { a: 1, b: undefined } as FabricValue;
+      const value = { a: 1, b: undefined };
       const result = cloneIfNecessary(value) as Record<string, unknown>;
       expect(result.b).toBe(undefined);
       expect("b" in result).toBe(true);
@@ -290,7 +290,7 @@ describe("cloneIfNecessary", () => {
     });
 
     it("preserves `undefined` in arrays", () => {
-      const value = [1, undefined, 3] as FabricValue;
+      const value = [1, undefined, 3];
       const result = cloneIfNecessary(value) as unknown[];
       expect(result[1]).toBe(undefined);
       expect(1 in result).toBe(true);
@@ -368,7 +368,7 @@ describe("cloneIfNecessary", () => {
     it("passes through `FabricEpochNsec` unchanged", () => {
       const epoch = new FabricEpochNsec(1234567890n);
       Object.freeze(epoch);
-      const result = cloneIfNecessary(epoch as unknown as FabricValue);
+      const result = cloneIfNecessary(epoch);
       expect(result).toBe(epoch); // identity -- special primitives are immutable
     });
 
@@ -377,7 +377,7 @@ describe("cloneIfNecessary", () => {
       Object.freeze(epoch);
       // frozen parameter is irrelevant for special primitives
       const result = cloneIfNecessary(
-        epoch as unknown as FabricValue,
+        epoch,
         { frozen: false },
       );
       expect(result).toBe(epoch); // identity -- special primitives are immutable
@@ -386,7 +386,7 @@ describe("cloneIfNecessary", () => {
     it("passes through `FabricEpochNsec` nested in an object", () => {
       const epoch = new FabricEpochNsec(999n);
       Object.freeze(epoch);
-      const value = { time: epoch, label: "test" } as FabricValue;
+      const value = { time: epoch, label: "test" };
       const result = cloneIfNecessary(value) as Record<string, unknown>;
       expect(Object.isFrozen(result)).toBe(true);
       expect(result.time).toBe(epoch); // same instance -- not cloned
@@ -414,7 +414,7 @@ describe("cloneIfNecessary", () => {
 
     it("does not report a frozen subclass instance as deep-frozen", () => {
       // This is what turns off the identity optimization below.
-      expect(isDeepFrozenFabricValue(frozenSmuggler() as FabricValue))
+      expect(isDeepFrozenFabricValue(frozenSmuggler()))
         .toBe(false);
     });
 
@@ -467,7 +467,7 @@ describe("cloneIfNecessary", () => {
 
     it("handles shared (diamond) references without throwing", () => {
       const shared = { x: 1 };
-      const value = { a: shared, b: shared } as FabricValue;
+      const value = { a: shared, b: shared };
       // Shared (non-circular) references should not throw.
       const result = cloneIfNecessary(value) as Record<string, unknown>;
       expect(result).toEqual({ a: { x: 1 }, b: { x: 1 } });
@@ -529,13 +529,12 @@ describe("cloneIfNecessary", () => {
     },
     {
       name: "ProblematicValue",
-      factory: () =>
-        new ProblematicValue("Foo@1", "state-data" as FabricValue, "boom"),
+      factory: () => new ProblematicValue("Foo@1", "state-data", "boom"),
       deepCloneImplemented: false,
     },
     {
       name: "UnknownValue",
-      factory: () => new UnknownValue("Foo@1", "state-data" as FabricValue),
+      factory: () => new UnknownValue("Foo@1", "state-data"),
       deepCloneImplemented: false,
     },
     // `FabricInstance` with all-protocol stubs (only shallow works).
@@ -544,15 +543,15 @@ describe("cloneIfNecessary", () => {
       factory: () =>
         new FabricMap(
           new Map<FabricValue, FabricValue>([[
-            "k" as FabricValue,
-            1 as FabricValue,
+            "k",
+            1,
           ]]),
         ),
       deepCloneImplemented: false,
     },
     {
       name: "FabricSet",
-      factory: () => new FabricSet(new Set<FabricValue>([1 as FabricValue])),
+      factory: () => new FabricSet(new Set<FabricValue>([1])),
       deepCloneImplemented: false,
     },
     // `FabricPrimitive` subclasses (intrinsically immutable).
@@ -701,14 +700,14 @@ describe("cloneIfNecessary", () => {
 
                 const expected = expectedOutcome(
                   c,
-                  value as unknown as FabricValue,
+                  value,
                   vec.opts,
                 );
 
                 if (expected.kind === "throws") {
                   expect(() =>
                     cloneIfNecessary(
-                      value as unknown as FabricValue,
+                      value,
                       vec.opts,
                     )
                   ).toThrow();
@@ -726,14 +725,14 @@ describe("cloneIfNecessary", () => {
                 } else if (vec.opts.deep) {
                   identityExpected = vec.opts.frozen &&
                     isDeepFrozenFabricValue(
-                      value as unknown as FabricValue,
+                      value,
                     );
                 } else {
                   identityExpected = wasFrozen === vec.opts.frozen;
                 }
 
                 const result = cloneIfNecessary(
-                  value as unknown as FabricValue,
+                  value,
                   vec.opts,
                 ) as FabricSpecialObject;
 

--- a/packages/data-model/test/codec-common/BaseFabricCodec.test.ts
+++ b/packages/data-model/test/codec-common/BaseFabricCodec.test.ts
@@ -42,12 +42,12 @@ describe("BaseFabricCodec", () => {
     describe("tagForValue()", () => {
       it("returns the codec's `recognizedTypeTag`", () => {
         const codec = new TestCodec("Foo@1", undefined);
-        expect(codec.tagForValue("anything" as FabricValue)).toBe("Foo@1");
+        expect(codec.tagForValue("anything")).toBe("Foo@1");
       });
 
       it("throws when the codec has no recognized tag (must be overridden)", () => {
         const codec = new TestCodec(undefined, undefined);
-        expect(() => codec.tagForValue("anything" as FabricValue)).toThrow(
+        expect(() => codec.tagForValue("anything")).toThrow(
           "no recognized tag",
         );
       });

--- a/packages/data-model/test/codec-json/CodecRegistry.test.ts
+++ b/packages/data-model/test/codec-json/CodecRegistry.test.ts
@@ -99,9 +99,9 @@ describe("CodecRegistry", () => {
       it(`given ${exampleStr}, finds the ${sourceName} codec by class`, () => {
         const { first, handler, last, registry } = buildRegistry(
           cls,
-          example as FabricValue,
+          example,
         );
-        expect(registry.codecFromValue(example as FabricValue)).toBe(handler);
+        expect(registry.codecFromValue(example)).toBe(handler);
         // Only the class-matched codec is consulted -- there is no linear scan.
         expect(first.canEncodeCalled).toBe(false);
         expect(handler.canEncodeCalled).toBe(true);
@@ -111,9 +111,9 @@ describe("CodecRegistry", () => {
       it(`returns undefined for ${counterStr} (no ${sourceName} match)`, () => {
         const { first, handler, last, registry } = buildRegistry(
           cls,
-          example as FabricValue,
+          example,
         );
-        expect(registry.codecFromValue(counter as FabricValue)).toBeUndefined();
+        expect(registry.codecFromValue(counter)).toBeUndefined();
         // A class miss consults no codec (no linear scan).
         expect(first.canEncodeCalled).toBe(false);
         expect(handler.canEncodeCalled).toBe(false);
@@ -124,7 +124,7 @@ describe("CodecRegistry", () => {
     it("returns undefined for a null-prototype object", () => {
       const { registry } = buildRegistry(
         FabricRegExp,
-        new FabricRegExp(/x/) as FabricValue,
+        new FabricRegExp(/x/),
       );
       const nullProto = Object.create(null) as Record<string, FabricValue>;
       nullProto.a = 1;

--- a/packages/data-model/test/codec-json/JsonEncodingContext.test.ts
+++ b/packages/data-model/test/codec-json/JsonEncodingContext.test.ts
@@ -122,7 +122,7 @@ describe("JsonEncodingContext", () => {
     it("produces valid JSON bytes from `encodeToBytes()`", () => {
       const { context } = makeTestContext();
       const bytes = context.encodeToBytes(
-        { a: 1 } as unknown as FabricValue,
+        { a: 1 },
       );
       const json = new TextDecoder().decode(bytes);
       expect(JSON.parse(json)).toEqual({ a: 1 });
@@ -143,7 +143,7 @@ describe("JsonEncodingContext", () => {
       const value = {
         name: "test",
         count: 42,
-      } as unknown as FabricValue;
+      };
       const bytes = context.encodeToBytes(value);
       const result = context.decodeFromBytes(
         bytes,
@@ -156,7 +156,7 @@ describe("JsonEncodingContext", () => {
     it("round-trips `FabricError` through `Uint8Array`", () => {
       const { context, runtime } = makeTestContext();
       const err = FabricError.fromNativeError(new TypeError("oops"));
-      const bytes = context.encodeToBytes(err as FabricValue);
+      const bytes = context.encodeToBytes(err);
       const result = context.decodeFromBytes(
         bytes,
         runtime,
@@ -180,7 +180,7 @@ describe("JsonEncodingContext", () => {
         users: [{ name: "Alice" }, { name: "Bob" }],
         error: FabricError.fromNativeError(new Error("fail")),
         nothing: undefined,
-      } as unknown as FabricValue;
+      };
       const bytes = context.encodeToBytes(value);
       const result = context.decodeFromBytes(
         bytes,
@@ -253,14 +253,14 @@ describe("JsonEncodingContext", () => {
     it("round-trips `undefined` at top level, in arrays, and as object values", () => {
       expect(roundTrip(undefined)).toBe(undefined);
 
-      const arr = [1, undefined, 3] as FabricValue;
+      const arr = [1, undefined, 3];
       const arrResult = roundTrip(arr) as FabricValue[];
       expect(arrResult[0]).toBe(1);
       expect(arrResult[1]).toBe(undefined);
       expect(1 in arrResult).toBe(true); // not a hole
       expect(arrResult[2]).toBe(3);
 
-      const obj = { a: 1, b: undefined } as unknown as FabricValue;
+      const obj = { a: 1, b: undefined };
       const objResult = roundTrip(obj) as Record<string, FabricValue>;
       expect(objResult.a).toBe(1);
       expect(objResult.b).toBe(undefined);
@@ -268,15 +268,15 @@ describe("JsonEncodingContext", () => {
     });
 
     it("round-trips `bigint` at top level, in arrays, and as object values", () => {
-      expect(roundTrip(42n as FabricValue)).toBe(42n);
+      expect(roundTrip(42n)).toBe(42n);
 
-      const arr = [1, 42n, "hello"] as unknown as FabricValue;
+      const arr = [1, 42n, "hello"];
       const arrResult = roundTrip(arr) as FabricValue[];
       expect(arrResult[0]).toBe(1);
       expect(arrResult[1]).toBe(42n);
       expect(arrResult[2]).toBe("hello");
 
-      const obj = { a: 1, b: 42n } as unknown as FabricValue;
+      const obj = { a: 1, b: 42n };
       const objResult = roundTrip(obj) as Record<string, FabricValue>;
       expect(objResult.a).toBe(1);
       expect(objResult.b).toBe(42n);
@@ -290,7 +290,7 @@ describe("JsonEncodingContext", () => {
       expect(roundTrip(Infinity)).toBe(Infinity);
       expect(roundTrip(-Infinity)).toBe(-Infinity);
 
-      const arr = [1, NaN, -0, Infinity, -Infinity, 2] as FabricValue;
+      const arr = [1, NaN, -0, Infinity, -Infinity, 2];
       const arrResult = roundTrip(arr) as number[];
       expect(arrResult[0]).toBe(1);
       expect(Number.isNaN(arrResult[1])).toBe(true);
@@ -304,7 +304,7 @@ describe("JsonEncodingContext", () => {
         nan: NaN,
         pinf: Infinity,
         ninf: -Infinity,
-      } as unknown as FabricValue;
+      };
       const objResult = roundTrip(obj) as Record<string, number>;
       expect(Object.is(objResult.nz, -0)).toBe(true);
       expect(Number.isNaN(objResult.nan)).toBe(true);
@@ -313,7 +313,7 @@ describe("JsonEncodingContext", () => {
     });
 
     it("round-trips interned symbols at top level, in arrays, and as object values", () => {
-      const top = roundTrip(Symbol.for("hello") as FabricValue);
+      const top = roundTrip(Symbol.for("hello"));
       expect(typeof top).toBe("symbol");
       expect(top).toBe(Symbol.for("hello"));
 
@@ -321,7 +321,7 @@ describe("JsonEncodingContext", () => {
         Symbol.for("a"),
         1,
         Symbol.for("b"),
-      ] as unknown as FabricValue;
+      ];
       const arrResult = roundTrip(arr) as unknown[];
       expect(arrResult[0]).toBe(Symbol.for("a"));
       expect(arrResult[1]).toBe(1);
@@ -330,7 +330,7 @@ describe("JsonEncodingContext", () => {
       const obj = {
         kind: Symbol.for("event"),
         flag: Symbol.for("ready"),
-      } as unknown as FabricValue;
+      };
       const objResult = roundTrip(obj) as Record<string, unknown>;
       expect(objResult.kind).toBe(Symbol.for("event"));
       expect(objResult.flag).toBe(Symbol.for("ready"));
@@ -341,14 +341,14 @@ describe("JsonEncodingContext", () => {
       // registry key), so no codec claims them. A default-configured context
       // must then fail loudly rather than silently flatten the symbol to `{}`.
       const { context } = makeTestContext();
-      expect(() => context.encode(Symbol("nope") as FabricValue)).toThrow(
+      expect(() => context.encode(Symbol("nope"))).toThrow(
         "no applicable codec",
       );
     });
 
     it("round-trips `FabricEpochNsec` at top level and in nested structures", () => {
       const top = roundTrip(
-        new FabricEpochNsec(1704067200000000000n) as FabricValue,
+        new FabricEpochNsec(1704067200000000000n),
       ) as unknown as FabricEpochNsec;
       expect(top).toBeInstanceOf(FabricEpochNsec);
       expect(top.value).toBe(1704067200000000000n);
@@ -356,7 +356,7 @@ describe("JsonEncodingContext", () => {
       const obj = {
         timestamp: new FabricEpochNsec(42000000000n),
         label: "test",
-      } as unknown as FabricValue;
+      };
       const result = roundTrip(obj) as Record<string, FabricValue>;
       expect(result.label).toBe("test");
       const ts = result.timestamp as unknown as FabricEpochNsec;
@@ -366,7 +366,7 @@ describe("JsonEncodingContext", () => {
 
     it("round-trips `FabricEpochDays` at top level and in nested structures", () => {
       const top = roundTrip(
-        new FabricEpochDays(19723n) as FabricValue,
+        new FabricEpochDays(19723n),
       ) as unknown as FabricEpochDays;
       expect(top).toBeInstanceOf(FabricEpochDays);
       expect(top.value).toBe(19723n);
@@ -374,7 +374,7 @@ describe("JsonEncodingContext", () => {
       const obj = {
         date: new FabricEpochDays(19723n),
         label: "birthday",
-      } as unknown as FabricValue;
+      };
       const result = roundTrip(obj) as Record<string, FabricValue>;
       expect(result.label).toBe("birthday");
       const d = result.date as unknown as FabricEpochDays;
@@ -384,7 +384,7 @@ describe("JsonEncodingContext", () => {
 
     it("round-trips `FabricRegExp` at top level and in nested structures", () => {
       const top = roundTrip(
-        new FabricRegExp(/ab+c/gi) as FabricValue,
+        new FabricRegExp(/ab+c/gi),
       ) as unknown as FabricRegExp;
       expect(top).toBeInstanceOf(FabricRegExp);
       expect(top.source).toBe("ab+c");
@@ -394,7 +394,7 @@ describe("JsonEncodingContext", () => {
       const obj = {
         pattern: new FabricRegExp(/\d+/g),
         label: "digits",
-      } as unknown as FabricValue;
+      };
       const result = roundTrip(obj) as Record<string, FabricValue>;
       expect(result.label).toBe("digits");
       const re = result.pattern as unknown as FabricRegExp;
@@ -407,7 +407,7 @@ describe("JsonEncodingContext", () => {
   describe("un-registered instance types", () => {
     it("throws when encoding a `FabricInstance` with no registered codec", () => {
       const { context } = makeTestContext();
-      expect(() => context.encode(new UnregisteredInstance() as FabricValue))
+      expect(() => context.encode(new UnregisteredInstance()))
         .toThrow("No codec registered");
     });
 
@@ -433,7 +433,7 @@ describe("JsonEncodingContext", () => {
     });
 
     it("round-trips mixed-type array", () => {
-      const arr = [null, "str", true, 42] as FabricValue;
+      const arr = [null, "str", true, 42];
       const result = roundTrip(arr) as FabricValue[];
       expect(result[0]).toBe(null);
       expect(result[1]).toBe("str");
@@ -442,7 +442,7 @@ describe("JsonEncodingContext", () => {
     });
 
     it("round-trips nested arrays", () => {
-      const arr = [[1, 2], [3, [4, 5]]] as FabricValue;
+      const arr = [[1, 2], [3, [4, 5]]];
       const result = roundTrip(arr) as FabricValue[];
       expect((result[0] as FabricValue[])[0]).toBe(1);
       expect((result[0] as FabricValue[])[1]).toBe(2);
@@ -455,7 +455,7 @@ describe("JsonEncodingContext", () => {
   describe("sparse arrays", () => {
     it("serializes `[1,,3]` with `/hole`", () => {
       // deno-lint-ignore no-sparse-arrays
-      const arr = [1, , 3] as FabricValue;
+      const arr = [1, , 3];
       const result = toWireFormat(arr) as JsonWireValue[];
       expect(result.length).toBe(3);
       expect(result[0]).toBe(1);
@@ -465,7 +465,7 @@ describe("JsonEncodingContext", () => {
 
     it("round-trips `[1,,3]` preserving holes", () => {
       // deno-lint-ignore no-sparse-arrays
-      const arr = [1, , 3] as FabricValue;
+      const arr = [1, , 3];
       const result = roundTrip(arr) as FabricValue[];
       expect(result.length).toBe(3);
       expect(result[0]).toBe(1);
@@ -475,7 +475,7 @@ describe("JsonEncodingContext", () => {
 
     it("serializes consecutive holes as run-length encoded", () => {
       // deno-lint-ignore no-sparse-arrays
-      const arr = [1, , , , 5] as FabricValue;
+      const arr = [1, , , , 5];
       const result = toWireFormat(arr) as JsonWireValue[];
       expect(result.length).toBe(3); // [1, {"/hole": 3}, 5]
       expect(result[0]).toBe(1);
@@ -485,7 +485,7 @@ describe("JsonEncodingContext", () => {
 
     it("round-trips `[1,,,,5]`", () => {
       // deno-lint-ignore no-sparse-arrays
-      const arr = [1, , , , 5] as FabricValue;
+      const arr = [1, , , , 5];
       const result = roundTrip(arr) as FabricValue[];
       expect(result.length).toBe(5);
       expect(result[0]).toBe(1);
@@ -497,7 +497,7 @@ describe("JsonEncodingContext", () => {
 
     it("round-trips all-holes array `[,,,]`", () => {
       // deno-lint-ignore no-sparse-arrays
-      const arr = [, , ,] as FabricValue;
+      const arr = [, , ,];
       const result = roundTrip(arr) as FabricValue[];
       expect(result.length).toBe(3);
       expect(0 in result).toBe(false);
@@ -508,7 +508,7 @@ describe("JsonEncodingContext", () => {
     it("round-trips very sparse array", () => {
       const arr = new Array(1000001) as FabricValue[];
       arr[1000000] = "x";
-      const result = roundTrip(arr as FabricValue) as FabricValue[];
+      const result = roundTrip(arr) as FabricValue[];
       expect(result.length).toBe(1000001);
       expect(0 in result).toBe(false);
       expect(999999 in result).toBe(false);
@@ -523,7 +523,7 @@ describe("JsonEncodingContext", () => {
       arr[2] = undefined;
       // index 3 is a hole
       arr[4] = 3;
-      const result = roundTrip(arr as FabricValue) as FabricValue[];
+      const result = roundTrip(arr) as FabricValue[];
       expect(result.length).toBe(5);
       expect(result[0]).toBe(1);
       expect(1 in result).toBe(false); // hole
@@ -538,7 +538,7 @@ describe("JsonEncodingContext", () => {
       arr[0] = 1;
       arr[2] = undefined;
       arr[4] = 3;
-      const result = toWireFormat(arr as FabricValue) as JsonWireValue[];
+      const result = toWireFormat(arr) as JsonWireValue[];
       expect(result).toEqual([
         1,
         { "/hole": 1 },
@@ -556,7 +556,7 @@ describe("JsonEncodingContext", () => {
     });
 
     it("round-trips simple object", () => {
-      const obj = { a: 1, b: "two", c: true } as unknown as FabricValue;
+      const obj = { a: 1, b: "two", c: true };
       const result = roundTrip(obj) as Record<string, FabricValue>;
       expect(result.a).toBe(1);
       expect(result.b).toBe("two");
@@ -564,7 +564,7 @@ describe("JsonEncodingContext", () => {
     });
 
     it("round-trips nested objects", () => {
-      const obj = { outer: { inner: 42 } } as unknown as FabricValue;
+      const obj = { outer: { inner: 42 } };
       const result = roundTrip(obj) as Record<
         string,
         Record<string, FabricValue>
@@ -573,7 +573,7 @@ describe("JsonEncodingContext", () => {
     });
 
     it("preserves `undefined` values in objects", () => {
-      const obj = { a: 1, b: undefined } as unknown as FabricValue;
+      const obj = { a: 1, b: undefined };
       const result = roundTrip(obj) as Record<string, FabricValue>;
       expect(result.a).toBe(1);
       expect(result.b).toBe(undefined);
@@ -582,15 +582,15 @@ describe("JsonEncodingContext", () => {
 
     describe("key ordering (Section 10)", () => {
       it("emits keys in UTF-8 byte order for a bare plain object", () => {
-        const obj = { c: 3, a: 1, b: 2 } as unknown as FabricValue;
+        const obj = { c: 3, a: 1, b: 2 };
         const wire = toWireFormat(obj) as Record<string, JsonWireValue>;
         expect(Object.keys(wire)).toEqual(["a", "b", "c"]);
       });
 
       it("emits keys in UTF-8 byte order regardless of insertion order", () => {
-        const obj1 = { x: 1, y: 2, z: 3 } as unknown as FabricValue;
-        const obj2 = { z: 3, x: 1, y: 2 } as unknown as FabricValue;
-        const obj3 = { y: 2, z: 3, x: 1 } as unknown as FabricValue;
+        const obj1 = { x: 1, y: 2, z: 3 };
+        const obj2 = { z: 3, x: 1, y: 2 };
+        const obj3 = { y: 2, z: 3, x: 1 };
         const ctx = new JsonEncodingContext();
         expect(ctx.encode(obj1)).toBe(ctx.encode(obj2));
         expect(ctx.encode(obj1)).toBe(ctx.encode(obj3));
@@ -600,7 +600,7 @@ describe("JsonEncodingContext", () => {
         const obj = {
           b: { z: 1, a: 2 },
           a: 0,
-        } as unknown as FabricValue;
+        };
         const wire = toWireFormat(obj) as Record<string, JsonWireValue>;
         expect(Object.keys(wire)).toEqual(["a", "b"]);
         const inner = wire.b as Record<string, JsonWireValue>;
@@ -614,7 +614,7 @@ describe("JsonEncodingContext", () => {
         const obj = {
           ["\u{10000}"]: 1,
           [""]: 2,
-        } as unknown as FabricValue;
+        };
         const wire = toWireFormat(obj) as Record<string, JsonWireValue>;
         expect(Object.keys(wire)).toEqual(["", "\u{10000}"]);
       });
@@ -630,7 +630,7 @@ describe("JsonEncodingContext", () => {
           b: 2,
           ["﻿"]: 3,
           a: 4,
-        } as unknown as FabricValue;
+        };
         const wire = toWireFormat(obj) as Record<string, JsonWireValue>;
         expect(Object.keys(wire)).toEqual([...utf8SortedKeysOf(obj as object)]);
       });
@@ -640,48 +640,48 @@ describe("JsonEncodingContext", () => {
   describe("/object escaping", () => {
     describe("/quote: literal-only /-keyed objects", () => {
       it("emits `/quote` for single-key literal `/`-prefixed object", () => {
-        const obj = { "/myKey": "val" } as unknown as FabricValue;
+        const obj = { "/myKey": "val" };
         expect(toWireFormat(obj)).toEqual({ "/quote": { "/myKey": "val" } });
       });
 
       it('round-trips `{ "/myKey": "val" }`', () => {
-        const obj = { "/myKey": "val" } as unknown as FabricValue;
+        const obj = { "/myKey": "val" };
         const result = roundTrip(obj) as Record<string, FabricValue>;
         expect(result["/myKey"]).toBe("val");
       });
 
       it('emits `/quote` for `{ "/Link@1": "fake" }` (looks like tag but is literal user data)', () => {
-        const obj = { "/Link@1": "fake" } as unknown as FabricValue;
+        const obj = { "/Link@1": "fake" };
         expect(toWireFormat(obj)).toEqual({ "/quote": { "/Link@1": "fake" } });
       });
 
       it('round-trips `{ "/Link@1": "fake" }`', () => {
-        const obj = { "/Link@1": "fake" } as unknown as FabricValue;
+        const obj = { "/Link@1": "fake" };
         const result = roundTrip(obj) as Record<string, FabricValue>;
         expect(result["/Link@1"]).toBe("fake");
       });
 
       it("emits `/quote` for multi-key literal object with one `/`-prefixed key", () => {
-        const obj = { a: 1, "/b": 2 } as unknown as FabricValue;
+        const obj = { a: 1, "/b": 2 };
         expect(toWireFormat(obj)).toEqual({ "/quote": { a: 1, "/b": 2 } });
       });
 
       it("round-trips multi-key literal object with one `/`-prefixed key", () => {
-        const obj = { a: 1, "/b": 2 } as unknown as FabricValue;
+        const obj = { a: 1, "/b": 2 };
         const result = roundTrip(obj) as Record<string, FabricValue>;
         expect(result["a"]).toBe(1);
         expect(result["/b"]).toBe(2);
       });
 
       it("emits `/quote` for multi-key literal object with multiple `/`-prefixed keys", () => {
-        const obj = { "/a": 1, "/b": 2, c: 3 } as unknown as FabricValue;
+        const obj = { "/a": 1, "/b": 2, c: 3 };
         expect(toWireFormat(obj)).toEqual({
           "/quote": { "/a": 1, "/b": 2, c: 3 },
         });
       });
 
       it("round-trips multi-key literal object with multiple `/`-prefixed keys", () => {
-        const obj = { "/a": 1, "/b": 2, c: 3 } as unknown as FabricValue;
+        const obj = { "/a": 1, "/b": 2, c: 3 };
         const result = roundTrip(obj) as Record<string, FabricValue>;
         expect(result["/a"]).toBe(1);
         expect(result["/b"]).toBe(2);
@@ -689,12 +689,12 @@ describe("JsonEncodingContext", () => {
       });
 
       it("emits `/quote` when value is a plain nested object (no `/`-keys inside)", () => {
-        const obj = { "/x": { a: 1 } } as unknown as FabricValue;
+        const obj = { "/x": { a: 1 } };
         expect(toWireFormat(obj)).toEqual({ "/quote": { "/x": { a: 1 } } });
       });
 
       it("round-trips `/`-keyed object whose value is a plain nested object", () => {
-        const obj = { "/x": { a: 1 } } as unknown as FabricValue;
+        const obj = { "/x": { a: 1 } };
         const result = roundTrip(obj) as Record<
           string,
           Record<string, FabricValue>
@@ -705,7 +705,7 @@ describe("JsonEncodingContext", () => {
 
     describe("/object: any value requires encoding", () => {
       it("emits `/quote` for doubly-nested `/`-prefixed literal object (whole subtree is literal)", () => {
-        const obj = { "/x": { "/y": 123 } } as unknown as FabricValue;
+        const obj = { "/x": { "/y": 123 } };
         const wire = toWireFormat(obj);
         // Whole subtree is deep-literal → single /quote wrap of original structure.
         expect(wire).toEqual({
@@ -720,7 +720,7 @@ describe("JsonEncodingContext", () => {
 
       it("boundary contrast: literal subtree uses `/quote`, Fabric type uses `/object`", () => {
         // All-literal: single /quote wraps the whole structure.
-        const literal = { "/x": { "/y": 123 } } as unknown as FabricValue;
+        const literal = { "/x": { "/y": 123 } };
         expect(toWireFormat(literal)).toEqual({
           "/quote": { "/x": { "/y": 123 } },
         });
@@ -728,7 +728,7 @@ describe("JsonEncodingContext", () => {
         // Fabric type as value: /object with the epoch encoded as its tagged form.
         const withEpoch = {
           "/x": new FabricEpochDays(42n),
-        } as unknown as FabricValue;
+        };
         expect(toWireFormat(withEpoch)).toEqual({
           "/object": { "/x": { "/EpochDays@1": expect.anything() } },
         });
@@ -736,14 +736,14 @@ describe("JsonEncodingContext", () => {
 
       it("emits `/object` for `/`-keyed object with `FabricError` value", () => {
         const err = FabricError.fromNativeError(new TypeError("eep!"));
-        const obj = { "/x": err } as unknown as FabricValue;
+        const obj = { "/x": err };
         const wire = toWireFormat(obj);
         expect(Object.keys(wire as object)).toEqual(["/object"]);
       });
 
       it("round-trips `FabricError` as value inside `/`-prefixed key object", () => {
         const err = FabricError.fromNativeError(new TypeError("eep!"));
-        const obj = { "/x": err } as unknown as FabricValue;
+        const obj = { "/x": err };
         const result = roundTrip(obj) as Record<string, FabricValue>;
         expect(result["/x"]).toBeInstanceOf(FabricError);
         expect((result["/x"] as unknown as FabricError).message).toBe(
@@ -753,7 +753,7 @@ describe("JsonEncodingContext", () => {
 
       it("round-trips `FabricEpochDays` as value inside `/`-prefixed key object", () => {
         const day = new FabricEpochDays(42n);
-        const obj = { "/x": day } as unknown as FabricValue;
+        const obj = { "/x": day };
         const result = roundTrip(obj) as Record<string, FabricValue>;
         expect(result["/x"]).toBeInstanceOf(FabricEpochDays);
         expect((result["/x"] as unknown as FabricEpochDays).value).toBe(42n);
@@ -763,7 +763,7 @@ describe("JsonEncodingContext", () => {
         const obj = {
           "/a": "literal",
           "/b": FabricError.fromNativeError(new Error("oops")),
-        } as unknown as FabricValue;
+        };
         const wire = toWireFormat(obj);
         expect(Object.keys(wire as object)).toEqual(["/object"]);
       });
@@ -772,7 +772,7 @@ describe("JsonEncodingContext", () => {
         const obj = {
           "/a": "literal",
           "/b": FabricError.fromNativeError(new Error("oops")),
-        } as unknown as FabricValue;
+        };
         const result = roundTrip(obj) as Record<string, FabricValue>;
         expect(result["/a"]).toBe("literal");
         expect(result["/b"]).toBeInstanceOf(FabricError);
@@ -798,7 +798,7 @@ describe("JsonEncodingContext", () => {
       });
 
       it("does not wrap plain object with no `/`-prefixed keys", () => {
-        const obj = { a: 1, b: 2 } as unknown as FabricValue;
+        const obj = { a: 1, b: 2 };
         expect(toWireFormat(obj)).toEqual({ a: 1, b: 2 });
       });
 
@@ -810,7 +810,7 @@ describe("JsonEncodingContext", () => {
       });
 
       it("round-trips nested object containing `/`-prefixed key", () => {
-        const obj = { outer: { "/inner": 1 } } as unknown as FabricValue;
+        const obj = { outer: { "/inner": 1 } };
         const result = roundTrip(obj) as Record<
           string,
           Record<string, FabricValue>
@@ -843,7 +843,7 @@ describe("JsonEncodingContext", () => {
       it("round-trips object whose value is a `/quote`-keyed literal", () => {
         // { "/x": { "/quote": "inner" } } — the value at "/x" is user data that
         // happens to have a /quote key. Must survive encode→decode intact.
-        const obj = { "/x": { "/quote": "inner" } } as unknown as FabricValue;
+        const obj = { "/x": { "/quote": "inner" } };
         const result = roundTrip(obj) as Record<
           string,
           Record<string, FabricValue>
@@ -994,7 +994,7 @@ describe("JsonEncodingContext", () => {
     it("preserves the `UnknownValue` tag in wire format via `encode()`", () => {
       // Encoding an UnknownValue produces the original tagged form.
       const us = new UnknownValue("FutureType@2", { some: "data" });
-      const wireFormat = toWireFormat(us as FabricValue);
+      const wireFormat = toWireFormat(us);
       expect(wireFormat).toEqual({
         "/FutureType@2": { some: "data" },
       });
@@ -1002,7 +1002,7 @@ describe("JsonEncodingContext", () => {
 
     it("round-trips `UnknownValue` through encode/decode", () => {
       const us = new UnknownValue("FutureType@2", { some: "data" });
-      const result = roundTrip(us as FabricValue);
+      const result = roundTrip(us);
       expect(result).toBeInstanceOf(UnknownValue);
       const unknown = result as unknown as UnknownValue;
       expect(unknown.wireTypeTag).toBe("FutureType@2");
@@ -1056,15 +1056,15 @@ describe("JsonEncodingContext", () => {
       state.eek.push(state);
 
       const us = new UnknownValue("Test@1", state);
-      expect(() => context.encode(us as FabricValue))
+      expect(() => context.encode(us))
         .toThrow(
           "Circular reference",
         );
     });
 
     it("allows shared references (same object at multiple positions)", () => {
-      const shared = { val: 42 } as unknown as FabricValue;
-      const obj = { a: shared, b: shared } as unknown as FabricValue;
+      const shared = { val: 42 };
+      const obj = { a: shared, b: shared };
       // Should not throw -- shared references are fine, only cycles are rejected.
       const result = toWireFormat(obj);
       expect(result).toEqual({ a: { val: 42 }, b: { val: 42 } });
@@ -1078,7 +1078,7 @@ describe("JsonEncodingContext", () => {
         "original data",
         "something went wrong",
       );
-      const wireFormat = toWireFormat(prob as FabricValue);
+      const wireFormat = toWireFormat(prob);
       expect(wireFormat).toEqual({ "/BadType@1": "original data" });
     });
 
@@ -1207,7 +1207,7 @@ describe("JsonEncodingContext", () => {
 
     it("codec round-trip yields a deep-frozen result", () => {
       const result = roundTrip(
-        new FabricEpochNsec(1704067200000000000n) as FabricValue,
+        new FabricEpochNsec(1704067200000000000n),
       );
       expect(result).toBeInstanceOf(FabricEpochNsec);
       expect(isDeepFrozen(result)).toBe(true);
@@ -1323,7 +1323,7 @@ describe("JsonEncodingContext", () => {
       const value = {
         "/a": 1,
         "/b": { plain: [1, 2] },
-      } as unknown as FabricValue;
+      };
       const result = roundTrip(value);
       expect(isDeepFrozen(result)).toBe(true);
       expect(result).toEqual({ "/a": 1, "/b": { plain: [1, 2] } });
@@ -1355,7 +1355,7 @@ describe("JsonEncodingContext", () => {
       const ctx = new JsonEncodingContext();
       const runtime = new TestReconstructionContext();
       const se = FabricError.fromNativeError(new Error("test"));
-      const encoded = ctx.encode(se as FabricValue);
+      const encoded = ctx.encode(se);
       const decoded = ctx.decode(encoded, runtime);
       expect(decoded).toBeInstanceOf(FabricError);
       expect((decoded as unknown as FabricError).message).toBe("test");
@@ -1367,7 +1367,7 @@ describe("JsonEncodingContext", () => {
       const data = {
         name: "test",
         error: FabricError.fromNativeError(new Error("fail")),
-      } as unknown as FabricValue;
+      };
       const bytes = ctx.encodeToBytes(data);
       expect(bytes).toBeInstanceOf(Uint8Array);
       const decoded = ctx.decodeFromBytes(bytes, runtime) as Record<
@@ -1397,7 +1397,7 @@ describe("JsonEncodingContext", () => {
           { name: "Bob", scores: [] },
         ],
         meta: { version: 1, debug: undefined },
-      } as unknown as FabricValue;
+      };
 
       const result = roundTrip(value) as Record<string, FabricValue>;
       const users = result.users as FabricValue[];
@@ -1417,7 +1417,7 @@ describe("JsonEncodingContext", () => {
 
     it("round-trips `FabricError` in array", () => {
       const se = FabricError.fromNativeError(new Error("oops"));
-      const arr = [1, se, 3] as unknown as FabricValue;
+      const arr = [1, se, 3];
       const result = roundTrip(arr) as FabricValue[];
       expect(result[0]).toBe(1);
       expect(result[1]).toBeInstanceOf(FabricError);
@@ -1431,7 +1431,7 @@ describe("JsonEncodingContext", () => {
       const obj = {
         error: FabricError.fromNativeError(new Error("fail")),
         code: 500,
-      } as unknown as FabricValue;
+      };
       const result = roundTrip(obj) as Record<string, FabricValue>;
       expect(result.error).toBeInstanceOf(FabricError);
       expect(
@@ -1444,7 +1444,7 @@ describe("JsonEncodingContext", () => {
       // FabricError should produce the same wire format as the old ErrorHandler.
       const se = FabricError.fromNativeError(new TypeError("compat test"));
       const serialized = toWireFormat(
-        se as FabricValue,
+        se,
       ) as Record<string, unknown>;
       expect(Object.keys(serialized)).toEqual(["/Error@1"]);
       const state = serialized["/Error@1"] as Record<string, unknown>;
@@ -1464,7 +1464,7 @@ describe("JsonEncodingContext", () => {
 
       it("round-trips with `wrapEncodedValueForTesting()`", () => {
         const encoded = new JsonEncodingContext().encode(
-          { b: 1, a: [true, null] } as unknown as FabricValue,
+          { b: 1, a: [true, null] },
         );
         const json = JsonEncodingContext.unwrapEncodedValueForTesting(encoded);
         expect(JsonEncodingContext.wrapEncodedValueForTesting(json))
@@ -1475,7 +1475,7 @@ describe("JsonEncodingContext", () => {
         // The case that motivates having a golden format at all: these survive
         // the trip only as tagged forms.
         const encoded = new JsonEncodingContext().encode(
-          { z: -0, n: NaN, i: -Infinity } as unknown as FabricValue,
+          { z: -0, n: NaN, i: -Infinity },
         );
         const rebuilt = new JsonEncodingContext().decode(
           JsonEncodingContext.wrapEncodedValueForTesting(

--- a/packages/data-model/test/codec-json/JsonEncodingContext.test.ts
+++ b/packages/data-model/test/codec-json/JsonEncodingContext.test.ts
@@ -1124,7 +1124,7 @@ describe("JsonEncodingContext", () => {
     it("deserialized arrays are frozen", () => {
       const result = fromWireFormat(
         [1, 2, 3] as JsonWireValue,
-      ) as FabricValue[];
+      );
       expect(Object.isFrozen(result)).toBe(true);
     });
 
@@ -1138,7 +1138,7 @@ describe("JsonEncodingContext", () => {
     it("mutation of deserialized array throws", () => {
       const result = fromWireFormat(
         [1, 2, 3] as JsonWireValue,
-      ) as FabricValue[];
+      );
       expect(() => {
         (result as unknown as number[])[0] = 99;
       }).toThrow();

--- a/packages/data-model/test/codec-json/json-encoding.test.ts
+++ b/packages/data-model/test/codec-json/json-encoding.test.ts
@@ -47,7 +47,7 @@ describe("json-encoding", () => {
   });
 
   it("round-trips `bigint`", () => {
-    expect(roundTrip(42n as FabricValue)).toBe(42n);
+    expect(roundTrip(42n)).toBe(42n);
   });
 
   it("`jsonFromValue()` encodes `undefined` to tagged JSON", () => {
@@ -55,7 +55,7 @@ describe("json-encoding", () => {
   });
 
   it("`jsonFromValue()` encodes `bigint` to tagged JSON", () => {
-    expectWireFormat(42n as FabricValue, { "/BigInt@1": "Kg" });
+    expectWireFormat(42n, { "/BigInt@1": "Kg" });
   });
 
   it("`valueFromJson()` decodes tagged `undefined`", () => {
@@ -69,12 +69,12 @@ describe("json-encoding", () => {
   });
 
   it("round-trips plain objects", () => {
-    const value = { a: 1, b: "two" } as FabricValue;
+    const value = { a: 1, b: "two" };
     expect(roundTrip(value)).toEqual({ a: 1, b: "two" });
   });
 
   it("round-trips arrays", () => {
-    const value = [1, "two", null] as FabricValue;
+    const value = [1, "two", null];
     expect(roundTrip(value)).toEqual([1, "two", null]);
   });
 
@@ -83,25 +83,25 @@ describe("json-encoding", () => {
   });
 
   it("JSON-safe primitives stringify normally (under the encoding prefix)", () => {
-    expect(jsonFromValue(42 as FabricValue)).toBe("fvj1:42");
-    expect(jsonFromValue("hello" as FabricValue)).toBe('fvj1:"hello"');
-    expect(jsonFromValue(true as FabricValue)).toBe("fvj1:true");
+    expect(jsonFromValue(42)).toBe("fvj1:42");
+    expect(jsonFromValue("hello")).toBe('fvj1:"hello"');
+    expect(jsonFromValue(true)).toBe("fvj1:true");
     expect(jsonFromValue(null)).toBe("fvj1:null");
   });
 
   describe("edge case", () => {
     it("round-trips object with slash-prefixed key", () => {
-      const value = { "/foo": "bar" } as FabricValue;
+      const value = { "/foo": "bar" };
       expect(roundTrip(value)).toEqual({ "/foo": "bar" });
     });
 
     it("decoded objects are frozen", () => {
-      const value = { a: 1, b: "two" } as FabricValue;
+      const value = { a: 1, b: "two" };
       expect(Object.isFrozen(roundTrip(value))).toBe(true);
     });
 
     it("decoded arrays are frozen", () => {
-      const value = [1, 2, 3] as FabricValue;
+      const value = [1, 2, 3];
       expect(Object.isFrozen(roundTrip(value))).toBe(true);
     });
 
@@ -110,7 +110,7 @@ describe("json-encoding", () => {
         name: "test",
         count: 42n,
         missing: undefined,
-      } as FabricValue;
+      };
       const decoded = roundTrip(value) as Record<string, unknown>;
       expect(decoded.name).toBe("test");
       expect(decoded.count).toBe(42n);
@@ -124,7 +124,7 @@ describe("json-encoding", () => {
       // /object, read path unwraps it.
       const slashObject = {
         "/": { kind: "widget", tags: ["a", "b"], size: 3 },
-      } as FabricValue;
+      };
       expect(roundTrip(slashObject)).toEqual(slashObject);
     });
 
@@ -132,7 +132,7 @@ describe("json-encoding", () => {
       const value = {
         name: "test",
         slashKeyed: { "/": { inner: { flag: true }, count: 0 } },
-      } as FabricValue;
+      };
       const decoded = roundTrip(value) as Record<string, unknown>;
       expect(decoded.name).toBe("test");
       expect(decoded.slashKeyed).toEqual(
@@ -143,19 +143,19 @@ describe("json-encoding", () => {
     it('`{ "/": "string" }` round-trips via `/object` escaping', () => {
       // An arbitrary string-valued `/` key — not an entity ref; exercises the
       // escaping for the `/` key per se.
-      const slashKeyed = { "/": "an arbitrary string" } as FabricValue;
+      const slashKeyed = { "/": "an arbitrary string" };
       expect(roundTrip(slashKeyed)).toEqual(slashKeyed);
     });
 
     it("`$stream` marker passes through unchanged", () => {
-      const value = { $stream: true } as FabricValue;
+      const value = { $stream: true };
       expect(roundTrip(value)).toEqual({ $stream: true });
     });
 
     it("`@Error` marker passes through unchanged", () => {
       const value = {
         "@Error": { name: "TypeError", message: "oops", stack: "" },
-      } as FabricValue;
+      };
       expect(roundTrip(value)).toEqual({
         "@Error": { name: "TypeError", message: "oops", stack: "" },
       });
@@ -167,7 +167,7 @@ describe("json-encoding", () => {
           path: ["value", "name"],
           cell: { "/": "an arbitrary string" },
         },
-      } as FabricValue;
+      };
       expect(roundTrip(value)).toEqual({
         $alias: {
           path: ["value", "name"],
@@ -181,7 +181,7 @@ describe("json-encoding", () => {
         count: 42n,
         slashKeyed: { "/": { values: [1, 2, 3], note: "hello" } },
         items: [1, { "/": "another arbitrary string" }, undefined],
-      } as FabricValue;
+      };
       const decoded = roundTrip(value) as Record<string, unknown>;
       expect(decoded.count).toBe(42n);
       expect(decoded.slashKeyed).toEqual(
@@ -198,7 +198,7 @@ describe("json-encoding", () => {
       const value = [
         { "/": { count: 1 } },
         { "/": { labels: ["x"], ready: true } },
-      ] as FabricValue;
+      ];
       expect(roundTrip(value)).toEqual(value);
     });
   });
@@ -215,7 +215,7 @@ describe("json-encoding", () => {
     });
 
     it("recognizes the actual output of `jsonFromValue()` (round-trip check)", () => {
-      const encoded = jsonFromValue({ a: 1, b: 42n } as FabricValue);
+      const encoded = jsonFromValue({ a: 1, b: 42n });
       expect(seemsLikeJsonEncodedFabricValue(encoded)).toBe(true);
     });
 
@@ -283,13 +283,13 @@ describe("json-encoding", () => {
       expect(valueFromJson("fvj1:42")).toBe(42);
       expect(valueFromJson('fvj1:{"a":1}')).toEqual({ a: 1 });
       expect(valueFromJson('fvj1:{"\/Undefined@1":null}')).toBe(undefined);
-      expect(roundTrip(7 as FabricValue)).toBe(7);
+      expect(roundTrip(7)).toBe(7);
     });
   });
 
   describe("plainObjectFromJson", () => {
     it("returns the decoded plain object", () => {
-      const json = jsonFromValue({ a: 1, b: 42n } as FabricValue);
+      const json = jsonFromValue({ a: 1, b: 42n });
       const result = plainObjectFromJson<{ a: number; b: bigint }>(json);
       expect(result.a).toBe(1);
       expect(result.b).toBe(42n);
@@ -297,7 +297,7 @@ describe("json-encoding", () => {
 
     it("throws on a class instance (`FabricError`)", () => {
       const err = FabricError.fromNativeError(new Error("test"));
-      const json = jsonFromValue(err as FabricValue);
+      const json = jsonFromValue(err);
       expect(() => plainObjectFromJson(json)).toThrow(/instance/);
     });
 

--- a/packages/data-model/test/deep-freeze.test.ts
+++ b/packages/data-model/test/deep-freeze.test.ts
@@ -6,7 +6,6 @@ import {
   isDeepFrozen,
   isDeepFrozenFabricValue,
 } from "@/deep-freeze.ts";
-import type { FabricValue } from "@/interface.ts";
 import { FabricError } from "@/fabric-instances/FabricError.ts";
 import { FabricEpochNsec } from "@/fabric-primitives/FabricEpochNsec.ts";
 

--- a/packages/data-model/test/deep-freeze.test.ts
+++ b/packages/data-model/test/deep-freeze.test.ts
@@ -279,7 +279,7 @@ describe("deep-freeze", () => {
         // frozen and every enumerable slot is a frozen primitive, but the
         // extras bag holds a mutable array -> not deep-frozen.
         const fe = FabricError.fromNativeError(new Error("has-extras"));
-        fe.setExtra("payload", [1, 2, 3] as unknown as FabricValue);
+        fe.setExtra("payload", [1, 2, 3]);
         Object.freeze(fe);
         expect(isDeepFrozen(fe)).toBe(false);
       });
@@ -336,7 +336,7 @@ describe("deep-freeze", () => {
 
       it("recurses into nested `FabricValue`s", () => {
         const fe = FabricError.fromNativeError(new Error("e"));
-        const container = { wrapped: fe as unknown as FabricValue, n: 1 };
+        const container = { wrapped: fe, n: 1 };
         deepFreeze(container);
         expect(Object.isFrozen(container)).toBe(true);
         expect(Object.isFrozen(fe)).toBe(true);
@@ -363,7 +363,7 @@ describe("deep-freeze", () => {
 
     it("returns `true` for a deep-frozen `FabricInstance` nested in a tree", () => {
       const fe = FabricError.fromNativeError(new Error("nested"));
-      const tree = deepFreeze({ a: 1, e: fe as unknown as FabricValue });
+      const tree = deepFreeze({ a: 1, e: fe });
       expect(isDeepFrozenFabricValue(tree)).toBe(true);
     });
 

--- a/packages/data-model/test/fabric-instances/BaseFabricInstance.test.ts
+++ b/packages/data-model/test/fabric-instances/BaseFabricInstance.test.ts
@@ -38,7 +38,7 @@ class Probe extends BaseFabricInstance {
     _subFreeze: (value: FabricValue) => FabricValue,
   ): FabricValue {
     Object.freeze(this);
-    return this as unknown as FabricValue;
+    return this;
   }
 
   [IS_DEEP_FROZEN](
@@ -79,16 +79,16 @@ class DeepProbe extends BaseFabricInstance {
   [DEEP_FREEZE](
     subFreeze: (value: FabricValue) => FabricValue,
   ): FabricValue {
-    subFreeze(this.state as unknown as FabricValue);
+    subFreeze(this.state);
     Object.freeze(this);
-    return this as unknown as FabricValue;
+    return this;
   }
 
   [IS_DEEP_FROZEN](
     subIsDeepFrozen: (value: FabricValue) => boolean,
   ): boolean {
     return Object.isFrozen(this) &&
-      subIsDeepFrozen(this.state as unknown as FabricValue);
+      subIsDeepFrozen(this.state);
   }
 
   protected [DEEP_CLONE_CORE](_frozen: boolean): DeepProbe {

--- a/packages/data-model/test/fabric-instances/FabricMap.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricMap.test.ts
@@ -61,7 +61,7 @@ describe("FabricMap", () => {
         expect(result).not.toBe(fm);
         expect(result).toBeInstanceOf(Map);
         expect(result).not.toBeInstanceOf(FrozenMap);
-        expect(result.get("a" as FabricValue)).toBe(1);
+        expect(result.get("a")).toBe(1);
       });
     });
 

--- a/packages/data-model/test/fabric-instances/FabricSet.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricSet.test.ts
@@ -55,7 +55,7 @@ describe("FabricSet", () => {
         expect(result).not.toBe(fs);
         expect(result).toBeInstanceOf(Set);
         expect(result).not.toBeInstanceOf(FrozenSet);
-        expect(result.has(1 as FabricValue)).toBe(true);
+        expect(result.has(1)).toBe(true);
       });
     });
 

--- a/packages/data-model/test/fabric-instances/ProblematicValue.test.ts
+++ b/packages/data-model/test/fabric-instances/ProblematicValue.test.ts
@@ -35,7 +35,7 @@ describe("ProblematicValue", () => {
         const child = { x: 1 };
         const pv = new ProblematicValue(
           "Bad@1",
-          child as unknown as FabricValue,
+          child,
           "oops",
         );
         const result = deepFreeze(pv);
@@ -49,7 +49,7 @@ describe("ProblematicValue", () => {
         const child = { x: 1 };
         const pv = new ProblematicValue(
           "Bad@1",
-          child as unknown as FabricValue,
+          child,
           "oops",
         );
         const result = pv[DEEP_FREEZE](subFreeze);

--- a/packages/data-model/test/fabric-instances/ProblematicValue.test.ts
+++ b/packages/data-model/test/fabric-instances/ProblematicValue.test.ts
@@ -1,7 +1,6 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
-import type { FabricValue } from "@/interface.ts";
 import {
   DEEP_FREEZE,
   IS_DEEP_FROZEN,

--- a/packages/data-model/test/fabric-instances/UnknownValue.test.ts
+++ b/packages/data-model/test/fabric-instances/UnknownValue.test.ts
@@ -34,7 +34,7 @@ describe("UnknownValue", () => {
         const child = { y: 2 };
         const uv = new UnknownValue(
           "Fancy@3",
-          child as unknown as FabricValue,
+          child,
         );
         const result = deepFreeze(uv);
         expect(result).toBe(uv);
@@ -47,7 +47,7 @@ describe("UnknownValue", () => {
         const child = { y: 2 };
         const uv = new UnknownValue(
           "Fancy@3",
-          child as unknown as FabricValue,
+          child,
         );
         const result = uv[DEEP_FREEZE](subFreeze);
         expect(result).toBe(uv);

--- a/packages/data-model/test/fabric-instances/UnknownValue.test.ts
+++ b/packages/data-model/test/fabric-instances/UnknownValue.test.ts
@@ -1,7 +1,6 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
-import type { FabricValue } from "@/interface.ts";
 import {
   DEEP_FREEZE,
   IS_DEEP_FROZEN,

--- a/packages/data-model/test/native-conversion.test.ts
+++ b/packages/data-model/test/native-conversion.test.ts
@@ -226,7 +226,7 @@ describe("native-conversion", () => {
     });
 
     it("preserves sparse holes", () => {
-      const arr = new Array(3) as FabricValue[];
+      const arr = new Array(3);
       arr[0] = 1;
       arr[2] = 3;
       Object.freeze(arr);
@@ -264,7 +264,7 @@ describe("native-conversion", () => {
     });
 
     it("deeply unwraps `FabricSet` to `FrozenSet`", () => {
-      const set = new Set<FabricValue>([42] as FabricValue[]);
+      const set = new Set<FabricValue>([42]);
       const ss = new FabricSet(set);
       const arr = [ss];
       const result = nativeFromFabricValue(arr) as unknown[];

--- a/packages/data-model/test/native-conversion.test.ts
+++ b/packages/data-model/test/native-conversion.test.ts
@@ -50,10 +50,10 @@ function roundTrip(value: FabricValue): FabricOrConvertibleNativeValue {
 describe("native-conversion", () => {
   describe("nativeFromFabricValue()", () => {
     it("round-trips primitives", () => {
-      expect(roundTrip(42 as FabricValue)).toBe(42);
-      expect(roundTrip("hello" as FabricValue)).toBe("hello");
+      expect(roundTrip(42)).toBe(42);
+      expect(roundTrip("hello")).toBe("hello");
       expect(roundTrip(null)).toBe(null);
-      expect(roundTrip(true as FabricValue)).toBe(true);
+      expect(roundTrip(true)).toBe(true);
     });
 
     it("round-trips `undefined`", () => {
@@ -61,16 +61,16 @@ describe("native-conversion", () => {
     });
 
     it("round-trips `bigint`", () => {
-      expect(roundTrip(42n as FabricValue)).toBe(42n);
+      expect(roundTrip(42n)).toBe(42n);
     });
 
     it("round-trips plain objects", () => {
-      const value = { a: 1, b: "two" } as FabricValue;
+      const value = { a: 1, b: "two" };
       expect(roundTrip(value)).toEqual({ a: 1, b: "two" });
     });
 
     it("round-trips arrays", () => {
-      const value = [1, "two", null] as FabricValue;
+      const value = [1, "two", null];
       expect(roundTrip(value)).toEqual([1, "two", null]);
     });
 
@@ -79,7 +79,7 @@ describe("native-conversion", () => {
         name: "test",
         count: 42n,
         missing: undefined,
-      } as FabricValue;
+      };
       const result = roundTrip(value) as Record<string, unknown>;
       expect(result.name).toBe("test");
       expect(result.count).toBe(42n);
@@ -88,7 +88,7 @@ describe("native-conversion", () => {
 
     it("unwraps a `FabricError` back to a native `Error`", () => {
       const error = new Error("test error");
-      const stored = fabricFromNativeValue(error as unknown as FabricValue);
+      const stored = fabricFromNativeValue(error);
       const restored = nativeFromFabricValue(stored);
       expect(restored).toBeInstanceOf(Error);
       expect((restored as Error).message).toBe("test error");
@@ -96,7 +96,7 @@ describe("native-conversion", () => {
 
     it("unwraps `FabricError` in nested object", () => {
       const se = FabricError.fromNativeError(new Error("deep"));
-      const obj = { error: se } as FabricValue;
+      const obj = { error: se };
       const result = nativeFromFabricValue(obj) as Record<
         string,
         unknown
@@ -109,7 +109,7 @@ describe("native-conversion", () => {
       const sm = new FabricMap(
         new Map<FabricValue, FabricValue>([["k", "v"]]),
       );
-      const arr = [sm] as FabricValue;
+      const arr = [sm];
       const result = nativeFromFabricValue(arr) as unknown[];
       expect(result[0]).toBeInstanceOf(FrozenMap);
     });
@@ -118,14 +118,14 @@ describe("native-conversion", () => {
       const sm = new FabricMap(
         new Map<FabricValue, FabricValue>([["k", "v"]]),
       );
-      const arr = [sm] as FabricValue;
+      const arr = [sm];
       const result = nativeFromFabricValue(arr, false) as unknown[];
       expect(result[0]).toBeInstanceOf(Map);
       expect(result[0]).not.toBeInstanceOf(FrozenMap);
     });
 
     it("passes through primitives at all levels", () => {
-      const obj = { a: 1, b: "two", c: null, d: true } as FabricValue;
+      const obj = { a: 1, b: "two", c: null, d: true };
       const result = nativeFromFabricValue(obj) as Record<
         string,
         unknown
@@ -139,7 +139,7 @@ describe("native-conversion", () => {
         outer: {
           inner: se,
         },
-      } as FabricValue;
+      };
       const result = nativeFromFabricValue(obj) as {
         outer: { inner: Error };
       };
@@ -153,7 +153,7 @@ describe("native-conversion", () => {
       const obj = {
         error: se,
         code: 500,
-      } as unknown as FabricValue;
+      };
       const result = nativeFromFabricValue(obj) as Record<
         string,
         unknown
@@ -170,7 +170,7 @@ describe("native-conversion", () => {
       err.name = "CustomName";
       const se = FabricError.fromNativeError(err);
       const result = nativeFromFabricValue(
-        se as unknown as FabricValue,
+        se,
       ) as Error;
 
       expect(result).toBeInstanceOf(TypeError);
@@ -181,7 +181,7 @@ describe("native-conversion", () => {
     it("leaves the class's own `name` in place when not overridden", () => {
       const se = FabricError.fromNativeError(new TypeError("plain"));
       const result = nativeFromFabricValue(
-        se as unknown as FabricValue,
+        se,
       ) as Error;
 
       expect(result).toBeInstanceOf(TypeError);
@@ -191,7 +191,7 @@ describe("native-conversion", () => {
     it("deeply unwraps `FabricError` in arrays (frozen)", () => {
       const err = new Error("array");
       const se = FabricError.fromNativeError(err);
-      const arr = [1, se, 3] as unknown as FabricValue;
+      const arr = [1, se, 3];
       const result = nativeFromFabricValue(arr) as unknown[];
       expect(result[0]).toBe(1);
       expect(result[1]).toBeInstanceOf(Error);
@@ -205,7 +205,7 @@ describe("native-conversion", () => {
       const obj = Object.freeze({
         a: 1,
         b: "two",
-      }) as unknown as FabricValue;
+      });
       const result = nativeFromFabricValue(obj, false) as Record<
         string,
         unknown
@@ -217,7 +217,7 @@ describe("native-conversion", () => {
     });
 
     it("freezes output when `frozen=true` (default)", () => {
-      const obj = { a: 1, b: "two" } as unknown as FabricValue;
+      const obj = { a: 1, b: "two" };
       const result = nativeFromFabricValue(obj) as Record<
         string,
         unknown
@@ -231,7 +231,7 @@ describe("native-conversion", () => {
       arr[2] = 3;
       Object.freeze(arr);
       const result = nativeFromFabricValue(
-        arr as FabricValue,
+        arr,
       ) as unknown[];
       expect(result.length).toBe(3);
       expect(result[0]).toBe(1);
@@ -241,7 +241,7 @@ describe("native-conversion", () => {
 
     it("passes through non-native `FabricInstance`", () => {
       const us = new UnknownValue("Test@1", null);
-      const obj = { thing: us } as unknown as FabricValue;
+      const obj = { thing: us };
       const result = nativeFromFabricValue(obj) as Record<
         string,
         unknown
@@ -254,7 +254,7 @@ describe("native-conversion", () => {
         ["x", 10],
       ] as [FabricValue, FabricValue][]);
       const sm = new FabricMap(map);
-      const obj = { data: sm } as unknown as FabricValue;
+      const obj = { data: sm };
       const result = nativeFromFabricValue(obj) as Record<
         string,
         unknown
@@ -266,7 +266,7 @@ describe("native-conversion", () => {
     it("deeply unwraps `FabricSet` to `FrozenSet`", () => {
       const set = new Set<FabricValue>([42] as FabricValue[]);
       const ss = new FabricSet(set);
-      const arr = [ss] as unknown as FabricValue;
+      const arr = [ss];
       const result = nativeFromFabricValue(arr) as unknown[];
       expect(result[0]).toBeInstanceOf(FrozenSet);
       expect((result[0] as Set<number>).has(42)).toBe(true);
@@ -284,7 +284,7 @@ describe("native-conversion", () => {
       const outerSe = FabricError.fromNativeError(outerErr);
 
       const result = nativeFromFabricValue(
-        outerSe as FabricValue,
+        outerSe,
       ) as Error;
       expect(result).toBeInstanceOf(Error);
       expect(result.message).toBe("outer");
@@ -304,7 +304,7 @@ describe("native-conversion", () => {
       const outerSe = FabricError.fromNativeError(outerErr);
 
       const result = nativeFromFabricValue(
-        outerSe as FabricValue,
+        outerSe,
         false,
       ) as Error;
       expect(result).toBeInstanceOf(Error);
@@ -383,7 +383,7 @@ describe("native-conversion", () => {
         [DEEP_FREEZE](
           _subFreeze: (value: FabricValue) => FabricValue,
         ): FabricValue {
-          return this as unknown as FabricValue;
+          return this;
         }
         [IS_DEEP_FROZEN](
           _subIsDeepFrozen: (value: FabricValue) => boolean,
@@ -416,7 +416,7 @@ describe("native-conversion", () => {
         type: "Error",
         name: null,
         message: "boom",
-      } as unknown as FabricValue;
+      };
       const frozen = FabricError[CODEC].decode(
         CODEC_TYPE_TAGS.Error,
         state,
@@ -433,7 +433,7 @@ describe("native-conversion", () => {
 
     it("`ProblematicValue`: `shouldDeepFreeze` is `true` => deep-frozen, `false` => mutable", () => {
       // Tag travels separately; the bare inner state is the codec payload.
-      const state = { x: 1 } as unknown as FabricValue;
+      const state = { x: 1 };
       const frozen = ProblematicValue[CODEC].decode("Bad@1", state, frozenCtx);
       expect(isDeepFrozen(frozen)).toBe(true);
       const mutable = ProblematicValue[CODEC].decode(
@@ -445,7 +445,7 @@ describe("native-conversion", () => {
     });
 
     it("`UnknownValue`: `shouldDeepFreeze` is `true` => deep-frozen, `false` => mutable", () => {
-      const state = { y: 2 } as unknown as FabricValue;
+      const state = { y: 2 };
       const frozen = UnknownValue[CODEC].decode("Fancy@3", state, frozenCtx);
       expect(isDeepFrozen(frozen)).toBe(true);
       const mutable = UnknownValue[CODEC].decode("Fancy@3", state, mutableCtx);

--- a/packages/data-model/test/value-debug.test.ts
+++ b/packages/data-model/test/value-debug.test.ts
@@ -11,7 +11,7 @@ import { FabricEpochNsec } from "@/fabric-primitives/FabricEpochNsec.ts";
 import { FabricError } from "@/fabric-instances/FabricError.ts";
 import { FabricMap } from "@/fabric-instances/FabricMap.ts";
 import { FabricRegExp } from "@/fabric-primitives/FabricRegExp.ts";
-import { FabricSpecialObject, type FabricValue } from "@/interface.ts";
+import { FabricSpecialObject } from "@/interface.ts";
 
 describe("value-debug", () => {
   describe("toCompactDebugString", () => {

--- a/packages/data-model/test/value-debug.test.ts
+++ b/packages/data-model/test/value-debug.test.ts
@@ -267,7 +267,7 @@ describe("value-debug", () => {
         // second failure on top of the first.
         class RogueSpecial extends FabricSpecialObject {}
 
-        expect(toCompactDebugString(new RogueSpecial() as FabricValue)).toBe(
+        expect(toCompactDebugString(new RogueSpecial())).toBe(
           "/RogueSpecial(...)",
         );
       });

--- a/packages/data-model/test/value-hash.test.ts
+++ b/packages/data-model/test/value-hash.test.ts
@@ -908,7 +908,7 @@ describe("value-hash", () => {
         // the same `getStringRep()` codepath as bare string values, so a long
         // key is fed as `[TAG_STRING_HASH][sha256(utf8)]`.
         const longKey = "x".repeat(100);
-        const obj = { [longKey]: 1 } as unknown as FabricValue;
+        const obj = { [longKey]: 1 };
         const keyHash = sha256(new TextEncoder().encode(longKey));
         // Stream: TAG_OBJECT, [TAG_STRING_HASH, keyHash], value(1.0), TAG_END
         const expected = sha256([
@@ -931,9 +931,9 @@ describe("value-hash", () => {
       });
 
       it("is deterministic and key-distinct for long object keys", () => {
-        const a1 = { ["a".repeat(100)]: 1 } as unknown as FabricValue;
-        const a2 = { ["a".repeat(100)]: 1 } as unknown as FabricValue;
-        const b = { ["b".repeat(100)]: 1 } as unknown as FabricValue;
+        const a1 = { ["a".repeat(100)]: 1 };
+        const a2 = { ["a".repeat(100)]: 1 };
+        const b = { ["b".repeat(100)]: 1 };
         expect(hex(hashBytesOf(a1))).toBe(hex(hashBytesOf(a2)));
         expect(hex(hashBytesOf(a1))).not.toBe(hex(hashBytesOf(b)));
       });
@@ -1301,13 +1301,13 @@ describe("value-hash", () => {
       // [TAG_STRING][len][utf8].
       // Final stream: [TAG_SYMBOL=0x2a, TAG_STRING=0x24, len=0x03, 'f','o','o']
       const expected = sha256([0x2a, 0x24, 0x03, 0x66, 0x6f, 0x6f]);
-      expect(hashBytesOf(Symbol.for("foo") as FabricValue)).toEqual(expected);
+      expect(hashBytesOf(Symbol.for("foo"))).toEqual(expected);
     });
 
     it('empty-key `Symbol.for("")` has length zero, not absent', () => {
       // [TAG_SYMBOL=0x2a, TAG_STRING=0x24, len=0x00]
       const expected = sha256([0x2a, 0x24, 0x00]);
-      expect(hashBytesOf(Symbol.for("") as FabricValue)).toEqual(expected);
+      expect(hashBytesOf(Symbol.for(""))).toEqual(expected);
     });
 
     it("takes the TAG_STRING_HASH path for a long key", () => {
@@ -1317,55 +1317,55 @@ describe("value-hash", () => {
       const key = "x".repeat(100);
       const keyHash = sha256(new TextEncoder().encode(key));
       const expected = sha256([0x2a, 0xf0, ...keyHash]);
-      expect(hashBytesOf(Symbol.for(key) as FabricValue)).toEqual(expected);
+      expect(hashBytesOf(Symbol.for(key))).toEqual(expected);
     });
 
     it("is deterministic and key-distinct on the long-key path", () => {
       // Two different keys both > 64 utf8 bytes should hash differently;
       // identical long keys should hash the same.
-      const a1 = Symbol.for("a".repeat(100)) as FabricValue;
-      const a2 = Symbol.for("a".repeat(100)) as FabricValue;
-      const b = Symbol.for("b".repeat(100)) as FabricValue;
+      const a1 = Symbol.for("a".repeat(100));
+      const a2 = Symbol.for("a".repeat(100));
+      const b = Symbol.for("b".repeat(100));
       expect(hex(hashBytesOf(a1))).toBe(hex(hashBytesOf(a2)));
       expect(hex(hashBytesOf(a1))).not.toBe(hex(hashBytesOf(b)));
     });
 
     it("hashes equal-keyed interned symbols identically", () => {
-      expect(hex(hashBytesOf(Symbol.for("hello") as FabricValue)))
-        .toBe(hex(hashBytesOf(Symbol.for("hello") as FabricValue)));
+      expect(hex(hashBytesOf(Symbol.for("hello"))))
+        .toBe(hex(hashBytesOf(Symbol.for("hello"))));
     });
 
     it("hashes differently-keyed interned symbols differently", () => {
-      expect(hex(hashBytesOf(Symbol.for("a") as FabricValue)))
-        .not.toBe(hex(hashBytesOf(Symbol.for("b") as FabricValue)));
+      expect(hex(hashBytesOf(Symbol.for("a"))))
+        .not.toBe(hex(hashBytesOf(Symbol.for("b"))));
     });
 
     it("does not collide a same-key string with an interned symbol", () => {
       // The TAG_SYMBOL prefix must distinguish a symbol from its key string.
-      expect(hex(hashBytesOf(Symbol.for("x") as FabricValue)))
+      expect(hex(hashBytesOf(Symbol.for("x"))))
         .not.toBe(hex(hashBytesOf("x")));
     });
 
     it("hashes deterministically for an interned symbol nested in an object", () => {
-      const a = { tag: Symbol.for("nested-tag") } as unknown as FabricValue;
-      const b = { tag: Symbol.for("nested-tag") } as unknown as FabricValue;
+      const a = { tag: Symbol.for("nested-tag") };
+      const b = { tag: Symbol.for("nested-tag") };
       expect(hex(hashBytesOf(a))).toBe(hex(hashBytesOf(b)));
     });
 
     it("hashes deterministically for an interned symbol nested in an array", () => {
-      const a = [Symbol.for("x"), 1] as unknown as FabricValue;
-      const b = [Symbol.for("x"), 1] as unknown as FabricValue;
+      const a = [Symbol.for("x"), 1];
+      const b = [Symbol.for("x"), 1];
       expect(hex(hashBytesOf(a))).toBe(hex(hashBytesOf(b)));
     });
 
     it("throws for `Symbol(desc)` (unique / uninterned)", () => {
-      expect(() => hashOf(Symbol("nope") as FabricValue)).toThrow(
+      expect(() => hashOf(Symbol("nope"))).toThrow(
         "Cannot hash unique (uninterned) symbol",
       );
     });
 
     it("also throws for a unique symbol nested in an object", () => {
-      const value = { tag: Symbol("nope") } as unknown as FabricValue;
+      const value = { tag: Symbol("nope") };
       expect(() => hashOf(value)).toThrow(
         "Cannot hash unique (uninterned) symbol",
       );

--- a/packages/memory/test/v2-client-test.ts
+++ b/packages/memory/test/v2-client-test.ts
@@ -535,7 +535,7 @@ Deno.test("memory v2 client fails closed without entity identifier capabilities"
       flags: {
         modernCellRep: getMemoryProtocolFlags().modernCellRep,
       },
-    } as FabricValue),
+    }),
   });
   const space = await client.mount(
     "did:key:z6Mk-memory-v2-client-legacy-entity-identifiers",

--- a/packages/memory/test/v2-sync-schema-table-test.ts
+++ b/packages/memory/test/v2-sync-schema-table-test.ts
@@ -1010,7 +1010,7 @@ Deno.test("schema table and reserved-ref detection handle modern cell-rep links"
               id: "of:contact",
               path: [],
               schema,
-            }) as unknown as FabricValue,
+            }),
           },
         } as unknown as EntityDocument,
       }],

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -6695,8 +6695,7 @@ const decodeStoredPatchList = (data: string | null): PatchOp[] => {
 const applyPatchDocument = (
   document: EntityDocument,
   patches: PatchOp[],
-): EntityDocument =>
-  applyPatch(document as FabricValue, patches) as EntityDocument;
+): EntityDocument => applyPatch(document, patches) as EntityDocument;
 
 const sameStoredOriginal = (
   stored: string,

--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -140,7 +140,7 @@ export class EngineObjectManager implements ObjectStorageManager {
         type: type as MIME,
         path: [],
       },
-      value: state.document as unknown as FabricValue,
+      value: state.document,
     };
     this.#attestations.set(key, attestation);
     this.#details.set(key, {

--- a/packages/patterns/test/source-coverage/commonfabric-shim.test.ts
+++ b/packages/patterns/test/source-coverage/commonfabric-shim.test.ts
@@ -136,7 +136,7 @@ export class Writable<T = unknown> {
     if (!Array.isArray(this.#value)) {
       throw new Error("addUnique requires an array value");
     }
-    const current = this.#value as FabricValue[];
+    const current = this.#value;
     for (const value of values) {
       if (!current.some((item) => valueEqual(item, value as FabricValue))) {
         current.push(value as FabricValue);
@@ -146,7 +146,7 @@ export class Writable<T = unknown> {
 
   removeByValue(value: unknown): void {
     if (!Array.isArray(this.#value)) return;
-    this.#value = (this.#value as FabricValue[]).filter((item) =>
+    this.#value = this.#value.filter((item) =>
       !valueEqual(item, value as FabricValue)
     ) as T;
   }

--- a/packages/piece/test/pull-materialization.test.ts
+++ b/packages/piece/test/pull-materialization.test.ts
@@ -1516,7 +1516,7 @@ describe("piece pull materialization", () => {
             includeSchema: true,
           }),
         },
-        ...originalInternal,
+        ...(originalInternal as FabricValue[]),
       ]);
       orphan.withTx(tx).setMetaRaw(
         "result",

--- a/packages/piece/test/pull-materialization.test.ts
+++ b/packages/piece/test/pull-materialization.test.ts
@@ -1516,7 +1516,7 @@ describe("piece pull materialization", () => {
             includeSchema: true,
           }),
         },
-        ...(originalInternal as FabricValue[]),
+        ...originalInternal,
       ]);
       orphan.withTx(tx).setMetaRaw(
         "result",

--- a/packages/runner/src/acl-manager.ts
+++ b/packages/runner/src/acl-manager.ts
@@ -43,7 +43,7 @@ export class ACLManager {
     // default) identity-passes the already-deep-frozen stored value (zero-copy)
     // and otherwise freezes a clone. Callers that change the ACL (`set` /
     // `remove`) build a fresh object rather than mutating this.
-    return cloneIfNecessary(aclData as FabricValue) as ACL;
+    return cloneIfNecessary(aclData) as ACL;
   }
 
   async set(user: ACLUser, capability: Capability): Promise<void> {

--- a/packages/runner/src/acl-manager.ts
+++ b/packages/runner/src/acl-manager.ts
@@ -6,10 +6,7 @@ import {
   isACL,
 } from "@commonfabric/memory/acl";
 import type { Capability, URI } from "@commonfabric/memory/interface";
-import {
-  cloneIfNecessary,
-  type FabricValue,
-} from "@commonfabric/data-model/fabric-value";
+import { cloneIfNecessary } from "@commonfabric/data-model/fabric-value";
 import type { Cell } from "./cell.ts";
 import type { Runtime } from "./runtime.ts";
 

--- a/packages/runner/src/builtins/sqlite-builtins.ts
+++ b/packages/runner/src/builtins/sqlite-builtins.ts
@@ -39,10 +39,7 @@ import { computeInputHashFromValue } from "./fetch-utils.ts";
 import { parseCfLinkToSigil } from "./sqlite/cf-link.ts";
 import { type IFCLabel, mergeLabel } from "../cfc/label-view-core.ts";
 import { cloneIfNecessary } from "@commonfabric/data-model/value-clone";
-import {
-  fabricFromNativeValue,
-  type FabricValue,
-} from "@commonfabric/data-model/fabric-value";
+import { fabricFromNativeValue } from "@commonfabric/data-model/fabric-value";
 import { stripEntityUriScheme } from "../entity-kind.ts";
 import {
   columnDeclaresIfc,

--- a/packages/runner/src/builtins/sqlite-builtins.ts
+++ b/packages/runner/src/builtins/sqlite-builtins.ts
@@ -586,7 +586,7 @@ export function sqliteDatabase(
             // Carry db.exec's write revision forward — dropping it would make
             // this re-derivation look like "new inputs" to every handle hasher.
             ...(typeof prior?.rev === "number" && { rev: prior.rev }),
-          }) as FabricValue,
+          }),
           true,
         );
       }

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -1684,7 +1684,7 @@ export class CellImpl<T extends FabricValue>
       // unconverted, and the strict conversion would reject their
       // non-string-keyed internals.
       const comparable = normalizeForComparison && !isCellLink(candidate)
-        ? fabricFromNativeValue(candidate) as FabricValue
+        ? fabricFromNativeValue(candidate)
         : candidate;
       return existing.some((element) => valueEqual(element, comparable));
     };
@@ -1814,7 +1814,7 @@ export class CellImpl<T extends FabricValue>
     for (const element of removed) {
       this.tx.recordMergeableOp?.(resolvedLink, {
         op: "remove-by-value",
-        value: element as FabricValue,
+        value: element,
       });
     }
   }
@@ -2377,7 +2377,7 @@ export class CellImpl<T extends FabricValue>
       path: [metaField],
       ...(this.link.scope !== undefined && { scope: this.link.scope }),
     };
-    this.tx.writeOrThrow(metaAddr, value as FabricValue);
+    this.tx.writeOrThrow(metaAddr, value);
   }
 
   /**

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -1645,7 +1645,7 @@ export class CellImpl<T extends FabricValue>
     // Keep only the values not already present (by stored-value equality,
     // matching the server's add-unique dedup). The server re-dedups against
     // durable state, catching elements the local replica had not loaded.
-    const candidates = value as FabricValue[];
+    const candidates = value;
     const existing = array;
     // A cell candidate matches an existing element by its (deterministic) link,
     // so re-adding the same keyed entity is a local no-op; a plain value matches
@@ -1774,7 +1774,7 @@ export class CellImpl<T extends FabricValue>
     const currentValue = this.tx.readValueOrThrow(resolvedLink, {
       meta: mergeableOpRead,
     });
-    const array = currentValue as FabricValue[];
+    const array = currentValue;
     if (array === undefined) {
       return;
     }

--- a/packages/runner/src/cfc/grants.ts
+++ b/packages/runner/src/cfc/grants.ts
@@ -1,7 +1,6 @@
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import type { CfcAtom } from "@commonfabric/api/cfc";
 import { isRecord } from "@commonfabric/utils/types";
-import type { FabricValue } from "@commonfabric/api";
 import type { URI } from "@commonfabric/memory/interface";
 import { getCommitPreconditionsConfig } from "@commonfabric/memory/v2";
 import type {

--- a/packages/runner/src/cfc/grants.ts
+++ b/packages/runner/src/cfc/grants.ts
@@ -318,7 +318,7 @@ export const flushCfcGrantConsumptionClaims = (
         id: claim.receiptId,
         type: "application/json",
         path: ["value"],
-      }, receipt as unknown as FabricValue);
+      }, receipt);
     } catch (error) {
       reasons.push(
         `cfc-grant: staging consumption receipt for single-use grant ` +

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -2719,7 +2719,7 @@ const writeInstallsInitialSchemaDefault = (
   return previousWriteValueForTarget(tx, pathTarget) === undefined &&
     valueEqual(
       writeValueForTarget(tx, pathTarget),
-      schema.default as FabricValue,
+      schema.default,
     );
 };
 
@@ -4518,7 +4518,7 @@ const ensureSchemaDocument = (
   }, {
     // System-owned canonical schema document. This is intentionally outside the
     // phase-1 value-surface attempted-target model.
-    value: schema as unknown as FabricValue,
+    value: schema,
   });
 };
 
@@ -6551,7 +6551,7 @@ export const prepareBoundaryCommit = (
       // System-owned embedded metadata write. Boundary evaluation is driven by
       // user-surface reads/writes plus explicit policy inputs, not by recursive
       // attempted-target tracking of this internal metadata update.
-    }, metadata as unknown as FabricValue);
+    }, metadata);
   }
   reasons.push(...verifySinkRequestCeilings(tx));
   // Single-use grant consumption (design §2.2): stage every claim the

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -765,7 +765,7 @@ export function normalizeAndDiff(
         try {
           tx.writeValueOrThrow(
             seedTarget,
-            fabricFromNativeValue(seedDefault) as FabricValue,
+            fabricFromNativeValue(seedDefault),
           );
           // The marker is what authorizes the write above past an
           // owner-protected schema's `writeAuthorizedBy` (cfc/prepare.ts
@@ -1368,7 +1368,7 @@ export function normalizeAndDiff(
     // instances short-circuit by identity.
     changes.push({
       location: link,
-      value: fabricFromNativeValue(newValue) as FabricValue,
+      value: fabricFromNativeValue(newValue),
     });
     return changes;
   }

--- a/packages/runner/src/data-uri.ts
+++ b/packages/runner/src/data-uri.ts
@@ -117,7 +117,7 @@ export function dataUriFromValueWithResolvedLinks(
             [key, value],
           ) => [
             key,
-            traverseAndAddBaseIdToRelativeLinks(value as FabricValue, seen),
+            traverseAndAddBaseIdToRelativeLinks(value, seen),
           ]),
         );
       }

--- a/packages/runner/src/pattern-binding.ts
+++ b/packages/runner/src/pattern-binding.ts
@@ -293,7 +293,7 @@ function sendValueToBindingInner<T>(
           cell.runtime,
           tx,
           scopedRef,
-          value as FabricValue,
+          value,
           { cell: cell.getAsNormalizedFullLink(), binding },
           { meta: ignoreReadForScheduling },
         );
@@ -302,7 +302,7 @@ function sendValueToBindingInner<T>(
         bindingLink,
         createSigilLinkFromParsedLink(scopedRef, {
           base: bindingLink,
-        }) as FabricValue,
+        }),
       );
       return;
     }
@@ -316,7 +316,7 @@ function sendValueToBindingInner<T>(
       ) {
         const newValue = createSigilLinkFromParsedLink(
           valueLink,
-        ) as FabricValue;
+        );
         // Skip the write when the redirect already holds this exact link. Raw
         // builtins (ifElse/when/unless/map/...) re-run and re-send their result
         // whenever their inputs change, but the output binding points at a
@@ -337,7 +337,7 @@ function sendValueToBindingInner<T>(
       cell.runtime,
       tx,
       ref,
-      value as FabricValue,
+      value,
       { cell: cell.getAsNormalizedFullLink(), binding },
       { meta: ignoreReadForScheduling },
     );

--- a/packages/runner/src/pattern-binding.ts
+++ b/packages/runner/src/pattern-binding.ts
@@ -1,9 +1,6 @@
 import { isRecord } from "@commonfabric/utils/types";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
-import {
-  type FabricValue,
-  valueEqual,
-} from "@commonfabric/data-model/fabric-value";
+import { valueEqual } from "@commonfabric/data-model/fabric-value";
 import {
   type FabricExecValue,
   isPattern,

--- a/packages/runner/src/runner-utils.ts
+++ b/packages/runner/src/runner-utils.ts
@@ -288,7 +288,7 @@ function extractDefaultValuesInternal(
         ) &&
         validateSchemaValue(canonical, candidate.value, resolvedRoot) ===
           undefined
-      ).map((candidate) => candidate.value as FabricValue);
+      ).map((candidate) => candidate.value);
       return validCandidates.length > 0 &&
           validCandidates.every((candidate) =>
             schemaDefaultValueEqual(candidate, validCandidates[0])
@@ -319,7 +319,7 @@ function extractDefaultValuesInternal(
       // children as inexpensive defense-in-depth against accidental deeper
       // mutation of the shared default.
       const obj = shallowMutableClone(
-        (isRecord(canonical.default) ? canonical.default : {}) as FabricValue,
+        isRecord(canonical.default) ? canonical.default : {},
       ) as Record<string, FabricValue>;
       for (
         const [propKey, propSchema] of Object.entries(canonical.properties)

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1357,7 +1357,7 @@ export class Runner {
       meta: ignoreReadForScheduling,
     });
     if (!deepEqual(previous, resultSchema)) {
-      cell.setMetaRaw("schema", resultSchema as FabricValue);
+      cell.setMetaRaw("schema", resultSchema);
     }
   }
 
@@ -4602,7 +4602,7 @@ export class Runner {
     // Sigil-only: `$event` is builder-generated and always unwraps to a sigil
     // link; a residual `$alias` here could only be an embedded pattern's
     // binding, which must not be followed at this level.
-    let value: FabricValue = inputs.$event as FabricValue;
+    let value: FabricValue = inputs.$event;
     let lastLink: NormalizedFullLink | undefined;
     while (isWriteRedirectLink(value)) {
       lastLink = resolveLink(
@@ -6726,7 +6726,7 @@ function initializePieceSourceHistory(
     source: sourceRetentionLink(runtime, resultCell, tx, pattern),
     ...(origin === undefined ? {} : { origin }),
     operation: "create",
-  }] as unknown as FabricValue);
+  }]);
 }
 
 function samePieceSourceSnapshot(

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -1433,7 +1433,7 @@ class TransformObjectCreator
         // Ensure value is mutable before injecting default properties.
         // cloneIfNecessary with { deep: false, frozen: false, force: false }
         // is a no-op for unfrozen objects and shallow-clones frozen ones.
-        value = cloneIfNecessary(value as FabricValue, {
+        value = cloneIfNecessary(value, {
           deep: false,
           frozen: false,
           force: false,

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -1659,7 +1659,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
         // as inexpensive defense-in-depth against accidental deeper mutation of
         // the shared input.
         valueObj = shallowMutableClone(
-          currentValue as FabricValue,
+          currentValue,
         ) as MutableFabricPlainObjectLayer;
       }
       const remainingPath = address.path.slice(lastExistingPath.length);
@@ -1681,7 +1681,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
           nextValue[key] =
             (isNextKeyArrayIndex ? [] : {}) as FabricPlainObject;
       }
-      nextValue[lastKey] = value as FabricValue;
+      nextValue[lastKey] = value;
       const parentAddress = { ...address, path: lastExistingPath };
       const writeResultRetry = this.tx.write(parentAddress, valueObj);
       if (writeResultRetry.error) {

--- a/packages/runner/src/storage/inspector.ts
+++ b/packages/runner/src/storage/inspector.ts
@@ -309,7 +309,7 @@ const receive = (
     case "task/effect":
       return integrate(state, time, {
         url: receipt.of,
-        value: receipt.is as unknown as FabricValue,
+        value: receipt.is,
       });
     case "task/return":
       return complete(state, time, receipt);

--- a/packages/runner/src/storage/mergeable-ops.ts
+++ b/packages/runner/src/storage/mergeable-ops.ts
@@ -242,7 +242,7 @@ const buildTailOp = (
       return { ops: [], suppress: [], abandon: true };
     }
   }
-  const values = array.slice(start) as FabricValue[];
+  const values = array.slice(start);
   if (values.length === 0) {
     return { ops: [], suppress: [], abandon: true };
   }
@@ -267,7 +267,7 @@ const withRemovalsApplied = (
   base: readonly FabricValue[],
   values: readonly FabricValue[],
 ): FabricValue[] => {
-  const result = base.slice() as FabricValue[];
+  const result = base.slice();
   for (const value of values) {
     for (let index = result.length - 1; index >= 0; index -= 1) {
       if (valueEqual(result[index], value)) {

--- a/packages/runner/src/storage/transaction/chronicle.ts
+++ b/packages/runner/src/storage/transaction/chronicle.ts
@@ -384,7 +384,7 @@ export class Chronicle {
 
           edit.assert({
             ...loaded,
-            is: alignedMerged as FabricValue,
+            is: alignedMerged,
             cause: causeRef,
           });
         }

--- a/packages/runner/src/storage/transaction/mutable-path-write.ts
+++ b/packages/runner/src/storage/transaction/mutable-path-write.ts
@@ -146,7 +146,7 @@ export const applyMutablePathWrite = (
       nextKeyAfterPath: leafKey,
       force: false,
     });
-    newRoot = result.value as FabricValue;
+    newRoot = result.value;
     parent = result.pathValue as
       | Record<string, FabricValue>
       | FabricValue[];
@@ -215,7 +215,7 @@ export const applyMutablePathWrite = (
   if (leafKey in obj && valueEqual(previousValue, value)) {
     return { ok: { root: newRoot, previousValue, changed: false } };
   }
-  obj[leafKey] = value as FabricValue;
+  obj[leafKey] = value;
   return { ok: { root: newRoot, previousValue, changed: true } };
 };
 

--- a/packages/runner/src/storage/v2-document.ts
+++ b/packages/runner/src/storage/v2-document.ts
@@ -8,7 +8,5 @@ export const toTransactionDocumentValue = (
     return undefined;
   }
 
-  return Object.keys(document).length === 0
-    ? undefined
-    : document as FabricValue;
+  return Object.keys(document).length === 0 ? undefined : document;
 };

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -613,7 +613,7 @@ const buildArrayPatchCandidates = (
         path: encodePointer(path),
         index: before.length,
         remove: 0,
-        add: after.slice(before.length) as FabricValue[],
+        add: after.slice(before.length),
       },
       path,
       coversDescendants: false,
@@ -2704,9 +2704,7 @@ export class V2StorageTransaction implements IStorageTransaction {
       })
     );
     return {
-      workingArray: Array.isArray(working)
-        ? working as FabricValue[]
-        : undefined,
+      workingArray: Array.isArray(working) ? working : undefined,
       hadInitialArray: Array.isArray(initial),
       // Presence, not definedness: an already-present slot (even holding
       // `undefined`) does not add a key to its parent, so the op does not

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -266,7 +266,7 @@ const freezeReadValue = <T extends FabricValue | undefined>(value: T): T => {
   // deep-clones-and-freezes -- isolating the result from later source
   // mutation. On the hot read path, repeated reads of the same stored
   // (deep-frozen) value collapse to a single cache lookup.
-  return cloneIfNecessary(value as FabricValue) as T;
+  return cloneIfNecessary(value) as T;
 };
 
 const collapseEmptyJsonDocumentEnvelope = (
@@ -1631,7 +1631,7 @@ export class V2StorageTransaction implements IStorageTransaction {
 
     const isolatedValue = value === undefined
       ? undefined
-      : cloneIfNecessary(value) as FabricValue;
+      : cloneIfNecessary(value);
 
     // Compute the activity path and previous-value snapshots BEFORE the
     // write -- `applyMutablePathWrite()` mutates `current.value` in place
@@ -1653,7 +1653,7 @@ export class V2StorageTransaction implements IStorageTransaction {
     const previousActivityValue = cloneIfNecessary(
       readValueAtPath(current.value, activityPath, {
         allowArrayLength: true,
-      }) as FabricValue,
+      }),
     ) as FabricValue | undefined;
     // Pre-write slot presence (distinct from value: a slot holding
     // `undefined` is present) for the write details — also read BEFORE the
@@ -1764,7 +1764,7 @@ export class V2StorageTransaction implements IStorageTransaction {
     for (const { address, value, delete: isDelete } of writes) {
       const isolatedValue = value === undefined
         ? undefined
-        : cloneIfNecessary(value) as FabricValue;
+        : cloneIfNecessary(value);
       const previousValue = readValueAtPath(nextRoot, address.path, {
         allowArrayLength: true,
       });
@@ -1789,7 +1789,7 @@ export class V2StorageTransaction implements IStorageTransaction {
       const previousActivityValue = cloneIfNecessary(
         readValueAtPath(nextRoot, activityPath, {
           allowArrayLength: true,
-        }) as FabricValue,
+        }),
       ) as FabricValue | undefined;
       // Pre-write slot presence for the write details (see
       // `writeWithinBranch`; empty path = root definedness, since

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -482,7 +482,7 @@ const applyPendingVersion = (
     case "delete":
       return undefined;
     case "set":
-      return cloneIfNecessary(pending.value as FabricValue) as EntityDocument;
+      return cloneIfNecessary(pending.value) as EntityDocument;
     case "patch": {
       let next = base;
       for (

--- a/packages/runner/src/traverse-recorder.ts
+++ b/packages/runner/src/traverse-recorder.ts
@@ -113,7 +113,7 @@ export class TraverseCaptureRecorder {
       // Snapshot via deep-frozen clone (identity-passes already-frozen
       // selectors): callers may mutate or intern them later.
       this.selectors.push(
-        cloneIfNecessary(selector as FabricValue) as SchemaPathSelector,
+        cloneIfNecessary(selector) as SchemaPathSelector,
       );
       this.selectorIndex.set(key, index);
     }
@@ -127,7 +127,7 @@ export class TraverseCaptureRecorder {
       index = this.links.length;
       this.links.push(
         cloneIfNecessary(
-          link as unknown as FabricValue,
+          link,
         ) as unknown as NormalizedFullLink,
       );
       this.linkIndex.set(key, index);
@@ -201,7 +201,7 @@ export class TraverseCaptureRecorder {
     if (ok !== undefined && ok.value !== undefined) {
       this.docs.set(
         key,
-        cloneIfNecessary(ok.value as FabricValue) as FabricValue,
+        cloneIfNecessary(ok.value),
       );
     }
   }

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -1515,7 +1515,7 @@ export abstract class BaseObjectTraverser {
         const v = this.traverseDAG(docItem, itemDefault, arrayElementLink);
         // Use null for missing/undefined elements (consistent with other value
         // transforms in this system, e.g. toJSON and shallowFabricFromNativeValue)
-        newValue[index] = v === undefined ? null : v as FabricValue;
+        newValue[index] = v === undefined ? null : v;
       });
       // Our link is based on the last link in the chain and not the first.
       const newLink = getNormalizedLink(doc.address, true);
@@ -1870,7 +1870,7 @@ export function getAtPath(
           ...curDoc.address,
           path: appendToPath(curDoc.address.path, part),
         },
-        value: cursorObj[part] as FabricValue,
+        value: cursorObj[part],
       };
       tx.read(curDoc.address, READ_NON_RECURSIVE_FOR_SCHEDULING);
     } else {
@@ -2355,7 +2355,7 @@ function traverseMetaLinkedDoc(
       ...doc.address,
       path: ["value"],
     },
-    value: fullDoc.value as FabricValue,
+    value: fullDoc.value,
   });
 }
 
@@ -3602,7 +3602,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
       return {
         ok: this.objectCreator.createObject(
           newLink,
-          newValue as FabricValue,
+          newValue,
         ),
       };
     }
@@ -3778,7 +3778,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
     return {
       ok: this.createPlainSchemaObject(
         newLink,
-        newValue as FabricValue,
+        newValue,
       ),
     };
   }

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -3249,7 +3249,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
             }
           }
           const merged = this.objectCreator.mergeMatches(
-            matches as FabricValue[],
+            matches,
             resolved,
           );
           if (matches.length > 0) {
@@ -3322,7 +3322,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
           }
         }
         const merged = this.objectCreator.mergeMatches(
-          matches as FabricValue[],
+          matches,
           resolved,
         );
         if (matches.length > 0) {
@@ -3422,7 +3422,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
         }
         if (allOf.length > 0) {
           const merged = this.objectCreator.mergeMatches(
-            matches as FabricValue[],
+            matches,
             resolved,
           );
           return {

--- a/packages/runner/test/attestation-claim-fabric.test.ts
+++ b/packages/runner/test/attestation-claim-fabric.test.ts
@@ -16,7 +16,6 @@ import type {
   ISpaceReplica,
   State,
 } from "../src/storage/interface.ts";
-import type { FabricHash } from "@commonfabric/data-model/fabric-primitives";
 
 // A replica whose stored state carries `storedValue`. `getDocument` is
 // deliberately absent so `claim()` takes its `read`-based `actual` path (the
@@ -28,7 +27,7 @@ const replicaHolding = (storedValue: FabricValue): ISpaceReplica => {
     of: "of:attest-claim-fabric",
     is: storedValue,
     // A real cause hash is irrelevant to the value comparison under test.
-    cause: undefined as unknown as FabricHash,
+    cause: undefined,
   } as State;
   return {
     did: () => "did:test:attest" as ReturnType<ISpaceReplica["did"]>,

--- a/packages/runner/test/cell-core.test.ts
+++ b/packages/runner/test/cell-core.test.ts
@@ -7,7 +7,6 @@ import "@commonfabric/utils/equal-ignoring-symbols";
 
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import type { FabricValue } from "@commonfabric/api";
 import { isCell } from "../src/cell.ts";
 import { LINK_V1_TAG } from "../src/sigil-types.ts";
 import { isCellResult } from "../src/query-result-proxy.ts";

--- a/packages/runner/test/cell-core.test.ts
+++ b/packages/runner/test/cell-core.test.ts
@@ -191,7 +191,7 @@ describe("Cell", () => {
     );
     parent.setRawUntyped({
       slot: target.getAsWriteRedirectLink(),
-    } as unknown as FabricValue);
+    });
 
     // Writing a `FabricInstance` (here, a native `Error` that gets wrapped
     // into `FabricError`) through the redirect must land at the target,
@@ -861,7 +861,7 @@ describe("Cell utility functions", () => {
       // Write a sigil link via setRawUntyped — this would not type-check
       // with setRaw because a link object is not assignable to string.
       const link = target.getAsWriteRedirectLink();
-      cell.setRawUntyped(link as FabricValue);
+      cell.setRawUntyped(link);
 
       // The raw untyped read should return the link structure.
       const raw = cell.getRawUntyped();
@@ -924,7 +924,7 @@ describe("Cell utility functions", () => {
         undefined,
         tx,
       );
-      cell.setRawUntyped([1, 2, 3] as FabricValue);
+      cell.setRawUntyped([1, 2, 3]);
       expect(cell.getRawUntyped()).toEqual([1, 2, 3]);
     });
 
@@ -935,7 +935,7 @@ describe("Cell utility functions", () => {
         undefined,
         tx,
       );
-      cell.setRawUntyped({ a: { b: { c: 42 } } } as FabricValue);
+      cell.setRawUntyped({ a: { b: { c: 42 } } });
       const raw = cell.getRawUntyped() as { a: { b: { c: number } } };
       expect(raw.a.b.c).toBe(42);
     });
@@ -948,7 +948,7 @@ describe("Cell utility functions", () => {
         tx,
       );
       cell.set(10);
-      cell.setRawUntyped(null as FabricValue);
+      cell.setRawUntyped(null);
       expect(cell.getRawUntyped()).toBe(null);
     });
 
@@ -959,7 +959,7 @@ describe("Cell utility functions", () => {
         undefined,
         tx,
       );
-      cell.setRawUntyped([] as FabricValue);
+      cell.setRawUntyped([]);
       expect(cell.getRawUntyped()).toEqual([]);
     });
 
@@ -968,7 +968,7 @@ describe("Cell utility functions", () => {
         space,
         "setRawUntyped no tx",
       );
-      expect(() => cell.setRawUntyped(42 as FabricValue)).toThrow(
+      expect(() => cell.setRawUntyped(42)).toThrow(
         "Transaction required",
       );
     });
@@ -1069,7 +1069,7 @@ describe("Cell raw methods: frozen-or-not", () => {
       undefined,
       tx,
     );
-    cell.setRawUntyped([10, 20, 30] as FabricValue);
+    cell.setRawUntyped([10, 20, 30]);
     const raw = cell.getRawUntyped();
     expect(raw).toEqual([10, 20, 30]);
     expect(Object.isFrozen(raw)).toBe(true);
@@ -1082,7 +1082,7 @@ describe("Cell raw methods: frozen-or-not", () => {
       undefined,
       tx,
     );
-    cell.setRawUntyped({ a: { b: [1, 2] } } as FabricValue);
+    cell.setRawUntyped({ a: { b: [1, 2] } });
     const raw = cell.getRawUntyped() as { a: { b: readonly number[] } };
     expect(raw.a.b).toEqual([1, 2]);
     expect(Object.isFrozen(raw)).toBe(true);
@@ -1098,7 +1098,7 @@ describe("Cell raw methods: frozen-or-not", () => {
       tx,
     );
     cell.set(5);
-    cell.setRawUntyped(null as FabricValue);
+    cell.setRawUntyped(null);
     expect(cell.getRawUntyped()).toBe(null);
   });
 

--- a/packages/runner/test/cfc-privileged-system-write.test.ts
+++ b/packages/runner/test/cfc-privileged-system-write.test.ts
@@ -54,7 +54,7 @@ describe("CFC privileged system write (S18)", () => {
         id,
         type: "application/json",
         path: ["cfc"],
-      }, forgedMetadata as unknown as FabricValue);
+      }, forgedMetadata);
 
       const result = await tx.commit();
       expect(result.error).toBeDefined();
@@ -88,7 +88,7 @@ describe("CFC privileged system write (S18)", () => {
         id,
         type: "application/json",
         path: ["cfc"],
-      }, forgedMetadata as unknown as FabricValue);
+      }, forgedMetadata);
 
       const result = await tx.commit();
       expect(result.ok).toBeDefined();
@@ -195,7 +195,7 @@ describe("CFC privileged system write (S18)", () => {
         id,
         type: "application/json",
         path: ["cfc"],
-      }, forgedMetadata as unknown as FabricValue);
+      }, forgedMetadata);
       // The forgery is recorded even though enforcement is disabled.
       expect(tx.getCfcState().unprivilegedSystemWrites.length).toBe(1);
 
@@ -236,7 +236,7 @@ describe("CFC privileged system write (S18)", () => {
         id,
         type: "application/json",
         path: ["cfc"],
-      }, forgedMetadata as unknown as FabricValue);
+      }, forgedMetadata);
 
       const result = await tx.commit();
       expect(result.ok).toBeDefined();
@@ -314,7 +314,7 @@ describe("CFC privileged system write (S18)", () => {
       const base = current && typeof current === "object" ? current : {};
       tx.writeOrThrow(
         docAddress,
-        { ...base, cfc: forgedMetadata } as unknown as FabricValue,
+        { ...base, cfc: forgedMetadata },
       );
       expect(tx.getCfcState().unprivilegedSystemWrites.length).toBe(0);
 

--- a/packages/runner/test/cfc-privileged-system-write.test.ts
+++ b/packages/runner/test/cfc-privileged-system-write.test.ts
@@ -2,7 +2,6 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
-import type { FabricValue } from "@commonfabric/data-model/interface";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { URI } from "@commonfabric/memory/interface";

--- a/packages/runner/test/cfc-write-reconstruction.test.ts
+++ b/packages/runner/test/cfc-write-reconstruction.test.ts
@@ -193,7 +193,7 @@ Deno.test("writeDetailValueForTarget: composition preserves large off-spine subt
     meta: { seen: false, tags: ["a", "b"] },
   }));
   const base = deepFreeze(
-    { items: bigList, status: "draft" } as unknown as FabricValue,
+    { items: bigList, status: "draft" },
   ) as unknown as Record<string, unknown>;
 
   const tx = txWith([

--- a/packages/runner/test/cfc-write-reconstruction.test.ts
+++ b/packages/runner/test/cfc-write-reconstruction.test.ts
@@ -2,7 +2,6 @@ import { assertEquals, assertStrictEquals } from "@std/assert";
 import { writeDetailValueForTarget } from "../src/cfc/prepare.ts";
 import { normalizeCellScope } from "../src/scope.ts";
 import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
-import type { FabricValue } from "@commonfabric/api";
 import type { MemorySpace, URI } from "@commonfabric/memory/interface";
 import type {
   IExtendedStorageTransaction,

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -877,7 +877,7 @@ const applyOperation = (
     );
   }
   const next = applyPatch(
-    { value: clone(current) ?? {} } as FabricValue,
+    { value: clone(current) ?? {} },
     operation.patches,
   ) as { value?: RootValue };
   return next.value;

--- a/packages/runner/test/mergeable-op-registry.test.ts
+++ b/packages/runner/test/mergeable-op-registry.test.ts
@@ -149,7 +149,7 @@ describe("mergeable tail-op build guards", () => {
       buildMergeableIntent(
         { op: "append", path: ["value"], count: 1 },
         {
-          workingArray: punched as FabricValue[],
+          workingArray: punched,
           hadInitialArray: true,
           hadInitialValue: true,
           initialArray: ["a", "b", "c"],
@@ -167,7 +167,7 @@ describe("mergeable tail-op build guards", () => {
       buildMergeableIntent(
         { op: "append", path: ["value"], count: 2 },
         {
-          workingArray: sparseTail as FabricValue[],
+          workingArray: sparseTail,
           hadInitialArray: true,
           hadInitialValue: true,
           initialArray: ["a", "b"],
@@ -187,7 +187,7 @@ describe("mergeable tail-op build guards", () => {
       buildMergeableIntent(
         { op: "append", path: ["value"], count: 1 },
         {
-          workingArray: sparse as FabricValue[],
+          workingArray: sparse,
           hadInitialArray: false,
           hadInitialValue: false,
         },
@@ -275,7 +275,7 @@ describe("mergeable remove-by-value build guards", () => {
   // distinct from a value (and from a stored `undefined`) rather than flattening
   // the distinction the way a length check would.
   it("abandons the intent when a hole in the base was filled", () => {
-    const base: FabricValue[] = ["a", , "c"] as FabricValue[];
+    const base: FabricValue[] = ["a", , "c"];
     expect(
       buildMergeableIntent(removeIntent("c"), ctx(["a", "b"], base)),
     ).toEqual({ ops: [], suppress: [], abandon: true });

--- a/packages/runner/test/reactive-dependencies.test.ts
+++ b/packages/runner/test/reactive-dependencies.test.ts
@@ -755,7 +755,7 @@ describe("determineTriggeredActions", () => {
       const result = determineTriggeredActions(
         dependencies,
         { a: 1 },
-        { a: undefined } as FabricValue,
+        { a: undefined },
       );
       expect(result).toEqual([action1]);
     });
@@ -1727,8 +1727,8 @@ describe("determineTriggeredActions", () => {
 
       const result = determineTriggeredActions(
         dependencies,
-        before as FabricValue,
-        after as FabricValue,
+        before,
+        after,
       );
 
       // Action B and C should trigger because __#0 appeared,
@@ -1893,8 +1893,8 @@ describe("determineTriggeredActions", () => {
 
       const result = determineTriggeredActions(
         dependencies,
-        before as FabricValue,
-        after as FabricValue,
+        before,
+        after,
       );
 
       // Should trigger
@@ -1922,8 +1922,8 @@ describe("determineTriggeredActions", () => {
 
       const result = determineTriggeredActions(
         dependencies,
-        before as FabricValue,
-        after as FabricValue,
+        before,
+        after,
         ["value", "a", "existing"],
         { nonRecursive: true },
       );
@@ -1940,8 +1940,8 @@ describe("determineTriggeredActions", () => {
 
       const result = determineTriggeredActions(
         dependencies,
-        before as FabricValue,
-        after as FabricValue,
+        before,
+        after,
         ["value", "a", "added"],
         { nonRecursive: true },
       );
@@ -1958,8 +1958,8 @@ describe("determineTriggeredActions", () => {
 
       const result = determineTriggeredActions(
         dependencies,
-        before as FabricValue,
-        after as FabricValue,
+        before,
+        after,
         ["value", "a", "added"],
         { nonRecursive: true },
       );
@@ -1984,8 +1984,8 @@ describe("determineTriggeredActions", () => {
       expect(() =>
         determineTriggeredActions(
           dependencies,
-          before as unknown as FabricValue,
-          after as unknown as FabricValue,
+          before,
+          after,
           ["value", "a"],
           { nonRecursive: true },
         )
@@ -2002,8 +2002,8 @@ describe("determineTriggeredActions", () => {
 
       const result = determineTriggeredActions(
         dependencies,
-        before as FabricValue,
-        after as FabricValue,
+        before,
+        after,
         ["value", "a"],
         { nonRecursive: true },
       );
@@ -2023,16 +2023,16 @@ describe("determineTriggeredActions", () => {
 
       const recursiveResult = determineTriggeredActions(
         new Map([[recursiveAction, [["value", "a"]]]]),
-        before as FabricValue,
-        after as FabricValue,
+        before,
+        after,
         ["value", "a", "existing"],
       );
       expect(recursiveResult).toEqual([recursiveAction]);
 
       const nonRecursiveResult = determineTriggeredActions(
         new Map([[nonRecursiveAction, [["value", "a"]]]]),
-        before as FabricValue,
-        after as FabricValue,
+        before,
+        after,
         ["value", "a", "existing"],
         { nonRecursive: true },
       );
@@ -2049,8 +2049,8 @@ describe("determineTriggeredActions", () => {
 
       const result = determineTriggeredActions(
         dependencies,
-        before as FabricValue,
-        after as FabricValue,
+        before,
+        after,
         ["value"],
         { nonRecursive: true },
       );
@@ -2159,8 +2159,8 @@ Deno.bench("determineTriggeredActions - many dependencies", () => {
 
   determineTriggeredActions(
     dependencies,
-    before as FabricValue,
-    after as FabricValue,
+    before,
+    after,
   );
 });
 
@@ -2268,7 +2268,7 @@ Deno.bench("determineTriggeredActions - complex real-world", () => {
 
   determineTriggeredActions(
     dependencies,
-    before as FabricValue,
-    after as FabricValue,
+    before,
+    after,
   );
 });

--- a/packages/runner/test/schema-anyof.test.ts
+++ b/packages/runner/test/schema-anyof.test.ts
@@ -6,7 +6,6 @@ import "@commonfabric/utils/equal-ignoring-symbols";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { type Cell, isCell } from "../src/cell.ts";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { type JSONSchema } from "../src/builder/types.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";

--- a/packages/runner/test/schema-anyof.test.ts
+++ b/packages/runner/test/schema-anyof.test.ts
@@ -527,7 +527,7 @@ describe("Schema - AnyOf Support", () => {
             childrenArrayCell.getAsLink(),
             "or just text",
           ],
-        } as unknown as FabricValue);
+        });
 
         const vdomSchema = {
           $ref: "#/$defs/VDom",

--- a/packages/runner/test/schema-dispatch-fabric-instance.test.ts
+++ b/packages/runner/test/schema-dispatch-fabric-instance.test.ts
@@ -101,7 +101,7 @@ describe("value-type dispatch: FabricSpecialObject subclasses", () => {
     const blob = new FabricBytes(new Uint8Array([1, 2, 3]));
     const { traverser, doc } = traverserOver(
       "of:dispatch-primitive",
-      { field: blob } as unknown as FabricValue,
+      { field: blob },
       objectSelector,
     );
 
@@ -135,7 +135,7 @@ describe("value-type dispatch: FabricSpecialObject subclasses", () => {
         {
           "of:dispatch-link-target": {
             name: "linked",
-          } as FabricValue,
+          },
         },
       );
 
@@ -166,7 +166,7 @@ describe("value-type dispatch: FabricSpecialObject subclasses", () => {
         {
           "of:unconstrained-link-target": {
             name: "linked",
-          } as FabricValue,
+          },
         },
       );
 
@@ -187,7 +187,7 @@ describe("value-type dispatch: FabricSpecialObject subclasses", () => {
     const failure = FabricError.fromNativeError(new Error("loud"));
     const { traverser, doc } = traverserOver(
       "of:dispatch-instance",
-      { field: failure } as unknown as FabricValue,
+      { field: failure },
       objectSelector,
     );
 
@@ -214,7 +214,7 @@ describe("plain-schema fast path: FabricSpecialObject subclasses", () => {
     const blob = new FabricBytes(new Uint8Array([7, 7]));
     const { traverser, doc } = traverserOver(
       "of:plan-primitive",
-      [blob] as unknown as FabricValue,
+      [blob],
       planSelector,
       false,
     );
@@ -227,7 +227,7 @@ describe("plain-schema fast path: FabricSpecialObject subclasses", () => {
     const failure = FabricError.fromNativeError(new Error("loud"));
     const { traverser, doc } = traverserOver(
       "of:plan-instance",
-      [failure] as unknown as FabricValue,
+      [failure],
       planSelector,
       false,
     );

--- a/packages/runner/test/schema-examples.test.ts
+++ b/packages/runner/test/schema-examples.test.ts
@@ -7,7 +7,6 @@ import "@commonfabric/utils/equal-ignoring-symbols";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { type Cell, isCell } from "../src/cell.ts";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { SigilLink } from "../src/sigil-types.ts";
 import { type JSONSchema } from "../src/builder/types.ts";
 import { Runtime } from "../src/runtime.ts";

--- a/packages/runner/test/schema-examples.test.ts
+++ b/packages/runner/test/schema-examples.test.ts
@@ -141,7 +141,7 @@ describe("Schema - Examples", () => {
       cell.withTx(tx).setRawUntyped({
         value: "root",
         current: innerCell.getAsLink(),
-      } as FabricValue);
+      });
 
       tx.commit();
       tx = runtime.edit();

--- a/packages/runner/test/schema-links.test.ts
+++ b/packages/runner/test/schema-links.test.ts
@@ -7,7 +7,6 @@ import "@commonfabric/utils/equal-ignoring-symbols";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { createCell, isCell } from "../src/cell.ts";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { type JSONSchema } from "../src/builder/types.ts";
 import { diffAndUpdate } from "../src/data-updating.ts";
 import { parseLink } from "../src/link-utils.ts";

--- a/packages/runner/test/schema-links.test.ts
+++ b/packages/runner/test/schema-links.test.ts
@@ -1800,7 +1800,7 @@ describe("Schema - Link Resolution", () => {
             includeSchema: true,
           }),
         },
-      } as FabricValue);
+      });
 
       // data cell's system points to cellB's argument.system
       const dataCellURI = dataUriFromValueWithResolvedLinks({

--- a/packages/runner/test/traverse-fabric-primitive.test.ts
+++ b/packages/runner/test/traverse-fabric-primitive.test.ts
@@ -15,7 +15,6 @@ import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { FabricError } from "@commonfabric/data-model/fabric-instances";
 import { hashOf } from "@commonfabric/data-model/value-hash";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import type {
   Entity,
   Revision,

--- a/packages/runner/test/traverse-fabric-primitive.test.ts
+++ b/packages/runner/test/traverse-fabric-primitive.test.ts
@@ -201,7 +201,7 @@ describe("FabricPrimitive leaf routing in schema traversal", () => {
     const value = {
       blob: new FabricBytes(
         new Uint8Array([4, 5, 6]),
-      ) as unknown as FabricValue,
+      ),
     };
     store.set(`${entity}/${type}`, {
       the: type,
@@ -244,7 +244,7 @@ describe("FabricPrimitive leaf routing in schema traversal", () => {
     const uri = "of:fabric-dag-instance" as URI;
     const entity = uri as Entity;
     const failure = FabricError.fromNativeError(new Error("leaf me"));
-    const value = { failure: failure as unknown as FabricValue };
+    const value = { failure: failure };
     store.set(`${entity}/${type}`, {
       the: type,
       of: entity,

--- a/packages/runner/test/traverse-replay/replay.ts
+++ b/packages/runner/test/traverse-replay/replay.ts
@@ -171,7 +171,7 @@ export class FixtureObjectManager implements ObjectStorageManager {
       // (decodeMemoryBoundary), so frozen corpus values are the faithful
       // replay shape — without this, frozen-identity fast paths in traverse
       // can never engage during replay even though they do in production.
-      value: deepFreeze(value) as FabricValue,
+      value: deepFreeze(value),
     };
     this.attestations.set(key, attestation);
     return attestation;

--- a/packages/runner/test/traverse.test.ts
+++ b/packages/runner/test/traverse.test.ts
@@ -695,7 +695,7 @@ describe("SchemaObjectTraverser array traversal", () => {
           path: ["value", "foo"],
           space: "did:null:null",
         },
-        value: (revA.is as any).value.foo as FabricValue,
+        value: (revA.is as any).value.foo,
       };
       const docASelector = {
         path: ["value", "foo"],
@@ -758,7 +758,7 @@ describe("SchemaObjectTraverser array traversal", () => {
           path: ["value", "current"],
           space: "did:null:null",
         },
-        value: (revA.is as any).value.current as FabricValue,
+        value: (revA.is as any).value.current,
       };
       const docASelector = { path: ["value", "current"], schema: true };
       const [curDoc, _selector1] = getAtPath(
@@ -822,7 +822,7 @@ describe("SchemaObjectTraverser array traversal", () => {
           path: ["value", "current"],
           space: "did:null:null",
         },
-        value: (revA.is as any).value.current as FabricValue,
+        value: (revA.is as any).value.current,
       };
       const docASelector = {
         path: ["value", "current"],

--- a/packages/runner/test/traverse.test.ts
+++ b/packages/runner/test/traverse.test.ts
@@ -1368,7 +1368,7 @@ describe("SchemaObjectTraverser array element validation fallback priority", () 
     // receives that self-contained schema and must resolve the $ref before
     // deciding whether undefined is a valid substitute.
     const docValue = ["hello", true];
-    const { store, docUri, type } = makeArrayDoc(docValue as FabricValue[]);
+    const { store, docUri, type } = makeArrayDoc(docValue);
 
     const schema = {
       type: "array",
@@ -1386,7 +1386,7 @@ describe("SchemaObjectTraverser array element validation fallback priority", () 
           type,
           path: ["value"],
         },
-        value: docValue as FabricValue[],
+        value: docValue,
       });
 
     // After fix: $ref is resolved to { type: "string" }, which does not allow

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -1564,7 +1564,7 @@ export class RuntimeProcessor {
     const body = blobUploadEncoding.encode({
       type: request.contentType,
       body: new FabricBytes(bytes),
-    } as FabricValue);
+    });
     const response = await fetch(target, {
       method: "POST",
       headers: { "Content-Type": "application/json" },

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -1,6 +1,5 @@
 import { DID, Identity, type Session } from "@commonfabric/identity";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { JsonEncodingContext } from "@commonfabric/data-model/codec-json";
 import { PieceManager } from "@commonfabric/piece";
 import {

--- a/packages/state-inspector/reconstruct.ts
+++ b/packages/state-inspector/reconstruct.ts
@@ -150,10 +150,9 @@ function reconstructWithinBranch(
     )
     .get<RevRow>(branch, id, scope, rowSeq, rowSeq, rowOpIndex);
 
-  let doc: FabricValue =
-    (base && base.op === "set" && base.data
-      ? (decodeStored(base.data) as FabricValue)
-      : {}) as FabricValue;
+  let doc: FabricValue = base && base.op === "set" && base.data
+    ? (decodeStored(base.data) as FabricValue)
+    : {};
   let baseSeq = base ? base.seq : 0;
   let baseOpIndex = base ? base.op_index : -1;
 

--- a/packages/state-inspector/timetravel.ts
+++ b/packages/state-inspector/timetravel.ts
@@ -215,7 +215,7 @@ export function entityTimeline(
         doc = r.data ? (decodeStored(r.data) as FabricValue) : undefined;
       } else if (r.op === "patch") {
         const ops = r.data ? (decodeStored(r.data) as PatchOp[]) : [];
-        doc = applyPatch((doc ?? {}) as FabricValue, ops);
+        doc = applyPatch(doc ?? {}, ops);
       } else if (r.op === "delete") {
         doc = undefined;
       }

--- a/packages/toolshed/routes/blobs/blobs.test.ts
+++ b/packages/toolshed/routes/blobs/blobs.test.ts
@@ -109,7 +109,7 @@ describe("Blob Routes", () => {
     const post = await app.request(`/${identity.did()}/blobs/image.gif`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: blobUploadEncoding.encode(contents as FabricValue),
+      body: blobUploadEncoding.encode(contents),
     });
     expect(post.status).toBe(201);
     expect(await post.json()).toEqual({

--- a/packages/toolshed/routes/blobs/blobs.test.ts
+++ b/packages/toolshed/routes/blobs/blobs.test.ts
@@ -13,7 +13,6 @@ import { encodeMemoryBoundary } from "@commonfabric/memory/v2";
 import type { URI } from "@commonfabric/memory/interface";
 import { Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { type FabricValue } from "@commonfabric/data-model/fabric-value";
 
 if (env.ENV !== "test") {
   throw new Error("ENV must be 'test'");

--- a/packages/utils/src/strip-undefined-props.ts
+++ b/packages/utils/src/strip-undefined-props.ts
@@ -23,9 +23,7 @@ export function stripUndefinedProps(
     // rather than triggering the prototype setter on `out` (which would
     // pollute the prototype chain of the returned object).
     Object.defineProperty(out, key, {
-      value: isPlainObject(val)
-        ? stripUndefinedProps(val as Record<string, unknown>)
-        : val,
+      value: isPlainObject(val) ? stripUndefinedProps(val) : val,
       enumerable: true,
       configurable: true,
       writable: true,


### PR DESCRIPTION
## What

Five separate cast-removal passes, one per commit, all purely type-level. Casts
are erased at compile time, so the emitted JavaScript is unchanged throughout;
what moves is how much the type checker is allowed to see.

| commit | pass | removed | kept |
|---|---|---|---|
| `ddbb856f0` | casts unlocked by #5267 | 4 | — |
| `8562dc277` | `as FabricValue` / `as unknown as FabricValue` | 375 | 76 |
| `7332694a4` | `as FabricValueLayer` | 6 | 1 |
| `59272c01d` | `as FabricValue[]` | 22 | 27 |
| `e8355fd71` | `as unknown as Fabric{Error,Hash,Bytes,RegExp,Epoch*}` | 2 | 45 |

409 of 558 removed. Figures are net across the branch: the `FabricValue[]` pass
removed 23 and `c49ab966c` put one back, for the reason under *Verification*
below. The branch also carries a merge of `main`.

## The unlocked four

#5267 made `isPlainObject()` and its kin narrow, so four sites that guarded a
value and then cast the result no longer need to. Each cast went to a *mutable*
`Record<string, unknown>` while every use behind it is a read, so removing it
also stops erasing the read-only-ness the predicate now hands back.

## The `FabricValue` passes

The double casts are the more interesting half. `as unknown as X` cannot be
checked at all — it launders any type into any other — so each one was
potentially hiding a real mismatch. Most turned out to be simply stale: a
`FabricInstance` method returning `Object.freeze(this) as unknown as
FabricValue` has satisfied `FabricValue` by type for some time, and the cast
only meant that a later mistake there would have gone unreported.

What stays is uniformly a real narrowing — `unknown` or `object` down to
`FabricValue`, or a member of the `FabricValue` union down to an array — which
genuinely needs an assertion.

## Method

Remove all candidates, type-check, restore only the lines the compiler objects
to, repeat to a fixed point. Two things that fixed point does not reach on its
own, both worth knowing for the next sweep of this shape:

- **The error is usually not at the cast.** It surfaces at a *use* of the cast
  value, sometimes dozens of lines away, and in either direction — an object
  literal's cast sits on its closing brace, *after* the argument that fails.
  `Cell.addUnique()` was the extreme case: the cast at `cell.ts:1625`, the error
  at `:1664`.
- **`deno task check` does not cover every package's `test` directory.** Its
  path list has `packages/schema-generator/src` but not the sibling `test`, and
  that package's test task type-checks — so five load-bearing casts there were
  invisible to the loop and surfaced only in the full suite.

## Noted, not changed

`Cell.addUnique()` opens with `let array = currentValue as FabricValue[]` and
then checks `Array.isArray(array)` on the next line — the cast asserts the very
thing the following line tests. It has to stay here (removing it breaks uses
further down), but an assertion standing in for a check that already exists is
worth revisiting on its own.

### Why the last pass yields so little

47 double casts name the *other* Fabric types, and only two say anything the
type does not already. They do different work from the `FabricValue` ones: a
`FabricValue` cast was usually asserting a value into a union it already
belonged to, whereas these mostly manufacture an instance of a specific class
from something that is not one — genuinely uncheckable, and so legitimately
asserted.

Casts to `FabricValue | undefined` are untouched. There were zero occurrences of
`as unknown as FabricValue[]` or `as unknown as FabricValueLayer`; every sweep's
pattern admitted the `unknown as` prefix, so the double-cast form was in scope
throughout.

## Verification

Each commit and the branch as a whole: `deno fmt --check`, `deno lint`, `deno
task check`, `deno task check-docs`, and the full workspace `deno task test` —
all gated on **exit code**. `data-model` is not on `tasks/check.sh`'s path list,
so it is type-checked explicitly as well, and the per-package test tasks for
`schema-generator`, `piece`, `memory`, `data-model`, `utils`, and `runner` are
run individually.

Both are deliberate, and each cost a red CI run on this branch before the gate
was tightened:

- `deno lint | tail -1` prints `Checked N files`, with `Found N problems` on the
  line *above* — so a tail reads as green either way. Nineteen imports orphaned
  by the removals went unnoticed that way.
- `packages/piece` runs its tests without type-checking, so a gate of "full
  suite + `check-docs`" never looks at that package's types. That is how one
  cast that should have stayed got through: `pull-materialization.test.ts`
  spreads `originalInternal`, a `FabricValue`, which is not iterable without the
  `as FabricValue[]` saying otherwise. Restored in `c49ab966c`, which is why the
  table's figure for that pass is 22 rather than 23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XVfNoL2iqhNckYT3Z2SH4y
