### PR TITLE
fix(cli): guard the --show-links walk at its entry, with the addressing test that pins it

### DIFF
--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -593,12 +593,13 @@ type BackingLink = {
  * containing `/` or `~` stays unambiguous.
  *
  * The walk covers the JSON of the value that was read back, and it ENFORCES
- * that rather than assuming it: descent stops at any non-plain object, so a
- * live runtime object reached through the result contributes its own link and
- * nothing below it. That bound is what makes the walk terminate. A result
- * carrying a piece that owns verbs is the case that proves the point — the
- * stream on that piece is a live object whose `runtime`/`scheduler` graph
- * refers back to itself, and walking into it exhausted the stack.
+ * that rather than assuming it: descent stops at any non-plain object —
+ * including a result that is itself one — so a live runtime object reached
+ * through the result contributes its own link and nothing below it. That
+ * bound is what makes the walk terminate. A result carrying a piece that
+ * owns verbs is the case that proves the point — the stream on that piece is
+ * a live object whose `runtime`/`scheduler` graph refers back to itself, and
+ * walking into it exhausted the stack.
  *
  * A receipt cell that cannot resolve links (no `resolveAsCell` /
  * `getAsNormalizedFullLink`) degrades to the receipt-root entry alone rather
@@ -632,7 +633,13 @@ export function collectInvocationResultLinks(
     pathSegments: string[],
     base: { id: string; space: string; scope?: CellScope },
   ): void => {
-    if (typeof val !== "object" || val === null) return;
+    // A non-plain object is not part of the result's JSON: it is a live
+    // runtime object the readback surfaced (a stream on a returned piece,
+    // most commonly). It keeps the entry its parent emitted — the root's
+    // "/" when the result itself is live — but the walk never goes inside:
+    // its properties are the runtime's, not the result's, and they refer
+    // back to themselves.
+    if (typeof val !== "object" || val === null || isInstance(val)) return;
     const keys = Array.isArray(val)
       ? val.map((_, index) => String(index))
       : Object.keys(val);
@@ -647,12 +654,6 @@ export function collectInvocationResultLinks(
       const resolved = child.resolveAsCell?.() ?? child;
       const childLink = resolved.getAsNormalizedFullLink?.();
       const segments = [...pathSegments, key];
-      // A non-plain object is not part of the result's JSON: it is a live
-      // runtime object the readback surfaced (a stream on a returned piece,
-      // most commonly). Annotate it if it has a document of its own, but do
-      // not descend — its properties are the runtime's, not the result's, and
-      // they refer back to themselves.
-      const descend = !isInstance(childValue);
       if (
         childLink?.id !== undefined && childLink.space !== undefined &&
         !sameBackingDocument(childLink as BackingLink, base)
@@ -660,10 +661,8 @@ export function collectInvocationResultLinks(
         links[encodeJsonPointer(["", ...segments])] = toInvocationResultLink(
           childLink as BackingLink,
         );
-        if (descend) {
-          walk(resolved, childValue, segments, childLink as BackingLink);
-        }
-      } else if (descend) {
+        walk(resolved, childValue, segments, childLink as BackingLink);
+      } else {
         // Same backing document — no entry — but descendants are still read
         // from the RESOLVED cell: a same-doc link can redirect to another
         // path, and the children live under its target.

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -2494,6 +2494,39 @@ function linkedReceiptCell(
   };
 }
 
+/**
+ * A fully addressable receipt cell that logs every `key()` segment the
+ * walk requests into `requested` (as `/`-joined paths) — the observable
+ * seam for "the walk never addresses inside a live object". Descent is cut
+ * off after a small budget, so an errant walk fails a path assertion
+ * deterministically instead of racing the stack limit, whose overflow the
+ * walk's own addressability catch can swallow.
+ */
+function recordingReceiptCell(
+  doc: MockLinkedDoc,
+  requested: string[],
+  path: string[] = [],
+): CallableCellLike {
+  const cell: CallableCellLike = {
+    get: () => undefined,
+    resolveAsCell: () => cell,
+    getAsNormalizedFullLink: () => ({
+      id: doc.id,
+      space: doc.space,
+      path,
+    }),
+    key: (segment: string) => {
+      if (requested.length >= 32) {
+        throw new Error("fake cell budget exhausted");
+      }
+      const next = [...path, segment];
+      requested.push(next.join("/"));
+      return recordingReceiptCell(doc, requested, next);
+    },
+  };
+  return cell;
+}
+
 describe("collectInvocationResultLinks", () => {
   const receiptLink = { id: "of:receipt-1", space: "did:key:test-home" };
   const receiptRef = {
@@ -2736,34 +2769,38 @@ describe("collectInvocationResultLinks", () => {
     }
     const value = { child: { touch: new FakeStream() } };
     const requested: string[] = [];
-    const recording = (path: string[]): CallableCellLike => {
-      const cell: CallableCellLike = {
-        get: () => undefined,
-        resolveAsCell: () => cell,
-        getAsNormalizedFullLink: () => ({
-          id: receiptLink.id,
-          space: receiptLink.space,
-          path,
-        }),
-        key: (segment: string) => {
-          if (requested.length >= 32) {
-            throw new Error("fake cell budget exhausted");
-          }
-          const next = [...path, segment];
-          requested.push(next.join("/"));
-          return recording(next);
-        },
-      };
-      return cell;
-    };
     const links = collectInvocationResultLinks(
       receiptLink,
-      recording([]),
+      recordingReceiptCell(receiptLink, requested),
       value,
     );
     // The stream itself is addressed — it is a property of the result and
     // may carry a document of its own. Nothing below it is.
     expect(requested).toEqual(["child", "child/touch"]);
+    expect(links).toEqual({ "/": receiptRef });
+  });
+
+  it("addresses nothing when the result is itself a live object", () => {
+    // The same contract at the root: the walk's entry guard — not only the
+    // per-child check — is what keeps a live result's properties
+    // unaddressed. With the guard on children alone, the walk enumerated a
+    // root instance and addressed "scheduler".
+    class FakeScheduler {
+      runtime!: FakeRuntime;
+    }
+    class FakeRuntime {
+      scheduler = new FakeScheduler();
+      constructor() {
+        this.scheduler.runtime = this;
+      }
+    }
+    const requested: string[] = [];
+    const links = collectInvocationResultLinks(
+      receiptLink,
+      recordingReceiptCell(receiptLink, requested),
+      new FakeRuntime(),
+    );
+    expect(requested).toEqual([]);
     expect(links).toEqual({ "/": receiptRef });
   });
 });

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -2706,6 +2706,66 @@ describe("collectInvocationResultLinks", () => {
       collectInvocationResultLinks(receiptLink, undefined, { a: { b: 1 } }),
     ).toEqual({ "/": receiptRef });
   });
+
+  it("addresses no path inside a live (non-plain) object in the result", () => {
+    // The --show-links crash shape: a stream on a returned piece is a live
+    // runtime object whose runtime/scheduler properties refer back to each
+    // other, and a walk that descends into it recurses until the stack runs
+    // out. "Terminates without throwing" is NOT a testable contract for that
+    // bug: when the overflow happens to land on the `cell.key()` call, the
+    // walk's own addressability catch swallows the RangeError and unwinds
+    // cleanly, so whether a crash is observable depends on where the stack
+    // limit falls (fake frame sizes, V8 --stack-size) — not on the walk.
+    // What the walk must guarantee is stronger and observable at this seam:
+    // it never ADDRESSES a path inside a non-plain object, whose properties
+    // belong to the runtime rather than the result. The fake records every
+    // key() the walk requests and cuts descent off after a small budget, so
+    // an errant walk fails the path assertion deterministically, far from
+    // any stack limit.
+    class FakeScheduler {
+      runtime!: FakeRuntime;
+    }
+    class FakeRuntime {
+      scheduler = new FakeScheduler();
+      constructor() {
+        this.scheduler.runtime = this;
+      }
+    }
+    class FakeStream {
+      runtime = new FakeRuntime();
+    }
+    const value = { child: { touch: new FakeStream() } };
+    const requested: string[] = [];
+    const recording = (path: string[]): CallableCellLike => {
+      const cell: CallableCellLike = {
+        get: () => undefined,
+        resolveAsCell: () => cell,
+        getAsNormalizedFullLink: () => ({
+          id: receiptLink.id,
+          space: receiptLink.space,
+          path,
+        }),
+        key: (segment: string) => {
+          if (requested.length >= 32) {
+            throw new Error("fake cell budget exhausted");
+          }
+          const next = [...path, segment];
+          requested.push(next.join("/"));
+          return recording(next);
+        },
+      };
+      return cell;
+    };
+    const links = collectInvocationResultLinks(
+      receiptLink,
+      recording([]),
+      value,
+    );
+    // The stream itself is addressed — it is a property of the result and
+    // may carry a document of its own. Nothing below it is.
+    expect(requested).toEqual(["child", "child/touch"]);
+    expect(links).toEqual({ "/": receiptRef });
+  });
 });
 
 describe("piece call --show-links", () => {


### PR DESCRIPTION
## Why

#5289 fixed the `--show-links` stack overflow but deliberately shipped without a unit test: two attempts to characterize the crash passed with and without the fix, and the commit left *why the fakes do not reproduce* as an open question. This PR answers that question with instrumentation rather than reasoning, adds the test the fix should be pinned by, and closes a gap that test promptly exposed: the merged guard checked children only, so a result that is *itself* a live object was still enumerated.

What the instrumented walk showed:

- The fakes **do** produce unbounded recursion. A cyclic plain value recursed to depth 2010; fake stream/runtime/scheduler classes to depth 3304. Nothing about the cell chain bounds the walk — it is driven purely by the value graph.
- What masks the crash is the walk's own addressability guard, `try { cell.key(key) } catch { continue }`: when V8's stack limit happens to be crossed by the `key()` call, the RangeError is swallowed as "not addressable" and the walk unwinds cleanly, returning a normal-looking links dictionary.
- Whether the overflow lands inside or outside that `try` is pure frame geometry. The same two fakes in one process split swallowed/escaped; any explicit `--v8-flags=--stack-size` (400–2000) flipped both to escaped. A test asserting "does not throw" tests where the stack limit lands, not the fix.
- A cyclic **plain** value additionally recurses to the stack limit even *with* the fix (`isInstance` does not guard plain objects), so that shape can never distinguish the two states.

So "terminates" is untestable here, but the fix's real guarantee is stronger and directly observable: the walk never **addresses** a path inside a non-plain object, because its properties belong to the runtime rather than the result.

## What Changed

- `packages/cli/lib/callable.ts`: the `isInstance` guard moves from the per-child `descend` check to the walk's entry, where it covers the root and every child uniformly and the branching collapses back to the original symmetric shape. Review found the child-only guard let a live *root* result be enumerated (the walk addressed `key("scheduler")` on a recording root Runtime instance) — bounded, since its children were guarded, but a violation of the stated contract.
- `packages/cli/test/piece-call.test.ts`: two new tests against a recording fake cell whose `key()` logs every segment the walk requests and refuses descent after a 32-call budget, so an errant walk fails the path assertion deterministically at depth ~30 with no stack-limit involvement. One drives the real crash shape — a stream whose `runtime`/`scheduler` refer back to each other — nested in the result; the other makes the result itself the live object.

## Test plan

- Nested-instance test on the fix's parent (`41a3acde4^` content): fails with an assertion diff showing the walk addressing `child/touch/runtime/scheduler/runtime/…` — the same path the original CLI instrumentation captured.
- Root-instance test on the child-only guard (`41a3acde4` / first commit of this branch): fails by addressing `"scheduler"`.
- On this branch: full `packages/cli` suite passes (123 tests / 179 steps), repo-wide `deno fmt --check` and `deno lint` clean, `deno check` on both files clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)