### PR TITLE
feat(piece): verb-event-role compat rule for closed-world event schemas

### DIFF
--- a/docs/plans/pattern-verb-contract-implementation.md
+++ b/docs/plans/pattern-verb-contract-implementation.md
@@ -1097,21 +1097,44 @@ change that alters them.
   review: the closed shapes already in argument-side baselines likely
   derive from `never`-typed events that were never meant to assert "only
   empty events are valid" — clean that up in the generator eventually;
-  until then the exemptions carry the cost. The chosen rule must still
-  weigh the
-  FORWARD skew case the stripped-was-never-contract argument does not cover:
-  adding an optional event field is legal argument widening, but during any
-  deploy window a newer client sends that field to a still-running older
-  piece whose closed schema does not declare it — today stripped and
-  harmless, under closed-world a hard reject at dispatch. Mixed-version
-  callers are exactly the live board's incident history (the cross-version
-  write storms, the legacy-field mirroring `topics` still carries), so the
-  decision needs a story for widened payloads against not-yet-updated
-  pieces — deploy ordering, a skew-tolerant reject-only-on-collision rule,
-  or an explicit versioning step — before emission lands. Until the rule
-  and its skew story land, generated event schemas stay open and
-  closed-world enforcement is per-schema opt-in at dispatch (C5's runner
-  gate).
+  until then the exemptions carry the cost. **The rule is built**: a
+  `verbEvent` compatibility context in
+  `packages/piece/src/schema-compatibility.ts`, entered where BOTH
+  contracts mark a node `asCell: ["stream"]` (the exemption never applies
+  across a one-sided marker — that stays an `asCell changed` refusal) and
+  carried through the event subtree. Below it, boolean↔boolean
+  `additionalProperties` transitions are free in both directions — closed
+  events also remain evolvable by optional fields under the existing
+  evolution policy, and closed→open stays free so the `never`-derived
+  closure cleanup never reads as a break — while schema-valued
+  `additionalProperties` still compares on either side: a constraint on
+  the extras' SHAPE is a data contract even on an event. Each of those
+  properties is pinned in `schema-compatibility.test.ts` ("verb event
+  closed-world transitions").
+
+  The FORWARD skew case is resolved by RECORDED POLICY rather than new
+  machinery — **reject-on-collision, loud, local-first, id-preserving**:
+  adding an optional event field is legal widening, and during a deploy
+  window a newer client's widened payload against a not-yet-updated closed
+  piece is REJECTED, deliberately. Three grounds. (1) The pre-closed
+  alternative was never harmless: the stale piece stripped the field and
+  ran anyway, so the caller believed semantics it did not get — the same
+  silent-loss defect class rule 1 exists to kill, now merely bounded to
+  deploy windows. (2) The common path never reaches dispatch: the CLI
+  validates against the DEPLOYED schema before sending (rule 1's own
+  design: "fails loudly instead of silently losing data") and the verbs
+  listing carries the deployed source identity for skew detection, so a
+  well-behaved client discovers the skew locally with the invocation id
+  unspent. (3) A payload that does reach dispatch is refused through C5's
+  thrown-handler path — no receipt, id preserved — so the recovery is a
+  same-id re-invoke once the piece updates, which completes exactly once.
+  No deploy ordering and no versioning step; the mixed-version incident
+  history (write storms, legacy-field mirroring) was silent-corruption
+  class, which loud rejection shrinks rather than grows. Until emission
+  lands (generator change + mapping-spec entry + `stream-result.test.ts`
+  flip + fixture/baseline re-records), generated event schemas stay open
+  and closed-world enforcement is per-schema opt-in at dispatch (C5's
+  runner gate).
 - **WS-E's gates may stall it** (OQ1, CFC review, collection unknown, trusted
   ingress mint and propagation): it is last and severable; everything through
   Phase 4 delivers without it, and `topics.agentName` remains the safe interim.

