### PR TITLE
runner: name the `data:` identifier test once instead of at every site

### DIFF
--- a/packages/data-model/src/data-uri-codec.ts
+++ b/packages/data-model/src/data-uri-codec.ts
@@ -23,6 +23,21 @@ type UriString = `${string}:${string}`;
 export const DATA_URI_MEDIA_TYPE = "application/vnd.common-fabric.data";
 
 /**
+ * Is `id` a `data:` URI? This is the broad test of the pair: does the
+ * identifier carry its own frozen value, rather than name a document stored
+ * in a space? Such a cell is read by decoding its identifier, so there is no
+ * document to fetch, to sync, or to write, and no commit precondition to
+ * state about one.
+ *
+ * Only the scheme is examined. Every media type counts, and the payload is
+ * neither decoded nor validated. {@link isFabricDataUri} is the narrow
+ * companion, accepting just the one media type this codec mints.
+ */
+export function hasDataUriScheme(id: string): boolean {
+  return id.startsWith("data:");
+}
+
+/**
  * Is `mediaType` the `data:` URI media type? Exactly one type is
  * accepted; there are no parameters (the payload is always base64url of
  * UTF-8 text, so none are needed).
@@ -32,11 +47,12 @@ export function isDataUriMediaType(mediaType: string): boolean {
 }
 
 /**
- * Does `id` look like one of this codec's `data:` URIs? (Prefix check
- * only -- notably NOT any-`data:`-URI-at-all; the payload
- * is not validated.)
+ * Does `id` carry this codec's media type? This is the narrow test of the
+ * pair, for readers that go on to decode the payload;
+ * {@link hasDataUriScheme} accepts any media type. Only the prefix is
+ * examined; the payload is not validated.
  */
