### PR TITLE
fix(runner): log the silent resume owned-cell skip; name the of:/computed: pair (CT-1940, CT-1943)

### DIFF
--- a/docs/development/debugging/README.md
+++ b/docs/development/debugging/README.md
@@ -115,7 +115,9 @@ guide:
 
 - [Console Commands](console-commands.md) - `globalThis.commonfabric.*` browser console reference
   - Starts with common tasks: read piece data, dump the rendered VDOM, diagnose
-    churn, find dead handlers, watch values, agent-browser recipes
+    churn, find dead handlers, watch values, agent-browser recipes — including
+    why a sub-pattern's cell reads `undefined` at an `of:` id while its value
+    lives at the `computed:` id of the same hash
   - Reference tail covers logger counts/timing/baselines/flags and worker traces
 - **Server-side write trace** — set `CF_DEBUG_MEMORY_WRITES=1` on the toolshed to
   log every memory write as `[memwrite] c=<conn> op=… id=… scope=… vhash=…`,

--- a/docs/development/debugging/README.md
+++ b/docs/development/debugging/README.md
@@ -116,7 +116,7 @@ guide:
 - [Console Commands](console-commands.md) - `globalThis.commonfabric.*` browser console reference
   - Starts with common tasks: read piece data, dump the rendered VDOM, diagnose
     churn, find dead handlers, watch values, agent-browser recipes — including
-    why a sub-pattern's cell reads `undefined` at an `of:` id while its value
+    why a sub-pattern's cell can read `undefined` at an `of:` id while its value
     lives at the `computed:` id of the same hash
   - Reference tail covers logger counts/timing/baselines/flags and worker traces
 - **Server-side write trace** — set `CF_DEBUG_MEMORY_WRITES=1` on the toolshed to

--- a/docs/development/debugging/console-commands.md
+++ b/docs/development/debugging/console-commands.md
@@ -48,28 +48,38 @@ Always check the actual stored value before assuming a write failed — see
 
 ### A sub-pattern's cell reads as `undefined` at the id you have
 
-A sub-pattern node's output spot exists as **two entity ids that differ only by
-URI scheme**: `of:fid1:<hash>` and `computed:fid1:<hash>`. Both are minted from
-the same cause, so they share a hash — the scheme carries the entity kind, and
-the kind is part of the identity, so these are two distinct entities. See
-[computed cell identity](../../specs/computed-cell-identity.md).
+`instantiatePatternNode` (`packages/runner/src/runner.ts`) binds a sub-pattern
+node's output spot twice, from the same cause, so both mints share a hash:
 
-The runner mints both, for different jobs (`instantiatePatternNode`,
-`packages/runner/src/runner.ts`):
+- the **identity bind** never sees the pattern's `derivedInternalCells`
+  manifest, so it has no entity kind and always lands on `of:fid1:<hash>`. Its
+  job is to name the child result cell as its `resultFor` cause, and it is the
+  spot the resume owned-cell walk keys on;
+- the **value bind** sees the manifest, so it mints under the descriptor's kind
+  — and the child link is sent to whatever that bind produced, so that is the
+  id holding the value.
 
-- **`of:fid1:<hash>` is identity only.** It names the child result cell as its
-  `resultFor` cause, and it is the spot the resume owned-cell walk keys on.
-  Nothing writes a value there.
-- **`computed:fid1:<hash>` holds the value.** The child link is sent to this
-  one, so this is the id to read.
+Whether those are one entity or two therefore depends on the descriptor. The
+URI scheme carries the kind, and the kind is part of the identity (see
+[computed cell identity](../../specs/computed-cell-identity.md)):
 
-A read at the `of:` id therefore returns `undefined` for a perfectly healthy
-piece — that is the expected answer at that id, not evidence that a sub-piece
-is missing. Read the `computed:` id before concluding anything:
+- **descriptor classified `kind: "computed"`** — the value bind mints
+  `computed:fid1:<hash>`, a **distinct entity from `of:fid1:<hash>`, differing
+  only by scheme**. Nothing writes a value at the `of:` id, so a read there
+  returns `undefined` for a perfectly healthy piece — that is the expected
+  answer at that id, not evidence that a sub-piece is missing. Read the
+  `computed:` id before concluding anything;
+- **kindless descriptor** — the classifier declined the node, or
+  `experimental.computedCellIds` is off (see
+  [experimental options](../EXPERIMENTAL_OPTIONS.md)). Both binds land on the
+  same `of:fid1:<hash>` entity, and the child link is written there. A read at
+  the `of:` id returns the value, and there is no `computed:` sibling.
+
+So an `undefined` read is only diagnostic once you have tried both ids:
 
 ```javascript
 // Shown at module scope.
-// Same hash, two kinds — read the computed one for the value.
+// Same hash, two possible kinds — try both before concluding anything.
 await commonfabric.readCell({ space: "did:key:z6Mkm...", id: "of:fid1:HASH" })
 await commonfabric.readCell({
   space: "did:key:z6Mkm...",
@@ -77,12 +87,12 @@ await commonfabric.readCell({
 })
 ```
 
