### PR TITLE
fix(schema-generator): call the fabric-backed natives `"object"`

### DIFF
--- a/docs/specs/schema-generator/ts_to_json_schema_mapping.md
+++ b/docs/specs/schema-generator/ts_to_json_schema_mapping.md
@@ -214,14 +214,29 @@ same-named types emit `$ref`s to it.
 
 `NATIVE_TYPE_SCHEMAS` (`src/formatters/native-type-formatter.ts`), as of
 this writing: `VNode` →
-`{ $ref: "https://commonfabric.org/schemas/vnode.json" }`; `Date` →
-`{ type: "string", format: "date-time" }`; `URL` → `{ type: "string", format:
+`{ $ref: "https://commonfabric.org/schemas/vnode.json" }`; `Date`, `RegExp`,
+and `Uint8Array` → `{ type: "object" }`; `URL` → `{ type: "string", format:
 "uri" }`; `ArrayBuffer`/`ArrayBufferLike`/`SharedArrayBuffer`/
-`ArrayBufferView`, the eleven typed arrays (`Uint8Array` … `BigUint64Array`),
-and `JSONSchemaObj`/`JSONSchema` → `true`.
+`ArrayBufferView`, the remaining ten typed arrays
+(`Uint8ClampedArray` … `BigUint64Array`), and `JSONSchemaObj`/`JSONSchema` →
+`true`.
+
+The three mapped to `{ type: "object" }` are the ones with a canonical fabric
+form: a `Date` is stored as a `FabricEpochNsec`, a `RegExp` as a
+`FabricRegExp`, and a `Uint8Array` as a `FabricBytes`. There is no schema
+vocabulary for `Fabric*` types yet, and `"object"` is what they are called in
+the meantime — a value stored as one reads back intact through it, where
+`{ type: "string" }` projects the read to `undefined`. `URL` is the exception
+that stays a string, because it converts to a plain string rather than to a
+fabric object.
+
+The remaining typed arrays and the buffer types map to `true` (accept
+anything), which overclaims: none of them is representable as a `FabricValue`,
+so a value of one of those types is rejected at the storage boundary rather
+than stored. `true` is the status quo for them, not an endorsement.
 
 Guard: the lib-declared subset (`LIB_DECLARED_NATIVE_TYPES` — `Date`
-through `BigUint64Array`) is claimed only when declared in a default-lib or
+through `BigUint64Array`, and `RegExp`) is claimed only when declared in a default-lib or
 `@types/node` file (`hasLibraryDeclaration`), so a user-defined
 `interface Date {…}` is not swallowed. `VNode`/`JSONSchemaObj`/`JSONSchema`
 have **no** such guard (untested collision). Native resolution also pierces

--- a/packages/schema-generator/src/formatters/native-type-formatter.ts
+++ b/packages/schema-generator/src/formatters/native-type-formatter.ts
@@ -5,13 +5,22 @@ import type { GenerationContext, TypeFormatter } from "../interface.ts";
 const NATIVE_TYPE_SCHEMAS: Record<string, MutableJSONSchema> = {
   // This schema is embedded in the code, so we can have simpler links.
   VNode: { $ref: "https://commonfabric.org/schemas/vnode.json" },
-  Date: { type: "string", format: "date-time" },
+  // A `Date` is stored as a `FabricEpochNsec` and a `Uint8Array` as a
+  // `FabricBytes`, so both are objects at the fabric boundary. There is no
+  // schema vocabulary for `Fabric*` types yet; `"object"` is what they are
+  // called in the meantime, and a value stored as one reads back intact
+  // through it. (`{ type: "string" }` does not: the read projects to
+  // `undefined`, which is what the `Date` mapping used to do to every value
+  // read through the schema its own TS type generates.)
+  Date: { type: "object" },
+  RegExp: { type: "object" },
+  Uint8Array: { type: "object" },
+  // A `URL` converts to a plain string, so this one is accurate as written.
   URL: { type: "string", format: "uri" },
   ArrayBuffer: true,
   ArrayBufferLike: true,
   SharedArrayBuffer: true,
   ArrayBufferView: true,
-  Uint8Array: true,
   Uint8ClampedArray: true,
   Int8Array: true,
   Uint16Array: true,
@@ -30,6 +39,7 @@ const NATIVE_TYPE_SCHEMAS: Record<string, MutableJSONSchema> = {
 const NATIVE_TYPE_NAMES = new Set(Object.keys(NATIVE_TYPE_SCHEMAS));
 const LIB_DECLARED_NATIVE_TYPES = new Set([
   "Date",
+  "RegExp",
   "URL",
   "ArrayBuffer",
   "ArrayBufferLike",

--- a/packages/schema-generator/test/fixtures/schema/date-types.expected.json
+++ b/packages/schema-generator/test/fixtures/schema/date-types.expected.json
@@ -8,18 +8,15 @@
               "type": "null"
             },
             {
-              "format": "date-time",
-              "type": "string"
+              "type": "object"
             }
           ]
         },
         "createdAt": {
-          "format": "date-time",
-          "type": "string"
+          "type": "object"
         },
         "publishedAt": {
-          "format": "date-time",
-          "type": "string"
+          "type": "object"
         },
         "title": {
           "type": "string"
@@ -38,8 +35,7 @@
         },
         "timestamp": {
           "default": "2023-01-01T00:00:00.000Z",
-          "format": "date-time",
-          "type": "string"
+          "type": "object"
         }
       },
       "required": [
@@ -51,8 +47,7 @@
     "UserProfile": {
       "properties": {
         "createdAt": {
-          "format": "date-time",
-          "type": "string"
+          "type": "object"
         },
         "lastLogin": {
           "anyOf": [
@@ -60,8 +55,7 @@
               "type": "null"
             },
             {
-              "format": "date-time",
-              "type": "string"
+              "type": "object"
             }
           ]
         },
@@ -74,8 +68,7 @@
               "type": "string"
             },
             "updatedAt": {
-              "format": "date-time",
-              "type": "string"
+              "type": "object"
             }
           },
           "required": [

--- a/packages/schema-generator/test/native-type-parameters.test.ts
+++ b/packages/schema-generator/test/native-type-parameters.test.ts
@@ -15,8 +15,8 @@ interface Wrapper {
     const generator = new SchemaGenerator();
     const schema = asObjectSchema(generator.generateSchema(type, checker));
     const props = schema.properties as Record<string, unknown> | undefined;
-    expect(props?.value).toBe(true);
-    expect(props?.pointer).toBe(true);
+    expect(props?.value).toEqual({ type: "object" });
+    expect(props?.pointer).toEqual({ type: "object" });
     expect((schema as Record<string, unknown>).$defs).toBeUndefined();
   });
 

--- a/packages/schema-generator/test/schema-generator.test.ts
+++ b/packages/schema-generator/test/schema-generator.test.ts
@@ -464,7 +464,7 @@ type Wrapper = {
   });
 
   describe("built-in mappings", () => {
-    it("formats Date as string with date-time format without hoisting", async () => {
+    it("formats Date as an object without hoisting", async () => {
       const generator = new SchemaGenerator();
       const code = `
 interface HasDate {
@@ -479,10 +479,9 @@ interface HasDate {
         | undefined;
 
       expect(objectSchema.$defs).toBeUndefined();
-      expect(props?.createdAt).toEqual({
-        type: "string",
-        format: "date-time",
-      });
+      // A `Date` is stored as a `FabricEpochNsec`, an object at the fabric
+      // boundary. Read through `{ type: "string" }` it projects to `undefined`.
+      expect(props?.createdAt).toEqual({ type: "object" });
     });
 
     it("formats URL as string with uri format without hoisting", async () => {
@@ -582,7 +581,7 @@ declare interface URL {
       });
     });
 
