### PR TITLE
feat(runner): let a space replica hand documents back

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,6 +169,10 @@ If you are developing runtime code, read the following documentation:
   layers. Its neighbour `mergeable-collection-writes.md` covers why the
   mergeable ops exist and what they do to conflict detection; read it before
   changing how a handler writes to a list
+- `docs/development/document-release.md` - What keeps a document in a space
+  replica, how the runner tells storage that nothing reads one any more, how the
+  watch set shrinks, and what a read of a released document does. Read it before
+  changing what a replica holds or how watches are installed
 - `docs/development/UI_TESTING.md` - How to work with shadow dom in our
   integration tests
 - `docs/development/EXPERIMENTAL_OPTIONS.md` - The central registry of every

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -693,6 +693,11 @@ the per-epic implementation notes).
 > - **`entityIdLookup`** is a build-inherent capability, hardwired to `true`.
 >   It advertises identifier-only `entity-id.exists` point lookup. Older
 >   servers omit it, which parses as `false`. It is permanent.
+> - **`watchRemove`** is a build-inherent capability, hardwired to `true`. It
+>   advertises `session.watch.remove`, which drops watches by id instead of
+>   replacing the whole set. Older servers omit it, which parses as `false`,
+>   and the runner shrinks its watch set with `session.watch.set` carrying the
+>   survivors — same effect, larger request. It is permanent.
 
 ### `experimentalConcurrentWatchRefresh`
 
@@ -730,6 +735,81 @@ the per-epic implementation notes).
   measured end-to-end over real latency.
 - **Path to removal.** Graduate to always-on once measured safe and beneficial,
   or remove if superseded by reducing the round-trip count at the source.
+
+### `experimentalDocumentRelease`
+
+- **Toggle via.** `experimentalDocumentRelease` on
+  `IRemoteStorageProviderSettings`
+  ([`packages/runner/src/storage/interface.ts`](../../packages/runner/src/storage/interface.ts)),
+  passed through `StorageManager` settings and fixed at `StorageManager.open`
+  time.
+- **Purpose.** Off, a space replica keeps every document it has ever pulled and
+  every watch it has ever installed for as long as it is open, so a view that
+  pages through a large collection costs memory per page visited and never gets
+  any of it back. On, the scheduler reports documents whose last reactive reader
+  has gone, the replica gives up the watches that cover them, and it discards
+  what the server then reports as having left the session's watch union. The
+  mechanism is described in
+  [document release](document-release.md); the measurement is in
+  [the release record](../history/development/performance/2026-07-document-release.md).
+- **Current default and planned end state.** Off by default. End state is
+  always-on, with the flag removed.
+- **Status on 2026-08-03.** Implemented and measured
+  (`packages/runner/test/measure-document-retention.ts`): over a forty-page walk
+  of a thousand-document collection it holds the replica to a bounded document
+  set instead of a monotonically growing one. It is off because it breaks the
+  runner suite, not for bake time.
+
+  Graduating the flag means every test runs with it, so the suite is the
+  experiment. Adding `experimentalDocumentRelease: true` to `defaultSettings`
+  and running all 539 runner test files gives three hangs and eleven failing
+  cases across ten files. All of them pass with the flag off.
+
+  Three files hang, none completing in 90 seconds where they otherwise finish in
+  under three:
+
+  - `array-push-mergeable.test.ts` (5 tests, 80 steps, 0.6 s with the flag off)
+  - `commit-conflict-reconcile.test.ts`
+  - `list-resume-preserve.test.ts`
+
+  All three are conflict work. A conflicted commit waits on
+  `waitForCaughtUpLocalSeq`, and `#caughtUpLocalSeq` only advances through
+  `noteCaughtUpLocalSeq` inside `applySessionSync` — that is, only when a sync
+  frame arrives, which needs the watch a release may have given up. The wait has
+  no timer, correctly, so it presents as a hang rather than an error. Holding
+  documents named by an unsettled commit's reads was tried and does **not**
+  clear it, so the read set is not the whole cause; this needs a real diagnosis
+  rather than a guess.
+
+  Eleven cases fail outright:
+
+  - `list-resume-container-defer.test.ts` — all three, filter, flatMap and map:
+    "resume confirms absence, seeds, then rebuilds durably". The aggregate comes
+    out empty against an expected `["a", "b", "d"]`. This is the stale-aggregate
+    symptom, in every builtin.
+  - `patterns-dynamic.test.ts` — "should clean up predicate runs when filter
+    list becomes undefined" and the flatMap equivalent.
+  - `effect-conflict-recovery.test.ts` — "recovers a plain effect off the retry
+    budget (not stranded)".
+  - `scheduler-observations.test.ts` — "resumes a clean piece without rerunning
+    or fetching cell data".
+  - `scheduler-event-receipts.test.ts` — "projects a plain JSON return into the
+    receipt under plainResultReceipts".
+  - `fetch-claim-takeover.test.ts` — "releases the entry it claimed when the
+    pattern is stopped".
+  - `llm-dialog-message-drop.test.ts` — "accepts once another replica's turn
+    passes the staleness bound".
+  - `llm-dialog.test.ts`, `llm-conversation-fixture.test.ts` and
+    `memory-v2-watch-remove-coverage.test.ts` — one case each.
+
+  (`document-release.test.ts` also fails, but only its own "off by default"
+  block, whose control the forced flag defeats. That one is an artefact of the
+  experiment.)
+- **Path to removal.** Two defects have to be fixed, and the suite re-run with
+  the flag forced on until it is clean — reasoning that a defect is gone is
+  worth nothing next to that one-line experiment. First, a released document
+  leaves a list projection's aggregate stale. Second, and separately, conflict
+  handling can wait forever for a sync frame the release made unreachable.
 
 ---
 

--- a/docs/development/document-release.md
+++ b/docs/development/document-release.md
@@ -1,0 +1,181 @@
+# Document release
+
+Every document a space replica pulls stays in `SpaceReplica`'s document map, and
+every watch it installs stays on the server, for as long as the tab is open.
+Nothing is ever released. A view that pages through a large collection therefore
+costs memory per page visited and never gets any of it back. This document
+describes the mechanism that hands documents back, which is implemented behind
+`experimentalDocumentRelease` and off by default —
+[the experimental options registry](EXPERIMENTAL_OPTIONS.md) records what has to
+be settled before it can be the default.
+
+What that costs, and what releasing documents does to it, is measured in
+[the release record](../history/development/performance/2026-07-document-release.md).
+
+## What counts as interest
+
+A document is wanted while any of these holds.
+
+**A live reactive reader.** The scheduler's trigger index maps each document to
+the actions that read it. Every `Cell.sink`, every running pattern node, and
+every view subscription is an action, and its reads are registered there when it
+runs and withdrawn when its read set changes or it is cancelled. That index is
+the runner's whole answer to "is anything still reading this?", and
+`Scheduler.hasDocumentReaders` exposes it.
+
+**An unfinished local write.** A record carrying pending versions is holding
+writes that have not been confirmed, and replaying them needs the record.
+
+**A conflict that has not caught up.** An identifier under a stale floor is
+waiting for the sequence number that clears it.
+
+**A provider-level `sink` subscriber.** These do not go through the scheduler.
+
+**An outstanding pull waiting for it.** Every document a pull is waiting for,
+not only the ones that pull is fetching: an entry an already-installed watch
+covers is one the caller is still waiting for, and giving up the covering watch
+would leave the pull resolving onto a document the server has stopped tracking.
+
+Everything else is releasable. Note what is *not* on the list: holding a `Cell`
+object does not retain its document. A `Cell` is a reference, not a
+subscription; reading through one outside a reactive action was only ever
+working because the document happened to still be cached.
+
+### The precondition this rests on
+
+Reads marked `ignoreReadForScheduling` deliberately register no trigger, and
+there are many of them — sixty-odd across the runner, in pattern binding, link
+resolution, schema traversal, and the runner's own bookkeeping. None of them can
+cause a document to be released out from under the code making them, and the
+reason is structural rather than a property of any individual call site.
+
+A release candidate can only be an entity the trigger index already held. Both
+routes into the record start from registered reads: `removeActionFromEntities`
+takes the entity set an action registered, and `applyActionReadDelta` takes the
+entities a re-run stopped reading. So a document that has only ever been read
+without registering a trigger is never a candidate, and is never released.
+`packages/runner/test/scheduler-trigger-index.test.ts` pins that.
+
+What remains is a document that *was* tracked, whose tracked readers have all
+gone, and which a non-registering read then touches. That read gets what a read
+of a never-pulled document gets — absent, and a load — which is the same thing
+it would get in a replica that had just started. Code that is correct against a
+cold replica is correct here.
+
+## How release travels
+
+The scheduler collects entities whose reader set has just emptied, in
+`SchedulerTriggerIndex`. When the scheduler reaches quiescence — no action is
+part-way through a run, and the read sets left behind are the ones that
+matter — it re-checks each candidate and hands the ones that still have no
+reader to `IStorageManager.releaseDocuments`. Filtering at quiescence rather
+than at the moment the reader goes is what stops a document that a page change
+drops and immediately re-reads from making a pointless round trip.
+
+The manager groups them by space and passes them to each replica, which adds
+its own reasons to keep a document before acting.
+
+## The server decides what may be dropped
+
+A replica may not discard a document on its own initiative. The server tracks
+which entities each session holds, and `session.watch.add` deliberately does not
+resend an entity the session already holds at the current sequence number
+(protocol §4.3.6). A document the client dropped without telling the server
+could therefore never be pulled back: every later request for it would be
+answered with nothing.
+
+**The invariant: a client must never discard a document without giving up the
+watch that covers it.** The server does not resend what it believes you hold, so
+a document dropped without telling the server is a document you can never get
+back. Anything that throws documents away — `reset()` is the one such path
+today, and it has no production callers — has to give up the watches behind them
+in the same breath, or leave the replica able to serve reads it can no longer
+keep current.
+
+So the replica shrinks its *watches*, and takes the server's answer as the
+authority for what it may then forget:
+
+1. Each pull installs a watch spec rooted at the document it asked for. The
+   replica keeps that spec list as a mirror of the server's.
+2. Releasing a document gives up the specs rooted at it, with
+   `session.watch.remove`.
+3. The server recomputes the union of the surviving watches and answers with
+   `removes` for every entity that left it.
+4. Those, and only those, are discarded.
+
+A server too old to advertise the `watchRemove` capability gets an equivalent
+`session.watch.set` carrying the survivors instead.
+
+A document that leaves the union while this replica still wants it — a dropped
+watch was covering it as well as its own root — is pulled again instead of
+discarded, and its value stays readable in the meantime. "Still wants it" is
+either arm of the interest test: a live reader, or one of the replica's own local
+reasons. That is a safety valve rather than a normal path: in a paging view, a
+page's rows lose their readers together with the spec that covers them.
+
+A background refresh whose re-evaluated union turned out smaller reports
+`removes` too. With release off those documents are handled exactly as before —
+the record stays, with its confirmed value cleared — so nothing about the
+default configuration changes.
+
+`session.watch.remove` names only the watches that go, so it is independent of
+what else is happening and never has to wait. The two shrinks that instead have
+to name the watches that *survive* — the one after a replica reset, which has no
+ids to name, and the fallback for a server without the verb — are built from a
+snapshot of the watch set, and watch mutations reach the server in issue order,
+so a snapshot taken before a concurrent refresh would take that refresh's new
+watches straight back off. Those two wait for the wire to be free of refreshes,
+and hold refreshes off for their own round trip.
+
+That is the reason the verb exists at all. Both forms cost the server the same
+work — dropping any watch means re-evaluating the union of the survivors — but
+the request bodies differ by orders of magnitude. Measured over a paging walk holding
+roughly thirteen hundred live watches, a replacement request carried 590 to 757
+kilobytes of surviving watch specs regardless of how little was being dropped,
+against 0.5 to 36 kilobytes of identifiers for a removal.
+
+## Reading a released document
+
+A released document reads exactly as a document this replica has never pulled:
+absent. The read path already handles that case — it is the fresh-replica read
+asymmetry that link resolution and schema traversal kick a background load for,
+recording the read reactively so the reader re-runs when the value lands, and
+registering the load so `Cell.pull()` and `storageManager.synced()` wait for it.
+
+Release is what makes that kick fire again: it retracts the one-shot
+reservations that say a load for the document has already been kicked
+(`StorageManager`'s pull kicks and `Runtime`'s missing-document kicks) and drops
+the document's selectors from the watch selector tracker, so the pull is neither
+suppressed as a duplicate nor skipped as already covered.
+
+A one-shot read taken between the release and the reload therefore sees absent
+where a value exists. This is the same contract, and the same one-round-trip
+window, that a read of a never-pulled document has always had. It is bounded by
+what release covers: nothing that a live reader depends on is released, so the
+reads that can land in that window are the ones taken from outside the reactive
+graph.
+
+That window is not yet closed everywhere, which is why the flag is off. Run the
+runner suite with release forced on and three files hang and eleven cases fail;
+the same suite is clean with it off. A list projection whose elements were
+released comes out with an empty aggregate in all three builtins, and conflict
+handling can wait forever for a sync frame that only arrives over a watch the
+release gave up. [The experimental options
+registry](EXPERIMENTAL_OPTIONS.md) lists the reproducers.
+
+The way to judge this is to run the suite with the flag forced on — one line in
+`defaultSettings` — not to reason about which shapes are affected. Hand probes
+of individual shapes have twice suggested the problem was gone when it was not:
+the shrink-then-regrow shape releases no element document at all, so a probe
+built on it cannot reach the condition it appears to test.
+
+## Observing it
+
+`ISpaceReplica.retentionStats()` reports how many documents a replica holds, how
+many it watches, and how many watch specs it has installed. Two things read it.
+`packages/runner/test/document-release.test.ts` pins the property this exists
+for: sliding a window of subscriptions across a collection holds a replica to a
+bounded set of documents with release on, and grows it monotonically without.
+`packages/runner/test/measure-document-retention.ts` is the same walk at scale,
+run by hand, printing the counts and the retained heap per page — that is where
+the numbers in the release record come from.

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -267,6 +267,9 @@ One line per archived document; each document's header carries the fuller
 - [2026-07-binary-artifact-transfer.md](development/performance/2026-07-binary-artifact-transfer.md)
   — binary artifact file and byte transfer snapshot before the per-binary
   workflow split, July 2026.
+- [2026-07-document-release.md](development/performance/2026-07-document-release.md)
+  — what a space replica held before and after documents could be released,
+  July 2026.
 - [scoped-cells-field-notes.md](development/scoped-cells-field-notes.md) —
   field journal from the first scoped-cell patterns.
 - [2026-07-02-convergence-evidence-appendix.md](plans/2026-07-02-convergence-evidence-appendix.md)