-The same trap applies to any offline scan that enumerates a space by matching
-the `of:fid1:` prefix: it will not see the cells holding sub-pattern children.
-In `cf inspect` output the distinction is there but quiet — it abbreviates ids
-by stripping `of:` while keeping a `computed:` scheme visible, so a bare
-`fid1:<hash>` in a row is the `of:` form and its `computed:` sibling is a
-separate row.
+Where the pair does exist, the same trap applies to any offline scan that
+enumerates a space by matching the `of:fid1:` prefix: it will not see the cells
+holding sub-pattern children. In `cf inspect` output the distinction is there
+but quiet — it abbreviates ids by stripping `of:` while keeping a `computed:`
+scheme visible, so a bare `fid1:<hash>` in a row is the `of:` form and its
+`computed:` sibling, when there is one, is a separate row.
 
 ### What's actually rendered?
 

--- a/docs/development/debugging/console-commands.md
+++ b/docs/development/debugging/console-commands.md
@@ -46,6 +46,44 @@ await commonfabric.readArgumentCell({ path: ["name"] })
 Always check the actual stored value before assuming a write failed — see
 [browser-stale-ui](gotchas/browser-stale-ui.md).
 
+### A sub-pattern's cell reads as `undefined` at the id you have
+
+A sub-pattern node's output spot exists as **two entity ids that differ only by
+URI scheme**: `of:fid1:<hash>` and `computed:fid1:<hash>`. Both are minted from
+the same cause, so they share a hash — the scheme carries the entity kind, and
+the kind is part of the identity, so these are two distinct entities. See
+[computed cell identity](../../specs/computed-cell-identity.md).
+
+The runner mints both, for different jobs (`instantiatePatternNode`,
+`packages/runner/src/runner.ts`):
+
+- **`of:fid1:<hash>` is identity only.** It names the child result cell as its
+  `resultFor` cause, and it is the spot the resume owned-cell walk keys on.
+  Nothing writes a value there.
+- **`computed:fid1:<hash>` holds the value.** The child link is sent to this
+  one, so this is the id to read.
+
+A read at the `of:` id therefore returns `undefined` for a perfectly healthy
+piece — that is the expected answer at that id, not evidence that a sub-piece
+is missing. Read the `computed:` id before concluding anything:
+
+```javascript
+// Shown at module scope.
+// Same hash, two kinds — read the computed one for the value.
+await commonfabric.readCell({ space: "did:key:z6Mkm...", id: "of:fid1:HASH" })
+await commonfabric.readCell({
+  space: "did:key:z6Mkm...",
+  id: "computed:fid1:HASH",
+})
+```
+
+The same trap applies to any offline scan that enumerates a space by matching
+the `of:fid1:` prefix: it will not see the cells holding sub-pattern children.
+In `cf inspect` output the distinction is there but quiet — it abbreviates ids
+by stripping `of:` while keeping a `computed:` scheme visible, so a bare
+`fid1:<hash>` in a row is the `of:` form and its `computed:` sibling is a
+separate row.
+
 ### What's actually rendered?
 
 ```javascript

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -3818,9 +3818,23 @@ export class Runner {
         // outputs bound, but held no write redirect the scan could resolve
         // (e.g. they consist only of deferred partialCause aliases, which
         // denote a deeper level's derived internal cells rather than this
-        // node's reserved result spot). Log it at the same level and with the
-        // same identity as its sibling, so neither exit is silent.
-        logger.warn("resume-owned-cells", () => [
+        // node's reserved result spot).
+        //
+        // DEBUG, not warn: this is the BY-DESIGN outcome for such outputs, not
+        // a failure. #5143 deliberately moved that case off the throwing path,
+        // and ordinary healthy runs of the home pattern take this exit several
+        // times per resume — warning here would be noise, not signal. It still
+        // hides a skipped subtree, so it carries the same key and the same
+        // identity payload as its sibling, and turning this logger up to debug
+        // brings it back for someone tracing a stranded piece:
+        // `commonfabric.logger["runner"].level = "debug"` on the main thread,
+        // `commonfabric.rt.setLoggerLevel("debug", "runner")` for the worker
+        // the runner actually lives in. (`CF_LOG_LEVEL` will NOT do it: it is a
+        // floor, and this logger's own configured level — `warn` — is the more
+        // restrictive of the two.) A console filter on `resume-owned-cells`
+        // then catches both exits. `resume-owned-cells-skip-log.test.ts` pins
+        // the level in both directions.
+        logger.debug("resume-owned-cells", () => [
           "skipping a sub-pattern node whose outputs resolved to no write redirect",
           describeSkippedSubPatternNode(link, nodeIndex, node, childPattern),
         ]);
@@ -6379,13 +6393,16 @@ export class Runner {
         sourceSchemas: { argument: pattern.argumentSchema },
       },
     );
-    // VALUE BIND (kind: `computed:`). Binding WITH the manifest resolves a
+    // VALUE BIND (kind: the descriptor's). Binding WITH the manifest resolves a
     // partialCause output to the descriptor's derived internal cell, so
-    // `getDerivedInternalCellLink` mints its id under the descriptor's kind —
-    // `computed:fid1:<hash>` for an ordinary derived internal cell. This is the
-    // binding the child link is SENT to (`sendValueToBinding` below), so this
-    // is where the child's value actually lives. The identity bind below
-    // resolves the SAME hash under the `of:` kind; see it for the pairing.
+    // `getDerivedInternalCellLink` mints its id under the descriptor's kind:
+    // `computed:fid1:<hash>` for a descriptor classified `kind: "computed"`,
+    // and the same `of:fid1:<hash>` the identity bind below mints for a kindless
+    // one (the classifier declines the node, or `experimental.computedCellIds`
+    // is off). This is the binding the child link is SENT to
+    // (`sendValueToBinding` below), so this is where the child's value actually
+    // lives — at a DIFFERENT entity from the identity bind's only when the
+    // descriptor carries a kind. See the identity bind for the pairing.
     const outputs = unwrapOneLevelAndBindToDoc(
       this.runtime.cfc,
       outputBindings,
@@ -6427,20 +6444,26 @@ export class Runner {
       // instantiate, so skip that work; we only need the pseudo-cell aliases
       // resolved to their concrete links.
       //
-      // IDENTITY BIND (kind: `of:`). CT-1943: this omits
+      // IDENTITY BIND (kind: always `of:`). CT-1943: this omits
       // `derivedInternalCells` where the value bind above passes it, and the
       // manifest descriptor is what carries the entity kind. Same cause, same
-      // hash preimage — but no descriptor means no kind, so the mint falls back
-      // to the unkinded `of:fid1:<hash>` while the value bind used the
-      // descriptor's kind, `computed:fid1:<hash>` whenever the internal is
-      // classified computed (docs/specs/computed-cell-identity.md: the preimage
-      // is kind-free, the URI scheme IS the kind). Those are then two distinct
-      // entities differing only by scheme; only for a kind-less descriptor do
-      // the two binds land on the same entity. The split is fine here, and in
-      // `collectResumeOwnedCells`, because both use the link purely as the
-      // `resultFor` CAUSE — a stable coordinate, never read for a value.
-      // Anything that wants to READ the child link must use the `computed:`
-      // id; reading the `of:` one returns undefined for a healthy piece.
+      // hash preimage — but no descriptor means no kind, so this mint always
+      // lands on the unkinded `of:fid1:<hash>`
+      // (docs/specs/computed-cell-identity.md: the preimage is kind-free, the
+      // URI scheme IS the kind). Whether that is a SECOND entity depends on the
+      // descriptor the value bind saw:
+      //   - descriptor with `kind: "computed"` — the value bind minted
+      //     `computed:fid1:<hash>`, so the two binds address two distinct
+      //     entities that differ only by scheme, and the child link lives on
+      //     the `computed:` one;
+      //   - kindless descriptor (the classifier declined the node, or
+      //     `experimental.computedCellIds` is off) — both binds land on this
+      //     same `of:` entity, and the child link is written here.
+      // The split is fine here, and in `collectResumeOwnedCells`, because both
+      // use the link purely as the `resultFor` CAUSE — a stable coordinate,
+      // never read for a value. But anything that wants to READ the child link
+      // must use the id the VALUE bind minted: where the descriptor was
+      // computed, reading the `of:` one returns undefined for a healthy piece.
       const mappedOutputBindings = unwrapOneLevelAndBindToDoc(
         this.runtime.cfc,
         outputBindings,

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -26,6 +26,7 @@ import {
   JSONValue,
   type Module,
   NAME,
+  type Node,
   type NodeFactory,
   type Pattern,
   UI,
@@ -516,6 +517,27 @@ export function firstResolvedOutputRedirect(
     }
   }
   return undefined;
+}
+
+/**
+ * Identity for a sub-pattern node the resume owned-cell walk skipped, shared by
+ * both of `collectResumeOwnedCells`'s skip exits so a console trace names the
+ * same things either way: the result cell being resumed and enough about the
+ * node to find it in the pattern that was resumed.
+ */
+function describeSkippedSubPatternNode(
+  resultCellLink: NormalizedFullLink,
+  nodeIndex: number,
+  node: Node,
+  childPattern: Pattern,
+): Record<string, unknown> {
+  return {
+    resultCell: resultCellLink.id,
+    space: resultCellLink.space,
+    nodeIndex,
+    ...(node.description !== undefined && { node: node.description }),
+    childPattern: describePatternOrModule(childPattern),
+  };
 }
 
 const recordSetupProjectionPolicyInputs = (
@@ -3746,7 +3768,7 @@ export class Runner {
     // (CT-1897).
     const argumentLink = getMetaLink(resultCell, "argument");
 
-    for (const node of pattern.nodes) {
+    for (const [nodeIndex, node] of pattern.nodes.entries()) {
       const module = node.module;
       if (module.type !== "pattern" || !isPattern(module.implementation)) {
         continue;
@@ -3785,10 +3807,25 @@ export class Runner {
         logger.warn("resume-owned-cells", () => [
           "skipping a sub-pattern node whose outputs did not bind or resolve",
           error,
+          describeSkippedSubPatternNode(link, nodeIndex, node, childPattern),
         ]);
         continue;
       }
-      if (spotLink === undefined) continue;
+      if (spotLink === undefined) {
+        // The same two skips as the catch above — this node's owned-cell
+        // pre-sync AND the recursion that would reach the child's own
+        // `derivedInternalCells` manifest — reached without an error: the
+        // outputs bound, but held no write redirect the scan could resolve
+        // (e.g. they consist only of deferred partialCause aliases, which
+        // denote a deeper level's derived internal cells rather than this
+        // node's reserved result spot). Log it at the same level and with the
+        // same identity as its sibling, so neither exit is silent.
+        logger.warn("resume-owned-cells", () => [
+          "skipping a sub-pattern node whose outputs resolved to no write redirect",
+          describeSkippedSubPatternNode(link, nodeIndex, node, childPattern),
+        ]);
+        continue;
+      }
       let childResultCell = this.runtime.getCell(
         targetSpace,
         {
@@ -6342,6 +6379,13 @@ export class Runner {
         sourceSchemas: { argument: pattern.argumentSchema },
       },
     );
+    // VALUE BIND (kind: `computed:`). Binding WITH the manifest resolves a
+    // partialCause output to the descriptor's derived internal cell, so
+    // `getDerivedInternalCellLink` mints its id under the descriptor's kind —
+    // `computed:fid1:<hash>` for an ordinary derived internal cell. This is the
+    // binding the child link is SENT to (`sendValueToBinding` below), so this
+    // is where the child's value actually lives. The identity bind below
+    // resolves the SAME hash under the `of:` kind; see it for the pairing.
     const outputs = unwrapOneLevelAndBindToDoc(
       this.runtime.cfc,
       outputBindings,
@@ -6382,6 +6426,21 @@ export class Runner {
       // `bindPatterns: false` — output bindings never carry sub-patterns to
       // instantiate, so skip that work; we only need the pseudo-cell aliases
       // resolved to their concrete links.
+      //
+      // IDENTITY BIND (kind: `of:`). CT-1943: this omits
+      // `derivedInternalCells` where the value bind above passes it, and the
+      // manifest descriptor is what carries the entity kind. Same cause, same
+      // hash preimage — but no descriptor means no kind, so the mint falls back
+      // to the unkinded `of:fid1:<hash>` while the value bind used the
+      // descriptor's kind, `computed:fid1:<hash>` whenever the internal is
+      // classified computed (docs/specs/computed-cell-identity.md: the preimage
+      // is kind-free, the URI scheme IS the kind). Those are then two distinct
+      // entities differing only by scheme; only for a kind-less descriptor do
+      // the two binds land on the same entity. The split is fine here, and in
+      // `collectResumeOwnedCells`, because both use the link purely as the
+      // `resultFor` CAUSE — a stable coordinate, never read for a value.
+      // Anything that wants to READ the child link must use the `computed:`
+      // id; reading the `of:` one returns undefined for a healthy piece.
       const mappedOutputBindings = unwrapOneLevelAndBindToDoc(
         this.runtime.cfc,
         outputBindings,

--- a/packages/runner/test/resume-owned-cells-skip-log.test.ts
+++ b/packages/runner/test/resume-owned-cells-skip-log.test.ts
@@ -1,0 +1,150 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { getLoggerCountsBreakdown } from "@commonfabric/utils/logger";
+import type { Pattern } from "../src/builder/types.ts";
+import { Runtime } from "../src/runtime.ts";
+import { trustExecutable } from "./support/trusted-builder.ts";
+
+// The resume owned-cell walk (collectResumeOwnedCells) has TWO exits that skip
+// the same work — a sub-pattern node's owned-cell pre-sync AND the recursion
+// that would reach that child's own derivedInternalCells manifest. One is the
+// catch around binding/resolution; the other is the resolution simply coming
+// back undefined, which happens when a node's outputs hold no write redirect
+// the scan can resolve (outputs consisting only of deferred partialCause
+// aliases are the shape seen live). Neither exit may be silent: the pre-sync
+// prevents the cold-cache commit-revert race, and a skipped subtree is
+// otherwise only discoverable by console probing.
+//
+// resume-output-redirect-partialcause.test.ts asserts the scan's return value;
+// this asserts the consequence at the call site.
+
+const signer = await Identity.fromPassphrase("resume owned cells skip log");
+const space = signer.did();
+
+const ownedCellWarns = (): number => {
+  const counts = getLoggerCountsBreakdown()["runner"] ?? {};
+  return (counts as Record<string, { warn?: number }>)["resume-owned-cells"]
+    ?.warn ?? 0;
+};
+
+/**
+ * Run `fn` with `console.warn` captured. The runner logger writes warns to
+ * `console.warn` unless `LOG_TO_STDERR=1`, so that sink is forced off for the
+ * duration and restored afterwards.
+ */
+const captureWarnings = async (
+  fn: () => Promise<void>,
+): Promise<unknown[][]> => {
+  const captured: unknown[][] = [];
+  const originalWarn = console.warn;
+  const originalStderrFlag = Deno.env.get("LOG_TO_STDERR");
+  Deno.env.set("LOG_TO_STDERR", "0");
+  console.warn = (...args: unknown[]) => {
+    captured.push(args);
+  };
+  try {
+    await fn();
+  } finally {
+    console.warn = originalWarn;
+    if (originalStderrFlag === undefined) Deno.env.delete("LOG_TO_STDERR");
+    else Deno.env.set("LOG_TO_STDERR", originalStderrFlag);
+  }
+  return captured;
+};
+
+// A sub-pattern node whose whole outputs record holds only a DEFERRED
+// partialCause alias. Such an alias denotes a derived internal cell of the
+// level it was deferred to, never this node's reserved result spot, so
+// firstResolvedOutputRedirect returns undefined for the node as a whole and the
+// walk skips it.
+const childPattern: Pattern = {
+  argumentSchema: {},
+  resultSchema: {},
+  result: {},
+  nodes: [],
+};
+
+const patternWithUnresolvableSubPatternOutputs = {
+  argumentSchema: {},
+  resultSchema: {},
+  result: {},
+  nodes: [
+    {
+      description: "sub-pattern node with no resolvable output spot",
+      module: { type: "pattern", implementation: childPattern },
+      inputs: {},
+      outputs: {
+        generated: {
+          $alias: { partialCause: { "$generated": 0 }, path: [], defer: 1 },
+        },
+      },
+    },
+  ],
+} as unknown as Pattern;
+
+describe("resume owned-cell walk skip logging", () => {
+  it("warns, with node identity, when a sub-pattern node's outputs resolve to no redirect", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    try {
+      // Seed run: a trivial pattern whose setup writes the result cell's
+      // argument meta link, so the resume below is a real resume.
+      const seedPattern: Pattern = {
+        argumentSchema: {},
+        resultSchema: {},
+        result: {},
+        nodes: [],
+      };
+      const rt1 = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager,
+      });
+      const rc1 = rt1.getCell(space, "owned-cells-skip-log");
+      await rt1.runSynced(rc1, trustExecutable(rt1, seedPattern), {});
+      await rc1.pull();
+      await rt1.dispose();
+
+      const rt2 = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager,
+      });
+      const rc2 = rt2.getCell(space, "owned-cells-skip-log");
+      const resultCellId = rc2.getAsNormalizedFullLink().id;
+      const before = ownedCellWarns();
+      const warnings = await captureWarnings(async () => {
+        try {
+          await rt2.runSynced(
+            rc2,
+            trustExecutable(rt2, patternWithUnresolvableSubPatternOutputs),
+            {},
+          );
+        } catch {
+          // Instantiation rejects the same outputs (a pattern node needs a
+          // write-redirect output binding); the resume walk must already have
+          // warned and skipped the node by then.
+        }
+      });
+      expect(ownedCellWarns()).toBeGreaterThan(before);
+      await rt2.dispose();
+
+      // The warn must carry enough to act on from a production console trace:
+      // which result cell was being resumed, and which node was skipped.
+      const rendered = warnings
+        .filter((args) => args.some((a) => a === "resume-owned-cells"))
+        .map((args) => JSON.stringify(args));
+      expect(rendered.length).toBeGreaterThan(0);
+      const skipLine = rendered.find((line) =>
+        line.includes("resolved to no write redirect")
+      );
+      expect(skipLine).toBeDefined();
+      expect(skipLine).toContain(resultCellId);
+      expect(skipLine).toContain('"nodeIndex":0');
+      expect(skipLine).toContain(
+        "sub-pattern node with no resolvable output spot",
+      );
+    } finally {
+      await storageManager.close();
+    }
+  });
+});

--- a/packages/runner/test/resume-owned-cells-skip-log.test.ts
+++ b/packages/runner/test/resume-owned-cells-skip-log.test.ts
@@ -1,8 +1,10 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { join } from "@std/path";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { getLoggerCountsBreakdown } from "@commonfabric/utils/logger";
+import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
+import { getLogger } from "@commonfabric/utils/logger";
 import type { Pattern } from "../src/builder/types.ts";
 import { Runtime } from "../src/runtime.ts";
 import { trustExecutable } from "./support/trusted-builder.ts";
@@ -13,9 +15,23 @@ import { trustExecutable } from "./support/trusted-builder.ts";
 // catch around binding/resolution; the other is the resolution simply coming
 // back undefined, which happens when a node's outputs hold no write redirect
 // the scan can resolve (outputs consisting only of deferred partialCause
-// aliases are the shape seen live). Neither exit may be silent: the pre-sync
-// prevents the cold-cache commit-revert race, and a skipped subtree is
-// otherwise only discoverable by console probing.
+// aliases are the shape seen live). Both hide a skipped subtree that is
+// otherwise only discoverable by console probing, so both emit under the
+// `resume-owned-cells` key with the same identity payload.
+//
+// Their LEVELS differ, and that difference is what these tests pin:
+//
+//   - the catch exit WARNS. Outputs that cannot even be bound are a genuine
+//     failure of an expectation.
+//   - the undefined exit DEBUGS. It is the by-design outcome for outputs made
+//     only of deferred partialCause aliases — #5143 deliberately moved that
+//     case off the throwing path — and the real home pattern takes it several
+//     times per healthy run. Warning there would be noise, not signal.
+//
+// So there are two obligations, and a test each way: the positive cases prove
+// each line still carries what a stranded-piece investigation needs, and the
+// healthy-home case proves an ordinary run stays SILENT at warn level. Putting
+// the debug back to warn fails the latter.
 //
 // resume-output-redirect-partialcause.test.ts asserts the scan's return value;
 // this asserts the consequence at the call site.
@@ -23,42 +39,58 @@ import { trustExecutable } from "./support/trusted-builder.ts";
 const signer = await Identity.fromPassphrase("resume owned cells skip log");
 const space = signer.did();
 
-const ownedCellWarns = (): number => {
-  const counts = getLoggerCountsBreakdown()["runner"] ?? {};
-  return (counts as Record<string, { warn?: number }>)["resume-owned-cells"]
-    ?.warn ?? 0;
-};
+type Emission = { level: "debug" | "warn"; key: string; parts: unknown[] };
 
 /**
- * Run `fn` with `console.warn` captured. The runner logger writes warns to
- * `console.warn` unless `LOG_TO_STDERR=1`, so that sink is forced off for the
- * duration and restored afterwards.
+ * Record every `debug`/`warn` the runner's logger emits while `fn` runs,
+ * resolving each call's lazy message thunk the way the logger itself does.
+ *
+ * This captures at the logger rather than at the console on purpose: the LEVEL
+ * of the call is what is under test, and reading the console would conflate it
+ * with the runner logger's own configured level (`warn`, so its debug calls
+ * never reach the console at all) and with `LOG_TO_STDERR`.
  */
-const captureWarnings = async (
+const captureRunnerLog = async (
   fn: () => Promise<void>,
-): Promise<unknown[][]> => {
-  const captured: unknown[][] = [];
-  const originalWarn = console.warn;
-  const originalStderrFlag = Deno.env.get("LOG_TO_STDERR");
-  Deno.env.set("LOG_TO_STDERR", "0");
-  console.warn = (...args: unknown[]) => {
-    captured.push(args);
-  };
+): Promise<Emission[]> => {
+  const logger = getLogger("runner") as unknown as Record<
+    "debug" | "warn",
+    (key: string, ...messages: unknown[]) => void
+  >;
+  const emissions: Emission[] = [];
+  const originals = { debug: logger.debug, warn: logger.warn };
+  const record =
+    (level: "debug" | "warn") => (key: string, ...messages: unknown[]) => {
+      emissions.push({
+        level,
+        key,
+        parts: messages.flatMap((message) => {
+          const resolved = typeof message === "function" ? message() : message;
+          return Array.isArray(resolved) ? resolved : [resolved];
+        }),
+      });
+      // Delegate, so the run under test logs exactly as it would in production
+      // (and the logger's own counters stay honest).
+      originals[level].call(logger, key, ...messages);
+    };
+  logger.debug = record("debug");
+  logger.warn = record("warn");
   try {
     await fn();
   } finally {
-    console.warn = originalWarn;
-    if (originalStderrFlag === undefined) Deno.env.delete("LOG_TO_STDERR");
-    else Deno.env.set("LOG_TO_STDERR", originalStderrFlag);
+    logger.debug = originals.debug;
+    logger.warn = originals.warn;
   }
-  return captured;
+  return emissions;
 };
 
-// A sub-pattern node whose whole outputs record holds only a DEFERRED
-// partialCause alias. Such an alias denotes a derived internal cell of the
-// level it was deferred to, never this node's reserved result spot, so
-// firstResolvedOutputRedirect returns undefined for the node as a whole and the
-// walk skips it.
+const skipEmissions = (emissions: Emission[]): Emission[] =>
+  emissions.filter((emission) => emission.key === "resume-owned-cells");
+
+/** The identity payload is the trailing record argument of the log call. */
+const payloadOf = (emission: Emission): unknown =>
+  emission.parts[emission.parts.length - 1];
+
 const childPattern: Pattern = {
   argumentSchema: {},
   resultSchema: {},
@@ -66,7 +98,12 @@ const childPattern: Pattern = {
   nodes: [],
 };
 
-const patternWithUnresolvableSubPatternOutputs = {
+// A sub-pattern node whose whole outputs record holds only a DEFERRED
+// partialCause alias. Such an alias denotes a derived internal cell of the
+// level it was deferred to, never this node's reserved result spot, so
+// firstResolvedOutputRedirect returns undefined for the node as a whole and the
+// walk skips it without an error.
+const unresolvableOutputsPattern = {
   argumentSchema: {},
   resultSchema: {},
   result: {},
@@ -84,66 +121,185 @@ const patternWithUnresolvableSubPatternOutputs = {
   ],
 } as unknown as Pattern;
 
-describe("resume owned-cell walk skip logging", () => {
-  it("warns, with node identity, when a sub-pattern node's outputs resolve to no redirect", async () => {
-    const storageManager = StorageManager.emulate({ as: signer });
-    try {
-      // Seed run: a trivial pattern whose setup writes the result cell's
-      // argument meta link, so the resume below is a real resume.
-      const seedPattern: Pattern = {
-        argumentSchema: {},
-        resultSchema: {},
-        result: {},
-        nodes: [],
-      };
-      const rt1 = new Runtime({
-        apiUrl: new URL(import.meta.url),
-        storageManager,
-      });
-      const rc1 = rt1.getCell(space, "owned-cells-skip-log");
-      await rt1.runSynced(rc1, trustExecutable(rt1, seedPattern), {});
-      await rc1.pull();
-      await rt1.dispose();
+// A sub-pattern node whose outputs alias the ARGUMENT doc. On a first run the
+// result cell has no argument meta link yet, so binding the outputs throws and
+// the walk takes its catch exit.
+const unbindableOutputsPattern = {
+  argumentSchema: {},
+  resultSchema: {},
+  result: {},
+  nodes: [
+    {
+      description: "sub-pattern node whose outputs alias the argument doc",
+      module: { type: "pattern", implementation: childPattern },
+      inputs: {},
+      outputs: { $alias: { cell: "argument", path: ["child"] } },
+    },
+  ],
+} as unknown as Pattern;
 
-      const rt2 = new Runtime({
-        apiUrl: new URL(import.meta.url),
-        storageManager,
-      });
-      const rc2 = rt2.getCell(space, "owned-cells-skip-log");
-      const resultCellId = rc2.getAsNormalizedFullLink().id;
-      const before = ownedCellWarns();
-      const warnings = await captureWarnings(async () => {
-        try {
-          await rt2.runSynced(
-            rc2,
-            trustExecutable(rt2, patternWithUnresolvableSubPatternOutputs),
+type SkipCase = {
+  name: string;
+  pattern: Pattern;
+  /**
+   * Seed the result cell with a prior run, so the run under test resumes a
+   * stored root whose argument meta link is already written.
+   */
+  seedFirst: boolean;
+  level: "debug" | "warn";
+  message: string;
+  node: string;
+  /** Parts the call carries ahead of the identity payload. */
+  leadingParts: number;
+  /** How the run under test is expected to end. */
+  rejectsWith?: RegExp;
+};
+
+const cases: SkipCase[] = [
+  {
+    name: "outputs resolve to no write redirect",
+    pattern: unresolvableOutputsPattern,
+    seedFirst: true,
+    level: "debug",
+    message:
+      "skipping a sub-pattern node whose outputs resolved to no write redirect",
+    node: "sub-pattern node with no resolvable output spot",
+    leadingParts: 1,
+    // The same outputs that gave the walk nothing to resolve also give
+    // instantiation nothing to anchor the child's identity on, so the run
+    // rejects. Pinned rather than swallowed, so this fixture cannot go green
+    // for some later, unrelated reason.
+    rejectsWith: /requires a write-redirect output binding/,
+  },
+  {
+    name: "outputs cannot be bound",
+    pattern: unbindableOutputsPattern,
+    seedFirst: false,
+    level: "warn",
+    message:
+      "skipping a sub-pattern node whose outputs did not bind or resolve",
+    node: "sub-pattern node whose outputs alias the argument doc",
+    // message, error, payload.
+    leadingParts: 2,
+  },
+];
+
+describe("resume owned-cell walk skip logging", () => {
+  for (const testCase of cases) {
+    it(`logs at ${testCase.level} when a sub-pattern node's ${testCase.name}`, async () => {
+      const storageManager = StorageManager.emulate({ as: signer });
+      const cause = `owned-cells-skip-log-${testCase.level}`;
+      try {
+        if (testCase.seedFirst) {
+          // A trivial pattern whose setup writes the result cell's argument
+          // meta link, so the run under test is a real resume.
+          const seedPattern: Pattern = {
+            argumentSchema: {},
+            resultSchema: {},
+            result: {},
+            nodes: [],
+          };
+          const seedRuntime = new Runtime({
+            apiUrl: new URL(import.meta.url),
+            storageManager,
+          });
+          const seedCell = seedRuntime.getCell(space, cause);
+          await seedRuntime.runSynced(
+            seedCell,
+            trustExecutable(seedRuntime, seedPattern),
             {},
           );
-        } catch {
-          // Instantiation rejects the same outputs (a pattern node needs a
-          // write-redirect output binding); the resume walk must already have
-          // warned and skipped the node by then.
+          await seedCell.pull();
+          await seedRuntime.dispose();
         }
-      });
-      expect(ownedCellWarns()).toBeGreaterThan(before);
-      await rt2.dispose();
 
