### PR TITLE
refactor(runner): let the guards produce the array type in `push()`/`addUnique()`

### DIFF
--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -1537,23 +1537,22 @@ export class CellImpl<T extends FabricValue>
     );
     // Read marked as the op's own incidental read: dropped from the commit's
     // conflict set so the append merges, while a handler's explicit read is not.
-    const currentValue = this.tx.readValueOrThrow(resolvedLink, {
+    let currentValue = this.tx.readValueOrThrow(resolvedLink, {
       meta: mergeableOpRead,
     });
     const cause = this._frame?.cause;
 
-    let array = currentValue as unknown[];
-    if (array !== undefined && !Array.isArray(array)) {
-      throw new Error(
-        "Cell.push() requires transaction and array value\n" +
-          "help: use in handlers only, ensure cell is typed as array",
-      );
-    }
+    if (!Array.isArray(currentValue)) {
+      if (currentValue !== undefined) {
+        throw new Error(
+          "Cell.push() requires transaction and array value\n" +
+            "help: use in handlers only, ensure cell is typed as array",
+        );
+      }
 
-    // If there is no array yet, create it first. We have to do this as a
-    // separate operation, so that in the next steps each object element is
-    // properly anchored in the array.
-    if (array === undefined) {
+      // No array yet, so create it first. This has to be a separate operation,
+      // so that in the next steps each object element is properly anchored in
+      // the array.
       diffAndUpdate(
         this.runtime,
         this.tx,
@@ -1562,15 +1561,24 @@ export class CellImpl<T extends FabricValue>
         cause,
       );
       const resolvedSchema = resolveSchema(this.schema);
-      array = isRecord(resolvedSchema) && Array.isArray(resolvedSchema.default)
-        ? processDefaultValue(
-          this.runtime,
-          this.tx,
-          this.link,
-          resolvedSchema.default,
-        )
-        : [];
+      // Annotated rather than inferred: `processDefaultValue()` answers `any`,
+      // and assigning that back to `currentValue` would discard the narrowing
+      // this block exists to establish.
+      const created: FabricValue[] =
+        isRecord(resolvedSchema) && Array.isArray(resolvedSchema.default)
+          ? processDefaultValue(
+            this.runtime,
+            this.tx,
+            this.link,
+            resolvedSchema.default,
+          )
+          : [];
+      currentValue = created;
     }
+
+    // Read-only: a stored `FabricArray` is a `ReadonlyArray`, and this method
+    // only reads it, building the replacement in `combined` below.
+    const array: readonly unknown[] = currentValue;
 
     // Append the new values to the array, preserving sparse holes in the original.
     const combined = new Array(array.length + value.length);
@@ -1617,30 +1625,38 @@ export class CellImpl<T extends FabricValue>
       resolvedLink,
       resolvedLink.schema ?? this.schema,
     );
-    const currentValue = this.tx.readValueOrThrow(resolvedLink, {
+    let currentValue = this.tx.readValueOrThrow(resolvedLink, {
       meta: mergeableOpRead,
     });
     const cause = this._frame?.cause;
 
-    let array = currentValue as FabricValue[];
-    if (array !== undefined && !Array.isArray(array)) {
-      throw new Error(
-        "Cell.addUnique() requires transaction and array value\n" +
-          "help: use in handlers only, ensure cell is typed as array",
-      );
-    }
-    if (array === undefined) {
+    if (!Array.isArray(currentValue)) {
+      if (currentValue !== undefined) {
+        throw new Error(
+          "Cell.addUnique() requires transaction and array value\n" +
+            "help: use in handlers only, ensure cell is typed as array",
+        );
+      }
+
       diffAndUpdate(this.runtime, this.tx, resolvedLink, [], cause);
       const resolvedSchema = resolveSchema(this.schema);
-      array = isRecord(resolvedSchema) && Array.isArray(resolvedSchema.default)
-        ? processDefaultValue(
-          this.runtime,
-          this.tx,
-          this.link,
-          resolvedSchema.default,
-        )
-        : [];
+      // Annotated for the same reason as in `push()`: `processDefaultValue()`
+      // answers `any`, which would discard the narrowing on assignment.
+      const created: FabricValue[] =
+        isRecord(resolvedSchema) && Array.isArray(resolvedSchema.default)
+          ? processDefaultValue(
+            this.runtime,
+            this.tx,
+            this.link,
+            resolvedSchema.default,
+          )
+          : [];
+      currentValue = created;
     }
+
+    // Read-only, as in `push()`: the comparisons below only read, and the
+    // replacement is built separately.
+    const array: readonly FabricValue[] = currentValue;
 
     // Keep only the values not already present (by stored-value equality,
     // matching the server's add-unique dedup). The server re-dedups against

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -1573,11 +1573,14 @@ export class CellImpl<T extends FabricValue>
             resolvedSchema.default,
           )
           : [];
+      // From here on `currentValue` is the array just created, not what the
+      // read returned.
       currentValue = created;
     }
 
-    // Read-only: a stored `FabricArray` is a `ReadonlyArray`, and this method
-    // only reads it, building the replacement in `combined` below.
+    // Read-only: a value that came from storage is a `FabricArray`, which is a
+    // `ReadonlyArray`, and though a freshly created one is not, this method
+    // only ever reads what it finds -- the replacement is `combined`, below.
     const array: readonly unknown[] = currentValue;
 
     // Append the new values to the array, preserving sparse holes in the original.
@@ -1651,11 +1654,12 @@ export class CellImpl<T extends FabricValue>
             resolvedSchema.default,
           )
           : [];
+      // As in `push()`, `currentValue` is now the created array.
       currentValue = created;
     }
 
-    // Read-only, as in `push()`: the comparisons below only read, and the
-    // replacement is built separately.
+    // Read-only for the same reason as in `push()`: the comparisons below only
+    // read, and the replacement is built separately.
     const array: readonly FabricValue[] = currentValue;
 
     // Keep only the values not already present (by stored-value equality,

--- a/packages/runner/test/array-write-guards.test.ts
+++ b/packages/runner/test/array-write-guards.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import { Runtime } from "../src/runtime.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+
+/**
+ * The three states `Cell.push()` and `Cell.addUnique()` can find the stored
+ * value in: absent, an array, or something else. Each method decides between
+ * them before it has an array to work with, so all three are covered here for
+ * both.
+ */
+const signer = await Identity.fromPassphrase("array write guards");
+const space = signer.did();
+
+describe("array write guards", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let tx: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    tx = runtime.edit();
+  });
+
+  afterEach(async () => {
+    await tx.commit();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  for (
+    const { name, write } of [
+      {
+        name: "push()",
+        write: (cell: ReturnType<Runtime["getCell"]>, v: string) =>
+          (cell as unknown as { push(v: string): void }).push(v),
+      },
+      {
+        name: "addUnique()",
+        write: (cell: ReturnType<Runtime["getCell"]>, v: string) =>
+          (cell as unknown as { addUnique(v: string): void }).addUnique(v),
+      },
+    ]
+  ) {
+    describe(name, () => {
+      it("creates the array when there is no value yet", () => {
+        const cell = runtime.getCell<string[]>(
+          space,
+          `absent-${name}`,
+          undefined,
+          tx,
+        );
+
+        write(cell, "one");
+
+        expect(cell.get()).toEqual(["one"]);
+      });
+
+      it("appends to an existing array", () => {
+        const cell = runtime.getCell<string[]>(
+          space,
+          `existing-${name}`,
+          undefined,
+          tx,
+        );
+        cell.set(["one"]);
+
+        write(cell, "two");
+
+        expect(cell.get()).toEqual(["one", "two"]);
+      });
+
+      it("throws when the stored value is not an array", () => {
+        const cell = runtime.getCell<string[]>(
+          space,
+          `non-array-${name}`,
+          undefined,
+          tx,
+        );
+        // A cell typed as an array whose stored value is not one. Only reachable
+        // through a cast, which is the point: the guard is what stands between
+        // that state and a silently wrong write.
+        cell.set("not an array" as unknown as string[]);
+
+        expect(() => write(cell, "one")).toThrow(
+          /requires transaction and array value/,
+        );
+      });
+    });
+  }
+});