-    it("formats Uint8Array as permissive true schema", async () => {
+    it("formats Uint8Array as an object", async () => {
       const generator = new SchemaGenerator();
       const code = `
 interface BinaryHolder {
@@ -597,7 +596,8 @@ interface BinaryHolder {
         | undefined;
 
       expect(objectSchema.$defs).toBeUndefined();
-      expect(props?.data).toBe(true);
+      // Stored as a `FabricBytes`, so an object -- not "anything goes".
+      expect(props?.data).toEqual({ type: "object" });
     });
 
     it("formats ArrayBuffer as permissive true schema", async () => {

--- a/packages/ts-transformers/test/fixtures/handler-schema/date-types.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/date-types.expected.jsx
@@ -21,8 +21,7 @@ const timedHandler = handler({
     type: "object",
     properties: {
         timestamp: {
-            type: "string",
-            format: "date-time"
+            type: "object"
         }
     },
     required: ["timestamp"]
@@ -30,8 +29,7 @@ const timedHandler = handler({
     type: "object",
     properties: {
         lastUpdate: {
-            type: "string",
-            format: "date-time",
+            type: "object",
             asCell: ["writeonly"]
         }
     },


### PR DESCRIPTION
`Date` generated `{ type: "string", format: "date-time" }` while the write
boundary stores a `Date` as a `FabricEpochNsec`. So a value read back through
**the schema its own TS type generates** came back `undefined` — schema and
storage disagreed about what the value is, and the read projection sided with
the schema.

There is no schema vocabulary for `Fabric*` types yet. In the meantime the
consensus name for these is `"object"`, which is both true of the JS type and
sufficient. Measured against real storage:

| stored `FabricBytes` read through | result |
| --- | --- |
| `true` (accept anything) | `FabricBytes bytes=[1,2,3]` |
| `{ type: "object" }` | `FabricBytes bytes=[1,2,3]` |
| `{ type: "object", properties: {} }` | `FabricBytes bytes=[1,2,3]` |
| `{ type: "string" }` | **`undefined`** ← the `Date` bug |

## What changed, chosen by measurement

Each native was run through `fabricFromNativeValue()` rather than inferred from
the table:

| type | converts to | was | now |
| --- | --- | --- | --- |
| `Date` | `FabricEpochNsec` | `{type:"string",format:"date-time"}` | `{type:"object"}` |
| `RegExp` | `FabricRegExp` | *absent from the table* | `{type:"object"}` |
| `Uint8Array` | `FabricBytes` | `true` | `{type:"object"}` |
| `URL` | `String` | `{type:"string",format:"uri"}` | **unchanged** |

`URL` stays a string because it converts to a plain string, not to a fabric
object — that mapping was already right.

The other typed arrays and buffer types keep `true`. That **overclaims**: none
is representable, and `fabricFromNativeValue` throws on every one
(`Uint8ClampedArray`, `Int8Array`, `Uint16Array`, `Int32Array`, `Float64Array`,
`BigInt64Array`, `ArrayBuffer`, …). But mapping them to `"object"` would swap
one wrong answer for another by implying they are storable. Left as status quo,
and now *stated* as such in the spec rather than left to be inferred.

## Known inconsistency this exposes

`Default<Date, "2023-01-01T00:00:00.000Z">` now generates:

```json
{ "default": "2023-01-01T00:00:00.000Z", "type": "object" }
```

— a string default under an object type. The default was consistent with the
old `type: "string"`, and is not consistent with storage either way: a `Date`
default that survived the boundary would have to be a `FabricEpochNsec`, not an
ISO string.

This change makes that disagreement **visible** instead of internally tidy and
externally wrong. Not fixed here — defaults for fabric-backed types are their
own question, and worth deciding rather than patching in passing.

## Testing

Three existing tests pinned the old mappings and had to be updated; **that they
failed is the red half of the red-green**. Two golden fixtures regenerated
(`schema-generator` date-types, `ts-transformers` handler-schema date-types),
each reviewed rather than blind-accepted.

Live spec updated in the same change
(`docs/specs/schema-generator/ts_to_json_schema_mapping.md` §5.2).

schema-generator **55 passed**; ts-transformers **1132 passed**; runner **1121
passed**; all five pattern-unit chunks green (24 each). `deno task check`,
`check-docs` (522 blocks), `deno fmt --check`, `deno lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eJcTLCQcXrXHA4CC8eDpp


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes JSON Schema generation for fabric-backed natives by emitting `{ type: "object" }` for `Date`, `RegExp`, and `Uint8Array` so schemas match storage and values no longer read as `undefined`. `URL` stays a string; other typed arrays and buffer types remain `true`.

- **Bug Fixes**
  - Map `Date`, `RegExp`, `Uint8Array` to `{ type: "object" }` in `NATIVE_TYPE_SCHEMAS`; keep `URL` as `{ type: "string", format: "uri" }`; leave remaining typed arrays/buffers as `true`.
  - Updated tests and goldens in `schema-generator` and `ts-transformers`; spec doc now reflects these mappings.
  - Known limitation: `Date` defaults now show a string default under `type: "object"`; follow-up needed to model fabric-backed defaults.

<sup>Written for commit 7f861c9b5dd590c047d3460a5966ea4f2383541b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