-      // The warn must carry enough to act on from a production console trace:
-      // which result cell was being resumed, and which node was skipped.
-      const rendered = warnings
-        .filter((args) => args.some((a) => a === "resume-owned-cells"))
-        .map((args) => JSON.stringify(args));
-      expect(rendered.length).toBeGreaterThan(0);
-      const skipLine = rendered.find((line) =>
-        line.includes("resolved to no write redirect")
+        const runtime = new Runtime({
+          apiUrl: new URL(import.meta.url),
+          storageManager,
+        });
+        const resultCell = runtime.getCell(space, cause);
+        const resultCellId = resultCell.getAsNormalizedFullLink().id;
+        const emissions = await captureRunnerLog(async () => {
+          const run = runtime.runSynced(
+            resultCell,
+            trustExecutable(runtime, testCase.pattern),
+            {},
+          );
+          if (testCase.rejectsWith !== undefined) {
+            await expect(run).rejects.toThrow(testCase.rejectsWith);
+          } else {
+            await run;
+          }
+        });
+        await runtime.dispose();
+
+        const skips = skipEmissions(emissions);
+        const emission = skips.find((candidate) =>
+          candidate.parts[0] === testCase.message
+        );
+        expect(emission).toBeDefined();
+        // The level is the finding: the by-design exit must not warn, and the
+        // genuine binding failure must.
+        expect(emission!.level).toBe(testCase.level);
+        expect(emission!.parts.length).toBe(testCase.leadingParts + 1);
+        // Asserted as a whole object, so a field that silently stops being
+        // populated — `space` and `childPattern` are advertised but only ever
+        // read from a production trace — fails here.
+        expect(payloadOf(emission!)).toEqual({
+          resultCell: resultCellId,
+          space,
+          nodeIndex: 0,
+          node: testCase.node,
+          childPattern: "pattern:nodes=0",
+        });
+        // No emission of the OTHER kind slipped in alongside it.
+        expect(skips.every((candidate) => candidate.level === testCase.level))
+          .toBe(true);
+      } finally {
+        await storageManager.close();
+      }
+    });
+  }
+
+  // The negative half, and the reason the undefined exit is a debug: a healthy
+  // run of the REAL home pattern takes that exit repeatedly. While it was a
+  // warn, this run emitted the warning twice, and CI showed eight occurrences
+  // across passing home tests. This fails if the log goes back to warn — and,
+  // via the "really does take the exit" assertion, also if the branch stops
+  // being reached, so the silence it proves cannot go vacuous.
+  it("stays silent at warn level through a healthy home pattern run", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    try {
+      const patternsRoot = join(import.meta.dirname!, "..", "..", "patterns");
+      const program = await runtime.harness.resolve(
+        new FileSystemProgramResolver(
+          join(patternsRoot, "system", "home.tsx"),
+          patternsRoot,
+        ),
       );
-      expect(skipLine).toBeDefined();
-      expect(skipLine).toContain(resultCellId);
-      expect(skipLine).toContain('"nodeIndex":0');
-      expect(skipLine).toContain(
-        "sub-pattern node with no resolvable output spot",
-      );
+      const homePattern = await runtime.patternManager.compilePattern(program, {
+        space,
+      });
+
+      const resultCell = runtime.getCell(space, "healthy-home-instance");
+      const emissions = await captureRunnerLog(async () => {
+        const home = await runtime.runSynced(resultCell, homePattern, {});
+        await home.pull();
+        await runtime.idle();
+      });
+
+      const skips = skipEmissions(emissions);
+      // The healthy run really does take the skip exit — otherwise the
+      // silence below would prove nothing.
+      expect(skips.length).toBeGreaterThan(0);
+      expect(skips.filter((emission) => emission.level === "warn")).toEqual([]);
+      expect(skips.every((emission) => emission.level === "debug")).toBe(true);
     } finally {
+      await runtime.dispose();
       await storageManager.close();
     }
   });


