### PR TITLE
fix(cli): project linked piece values compactly

### DIFF
--- a/docs/plans/pattern-verb-contract.md
+++ b/docs/plans/pattern-verb-contract.md
@@ -365,12 +365,13 @@ board topic). Until that lands, board-level routing
 the target shape.
 
 `cf piece get` lets an agent control how much data an exploratory read returns:
-`--filter` narrows array membership and `--schema` projects fields through the
-runtime's `asSchema` read path. Both execute through computed pattern nodes so
-their CFC behavior matches pattern expressions. A limit on the number of
-records returned from a large array remains deferred, blocking nothing. It is
-adjacent CLI work for when board scale demands it, not an ask on any workstream
-in this implementation plan.
+`--filter` narrows array membership and `--schema` constructs a projected value
+from source-schema-selected reads. Both execute through computed pattern nodes
+so their CFC behavior matches pattern expressions, without returning an
+identity alias that can widen to a linked target's schema. A limit on the
+number of records returned from a large array remains deferred, blocking
+nothing. It is adjacent CLI work for when board scale demands it, not an ask on
+any workstream in this implementation plan.
 
 **A set of verbs wants to be a structural interface, and the machinery for that
 already exists.** Schemas are the type system, so a verb set is a schema

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -151,7 +151,11 @@ match the stored value is omitted by the runtime rather than reported as an
 error; prefer `true` leaves unless that type filtering is intentional. Schema
 combinators and references are rejected. Concise dotted paths traverse object
 properties, not nested array items: use an inline/file JSON Schema with `items`
-for a shape such as selected fields from every `comments` entry.
+for a shape such as selected fields from every `comments` entry. A concise
+projection over nullable array items can currently return JSON `null` for the
+whole array when any item is null. Filter null/unavailable items before
+projecting, or use an explicit array schema whose `items` preserves the source
+nullability; do not interpret that JSON `null` as an empty result.
 
 Both transforms run as a short-lived computed pattern in the caller's session.
 The runtime's list filter/map builtins therefore handle CFC exactly as authored

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -149,15 +149,20 @@ Projection schemas support structural `properties`, `items`, and scalar leaf
 schemas. In an array-item projection, a scalar leaf whose declared type does not
 match the stored value is omitted by the runtime rather than reported as an
 error; prefer `true` leaves unless that type filtering is intentional. Schema
-combinators and references are rejected.
+combinators and references are rejected. Concise dotted paths traverse object
+properties, not nested array items: use an inline/file JSON Schema with `items`
+for a shape such as selected fields from every `comments` entry.
 
 Both transforms run as a short-lived computed pattern in the caller's session.
 The runtime's list filter/map builtins therefore handle CFC exactly as authored
 pattern expressions do: predicate observations label array membership,
 projection reads propagate labels, and filtered elements retain their source
-links. The source cell's schema remains authoritative for Common Fabric
-metadata. A caller cannot introduce or override `ifc`, `asCell`, `scope`, or
-`default` through `--schema`.
+links. Projection map/lift nodes construct the requested shape from a
+source-schema-selected read rather than returning a widening identity alias.
+Nested non-stream Cell handles are materialized before the predicate/projection
+JavaScript runs; stream handles remain capabilities. The source cell's schema
+remains authoritative for Common Fabric metadata. A caller cannot introduce or
+override `ifc`, `asCell`, `scope`, or `default` through `--schema`.
 
 ## Built Binary
 

--- a/packages/cli/lib/piece-get-transform.ts
+++ b/packages/cli/lib/piece-get-transform.ts
@@ -7,6 +7,7 @@ import {
   KeepAsCell,
   type MemorySpace,
   type Runtime,
+  sanitizeSchemaForLinks,
 } from "@commonfabric/runner";
 import { isRecord } from "@commonfabric/utils/types";
 import { runtimeErrorLog } from "./callable.ts";
