### PR TITLE
docs(schema-generator): mark the fabric-backed-native default mismatch

### DIFF
--- a/packages/schema-generator/src/formatters/common-fabric-formatter.ts
+++ b/packages/schema-generator/src/formatters/common-fabric-formatter.ts
@@ -280,6 +280,19 @@ export class CommonFabricFormatter implements TypeFormatter {
       if (typeWithAlias.aliasTypeArguments.length >= 2) {
         const defaultType = typeWithAlias.aliasTypeArguments[1]!;
         const defaultValue = this.extractDefaultValue(defaultType, context);
+        // TODO(danfuzz): A default for a fabric-backed native disagrees with
+        // the value its type actually stores. `Date`, `RegExp`, and
+        // `Uint8Array` map to `{ type: "object" }` because they are stored as
+        // `FabricEpochNsec` / `FabricRegExp` / `FabricBytes`, but the default
+        // captured here is the authored TS literal. So
+        // `Default<Date, "2020-01-01T00:00:00.000Z">` emits
+        // `{ type: "object", default: "2020-01-01T00:00:00.000Z" }` -- a string
+        // standing in for an object, and not the form a read of that slot would
+        // ever produce. Decide how a default for these types is expressed
+        // (converted to the fabric form here, converted where the default is
+        // applied, or refused outright) instead of leaving the two disagreeing.
+        // The node-based path below attaches defaults the same way and needs
+        // the same answer.
         if (defaultValue !== undefined) {
           if (typeof valueSchema === "boolean") {
             return (valueSchema === false
@@ -948,6 +961,11 @@ export class CommonFabricFormatter implements TypeFormatter {
     }
 
     if (defaultValue !== undefined) {
+      // TODO(danfuzz): This attaches a default without checking it against the
+      // shape its type stores -- see the marker on the type-based path above,
+      // which describes the fabric-backed-native mismatch and needs one answer
+      // covering both paths.
+      //
       // JSON Schema Draft 2020-12 allows default as a sibling of $ref
       // Simply add the default property directly to the schema
       if (typeof valueSchema === "boolean") {


### PR DESCRIPTION
`Date`, `RegExp`, and `Uint8Array` generate `{ type: "object" }`, because that is
what they are at the fabric boundary — they are stored as `FabricEpochNsec`,
`FabricRegExp`, and `FabricBytes`. A `Default<T, V>` on one of them still
captures the authored TS literal, so the two disagree:

```
Default<Date, "2020-01-01T00:00:00.000Z">
  ->  { type: "object", default: "2020-01-01T00:00:00.000Z" }
```

A string standing in for an object, and not a form a read of that slot could
ever produce.

**The disagreement predates the `"object"` mapping.** The default was merely
consistent with the old `{ type: "string" }` while being just as wrong against
storage — tidy rather than correct. Making the type honest is what exposed it.

## Marked, not fixed — deliberately

There are at least three defensible answers:

- convert the literal to its fabric form where the default is **attached**
- convert it where the default is **applied**
- **refuse** a literal default for these types, and require the author to say
  what they mean

Picking one is a decision about how authors express such a default, not a patch,
so this records the problem where it is created rather than guessing.

## Placement

Both sites that attach a default carry a marker. The type-based path states the
problem in full; the node-based path points at it, since one answer has to cover
both. (The two analysis paths are the ones the package guide warns can encode
things differently — worth having the marker on each rather than trusting a
reader to find the other.)

## Testing

Comment only. schema-generator 55 passed, `deno fmt --check` (4315 files) and
`deno lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eJcTLCQcXrXHA4CC8eDpp


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document the mismatch between authored default literals and stored schema shape for fabric-backed natives (`Date`, `RegExp`, `Uint8Array`) in the schema generator. Add TODOs in both default-attachment paths to force a decision (convert on attach, convert on apply, or refuse), with no runtime change.

<sup>Written for commit 9d8f4a3e4dcee6d4a22951b466e979b9331fca3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

