### PR TITLE
docs(runner): write down what a `data:` cell identifier is

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,6 +169,12 @@ If you are developing runtime code, read the following documentation:
   layers. Its neighbour `mergeable-collection-writes.md` covers why the
   mergeable ops exist and what they do to conflict detection; read it before
   changing how a handler writes to a list
+- `docs/development/data-uri-identifiers.md` - `data:` cell identifiers, which
+  carry their own frozen value instead of naming a document in a space: how one
+  is minted and read, why there are two tests for them (a broad one asking
+  whether a document exists at all, and a narrow one asking whether a payload is
+  this codebase's to decode), and why such an address is read-only. Read it
+  before touching a branch that tests for a `data:` identifier
 - `docs/development/UI_TESTING.md` - How to work with shadow dom in our
   integration tests
 - `docs/development/EXPERIMENTAL_OPTIONS.md` - The central registry of every

--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -18,6 +18,10 @@ covered in [Dependencies](DEPENDENCIES.md).
 - [Committed-write backpressure](committed-write-backpressure.md) explains how
   the scheduler surfaces or retries a committed write that the server rejects
   under contention.
+- [`data:` cell identifiers](data-uri-identifiers.md) explains the identifiers
+  that carry their own frozen value, why the runtime has both a broad and a
+  narrow test for them, and what follows from there being no document behind
+  one.
 - [Code coverage in CI](COVERAGE.md) explains the runtime and authored-pattern
   coverage mechanisms. Its
   [one-line guard note](deno-coverage-guard-line-artifact.md) explains a V8

--- a/docs/development/data-uri-identifiers.md
+++ b/docs/development/data-uri-identifiers.md
@@ -1,0 +1,215 @@
+# `data:` cell identifiers
+
+A `data:` identifier is a cell identifier that carries a frozen value inside
+the identifier string itself. A cell identified this way is read by decoding
+its own identifier. There is no document stored in a space behind it, so there
+is nothing to fetch, nothing to sync, nothing to write, and no commit
+precondition to state about it.
+
+Code in `packages/runner` branches on this distinction in many places — in the
+storage transaction, in the sync layer, in link resolution, in query traversal,
+and in the confidentiality-contract checks. This document explains what the
+distinction means, so that meeting one of those branches does not require
+reconstructing the concept from the branch itself.
+
+## How it differs from an entity identifier
+
+An ordinary cell is named by an entity identifier: a content-derived hash
+carried under an entity URI scheme. `packages/runner/src/entity-kind.ts`
+defines the set of those schemes in `ENTITY_URI_SCHEMES` — `of:` for the
+unkinded default, and `computed:` for entities whose contents the runtime that
+minted them can re-derive. Both name a document that lives in a space, is
+fetched from a replica, participates in conflict validation, and can be written
+to.
+
+A `data:` identifier is not an entity identifier and carries no entity kind.
+`hasEntityUriScheme` returns false for it, and `entityKindOfIdString` returns
+`undefined`. Two helpers in `packages/runner/src/uri-utils.ts` treat it
+specially rather than by scheme-stripping: `toURI` accepts an already-schemed
+`data:` string as a valid URI, and `fromURI` returns the hash of the whole URI
+string rather than trying to strip a scheme off it.
+
+The practical difference is that everything a document identifier implies —
+a replica to pull from, a sequence number, a conflict domain, a write target —
+is absent. The identifier is the content.
+
+## The shape of the identifier
+
+The single media type this codebase mints is
+`application/vnd.common-fabric.data`, exported as `DATA_URI_MEDIA_TYPE` from
+`packages/data-model/src/data-uri-codec.ts`. A minted identifier looks like
+this:
+
+```text
+data:application/vnd.common-fabric.data,<payload>
+```
+
+The payload is base64url of UTF-8 text, and that text is the standard
+`data-model` JSON-embedded encoding of a `FabricValue`, which carries the
+`fvj1:` prefix tag. There are no media-type parameters: no `;charset=` and no
+`;base64`, because the payload encoding is fixed. `extractDataUriPayloadText`
+takes the surface syntax apart, returning everything between `data:` and the
+first comma verbatim as the media type. Per the URL grammar, a raw `?` or `#`
+after the comma starts a query or fragment; everything from that delimiter
+onward is ignored.
+
+## Minting one
+
+There are two mint functions, and they differ in whether they prepare the value
+first.
+
+`dataUriFromValue(value)` in `packages/data-model/src/data-uri-codec.ts` is the
+single place the identifier's shape is assembled: scheme, media type, and
+base64url payload. It does no preparation of the value at all; callers hand it
+a ready `FabricValue`.
+
+`dataUriFromValueWithResolvedLinks(data, base?)` in
+`packages/runner/src/data-uri.ts` prepares the value first, then calls
+`dataUriFromValue`. Its preparation is a walk that rewrites each primitive cell
+link within `data` into a full sigil link, resolving relative links against
+`base`. That rewriting is what makes the resulting identifier self-contained:
+the identifiers it embeds no longer depend on where the value was minted, so
+the identifier denotes the same value wherever it is later read. The walk
+throws if `data` contains a reference cycle. It lives in the runner rather than
+in the codec because it needs the cell and link machinery, which `data-model`
+does not have.
+
+Because the standard encoding canonicalizes plain-object key order, two
+runtimes holding the same value mint the same identifier regardless of the
+order in which the keys were inserted. That is the property that makes this
+content addressing rather than merely content embedding.
+
+Representative places that mint one:
+
+- `Runtime.getImmutableCell()` in `packages/runner/src/runtime.ts` boxes a
+  caller-supplied value into a cell. It calls `dataUriFromValue` directly on
+  the result of `fabricFromNativeValue(data)`, deliberately skipping the
+  link-rewriting walk, because the data is immutable as given.
+- `undefinedDataLink()` in `packages/runner/src/link-resolution.ts` produces
+  the link that a blocked or dead-ended link chain resolves to: an identifier
+  encoding `undefined`, so the chain ends in undefined data in place.
+- `resolveAsCell()` in `packages/runner/src/cell.ts` re-roots a link whose path
+  passes through an array element. Its helper
+  `maybeConvertArrayPathToDataURILink` encodes that element's value into a
+  `data:` identifier and keeps the rest of the path.
+- Query traversal in `packages/runner/src/traverse.ts` substitutes a `data:`
+  document for an array element it needs to read recursively.
+
+## Reading one
+
+`valueFromDataUri(uri)` in `packages/data-model/src/data-uri-codec.ts` extracts
+and decodes the payload. It accepts exactly the shape `dataUriFromValue`
+writes, and throws for anything else — a different media type, a payload that
+is not base64url, an empty payload, or bare JSON where the `fvj1:`-tagged
+encoding is required. The two halves are also exported separately:
+`extractDataUriPayloadText` splits the identifier and base64url-decodes it, and
+`valueFromDataUriPayloadText` decodes that text into a value. Decoded results
+are deep-frozen.
+
+`findAndInlineDataUriLinks(value)` in `packages/runner/src/data-uri.ts` works
+the other direction from minting: it walks a value looking for links whose
+identifier is a `data:` URI and replaces each with the value that identifier
+carries. If the decoded payload has another link on the way to the link's path,
+that link is followed instead, with the remaining path segments appended to it.
+
+### The payload is the value, not the document
+
+The payload encodes the cell's **value**. The document view that the address
+grammar requires — paths rooted at `["value", …]`, plus the document's facet
+paths — is not in the payload. It is synthesized on read, by `load()` in
+`packages/runner/src/storage/transaction/attestation.ts`, which is the one
+reader that thinks in documents. `load()` decodes the payload and wraps it as
+`{ value: <decoded> }`, frozen. Because the wrapper is built here rather than
+taken from the payload, payload content can never alias a document facet such
+as `cfc` or `source`. Results are cached by identifier, so decoding the same
+identifier repeatedly costs one parse.
+
+## The two tests, and why both exist
+
+Two predicates in `packages/data-model/src/data-uri-codec.ts` answer different
+questions, and they are used at different points of the same path. Swapping one
+for the other changes behavior.
+
+`hasDataUriScheme(id)` is the **broad** test. It examines only the scheme, so
+every media type counts and the payload is neither decoded nor validated. It
+answers the storage layer's question: is there a document to fetch at all? Any
+`data:` identifier means no, whatever the media type says.
+
+`isFabricDataUri(id)` is the **narrow** test. It accepts only
+`data:application/vnd.common-fabric.data`, the one media type this codebase
+mints. It answers a reader's question, asked immediately before decoding: is
+this mine to decode? A reader that decodes without screening does not get a
+wrong value, because `valueFromDataUri` checks the media type itself and
+throws. Screening first is what lets a reader tell "not mine" apart from
+"mine but malformed", and report each differently.
+
+The load path shows both in sequence. `loadRoot` in
+`packages/runner/src/storage/v2-transaction.ts` uses the broad test: any
+`data:` identifier is routed to the attestation loader (imported there as
+`loadInline`) instead of to `branch.replica.getDocument()`. The loader then
+applies the narrow test, and turns anything that is not this codebase's media
+type into an `UnsupportedMediaTypeError`; a payload that fails to decode
+becomes an `InvalidDataURIError`. Using the narrow test at the routing step
+instead would send, say, a `data:text/plain,…` identifier to the replica to be
+fetched as though a document existed for it, rather than reporting an
+unsupported media type. Using the broad test inside the loader instead would
+have it try to decode payloads in encodings it does not speak.
+
+The confidentiality contract code makes the same split. `eventEnvelopePayloads`
+in `packages/runner/src/cfc/ui-contract.ts` screens an event link with the
+narrow test before calling `valueFromDataUri` on it, so a `data:` link of some
+other media type simply contributes no authoring context.
+
+`Address.isInline(address)` in
+`packages/runner/src/storage/transaction/address.ts` is the broad test applied
+to a memory address; `Chronicle` in the neighbouring `chronicle.ts` uses it to
+route both reads and writes.
+
+As a rule of thumb: the broad test belongs anywhere the question is about
+documents — fetching, syncing, writing, recording a read, stating a commit
+precondition. The narrow test belongs at the point where a payload is about to
+be decoded.
+
+## `data:` addresses are read-only
+
+Writing to a `data:` address fails with `ReadOnlyAddressError`.
+`writeWithinBranch` in `packages/runner/src/storage/v2-transaction.ts` returns
+that error before doing anything else, and `Chronicle.write` in
+`packages/runner/src/storage/transaction/chronicle.ts` returns the same error
+through `Address.isInline`. Every write on a `data:` address funnels through
+one of those two. There is no way to change what such an identifier denotes:
+a different value is a different identifier.
+
+## No document, no sync, no precondition
+
+The rest of the branching follows from there.
+
+Reads are not recorded as commit preconditions. `read` and `trackReadPaths` in
+`packages/runner/src/storage/v2-transaction.ts` skip pushing a read activity
+for a `data:` identifier and skip marking the document validated, and
+`buildReads` in `packages/runner/src/storage/v2.ts` drops such reads from the
+set it assembles. The memory protocol states the same rule on the wire:
+inline `data:` document reads are local-only and must not be serialized into
+`ClientCommit.reads`, because they have no server sequence and do not
+participate in conflict validation (see
+[the memory protocol spec](../specs/memory-v2/04-protocol.md)).
+
+Nothing is pulled for one. `shouldPullDoc` in
+`packages/runner/src/storage/v2.ts` returns false, and `syncCell` routes to
+`syncDataURICell`. What that syncs is not the identifier — there is nothing to
+fetch for it — but the documents that the links embedded in its decoded
+payload point at.
+
+The traverse capture and replay fixtures skip them too: `captureDoc` in
+`packages/runner/src/traverse-recorder.ts` returns early, because replay
+decodes the identifier directly rather than replaying a stored document.
+
+## Related documents
+
+- [Computed cell identity](../specs/computed-cell-identity.md) — the
+  `computed:` entity URI scheme, and why an entity's URI string, scheme
+  included, is its identity.
+- [Identity and references](../specs/space-model/3-identity-and-references.md)
+  — entity identifiers and the sigil link format that `data:` links use.
+- [The memory protocol](../specs/memory-v2/04-protocol.md) — the wire rules,
+  including the local-only treatment of inline document reads.

--- a/packages/runner/src/storage/transaction/address.ts
+++ b/packages/runner/src/storage/transaction/address.ts
@@ -60,7 +60,11 @@ export const intersects = (
 };
 
 /**
- * Returns true if the address represents an inline data URI.
+ * Returns true if the address is served by decoding its own id -- a `data:`
+ * URI carrying the value -- rather than by a document stored in a space.
+ * There is nothing to fetch, to sync, or to write for such an address. This
+ * is the broad test: every media type counts, and the payload is not
+ * examined (see `data-uri-codec.ts`).
  */
 export const isInline = (address: IMemoryAddress): boolean => {
   return hasDataUriScheme(address.id);


### PR DESCRIPTION
A `data:` identifier is a cell identifier that carries a frozen value inside the identifier string itself, rather than naming a document stored in a space. A cell identified that way is read by decoding its own identifier: there is no document to fetch, to sync, or to write, and no commit precondition to state about one. Code across the runner branches on this distinction in the storage transaction, the sync layer, link resolution, query traversal, and the confidentiality-contract checks, but the concept was written down only in scattered docstrings. Someone meeting one of those branches had no document to read.

The new guide covers what the identifier is and how it differs from an entity identifier (`of:`, `computed:`), the shape of the URI, both mint functions and how they differ, both read entry points, and the fact that the payload encodes the cell's value while the document view the address grammar needs is synthesized on read by the attestation loader.

It gives most space to the pair of predicates, which is the part most likely to mislead. `hasDataUriScheme` is broad: any `data:` URI, any media type, answering the storage layer's question of whether there is a document to fetch at all. `isFabricDataUri` is narrow: only the one media type this codebase mints, answering a reader's question immediately before decoding. Both appear on the same load path — the transaction routes on the broad test and the loader screens on the narrow one — so the guide spells out what swapping either for the other would do. It also records that a `data:` address is read-only, and what follows from there being no document: no pull, no commit precondition, and a sync that reaches the documents the payload's links point at instead of the identifier.

The guide is wired into the focused-guides list in the development guide and into the runtime-development reading list in AGENTS.md.

Alongside it, `isInline` in the storage transaction's address helpers had a docstring that defined "inline" in terms of "inline". It now says what being inline means for an address: that it is served by decoding its own id, with no document behind it, and that the test is the broad one of the pair.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a focused guide on `data:` cell identifiers and wires it into the dev docs. Clarifies how the runtime routes and reads these addresses to avoid confusion between broad and narrow checks.

- **Docs**
  - Added `docs/development/data-uri-identifiers.md` explaining URI shape, mint/read APIs, and when to use `hasDataUriScheme` (broad) vs `isFabricDataUri` (narrow). Linked from `AGENTS.md` and `docs/development/DEVELOPMENT.md`.
  - Updated the `isInline` comment in `packages/runner/src/storage/transaction/address.ts` to state it uses the broad `data:` check, is served by decoding its id, and implies no fetch/sync/write.

<sup>Written for commit f2e477a09501adbe77c9817ff547603435e25270. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