--- a/packages/piece/src/schema-compatibility.ts
+++ b/packages/piece/src/schema-compatibility.ts
@@ -39,6 +39,20 @@ interface CompatibilityContext {
   allowTargetDefaults: boolean;
   /** Whether defaults describe a pattern migration or link materialization. */
   defaultComparison: "evolution" | "target";
+  /**
+   * True below a node both contracts mark `asCell: ["stream"]` — a verb, so
+   * everything beneath is the verb's EVENT schema. There, a boolean
+   * `additionalProperties` is an enforcement dial rather than a data
+   * contract: the runtime schema-strips undeclared event fields before any
+   * handler runs, so an open event's "acceptance" of extras was never
+   * observable behavior (accepted-and-STRIPPED was never contract — verb
+   * contract WS-C, decided 2026-08-03), and closing one surfaces the silent
+   * loss as the typed rejection rule 1 requires. The reverse transition is
+   * equally free: rejection of undeclared fields is not a capability a
+   * caller can depend on, and generator cleanup of `never`-derived closures
+   * must not read as a contract break.
+   */
+  verbEvent?: boolean;
 }
 
 export interface SchemaSubsetOptions {
@@ -276,10 +290,18 @@ function schemaSubsetIssue(
   }
   const source = sourceResolution.schema;
   const target = targetResolution.schema;
+  // The stream marker rides the REFERENCING node (`{$ref, asCell:["stream"]}`),
+  // so test the pre-resolution inputs as well as the resolved schemas. Both
+  // contracts must agree the node is a verb: a one-sided marker is a shape
+  // change the ordinary rules judge, not an exemption.
+  const entersVerbEvent = !context.verbEvent &&
+    (declaresVerbStream(sourceInput) || declaresVerbStream(source)) &&
+    (declaresVerbStream(targetInput) || declaresVerbStream(target));
   context = {
     ...context,
     sourceRoot: sourceResolution.root,
     targetRoot: targetResolution.root,
+    ...(entersVerbEvent ? { verbEvent: true } : {}),
   };
   if (
     context.defaultComparison === "target" &&
@@ -670,6 +692,12 @@ function matchingPatternPropertySchemas(
   return matches;
 }
 
+function declaresVerbStream(schema: JSONSchema): boolean {
+  if (typeof schema !== "object" || schema === null) return false;
+  const asCell = (schema as SchemaObject).asCell;
+  return Array.isArray(asCell) && asCell.includes("stream");
+}
+
 function additionalPropertiesSubsetIssue(
   source: SchemaObject,
   target: SchemaObject,
@@ -678,6 +706,17 @@ function additionalPropertiesSubsetIssue(
 ): string | undefined {
   const sourceAdditional = source.additionalProperties ?? true;
   const targetAdditional = target.additionalProperties ?? true;
+  // Verb events: a boolean↔boolean additionalProperties transition is free
+  // in both directions (see CompatibilityContext.verbEvent). Schema-valued
+  // additionalProperties on either side still compares — a constraint on the
+  // extras' SHAPE is a data contract even on an event.
+  if (
+    context.verbEvent &&
+    typeof sourceAdditional === "boolean" &&
+    typeof targetAdditional === "boolean"
+  ) {
+    return undefined;
+  }
   if (sourceAdditional === false || targetAdditional === true) return undefined;
   if (sourceAdditional === true && targetAdditional === false) {
     return `${path}: additional properties accepted previously would now be rejected`;

--- a/packages/piece/test/schema-compatibility.test.ts
+++ b/packages/piece/test/schema-compatibility.test.ts
@@ -1858,3 +1858,152 @@ describe("piece schema compatibility", () => {
     }
   });
 });
+
+describe("verb event closed-world transitions", () => {
+  // A verb node is `{$ref → event, asCell: ["stream"]}` in recorded
+  // contracts (or the event inline beside the marker). Below one, a boolean
+  // additionalProperties is an enforcement dial, not a data contract: the
+  // runtime schema-strips undeclared event fields before any handler runs,
+  // so open→closed surfaces silent loss as rule 1's typed rejection
+  // (accepted-and-STRIPPED was never contract, decided 2026-08-03), and
+  // closed→open must stay free for `never`-derived closure cleanup.
+  const verbPattern = (event: JSONSchema, viaRef = true): Pattern => {
+    const argument: JSONSchema = viaRef
+      ? {
+        type: "object",
+        properties: {
+          addComment: { $ref: "#/$defs/Ev", asCell: ["stream"] },
+        },
+        $defs: { Ev: event },
+      }
+      : {
+        type: "object",
+        properties: {
+          addComment: { ...(event as object), asCell: ["stream"] },
+        },
+      };
+    return pattern(argument, { type: "object", properties: {} });
+  };
+
+  const openEvent: JSONSchema = {
+    type: "object",
+    properties: { body: { type: "string" } },
+  };
+  const closedEvent: JSONSchema = {
+    ...openEvent,
+    additionalProperties: false,
+  };
+
+  it("lets a verb event close (ref-marked stream)", () => {
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        verbPattern(openEvent),
+        verbPattern(closedEvent),
+      )
+    ).not.toThrow();
+  });
+
+  it("lets a verb event close (inline-marked stream)", () => {
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        verbPattern(openEvent, false),
+        verbPattern(closedEvent, false),
+      )
+    ).not.toThrow();
+  });
+
+  it("lets a verb event reopen (never-derived closure cleanup)", () => {
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        verbPattern(closedEvent),
+        verbPattern(openEvent),
+      )
+    ).not.toThrow();
+  });
+
+  it("carries the exemption through the event's nested objects", () => {
+    const nested = (extra: Record<string, unknown>): JSONSchema => ({
+      type: "object",
+      properties: {
+        payload: {
+          type: "object",
+          properties: { note: { type: "string" } },
+          ...extra,
+        },
+      },
+    });
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        verbPattern(nested({})),
+        verbPattern(nested({ additionalProperties: false })),
+      )
+    ).not.toThrow();
+  });
+
+  it("still refuses closing a plain argument object", () => {
+    const settings = (extra: Record<string, unknown>): Pattern =>
+      pattern({
+        type: "object",
+        properties: {
+          settings: {
+            type: "object",
+            properties: { theme: { type: "string" } },
+            ...extra,
+          },
+        },
+      }, { type: "object", properties: {} });
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        settings({}),
+        settings({ additionalProperties: false }),
+      )
+    ).toThrow(
+      /additional properties accepted previously would now be rejected/,
+    );
+  });
+
+  it("does not exempt a node only one contract marks as a stream", () => {
+    const demoted = pattern({
+      type: "object",
+      properties: { addComment: { ...(closedEvent as object) } },
+    }, { type: "object", properties: {} });
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(verbPattern(openEvent), demoted)
+    ).toThrow(/asCell changed/);
+  });
+
+  it("still compares schema-valued additionalProperties on a verb event", () => {
+    const shaped: JSONSchema = {
+      ...openEvent,
+      additionalProperties: { type: "string" },
+    };
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        verbPattern(shaped),
+        verbPattern(closedEvent),
+      )
+    ).toThrow(
+      /additional properties accepted previously would now be rejected/,
+    );
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        verbPattern(openEvent),
+        verbPattern(shaped),
+      )
+    ).toThrow(/additional properties are now constrained/);
+  });
+
+  it("closed verb events still gain optional fields (evolution policy)", () => {
+    const widened: JSONSchema = {
+      type: "object",
+      properties: { body: { type: "string" }, tag: { type: "string" } },
+      additionalProperties: false,
+    };
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        verbPattern(closedEvent),
+        verbPattern(widened),
+      )
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Why

C5 (#5246) shipped dispatch-side closed-world enforcement, but the schema-generator half — emitting `additionalProperties: false` on event schemas — was backed out because the update gate refused it for all 28 baseline groups with argument-side verbs. Berni decided the fork on #5246: a verb-event-role rule taking the position that accepted-and-STRIPPED was never contract (the runtime never delivered an undeclared event field to any handler). This PR is that rule, plus the plan-recorded forward-skew policy the emission will land under. The rule is inert until emission (follow-up PR): no schema changes here, and the fleet gate still records 336 patterns updatable from every contract.

## What Changed

- `packages/piece/src/schema-compatibility.ts`: a `verbEvent` compatibility context, entered where **both** contracts mark a node `asCell: ["stream"]` and carried through the event subtree. Below it, boolean↔boolean `additionalProperties` transitions are free in both directions — open→closed is the migration; closed→open keeps the `never`-derived closure cleanup (Berni's note) from reading as a break. Deliberate boundaries: schema-valued `additionalProperties` still compares on either side (the extras' shape is a data contract even on an event); a one-sided marker is never exempt (stays an `asCell changed` refusal); closed events remain evolvable by optional fields under the existing evolution policy.
- `packages/piece/test/schema-compatibility.test.ts`: eight pins covering every boundary above, both marker forms (`$ref`-marked and inline), and the nested-subtree propagation.
- Plan doc: the Risks entry's open skew question is replaced by recorded policy — **reject-on-collision, loud, local-first, id-preserving**: the CLI already validates against the deployed schema so the common path fails locally with the id unspent; a payload reaching dispatch is refused through the thrown-handler path with the id preserved, so recovery is a same-id re-invoke after the piece updates. No deploy ordering, no versioning machinery. Rationale recorded: skew-window stripping was the same silent-loss defect class rule 1 exists to kill.

## Test plan

- `deno task test` in `packages/piece` — 32 passed (378 steps), including the new "verb event closed-world transitions" block
- `deno task pattern-compat` — 336 patterns updatable (rule inert on current schemas)
- `deno task check-docs`, `deno fmt --check`, `deno lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce a verb-event compatibility rule that allows boolean `additionalProperties` to move open↔closed under stream-marked verb events, unblocking closed-world event schemas without breaking contracts. Docs record a reject-on-collision skew policy; behavior is unchanged until generator emission.

- **New Features**
  - Added `verbEvent` context in `packages/piece/src/schema-compatibility.ts`, entered only when both contracts mark a node `asCell: ["stream"]`.
  - Within the event subtree, boolean `additionalProperties` transitions are free in both directions; schema-valued `additionalProperties` still compares.
  - No exemption on one-sided stream markers; propagation covers nested event objects. Closed events can still add optional fields.
  - Tests in `packages/piece/test/schema-compatibility.test.ts` pin all boundaries and marker forms. Plan doc updated with the recorded policy.

- **Migration**
  - No action now; schemas are unchanged. Rule activates when the generator emits `additionalProperties: false`.
  - Forward-skew policy: reject-on-collision, loud, local-first, id-preserving (CLI validates against deployed schema; dispatch rejects with the same id).

<sup>Written for commit 35e8e47d23ddb2b7e292368a77bf7d9383978df6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

