### PR TITLE
refactor(runner): rename `toJSONWithAliasBindings()` to `withAliasBindings()`

### DIFF
--- a/docs/specs/content-addressed-action-identity.md
+++ b/docs/specs/content-addressed-action-identity.md
@@ -214,7 +214,7 @@ or stops needing identity-carry, the symbols die with it.)
 
 | # | Copy site | What it does | Verdict |
 |---|---|---|---|
-| C1 | `createPattern` (`builder/pattern.ts` ~332, 368–373): build-time serialization of `result` + every node's `module`/`inputs`/`outputs` via `toJSONWithAliasBindings` | Produces the `Pattern` object — the durable graph representation. Writes `unsafe_originalPattern` onto every nested pattern copy (`json-utils.ts:183`) | **Copy stays in memory; stops crossing the serialization boundary.** The in-memory graph remains the instantiation representation; `toJSON` at the storage boundary emits refs (§7). The *backref* is replaced by registering the copy in a side table at copy time (§ Trust). |
+| C1 | `createPattern` (`builder/pattern.ts` ~332, 368–373): build-time serialization of `result` + every node's `module`/`inputs`/`outputs` via `withAliasBindings` | Produces the `Pattern` object — the durable graph representation. Writes `unsafe_originalPattern` onto every nested pattern copy (`json-utils.ts:183`) | **Copy stays in memory; stops crossing the serialization boundary.** The in-memory graph remains the instantiation representation; `toJSON` at the storage boundary emits refs (§7). The *backref* is replaced by registering the copy in a side table at copy time (§ Trust). |
 | C2 | `moduleToJSON` pattern-type implementation (`json-utils.ts:387`, the CT-1230 workaround): sub-pattern passed as a module implementation (e.g. to `.map()`) | Serializes the nested pattern graph instead of stringifying it | **Subsumed by op-by-identity.** The op already travels as `$patternRef` + `$opFallback`; with `$opFallback` retained the embedded copy is only the fallback payload. When the fallback is dropped (Phase 4), this copy site disappears. |
 | C3 | `traverseValue` (`traverse-utils.ts:54`): copies during build traversal (`collectCellsAndNodes`, `node-utils` connect) | Preserves the backref so a traversal copy still resolves `getArtifactEntryRef` | **Copy stays; backref replaced** by side-table registration at the same line. |
 | C4 | `unwrapOneLevelAndBindToDoc` (`pattern-binding.ts:333–340`): instantiation-time rebinding copies | Propagates backref + the `verifiedLoadId` side-table entry to the bound copy | **Copy stays; backref replaced** by side-table registration; the `verifiedLoadId` propagation is deleted outright (CFC identity no longer flows through loadIds — § CFC). |
@@ -474,7 +474,7 @@ tolerate a miss. E4 (same day) removed that blocker and completed the flip:
   vintage's two resolution paths.
 - The internal/boundary split is structural: `serializePatternGraph()`
   (json-utils) serializes the full graph under an internal-serialization