--- a/docs/history/development/performance/2026-07-document-release.md
+++ b/docs/history/development/performance/2026-07-document-release.md
@@ -1,0 +1,102 @@
+---
+status: historical
+created: 2026-07-29
+archived: 2026-07-29
+reason: "Measurement record: what a space replica holds as a view pages through a collection, before and after documents could be released."
+---
+
+# Releasing documents bounds what a paging view retains, July 2026
+
+The mechanism measured here is described in
+[document release](../../../development/document-release.md), and is implemented
+behind `experimentalDocumentRelease`.
+
+## Result
+
+A replica that starts empty, sliding a window of live subscriptions across a
+thousand-document collection twenty-five at a time — the shape of any view paging
+through more data than fits on screen:
+
+| After forty pages    | Off   | On   |
+| -------------------- | ----- | ---- |
+| Documents held       | 1,000 | 0    |
+| Documents watched    | 1,000 | 0    |
+| Post-collection heap | 45 MB | 39 MB |
+
+Off, the replica gains exactly one page of documents and one page of watched
+identifiers per page turned, and gives back none of it: the count after page *n*
+is 25(*n*+1), all the way to the whole collection. Heap climbs monotonically with
+it, about 0.18 MB per page.
+
+On, the count returns to zero after every page. Nothing is read at the point of
+measurement — each page's subscriptions are cancelled before it is taken — so
+zero is the correct answer, and the contrast is the point: the same walk either
+accumulates the entire collection or holds nothing. Heap growth over the forty
+pages falls from 7.1 MB to 0.7 MB, and what remains is not document retention,
+since the document count is flat.
+
+| Page | Off: docs / heap | On: docs / heap |
+| ---- | ---------------- | --------------- |
+| 0    | 25 / 38.2 MB     | 0 / 38.1 MB     |
+| 9    | 250 / 40.0 MB    | 0 / 38.5 MB     |
+| 19   | 500 / 41.8 MB    | 0 / 38.6 MB     |
+| 29   | 750 / 43.7 MB    | 0 / 38.8 MB     |
+| 39   | 1,000 / 45.3 MB  | 0 / 38.8 MB     |
+
+## How it was measured
+
+`packages/runner/test/measure-document-retention.ts`, run as
+
+```
+deno run -A --v8-flags=--expose-gc \
+  packages/runner/test/measure-document-retention.ts --pages 40 --page-size 25
+```
+
+and again with `--release`. It populates a space from one replica, then opens a
+second replica against the same in-process server that starts empty and has to
+pull whatever it reads. Rows are two kilobytes of text plus sixteen tags each, so
+retaining one costs enough to show in the heap column. Two full collections are
+forced before each reading, so every number is retained heap rather than
+allocation noise, and the counts come from the replica itself through
+`ISpaceReplica.retentionStats()`.
+
+Both runs were taken on the same machine with nothing else running, back to back.
+
+`packages/runner/test/document-release.test.ts` pins the same property as an
+assertion rather than a reading: bounded with release, strictly monotonic
+without.
+
+## Where the numbers came from originally
+
+The same growth was first seen at a much larger scale in an experimental view
+that paged through several hundred records of live agent data, each with a nested
+raw-data projection. There a page turn cost about five hundred documents and five
+hundred watched identifiers, and twenty page turns took the client to fifteen
+thousand documents and 438 MB of retained heap — enough to exhaust a browser
+renderer's heap and kill the tab. That view is exploratory and may never land, so
+the measurement above deliberately reproduces the effect with nothing but the
+runner and the memory server. The per-page ratios agree; the absolute numbers
+scale with how much each record carries.
+
+## What this does not yet do
+
+The mechanism is off by default because it breaks the runner suite. Forcing
+`experimentalDocumentRelease` on in `defaultSettings` and running all 539 runner
+test files gives three hangs and eleven failing cases across ten files; the same
+suite is clean with the flag off. A list projection whose elements were released
+comes out with an empty aggregate in all three builtins, and conflict handling
+can wait forever for a sync frame that only arrives over a watch the release
+gave up.
+
+The retention figures above are unaffected by that — they measure what the
+replica holds, which is the thing this changes — but they are not a readiness
+claim. The experimental options registry carries the reproducers.
+
+## What the shrink verb is worth
+
+`session.watch.remove` was added for this change rather than reusing
+`session.watch.set`, whose request has to carry every watch spec that survives.
+Logging both request bodies at each shrink over a paging walk with roughly
+thirteen hundred live watches, a replacement carried 590 to 757 kB and a removal
+0.5 to 36 kB — and the replacement's size tracks what survives, so it does not
+fall as the working set settles. Two shrinks land per page turn.

--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -30,8 +30,7 @@ rewrite. In particular:
   than a server-issued, principal-bound identifier
 - the public one-shot read surfaces are `graph.query`, `entity-id.list`, and
   `entity-id.exists`
-- watch-set mutations return inline `sync` payloads, and steady-state topology
-  shrink does not yet guarantee automatic `removes`
+- watch-set mutations return inline `sync` payloads
 
 ## 4.1 Transport
 
@@ -55,7 +54,8 @@ The client MUST declare its protocol version in the first WebSocket message:
     "syncSchemaTableV2": true,
     "entityIdListing": true,
     "entityIdPagination": true,
