### PR TITLE
docs(runner): the write-redirect walk's `Latent` premise is already false

### DIFF
--- a/packages/runner/src/pattern-binding.ts
+++ b/packages/runner/src/pattern-binding.ts
@@ -700,11 +700,16 @@ export function findAllWriteRedirectCells<T>(
     } else if (Array.isArray(binding)) {
       // If the binding is an array, recurse into each element.
       for (const value of binding) find(value, baseCell);
-      // TODO(danfuzz): Latent — schemas don't admit `Fabric*` values on this
-      // path today, but will in the not-too-distant future; at that point this
-      // guard-less `isRecord`-walk fails (a `FabricPrimitive` is decomposed, a
-      // `FabricInstance` is walked by internal slots rather than codec
-      // contents). Mark ahead of that.
+      // A `FabricPrimitive` reaches the `isRecord` branch below, and is
+      // harmless there. This walk collects write-redirect links, and a
+      // primitive is an opaque scalar: it can contain no redirect, and its
+      // state lives in private fields, so `Object.values()` yields nothing and
+      // the recursion ends immediately. Decomposition would matter to a walk
+      // that REBUILT its input; this one only reads.
+      //
+      // TODO(danfuzz): Latent — a `FabricInstance` is not harmless in the same
+      // way. It is a container reached by its codec contents rather than by
+      // property name, so a write redirect nested inside one is missed here.
     } else if (isRecord(binding) && !isCellLink(binding)) {
       // If the binding is an object, recurse into each value.
       for (const value of Object.values(binding)) find(value, baseCell);


### PR DESCRIPTION
`findAllWriteRedirectCells`'s `TODO(danfuzz): Latent` marker read "schemas don't
admit `Fabric*` values on this path today, but will in the not-too-distant
future". **The first half is not true.** A `FabricPrimitive` reaches this walk
now.

## Measured, not argued

Instrumenting the `isRecord` branch and running the full runner package suite
gives **ZERO** arrivals — which is exactly why the claim looked safe. But the
suite contains no pattern that embeds one. A pattern that does, authored and
compiled through the real pipeline, delivers one immediately:

```ts
export const p = pattern<Input, Output>((cell) => {
  const stamp = new FabricBytes(new Uint8Array([1, 2, 3]));
  const len = computed(() => stamp.slice().length + cell.n);
  return { n: cell.n, len };
}, model);
```

```
-> 1 FabricBytes arrival at findAllWriteRedirectCells
```

That is the same producer shape that falsified the identical assumption at
`convert()`, which #5074 then fixed. The lesson generalizes: **"does not reach
this path today", measured against a suite that never constructs the value, is
a statement about the suite rather than about the path.**

## It still does not matter here — and now says why

The marker's instinct was right about consequences, so the comment states the
reason instead of implying a pending hazard.

This walk collects write-redirect links: it **reads** rather than **rebuilds**.
A primitive is an opaque scalar that can contain no redirect, and its zero
enumerable own properties mean `Object.values()` yields nothing, so the
recursion ends immediately. Decomposition harms a walk that reconstructs its
input; this one never does.

The `FabricInstance` half stays `Latent`, and is what was always the real
content of this marker: it **is** a container, reached by codec contents rather
than by property name, so a write redirect nested inside one is genuinely
missed.

## Scope

Comment only — no behavior change, and none is owed. A `FabricPrimitive` guard
here would be behavior-neutral and therefore untestable, so none is added.

Found by a `FabricPrimitive` end-to-end audit; the reachability claim was
re-derived here rather than taken on report.

## Testing

`deno fmt --check` (4318 files), `deno lint` (4291 files), and `deno check` of
the changed file all clean. The instrumented full-suite run used for the
measurement above was green (1116 passed, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eJcTLCQcXrXHA4CC8eDpp


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified the comment in `findAllWriteRedirectCells` to state that `FabricPrimitive` values can reach the `isRecord` branch and are harmless for this read-only write-redirect walk. Kept the `Latent` note for `FabricInstance` (a container reached via codec contents); no behavior change.

<sup>Written for commit 9c88a619eb43f7a76d59b1f99378b5a279ed0254. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

