### PR TITLE
fix(runner): pull() awaits the first sync of a doc its replica never saw

### DIFF
--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -1129,7 +1129,21 @@ export class CellImpl<T extends FabricValue>
    *          dependencies have been computed.
    */
   pull(): Promise<Readonly<T>> {
-    if (!this.synced) this.sync(); // No await, just kicking this off
+    if (!this.synced) {
+      // Register the kicked first sync in the settled pool the convergence
+      // loop below drains. sync() resolves once the doc is confirmed —
+      // arrived or absent — and an UNREGISTERED kick is exactly the race
+      // sync()'s own doc comment warns about: over a low-latency link the
+      // doc lands before the scheduler goes idle, so the read sees it; over
+      // a real network it does not, and pull() resolved from held,
+      // not-yet-loaded state (measured: a same-id retry's receipt readback
+      // returned undefined against a remote host while identical calls
+      // passed against a local toolshed). Failures are swallowed like
+      // link-resolution's kicks: the read still resolves from the replica.
+      this.runtime.storageManager.trackUntilSettled(
+        this.sync().catch(() => {}),
+      );
+    }
 
     // Check if we need to traverse the result to register all dependencies.
     // This is needed when there's no schema or when the schema is TrueSchema ("any"),

--- a/packages/runner/test/compiled-module-verifier.test.ts
+++ b/packages/runner/test/compiled-module-verifier.test.ts
@@ -601,3 +601,24 @@ exports.default = (0, commonfabric_1.patternTool)(() => ({ ok: true }));
     );
   });
 });
+
+it("accepts multiUserTest's descriptor of trusted-builder results", () => {
+  // The one builder WITHOUT a callback: it tags a descriptor object whose
+  // leaves are other trusted-builder results, so each argument verifies as
+  // a trusted value expression rather than through the callback path. The
+  // real shape `cf test` compiles: patterns hoisted to module consts, then
+  // `multiUserTest({ setup, participants: { ... } })` as the default
+  // export. Pinned here deterministically — this branch was otherwise
+  // covered only when integration sharding happened to compile a
+  // multi-user fixture, which made the coverage gate's runner count
+  // flutter by scheduling rather than by anyone's diff.
+  const body = `
+${IMPORT}
+const __cfPattern_1 = (0, commonfabric_1.pattern)(() => ({}));
+const __cfPattern_2 = (0, commonfabric_1.pattern)(() => ({}));
+const __cfPattern_3 = (0, commonfabric_1.pattern)(() => ({}));
+exports.default = (0, commonfabric_1.multiUserTest)({ setup: __cfPattern_1, participants: { gideon: __cfPattern_2, fable: __cfPattern_3 } });
+`;
+
+  expect(() => verify(body)).not.toThrow();
+});

--- a/packages/runner/test/pull-first-sync-race.test.ts
+++ b/packages/runner/test/pull-first-sync-race.test.ts
@@ -139,6 +139,39 @@ describe("pull() and the first sync of an unseen doc", () => {
     }
   });
 
