### PR TITLE
feat(topics): compact discovery index — one bounded read surveys the board (WS-A)

### DIFF
--- a/docs/plans/pattern-verb-contract-implementation.md
+++ b/docs/plans/pattern-verb-contract-implementation.md
@@ -134,8 +134,9 @@ Size S–M (~2–4 days). No dependencies. `packages/patterns/topics`.
   `index` rows reuse the crossref join, but every reference-valued field is
   DECLARED through a title-only `TopicIndexRef` — schemas filter visibility,
   so the row schema rather than reader discipline is what bounds a survey
-  read. The summary scalars ride in the row itself; the mixed-version scalars
-  mirror `TopicReference`'s absent-path shaping. The compat gate records the
+  read. The summary scalars ride in the row itself as plain numbers — the
+  computed coalesces a mixed-version sibling's absent path to 0, so only
+  `createdBy` (which has no honest zero) keeps the absent-path shaping. The compat gate records the
   new contract as updatable from every recorded baseline (a result addition
   is widening).
 - ~~Tests: `topics.test.tsx` / `multi-user.test.tsx` cover body-at-create,

--- a/docs/plans/pattern-verb-contract-implementation.md
+++ b/docs/plans/pattern-verb-contract-implementation.md
@@ -110,30 +110,52 @@ Named so their absence reads as intent, not oversight:
 
 Size S–M (~2–4 days). No dependencies. `packages/patterns/topics`.
 
-- `AddTopicEvent` gains optional `body` — argument widening, compat-checker
+- ~~`AddTopicEvent` gains optional `body` — argument widening, compat-checker
   clean — and `addTopic` creates the child with it, making `setBody` an
