### PR TITLE
fix(cli): make concise projections array-aware

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -157,9 +157,10 @@ properties, including `type` arrays and `anyOf` unions. When the source schema
 does not identify a nested container, the concise form applies the same field
 mask across arrays encountered in the value so siblings still cannot leak; use
 an explicit JSON Schema when the output schema itself must be fixed. If a
-transformed value is unavailable or rejected, the command exits nonzero and
-states that the failure is not JSON `null`; a printed `null` is therefore a
-valid projected null.
+present source value cannot materialize the transform, the command exits nonzero
+and states that the failure is not JSON `null`. An absent optional source
+remains the ordinary successful `null` CLI response, as does a valid projected
+null.
 
 Both transforms run as a short-lived computed pattern in the caller's session.
 The runtime's list filter/map builtins therefore handle CFC exactly as authored

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -149,13 +149,17 @@ Projection schemas support structural `properties`, `items`, and scalar leaf
 schemas. In an array-item projection, a scalar leaf whose declared type does not
 match the stored value is omitted by the runtime rather than reported as an
 error; prefer `true` leaves unless that type filtering is intentional. Schema
-combinators and references are rejected. Concise dotted paths traverse object
-properties, not nested array items: use an inline/file JSON Schema with `items`
-for a shape such as selected fields from every `comments` entry. A concise
-projection over nullable array items can currently return JSON `null` for the
-whole array when any item is null. Filter null/unavailable items before
-projecting, or use an explicit array schema whose `items` preserves the source
-nullability; do not interpret that JSON `null` as an empty result.
+combinators and references are rejected in caller-supplied projection schemas.
+Concise dotted paths follow the declared source schema through nested arrays, so
+`comments.body` selects `body` from every comment without retaining comment
+siblings. The projection preserves source-declared nullable items and
+properties, including `type` arrays and `anyOf` unions. When the source schema
+does not identify a nested container, the concise form applies the same field
+mask across arrays encountered in the value so siblings still cannot leak; use
+an explicit JSON Schema when the output schema itself must be fixed. If a
+transformed value is unavailable or rejected, the command exits nonzero and
+states that the failure is not JSON `null`; a printed `null` is therefore a
+valid projected null.
 
 Both transforms run as a short-lived computed pattern in the caller's session.
 The runtime's list filter/map builtins therefore handle CFC exactly as authored