-    "entityIdLookup": true
+    "entityIdLookup": true,
+    "watchRemove": true
   }
 }
 ```
@@ -72,7 +72,8 @@ If the server accepts the protocol, it returns:
     "syncSchemaTableV2": true,
     "entityIdListing": true,
     "entityIdPagination": true,
-    "entityIdLookup": true
+    "entityIdLookup": true,
+    "watchRemove": true
   },
   "sessionOpen": {
     "audience": "did:key:z6Mk...",
@@ -153,6 +154,11 @@ advertises the capability.
 `entity-id.exists`. Both default to `false` when absent. A client connected to
 an older server may make the historical unpaginated list request, but must not
 send continuation fields or an existence request.
+
+`watchRemove` advertises support for `session.watch.remove`. It defaults to
+`false` when absent. A client connected to an older server shrinks its watch
+set with `session.watch.set` carrying the survivors, which has the same
+effect.
 
 ### 4.1.2 Logical Sessions and Resume
 
@@ -273,6 +279,7 @@ interface HelloMessage {
     entityIdListing?: boolean;
     entityIdPagination?: boolean;
     entityIdLookup?: boolean;
+    watchRemove?: boolean;
   };
 }
 
@@ -285,6 +292,7 @@ interface RequestMessage {
     | "entity-id.exists"
     | "session.watch.set"
     | "session.watch.add"
+    | "session.watch.remove"
     | "session.ack";
   requestId: string;
   space: SpaceId;
@@ -635,9 +643,21 @@ Semantics:
 
 - the provided watch list replaces the entire prior watch set for the session
 - the server recomputes the union of watched entities
-- the response carries the initial `sync` needed to bring the session cache in
-  line with the new interest set
+- the response carries the `sync` needed to bring the session cache in line
+  with the new interest set: `upserts` for entities the session does not
+  already hold at that sequence number, and `removes` for entities that left
+  the union
+- a session that has just been opened fresh holds nothing, so its first
+  `session.watch.set` carries every entity in the union
 - later committed changes continue to arrive via `session/effect`
+
+Shrinking the watch set is how a client hands memory back. The server tracks
+which entities each session holds, and `session.watch.add` deliberately does
+not resend an entity the session already holds at the current sequence number,
+so a client that drops a document on its own initiative can never pull it back.
+A client that wants to forget a document must therefore drop the watches that
+cover it and take the resulting `removes` as the authority for what it may
+discard.
 
 ### 4.3.6 `session.watch.add` — Extend the Session Watch Set
 
@@ -673,13 +693,48 @@ Semantics:
   entity-plus-selector pair
 - the server returns the inline `sync` needed for the mutation; pure additive
   growth does not emit `removes`
-- in the current pass, `removes` are only guaranteed for explicit watch-set
-  replacement; steady-state topology shrink does not yet drive automatic
-  unwatch behavior
+- `removes` are emitted by an explicit watch-set change — `session.watch.set`
+  and `session.watch.remove` — and by a background refresh whose re-evaluated
+  union turned out smaller. Pure additive growth emits none
 - watch mutations are applied in order per session; clients must serialize
   `session.watch.set` and `session.watch.add`
 
-### 4.3.7 Branch Lifecycle Commands
+### 4.3.7 `session.watch.remove` — Shrink the Session Watch Set
+
+`session.watch.remove` drops watches from the session watch set by `id`.
+Requires the `watchRemove` capability.
+
+```typescript
+// Shown at module scope.
+interface WatchRemoveRequest {
+  type: "session.watch.remove";
+  requestId: string;
+  space: SpaceId;
+  sessionId: SessionId;
+  watchIds: string[];
+}
+
+interface WatchRemoveResult {
+  serverSeq: number;
+  sync: SessionSync;
+}
+```
+
+Semantics:
+
+- each named watch is dropped; an `id` the session does not hold is ignored
+- the server recomputes the union of the surviving watches and answers exactly
+  as `session.watch.set` would for that same surviving list: `upserts` for
+  entities the session does not already hold at that sequence number, and
+  `removes` for entities that left the union
+- the two verbs differ only in what the request has to carry. Replacement names
+  everything that stays, so its request grows with the size of the watch set; a
+  removal names only what goes. A client shrinking a large watch set a page at a
+  time should prefer this one
+- watch mutations are applied in order per session, alongside
+  `session.watch.set` and `session.watch.add`
+
+### 4.3.8 Branch Lifecycle Commands
 
 Branch create / delete / merge lifecycle commands are not currently exposed on
 the v2 wire. The engine already carries branch state internally, but public wire
@@ -827,9 +882,10 @@ When the client replaces the watch set:
 - entities still relevant but unchanged are not resent unless needed for
   catch-up
 
-In the current pass, that `removes` guarantee only applies to explicit
-watch-set replacement. Steady-state topology shrink during background refresh
-does not yet drive automatic unwatch behavior.
+The same holds for a background refresh: the server diffs the re-evaluated
+union against what the session holds, so an entity that has left it is reported
+as a `remove` there too. What no verb does is shrink the watch set on the
+client's behalf — the set changes only when the client changes it.
 
 ### 4.6.4 Cross-Session Delivery
 

--- a/packages/memory/test/v2-server-sync-test.ts
+++ b/packages/memory/test/v2-server-sync-test.ts
@@ -1,7 +1,6 @@
 import { assertEquals } from "@std/assert";
 import {
   buildDiffSync,
-  buildFullSync,
   cacheKeyForEntity,
   toCacheEntry,
 } from "../v2/server-sync.ts";
@@ -58,15 +57,6 @@ Deno.test("memory v2 session sync removes include scope", () => {
     }],
   ]);
 
-  assertEquals(buildFullSync(previous, new Map(), 1, 2).removes, [{
-    branch: "",
-    id: "of:space",
-    scope: "space",
-  }, {
-    branch: "",
-    id: "of:user",
-    scope: "user",
-  }]);
   assertEquals(buildDiffSync(previous, new Map(), 1, 2).removes, [{
     branch: "",
     id: "of:space",

--- a/packages/memory/test/v2-test.ts
+++ b/packages/memory/test/v2-test.ts
@@ -146,6 +146,7 @@ describe("memory v2 flags", () => {
       entityIdListing: true,
       entityIdPagination: true,
       entityIdLookup: true,
+      watchRemove: true,
       syncSchemaTableV2: false,
     });
 
@@ -164,6 +165,7 @@ describe("memory v2 flags", () => {
       entityIdListing: true,
       entityIdPagination: true,
       entityIdLookup: true,
+      watchRemove: true,
       syncSchemaTableV2: true,
     });
 
@@ -186,6 +188,7 @@ describe("memory v2 flags", () => {
         entityIdListing: true,
         entityIdPagination: true,
         entityIdLookup: true,
+        watchRemove: false,
       },
       {
         modernCellRep: true,
@@ -201,6 +204,7 @@ describe("memory v2 flags", () => {
         entityIdListing: false,
         entityIdPagination: false,
         entityIdLookup: false,
+        watchRemove: false,
       },
     ));
   });
@@ -219,6 +223,7 @@ describe("parseMemoryProtocolFlags", () => {
       entityIdListing: false,
       entityIdPagination: false,
       entityIdLookup: false,
+      watchRemove: false,
     });
     assertEquals(parseMemoryProtocolFlags({ modernCellRep: false }), {
       modernCellRep: false,
@@ -231,6 +236,7 @@ describe("parseMemoryProtocolFlags", () => {
       entityIdListing: false,
       entityIdPagination: false,
       entityIdLookup: false,
+      watchRemove: false,
     });
   });
 
@@ -250,6 +256,7 @@ describe("parseMemoryProtocolFlags", () => {
         entityIdListing: false,
         entityIdPagination: false,
         entityIdLookup: false,
+        watchRemove: false,
       },
     );
   });
@@ -270,6 +277,7 @@ describe("parseMemoryProtocolFlags", () => {
         entityIdListing: false,
         entityIdPagination: false,
         entityIdLookup: false,
+        watchRemove: false,
       },
     );
   });
@@ -290,6 +298,7 @@ describe("parseMemoryProtocolFlags", () => {
         entityIdListing: false,
         entityIdPagination: false,
         entityIdLookup: false,
+        watchRemove: false,
       },
     );
   });
@@ -310,6 +319,7 @@ describe("parseMemoryProtocolFlags", () => {
         entityIdListing: false,
         entityIdPagination: false,
         entityIdLookup: false,
+        watchRemove: false,
       },
     );
   });
@@ -330,6 +340,7 @@ describe("parseMemoryProtocolFlags", () => {
         entityIdListing: false,
         entityIdPagination: false,
         entityIdLookup: false,
+        watchRemove: false,
       },
     );
   });
@@ -350,6 +361,7 @@ describe("parseMemoryProtocolFlags", () => {
         entityIdListing: false,
         entityIdPagination: false,
         entityIdLookup: false,
+        watchRemove: false,
       },
     );
   });
@@ -368,6 +380,7 @@ describe("parseMemoryProtocolFlags", () => {
         entityIdListing: true,
         entityIdPagination: false,
         entityIdLookup: false,
+        watchRemove: false,
       },
     );
   });
@@ -389,8 +402,29 @@ describe("parseMemoryProtocolFlags", () => {
         entityIdListing: false,
         entityIdPagination: true,
         entityIdLookup: true,
+        watchRemove: false,
       },
     );
+  });
+
+  it("accepts the watchRemove capability key", () => {
+    assertEquals(
+      parseMemoryProtocolFlags({ watchRemove: true }),
+      {
+        modernCellRep: false,
+        persistentSchedulerState: false,
+        commitPreconditions: false,
+        syncSchemaTable: false,
+        syncSchemaTableV2: false,
+        sqliteCommitRowLabelEval: false,
+        pendingReadStacks: false,
+        entityIdListing: false,
+        entityIdPagination: false,
+        entityIdLookup: false,
+        watchRemove: true,
+      },
+    );
+    assertEquals(parseMemoryProtocolFlags({ watchRemove: "true" }), null);
   });
 
   it("rejects values that are not a recognizable flags shape", () => {

--- a/packages/memory/test/v2-watch-remove-test.ts
+++ b/packages/memory/test/v2-watch-remove-test.ts
@@ -1,0 +1,210 @@
+import { assertEquals, assertExists } from "@std/assert";
+import { Server } from "../v2/server.ts";
+import {
+  encodeMemoryBoundary,
+  getMemoryProtocolFlags,
+  type HelloOkMessage,
+  MEMORY_PROTOCOL,
+  type ResponseMessage,
+  type ServerMessage,
+  type SessionOpenAuthMetadata,
+  type SessionSync,
+} from "../v2.ts";
+import * as MemoryV2Client from "../v2/client.ts";
+import {
+  testSessionOpenAuthFactory,
+  testSessionOpenServerOptions,
+} from "./v2-auth-test-helpers.ts";
+
+const HELLO = {
+  type: "hello",
+  protocol: MEMORY_PROTOCOL,
+  flags: getMemoryProtocolFlags(),
+} as const;
+
+const shiftMessage = (messages: ServerMessage[]): ServerMessage => {
+  const message = messages.shift();
+  assertExists(message);
+  return message;
+};
+
+const assertResponse = <Result>(
+  message: ServerMessage,
+): ResponseMessage<Result> => {
+  assertEquals(message.type, "response");
+  return message as ResponseMessage<Result>;
+};
+
+const expectHelloOk = (messages: ServerMessage[]): SessionOpenAuthMetadata => {
+  const hello = shiftMessage(messages) as HelloOkMessage;
+  assertEquals(hello.type, "hello.ok");
+  assertExists(hello.sessionOpen);
+  return hello.sessionOpen;
+};
+
+const watchSpec = (id: string) => ({
+  id: `watch-${id}`,
+  kind: "graph" as const,
+  query: {
+    roots: [{ id, selector: { path: [], schema: false } }],
+  },
+});
+
+type WatchResult = { serverSeq: number; sync: SessionSync };
+
+Deno.test("memory v2 server advertises the watchRemove capability", () => {
+  assertEquals(getMemoryProtocolFlags().watchRemove, true);
+});
+
+Deno.test("memory v2 client removes watches on a session holding none", async () => {
+  const server = new Server({
+    ...testSessionOpenServerOptions,
+    store: new URL("memory://memory-v2-watch-remove-empty"),
+    subscriptionRefreshDelayMs: 0,
+  });
+  const client = await MemoryV2Client.connect({
+    transport: MemoryV2Client.loopback(server),
+  });
+  try {
+    const session = await client.mount(
+      "did:key:z6Mk-watch-remove-empty",
+      {},
+      testSessionOpenAuthFactory,
+    );
+    // No watch has been installed, so the session has no view to apply the
+    // answer to and no watch to drop. It still gets a usable view back.
+    const { view, sync } = await session.watchRemoveSync(["watch-absent"]);
+    assertEquals(sync.upserts, []);
+    assertEquals(sync.removes, []);
+    assertExists(view);
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});
+
+Deno.test("memory v2 server drops named watches and reports what left the union", async () => {
+  const server = new Server({
+    ...testSessionOpenServerOptions,
+    store: new URL("memory://memory-v2-watch-remove"),
+    subscriptionRefreshDelayMs: 0,
+  });
+  const messages: ServerMessage[] = [];
+  const writerMessages: ServerMessage[] = [];
+  const connection = server.connect((message) => messages.push(message));
+  const writer = server.connect((message) => writerMessages.push(message));
+  const space = "did:key:z6Mk-watch-remove";
+
+  try {
+    await connection.receive(encodeMemoryBoundary(HELLO));
+    await writer.receive(encodeMemoryBoundary(HELLO));
+    const sessionOpen = expectHelloOk(messages);
+    const writerSessionOpen = expectHelloOk(writerMessages);
+    await connection.receive(encodeMemoryBoundary({
+      type: "session.open",
+      requestId: "open",
+      space,
+      session: {},
+      invocation: {
+        aud: sessionOpen.audience,
+        challenge: sessionOpen.challenge.value,
+      },
+    }));
+    const opened = assertResponse<{ sessionId: string }>(
+      shiftMessage(messages),
+    );
+    const sessionId = opened.ok!.sessionId;
+
+    await writer.receive(encodeMemoryBoundary({
+      type: "session.open",
+      requestId: "writer-open",
+      space,
+      session: {},
+      invocation: {
+        aud: writerSessionOpen.audience,
+        challenge: writerSessionOpen.challenge.value,
+      },
+    }));
+    const writerOpened = assertResponse<{ sessionId: string }>(
+      shiftMessage(writerMessages),
+    );
+    const writerSessionId = writerOpened.ok!.sessionId;
+
+    for (const [index, id] of ["of:doc:1", "of:doc:2"].entries()) {
+      await writer.receive(encodeMemoryBoundary({
+        type: "transact",
+        requestId: `tx-${index}`,
+        space,
+        sessionId: writerSessionId,
+        commit: {
+          localSeq: index + 1,
+          reads: { confirmed: [], pending: [] },
+          operations: [{ op: "set", id, value: { value: { n: index } } }],
+        },
+      }));
+      shiftMessage(writerMessages);
+    }
+
+    await connection.receive(encodeMemoryBoundary({
+      type: "session.watch.set",
+      requestId: "watch",
+      space,
+      sessionId,
+      watches: [watchSpec("of:doc:1"), watchSpec("of:doc:2")],
+    }));
+    const installed = assertResponse<WatchResult>(shiftMessage(messages));
+    assertEquals(
+      installed.ok!.sync.upserts.map((upsert) => upsert.id),
+      ["of:doc:1", "of:doc:2"],
+    );
+
+    await connection.receive(encodeMemoryBoundary({
+      type: "session.watch.remove",
+      requestId: "remove",
+      space,
+      sessionId,
+      // The unknown id is ignored rather than rejected.
+      watchIds: ["watch-of:doc:1", "watch-of:nothing"],
+    }));
+    const removed = assertResponse<WatchResult>(shiftMessage(messages));
+    // Only the document that left the union is named, and the one that stayed
+    // is not resent: the session already holds it at this sequence number.
+    assertEquals(removed.ok!.sync.removes, [{
+      branch: "",
+      id: "of:doc:1",
+      scope: "space",
+    }]);
+    assertEquals(removed.ok!.sync.upserts, []);
+
+    // A write to the dropped document no longer reaches this session, and one
+    // to the surviving document still does.
+    await writer.receive(encodeMemoryBoundary({
+      type: "transact",
+      requestId: "tx-after",
+      space,
+      sessionId: writerSessionId,
+      commit: {
+        localSeq: 3,
+        reads: { confirmed: [], pending: [] },
+        operations: [
+          { op: "set", id: "of:doc:1", value: { value: { n: 100 } } },
+          { op: "set", id: "of:doc:2", value: { value: { n: 200 } } },
+        ],
+      },
+    }));
+    shiftMessage(writerMessages);
+    // Drive the subscription refresh rather than waiting for its timer, so the
+    // assertion below reads a settled state.
+    await server.flushSessions();
+
+    const effects = messages.filter((message) =>
+      message.type === "session/effect"
+    ) as { effect: SessionSync }[];
+    const touched = effects.flatMap((message) =>
+      message.effect.upserts.map((upsert) => upsert.id)
+    );
+    assertEquals(touched, ["of:doc:2"]);
+  } finally {
+    await server.close();
+  }
+});

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -321,6 +321,13 @@ export type MemoryProtocolFlags = {
   entityIdPagination: boolean;
   /** The server can test one entity identifier without loading its value. */
   entityIdLookup: boolean;
+  /**
+   * The server accepts `session.watch.remove`, which drops watches by id and
+   * recomputes the session's watch union. A client that sees this absent (an
+   * older server) shrinks its watch set with `session.watch.set` instead,
+   * which is equivalent but carries every surviving spec in the request.
+   */
+  watchRemove: boolean;
 };
 
 /**
@@ -337,6 +344,7 @@ export type WireMemoryProtocolFlags = {
   entityIdListing?: boolean;
   entityIdPagination?: boolean;
   entityIdLookup?: boolean;
+  watchRemove?: boolean;
 };
 
 export type HelloMessage = {
@@ -476,6 +484,11 @@ export type WatchSetResult = {
 };
 
 export type WatchAddResult = {
+  serverSeq: number;
+  sync: SessionSync;
+};
+
+export type WatchRemoveResult = {
   serverSeq: number;
   sync: SessionSync;
 };
@@ -646,6 +659,15 @@ export type WatchAddRequest = {
   space: string;
   sessionId: SessionId;
   watches: WatchSpec[];
+};
+
+export type WatchRemoveRequest = {
+  type: "session.watch.remove";
+  requestId: string;
+  space: string;
+  sessionId: SessionId;
+  /** Watch ids to drop. Ids the session does not hold are ignored. */
+  watchIds: string[];
 };
 
 export type SessionAckRequest = {
@@ -856,6 +878,7 @@ export type ClientMessage =
   | SqliteRegisterDiskSourceRequest
   | WatchSetRequest
   | WatchAddRequest
+  | WatchRemoveRequest
   | SchedulerSnapshotListRequest
   | SessionAckRequest;
 export type ServerMessage =
@@ -946,6 +969,8 @@ export const getMemoryProtocolFlags = (): MemoryProtocolFlags => ({
   entityIdListing: true,
   entityIdPagination: true,
   entityIdLookup: true,
+  // Build-inherent: this build's server implements the verb.
+  watchRemove: true,
   syncSchemaTableV2: getSyncSchemaTableConfig(),
 });
 
@@ -1051,6 +1076,14 @@ export const parseMemoryProtocolFlags = (
     return null;
   }
 
+  const watchRemove = value.watchRemove;
+  if (
+    watchRemove !== undefined &&
+    typeof watchRemove !== "boolean"
+  ) {
+    return null;
+  }
+
   return {
     modernCellRep: modernCellRep === true,
     persistentSchedulerState: persistentSchedulerState === true,
@@ -1066,6 +1099,9 @@ export const parseMemoryProtocolFlags = (
     entityIdListing: entityIdListing === true,
     entityIdPagination: entityIdPagination === true,
     entityIdLookup: entityIdLookup === true,
+    // Absent (an older server) parses to false: the client shrinks its watch
+    // set with `session.watch.set` unless the verb is positively advertised.
+    watchRemove: watchRemove === true,
   };
 };
 
@@ -1085,6 +1121,7 @@ export const wireMemoryProtocolFlags = (
   entityIdListing: flags.entityIdListing,
   entityIdPagination: flags.entityIdPagination,
   entityIdLookup: flags.entityIdLookup,
+  watchRemove: flags.watchRemove,
 });
 
 /**

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -31,6 +31,7 @@ import {
   type SqliteQueryResult,
   type SqliteRegisterDiskSourceResult,
   type WatchAddResult,
+  type WatchRemoveResult,
   type WatchSetResult,
   type WatchSpec,
 } from "../v2.ts";
@@ -876,6 +877,47 @@ export class SpaceSession {
             [...this.#watchSpecs, ...watches].map((watch) => [watch.id, watch]),
           ).values(),
         ];
+        if (this.#watchView === null) {
+          this.#watchView = WatchView.fromSync(result.sync);
+        } else {
+          this.#watchView.applySync(result.sync, false);
+        }
+        this.scheduleAck(result.serverSeq);
+        return {
+          view: this.#watchView,
+          sync: result.sync,
+        };
+      },
+    );
+  }
+
+  /**
+   * Whether this session's server accepts `session.watch.remove`. A caller
+   * shrinking its watch set uses `watchRemoveSync` when it does and
+   * `watchSetSync` with the survivors when it does not; the two have the same
+   * effect, and only the request differs.
+   */
+  get supportsWatchRemove(): boolean {
+    return this.client.serverFlags?.watchRemove === true;
+  }
+
+  async watchRemoveSync(watchIds: string[]): Promise<WatchMutationResult> {
+    this.#assertOpen();
+    return await this.runWatchMutation(
+      () =>
+        this.client.request<WatchRemoveResult>({
+          type: "session.watch.remove",
+          requestId: crypto.randomUUID(),
+          space: this.space,
+          sessionId: this.#sessionId,
+          watchIds,
+        }),
+      (result) => {
+        this.noteResult(result.serverSeq);
+        const dropped = new Set(watchIds);
+        this.#watchSpecs = this.#watchSpecs.filter((watch) =>
+          !dropped.has(watch.id)
+        );
         if (this.#watchView === null) {
           this.#watchView = WatchView.fromSync(result.sync);
         } else {

--- a/packages/memory/v2/server-sync.ts
+++ b/packages/memory/v2/server-sync.ts
@@ -130,34 +130,6 @@ export const sameWatchSpec = (
   left.kind === right.kind &&
   watchQueryIdentity(left) === watchQueryIdentity(right);
 
-export const buildFullSync = (
-  previous: ReadonlyMap<string, SessionCacheEntry>,
-  next: ReadonlyMap<string, SessionCacheEntry>,
-  fromSeq: number,
-  toSeq: number,
-): SessionSync => {
-  const removes = [...previous.values()]
-    .filter((entry) =>
-      !next.has(
-        cacheKeyForEntity(entry.branch, entry.id, entry.scope),
-      )
-    )
-    .map((entry) => ({
-      branch: entry.branch,
-      id: entry.id,
-      scope: entry.scope,
-    }))
-    .sort(compareSyncAddress);
-  const upserts = [...next.values()].sort(compareSyncAddress);
-  return {
-    type: "sync",
-    fromSeq,
-    toSeq,
-    upserts,
-    removes,
-  };
-};
-
 export const buildDiffSync = (
   previous: ReadonlyMap<string, SessionCacheEntry>,
   next: ReadonlyMap<string, SessionCacheEntry>,

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -48,6 +48,8 @@ import {
   type V2Error,
   type WatchAddRequest,
   type WatchAddResult,
+  type WatchRemoveRequest,
+  type WatchRemoveResult,
   type WatchSetRequest,
   type WatchSetResult,
   type WatchSpec,
@@ -91,7 +93,6 @@ import { respondToHello } from "./handshake.ts";
 import { compressServerMessageSchemas } from "./sync-schema-table.ts";
 import {
   buildDiffSync,
-  buildFullSync,
   cacheKeyForEntity,
   groupedQueries,
   isEmptySync,
@@ -775,6 +776,26 @@ class Connection {
         }
         {
           const response = await this.server.watchAdd(parsed);
+          this.sendSessionResponse(
+            parsed.space,
+            parsed.sessionId,
+            parsed.requestId,
+            response,
+          );
+        }
+        return;
+      case "session.watch.remove":
+        if (
+          !this.requireSession(
+            parsed.requestId,
+            parsed.space,
+            parsed.sessionId,
+          )
+        ) {
+          return;
+        }
+        {
+          const response = await this.server.watchRemove(parsed);
           this.sendSessionResponse(
             parsed.space,
             parsed.sessionId,
@@ -2543,8 +2564,30 @@ export class Server {
     }
   }
 
-  async watchSet(
+  watchSet(
     message: WatchSetRequest,
+  ): Promise<ResponseMessage<WatchSetResult>> {
+    return this.replaceSessionWatches(message, () => message.watches);
+  }
+
+  /**
+   * Drop watches by id. Equivalent to a `session.watch.set` carrying the
+   * survivors, but the request names only what goes — which is what a client
+   * shrinking a large watch set one page at a time actually has to say.
+   */
+  watchRemove(
+    message: WatchRemoveRequest,
+  ): Promise<ResponseMessage<WatchRemoveResult>> {
+    const dropped = new Set(message.watchIds);
+    return this.replaceSessionWatches(
+      message,
+      (current) => current.filter((watch) => !dropped.has(watch.id)),
+    );
+  }
+
+  private async replaceSessionWatches(
+    message: WatchSetRequest | WatchRemoveRequest,
+    next: (current: readonly WatchSpec[]) => WatchSpec[],
   ): Promise<ResponseMessage<WatchSetResult>> {
     const session = this.#sessions.get(message.space, message.sessionId);
     if (session === null) {
@@ -2575,23 +2618,30 @@ export class Server {
       }
     }
 
+    const watches = next(session.watches);
     try {
       const { serverSeq, graphs, entities } = await this.evaluateWatchSet(
         message.space,
-        message.watches,
+        watches,
         aclEngine,
         {
           principal: session.principal,
           sessionId: message.sessionId,
         },
+        message.type,
       );
-      const sync = buildFullSync(
+      // Entities the session already holds at the same seq are not resent
+      // (protocol §4.6.3); the client learns what left the union from
+      // `removes`. On the reconnect path, where a non-resumed session starts
+      // with an empty entity cache, this produces the same frame a full
+      // send would.
+      const sync = buildDiffSync(
         session.entities,
         entities,
         session.seenSeq,
         serverSeq,
       );
-      session.watches = message.watches;
+      session.watches = watches;
       session.graphs = graphs;
       session.entities = entities;
       session.trackedIds = trackedIdsFromEntries(entities.values());
@@ -2822,6 +2872,7 @@ export class Server {
     watches: readonly WatchSpec[],
     engine?: Engine.Engine,
     scopeContext: { principal?: string; sessionId?: string } = {},
+    label = "session.watch.set",
   ): Promise<{
     serverSeq: number;
     graphs: Map<string, TrackedGraphState>;
@@ -2864,7 +2915,7 @@ export class Server {
       }
     }
 
-    recordSlowQueryDuration("session.watch.set", space, startedAt, {
+    recordSlowQueryDuration(label, space, startedAt, {
       watches: watches.length,
     });
     return {
@@ -3920,6 +3971,23 @@ export const parseClientMessage = (
       space: parsed.space,
       sessionId: parsed.sessionId,
       watches: parsed.watches as WatchSpec[],
+    };
+  }
+
+  if (
+    parsed.type === "session.watch.remove" &&
+    typeof parsed.requestId === "string" &&
+    typeof parsed.space === "string" &&
+    typeof parsed.sessionId === "string" &&
+    Array.isArray(parsed.watchIds) &&
+    parsed.watchIds.every((id: unknown) => typeof id === "string")
+  ) {
+    return {
+      type: "session.watch.remove",
+      requestId: parsed.requestId,
+      space: parsed.space,
+      sessionId: parsed.sessionId,
+      watchIds: parsed.watchIds as string[],
     };
   }
 

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -40,6 +40,7 @@ import type {
   ChangeGroup,
   CommitError,
   DID,
+  IDocumentReleaseHooks,
   IExtendedStorageTransaction,
   IStorageManager,
   IStorageProvider,
@@ -1102,6 +1103,23 @@ export class Runtime {
       options.consoleHandler,
       options.errorHandlers,
     );
+
+    // Hand the storage layer the two answers it needs to release documents:
+    // whether a live reactive reader still depends on one, and what to forget
+    // once one is gone. Duck-typed like the telemetry hand-off above: only the
+    // v2 manager implements it.
+    (this.storageManager as {
+      setDocumentReleaseHooks?: (hooks: IDocumentReleaseHooks) => void;
+    }).setDocumentReleaseHooks?.({
+      hasReaders: (space, id, scope) =>
+        this.scheduler.hasDocumentReaders({ space, id, scope }),
+      documentDropped: (space, id, scope) => {
+        this.missingDocLoadKicks.delete(
+          `${space}\0${normalizeCellScope(scope)}\0${id}`,
+        );
+        this.storageManager.retractDocPullKick?.(space, id, scope);
+      },
+    });
 
     // Register built-in modules with runtime injection
     registerBuiltins(this);

--- a/packages/runner/src/scheduler/continuation.ts
+++ b/packages/runner/src/scheduler/continuation.ts
@@ -19,6 +19,7 @@ export interface ExecuteContinuationState {
   readonly setPendingQueueTaskTimer: (
     timer: ReturnType<typeof setTimeout> | null,
   ) => void;
+  readonly releaseUnreadDocuments: () => void;
   readonly execute: () => void;
 }
 
@@ -90,6 +91,11 @@ function resolveIdlePromises(promises: (() => void)[]): void {
 }
 
 function finishIdleEpisode(state: ExecuteContinuationState): void {
+  // The reactive graph has settled, so the read sets it leaves behind are the
+  // ones that matter: documents nothing reads any more can go back. Done
+  // before idle waiters resume, so a caller that awaits idle and then measures
+  // sees the decision taken.
+  state.releaseUnreadDocuments();
   resolveIdlePromises(state.idlePromises);
   state.resetConvergenceHoldPasses();
   state.resetSettlingTracker();

--- a/packages/runner/src/scheduler/facade.ts
+++ b/packages/runner/src/scheduler/facade.ts
@@ -172,7 +172,7 @@ import type {
   TriggerTraceEntry,
 } from "./types.ts";
 import { ensureNotRenderThread } from "@commonfabric/utils/env";
-import { entityKey } from "./keys.ts";
+import { entityKey, parseEntityKey } from "./keys.ts";
 
 ensureNotRenderThread();
 
@@ -1190,6 +1190,47 @@ export class Scheduler {
 
   async run(action: Action): Promise<any> {
     return await runSchedulerAction(this.actionRunState, action);
+  }
+
+  /**
+   * Whether any live action reads this document. This is the runner's record
+   * of reactive interest, and the storage layer's answer to "does anything
+   * still want this?".
+   */
+  hasDocumentReaders(
+    address: Pick<IMemorySpaceAddress, "space" | "id" | "scope">,
+  ): boolean {
+    return this.triggerIndex.hasReaders(entityKey(address));
+  }
+
+  /**
+   * Tell the storage layer about documents whose last reactive reader has
+   * gone. Called when the scheduler reaches quiescence, so no action is
+   * part-way through a run and the trigger index is settled: an entity that
+   * lost a reader and gained another during the same wave is filtered out
+   * here rather than released and immediately pulled back.
+   */
+  private releaseUnreadDocuments(): void {
+    // Drained unconditionally: the record is only bounded by something taking
+    // it, so leaving it to grow when nothing releases documents would be a leak
+    // of its own.
+    const candidates = this.triggerIndex.drainIdleCandidates();
+    const storage = this.runtime.storageManager;
+    if (storage.releasesDocuments?.() !== true) return;
+    const unread = candidates
+      .filter((entity) => !this.triggerIndex.hasReaders(entity))
+      .map(parseEntityKey)
+      // A `data:` identifier carries its value rather than naming a stored
+      // document, so there is nothing behind it to release. Decided here, where
+      // the identifier comes back out of its key, so the storage layer does not
+      // have to know the difference.
+      .filter(({ id }) => !id.startsWith("data:"));
+    // Reported even when this pass found nothing. A shrink that failed leaves
+    // its documents queued, and quiescence is the event that arms another
+    // attempt: without this it would wait for a fresh set of documents to lose
+    // their last reader, which may never come, and the release would silently
+    // stop happening.
+    storage.releaseDocuments?.(unread);
   }
 
   idle(): Promise<void> {
@@ -2477,6 +2518,7 @@ export class Scheduler {
       setPendingQueueTaskTimer: (timer) => {
         this.pendingQueueTaskTimer = timer;
       },
+      releaseUnreadDocuments: () => this.releaseUnreadDocuments(),
       execute: () => this.execute(),
     };
   }

--- a/packages/runner/src/scheduler/keys.ts
+++ b/packages/runner/src/scheduler/keys.ts
@@ -1,9 +1,31 @@
+import type { MemorySpace } from "@commonfabric/memory/interface";
+import type { CellScope } from "../builder/types.ts";
 import { normalizeCellScope } from "../scope.ts";
-import type { IMemorySpaceAddress } from "../storage/interface.ts";
+import type { IMemorySpaceAddress, URI } from "../storage/interface.ts";
 import type { SpaceScopeAndURI } from "./types.ts";
 
 export function entityKey(
   address: Pick<IMemorySpaceAddress, "space" | "id" | "scope">,
 ): SpaceScopeAndURI {
   return `${address.space}/${normalizeCellScope(address.scope)}/${address.id}`;
+}
+
+/**
+ * The inverse of `entityKey`. A space is a DID and a scope is one of a small
+ * fixed set of words, and neither contains a slash, so the first two slashes
+ * delimit them. Everything after the second slash is the identifier, which may
+ * contain slashes of its own: a `data:` identifier, which carries a frozen
+ * value rather than naming a stored document, holds a MIME type and the value
+ * itself.
+ */
+export function parseEntityKey(
+  key: SpaceScopeAndURI,
+): { space: MemorySpace; scope: CellScope; id: URI } {
+  const firstSlash = key.indexOf("/");
+  const secondSlash = key.indexOf("/", firstSlash + 1);
+  return {
+    space: key.slice(0, firstSlash) as MemorySpace,
+    scope: key.slice(firstSlash + 1, secondSlash) as CellScope,
+    id: key.slice(secondSlash + 1) as URI,
+  };
 }

--- a/packages/runner/src/scheduler/trigger-index.ts
+++ b/packages/runner/src/scheduler/trigger-index.ts
@@ -39,6 +39,13 @@ export interface TriggerIndexState {
   removeSpace(space: MemorySpace): void;
   collectReadersForWrite(write: IMemorySpaceAddress): Set<Action>;
   hasRegisteredTriggers(): boolean;
+  /**
+   * Remember entities whose reader set may have just emptied, so the storage
+   * layer can be told about them once the scheduler is quiescent. Entities
+   * that still have readers are dropped on the way in. The record is read back
+   * with `SchedulerTriggerIndex.drainIdleCandidates`.
+   */
+  noteIdleCandidates(entities: Iterable<SpaceScopeAndURI>): void;
   clear(): void;
   collectTriggeredActionsForChange(
     space: MemorySpace,
@@ -153,6 +160,10 @@ export class SchedulerTriggerSubscriptions implements TriggerSubscriptionState {
     return this.state.triggerIndex.hasRegisteredTriggers();
   }
 
+  noteIdleCandidates(entities: Iterable<SpaceScopeAndURI>): void {
+    this.state.triggerIndex.noteIdleCandidates(entities);
+  }
+
   clear(): void {
     this.state.triggerIndex.clear();
   }
@@ -185,6 +196,7 @@ export class SchedulerTriggerIndex implements TriggerIndexState {
     Action,
     Set<SpaceScopeAndURI>
   >();
+  readonly #idleCandidates = new Set<SpaceScopeAndURI>();
 
   addActionReads(
     action: Action,
@@ -240,12 +252,16 @@ export class SchedulerTriggerIndex implements TriggerIndexState {
         action,
       );
     }
+    this.noteIdleCandidates(entities);
   }
 
   removeSpace(space: MemorySpace): void {
     const spacePrefix = `${space}/`;
     removeTriggerMapSpace(this.triggers, spacePrefix);
     removeTriggerMapSpace(this.nonRecursiveTriggers, spacePrefix);
+    for (const entity of this.#idleCandidates) {
+      if (entity.startsWith(spacePrefix)) this.#idleCandidates.delete(entity);
+    }
   }
 
   collectReadersForWrite(write: IMemorySpaceAddress): Set<Action> {
@@ -281,9 +297,34 @@ export class SchedulerTriggerIndex implements TriggerIndexState {
     return this.triggers.size > 0 || this.nonRecursiveTriggers.size > 0;
   }
 
+  /**
+   * Whether any live action reads this entity. This is the runner's record of
+   * reactive interest in a document: every sink, running node, and view
+   * subscription registers its reads here, and they are withdrawn when the
+   * action's read set changes or the action is cancelled.
+   */
+  hasReaders(entity: SpaceScopeAndURI): boolean {
+    return this.triggers.has(entity) || this.nonRecursiveTriggers.has(entity);
+  }
+
+  noteIdleCandidates(entities: Iterable<SpaceScopeAndURI>): void {
+    for (const entity of entities) {
+      if (this.hasReaders(entity)) continue;
+      this.#idleCandidates.add(entity);
+    }
+  }
+
+  drainIdleCandidates(): SpaceScopeAndURI[] {
+    if (this.#idleCandidates.size === 0) return [];
+    const drained = [...this.#idleCandidates];
+    this.#idleCandidates.clear();
+    return drained;
+  }
+
   clear(): void {
     this.triggers.clear();
     this.nonRecursiveTriggers.clear();
+    this.#idleCandidates.clear();
   }
 
   collectTriggeredActionsForChange(
@@ -377,6 +418,18 @@ export function applyActionReadDelta(
     ...nextNonRecursivePathsByEntity.keys(),
   ]);
   state.actionTriggerEntities.set(action, entities);
+
+  // Entities this run stopped reading may have just lost their last reader.
+  const dropped: SpaceScopeAndURI[] = [];
+  for (
+    const entity of [
+      ...prevPathsByEntity.keys(),
+      ...prevNonRecursivePathsByEntity.keys(),
+    ]
+  ) {
+    if (!entities.has(entity)) dropped.push(entity);
+  }
+  state.noteIdleCandidates(dropped);
 
   return { entities, triggerPathsByEntity: nextPathsByEntity };
 }

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -319,6 +319,56 @@ export interface IStorageManager extends IStorageSubscriptionCapability {
    * @returns Promise that resolves when the cell sync is complete.
    */
   syncCell<T>(cell: Cell<T>): Promise<Cell<T>>;
+
+  /**
+   * Attach the runner-side half of document release. Late-bound and optional,
+   * for the same reason `setTelemetry` is: the manager is built before the
+   * Runtime that owns the reactive graph. See `IDocumentReleaseHooks`.
+   */
+  setDocumentReleaseHooks?(hooks: IDocumentReleaseHooks): void;
+
+  /**
+   * Whether this manager releases documents at all, so a caller can skip the
+   * work of collecting them. False when `experimentalDocumentRelease` is off,
+   * in which case `releaseDocuments` is a no-op.
+   */
+  releasesDocuments?(): boolean;
+
+  /**
+   * Report documents no live reactive reader depends on any more. The manager
+   * drops the watches that cover them, and the server's answer says which
+   * documents may then be discarded. Called when the scheduler reaches
+   * quiescence, so no action is part-way through a run. A no-op when
+   * `releasesDocuments()` is false.
+   */
+  releaseDocuments?(
+    addresses: readonly Pick<
+      IMemorySpaceAddress,
+      "space" | "scope" | "id"
+    >[],
+  ): void;
+}
+
+/**
+ * What the storage layer needs from the runner to release documents. The
+ * runner's reactive graph is the authority on which documents are still
+ * wanted; storage is the authority on which ones it may drop.
+ */
+export interface IDocumentReleaseHooks {
+  /**
+   * Whether a live reactive reader depends on this document. Consulted when
+   * the server retires a document from the session's watch union, to tell a
+   * document nothing wants any more from one that is still being read and so
+   * has to be pulled again.
+   */
+  hasReaders(space: MemorySpace, id: URI, scope?: CellScope): boolean;
+
+  /**
+   * Called after a document has been dropped from the replica. The runner
+   * clears the one-shot bookkeeping that says "a load for this document has
+   * already been kicked", so the next read of it kicks a fresh one.
+   */
+  documentDropped(space: MemorySpace, id: URI, scope?: CellScope): void;
 }
 
 export interface IRemoteStorageProviderSettings {
@@ -347,6 +397,19 @@ export interface IRemoteStorageProviderSettings {
    * docs/development/EXPERIMENTAL_OPTIONS.md.
    */
   experimentalConcurrentWatchRefresh?: boolean;
+
+  /**
+   * EXPERIMENTAL (default off): hand documents back when no live reactive
+   * reader depends on them any more, by giving up the watches that cover them
+   * and discarding what the server then reports as having left the session's
+   * watch union. Off, a replica keeps every document it has ever pulled for as
+   * long as it is open, so a view that pages through a large collection costs
+   * memory per page visited and never gets any of it back. See
+   * docs/development/document-release.md, and
+   * docs/development/EXPERIMENTAL_OPTIONS.md for what still has to be true
+   * before this can be the default.
+   */
+  experimentalDocumentRelease?: boolean;
 }
 
 export interface LocalStorageOptions {
@@ -1773,6 +1836,19 @@ export interface ISpaceReplica extends ISpace {
     transaction: NativeStorageCommit,
     source?: IStorageTransaction,
   ): Promise<Result<Unit, StorageTransactionRejected>>;
+
+  /**
+   * Give up the watches rooted at these documents. The server recomputes the
+   * union of the surviving watches and answers with the entities that left it;
+   * those are the documents this replica then discards. A no-op unless
+   * `experimentalDocumentRelease` is on.
+   */
+  releaseDocuments?(
+    entries: readonly { id: URI; scope?: CellScope }[],
+  ): void;
+
+  /** How many documents this replica holds, and how many it watches. */
+  retentionStats?(): { documents: number; watched: number; watches: number };
 }
 
 export type PushError =

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -40,6 +40,7 @@ import {
   type SqliteQueryResult,
   type SqliteRegisterDiskSourceResult,
   toDocumentPath,
+  type WatchSpec,
 } from "@commonfabric/memory/v2";
 import { parentPath } from "../../../memory/v2/path.ts";
 import {
@@ -69,6 +70,7 @@ import type { Cancel } from "../cancel.ts";
 import { recordCommitLocalSeq } from "./commit-identity.ts";
 import * as Differential from "./differential.ts";
 import type {
+  IDocumentReleaseHooks,
   IMemoryAddress,
   IMemorySpaceAddress,
   IMergedChanges,
@@ -895,6 +897,8 @@ export class StorageManager implements IStorageManager {
   #defaultStorageRoute?: string;
   /** Late-bound marker sink (the Runtime's telemetry bus); see setTelemetry. */
   #telemetry?: TelemetrySink;
+  /** Late-bound runner half of document release; see setDocumentReleaseHooks. */
+  #releaseHooks?: IDocumentReleaseHooks;
 
   /**
    * Attach the runtime's telemetry bus so replicas can emit the
@@ -904,6 +908,49 @@ export class StorageManager implements IStorageManager {
    */
   setTelemetry(telemetry: TelemetrySink): void {
     this.#telemetry = telemetry;
+  }
+
+  /**
+   * Attach the runner's answers to "is anything still reading this document"
+   * and "this document is gone". Late-bound for the same reason as the
+   * telemetry bus, and read through a getter so replicas opened earlier pick
+   * it up.
+   */
+  setDocumentReleaseHooks(hooks: IDocumentReleaseHooks): void {
+    this.#releaseHooks = hooks;
+  }
+
+  releasesDocuments(): boolean {
+    return this.#settings.experimentalDocumentRelease === true;
+  }
+
+  releaseDocuments(
+    addresses: readonly Pick<
+      IMemorySpaceAddress,
+      "space" | "scope" | "id"
+    >[],
+  ): void {
+    if (!this.releasesDocuments()) return;
+    if (addresses.length === 0) {
+      // Nothing new to give up, but a replica may still be holding a decision
+      // from a shrink that failed. This is the event that arms another attempt.
+      for (const provider of this.#providers.values()) {
+        provider.releaseDocuments([]);
+      }
+      return;
+    }
+    const bySpace = new Map<
+      MemorySpace,
+      { id: URI; scope?: CellScope }[]
+    >();
+    for (const address of addresses) {
+      let entries = bySpace.get(address.space);
+      if (entries === undefined) bySpace.set(address.space, entries = []);
+      entries.push({ id: address.id as URI, scope: address.scope });
+    }
+    for (const [space, entries] of bySpace) {
+      this.#providers.get(space)?.releaseDocuments(entries);
+    }
   }
 
   static open(options: Options) {
@@ -1037,6 +1084,7 @@ export class StorageManager implements IStorageManager {
         syncReplayDependencies: (document) =>
           this.syncCfcSchemaDocument(space, document),
         getTelemetry: () => this.#telemetry,
+        getReleaseHooks: () => this.#releaseHooks,
       });
       this.#providers.set(space, provider);
     }
@@ -1758,6 +1806,8 @@ type ProviderOptions = {
   ) => Promise<Error | undefined>;
   /** Late-bound: resolves to the Runtime's telemetry bus once attached. */
   getTelemetry?: () => TelemetrySink | undefined;
+  /** Late-bound: resolves to the runner's release hooks once attached. */
+  getReleaseHooks?: () => IDocumentReleaseHooks | undefined;
 };
 
 type SpaceReplicaOptions = Omit<ProviderOptions, "createSession"> & {
@@ -1973,6 +2023,12 @@ class Provider implements IStorageProviderWithReplica {
     return this.replica.sinkDocument(uri, callback);
   }
 
+  releaseDocuments(
+    entries: readonly { id: URI; scope?: CellScope }[],
+  ): void {
+    this.replica.releaseDocuments(entries);
+  }
+
   async destroy(): Promise<void> {
     if (this.#destroyed) {
       return;
@@ -2153,6 +2209,29 @@ class SpaceReplica implements ISpaceReplica {
   #subscribedWatchView: MemoryV2Client.WatchView | null = null;
   #watchSelectorTracker = new SelectorTracker<Result<Unit, PullError>>();
   #watchedIds = new Set<string>();
+  // Every watch spec this replica has installed on the server, keyed by the
+  // spec id, together with the document it is rooted at. A shrink needs the
+  // root association to decide which specs to give up, and the fallback form
+  // needs the specs themselves to re-send the survivors. Only kept when
+  // `experimentalDocumentRelease` is on; nothing prunes it otherwise.
+  readonly #watchSpecs = new Map<string, {
+    spec: WatchSpec;
+    docKey: string;
+  }>();
+  // Documents whose watches are to be given up, gathered between sweeps.
+  readonly #pendingRelease = new Set<string>();
+  // Set when the replica has thrown away documents it did not have the server's
+  // agreement to drop (`reset`), so the whole watch set has to be re-sent even
+  // though no individual document was released.
+  #watchSetAbandoned = false;
+  #watchShrinkInFlight: Promise<Result<Unit, PullError>> | undefined;
+  // True while the shrink in flight is the kind that names the watches that
+  // survive. Only that kind conflicts with a refresh; see
+  // `replacesWholeWatchSet`.
+  #watchSetReplaceInFlight = false;
+  // Documents named as the root of a pull that has not resolved. Their watches
+  // survive a sweep: the request that asked for them is still outstanding.
+  readonly #pullRoots = new Map<string, number>();
   #nextLocalSeq = 1;
   #closed = false;
   readonly #closeSignal = Promise.withResolvers<void>();
@@ -2192,12 +2271,14 @@ class SpaceReplica implements ISpaceReplica {
     | undefined;
 
   #settings: IRemoteStorageProviderSettings;
+  #getReleaseHooks: () => IDocumentReleaseHooks | undefined;
 
   constructor(options: SpaceReplicaOptions) {
     this.#space = options.space;
     this.#subscription = options.subscription;
     this.#createSession = options.createSession;
     this.#getTelemetry = options.getTelemetry ?? (() => undefined);
+    this.#getReleaseHooks = options.getReleaseHooks ?? (() => undefined);
     this.#settings = options.settings;
     this.#routeState = options.routeState;
     this.#routeGeneration = options.routeGeneration;
@@ -2541,6 +2622,8 @@ class SpaceReplica implements ISpaceReplica {
     await Promise.allSettled([...this.#syncPromises]);
     await Promise.allSettled([...this.#updatePromises]);
     this.#syncTasks.clear();
+    this.#watchSpecs.clear();
+    this.#pendingRelease.clear();
     this.#watchSelectorTracker = new SelectorTracker<Result<Unit, PullError>>();
   }
 
@@ -2622,6 +2705,8 @@ class SpaceReplica implements ISpaceReplica {
     void Promise.allSettled([...this.#suppressedVerdicts]);
     this.rejectCaughtUpLocalSeqWaiters(new Error("memory replica closed"));
     this.#syncTasks.clear();
+    this.#watchSpecs.clear();
+    this.#pendingRelease.clear();
     this.#watchSelectorTracker = new SelectorTracker<Result<Unit, PullError>>();
   }
 
@@ -2653,6 +2738,34 @@ class SpaceReplica implements ISpaceReplica {
     }
 
     const normalizedEntries = normalizeSyncEntries(entries);
+    // Hold every document this pull is waiting for against a concurrent sweep,
+    // for as long as the pull is outstanding. Not just the ones fetched below:
+    // an entry an in-flight watch already covers is one the caller is still
+    // waiting for, and giving up the watch that covers it would leave the pull
+    // resolving successfully onto a document the server has stopped tracking.
+    const heldRoots = normalizedEntries.map(([address]) =>
+      docKey(address.id, address.scope)
+    );
+    for (const root of heldRoots) {
+      this.#pullRoots.set(root, (this.#pullRoots.get(root) ?? 0) + 1);
+    }
+    try {
+      return await this.pullHeld(normalizedEntries);
+    } finally {
+      for (const root of heldRoots) {
+        const held = this.#pullRoots.get(root)! - 1;
+        if (held === 0) this.#pullRoots.delete(root);
+        else this.#pullRoots.set(root, held);
+      }
+    }
+  }
+
+  private async pullHeld(
+    normalizedEntries: [
+      { id: URI; type: MIME; scope?: CellScope },
+      SchemaPathSelector,
+    ][],
+  ): Promise<Result<Unit, PullError>> {
     // Compose the dedup key from per-part hashes instead of hashing a fresh
     // wrapper object: hashOf's frozen-object cache is only consulted at entry
     // level, so embedding the (large, already canonical) selector schema in a
@@ -2830,6 +2943,15 @@ class SpaceReplica implements ISpaceReplica {
     );
   }
 
+  /**
+   * Throw away every document this replica holds.
+   *
+   * A replica must never discard a document without also giving up the watch
+   * that covers it: the server does not resend what it believes this session
+   * holds, so a document dropped on the client's own initiative can never be
+   * pulled back. That is why this gives up the whole watch set as well —
+   * anything added here that discards documents has to do the same.
+   */
   reset(): void {
     // Every unsettled in-flight commit's optimistic pending write is about to
     // be wiped by #docs.clear(); locally reject each so its pushCommit
@@ -2844,6 +2966,19 @@ class SpaceReplica implements ISpaceReplica {
     }
     this.#docs.clear();
     this.#watchedIds.clear();
+    this.#pendingRelease.clear();
+    // The server tracks what this session holds, and answers a watch mutation
+    // only with what it believes the session is missing. A replica that has
+    // just thrown its documents away holds nothing, so it must give up its
+    // watches too; the pulls that rebuild it then arrive as new watches and
+    // carry their documents with them.
+    if (
+      this.#watchSpecs.size > 0 && this.#settings.experimentalDocumentRelease
+    ) {
+      this.#watchSpecs.clear();
+      this.#watchSetAbandoned = true;
+      this.startWatchShrink();
+    }
     this.resetConflictAdmissionState();
     this.rejectCaughtUpLocalSeqWaiters(new Error("memory replica reset"));
     this.cancelQueuedWatchRefresh();
@@ -2895,23 +3030,229 @@ class SpaceReplica implements ISpaceReplica {
         return { error: toConnectionError(new Error("memory replica closed")) };
       }
 
-      this.#watchView = view;
-      this.applySessionSync(sync, type);
-      if (this.#updatePromises.size === 0) {
-        this.#subscribedWatchView = view;
-        const updates = this.consumeUpdates(view.subscribeSync())
-          .finally(() => {
-            this.#updatePromises.delete(updates);
-            if (this.#subscribedWatchView === view) {
-              this.#subscribedWatchView = null;
-            }
-          });
-        this.#updatePromises.add(updates);
+      if (this.#settings.experimentalDocumentRelease) {
+        watchEntries.forEach(([address], index) => {
+          const spec = watches[index]!;
+          const root = docKey(address.id, address.scope);
+          this.#watchSpecs.set(spec.id, { spec, docKey: root });
+          // A watch just installed for this document supersedes a queued
+          // decision to give it up.
+          this.#pendingRelease.delete(root);
+        });
       }
+      this.adoptWatchView(view);
+      this.applySessionSync(sync, type);
       return { ok: {} };
     } catch (error) {
       return { error: toPullError(error) };
     }
+  }
+
+  /**
+   * Take a watch view as the replica's current one, starting the update
+   * consumer when none is running. The memory client hands back the same view
+   * instance across watch mutations once one exists, so a set that follows an
+   * add reuses the running consumer rather than opening a second.
+   */
+  private adoptWatchView(view: MemoryV2Client.WatchView): void {
+    this.#watchView = view;
+    if (this.#updatePromises.size > 0) {
+      return;
+    }
+    this.#subscribedWatchView = view;
+    const updates = this.consumeUpdates(view.subscribeSync())
+      .finally(() => {
+        this.#updatePromises.delete(updates);
+        if (this.#subscribedWatchView === view) {
+          this.#subscribedWatchView = null;
+        }
+      });
+    this.#updatePromises.add(updates);
+  }
+
+  /**
+   * Give up the watches rooted at these documents. Nothing is discarded here:
+   * the watch set is re-sent without those roots, and the server's answer says
+   * which documents left the session's watch union. Those, and only those, are
+   * the ones this replica may drop — `session.watch.add` does not resend an
+   * entity the server believes the session already holds, so a document
+   * dropped without the server's agreement could never be pulled back.
+   */
+  releaseDocuments(
+    entries: readonly { id: URI; scope?: CellScope }[],
+  ): void {
+    if (this.#closed || !this.#settings.experimentalDocumentRelease) {
+      return;
+    }
+    for (const { id, scope } of entries) {
+      this.#pendingRelease.add(docKey(id, scope));
+    }
+    // Called with nothing to add as well, as the nudge that arms a shrink whose
+    // last attempt failed and left its documents queued.
+    this.startWatchShrink();
+  }
+
+  /**
+   * A shrink that has to name the watches that SURVIVE is built from a
+   * snapshot of the watch set, so it must not overlap a refresh: watch
+   * mutations reach the server in issue order, and a set built from a snapshot
+   * taken before the refresh would take the refresh's new watches straight back
+   * off. Two shrinks need that form — the one after `reset`, which has no ids
+   * to name, and the fallback for a server without `session.watch.remove`. A
+   * shrink that names only the watches that GO is independent of the snapshot
+   * and never has to wait.
+   */
+  private replacesWholeWatchSet(): boolean {
+    return this.#watchSetAbandoned ||
+      this.#sessionSession?.supportsWatchRemove !== true;
+  }
+
+  private startWatchShrink(): void {
+    if (this.#closed || this.#watchShrinkInFlight !== undefined) {
+      return;
+    }
+    if (this.#pendingRelease.size === 0 && !this.#watchSetAbandoned) {
+      return;
+    }
+    const replacing = this.replacesWholeWatchSet();
+    if (
+      replacing &&
+      (this.#watchRefreshInFlight > 0 || this.#queuedWatchRefresh !== null)
+    ) {
+      // A refresh finishing re-arms this.
+      return;
+    }
+    // Registered as storage work in flight from the moment the shrink is
+    // issued, so `synced()` covers it and teardown drains it rather than
+    // leaving a request outstanding. Resolved rather than rejected on failure,
+    // matching how a watch refresh reports one, so `synced()` cannot reject on
+    // a shrink the caller did not ask for.
+    this.#watchSetReplaceInFlight = replacing;
+    const tracked: Promise<Result<Unit, PullError>> = this.shrinkWatchSet()
+      .catch((error): boolean => {
+        logger.warn(
+          "watch-shrink",
+          () => [`giving up watches failed: ${error}`],
+        );
+        return false;
+      })
+      .then((sent): Result<Unit, PullError> => {
+        this.#watchShrinkInFlight = undefined;
+        this.#watchSetReplaceInFlight = false;
+        this.#syncPromises.delete(tracked);
+        this.scheduleWatchRefreshFlush();
+        // Only a shrink that reached the server arms another. A failed one
+        // leaves its decision queued for whatever releases documents next,
+        // rather than retrying against a session that is still broken.
+        if (
+          sent && (this.#pendingRelease.size > 0 || this.#watchSetAbandoned)
+        ) {
+          this.startWatchShrink();
+        }
+        return { ok: {} };
+      });
+    this.#syncPromises.add(tracked);
+    this.#watchShrinkInFlight = tracked;
+  }
+
+  /** Whether the shrink reached the server. */
+  private async shrinkWatchSet(): Promise<boolean> {
+    // Documents held back by a local reason stay queued: they have already lost
+    // their readers, so nothing will offer them again.
+    const dropping = new Set<string>();
+    for (const key of this.#pendingRelease) {
+      if (this.mustKeepDocument(key)) continue;
+      dropping.add(key);
+    }
+    for (const key of dropping) this.#pendingRelease.delete(key);
+
+    const surviving: WatchSpec[] = [];
+    const dropped: { id: string; spec: WatchSpec }[] = [];
+    for (const [id, entry] of this.#watchSpecs) {
+      if (dropping.has(entry.docKey)) dropped.push({ id, spec: entry.spec });
+      else surviving.push(entry.spec);
+    }
+    const abandoned = this.#watchSetAbandoned;
+    this.#watchSetAbandoned = false;
+    if ((dropped.length === 0 && !abandoned) || this.#closed) {
+      return true;
+    }
+
+    try {
+      const { session } = await this.sessionHandle();
+      session.setConcurrentWatchRefresh?.(
+        this.#settings.experimentalConcurrentWatchRefresh === true,
+      );
+      // Naming what goes keeps the request proportional to the page just left
+      // rather than to everything still on screen. A server too old for the
+      // verb gets the equivalent full replacement, and so does an abandoned
+      // watch set, which has no list of ids to name.
+      const { view, sync } = !abandoned &&
+          session.supportsWatchRemove === true
+        ? await session.watchRemoveSync(dropped.map((entry) => entry.id))
+        : await session.watchSetSync(surviving);
+      if (this.#closed) {
+        view.close();
+        return false;
+      }
+      for (const entry of dropped) {
+        this.#watchSpecs.delete(entry.id);
+        // The pull path treats a document covered by a registered selector as
+        // already available. With the watch gone that is no longer true, so the
+        // selectors go with it and a later read pulls the document again.
+        this.forgetSelectorsFor(entry.spec);
+      }
+      this.adoptWatchView(view);
+      this.applySessionSync(sync, "pull");
+      return true;
+    } catch (error) {
+      // The server's watch set is whatever it was; the specs stay recorded and
+      // the documents stay held. Put the decision back so a later sweep tries
+      // again rather than holding these documents for the session's lifetime.
+      logger.warn(
+        "watch-shrink",
+        () => [`giving up watches failed: ${error}`],
+      );
+      for (const key of dropping) this.#pendingRelease.add(key);
+      this.#watchSetAbandoned ||= abandoned;
+      return false;
+    }
+  }
+
+  private forgetSelectorsFor(spec: WatchSpec): void {
+    for (const root of spec.query.roots) {
+      const address = {
+        id: root.id as URI,
+        type: DOCUMENT_MIME,
+        scope: normalizeCellScope(root.scope as CellScope | undefined),
+      };
+      this.#watchSelectorTracker.delete(
+        address,
+        root.selector as SchemaPathSelector,
+      );
+    }
+  }
+
+  /**
+   * Local reasons a document must stay, whatever the runner's readers say:
+   * unconfirmed writes that have yet to be replayed, an identifier a conflict
+   * marked stale, a provider-level `sink` subscriber, and a pull that named it
+   * as a root and has not come back.
+   */
+  private mustKeepDocument(key: string): boolean {
+    if (this.#pullRoots.has(key)) return true;
+    if (this.#staleFloor.has(key)) return true;
+    if ((this.#sinks.get(key)?.size ?? 0) > 0) return true;
+    const record = this.#docs.get(key);
+    return record !== undefined && record.pending.length > 0;
+  }
+
+  retentionStats(): { documents: number; watched: number; watches: number } {
+    return {
+      documents: this.#docs.size,
+      watched: this.#watchedIds.size,
+      watches: this.#watchSpecs.size,
+    };
   }
 
   private enqueueWatchRefresh(
@@ -2964,6 +3305,7 @@ class SpaceReplica implements ISpaceReplica {
     if (
       this.#queuedWatchRefresh === null ||
       this.#queuedWatchRefreshScheduled ||
+      this.#watchSetReplaceInFlight ||
       this.#watchRefreshInFlight >= this.#maxWatchRefreshInFlight()
     ) {
       return;
@@ -2973,6 +3315,7 @@ class SpaceReplica implements ISpaceReplica {
       this.#queuedWatchRefreshScheduled = false;
       if (
         this.#queuedWatchRefresh === null ||
+        this.#watchSetReplaceInFlight ||
         this.#watchRefreshInFlight >= this.#maxWatchRefreshInFlight()
       ) {
         return;
@@ -3005,6 +3348,13 @@ class SpaceReplica implements ISpaceReplica {
     } finally {
       this.#watchRefreshInFlight -= 1;
       this.scheduleWatchRefreshFlush();
+      // A shrink that stood aside for this refresh can go once the wire is
+      // free again.
+      if (
+        this.#watchRefreshInFlight === 0 && this.#queuedWatchRefresh === null
+      ) {
+        this.startWatchShrink();
+      }
     }
   }
 
@@ -4053,12 +4403,46 @@ class SpaceReplica implements ISpaceReplica {
       record.materialized = undefined;
       this.#watchedIds.add(docKey(upsert.id as URI, upsert.scope));
     }
+    const repull: [
+      { id: URI; type: MIME; scope?: CellScope },
+      SchemaPathSelector | undefined,
+    ][] = [];
     for (const remove of sync.removes) {
       const id = remove.id as URI;
-      const record = this.record(id, remove.scope);
-      record.confirmed = confirmedVersion(0, undefined);
-      record.materialized = undefined;
-      this.#watchedIds.delete(docKey(id, remove.scope));
+      const key = docKey(id, remove.scope);
+      this.#watchedIds.delete(key);
+      if (!this.#settings.experimentalDocumentRelease) {
+        const record = this.record(id, remove.scope);
+        record.confirmed = confirmedVersion(0, undefined);
+        record.materialized = undefined;
+        continue;
+      }
+      const hooks = this.#getReleaseHooks();
+      if (
+        hooks?.hasReaders(this.#space, id, remove.scope) === true ||
+        this.mustKeepDocument(key)
+      ) {
+        // Still wanted here, so this document left the union as collateral: the
+        // shrink gave up a watch that was covering it as well as its own root.
+        // Pull it again to get a watch back, and leave the value in place
+        // meanwhile — the document did not go away, it only left this session's
+        // watch union. The value stands rather than being wiped to absent: a
+        // reader would see a deletion that did not happen, and a pending write
+        // replays onto the confirmed base, which must not move backwards.
+        //
+        // The default selector asks for the document itself and nothing it
+        // links to. That is all this pull is for: a watch covering this
+        // document again. Whatever else the dropped watch reached stays
+        // reachable from its own roots, and a reader that walks onward from
+        // here pulls what it walks into, as it did the first time.
+        this.forgetSelectorsForDocument(id, remove.scope);
+        repull.push([
+          { id, type: DOCUMENT_MIME as MIME, scope: remove.scope },
+          undefined,
+        ]);
+        continue;
+      }
+      this.dropDocument(id, remove.scope);
     }
 
     if (before !== undefined) {
@@ -4093,6 +4477,92 @@ class SpaceReplica implements ISpaceReplica {
       } as StorageNotification);
     }
     this.noteCaughtUpLocalSeq(sync.caughtUpLocalSeq);
+    if (repull.length > 0) {
+      // An ordinary consequence of shrinking, not a fault: a watch this replica
+      // gave up was covering these documents as well as its own root.
+      logger.debug(
+        "watch-shrink",
+        () => [
+          `${repull.length} document(s) left the watch union while still ` +
+          `read; pulling them again`,
+        ],
+      );
+      // Registered as storage work, so `synced()` covers getting the watch back
+      // — and covers the drop that follows if it cannot be got.
+      const restored: Promise<Result<Unit, PullError>> = this
+        .restoreWatchesFor(repull)
+        .then(() => {
+          this.#syncPromises.delete(restored);
+          return { ok: {} };
+        });
+      this.#syncPromises.add(restored);
+    }
+  }
+
+  /**
+   * Get a watch back for documents that left the union while this replica still
+   * wanted them. Until one lands, the replica holds a value the server has
+   * stopped sending updates for, so a failure here cannot pass silently: the
+   * document is dropped instead. That makes the state honest — the next read
+   * reports absent and kicks a load, exactly as for any document this replica
+   * does not hold — rather than serving a value that has quietly stopped
+   * tracking the server for as long as the tab is open.
+   */
+  private async restoreWatchesFor(
+    entries: [
+      { id: URI; type: MIME; scope?: CellScope },
+      SchemaPathSelector | undefined,
+    ][],
+  ): Promise<void> {
+    let failure: unknown;
+    try {
+      const result = await this.pull(entries);
+      if (result.error === undefined) return;
+      failure = result.error;
+    } catch (error) {
+      failure = error;
+    }
+    if (this.#closed) return;
+    logger.error(
+      "watch-shrink",
+      () => [
+        `could not get a watch back for ${entries.length} document(s) after a ` +
+        `shrink; dropping them rather than serving a value the server no ` +
+        `longer updates: ${failure}`,
+      ],
+    );
+    for (const [address] of entries) {
+      // A local reason to keep it outranks this: a document with an unreplayed
+      // write still needs its record, and dropping it would lose the write.
+      if (this.mustKeepDocument(docKey(address.id, address.scope))) continue;
+      this.dropDocument(address.id, address.scope);
+    }
+  }
+
+  /**
+   * Discard a document. The replica keeps no trace of it, so a later read of
+   * it behaves exactly as a read of a document this replica has never pulled:
+   * it reports absent, and the read path kicks a load whose arrival re-runs the
+   * reader. The one-shot bookkeeping that says such a load has already been
+   * kicked is retracted here, so that kick is actually issued.
+   */
+  private dropDocument(id: URI, scope?: CellScope): void {
+    const key = docKey(id, scope);
+    this.#docs.delete(key);
+    this.#watchedIds.delete(key);
+    this.forgetSelectorsForDocument(id, scope);
+    this.#getReleaseHooks()?.documentDropped(this.#space, id, scope);
+  }
+
+  private forgetSelectorsForDocument(id: URI, scope?: CellScope): void {
+    const address = {
+      id,
+      type: DOCUMENT_MIME,
+      scope: normalizeCellScope(scope),
+    };
+    for (const selector of [...this.#watchSelectorTracker.get(address)]) {
+      this.#watchSelectorTracker.delete(address, selector);
+    }
   }
 
   // Mark every id this conflicted commit touched (reads + writes) stale until

--- a/packages/runner/test/document-release.test.ts
+++ b/packages/runner/test/document-release.test.ts
@@ -1,0 +1,662 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import * as MemoryV2Client from "@commonfabric/memory/v2/client";
+import type * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import type { SessionSync } from "@commonfabric/memory/v2";
+import { StorageManager as EmulatedStorageManager } from "../src/storage/cache.deno.ts";
+import {
+  defaultSettings,
+  type StorageManager,
+  StorageManager as V2StorageManager,
+} from "../src/storage/v2.ts";
+import type { MemorySpace, URI } from "../src/storage/interface.ts";
+import { entityKey, parseEntityKey } from "../src/scheduler/keys.ts";
+import { Runtime } from "../src/runtime.ts";
+import {
+  makeSharedServer,
+  openSharedServerRuntime,
+} from "./shared-server-storage.ts";
+
+const signer = await Identity.fromPassphrase("document-release");
+const space = signer.did();
+
+type Retention = { documents: number; watched: number; watches: number };
+
+describe("document release", () => {
+  let runtime: Runtime;
+  let storageManager: ReturnType<typeof EmulatedStorageManager.emulate>;
+
+  beforeEach(() => {
+    storageManager = EmulatedStorageManager.emulate({
+      as: signer,
+      settings: { ...defaultSettings, experimentalDocumentRelease: true },
+    });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  const retention = (): Retention =>
+    storageManager.open(space).replica.retentionStats!();
+
+  const holds = (id: URI): boolean =>
+    storageManager.open(space).replica.getDocument(id) !== undefined;
+
+  it("keeps a document a live subscription reads", async () => {
+    const cell = runtime.getCell<{ value: number }>(space, "retained");
+    const tx = runtime.edit();
+    cell.withTx(tx).set({ value: 1 });
+    await tx.commit();
+    await runtime.settled();
+
+    const seen: unknown[] = [];
+    const cancel = cell.sink((value) => {
+      seen.push(value);
+    });
+    await runtime.settled();
+    expect(seen.length).toBeGreaterThan(0);
+
+    expect(holds(cell.getAsNormalizedFullLink().id)).toBe(true);
+    cancel();
+  });
+
+  it("gives up a document once its last reader goes", async () => {
+    const cell = runtime.getCell<{ value: number }>(space, "released");
+    const id = cell.getAsNormalizedFullLink().id;
+    const tx = runtime.edit();
+    cell.withTx(tx).set({ value: 1 });
+    await tx.commit();
+    await runtime.settled();
+
+    const cancel = cell.sink(() => {});
+    await runtime.settled();
+    const before = retention();
+    expect(holds(id)).toBe(true);
+
+    cancel();
+    await runtime.settled();
+
+    expect(holds(id)).toBe(false);
+    expect(retention().watches).toBeLessThan(before.watches);
+  });
+
+  it("re-reads a released document from the server", async () => {
+    const cell = runtime.getCell<{ value: number }>(space, "re-read");
+    const id = cell.getAsNormalizedFullLink().id;
+    const tx = runtime.edit();
+    cell.withTx(tx).set({ value: 7 });
+    await tx.commit();
+    await runtime.settled();
+
+    const cancel = cell.sink(() => {});
+    await runtime.settled();
+    cancel();
+    await runtime.settled();
+    expect(holds(id)).toBe(false);
+
+    // A fresh cell for the same document: the replica no longer holds it, so
+    // this has to reach the server again.
+    const again = runtime.getCell<{ value: number }>(space, "re-read");
+    await again.sync();
+    expect(again.get()).toEqual({ value: 7 });
+    expect(holds(id)).toBe(true);
+  });
+
+  it("keeps a document whose local write is not yet confirmed", async () => {
+    const cell = runtime.getCell<{ value: number }>(space, "unconfirmed");
+    const id = cell.getAsNormalizedFullLink().id;
+    const setup = runtime.edit();
+    cell.withTx(setup).set({ value: 1 });
+    await setup.commit();
+    await runtime.settled();
+
+    const cancel = cell.sink(() => {});
+    await runtime.settled();
+
+    // Issue a write, then release the reader while the commit is still in
+    // flight. Dropping the record now would drop the optimistic write with it,
+    // and the replay would have nothing to replay onto.
+    const tx = runtime.edit();
+    cell.withTx(tx).set({ value: 2 });
+    const commit = tx.commit();
+    cancel();
+    storageManager.releaseDocuments!([{ space, scope: "space", id }]);
+
+    await commit;
+    await runtime.settled();
+    // The write reached the server. Read it through a cell that has not been
+    // told the document is already loaded, since the release may since have
+    // discarded the record — that is the documented cost, and it is not what
+    // this test is about.
+    const fresh = runtime.getCell<{ value: number }>(space, "unconfirmed");
+    await fresh.sync();
+    expect(fresh.get()).toEqual({ value: 2 });
+  });
+
+  it("settles close() with a release decided but not yet sent", async () => {
+    const cell = runtime.getCell<{ value: number }>(space, "closing");
+    const id = cell.getAsNormalizedFullLink().id;
+    const tx = runtime.edit();
+    cell.withTx(tx).set({ value: 1 });
+    await tx.commit();
+    await runtime.settled();
+
+    // Decide the release and close before its shrink reaches the wire. The
+    // release round is registered as storage work, and `close()` drains that
+    // set, so a round left open here would hang teardown.
+    storageManager.releaseDocuments!([{ space, scope: "space", id }]);
+    await runtime.dispose();
+    await storageManager.close();
+    // Re-created in afterEach's place: both are already closed.
+    runtime = undefined as unknown as Runtime;
+    storageManager = undefined as unknown as typeof storageManager;
+  });
+
+  it("keeps a document a provider-level sink subscribes to", async () => {
+    const cell = runtime.getCell<{ value: number }>(space, "sunk");
+    const id = cell.getAsNormalizedFullLink().id;
+    const tx = runtime.edit();
+    cell.withTx(tx).set({ value: 3 });
+    await tx.commit();
+    await runtime.settled();
+
+    // A provider-level sink does not go through the scheduler, so the trigger
+    // index reports no reader for this document even while the sink is live.
+    // `sink` is on the concrete provider rather than the interface.
+    const provider = storageManager.open(space) as unknown as {
+      sink(uri: URI, callback: (value: unknown) => void): () => void;
+    };
+    const cancel = provider.sink(id, () => {});
+    // Let the sink's own pull settle first, so what holds the document below is
+    // the subscription rather than a request still in flight.
+    await storageManager.synced();
+    storageManager.releaseDocuments!([{ space, scope: "space", id }]);
+    await storageManager.synced();
+
+    expect(holds(id)).toBe(true);
+    cancel();
+  });
+
+  it("keeps serving a document that leaves the union while still read", async () => {
+    const cell = runtime.getCell<{ value: number }>(space, "still-read");
+    const id = cell.getAsNormalizedFullLink().id;
+    const tx = runtime.edit();
+    cell.withTx(tx).set({ value: 5 });
+    await tx.commit();
+    await runtime.settled();
+
+    const seen: unknown[] = [];
+    const cancel = cell.sink((value) => {
+      seen.push(value);
+    });
+    await runtime.settled();
+
+    // Report the document as released while its subscription is still live —
+    // what the server does when a dropped watch was covering a document as
+    // well as its own root. The value must stay readable and be pulled again,
+    // not be wiped to absent.
+    storageManager.releaseDocuments!([{ space, scope: "space", id }]);
+    await storageManager.synced();
+    await runtime.settled();
+
+    expect(cell.get()).toEqual({ value: 5 });
+    expect(holds(id)).toBe(true);
+    cancel();
+  });
+});
+
+describe("document retention over a sliding window", () => {
+  let server: MemoryV2Server.Server;
+  let runtime: Runtime;
+  let storageManager: StorageManager;
+
+  const WINDOW = 5;
+  const TOTAL = 40;
+  const ids = Array.from(
+    { length: TOTAL },
+    (_, index) => `of:row-${index}` as URI,
+  );
+
+  beforeEach(() => {
+    server = makeSharedServer();
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+    await server.close();
+  });
+
+  /** Populate the space from a replica that is then thrown away. */
+  const publish = async () => {
+    const writer = openSharedServerRuntime(signer, server);
+    const tx = writer.runtime.edit();
+    for (const [index, id] of ids.entries()) {
+      writer.runtime
+        .getCellFromLink({ space, id, path: [] })
+        .withTx(tx)
+        .set({ value: index });
+    }
+    await tx.commit();
+    await writer.runtime.settled();
+    await writer.manager.synced();
+    await writer.runtime.dispose();
+    await writer.manager.close();
+  };
+
+  /**
+   * Slide a `WINDOW`-wide band of live subscriptions across the collection in a
+   * replica that starts empty, reporting what it holds after each slide. This is
+   * the shape of a view paging through a collection: each slide pulls a page's
+   * worth of documents and drops the previous page's readers.
+   */
+  const slideWindow = async (release: boolean): Promise<number[]> => {
+    await publish();
+    const opened = openSharedServerRuntime(signer, server, release);
+    runtime = opened.runtime;
+    storageManager = opened.manager;
+
+    const held: number[] = [];
+    for (let start = 0; start + WINDOW <= TOTAL; start += WINDOW) {
+      const cancels = ids.slice(start, start + WINDOW).map((id) =>
+        runtime
+          .getCellFromLink({ space, id, path: [] })
+          .sink(() => {})
+      );
+      await runtime.settled();
+      for (const cancel of cancels) cancel();
+      await runtime.settled();
+      held.push(
+        storageManager.open(space).replica.retentionStats!().documents,
+      );
+    }
+    return held;
+  };
+
+  it("stops growing once documents are released", async () => {
+    const held = await slideWindow(true);
+    expect(held.length).toBe(TOTAL / WINDOW);
+    // Bounded: no slide holds more than the first one did.
+    expect(Math.max(...held)).toBe(held[0]);
+  });
+
+  it("grows with every window visited when release is off", async () => {
+    const held = await slideWindow(false);
+    expect(held.length).toBe(TOTAL / WINDOW);
+    // Strictly monotonic: nothing is ever given back.
+    for (let index = 1; index < held.length; index++) {
+      expect(held[index]).toBeGreaterThan(held[index - 1]);
+    }
+  });
+});
+
+describe("document release, off by default", () => {
+  let runtime: Runtime;
+  let storageManager: ReturnType<typeof EmulatedStorageManager.emulate>;
+
+  beforeEach(() => {
+    storageManager = EmulatedStorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("keeps a document whose last reader has gone", async () => {
+    const cell = runtime.getCell<{ value: number }>(space, "kept-when-off");
+    const id = cell.getAsNormalizedFullLink().id;
+    const tx = runtime.edit();
+    cell.withTx(tx).set({ value: 1 });
+    await tx.commit();
+    await runtime.settled();
+
+    const cancel = cell.sink(() => {});
+    await runtime.settled();
+    cancel();
+    await runtime.settled();
+
+    expect(
+      storageManager.open(space).replica.getDocument(id) !== undefined,
+    ).toBe(true);
+    // Nor does it carry the bookkeeping release needs: the mirror of the
+    // server's watch set is only worth keeping when something prunes it.
+    expect(storageManager.open(space).replica.retentionStats!().watches)
+      .toBe(0);
+  });
+
+  it("does nothing when asked to release", async () => {
+    const cell = runtime.getCell<{ value: number }>(space, "asked-when-off");
+    const id = cell.getAsNormalizedFullLink().id;
+    const tx = runtime.edit();
+    cell.withTx(tx).set({ value: 1 });
+    await tx.commit();
+    await runtime.settled();
+
+    expect(storageManager.releasesDocuments!()).toBe(false);
+    storageManager.releaseDocuments!([{ space, scope: "space", id }]);
+    await storageManager.synced();
+    expect(
+      storageManager.open(space).replica.getDocument(id) !== undefined,
+    ).toBe(true);
+  });
+
+  it("keeps the record when the server retires a document", async () => {
+    const cell = runtime.getCell<{ value: number }>(space, "retired-when-off");
+    const id = cell.getAsNormalizedFullLink().id;
+    const tx = runtime.edit();
+    cell.withTx(tx).set({ value: 1 });
+    await tx.commit();
+    await runtime.settled();
+
+    const replica = storageManager.open(space).replica;
+    const before = replica.retentionStats!().documents;
+
+    // A background refresh whose re-evaluated union came out smaller reports
+    // the entities that left it. With release off that must read exactly as it
+    // always has: the record stays, holding no value.
+    (replica as unknown as {
+      applySessionSync(sync: SessionSync, type: "pull" | "integrate"): void;
+    }).applySessionSync({
+      type: "sync",
+      fromSeq: 0,
+      toSeq: 0,
+      upserts: [],
+      removes: [{ branch: "", id, scope: "space" }],
+    }, "integrate");
+
+    expect(replica.retentionStats!().documents).toBe(before);
+    expect(replica.getDocument(id)).toBeUndefined();
+  });
+});
+
+describe("entity keys", () => {
+  const roundTrip = (
+    address: { space: MemorySpace; id: URI; scope?: "space" | "user" },
+  ) => parseEntityKey(entityKey(address));
+
+  it("round-trips an ordinary identifier", () => {
+    expect(roundTrip({ space: space as MemorySpace, id: "of:abc" as URI }))
+      .toEqual({ space, scope: "space", id: "of:abc" });
+  });
+
+  it("round-trips a scoped identifier", () => {
+    expect(
+      roundTrip({
+        space: space as MemorySpace,
+        id: "of:abc" as URI,
+        scope: "user",
+      }),
+    ).toEqual({ space, scope: "user", id: "of:abc" });
+  });
+
+  it("round-trips an identifier containing slashes", () => {
+    const id = 'data:application/json,{"a":"b/c"}' as URI;
+    expect(roundTrip({ space: space as MemorySpace, id }))
+      .toEqual({ space, scope: "space", id });
+  });
+});
+
+describe("shrinking against a stubbed session", () => {
+  const uri = "of:shrink-probe" as URI;
+
+  type Calls = {
+    added: string[][];
+    replaced: string[][];
+    removed: string[][];
+  };
+
+  /**
+   * A storage manager over a session that records which watch mutation the
+   * shrink reached for, so the two forms can be told apart without a server.
+   */
+  const openStubbed = (options: {
+    supportsWatchRemove: boolean;
+    failShrink?: boolean;
+    /** Identifiers the shrink's answer reports as having left the union. */
+    removesOnShrink?: URI[];
+    /** Report a live reader for everything, forcing the collateral re-pull. */
+    stillRead?: boolean;
+    /** Fail the pull that would get the watch back. */
+    failRepull?: boolean;
+    /** Identifiers the first watch install delivers. */
+    deliverOnAdd?: URI[];
+  }) => {
+    const calls: Calls = { added: [], replaced: [], removed: [] };
+    const sync: SessionSync = {
+      type: "sync",
+      fromSeq: 0,
+      toSeq: 0,
+      upserts: [],
+      removes: [],
+    };
+    const view = MemoryV2Client.WatchView.fromSync(sync);
+    const session = {
+      get supportsWatchRemove() {
+        return options.supportsWatchRemove;
+      },
+      setConcurrentWatchRefresh: () => {},
+      watchAddSync: (watches: { id: string }[]) => {
+        calls.added.push(watches.map((watch) => watch.id));
+        if (options.failRepull && calls.added.length > 1) {
+          return Promise.reject(new Error("pull refused"));
+        }
+        // Answer the first install with the document, so the replica has
+        // something to hold and, later, something to give up.
+        return Promise.resolve({
+          view,
+          sync: options.deliverOnAdd
+            ? {
+              ...sync,
+              upserts: options.deliverOnAdd.map((id) => ({
+                branch: "",
+                id,
+                scope: "space" as const,
+                seq: 1,
+                doc: { value: { held: true } },
+              })),
+            }
+            : sync,
+        });
+      },
+      watchSetSync: (watches: { id: string }[]) => {
+        calls.replaced.push(watches.map((watch) => watch.id));
+        if (options.failShrink) {
+          return Promise.reject(new Error("shrink refused"));
+        }
+        return Promise.resolve({ view, sync });
+      },
+      watchRemoveSync: (ids: string[]) => {
+        calls.removed.push(ids);
+        if (options.failShrink) {
+          return Promise.reject(new Error("shrink refused"));
+        }
+        return Promise.resolve({
+          view,
+          sync: {
+            ...sync,
+            removes: (options.removesOnShrink ?? []).map((id) => ({
+              branch: "",
+              id,
+              scope: "space" as const,
+            })),
+          },
+        });
+      },
+    } as unknown as MemoryV2Client.SpaceSession;
+    const client = {
+      close: () => Promise.resolve(),
+    } as unknown as MemoryV2Client.Client;
+
+    class StubbedStorageManager extends V2StorageManager {
+      constructor() {
+        super(
+          {
+            as: signer,
+            memoryHost: new URL("memory://"),
+            settings: {
+              ...defaultSettings,
+              experimentalDocumentRelease: true,
+            },
+          },
+          { create: () => Promise.resolve({ client, session }) },
+        );
+      }
+      override registerSpaceHost(): boolean {
+        return false;
+      }
+    }
+    const manager = new StubbedStorageManager();
+    if (options.stillRead) {
+      manager.setDocumentReleaseHooks!({
+        hasReaders: () => true,
+        documentDropped: () => {},
+      });
+    }
+    return { manager, calls };
+  };
+
+  /** Install one watch, then give it up. */
+  const installThenRelease = async (manager: StorageManager) => {
+    const provider = manager.open(space);
+    await provider.sync(uri, { path: [], schema: false });
+    manager.releaseDocuments!([{ space, scope: "space", id: uri }]);
+    await manager.synced();
+    return provider;
+  };
+
+  it("names the watches that go when the server takes a removal", async () => {
+    const { manager, calls } = openStubbed({ supportsWatchRemove: true });
+    try {
+      await installThenRelease(manager);
+      expect(calls.added.length).toBe(1);
+      expect(calls.removed).toEqual(calls.added);
+      expect(calls.replaced).toEqual([]);
+    } finally {
+      await manager.close();
+    }
+  });
+
+  it("replaces the whole set for a server without the verb", async () => {
+    const { manager, calls } = openStubbed({ supportsWatchRemove: false });
+    try {
+      await installThenRelease(manager);
+      expect(calls.removed).toEqual([]);
+      // The only installed watch was the one released, so nothing survives.
+      expect(calls.replaced).toEqual([[]]);
+    } finally {
+      await manager.close();
+    }
+  });
+
+  it("keeps the documents when the shrink is refused", async () => {
+    const { manager, calls } = openStubbed({
+      supportsWatchRemove: true,
+      failShrink: true,
+    });
+    try {
+      const provider = await installThenRelease(manager);
+      expect(calls.removed.length).toBe(1);
+      // The server's watch set is unchanged, so the replica still holds its
+      // watch rather than acting on a shrink that never landed.
+      expect(provider.replica.retentionStats!().watches).toBe(1);
+
+      // The decision is still queued, so the next release retries it.
+      manager.releaseDocuments!([{ space, scope: "space", id: uri }]);
+      await manager.synced();
+      expect(calls.removed.length).toBe(2);
+    } finally {
+      await manager.close();
+    }
+  });
+
+  it("abandons a shrink whose replica closed while it was in flight", async () => {
+    const { manager, calls } = openStubbed({ supportsWatchRemove: true });
+    const provider = manager.open(space);
+    await provider.sync(uri, { path: [], schema: false });
+    manager.releaseDocuments!([{ space, scope: "space", id: uri }]);
+    // Close before the shrink's answer is applied. The answer is dropped
+    // rather than applied to a replica that is gone, and the close still
+    // settles.
+    await manager.close();
+    expect(calls.removed.length).toBe(1);
+  });
+
+  it("drops a document whose watch cannot be got back", async () => {
+    const { manager, calls } = openStubbed({
+      supportsWatchRemove: true,
+      failRepull: true,
+      deliverOnAdd: [uri],
+      removesOnShrink: [uri],
+      stillRead: true,
+    });
+    try {
+      const provider = manager.open(space);
+      await provider.sync(uri, { path: [], schema: false });
+      expect(provider.replica.getDocument(uri)).toBeDefined();
+
+      manager.releaseDocuments!([{ space, scope: "space", id: uri }]);
+      await manager.synced();
+      await manager.synced();
+
+      // The server retired it while a reader still wanted it, and the pull that
+      // would have got a watch back failed. Holding the value would mean
+      // serving something the server has stopped updating, with nothing saying
+      // so, so it goes instead.
+      expect(calls.removed.length).toBeGreaterThan(0);
+      expect(provider.replica.getDocument(uri)).toBeUndefined();
+    } finally {
+      await manager.close();
+    }
+  });
+
+  it("retries a failed shrink at the next quiescence", async () => {
+    const { manager, calls } = openStubbed({
+      supportsWatchRemove: true,
+      failShrink: true,
+    });
+    try {
+      await installThenRelease(manager);
+      expect(calls.removed.length).toBe(1);
+
+      // Quiescence with nothing new to give up. The failed decision is still
+      // queued, and this is the event that arms another attempt — without it a
+      // reader who stops paging keeps those documents for the session.
+      manager.releaseDocuments!([]);
+      await manager.synced();
+      expect(calls.removed.length).toBe(2);
+    } finally {
+      await manager.close();
+    }
+  });
+
+  it("gives up the whole watch set when the replica is reset", async () => {
+    const { manager, calls } = openStubbed({ supportsWatchRemove: true });
+    try {
+      const provider = manager.open(space);
+      await provider.sync(uri, { path: [], schema: false });
+      expect(provider.replica.retentionStats!().watches).toBe(1);
+
+      // A reset throws the documents away, so the watches behind them have to
+      // go too: the server would otherwise believe this session still holds
+      // what it just discarded, and never resend it.
+      (provider.replica as unknown as { reset(): void }).reset();
+      await manager.synced();
+      expect(calls.replaced).toEqual([[]]);
+      expect(provider.replica.retentionStats!().watches).toBe(0);
+    } finally {
+      await manager.close();
+    }
+  });
+});

--- a/packages/runner/test/measure-document-retention.ts
+++ b/packages/runner/test/measure-document-retention.ts
@@ -1,0 +1,122 @@
+#!/usr/bin/env deno run -A
+/**
+ * measure-document-retention.ts — what a space replica holds as a view pages
+ *
+ * Populates a space from one replica, then opens a second replica that starts
+ * empty and slides a window of live subscriptions across the collection, one
+ * page at a time. After each page it reports what that replica holds and how
+ * much heap survives a collection.
+ *
+ * This is the shape of any view that pages through more data than fits on
+ * screen, and it is the workload `experimentalDocumentRelease` exists for: run
+ * it both ways to see what the setting is worth. Not a test — it takes a minute
+ * and is run by hand. `packages/runner/test/document-release.test.ts` pins the
+ * property it measures.
+ *
+ * Its neighbour `window-retention-probe.ts` measures a different thing, and the
+ * two do not substitute for each other. That one drives a pattern projecting a
+ * window over a list in a single runtime, and reports retained heap. Here the
+ * reader is a second replica that has to pull what it reads, and the report is
+ * the replica's own counts — documents held, identifiers watched, watch specs
+ * installed. A single runtime already holds every document from having written
+ * them, so it cannot show a replica gaining or shedding them.
+ *
+ * Usage:
+ *   deno run -A --v8-flags=--expose-gc \
+ *     packages/runner/test/measure-document-retention.ts \
+ *     [--pages N] [--page-size N] [--release]
+ *
+ * `--expose-gc` is required: without it the heap column is allocation noise
+ * rather than retained heap.
+ */
+
+import { Identity } from "@commonfabric/identity";
+import type { MemorySpace } from "@commonfabric/memory/interface";
+import type { URI } from "../src/storage/interface.ts";
+import {
+  makeSharedServer,
+  openSharedServerRuntime,
+} from "./shared-server-storage.ts";
+
+const flag = (name: string): boolean => Deno.args.includes(`--${name}`);
+const option = (name: string, fallback: number): number => {
+  const at = Deno.args.indexOf(`--${name}`);
+  return at === -1 ? fallback : Number(Deno.args[at + 1]);
+};
+
+const pages = option("pages", 40);
+const pageSize = option("page-size", 25);
+const release = flag("release");
+// deno-lint-ignore no-explicit-any
+const collect = (globalThis as any).gc as (() => void) | undefined;
+if (collect === undefined) {
+  console.error(
+    "Run with --v8-flags=--expose-gc; the heap column means nothing without it.",
+  );
+  Deno.exit(1);
+}
+
+const identity = await Identity.fromPassphrase("document retention measure");
+const space = identity.did() as MemorySpace;
+const server = makeSharedServer();
+
+const total = pages * pageSize;
+const ids = Array.from(
+  { length: total },
+  (_, index) => `of:row-${index}` as URI,
+);
+
+// Wide enough that retaining a row costs something measurable, so the heap
+// column tracks the documents rather than the machinery around them.
+const row = (index: number) => ({
+  index,
+  title: `Row ${index}`,
+  body: "x".repeat(2048),
+  tags: Array.from({ length: 16 }, (_, tag) => `tag-${index}-${tag}`),
+});
+
+console.log(`populating ${total} documents (${pages} pages of ${pageSize})`);
+{
+  const writer = openSharedServerRuntime(identity, server);
+  for (let start = 0; start < total; start += pageSize) {
+    const tx = writer.runtime.edit();
+    for (let index = start; index < start + pageSize; index++) {
+      writer.runtime
+        .getCellFromLink({ space, id: ids[index], path: [] })
+        .withTx(tx)
+        .set(row(index));
+    }
+    await tx.commit();
+  }
+  await writer.runtime.settled();
+  await writer.manager.synced();
+  await writer.runtime.dispose();
+  await writer.manager.close();
+}
+
+const reader = openSharedServerRuntime(identity, server, release);
+console.log(`release=${release}`);
+console.log("page\tdocs\twatched\twatches\theapMB");
+
+for (let page = 0; page < pages; page++) {
+  const cancels = ids
+    .slice(page * pageSize, (page + 1) * pageSize)
+    .map((id) =>
+      reader.runtime.getCellFromLink({ space, id, path: [] }).sink(() => {})
+    );
+  await reader.runtime.settled();
+  for (const cancel of cancels) cancel();
+  await reader.runtime.settled();
+
+  collect();
+  collect();
+  const held = reader.manager.open(space).replica.retentionStats!();
+  const heapMB = (Deno.memoryUsage().heapUsed / (1024 * 1024)).toFixed(1);
+  console.log(
+    `${page}\t${held.documents}\t${held.watched}\t${held.watches}\t${heapMB}`,
+  );
+}
+
+await reader.runtime.dispose();
+await reader.manager.close();
+await server.close();

--- a/packages/runner/test/scheduler-split-clock.test.ts
+++ b/packages/runner/test/scheduler-split-clock.test.ts
@@ -56,6 +56,7 @@ describe("split-clock readiness decisions", () => {
       resetSettlingTracker: () => {},
       resetConvergenceHoldPasses: () => {},
       setPendingQueueTaskTimer: () => {},
+      releaseUnreadDocuments: () => {},
       execute: () => {},
     } satisfies ExecuteContinuationState;
 
@@ -85,6 +86,7 @@ describe("split-clock readiness decisions", () => {
       resetSettlingTracker: () => {},
       resetConvergenceHoldPasses: () => holdResets++,
       setPendingQueueTaskTimer: () => {},
+      releaseUnreadDocuments: () => {},
       execute: () => {},
     } satisfies ExecuteContinuationState;
 
@@ -118,6 +120,7 @@ describe("split-clock readiness decisions", () => {
       resetSettlingTracker: () => {},
       resetConvergenceHoldPasses: () => holdResets++,
       setPendingQueueTaskTimer: () => {},
+      releaseUnreadDocuments: () => {},
       execute: () => {},
     } satisfies ExecuteContinuationState;
 
@@ -145,6 +148,7 @@ describe("split-clock readiness decisions", () => {
       resetSettlingTracker: () => {},
       resetConvergenceHoldPasses: () => holdResets++,
       setPendingQueueTaskTimer: () => {},
+      releaseUnreadDocuments: () => {},
       execute: () => {},
     } satisfies ExecuteContinuationState;
 

--- a/packages/runner/test/scheduler-trigger-index.test.ts
+++ b/packages/runner/test/scheduler-trigger-index.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../src/scheduler/trigger-index.ts";
 import type { Action, ReactivityLog } from "../src/scheduler/types.ts";
 import type { IMemorySpaceAddress } from "../src/storage/interface.ts";
+import { entityKey } from "../src/scheduler/keys.ts";
 
 describe("SchedulerTriggerIndex", () => {
   it("removes empty trigger entities when the last action unsubscribes", () => {
@@ -147,5 +148,45 @@ describe("applyActionReadDelta", () => {
     expect(triggerIndex.collectReadersForWrite(secondRead).has(action)).toBe(
       false,
     );
+  });
+
+  it("forgets a removed space's idle candidates", () => {
+    const triggerIndex = new SchedulerTriggerIndex();
+    const space = "did:key:z6Mk-trigger-space" as IMemorySpaceAddress["space"];
+    const other = "did:key:z6Mk-trigger-other" as IMemorySpaceAddress["space"];
+    const mine = `${space}/space/of:doc` as const;
+    const theirs = `${other}/space/of:doc` as const;
+
+    triggerIndex.noteIdleCandidates([mine, theirs]);
+    // A space that has gone takes its candidates with it: nothing will read
+    // them again, and releasing against a replica that is closing is pointless.
+    triggerIndex.removeSpace(space);
+
+    expect(triggerIndex.drainIdleCandidates()).toEqual([theirs]);
+  });
+
+  it("never offers an entity no action ever read", () => {
+    const triggerIndex = new SchedulerTriggerIndex();
+    const action: Action = () => {};
+    const read: IMemorySpaceAddress = {
+      space: "did:key:z6Mk-untracked" as IMemorySpaceAddress["space"],
+      id: "of:tracked" as IMemorySpaceAddress["id"],
+      type: "application/json",
+      path: [],
+    };
+
+    // This is the precondition document release rests on: a release candidate
+    // can only be an entity that was registered as a read and then lost its
+    // last reader. A document only ever read without registering a trigger —
+    // every `ignoreReadForScheduling` read — is never a candidate, so it is
+    // never released out from under the code reading it that way.
+    triggerIndex.addActionReads(action, [read], []);
+    triggerIndex.removeActionFromEntities(action, [entityKey(read)]);
+
+    const offered = triggerIndex.drainIdleCandidates();
+    expect(offered).toEqual([entityKey(read)]);
+    // Nothing else: an untracked identifier cannot appear here, because both
+    // routes into the record start from entities the index already held.
+    expect(offered.length).toBe(1);
   });
 });

--- a/packages/runner/test/shared-server-storage.ts
+++ b/packages/runner/test/shared-server-storage.ts
@@ -1,0 +1,69 @@
+import type { Identity } from "@commonfabric/identity";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import { defaultSettings, type Options } from "../src/storage/v2.ts";
+import { Runtime } from "../src/runtime.ts";
+import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
+
+/**
+ * An in-process memory server the caller owns, so several managers can be
+ * pointed at one space: one to populate it, and one that starts empty and has
+ * to pull whatever it reads.
+ */
+export function makeSharedServer(): MemoryV2Server.Server {
+  return new MemoryV2Server.Server({
+    authorizeSessionOpen(message) {
+      const principal = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof principal === "string" ? principal : undefined;
+    },
+    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
+  });
+}
+
+/**
+ * A manager on a server the caller owns. About twenty runner tests carry a
+ * private copy of this; it is the same shape, with the storage settings opened
+ * up so a test can choose them.
+ */
+export class SharedServerStorageManager extends EmulatedStorageManager {
+  static connectTo(
+    server: MemoryV2Server.Server,
+    options: Omit<Options, "memoryHost" | "spaceHostMap">,
+  ): SharedServerStorageManager {
+    const manager = new SharedServerStorageManager(
+      { ...options, memoryHost: new URL("memory://") },
+      () => server,
+    );
+    manager.sharedServer = server;
+    return manager;
+  }
+
+  private sharedServer!: MemoryV2Server.Server;
+
+  // The server is SHARED between managers and closed once by the caller — serve
+  // it without ever initializing the base class's private `#server`, whose
+  // `close()` would otherwise close the shared server once per manager.
+  protected override server(): MemoryV2Server.Server {
+    return this.sharedServer;
+  }
+}
+
+/** A runtime on its own replica of `server`. */
+export function openSharedServerRuntime(
+  as: Identity,
+  server: MemoryV2Server.Server,
+  experimentalDocumentRelease = false,
+): { manager: SharedServerStorageManager; runtime: Runtime } {
+  const manager = SharedServerStorageManager.connectTo(server, {
+    as,
+    settings: { ...defaultSettings, experimentalDocumentRelease },
+  } as Omit<Options, "memoryHost" | "spaceHostMap">);
+  return {
+    manager,
+    runtime: new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: manager,
+    }),
+  };
+}


