### PR TITLE
fix(cli): let the verb refusal win over a result-projection failure

### DIFF
--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -2238,6 +2238,28 @@ interface ReadPathVerb {
  * `callable` is true only for root-level names — the dispatcher's resolution
  * paths all start at a root — so the refusal message can redirect honestly.
  */
+/**
+ * The read-path guard's refusal, preferred over a result-projection failure.
+ *
+ * A verb is not a materializable result, so a read that lands on one fails the
+ * projection check as a matter of course — and that error tells the caller to
+ * retry with `--step`, which sends them to re-run a read that cannot succeed
+ * at any number of steps. Classify before surrendering to the projection
+ * error so the refusal naming `cf piece call` wins. Returns null when the path
+ * is not certainly a verb, leaving the projection error exactly as it was.
+ */
+async function verbReadRefusalOrNull(
+  piece: any,
+  prop: "input" | "result",
+  path: readonly (string | number)[],
+  pieceId: string,
+): Promise<PieceVerbReadError | null> {
+  const verb = await classifyReadPathVerb(piece, prop, path);
+  return verb
+    ? new PieceVerbReadError(verb.verb, pieceId, verb.callable)
+    : null;
+}
+
 async function classifyReadPathVerb(
   piece: any,
   prop: "input" | "result",
@@ -2318,7 +2340,12 @@ export async function getCellValue(
           error.message.startsWith("Cannot access path") &&
           await resultProjectionFailedAtPath(piece, path)
         ) {
-          throw new PieceResultProjectionError(path, shouldStep);
+          throw await verbReadRefusalOrNull(
+            piece,
+            prop,
+            path,
+            resolvedConfig.piece,
+          ) ?? new PieceResultProjectionError(path, shouldStep);
         }
         throw error;
       }
@@ -2339,7 +2366,12 @@ export async function getCellValue(
         !options.input && transformed === undefined &&
         await resultProjectionFailedAtPath(piece, path)
       ) {
-        throw new PieceResultProjectionError(path, shouldStep);
+        throw await verbReadRefusalOrNull(
+          piece,
+          prop,
+          path,
+          resolvedConfig.piece,
+        ) ?? new PieceResultProjectionError(path, shouldStep);
       }
       if (transformed === undefined && !sourceWasAbsent) {
         throw new PieceGetTransformError(
@@ -2364,7 +2396,12 @@ export async function getCellValue(
         error.message.startsWith("Cannot access path") &&
         await resultProjectionFailedAtPath(piece, path)
       ) {
-        throw new PieceResultProjectionError(path, shouldStep);
+        throw await verbReadRefusalOrNull(
+          piece,
+          prop,
+          path,
+          resolvedConfig.piece,
+        ) ?? new PieceResultProjectionError(path, shouldStep);
       }
       throw error;
     }
@@ -2373,7 +2410,12 @@ export async function getCellValue(
       !options.input && value === undefined &&
       await resultProjectionFailedAtPath(piece, path)
     ) {
-      throw new PieceResultProjectionError(path, shouldStep);
+      throw await verbReadRefusalOrNull(
+        piece,
+        prop,
+        path,
+        resolvedConfig.piece,
+      ) ?? new PieceResultProjectionError(path, shouldStep);
     }
 
     // Read-path guard (verb contract WS-F): a path that lands ON a verb would

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -2238,28 +2238,6 @@ interface ReadPathVerb {
  * `callable` is true only for root-level names — the dispatcher's resolution
  * paths all start at a root — so the refusal message can redirect honestly.
  */
-/**
- * The read-path guard's refusal, preferred over a result-projection failure.
- *
- * A verb is not a materializable result, so a read that lands on one fails the
- * projection check as a matter of course — and that error tells the caller to
- * retry with `--step`, which sends them to re-run a read that cannot succeed
- * at any number of steps. Classify before surrendering to the projection
- * error so the refusal naming `cf piece call` wins. Returns null when the path
- * is not certainly a verb, leaving the projection error exactly as it was.
- */
-async function verbReadRefusalOrNull(
-  piece: any,
-  prop: "input" | "result",
-  path: readonly (string | number)[],
-  pieceId: string,
-): Promise<PieceVerbReadError | null> {
-  const verb = await classifyReadPathVerb(piece, prop, path);
-  return verb
-    ? new PieceVerbReadError(verb.verb, pieceId, verb.callable)
-    : null;
-}
-
 async function classifyReadPathVerb(
   piece: any,
   prop: "input" | "result",
@@ -2286,6 +2264,28 @@ async function classifyReadPathVerb(
   } catch {
     return null;
   }
+}
+
+/**
+ * The read-path guard's refusal, preferred over a result-projection failure.
+ *
+ * A verb is not a materializable result, so a read that lands on one fails the
+ * projection check as a matter of course — and that error tells the caller to
+ * retry with `--step`, which sends them to re-run a read that cannot succeed
+ * at any number of steps. Classify before surrendering to the projection
+ * error so the refusal naming `cf piece call` wins. Returns null when the path
+ * is not certainly a verb, leaving the projection error exactly as it was.
+ */
+async function verbReadRefusalOrNull(
+  piece: any,
+  prop: "input" | "result",
+  path: readonly (string | number)[],
+  pieceId: string,
+): Promise<PieceVerbReadError | null> {
+  const verb = await classifyReadPathVerb(piece, prop, path);
+  return verb
+    ? new PieceVerbReadError(verb.verb, pieceId, verb.callable)
+    : null;
 }
 
 export async function getCellValue(

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -1265,6 +1265,59 @@ describe("cli piece parsing", () => {
       expect((error as Error).message).not.toContain("--step");
     });
 
+    it("refuses a verb read through a transform, not a projection error", async () => {
+      // The transform path has its own projection-failure exits, so a verb
+      // read through --filter/--schema must reach the same refusal: asking a
+      // stream to project is the same mistake whichever route it takes.
+      const verbCell = {
+        schema: { type: "object" },
+        getRaw: () => ({ "/": "stream-link" }),
+        asSchemaFromLinks: () => verbCell,
+      };
+      const rootCell = {
+        schema: {
+          type: "object",
+          properties: { addTopic: { type: "object" } },
+          required: ["addTopic"],
+        },
+        get: () => ({ addTopic: { $stream: true } }),
+        key: () => verbCell,
+      };
+      const piece = {
+        result: {
+          get: () => Promise.resolve(undefined),
+          getCell: () => Promise.resolve(rootCell),
+        },
+      };
+      const deps = {
+        ...guardDeps(piece),
+        loadManager: () =>
+          Promise.resolve(
+            { runtime: {}, getSpace: () => "did:key:test-space" } as never,
+          ),
+      };
+      const options = { transform: { filter: parsePieceGetFilter(".active") } };
+
+      // The transform throws the "Cannot access path" shape a real projection
+      // failure raises.
+      const thrown = await getCellValue(config, ["addTopic"], options, {
+        ...deps,
+        derivePieceGetValue: () =>
+          Promise.reject(
+            new Error('Cannot access path "addTopic" - property not found'),
+          ),
+      }).catch((error) => error);
+      expect(thrown).toBeInstanceOf(PieceVerbReadError);
+      expect((thrown as Error).message).toContain("cf piece call");
+
+      // And the same when the transform simply yields nothing.
+      const empty = await getCellValue(config, ["addTopic"], options, {
+        ...deps,
+        derivePieceGetValue: () => Promise.resolve(undefined),
+      }).catch((error) => error);
+      expect(empty).toBeInstanceOf(PieceVerbReadError);
+    });
+
     it("fails open when classification itself fails", async () => {
       // A cell surface that throws during the guard's walk must never turn
       // a successful read into a refusal: the guard swallows the failure

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -1226,6 +1226,45 @@ describe("cli piece parsing", () => {
       await expect(getCellValue(config, ["count"], {}, deps)).resolves.toBe(3);
     });
 
+    it("refuses a verb whose result projection also fails", async () => {
+      // The shape a real board hits: reading `addTopic` on an unstepped piece
+      // fails the result-projection check BEFORE the verb is classified, so
+      // the caller was told "use --step" — advice that sends them to re-run a
+      // read which can never succeed, because a verb is not a materializable
+      // result. The verb refusal has to win over the projection error.
+      const verbCell = {
+        schema: { type: "object" },
+        getRaw: () => ({ "/": "stream-link" }),
+        asSchemaFromLinks: () => verbCell,
+      };
+      const rootCell = {
+        schema: {
+          type: "object",
+          properties: { addTopic: { type: "object" } },
+          required: ["addTopic"],
+        },
+        get: () => ({ addTopic: { $stream: true } }),
+        key: () => verbCell,
+      };
+      const piece = {
+        result: {
+          // The read yields nothing: the projection could not materialize it.
+          get: () => Promise.resolve(undefined),
+          getCell: () => Promise.resolve(rootCell),
+        },
+      };
+      const error = await getCellValue(
+        config,
+        ["addTopic"],
+        {},
+        guardDeps(piece),
+      )
+        .catch((error) => error);
+      expect(error).toBeInstanceOf(PieceVerbReadError);
+      expect((error as Error).message).toContain("cf piece call");
+      expect((error as Error).message).not.toContain("--step");
+    });
+
     it("fails open when classification itself fails", async () => {
       // A cell surface that throws during the guard's walk must never turn
       // a successful read into a refusal: the guard swallows the failure


### PR DESCRIPTION
## Why

Found by rehearsing the verb contract against a live toolshed — the first pass of the local → rapids → Estuary plan. Reading a verb path on a deployed topics board reported:

```
Cannot read piece result at "addTopic": stored data is present, but its schema
could not resolve all required values. Use --step to start the piece and
materialize session-scoped computed values before reading.
```

Following that advice reports *"The piece was stepped, but the required value still did not materialize."* The caller is sent to re-run a read that **cannot succeed at any number of steps**, and is never told the actual problem: `addTopic` is a verb, and a verb is not a materializable result.

The read-path guard (WS-F, #5232) is deliberately classified *after* the read, so the piece's links and schema are materialized locally when it runs. But a verb path fails the result-projection check first — precisely **because** a stream does not project — so `PieceResultProjectionError` was thrown before classification ever ran.

Both paths exit 1, so this was a misleading message rather than a wrong verdict. That is what let it survive #5232's own tests: the existing guard fixtures carry no schema, so `resultProjectionFailedAtPath` returns false for them and the projection branch is never taken.

## What Changed

- **`verbReadRefusalOrNull`** (`packages/cli/lib/piece.ts`) — classifies the path and returns the `PieceVerbReadError`, or **null when the path is not certainly a verb**. The guard stays certain-only, per #5232's own follow-up correction.
- All **four** projection-error throw sites now prefer it: the transform-path catch, the transform-path `undefined` check, the plain-read catch, and the plain-read `undefined` check. A non-verb read keeps `PieceResultProjectionError` byte-for-byte.
- `classifyReadPathVerb` is already self-contained — it re-reads the cell itself and swallows its own failures — so calling it on the failure path adds no new way to fail.

## Test plan

- **Characterized red first:** a new case in `piece.test.ts`'s read-path-guard block builds a verb whose result projection also fails; it asserted `PieceVerbReadError` and observed `PieceResultProjectionError`. Green after the fix.
- `packages/cli` suite: **123 passed, 0 failed**.
- Repo-wide `deno task test`: **all packages passing** (304.8s).
- `deno fmt --check`, `deno lint` clean.
- **Live confirmation** against a local toolshed: the rehearsal script went 18/19 → **19/19**, with `cf piece get <board> addTopic` now refusing and naming `cf piece call`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CLI reads that land on verbs to return a clear refusal that points to `cf piece call` instead of a result-projection error suggesting `--step`. This prevents misleading retries and aligns with the verb read guard behavior.

- **Bug Fixes**
  - Added `verbReadRefusalOrNull` in `packages/cli/lib/piece.ts` to classify the path and prefer `PieceVerbReadError` over projection failures.
  - Applied at four projection-error exits (transform catch/undefined, plain catch/undefined) so verb refusal wins; non-verb reads still throw `PieceResultProjectionError`.
  - Guard remains certain-only; classification is self-contained and adds no new failure mode.
  - Expanded tests in `packages/cli/test/piece.test.ts` to cover a verb with projection failure and both transform exits (“Cannot access path” and undefined).

- **Refactors**
  - Moved the new helper below `classifyReadPathVerb` to reattach its JSDoc; no behavior change.

<sup>Written for commit d6bfd839c56891a5e74ad6edbdca92b105b87ed2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