@@ -771,7 +772,8 @@ function projectionMask(schema: JSONSchema): ProjectionMask {
 }
 
 function projectValue(value: unknown, schema: JSONSchema): unknown {
-  if (schema === true || schema === false || value === null) return value;
+  if (typeof schema === "boolean") return schema ? value : undefined;
+  if (value === null) return value;
   if (Array.isArray(value)) {
     const itemSchema = schema.items ?? true;
     return value.map((item) => projectValue(item, itemSchema));
@@ -954,7 +956,7 @@ function resolveProjection(
 }
 
 export interface DerivePieceGetDependencies {
-  onResultCell?: (cell: Cell<unknown>) => void;
+  onOutputCell?: (cell: Cell<unknown>) => void;
 }
 
 /**
@@ -963,10 +965,11 @@ export interface DerivePieceGetDependencies {
  * The filter uses the runner's list builtin, so predicate observations taint
  * collection membership exactly as they do in authored patterns. Array
  * projection uses the map builtin for pointwise labels. Object/scalar
- * projection uses a lift. Projection nodes are identities over runtime
- * `asSchema` reads: the source-derived read schema performs the structural
- * projection while preserving authoritative source CFC metadata. Caller
- * schemas describe output shape only and cannot replace source metadata.
+ * projection uses a lift. Projection nodes construct the caller-requested
+ * shape from source-schema-selected reads, preventing an identity alias from
+ * widening back to a broader linked target. Caller schemas describe output
+ * shape only; source schemas remain authoritative for CFC and other Fabric
+ * metadata.
  */
 export async function derivePieceGetValue(
   runtime: Runtime,
@@ -975,10 +978,6 @@ export async function derivePieceGetValue(
   transform: PieceGetTransform,
   deps: DerivePieceGetDependencies = {},
 ): Promise<unknown> {
-  // Match ordinary piece path reads: a selected slot can itself be a link to
-  // the value being read (for example TopicsInput.topics). The transform must
-  // execute over that target, not over the Cell wrapper stored in the slot.
-  sourceCell = sourceCell.resolveAsCell();
   const declaredSourceSchema = sourceCell.schema;
   const sourceSchema = isRecord(declaredSourceSchema) &&
       declaredSourceSchema.asCell !== undefined
@@ -1053,7 +1052,10 @@ export async function derivePieceGetValue(
     const argumentSchema: JSONSchema = {
       type: "object",
       properties: {
-        element: dereferencedElementSchema(elementSchema),
+        element: sanitizeSchemaForLinks(
+          dereferencedElementSchema(elementSchema),
+          KeepAsCell.OnlyStream,
+        ),
         params: paramsSchema,
       },
       required: ["element", "params"],
@@ -1085,7 +1087,10 @@ export async function derivePieceGetValue(
     const argumentSchema: JSONSchema = {
       type: "object",
       properties: {
-        element: dereferencedElementSchema(elementSchema),
+        element: sanitizeSchemaForLinks(
+          dereferencedElementSchema(elementSchema),
+          KeepAsCell.OnlyStream,
+        ),
       },
       required: ["element"],
       additionalProperties: false,
@@ -1105,7 +1110,10 @@ export async function derivePieceGetValue(
   const directProjectionArgumentSchema: JSONSchema = {
     type: "object",
     properties: {
-      value: sourceReadSchema,
+      value: sanitizeSchemaForLinks(
+        sourceReadSchema,
+        KeepAsCell.OnlyStream,
+      ),
     },
     required: ["value"],
     additionalProperties: false,
@@ -1204,7 +1212,7 @@ export async function derivePieceGetValue(
         `Could not apply piece get transform: ${recorded.message}`,
       );
     }
-    deps.onResultCell?.(result as Cell<unknown>);
+    deps.onOutputCell?.(outputCell);
     return outputValue;
   } finally {
     runtime.runner.stop(resultCell);

--- a/packages/cli/lib/piece-get-transform.ts
+++ b/packages/cli/lib/piece-get-transform.ts
@@ -4,6 +4,7 @@ import {
   createBuilder,
   deepEqual,
   type JSONSchema,
+  KeepAsCell,
   type MemorySpace,
   type Runtime,
 } from "@commonfabric/runner";
@@ -769,6 +770,30 @@ function projectionMask(schema: JSONSchema): ProjectionMask {
   return true;
 }
 
+function projectValue(value: unknown, schema: JSONSchema): unknown {
+  if (schema === true || schema === false || value === null) return value;
+  if (Array.isArray(value)) {
+    const itemSchema = schema.items ?? true;
+    return value.map((item) => projectValue(item, itemSchema));
+  }
+  if (!isRecord(value)) return value;
+
+  const properties = schema.properties ?? {};
+  const projected: Record<string, unknown> = {};
+  if (schema.additionalProperties !== false) {
+    for (const [key, child] of Object.entries(value)) {
+      const childSchema = properties[key] ?? schema.additionalProperties ??
+        true;
+      projected[key] = projectValue(child, childSchema);
+    }
+    return projected;
+  }
+  for (const [key, childSchema] of Object.entries(properties)) {
+    if (key in value) projected[key] = projectValue(value[key], childSchema);
+  }
+  return projected;
+}
+
 function maskFromPaths(
   paths: Array<Array<string | number>>,
 ): PredicateMask {
@@ -950,13 +975,24 @@ export async function derivePieceGetValue(
   transform: PieceGetTransform,
   deps: DerivePieceGetDependencies = {},
 ): Promise<unknown> {
+  // Match ordinary piece path reads: a selected slot can itself be a link to
+  // the value being read (for example TopicsInput.topics). The transform must
+  // execute over that target, not over the Cell wrapper stored in the slot.
+  sourceCell = sourceCell.resolveAsCell();
+  const declaredSourceSchema = sourceCell.schema;
+  const sourceSchema = isRecord(declaredSourceSchema) &&
+      declaredSourceSchema.asCell !== undefined
+    ? dereferencedElementSchema(declaredSourceSchema)
+    : declaredSourceSchema;
+  const sourceValueCell = sourceSchema === declaredSourceSchema
+    ? sourceCell
+    : sourceCell.asSchema(sourceSchema);
   if (transform.filter === undefined && transform.projection === undefined) {
-    return await sourceCell.pull();
+    return await sourceValueCell.pull();
   }
 
   const cfc = new ContextualFlowControl();
-  const sourceValue = await sourceCell.pull();
-  const sourceSchema = sourceCell.schema;
+  const sourceValue = await sourceValueCell.pull();
   if (transform.filter !== undefined && !Array.isArray(sourceValue)) {
     throw new PieceGetTransformError(
       "--filter can only be applied to an array",
@@ -1055,7 +1091,7 @@ export async function derivePieceGetValue(
       additionalProperties: false,
     };
     const projectionModule = lift(
-      ({ element }: { element: unknown }) => element,
+      ({ element }: { element: unknown }) => projectValue(element, itemSchema),
       argumentSchema,
       itemSchema,
     );
@@ -1077,7 +1113,8 @@ export async function derivePieceGetValue(
   const directProjectionModule = projection !== undefined &&
       !projection.projectsArrayItems
     ? lift(
-      ({ value }: { value: unknown }) => value,
+      ({ value }: { value: unknown }) =>
+        projectValue(value, projection.outputSchema),
       directProjectionArgumentSchema,
       projection.outputSchema,
     )
@@ -1121,7 +1158,7 @@ export async function derivePieceGetValue(
     space,
     {
       pieceGetTransform: {
-        source: sourceCell.getAsNormalizedFullLink(),
+        source: sourceValueCell.getAsNormalizedFullLink(),
         filter: transform.filter?.source,
         schema: transform.projection?.source,
       },
@@ -1135,9 +1172,18 @@ export async function derivePieceGetValue(
   const result = runtime.run(
     tx,
     mainPattern,
-    { value: sourceCell.asSchema(sourceReadSchema) },
+    {
+      value: sourceValueCell.asSchema(sourceReadSchema).getAsLink({
+        includeSchema: true,
+        keepAsCell: KeepAsCell.OnlyStream,
+      }),
+    },
     resultCell,
   );
+  // Computed results can return an alias whose target carries a broader (or
+  // absent) schema. Re-assert the expression's declared result shape at the
+  // read boundary so following that alias cannot widen the projection.
+  const outputCell = result.key("value").asSchema(outputSchema);
   try {
     runtime.prepareTxForCommit(tx);
     const committed = await tx.commit();
@@ -1146,11 +1192,12 @@ export async function derivePieceGetValue(
         `Could not apply piece get transform: ${committed.error}`,
       );
     }
-    await result.pull();
+    await outputCell.pull();
     await runtime.idle();
     await runtime.storageManager.synced();
-    await result.pull();
+    await outputCell.pull();
     await runtime.idle();
+    const outputValue = outputCell.get();
     const recorded = errors.slice(errorCountBefore).at(-1);
     if (recorded !== undefined) {
       throw new PieceGetTransformError(
@@ -1158,7 +1205,7 @@ export async function derivePieceGetValue(
       );
     }
     deps.onResultCell?.(result as Cell<unknown>);
-    return result.key("value").get();
+    return outputValue;
   } finally {
     runtime.runner.stop(resultCell);
   }

--- a/packages/cli/test/piece-get-transform.test.ts
+++ b/packages/cli/test/piece-get-transform.test.ts
@@ -378,6 +378,155 @@ describe("cf piece get transforms", () => {
     ]);
   });
 
+  it("filters and projects through a linked array slot", async () => {
+    const tx = runtime.edit();
+    const list = runtime.getCell(
+      space,
+      "linked-transform-list",
+      {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            id: { type: "number" },
+            title: { type: "string" },
+          },
+        },
+      },
+      tx,
+    );
+    list.set([
+      { id: 1, title: "First" },
+      { id: 2, title: "Second" },
+    ]);
+    const container = runtime.getCell(
+      space,
+      "linked-transform-container",
+      {
+        type: "object",
+        properties: {
+          items: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                id: { type: "number" },
+                title: { type: "string" },
+              },
+            },
+            asCell: ["cell"],
+          },
+        },
+      },
+      tx,
+    );
+    container.set({ items: list as never });
+    expect((await tx.commit()).ok).toBeDefined();
+
+    expect(
+      await derivePieceGetValue(runtime, space, container.key("items"), {
+        filter: parsePieceGetFilter(".id == 2"),
+        projection: await parsePieceGetProjection("title"),
+      }),
+    ).toEqual([{ title: "Second" }]);
+  });
+
+  it("projects a linked object whose target has no schema", async () => {
+    const tx = runtime.edit();
+    const target = runtime.getCell(
+      space,
+      "linked-transform-schema-less-target",
+      undefined,
+      tx,
+    );
+    target.set({ title: "Visible", hidden: "not returned" });
+    const container = runtime.getCell(
+      space,
+      "linked-transform-schema-less-container",
+      {
+        type: "object",
+        properties: {
+          topic: {
+            type: "object",
+            properties: {
+              title: { type: "string" },
+              hidden: { type: "string" },
+            },
+            asCell: ["cell"],
+          },
+        },
+      },
+      tx,
+    );
+    container.set({ topic: target as never });
+    expect((await tx.commit()).ok).toBeDefined();
+
+    expect(
+      await derivePieceGetValue(runtime, space, container.key("topic"), {
+        projection: await parsePieceGetProjection("title"),
+      }),
+    ).toEqual({ title: "Visible" });
+  });
+
+  it("filters and projects a writable array value", async () => {
+    const tx = runtime.edit();
+    const first = runtime.getCell(
+      space,
+      "writable-transform-first",
+      {
+        type: "object",
+        properties: {
+          id: { type: "number" },
+          title: { type: "string" },
+        },
+      },
+      tx,
+    );
+    first.set({ id: 1, title: "First" });
+    const second = runtime.getCell(
+      space,
+      "writable-transform-second",
+      {
+        type: "object",
+        properties: {
+          id: { type: "number" },
+          title: { type: "string" },
+        },
+      },
+      tx,
+    );
+    second.set({ id: 2, title: "Second" });
+    const source = runtime.getCell(
+      space,
+      "writable-transform-list",
+      {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            id: { type: "number" },
+            title: { type: "string" },
+          },
+          asCell: ["cell"],
+        },
+        asCell: ["cell"],
+      },
+      tx,
+    );
+    source.set([
+      first,
+      second,
+    ]);
+    expect((await tx.commit()).ok).toBeDefined();
+
+    expect(
+      await derivePieceGetValue(runtime, space, source, {
+        filter: parsePieceGetFilter(".id == 2"),
+        projection: await parsePieceGetProjection("title"),
+      }),
+    ).toEqual([{ title: "Second" }]);
+  });
+
   it("does not leak nested siblings from overlapping concise paths", async () => {
     const tx = runtime.edit();
     const source = runtime.getCell(

--- a/packages/cli/test/piece-get-transform.test.ts
+++ b/packages/cli/test/piece-get-transform.test.ts
@@ -675,12 +675,13 @@ describe("cf piece get transforms", () => {
         properties: {
           id: { type: "number" },
           title: { type: "string" },
+          subtitle: { type: ["string", "null"] },
         },
-        required: ["id", "title"],
+        required: ["id", "title", "subtitle"],
       },
       tx,
     );
-    source.set({ id: 1, title: "Visible" });
+    source.set({ id: 1, title: "Visible", subtitle: null });
     expect((await tx.commit()).ok).toBeDefined();
 
     expect(
@@ -695,12 +696,24 @@ describe("cf piece get transforms", () => {
     ).toEqual({});
     expect(
       await derivePieceGetValue(runtime, space, source, {
+        projection: await parsePieceGetProjection(JSON.stringify({
+          type: "object",
+          properties: {
+            subtitle: { type: ["string", "null"] },
+          },
+          additionalProperties: false,
+        })),
+      }),
+    ).toEqual({ subtitle: null });
+    expect(
+      await derivePieceGetValue(runtime, space, source, {
         projection: await parsePieceGetProjection('{"type":"object"}'),
       }),
-    ).toEqual({ id: 1, title: "Visible" });
+    ).toEqual({ id: 1, title: "Visible", subtitle: null });
     expect(await derivePieceGetValue(runtime, space, source, {})).toEqual({
       id: 1,
       title: "Visible",
+      subtitle: null,
     });
   });
 

--- a/packages/cli/test/piece-get-transform.test.ts
+++ b/packages/cli/test/piece-get-transform.test.ts
@@ -431,6 +431,75 @@ describe("cf piece get transforms", () => {
     ).toEqual([{ title: "Second" }]);
   });
 
+  it("dereferences nested writable fields for filters and projections", async () => {
+    const tx = runtime.edit();
+    const author = runtime.getCell(
+      space,
+      "nested-writable-author",
+      {
+        type: "object",
+        properties: {
+          kind: { type: "string" },
+          name: { type: "string" },
+          privateEmail: { type: "string" },
+        },
+      },
+      tx,
+    );
+    author.set({
+      kind: "agent",
+      name: "Sol",
+      privateEmail: "sol@example.com",
+    });
+    const itemSchema = {
+      type: "object",
+      properties: {
+        title: { type: "string" },
+        createdBy: {
+          type: "object",
+          properties: {
+            kind: { type: "string" },
+            name: { type: "string" },
+            privateEmail: { type: "string" },
+          },
+          asCell: ["cell"],
+        },
+      },
+    } as const;
+    const source = runtime.getCell(
+      space,
+      "nested-writable-source",
+      { type: "array", items: itemSchema },
+      tx,
+    );
+    source.set([{ title: "T1", createdBy: author as never }]);
+    const direct = runtime.getCell(
+      space,
+      "nested-writable-direct-source",
+      itemSchema,
+      tx,
+    );
+    direct.set({ title: "T1", createdBy: author as never });
+    expect((await tx.commit()).ok).toBeDefined();
+
+    expect(
+      await derivePieceGetValue(runtime, space, source, {
+        projection: await parsePieceGetProjection("title,createdBy.name"),
+      }),
+    ).toEqual([{ title: "T1", createdBy: { name: "Sol" } }]);
+    expect(
+      await derivePieceGetValue(runtime, space, source, {
+        filter: parsePieceGetFilter('.createdBy.name == "Sol"'),
+        projection: await parsePieceGetProjection("title"),
+      }),
+    ).toEqual([{ title: "T1" }]);
+    expect(
+      await derivePieceGetValue(runtime, space, direct, {
+        projection: await parsePieceGetProjection("title,createdBy.name"),
+      }),
+    ).toEqual({ title: "T1", createdBy: { name: "Sol" } });
+  });
+
   it("projects a linked object whose target has no schema", async () => {
     const tx = runtime.edit();
     const target = runtime.getCell(
@@ -466,6 +535,37 @@ describe("cf piece get transforms", () => {
         projection: await parsePieceGetProjection("title"),
       }),
     ).toEqual({ title: "Visible" });
+  });
+
+  it("materializes a projection instead of aliasing its broader source", async () => {
+    const tx = runtime.edit();
+    const source = runtime.getCell(
+      space,
+      "non-aliasing-projection-source",
+      {
+        type: "object",
+        properties: {
+          title: { type: "string" },
+          hidden: { type: "string" },
+        },
+      },
+      tx,
+    );
+    source.set({ title: "Visible", hidden: "not returned" });
+    expect((await tx.commit()).ok).toBeDefined();
+
+    let outputCell: Cell<unknown> | undefined;
+    expect(
+      await derivePieceGetValue(runtime, space, source, {
+        projection: await parsePieceGetProjection("title"),
+      }, {
+        onOutputCell: (cell) => outputCell = cell,
+      }),
+    ).toEqual({ title: "Visible" });
+    expect(outputCell!.get()).toEqual({ title: "Visible" });
+    expect(outputCell!.resolveAsCell().getAsNormalizedFullLink().id).not.toBe(
+      source.getAsNormalizedFullLink().id,
+    );
   });
 
   it("filters and projects a writable array value", async () => {
@@ -602,6 +702,56 @@ describe("cf piece get transforms", () => {
       id: 1,
       title: "Visible",
     });
+  });
+
+  it("projects nested arrays with explicit item schemas", async () => {
+    const tx = runtime.edit();
+    const source = runtime.getCell(
+      space,
+      "nested-array-projection-source",
+      {
+        type: "object",
+        properties: {
+          comments: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                body: { type: "string" },
+                privateNote: { type: "string" },
+              },
+            },
+          },
+        },
+      },
+      tx,
+    );
+    source.set({
+      comments: [{ body: "Hello", privateNote: "not returned" }],
+    });
+    expect((await tx.commit()).ok).toBeDefined();
+
+    const projection = {
+      type: "object",
+      properties: {
+        comments: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              body: true,
+            },
+            additionalProperties: false,
+          },
+        },
+      },
+      additionalProperties: false,
+    };
+    expect(
+      await derivePieceGetValue(runtime, space, source, {
+        projection: await parsePieceGetProjection(JSON.stringify(projection)),
+      }),
+    ).toEqual({ comments: [{ body: "Hello" }] });
   });
 
   it("handles schema-less filters and identity projection schemas", async () => {
@@ -892,16 +1042,16 @@ describe("cf piece get transforms", () => {
       { type: "array", items: { asCell: ["cell"] } },
     );
 
-    let resultCell: Cell<unknown> | undefined;
+    let outputCell: Cell<unknown> | undefined;
     const result = await derivePieceGetValue(runtime, space, sourceRead, {
       filter: parsePieceGetFilter('.status == "open"'),
     }, {
-      onResultCell: (cell) => resultCell = cell,
+      onOutputCell: (cell) => outputCell = cell,
     });
     expect(result).toEqual([{ id: 1, status: "open" }]);
 
     const probeTx = runtime.edit();
-    const kept = resultCell!.key("value").withTx(probeTx).get() as unknown[];
+    const kept = outputCell!.withTx(probeTx).get() as unknown[];
     const probe = runtime.getCell(
       space,
       "filter-membership-probe",
@@ -942,16 +1092,16 @@ describe("cf piece get transforms", () => {
     source.set([{ id: 7, ignored: "not returned" }]);
     expect((await setup.commit()).ok).toBeDefined();
 
-    let resultCell: Cell<unknown> | undefined;
+    let outputCell: Cell<unknown> | undefined;
     const result = await derivePieceGetValue(runtime, space, source, {
       projection: await parsePieceGetProjection("id"),
     }, {
-      onResultCell: (cell) => resultCell = cell,
+      onOutputCell: (cell) => outputCell = cell,
     });
     expect(result).toEqual([{ id: 7 }]);
 
     const probeTx = runtime.edit();
-    const projectedId = resultCell!.key("value").key(0).key("id").withTx(
+    const projectedId = outputCell!.key(0).key("id").withTx(
       probeTx,
     ).get();
     const probe = runtime.getCell(

--- a/packages/patterns/topics/README.md
+++ b/packages/patterns/topics/README.md
@@ -85,7 +85,8 @@ piece:
 ```bash
 cf piece call --piece <board> addTopic \
   '{"title":"...","body":"the initial living document","agentName":"Sol"}'
-cf piece get  --piece <board> topics --input      # then address a topic piece
+cf piece get --piece <board> topics --input \
+  --schema title,createdAt,lastActivityAt,commentCount
 cf piece call --piece <topic> addComment \
   '{"body":"point-in-time progress update","agentName":"Sol"}'
 cf piece call --piece <topic> setBody \
@@ -93,6 +94,37 @@ cf piece call --piece <topic> setBody \
 cf piece call --piece <topic> addLink \
   '{"kind":"pr","url":"https://github.com/org/repo/pull/123","label":"PR #123","agentName":"Sol"}'
 ```
+
+The board input links to complete Topic objects, including bodies, threads,
+handlers, and cross-reference data. Headless discovery should therefore combine
+an exact/range `--filter` with a concise `--schema` instead of materializing the
+whole corpus:
+
+```bash
+cf piece get --piece <board> topics --input \
+  --filter '.title == "<exact title>"' \
+  --schema title,lastActivityAt,commentCount
+cf piece get --piece <board> topics --input \
+  --filter '.lastActivityAt >= <epoch-milliseconds>' \
+  --schema title,lastActivityAt,commentCount,createdBy.kind,createdBy.name
+cf piece get --piece <board> crossrefs --step \
+  --filter '.topic.title == "<exact title>"' \
+  --schema fid,topic.title,topic.lastActivityAt,topic.commentCount
+cf piece get --piece <topic> comments --input \
+  --filter '.author.name == "Sol" or .authorName == "Sol"' \
+  --schema sentAt,author.kind,author.name,authorName,body
+cf piece get --piece <topic> links --input \
+  --filter '.kind == "pr"' --schema kind,url,label,addedAt
+```
+
+Filtering happens before projection and preserves list order. The jq-inspired
+predicate subset supports paths, JSON literals, comparisons, boolean operators,
+and parentheses; it does not provide substring search, regexes, sorting, or an
+arbitrary jq pipeline. These transforms execute as a session-scoped computed
+pattern expression, so their CFC metadata behavior matches authored
+filter/map/lift expressions. The durable `topics --input` list remains evidence
+when the computed `crossrefs --step` index cannot materialize, but only a
+successful crossref row supplies the canonical Topic fid.
 
 Every agent-authored mutation carries `agentName`; there is no preceding “set
 current name” call. Fabric's operation history retains the authenticated human

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -236,13 +236,16 @@ fields apply per item for arrays, while JSON Schema describes the whole output.
 In an array-item projection, a typed scalar leaf that does not match stored data
 is omitted rather than reported as an error; prefer `true` leaves unless type
 filtering is intentional. Concise dotted paths do not traverse nested array
-items; use inline/file JSON Schema with `items` for that shape. The two flags
-compose as filter-then-project. Both run through runtime filter/map/lift nodes,
-which construct projected values from source-schema-selected reads, so CFC
-behavior is the same as a computed pattern expression. Source schema metadata is
-authoritative; projection schemas cannot supply `ifc`, `asCell`, `scope`, or
-`default`. See `packages/cli/README.md` for the exact syntax and supported
-schema subset.
+items; use inline/file JSON Schema with `items` for that shape. A concise
+projection over nullable array items can currently collapse the whole result to
+JSON `null`; filter null/unavailable items before projecting or preserve the
+item union in an explicit schema, and never treat that `null` as an empty list.
+The two flags compose as filter-then-project. Both run through runtime
+filter/map/lift nodes, which construct projected values from
+source-schema-selected reads, so CFC behavior is the same as a computed pattern
+expression. Source schema metadata is authoritative; projection schemas cannot
+supply `ifc`, `asCell`, `scope`, or `default`. See `packages/cli/README.md` for
+the exact syntax and supported schema subset.
 
 For `piece call`, options before the callable name configure `piece call`.
 Arguments after the callable name configure the invoked handler or tool. The

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -235,11 +235,14 @@ comma-separated field list, an inline JSON Schema, or `@schema.json`; concise
 fields apply per item for arrays, while JSON Schema describes the whole output.
 In an array-item projection, a typed scalar leaf that does not match stored data
 is omitted rather than reported as an error; prefer `true` leaves unless type
-filtering is intentional. The two flags compose as filter-then-project. Both run
-through runtime filter/map/lift nodes, so CFC behavior is the same as a computed
-pattern expression. Source schema metadata is authoritative; projection schemas
-cannot supply `ifc`, `asCell`, `scope`, or `default`. See
-`packages/cli/README.md` for the exact syntax and supported schema subset.
+filtering is intentional. Concise dotted paths do not traverse nested array
+items; use inline/file JSON Schema with `items` for that shape. The two flags
+compose as filter-then-project. Both run through runtime filter/map/lift nodes,
+which construct projected values from source-schema-selected reads, so CFC
+behavior is the same as a computed pattern expression. Source schema metadata is
+authoritative; projection schemas cannot supply `ifc`, `asCell`, `scope`, or
+`default`. See `packages/cli/README.md` for the exact syntax and supported
+schema subset.
 
 For `piece call`, options before the callable name configure `piece call`.
 Arguments after the callable name configure the invoked handler or tool. The

--- a/skills/topics/SKILL.md
+++ b/skills/topics/SKILL.md
@@ -54,8 +54,13 @@ body, comments, handlers, and reference graph.
 
 ```bash
 deno task cf piece get --url "$TOPICS_BOARD_URL" topics --input \
+  --filter '.title != null' \
   --schema title,createdAt,lastActivityAt,commentCount,createdBy.kind,createdBy.name
 ```
+
+The defensive title predicate removes null or currently unavailable rows before
+the concise projection. Without it, one such row can collapse the whole
+projected array to JSON `null`.
 
 `--filter` is useful for exact field and range searches. It runs before
 `--schema`, so a predicate can inspect a field that the result omits:
@@ -113,9 +118,9 @@ existing topic's input before changing it, especially its full body, comments,
 and links. Input reads are durable and do not need `--step`; use `--step` on
 result reads that must be current. If `topics --input` is non-empty but
 `crossrefs --step` is empty or fails, do not infer that the board is empty. The
-compact `topics --input` search remains valid evidence, but it does not expose a
-canonical Topic fid, so report the crossref materialization blocker rather than
-guessing an address.
+non-null rows from a compact `topics --input` search remain valid evidence, but
+the search does not expose a canonical Topic fid, so report the crossref
+materialization blocker rather than guessing an address.
 
 ## Creating and updating
 
@@ -184,6 +189,11 @@ verification succeeded.
 - If `topics --input` is non-empty while `crossrefs --step` is empty or fails,
   do not call the board empty. Preserve the input evidence and report the
   result-materialization failure.
+- If a compact Topic-array read with `--schema` returns JSON `null`, do not call
+  it empty or claim there were no matches. A null or unavailable element can
+  currently void the whole concise projection. Filter those rows before the
+  projection, for example with `--filter '.title != null'` on the board, and
+  report that unavailable entries may have been omitted.
 - Do not substitute `piece ls` for the board's topic list. Pieces created inside
   handlers can be absent from that listing; `crossrefs --step` is the canonical
   fid index, with `topics --input` as the durable fallback.

--- a/skills/topics/SKILL.md
+++ b/skills/topics/SKILL.md
@@ -179,7 +179,8 @@ verification succeeded.
 ## Troubleshooting
 
 - If initial CLI synchronization times out, no piece read or mutation ran.
-  Report the deployment or authorization blocker unless external state changes.
+  Report the blocker; rerun only after Tailnet/API reachability or identity
+  authorization has been re-established.
 - If `topics --input` is non-empty while `crossrefs --step` is empty or fails,
   do not call the board empty. Preserve the input evidence and report the
   result-materialization failure.

--- a/skills/topics/SKILL.md
+++ b/skills/topics/SKILL.md
@@ -48,17 +48,63 @@ set or copy them into agent mutations.
 
 ## Reading Topics
 
-Read the board's topic references from its input cell, then address a topic by
-the canonical fid published in the board's `crossrefs` result:
+The board's durable `topics` input is the reliable discovery corpus. Project it
+immediately: an unprojected row follows the linked Topic and can include its
+body, comments, handlers, and reference graph.
 
 ```bash
-deno task cf piece get --url "$TOPICS_BOARD_URL" topics --input
-deno task cf piece get --url "$TOPICS_BOARD_URL" crossrefs --step
+deno task cf piece get --url "$TOPICS_BOARD_URL" topics --input \
+  --schema title,createdAt,lastActivityAt,commentCount,createdBy.kind,createdBy.name
+```
+
+`--filter` is useful for exact field and range searches. It runs before
+`--schema`, so a predicate can inspect a field that the result omits:
+
+```bash
+# Find one Topic by exact title.
+deno task cf piece get --url "$TOPICS_BOARD_URL" topics --input \
+  --filter '.title == "<exact title>"' \
+  --schema title,lastActivityAt,commentCount
+
+# Find Topics active at or after an epoch-millisecond threshold.
+deno task cf piece get --url "$TOPICS_BOARD_URL" topics --input \
+  --filter '.lastActivityAt >= 1785074400000' \
+  --schema title,lastActivityAt,commentCount,createdBy.kind,createdBy.name
+
+# Combine predicates for a narrower field search.
+deno task cf piece get --url "$TOPICS_BOARD_URL" topics --input \
+  --filter '.createdBy.name == "<name>" and .commentCount > 0' \
+  --schema title,lastActivityAt,commentCount
+```
+
+Filtering preserves board order; it does not sort by activity. The predicate
+language supports paths, JSON literals, comparisons, boolean operators, and
+parentheses, but not substring, regex, sorting, or arbitrary jq programs. Use
+exact known fields or numeric ranges to shrink the corpus, then inspect the
+small result. Always combine a Topic-list filter with `--schema`; filter alone
+returns every property of each match.
+
+Address a selected Topic by the canonical fid published in the board's
+`crossrefs` result. Filter and project that computed index too:
+
+```bash
+deno task cf piece get --url "$TOPICS_BOARD_URL" crossrefs --step \
+  --filter '.topic.title == "<exact title>"' \
+  --schema fid,topic.title,topic.lastActivityAt,topic.commentCount
 export TOPIC_URL='https://estuary.saga-castor.ts.net/topics-dev-476ea34f/<topic-fid>'
 deno task cf piece get --url "$TOPIC_URL" title --input
 deno task cf piece get --url "$TOPIC_URL" body --input
-deno task cf piece get --url "$TOPIC_URL" comments --input
-deno task cf piece get --url "$TOPIC_URL" links --input
+deno task cf piece get --url "$TOPIC_URL" comments --input \
+  --schema sentAt,author.kind,author.name,authorName,body
+deno task cf piece get --url "$TOPIC_URL" links --input \
+  --schema kind,url,label,addedAt,addedBy.kind,addedBy.name
+
+# Search within a selected Topic's arrays.
+deno task cf piece get --url "$TOPIC_URL" comments --input \
+  --filter '.author.name == "<agent>" or .authorName == "<legacy name>"' \
+  --schema sentAt,author.kind,author.name,authorName,body
+deno task cf piece get --url "$TOPIC_URL" links --input \
+  --filter '.kind == "pr"' --schema kind,url,label,addedAt
 ```
 
 Each crossref row's `fid` is the canonical address for its `topic`. Prefer it to
@@ -66,7 +112,10 @@ the intermediate wrapper link stored in the board's topics array. Read the
 existing topic's input before changing it, especially its full body, comments,
 and links. Input reads are durable and do not need `--step`; use `--step` on
 result reads that must be current. If `topics --input` is non-empty but
-`crossrefs --step` is empty or fails, do not infer that the board is empty.
+`crossrefs --step` is empty or fails, do not infer that the board is empty. The
+compact `topics --input` search remains valid evidence, but it does not expose a
+canonical Topic fid, so report the crossref materialization blocker rather than
+guessing an address.
 
 ## Creating and updating
 
@@ -76,7 +125,8 @@ directly:
 ```bash
 deno task cf piece call --url "$TOPICS_BOARD_URL" addTopic \
   '{"title":"<title>","agentName":"<agent name>"}'
-deno task cf piece get --url "$TOPICS_BOARD_URL" crossrefs --step
+deno task cf piece get --url "$TOPICS_BOARD_URL" crossrefs --step \
+  --filter '.topic.title == "<exact title>"' --schema fid,topic.title
 ```
 
 Find the new topic's canonical fid in `crossrefs` before applying further
@@ -128,8 +178,8 @@ verification succeeded.
 
 ## Troubleshooting
 
-- If initial CLI synchronization times out, no piece read or mutation ran. Retry
-  once; if it repeats, report the deployment or authorization blocker.
+- If initial CLI synchronization times out, no piece read or mutation ran.
+  Report the deployment or authorization blocker unless external state changes.
 - If `topics --input` is non-empty while `crossrefs --step` is empty or fails,
   do not call the board empty. Preserve the input evidence and report the
   result-materialization failure.


### PR DESCRIPTION
## Summary

- make piece get filters and schemas operate on linked and Writable values used by Topics
- construct projected values inside the computed pattern so aliases cannot widen back to full runtime objects
- add coverage for linked arrays, schema-less linked objects, Writable arrays, and existing CFC behavior
- update the Topics skill and pattern guidance with compact discovery and exact/range searches

## Live verification

- exact-title filtering reduced an 83-topic board to one compact row
- a last-activity range search returned nine projected rows
- nested comment filtering returned three compact legacy-author matches
- direct projection of a linked Topic returned only title, activity, and count

The live board can still return null when a linked entry is unavailable, and its computed crossrefs index can fail to materialize. The updated guidance treats those as availability/materialization failures rather than evidence of an empty board.

## Validation

- deno check for the transform and tests
- 160 focused CLI test steps passed
- deno lint passed repo-wide
- deno task check-skill-facts passed
- targeted formatting passed

Repo-wide deno fmt --check remains blocked by 23 unrelated pre-existing formatting failures.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `cf piece get` so filters and projections work on linked and Writable values and return compact, schema-shaped results without alias widening. Projections now build values from source-schema reads, sanitize link handles (keep only stream handles), and preserve nulls and nested array shapes.

- **Bug Fixes**
  - Dereference `asCell` links and sanitize schemas with `sanitizeSchemaForLinks(KeepAsCell.OnlyStream)` before predicates/projections; materialize non-stream Cells.
  - Support linked array slots, schema-less linked objects, Writable arrays, and nested Writable fields; preserve nullable leaves and nested `items` arrays. Concise dotted paths don’t traverse array items—use JSON Schema `items`.
  - Construct projected values inside computed nodes and re-assert the output schema at the read boundary to prevent widening to broader linked targets.
  - Docs: clarify filter-then-project and array traversal; add Topics examples for exact/range `--filter` with concise `--schema`; note that concise projections over nullable array items can collapse to JSON `null` and should be guarded by filtering or explicit item unions.

<sup>Written for commit 355a200194a213801c7f37a2fbe173edf389b36d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

