### PR TITLE
runner: classify `data:` links by media type where the payload gets d…

### DIFF
--- a/docs/development/data-uri-identifiers.md
+++ b/docs/development/data-uri-identifiers.md
@@ -108,9 +108,12 @@ are deep-frozen.
 
 `findAndInlineDataUriLinks(value)` in `packages/runner/src/data-uri.ts` works
 the other direction from minting: it walks a value looking for links whose
-identifier is a `data:` URI and replaces each with the value that identifier
-carries. If the decoded payload has another link on the way to the link's path,
-that link is followed instead, with the remaining path segments appended to it.
+identifier is a `data:` URI of this codebase's media type, and replaces each
+with the value that identifier carries. If the decoded payload has another link
+on the way to the link's path, that link is followed instead, with the
+remaining path segments appended to it. A link carrying any other media type is
+returned as it came in, on the same footing as a link naming a document in a
+space.
 
 ### The payload is the value, not the document
 
@@ -159,6 +162,19 @@ The confidentiality contract code makes the same split. `eventEnvelopePayloads`
 in `packages/runner/src/cfc/ui-contract.ts` screens an event link with the
 narrow test before calling `valueFromDataUri` on it, so a `data:` link of some
 other media type simply contributes no authoring context.
+
+The inlining path uses the narrow test at two points that have to agree.
+`findAndInlineDataUriLinks` screens with it before decoding.
+`normalizeAndDiff` in `packages/runner/src/data-updating.ts` screens with it
+before re-entering itself on that call's result, which is progress only when
+the call replaced the link with the content behind it. Using the broad test at
+either point breaks the agreement. At the first, the decode throws on a media
+type it does not speak, and the throw escapes the whole walk rather than
+leaving one link alone. At the second, the re-entry repeats on a link the
+inlining call handed back unchanged, until the stack runs out. Both screening
+narrowly, a foreign media type is simply an ordinary link: a write stores it
+as one, and a read through it reports the media type as the loader's
+`UnsupportedMediaTypeError`.
 
 `Address.isInline(address)` in
 `packages/runner/src/storage/transaction/address.ts` is the broad test applied

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -51,7 +51,7 @@ import type {
   IReadOptions,
 } from "./storage/interface.ts";
 import { type Runtime } from "./runtime.ts";