-  context that suppresses `$patternRef`; `toJSONWithAliasBindings` (the
+  context that suppresses `$patternRef`; `withAliasBindings` (the
   builder-time node serializer) routes pattern values through it, so
   `Pattern.nodes` stays a bare-graph in-memory representation.
 

--- a/docs/specs/space-model/3-identity-and-references.md
+++ b/docs/specs/space-model/3-identity-and-references.md
@@ -58,7 +58,7 @@ Example:
 **`$alias` format** — no longer a link. Generic link recognition and parsing
 (`isWriteRedirectLink`, `parseLink`, `isCellLink`) are sigil-only, so an
 `$alias` record found in data is a plain value. The form survives solely as
-Pattern *binding* vocabulary (produced by `toJSONWithAliasBindings`, consumed
+Pattern *binding* vocabulary (produced by `withAliasBindings`, consumed
 via `isAliasBinding`/`parseAliasBinding`), where it marks intermediate
 bindings — e.g.
 ```json
@@ -68,7 +68,7 @@ bindings — e.g.
 
 The plain-value reading applies to *data* only. Inside a Pattern object the
 interpretation is positional and shape-based with no escape encoding: pattern
-serialization (`toJSONWithAliasBindings`) treats any `$alias`-shaped record it
+serialization (`withAliasBindings`) treats any `$alias`-shaped record it
 encounters as a binding. A literal `{ "$alias": { "path": [...] } }` object
 passed as factory inputs (via `.with(...)`/`.bind(...)`, captured closure
 state, or a pattern's outputs) is therefore not preserved as data: the

--- a/packages/patterns/gideon-tests/style-object-repro/README.md
+++ b/packages/patterns/gideon-tests/style-object-repro/README.md
@@ -8,16 +8,15 @@ the first two siblings got styles applied. Siblings 3+ rendered without styling
 
 ## Why it happened
 
-The `toJSONWithAliasBindings` function in
-`packages/runner/src/builder/json-utils.ts` used a `WeakSet` to guard against
-circular object references during pattern serialization. However, this guard
-also triggered on shared (non-circular) references, returning `{}` instead of
-re-serializing the value.
+The `withAliasBindings` function in `packages/runner/src/builder/json-utils.ts`
+used a `WeakSet` to guard against circular object references during pattern
+serialization. However, this guard also triggered on shared (non-circular)
+references, returning `{}` instead of re-serializing the value.
 
 The reason 2 siblings worked (not just 1) is that `traverseValue` upstream
 creates one copy of the shared object and returns the original for subsequent
-encounters, giving `toJSONWithAliasBindings` 2 distinct object identities before
-it hits duplicates on the 3rd+.
+encounters, giving `withAliasBindings` 2 distinct object identities before it
+hits duplicates on the 3rd+.
 
 ## The fix
 

--- a/packages/runner/src/builder/json-utils.ts
+++ b/packages/runner/src/builder/json-utils.ts
@@ -38,7 +38,7 @@ export type CellAliasResolver = (
   ignoreSelfAliases: boolean,
 ) => AliasBinding | null | undefined;
 
-export function toJSONWithAliasBindings(
+export function withAliasBindings(
   value: FactoryInput<any>,
   resolveCellAlias?: CellAliasResolver,
   ignoreSelfAliases: boolean = false,
@@ -111,7 +111,7 @@ export function toJSONWithAliasBindings(
   // If this is an array, process each element recursively.
   if (Array.isArray(value)) {
     return (value as FactoryInput<any>).map((v: FactoryInput<any>, i: number) =>
-      toJSONWithAliasBindings(v, resolveCellAlias, ignoreSelfAliases, [
+      withAliasBindings(v, resolveCellAlias, ignoreSelfAliases, [
         ...path,
         i,
       ], seen)
@@ -156,7 +156,7 @@ export function toJSONWithAliasBindings(
     // won't do correctly. This site will need attention once FabricInstances see
     // real use.
     for (const key in valueToProcess as any) {
-      const jsonValue = toJSONWithAliasBindings(
+      const jsonValue = withAliasBindings(
         valueToProcess[key],
         resolveCellAlias,
         ignoreSelfAliases,
@@ -369,7 +369,7 @@ export function moduleToJSON(module: Module) {
   // the actual pattern structure. This caused "Invalid pattern" errors at runtime
   // because isPattern() check failed on the string.
   //
-  // Why this helps: Using toJSONWithAliasBindings ensures nested $alias bindings
+  // Why this helps: Using withAliasBindings ensures nested $alias bindings
   // get their nesting level incremented properly. Without this, aliases could be
   // bound to a specific doc too early, causing handlers to point at stale docs
   // when the pattern is later executed in a different context.
@@ -380,7 +380,7 @@ export function moduleToJSON(module: Module) {
   if (
     module.type === "pattern" && implementation && isPattern(implementation)
   ) {
-    implementation = toJSONWithAliasBindings(
+    implementation = withAliasBindings(
       implementation as unknown as FactoryInput<any>,
     ) as unknown as Pattern;
     return {
@@ -460,7 +460,7 @@ export function moduleToJSON(module: Module) {
 
 // Ambient context: true while serializing the runtime-INTERNAL graph
 // representation (builder-time node serialization via
-// `toJSONWithAliasBindings`, and through it the `$opFallback` eviction
+// `withAliasBindings`, and through it the `$opFallback` eviction
 // fallback graphs). The JSON boundary (`Pattern.toJSON()`, fired by
 // JSON.stringify and by cell writes via native-conversion's HasToJSON) adds
 // the content-addressed `$patternRef` on top of the graph; internal
@@ -474,7 +474,7 @@ let internalGraphSerialization = false;
 /**
  * Serialize a pattern's full node-graph — the runtime-internal representation
  * (design §7: the graph is internal; the boundary speaks refs-first). Used by
- * `toJSONWithAliasBindings` (builder-time node serialization, which the
+ * `withAliasBindings` (builder-time node serialization, which the
  * `$opFallback` graphs descend from) and debug tooling.
  *
  * Calls the pattern's own `toJSON` rather than `patternToJSON` directly:

--- a/packages/runner/src/builder/pattern.ts
+++ b/packages/runner/src/builder/pattern.ts
@@ -45,7 +45,7 @@ import {
   type CellAliasResolver,
   moduleToJSON,
   patternToJSON,
-  toJSONWithAliasBindings,
+  withAliasBindings,
 } from "./json-utils.ts";
 import { traverseValue } from "./traverse-utils.ts";
 import {
@@ -531,7 +531,7 @@ function factoryFromPattern<T, R>(
     }
   };
   // Creates a query (i.e. aliases) into the cells for the result
-  const result = toJSONWithAliasBindings(
+  const result = withAliasBindings(
     outputs ?? {},
     resolveCellAlias,
     true,
@@ -554,17 +554,17 @@ function factoryFromPattern<T, R>(
     applyArgumentIfcToResult(argumentSchema, resultSchemaArg) ?? {};
 
   const serializedNodes = Array.from(allNodes).map((node) => {
-    const module = toJSONWithAliasBindings(
+    const module = withAliasBindings(
       node.module,
       resolveCellAlias,
       false,
     ) as unknown as Module;
-    const inputs = toJSONWithAliasBindings(
+    const inputs = withAliasBindings(
       node.inputs,
       resolveCellAlias,
       false,
     )!;
-    const outputs = toJSONWithAliasBindings(
+    const outputs = withAliasBindings(
       node.outputs,
       resolveCellAlias,
       false,

--- a/packages/runner/src/builder/traverse-utils.ts
+++ b/packages/runner/src/builder/traverse-utils.ts
@@ -60,7 +60,7 @@ export function traverseValue(
       // `resolveOriginal`/`getArtifactEntryRef` would be severed, which is how
       // a pattern passed as an `op` is later identified by
       // `{ identity, symbol }`. Mirrors the registration in
-      // `toJSONWithAliasBindings`.
+      // `withAliasBindings`.
       if (isPattern(value)) noteDerivedCopy(copy, value);
       return copy;
     }

--- a/packages/runner/test/json-utils.test.ts
+++ b/packages/runner/test/json-utils.test.ts
@@ -9,7 +9,7 @@ import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import {
   createJsonSchema,
   moduleToJSON,
-  toJSONWithAliasBindings,
+  withAliasBindings,
 } from "../src/builder/json-utils.ts";
 import { type JSONSchema, type JSONSchemaObj } from "../src/builder/types.ts";
 import { isInternedSchema } from "@commonfabric/data-model/schema-hash";
@@ -674,7 +674,7 @@ describe("json-utils", () => {
     });
   });
 
-  describe("toJSONWithAliasBindings", () => {
+  describe("withAliasBindings", () => {
     it("should serialize shared object references correctly", () => {
       // Regression test: shared style objects used across siblings in .map()
       // should all serialize with full data, not {} for the 3rd+ occurrence.
@@ -696,7 +696,7 @@ describe("json-utils", () => {
         ],
       };
 
-      const result = toJSONWithAliasBindings(tree as any) as any;
+      const result = withAliasBindings(tree as any) as any;
 
       // All 5 children should have the full style object
       for (let i = 0; i < 5; i++) {
@@ -712,7 +712,7 @@ describe("json-utils", () => {
       const circular: any = { name: "root", child: {} };
       circular.child.parent = circular; // true circular reference
 
-      const result = toJSONWithAliasBindings(circular as any) as any;
+      const result = withAliasBindings(circular as any) as any;
 
       // The root should serialize, but the circular back-reference should be {}
       expect(result.name).toEqual("root");
@@ -729,7 +729,7 @@ describe("json-utils", () => {
         ],
       };
 
-      const result = toJSONWithAliasBindings(tree as any) as any;
+      const result = withAliasBindings(tree as any) as any;
 
       expect(result.items[0].meta).toEqual({ author: "test", version: 1 });
       expect(result.items[1].meta).toEqual({ author: "test", version: 1 });
@@ -746,7 +746,7 @@ describe("json-utils", () => {
         path: [],
       });
 
-      const result = toJSONWithAliasBindings(
+      const result = withAliasBindings(
         cellWithFalseSchema as any,
         (cell) => {
           const { schema, scope } = cell.export();
@@ -782,7 +782,7 @@ describe("json-utils", () => {
       // pass through unchanged.
       const bytes = new FabricBytes(new Uint8Array([1, 2, 3]));
 
-      const result = toJSONWithAliasBindings({ payload: bytes } as any) as any;
+      const result = withAliasBindings({ payload: bytes } as any) as any;
 
       expect(result.payload).toBe(bytes);
     });

--- a/packages/runner/test/pattern-ref-boundary.test.ts
+++ b/packages/runner/test/pattern-ref-boundary.test.ts
@@ -9,7 +9,7 @@ import type { Pattern } from "../src/builder/types.ts";
 import {
   patternToJSON,
   serializePatternGraph,
-  toJSONWithAliasBindings,
+  withAliasBindings,
 } from "../src/builder/json-utils.ts";
 import {
   resolveOpPattern,
@@ -26,7 +26,7 @@ import type { FactoryInput } from "../src/builder/types.ts";
  * session-lifetime artifact index (sync) or the storage-backed
  * `loadPatternByIdentity` (async; compiled artifacts persist in-space as part
  * of compilation). INTERNAL serialization (`serializePatternGraph`, used by
- * builder-time node serialization through `toJSONWithAliasBindings`) stays the
+ * builder-time node serialization through `withAliasBindings`) stays the
  * full bare graph — `Pattern.nodes` is the in-memory instantiation
  * representation, not a wire format.
  */
@@ -121,7 +121,7 @@ describe("refs-only pattern JSON at the boundary", () => {
     expect("$patternRef" in internal).toBe(false);
     expect(Array.isArray((internal as { nodes: unknown }).nodes)).toBe(true);
 
-    const viaLegacyAliases = toJSONWithAliasBindings(
+    const viaLegacyAliases = withAliasBindings(
       compiled as unknown as FactoryInput<unknown>,
     ) as Record<string, unknown>;
     expect("$patternRef" in viaLegacyAliases).toBe(false);


### PR DESCRIPTION
The `toJSON` prefix stopped being true a while ago, and is now plainly false.
This function returns `FabricPrimitive` instances — `FabricBytes`,
`FabricEpochNsec` — and those are not JSON. It also never took JSON *in*: its
input is builder vocabulary (`Cell`s, `OpaqueRef`s, `$alias` records,
`Pattern`s) interleaved with data.

So neither end of the old name was accurate — and no type-mentioning name would
be either, because neither end is one clean type. What the function actually
does is narrower and nameable: it hands back the same structure with cell
references replaced by alias bindings. `withAliasBindings()` says exactly that,
in the established copy-but-with idiom (compare `Array.prototype.with`), and it
reads well at the call sites:

```ts
const inputs = withAliasBindings(node.inputs, resolveCellAlias, false);
```

Rejected `resolveCellAliases()`, which points the wrong way — this **creates**
aliases from cell references rather than resolving them.

Pure rename, no behavior change: **29 references across 8 files**, including the
two live specs that name it and one pattern README.

## Deliberately not included, and why

The declared return type `JSONValue | undefined` is a matching lie, propped up
by `as unknown as JSONValue` double casts — a cast being the code's own
admission that it isn't true. The honest type is `FabricExecValue`.

That correction was measured before being split out, rather than assumed. It
cascades well past this function:

| depth | what has to change |
| --- | --- |
| 1 | `withAliasBindings()`'s return type |
| 2 | `Node.inputs`, `Node.outputs`, `Pattern.result` — all declared `JSONValue` |
| 3 | `instantiateNode()`'s `inputBindings` / `outputBindings` — declared `FabricValue` |
| 4 | four of `instantiateNode`'s callees, same mistyping — **still unresolved when the measurement stopped** |

It is a real and worthwhile correction: the whole node-instantiation path types
exec values as `FabricValue`. But it is not a rename, and bundling them would
have turned a mechanical no-op into something unreviewable. It goes in its own
change.

## Testing

Full runner suite green (1117 passed, 0 failed). `deno task check`,
`check-docs` (522 blocks), `deno fmt --check` (4320 files), and `deno lint`
(4293 files) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eJcTLCQcXrXHA4CC8eDpp


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed `toJSONWithAliasBindings()` to `withAliasBindings()` to match its actual behavior: return the same structure with cell references replaced by alias bindings. No behavior change.

- **Refactors**
  - Updated all references across runner, pattern builder, tests, and specs (8 files).
  - Adjusted docs and comments to reference `withAliasBindings`.

<sup>Written for commit 3101941a95fd62f46295240a9620f9ffe5f07b2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