-export function isDataUri(id: string): boolean {
+export function isFabricDataUri(id: string): boolean {
   return id.startsWith(`data:${DATA_URI_MEDIA_TYPE}`);
 }
 
@@ -88,7 +104,7 @@ export function extractDataUriPayloadText(
   uri: string,
 ): { mediaType: string; text: string } {
   const commaIndex = uri.indexOf(",");
-  if (!uri.startsWith("data:") || commaIndex === -1) {
+  if (!hasDataUriScheme(uri) || commaIndex === -1) {
     throw new Error(`Invalid data URI format: ${uri}`);
   }
 

--- a/packages/data-model/test/data-uri-codec.test.ts
+++ b/packages/data-model/test/data-uri-codec.test.ts
@@ -13,8 +13,9 @@ import {
 import {
   DATA_URI_MEDIA_TYPE,
   dataUriFromValue,
-  isDataUri,
+  hasDataUriScheme,
   isDataUriMediaType,
+  isFabricDataUri,
   valueFromDataUri,
   valueFromDataUriPayloadText,
 } from "@/data-uri-codec.ts";
@@ -29,9 +30,18 @@ describe("data-uri-codec", () => {
     });
 
     it("recognizes only this codec's `data:` URIs", () => {
-      expect(isDataUri(dataUriFromValue({ a: 1 }))).toBe(true);
-      expect(isDataUri("data:image/png;base64,aGVsbG8")).toBe(false);
-      expect(isDataUri("of:xyz")).toBe(false);
+      expect(isFabricDataUri(dataUriFromValue({ a: 1 }))).toBe(true);
+      expect(isFabricDataUri("data:image/png;base64,aGVsbG8")).toBe(false);
+      expect(isFabricDataUri("of:xyz")).toBe(false);
+    });
+
+    it("recognizes a `data:` URI of any media type", () => {
+      expect(hasDataUriScheme(dataUriFromValue({ a: 1 }))).toBe(true);
+      expect(hasDataUriScheme("data:image/png;base64,aGVsbG8")).toBe(true);
+      expect(hasDataUriScheme("data:,")).toBe(true);
+      expect(hasDataUriScheme("of:xyz")).toBe(false);
+      expect(hasDataUriScheme("computed:fid1:xyz")).toBe(false);
+      expect(hasDataUriScheme("")).toBe(false);
     });
   });
 

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -57,6 +57,7 @@ import {
   recordRelevantSchemaWritePolicyInput,
 } from "../cell.ts";
 import { resolveLinkScope } from "../scope.ts";
+import { hasDataUriScheme } from "@commonfabric/data-model/data-uri-codec";
 import { type CellScope, NAME, type Pattern } from "../builder/types.ts";
 import { resolveStoredPatternAsync } from "./op-pattern-ref.ts";
 import { getEntityId } from "../create-ref.ts";
@@ -619,7 +620,7 @@ function serializeForLLMObservation(
   // Turn cells into a link, unless they are data: URIs and traverse instead
   if (isCell(value)) {
     const link = value.resolveAsCell().getAsNormalizedFullLink();
-    if (link.id.startsWith("data:")) {
+    if (hasDataUriScheme(link.id)) {
       return serializeForLLMObservation({
         value: value.get(),
         schema,
@@ -686,7 +687,7 @@ function serializeForLLMObservation(
       if (isRecord(child.value) && isCellResultForDereferencing(v)) {
         const link = getCellOrThrow(v).resolveAsCell()
           .getAsNormalizedFullLink();
-        if (!link.id.startsWith("data:")) {
+        if (!hasDataUriScheme(link.id)) {
           child = {
             ...child,
             value: {

--- a/packages/runner/src/cfc/ui-contract.ts
+++ b/packages/runner/src/cfc/ui-contract.ts
@@ -4,7 +4,7 @@ import { type NormalizedFullLink, parseLink } from "../link-utils.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 import { findAndInlineDataUriLinks } from "../data-uri.ts";
 import {
-  isDataUri,
+  isFabricDataUri,
   valueFromDataUri,
 } from "@commonfabric/data-model/data-uri-codec";
 import { ContextualFlowControl } from "../cfc.ts";
@@ -558,7 +558,7 @@ const eventEnvelopePayloads = (
   }
   try {
     const eventLink = parseLink(event);
-    if (eventLink?.id && isDataUri(eventLink.id)) {
+    if (eventLink?.id && isFabricDataUri(eventLink.id)) {
       const decoded = valueFromDataUri(eventLink.id);
       addPayload(decoded, eventLink.space);
     }

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -51,6 +51,7 @@ import type {
   IReadOptions,
 } from "./storage/interface.ts";
 import { type Runtime } from "./runtime.ts";
+import { hasDataUriScheme } from "@commonfabric/data-model/data-uri-codec";
 import { toURI } from "./uri-utils.ts";
 import {
   allowMutableTransactionRead,
@@ -841,9 +842,10 @@ export function normalizeAndDiff(
   // deliberately does not carry over: inlined content in an array slot stores
   // inline, exactly as the annotation scheme (which never looked behind
   // links) stored it.
-  if (
-    isCellLink(newValue) && parseLink(newValue, link).id?.startsWith("data:")
-  ) {
+  const newValueLinkId = isCellLink(newValue)
+    ? parseLink(newValue, link).id
+    : undefined;
+  if (newValueLinkId !== undefined && hasDataUriScheme(newValueLinkId)) {
     return normalizeAndDiff(
       runtime,
       tx,

--- a/packages/runner/src/data-uri.ts
+++ b/packages/runner/src/data-uri.ts
@@ -37,6 +37,7 @@ import {
   KeepAsCell,
   parseLink,
 } from "./link-utils.ts";
+import { hasDataUriScheme } from "@commonfabric/data-model/data-uri-codec";
 import { ContextualFlowControl } from "./cfc.ts";
 import type { URI } from "./sigil-types.ts";
 import {
@@ -151,7 +152,7 @@ export function findAndInlineDataUriLinks(value: any): any {
   if (isCellLink(value)) {
     const dataLink = parseLink(value)!;
 
-    if (dataLink.id?.startsWith("data:")) {
+    if (dataLink.id !== undefined && hasDataUriScheme(dataLink.id)) {
       let dataValue: any = valueFromDataUri(dataLink.id);
       const path = [...dataLink.path];
 

--- a/packages/runner/src/storage/transaction/address.ts
+++ b/packages/runner/src/storage/transaction/address.ts
@@ -1,5 +1,6 @@
 import type { IMemoryAddress } from "../interface.ts";
 import { normalizeCellScope } from "../../scope.ts";
+import { hasDataUriScheme } from "@commonfabric/data-model/data-uri-codec";
 export const toString = (address: IMemoryAddress) =>
   `/${normalizeCellScope(address.scope)}/${address.id}/${
     JSON.stringify(address.path)
@@ -62,5 +63,5 @@ export const intersects = (
  * Returns true if the address represents an inline data URI.
  */
 export const isInline = (address: IMemoryAddress): boolean => {
-  return address.id.startsWith("data:");
+  return hasDataUriScheme(address.id);
 };

--- a/packages/runner/src/storage/transaction/attestation.ts
+++ b/packages/runner/src/storage/transaction/attestation.ts
@@ -25,8 +25,8 @@ import { LRUCache } from "@commonfabric/utils/cache";
 import { toTransactionDocumentValue } from "../v2-document.ts";
 import {
   extractDataUriPayloadText,
-  isDataUri,
   isDataUriMediaType,
+  isFabricDataUri,
   valueFromDataUriPayloadText,
 } from "@commonfabric/data-model/data-uri-codec";
 
@@ -244,7 +244,7 @@ export const load = (
   >;
 
   try {
-    if (!isDataUri(address.id)) {
+    if (!isFabricDataUri(address.id)) {
       result = {
         error: UnsupportedMediaTypeError(
           `Unsupported media type in data URI: ${address.id.slice(0, 64)}`,

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -97,6 +97,7 @@ import {
 } from "./mergeable-ops.ts";
 import { recordWriteStackTrace } from "./write-stack-trace.ts";
 import { normalizeCellScope } from "../scope.ts";
+import { hasDataUriScheme } from "@commonfabric/data-model/data-uri-codec";
 import type { CellScope } from "../builder/types.ts";
 
 type RootAttestation = IAttestation;
@@ -1382,7 +1383,7 @@ export class V2StorageTransaction implements IStorageTransaction {
     const skipCommitPrecondition = isUiInputBlindWriteTx(this);
     const { space: _, ...memoryAddress } = address;
 
-    if (!address.id.startsWith("data:")) {
+    if (!hasDataUriScheme(address.id)) {
       const readActivity = {
         space: address.space,
         scope: normalizeCellScope(address.scope),
@@ -1398,7 +1399,7 @@ export class V2StorageTransaction implements IStorageTransaction {
       this.invalidateReactivityLog();
     }
     if (options?.trackReadWithoutLoad === true) {
-      if (!address.id.startsWith("data:") && !skipCommitPrecondition) {
+      if (!hasDataUriScheme(address.id) && !skipCommitPrecondition) {
         doc.validated = true;
       }
       return { ok: { address, value: undefined } };
@@ -1406,7 +1407,7 @@ export class V2StorageTransaction implements IStorageTransaction {
 
     if (isMutableTransactionReadAllowed(readMeta)) {
       if (
-        !address.id.startsWith("data:") &&
+        !hasDataUriScheme(address.id) &&
         !doc.validated &&
         !skipCommitPrecondition
       ) {
@@ -1433,7 +1434,7 @@ export class V2StorageTransaction implements IStorageTransaction {
 
     const result = readAttestation(current, memoryAddress);
     if (
-      !address.id.startsWith("data:") &&
+      !hasDataUriScheme(address.id) &&
       !doc.validated &&
       !skipCommitPrecondition
     ) {
@@ -1464,7 +1465,7 @@ export class V2StorageTransaction implements IStorageTransaction {
 
     const branch = this.branch(address.space);
     const { doc } = this.document(branch, address);
-    if (address.id.startsWith("data:")) return { ok: {} };
+    if (hasDataUriScheme(address.id)) return { ok: {} };
 
     const readMeta = options?.meta ?? EMPTY_META;
     const skipCommitPrecondition = isUiInputBlindWriteTx(this);
@@ -1607,7 +1608,7 @@ export class V2StorageTransaction implements IStorageTransaction {
     value?: FabricValue,
     options?: IWriteOptions,
   ): Result<IAttestation, WriteError> {
-    if (address.id.startsWith("data:")) {
+    if (hasDataUriScheme(address.id)) {
       return { error: ReadOnlyAddressError(address).from(space) };
     }
     const isDelete = options?.delete === true;
@@ -1721,7 +1722,7 @@ export class V2StorageTransaction implements IStorageTransaction {
   ): Result<Unit, WriteError> {
     if (
       writes.length <= 1 ||
-      writes.some(({ address }) => address.id.startsWith("data:"))
+      writes.some(({ address }) => hasDataUriScheme(address.id))
     ) {
       // Singleton-batch / data:URI fallback: route each write through the
       // unified single-write entry, which itself handles
@@ -2382,7 +2383,7 @@ export class V2StorageTransaction implements IStorageTransaction {
     address: Pick<IMemoryAddress, "id" | "type" | "scope">,
   ): RootAttestation {
     const type = address.type ?? DOCUMENT_MIME;
-    if (address.id.startsWith("data:")) {
+    if (hasDataUriScheme(address.id)) {
       const loaded = loadInline({ id: address.id, type });
       if (loaded.error) {
         throw loaded.error;

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -153,6 +153,7 @@ import {
 } from "./v2-remote-session.ts";
 import * as V2Transaction from "./v2-transaction.ts";
 import { normalizeCellScope } from "../scope.ts";
+import { hasDataUriScheme } from "@commonfabric/data-model/data-uri-codec";
 
 export { watchIdForEntry } from "./v2-watch.ts";
 export type { SessionFactory } from "./v2-remote-session.ts";
@@ -1327,7 +1328,7 @@ export class StorageManager implements IStorageManager {
   }
 
   shouldPullDoc(space: MemorySpace, id: URI, scope?: CellScope): boolean {
-    if (id.startsWith("data:")) {
+    if (hasDataUriScheme(id)) {
       return false;
     }
     const key = `${space}\0${docKey(id, scope)}`;
@@ -1493,7 +1494,7 @@ export class StorageManager implements IStorageManager {
       throw new Error("No space set");
     }
 
-    if (id.startsWith("data:")) {
+    if (hasDataUriScheme(id)) {
       return this.syncDataURICell(cell, space, id, schema, scope);
     }
 
@@ -1672,7 +1673,7 @@ export class StorageManager implements IStorageManager {
 
     if (isPrimitiveCellLink(value)) {
       const link = parseLinkPrimitive(value, base);
-      if (link.id && !link.id.startsWith("data:")) {
+      if (link.id && !hasDataUriScheme(link.id)) {
         const space = link.space ?? base.space!;
         const scope = normalizeCellScope(
           link.scope as CellScope | undefined,
@@ -3909,7 +3910,7 @@ class SpaceReplica implements ISpaceReplica {
       if (
         read.space !== this.#space ||
         (read.type ?? DOCUMENT_MIME) !== DOCUMENT_MIME ||
-        read.id.startsWith("data:")
+        hasDataUriScheme(read.id)
       ) {
         continue;
       }

--- a/packages/runner/src/traverse-recorder.ts
+++ b/packages/runner/src/traverse-recorder.ts
@@ -4,6 +4,7 @@ import type { SchemaPathSelector } from "@commonfabric/api";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { getLogger } from "../../utils/src/logger.ts";
 import type { NormalizedFullLink } from "./link-utils.ts";
+import { hasDataUriScheme } from "@commonfabric/data-model/data-uri-codec";
 import type {
   IExtendedStorageTransaction,
   IMemorySpaceAddress,
@@ -185,7 +186,7 @@ export class TraverseCaptureRecorder {
     address: IMemorySpaceAddress,
   ): void {
     // data: URIs carry their value in the id; replay decodes them directly.
-    if (address.id.startsWith("data:")) return;
+    if (hasDataUriScheme(address.id)) return;
     const key = fixtureDocKey(address);
     if (this.docs.has(key)) return;
     const { ok } = tx.read(

--- a/packages/runner/src/uri-utils.ts
+++ b/packages/runner/src/uri-utils.ts
@@ -11,6 +11,7 @@ import {
   entityRefToString,
   isEntityRef,
 } from "@commonfabric/data-model/cell-rep";
+import { hasDataUriScheme } from "@commonfabric/data-model/data-uri-codec";
 import type { URI } from "./sigil-types.ts";
 
 /**
@@ -44,7 +45,7 @@ export function toURI(value: unknown, kind?: EntityKind): URI {
       }
       // TODO(seefeld): Remove this once we want to support any URI, ideally
       // once there are no bare ids anymore
-      if (!hasEntityUriScheme(value) && !value.startsWith("data:")) {
+      if (!hasEntityUriScheme(value) && !hasDataUriScheme(value)) {
         throw new Error(`Invalid URI: ${value}`);
       }
       return value as URI;
@@ -71,7 +72,7 @@ export function fromURI(uri: URI | string): string {
     return uri;
   } else if (entityScheme !== undefined) {
     return uri.slice(entityScheme.length);
-  } else if (uri.startsWith("data:")) {
+  } else if (hasDataUriScheme(uri)) {
     return hashOf(uri).toString();
   } else {
     // TODO(seefeld): Remove this once we want to support any URI

--- a/packages/runner/test/list-resume-container-defer.test.ts
+++ b/packages/runner/test/list-resume-container-defer.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../src/storage/v2.ts";
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
 import { ENTITY_URI_SCHEMES } from "../src/entity-kind.ts";
+import { hasDataUriScheme } from "@commonfabric/data-model/data-uri-codec";
 import { Runtime } from "../src/runtime.ts";
 import type { Cell } from "../src/cell.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
@@ -900,7 +901,7 @@ describe("list builtin resume container defer", () => {
       // the server stores.
       for (const id of elementLinkIds) {
         expect(id).not.toBe(created.containerId);
-        if (id.startsWith("data:")) continue;
+        if (hasDataUriScheme(id)) continue;
         expect(
           [...persisted.values()].some((entry) => entry.id === id),
         ).toBe(true);

--- a/packages/runner/test/traverse-replay/replay.ts
+++ b/packages/runner/test/traverse-replay/replay.ts
@@ -32,6 +32,7 @@ import {
 import { ContextualFlowControl } from "../../src/cfc.ts";
 import { ExtendedStorageTransaction } from "../../src/storage/extended-storage-transaction.ts";
 import { load as loadDataURI } from "../../src/storage/transaction/attestation.ts";
+import { hasDataUriScheme } from "@commonfabric/data-model/data-uri-codec";
 import type {
   IExtendedStorageTransaction,
   IMemorySpaceAddress,
@@ -152,7 +153,7 @@ export class FixtureObjectManager implements ObjectStorageManager {
   constructor(private docs: Record<string, FabricValue>) {}
 
   load(address: BaseMemoryAddress): IAttestation | null {
-    if (address.id.startsWith("data:")) {
+    if (hasDataUriScheme(address.id)) {
       // Use the canonical data-URI attestation loader so replay matches live
       // semantics (decoded JSON rooted at path [], LRU-cached).
       const { ok } = loadDataURI(address);


### PR DESCRIPTION
A `data:` identifier carries a frozen value inside the identifier itself rather than naming a document stored in a space. A cell so identified is read by decoding its identifier, so there is nothing to fetch, nothing to sync, nothing to write, and no commit precondition to state about a stored document. Code all over the runner needs to know which kind of identifier it is holding, and every one of those places worked it out the same way, by hand: `id.startsWith("data:")`. There were twenty such spellings across eight files, eight of them in `storage/v2-transaction.ts` alone, where several are negated and combined with other conditions so that the reader has to reassemble the meaning of the check from its punctuation each time.

Spreading the test out this way costs three things. A reader meets a bare string comparison and has to reconstruct what it implies, which is a claim about documents and storage rather than about prefixes. The `"data:"` literal belongs to the codec that mints, splits and templates it, so twenty copies of it a layer up are real coupling. And the same expression already means unrelated things elsewhere in the repository -- a field label in a server-sent-events line, an embedded image source -- so the concept cannot be found by searching for the syntax.

This gives the test a name and one definition. `hasDataUriScheme` goes into `data-model`'s `data-uri-codec.ts`, which already holds the media-type facts and both halves of the encoding, and every site now calls it. Searching for the name now returns the cell-identifier sites and nothing else.

The codec is the right home because a second, narrower test already lived there and is easy to confuse with this one. It accepts only `data:application/vnd.common-fabric.data`, the single media type this codebase mints, where each hand-rolled site accepted a `data:` URI of any media type. Both tests are load-bearing, and they are used at different points of the same path. `loadRoot` routes any `data:` URI to the attestation loader on the broad test; the loader then applies the narrow one and turns anything that is not this codec's into an `UnsupportedMediaTypeError`. The confidentiality contract code does the same before handing an identifier to `valueFromDataUri`. Swapping either test for the other would change behaviour rather than merely read differently. Splitting the pair across two packages would have hidden that from whoever finds one of them first.

Nothing in the old names conveyed which was which. If anything they suggested the opposite of the truth: "is a data URI" sounds like the general test and "has the data URI scheme" like the specific one, when it is the other way round. The narrow name was carrying the burden in its docstring instead, which had to interrupt itself to warn that the function is "notably NOT any-`data:`-URI-at-all" -- a disclaimer a well-chosen name would not need. So `isDataUri` becomes `isFabricDataUri`. The qualifier names the media type family the way the rest of the package already does, alongside `isFabricValue` and `isFabricPlainObject`, and it puts the narrowing where a reader meets it first. Both docstrings now say plainly which of the pair each one is and what each is for.

The broad test keeps a name describing what it examines rather than what a caller concludes from it. A name promising that the identifier carries a readable value would be false for precisely the case the pair exists to separate: a `data:` URI of a foreign media type passes this test and cannot be decoded. The name also matches `hasEntityUriScheme`, so `toURI`'s check that a string is neither an entity URI nor a `data:` URI reads as a single thought.

The broad test gains a unit test, beside the existing one for the narrow test and asserting the property that separates them, so exchanging one for the other fails a test rather than passing quietly.

Nothing changes about what any of these sites decide. Each replacement keeps its surrounding operators exactly, negations included. Two sites tested an optional id through `?.`, which yields `undefined` and so reads as false; both now say `id !== undefined && hasDataUriScheme(id)`, which is the same test for an `id` that is either absent or a schemed string. The signature stays `string` rather than admitting `undefined`, because half the sites test the result negated, and a widened test would answer false for a missing id and quietly sweep id-less links into the paths those guards exclude. `storage/transaction/address.ts`'s `isInline` keeps its address-level signature and calls the shared test. The three call sites of the renamed narrow test keep their exact conditions.

Three further copies of the hand-rolled check go the same way: `extractDataUriPayloadText` inside the codec, which was checking the prefix by hand a few lines above the new definition, and two in the runner's tests -- the traverse-replay harness, whose whole purpose is to match live semantics, and one assertion that skips inline literals when checking what the server persisted.

One `startsWith("data:")` in `builtins/stream-data.ts` is left alone: it reads a field name out of a server-sent-events line, next to `id:` and `event:`, and has nothing to do with cell identifiers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes the `data:` URI check with `hasDataUriScheme` and replaces scattered `id.startsWith("data:")` usages for clearer, safer logic with no behavior changes. Also renames the narrow check `isDataUri` to `isFabricDataUri` and adds a unit test to distinguish the two.

- **Refactors**
  - Added `hasDataUriScheme(id: string)` to `@commonfabric/data-model/data-uri-codec`.
  - Renamed `isDataUri` to `isFabricDataUri`; updated all call sites.
  - Replaced ~20 inline `startsWith("data:")` checks across the runner (e.g., `v2-transaction`, `v2`, `data-uri`, `llm-dialog`, tests).
  - Updated `extractDataUriPayloadText` to use the new helper; added a unit test for the broad scheme check.
  - Left the SSE parser in `builtins/stream-data.ts` unchanged (it reads event field names).

- **Migration**
  - Use `hasDataUriScheme(id)` to detect any `data:` URI.
  - Use `isFabricDataUri(id)` to require `application/vnd.common-fabric.data`.
  - If you previously used optional chaining on `id`, prefer `id !== undefined && hasDataUriScheme(id)`.

<sup>Written for commit 124a75340a6d529970c9ba53d8bbc828fcc695b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