+  it("resolves from the replica when the first sync fails outright", async () => {
+    // The swallow arm: a failed first sync must degrade to what the replica
+    // holds (here: nothing), never reject or hang the pull. Same stance as
+    // link-resolution's kicks — the read still resolves.
+    const readerStorage = SharedServerStorageManager.connectTo(server, {
+      as: signer,
+    });
+    const readerRt = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: readerStorage,
+    });
+    try {
+      const link = writerRt
+        .getCell(space, RECEIPT_CAUSE, undefined)
+        .getAsNormalizedFullLink();
+
+      const originalSyncCell = readerStorage.syncCell.bind(readerStorage);
+      readerStorage.syncCell = (<T>(cell: Cell<T>): Promise<Cell<T>> => {
+        const target = cell.getAsNormalizedFullLink();
+        if (target.id === link.id) {
+          return Promise.reject(new Error("network unreachable"));
+        }
+        return originalSyncCell(cell);
+      }) as typeof readerStorage.syncCell;
+
+      const receipt = readerRt.getCellFromLink<typeof RECEIPT_VALUE>(link);
+      expect(await receipt.pull()).toBeUndefined();
+    } finally {
+      await readerRt.dispose();
+      await readerStorage.close();
+    }
+  });
+
   it("still resolves promptly when the doc is already in the replica (control)", async () => {
     // The writer's own replica: pull() must not begin waiting on network
     // confirmation it already has.

--- a/packages/runner/test/pull-first-sync-race.test.ts
+++ b/packages/runner/test/pull-first-sync-race.test.ts
@@ -1,0 +1,152 @@
+// pull() must await its own first sync — the root-doc half of the
+// fresh-replica story (fresh-replica-read-asymmetry.test.ts covers the
+// link-target half).
+//
+// pull() used to KICK the cell's first sync without registering it anywhere
+// ("No await, just kicking this off"), then wait only on scheduler idle plus
+// the cross-space load pool. The root doc's own round-trip was in neither, so
+// pull resolved whenever the scheduler quiesced — which over a low-latency
+// link is AFTER the doc arrives, and over a real network is BEFORE. Measured
+// in production shape: a same-id retry's receipt readback (`cf piece call
+// --invocation`, the WS-D collision path reading the winner's receipt via
+// getCellFromLink → pull) returned the original result against a local
+// toolshed and `undefined` against a remote host, every time. sync()'s own
+// doc comment names the trap: code gating on idle() alone can race the
+// deferred sync; register it with trackUntilSettled so pull() awaits it.
+//
+// The gate below makes the race deterministic instead of latency-shaped: the
+// reader's syncCell for the target doc is held until the test has SEEN the
+// reader's scheduler go idle — the exact moment the unregistered kick used to
+// lose — and only then lets the "network" answer.
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import type { Options } from "../src/storage/v2.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { Cell } from "../src/cell.ts";
+import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
+
+class SharedServerStorageManager extends EmulatedStorageManager {
+  static connectTo(
+    server: MemoryV2Server.Server,
+    options: Omit<Options, "memoryHost" | "spaceHostMap">,
+  ): SharedServerStorageManager {
+    const manager = new SharedServerStorageManager(
+      { ...options, memoryHost: new URL("memory://") },
+      () => server,
+    );
+    manager.sharedServer = server;
+    return manager;
+  }
+
+  private sharedServer!: MemoryV2Server.Server;
+
+  protected override server(): MemoryV2Server.Server {
+    return this.sharedServer;
+  }
+}
+
+const newSharedServer = () =>
+  new MemoryV2Server.Server({
+    authorizeSessionOpen(message) {
+      const principal = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof principal === "string" ? principal : undefined;
+    },
+    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
+  });
+
+const signer = await Identity.fromPassphrase("pull-first-sync-race");
+const space = signer.did();
+
+const RECEIPT_CAUSE = "receipt-race-doc";
+const RECEIPT_VALUE = { note: { title: "Original", revision: 1 } };
+
+describe("pull() and the first sync of an unseen doc", () => {
+  let server: MemoryV2Server.Server;
+  let writerStorage: SharedServerStorageManager;
+  let writerRt: Runtime;
+
+  beforeEach(async () => {
+    server = newSharedServer();
+    writerStorage = SharedServerStorageManager.connectTo(server, {
+      as: signer,
+    });
+    writerRt = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: writerStorage,
+    });
+
+    // The winner's receipt, as the collision path leaves it: a plain-JSON
+    // outcome in a doc this writer committed and a later reader never saw.
+    const tx = writerRt.edit();
+    const receipt = writerRt.getCell(space, RECEIPT_CAUSE, undefined, tx);
+    receipt.set(RECEIPT_VALUE);
+    const result = await tx.commit();
+    expect(result.error).toBeUndefined();
+    await writerStorage.synced();
+  });
+
+  afterEach(async () => {
+    await writerRt?.dispose();
+    await writerStorage?.close();
+    await server?.close();
+  });
+
+  it("resolves the doc's value even when the sync answer arrives after idle", async () => {
+    const readerStorage = SharedServerStorageManager.connectTo(server, {
+      as: signer,
+    });
+    const readerRt = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: readerStorage,
+    });
+    try {
+      const link = writerRt
+        .getCell(space, RECEIPT_CAUSE, undefined)
+        .getAsNormalizedFullLink();
+
+      // Hold the target doc's sync until the test releases it; everything
+      // else passes through. The gated promise is what pull() must await.
+      const gate = Promise.withResolvers<void>();
+      const originalSyncCell = readerStorage.syncCell.bind(readerStorage);
+      readerStorage.syncCell = (<T>(cell: Cell<T>): Promise<Cell<T>> => {
+        const target = cell.getAsNormalizedFullLink();
+        if (target.id === link.id) {
+          return gate.promise.then(() => originalSyncCell(cell));
+        }
+        return originalSyncCell(cell);
+      }) as typeof readerStorage.syncCell;
+
+      // The CLI readback shape exactly: getCellFromLink → pull, no schema.
+      const receipt = readerRt.getCellFromLink<typeof RECEIPT_VALUE>(link);
+      const pullPromise = receipt.pull();
+
+      // Let the reader's scheduler go fully idle. This is the moment the
+      // unregistered kick used to resolve at — with the doc still in flight.
+      await readerRt.scheduler.idle();
+
+      // Only now does the "network" answer.
+      gate.resolve();
+
+      expect(await pullPromise).toEqual(RECEIPT_VALUE);
+    } finally {
+      await readerRt.dispose();
+      await readerStorage.close();
+    }
+  });
+
+  it("still resolves promptly when the doc is already in the replica (control)", async () => {
+    // The writer's own replica: pull() must not begin waiting on network
+    // confirmation it already has.
+    const receipt = writerRt.getCell<typeof RECEIPT_VALUE>(
+      space,
+      RECEIPT_CAUSE,
+      undefined,
+    );
+    expect(await receipt.pull()).toEqual(RECEIPT_VALUE);
+  });
+});