-  editing verb rather than part of every create.
-- Silent early-returns on mutating verbs become throws: empty title, blank
+  editing verb rather than part of every create.~~ — **done (#4991)**: the
+  create is atomic (no reader observes the title-only halfway state) and the
+  body is preserved verbatim, matching `setBody`.
+- ~~Silent early-returns on mutating verbs become throws: empty title, blank
   `agentName`, empty comment body, invalid link URL. UI composer wrappers
   (`submitTopic`, `submitComment`, `saveBody`, …) keep their silent guards —
-  an empty draft is a non-event in a composer, a defect headlessly.
-- A compact discovery `index` result on the board — one reference-plus-summary
+  an empty draft is a non-event in a composer, a defect headlessly.~~ —
+  **done (#4991)**: `rejectMutation` throws on every headless mutating verb;
+  `topics-rejections.test.tsx` pins each rejection asserting no write
+  happened, and the composer wrappers' silent guards are exercised in
+  `topics.test.tsx`.
+- ~~A compact discovery `index` result on the board — one reference-plus-summary
   row per topic: the child reference plus scalar summaries (`title`,
   `createdAt`, `createdBy`, `commentCount`, `lastActivityAt`) and reference
   edges as sibling references — never expanded pieces, and no pattern-authored
   fid fields (identity rendering is the CLI's job — decision 6, F2).
   `crossrefs` stays as the UI's reference graph; it is not compact — each row
   expands to full pieces, and a live full-board read through it exceeded 300k
-  tokens — and stops being the documented survey surface.
-- Tests: `topics.test.tsx` / `multi-user.test.tsx` cover body-at-create,
+  tokens — and stops being the documented survey surface.~~ — **done**:
+  `index` rows reuse the crossref join, but every reference-valued field is
+  DECLARED through a title-only `TopicIndexRef` — schemas filter visibility,
+  so the row schema rather than reader discipline is what bounds a survey
+  read. The summary scalars ride in the row itself; the mixed-version scalars
+  mirror `TopicReference`'s absent-path shaping. The compat gate records the
+  new contract as updatable from every recorded baseline (a result addition
+  is widening).
+- ~~Tests: `topics.test.tsx` / `multi-user.test.tsx` cover body-at-create,
   each thrown rejection (asserting no write happened), and the index
-  (asserting no expanded piece/action/runtime values serialize).
-- Docs riding the change: `packages/patterns/topics/README.md`,
+  (asserting no expanded piece/action/runtime values serialize).~~ —
+  **done**: the rejection pins landed with #4991 in their own
+  `topics-rejections.test.tsx` (those runs expect runtime errors);
+  `topics.test.tsx` covers body-at-create and now the index — rows, edges,
+  and a serialization pin asserting no expanded content, no verb streams,
+  and title-only reference projections (`Object.keys` is exactly `title`).
+- ~~Docs riding the change: `packages/patterns/topics/README.md`,
   `skills/topics/SKILL.md` (`addTopic` example gains `body`;
-  `deno task check-skill-facts` gates the citations).
-- **Exit:** filing-with-body is five CLI calls; a blank `agentName` fails with
-  a nonzero exit; a full-board survey is one bounded read of `index`; live
-  board updated via `setsrc` (gated — see Risks).
+  `deno task check-skill-facts` gates the citations).~~ — **done** across
+  #4991 (body) and the index change (README names `index` as the bounded
+  survey read; the skill documents it with a deployed-board lag caveat until
+  the setsrc lands).
+- **Exit:** filing-with-body is five CLI calls ✓; a blank `agentName` fails
+  with a nonzero exit ✓ (#4991); a full-board survey is one bounded read of
+  `index` ✓ in the pattern (deploy pending); live board updated via `setsrc`
+  — OPEN, gated on the clone rehearsal (see Risks).
 
 ### WS-B — CLI settlement hygiene
 

--- a/packages/patterns/baselines/topics/main.tsx/20260803T184838Z-fY7qNgyUsmt1SSAX.json
+++ b/packages/patterns/baselines/topics/main.tsx/20260803T184838Z-fY7qNgyUsmt1SSAX.json
@@ -1,0 +1,1055 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "AddCommentEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Optional only so callers of the previous deployed schema\nremain valid; new callers must provide a non-blank name.",
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "body"
+        ],
+        "type": "object"
+      },
+      "AddLinkEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Optional only so callers of the previous deployed schema\nremain valid; new callers must provide a non-blank name.",
+            "type": "string"
+          },
+          "kind": {
+            "$ref": "#/$defs/TopicLinkKind"
+          },
+          "label": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "url",
+          "label"
+        ],
+        "type": "object"
+      },
+      "SetBodyEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Optional only so callers of the previous deployed schema\nremain valid; new callers must provide a non-blank name.",
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "body"
+        ],
+        "type": "object"
+      },
+      "TopicAuthor": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "kind": {
+            "enum": [
+              "person",
+              "agent"
+            ]
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "name"
+        ],
+        "type": "object"
+      },
+      "TopicComment": {
+        "properties": {
+          "author": {
+            "$ref": "#/$defs/TopicAuthor",
+            "description": "Snapshot taken at write time (profile enrichment comes later; never gate\nauthorship on a profile wish — CT-1879). Comments carry no minted id:\narray elements have stable entity identity; future editing addresses\nelements by reference (`equals()`), not by a synthetic key."
+          },
+          "authorName": {
+            "default": "",
+            "type": "string"
+          },
+          "body": {
+            "default": "",
+            "type": "string"
+          },
+          "sentAt": {
+            "default": 0,
+            "type": "number"
+          }
+        },
+        "required": [
+          "authorName",
+          "body",
+          "sentAt"
+        ],
+        "type": "object"
+      },
+      "TopicLink": {
+        "properties": {
+          "addedAt": {
+            "type": "number"
+          },
+          "addedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "kind": {
+            "$ref": "#/$defs/TopicLinkKind",
+            "default": "web"
+          },
+          "label": {
+            "default": "",
+            "type": "string"
+          },
+          "url": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "url",
+          "label"
+        ],
+        "type": "object"
+      },
+      "TopicLinkKind": {
+        "enum": [
+          "session",
+          "pr",
+          "topic",
+          "web"
+        ]
+      },
+      "TopicPiece": {
+        "properties": {
+          "$NAME": {
+            "default": "",
+            "description": "Like the other derived display fields, a cold retained sibling may not\nhave produced this path yet. Its persisted title remains authoritative.",
+            "type": [
+              "string",
+              "undefined"
+            ]
+          },
+          "addComment": {
+            "$ref": "#/$defs/AddCommentEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "addLink": {
+            "$ref": "#/$defs/AddLinkEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "body": {
+            "type": "string"
+          },
+          "bodyUpdatedAt": {
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "bodyUpdatedBy": {
+            "anyOf": [
+              {
+                "type": "undefined"
+              },
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              }
+            ]
+          },
+          "commentCount": {
+            "default": 0,
+            "description": "Cold mixed-version references can expose an unresolved computed path as\nexplicit undefined. Shape it to zero until the sibling starts.",
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "comments": {
+            "items": {
+              "$ref": "#/$defs/TopicComment"
+            },
+            "type": "array"
+          },
+          "createdAt": {
+            "type": "number"
+          },
+          "createdBy": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              {
+                "type": "undefined"
+              }
+            ],
+            "default": {
+              "kind": "person",
+              "name": ""
+            },
+            "description": "Mixed-version list projections can resolve an older sibling's absent\npath as undefined. Fabric shapes that absence to this inert legacy\nsentinel at the list boundary; newly computed non-empty authorship remains\na structured TopicAuthor."
+          },
+          "createdByName": {
+            "type": "string"
+          },
+          "crossrefs": {
+            "anyOf": [
+              {
+                "properties": {
+                  "referencedBy": {
+                    "items": {
+                      "$ref": "#/$defs/TopicReference"
+                    },
+                    "type": "array"
+                  },
+                  "refsOut": {
+                    "items": {
+                      "$ref": "#/$defs/TopicReference"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "refsOut",
+                  "referencedBy"
+                ],
+                "type": "object"
+              },
+              {
+                "type": "undefined"
+              }
+            ],
+            "default": {
+              "referencedBy": [],
+              "refsOut": []
+            },
+            "description": "This topic's own place in the board's prose graph, derived read-side\nfrom `mentionable` (the sibling pieces it links, resolved from the\nboard's own list). Both sets stay empty until `mentionable` is wired.\nOptional (2026-07-21 deploy): pieces healed before their `mentionable`\nlink exists carry a session-scoped crossrefs indirection that resolves\nundefined outside the minting session; the list projection must accept\nthat rather than fail argument validation."
+          },
+          "lastActivityAt": {
+            "default": 0,
+            "description": "Max of creation, comments, body saves, and link additions.",
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "links": {
+            "items": {
+              "$ref": "#/$defs/TopicLink"
+            },
+            "type": "array"
+          },
+          "setBody": {
+            "$ref": "#/$defs/SetBodyEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "body",
+          "comments",
+          "links",
+          "createdAt",
+          "createdByName",
+          "commentCount",
+          "lastActivityAt",
+          "addComment",
+          "addLink",
+          "setBody",
+          "$NAME"
+        ],
+        "type": "object"
+      },
+      "TopicReference": {
+        "properties": {
+          "$NAME": {
+            "default": "",
+            "description": "Like the other derived display fields, a cold retained sibling may not\nhave produced this path yet. Its persisted title remains authoritative.",
+            "type": [
+              "string",
+              "undefined"
+            ]
+          },
+          "addComment": {
+            "$ref": "#/$defs/AddCommentEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "addLink": {
+            "$ref": "#/$defs/AddLinkEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "body": {
+            "type": "string"
+          },
+          "bodyUpdatedAt": {
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "bodyUpdatedBy": {
+            "anyOf": [
+              {
+                "type": "undefined"
+              },
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              }
+            ]
+          },
+          "commentCount": {
+            "default": 0,
+            "description": "Cold mixed-version references can expose an unresolved computed path as\nexplicit undefined. Shape it to zero until the sibling starts.",
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "comments": {
+            "items": {
+              "$ref": "#/$defs/TopicComment"
+            },
+            "type": "array"
+          },
+          "createdAt": {
+            "type": "number"
+          },
+          "createdBy": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              {
+                "type": "undefined"
+              }
+            ],
+            "default": {
+              "kind": "person",
+              "name": ""
+            },
+            "description": "Mixed-version list projections can resolve an older sibling's absent\npath as undefined. Fabric shapes that absence to this inert legacy\nsentinel at the list boundary; newly computed non-empty authorship remains\na structured TopicAuthor."
+          },
+          "createdByName": {
+            "type": "string"
+          },
+          "lastActivityAt": {
+            "default": 0,
+            "description": "Max of creation, comments, body saves, and link additions.",
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "links": {
+            "items": {
+              "$ref": "#/$defs/TopicLink"
+            },
+            "type": "array"
+          },
+          "setBody": {
+            "$ref": "#/$defs/SetBodyEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "body",
+          "comments",
+          "links",
+          "createdAt",
+          "createdByName",
+          "commentCount",
+          "lastActivityAt",
+          "addComment",
+          "addLink",
+          "setBody",
+          "$NAME"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "myName": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "user"
+          }
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "topics": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/TopicPiece"
+        },
+        "type": "array"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "topics/main.tsx",
+  "resultSchema": {
+    "$defs": {
+      "AddCommentEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Optional only so callers of the previous deployed schema\nremain valid; new callers must provide a non-blank name.",
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "body"
+        ],
+        "type": "object"
+      },
+      "AddLinkEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Optional only so callers of the previous deployed schema\nremain valid; new callers must provide a non-blank name.",
+            "type": "string"
+          },
+          "kind": {
+            "$ref": "#/$defs/TopicLinkKind"
+          },
+          "label": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "url",
+          "label"
+        ],
+        "type": "object"
+      },
+      "AddTopicEvent": {
+        "properties": {
+          "agentName": {
+            "description": "The agent making this mutation. The authenticated principal remains the\nhuman whose identity key invoked the stream; this is the agent's explicit\ncontent-level signature under that shared principal. Optional only so\ncallers of the previous deployed schema remain valid; new callers must\nprovide a non-blank name.",
+            "type": "string"
+          },
+          "body": {
+            "description": "The topic's initial living-document body. A topic born with a body\nappears with it atomically — no reader observes the title-only halfway\nstate, and no follow-up `setBody` call is needed to finish a create\n(verb contract: the atomic-unit rule).",
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title"
+        ],
+        "type": "object"
+      },
+      "SetBodyEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Optional only so callers of the previous deployed schema\nremain valid; new callers must provide a non-blank name.",
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "body"
+        ],
+        "type": "object"
+      },
+      "TopicAuthor": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "kind": {
+            "enum": [
+              "person",
+              "agent"
+            ]
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "name"
+        ],
+        "type": "object"
+      },
+      "TopicComment": {
+        "properties": {
+          "author": {
+            "$ref": "#/$defs/TopicAuthor",
+            "description": "Snapshot taken at write time (profile enrichment comes later; never gate\nauthorship on a profile wish — CT-1879). Comments carry no minted id:\narray elements have stable entity identity; future editing addresses\nelements by reference (`equals()`), not by a synthetic key."
+          },
+          "authorName": {
+            "default": "",
+            "type": "string"
+          },
+          "body": {
+            "default": "",
+            "type": "string"
+          },
+          "sentAt": {
+            "default": 0,
+            "type": "number"
+          }
+        },
+        "required": [
+          "authorName",
+          "body",
+          "sentAt"
+        ],
+        "type": "object"
+      },
+      "TopicCrossref": {
+        "properties": {
+          "fid": {
+            "description": "The topic's own fid in tagged form (`fid1:…`); \"\" until known.",
+            "type": "string"
+          },
+          "referencedBy": {
+            "description": "Sibling topics whose prose mentions this topic's fid.",
+            "items": {
+              "$ref": "#/$defs/TopicPiece"
+            },
+            "type": "array"
+          },
+          "refsOut": {
+            "description": "Sibling topics whose fids this topic's prose mentions.",
+            "items": {
+              "$ref": "#/$defs/TopicPiece"
+            },
+            "type": "array"
+          },
+          "topic": {
+            "$ref": "#/$defs/TopicPiece"
+          }
+        },
+        "required": [
+          "fid",
+          "topic",
+          "refsOut",
+          "referencedBy"
+        ],
+        "type": "object"
+      },
+      "TopicIndexRef": {
+        "properties": {
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title"
+        ],
+        "type": "object"
+      },
+      "TopicIndexRow": {
+        "properties": {
+          "commentCount": {
+            "default": 0,
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "createdAt": {
+            "type": "number"
+          },
+          "createdBy": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              {
+                "type": "undefined"
+              }
+            ],
+            "default": {
+              "kind": "person",
+              "name": ""
+            }
+          },
+          "lastActivityAt": {
+            "default": 0,
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "referencedBy": {
+            "description": "Sibling topics whose prose mentions this topic's fid.",
+            "items": {
+              "$ref": "#/$defs/TopicIndexRef"
+            },
+            "type": "array"
+          },
+          "refsOut": {
+            "description": "Sibling topics whose fids this topic's prose mentions.",
+            "items": {
+              "$ref": "#/$defs/TopicIndexRef"
+            },
+            "type": "array"
+          },
+          "title": {
+            "type": "string"
+          },
+          "topic": {
+            "$ref": "#/$defs/TopicIndexRef"
+          }
+        },
+        "required": [
+          "topic",
+          "title",
+          "createdAt",
+          "commentCount",
+          "lastActivityAt",
+          "refsOut",
+          "referencedBy"
+        ],
+        "type": "object"
+      },
+      "TopicLink": {
+        "properties": {
+          "addedAt": {
+            "type": "number"
+          },
+          "addedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "kind": {
+            "$ref": "#/$defs/TopicLinkKind",
+            "default": "web"
+          },
+          "label": {
+            "default": "",
+            "type": "string"
+          },
+          "url": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "url",
+          "label"
+        ],
+        "type": "object"
+      },
+      "TopicLinkKind": {
+        "enum": [
+          "session",
+          "pr",
+          "topic",
+          "web"
+        ]
+      },
+      "TopicPiece": {
+        "properties": {
+          "$NAME": {
+            "default": "",
+            "description": "Like the other derived display fields, a cold retained sibling may not\nhave produced this path yet. Its persisted title remains authoritative.",
+            "type": [
+              "string",
+              "undefined"
+            ]
+          },
+          "addComment": {
+            "$ref": "#/$defs/AddCommentEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "addLink": {
+            "$ref": "#/$defs/AddLinkEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "body": {
+            "type": "string"
+          },
+          "bodyUpdatedAt": {
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "bodyUpdatedBy": {
+            "anyOf": [
+              {
+                "type": "undefined"
+              },
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              }
+            ]
+          },
+          "commentCount": {
+            "default": 0,
+            "description": "Cold mixed-version references can expose an unresolved computed path as\nexplicit undefined. Shape it to zero until the sibling starts.",
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "comments": {
+            "items": {
+              "$ref": "#/$defs/TopicComment"
+            },
+            "type": "array"
+          },
+          "createdAt": {
+            "type": "number"
+          },
+          "createdBy": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              {
+                "type": "undefined"
+              }
+            ],
+            "default": {
+              "kind": "person",
+              "name": ""
+            },
+            "description": "Mixed-version list projections can resolve an older sibling's absent\npath as undefined. Fabric shapes that absence to this inert legacy\nsentinel at the list boundary; newly computed non-empty authorship remains\na structured TopicAuthor."
+          },
+          "createdByName": {
+            "type": "string"
+          },
+          "crossrefs": {
+            "anyOf": [
+              {
+                "properties": {
+                  "referencedBy": {
+                    "items": {
+                      "$ref": "#/$defs/TopicReference"
+                    },
+                    "type": "array"
+                  },
+                  "refsOut": {
+                    "items": {
+                      "$ref": "#/$defs/TopicReference"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "refsOut",
+                  "referencedBy"
+                ],
+                "type": "object"
+              },
+              {
+                "type": "undefined"
+              }
+            ],
+            "default": {
+              "referencedBy": [],
+              "refsOut": []
+            },
+            "description": "This topic's own place in the board's prose graph, derived read-side\nfrom `mentionable` (the sibling pieces it links, resolved from the\nboard's own list). Both sets stay empty until `mentionable` is wired.\nOptional (2026-07-21 deploy): pieces healed before their `mentionable`\nlink exists carry a session-scoped crossrefs indirection that resolves\nundefined outside the minting session; the list projection must accept\nthat rather than fail argument validation."
+          },
+          "lastActivityAt": {
+            "default": 0,
+            "description": "Max of creation, comments, body saves, and link additions.",
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "links": {
+            "items": {
+              "$ref": "#/$defs/TopicLink"
+            },
+            "type": "array"
+          },
+          "setBody": {
+            "$ref": "#/$defs/SetBodyEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "body",
+          "comments",
+          "links",
+          "createdAt",
+          "createdByName",
+          "commentCount",
+          "lastActivityAt",
+          "addComment",
+          "addLink",
+          "setBody",
+          "$NAME"
+        ],
+        "type": "object"
+      },
+      "TopicReference": {
+        "properties": {
+          "$NAME": {
+            "default": "",
+            "description": "Like the other derived display fields, a cold retained sibling may not\nhave produced this path yet. Its persisted title remains authoritative.",
+            "type": [
+              "string",
+              "undefined"
+            ]
+          },
+          "addComment": {
+            "$ref": "#/$defs/AddCommentEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "addLink": {
+            "$ref": "#/$defs/AddLinkEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "body": {
+            "type": "string"
+          },
+          "bodyUpdatedAt": {
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "bodyUpdatedBy": {
+            "anyOf": [
+              {
+                "type": "undefined"
+              },
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              }
+            ]
+          },
+          "commentCount": {
+            "default": 0,
+            "description": "Cold mixed-version references can expose an unresolved computed path as\nexplicit undefined. Shape it to zero until the sibling starts.",
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "comments": {
+            "items": {
+              "$ref": "#/$defs/TopicComment"
+            },
+            "type": "array"
+          },
+          "createdAt": {
+            "type": "number"
+          },
+          "createdBy": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              {
+                "type": "undefined"
+              }
+            ],
+            "default": {
+              "kind": "person",
+              "name": ""
+            },
+            "description": "Mixed-version list projections can resolve an older sibling's absent\npath as undefined. Fabric shapes that absence to this inert legacy\nsentinel at the list boundary; newly computed non-empty authorship remains\na structured TopicAuthor."
+          },
+          "createdByName": {
+            "type": "string"
+          },
+          "lastActivityAt": {
+            "default": 0,
+            "description": "Max of creation, comments, body saves, and link additions.",
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "links": {
+            "items": {
+              "$ref": "#/$defs/TopicLink"
+            },
+            "type": "array"
+          },
+          "setBody": {
+            "$ref": "#/$defs/SetBodyEvent",
+            "asCell": [
+              "stream"
+            ]
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "body",
+          "comments",
+          "links",
+          "createdAt",
+          "createdByName",
+          "commentCount",
+          "lastActivityAt",
+          "addComment",
+          "addLink",
+          "setBody",
+          "$NAME"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "Topics — a tracker over #topic pieces: durable units of shared attention\n(CT-1878). Deliberately minimal: no statuses, labels, or assignees; topics\nsort by last activity. Replaces Linear / GitHub issues / loose process docs\nfor the team; PR workflows stay in GitHub and arrive here as links.",
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addTopic": {
+        "$ref": "#/$defs/AddTopicEvent",
+        "asCell": [
+          "stream"
+        ]
+      },
+      "crossrefs": {
+        "default": [],
+        "description": "The prose reference graph over the board's own topics, one row per\n(non-null) entry of `topics`. Rows carry their topic, so consumers never\nneed to correlate by index — indices are not a stable address.",
+        "items": {
+          "$ref": "#/$defs/TopicCrossref"
+        },
+        "type": "array"
+      },
+      "index": {
+        "default": [],
+        "description": "Compact discovery index — the documented full-board survey surface: one\nreference-plus-summary row per (non-null) entry of `topics`. Everything\nreference-valued in a row is declared through the title-only\n`TopicIndexRef`, so one bounded read surveys the whole board.\n`crossrefs` stays as the UI's reference graph; it is not compact — each\nrow expands to full pieces — and is not the survey surface.",
+        "items": {
+          "$ref": "#/$defs/TopicIndexRow"
+        },
+        "type": "array"
+      },
+      "mentionable": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/TopicPiece"
+        },
+        "type": "array"
+      },
+      "myName": {
+        "type": "string"
+      },
+      "newTitle": {
+        "description": "Session-local draft for the footer composer (exposed for embedding and\nheadless driving, like the chat exemplar's drafts).",
+        "type": "string"
+      },
+      "setMyName": {
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "submitTopic": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "Submit the footer composer as the current viewer's canonical Profile."
+      },
+      "topicCount": {
+        "type": "number"
+      },
+      "topics": {
+        "items": {
+          "$ref": "#/$defs/TopicPiece"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "topics",
+      "mentionable",
+      "topicCount",
+      "crossrefs",
+      "index",
+      "addTopic",
+      "myName",
+      "setMyName",
+      "submitTopic",
+      "$NAME",
+      "$UI"
+    ],
+    "tags": [
+      "topic"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/topics/main.tsx/20260803T191013Z-jUl4tnb6Dw8LBVJj.json
+++ b/packages/patterns/baselines/topics/main.tsx/20260803T191013Z-jUl4tnb6Dw8LBVJj.json
@@ -595,11 +595,7 @@
       "TopicIndexRow": {
         "properties": {
           "commentCount": {
-            "default": 0,
-            "type": [
-              "number",
-              "undefined"
-            ]
+            "type": "number"
           },
           "createdAt": {
             "type": "number"
@@ -619,11 +615,7 @@
             }
           },
           "lastActivityAt": {
-            "default": 0,
-            "type": [
-              "number",
-              "undefined"
-            ]
+            "type": "number"
           },
           "referencedBy": {
             "description": "Sibling topics whose prose mentions this topic's fid.",

--- a/packages/patterns/topics/README.md
+++ b/packages/patterns/topics/README.md
@@ -96,10 +96,20 @@ cf piece call --piece <topic> addLink \
   '{"kind":"pr","url":"https://github.com/org/repo/pull/123","label":"PR #123","agentName":"Sol"}'
 ```
 
+**A full-board survey is one bounded read of `index`.** Each row is the child
+reference plus scalar summaries (`title`, `createdAt`, `createdBy`,
+`commentCount`, `lastActivityAt`) and the prose reference edges as sibling
+references — every reference declared through a title-only schema, so the read
+cannot expand a topic's body, thread, or verbs no matter how it is projected:
+
+```bash
+cf piece get --piece <board> index --step
+```
+
 The board input links to complete Topic objects, including bodies, threads,
-handlers, and cross-reference data. Headless discovery should therefore combine
-an exact/range `--filter` with a concise `--schema` instead of materializing the
-whole corpus:
+handlers, and cross-reference data. Targeted headless discovery beyond the index
+should therefore combine an exact/range `--filter` with a concise `--schema`
+instead of materializing the whole corpus:
 
 ```bash
 cf piece get --piece <board> topics --input \

--- a/packages/patterns/topics/main.tsx
+++ b/packages/patterns/topics/main.tsx
@@ -119,15 +119,17 @@ export interface TopicIndexRef {
 
 /** One row of the board's compact discovery index: the child reference plus
  * scalar summaries and the prose reference edges as sibling references.
- * The mixed-version scalars mirror TopicReference's absent-path shaping — a
- * cold or older sibling projects them as the declared defaults. */
+ * The count/activity scalars are plain numbers — the computed coalesces a
+ * cold or older sibling's absent path to 0, so the row itself never carries
+ * the mixed-version undefined. `createdBy` keeps TopicReference's shaping:
+ * authorship has no honest zero, so absence stays declared. */
 export interface TopicIndexRow {
   topic: TopicIndexRef;
   title: string;
   createdAt: number;
   createdBy?: TopicAuthor | Default<{ kind: "person"; name: "" }> | undefined;
-  commentCount: number | Default<0> | undefined;
-  lastActivityAt: number | Default<0> | undefined;
+  commentCount: number;
+  lastActivityAt: number;
   /** Sibling topics whose fids this topic's prose mentions. */
   refsOut: TopicIndexRef[];
   /** Sibling topics whose prose mentions this topic's fid. */

--- a/packages/patterns/topics/main.tsx
+++ b/packages/patterns/topics/main.tsx
@@ -22,6 +22,7 @@ import Topic, {
   fidPayload,
   rejectMutation,
   snippet,
+  type TopicAuthor,
   topicAuthorFromAgent,
   topicAuthorFromPerson,
   topicAuthorLabel,
@@ -106,6 +107,33 @@ interface TopicCrossrefView extends TopicCrossref {
   referencedByLinks: TopicNavigationLink[];
 }
 
+/** A sibling topic as the index carries it: the piece reference itself
+ * (stored as a link to the child) declared through a title-only schema.
+ * The declared schema is the bound — schemas filter visibility, so a reader
+ * following an index edge through this type cannot expand the sibling's
+ * body, thread, or verbs. No pattern-authored fid fields: rendering a
+ * reference as an address is the CLI's job (decision 6, F2). */
+export interface TopicIndexRef {
+  title: string;
+}
+
+/** One row of the board's compact discovery index: the child reference plus
+ * scalar summaries and the prose reference edges as sibling references.
+ * The mixed-version scalars mirror TopicReference's absent-path shaping — a
+ * cold or older sibling projects them as the declared defaults. */
+export interface TopicIndexRow {
+  topic: TopicIndexRef;
+  title: string;
+  createdAt: number;
+  createdBy?: TopicAuthor | Default<{ kind: "person"; name: "" }> | undefined;
+  commentCount: number | Default<0> | undefined;
+  lastActivityAt: number | Default<0> | undefined;
+  /** Sibling topics whose fids this topic's prose mentions. */
+  refsOut: TopicIndexRef[];
+  /** Sibling topics whose prose mentions this topic's fid. */
+  referencedBy: TopicIndexRef[];
+}
+
 /**
  * Topics — a tracker over #topic pieces: durable units of shared attention
  * (CT-1878). Deliberately minimal: no statuses, labels, or assignees; topics
@@ -122,6 +150,13 @@ export interface TopicsOutput {
    * (non-null) entry of `topics`. Rows carry their topic, so consumers never
    * need to correlate by index — indices are not a stable address. */
   crossrefs: TopicCrossref[] | Default<[]>;
+  /** Compact discovery index — the documented full-board survey surface: one
+   * reference-plus-summary row per (non-null) entry of `topics`. Everything
+   * reference-valued in a row is declared through the title-only
+   * `TopicIndexRef`, so one bounded read surveys the whole board.
+   * `crossrefs` stays as the UI's reference graph; it is not compact — each
+   * row expands to full pieces — and is not the survey surface. */
+  index: TopicIndexRow[] | Default<[]>;
   /** Session-local draft for the footer composer (exposed for embedding and
    * headless driving, like the chat exemplar's drafts). */
   newTitle?: PerSession<Writable<string>>;
@@ -292,6 +327,25 @@ export default pattern<TopicsInput, TopicsOutput>(({ topics, myName }) => {
     }))
   );
 
+  // The compact discovery surface. Rows reuse the crossref join, but every
+  // reference-valued field is DECLARED through the title-only TopicIndexRef,
+  // so the row schema — not reader discipline — is what keeps a full-board
+  // survey bounded (a live full-board read through `crossrefs` exceeded 300k
+  // tokens). The summary scalars are read into the row here so a survey needs
+  // no second hop to answer "what changed lately".
+  const index = computed(() =>
+    crossrefView.map((row) => ({
+      topic: row.topic,
+      title: row.topic?.title ?? "",
+      createdAt: row.topic?.createdAt ?? 0,
+      createdBy: row.topic?.createdBy,
+      commentCount: row.topic?.commentCount ?? 0,
+      lastActivityAt: row.topic?.lastActivityAt ?? 0,
+      refsOut: row.refsOut,
+      referencedBy: row.referencedBy,
+    }))
+  );
+
   const hasNoTopics = computed(() =>
     asArray(topics.get()).filter((t) => t).length === 0
   );
@@ -406,6 +460,7 @@ export default pattern<TopicsInput, TopicsOutput>(({ topics, myName }) => {
     mentionable: topics,
     topicCount,
     crossrefs,
+    index,
     newTitle,
     addTopic,
     myName: myNameView,

--- a/packages/patterns/topics/topics.test.tsx
+++ b/packages/patterns/topics/topics.test.tsx
@@ -563,6 +563,53 @@ export default pattern(() => {
     (board.crossrefs?.[0]?.refsOut ?? []).length === 0
   );
 
+  // --- index: the compact discovery surface ---
+
+  // Reference-plus-summary rows mirror the board at the two-topic point: the
+  // summary scalars answer the survey questions directly, and no edges are
+  // claimed before any prose references exist.
+  const assert_index_baseline = assert(() =>
+    (board.index ?? []).length === 2 &&
+    board.index?.[0]?.title === "First topic" &&
+    board.index?.[0]?.topic?.title === "First topic" &&
+    (board.index?.[0]?.createdAt ?? 0) > 0 &&
+    board.index?.[0]?.createdBy?.kind === "agent" &&
+    board.index?.[0]?.createdBy?.name === "Sol" &&
+    board.index?.[0]?.commentCount === 1 &&
+    (board.index?.[0]?.lastActivityAt ?? 0) >=
+      (board.index?.[0]?.createdAt ?? 0) &&
+    board.index?.[1]?.title === "Second topic" &&
+    (board.index?.[0]?.refsOut ?? []).length === 0 &&
+    (board.index?.[1]?.refsOut ?? []).length === 0
+  );
+
+  // The prose edge surfaces in the index as title-only sibling references.
+  const assert_index_edge = assert(() =>
+    (board.index?.[1]?.refsOut ?? []).length === 1 &&
+    board.index?.[1]?.refsOut?.[0]?.title === "First topic" &&
+    (board.index?.[0]?.referencedBy ?? []).length === 1 &&
+    board.index?.[0]?.referencedBy?.[0]?.title === "Second topic"
+  );
+
+  // The bound itself: serializing the whole index carries no expanded piece
+  // content (body/comments/links), no verb streams, and no runtime values —
+  // the declared schema, not reader discipline, is the guarantee. Every
+  // reference in a row exposes exactly the title-only projection.
+  const assert_index_bounded = assert(() => {
+    const rows = board.index ?? [];
+    if (rows.length < 2) return false;
+    const serialized = JSON.stringify(rows);
+    return !serialized.includes('"body"') &&
+      !serialized.includes('"comments"') &&
+      !serialized.includes('"links"') &&
+      !serialized.includes('"addComment"') &&
+      !serialized.includes('"setBody"') &&
+      !serialized.includes('"addLink"') &&
+      !serialized.includes("vnode") &&
+      Object.keys(rows[0]?.topic ?? {}).join(",") === "title" &&
+      Object.keys(rows[1]?.refsOut?.[0] ?? {}).join(",") === "title";
+  });
+
   // Detail-page view of the same edge: each board-created topic derives its
   // own row from the mentionable siblings wired at creation (piece-valued,
   // resolved from `mentionable` = the board's own list), while a piece with no
@@ -766,8 +813,11 @@ export default pattern(() => {
       { assertion: assert_second_topic },
       { render: board[UI] },
       { assertion: assert_crossrefs_baseline },
+      { assertion: assert_index_baseline },
       { action: action_body_ref_first },
       { assertion: assert_body_edge },
+      { assertion: assert_index_edge },
+      { assertion: assert_index_bounded },
       { render: board[UI] },
       { assertion: assert_detail_edges },
       { assertion: assert_lone_edgeless },

--- a/skills/topics/SKILL.md
+++ b/skills/topics/SKILL.md
@@ -48,9 +48,18 @@ set or copy them into agent mutations.
 
 ## Reading Topics
 
-The board's durable `topics` input is the reliable discovery corpus. Project it
-immediately: an unprojected row follows the linked Topic and can include its
-body, comments, handlers, and reference graph.
+The current pattern exports `index` — a compact discovery result whose rows
+carry scalar summaries plus title-only sibling references, so one read surveys
+the whole board without expanding any topic:
+
+```bash
+deno task cf piece get --url "$TOPICS_BOARD_URL" index --step
+```
+
+A deployed board can run an older pattern without `index` — the read above
+erroring on an unknown path is the tell. Survey such a board through the durable
+`topics` input instead, projected immediately: an unprojected row follows the
+linked Topic and can include its body, comments, handlers, and reference graph.
 
 ```bash
 deno task cf piece get --url "$TOPICS_BOARD_URL" topics --input \


### PR DESCRIPTION
## Why

A full-board survey had no bounded surface: `crossrefs` rows expand to full pieces (a live full-board read through it exceeded 300k tokens), and the `topics --input` projection is bounded only if every reader remembers to project. This closes WS-A's last open item (plan: docs/plans/pattern-verb-contract-implementation.md, WS-A) — #4991 already landed body-at-create and the thrown rejections — and it is the final pattern change before the topics source is cut for the prod-board rehearsal, so the eventual setsrc carries Part 1 complete in one update.

## What Changed

- `index` result on the board: one reference-plus-summary row per (non-null) topic — scalar summaries (`title`, `createdAt`, `createdBy`, `commentCount`, `lastActivityAt`) in the row, prose reference edges as sibling references. Every reference-valued field is declared through the title-only `TopicIndexRef`: schemas filter visibility, so the row schema — not reader discipline — is the bound. No pattern-authored fid fields (identity rendering is the CLI's job, decision 6/F2).
- Generated schema verified: `TopicIndexRef` emits as `{title}` required-only; the compat gate records the new contract as updatable from every recorded baseline (result addition is widening; baseline recorded in this PR).
- Tests: index rows/edges asserts plus a serialization pin — no expanded content, no verb streams, `Object.keys` on every reference is exactly `title`.
- Docs riding the change: README names `index` as the bounded survey read; `skills/topics` documents it with a deployed-board lag caveat; the plan's WS-A bullets struck with done notes (the live-board `setsrc` stays open, gated on the clone rehearsal).

## Test plan

- `deno task cf test packages/patterns/topics/topics.test.tsx` — 36 passed (3 new index assertions)
- `deno task cf test .../multi-user.test.tsx .../topics-rejections.test.tsx` — 17 passed
- `deno task pattern-compat` — 336 patterns updatable from every recorded contract
- `deno task check-skill-facts`, `deno task check-docs`, repo-wide `deno fmt --check` + `deno lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a compact `index` result to the Topics board so one bounded read surveys all topics with summaries and title-only references. This completes WS‑A’s last open item and replaces `crossrefs` as the documented survey surface.

- **New Features**
  - New `index`: one row per topic with `title`, `createdAt`, `createdBy`, `commentCount`, `lastActivityAt`, plus `refsOut`/`referencedBy` as `TopicIndexRef` (title-only).
  - Schemas `TopicIndexRef` and `TopicIndexRow` added; `createdAt`, `commentCount`, `lastActivityAt` are declared as plain numbers; compat baseline re-recorded at the tightened schema (result addition is widening).
  - Implementation in `packages/patterns/topics/main.tsx`; tests in `packages/patterns/topics/topics.test.tsx` include a serialization pin; docs updated in `packages/patterns/topics/README.md`, `skills/topics/SKILL.md`, and plan notes.

- **Migration**
  - Use `index` for full-board surveys.
  - For boards without `index`, use `topics --input` with a narrow `--schema`.
  - `crossrefs` remains for UI graph only; not for surveys.

<sup>Written for commit dd4bb842d999dc5f6f51a1bf1a99b7f239d545a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

