### PR TITLE
docs(plan): spec the wrapper-tier + deprecation listing marks (queued)

### DIFF
--- a/docs/plans/pattern-verb-contract-implementation.md
+++ b/docs/plans/pattern-verb-contract-implementation.md
@@ -122,7 +122,8 @@ Made 2026-07-24, shaping everything below:
 Named so their absence reads as intent, not oversight:
 
 - The **wrapper-tier marker** for verb listing (semantics are settled in the
-  design; the marker mechanism ships after the listing).
+  design; the marker mechanism ships after the listing — specced 2026-08-03
+  as queued work, see the WS-F bullet).
 - **Cryptographic agent identity / delegation** (design OQ2) — the CFC track
   distinguishes runtime-attested execution context from a separately keyed or
   delegated agent, but does not deliver delegation.
@@ -836,6 +837,50 @@ Size M, mostly parallel. `packages/cli`, `skills/cf`.
   everything per the decided semantics; handler result schemas appear once
   WS-C lands, tier filtering with the marker, later. The 2026-07-24 amendment is absorbed: the listing carries the
   deployed pattern's source identity (skew detection).
+- **Wrapper-tier + deprecation marks for the listing default (specced
+  2026-08-03; queued).** Everything stays CALLABLE — the marks shape only
+  what `cf piece verbs` shows by default (decided with Mike, 2026-08-03).
+  One mechanism, two producers, one consumer:
+  - The generated stream schema carries two independent annotation-class
+    marks: `tier: "wrapper"` (a UI affordance outside the headless
+    contract) and standard JSON Schema `deprecated: true`. Compile-time
+    facts in the schema — no client-side heuristics, so FUSE and shell
+    inherit the same classification for free.
+  - Producer 1, inference: a stream whose handler binds session-scoped
+    state is wrapper-tier by the design's own settled semantics ("reading
+    per-session state is very nearly the tier's definition"). Bound-state
+    schemas already carry the `scope` extension, so a handler context
+    containing session scope at any depth stamps the stream — zero
+    authoring; topics' five composer wrappers get marked without touching
+    topics. No explicit author override ships until a real pattern needs
+    one.
+  - Producer 2, `@deprecated` JSDoc lowers to `deprecated: true` (the
+    generator already reads JSDoc and today filters `@`-tags out of
+    descriptions). Catches `setMyName`-class legacy streams, which
+    inference cannot — deprecation is a different axis (user-scoped
+    bindings, still contract).
+  - Consumer: `cf piece verbs` — text and `--json` alike — omits both
+    classes by default and reports the omission ("N wrapper, M deprecated
+    hidden; --all lists them"), so nothing is silently invisible. `--all`
+    shows everything; listed rows always carry their marks; `cf piece
+    call` never consults them.
+  - **Step zero, measured 2026-08-03:** the compat checker refuses both
+    keys today — `unknownKeywordIssue`
+    (`packages/piece/src/schema-compatibility.ts`) equality-compares every
+    key outside its handled set, so adding OR later removing either mark
+    fails the gate: precisely the C3 append-only lesson. The unblock is
+    one principled change: classify both keys in `ANNOTATION_KEYS` — they
+    are validation-neutral by construction, the same class as
+    `description`/`title`/`tags`. Riding the existing `tags` hashtag
+    channel was weighed and rejected: it is a general JSDoc-mirror
+    surface, and a hashtag that hides a verb is load-bearing spooky
+    action.
+  - Order of work: (1) `ANNOTATION_KEYS` + a checker pin that the marks
+    add and remove freely; (2) generator emission — inference +
+    `@deprecated` — with mapping-spec entries and fixtures; (3) the CLI
+    default filter, hidden-count line, and `--all`; (4) fleet re-record
+    where schemas gain marks (annotation-class, so baselines move
+    freely).
 - Generic identity annotation for data reads and callable results
   (`--show-links` / `--include-ids`). Patterns return child references and
   never manufacture their own fid fields for this purpose. Two shapes were


### PR DESCRIPTION
## Why

The verb listing deliberately shipped unmarked (plan Non-goals: "the marker mechanism ships after the listing"), which leaves `cf piece verbs` handing agents trap verbs — session-UI wrappers that silently no-op headlessly, and deprecated compat streams. Mike asked for the mechanism to be specced for the queue; this records the spec plus the measured step-zero finding that shapes it: the compat checker equality-compares unknown schema keywords (`unknownKeywordIssue`, `packages/piece/src/schema-compatibility.ts`), so the marks would be refused on add and on removal — the C3 append-only lesson — unless first classified as annotation-class keys. Recording that before implementation is the difference between a one-line principled unblock and rediscovering C3.

## What Changed

One plan-doc edit: a new WS-F bullet with the full spec (marks: `tier: "wrapper"` + standard `deprecated: true`; producers: session-scope inference and `@deprecated` JSDoc; consumer: default-filtered listing with an explicit hidden-count and `--all`; everything stays callable), the step-zero verdict, the rejected `tags`-channel alternative, and the order of work. The Non-goals bullet now points at it.

## Test plan

`deno task check-docs` green (docs-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Specs the wrapper-tier and deprecation marks for verb listings and queues the work. Calls remain unaffected; this only changes how `cf piece verbs` lists by default.

- **New Features**
  - Add two annotation marks to generated stream schema: `tier: "wrapper"` and `deprecated: true`.
  - Produced by session-scope inference (wrapper-tier) and `@deprecated` JSDoc (`deprecated: true`).
  - Consumed by `cf piece verbs`: hide both by default, show hidden counts, `--all` lists everything; rows include marks; `cf piece call` ignores them.
  - Step-zero: update `packages/piece/src/schema-compatibility.ts` to classify both keys in `ANNOTATION_KEYS` so they can be added/removed without compat failures.
  - Order: (1) `ANNOTATION_KEYS` change, (2) generator emission, (3) CLI default filter + `--all`, (4) re-record schemas.

<sup>Written for commit 5a67d961eeec073813ec2a0ffc4687fb4d003230. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