### PR DESCRIPTION
Every document a space replica pulls stays in `SpaceReplica`'s document map, and every watch it installs stays on the server, for as long as the tab is open: the only code that removes a document is `reset()`, which nothing outside tests calls. Nothing is ever released, so any view that pages through more data than fits on screen costs memory per page visited and gets none of it back. Sliding a window of subscriptions across a thousand-document collection twenty-five at a time gains exactly one page of documents and one page of watched identifiers per page turned, ending with the whole collection resident. At the scale of an experimental view paging through several hundred records of live agent data, each carrying a nested projection, the same effect reached fifteen thousand documents and 438 MB of retained heap after twenty page turns — enough to exhaust a browser renderer's heap and kill the tab. The frozen document values a replica keeps are also what keeps the deep-freeze, sorted-key, and value-hash caches growing, since those are keyed on the values.

Two things were missing. The replica had no way to tell which documents a live cell still needed, so it could not evict anything safely; and nothing ever shrank the set of watches, so the server kept streaming updates for pages that had scrolled out of view.

Interest comes from the scheduler. Its trigger index already maps each document to the actions that read it — every sink, every running node, every view subscription — and prunes an action's entry when its read set changes or it is cancelled. That index is the runner's record of what is still wanted, so this adds a way to ask it (`Scheduler.hasDocumentReaders`) and a way for it to report entities whose last reader has gone. The scheduler collects those, re-checks them when it reaches quiescence — so an entity that loses a reader and gains another during the same wave is filtered out rather than released and immediately pulled back — and hands the rest to the storage manager. The replica adds its own reasons to keep a document: unconfirmed writes waiting to be replayed, an identifier a conflict marked stale, a provider-level `sink` subscriber, and every document an outstanding pull is waiting for, including the ones it is waiting for through a watch that already covers them.