### PR DESCRIPTION
## Why

Two diagnosability gaps found while investigating a live estuary home space
whose Favorites / Profile / Self tabs rendered empty with **zero** console
output — even with `forwardWorkerConsole` on. Localizing that took a full
session of browser-console probing, and both of these are reasons why.

Neither change alters behaviour. Both are about making the runtime say what it
is doing.

## What changed

**CT-1940 — the silent skip is now audible.**

`collectResumeOwnedCells` has two exits that skip the same work — a node's
owned-cell pre-sync AND the recursion that would reach the child's own
`derivedInternalCells` manifest — but only the throwing one logged:

```ts
} catch (error) {
  logger.warn("resume-owned-cells", …);
  continue;
}
if (spotLink === undefined) continue;   // <- silent
```

The `undefined` exit now warns at the same level under the same
`resume-owned-cells` key, so existing console filters catch both. Its message
names the *different* cause — `…outputs resolved to no write redirect`, versus
the sibling's `…did not bind or resolve`, which reads as a throw. The sibling's
message string is unchanged, so anything grepping it still matches.

Both exits now carry a shared identity payload
(`describeSkippedSubPatternNode`): result cell, space, node index, node
description, child pattern — enough to find the node from a production trace.

This matters because #5143 deliberately moved a real case from the throwing
path to the `undefined` path (`firstResolvedOutputRedirect` now returns
`undefined` for outputs holding only `partialCause` aliases, where it used to
throw). That was right for the scan, but it converted a loud skip into a silent
one.