--- a/packages/cli/lib/piece-get-transform.ts
+++ b/packages/cli/lib/piece-get-transform.ts
@@ -794,32 +794,40 @@ function schemaFromProjectionMask(mask: ProjectionMask): JSONSchema {
 /** @internal Exported for focused schema-shape tests. */
 export function schemaMayBeArray(
   schema: JSONSchema | undefined,
-  seen = new Set<object>(),
+  root: JSONSchema = schema ?? true,
+  ancestors = new Set<object>(),
 ): boolean {
   if (!isRecord(schema)) return false;
-  if (seen.has(schema)) return false;
-  seen.add(schema);
-  if (schema.$ref !== undefined) {
-    try {
-      return schemaMayBeArray(
-        ContextualFlowControl.resolveSchemaRefsOrThrow(schema, schema),
-        seen,
-      );
-    } catch (error) {
-      throw new PieceGetTransformError(
-        `Could not resolve source schema reference for --schema: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-        { cause: error },
-      );
+  if (ancestors.has(schema)) return false;
+  ancestors.add(schema);
+  const documentRoot = schema.$defs !== undefined ? schema : root;
+  try {
+    if (schema.$ref !== undefined) {
+      let resolved: JSONSchema;
+      try {
+        resolved = ContextualFlowControl.resolveSchemaRefsOrThrow(
+          schema,
+          documentRoot,
+        );
+      } catch (error) {
+        throw new PieceGetTransformError(
+          `Could not resolve source schema reference for --schema: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+          { cause: error },
+        );
+      }
+      return schemaMayBeArray(resolved, documentRoot, ancestors);
     }
+    if (schemaTypes(schema).includes("array")) return true;
+    return [
+      ...schema.anyOf ?? [],
+      ...schema.oneOf ?? [],
+      ...schema.allOf ?? [],
+    ].some((option) => schemaMayBeArray(option, documentRoot, ancestors));
+  } finally {
+    ancestors.delete(schema);
   }
-  if (schemaTypes(schema).includes("array")) return true;
-  return [
-    ...schema.anyOf ?? [],
-    ...schema.oneOf ?? [],
-    ...schema.allOf ?? [],
-  ].some((option) => schemaMayBeArray(option, seen));
 }
 
 function alignConciseProjectionMask(
@@ -831,10 +839,9 @@ function alignConciseProjectionMask(
 
   if (schemaMayBeArray(source)) {
     const sourceItem = schemaAtArrayItem(cfc, source);
-    const itemMask = mask.type === "array" ? mask.items : mask;
     return {
       type: "array",
-      items: alignConciseProjectionMask(cfc, sourceItem, itemMask),
+      items: alignConciseProjectionMask(cfc, sourceItem, mask),
     };
   }
 
@@ -872,6 +879,9 @@ function projectValue(
     );
   }
   if (!isRecord(value)) return value;
+  if (implicitArrayTraversal && schema.items !== undefined) {
+    return projectValue(value, schema.items, implicitArrayTraversal);
+  }
 
   const properties = schema.properties ?? {};
   const projected: Record<string, unknown> = {};
@@ -927,12 +937,18 @@ function maskFromPaths(
   return paths.length === 0 ? true : build(paths);
 }
 
-function mergeMasks(
+/** @internal Exported for focused mask-composition tests. */
+export function mergeMasks(
   left: PredicateMask,
   right: ProjectionMask,
 ): ProjectionMask {
   if (left === true || right === true) return true;
-  if (right.type !== "object") return true;
+  if (right.type === "array") {
+    return {
+      type: "array",
+      items: mergeMasks(left, right.items),
+    };
+  }
   const properties: Record<string, ProjectionMask> = {};
   for (
     const key of new Set([
@@ -951,10 +967,12 @@ function mergeMasks(
   return { type: "object", properties, additionalProperties: false };
 }
 
-function selectSourceSchema(
+/** @internal Exported for focused source-schema selection tests. */
+export function selectSourceSchema(
   cfc: ContextualFlowControl,
   source: JSONSchema | undefined,
   mask: ProjectionMask,
+  purpose: "source-read" | "projected-output" = "source-read",
 ): JSONSchema {
   // An absent/wildcard source schema cannot prove that a structural mask has
   // the same container shape as the current value. Keep that read permissive;
@@ -966,24 +984,36 @@ function selectSourceSchema(
   if (source.$ref !== undefined) {
     return source;
   }
-  if (source.anyOf !== undefined || source.oneOf !== undefined) {
+  if (
+    source.anyOf !== undefined || source.oneOf !== undefined ||
+    source.allOf !== undefined
+  ) {
     const {
-      anyOf: _anyOf,
-      oneOf: _oneOf,
+      anyOf,
+      oneOf,
+      allOf,
       ...metadata
     } = source;
-    const options = [...source.anyOf ?? [], ...source.oneOf ?? []].map(
-      (option) => selectSourceSchema(cfc, option, mask),
-    );
-    return { ...metadata, anyOf: options };
-  }
-  if (source.allOf !== undefined) {
-    const { allOf: _allOf, ...metadata } = source;
+    if (purpose === "source-read") {
+      // Projection can make formerly exclusive branches overlap or discard a
+      // discriminator altogether. Keep the declared composition intact at the
+      // read boundary; only the materialized output schema uses projected
+      // (existential) branches.
+      return source;
+    }
+    const projectOptions = (options: readonly JSONSchema[] | undefined) =>
+      options?.map((option) => selectSourceSchema(cfc, option, mask, purpose));
+    const projectedAnyOf = projectOptions(anyOf);
+    const projectedOneOf = projectOptions(oneOf);
+    const projectedAllOf = projectOptions(allOf);
+    const conjunctions = [
+      ...projectedAllOf ?? [],
+      ...(projectedOneOf === undefined ? [] : [{ anyOf: projectedOneOf }]),
+    ];
     return {
       ...metadata,
-      allOf: source.allOf.map((option) =>
-        selectSourceSchema(cfc, option, mask)
-      ),
+      ...(projectedAnyOf === undefined ? {} : { anyOf: projectedAnyOf }),
+      ...(conjunctions.length === 0 ? {} : { allOf: conjunctions }),
     };
   }
 
@@ -993,7 +1023,7 @@ function selectSourceSchema(
     const { items: _items, prefixItems: _prefixItems, ...metadata } = source;
     return {
       ...metadata,
-      items: selectSourceSchema(cfc, sourceItem, mask.items),
+      items: selectSourceSchema(cfc, sourceItem, mask.items, purpose),
     };
   }
 
@@ -1017,6 +1047,7 @@ function selectSourceSchema(
       cfc,
       child === false ? undefined : child,
       childMask,
+      purpose,
     );
   }
   const selectedRequired = required?.filter((key) => key in properties);
@@ -1062,9 +1093,10 @@ function resolveProjection(
         cfc,
         dereferencedElementSchema(source),
         mask,
+        "projected-output",
       ),
       KeepAsCell.OnlyStream,
-    ) ?? projectionSchema;
+    );
     return projectsArrayItems
       ? {
         outputSchema: filteredOutputSchema(sourceSchema, outputSchema),

--- a/packages/cli/lib/piece-get-transform.ts
+++ b/packages/cli/lib/piece-get-transform.ts
@@ -705,7 +705,7 @@ function dereferencedElementSchema(
 
 function filteredOutputSchema(
   sourceSchema: JSONSchema | undefined,
-  sourceItemSchema: JSONSchema | undefined,
+  outputItemSchema: JSONSchema | undefined,
 ): JSONSchema {
   if (!isRecord(sourceSchema)) {
     return { type: "array", items: true };
@@ -715,7 +715,7 @@ function filteredOutputSchema(
   return {
     ...metadata,
     type: "array",
-    items: dereferencedElementSchema(sourceItemSchema),
+    items: dereferencedElementSchema(outputItemSchema),
   };
 }
 
@@ -771,12 +771,105 @@ function projectionMask(schema: JSONSchema): ProjectionMask {
   return true;
 }
 
-function projectValue(value: unknown, schema: JSONSchema): unknown {
+function schemaFromProjectionMask(mask: ProjectionMask): JSONSchema {
+  if (mask === true) return true;
+  if (mask.type === "array") {
+    return {
+      type: "array",
+      items: schemaFromProjectionMask(mask.items),
+    };
+  }
+  return {
+    type: "object",
+    properties: Object.fromEntries(
+      Object.entries(mask.properties).map(([key, child]) => [
+        key,
+        schemaFromProjectionMask(child),
+      ]),
+    ),
+    additionalProperties: false,
+  };
+}
+
+/** @internal Exported for focused schema-shape tests. */
+export function schemaMayBeArray(
+  schema: JSONSchema | undefined,
+  seen = new Set<object>(),
+): boolean {
+  if (!isRecord(schema)) return false;
+  if (seen.has(schema)) return false;
+  seen.add(schema);
+  if (schema.$ref !== undefined) {
+    try {
+      return schemaMayBeArray(
+        ContextualFlowControl.resolveSchemaRefsOrThrow(schema, schema),
+        seen,
+      );
+    } catch (error) {
+      throw new PieceGetTransformError(
+        `Could not resolve source schema reference for --schema: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        { cause: error },
+      );
+    }
+  }
+  if (schemaTypes(schema).includes("array")) return true;
+  return [
+    ...schema.anyOf ?? [],
+    ...schema.oneOf ?? [],
+    ...schema.allOf ?? [],
+  ].some((option) => schemaMayBeArray(option, seen));
+}
+
+function alignConciseProjectionMask(
+  cfc: ContextualFlowControl,
+  source: JSONSchema | undefined,
+  mask: ProjectionMask,
+): ProjectionMask {
+  if (mask === true || source === undefined || source === true) return mask;
+
+  if (schemaMayBeArray(source)) {
+    const sourceItem = schemaAtArrayItem(cfc, source);
+    const itemMask = mask.type === "array" ? mask.items : mask;
+    return {
+      type: "array",
+      items: alignConciseProjectionMask(cfc, sourceItem, itemMask),
+    };
+  }
+
+  const objectMask = mask as ObjectProjectionMask;
+  return {
+    ...objectMask,
+    properties: Object.fromEntries(
+      Object.entries(objectMask.properties).map(([key, childMask]) => {
+        const child = cfc.schemaAtPath(source, [key]);
+        return [
+          key,
+          alignConciseProjectionMask(
+            cfc,
+            child === false ? undefined : child,
+            childMask,
+          ),
+        ];
+      }),
+    ),
+  };
+}
+
+function projectValue(
+  value: unknown,
+  schema: JSONSchema,
+  implicitArrayTraversal = false,
+): unknown {
   if (typeof schema === "boolean") return schema ? value : undefined;
   if (value === null) return value;
   if (Array.isArray(value)) {
-    const itemSchema = schema.items ?? true;
-    return value.map((item) => projectValue(item, itemSchema));
+    const itemSchema = schema.items ??
+      (implicitArrayTraversal ? schema : true);
+    return value.map((item) =>
+      projectValue(item, itemSchema, implicitArrayTraversal)
+    );
   }
   if (!isRecord(value)) return value;
 
@@ -786,12 +879,22 @@ function projectValue(value: unknown, schema: JSONSchema): unknown {
     for (const [key, child] of Object.entries(value)) {
       const childSchema = properties[key] ?? schema.additionalProperties ??
         true;
-      projected[key] = projectValue(child, childSchema);
+      projected[key] = projectValue(
+        child,
+        childSchema,
+        implicitArrayTraversal,
+      );
     }
     return projected;
   }
   for (const [key, childSchema] of Object.entries(properties)) {
-    if (key in value) projected[key] = projectValue(value[key], childSchema);
+    if (key in value) {
+      projected[key] = projectValue(
+        value[key],
+        childSchema,
+        implicitArrayTraversal,
+      );
+    }
   }
   return projected;
 }
@@ -853,15 +956,35 @@ function selectSourceSchema(
   source: JSONSchema | undefined,
   mask: ProjectionMask,
 ): JSONSchema {
-  if (source === undefined || source === true) return mask;
+  // An absent/wildcard source schema cannot prove that a structural mask has
+  // the same container shape as the current value. Keep that read permissive;
+  // the materializing projector still applies the mask and drops siblings.
+  if (source === undefined || source === true) return true;
   if (source === false || mask === true || !isRecord(mask)) {
     return source;
   }
-  if (
-    source.$ref !== undefined || source.anyOf !== undefined ||
-    source.oneOf !== undefined || source.allOf !== undefined
-  ) {
+  if (source.$ref !== undefined) {
     return source;
+  }
+  if (source.anyOf !== undefined || source.oneOf !== undefined) {
+    const {
+      anyOf: _anyOf,
+      oneOf: _oneOf,
+      ...metadata
+    } = source;
+    const options = [...source.anyOf ?? [], ...source.oneOf ?? []].map(
+      (option) => selectSourceSchema(cfc, option, mask),
+    );
+    return { ...metadata, anyOf: options };
+  }
+  if (source.allOf !== undefined) {
+    const { allOf: _allOf, ...metadata } = source;
+    return {
+      ...metadata,
+      allOf: source.allOf.map((option) =>
+        selectSourceSchema(cfc, option, mask)
+      ),
+    };
   }
 
   if (mask.type === "array") {
@@ -870,7 +993,6 @@ function selectSourceSchema(
     const { items: _items, prefixItems: _prefixItems, ...metadata } = source;
     return {
       ...metadata,
-      type: "array",
       items: selectSourceSchema(cfc, sourceItem, mask.items),
     };
   }
@@ -900,7 +1022,6 @@ function selectSourceSchema(
   const selectedRequired = required?.filter((key) => key in properties);
   return {
     ...metadata,
-    type: "object",
     properties,
     ...(selectedRequired?.length ? { required: selectedRequired } : {}),
     additionalProperties: false,
@@ -909,26 +1030,61 @@ function selectSourceSchema(
 
 interface ResolvedProjection {
   outputSchema: JSONSchema;
+  projectionSchema: JSONSchema;
+  mask: ProjectionMask;
   projectsArrayItems: boolean;
-  itemSchema?: JSONSchema;
+  itemOutputSchema?: JSONSchema;
+  itemProjectionSchema?: JSONSchema;
+  itemMask?: ProjectionMask;
+  implicitArrayTraversal: boolean;
 }
 
 function resolveProjection(
+  cfc: ContextualFlowControl,
   projection: PieceGetProjection | undefined,
+  sourceSchema: JSONSchema | undefined,
   sourceIsArray: boolean,
 ): ResolvedProjection | undefined {
   if (projection === undefined) return undefined;
   if (projection.kind === "concise") {
     const projectsArrayItems = sourceIsArray;
+    const source = projectsArrayItems
+      ? schemaAtArrayItem(cfc, sourceSchema)
+      : sourceSchema;
+    const mask = alignConciseProjectionMask(
+      cfc,
+      source,
+      projectionMask(projection.schema),
+    );
+    const projectionSchema = schemaFromProjectionMask(mask);
+    const outputSchema = sanitizeSchemaForLinks(
+      selectSourceSchema(
+        cfc,
+        dereferencedElementSchema(source),
+        mask,
+      ),
+      KeepAsCell.OnlyStream,
+    ) ?? projectionSchema;
     return projectsArrayItems
       ? {
-        outputSchema: { type: "array", items: projection.schema },
+        outputSchema: filteredOutputSchema(sourceSchema, outputSchema),
+        projectionSchema: {
+          type: "array",
+          items: projectionSchema,
+        },
+        mask: { type: "array", items: mask },
         projectsArrayItems: true,
-        itemSchema: projection.schema,
+        itemOutputSchema: outputSchema,
+        itemProjectionSchema: projectionSchema,
+        itemMask: mask,
+        implicitArrayTraversal: true,
       }
       : {
-        outputSchema: projection.schema,
+        outputSchema,
+        projectionSchema,
+        mask,
         projectsArrayItems: false,
+        implicitArrayTraversal: true,
       };
   }
   const projectsArrayItems = schemaIsArray(projection.schema);
@@ -943,13 +1099,21 @@ function resolveProjection(
         : "An array-rooted JSON --schema can only be applied to an array value.",
     );
   }
+  const mask = projectionMask(projection.schema);
+  const itemSchema = projectsArrayItems
+    ? (projection.schema as Exclude<JSONSchema, boolean>).items ?? true
+    : undefined;
   return {
     outputSchema: projection.schema,
+    projectionSchema: projection.schema,
+    mask,
     projectsArrayItems,
+    implicitArrayTraversal: false,
     ...(projectsArrayItems
       ? {
-        itemSchema: (projection.schema as Exclude<JSONSchema, boolean>).items ??
-          true,
+        itemOutputSchema: itemSchema,
+        itemProjectionSchema: itemSchema,
+        itemMask: projectionMask(itemSchema!),
       }
       : {}),
   };
@@ -998,19 +1162,17 @@ export async function derivePieceGetValue(
     );
   }
   const projection = resolveProjection(
+    cfc,
     transform.projection,
+    sourceSchema,
     Array.isArray(sourceValue),
   );
   const sourceItemSchema = schemaAtArrayItem(cfc, sourceSchema);
   const predicateItemMask = transform.filter === undefined
     ? undefined
     : maskFromPaths(transform.filter.paths);
-  const projectionMaskSchema = projection === undefined
-    ? undefined
-    : projectionMask(projection.outputSchema);
-  const projectionItemMask = projection?.projectsArrayItems
-    ? projectionMask(projection.itemSchema!)
-    : undefined;
+  const projectionMaskSchema = projection?.mask;
+  const projectionItemMask = projection?.itemMask;
 
   let sourceMask: ProjectionMask = true;
   if (transform.filter !== undefined && projection === undefined) {
@@ -1078,7 +1240,8 @@ export async function derivePieceGetValue(
 
   let itemProjectionPattern: ReturnType<typeof pattern> | undefined;
   if (projection?.projectsArrayItems) {
-    const itemSchema = projection.itemSchema!;
+    const itemOutputSchema = projection.itemOutputSchema!;
+    const itemProjectionSchema = projection.itemProjectionSchema!;
     const elementSchema = selectSourceSchema(
       cfc,
       sourceItemSchema,
@@ -1096,14 +1259,19 @@ export async function derivePieceGetValue(
       additionalProperties: false,
     };
     const projectionModule = lift(
-      ({ element }: { element: unknown }) => projectValue(element, itemSchema),
+      ({ element }: { element: unknown }) =>
+        projectValue(
+          element,
+          itemProjectionSchema,
+          projection.implicitArrayTraversal,
+        ),
       argumentSchema,
-      itemSchema,
+      itemOutputSchema,
     );
     itemProjectionPattern = pattern(
       ({ element }: any) => projectionModule({ element }),
       argumentSchema,
-      itemSchema,
+      itemOutputSchema,
     );
   }
 
@@ -1122,7 +1290,11 @@ export async function derivePieceGetValue(
       !projection.projectsArrayItems
     ? lift(
       ({ value }: { value: unknown }) =>
-        projectValue(value, projection.outputSchema),
+        projectValue(
+          value,
+          projection.projectionSchema,
+          projection.implicitArrayTraversal,
+        ),
       directProjectionArgumentSchema,
       projection.outputSchema,
     )

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -2229,13 +2229,15 @@ export async function getCellValue(
         }
         throw error;
       }
+      const sourceWasAbsent = typeof targetCell.getRaw === "function" &&
+        targetCell.getRaw() === undefined;
       if (
         !options.input && transformed === undefined &&
         await resultProjectionFailedAtPath(piece, path)
       ) {
         throw new PieceResultProjectionError(path, shouldStep);
       }
-      if (transformed === undefined) {
+      if (transformed === undefined && !sourceWasAbsent) {
         throw new PieceGetTransformError(
           "Cannot read transformed value: the filter/schema expression did " +
             "not materialize a JSON-renderable value. This is not JSON " +

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -75,6 +75,7 @@ import { stderrConsoleHandler } from "./json-output.ts";
 import {
   derivePieceGetValue,
   type PieceGetTransform,
+  PieceGetTransformError,
 } from "./piece-get-transform.ts";
 
 export interface EntryConfig {
@@ -2233,6 +2234,14 @@ export async function getCellValue(
         await resultProjectionFailedAtPath(piece, path)
       ) {
         throw new PieceResultProjectionError(path, shouldStep);
+      }
+      if (transformed === undefined) {
+        throw new PieceGetTransformError(
+          "Cannot read transformed value: the filter/schema expression did " +
+            "not materialize a JSON-renderable value. This is not JSON " +
+            "null. Retry with --step for a computed result, or inspect the " +
+            "selected source data and schema.",
+        );
       }
       return transformed;
     }

--- a/packages/cli/test/piece-get-transform.test.ts
+++ b/packages/cli/test/piece-get-transform.test.ts
@@ -2,15 +2,22 @@ import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import type { FabricValue } from "@commonfabric/data-model/interface";
 import { Identity } from "@commonfabric/identity";
-import { type Cell, type JSONSchema, Runtime } from "@commonfabric/runner";
+import {
+  type Cell,
+  ContextualFlowControl,
+  type JSONSchema,
+  Runtime,
+} from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import {
   derivePieceGetValue,
   evaluatePieceGetPredicate,
+  mergeMasks,
   parsePieceGetFilter,
   parsePieceGetProjection,
   PieceGetTransformError,
   schemaMayBeArray,
+  selectSourceSchema,
 } from "../lib/piece-get-transform.ts";
 
 const signer = await Identity.fromPassphrase("cf-piece-get-transform");
@@ -236,15 +243,54 @@ describe("cf piece get transforms", () => {
   it("detects arrays through refs and cyclic schema compositions", () => {
     const cyclic: Record<string, unknown> = {};
     cyclic.anyOf = [cyclic, { type: "array" }];
+    const rootDefs: JSONSchema = {
+      $ref: "#/$defs/Node",
+      $defs: {
+        Node: {
+          anyOf: [
+            { $ref: "#/$defs/Leaf" },
+            { $ref: "#/$defs/Branch" },
+          ],
+        },
+        Leaf: { type: "object" },
+        Branch: { type: "array", items: { $ref: "#/$defs/Leaf" } },
+      },
+    };
 
     expect(schemaMayBeArray(false)).toBe(false);
     expect(schemaMayBeArray(cyclic as JSONSchema)).toBe(true);
+    expect(schemaMayBeArray(rootDefs)).toBe(true);
     expect(() =>
       schemaMayBeArray({
         $ref: "#/$defs/Missing",
         $defs: {},
       })
     ).toThrow("Could not resolve source schema reference for --schema");
+  });
+
+  it("merges predicate reads through aligned array masks", () => {
+    expect(mergeMasks(
+      {
+        type: "object",
+        properties: { body: true },
+        additionalProperties: false,
+      },
+      {
+        type: "array",
+        items: {
+          type: "object",
+          properties: { author: true },
+          additionalProperties: false,
+        },
+      },
+    )).toEqual({
+      type: "array",
+      items: {
+        type: "object",
+        properties: { body: true, author: true },
+        additionalProperties: false,
+      },
+    });
   });
 
   it("collapses overlapping concise paths without exposing siblings", async () => {
@@ -1055,17 +1101,24 @@ describe("cf piece get transforms", () => {
         properties: {
           comments: {
             $ref: "#/$defs/Comments",
-            $defs: {
-              Comments: {
-                type: "array",
-                items: {
-                  type: "object",
-                  properties: {
-                    body: { type: "string" },
-                    privateNote: { type: "string" },
-                  },
-                },
-              },
+          },
+        },
+        $defs: {
+          Comments: {
+            anyOf: [
+              { $ref: "#/$defs/CommentList" },
+              { type: "null" },
+            ],
+          },
+          CommentList: {
+            type: "array",
+            items: { $ref: "#/$defs/Comment" },
+          },
+          Comment: {
+            type: "object",
+            properties: {
+              body: { type: "string" },
+              privateNote: { type: "string" },
             },
           },
         },
@@ -1105,6 +1158,93 @@ describe("cf piece get transforms", () => {
         projection: await parsePieceGetProjection("comments.body"),
       }),
     ).toEqual({ comments: [{ body: "Visible" }] });
+  });
+
+  it("does not leak siblings when a nested value may be an array or object", async () => {
+    const variants: JSONSchema[] = [
+      {
+        anyOf: [
+          {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                body: { type: "string" },
+                privateNote: { type: "string" },
+              },
+            },
+          },
+          {
+            type: "object",
+            properties: {
+              body: { type: "string" },
+              privateNote: { type: "string" },
+            },
+          },
+        ],
+      },
+      {
+        type: ["array", "object"],
+        items: {
+          type: "object",
+          properties: {
+            body: { type: "string" },
+            privateNote: { type: "string" },
+          },
+        },
+        properties: {
+          body: { type: "string" },
+          privateNote: { type: "string" },
+        },
+      },
+    ];
+
+    for (const [index, entrySchema] of variants.entries()) {
+      const tx = runtime.edit();
+      const source = runtime.getCell(
+        space,
+        `array-object-union-${index}`,
+        {
+          type: "object",
+          properties: { entry: entrySchema },
+        },
+        tx,
+      );
+      source.set({
+        entry: { body: "Visible", privateNote: "hidden" },
+      });
+      expect((await tx.commit()).ok).toBeDefined();
+
+      expect(
+        await derivePieceGetValue(runtime, space, source, {
+          projection: await parsePieceGetProjection("entry.body"),
+        }),
+      ).toEqual({ entry: { body: "Visible" } });
+    }
+  });
+
+  it("keeps anyOf and oneOf constraints distinct on source reads", () => {
+    const source: JSONSchema = {
+      anyOf: [{ type: "string" }, { type: "number" }],
+      oneOf: [{ const: "a" }, { const: "b" }],
+      allOf: [{ type: "string" }],
+    };
+    const mask = {
+      type: "object" as const,
+      properties: { body: true as const },
+      additionalProperties: false as const,
+    };
+    const cfc = new ContextualFlowControl();
+    expect(selectSourceSchema(cfc, source, mask)).toBe(source);
+    expect(
+      selectSourceSchema(cfc, source, mask, "projected-output"),
+    ).toEqual({
+      anyOf: source.anyOf,
+      allOf: [
+        { type: "string" },
+        { anyOf: source.oneOf },
+      ],
+    });
   });
 
   it("handles schema-less filters and identity projection schemas", async () => {

--- a/packages/cli/test/piece-get-transform.test.ts
+++ b/packages/cli/test/piece-get-transform.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import type { FabricValue } from "@commonfabric/data-model/interface";
 import { Identity } from "@commonfabric/identity";
-import { type Cell, Runtime } from "@commonfabric/runner";
+import { type Cell, type JSONSchema, Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import {
   derivePieceGetValue,
@@ -10,6 +10,7 @@ import {
   parsePieceGetFilter,
   parsePieceGetProjection,
   PieceGetTransformError,
+  schemaMayBeArray,
 } from "../lib/piece-get-transform.ts";
 
 const signer = await Identity.fromPassphrase("cf-piece-get-transform");
@@ -230,6 +231,20 @@ describe("cf piece get transforms", () => {
     } finally {
       await Deno.remove(path);
     }
+  });
+
+  it("detects arrays through refs and cyclic schema compositions", () => {
+    const cyclic: Record<string, unknown> = {};
+    cyclic.anyOf = [cyclic, { type: "array" }];
+
+    expect(schemaMayBeArray(false)).toBe(false);
+    expect(schemaMayBeArray(cyclic as JSONSchema)).toBe(true);
+    expect(() =>
+      schemaMayBeArray({
+        $ref: "#/$defs/Missing",
+        $defs: {},
+      })
+    ).toThrow("Could not resolve source schema reference for --schema");
   });
 
   it("collapses overlapping concise paths without exposing siblings", async () => {
@@ -765,6 +780,331 @@ describe("cf piece get transforms", () => {
         projection: await parsePieceGetProjection(JSON.stringify(projection)),
       }),
     ).toEqual({ comments: [{ body: "Hello" }] });
+  });
+
+  it("preserves nullable array items through concise projections", async () => {
+    const tx = runtime.edit();
+    const source = runtime.getCell(
+      space,
+      "nullable-concise-projection-source",
+      {
+        type: "array",
+        items: {
+          type: ["object", "null"],
+          properties: {
+            name: { type: "string" },
+            secret: { type: "string" },
+          },
+        },
+      },
+      tx,
+    );
+    source.set([{ name: "a", secret: "hidden" }, null]);
+    expect((await tx.commit()).ok).toBeDefined();
+
+    expect(await derivePieceGetValue(runtime, space, source, {})).toEqual([
+      { name: "a", secret: "hidden" },
+      null,
+    ]);
+    expect(
+      await derivePieceGetValue(runtime, space, source, {
+        filter: parsePieceGetFilter('.name == "a"'),
+      }),
+    ).toEqual([{ name: "a", secret: "hidden" }]);
+    expect(
+      await derivePieceGetValue(runtime, space, source, {
+        projection: await parsePieceGetProjection("name"),
+      }),
+    ).toEqual([{ name: "a" }, null]);
+    expect(
+      await derivePieceGetValue(runtime, space, source, {
+        projection: await parsePieceGetProjection(JSON.stringify({
+          type: "array",
+          items: {
+            type: ["object", "null"],
+            properties: { name: true },
+            additionalProperties: false,
+          },
+        })),
+      }),
+    ).toEqual([{ name: "a" }, null]);
+  });
+
+  it("projects concise paths through nested and repeated arrays", async () => {
+    const tx = runtime.edit();
+    const source = runtime.getCell(
+      space,
+      "nested-concise-array-projection-source",
+      {
+        type: "object",
+        properties: {
+          comments: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                body: { type: "string" },
+                privateNote: { type: "string" },
+                replies: {
+                  type: "array",
+                  items: {
+                    type: "object",
+                    properties: {
+                      body: { type: "string" },
+                      privateNote: { type: "string" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      tx,
+    );
+    source.set({
+      comments: [{
+        body: "Top level",
+        privateNote: "hidden",
+        replies: [{ body: "Nested", privateNote: "also hidden" }],
+      }],
+    });
+    expect((await tx.commit()).ok).toBeDefined();
+
+    expect(
+      await derivePieceGetValue(runtime, space, source, {
+        projection: await parsePieceGetProjection(
+          "comments.body,comments.replies.body",
+        ),
+      }),
+    ).toEqual({
+      comments: [{
+        body: "Top level",
+        replies: [{ body: "Nested" }],
+      }],
+    });
+  });
+
+  it("preserves nullable property unions independently of their parent", async () => {
+    for (const additionalProperties of [false, true]) {
+      const tx = runtime.edit();
+      const source = runtime.getCell(
+        space,
+        `nullable-property-${additionalProperties}`,
+        {
+          type: "object",
+          properties: {
+            profiles: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  profile: {
+                    type: ["object", "null"],
+                    properties: {
+                      name: { type: "string" },
+                      secret: { type: "string" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          additionalProperties,
+        },
+        tx,
+      );
+      source.set({
+        profiles: [
+          { profile: { name: "Ada", secret: "hidden" } },
+          { profile: null },
+        ],
+      });
+      expect((await tx.commit()).ok).toBeDefined();
+
+      expect(
+        await derivePieceGetValue(runtime, space, source, {
+          projection: await parsePieceGetProjection("profiles.profile.name"),
+        }),
+      ).toEqual({
+        profiles: [{ profile: { name: "Ada" } }, { profile: null }],
+      });
+    }
+  });
+
+  it("preserves anyOf nullability in concise array projections", async () => {
+    const tx = runtime.edit();
+    const source = runtime.getCell(
+      space,
+      "any-of-nullable-concise-source",
+      {
+        type: "array",
+        items: {
+          anyOf: [
+            {
+              type: "object",
+              properties: {
+                name: { type: "string" },
+                secret: { type: "string" },
+              },
+            },
+            { type: "null" },
+          ],
+        },
+      },
+      tx,
+    );
+    source.set([{ name: "Ada", secret: "hidden" }, null]);
+    expect((await tx.commit()).ok).toBeDefined();
+
+    expect(
+      await derivePieceGetValue(runtime, space, source, {
+        projection: await parsePieceGetProjection("name"),
+      }),
+    ).toEqual([{ name: "Ada" }, null]);
+  });
+
+  it("projects concise fields through allOf source schemas", async () => {
+    const tx = runtime.edit();
+    const source = runtime.getCell(
+      space,
+      "all-of-concise-source",
+      {
+        type: "array",
+        items: {
+          allOf: [
+            {
+              type: "object",
+              properties: { name: { type: "string" } },
+            },
+            {
+              type: "object",
+              properties: { secret: { type: "string" } },
+            },
+          ],
+        },
+      },
+      tx,
+    );
+    source.set([{ name: "Ada", secret: "hidden" }]);
+    expect((await tx.commit()).ok).toBeDefined();
+
+    expect(
+      await derivePieceGetValue(runtime, space, source, {
+        projection: await parsePieceGetProjection("name"),
+      }),
+    ).toEqual([{ name: "Ada" }]);
+  });
+
+  it("projects concise paths through a linked nested array", async () => {
+    const tx = runtime.edit();
+    const comments = runtime.getCell(
+      space,
+      "linked-nested-comments",
+      {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            body: { type: "string" },
+            privateNote: { type: "string" },
+          },
+        },
+      },
+      tx,
+    );
+    comments.set([{ body: "Visible", privateNote: "hidden" }]);
+    const source = runtime.getCell(
+      space,
+      "linked-nested-array-source",
+      {
+        type: "object",
+        properties: {
+          comments: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                body: { type: "string" },
+                privateNote: { type: "string" },
+              },
+            },
+            asCell: ["cell"],
+          },
+        },
+      },
+      tx,
+    );
+    source.set({ comments: comments as never });
+    expect((await tx.commit()).ok).toBeDefined();
+
+    expect(
+      await derivePieceGetValue(runtime, space, source, {
+        projection: await parsePieceGetProjection("comments.body"),
+      }),
+    ).toEqual({ comments: [{ body: "Visible" }] });
+  });
+
+  it("projects concise array paths through source schema references", async () => {
+    const tx = runtime.edit();
+    const source = runtime.getCell(
+      space,
+      "referenced-nested-array-source",
+      {
+        type: "object",
+        properties: {
+          comments: {
+            $ref: "#/$defs/Comments",
+            $defs: {
+              Comments: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    body: { type: "string" },
+                    privateNote: { type: "string" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      tx,
+    );
+    source.set({
+      comments: [{ body: "Visible", privateNote: "hidden" }],
+    });
+    expect((await tx.commit()).ok).toBeDefined();
+
+    expect(
+      await derivePieceGetValue(runtime, space, source, {
+        projection: await parsePieceGetProjection("comments.body"),
+      }),
+    ).toEqual({ comments: [{ body: "Visible" }] });
+  });
+
+  it("does not leak siblings when a nested array schema is ambiguous", async () => {
+    const tx = runtime.edit();
+    const source = runtime.getCell(
+      space,
+      "ambiguous-nested-array-source",
+      {
+        type: "object",
+        properties: { comments: true },
+      },
+      tx,
+    );
+    source.set({
+      comments: [{ body: "Visible", privateNote: "hidden" }],
+    });
+    expect((await tx.commit()).ok).toBeDefined();
+
+    expect(
+      await derivePieceGetValue(runtime, space, source, {
+        projection: await parsePieceGetProjection("comments.body"),
+      }),
+    ).toEqual({ comments: [{ body: "Visible" }] });
   });
 
   it("handles schema-less filters and identity projection schemas", async () => {

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -50,6 +50,7 @@ import {
 } from "../commands/piece.ts";
 import {
   parsePieceGetFilter,
+  parsePieceGetProjection,
   PieceGetTransformError,
 } from "../lib/piece-get-transform.ts";
 
@@ -723,6 +724,54 @@ describe("cli piece parsing", () => {
         derivePieceGetValue: () => Promise.resolve(undefined),
       },
     )).rejects.toThrow(PieceResultProjectionError);
+  });
+
+  it("distinguishes an unavailable transformed value from JSON null", async () => {
+    const targetCell = {
+      schema: { type: ["object", "null"] },
+      getRaw: () => undefined,
+    };
+    const rootCell = { key: () => targetCell };
+    const controller = {
+      get: () =>
+        Promise.resolve({
+          input: { getCell: () => Promise.resolve(rootCell) },
+        }),
+    };
+
+    const options = {
+      input: true,
+      transform: { projection: await parsePieceGetProjection("id") },
+    };
+    const deps = {
+      loadManager: () =>
+        Promise.resolve({
+          runtime: {},
+          getSpace: () => "did:key:test-space",
+        } as any),
+      resolvePieceAddress: (_manager: any, id: string) => Promise.resolve(id),
+      createController: () => controller as any,
+    };
+
+    await expect(getCellValue(
+      { apiUrl: API_URL, space: SPACE, identity: ID, piece: PIECE },
+      ["value"],
+      options,
+      {
+        ...deps,
+        derivePieceGetValue: () => Promise.resolve(undefined),
+      },
+    )).rejects.toThrow("This is not JSON null");
+
+    await expect(getCellValue(
+      { apiUrl: API_URL, space: SPACE, identity: ID, piece: PIECE },
+      ["value"],
+      options,
+      {
+        ...deps,
+        derivePieceGetValue: () => Promise.resolve(null),
+      },
+    )).resolves.toBeNull();
   });
 
   it("steps, reads, syncs, and stops in one get operation", async () => {

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -726,10 +726,11 @@ describe("cli piece parsing", () => {
     )).rejects.toThrow(PieceResultProjectionError);
   });
 
-  it("distinguishes an unavailable transformed value from JSON null", async () => {
+  it("distinguishes failed transforms, JSON null, and absent sources", async () => {
+    let sourceRaw: unknown;
     const targetCell = {
       schema: { type: ["object", "null"] },
-      getRaw: () => undefined,
+      getRaw: () => sourceRaw,
     };
     const rootCell = { key: () => targetCell };
     const controller = {
@@ -759,10 +760,14 @@ describe("cli piece parsing", () => {
       options,
       {
         ...deps,
-        derivePieceGetValue: () => Promise.resolve(undefined),
+        derivePieceGetValue: () => {
+          sourceRaw = { id: "loaded-during-transform" };
+          return Promise.resolve(undefined);
+        },
       },
     )).rejects.toThrow("This is not JSON null");
 
+    sourceRaw = null;
     await expect(getCellValue(
       { apiUrl: API_URL, space: SPACE, identity: ID, piece: PIECE },
       ["value"],
@@ -772,6 +777,17 @@ describe("cli piece parsing", () => {
         derivePieceGetValue: () => Promise.resolve(null),
       },
     )).resolves.toBeNull();
+
+    sourceRaw = undefined;
+    await expect(getCellValue(
+      { apiUrl: API_URL, space: SPACE, identity: ID, piece: PIECE },
+      ["value"],
+      options,
+      {
+        ...deps,
+        derivePieceGetValue: () => Promise.resolve(undefined),
+      },
+    )).resolves.toBeUndefined();
   });
 
   it("steps, reads, syncs, and stops in one get operation", async () => {

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -235,11 +235,13 @@ comma-separated field list, an inline JSON Schema, or `@schema.json`; concise
 fields apply per item for arrays, while JSON Schema describes the whole output.
 In an array-item projection, a typed scalar leaf that does not match stored data
 is omitted rather than reported as an error; prefer `true` leaves unless type
-filtering is intentional. Concise dotted paths do not traverse nested array
-items; use inline/file JSON Schema with `items` for that shape. A concise
-projection over nullable array items can currently collapse the whole result to
-JSON `null`; filter null/unavailable items before projecting or preserve the
-item union in an explicit schema, and never treat that `null` as an empty list.
+filtering is intentional. Concise dotted paths follow declared source schemas
+through nested arrays: `comments.body` selects `body` from every comment and
+drops its siblings. Source-declared nullable items and properties remain null;
+an unavailable or rejected transformed value exits nonzero with an explicit "not
+JSON null" error. If the source schema does not identify a nested container,
+concise projection still applies its field mask across encountered arrays to
+prevent sibling disclosure; use an explicit schema for a fixed output contract.
 The two flags compose as filter-then-project. Both run through runtime
 filter/map/lift nodes, which construct projected values from
 source-schema-selected reads, so CFC behavior is the same as a computed pattern

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -237,13 +237,14 @@ In an array-item projection, a typed scalar leaf that does not match stored data
 is omitted rather than reported as an error; prefer `true` leaves unless type
 filtering is intentional. Concise dotted paths follow declared source schemas
 through nested arrays: `comments.body` selects `body` from every comment and
-drops its siblings. Source-declared nullable items and properties remain null;
-an unavailable or rejected transformed value exits nonzero with an explicit "not
-JSON null" error. If the source schema does not identify a nested container,
-concise projection still applies its field mask across encountered arrays to
-prevent sibling disclosure; use an explicit schema for a fixed output contract.
-The two flags compose as filter-then-project. Both run through runtime
-filter/map/lift nodes, which construct projected values from
+drops its siblings. Source-declared nullable items and properties remain null.
+If a present source cannot materialize the transform, the command exits nonzero
+with an explicit "not JSON null" error; an absent optional source retains the
+ordinary successful `null` response. If the source schema does not identify a
+nested container, concise projection still applies its field mask across
+encountered arrays to prevent sibling disclosure; use an explicit schema for a
+fixed output contract. The two flags compose as filter-then-project. Both run
+through runtime filter/map/lift nodes, which construct projected values from
 source-schema-selected reads, so CFC behavior is the same as a computed pattern
 expression. Source schema metadata is authoritative; projection schemas cannot
 supply `ifc`, `asCell`, `scope`, or `default`. See `packages/cli/README.md` for

--- a/skills/topics/SKILL.md
+++ b/skills/topics/SKILL.md
@@ -58,9 +58,9 @@ deno task cf piece get --url "$TOPICS_BOARD_URL" topics --input \
   --schema title,createdAt,lastActivityAt,commentCount,createdBy.kind,createdBy.name
 ```
 
-The defensive title predicate removes null or currently unavailable rows before
-the concise projection. Without it, one such row can collapse the whole
-projected array to JSON `null`.
+The title predicate keeps discovery output uniformly object-shaped by omitting
+valid null rows. Concise projection itself preserves nullable rows and follows
+declared nested arrays without exposing sibling fields.
 
 `--filter` is useful for exact field and range searches. It runs before
 `--schema`, so a predicate can inspect a field that the result omits:
@@ -189,11 +189,10 @@ verification succeeded.
 - If `topics --input` is non-empty while `crossrefs --step` is empty or fails,
   do not call the board empty. Preserve the input evidence and report the
   result-materialization failure.
-- If a compact Topic-array read with `--schema` returns JSON `null`, do not call
-  it empty or claim there were no matches. A null or unavailable element can
-  currently void the whole concise projection. Filter those rows before the
-  projection, for example with `--filter '.title != null'` on the board, and
-  report that unavailable entries may have been omitted.
+- A compact transformed read exits nonzero when its value is unavailable or
+  rejected and explicitly says the failure is not JSON `null`. A printed `null`
+  is a valid projected null, not an empty array or proof of no matches; use
+  `--filter '.title != null'` when null Topic rows are irrelevant.
 - Do not substitute `piece ls` for the board's topic list. Pieces created inside
   handlers can be absent from that listing; `crossrefs --step` is the canonical
   fid index, with `topics --input` as the durable fallback.

--- a/skills/topics/SKILL.md
+++ b/skills/topics/SKILL.md
@@ -189,10 +189,11 @@ verification succeeded.
 - If `topics --input` is non-empty while `crossrefs --step` is empty or fails,
   do not call the board empty. Preserve the input evidence and report the
   result-materialization failure.
-- A compact transformed read exits nonzero when its value is unavailable or
-  rejected and explicitly says the failure is not JSON `null`. A printed `null`
-  is a valid projected null, not an empty array or proof of no matches; use
-  `--filter '.title != null'` when null Topic rows are irrelevant.
+- A compact transformed read of a present source exits nonzero when its value
+  cannot materialize and explicitly says the failure is not JSON `null`. A
+  printed `null` is a valid projected null or an absent optional source, not an
+  empty array or proof of no matches; use `--filter '.title != null'` when null
+  Topic rows are irrelevant.
 - Do not substitute `piece ls` for the board's topic list. Pieces created inside
   handlers can be absent from that listing; `crossrefs --step` is the canonical
   fid index, with `topics --input` as the durable fallback.


### PR DESCRIPTION
## Summary

- make concise `cf piece get --schema` paths traverse declared nested and repeated arrays
- preserve source-declared nullable items and properties through projection
- distinguish unavailable transformed values from valid JSON `null`
- update CLI, CF, and Topics guidance for the corrected behavior

## Linear

- [CT-1932](https://linear.app/common-tools/issue/CT-1932/cf-piece-get-preserve-nullable-linked-array-entries-through)
- [CT-1934](https://linear.app/common-tools/issue/CT-1934/cf-piece-get-make-concise-schema-paths-array-and-union-aware)

## Verification

- `deno test -A packages/cli/test/piece-get-transform.test.ts` — 39 steps passed
- `deno test -A packages/cli/test/piece.test.ts` — 66 steps passed
- focused coverage — no uncovered executable lines in either changed implementation file
- `deno check packages/cli/mod.ts`
- `deno lint`
- touched-file `deno fmt --check`
- `deno task check-docs`
- `deno task check-skill-facts`
- CF and Topics skill validation

The full CLI package suite passed 1,650 tests and failed two unrelated existing color/TTY assertions in `color-mode.test.ts`. Repository-wide `deno fmt --check` also reports 23 unrelated pre-existing files; every file changed by this PR passes formatting.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make concise `cf piece get --schema` projections array- and union-aware, preserve source-declared nullability, and clearly fail when a transformed value can’t materialize (not JSON null). Addresses CT-1932 and CT-1934.

- New Features
  - Concise dotted paths follow declared arrays across nested and repeated arrays (e.g., `comments.body`), aligning through `$ref`, `anyOf`, `oneOf`, and `allOf`. When a nested container isn’t identified by the source schema, the same field mask is applied across encountered arrays to prevent sibling leakage; use explicit JSON Schema when you need a fixed output shape.
  - Union-aware selection: respects `type` arrays plus `anyOf`/`oneOf`/`allOf` during projection; keeps read-time compositions intact and derives existential branches only for the materialized output schema.

- Bug Fixes
  - Preserve nullable items and properties through projection, including linked arrays (CT-1932).
  - Distinguish an unavailable/rejected transformed value from JSON `null`; command exits nonzero with a clear message, while absent optional sources and valid projected nulls remain successful.

<sup>Written for commit dd86e4e70ff88bdb7f13f7575d3bbb6b8ad02d29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