Eviction is server-driven, and it has to be. The server tracks which entities each session holds, and `session.watch.add` deliberately does not resend an entity it believes the session already has, so a document the client dropped on its own initiative could never be pulled back: every later request for it would be answered with nothing. So the replica gives up the watches rooted at released documents and takes the server's `removes` as the authority for what it may then discard. A document that leaves the union while this replica still wants it — a dropped watch was covering it as well as its own root — is pulled again rather than discarded, with its value left in place: wiping it would show a reader a deletion that did not happen, and a pending write replays onto the confirmed base, which must not move backwards.

Shrinking needs a verb that names what goes. `session.watch.set` can express the same change, but its request carries every spec that stays: measured over a paging walk holding roughly thirteen hundred live watches, a replacement carried 590 to 757 kB of surviving watch specs regardless of how little was being dropped, against 0.5 to 36 kB of identifiers for a removal, with two shrinks per page turn — and the replacement's size tracks what survives, so it does not fall as the working set settles. This adds `session.watch.remove`, negotiated through the existing capability flags, with `session.watch.set` as the fallback for a server that does not advertise it. Naming only what goes also makes a removal independent of any concurrent watch refresh; only the two forms that name the survivors — after a replica reset, and that fallback — have to wait for the wire, rather than every shrink blocking every pull for a round trip.