--- a/packages/runner/test/array-write-guards.test.ts
+++ b/packages/runner/test/array-write-guards.test.ts
@@ -4,6 +4,7 @@ import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 
 import { Runtime } from "../src/runtime.ts";
+import type { Cell } from "../src/cell.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 
 /**
@@ -35,17 +36,18 @@ describe("array write guards", () => {
     await storageManager?.close();
   });
 
+  // Typed as `Cell<string[]>` rather than cast to a structural `{ push(...) }`,
+  // so these calls are checked against the real signatures and would stop
+  // compiling if either method changed shape or left `Cell`.
   for (
     const { name, write } of [
       {
         name: "push()",
-        write: (cell: ReturnType<Runtime["getCell"]>, v: string) =>
-          (cell as unknown as { push(v: string): void }).push(v),
+        write: (cell: Cell<string[]>, v: string) => cell.push(v),
       },
       {
         name: "addUnique()",
-        write: (cell: ReturnType<Runtime["getCell"]>, v: string) =>
-          (cell as unknown as { addUnique(v: string): void }).addUnique(v),
+        write: (cell: Cell<string[]>, v: string) => cell.addUnique(v),
       },
     ]
   ) {
@@ -61,6 +63,26 @@ describe("array write guards", () => {
         write(cell, "one");
 
         expect(cell.get()).toEqual(["one"]);
+      });
+
+      it("seeds from the schema default when there is no value yet", () => {
+        // The other absent-value case takes the `: []` arm. This one reaches
+        // `processDefaultValue()`, whose `any` return is what the created
+        // array's annotation exists to constrain.
+        const cell = runtime.getCell<string[]>(
+          space,
+          `defaulted-${name}`,
+          {
+            type: "array",
+            items: { type: "string" },
+            default: ["seed"],
+          } as const,
+          tx,
+        );
+
+        write(cell, "one");
+
+        expect(cell.get()).toEqual(["seed", "one"]);
       });
 
       it("appends to an existing array", () => {


### PR DESCRIPTION
## What

`Cell.push()` and `Cell.addUnique()` each opened by asserting the read was an
array, then spent the next two statements handling the cases where it is not:

```ts
let array = currentValue as unknown[];
if (array !== undefined && !Array.isArray(array)) throw ...;
if (array === undefined) { ...create... }
```

The declared type contradicted the control flow beneath it. Now the guard runs
first and narrowing produces the type, so neither method casts at all.

## Why it mattered

- **In the absent case the type was simply false.** `array` held `undefined`
  under a type saying it was an array, until the reassignment. Anything moved
  above that point would have been unprotected.
- **Both `undefined` comparisons were, per the declared type, incapable of being
  true.** TypeScript does not flag them, but it also cannot help: get the
  polarity backwards and the checker stays silent, having been told the value is
  an array.
- **`addUnique()`'s `as FabricValue[]` asserted the element type too**, which
  nothing checks.

## The concrete payoff: guard-polarity errors are now caught

This is the strongest way to state the change, and it is measurable. Invert the
polarity of both guards and ask the checker:

- **Before** — `if (array === undefined && Array.isArray(array))` in both
  methods: `deno check` **exits 0**. Completely clean. The value had been
  asserted to be an array, so the checker had nothing to say about a test of
  whether it is one.
- **After** — the same inversion: **2 type errors**, `deno check` exits 1.

So a class of mistake that was previously invisible in these two write paths now
fails to compile.

## What removing the assertion surfaced

A stored `FabricArray` is a `ReadonlyArray<FabricValue>`, so `as unknown[]` was
handing back a *mutable* view of a read-only value. Both methods only read what
they find — each builds its replacement separately — so `array` is now declared
read-only, which is what it always was.

The compiler forces this rather than it being a style choice: annotating the
joined value as mutable `unknown[]` fails with `Type 'FabricArray' is not
assignable to type 'unknown[]'`. The element type is checked too — annotating
`addUnique()`'s as `readonly string[]` fails with `Type 'FabricValue' is not
assignable to type 'string'` — so the replacement is not a restatement of the
`as FabricValue[]` it removed.

## Notes

The created default is annotated rather than inferred: `processDefaultValue()`
answers `any`, and assigning that back to `currentValue` would discard the
narrowing the guard exists to establish.

That annotation is unchecked, being over an `any`, and `processDefaultValue()`
can in principle answer a non-array (`schema.ts:673` returns a `Cell` for an
`asStream` schema, `:684` returns `undefined`). The previous code assigned the
same `any` into a `let array: unknown[]`, so this is a pre-existing hole that
the change neither widens nor narrows — noted rather than fixed, since closing
it belongs with `processDefaultValue()`'s own contract.

## Verification

Behaviour is unchanged on all four inputs: absent creates, an array is used,
`null` and any other non-array throw.

`array-write-guards.test.ts` covers four cases per method — absent, absent with
a schema default, an existing array, and a non-array. The non-array case had
**no** coverage before, and the schema-default case is what reaches
`processDefaultValue()`.

Two checks matter more than the pass:

- **They pass unchanged against the previous implementation**, which is what
  makes this behavior-preserving rather than merely type-clean. A test written
  against the new code that only passes there would prove nothing.
- **They are not vacuous.** Breaking each guard branch in turn — dropping the
  absent case, inverting the array check, removing the throw — kills them, in
  both methods.

`deno fmt --check`, `deno lint`, `deno task check`, `deno task check-docs`, the
`runner` suite (1112 passed), and the full workspace `deno task test` — all
gated on exit code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XVfNoL2iqhNckYT3Z2SH4y
