### PR TITLE
feat(data-model): custom inspector for fabric special objects

### DIFF
--- a/packages/data-model/src/fabric-instances/BaseFabricInstance.ts
+++ b/packages/data-model/src/fabric-instances/BaseFabricInstance.ts
@@ -1,4 +1,5 @@
 import { FabricInstance, type FabricValue } from "@/interface.ts";
+import { toCompactDebugString } from "@/value-debug.ts";
 // Used only inside method bodies: this import participates in a module cycle
 // with `deep-freeze.ts` (which imports this module's symbols and class for its
 // generic dispatch), which is safe for call-time function use but must not be
@@ -78,6 +79,23 @@ export abstract class BaseFabricInstance extends FabricInstance {
   //
   // Instance members
   //
+
+  /**
+   * Custom inspector, so that a `console.log()` or a debugger shows what this
+   * value IS. The default rendering is `{}`: state lives in private fields,
+   * which have no enumerable own properties for an inspector to find.
+   *
+   * Delegates to the canonical debug renderer rather than formatting here, so
+   * that this surface improves whenever that one does -- including the state
+   * rendering its own `TODO` describes, currently elided as `(...)`.
+   *
+   * Duplicated on `BaseFabricPrimitive`, unavoidably. There is no shared base
+   * class below `FabricSpecialObject`, and `FabricSpecialObject` itself is the
+   * runtime-import-free abstract contract, so it cannot reach `value-debug`.
+   */
+  [Symbol.for("Deno.customInspect")](): string {
+    return toCompactDebugString(this);
+  }
 
   /**
    * Deeply freezes this instance in place: freezes this instance's own

--- a/packages/data-model/src/fabric-primitives/BaseFabricPrimitive.ts
+++ b/packages/data-model/src/fabric-primitives/BaseFabricPrimitive.ts
@@ -1,4 +1,5 @@
 import { FabricPrimitive } from "@/interface.ts";
+import { toCompactDebugString } from "@/value-debug.ts";
 
 /**
  * Well-known symbol seeding `BaseFabricPrimitive`'s symbol-keyed member set.
@@ -30,6 +31,23 @@ export abstract class BaseFabricPrimitive extends FabricPrimitive {
   //
   // Instance members
   //
+
+  /**
+   * Custom inspector, so that a `console.log()` or a debugger shows what this
+   * value IS. The default rendering is `{}`: state lives in private fields,
+   * which have no enumerable own properties for an inspector to find.
+   *
+   * Delegates to the canonical debug renderer rather than formatting here, so
+   * that this surface improves whenever that one does -- including the state
+   * rendering its own `TODO` describes, currently elided as `(...)`.
+   *
+   * Duplicated on `BaseFabricInstance`, unavoidably. There is no shared base class
+   * below `FabricSpecialObject`, and `FabricSpecialObject` itself is the
+   * runtime-import-free abstract contract, so it cannot reach `value-debug`.
+   */
+  [Symbol.for("Deno.customInspect")](): string {
+    return toCompactDebugString(this);
+  }
 
   /**
    * Placeholder seed member (a throwing stub). Its only purpose today is to

--- a/packages/data-model/src/value-debug.ts
+++ b/packages/data-model/src/value-debug.ts
@@ -9,7 +9,14 @@ import {
   FabricPrimitive,
   FabricSpecialObject,
 } from "./interface.ts";
-import { codecOf } from "@/codec-common/index.ts";
+// Imported from its own module rather than the package barrel, deliberately:
+// the barrel pulls in every codec, and three of those import
+// `ProblematicValue` -- a `BaseFabricInstance` subclass. Going through the
+// barrel would make this module part of a cycle with the fabric base classes,
+// whose custom inspectors import it, and an `extends` clause evaluated inside
+// that cycle fails with "Cannot access 'BaseFabricInstance' before
+// initialization". `codecOf.ts` itself is a leaf.
+import { codecOf } from "@/codec-common/codecOf.ts";
 
 /**
  * Sentinel marker used to wrap content that should appear unquoted in the

--- a/packages/data-model/test/value-debug.test.ts
+++ b/packages/data-model/test/value-debug.test.ts
@@ -489,3 +489,25 @@ describe("value-debug", () => {
     });
   });
 });
+
+describe("custom inspector", () => {
+  // Without the inspector these all render as `{}`: state lives in private
+  // fields, which have no enumerable own properties for an inspector to find.
+  // The elided `(...)` is the debug renderer's own current limitation, marked
+  // by a TODO there; delegating means this surface inherits the fix.
+  it("renders a FabricPrimitive as its debug string, not `{}`", () => {
+    const bytes = new FabricBytes(new Uint8Array([1, 2, 3]));
+    expect(Deno.inspect(bytes)).toBe("/Bytes(...)");
+  });
+
+  it("renders a FabricInstance as its debug string, not `{}`", () => {
+    const err = FabricError.fromNativeError(new Error("boom"));
+    expect(Deno.inspect(err)).toBe("/Error(...)");
+  });
+
+  it("renders when nested in containers", () => {
+    const bytes = new FabricBytes(new Uint8Array([9]));
+    expect(Deno.inspect({ blob: bytes })).toBe("{ blob: /Bytes(...) }");
+    expect(Deno.inspect([bytes, bytes])).toBe("[ /Bytes(...), /Bytes(...) ]");
+  });
+});


### PR DESCRIPTION
A `FabricPrimitive` or `FabricInstance` renders as `{}` in a debugger and in
`console.log()` — its state lives in private fields, which expose no enumerable
own properties for an inspector to find. The one place a developer most wants to
know what a value is, is the place that tells them nothing.

`BaseFabricPrimitive` and `BaseFabricInstance` now each carry a
`Symbol.for("Deno.customInspect")` method delegating to `toCompactDebugString()`:

```
before:  { blob: {},            err: {} }
after:   { blob: /Bytes(...),   err: /Error(...) }
```

**Delegating rather than formatting in place** means this surface improves
whenever the renderer does — including the state rendering that
`value-debug.ts`'s own `TODO` describes, currently elided as `(...)`. The class
name and its known-encodable-type marker are the immediate win; contents follow
for free.

Duplicated across the two base classes, unavoidably: there is no shared base
below `FabricSpecialObject`, and `FabricSpecialObject` itself is the
runtime-import-free abstract contract, so it cannot reach `value-debug`. Each
copy is four lines.

## The import cycle this exposed

Adding the edge broke **every** fabric-instance test outright:

```
ReferenceError: Cannot access 'BaseFabricInstance' before initialization
  export abstract class ExplicitTagValue extends BaseFabricInstance {
```

`value-debug` imported `codecOf` from the `codec-common` **barrel**, which pulls
in every codec — and three of those import `ProblematicValue`, itself a
`BaseFabricInstance` subclass:

```
BaseFabricInstance → value-debug → codec-common/index → BigIntCodec
                   → ProblematicValue → ExplicitTagValue → BaseFabricInstance
```

An `extends` clause is evaluated **eagerly** at module init, so it landed in the
temporal dead zone. Worth stating plainly because the intuition is wrong: an
import used only inside a method body does *not* defer this. What matters is the
module graph, not where the reference is written.

Fixed by importing `codecOf` from its own module, which is a leaf — only the
`CODEC` symbol and types. **`codecOf` itself is untouched, deliberately**:
routing around it would cost the renderer the genericity that makes it work for
every fabric class, which is the whole reason it goes through the codec.

## Testing

Three tests, red-greened against real `origin/main` (all three fail there):
bare primitive, bare instance, and nested in an object and an array.

Full **workspace** suite green (238s, every package) — the breadth is the point
here, since the failure mode was a module-init cycle rather than anything a
targeted test would have caught. `deno task check`, `deno fmt --check` (4315
files), and `deno lint` (4287 files) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eJcTLCQcXrXHA4CC8eDpp


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a custom inspector so fabric special objects show meaningful output in logs and the debugger, and fix an import cycle exposed by this change. `FabricPrimitive` and `FabricInstance` now render via `toCompactDebugString()` instead of `{}`.

- **New Features**
  - Added `Symbol.for("Deno.customInspect")` to `BaseFabricPrimitive` and `BaseFabricInstance`, delegating to `toCompactDebugString()`.
  - Example: `{ blob: {}, err: {} }` → `{ blob: /Bytes(...), err: /Error(...) }`.

- **Bug Fixes**
  - Resolved module init cycle by importing `codecOf` from `@/codec-common/codecOf.ts` instead of the `codec-common` barrel.
  - Added tests for primitives, instances, and nested containers.

<sup>Written for commit a849c0773692d3e5311f9c426847b278fcef8cfe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