`session.watch.set` itself now answers with a diff rather than resending every surviving entity, which is what section 4.6.3 of the protocol already specified and what the effect path already did. On the reconnect path, where a non-resumed session's entity cache is empty, the two produce the same frame. This also retires `buildFullSync`, whose last caller it was.

A read of a released document behaves exactly as a read of a document the replica has never pulled: it reports absent, and the read path kicks a load whose arrival re-runs the reader. Release retracts the one-shot reservations that say such a load has already been kicked, and drops the document's selectors from the watch selector tracker, so the pull is neither suppressed as a duplicate nor skipped as already covered.

This lands behind `experimentalDocumentRelease`, off by default, because one thing is not yet right. A list element whose result document was released and whose element run is then re-instantiated — a list that shrinks and grows back, or a page revisited — has its value restored by recomputation rather than by a load. The coordinator's first read of the released document reports absent, and the corrected value only reaches the aggregate on the next demanded scheduler pass, which `Cell.pull()` and `runtime.settled()` do not wait for: they converge on outstanding loads, and there is no outstanding load to see. Five runner test cases pin that timing. With the flag off nothing changes: the watch mirror the shrink needs is not kept, the scheduler does no collection work, and a `removes` frame is handled exactly as before. The experimental options registry records the gap and what closing it requires.

