### PR TITLE
feat(cli): toggle Markdown and test files in cf view

### DIFF
--- a/packages/cli/lib/view/fold.ts
+++ b/packages/cli/lib/view/fold.ts
@@ -8,6 +8,7 @@
  */
 import type { Line, Span, TokenClass } from "./model.ts";
 import { parseDiff } from "./diff.ts";
+import { languageForFile } from "./languages/language.ts";
 
 /** One file in the diff, with the collapsed one-line summary to show for it. */
 export interface DiffFileRange {
@@ -17,9 +18,10 @@ export interface DiffFileRange {
    * hunk line). */
   readonly headerLine: number;
   readonly endLine: number;
-  /** The path used for test-file detection (new side, else old side). */
+  /** The path used for file-category detection (new side, else old side). */
   readonly path: string;
   readonly isTest: boolean;
+  readonly isMarkdown: boolean;
   /** The one-line summary shown when the file is collapsed. */
   readonly summary: Line;
 }
@@ -45,6 +47,7 @@ export function diffFiles(text: string): DiffFileRange[] {
       endLine: file.endLine,
       path,
       isTest: isTestPath(path),
+      isMarkdown: isMarkdownPath(path),
       summary: summaryLine({
         oldPath: file.oldPath,
         newPath: file.newPath,
@@ -196,7 +199,12 @@ function clamp(n: number, lo: number, hi: number): number {
   return Math.max(lo, Math.min(hi, n));
 }
 
-// --- test-file detection ----------------------------------------------------
+// --- file-category detection ------------------------------------------------
+
+/** Whether a path selects the pager's Markdown language. */
+export function isMarkdownPath(path: string): boolean {
+  return languageForFile(path).id === "markdown";
+}
 
 const TEST_SEGMENTS = new Set([
   "test",

--- a/packages/cli/lib/view/session.ts
+++ b/packages/cli/lib/view/session.ts
@@ -1895,7 +1895,10 @@ export class Session {
         this.expandAllFiles();
         return;
       case "T":
-        this.collapseTestFiles();
+        this.toggleFileCategory((file) => file.isTest, "test");
+        return;
+      case "M":
+        this.toggleFileCategory((file) => file.isMarkdown, "Markdown");
         return;
       case "escape": {
         const anchor = this.wrapLines ? this.viewportAnchor() : null;
@@ -2058,21 +2061,33 @@ export class Session {
     this.message = "Showing all files.";
   }
 
-  /** Hide every test / test-support file, leaving the rest shown. */
-  private collapseTestFiles(): void {
+  /** Toggle one kind of file as a group. A mixed group is made fully hidden. */
+  private toggleFileCategory(
+    matches: (file: DiffFileRange) => boolean,
+    label: string,
+  ): void {
     if (!this.ensureDiffForFolding()) return;
+    const files = this.foldFiles().filter(matches);
+    if (files.length === 0) {
+      this.message = `No ${label} files.`;
+      return;
+    }
     const anchor = this.foldAnchor();
-    let n = 0;
-    for (const f of this.foldFiles()) {
-      if (f.isTest && !this.collapsed.has(f.index)) {
+    const expand = files.every((file) => this.collapsed.has(file.index));
+    let changed = 0;
+    for (const f of files) {
+      if (expand) {
+        this.collapsed.delete(f.index);
+        changed++;
+      } else if (!this.collapsed.has(f.index)) {
         this.collapsed.add(f.index);
-        n++;
+        changed++;
       }
     }
-    if (n > 0) this.applyFoldChange(anchor);
-    this.message = n > 0
-      ? `Hid ${n} test file${n === 1 ? "" : "s"}.`
-      : "No shown test files to hide.";
+    this.applyFoldChange(anchor);
+    this.message = `${expand ? "Showing" : "Hid"} ${changed} ${label} file${
+      changed === 1 ? "" : "s"
+    }.`;
   }
 
   // --- editing ---------------------------------------------------------------
@@ -4043,7 +4058,7 @@ export class Session {
     for (const file of this.foldFiles()) {
       entries.push({
         line: file.headerLine,
-        display: file.summary,
+        display: fileJumpLine(file, this.collapsed.has(file.index)),
         filterText: file.path.toLowerCase(),
         name: file.path,
       });
@@ -4264,6 +4279,26 @@ function commitJumpLine(shortSha: string, subject: string): Line {
   return { text, spans };
 }
 
+/** Add the category keys that affect a file to its jump-list row. Collapsed
+ * rows use the dialog's muted style. */
+function fileJumpLine(file: DiffFileRange, collapsed: boolean): Line {
+  const flags = `${file.isMarkdown ? "M" : " "}${file.isTest ? "T" : " "}`;
+  const prefix = `${flags} `;
+  const spans: Span[] = [
+    { col: 0, text: prefix, cls: "builderCall" },
+    ...file.summary.spans.map((span) => ({
+      ...span,
+      col: span.col + 3,
+    })),
+  ];
+  return {
+    text: prefix + file.summary.text,
+    spans: collapsed
+      ? spans.map((span) => ({ ...span, cls: "comment" }))
+      : spans,
+  };
+}
+
 export function helpOverlay(): {
   title: string;
   info: Line[];
@@ -4289,7 +4324,8 @@ export function helpOverlay(): {
     ["Diff files", ""],
     ["  f", "hide / show the file under the cursor (collapse to a summary)"],
     ["  F / E", "hide all files / show all files"],
-    ["  T", "hide test and test-support files"],
+    ["  T", "hide / show test and test-support files"],
+    ["  M", "hide / show Markdown files"],
     ["  i", "list the diff's files and commits, jump to one"],
     ["", ""],
     ["Structure tree", ""],

--- a/packages/cli/test/view-fold.test.ts
+++ b/packages/cli/test/view-fold.test.ts
@@ -4,6 +4,7 @@ import {
   buildFoldPlan,
   diffFiles,
   identityFold,
+  isMarkdownPath,
   isTestPath,
 } from "../lib/view/fold.ts";
 import type { Document, Line } from "../lib/view/model.ts";
@@ -15,6 +16,7 @@ import { diffSource } from "../lib/view/diffedit.ts";
 import { renderFrame, type ViewState } from "../lib/view/render.ts";
 import { stripAnsi } from "../lib/view/ansi.ts";
 import { frameTop } from "../lib/view/actions.ts";
+import { languageForFile } from "../lib/view/languages/language.ts";
 
 const TWO_FILES = [
   "diff --git a/src/app.ts b/src/app.ts",
@@ -42,9 +44,11 @@ Deno.test("diffFiles: ranges, counts, test flag, and summary text", () => {
   assertEquals(files[0].headerLine, 0);
   assertEquals(files[0].endLine, 7);
   assertEquals(files[0].isTest, false);
+  assertEquals(files[0].isMarkdown, false);
   assertEquals(files[0].summary.text, "▸ src/app.ts  +1 −1");
   assertEquals(files[1].path, "src/app.test.ts");
   assertEquals(files[1].isTest, true, "a .test.ts file is a test file");
+  assertEquals(files[1].isMarkdown, false);
   assertEquals(files[1].summary.text, "▸ src/app.test.ts  +1 −0");
 });
 
@@ -167,6 +171,27 @@ Deno.test("buildFoldPlan: nothing collapsed is the identity", () => {
 });
 
 // --- test-path detection -----------------------------------------------------
+
+Deno.test("isMarkdownPath: matches the pager's filename classification", () => {
+  for (
+    const path of [
+      "README.md",
+      "docs/guide.MARKDOWN",
+      "notes.mdown",
+      "notes.mkd",
+      "components/example.MDX",
+      "src/app.ts",
+      "notes.md.ts",
+      "docs/markdown",
+    ]
+  ) {
+    assertEquals(
+      isMarkdownPath(path),
+      languageForFile(path).id === "markdown",
+      path,
+    );
+  }
+});
 
 Deno.test("isTestPath: directories and basenames", () => {
   for (
@@ -368,8 +393,9 @@ Deno.test("fold: F hides all files, E shows all files", () => {
   assertEquals(s.displayDoc().lines.length, full, "E restores every file");
 });
 
-Deno.test("fold: T hides only test / test-support files", () => {
+Deno.test("fold: T hides shown test files and shows them when all are hidden", () => {
   const s = foldSession(TWO_FILES);
+  const full = s.displayDoc().lines.length;
   press(s, "T");
   const lines = s.displayDoc().lines.map((l) => l.text);
   // The test file is a summary; the source file is shown in full.
@@ -380,6 +406,72 @@ Deno.test("fold: T hides only test / test-support files", () => {
     "the source file is not collapsed",
   );
   assert(s.view().message.includes("Hid 1 test file"), s.view().message);
+
+  press(s, "T");
+  assertEquals(s.displayDoc().lines.length, full, "T shows the hidden test");
+  assertEquals(s.view().message, "Showing 1 test file.");
+});
+
+const CATEGORY_FILES = [
+  "diff --git a/src/app.ts b/src/app.ts",
+  "--- a/src/app.ts",
+  "+++ b/src/app.ts",
+  "@@ -1 +1 @@",
+  "-old",
+  "+new",
+  "diff --git a/docs/README.md b/docs/README.md",
+  "--- a/docs/README.md",
+  "+++ b/docs/README.md",
+  "@@ -1 +1 @@",
+  "-old",
+  "+new",
+  "diff --git a/src/app.test.ts b/src/app.test.ts",
+  "--- a/src/app.test.ts",
+  "+++ b/src/app.test.ts",
+  "@@ -1 +1 @@",
+  "-old",
+  "+new",
+  "diff --git a/docs/guide.test.md b/docs/guide.test.md",
+  "--- a/docs/guide.test.md",
+  "+++ b/docs/guide.test.md",
+  "@@ -1 +1 @@",
+  "-old",
+  "+new",
+  "",
+].join("\n");
+
+Deno.test("fold: M toggles every Markdown file", () => {
+  const s = foldSession(CATEGORY_FILES);
+  const full = s.displayDoc().lines.length;
+  press(s, "M");
+  const hidden = s.displayDoc().lines.map((line) => line.text);
+  assert(hidden.includes("▸ docs/README.md  +1 −1"));
+  assert(hidden.includes("▸ docs/guide.test.md  +1 −1"));
+  assert(!hidden.includes("▸ src/app.ts  +1 −1"));
+  assert(!hidden.includes("▸ src/app.test.ts  +1 −1"));
+  assertEquals(s.view().message, "Hid 2 Markdown files.");
+
+  press(s, "M");
+  assertEquals(s.displayDoc().lines.length, full, "M shows all Markdown files");
+  assertEquals(s.view().message, "Showing 2 Markdown files.");
+});
+
+Deno.test("fold: a category key reports when the diff has no matching files", () => {
+  const s = foldSession(TWO_FILES);
+  const full = s.displayDoc().lines.length;
+  press(s, "M");
+  assertEquals(s.displayDoc().lines.length, full);
+  assertEquals(s.view().message, "No Markdown files.");
+});
+
+Deno.test("fold: a partly hidden category is made fully hidden", () => {
+  const s = foldSession(CATEGORY_FILES);
+  press(s, "M");
+  press(s, "T");
+  const lines = s.displayDoc().lines.map((line) => line.text);
+  assert(lines.includes("▸ src/app.test.ts  +1 −1"));
+  assert(lines.includes("▸ docs/guide.test.md  +1 −1"));
+  assertEquals(s.view().message, "Hid 1 test file.");
 });
 
 Deno.test("fold: bulk commands preserve a wrapped viewport column", () => {
@@ -402,7 +494,7 @@ Deno.test("fold: bulk commands preserve a wrapped viewport column", () => {
   const anchor = s.view().top;
   assert(anchor > firstRow, "the viewport starts on a continuation row");
 
-  for (const key of ["T", "T", "F", "F", "E", "E"]) {
+  for (const key of ["T", "T", "M", "M", "F", "F", "E", "E"]) {
     press(s, key);
     assertEquals(s.view().top, anchor, `${key} preserves the continuation`);
   }
@@ -597,7 +689,7 @@ Deno.test("fold: a selected node and a search match map onto the summary row", (
   );
 });
 
-Deno.test("fold: F / E / T are refused on a non-diff view", () => {
+Deno.test("fold: F / E / T / M are refused on a non-diff view", () => {
   const doc = {
     text: "const x = 1;\n",
     lines: [{ text: "const x = 1;", spans: [] }],
@@ -609,7 +701,7 @@ Deno.test("fold: F / E / T are refused on a non-diff view", () => {
     width: 80,
     height: 10,
   });
-  for (const k of ["F", "E", "T"]) {
+  for (const k of ["F", "E", "T", "M"]) {
     press(s, k);
     assert(s.view().message.includes("diff view"), `${k}: ${s.view().message}`);
   }

--- a/packages/cli/test/view-jumplist.test.ts
+++ b/packages/cli/test/view-jumplist.test.ts
@@ -92,8 +92,8 @@ Deno.test("jumplist: i lists the diff's files, dirs summarised", () => {
   const s = diffSession(TWO_FILES);
   press(s, "i");
   assertEquals(entryText(s), [
-    "▸ src/app.ts  +1 −1",
-    "▸ src/app.test.ts  +1 −0",
+    "   ▸ src/app.ts  +1 −1",
+    " T ▸ src/app.test.ts  +1 −0",
   ]);
   assertEquals(s.view().inputLine, "jump to: ");
   assertEquals(s.view().overlay?.title, "Jump to file or commit");
@@ -105,8 +105,8 @@ Deno.test("jumplist: a git show lists the commit message before its files", () =
   press(s, "i");
   assertEquals(entryText(s), [
     "● commit 012345678  Fix the widget alignment",
-    "▸ src/app.ts  +1 −1",
-    "▸ src/app.test.ts  +1 −0",
+    "   ▸ src/app.ts  +1 −1",
+    " T ▸ src/app.test.ts  +1 −0",
   ]);
 });
 
@@ -156,7 +156,7 @@ Deno.test("jumplist: typing filters the list", () => {
   const s = diffSession(SHOW);
   press(s, "i");
   type(s, "test");
-  assertEquals(entryText(s), ["▸ src/app.test.ts  +1 −0"]);
+  assertEquals(entryText(s), [" T ▸ src/app.test.ts  +1 −0"]);
   assertEquals(s.view().inputLine, "jump to: test");
   // Backspacing widens it again.
   press(s, "backspace", "backspace", "backspace", "backspace");
@@ -243,9 +243,9 @@ Deno.test("jumplist: git log -p interleaves each commit with its own files", () 
   press(s, "i");
   assertEquals(entryText(s), [
     "● commit a1a1a1a1a  Second change",
-    "▸ b.ts  +1 −1",
+    "   ▸ b.ts  +1 −1",
     "● commit b2b2b2b2b  First change",
-    "▸ a.ts  +1 −1",
+    "   ▸ a.ts  +1 −1",
   ]);
 });
 
@@ -254,6 +254,13 @@ Deno.test("jumplist: files stay listed and jumpable while collapsed", () => {
   press(s, "F"); // collapse every file to a summary line
   press(s, "i");
   assertEquals(entryText(s).length, 3, "commit and both files still listed");
+  const fileLines = s.view().overlay!.lines.slice(1);
+  assert(
+    fileLines.every((line) =>
+      line.spans.every((span) => span.cls === "comment")
+    ),
+    "collapsed file rows are muted",
+  );
   press(s, "down", "down", "enter"); // commit -> app.ts -> app.test.ts
   assert(s.view().message.includes("src/app.test.ts"));
   // The jump scrolls the collapsed file's summary row into the viewport.
@@ -264,6 +271,45 @@ Deno.test("jumplist: files stay listed and jumpable while collapsed", () => {
     summaryRow >= top && summaryRow < top + 5,
     `summary row ${summaryRow} visible in [${top}, ${top + 5})`,
   );
+});
+
+const CATEGORY_FILES = [
+  "src/app.ts",
+  "docs/README.md",
+  "src/app.test.ts",
+  "docs/guide.test.md",
+].flatMap((path) => [
+  `diff --git a/${path} b/${path}`,
+  `--- a/${path}`,
+  `+++ b/${path}`,
+  "@@ -1 +1 @@",
+  "-old",
+  "+new",
+]).concat("").join("\n");
+
+Deno.test("jumplist: file rows use an aligned category-toggle column", () => {
+  const s = diffSession(CATEGORY_FILES);
+  press(s, "i");
+  assertEquals(entryText(s), [
+    "   ▸ src/app.ts  +1 −1",
+    "M  ▸ docs/README.md  +1 −1",
+    " T ▸ src/app.test.ts  +1 −1",
+    "MT ▸ docs/guide.test.md  +1 −1",
+  ]);
+});
+
+Deno.test("jumplist: only currently collapsed file rows are muted", () => {
+  const s = diffSession(CATEGORY_FILES);
+  press(s, "M", "i");
+  const lines = s.view().overlay!.lines;
+  for (const line of lines) {
+    const markdown = line.text.startsWith("M");
+    assertEquals(
+      line.spans.every((span) => span.cls === "comment"),
+      markdown,
+      line.text,
+    );
+  }
 });
 
 Deno.test("jumplist: i on a non-diff view says it is diff-only", () => {
@@ -302,7 +348,7 @@ Deno.test("jumplist: an email patch shows and filters by its Subject", () => {
   press(s, "i");
   assertEquals(entryText(s), [
     "● commit 012345678  Fix the widget alignment",
-    "▸ src/app.ts  +1 −1",
+    "   ▸ src/app.ts  +1 −1",
   ]);
   // The subject (with its [PATCH] prefix stripped) is filterable.
   type(s, "widget");
@@ -313,7 +359,7 @@ Deno.test("jumplist: a plain diff with no commit lists only files", () => {
   const s = diffSession(TWO_FILES);
   press(s, "i");
   assert(
-    entryText(s).every((t) => t.startsWith("▸")),
+    entryText(s).every((text) => text.includes("▸")),
     "no commit entry without a commit header",
   );
 });

--- a/packages/cli/test/view-session.test.ts
+++ b/packages/cli/test/view-session.test.ts
@@ -1043,7 +1043,8 @@ Deno.test("session: the help overlay documents file folding and scrolling", () =
   assert(text.includes("Diff files"), "has a Diff files section");
   assert(/hide\s*\/\s*show/.test(text), "documents hide/show");
   assert(text.includes("hide all files"), "documents hide all");
-  assert(text.includes("hide test"), "documents hiding test files");
+  assert(text.includes("show test"), "documents toggling test files");
+  assert(text.includes("Markdown files"), "documents toggling Markdown files");
   assert(
     text.includes("line wrapping: off / hard / word"),
     "documents line wrapping",


### PR DESCRIPTION
Large diffs often mix implementation, test, and documentation files. The pager could only hide test files, and it could not reveal them as a group after every test was hidden. Add a shared category toggle that hides a visible or mixed category and expands it when every matching file is hidden. Use it for the existing T key and the new M key.

Classify Markdown paths with the canonical filename language selector. In the jump list, reserve the first marker column for M and the second for T, leave missing categories blank, and mute rows for currently collapsed files. Keep every file path aligned after the fixed-width marker field.

Update the built-in help and cover hidden, mixed, overlapping, absent-category, jump-list alignment, and viewport-preservation states. Verified with the affected cf view suites, repository-wide deno lint, deno fmt --check on every changed file, and forward and reverse reviews.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add category toggles to the `cf` diff view: press `M` to hide/show Markdown files and `T` to hide/show test files as a group. The jump list now shows aligned `M`/`T` markers and mutes rows for collapsed files.

- **New Features**
  - Shared category toggle in `Session`: `T` and new `M` hide mixed groups and expand when all are hidden; clear count messages and “no files” feedback.
  - Markdown detection via `languageForFile`; `DiffFileRange` now includes `isMarkdown`.
  - Jump list: fixed-width marker field with `M` then `T`; missing categories left blank; collapsed file rows rendered muted; file paths stay aligned.
  - Help updated for `M`/`T`. Tests cover hidden/mixed/overlapping/absent categories, jump-list alignment, and viewport preservation.

<sup>Written for commit 9d161c0786bfa00932b54afcbaec29dfbb5cb24b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