### PR DESCRIPTION
## Why

Found rehearsing the verb walkthrough against **rapids** — the first remote host in the local → rapids → estuary sequence, and the reason that sequence exists. A same-id retry settled with `deduplicated: true` but **no result**:

```json
{ "invocation": "dd-2", "status": "settled", "deduplicated": true }
```

The collision path worked exactly as designed — `tx.handlingReceiptLink` correctly addressed the winner's original receipt — but reading that receipt returned `undefined`. The identical scenario passes against a local toolshed **every time**, which is why D3's retry scenarios, D4's three-topic fixture, and the walkthrough never caught it: all ran where the answer arrives before the scheduler goes idle. This is the one property `--invocation` exists to provide — an agent that loses a response retries and learns *what* happened — and against a remote host it degraded to learning only *that* it happened.

## The race

`pull()` kicked the cell's first sync without registering it anywhere (*"No await, just kicking this off"*), then waited on scheduler idle plus the cross-space load pool. The root doc's own round-trip was in **neither**, so pull resolved from held, not-yet-loaded state whenever the network was slower than the scheduler. Instrumented against rapids: `handlingReceiptLink` correct, `receipt.pull()` → `undefined`.

`sync()`'s own doc comment names this exact trap — *"code gating on `idle()` alone can still race the deferred sync"* — and names the registration to use: `trackUntilSettled`, which feeds the pool pull's convergence loop already drains. `link-resolution.ts` registers its kicked loads this way; `pull()` itself was the one caller ignoring its own file's advice.

## What Changed

One registration in `Cell.pull()`: the kicked first sync goes through `storageManager.trackUntilSettled`. `sync()` resolves once the doc is confirmed — arrived or absent — and the existing convergence loop (settle the pool, re-idle so the subscribed read re-runs, re-check) does the rest. Failures are swallowed like link-resolution's kicks: the read still resolves from the replica. No new mechanism.

## Test plan

- **`pull-first-sync-race.test.ts`** — two storage managers over one in-memory server (the `fresh-replica-read-asymmetry` harness, which covers the *link-target* half of this story; this is the *root-doc* half). The reader's `syncCell` for the target doc is **held until the test has seen the reader's scheduler go idle** — the exact moment the unregistered kick used to lose — then released. **Red on main, green with the fix**; the already-in-replica control passes in both states. Mirrors the CLI readback shape exactly: `getCellFromLink` → `pull`, no schema.
- **Against rapids:** the replay returns the original result (`{deduplicated: true, title: "Original"}`) and the verb walkthrough goes **22/1 → 23/23**. `pull()` runs client-side, so this verifies end to end without a server deploy.
- `packages/runner`: **1128 passed (5950 steps), 0 failed**, normal duration — awaiting the first sync stalls nothing.
- `deno fmt --check`, `deno lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race where `pull()` could resolve before the first sync of an unseen doc, causing undefined reads on remote hosts. `pull()` now waits for that initial sync via the settled pool, restoring correct receipt readbacks without slowing normal flows.

- **Bug Fixes**
  - In `packages/runner`, `CellImpl.pull()` registers its first sync with `storageManager.trackUntilSettled(this.sync().catch(() => {}))` so it waits for doc confirmation (arrived or absent).
  - Prevents undefined reads when using `getCellFromLink` → `pull()` over real networks; no change when the doc is already in the replica.
  - Adds `pull-first-sync-race.test.ts` to deterministically reproduce the race and verify the fix (including the failure arm where the first sync rejects), and pins the `multiUserTest` verifier branch in `compiled-module-verifier.test.ts` to stop flakey coverage unrelated to this change.

<sup>Written for commit 9a4ebece65490b031432b814741232f6fa69f068. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



## Coverage-debt acceptance (+1, root-caused as unrelated)

The Coverage Check failed three times at +1 for `packages/runner`, with its own report unable to tie the regression to the diff. An lcov diff of the runs' uploaded profiles (twice) showed why: this PR's `cell.ts` region is exactly net-zero — the diff's comment block shifts every uncovered line number below it — and the flipped lines were in files this PR never touches. The first culprit, `compiled-bundle-verifier.ts`'s multiUserTest branch, is now **pinned deterministically in this PR** (a real coverage improvement); the remainder is one scheduler-timing-dependent line, `scheduler/facade.ts:239` (`crossesSpace && rank === 0`), reachable only through a live cross-space observation — a scheduler-harness build that does not belong to this PR.

Accepting the one line, visibly:

ACCEPT_COVERAGE_DEBT: coverage-debt: packages/runner uncovered lines = 5513 lines