-import { hasDataUriScheme } from "@commonfabric/data-model/data-uri-codec";
+import { isFabricDataUri } from "@commonfabric/data-model/data-uri-codec";
 import { toURI } from "./uri-utils.ts";
 import {
   allowMutableTransactionRead,
@@ -842,10 +842,14 @@ export function normalizeAndDiff(
   // deliberately does not carry over: inlined content in an array slot stores
   // inline, exactly as the annotation scheme (which never looked behind
   // links) stored it.
+  //
+  // The re-entry hands on what `findAndInlineDataUriLinks` produced, so the
+  // check accepts exactly the media type that call inlines: this codec's
+  // own. A `data:` URI of any other media type stores as an ordinary link.
   const newValueLinkId = isCellLink(newValue)
     ? parseLink(newValue, link).id
     : undefined;
-  if (newValueLinkId !== undefined && hasDataUriScheme(newValueLinkId)) {
+  if (newValueLinkId !== undefined && isFabricDataUri(newValueLinkId)) {
     return normalizeAndDiff(
       runtime,
       tx,

--- a/packages/runner/src/data-uri.ts
+++ b/packages/runner/src/data-uri.ts
@@ -37,11 +37,11 @@ import {
   KeepAsCell,
   parseLink,
 } from "./link-utils.ts";
-import { hasDataUriScheme } from "@commonfabric/data-model/data-uri-codec";
 import { ContextualFlowControl } from "./cfc.ts";
 import type { URI } from "./sigil-types.ts";
 import {
   dataUriFromValue,
+  isFabricDataUri,
   valueFromDataUri,
 } from "@commonfabric/data-model/data-uri-codec";
 
@@ -135,6 +135,11 @@ export function dataUriFromValueWithResolvedLinks(
 /**
  * Find any data: URI links and inline them.
  *
+ * Only this codec's media type is inlined, the one
+ * {@link dataUriFromValue} mints. A link naming a `data:` URI of any other
+ * media type is returned as it came in, on the same footing as a link
+ * naming a document in a space.
+ *
  * TODO(danfuzz): This `isRecord`-gated walk has no `FabricSpecialObject`
  * guard: after the link check, a non-link `FabricPrimitive`/`FabricInstance`
  * falls into the `Object.entries` descent, which walks it by enumerable own
@@ -152,7 +157,7 @@ export function findAndInlineDataUriLinks(value: any): any {
   if (isCellLink(value)) {
     const dataLink = parseLink(value)!;
 
-    if (dataLink.id !== undefined && hasDataUriScheme(dataLink.id)) {
+    if (dataLink.id !== undefined && isFabricDataUri(dataLink.id)) {
       let dataValue: any = valueFromDataUri(dataLink.id);
       const path = [...dataLink.path];
 

--- a/packages/runner/test/data-uri-inlining.test.ts
+++ b/packages/runner/test/data-uri-inlining.test.ts
@@ -197,6 +197,30 @@ describe("data URI inlining", () => {
       expect(result).toBe(link);
     });
 
+    it("should preserve links whose data: URI carries a foreign media type", () => {
+      // Only this codec's media type names content that can be inlined. A
+      // `data:` URI of any other media type is left alone, exactly as a link
+      // naming a document in a space is.
+      for (
+        const id of [
+          "data:image/png;base64,iVBORw0KGgo",
+          "data:text/plain,hello",
+          "data:,",
+        ]
+      ) {
+        const link = {
+          "/": {
+            [LINK_V1_TAG]: {
+              id,
+              path: [],
+            },
+          },
+        };
+
+        expect(findAndInlineDataUriLinks(link)).toBe(link);
+      }
+    });
+
     it("should preserve object identity when no data URI links are present", () => {
       const value = {
         name: "Ada",
@@ -444,6 +468,32 @@ describe("data URI inlining", () => {
 
       // The raw value should be the inlined value, not the data URI link
       expect(rawValue).toBe("test");
+    });
+
+    it("should surface the storage error for a foreign-media-type data URI", () => {
+      // Such a link is not inlined, so the write treats it as an ordinary
+      // link and reads through it to diff against what it names. That read
+      // reports the media type, as the storage layer's typed error. Landing
+      // on that error is also what pins the inlining re-entry as unreached;
+      // the re-entry recurs on a value the inlining call leaves alone.
+      const targetCell = runtime.getCell(space, "target", undefined, tx);
+
+      const link = {
+        "/": {
+          [LINK_V1_TAG]: {
+            id: "data:image/png;base64,iVBORw0KGgo",
+            path: [],
+          },
+        },
+      };
+
+      let error: { name?: string } | undefined;
+      try {
+        targetCell.set(link);
+      } catch (caught) {
+        error = caught as { name?: string };
+      }
+      expect(error?.name).toBe("UnsupportedMediaTypeError");
     });
   });
 


### PR DESCRIPTION
…ecoded

There are two tests for a `data:` URI, and they mean different things. The broad one, `hasDataUriScheme()`, asks only whether an identifier carries its own value rather than naming a document in a space; every media type counts. The narrow one, `isFabricDataUri()`, asks whether the payload is in the one encoding this runtime mints and reads, `application/vnd.common-fabric.data`. Storage-layer code is right to use the broad test: whatever the media type, there is no document to fetch, sync, or write. Code that goes on to decode the payload needs the narrow one.

`findAndInlineDataUriLinks()` used the broad test and then decoded with `valueFromDataUri()`, which accepts only the narrow media type and throws `Invalid URI: ...` for anything else. A link naming, say, a `data:image/png` URI therefore entered the inlining branch and threw out of the whole walk, taking every unrelated part of the value with it, rather than falling through to the branch that returns such a link untouched. Nothing mints a foreign media type today -- the only minter is `dataUriFromValue()` -- so this was latent, but it is a seam that opens the moment anything does.

Narrowing that one test alone turns the throw into an unbounded recursion at the caller. `normalizeAndDiff()` in `data-updating.ts` also classified broadly, and re-enters itself with `findAndInlineDataUriLinks()` applied to the value. That re-entry is productive only because the call replaces the link with the content behind it; hand it a link the call leaves alone and it repeats the same step on the same value until the stack runs out. So both sites move to the narrow test together: the classify has to accept exactly what the inlining call inlines.

With both narrowed, a foreign-media-type link is simply an ordinary link. A write stores it as one, and a read through it reports the media type as the storage layer's typed `UnsupportedMediaTypeError` from `loadInline()`, which is where that judgement belongs.

Two tests cover this. One pins that `findAndInlineDataUriLinks()` returns a foreign-media-type link by identity, across a payload that is valid base64url under a foreign type, one that is not base64url at all, and the empty `data:,`. The other pins the write path, where landing on the typed storage error is what shows the inlining re-entry was never reached.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classify `data:` links by media type during inlining using `isFabricDataUri`, so only `application/vnd.common-fabric.data` is decoded. This avoids decode throws and recursion; other media types stay as links and surface `UnsupportedMediaTypeError` from storage.

- **Bug Fixes**
  - Switched `hasDataUriScheme` to `isFabricDataUri` in `findAndInlineDataUriLinks()` and `normalizeAndDiff()` to inline only our minted media type (`@commonfabric/data-model/data-uri-codec`).
  - Added tests that preserve foreign-media-type links by identity and confirm writes report `UnsupportedMediaTypeError` (covers base64, text, and empty `data:,`).

- **Documentation**
  - Updated `docs/development/data-uri-identifiers.md` to document the narrow test at both inlining and re-entry points and how foreign media types are handled.

<sup>Written for commit 3003d625a741a25a66e9b366f1c6f4202bb0883a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