Two things exercise this. `packages/runner/test/document-release.test.ts` pins the property: sliding a window of subscriptions across a collection, in a replica that has to pull what it reads, holds a bounded set of documents with release on and grows monotonically without. It also covers the interest guards, the re-pull path, and teardown with a release decided but not yet sent. `packages/runner/test/measure-document-retention.ts` is the same walk at scale, run by hand, reporting the counts and the retained heap per page; its readings are in docs/history/development/performance/2026-07-document-release.md. Both build on a shared in-process server so two replicas can be opened against one space, which `StorageManager.emulate` cannot express.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let a space replica release documents when no live readers remain, shrinking its server watch set and bounding memory while paging large lists. Server-driven eviction is wired through the scheduler and a new `session.watch.remove` verb; gated by `experimentalDocumentRelease` (off by default).

- **New Features**
  - Scheduler collects entities that lost their last reader and, at quiescence, hands them to storage; runtime wires this via release hooks.
  - Storage drops covering watches, then discards docs per server `removes`; if a dropped watch also covered a needed doc, it re-pulls, tracks the work, and drops the doc if the watch cannot be restored; failed shrinks requeue and retry at the next quiescence sweep.
  - Docs with pending writes, stale ids from conflicts, provider-level `sink` subscribers, or pending pulls are kept.
  - Reads of released docs behave like first reads: report absent, kick a load, and clear one-shot reservations and selector tracking.

- **Protocol**
  - Added permanent `watchRemove` capability and `session.watch.remove` to drop watches by id; client exposes `supportsWatchRemove` and `watchRemoveSync`; fallback is `session.watch.set`.
  - `session.watch.set` now returns a diff; retired the full-sync path. New docs and tests included, plus a retention benchmark and a `watch.remove` test.

<sup>Written for commit ac807702bf4c5a97dd067004f5ce8106fda10552. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

