### PR TITLE
refactor(runner): type the node-instantiation path as `FabricExecValue`

### DIFF
--- a/packages/runner/src/builder/json-utils.ts
+++ b/packages/runner/src/builder/json-utils.ts
@@ -8,6 +8,7 @@ import {
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { type AliasBinding } from "../sigil-types.ts";
 import {
+  type FabricExecValue,
   type FactoryInput,
   isPattern,
   type JSONSchema,
@@ -44,7 +45,7 @@ export function withAliasBindings(
   ignoreSelfAliases: boolean = false,
   path: readonly PropertyKey[] = [],
   seen?: WeakMap<object, number>,
-): JSONValue | undefined {
+): FabricExecValue | undefined {
   // Turn strongly typed builder values into legacy JSON structures while
   // preserving alias metadata for consumers that still rely on it.
 
@@ -55,7 +56,7 @@ export function withAliasBindings(
     const { external, frame } = value.export();
 
     // If this is an external reference, just copy the reference as is.
-    if (external) return external as JSONValue;
+    if (external) return external as FabricExecValue;
 
     // Verify that opaque refs are not in a parent frame
     if (frame !== getTopFrame()) {
@@ -72,7 +73,7 @@ export function withAliasBindings(
       ignoreSelfAliases,
     );
     if (alias === null) return undefined;
-    if (alias !== undefined) return alias as unknown as JSONValue;
+    if (alias !== undefined) return alias as unknown as FabricExecValue;
     throw new Error(`Cell not found in pattern aliases`);
   }
 
@@ -123,7 +124,7 @@ export function withAliasBindings(
   // it to `{}`, so return it unchanged here — after the cell / alias / array
   // handling above, which must still win for those forms.
   if (value instanceof FabricPrimitive) {
-    return value as unknown as JSONValue;
+    return value;
   }
 
   // If this is an object or a pattern, process each key recursively.

--- a/packages/runner/src/builder/json-utils.ts
+++ b/packages/runner/src/builder/json-utils.ts
@@ -45,9 +45,10 @@ export function withAliasBindings(
   ignoreSelfAliases: boolean = false,
   path: readonly PropertyKey[] = [],
   seen?: WeakMap<object, number>,
-): FabricExecValue | undefined {
-  // Turn strongly typed builder values into legacy JSON structures while
-  // preserving alias metadata for consumers that still rely on it.
+): FabricExecValue {
+  // Turn strongly typed builder values into the serialized binding structure:
+  // cell references become `$alias` records, and data leaves come through as
+  // the fabric values they are.
 
   // Convert regular cells and results from Cell.get() to opaque refs
   if (isCellResultForDereferencing(value)) value = getCellOrThrow(value);

--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -24,6 +24,7 @@ import type {
   ComputedFunction,
   EntityRefToStringFunction,
   EqualsFunction,
+  FabricExecValue,
   FactoryInput,
   FetchBinaryFunction,
   FetchJsonFunction,
@@ -256,8 +257,8 @@ export function isModule(value: unknown): value is Module {
 export type Node = {
   description?: string;
   module: Module; // TODO(seefeld): Add `Alias` here once supported
-  inputs: JSONValue;
-  outputs: JSONValue;
+  inputs: FabricExecValue;
+  outputs: FabricExecValue;
 };
 
 export type DerivedInternalCellDescriptor = {
@@ -279,7 +280,7 @@ declare module "@commonfabric/api" {
     argumentSchema: JSONSchema;
     resultSchema: JSONSchema;
     derivedInternalCells?: DerivedInternalCellDescriptor[];
-    result: JSONValue;
+    result: FabricExecValue;
     nodes: Node[];
     // NOTE: `program` (rehydration source) and the derivation link to a
     // copy's original live in WeakMaps/WeakSets in ./pattern-metadata.ts (so

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -19,6 +19,7 @@ import { rendererVDOMSchema } from "./schemas.ts";
 import { forEachSubschema } from "./schema-walk.ts";
 import {
   type CellScope,
+  type FabricExecValue,
   type Frame,
   isModule,
   isPattern,
@@ -716,8 +717,8 @@ type DeferredStartResult<R> = {
 };
 
 type BoundNodeIO = {
-  inputs: FabricValue;
-  outputs: FabricValue;
+  inputs: FabricExecValue;
+  outputs: FabricExecValue;
   reads: NormalizedFullLink[];
   writes: NormalizedFullLink[];
 };
@@ -4048,8 +4049,8 @@ export class Runner {
   private instantiateNode(
     tx: IExtendedStorageTransaction,
     module: Module,
-    inputBindings: FabricValue,
-    outputBindings: FabricValue,
+    inputBindings: FabricExecValue,
+    outputBindings: FabricExecValue,
     resultCell: Cell<any>,
     addCancel: AddCancel,
     pattern: Pattern,
@@ -4139,8 +4140,8 @@ export class Runner {
   }
 
   private bindNodeIO(
-    inputBindings: FabricValue,
-    outputBindings: FabricValue,
+    inputBindings: FabricExecValue,
+    outputBindings: FabricExecValue,
     resultCell: Cell<any>,
     pattern: Pattern,
   ): BoundNodeIO {
@@ -4679,7 +4680,7 @@ export class Runner {
    * @returns
    */
   private resolveJavaScriptStreamLink(
-    inputs: FabricValue,
+    inputs: FabricExecValue,
     base: NormalizedFullLink,
     tx: IExtendedStorageTransaction,
   ): {
@@ -4691,7 +4692,10 @@ export class Runner {
     // Sigil-only: `$event` is builder-generated and always unwraps to a sigil
     // link; a residual `$alias` here could only be an embedded pattern's
     // binding, which must not be followed at this level.
-    let value: FabricValue = inputs.$event;
+    // Narrowing, not papering over: `$event` is a sigil link, which IS a
+    // `FabricValue`. Only the exec-typed container widens it here, and the
+    // sigil-only invariant above is what licenses the assertion.
+    let value = inputs.$event as FabricValue;
     let lastLink: NormalizedFullLink | undefined;
     while (isWriteRedirectLink(value)) {
       lastLink = resolveLink(
@@ -5130,9 +5134,13 @@ export class Runner {
     resultHasReactives: boolean,
     frame: Frame,
     resultCell: Cell<any>,
-    outputs: FabricValue,
+    outputs: FabricExecValue,
     addCancel: AddCancel,
-    _resultFor: { inputs: FabricValue; outputs: FabricValue; fn: string },
+    _resultFor: {
+      inputs: FabricExecValue;
+      outputs: FabricExecValue;
+      fn: string;
+    },
     previousResultCellRef: JavaScriptActionResultCells,
     narrowestReadScope?: CellScope,
   ): any {
@@ -5855,8 +5863,8 @@ export class Runner {
   private instantiateJavaScriptNode(
     tx: IExtendedStorageTransaction,
     module: Module,
-    inputBindings: FabricValue,
-    outputBindings: FabricValue,
+    inputBindings: FabricExecValue,
+    outputBindings: FabricExecValue,
     resultCell: Cell<any>,
     addCancel: AddCancel,
     pattern: Pattern,
@@ -6025,7 +6033,7 @@ export class Runner {
    */
   private substituteOpPatternRefs(
     moduleRefName: string | undefined,
-    inputBindings: FabricValue,
+    inputBindings: FabricExecValue,
   ): void {
     if (
       moduleRefName !== "map" && moduleRefName !== "filter" &&
@@ -6057,8 +6065,8 @@ export class Runner {
   private instantiateRawNode(
     tx: IExtendedStorageTransaction,
     module: Module,
-    inputBindings: FabricValue,
-    outputBindings: FabricValue,
+    inputBindings: FabricExecValue,
+    outputBindings: FabricExecValue,
     resultCell: Cell<any>,
     addCancel: AddCancel,
     pattern: Pattern,
@@ -6351,8 +6359,8 @@ export class Runner {
   private instantiatePassthroughNode(
     tx: IExtendedStorageTransaction,
     _module: Module,
-    inputBindings: FabricValue,
-    outputBindings: FabricValue,
+    inputBindings: FabricExecValue,
+    outputBindings: FabricExecValue,
     resultCell: Cell<any>,
     _addCancel: AddCancel,
     pattern: Pattern,
@@ -6386,8 +6394,8 @@ export class Runner {
   private instantiatePatternNode(
     tx: IExtendedStorageTransaction,
     module: Module,
-    inputBindings: FabricValue,
-    outputBindings: FabricValue,
+    inputBindings: FabricExecValue,
+    outputBindings: FabricExecValue,
     resultCell: Cell<any>,
     addCancel: AddCancel,
     pattern: Pattern,

--- a/packages/runner/test/exec-value-node-typing.test.ts
+++ b/packages/runner/test/exec-value-node-typing.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Type-level tests pinning what a serialized node's bindings can hold.
+ *
+ * If any assertion here is wrong, this file fails to compile.
+ *
+ * `Node.inputs` / `Node.outputs` and `Pattern.result` hold what
+ * `withAliasBindings()` produces: a structure of `$alias` records and data
+ * whose leaves include `FabricPrimitive`s. `JSONValue` cannot express a
+ * `FabricPrimitive` — it is a class instance with zero enumerable own
+ * properties — so declaring these fields `JSONValue` was false, and was held
+ * up by `as unknown as JSONValue` casts at the producing end.
+ *
+ * The negative assertions are the point. A positive assertion alone would pass
+ * just as well against the old `JSONValue` typing for the plain-data cases,
+ * proving nothing about the change; each `@ts-expect-error` below fails to
+ * compile if `JSONValue` ever does accept these, which is what makes this a
+ * differential rather than a restatement.
+ */
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
+import type { FabricExecValue, JSONValue, Node } from "../src/builder/types.ts";
+
+describe("serialized node binding typing", () => {
+  it("admits a FabricPrimitive where JSONValue cannot", () => {
+    const bytes = new FabricBytes(new Uint8Array([1, 2, 3]));
+
+    // The honest type accepts it, bare and nested.
+    const bare: FabricExecValue = bytes;
+    const nested: FabricExecValue = { blob: bytes, list: [bytes] };
+
+    // ...and `JSONValue` does not, which is what the old declaration claimed.
+    // @ts-expect-error a `FabricPrimitive` is not expressible as `JSONValue`
+    const _bareAsJson: JSONValue = bytes;
+    // @ts-expect-error ...nor is one nested inside a container
+    const _nestedAsJson: JSONValue = { blob: bytes };
+
+    // Assert assignability rather than mutate: these values are frozen-ish
+    // fabric data, and the declarations above are the actual test.
+    expect(bare).toBeInstanceOf(FabricBytes);
+    expect((nested as { blob: unknown }).blob).toBeInstanceOf(FabricBytes);
+  });
+
+  it("types a node's bindings as execution values", () => {
+    const node: Pick<Node, "inputs" | "outputs"> = {
+      inputs: { $alias: { cell: "argument", path: [] } } as FabricExecValue,
+      outputs: { blob: new FabricBytes(new Uint8Array([4, 5])) },
+    };
+
+    expect((node.outputs as { blob: unknown }).blob).toBeInstanceOf(
+      FabricBytes,
+    );
+  });
+});


### PR DESCRIPTION
`withAliasBindings()` declared `JSONValue | undefined` and returned
`FabricPrimitive` instances. Its consumers inherited the lie: `Node.inputs`,
`Node.outputs`, and `Pattern.result` all declared `JSONValue` for values that
carry `$alias` records and `FabricBytes`.

Nothing was broken by this at runtime — it was held together by
`as unknown as JSONValue` at the producing end. **A cast is the code's own
admission that its signature is false**, and removing the lie removes the casts.

The honest type is `FabricExecValue`: a `FabricValue`, or a function, array, or
plain object of them. That is exactly what a binding structure is, and it is
already the vocabulary `unwrapOneLevelAndBindToDoc()` uses for the same values.

## The seam, followed to the end

Corrected one level at a time, re-checking after each. **Every level below was
discovered by the checker rather than predicted:**

| depth | site |
| ---: | --- |
| 1 | `withAliasBindings()` return type |
| 2 | `Node.inputs` / `Node.outputs` / `Pattern.result` |
| 3 | `instantiateNode()` |
| 4 | `instantiateJavaScriptNode` / `Raw` / `Passthrough` / `Pattern` |
| 5 | `bindNodeIO()`, `substituteOpPatternRefs()` |
| 6 | `BoundNodeIO`, `resolveJavaScriptStreamLink()`, `_resultFor` |
| 7 | the `$event` leaf |

The whole node-instantiation path was typing execution values as `FabricValue`.
That it reached seven levels is itself the finding: this was not a local slip.

Net: **3 source files, +32/−26**, plus one test file.

## One cast added, deliberately

`resolveJavaScriptStreamLink()` now narrows rather than inherits:

```ts
let value = inputs.$event as FabricValue;
```

That is a **narrowing at a stated invariant**, not a papering-over. `$event` is
builder-generated and always a sigil link, which IS a `FabricValue`; only the
exec-typed container widens it. The function's pre-existing "sigil-only" comment
is what licenses the assertion, and the new comment says so. Called out rather
than left to be noticed, since the rest of this PR is about deleting casts.

## Red-green, for a type change

A type test that merely compiles proves nothing, so the assertions are
**differential**. The `@ts-expect-error` lines fail to compile if `JSONValue`
ever does accept a `FabricPrimitive`; and ablating `Node`'s bindings back to
`JSONValue` makes the new file stop compiling:

```
TS2322: Type 'FabricExecValue' is not assignable to type 'JSONValue'.
TS2322: Type '{ blob: FabricBytes; }' is not assignable to type 'JSONValue'.
```

**Where that guard lives matters:** the runner suite runs `--no-check`, so this
file is enforced by `deno task check` (the Check CI job), *not* by the test run.
A green suite says nothing about it.

## Testing

`deno task check` clean. Full runner suite green (1121 passed, 0 failed). All
five pattern-unit chunks green (24 tests each). `deno fmt --check` (4309 files),
`deno lint` (4282 files), `check-docs` (522 blocks) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eJcTLCQcXrXHA4CC8eDpp

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Typed node bindings and results as `FabricExecValue` instead of `JSONValue` across the runner, matching what we actually serialize and execute. Removes unsafe casts, narrows `$event` at a documented invariant, and adds a type-level guard test.

- **Refactors**
  - `withAliasBindings()` now returns `FabricExecValue` (dropped redundant `| undefined`).
  - `Node.inputs`, `Node.outputs`, and `Pattern.result` are typed as `FabricExecValue`.
  - Node-instantiation path now uses `FabricExecValue` (`instantiateNode`, JavaScript/Raw/Passthrough/Pattern variants, `bindNodeIO`, `BoundNodeIO`, `substituteOpPatternRefs`).
  - `resolveJavaScriptStreamLink()` narrows `inputs.$event` to `FabricValue` with a clear invariant.
  - Deleted `as unknown as JSONValue` casts and aligned helpers accordingly.
  - Added `exec-value-node-typing.test.ts` to pin the new typing; enforced by `deno task check`.

- **Migration**
  - Update any code expecting `JSONValue` for `Node.inputs`/`outputs` or `Pattern.result` to accept `FabricExecValue`.
  - Remove casts to `JSONValue` around bindings; use `FabricValue` only for actual sigil links like `$event`.

<sup>Written for commit 845b2cce2d4665b5cbbd06b1a0d438713e42f6ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