**CT-1943 — the dual entity kind is documented.**

`instantiatePatternNode` binds a sub-pattern node's outputs twice: once WITH
`derivedInternalCells` (the value bind — the manifest descriptor carries the
kind, so the mint lands at `computed:fid1:<hash>`, and this is where
`sendValueToBinding` writes the child link), and once WITHOUT it (the identity
bind — no descriptor means no kind, so the same hash mints as `of:fid1:<hash>`,
used only as the `resultFor` cause).

Two entities differing only by scheme. Reading the child link at the `of:` id
returns `undefined` for a perfectly healthy piece — which has now produced
wrong conclusions in two separate investigations. Comments at both bind sites,
plus a recipe under `docs/development/debugging/console-commands.md` so someone
probing live state knows to look for both.

## Deliberately NOT in this PR

CT-1940 also asks whether skipping the child recursion is correct at all. It
probably is not — the justification at `firstResolvedOutputRedirect` ("the
derived cells themselves are collected from each pattern's own
`derivedInternalCells` manifest") is exactly what the `continue` prevents. But
fixing it means minting a child result cell from something other than the
resolved output spot, which CT-1897 warns derives the wrong `resultFor`
identity and pre-syncs the wrong subtree. That is a design decision about
child-cell identity, not a refactor, and it needs an owner. Recorded on
CT-1940.

Surfacing the `of:` / `computed:` pairing in `cf inspect` output is likewise
deferred — `packages/state-inspector/decode.ts` strips `of:` and keeps
`computed:` visible, so the pairing is encoded in the output but never
explained. Real inspector change; recorded on CT-1943.

## Test plan

- New `packages/runner/test/resume-owned-cells-skip-log.test.ts`: resumes a
  pattern whose sub-pattern node's outputs hold only a deferred `partialCause`
  alias, and asserts the warn fires and carries the result cell id, node index
  and node description. Verified red without the change.
- Full `packages/runner` suite: **1113 passed (5836 steps), 0 failed** — run
  independently of the authoring pass.
- `deno fmt --check` and `deno lint` clean on the changed files (the repo's ~23
  pre-existing unformatted files are untouched).
- `deno task check-docs`: 522 blocks pass, including the new fence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves diagnosability during resume by logging skipped sub-pattern nodes with clear identity and documenting when reads should use `computed:` instead of `of:`. Addresses CT-1940 and CT-1943. No behavior changes.

- **New Features**
  - Runner now logs both skip paths under `resume-owned-cells`: binding failures stay warn; “no write redirect” skips are debug. Both include result cell id, space, node index, node description, and child pattern.
  - Clarified `of:` vs `computed:` identities: when a descriptor is `kind: "computed"`, the value lives at `computed:fid1:<hash>` and reads at `of:fid1:<hash>` return undefined; with a kindless descriptor or `experimental.computedCellIds` off, both binds land on `of:`. Notes added in `packages/runner/src/runner.ts` and a recipe in `docs/development/debugging/console-commands.md` (README links to it).
  - Tests in `packages/runner/test/resume-owned-cells-skip-log.test.ts` table-drive both exits, pin levels (debug vs warn), assert the identity payload, and verify the healthy Home run emits no warns under this key.

<sup>Written for commit 866869add05afcae6e1ddce6314fd484ca104d28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

