### PR TITLE
fix(runner): keep a `FabricPrimitive` whole in a stream event payload

### DIFF
--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -7,6 +7,7 @@ import {
 import {
   cloneIfNecessary,
   fabricFromNativeValue,
+  FabricPrimitive,
   FabricSpecialObject,
   type FabricValue,
   shallowCleanArray,
@@ -3238,6 +3239,20 @@ export function convertCellsToLinks(
   // throwing away the copy just made above. One copy could serve both.
   if (!isRecord(value)) {
     // `shallowFabricFromNativeValue()` converted this into a primitive value of some sort.
+    return value;
+  } else if (value instanceof FabricPrimitive) {
+    // An opaque scalar whose state lives in private fields, so it has zero
+    // enumerable own properties and the object branch below would rebuild it
+    // from its (empty) entries as a bare `{}`. It leaves whole instead.
+    //
+    // This catches both forms that arrive here: one the caller already built,
+    // and one `shallowFabricFromNativeValue()` just minted from a native (a
+    // `Uint8Array`, a `Date`) immediately above.
+    //
+    // TODO(danfuzz): Latent — a `FabricInstance` is NOT a leaf. It is a
+    // container reached by its codec contents rather than by property name, so
+    // it still falls to the object branch and is rebuilt from zero enumerable
+    // own properties. Same marker as the sibling walk in `builder/json-utils.ts`.
     return value;
   } else if (Array.isArray(value)) {
     return value.map((value, index) =>

--- a/packages/runner/test/stream-event-fabric-primitives.test.ts
+++ b/packages/runner/test/stream-event-fabric-primitives.test.ts
@@ -1,0 +1,160 @@
+// A stream event payload goes through `convertCellsToLinks()` on its way to the
+// handler. That walk rebuilds each plain object it meets from its enumerable
+// own properties, and a `FabricPrimitive` keeps its state in private fields and
+// has none — so an unguarded rebuild delivers a bare `{}` to the handler, with
+// class, identity, and contents gone.
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import {
+  FabricBytes,
+  FabricEpochNsec,
+} from "@commonfabric/data-model/fabric-primitives";
+
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { convertCellsToLinks } from "../src/cell.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+
+const signer = await Identity.fromPassphrase("stream-event-fabric-primitives");
+const space = signer.did();
+
+// Echoes the payload's byte length back into the result, which is only
+// computable if the value arrived as a real `FabricBytes`.
+const FIXTURE_SRC = `
+import { handler, pattern, schema, type Stream } from "commonfabric";
+import "commonfabric/schema";
+
+interface Input {
+  seen: number;
+}
+
+interface Output {
+  seen: number;
+  record: Stream<{ payload?: unknown }>;
+}
+
+const model = schema({
+  type: "object",
+  properties: {
+    seen: { type: "number", default: -1, asCell: ["cell"] },
+  },
+  default: { seen: -1 },
+});
+
+const record = handler(
+  {
+    type: "object",
+    properties: { payload: {} },
+  } as const,
+  model,
+  (event, state) => {
+    const payload = event?.payload as { length?: number } | undefined;
+    state.seen.set(typeof payload?.length === "number" ? payload.length : -1);
+  },
+);
+
+export const echoPattern = pattern<Input, Output>(
+  (cell) => ({ seen: cell.seen, record: record(cell) }),
+  model,
+);
+`;
+
+describe("stream event payloads carrying a FabricPrimitive", () => {
+  describe("convertCellsToLinks() directly", () => {
+    let runtime: Runtime;
+    let storageManager: ReturnType<typeof StorageManager.emulate>;
+
+    beforeEach(() => {
+      storageManager = StorageManager.emulate({ as: signer });
+      runtime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager,
+      });
+    });
+    afterEach(async () => {
+      await runtime?.dispose();
+      await storageManager?.close();
+    });
+
+    it("keeps a FabricPrimitive whole at the top level", () => {
+      const bytes = new FabricBytes(new Uint8Array([9, 7]));
+      const out = convertCellsToLinks(bytes);
+      expect(out).toBeInstanceOf(FabricBytes);
+      expect([...(out as FabricBytes).slice()]).toEqual([9, 7]);
+    });
+
+    it("keeps a FabricPrimitive whole inside an object and an array", () => {
+      const stamp = new FabricEpochNsec(123n);
+      const wrapped = convertCellsToLinks({ stamp, n: 1 }) as {
+        stamp: unknown;
+        n: number;
+      };
+      expect(wrapped.stamp).toBeInstanceOf(FabricEpochNsec);
+      expect(wrapped.n).toBe(1);
+
+      const listed = convertCellsToLinks([stamp]) as unknown[];
+      expect(listed[0]).toBeInstanceOf(FabricEpochNsec);
+    });
+
+    it("converts a native payload to a primitive rather than flattening it", () => {
+      // `shallowFabricFromNativeValue()` mints the primitive just before the
+      // container dispatch, so a native arrives as the converted form and must
+      // survive the same way an already-built one does.
+      const out = convertCellsToLinks({ payload: new Uint8Array([4, 5, 6]) });
+      const payload = (out as { payload: unknown }).payload;
+      expect(payload).toBeInstanceOf(FabricBytes);
+      expect([...(payload as FabricBytes).slice()]).toEqual([4, 5, 6]);
+    });
+  });
+
+  describe("end to end, through a handler", () => {
+    let storageManager: ReturnType<typeof StorageManager.emulate>;
+
+    beforeEach(() => {
+      storageManager = StorageManager.emulate({ as: signer });
+    });
+    afterEach(async () => {
+      await storageManager?.close();
+    });
+
+    it("delivers a FabricBytes payload to the handler intact", async () => {
+      const runtime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager,
+      });
+      try {
+        const program: RuntimeProgram = {
+          main: "/main.tsx",
+          mainExport: "echoPattern",
+          files: [{ name: "/main.tsx", contents: FIXTURE_SRC }],
+        };
+        const tx = runtime.edit();
+        const compiled = await runtime.patternManager.compilePattern(program, {
+          space,
+          tx,
+        });
+        const resultCell = runtime.getCell<Record<string, unknown>>(
+          space,
+          "stream-event-primitive-result",
+          undefined,
+          tx,
+        );
+        const run = runtime.run(tx, compiled, {}, resultCell);
+        await tx.commit();
+        await run.pull();
+
+        run.key("record").send({
+          payload: new FabricBytes(new Uint8Array([1, 2, 3, 4, 5])),
+        });
+        const after = await run.pull() as { seen: number };
+
+        // A flattened `{}` has no `length`, so the handler records -1.
+        expect(after.seen).toBe(5);
+      } finally {
+        await runtime.dispose();
+      }
+    });
+  });
+});


### PR DESCRIPTION
`Cell.send()` routes its event through `convertCellsToLinks()`, whose object
branch rebuilds each value it meets with
`Object.fromEntries(Object.entries(...))`. A `FabricPrimitive` keeps its state
in private fields and has **zero enumerable own properties**, so that rebuild
produced a bare `{}` — class, identity, and contents gone — and that is what the
handler received.

Observed directly at the function, before the fix:

| input | delivered |
| --- | --- |
| `FabricBytes` instance | `{}` |
| `{ payload: FabricEpochNsec }` | `{"payload":{}}` |
| `{ payload: Uint8Array }` | `{"payload":{}}` |
| `{ ok: 1, n: "x" }` *(control)* | `{"ok":1,"n":"x"}` |

Native payloads were lost the same way, and for a sharper reason: the walk calls
`shallowFabricFromNativeValue()` immediately above, so a `Uint8Array` or a
`Date` was converted **into** a `FabricPrimitive` and then flattened by the very
next statement.

A `FabricPrimitive` now leaves ahead of the container dispatch — the disposition
its sibling walks already use.

## This is the fifth site in a known family

Same defect class #4530 fixed in `traverseValue`, `toJSONWithLegacyAliases`, and
`traverseAndCellify`, and #5074 fixed in `pattern-binding.ts`'s `convert()`.
This one carried **no marker at all**, while `builder/json-utils.ts` had already
grown the identical guard twenty lines from an identical `for...in` rebuild.

A `FabricInstance` still falls through to the object branch and is rebuilt from
zero enumerable own properties. That gap is not new, and it now carries a
`TODO(danfuzz): Latent` marker matching the `json-utils.ts` sibling's.

**Deliberately not touched:** `validateStaticData()` in this same file carries a
marker for the same hazard and is correctly latent — that walk returns `void`,
detecting cycles rather than rebuilding a value, so meeting a primitive it
cannot see into loses nothing.

## Tests

Four, red-greened against **real `origin/main`**, not a reconstruction: three
against `convertCellsToLinks()` directly (top level, nested in an object and an
array, and the native-conversion case), plus one end-to-end through a compiled
pattern whose handler reports `payload.length`.

| source | all four tests |
| --- | --- |
| real `origin/main` | **4 FAILED** |
| this PR | 4 ok |

The end-to-end one is the user-visible symptom: the handler records `5` with the
fix and `-1` without, since a flattened `{}` has no `length`.

## Provenance

Found by a `FabricPrimitive` end-to-end audit of the system, and reproduced
independently at the function before this branch was opened.

## Testing

Full runner suite green (1117 passed, 0 failed). `deno fmt --check` (4319
files), `deno lint` (4292 files), and `deno check` of both changed files clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eJcTLCQcXrXHA4CC8eDpp


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stream event payload handling by keeping `FabricPrimitive` values intact in `convertCellsToLinks()`, preventing them from being rebuilt into `{}`. Restores correct delivery of primitives and native values (e.g., `Uint8Array`, `Date`) to handlers.

- **Bug Fixes**
  - Return early when value is `instanceof FabricPrimitive` to skip object rebuild (TODO left for `FabricInstance`).
  - Covers primitives created from natives by `shallowFabricFromNativeValue()`.
  - Adds focused tests (direct and end-to-end) confirming `FabricBytes`/`FabricEpochNsec` arrive intact and `payload.length` is computed correctly.

<sup>Written for commit 874eb8d2a0800c448f956fbd20293ba09a81f222. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

