### PR TITLE
feat(schema-generator,ts-transformers): emit closed-world verb event schemas (C5 second half)

### DIFF
--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -183,8 +183,9 @@ holds one that moves.
 anything reactive gets none, which is what item 1 decides.
 
 **9. Closed-world event schemas and listing marks.** #5307 and #5309, from the
-verb contract arc. Both unblocked; both wanted a courtesy review rather than a
-gate.
+verb contract arc. #5309 is unblocked and wants a courtesy review rather than a
+gate. #5307's emission is written and its update gate is clear; item 11 is the
+question it now waits behind.
 
 **10. Listing rows carry a handler's declared result.** *(S)* `cf piece verbs`
 already reports an `outputSchema` per row, and the type says why it is empty for
@@ -199,6 +200,38 @@ The two share the words and nothing else, which is why the listing work and the
 declared-result work read as coupled when they are independent. Only this item
 joins them.
 
+**11. A DOM event is a caller too.** *(M)* The dispatch gate reads the
+transformer-injected `$event` schema, and that is the schema a browser event
+arrives against: the renderer serializes a DOM event into the payload and sends
+it to the stream. Closing that root judges the whole envelope, and the envelope
+is nothing a pattern's event type describes — `type`, `provenance`, the
+allowlisted key/modifier/button properties, a `MouseEvent.detail` that is a
+click count rather than a `CustomEvent`'s payload, and a `target.value` whose
+type is the element's, not the author's. An open root lets the schema-shaped read
+deliver the declared subset and ignore the rest; a closed one makes each of those
+a rejection.
+
+The runtime already has the mechanism for exactly this: `runtimeInjectedEventKeys`
+(`packages/runner/src/cell.ts`), mint-gated by `markRuntimeInjectedEventKeys`, is
+how the LLM tool-call path hides its injected `result` from the gate. Only that
+one path mints today. The choices are to mint the renderer envelope the same way
+— which strips an undeclared envelope key and leaves a declared one to be judged,
+so it also wants the serializer to stop carrying a non-`CustomEvent` `detail` —
+or to close only the pattern-level `Stream` property schema that `cf piece verbs`
+publishes and `piece call` validates, and leave the dispatch surface open. The
+first keeps design rule 1 whole; the second is smaller and gives up dispatch
+enforcement for DOM-wired verbs.
+
+Closure also turns on full payload validation, not just the undeclared-key check:
+against a closed root, a payload missing a required field or carrying one of the
+wrong type is a rejection too. That reaches a probe.
+`packages/patterns/integration/time-capability-full.test.ts` fires `.send({})` at
+every result stream to make handler-context clock reads run, and tolerates the
+throw from a key that is not a stream. A dispatch-time rejection is not that
+throw — it arrives after the call returns — so the probe would report success
+while covering nothing. Whichever answer item 11 takes, that probe needs to fail
+loudly on a rejected send.
+
 ## Ordering
 
 | Item | After | Why |
@@ -206,7 +239,10 @@ joins them.
 | 6 (stack) | — | the stack merges bottom-up: #5458 → #5470 → #5497 → #5500 → {#5504, #5505} |
 | 6 (#5459) | — | not in the stack; entity-URI intake stands alone and merges whenever |
 | 7 | — | independent of 6; must precede 4 |
-| 8, 9 | — | independent |
+| 8 | — | independent |
+| 9 (#5309) | — | independent |
+| 11 | — | independent; decides what closure means at dispatch |
+| 9 (#5307) | 11 | emission is written, but what it enforces is 11's answer |
 | 2 | 6 | changes what the flags accept |
 | 3 | 6 | completes the suppression property |
 | 4 | 7 | publishes an address, so the address must have stopped moving |

--- a/docs/specs/schema-generator/ts_to_json_schema_mapping.md
+++ b/docs/specs/schema-generator/ts_to_json_schema_mapping.md
@@ -408,22 +408,35 @@ named types still hoist, as the fixture shows. The ts-transformers behavior
 spec §12 uses the same single-`asCell` vocabulary. Any doc claiming `Reactive`
 emits `asCell: ["opaque"]` is wrong on this tree.
 
-### 6.5 Stream event schemas — deliberately open (C5)
+### 6.5 Stream event schemas — closed-world (C5)
 
 A stream property's schema object is the verb's **event** schema — what a
 caller sends, which `cf piece verbs` publishes and `piece call` validates
-payloads against. It carries no `additionalProperties` of its own — only
-what the event type itself demands (an index signature, a `Record` value
-type). The verb contract wants event schemas closed-world
-(`additionalProperties: false` — an undeclared field is a rejection, never
-ignored), but emitting that is blocked on a pattern-update-gate migration:
-the argument-role compatibility rule refuses the open→closed direction for
-verbs reachable through a piece's argument schema (plan
-`docs/history/plans/pattern-verb-contract-implementation.md`, WS-C and Risks).
-The
-open event side is pinned as a decision in `test/stream-result.test.ts`; a
-schema that declares the closure by hand is enforced at dispatch by the
-runner (C5).
+payloads against. Its root is emitted **closed**: `additionalProperties:
+false`, so an undeclared field in a call payload is a typed rejection at
+dispatch, never silently stripped (verb contract design rule 1; the runner
+gate is C5's `closedWorldEventRejection`; the update-gate transition is
+legal via the verb-event-role compatibility rule, #5302). The stamp is
+`closeVerbEventRoot` (`src/event-closure.ts`), applied by the `Stream`
+wrapper branch, and it is position-scoped and conservative:
+
+- An inline object event gains the keyword directly; a `$ref` event gains
+  it BESIDE the reference (sibling keywords apply conjunctively), so a
+  shared `$defs` entry stays open at data-position use sites and the def
+  itself is never mutated.
+- An event that already carries `additionalProperties` — including through
+  its def (an index signature or `Record` value type is the author's
+  organic opt-out) — is left untouched: `false` beside a schema-valued
+  constraint would override it conjunctively.
+- Non-object roots (unions, primitives, `never`'s emission, booleans) are
+  left untouched — union-event closure is out of scope, and
+  `never`-derived shapes must not read as intentional closure.
+
+The same helper closes the transformer-injected handler `$event` schema
+(the surface the dispatch gate actually reads) — see the ts-transformers
+behavior spec. Hand-authored schema literals are never stamped on either
+surface; closure there remains the author's own declaration. Pinned in
+`test/stream-result.test.ts`.
 
 ## 7. `Default<T,V>` And `DeepDefault<V>`
 

--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -1424,7 +1424,23 @@ Behavior:
 3. extract `widenLiterals` generation option
 4. generate schema via a `SchemaGenerator` instance
 5. merge non-generation options into resulting schema object
-6. emit literal as:
+6. **verb event closure**: when the `toSchema` call is the FIRST argument of
+   a handler-family call — callee `__cfHelpers.handler`, or a call whose
+   detected kind is builder `handler` — the merged schema's root is closed
+   with `closeVerbEventRoot` (`@commonfabric/schema-generator`,
+   `src/event-closure.ts`): an object root (direct, or a `$ref` whose def in
+   the literal's own `$defs` is an object) gains
+   `additionalProperties: false`, stamped beside a `$ref` rather than into
+   the def. Roots that already declare `additionalProperties` (index
+   signatures — the author's organic opt-out), non-object roots (unions,
+   primitives, `never`), and booleans are untouched. Membership is the
+   provenance: only transformer-injected `toSchema` calls sit in that
+   argument position, so a hand-authored schema literal passed to `handler`
+   directly is never stamped. This is the schema C5's dispatch gate reads
+   (`module.argumentSchema.properties.$event`); the pattern-level `Stream`
+   property schema closes identically inside the schema-generator package
+   (mapping spec §6.5)
+7. emit literal as:
    - `<schemaAst> as const satisfies __cfHelpers.JSONSchema`
 
 Special path:

--- a/packages/cli/lib/multi-user-test-worker.ts
+++ b/packages/cli/lib/multi-user-test-worker.ts
@@ -455,7 +455,11 @@ const handlers: Record<
   async action({ index }) {
     const stepCell = stepCells[index as number];
     const stream = stepCell.key("action" as never) as unknown as {
-      send?: (value: unknown) => void;
+      send?: (
+        value: unknown,
+        onCommit?: undefined,
+        sendOptions?: { runtimeInjectedEventKeys?: readonly string[] },
+      ) => void;
     };
     if (typeof stream?.send !== "function") {
       throw new Error(`Test step ${index} action is not a stream`);
@@ -464,7 +468,8 @@ const handlers: Record<
       event?: unknown;
       trustedUi?: unknown;
     };
-    stream.send(buildActionEvent(meta?.event, meta?.trustedUi));
+    const action = buildActionEvent(meta?.event, meta?.trustedUi);
+    stream.send(action.value, undefined, action.sendOptions);
     await settle();
     return {};
   },

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -1491,9 +1491,11 @@ export async function runTestPattern(
         // Send the step's event (undefined for plain void actions), wrapped
         // with renderer-trusted provenance when the step declares `trustedUi`.
         await withPhase(["runTestPattern", "step", actionName, "send"], () => {
-          actionStream.send(
-            buildActionEvent(stepValue.event, stepValue.trustedUi),
+          const action = buildActionEvent(
+            stepValue.event,
+            stepValue.trustedUi,
           );
+          actionStream.send(action.value, undefined, action.sendOptions);
         });
 
         // Wait for idle, then settle commits and re-idle.

--- a/packages/cli/lib/trusted-test-event.ts
+++ b/packages/cli/lib/trusted-test-event.ts
@@ -14,7 +14,10 @@
  * `packages/html/src/worker/reconciler.ts`.
  */
 
-import { markRendererTrustedEvent } from "@commonfabric/runner/cfc";
+import {
+  markRendererTrustedEvent,
+  markRuntimeInjectedEventKeys,
+} from "@commonfabric/runner/cfc";
 
 export interface TrustedUiDescriptor {
   /** `data-ui-pattern` / `data-ui-event-integrity` of the trusted surface. */
@@ -33,24 +36,43 @@ export const isTrustedUiDescriptor = (
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
+/** An action step's event value together with the send options it needs. */
+export interface ActionEvent {
+  /** The value to hand `stream.send`. */
+  value: unknown;
+  /**
+   * Send options naming the keys this runner injected, so a verb's closed
+   * event schema judges only what the step itself supplied. Names nothing
+   * when the step's payload passes through untouched.
+   */
+  sendOptions: { runtimeInjectedEventKeys?: readonly string[] };
+}
+
 /**
  * Resolve the event value to send for an action step: the step's literal
  * `event` payload (if any), wrapped with trusted DOM provenance and the
  * renderer-trusted mark when a `trustedUi` descriptor is present.
  *
  * A trusted gesture without a payload sends `{ type: "click" }` (renderer
- * parity). An explicit record payload is sent exactly as authored — handlers
- * may branch on fields like `type`, so none are injected.
+ * parity). An explicit record payload keeps every field the step authored —
+ * handlers may branch on fields like `type`, so none are overwritten.
+ *
+ * The wrapper's own fields are declared as runtime-injected, the same way the
+ * renderer declares the envelope it builds around a real gesture: `provenance`
+ * always, and the synthesized `type` when the step supplied no payload to take
+ * it from. A step's own fields are never declared — an undeclared one is the
+ * step's mistake, and the verb's closed event schema must still catch it.
  */
 export function buildActionEvent(
   event: unknown,
   trustedUi: unknown,
-): unknown {
+): ActionEvent {
   if (!isTrustedUiDescriptor(trustedUi)) {
-    return event;
+    return { value: event, sendOptions: {} };
   }
+  const authored = isRecord(event) ? event : undefined;
   const eventValue = {
-    ...(isRecord(event) ? event : { type: "click" }),
+    ...(authored ?? { type: "click" }),
     provenance: {
       origin: "dom",
       trusted: true,
@@ -62,5 +84,12 @@ export function buildActionEvent(
     },
   };
   markRendererTrustedEvent(eventValue);
-  return eventValue;
+  return {
+    value: eventValue,
+    sendOptions: {
+      runtimeInjectedEventKeys: markRuntimeInjectedEventKeys(
+        authored ? ["provenance"] : ["type", "provenance"],
+      ),
+    },
+  };
 }

--- a/packages/cli/test/trusted-test-event.test.ts
+++ b/packages/cli/test/trusted-test-event.test.ts
@@ -2,22 +2,42 @@ import { assertEquals } from "@std/assert";
 import { isRendererTrustedEvent } from "../../runner/src/cfc/ui-contract.ts";
 import { buildActionEvent } from "../lib/trusted-test-event.ts";
 
+const trustedUi = { surface: "pattern-id", action: "save" };
+
+const provenance = {
+  origin: "dom",
+  trusted: true,
+  ui: {
+    pattern: "pattern-id",
+    eventIntegrity: ["pattern-id"],
+    uiContractDataset: { uiAction: "save" },
+  },
+};
+
 Deno.test("trusted UI action without a payload synthesizes a click event", () => {
-  const event = buildActionEvent(undefined, {
-    surface: "pattern-id",
-    action: "save",
-  });
-  assertEquals(event, {
-    type: "click",
-    provenance: {
-      origin: "dom",
-      trusted: true,
-      ui: {
-        pattern: "pattern-id",
-        eventIntegrity: ["pattern-id"],
-        uiContractDataset: { uiAction: "save" },
-      },
-    },
-  });
-  assertEquals(isRendererTrustedEvent(event), true);
+  const action = buildActionEvent(undefined, trustedUi);
+  assertEquals(action.value, { type: "click", provenance });
+  assertEquals(isRendererTrustedEvent(action.value), true);
+});
+
+Deno.test("a synthesized click declares both of its fields as injected", () => {
+  const action = buildActionEvent(undefined, trustedUi);
+  assertEquals(action.sendOptions.runtimeInjectedEventKeys, [
+    "type",
+    "provenance",
+  ]);
+});
+
+Deno.test("a step's own payload fields are not declared as injected", () => {
+  const action = buildActionEvent({ type: "submit", note: "hi" }, trustedUi);
+  assertEquals(action.value, { type: "submit", note: "hi", provenance });
+  // `note` and the authored `type` stay the step's own, so a verb whose event
+  // schema does not declare them still rejects the send.
+  assertEquals(action.sendOptions.runtimeInjectedEventKeys, ["provenance"]);
+});
+
+Deno.test("an untrusted action passes its payload through undeclared", () => {
+  const action = buildActionEvent({ note: "hi" }, undefined);
+  assertEquals(action.value, { note: "hi" });
+  assertEquals(action.sendOptions.runtimeInjectedEventKeys, undefined);
 });

--- a/packages/html/src/event-envelope.ts
+++ b/packages/html/src/event-envelope.ts
@@ -1,0 +1,54 @@
+/**
+ * The shape of the event value the renderer builds out of a browser event.
+ *
+ * A DOM event is not a JSON value and cannot cross the worker boundary, so
+ * `serializeEvent` (main/events.ts) copies an allowlisted subset of it into a
+ * plain object. Every key of that object comes from the renderer, never from
+ * the pattern author: the author wires a stream to `onClick`, and the runtime
+ * decides what the click looks like.
+ *
+ * That authorship is why the lists live here rather than beside the
+ * serializer. The worker side needs the same set to mint the send's
+ * injection-provenance marker (`markRuntimeInjectedEventKeys`), which exempts
+ * these keys — and only these — from a verb's closed event schema, and the
+ * worker must not import the main thread's DOM code to learn it. Adding a
+ * property to `serializeEvent` means adding it here too; forgetting fails
+ * closed, with the new key rejected by the closed-world gate.
+ */
+
+/** Event properties `serializeEvent` copies straight off the DOM event. */
+export const ALLOWLISTED_EVENT_PROPERTIES = [
+  "type",
+  "key",
+  "code",
+  "repeat",
+  "altKey",
+  "ctrlKey",
+  "metaKey",
+  "shiftKey",
+  "inputType",
+  "data",
+  "button",
+  "buttons",
+] as const;
+
+/** Event-target properties `serializeEvent` copies into `target`. */
+export const ALLOWLISTED_TARGET_PROPERTIES = [
+  "name",
+  "value",
+  "checked",
+  "selected",
+  "selectedIndex",
+] as const;
+
+/**
+ * Every top-level key a serialized DOM event can carry: the properties copied
+ * off the event itself, plus the three the serializer composes — the renderer's
+ * `provenance` hint, the `target` projection, and `detail`.
+ */
+export const SERIALIZED_EVENT_KEYS = [
+  ...ALLOWLISTED_EVENT_PROPERTIES,
+  "provenance",
+  "target",
+  "detail",
+] as const;

--- a/packages/html/src/main/events.ts
+++ b/packages/html/src/main/events.ts
@@ -7,6 +7,10 @@
 
 import type { JSONValue } from "@commonfabric/runtime-client";
 import {
+  ALLOWLISTED_EVENT_PROPERTIES,
+  ALLOWLISTED_TARGET_PROPERTIES,
+} from "../event-envelope.ts";
+import {
   type EventProvenance,
   getEventProvenance,
   getEventTargetDataset,
@@ -96,36 +100,6 @@ export function isDomEventMessage(value: unknown): value is DomEventMessage {
     typeof msg.nodeId === "number"
   );
 }
-
-/**
- * Allowlisted event properties that can be serialized.
- * These are the standard properties we copy from events.
- */
-export const ALLOWLISTED_EVENT_PROPERTIES = [
-  "type",
-  "key",
-  "code",
-  "repeat",
-  "altKey",
-  "ctrlKey",
-  "metaKey",
-  "shiftKey",
-  "inputType",
-  "data",
-  "button",
-  "buttons",
-] as const;
-
-/**
- * Allowlisted event target properties that can be serialized.
- */
-export const ALLOWLISTED_TARGET_PROPERTIES = [
-  "name",
-  "value",
-  "checked",
-  "selected",
-  "selectedIndex",
-] as const;
 
 /**
  * Serialize a DOM event for IPC transmission.

--- a/packages/html/src/main/mod.ts
+++ b/packages/html/src/main/mod.ts
@@ -15,9 +15,8 @@ export type { VDomRendererOptions } from "./renderer.ts";
 export {
   ALLOWLISTED_EVENT_PROPERTIES,
   ALLOWLISTED_TARGET_PROPERTIES,
-  isDomEventMessage,
-  serializeEvent,
-} from "./events.ts";
+} from "../event-envelope.ts";
+export { isDomEventMessage, serializeEvent } from "./events.ts";
 export type {
   DomEventMessage,
   EventProvenance,

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -65,10 +65,12 @@ import {
   cfcLabelViewForCell,
   clauseAlternatives,
   markRendererTrustedEvent,
+  markRuntimeInjectedEventKeys,
   type RenderConfidentialityResolver,
   spaceAtomIdsInConfidentiality,
   type SpaceMembershipProvider,
 } from "@commonfabric/runner/cfc";
+import { SERIALIZED_EVENT_KEYS } from "../event-envelope.ts";
 import type { VDomOp } from "../vdom-ops.ts";
 import { generateChildKeys } from "./keying.ts";
 import {
@@ -120,6 +122,57 @@ const CFC_CAVEAT_ATOM_TYPE = "https://commonfabric.org/cfc/atom/Caveat";
  * The main thread registers the actual container DOM element with this ID.
  */
 export const CONTAINER_NODE_ID = 0;
+
+/**
+ * Injection provenance for the event values this reconciler delivers.
+ *
+ * A pattern wires a stream to `onClick`; the runtime decides what a click
+ * looks like. Every key of the value that arrives at `dispatchEvent` was put
+ * there by the renderer's serializer, so the send that carries it to a verb
+ * declares them as runtime-injected and the closed-world gate leaves them
+ * unjudged instead of refusing an envelope no author's event type describes.
+ *
+ * The declaration is a capability, not a shape: `markRuntimeInjectedEventKeys`
+ * mints an array the stream-send path recognizes, and only a minted one is
+ * honored. Keying it off the event object — the way `markRendererTrustedEvent`
+ * keys DOM trust — keeps the marker tied to the value the renderer produced
+ * rather than to any value that happens to look like one.
+ */
+const rendererInjectedEventKeys = new WeakMap<object, readonly string[]>();
+
+/**
+ * Record which envelope keys the renderer put in `event`. Bounded by
+ * `SERIALIZED_EVENT_KEYS`, so a key no serializer writes is never exempted,
+ * however the event value reached the worker.
+ */
+const markRendererInjectedEventKeys = (event: unknown): void => {
+  if (!isRecord(event)) return;
+  const injected = SERIALIZED_EVENT_KEYS.filter((key) =>
+    Object.hasOwn(event, key)
+  );
+  if (injected.length === 0) return;
+  rendererInjectedEventKeys.set(
+    event,
+    markRuntimeInjectedEventKeys(injected),
+  );
+};
+
+/**
+ * Send a delivered DOM event to the stream an event prop resolved to, naming
+ * the keys the renderer injected so the verb's closed event schema judges only
+ * what a caller could have supplied.
+ */
+const sendRendererEvent = (
+  target: Cell<unknown> | Stream<unknown>,
+  event: unknown,
+): void => {
+  const keys = isRecord(event)
+    ? rendererInjectedEventKeys.get(event)
+    : undefined;
+  target.withTx(undefined).send(event, undefined, {
+    runtimeInjectedEventKeys: keys,
+  });
+};
 
 const logger = getLogger("worker-reconciler", {
   enabled: false,
@@ -394,6 +447,7 @@ export class WorkerReconciler {
     if (handler) {
       try {
         markRendererTrustedEvent(event);
+        markRendererInjectedEventKeys(event);
         handler(event);
       } catch (error) {
         this.onError?.(
@@ -1952,7 +2006,7 @@ export class WorkerReconciler {
     if (isStream(value)) {
       const stream = value as Stream<unknown>;
       const handlerId = ctx.registerHandler((event) => {
-        stream.withTx(undefined).send(event);
+        sendRendererEvent(stream, event);
       });
       state.eventHandlers.set(eventType, handlerId);
       this.queueOps([{
@@ -2154,7 +2208,7 @@ export class WorkerReconciler {
           if (existingState) existingState.cancel();
 
           const handlerId = ctx.registerHandler((event) =>
-            resolvedTarget.withTx(undefined).send(event)
+            sendRendererEvent(resolvedTarget, event)
           );
           state.eventHandlers.set(eventType, handlerId);
           this.queueOps([{
@@ -2927,7 +2981,7 @@ export class WorkerReconciler {
         if (isStream(value)) {
           const stream = value as Stream<unknown>;
           const handlerId = ctx.registerHandler((event) => {
-            stream.withTx(undefined).send(event);
+            sendRendererEvent(stream, event);
           });
           state.eventHandlers.set(eventType, handlerId);
           this.queueOps([{

--- a/packages/html/test/worker-reconciler-event-injection.test.ts
+++ b/packages/html/test/worker-reconciler-event-injection.test.ts
@@ -1,0 +1,158 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "@commonfabric/runner";
+import { WorkerReconciler } from "../src/worker/reconciler.ts";
+import type { VDomOp } from "../src/vdom-ops.ts";
+
+/**
+ * What the reconciler declares to a verb about the event it delivers.
+ *
+ * A DOM event is the renderer's construction: the pattern wires a stream to
+ * `onClick` and the serializer decides what a click looks like. The send says
+ * so, through the mint-gated `runtimeInjectedEventKeys` option, and the
+ * closed-world gate leaves exactly those keys unjudged. The rule the gate
+ * exists to enforce survives only if that declaration stays bounded — hence
+ * the second case, which is the one that would rot first.
+ */
+
+const signer = await Identity.fromPassphrase("test reconciler event injection");
+
+type SendCall = {
+  event: unknown;
+  options?: { runtimeInjectedEventKeys?: readonly string[] };
+};
+
+const storageManager = StorageManager.emulate({ as: signer });
+const runtime = new Runtime({
+  storageManager,
+  apiUrl: new URL("http://localhost"),
+});
+const dummyTx = runtime.edit();
+const CellImplConstructor = runtime
+  .getCell(signer.did(), "dummy", undefined, dummyTx)
+  .constructor;
+
+class MockCell extends (CellImplConstructor as any) {
+  constructor(public value: unknown) {
+    super(runtime, undefined, undefined, false, undefined, "cell");
+    this.value = value;
+  }
+
+  sink(callback: (value: unknown) => void) {
+    callback(this.value);
+    return () => {};
+  }
+
+  isStream() {
+    return false;
+  }
+}
+
+/** Records what the reconciler hands `send`, options included. */
+class MockStream extends MockCell {
+  static nextId = 0;
+  public calls: SendCall[] = [];
+  private readonly linkId = `event-injection-stream-${++MockStream.nextId}`;
+
+  constructor() {
+    super(undefined);
+  }
+
+  override isStream() {
+    return true;
+  }
+
+  withTx(_tx?: unknown) {
+    return this;
+  }
+
+  send(event: unknown, _onCommit?: unknown, options?: SendCall["options"]) {
+    this.calls.push({ event, options });
+  }
+
+  getAsNormalizedFullLink() {
+    return { space: "test-space", id: this.linkId, path: [] };
+  }
+}
+
+/**
+ * Mount a button whose `onclick` is `stream`, then deliver `event` to the
+ * handler the reconciler registered for it.
+ */
+const deliver = (event: unknown): SendCall => {
+  const ops: VDomOp[] = [];
+  const stream = new MockStream();
+  const reconciler = new WorkerReconciler({
+    onOps: (batch: VDomOp[]) => {
+      ops.push(...batch);
+      return 0;
+    },
+  });
+  const root = new MockCell({
+    type: "vnode",
+    name: "button",
+    props: { onclick: stream },
+    children: ["Click"],
+  });
+  const cancel = reconciler.mount(root as never);
+  try {
+    reconciler.flush();
+    const setEvent = ops.find((op) => op.op === "set-event") as Extract<
+      VDomOp,
+      { op: "set-event" }
+    >;
+    expect(reconciler.dispatchEvent(setEvent.handlerId, event)).toBe(true);
+    expect(stream.calls.length).toBe(1);
+    return stream.calls[0];
+  } finally {
+    cancel();
+  }
+};
+
+describe("worker-reconciler-event-injection", () => {
+  it("declares the envelope keys the delivered event carries", () => {
+    const { options } = deliver({
+      type: "click",
+      provenance: { origin: "dom", trusted: true },
+      altKey: false,
+      button: 0,
+      target: { value: "typed text" },
+      detail: 1,
+    });
+
+    expect(options?.runtimeInjectedEventKeys).toEqual([
+      "type",
+      "altKey",
+      "button",
+      "provenance",
+      "target",
+      "detail",
+    ]);
+  });
+
+  it("declares only keys the serializer can produce", () => {
+    // The bound is the envelope, not the event value's own keys. A field no
+    // serializer writes stays the caller's, so a verb whose closed event
+    // schema does not declare it still rejects the send — the rule the
+    // closed-world gate exists to enforce.
+    const { options } = deliver({ type: "click", title: "smuggled" });
+
+    expect(options?.runtimeInjectedEventKeys).toEqual(["type"]);
+  });
+
+  it("mints the declaration, so the send path honors it", () => {
+    // `Cell.set`'s stream branch forwards the option only for an array minted
+    // by `markRuntimeInjectedEventKeys`, which freezes what it mints.
+    const { options } = deliver({ type: "click" });
+
+    expect(Object.isFrozen(options?.runtimeInjectedEventKeys)).toBe(true);
+  });
+
+  it("declares nothing for an event that is not a record", () => {
+    const { options } = deliver(undefined);
+
+    expect(options?.runtimeInjectedEventKeys).toBeUndefined();
+  });
+});

--- a/packages/patterns/baselines/agent/agent.tsx/20260807T235141Z-rzOogTwDtik-3iWp.json
+++ b/packages/patterns/baselines/agent/agent.tsx/20260807T235141Z-rzOogTwDtik-3iWp.json
@@ -1,0 +1,231 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "AgentStatus": {
+        "enum": [
+          "idle",
+          "running",
+          "error"
+        ]
+      }
+    },
+    "properties": {
+      "agentName": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "Unnamed Agent",
+        "type": "string"
+      },
+      "directive": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "enabled": {
+        "asCell": [
+          "cell"
+        ],
+        "default": true,
+        "type": "boolean"
+      },
+      "isAgent": {
+        "default": true,
+        "type": "boolean"
+      },
+      "lastRun": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "lastRunSummary": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "learned": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "status": {
+        "$ref": "#/$defs/AgentStatus",
+        "asCell": [
+          "cell"
+        ],
+        "default": "idle"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "agent/agent.tsx",
+  "resultSchema": {
+    "$defs": {
+      "AgentStatus": {
+        "enum": [
+          "idle",
+          "running",
+          "error"
+        ]
+      }
+    },
+    "description": "An #agent piece — autonomous worker with directive, learned state, and status.",
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "agentName": {
+        "type": "string"
+      },
+      "appendLearned": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "entry": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "entry"
+        ],
+        "type": "object"
+      },
+      "directive": {
+        "type": "string"
+      },
+      "enabled": {
+        "type": "boolean"
+      },
+      "isAgent": {
+        "type": "boolean"
+      },
+      "lastRun": {
+        "type": "string"
+      },
+      "lastRunSummary": {
+        "type": "string"
+      },
+      "learned": {
+        "type": "string"
+      },
+      "markError": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "summary": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
+      "markIdle": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "learned": {
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "summary"
+        ],
+        "type": "object"
+      },
+      "markRunning": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "setDirective": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "value": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "value"
+        ],
+        "type": "object"
+      },
+      "setLearned": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "value": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "value"
+        ],
+        "type": "object"
+      },
+      "status": {
+        "$ref": "#/$defs/AgentStatus"
+      },
+      "summary": {
+        "type": "string"
+      },
+      "toggleEnabled": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      }
+    },
+    "required": [
+      "agentName",
+      "directive",
+      "enabled",
+      "learned",
+      "status",
+      "lastRun",
+      "lastRunSummary",
+      "isAgent",
+      "summary",
+      "setDirective",
+      "setLearned",
+      "appendLearned",
+      "toggleEnabled",
+      "markRunning",
+      "markIdle",
+      "markError",
+      "$NAME",
+      "$UI"
+    ],
+    "tags": [
+      "agent"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/battleship/multiplayer/lobby.tsx/20260807T235141Z-xfHG9i1R39Hyle2c.json
+++ b/packages/patterns/baselines/battleship/multiplayer/lobby.tsx/20260807T235141Z-xfHG9i1R39Hyle2c.json
@@ -1,0 +1,502 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "Coordinate": {
+        "properties": {
+          "col": {
+            "type": "number"
+          },
+          "row": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "row",
+          "col"
+        ],
+        "type": "object"
+      },
+      "GameState": {
+        "properties": {
+          "currentTurn": {
+            "enum": [
+              1,
+              2
+            ]
+          },
+          "lastMessage": {
+            "type": "string"
+          },
+          "phase": {
+            "enum": [
+              "waiting",
+              "playing",
+              "finished"
+            ]
+          },
+          "winner": {
+            "enum": [
+              1,
+              2,
+              null
+            ]
+          }
+        },
+        "required": [
+          "phase",
+          "currentTurn",
+          "winner",
+          "lastMessage"
+        ],
+        "type": "object"
+      },
+      "PlayerData": {
+        "properties": {
+          "avatar": {
+            "description": "Avatar URL or glyph, snapshotted from the joiner's shared profile.",
+            "type": "string"
+          },
+          "color": {
+            "type": "string"
+          },
+          "joinedAt": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "ships": {
+            "items": {
+              "$ref": "#/$defs/Ship"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "name",
+          "ships",
+          "color",
+          "joinedAt"
+        ],
+        "type": "object"
+      },
+      "Ship": {
+        "properties": {
+          "orientation": {
+            "enum": [
+              "horizontal",
+              "vertical"
+            ]
+          },
+          "start": {
+            "$ref": "#/$defs/Coordinate"
+          },
+          "type": {
+            "$ref": "#/$defs/ShipType"
+          }
+        },
+        "required": [
+          "type",
+          "start",
+          "orientation"
+        ],
+        "type": "object"
+      },
+      "ShipType": {
+        "enum": [
+          "carrier",
+          "battleship",
+          "cruiser",
+          "submarine",
+          "destroyer"
+        ]
+      },
+      "ShotsState": {
+        "properties": {
+          "1": {
+            "items": {
+              "items": {
+                "$ref": "#/$defs/SquareState"
+              },
+              "type": "array"
+            },
+            "type": "array"
+          },
+          "2": {
+            "items": {
+              "items": {
+                "$ref": "#/$defs/SquareState"
+              },
+              "type": "array"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "1",
+          "2"
+        ],
+        "type": "object"
+      },
+      "SquareState": {
+        "enum": [
+          "empty",
+          "miss",
+          "hit"
+        ]
+      }
+    },
+    "description": "Shared match state is per-space; viewer identity is scoped per user. The\njoin name/avatar come from the viewer's shared profile (resolved via\n`wish({ query: \"#profile\" })` in the lobby), so there is no join-form text.",
+    "properties": {
+      "gameName": {
+        "default": "Battleship",
+        "scope": "space",
+        "type": "string"
+      },
+      "gameState": {
+        "$ref": "#/$defs/GameState",
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ],
+        "default": {
+          "currentTurn": 1,
+          "lastMessage": "Waiting for players...",
+          "phase": "waiting",
+          "winner": null
+        }
+      },
+      "myName": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "user"
+          }
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "myPlayerNumber": {
+        "anyOf": [
+          {
+            "enum": [
+              1,
+              2
+            ],
+            "type": "number"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "user"
+          }
+        ],
+        "default": null
+      },
+      "player1": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/PlayerData"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ],
+        "default": null
+      },
+      "player2": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/PlayerData"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ],
+        "default": null
+      },
+      "shots": {
+        "$ref": "#/$defs/ShotsState",
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ]
+      }
+    },
+    "tags": [
+      "profile"
+    ],
+    "type": "object"
+  },
+  "pattern": "battleship/multiplayer/lobby.tsx",
+  "resultSchema": {
+    "$defs": {
+      "Coordinate": {
+        "properties": {
+          "col": {
+            "type": "number"
+          },
+          "row": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "row",
+          "col"
+        ],
+        "type": "object"
+      },
+      "GameState": {
+        "properties": {
+          "currentTurn": {
+            "enum": [
+              1,
+              2
+            ]
+          },
+          "lastMessage": {
+            "type": "string"
+          },
+          "phase": {
+            "enum": [
+              "waiting",
+              "playing",
+              "finished"
+            ]
+          },
+          "winner": {
+            "enum": [
+              1,
+              2,
+              null
+            ]
+          }
+        },
+        "required": [
+          "phase",
+          "currentTurn",
+          "winner",
+          "lastMessage"
+        ],
+        "type": "object"
+      },
+      "PlayerData": {
+        "properties": {
+          "avatar": {
+            "description": "Avatar URL or glyph, snapshotted from the joiner's shared profile.",
+            "type": "string"
+          },
+          "color": {
+            "type": "string"
+          },
+          "joinedAt": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "ships": {
+            "items": {
+              "$ref": "#/$defs/Ship"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "name",
+          "ships",
+          "color",
+          "joinedAt"
+        ],
+        "type": "object"
+      },
+      "Ship": {
+        "properties": {
+          "orientation": {
+            "enum": [
+              "horizontal",
+              "vertical"
+            ]
+          },
+          "start": {
+            "$ref": "#/$defs/Coordinate"
+          },
+          "type": {
+            "$ref": "#/$defs/ShipType"
+          }
+        },
+        "required": [
+          "type",
+          "start",
+          "orientation"
+        ],
+        "type": "object"
+      },
+      "ShipType": {
+        "enum": [
+          "carrier",
+          "battleship",
+          "cruiser",
+          "submarine",
+          "destroyer"
+        ]
+      },
+      "ShotsState": {
+        "properties": {
+          "1": {
+            "items": {
+              "items": {
+                "$ref": "#/$defs/SquareState"
+              },
+              "type": "array"
+            },
+            "type": "array"
+          },
+          "2": {
+            "items": {
+              "items": {
+                "$ref": "#/$defs/SquareState"
+              },
+              "type": "array"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "1",
+          "2"
+        ],
+        "type": "object"
+      },
+      "SquareState": {
+        "enum": [
+          "empty",
+          "miss",
+          "hit"
+        ]
+      }
+    },
+    "properties": {
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json",
+        "scope": "session"
+      },
+      "gameName": {
+        "type": "string"
+      },
+      "gameState": {
+        "$ref": "#/$defs/GameState"
+      },
+      "joinPlayer1": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "joinPlayer2": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "joinWithName": {
+        "asCell": [
+          "stream"
+        ],
+        "type": "string"
+      },
+      "myName": {
+        "type": "string"
+      },
+      "myPlayerNumber": {
+        "enum": [
+          1,
+          2,
+          null
+        ]
+      },
+      "player1": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/PlayerData"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "player2": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/PlayerData"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "reset": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "shots": {
+        "$ref": "#/$defs/ShotsState"
+      }
+    },
+    "required": [
+      "gameName",
+      "player1",
+      "player2",
+      "shots",
+      "gameState",
+      "myName",
+      "myPlayerNumber",
+      "joinWithName",
+      "joinPlayer1",
+      "joinPlayer2",
+      "reset",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/battleship/multiplayer/room.tsx/20260807T235141Z-P_jSMJnGmYrm3Ixl.json
+++ b/packages/patterns/baselines/battleship/multiplayer/room.tsx/20260807T235141Z-P_jSMJnGmYrm3Ixl.json
@@ -1,0 +1,288 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "Coordinate": {
+        "properties": {
+          "col": {
+            "type": "number"
+          },
+          "row": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "row",
+          "col"
+        ],
+        "type": "object"
+      },
+      "GameState": {
+        "properties": {
+          "currentTurn": {
+            "enum": [
+              1,
+              2
+            ]
+          },
+          "lastMessage": {
+            "type": "string"
+          },
+          "phase": {
+            "enum": [
+              "waiting",
+              "playing",
+              "finished"
+            ]
+          },
+          "winner": {
+            "enum": [
+              1,
+              2,
+              null
+            ]
+          }
+        },
+        "required": [
+          "phase",
+          "currentTurn",
+          "winner",
+          "lastMessage"
+        ],
+        "type": "object"
+      },
+      "PlayerData": {
+        "properties": {
+          "avatar": {
+            "description": "Avatar URL or glyph, snapshotted from the joiner's shared profile.",
+            "type": "string"
+          },
+          "color": {
+            "type": "string"
+          },
+          "joinedAt": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "ships": {
+            "items": {
+              "$ref": "#/$defs/Ship"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "name",
+          "ships",
+          "color",
+          "joinedAt"
+        ],
+        "type": "object"
+      },
+      "Ship": {
+        "properties": {
+          "orientation": {
+            "enum": [
+              "horizontal",
+              "vertical"
+            ]
+          },
+          "start": {
+            "$ref": "#/$defs/Coordinate"
+          },
+          "type": {
+            "$ref": "#/$defs/ShipType"
+          }
+        },
+        "required": [
+          "type",
+          "start",
+          "orientation"
+        ],
+        "type": "object"
+      },
+      "ShipType": {
+        "enum": [
+          "carrier",
+          "battleship",
+          "cruiser",
+          "submarine",
+          "destroyer"
+        ]
+      },
+      "ShotsState": {
+        "properties": {
+          "1": {
+            "items": {
+              "items": {
+                "$ref": "#/$defs/SquareState"
+              },
+              "type": "array"
+            },
+            "type": "array"
+          },
+          "2": {
+            "items": {
+              "items": {
+                "$ref": "#/$defs/SquareState"
+              },
+              "type": "array"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "1",
+          "2"
+        ],
+        "type": "object"
+      },
+      "SquareState": {
+        "enum": [
+          "empty",
+          "miss",
+          "hit"
+        ]
+      }
+    },
+    "description": "Room pattern receives shared cells plus per-user player identity.",
+    "properties": {
+      "gameName": {
+        "type": "string"
+      },
+      "gameState": {
+        "$ref": "#/$defs/GameState",
+        "asCell": [
+          "cell"
+        ],
+        "default": {
+          "currentTurn": 1,
+          "lastMessage": "Waiting for players...",
+          "phase": "waiting",
+          "winner": null
+        }
+      },
+      "myName": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "myPlayerNumber": {
+        "anyOf": [
+          {
+            "enum": [
+              1,
+              2
+            ],
+            "type": "number"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "asCell": [
+          "cell"
+        ],
+        "default": null
+      },
+      "player1": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/PlayerData"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "asCell": [
+          "cell"
+        ],
+        "default": null
+      },
+      "player2": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/PlayerData"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "asCell": [
+          "cell"
+        ],
+        "default": null
+      },
+      "shots": {
+        "$ref": "#/$defs/ShotsState",
+        "asCell": [
+          "cell"
+        ]
+      }
+    },
+    "required": [
+      "gameName",
+      "player1",
+      "player2",
+      "shots",
+      "gameState",
+      "myName",
+      "myPlayerNumber"
+    ],
+    "type": "object"
+  },
+  "pattern": "battleship/multiplayer/room.tsx",
+  "resultSchema": {
+    "description": "Room pattern output exposes player identity and actions for testing.",
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json",
+        "scope": "session"
+      },
+      "fireShot": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "description": "Fire a shot at the enemy board - exported for testing",
+        "properties": {
+          "col": {
+            "type": "number"
+          },
+          "row": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "row",
+          "col"
+        ],
+        "type": "object"
+      },
+      "myName": {
+        "type": "string"
+      },
+      "myPlayerNumber": {
+        "enum": [
+          1,
+          2,
+          null
+        ]
+      }
+    },
+    "required": [
+      "myName",
+      "myPlayerNumber",
+      "fireShot",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/battleship/pass-and-play/main.tsx/20260807T235141Z-Px7dYMmDbqu3jIHM.json
+++ b/packages/patterns/baselines/battleship/pass-and-play/main.tsx/20260807T235141Z-Px7dYMmDbqu3jIHM.json
@@ -1,0 +1,192 @@
+{
+  "argumentSchema": {
+    "additionalProperties": false,
+    "properties": {},
+    "type": "object"
+  },
+  "pattern": "battleship/pass-and-play/main.tsx",
+  "resultSchema": {
+    "$defs": {
+      "Coordinate": {
+        "properties": {
+          "col": {
+            "type": "number"
+          },
+          "row": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "row",
+          "col"
+        ],
+        "type": "object"
+      },
+      "GameState": {
+        "properties": {
+          "awaitingPass": {
+            "type": "boolean"
+          },
+          "currentTurn": {
+            "enum": [
+              1,
+              2
+            ]
+          },
+          "lastMessage": {
+            "type": "string"
+          },
+          "phase": {
+            "enum": [
+              "playing",
+              "finished"
+            ]
+          },
+          "player1": {
+            "$ref": "#/$defs/PlayerBoard"
+          },
+          "player2": {
+            "$ref": "#/$defs/PlayerBoard"
+          },
+          "viewingAs": {
+            "enum": [
+              1,
+              2,
+              null
+            ]
+          },
+          "winner": {
+            "enum": [
+              1,
+              2,
+              null
+            ]
+          }
+        },
+        "required": [
+          "phase",
+          "currentTurn",
+          "player1",
+          "player2",
+          "winner",
+          "lastMessage",
+          "viewingAs",
+          "awaitingPass"
+        ],
+        "type": "object"
+      },
+      "PlayerBoard": {
+        "properties": {
+          "ships": {
+            "items": {
+              "$ref": "#/$defs/Ship"
+            },
+            "type": "array"
+          },
+          "shots": {
+            "items": {
+              "items": {
+                "$ref": "#/$defs/SquareState"
+              },
+              "type": "array"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "ships",
+          "shots"
+        ],
+        "type": "object"
+      },
+      "Ship": {
+        "properties": {
+          "orientation": {
+            "enum": [
+              "horizontal",
+              "vertical"
+            ]
+          },
+          "start": {
+            "$ref": "#/$defs/Coordinate"
+          },
+          "type": {
+            "$ref": "#/$defs/ShipType"
+          }
+        },
+        "required": [
+          "type",
+          "start",
+          "orientation"
+        ],
+        "type": "object"
+      },
+      "ShipType": {
+        "enum": [
+          "carrier",
+          "battleship",
+          "cruiser",
+          "submarine",
+          "destroyer"
+        ]
+      },
+      "SquareState": {
+        "enum": [
+          "empty",
+          "miss",
+          "hit"
+        ]
+      }
+    },
+    "properties": {
+      "fireShot": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "col": {
+            "type": "number"
+          },
+          "row": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "row",
+          "col"
+        ],
+        "type": "object"
+      },
+      "game": {
+        "$ref": "#/$defs/GameState"
+      },
+      "passDevice": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "playerReady": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "resetGame": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      }
+    },
+    "required": [
+      "game",
+      "fireShot",
+      "passDevice",
+      "playerReady",
+      "resetGame"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/budget-tracker/expense-form.tsx/20260807T235141Z-wTbPkwPRBHztEwcA.json
+++ b/packages/patterns/baselines/budget-tracker/expense-form.tsx/20260807T235141Z-wTbPkwPRBHztEwcA.json
@@ -1,0 +1,175 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "CategoryBudget": {
+        "properties": {
+          "category": {
+            "type": "string"
+          },
+          "limit": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "category",
+          "limit"
+        ],
+        "type": "object"
+      },
+      "Expense": {
+        "properties": {
+          "amount": {
+            "type": "number"
+          },
+          "category": {
+            "default": "Other",
+            "type": "string"
+          },
+          "date": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "description",
+          "amount",
+          "category",
+          "date"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "budgets": {
+        "asCell": [
+          "cell"
+        ],
+        "items": {
+          "$ref": "#/$defs/CategoryBudget"
+        },
+        "type": "array"
+      },
+      "expenses": {
+        "asCell": [
+          "cell"
+        ],
+        "items": {
+          "$ref": "#/$defs/Expense"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "expenses",
+      "budgets"
+    ],
+    "type": "object"
+  },
+  "pattern": "budget-tracker/expense-form.tsx",
+  "resultSchema": {
+    "$defs": {
+      "JSXElement": {
+        "anyOf": [
+          {
+            "$ref": "https://commonfabric.org/schemas/vnode.json"
+          },
+          {
+            "$ref": "#/$defs/UIRenderable"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ]
+      },
+      "UIRenderable": {
+        "properties": {
+          "$UI": {
+            "$ref": "https://commonfabric.org/schemas/vnode.json"
+          }
+        },
+        "required": [
+          "$UI"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "#/$defs/JSXElement"
+      },
+      "addExpense": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "amount": {
+            "type": "number"
+          },
+          "category": {
+            "type": "string"
+          },
+          "date": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "description",
+          "amount"
+        ],
+        "type": "object"
+      },
+      "removeBudget": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "category": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "category"
+        ],
+        "type": "object"
+      },
+      "setBudget": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "category": {
+            "type": "string"
+          },
+          "limit": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "category",
+          "limit"
+        ],
+        "type": "object"
+      }
+    },
+    "required": [
+      "$NAME",
+      "$UI",
+      "addExpense",
+      "setBudget",
+      "removeBudget"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/calendar/calendar.tsx/20260807T235141Z-4ZwbptcIm9-RvIQl.json
+++ b/packages/patterns/baselines/calendar/calendar.tsx/20260807T235141Z-4ZwbptcIm9-RvIQl.json
@@ -1,0 +1,304 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "EventDetailOutput": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "$UI": {
+            "$ref": "https://commonfabric.org/schemas/vnode.json"
+          },
+          "date": {
+            "type": "string"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "setDate": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "date": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "date"
+            ],
+            "type": "object"
+          },
+          "setNotes": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "notes": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "notes"
+            ],
+            "type": "object"
+          },
+          "setTime": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "time": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "time"
+            ],
+            "type": "object"
+          },
+          "setTitle": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "title": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "title"
+            ],
+            "type": "object"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "time": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "date",
+          "time",
+          "notes",
+          "summary",
+          "setTitle",
+          "setDate",
+          "setTime",
+          "setNotes",
+          "$NAME",
+          "$UI"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "events": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/EventDetailOutput"
+        },
+        "type": "array"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "calendar/calendar.tsx",
+  "resultSchema": {
+    "$defs": {
+      "EventDetailOutput": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "$UI": {
+            "$ref": "https://commonfabric.org/schemas/vnode.json"
+          },
+          "date": {
+            "type": "string"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "setDate": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "date": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "date"
+            ],
+            "type": "object"
+          },
+          "setNotes": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "notes": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "notes"
+            ],
+            "type": "object"
+          },
+          "setTime": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "time": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "time"
+            ],
+            "type": "object"
+          },
+          "setTitle": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "title": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "title"
+            ],
+            "type": "object"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "time": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "date",
+          "time",
+          "notes",
+          "summary",
+          "setTitle",
+          "setDate",
+          "setTime",
+          "setNotes",
+          "$NAME",
+          "$UI"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addEvent": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "date": {
+            "type": "string"
+          },
+          "time": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "date",
+          "time"
+        ],
+        "type": "object"
+      },
+      "events": {
+        "items": {
+          "$ref": "#/$defs/EventDetailOutput"
+        },
+        "type": "array"
+      },
+      "mentionable": {
+        "items": {
+          "$ref": "#/$defs/EventDetailOutput"
+        },
+        "type": "array"
+      },
+      "removeEvent": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "event": {
+            "$ref": "#/$defs/EventDetailOutput"
+          }
+        },
+        "required": [
+          "event"
+        ],
+        "type": "object"
+      },
+      "sortedEvents": {
+        "items": {
+          "$ref": "#/$defs/EventDetailOutput"
+        },
+        "type": "array"
+      },
+      "summary": {
+        "type": "string"
+      },
+      "todayDate": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "events",
+      "sortedEvents",
+      "mentionable",
+      "todayDate",
+      "summary",
+      "addEvent",
+      "removeEvent",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/calendar/event-detail.tsx/20260807T235141Z-Nnvcz-52eEgQQkZ3.json
+++ b/packages/patterns/baselines/calendar/event-detail.tsx/20260807T235141Z-Nnvcz-52eEgQQkZ3.json
@@ -1,0 +1,140 @@
+{
+  "argumentSchema": {
+    "description": "Input for creating a new event detail piece",
+    "properties": {
+      "date": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "notes": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "time": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "title": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "calendar/event-detail.tsx",
+  "resultSchema": {
+    "description": "Output shape of the event piece - this is what gets stored in calendars\n#event",
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "date": {
+        "type": "string"
+      },
+      "notes": {
+        "type": "string"
+      },
+      "setDate": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "date": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "date"
+        ],
+        "type": "object"
+      },
+      "setNotes": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "notes": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "notes"
+        ],
+        "type": "object"
+      },
+      "setTime": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "time": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "time"
+        ],
+        "type": "object"
+      },
+      "setTitle": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title"
+        ],
+        "type": "object"
+      },
+      "summary": {
+        "type": "string"
+      },
+      "time": {
+        "type": "string"
+      },
+      "title": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "title",
+      "date",
+      "time",
+      "notes",
+      "summary",
+      "setTitle",
+      "setDate",
+      "setTime",
+      "setNotes",
+      "$NAME",
+      "$UI"
+    ],
+    "tags": [
+      "event"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/card-piles/main.tsx/20260807T235141Z-6LcMCfOPV9q2CQDF.json
+++ b/packages/patterns/baselines/card-piles/main.tsx/20260807T235141Z-6LcMCfOPV9q2CQDF.json
@@ -1,0 +1,214 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "Card": {
+        "properties": {
+          "rank": {
+            "enum": [
+              "A",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "J",
+              "Q",
+              "K"
+            ]
+          },
+          "suit": {
+            "enum": [
+              "hearts",
+              "diamonds",
+              "clubs",
+              "spades"
+            ]
+          }
+        },
+        "required": [
+          "suit",
+          "rank"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "pile1": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [
+          {
+            "rank": "A",
+            "suit": "hearts"
+          },
+          {
+            "rank": "K",
+            "suit": "spades"
+          },
+          {
+            "rank": "7",
+            "suit": "diamonds"
+          }
+        ],
+        "items": {
+          "$ref": "#/$defs/Card"
+        },
+        "type": "array"
+      },
+      "pile2": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [
+          {
+            "rank": "Q",
+            "suit": "clubs"
+          },
+          {
+            "rank": "10",
+            "suit": "hearts"
+          },
+          {
+            "rank": "3",
+            "suit": "spades"
+          }
+        ],
+        "items": {
+          "$ref": "#/$defs/Card"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "pile1",
+      "pile2"
+    ],
+    "type": "object"
+  },
+  "pattern": "card-piles/main.tsx",
+  "resultSchema": {
+    "$defs": {
+      "Card": {
+        "properties": {
+          "rank": {
+            "enum": [
+              "A",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "J",
+              "Q",
+              "K"
+            ]
+          },
+          "suit": {
+            "enum": [
+              "hearts",
+              "diamonds",
+              "clubs",
+              "spades"
+            ]
+          }
+        },
+        "required": [
+          "suit",
+          "rank"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "moveToPile1": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "detail": {
+            "properties": {
+              "sourceCell": {
+                "$ref": "#/$defs/Card"
+              }
+            },
+            "required": [
+              "sourceCell"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "detail"
+        ],
+        "type": "object"
+      },
+      "moveToPile2": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "detail": {
+            "properties": {
+              "sourceCell": {
+                "$ref": "#/$defs/Card"
+              }
+            },
+            "required": [
+              "sourceCell"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "detail"
+        ],
+        "type": "object"
+      },
+      "pile1": {
+        "items": {
+          "$ref": "#/$defs/Card"
+        },
+        "type": "array"
+      },
+      "pile2": {
+        "items": {
+          "$ref": "#/$defs/Card"
+        },
+        "type": "array"
+      },
+      "shuffle": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      }
+    },
+    "required": [
+      "pile1",
+      "pile2",
+      "shuffle",
+      "moveToPile1",
+      "moveToPile2",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/cfc-group-chat-demo/main.tsx/20260807T235141Z-6Q5MziAnWjwSxbqS.json
+++ b/packages/patterns/baselines/cfc-group-chat-demo/main.tsx/20260807T235141Z-6Q5MziAnWjwSxbqS.json
@@ -1,0 +1,1114 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "ChatAdminBootstrapRole": {
+        "$ref": "#/$defs/ChatAdminRoleAssignment",
+        "ifc": {
+          "addIntegrity": [
+            "group-chat-admin"
+          ]
+        }
+      },
+      "ChatAdminList": {
+        "ifc": {
+          "requiredIntegrity": [
+            "group-chat-admin"
+          ],
+          "uiContract": {
+            "action": "TrustedGroupChatSetAdmin",
+            "helper": "UiAction",
+            "requiredEventIntegrity": [
+              "TrustedGroupChatAdminSurface"
+            ],
+            "trustedPattern": "TrustedGroupChatAdminSurface"
+          },
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/cfc-group-chat-demo/trusted.tsx",
+              "moduleIdentity": "8xqVHyLs4YTIiBoTI_Jd8ZU4_SUWqgR1Rx95obfn7LM",
+              "path": [
+                "commitTrustedAdminToggle"
+              ]
+            }
+          }
+        },
+        "items": {
+          "$ref": "#/$defs/ChatAdminRole"
+        },
+        "type": "array"
+      },
+      "ChatAdminRegistryStoredValue": {
+        "properties": {
+          "admins": {
+            "$ref": "#/$defs/ChatAdminList"
+          },
+          "bootstrapAdmin": {
+            "$ref": "#/$defs/ChatAdminBootstrapRole"
+          },
+          "everyoneIsAdmin": {
+            "$ref": "#/$defs/ChatEveryoneAdminFlag"
+          }
+        },
+        "type": "object"
+      },
+      "ChatAdminRegistryValue": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/ChatAdminRegistryStoredValue"
+          },
+          {
+            "$ref": "#/$defs/EmptyAdminRegistryValue"
+          }
+        ]
+      },
+      "ChatAdminRole": {
+        "$ref": "#/$defs/ChatAdminRoleAssignment",
+        "ifc": {
+          "addIntegrity": [
+            "group-chat-admin"
+          ]
+        }
+      },
+      "ChatAdminRoleAssignment": {
+        "properties": {
+          "displayName": {
+            "type": "string"
+          },
+          "subject": {
+            "anyOf": [
+              {
+                "type": "undefined"
+              },
+              {
+                "$ref": "#/$defs/ChatProfile"
+              }
+            ],
+            "asCell": [
+              "cell"
+            ]
+          }
+        },
+        "required": [
+          "subject",
+          "displayName"
+        ],
+        "type": "object"
+      },
+      "ChatEveryoneAdminFlag": {
+        "anyOf": [
+          {
+            "enum": [
+              true
+            ],
+            "ifc": {
+              "addIntegrity": [
+                "group-chat-admin"
+              ],
+              "requiredIntegrity": [
+                "group-chat-admin"
+              ],
+              "uiContract": {
+                "action": "TrustedGroupChatSetAdmin",
+                "helper": "UiAction",
+                "requiredEventIntegrity": [
+                  "TrustedGroupChatAdminSurface"
+                ],
+                "trustedPattern": "TrustedGroupChatAdminSurface"
+              }
+            },
+            "type": "boolean"
+          },
+          {
+            "enum": [
+              false
+            ],
+            "ifc": {
+              "uiContract": {
+                "action": "TrustedGroupChatSetAdmin",
+                "helper": "UiAction",
+                "requiredEventIntegrity": [
+                  "TrustedGroupChatAdminSurface"
+                ],
+                "trustedPattern": "TrustedGroupChatAdminSurface"
+              },
+              "writeAuthorizedBy": {
+                "__ctWriterIdentityOf": {
+                  "file": "/packages/patterns/cfc-group-chat-demo/trusted.tsx",
+                  "moduleIdentity": "8xqVHyLs4YTIiBoTI_Jd8ZU4_SUWqgR1Rx95obfn7LM",
+                  "path": [
+                    "commitTrustedAdminToggle"
+                  ]
+                }
+              }
+            },
+            "type": "boolean"
+          }
+        ]
+      },
+      "ChatProfile": {
+        "properties": {
+          "accentColor": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "accentColor"
+        ],
+        "type": "object"
+      },
+      "ChatRoom": {
+        "properties": {
+          "createdAt": {
+            "type": "number"
+          },
+          "messages": {
+            "items": {
+              "$ref": "#/$defs/SharedChatMessage"
+            },
+            "type": "array"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "messages",
+          "createdAt"
+        ],
+        "type": "object"
+      },
+      "EmptyAdminRegistryValue": {
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object"
+      },
+      "EmptyMyProfileValue": {
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object"
+      },
+      "EmptySharedRoomsValue": {
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object"
+      },
+      "ImportedClaimedChatMessage": {
+        "properties": {
+          "authorName": {
+            "type": "string"
+          },
+          "authorProfile": {
+            "anyOf": [
+              {
+                "type": "undefined"
+              },
+              {
+                "anyOf": [
+                  {
+                    "type": "undefined"
+                  },
+                  {
+                    "$ref": "#/$defs/ChatProfile"
+                  }
+                ],
+                "asCell": [
+                  "cell"
+                ]
+              }
+            ]
+          },
+          "body": {
+            "type": "string"
+          },
+          "origin": {
+            "enum": [
+              "imported"
+            ],
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "origin",
+          "authorName",
+          "body",
+          "timestamp"
+        ],
+        "type": "object"
+      },
+      "MyProfileCellValue": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/MyProfileStoredValue"
+          },
+          {
+            "$ref": "#/$defs/EmptyMyProfileValue"
+          }
+        ]
+      },
+      "MyProfileStoredValue": {
+        "properties": {
+          "profile": {
+            "$ref": "#/$defs/ChatProfile"
+          }
+        },
+        "type": "object"
+      },
+      "SharedChatMessage": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/TrustedSentChatMessage"
+          },
+          {
+            "$ref": "#/$defs/ImportedClaimedChatMessage"
+          }
+        ]
+      },
+      "SharedMessagesValue": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/SharedChatMessage"
+        },
+        "type": "array"
+      },
+      "SharedProfileEntry": {
+        "properties": {
+          "profile": {
+            "anyOf": [
+              {
+                "type": "undefined"
+              },
+              {
+                "$ref": "#/$defs/ChatProfile"
+              }
+            ],
+            "asCell": [
+              "cell"
+            ]
+          }
+        },
+        "required": [
+          "profile"
+        ],
+        "type": "object"
+      },
+      "SharedProfilesValue": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/SharedProfileEntry"
+        },
+        "type": "array"
+      },
+      "SharedRoomList": {
+        "ifc": {
+          "requiredIntegrity": [
+            "group-chat-admin"
+          ],
+          "uiContract": {
+            "action": "TrustedGroupChatAddRoom",
+            "helper": "UiAction",
+            "requiredEventIntegrity": [
+              "TrustedGroupChatRoomSurface"
+            ],
+            "trustedPattern": "TrustedGroupChatRoomSurface"
+          },
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/cfc-group-chat-demo/trusted.tsx",
+              "moduleIdentity": "8xqVHyLs4YTIiBoTI_Jd8ZU4_SUWqgR1Rx95obfn7LM",
+              "path": [
+                "commitTrustedRoomAdd"
+              ]
+            }
+          }
+        },
+        "items": {
+          "$ref": "#/$defs/ChatRoom"
+        },
+        "type": "array"
+      },
+      "SharedRoomsStoredValue": {
+        "properties": {
+          "list": {
+            "$ref": "#/$defs/SharedRoomList"
+          }
+        },
+        "type": "object"
+      },
+      "SharedRoomsValue": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/SharedRoomsStoredValue"
+          },
+          {
+            "$ref": "#/$defs/EmptySharedRoomsValue"
+          }
+        ]
+      },
+      "TrustedSentChatMessage": {
+        "ifc": {
+          "addIntegrity": [
+            {
+              "kind": "authored-by",
+              "subject": {
+                "__ctCurrentPrincipal": true
+              }
+            }
+          ],
+          "uiContract": {
+            "action": "TrustedGroupChatSendMessage",
+            "helper": "UiAction",
+            "requiredEventIntegrity": [
+              "TrustedGroupChatSendSurface"
+            ],
+            "trustedPattern": "TrustedGroupChatSendSurface"
+          },
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/cfc-group-chat-demo/trusted.tsx",
+              "moduleIdentity": "8xqVHyLs4YTIiBoTI_Jd8ZU4_SUWqgR1Rx95obfn7LM",
+              "path": [
+                "commitTrustedMessageSend"
+              ]
+            }
+          }
+        },
+        "properties": {
+          "authorName": {
+            "type": "string"
+          },
+          "authorProfile": {
+            "anyOf": [
+              {
+                "type": "undefined"
+              },
+              {
+                "$ref": "#/$defs/ChatProfile"
+              }
+            ],
+            "asCell": [
+              "cell"
+            ]
+          },
+          "body": {
+            "type": "string"
+          },
+          "origin": {
+            "enum": [
+              "sent"
+            ],
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "origin",
+          "authorName",
+          "authorProfile",
+          "body",
+          "timestamp"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "adminRegistry": {
+        "$ref": "#/$defs/ChatAdminRegistryValue",
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ]
+      },
+      "hostMessageDraft": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "session"
+          }
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "messageDraft": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "user"
+          }
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "messages": {
+        "$ref": "#/$defs/SharedMessagesValue",
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ]
+      },
+      "myProfile": {
+        "$ref": "#/$defs/MyProfileCellValue",
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "user"
+          }
+        ]
+      },
+      "profileDraft": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "user"
+          }
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "profiles": {
+        "$ref": "#/$defs/SharedProfilesValue",
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ]
+      },
+      "roomDraft": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "session"
+          }
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "rooms": {
+        "$ref": "#/$defs/SharedRoomsValue",
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ]
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "cfc-group-chat-demo/main.tsx",
+  "resultSchema": {
+    "$defs": {
+      "ChatAdminBootstrapRole": {
+        "$ref": "#/$defs/ChatAdminRoleAssignment",
+        "ifc": {
+          "addIntegrity": [
+            "group-chat-admin"
+          ]
+        }
+      },
+      "ChatAdminList": {
+        "ifc": {
+          "requiredIntegrity": [
+            "group-chat-admin"
+          ],
+          "uiContract": {
+            "action": "TrustedGroupChatSetAdmin",
+            "helper": "UiAction",
+            "requiredEventIntegrity": [
+              "TrustedGroupChatAdminSurface"
+            ],
+            "trustedPattern": "TrustedGroupChatAdminSurface"
+          },
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/cfc-group-chat-demo/trusted.tsx",
+              "moduleIdentity": "8xqVHyLs4YTIiBoTI_Jd8ZU4_SUWqgR1Rx95obfn7LM",
+              "path": [
+                "commitTrustedAdminToggle"
+              ]
+            }
+          }
+        },
+        "items": {
+          "$ref": "#/$defs/ChatAdminRole"
+        },
+        "type": "array"
+      },
+      "ChatAdminRegistryStoredValue": {
+        "properties": {
+          "admins": {
+            "$ref": "#/$defs/ChatAdminList"
+          },
+          "bootstrapAdmin": {
+            "$ref": "#/$defs/ChatAdminBootstrapRole"
+          },
+          "everyoneIsAdmin": {
+            "$ref": "#/$defs/ChatEveryoneAdminFlag"
+          }
+        },
+        "type": "object"
+      },
+      "ChatAdminRegistryValue": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/ChatAdminRegistryStoredValue"
+          },
+          {
+            "$ref": "#/$defs/EmptyAdminRegistryValue"
+          }
+        ]
+      },
+      "ChatAdminRole": {
+        "$ref": "#/$defs/ChatAdminRoleAssignment",
+        "ifc": {
+          "addIntegrity": [
+            "group-chat-admin"
+          ]
+        }
+      },
+      "ChatAdminRoleAssignment": {
+        "properties": {
+          "displayName": {
+            "type": "string"
+          },
+          "subject": {
+            "anyOf": [
+              {
+                "type": "undefined"
+              },
+              {
+                "$ref": "#/$defs/ChatProfile"
+              }
+            ]
+          }
+        },
+        "required": [
+          "subject",
+          "displayName"
+        ],
+        "type": "object"
+      },
+      "ChatEveryoneAdminFlag": {
+        "anyOf": [
+          {
+            "enum": [
+              true
+            ],
+            "ifc": {
+              "addIntegrity": [
+                "group-chat-admin"
+              ],
+              "requiredIntegrity": [
+                "group-chat-admin"
+              ],
+              "uiContract": {
+                "action": "TrustedGroupChatSetAdmin",
+                "helper": "UiAction",
+                "requiredEventIntegrity": [
+                  "TrustedGroupChatAdminSurface"
+                ],
+                "trustedPattern": "TrustedGroupChatAdminSurface"
+              }
+            },
+            "type": "boolean"
+          },
+          {
+            "enum": [
+              false
+            ],
+            "ifc": {
+              "uiContract": {
+                "action": "TrustedGroupChatSetAdmin",
+                "helper": "UiAction",
+                "requiredEventIntegrity": [
+                  "TrustedGroupChatAdminSurface"
+                ],
+                "trustedPattern": "TrustedGroupChatAdminSurface"
+              },
+              "writeAuthorizedBy": {
+                "__ctWriterIdentityOf": {
+                  "file": "/packages/patterns/cfc-group-chat-demo/trusted.tsx",
+                  "moduleIdentity": "8xqVHyLs4YTIiBoTI_Jd8ZU4_SUWqgR1Rx95obfn7LM",
+                  "path": [
+                    "commitTrustedAdminToggle"
+                  ]
+                }
+              }
+            },
+            "type": "boolean"
+          }
+        ]
+      },
+      "ChatProfile": {
+        "properties": {
+          "accentColor": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "accentColor"
+        ],
+        "type": "object"
+      },
+      "ChatRoom": {
+        "properties": {
+          "createdAt": {
+            "type": "number"
+          },
+          "messages": {
+            "items": {
+              "$ref": "#/$defs/SharedChatMessage"
+            },
+            "type": "array"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "messages",
+          "createdAt"
+        ],
+        "type": "object"
+      },
+      "EmptyAdminRegistryValue": {
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object"
+      },
+      "EmptyMyProfileValue": {
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object"
+      },
+      "EmptySharedRoomsValue": {
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object"
+      },
+      "ImportedClaimedChatMessage": {
+        "properties": {
+          "authorName": {
+            "type": "string"
+          },
+          "authorProfile": {
+            "anyOf": [
+              {
+                "type": "undefined"
+              },
+              {
+                "anyOf": [
+                  {
+                    "type": "undefined"
+                  },
+                  {
+                    "$ref": "#/$defs/ChatProfile"
+                  }
+                ]
+              }
+            ]
+          },
+          "body": {
+            "type": "string"
+          },
+          "origin": {
+            "enum": [
+              "imported"
+            ],
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "origin",
+          "authorName",
+          "body",
+          "timestamp"
+        ],
+        "type": "object"
+      },
+      "MyProfileCellValue": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/MyProfileStoredValue"
+          },
+          {
+            "$ref": "#/$defs/EmptyMyProfileValue"
+          }
+        ]
+      },
+      "MyProfileStoredValue": {
+        "properties": {
+          "profile": {
+            "$ref": "#/$defs/ChatProfile"
+          }
+        },
+        "type": "object"
+      },
+      "SharedChatMessage": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/TrustedSentChatMessage"
+          },
+          {
+            "$ref": "#/$defs/ImportedClaimedChatMessage"
+          }
+        ]
+      },
+      "SharedMessagesValue": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/SharedChatMessage"
+        },
+        "type": "array"
+      },
+      "SharedProfileEntry": {
+        "properties": {
+          "profile": {
+            "anyOf": [
+              {
+                "type": "undefined"
+              },
+              {
+                "$ref": "#/$defs/ChatProfile"
+              }
+            ]
+          }
+        },
+        "required": [
+          "profile"
+        ],
+        "type": "object"
+      },
+      "SharedProfilesValue": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/SharedProfileEntry"
+        },
+        "type": "array"
+      },
+      "SharedRoomList": {
+        "ifc": {
+          "requiredIntegrity": [
+            "group-chat-admin"
+          ],
+          "uiContract": {
+            "action": "TrustedGroupChatAddRoom",
+            "helper": "UiAction",
+            "requiredEventIntegrity": [
+              "TrustedGroupChatRoomSurface"
+            ],
+            "trustedPattern": "TrustedGroupChatRoomSurface"
+          },
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/cfc-group-chat-demo/trusted.tsx",
+              "moduleIdentity": "8xqVHyLs4YTIiBoTI_Jd8ZU4_SUWqgR1Rx95obfn7LM",
+              "path": [
+                "commitTrustedRoomAdd"
+              ]
+            }
+          }
+        },
+        "items": {
+          "$ref": "#/$defs/ChatRoom"
+        },
+        "type": "array"
+      },
+      "SharedRoomsStoredValue": {
+        "properties": {
+          "list": {
+            "$ref": "#/$defs/SharedRoomList"
+          }
+        },
+        "type": "object"
+      },
+      "SharedRoomsValue": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/SharedRoomsStoredValue"
+          },
+          {
+            "$ref": "#/$defs/EmptySharedRoomsValue"
+          }
+        ]
+      },
+      "TrustedAdminPolicyEvent": {
+        "properties": {
+          "detail": {
+            "properties": {
+              "checked": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "everyoneIsAdmin": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "target": {
+            "properties": {
+              "dataset": {
+                "properties": {
+                  "adminName": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "name": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "TrustedSentChatMessage": {
+        "ifc": {
+          "addIntegrity": [
+            {
+              "kind": "authored-by",
+              "subject": {
+                "__ctCurrentPrincipal": true
+              }
+            }
+          ],
+          "uiContract": {
+            "action": "TrustedGroupChatSendMessage",
+            "helper": "UiAction",
+            "requiredEventIntegrity": [
+              "TrustedGroupChatSendSurface"
+            ],
+            "trustedPattern": "TrustedGroupChatSendSurface"
+          },
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/cfc-group-chat-demo/trusted.tsx",
+              "moduleIdentity": "8xqVHyLs4YTIiBoTI_Jd8ZU4_SUWqgR1Rx95obfn7LM",
+              "path": [
+                "commitTrustedMessageSend"
+              ]
+            }
+          }
+        },
+        "properties": {
+          "authorName": {
+            "type": "string"
+          },
+          "authorProfile": {
+            "anyOf": [
+              {
+                "type": "undefined"
+              },
+              {
+                "$ref": "#/$defs/ChatProfile"
+              }
+            ]
+          },
+          "body": {
+            "type": "string"
+          },
+          "origin": {
+            "enum": [
+              "sent"
+            ],
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "origin",
+          "authorName",
+          "authorProfile",
+          "body",
+          "timestamp"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": true,
+      "addRandomMessages": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "addTrustedRoom": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "adminRegistry": {
+        "$ref": "#/$defs/ChatAdminRegistryValue"
+      },
+      "currentProfileName": {
+        "type": "string"
+      },
+      "currentUserCanManageAdmins": {
+        "type": "boolean"
+      },
+      "currentUserIsAdmin": {
+        "type": "boolean"
+      },
+      "hostLookalikeSend": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "hostMessageDraft": {
+        "default": "",
+        "type": "string"
+      },
+      "messageDraft": {
+        "default": "",
+        "type": "string"
+      },
+      "messages": {
+        "$ref": "#/$defs/SharedMessagesValue"
+      },
+      "myProfile": {
+        "$ref": "#/$defs/MyProfileCellValue"
+      },
+      "profileDraft": {
+        "default": "",
+        "type": "string"
+      },
+      "profiles": {
+        "$ref": "#/$defs/SharedProfilesValue"
+      },
+      "roomDraft": {
+        "default": "",
+        "type": "string"
+      },
+      "rooms": {
+        "$ref": "#/$defs/SharedRoomsValue"
+      },
+      "saveProfile": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "sendTrustedMessage": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "setHostMessageDraft": {
+        "asCell": [
+          "stream"
+        ],
+        "type": "string"
+      },
+      "setMessageDraft": {
+        "asCell": [
+          "stream"
+        ],
+        "type": "string"
+      },
+      "setProfileDraft": {
+        "asCell": [
+          "stream"
+        ],
+        "type": "string"
+      },
+      "setRoomDraft": {
+        "asCell": [
+          "stream"
+        ],
+        "type": "string"
+      },
+      "toggleCurrentUserAdmin": {
+        "$ref": "#/$defs/TrustedAdminPolicyEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "toggleEveryoneAdmin": {
+        "$ref": "#/$defs/TrustedAdminPolicyEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "toggleParticipantAdmin": {
+        "$ref": "#/$defs/TrustedAdminPolicyEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      }
+    },
+    "required": [
+      "myProfile",
+      "profiles",
+      "messages",
+      "rooms",
+      "adminRegistry",
+      "profileDraft",
+      "messageDraft",
+      "hostMessageDraft",
+      "roomDraft",
+      "setProfileDraft",
+      "setMessageDraft",
+      "setHostMessageDraft",
+      "setRoomDraft",
+      "currentProfileName",
+      "currentUserIsAdmin",
+      "currentUserCanManageAdmins",
+      "saveProfile",
+      "toggleCurrentUserAdmin",
+      "toggleParticipantAdmin",
+      "toggleEveryoneAdmin",
+      "sendTrustedMessage",
+      "addTrustedRoom",
+      "hostLookalikeSend",
+      "addRandomMessages",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/chatbot.tsx/20260807T235141Z-iHwLvreNHoh-zcnp.json
+++ b/packages/patterns/baselines/chatbot.tsx/20260807T235141Z-iHwLvreNHoh-zcnp.json
@@ -1,0 +1,517 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "BuiltInLLMContent": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/BuiltInLLMContentPart"
+            },
+            "type": "array"
+          }
+        ]
+      },
+      "BuiltInLLMContentPart": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/BuiltInLLMTextPart"
+          },
+          {
+            "$ref": "#/$defs/BuiltInLLMImagePart"
+          },
+          {
+            "$ref": "#/$defs/BuiltInLLMToolCallPart"
+          },
+          {
+            "$ref": "#/$defs/BuiltInLLMToolResultPart"
+          }
+        ]
+      },
+      "BuiltInLLMImagePart": {
+        "properties": {
+          "image": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "image"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "image"
+        ],
+        "type": "object"
+      },
+      "BuiltInLLMMessage": {
+        "properties": {
+          "content": {
+            "$ref": "#/$defs/BuiltInLLMContent"
+          },
+          "role": {
+            "enum": [
+              "user",
+              "system",
+              "assistant",
+              "tool"
+            ]
+          }
+        },
+        "required": [
+          "role",
+          "content"
+        ],
+        "type": "object"
+      },
+      "BuiltInLLMTextPart": {
+        "properties": {
+          "text": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "text"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "text"
+        ],
+        "type": "object"
+      },
+      "BuiltInLLMToolCallPart": {
+        "properties": {
+          "input": {
+            "additionalProperties": true,
+            "properties": {},
+            "type": "object"
+          },
+          "toolCallId": {
+            "type": "string"
+          },
+          "toolName": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "tool-call"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "toolCallId",
+          "toolName",
+          "input"
+        ],
+        "type": "object"
+      },
+      "BuiltInLLMToolResultPart": {
+        "properties": {
+          "output": {
+            "anyOf": [
+              {
+                "properties": {
+                  "type": {
+                    "enum": [
+                      "text"
+                    ],
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "type": {
+                    "enum": [
+                      "json"
+                    ],
+                    "type": "string"
+                  },
+                  "value": true
+                },
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "type": "object"
+              }
+            ]
+          },
+          "toolCallId": {
+            "type": "string"
+          },
+          "toolName": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "tool-result"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "toolCallId",
+          "toolName",
+          "output"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "messages": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/BuiltInLLMMessage"
+        },
+        "type": "array"
+      },
+      "system": {
+        "type": "string"
+      },
+      "theme": true,
+      "tools": true
+    },
+    "type": "object"
+  },
+  "pattern": "chatbot.tsx",
+  "resultSchema": {
+    "$defs": {
+      "BuiltInLLMContent": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/BuiltInLLMContentPart"
+            },
+            "type": "array"
+          }
+        ]
+      },
+      "BuiltInLLMContentPart": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/BuiltInLLMTextPart"
+          },
+          {
+            "$ref": "#/$defs/BuiltInLLMImagePart"
+          },
+          {
+            "$ref": "#/$defs/BuiltInLLMToolCallPart"
+          },
+          {
+            "$ref": "#/$defs/BuiltInLLMToolResultPart"
+          }
+        ]
+      },
+      "BuiltInLLMImagePart": {
+        "properties": {
+          "image": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "image"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "image"
+        ],
+        "type": "object"
+      },
+      "BuiltInLLMMessage": {
+        "properties": {
+          "content": {
+            "$ref": "#/$defs/BuiltInLLMContent"
+          },
+          "role": {
+            "enum": [
+              "user",
+              "system",
+              "assistant",
+              "tool"
+            ]
+          }
+        },
+        "required": [
+          "role",
+          "content"
+        ],
+        "type": "object"
+      },
+      "BuiltInLLMTextPart": {
+        "properties": {
+          "text": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "text"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "text"
+        ],
+        "type": "object"
+      },
+      "BuiltInLLMToolCallPart": {
+        "properties": {
+          "input": {
+            "additionalProperties": true,
+            "properties": {},
+            "type": "object"
+          },
+          "toolCallId": {
+            "type": "string"
+          },
+          "toolName": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "tool-call"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "toolCallId",
+          "toolName",
+          "input"
+        ],
+        "type": "object"
+      },
+      "BuiltInLLMToolResultPart": {
+        "properties": {
+          "output": {
+            "anyOf": [
+              {
+                "properties": {
+                  "type": {
+                    "enum": [
+                      "text"
+                    ],
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "type": {
+                    "enum": [
+                      "json"
+                    ],
+                    "type": "string"
+                  },
+                  "value": true
+                },
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "type": "object"
+              }
+            ]
+          },
+          "toolCallId": {
+            "type": "string"
+          },
+          "toolName": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "tool-result"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "toolCallId",
+          "toolName",
+          "output"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "addMessage": {
+        "$ref": "#/$defs/BuiltInLLMMessage",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "cancelGeneration": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "clearChat": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "messages": {
+        "items": {
+          "$ref": "#/$defs/BuiltInLLMMessage"
+        },
+        "type": "array"
+      },
+      "pending": {
+        "anyOf": [
+          {
+            "type": "undefined"
+          },
+          {
+            "type": "boolean"
+          }
+        ]
+      },
+      "pinCell": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path",
+          "name"
+        ],
+        "type": "object"
+      },
+      "pinToChat": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "accumulate": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path",
+          "name",
+          "accumulate"
+        ],
+        "type": "object"
+      },
+      "pinnedCells": {
+        "items": {
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "path": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "name"
+          ],
+          "type": "object"
+        },
+        "type": "array"
+      },
+      "title": {
+        "type": "string"
+      },
+      "tools": true,
+      "ui": {
+        "properties": {
+          "attachmentsAndTools": {
+            "$ref": "https://commonfabric.org/schemas/vnode.json"
+          },
+          "chatLog": {
+            "$ref": "https://commonfabric.org/schemas/vnode.json"
+          },
+          "promptInput": {
+            "$ref": "https://commonfabric.org/schemas/vnode.json"
+          }
+        },
+        "required": [
+          "chatLog",
+          "promptInput",
+          "attachmentsAndTools"
+        ],
+        "type": "object"
+      },
+      "unpinAllCells": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      }
+    },
+    "required": [
+      "messages",
+      "pending",
+      "addMessage",
+      "clearChat",
+      "cancelGeneration",
+      "pinnedCells",
+      "pinCell",
+      "unpinAllCells",
+      "pinToChat",
+      "tools",
+      "ui"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/compiler.tsx/20260807T235141Z-DlxrYJLsGrUon72x.json
+++ b/packages/patterns/baselines/compiler.tsx/20260807T235141Z-DlxrYJLsGrUon72x.json
@@ -1,0 +1,87 @@
+{
+  "argumentSchema": {
+    "properties": {
+      "code": {
+        "default": "import { computed, Default, handler, NAME, pattern, UI, Writable } from \"commonfabric\";\n\ninterface Input {\n  value: number | Default<0>;\n}\n\nconst increment = handler<unknown, { value: Writable<number> }>((_, state) => {\n  state.value.set(state.value.get() + 1);\n});\n\nconst decrement = handler<unknown, { value: Writable<number> }>((_, state) => {\n  state.value.set(state.value.get() - 1);\n});\n\nexport default pattern<Input>(({ value }) => {\n  return {\n    [NAME]: computed(() => `Simple counter: ${value}`),\n    [UI]: (\n      <div>\n        <cf-button onClick={decrement({ value })}>-</cf-button>\n        <b>{value}</b>\n        <cf-button onClick={increment({ value })}>+</cf-button>\n      </div>\n    ),\n    value,\n  };\n});\n",
+        "type": "string"
+      }
+    },
+    "required": [
+      "code"
+    ],
+    "type": "object"
+  },
+  "pattern": "compiler.tsx",
+  "resultSchema": {
+    "$defs": {
+      "JSXElement": {
+        "anyOf": [
+          {
+            "$ref": "https://commonfabric.org/schemas/vnode.json"
+          },
+          {
+            "$ref": "#/$defs/UIRenderable"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ]
+      },
+      "UIRenderable": {
+        "properties": {
+          "$UI": {
+            "$ref": "https://commonfabric.org/schemas/vnode.json"
+          }
+        },
+        "required": [
+          "$UI"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "enum": [
+          "My First Compiler"
+        ],
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "#/$defs/JSXElement"
+      },
+      "code": {
+        "type": "string"
+      },
+      "updateCode": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "code": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code"
+        ],
+        "type": "object"
+      },
+      "visit": {
+        "asCell": [
+          "stream"
+        ],
+        "type": "unknown"
+      }
+    },
+    "required": [
+      "$NAME",
+      "$UI",
+      "code",
+      "updateCode",
+      "visit"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/cozy-poll/main.tsx/20260807T235141Z-naw1oOI11V8DpPjo.json
+++ b/packages/patterns/baselines/cozy-poll/main.tsx/20260807T235141Z-naw1oOI11V8DpPjo.json
@@ -1,0 +1,372 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "Option": {
+        "properties": {
+          "addedByName": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "addedByName"
+        ],
+        "type": "object"
+      },
+      "User": {
+        "properties": {
+          "avatar": {
+            "description": "Avatar URL or glyph, snapshotted from the joiner's shared profile.",
+            "type": "string"
+          },
+          "color": {
+            "type": "string"
+          },
+          "joinedAt": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "color",
+          "joinedAt"
+        ],
+        "type": "object"
+      },
+      "Vote": {
+        "properties": {
+          "optionId": {
+            "type": "string"
+          },
+          "voteType": {
+            "$ref": "#/$defs/VoteColor"
+          },
+          "voterName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "voterName",
+          "optionId",
+          "voteType"
+        ],
+        "type": "object"
+      },
+      "VoteColor": {
+        "enum": [
+          "green",
+          "yellow",
+          "red"
+        ]
+      }
+    },
+    "properties": {
+      "adminName": {
+        "default": "",
+        "scope": "space",
+        "type": "string"
+      },
+      "myName": {
+        "default": "",
+        "scope": "user",
+        "type": "string"
+      },
+      "options": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/Option"
+        },
+        "scope": "space",
+        "type": "array"
+      },
+      "question": {
+        "default": "What should we pick?",
+        "scope": "space",
+        "type": "string"
+      },
+      "users": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/User"
+        },
+        "scope": "space",
+        "type": "array"
+      },
+      "votes": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/Vote"
+        },
+        "scope": "space",
+        "type": "array"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "cozy-poll/main.tsx",
+  "resultSchema": {
+    "$defs": {
+      "AddOptionEvent": {
+        "properties": {
+          "title": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "CastVoteEvent": {
+        "properties": {
+          "optionId": {
+            "type": "string"
+          },
+          "voteType": {
+            "$ref": "#/$defs/VoteColor"
+          }
+        },
+        "required": [
+          "optionId",
+          "voteType"
+        ],
+        "type": "object"
+      },
+      "ClaimHostEvent": {
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object"
+      },
+      "ClearVoteEvent": {
+        "properties": {
+          "optionId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "optionId"
+        ],
+        "type": "object"
+      },
+      "JoinEvent": {
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "Option": {
+        "properties": {
+          "addedByName": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "addedByName"
+        ],
+        "type": "object"
+      },
+      "RemoveOptionEvent": {
+        "properties": {
+          "optionId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "optionId"
+        ],
+        "type": "object"
+      },
+      "ResetVotesEvent": {
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object"
+      },
+      "User": {
+        "properties": {
+          "avatar": {
+            "description": "Avatar URL or glyph, snapshotted from the joiner's shared profile.",
+            "type": "string"
+          },
+          "color": {
+            "type": "string"
+          },
+          "joinedAt": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "color",
+          "joinedAt"
+        ],
+        "type": "object"
+      },
+      "Vote": {
+        "properties": {
+          "optionId": {
+            "type": "string"
+          },
+          "voteType": {
+            "$ref": "#/$defs/VoteColor"
+          },
+          "voterName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "voterName",
+          "optionId",
+          "voteType"
+        ],
+        "type": "object"
+      },
+      "VoteColor": {
+        "enum": [
+          "green",
+          "yellow",
+          "red"
+        ]
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addOption": {
+        "$ref": "#/$defs/AddOptionEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "adminName": {
+        "type": "string"
+      },
+      "castVote": {
+        "$ref": "#/$defs/CastVoteEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "claimHost": {
+        "$ref": "#/$defs/ClaimHostEvent",
+        "asCell": [
+          "stream"
+        ]
+      },
+      "clearMyVote": {
+        "$ref": "#/$defs/ClearVoteEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "isAdmin": {
+        "type": "boolean"
+      },
+      "isJoined": {
+        "type": "boolean"
+      },
+      "joinAs": {
+        "$ref": "#/$defs/JoinEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "myName": {
+        "type": "string"
+      },
+      "optionCount": {
+        "type": "number"
+      },
+      "options": {
+        "items": {
+          "$ref": "#/$defs/Option"
+        },
+        "type": "array"
+      },
+      "question": {
+        "type": "string"
+      },
+      "removeOption": {
+        "$ref": "#/$defs/RemoveOptionEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "resetVotes": {
+        "$ref": "#/$defs/ResetVotesEvent",
+        "asCell": [
+          "stream"
+        ]
+      },
+      "userCount": {
+        "type": "number"
+      },
+      "users": {
+        "items": {
+          "$ref": "#/$defs/User"
+        },
+        "type": "array"
+      },
+      "voteCount": {
+        "type": "number"
+      },
+      "votes": {
+        "items": {
+          "$ref": "#/$defs/Vote"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "question",
+      "options",
+      "votes",
+      "users",
+      "adminName",
+      "myName",
+      "userCount",
+      "optionCount",
+      "voteCount",
+      "isJoined",
+      "isAdmin",
+      "joinAs",
+      "claimHost",
+      "addOption",
+      "removeOption",
+      "castVote",
+      "clearMyVote",
+      "resetVotes",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/dice.tsx/20260807T235141Z-jSPxBlRxjqRvXpjS.json
+++ b/packages/patterns/baselines/dice.tsx/20260807T235141Z-jSPxBlRxjqRvXpjS.json
@@ -1,0 +1,51 @@
+{
+  "argumentSchema": {
+    "properties": {
+      "value": {
+        "default": 1,
+        "type": "number"
+      }
+    },
+    "required": [
+      "value"
+    ],
+    "type": "object"
+  },
+  "pattern": "dice.tsx",
+  "resultSchema": {
+    "properties": {
+      "roll": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "sides": {
+            "type": "number"
+          }
+        },
+        "type": "object"
+      },
+      "something": {
+        "properties": {
+          "nested": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "nested"
+        ],
+        "type": "object"
+      },
+      "value": {
+        "type": "number"
+      }
+    },
+    "required": [
+      "value",
+      "something",
+      "roll"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/do-list/do-list.tsx/20260807T235141Z-hdEd7pzJ5oNSZzkI.json
+++ b/packages/patterns/baselines/do-list/do-list.tsx/20260807T235141Z-hdEd7pzJ5oNSZzkI.json
@@ -1,0 +1,307 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "DoItem": {
+        "properties": {
+          "aiEnabled": {
+            "default": false,
+            "type": "boolean"
+          },
+          "attachments": {
+            "default": [],
+            "items": {
+              "asCell": [
+                "cell"
+              ]
+            },
+            "type": "array"
+          },
+          "done": {
+            "default": false,
+            "type": "boolean"
+          },
+          "indent": {
+            "default": 0,
+            "type": "number"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "done",
+          "indent",
+          "aiEnabled",
+          "attachments"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "items": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/DoItem"
+        },
+        "type": "array"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "do-list/do-list.tsx",
+  "resultSchema": {
+    "$defs": {
+      "DoItem": {
+        "properties": {
+          "aiEnabled": {
+            "default": false,
+            "type": "boolean"
+          },
+          "attachments": {
+            "default": [],
+            "items": {},
+            "type": "array"
+          },
+          "done": {
+            "default": false,
+            "type": "boolean"
+          },
+          "indent": {
+            "default": 0,
+            "type": "number"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "done",
+          "indent",
+          "aiEnabled",
+          "attachments"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addItem": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream",
+          "stream"
+        ],
+        "properties": {
+          "attachments": {
+            "items": {},
+            "type": "array"
+          },
+          "indent": {
+            "type": "number"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title"
+        ],
+        "type": "object"
+      },
+      "addItems": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream",
+          "stream"
+        ],
+        "properties": {
+          "items": {
+            "items": {
+              "properties": {
+                "attachments": {
+                  "items": {},
+                  "type": "array"
+                },
+                "indent": {
+                  "type": "number"
+                },
+                "title": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "title"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "type": "object"
+      },
+      "archiveCompleted": {
+        "asCell": [
+          "stream",
+          "stream",
+          "opaque"
+        ]
+      },
+      "compactUI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "isHidden": {
+        "enum": [
+          true
+        ],
+        "type": "boolean"
+      },
+      "itemCount": {
+        "type": "number"
+      },
+      "items": {
+        "items": {
+          "$ref": "#/$defs/DoItem"
+        },
+        "type": "array"
+      },
+      "mentionable": {
+        "items": {
+          "properties": {
+            "$NAME": {
+              "type": "string"
+            },
+            "$UI": {
+              "$ref": "https://commonfabric.org/schemas/vnode.json"
+            },
+            "summary": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "summary",
+            "$NAME",
+            "$UI"
+          ],
+          "type": "object"
+        },
+        "type": "array"
+      },
+      "removeItem": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream",
+          "stream"
+        ],
+        "properties": {
+          "item": {
+            "$ref": "#/$defs/DoItem"
+          }
+        },
+        "required": [
+          "item"
+        ],
+        "type": "object"
+      },
+      "removeItemByTitle": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream",
+          "stream"
+        ],
+        "description": "Remove a task and its subtasks by title",
+        "properties": {
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title"
+        ],
+        "type": "object"
+      },
+      "summary": {
+        "type": "string"
+      },
+      "updateItem": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream",
+          "stream"
+        ],
+        "properties": {
+          "done": {
+            "type": "boolean"
+          },
+          "item": {
+            "$ref": "#/$defs/DoItem"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "item"
+        ],
+        "type": "object"
+      },
+      "updateItemByTitle": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream",
+          "stream"
+        ],
+        "description": "Update a task by title. Set done to mark complete, newTitle to rename, attachments to add references.",
+        "properties": {
+          "attachments": {
+            "items": {},
+            "type": "array"
+          },
+          "done": {
+            "type": "boolean"
+          },
+          "newTitle": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title"
+        ],
+        "type": "object"
+      }
+    },
+    "required": [
+      "compactUI",
+      "isHidden",
+      "items",
+      "itemCount",
+      "summary",
+      "mentionable",
+      "addItem",
+      "removeItem",
+      "updateItem",
+      "addItems",
+      "removeItemByTitle",
+      "updateItemByTitle",
+      "archiveCompleted",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/examples/array-in-cell-with-remove-editable.tsx/20260807T235141Z-wwJBsq0wvR8Ovur8.json
+++ b/packages/patterns/baselines/examples/array-in-cell-with-remove-editable.tsx/20260807T235141Z-wwJBsq0wvR8Ovur8.json
@@ -1,0 +1,135 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "Item": {
+        "properties": {
+          "text": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "text"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "items": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/Item"
+        },
+        "type": "array"
+      },
+      "title": {
+        "default": "untitled",
+        "type": "string"
+      }
+    },
+    "required": [
+      "title",
+      "items"
+    ],
+    "type": "object"
+  },
+  "pattern": "examples/array-in-cell-with-remove-editable.tsx",
+  "resultSchema": {
+    "$defs": {
+      "InputEventType": {
+        "properties": {
+          "detail": {
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "message"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "detail"
+        ],
+        "type": "object"
+      },
+      "Item": {
+        "properties": {
+          "text": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "text"
+        ],
+        "type": "object"
+      },
+      "JSXElement": {
+        "anyOf": [
+          {
+            "$ref": "https://commonfabric.org/schemas/vnode.json"
+          },
+          {
+            "$ref": "#/$defs/UIRenderable"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ]
+      },
+      "UIRenderable": {
+        "properties": {
+          "$UI": {
+            "$ref": "https://commonfabric.org/schemas/vnode.json"
+          }
+        },
+        "required": [
+          "$UI"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "#/$defs/JSXElement"
+      },
+      "addItem": {
+        "$ref": "#/$defs/InputEventType",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "items": {
+        "items": {
+          "$ref": "#/$defs/Item"
+        },
+        "type": "array"
+      },
+      "title": {
+        "type": "string"
+      },
+      "updateItem": {
+        "asCell": [
+          "stream"
+        ]
+      }
+    },
+    "required": [
+      "$NAME",
+      "$UI",
+      "title",
+      "items",
+      "addItem",
+      "updateItem"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/examples/reactive-now.tsx/20260807T235141Z-9N6STbyD7YWJWwDQ.json
+++ b/packages/patterns/baselines/examples/reactive-now.tsx/20260807T235141Z-9N6STbyD7YWJWwDQ.json
@@ -1,0 +1,93 @@
+{
+  "argumentSchema": {
+    "asCell": [
+      "opaque"
+    ]
+  },
+  "pattern": "examples/reactive-now.tsx",
+  "resultSchema": {
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "charCount": {
+        "description": "Length of `typed`, derived — updates as the keystroke write propagates.",
+        "type": "number"
+      },
+      "echo": {
+        "description": "`typed` upper-cased, derived — a second observer of the same cell flip.",
+        "type": "string"
+      },
+      "lastTapAt": {
+        "description": "Coarse time the last tap was delivered (\"—\" before the first).",
+        "type": "string"
+      },
+      "loadedAt": {
+        "description": "The piece's first-load time, \"HH:MM:SS\" (or \"…\" before #now resolves).",
+        "tags": [
+          "now"
+        ],
+        "type": "string"
+      },
+      "now": {
+        "description": "The ticking current time, \"HH:MM:SS\" (or \"…\").",
+        "type": "string"
+      },
+      "sinceLoad": {
+        "description": "Whole seconds since load, e.g. \"12s ago\" (or \"…\").",
+        "type": "string"
+      },
+      "tap": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "description": "The tap event stream (also driven by the button).",
+        "properties": {},
+        "type": "object"
+      },
+      "taps": {
+        "description": "How many times the tap handler has actually been delivered.",
+        "type": "number"
+      },
+      "type": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "description": "Test-only stream to set the text box (the browser uses the `$value` bind).",
+        "properties": {
+          "value": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "value"
+        ],
+        "type": "object"
+      },
+      "typed": {
+        "description": "The current text of the bound `$value` box.",
+        "type": "string"
+      }
+    },
+    "required": [
+      "loadedAt",
+      "now",
+      "sinceLoad",
+      "taps",
+      "lastTapAt",
+      "tap",
+      "typed",
+      "charCount",
+      "echo",
+      "type",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/experimental/chat-note.tsx/20260807T235141Z-27UQJGMpkraCHfqc.json
+++ b/packages/patterns/baselines/experimental/chat-note.tsx/20260807T235141Z-27UQJGMpkraCHfqc.json
@@ -1,0 +1,148 @@
+{
+  "argumentSchema": {
+    "properties": {
+      "content": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "isHidden": {
+        "default": false,
+        "type": "boolean"
+      },
+      "linkPattern": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "description": "Pattern JSON for [[wiki-links]]. Defaults to creating new ChatNotes.",
+        "type": "string"
+      },
+      "model": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "anthropic:claude-sonnet-4-5",
+        "description": "Selected model for generation. Defaults to Sonnet 4.5",
+        "type": "string"
+      },
+      "noteId": {
+        "default": "",
+        "type": "string"
+      },
+      "parentNotebook": true,
+      "title": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "Chat Note",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "experimental/chat-note.tsx",
+  "resultSchema": {
+    "$defs": {
+      "AnonymousType_1": {
+        "items": {
+          "$ref": "#/$defs/MentionablePiece"
+        },
+        "type": "array"
+      },
+      "MentionablePiece": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "backlinks": {
+            "$ref": "#/$defs/AnonymousType_1"
+          },
+          "content": {
+            "type": "string"
+          },
+          "isHidden": {
+            "type": "boolean"
+          },
+          "mentioned": {
+            "$ref": "#/$defs/AnonymousType_1"
+          }
+        },
+        "required": [
+          "mentioned",
+          "backlinks"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "Represents a chat-enabled note with inline LLM conversations.",
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "backlinks": {
+        "$ref": "#/$defs/AnonymousType_1"
+      },
+      "content": {
+        "default": "",
+        "type": "string"
+      },
+      "editContent": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "detail": {
+            "properties": {
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "detail"
+        ],
+        "type": "object"
+      },
+      "isGenerating": {
+        "type": "boolean"
+      },
+      "isHidden": {
+        "default": false,
+        "type": "boolean"
+      },
+      "mentioned": {
+        "$ref": "#/$defs/AnonymousType_1",
+        "default": []
+      },
+      "noteId": {
+        "default": "",
+        "type": "string"
+      },
+      "parentNotebook": true
+    },
+    "required": [
+      "mentioned",
+      "backlinks",
+      "parentNotebook",
+      "content",
+      "isHidden",
+      "noteId",
+      "isGenerating",
+      "editContent",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/experimental/folksonomy-aggregator.tsx/20260807T235141Z-XmrRJsOs5S7K5MdL.json
+++ b/packages/patterns/baselines/experimental/folksonomy-aggregator.tsx/20260807T235141Z-XmrRJsOs5S7K5MdL.json
@@ -1,0 +1,128 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "TagEvent": {
+        "properties": {
+          "action": {
+            "enum": [
+              "add",
+              "use",
+              "remove"
+            ]
+          },
+          "scope": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "scope",
+          "tag",
+          "action",
+          "timestamp"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "events": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/TagEvent"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "events"
+    ],
+    "type": "object"
+  },
+  "pattern": "experimental/folksonomy-aggregator.tsx",
+  "resultSchema": {
+    "$defs": {
+      "CommunityTagSuggestion": {
+        "properties": {
+          "count": {
+            "type": "number"
+          },
+          "tag": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "tag",
+          "count"
+        ],
+        "type": "object"
+      },
+      "TagEvent": {
+        "properties": {
+          "action": {
+            "enum": [
+              "add",
+              "use",
+              "remove"
+            ]
+          },
+          "scope": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "scope",
+          "tag",
+          "action",
+          "timestamp"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "A #folksonomyAggregator that collects tag usage events and serves community suggestions.\n\nThe #folksonomyAggregator tag is how folksonomy-tags instances discover this piece via wish().",
+    "properties": {
+      "events": {
+        "items": {
+          "$ref": "#/$defs/TagEvent"
+        },
+        "type": "array"
+      },
+      "postEvent": {
+        "$ref": "#/$defs/TagEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "suggestions": {
+        "additionalProperties": {
+          "items": {
+            "$ref": "#/$defs/CommunityTagSuggestion"
+          },
+          "type": "array"
+        },
+        "properties": {},
+        "type": "object"
+      }
+    },
+    "required": [
+      "events",
+      "suggestions",
+      "postEvent"
+    ],
+    "tags": [
+      "folksonomyaggregator"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/experimental/folksonomy-tags.tsx/20260807T235141Z-BF_1GKBjBJ1Eyylr.json
+++ b/packages/patterns/baselines/experimental/folksonomy-tags.tsx/20260807T235141Z-BF_1GKBjBJ1Eyylr.json
@@ -1,0 +1,166 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "AggregatorPiece": {
+        "properties": {
+          "events": {
+            "items": {
+              "$ref": "#/$defs/TagEvent"
+            },
+            "type": "array"
+          },
+          "postEvent": {
+            "$ref": "#/$defs/TagEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "suggestions": {
+            "additionalProperties": {
+              "items": {
+                "$ref": "#/$defs/CommunityTagSuggestion"
+              },
+              "type": "array"
+            },
+            "properties": {},
+            "type": "object"
+          }
+        },
+        "required": [
+          "events",
+          "postEvent",
+          "suggestions"
+        ],
+        "type": "object"
+      },
+      "CommunityTagSuggestion": {
+        "properties": {
+          "count": {
+            "type": "number"
+          },
+          "tag": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "tag",
+          "count"
+        ],
+        "type": "object"
+      },
+      "TagEvent": {
+        "properties": {
+          "action": {
+            "enum": [
+              "add",
+              "use",
+              "remove"
+            ]
+          },
+          "scope": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "scope",
+          "tag",
+          "action",
+          "timestamp"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "aggregator": {
+        "$ref": "#/$defs/AggregatorPiece",
+        "description": "Optional: Direct reference to aggregator (bypasses wish() discovery)"
+      },
+      "scope": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "description": "Namespace key (e.g., GitHub URL of the pattern using it)",
+        "type": "string"
+      },
+      "tags": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "description": "User's tags for this scope - bidirectional binding",
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "scope",
+      "tags"
+    ],
+    "type": "object"
+  },
+  "pattern": "experimental/folksonomy-tags.tsx",
+  "resultSchema": {
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addTag": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "tag": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "tag"
+        ],
+        "type": "object"
+      },
+      "removeTag": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "tag": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "tag"
+        ],
+        "type": "object"
+      },
+      "tags": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "tags",
+      "addTag",
+      "removeTag",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/factory-outputs/lot-watch/main.tsx/20260807T235141Z-4lW5h5EB27qVZHOp.json
+++ b/packages/patterns/baselines/factory-outputs/lot-watch/main.tsx/20260807T235141Z-4lW5h5EB27qVZHOp.json
@@ -1,0 +1,880 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "Classification": {
+        "enum": [
+          "ours",
+          "guest",
+          "offender",
+          "unknown"
+        ]
+      },
+      "KnownVehicle": {
+        "properties": {
+          "category": {
+            "enum": [
+              "guest",
+              "offender"
+            ]
+          },
+          "description": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "org": {
+            "type": "string"
+          },
+          "plateNumber": {
+            "type": "string"
+          },
+          "plateState": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "plateNumber",
+          "plateState",
+          "description",
+          "category",
+          "org",
+          "label"
+        ],
+        "type": "object"
+      },
+      "LotWatchAdminList": {
+        "ifc": {
+          "requiredIntegrity": [
+            "lot-watch-admin-manager"
+          ]
+        },
+        "items": {
+          "$ref": "#/$defs/LotWatchAdminRole"
+        },
+        "type": "array"
+      },
+      "LotWatchAdminManagerCredential": {
+        "ifc": {
+          "addIntegrity": [
+            "lot-watch-admin-manager"
+          ]
+        },
+        "properties": {
+          "canManageAdmins": {
+            "enum": [
+              true
+            ],
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "canManageAdmins"
+        ],
+        "type": "object"
+      },
+      "LotWatchAdminRegistryStoredValue": {
+        "properties": {
+          "admins": {
+            "$ref": "#/$defs/LotWatchAdminList"
+          }
+        },
+        "type": "object"
+      },
+      "LotWatchAdminRegistryValue": {
+        "$ref": "#/$defs/LotWatchAdminRegistryStoredValue"
+      },
+      "LotWatchAdminRole": {
+        "$ref": "#/$defs/LotWatchAdminRoleAssignment",
+        "ifc": {
+          "addIntegrity": [
+            "lot-watch-admin"
+          ]
+        }
+      },
+      "LotWatchAdminRoleAssignment": {
+        "properties": {
+          "displayName": {
+            "type": "string"
+          },
+          "subject": {
+            "$ref": "#/$defs/LotWatchAdminSubject"
+          }
+        },
+        "required": [
+          "subject",
+          "displayName"
+        ],
+        "type": "object"
+      },
+      "LotWatchAdminSubject": {
+        "properties": {
+          "personName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "personName"
+        ],
+        "type": "object"
+      },
+      "ParkingSpot": {
+        "properties": {
+          "active": {
+            "type": "boolean"
+          },
+          "label": {
+            "type": "string"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "spotNumber": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "spotNumber",
+          "label"
+        ],
+        "type": "object"
+      },
+      "PersonWithVehicles": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "vehicles": {
+            "items": {
+              "properties": {
+                "color": {
+                  "type": "string"
+                },
+                "make": {
+                  "type": "string"
+                },
+                "model": {
+                  "type": "string"
+                },
+                "plateId": {
+                  "type": "string"
+                },
+                "plateState": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "plateId",
+                "plateState"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "Sighting": {
+        "properties": {
+          "capturedAt": {
+            "type": "number"
+          },
+          "classification": {
+            "$ref": "#/$defs/Classification"
+          },
+          "description": {
+            "type": "string"
+          },
+          "extractionError": {
+            "type": "string"
+          },
+          "extractionPending": {
+            "type": "boolean"
+          },
+          "humanCorrected": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string"
+          },
+          "image": {
+            "$ref": "#/$defs/SightingImage"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "plateNumber": {
+            "type": "string"
+          },
+          "plateState": {
+            "type": "string"
+          },
+          "reportedBy": {
+            "type": "string"
+          },
+          "spotNumber": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "spotNumber",
+          "capturedAt",
+          "reportedBy",
+          "image",
+          "description",
+          "plateNumber",
+          "plateState",
+          "extractionPending",
+          "extractionError",
+          "humanCorrected",
+          "classification",
+          "notes"
+        ],
+        "type": "object"
+      },
+      "SightingImage": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "url",
+          "name"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "adminManagerCredential": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/LotWatchAdminManagerCredential"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "user"
+          }
+        ]
+      },
+      "adminRegistry": {
+        "$ref": "#/$defs/LotWatchAdminRegistryValue",
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ]
+      },
+      "knownVehicles": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/KnownVehicle"
+        },
+        "type": "array"
+      },
+      "people": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/PersonWithVehicles"
+        },
+        "type": "array"
+      },
+      "sightings": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/Sighting"
+        },
+        "type": "array"
+      },
+      "spots": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ],
+        "default": [
+          {
+            "label": "Near entrance",
+            "spotNumber": "1"
+          },
+          {
+            "label": "",
+            "spotNumber": "5"
+          },
+          {
+            "label": "Compact only",
+            "spotNumber": "12"
+          },
+          {
+            "label": "",
+            "spotNumber": "13"
+          }
+        ],
+        "items": {
+          "$ref": "#/$defs/ParkingSpot"
+        },
+        "type": "array"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "factory-outputs/lot-watch/main.tsx",
+  "resultSchema": {
+    "$defs": {
+      "Classification": {
+        "enum": [
+          "ours",
+          "guest",
+          "offender",
+          "unknown"
+        ]
+      },
+      "ImageData": {
+        "properties": {
+          "data": {
+            "type": "string"
+          },
+          "exif": {
+            "properties": {
+              "dateTime": {
+                "type": "string"
+              },
+              "exposureTime": {
+                "type": "string"
+              },
+              "fNumber": {
+                "type": "number"
+              },
+              "focalLength": {
+                "type": "number"
+              },
+              "gpsAltitude": {
+                "type": "number"
+              },
+              "gpsLatitude": {
+                "type": "number"
+              },
+              "gpsLongitude": {
+                "type": "number"
+              },
+              "iso": {
+                "type": "number"
+              },
+              "make": {
+                "type": "string"
+              },
+              "model": {
+                "type": "string"
+              },
+              "orientation": {
+                "type": "number"
+              },
+              "pixelXDimension": {
+                "type": "number"
+              },
+              "pixelYDimension": {
+                "type": "number"
+              },
+              "raw": {
+                "additionalProperties": true,
+                "properties": {},
+                "type": "object"
+              },
+              "software": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "height": {
+            "type": "number"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "size": {
+            "type": "number"
+          },
+          "timestamp": {
+            "type": "number"
+          },
+          "type": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "width": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "url",
+          "data",
+          "timestamp",
+          "size",
+          "type"
+        ],
+        "type": "object"
+      },
+      "KnownVehicle": {
+        "properties": {
+          "category": {
+            "enum": [
+              "guest",
+              "offender"
+            ]
+          },
+          "description": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "org": {
+            "type": "string"
+          },
+          "plateNumber": {
+            "type": "string"
+          },
+          "plateState": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "plateNumber",
+          "plateState",
+          "description",
+          "category",
+          "org",
+          "label"
+        ],
+        "type": "object"
+      },
+      "PersonWithVehicles": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "vehicles": {
+            "items": {
+              "properties": {
+                "color": {
+                  "type": "string"
+                },
+                "make": {
+                  "type": "string"
+                },
+                "model": {
+                  "type": "string"
+                },
+                "plateId": {
+                  "type": "string"
+                },
+                "plateState": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "plateId",
+                "plateState"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "Sighting": {
+        "properties": {
+          "capturedAt": {
+            "type": "number"
+          },
+          "classification": {
+            "$ref": "#/$defs/Classification"
+          },
+          "description": {
+            "type": "string"
+          },
+          "extractionError": {
+            "type": "string"
+          },
+          "extractionPending": {
+            "type": "boolean"
+          },
+          "humanCorrected": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string"
+          },
+          "image": {
+            "$ref": "#/$defs/SightingImage"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "plateNumber": {
+            "type": "string"
+          },
+          "plateState": {
+            "type": "string"
+          },
+          "reportedBy": {
+            "type": "string"
+          },
+          "spotNumber": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "spotNumber",
+          "capturedAt",
+          "reportedBy",
+          "image",
+          "description",
+          "plateNumber",
+          "plateState",
+          "extractionPending",
+          "extractionError",
+          "humanCorrected",
+          "classification",
+          "notes"
+        ],
+        "type": "object"
+      },
+      "SightingImage": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "url",
+          "name"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "assignToPerson": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "cancelAssign": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "cancelGuest": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "captureSighting": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "image": {
+            "$ref": "#/$defs/ImageData"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "plateNumber": {
+            "type": "string"
+          },
+          "plateState": {
+            "type": "string"
+          },
+          "spotNumber": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "spotNumber",
+          "image",
+          "description",
+          "plateNumber",
+          "plateState",
+          "notes"
+        ],
+        "type": "object"
+      },
+      "deleteSighting": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
+      },
+      "enableAdminManager": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "knownVehicles": {
+        "items": {
+          "$ref": "#/$defs/KnownVehicle"
+        },
+        "type": "array"
+      },
+      "markVehicle": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "category": {
+            "enum": [
+              "guest",
+              "offender"
+            ]
+          },
+          "label": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "org": {
+            "type": "string"
+          },
+          "plateNumber": {
+            "type": "string"
+          },
+          "plateState": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "plateNumber",
+          "plateState",
+          "category",
+          "org"
+        ],
+        "type": "object"
+      },
+      "openAssign": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
+      },
+      "openGuest": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
+      },
+      "people": {
+        "items": {
+          "$ref": "#/$defs/PersonWithVehicles"
+        },
+        "type": "array"
+      },
+      "removeKnownVehicle": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "plateNumber": {
+            "type": "string"
+          },
+          "plateState": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "plateNumber",
+          "plateState"
+        ],
+        "type": "object"
+      },
+      "saveGuest": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "selectTab": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "tab": {
+            "enum": [
+              "capture",
+              "sightings",
+              "report"
+            ]
+          }
+        },
+        "required": [
+          "tab"
+        ],
+        "type": "object"
+      },
+      "setReporterName": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "sightings": {
+        "items": {
+          "$ref": "#/$defs/Sighting"
+        },
+        "type": "array"
+      },
+      "toggleAdminMode": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "togglePersonAdmin": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      }
+    },
+    "required": [
+      "sightings",
+      "knownVehicles",
+      "people",
+      "captureSighting",
+      "deleteSighting",
+      "selectTab",
+      "setReporterName",
+      "markVehicle",
+      "removeKnownVehicle",
+      "openAssign",
+      "cancelAssign",
+      "assignToPerson",
+      "openGuest",
+      "cancelGuest",
+      "saveGuest",
+      "enableAdminManager",
+      "togglePersonAdmin",
+      "toggleAdminMode",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/factory-outputs/lot-watch/main.tsx/20260810T184538Z-SqJWfO-0YB43RQ7q.json
+++ b/packages/patterns/baselines/factory-outputs/lot-watch/main.tsx/20260810T184538Z-SqJWfO-0YB43RQ7q.json
@@ -1,0 +1,885 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "Classification": {
+        "enum": [
+          "ours",
+          "guest",
+          "offender",
+          "unknown"
+        ]
+      },
+      "KnownVehicle": {
+        "properties": {
+          "category": {
+            "enum": [
+              "guest",
+              "offender"
+            ]
+          },
+          "description": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "org": {
+            "type": "string"
+          },
+          "plateNumber": {
+            "type": "string"
+          },
+          "plateState": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "plateNumber",
+          "plateState",
+          "description",
+          "category",
+          "org",
+          "label"
+        ],
+        "type": "object"
+      },
+      "LotWatchAdminList": {
+        "ifc": {
+          "requiredIntegrity": [
+            "lot-watch-admin-manager"
+          ]
+        },
+        "items": {
+          "$ref": "#/$defs/LotWatchAdminRole"
+        },
+        "type": "array"
+      },
+      "LotWatchAdminManagerCredential": {
+        "ifc": {
+          "addIntegrity": [
+            "lot-watch-admin-manager"
+          ]
+        },
+        "properties": {
+          "canManageAdmins": {
+            "enum": [
+              true
+            ],
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "canManageAdmins"
+        ],
+        "type": "object"
+      },
+      "LotWatchAdminRegistryStoredValue": {
+        "properties": {
+          "admins": {
+            "$ref": "#/$defs/LotWatchAdminList"
+          }
+        },
+        "type": "object"
+      },
+      "LotWatchAdminRegistryValue": {
+        "$ref": "#/$defs/LotWatchAdminRegistryStoredValue"
+      },
+      "LotWatchAdminRole": {
+        "$ref": "#/$defs/LotWatchAdminRoleAssignment",
+        "ifc": {
+          "addIntegrity": [
+            "lot-watch-admin"
+          ]
+        }
+      },
+      "LotWatchAdminRoleAssignment": {
+        "properties": {
+          "displayName": {
+            "type": "string"
+          },
+          "subject": {
+            "$ref": "#/$defs/LotWatchAdminSubject"
+          }
+        },
+        "required": [
+          "subject",
+          "displayName"
+        ],
+        "type": "object"
+      },
+      "LotWatchAdminSubject": {
+        "properties": {
+          "personName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "personName"
+        ],
+        "type": "object"
+      },
+      "ParkingSpot": {
+        "properties": {
+          "active": {
+            "type": "boolean"
+          },
+          "label": {
+            "type": "string"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "spotNumber": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "spotNumber",
+          "label"
+        ],
+        "type": "object"
+      },
+      "PersonWithVehicles": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "vehicles": {
+            "items": {
+              "properties": {
+                "color": {
+                  "type": "string"
+                },
+                "make": {
+                  "type": "string"
+                },
+                "model": {
+                  "type": "string"
+                },
+                "plateId": {
+                  "type": "string"
+                },
+                "plateState": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "plateId",
+                "plateState"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "Sighting": {
+        "properties": {
+          "capturedAt": {
+            "type": "number"
+          },
+          "classification": {
+            "$ref": "#/$defs/Classification"
+          },
+          "description": {
+            "type": "string"
+          },
+          "extractionError": {
+            "type": "string"
+          },
+          "extractionPending": {
+            "type": "boolean"
+          },
+          "humanCorrected": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string"
+          },
+          "image": {
+            "$ref": "#/$defs/SightingImage"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "plateNumber": {
+            "type": "string"
+          },
+          "plateState": {
+            "type": "string"
+          },
+          "reportedBy": {
+            "type": "string"
+          },
+          "spotNumber": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "spotNumber",
+          "capturedAt",
+          "reportedBy",
+          "image",
+          "description",
+          "plateNumber",
+          "plateState",
+          "extractionPending",
+          "extractionError",
+          "humanCorrected",
+          "classification",
+          "notes"
+        ],
+        "type": "object"
+      },
+      "SightingImage": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "url",
+          "name"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "adminManagerCredential": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/LotWatchAdminManagerCredential"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "user"
+          }
+        ]
+      },
+      "adminRegistry": {
+        "$ref": "#/$defs/LotWatchAdminRegistryValue",
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ]
+      },
+      "knownVehicles": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/KnownVehicle"
+        },
+        "type": "array"
+      },
+      "people": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/PersonWithVehicles"
+        },
+        "type": "array"
+      },
+      "sightings": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/Sighting"
+        },
+        "type": "array"
+      },
+      "spots": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ],
+        "default": [
+          {
+            "label": "Near entrance",
+            "spotNumber": "1"
+          },
+          {
+            "label": "",
+            "spotNumber": "5"
+          },
+          {
+            "label": "Compact only",
+            "spotNumber": "12"
+          },
+          {
+            "label": "",
+            "spotNumber": "13"
+          }
+        ],
+        "items": {
+          "$ref": "#/$defs/ParkingSpot"
+        },
+        "type": "array"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "factory-outputs/lot-watch/main.tsx",
+  "resultSchema": {
+    "$defs": {
+      "Classification": {
+        "enum": [
+          "ours",
+          "guest",
+          "offender",
+          "unknown"
+        ]
+      },
+      "ImageData": {
+        "properties": {
+          "data": {
+            "type": "string"
+          },
+          "exif": {
+            "properties": {
+              "dateTime": {
+                "type": "string"
+              },
+              "exposureTime": {
+                "type": "string"
+              },
+              "fNumber": {
+                "type": "number"
+              },
+              "focalLength": {
+                "type": "number"
+              },
+              "gpsAltitude": {
+                "type": "number"
+              },
+              "gpsLatitude": {
+                "type": "number"
+              },
+              "gpsLongitude": {
+                "type": "number"
+              },
+              "iso": {
+                "type": "number"
+              },
+              "make": {
+                "type": "string"
+              },
+              "model": {
+                "type": "string"
+              },
+              "orientation": {
+                "type": "number"
+              },
+              "pixelXDimension": {
+                "type": "number"
+              },
+              "pixelYDimension": {
+                "type": "number"
+              },
+              "raw": {
+                "additionalProperties": true,
+                "properties": {},
+                "type": "object"
+              },
+              "software": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "height": {
+            "type": "number"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "size": {
+            "type": "number"
+          },
+          "timestamp": {
+            "type": "number"
+          },
+          "type": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "width": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "url",
+          "data",
+          "timestamp",
+          "size",
+          "type"
+        ],
+        "type": "object"
+      },
+      "KnownVehicle": {
+        "properties": {
+          "category": {
+            "enum": [
+              "guest",
+              "offender"
+            ]
+          },
+          "description": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "org": {
+            "type": "string"
+          },
+          "plateNumber": {
+            "type": "string"
+          },
+          "plateState": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "plateNumber",
+          "plateState",
+          "description",
+          "category",
+          "org",
+          "label"
+        ],
+        "type": "object"
+      },
+      "PersonWithVehicles": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "vehicles": {
+            "items": {
+              "properties": {
+                "color": {
+                  "type": "string"
+                },
+                "make": {
+                  "type": "string"
+                },
+                "model": {
+                  "type": "string"
+                },
+                "plateId": {
+                  "type": "string"
+                },
+                "plateState": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "plateId",
+                "plateState"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "Sighting": {
+        "properties": {
+          "capturedAt": {
+            "type": "number"
+          },
+          "classification": {
+            "$ref": "#/$defs/Classification"
+          },
+          "description": {
+            "type": "string"
+          },
+          "extractionError": {
+            "type": "string"
+          },
+          "extractionPending": {
+            "type": "boolean"
+          },
+          "humanCorrected": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string"
+          },
+          "image": {
+            "$ref": "#/$defs/SightingImage"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "plateNumber": {
+            "type": "string"
+          },
+          "plateState": {
+            "type": "string"
+          },
+          "reportedBy": {
+            "type": "string"
+          },
+          "spotNumber": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "spotNumber",
+          "capturedAt",
+          "reportedBy",
+          "image",
+          "description",
+          "plateNumber",
+          "plateState",
+          "extractionPending",
+          "extractionError",
+          "humanCorrected",
+          "classification",
+          "notes"
+        ],
+        "type": "object"
+      },
+      "SightingImage": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "url",
+          "name"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "assignToPerson": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "tier": "wrapper"
+      },
+      "cancelAssign": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "tier": "wrapper"
+      },
+      "cancelGuest": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "tier": "wrapper"
+      },
+      "captureSighting": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "image": {
+            "$ref": "#/$defs/ImageData"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "plateNumber": {
+            "type": "string"
+          },
+          "plateState": {
+            "type": "string"
+          },
+          "spotNumber": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "spotNumber",
+          "image",
+          "description",
+          "plateNumber",
+          "plateState",
+          "notes"
+        ],
+        "type": "object"
+      },
+      "deleteSighting": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
+      },
+      "enableAdminManager": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "knownVehicles": {
+        "items": {
+          "$ref": "#/$defs/KnownVehicle"
+        },
+        "type": "array"
+      },
+      "markVehicle": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "category": {
+            "enum": [
+              "guest",
+              "offender"
+            ]
+          },
+          "label": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "org": {
+            "type": "string"
+          },
+          "plateNumber": {
+            "type": "string"
+          },
+          "plateState": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "plateNumber",
+          "plateState",
+          "category",
+          "org"
+        ],
+        "type": "object"
+      },
+      "openAssign": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
+      },
+      "openGuest": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
+      },
+      "people": {
+        "items": {
+          "$ref": "#/$defs/PersonWithVehicles"
+        },
+        "type": "array"
+      },
+      "removeKnownVehicle": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "plateNumber": {
+            "type": "string"
+          },
+          "plateState": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "plateNumber",
+          "plateState"
+        ],
+        "type": "object"
+      },
+      "saveGuest": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "tier": "wrapper"
+      },
+      "selectTab": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "tab": {
+            "enum": [
+              "capture",
+              "sightings",
+              "report"
+            ]
+          }
+        },
+        "required": [
+          "tab"
+        ],
+        "type": "object"
+      },
+      "setReporterName": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "sightings": {
+        "items": {
+          "$ref": "#/$defs/Sighting"
+        },
+        "type": "array"
+      },
+      "toggleAdminMode": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "tier": "wrapper"
+      },
+      "togglePersonAdmin": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      }
+    },
+    "required": [
+      "sightings",
+      "knownVehicles",
+      "people",
+      "captureSighting",
+      "deleteSighting",
+      "selectTab",
+      "setReporterName",
+      "markVehicle",
+      "removeKnownVehicle",
+      "openAssign",
+      "cancelAssign",
+      "assignToPerson",
+      "openGuest",
+      "cancelGuest",
+      "saveGuest",
+      "enableAdminManager",
+      "togglePersonAdmin",
+      "toggleAdminMode",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/factory-outputs/parking-coordinator/main.tsx/20260807T235141Z-xNYG37EuzmOLWhjE.json
+++ b/packages/patterns/baselines/factory-outputs/parking-coordinator/main.tsx/20260807T235141Z-xNYG37EuzmOLWhjE.json
@@ -1,0 +1,837 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "CommuteMode": {
+        "enum": [
+          "drive",
+          "transit",
+          "bike",
+          "wfh",
+          "other"
+        ]
+      },
+      "ParkingAdminList": {
+        "ifc": {
+          "requiredIntegrity": [
+            "parking-admin-manager"
+          ]
+        },
+        "items": {
+          "$ref": "#/$defs/ParkingAdminRole"
+        },
+        "type": "array"
+      },
+      "ParkingAdminRegistryStoredValue": {
+        "properties": {
+          "admins": {
+            "$ref": "#/$defs/ParkingAdminList"
+          }
+        },
+        "type": "object"
+      },
+      "ParkingAdminRegistryValue": {
+        "$ref": "#/$defs/ParkingAdminRegistryStoredValue"
+      },
+      "ParkingAdminRole": {
+        "$ref": "#/$defs/ParkingAdminRoleAssignment",
+        "ifc": {
+          "addIntegrity": [
+            "parking-admin"
+          ]
+        }
+      },
+      "ParkingAdminRoleAssignment": {
+        "properties": {
+          "displayName": {
+            "type": "string"
+          },
+          "subject": {
+            "$ref": "#/$defs/ParkingAdminSubject"
+          }
+        },
+        "required": [
+          "subject",
+          "displayName"
+        ],
+        "type": "object"
+      },
+      "ParkingAdminSubject": {
+        "properties": {
+          "personName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "personName"
+        ],
+        "type": "object"
+      },
+      "ParkingSpot": {
+        "properties": {
+          "active": {
+            "type": "boolean"
+          },
+          "label": {
+            "type": "string"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "spotNumber": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "spotNumber",
+          "label",
+          "notes",
+          "active"
+        ],
+        "type": "object"
+      },
+      "ParkingSpotList": {
+        "ifc": {
+          "requiredIntegrity": [
+            "parking-admin"
+          ]
+        },
+        "items": {
+          "$ref": "#/$defs/ParkingSpot"
+        },
+        "type": "array"
+      },
+      "Person": {
+        "properties": {
+          "commuteMode": {
+            "$ref": "#/$defs/CommuteMode"
+          },
+          "defaultSpot": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "priorityRank": {
+            "type": "number"
+          },
+          "spotPreferences": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "vehicles": {
+            "items": {
+              "$ref": "#/$defs/Vehicle"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "name",
+          "email",
+          "commuteMode",
+          "spotPreferences",
+          "defaultSpot",
+          "priorityRank"
+        ],
+        "type": "object"
+      },
+      "RequestStatus": {
+        "enum": [
+          "pending",
+          "allocated",
+          "denied",
+          "cancelled"
+        ]
+      },
+      "SpotRequest": {
+        "properties": {
+          "assignedSpot": {
+            "type": "string"
+          },
+          "autoAllocated": {
+            "type": "boolean"
+          },
+          "date": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "personName": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/$defs/RequestStatus"
+          }
+        },
+        "required": [
+          "id",
+          "personName",
+          "date",
+          "status",
+          "assignedSpot",
+          "autoAllocated"
+        ],
+        "type": "object"
+      },
+      "Vehicle": {
+        "properties": {
+          "color": {
+            "type": "string"
+          },
+          "make": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "plateId": {
+            "type": "string"
+          },
+          "plateState": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "plateId",
+          "plateState",
+          "color",
+          "make",
+          "model"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "adminRegistry": {
+        "$ref": "#/$defs/ParkingAdminRegistryValue",
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ]
+      },
+      "people": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/Person"
+        },
+        "type": "array"
+      },
+      "requests": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/SpotRequest"
+        },
+        "type": "array"
+      },
+      "spots": {
+        "$ref": "#/$defs/ParkingSpotList",
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ],
+        "default": [
+          {
+            "active": true,
+            "label": "Near entrance",
+            "notes": "",
+            "spotNumber": "1"
+          },
+          {
+            "active": true,
+            "label": "",
+            "notes": "",
+            "spotNumber": "5"
+          },
+          {
+            "active": true,
+            "label": "Compact only",
+            "notes": "Tight, no large vehicles",
+            "spotNumber": "12"
+          }
+        ]
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "factory-outputs/parking-coordinator/main.tsx",
+  "resultSchema": {
+    "$defs": {
+      "CommuteMode": {
+        "enum": [
+          "drive",
+          "transit",
+          "bike",
+          "wfh",
+          "other"
+        ]
+      },
+      "ParkingAdminList": {
+        "ifc": {
+          "requiredIntegrity": [
+            "parking-admin-manager"
+          ]
+        },
+        "items": {
+          "$ref": "#/$defs/ParkingAdminRole"
+        },
+        "type": "array"
+      },
+      "ParkingAdminRegistryStoredValue": {
+        "properties": {
+          "admins": {
+            "$ref": "#/$defs/ParkingAdminList"
+          }
+        },
+        "type": "object"
+      },
+      "ParkingAdminRegistryValue": {
+        "$ref": "#/$defs/ParkingAdminRegistryStoredValue"
+      },
+      "ParkingAdminRole": {
+        "$ref": "#/$defs/ParkingAdminRoleAssignment",
+        "ifc": {
+          "addIntegrity": [
+            "parking-admin"
+          ]
+        }
+      },
+      "ParkingAdminRoleAssignment": {
+        "properties": {
+          "displayName": {
+            "type": "string"
+          },
+          "subject": {
+            "$ref": "#/$defs/ParkingAdminSubject"
+          }
+        },
+        "required": [
+          "subject",
+          "displayName"
+        ],
+        "type": "object"
+      },
+      "ParkingAdminSubject": {
+        "properties": {
+          "personName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "personName"
+        ],
+        "type": "object"
+      },
+      "ParkingSpot": {
+        "properties": {
+          "active": {
+            "type": "boolean"
+          },
+          "label": {
+            "type": "string"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "spotNumber": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "spotNumber",
+          "label",
+          "notes",
+          "active"
+        ],
+        "type": "object"
+      },
+      "Person": {
+        "properties": {
+          "commuteMode": {
+            "$ref": "#/$defs/CommuteMode"
+          },
+          "defaultSpot": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "priorityRank": {
+            "type": "number"
+          },
+          "spotPreferences": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "vehicles": {
+            "items": {
+              "$ref": "#/$defs/Vehicle"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "name",
+          "email",
+          "commuteMode",
+          "spotPreferences",
+          "defaultSpot",
+          "priorityRank"
+        ],
+        "type": "object"
+      },
+      "RequestStatus": {
+        "enum": [
+          "pending",
+          "allocated",
+          "denied",
+          "cancelled"
+        ]
+      },
+      "SpotRequest": {
+        "properties": {
+          "assignedSpot": {
+            "type": "string"
+          },
+          "autoAllocated": {
+            "type": "boolean"
+          },
+          "date": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "personName": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/$defs/RequestStatus"
+          }
+        },
+        "required": [
+          "id",
+          "personName",
+          "date",
+          "status",
+          "assignedSpot",
+          "autoAllocated"
+        ],
+        "type": "object"
+      },
+      "Vehicle": {
+        "properties": {
+          "color": {
+            "type": "string"
+          },
+          "make": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "plateId": {
+            "type": "string"
+          },
+          "plateState": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "plateId",
+          "plateState",
+          "color",
+          "make",
+          "model"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addPerson": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "commuteMode": {
+            "$ref": "#/$defs/CommuteMode"
+          },
+          "defaultSpot": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "preferences": {
+            "type": "string"
+          },
+          "priorityRank": {
+            "type": "number"
+          },
+          "vehicles": {
+            "items": {
+              "$ref": "#/$defs/Vehicle"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "name",
+          "email",
+          "commuteMode",
+          "priorityRank",
+          "defaultSpot",
+          "preferences"
+        ],
+        "type": "object"
+      },
+      "addSpot": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "spotNumber": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "spotNumber",
+          "label",
+          "notes"
+        ],
+        "type": "object"
+      },
+      "adminMode": {
+        "type": "boolean"
+      },
+      "adminOverride": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "date": {
+            "type": "string"
+          },
+          "personName": {
+            "type": "string"
+          },
+          "spotNumber": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "spotNumber",
+          "date",
+          "personName"
+        ],
+        "type": "object"
+      },
+      "adminRegistry": {
+        "$ref": "#/$defs/ParkingAdminRegistryValue"
+      },
+      "cancelRequest": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "requestId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "requestId"
+        ],
+        "type": "object"
+      },
+      "currentPersonIsAdmin": {
+        "type": "boolean"
+      },
+      "currentUserCanManageAdmins": {
+        "type": "boolean"
+      },
+      "editPerson": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "commuteMode": {
+            "$ref": "#/$defs/CommuteMode"
+          },
+          "defaultSpot": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "originalName": {
+            "type": "string"
+          },
+          "preferences": {
+            "type": "string"
+          },
+          "priorityRank": {
+            "type": "number"
+          },
+          "vehicles": {
+            "items": {
+              "$ref": "#/$defs/Vehicle"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "originalName",
+          "name",
+          "email",
+          "commuteMode",
+          "priorityRank",
+          "defaultSpot",
+          "preferences"
+        ],
+        "type": "object"
+      },
+      "editSpot": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "active": {
+            "type": "boolean"
+          },
+          "label": {
+            "type": "string"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "originalNumber": {
+            "type": "string"
+          },
+          "spotNumber": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "originalNumber",
+          "spotNumber",
+          "label",
+          "notes",
+          "active"
+        ],
+        "type": "object"
+      },
+      "enableAdminManager": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "movePersonDown": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "movePersonUp": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "people": {
+        "items": {
+          "$ref": "#/$defs/Person"
+        },
+        "type": "array"
+      },
+      "removePerson": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "removeSpot": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "spotNumber": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "spotNumber"
+        ],
+        "type": "object"
+      },
+      "requestDate": {
+        "type": "string"
+      },
+      "requestResult": {
+        "type": "string"
+      },
+      "requests": {
+        "items": {
+          "$ref": "#/$defs/SpotRequest"
+        },
+        "type": "array"
+      },
+      "selectedPersonName": {
+        "type": "string"
+      },
+      "spots": {
+        "items": {
+          "$ref": "#/$defs/ParkingSpot"
+        },
+        "type": "array"
+      },
+      "submitRequest": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "date": {
+            "type": "string"
+          },
+          "personName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "personName",
+          "date"
+        ],
+        "type": "object"
+      },
+      "toggleAdminMode": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "togglePersonAdmin": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      }
+    },
+    "required": [
+      "spots",
+      "people",
+      "requests",
+      "adminMode",
+      "selectedPersonName",
+      "requestDate",
+      "requestResult",
+      "adminRegistry",
+      "currentPersonIsAdmin",
+      "currentUserCanManageAdmins",
+      "enableAdminManager",
+      "togglePersonAdmin",
+      "toggleAdminMode",
+      "submitRequest",
+      "cancelRequest",
+      "addPerson",
+      "editPerson",
+      "removePerson",
+      "movePersonUp",
+      "movePersonDown",
+      "addSpot",
+      "editSpot",
+      "removeSpot",
+      "adminOverride",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/factory-outputs/parking-coordinator/main.tsx/20260810T184538Z-8mG0exmgYEBzKPFX.json
+++ b/packages/patterns/baselines/factory-outputs/parking-coordinator/main.tsx/20260810T184538Z-8mG0exmgYEBzKPFX.json
@@ -1,0 +1,838 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "CommuteMode": {
+        "enum": [
+          "drive",
+          "transit",
+          "bike",
+          "wfh",
+          "other"
+        ]
+      },
+      "ParkingAdminList": {
+        "ifc": {
+          "requiredIntegrity": [
+            "parking-admin-manager"
+          ]
+        },
+        "items": {
+          "$ref": "#/$defs/ParkingAdminRole"
+        },
+        "type": "array"
+      },
+      "ParkingAdminRegistryStoredValue": {
+        "properties": {
+          "admins": {
+            "$ref": "#/$defs/ParkingAdminList"
+          }
+        },
+        "type": "object"
+      },
+      "ParkingAdminRegistryValue": {
+        "$ref": "#/$defs/ParkingAdminRegistryStoredValue"
+      },
+      "ParkingAdminRole": {
+        "$ref": "#/$defs/ParkingAdminRoleAssignment",
+        "ifc": {
+          "addIntegrity": [
+            "parking-admin"
+          ]
+        }
+      },
+      "ParkingAdminRoleAssignment": {
+        "properties": {
+          "displayName": {
+            "type": "string"
+          },
+          "subject": {
+            "$ref": "#/$defs/ParkingAdminSubject"
+          }
+        },
+        "required": [
+          "subject",
+          "displayName"
+        ],
+        "type": "object"
+      },
+      "ParkingAdminSubject": {
+        "properties": {
+          "personName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "personName"
+        ],
+        "type": "object"
+      },
+      "ParkingSpot": {
+        "properties": {
+          "active": {
+            "type": "boolean"
+          },
+          "label": {
+            "type": "string"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "spotNumber": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "spotNumber",
+          "label",
+          "notes",
+          "active"
+        ],
+        "type": "object"
+      },
+      "ParkingSpotList": {
+        "ifc": {
+          "requiredIntegrity": [
+            "parking-admin"
+          ]
+        },
+        "items": {
+          "$ref": "#/$defs/ParkingSpot"
+        },
+        "type": "array"
+      },
+      "Person": {
+        "properties": {
+          "commuteMode": {
+            "$ref": "#/$defs/CommuteMode"
+          },
+          "defaultSpot": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "priorityRank": {
+            "type": "number"
+          },
+          "spotPreferences": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "vehicles": {
+            "items": {
+              "$ref": "#/$defs/Vehicle"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "name",
+          "email",
+          "commuteMode",
+          "spotPreferences",
+          "defaultSpot",
+          "priorityRank"
+        ],
+        "type": "object"
+      },
+      "RequestStatus": {
+        "enum": [
+          "pending",
+          "allocated",
+          "denied",
+          "cancelled"
+        ]
+      },
+      "SpotRequest": {
+        "properties": {
+          "assignedSpot": {
+            "type": "string"
+          },
+          "autoAllocated": {
+            "type": "boolean"
+          },
+          "date": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "personName": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/$defs/RequestStatus"
+          }
+        },
+        "required": [
+          "id",
+          "personName",
+          "date",
+          "status",
+          "assignedSpot",
+          "autoAllocated"
+        ],
+        "type": "object"
+      },
+      "Vehicle": {
+        "properties": {
+          "color": {
+            "type": "string"
+          },
+          "make": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "plateId": {
+            "type": "string"
+          },
+          "plateState": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "plateId",
+          "plateState",
+          "color",
+          "make",
+          "model"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "adminRegistry": {
+        "$ref": "#/$defs/ParkingAdminRegistryValue",
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ]
+      },
+      "people": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/Person"
+        },
+        "type": "array"
+      },
+      "requests": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/SpotRequest"
+        },
+        "type": "array"
+      },
+      "spots": {
+        "$ref": "#/$defs/ParkingSpotList",
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ],
+        "default": [
+          {
+            "active": true,
+            "label": "Near entrance",
+            "notes": "",
+            "spotNumber": "1"
+          },
+          {
+            "active": true,
+            "label": "",
+            "notes": "",
+            "spotNumber": "5"
+          },
+          {
+            "active": true,
+            "label": "Compact only",
+            "notes": "Tight, no large vehicles",
+            "spotNumber": "12"
+          }
+        ]
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "factory-outputs/parking-coordinator/main.tsx",
+  "resultSchema": {
+    "$defs": {
+      "CommuteMode": {
+        "enum": [
+          "drive",
+          "transit",
+          "bike",
+          "wfh",
+          "other"
+        ]
+      },
+      "ParkingAdminList": {
+        "ifc": {
+          "requiredIntegrity": [
+            "parking-admin-manager"
+          ]
+        },
+        "items": {
+          "$ref": "#/$defs/ParkingAdminRole"
+        },
+        "type": "array"
+      },
+      "ParkingAdminRegistryStoredValue": {
+        "properties": {
+          "admins": {
+            "$ref": "#/$defs/ParkingAdminList"
+          }
+        },
+        "type": "object"
+      },
+      "ParkingAdminRegistryValue": {
+        "$ref": "#/$defs/ParkingAdminRegistryStoredValue"
+      },
+      "ParkingAdminRole": {
+        "$ref": "#/$defs/ParkingAdminRoleAssignment",
+        "ifc": {
+          "addIntegrity": [
+            "parking-admin"
+          ]
+        }
+      },
+      "ParkingAdminRoleAssignment": {
+        "properties": {
+          "displayName": {
+            "type": "string"
+          },
+          "subject": {
+            "$ref": "#/$defs/ParkingAdminSubject"
+          }
+        },
+        "required": [
+          "subject",
+          "displayName"
+        ],
+        "type": "object"
+      },
+      "ParkingAdminSubject": {
+        "properties": {
+          "personName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "personName"
+        ],
+        "type": "object"
+      },
+      "ParkingSpot": {
+        "properties": {
+          "active": {
+            "type": "boolean"
+          },
+          "label": {
+            "type": "string"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "spotNumber": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "spotNumber",
+          "label",
+          "notes",
+          "active"
+        ],
+        "type": "object"
+      },
+      "Person": {
+        "properties": {
+          "commuteMode": {
+            "$ref": "#/$defs/CommuteMode"
+          },
+          "defaultSpot": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "priorityRank": {
+            "type": "number"
+          },
+          "spotPreferences": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "vehicles": {
+            "items": {
+              "$ref": "#/$defs/Vehicle"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "name",
+          "email",
+          "commuteMode",
+          "spotPreferences",
+          "defaultSpot",
+          "priorityRank"
+        ],
+        "type": "object"
+      },
+      "RequestStatus": {
+        "enum": [
+          "pending",
+          "allocated",
+          "denied",
+          "cancelled"
+        ]
+      },
+      "SpotRequest": {
+        "properties": {
+          "assignedSpot": {
+            "type": "string"
+          },
+          "autoAllocated": {
+            "type": "boolean"
+          },
+          "date": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "personName": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/$defs/RequestStatus"
+          }
+        },
+        "required": [
+          "id",
+          "personName",
+          "date",
+          "status",
+          "assignedSpot",
+          "autoAllocated"
+        ],
+        "type": "object"
+      },
+      "Vehicle": {
+        "properties": {
+          "color": {
+            "type": "string"
+          },
+          "make": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "plateId": {
+            "type": "string"
+          },
+          "plateState": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "plateId",
+          "plateState",
+          "color",
+          "make",
+          "model"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addPerson": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "commuteMode": {
+            "$ref": "#/$defs/CommuteMode"
+          },
+          "defaultSpot": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "preferences": {
+            "type": "string"
+          },
+          "priorityRank": {
+            "type": "number"
+          },
+          "vehicles": {
+            "items": {
+              "$ref": "#/$defs/Vehicle"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "name",
+          "email",
+          "commuteMode",
+          "priorityRank",
+          "defaultSpot",
+          "preferences"
+        ],
+        "type": "object"
+      },
+      "addSpot": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "spotNumber": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "spotNumber",
+          "label",
+          "notes"
+        ],
+        "type": "object"
+      },
+      "adminMode": {
+        "type": "boolean"
+      },
+      "adminOverride": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "date": {
+            "type": "string"
+          },
+          "personName": {
+            "type": "string"
+          },
+          "spotNumber": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "spotNumber",
+          "date",
+          "personName"
+        ],
+        "type": "object"
+      },
+      "adminRegistry": {
+        "$ref": "#/$defs/ParkingAdminRegistryValue"
+      },
+      "cancelRequest": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "requestId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "requestId"
+        ],
+        "type": "object"
+      },
+      "currentPersonIsAdmin": {
+        "type": "boolean"
+      },
+      "currentUserCanManageAdmins": {
+        "type": "boolean"
+      },
+      "editPerson": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "commuteMode": {
+            "$ref": "#/$defs/CommuteMode"
+          },
+          "defaultSpot": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "originalName": {
+            "type": "string"
+          },
+          "preferences": {
+            "type": "string"
+          },
+          "priorityRank": {
+            "type": "number"
+          },
+          "vehicles": {
+            "items": {
+              "$ref": "#/$defs/Vehicle"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "originalName",
+          "name",
+          "email",
+          "commuteMode",
+          "priorityRank",
+          "defaultSpot",
+          "preferences"
+        ],
+        "type": "object"
+      },
+      "editSpot": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "active": {
+            "type": "boolean"
+          },
+          "label": {
+            "type": "string"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "originalNumber": {
+            "type": "string"
+          },
+          "spotNumber": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "originalNumber",
+          "spotNumber",
+          "label",
+          "notes",
+          "active"
+        ],
+        "type": "object"
+      },
+      "enableAdminManager": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "movePersonDown": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "movePersonUp": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "people": {
+        "items": {
+          "$ref": "#/$defs/Person"
+        },
+        "type": "array"
+      },
+      "removePerson": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "removeSpot": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "spotNumber": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "spotNumber"
+        ],
+        "type": "object"
+      },
+      "requestDate": {
+        "type": "string"
+      },
+      "requestResult": {
+        "type": "string"
+      },
+      "requests": {
+        "items": {
+          "$ref": "#/$defs/SpotRequest"
+        },
+        "type": "array"
+      },
+      "selectedPersonName": {
+        "type": "string"
+      },
+      "spots": {
+        "items": {
+          "$ref": "#/$defs/ParkingSpot"
+        },
+        "type": "array"
+      },
+      "submitRequest": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "date": {
+            "type": "string"
+          },
+          "personName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "personName",
+          "date"
+        ],
+        "type": "object"
+      },
+      "toggleAdminMode": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "tier": "wrapper"
+      },
+      "togglePersonAdmin": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      }
+    },
+    "required": [
+      "spots",
+      "people",
+      "requests",
+      "adminMode",
+      "selectedPersonName",
+      "requestDate",
+      "requestResult",
+      "adminRegistry",
+      "currentPersonIsAdmin",
+      "currentUserCanManageAdmins",
+      "enableAdminManager",
+      "togglePersonAdmin",
+      "toggleAdminMode",
+      "submitRequest",
+      "cancelRequest",
+      "addPerson",
+      "editPerson",
+      "removePerson",
+      "movePersonUp",
+      "movePersonDown",
+      "addSpot",
+      "editSpot",
+      "removeSpot",
+      "adminOverride",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/gideon-tests/array-length-repro.tsx/20260807T235141Z-K1ndjzGadgeztCLt.json
+++ b/packages/patterns/baselines/gideon-tests/array-length-repro.tsx/20260807T235141Z-K1ndjzGadgeztCLt.json
@@ -1,0 +1,85 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "Item": {
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "items": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/Item"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "items"
+    ],
+    "type": "object"
+  },
+  "pattern": "gideon-tests/array-length-repro.tsx",
+  "resultSchema": {
+    "$defs": {
+      "Item": {
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addItem": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "items": {
+        "items": {
+          "$ref": "#/$defs/Item"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "items",
+      "addItem",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/gideon-tests/test-helper-owned-handler-nested-captures.tsx/20260807T235141Z-paRfTo1zwlejoTp9.json
+++ b/packages/patterns/baselines/gideon-tests/test-helper-owned-handler-nested-captures.tsx/20260807T235141Z-paRfTo1zwlejoTp9.json
@@ -1,0 +1,68 @@
+{
+  "argumentSchema": {
+    "properties": {
+      "content": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "fileId": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "onSaveFile": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "fileId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "fileId",
+          "content"
+        ],
+        "type": "object"
+      },
+      "savedContent": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "type": "string"
+      }
+    },
+    "required": [
+      "fileId",
+      "content",
+      "savedContent",
+      "onSaveFile"
+    ],
+    "type": "object"
+  },
+  "pattern": "gideon-tests/test-helper-owned-handler-nested-captures.tsx",
+  "resultSchema": {
+    "properties": {
+      "trigger": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      }
+    },
+    "required": [
+      "trigger"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/google/core/bill-extractor/index.tsx/20260807T235141Z-EImUA4BSgFUDq9ME.json
+++ b/packages/patterns/baselines/google/core/bill-extractor/index.tsx/20260807T235141Z-EImUA4BSgFUDq9ME.json
@@ -1,0 +1,734 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "Auth": {
+        "properties": {
+          "expiresAt": {
+            "default": 0,
+            "type": "number"
+          },
+          "expiresIn": {
+            "default": 0,
+            "type": "number"
+          },
+          "refreshToken": {
+            "default": "",
+            "type": "string"
+          },
+          "scope": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "token": {
+            "default": "",
+            "type": "string"
+          },
+          "tokenType": {
+            "default": "",
+            "type": "string"
+          },
+          "user": {
+            "default": {
+              "email": "",
+              "name": "",
+              "picture": ""
+            },
+            "properties": {
+              "email": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "picture": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "email",
+              "name",
+              "picture"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "token",
+          "tokenType",
+          "scope",
+          "expiresIn",
+          "expiresAt",
+          "refreshToken",
+          "user"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "Input configuration for BillExtractor.",
+    "properties": {
+      "brandColor": {
+        "default": "#3b82f6",
+        "description": "Brand color for website button (hex)",
+        "type": "string"
+      },
+      "demoMode": {
+        "asCell": [
+          "cell"
+        ],
+        "default": true,
+        "description": "Whether to show fake amounts for privacy (demo mode)",
+        "type": "boolean"
+      },
+      "extractionPrompt": {
+        "description": "Extraction prompt with {{email.*}} placeholders.\nMust instruct LLM what to extract for the \"identifier\" field.",
+        "type": "string"
+      },
+      "gmailQuery": {
+        "description": "Gmail search query (e.g., \"from:alerts@bankofamerica.com\")",
+        "type": "string"
+      },
+      "identifierType": {
+        "description": "Display format for identifier:\n- \"card\": \"...1234\"\n- \"account\": \"Acct: 1234\"",
+        "enum": [
+          "card",
+          "account"
+        ]
+      },
+      "limit": {
+        "default": 100,
+        "description": "Maximum number of emails to fetch",
+        "type": "number"
+      },
+      "manuallyPaid": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "description": "State for persistence - which bills user manually marked as paid",
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "overrideAuth": {
+        "$ref": "#/$defs/Auth",
+        "asCell": [
+          "cell"
+        ],
+        "description": "Gmail auth (optional - uses wish() if not provided)"
+      },
+      "shortName": {
+        "description": "Short name for compact displays (e.g., \"BofA\")",
+        "type": "string"
+      },
+      "supportsAutoDetect": {
+        "default": true,
+        "description": "Whether this provider sends payment confirmation emails.\nWhen false, shows a banner explaining manual tracking is required.\nDefaults to true.",
+        "type": "boolean"
+      },
+      "title": {
+        "description": "Full title for header (e.g., \"Bank of America Bill Tracker\")",
+        "type": "string"
+      },
+      "websiteUrl": {
+        "description": "Provider website URL",
+        "type": "string"
+      }
+    },
+    "required": [
+      "gmailQuery",
+      "extractionPrompt",
+      "identifierType",
+      "title",
+      "shortName"
+    ],
+    "type": "object"
+  },
+  "pattern": "google/core/bill-extractor/index.tsx",
+  "resultSchema": {
+    "$defs": {
+      "BillStatus": {
+        "enum": [
+          "unpaid",
+          "paid",
+          "overdue",
+          "likely_paid"
+        ]
+      },
+      "Email": {
+        "properties": {
+          "date": {
+            "type": "string"
+          },
+          "from": {
+            "type": "string"
+          },
+          "htmlContent": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "labelIds": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "markdownContent": {
+            "type": "string"
+          },
+          "plainText": {
+            "type": "string"
+          },
+          "snippet": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "summary": {
+            "default": "",
+            "type": "string"
+          },
+          "threadId": {
+            "type": "string"
+          },
+          "to": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "threadId",
+          "labelIds",
+          "snippet",
+          "subject",
+          "from",
+          "date",
+          "to",
+          "plainText",
+          "htmlContent",
+          "markdownContent",
+          "summary"
+        ],
+        "type": "object"
+      },
+      "GmailExtractorOutput": {
+        "properties": {
+          "addLabels": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "description": "Add labels to a message",
+            "properties": {
+              "labels": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "messageId": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "messageId",
+              "labels"
+            ],
+            "type": "object"
+          },
+          "completedCount": {
+            "description": "Count of completed analyses",
+            "type": "number"
+          },
+          "emailCount": {
+            "description": "Count of emails fetched",
+            "type": "number"
+          },
+          "emails": {
+            "description": "Raw emails from Gmail",
+            "items": {
+              "$ref": "#/$defs/Email"
+            },
+            "type": "array"
+          },
+          "gmailImporter": {
+            "$ref": "#/$defs/Output",
+            "description": "Access to underlying GmailImporter (for advanced use)"
+          },
+          "isConnected": {
+            "description": "Whether Gmail is connected",
+            "type": "boolean"
+          },
+          "pendingCount": {
+            "description": "Count of pending analyses",
+            "type": "number"
+          },
+          "rawAnalyses": {
+            "description": "Analysis results (empty when extraction not provided)",
+            "items": {
+              "properties": {
+                "analysis": {
+                  "properties": {
+                    "error": {
+                      "type": "unknown"
+                    },
+                    "pending": {
+                      "type": "boolean"
+                    },
+                    "result": {
+                      "type": "unknown"
+                    }
+                  },
+                  "type": "object"
+                },
+                "email": {
+                  "$ref": "#/$defs/Email"
+                },
+                "emailDate": {
+                  "type": "string"
+                },
+                "emailId": {
+                  "type": "string"
+                },
+                "error": {
+                  "type": "unknown"
+                },
+                "pending": {
+                  "type": "boolean"
+                },
+                "result": {
+                  "type": "unknown"
+                }
+              },
+              "required": [
+                "email",
+                "emailId",
+                "emailDate",
+                "analysis",
+                "pending",
+                "error"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "refresh": {
+            "asCell": [
+              "stream"
+            ],
+            "description": "Refresh emails from Gmail",
+            "type": "unknown"
+          },
+          "removeLabels": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "description": "Remove labels from a message",
+            "properties": {
+              "labels": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "messageId": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "messageId",
+              "labels"
+            ],
+            "type": "object"
+          },
+          "ui": {
+            "description": "UI bundle (JSX elements)",
+            "properties": {
+              "analysisProgressUI": {
+                "$ref": "#/$defs/JSXElement"
+              },
+              "authStatusUI": {
+                "$ref": "#/$defs/JSXElement"
+              },
+              "connectionStatusUI": {
+                "$ref": "#/$defs/JSXElement"
+              },
+              "previewUI": {
+                "$ref": "#/$defs/JSXElement"
+              }
+            },
+            "required": [
+              "authStatusUI",
+              "connectionStatusUI",
+              "analysisProgressUI",
+              "previewUI"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "emails",
+          "emailCount",
+          "rawAnalyses",
+          "pendingCount",
+          "completedCount",
+          "isConnected",
+          "refresh",
+          "addLabels",
+          "removeLabels",
+          "ui",
+          "gmailImporter"
+        ],
+        "type": "object"
+      },
+      "JSXElement": {
+        "anyOf": [
+          {
+            "$ref": "https://commonfabric.org/schemas/vnode.json"
+          },
+          {
+            "$ref": "#/$defs/UIRenderable"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ]
+      },
+      "Output": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "$UI": {
+            "$ref": "https://commonfabric.org/schemas/vnode.json"
+          },
+          "authUI": {
+            "$ref": "https://commonfabric.org/schemas/vnode.json",
+            "description": "Auth UI component for managing Google OAuth connection"
+          },
+          "bgUpdater": {
+            "asCell": [
+              "stream",
+              "opaque"
+            ],
+            "description": "Handler to trigger email fetch from external patterns"
+          },
+          "emailCount": {
+            "description": "Number of emails imported",
+            "type": "number"
+          },
+          "emails": {
+            "description": "Array of imported emails",
+            "items": {
+              "$ref": "#/$defs/Email"
+            },
+            "type": "array"
+          },
+          "isReady": {
+            "description": "Whether auth is ready (has valid token)",
+            "type": "boolean"
+          },
+          "mentionable": {
+            "description": "Mentionables — email cards with NAME and summary for search indexing",
+            "items": {
+              "properties": {
+                "$NAME": {
+                  "type": "string"
+                },
+                "$UI": {
+                  "$ref": "https://commonfabric.org/schemas/vnode.json"
+                },
+                "summary": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "summary",
+                "$NAME",
+                "$UI"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "summary": {
+            "description": "Summary of container-level emails for hierarchical indexing",
+            "type": "string"
+          }
+        },
+        "required": [
+          "emails",
+          "mentionable",
+          "emailCount",
+          "summary",
+          "authUI",
+          "bgUpdater",
+          "isReady",
+          "$NAME",
+          "$UI"
+        ],
+        "type": "object"
+      },
+      "TrackedBill": {
+        "properties": {
+          "amount": {
+            "description": "Bill amount in dollars",
+            "type": "number"
+          },
+          "daysUntilDue": {
+            "description": "Days until due (negative = overdue)",
+            "type": "number"
+          },
+          "dueDate": {
+            "description": "Due date in ISO format",
+            "type": "string"
+          },
+          "emailDate": {
+            "description": "Date the email was received",
+            "type": "string"
+          },
+          "emailId": {
+            "description": "Gmail message ID",
+            "type": "string"
+          },
+          "identifier": {
+            "description": "Generic identifier (card last 4, account number, etc.)",
+            "type": "string"
+          },
+          "isLikelyPaid": {
+            "description": "Whether assumed paid due to age (>45 days overdue)",
+            "type": "boolean"
+          },
+          "isManuallyPaid": {
+            "description": "Whether user manually marked as paid",
+            "type": "boolean"
+          },
+          "isPaid": {
+            "description": "Whether the bill is considered paid",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "Unique key for deduplication (identifier|dueDate)",
+            "type": "string"
+          },
+          "paidDate": {
+            "description": "Date the bill was paid (if known)",
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/$defs/BillStatus",
+            "description": "Current status"
+          }
+        },
+        "required": [
+          "key",
+          "identifier",
+          "amount",
+          "dueDate",
+          "status",
+          "isPaid",
+          "emailDate",
+          "emailId",
+          "isManuallyPaid",
+          "isLikelyPaid",
+          "daysUntilDue"
+        ],
+        "type": "object"
+      },
+      "UIRenderable": {
+        "properties": {
+          "$UI": {
+            "$ref": "https://commonfabric.org/schemas/vnode.json"
+          }
+        },
+        "required": [
+          "$UI"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "Output from BillExtractor.",
+    "properties": {
+      "bills": {
+        "items": {
+          "$ref": "#/$defs/TrackedBill"
+        },
+        "type": "array"
+      },
+      "brandColor": {
+        "type": "string"
+      },
+      "completedCount": {
+        "type": "number"
+      },
+      "emailCount": {
+        "type": "number"
+      },
+      "gmailExtractor": {
+        "$ref": "#/$defs/GmailExtractorOutput"
+      },
+      "identifierType": {
+        "enum": [
+          "card",
+          "account"
+        ]
+      },
+      "isConnected": {
+        "type": "boolean"
+      },
+      "likelyPaidBills": {
+        "items": {
+          "$ref": "#/$defs/TrackedBill"
+        },
+        "type": "array"
+      },
+      "overdueCount": {
+        "type": "number"
+      },
+      "paidBills": {
+        "items": {
+          "$ref": "#/$defs/TrackedBill"
+        },
+        "type": "array"
+      },
+      "paymentConfirmations": {
+        "additionalProperties": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "properties": {},
+        "type": "object"
+      },
+      "pendingCount": {
+        "type": "number"
+      },
+      "rawAnalyses": {
+        "items": {
+          "properties": {
+            "analysis": {
+              "properties": {
+                "result": {
+                  "type": "unknown"
+                }
+              },
+              "type": "object"
+            },
+            "emailDate": {
+              "type": "string"
+            },
+            "emailId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "emailId",
+            "emailDate"
+          ],
+          "type": "object"
+        },
+        "type": "array"
+      },
+      "refresh": {
+        "asCell": [
+          "stream"
+        ],
+        "type": "unknown"
+      },
+      "shortName": {
+        "type": "string"
+      },
+      "supportsAutoDetect": {
+        "type": "boolean"
+      },
+      "title": {
+        "type": "string"
+      },
+      "totalUnpaid": {
+        "type": "number"
+      },
+      "ui": {
+        "properties": {
+          "analysisProgressUI": {
+            "$ref": "#/$defs/JSXElement"
+          },
+          "authStatusUI": {
+            "$ref": "#/$defs/JSXElement"
+          },
+          "connectionStatusUI": {
+            "$ref": "#/$defs/JSXElement"
+          },
+          "manualTrackingBannerUI": {
+            "$ref": "#/$defs/JSXElement",
+            "description": "Banner shown when supportsAutoDetect is false"
+          },
+          "overdueAlertUI": {
+            "$ref": "#/$defs/JSXElement"
+          },
+          "previewUI": {
+            "$ref": "#/$defs/JSXElement"
+          },
+          "summaryStatsUI": {
+            "$ref": "#/$defs/JSXElement"
+          },
+          "websiteLinkUI": {
+            "$ref": "#/$defs/JSXElement"
+          }
+        },
+        "required": [
+          "authStatusUI",
+          "connectionStatusUI",
+          "analysisProgressUI",
+          "previewUI",
+          "summaryStatsUI",
+          "overdueAlertUI",
+          "websiteLinkUI",
+          "manualTrackingBannerUI"
+        ],
+        "type": "object"
+      },
+      "unpaidBills": {
+        "items": {
+          "$ref": "#/$defs/TrackedBill"
+        },
+        "type": "array"
+      },
+      "websiteUrl": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "bills",
+      "unpaidBills",
+      "paidBills",
+      "likelyPaidBills",
+      "totalUnpaid",
+      "overdueCount",
+      "rawAnalyses",
+      "paymentConfirmations",
+      "identifierType",
+      "title",
+      "shortName",
+      "brandColor",
+      "supportsAutoDetect",
+      "pendingCount",
+      "completedCount",
+      "emailCount",
+      "isConnected",
+      "refresh",
+      "ui",
+      "gmailExtractor"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/google/core/gmail-extractor.tsx/20260807T235141Z-klrID0NL3aBU-_r6.json
+++ b/packages/patterns/baselines/google/core/gmail-extractor.tsx/20260807T235141Z-klrID0NL3aBU-_r6.json
@@ -1,0 +1,454 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "Auth": {
+        "properties": {
+          "expiresAt": {
+            "default": 0,
+            "type": "number"
+          },
+          "expiresIn": {
+            "default": 0,
+            "type": "number"
+          },
+          "refreshToken": {
+            "default": "",
+            "type": "string"
+          },
+          "scope": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "token": {
+            "default": "",
+            "type": "string"
+          },
+          "tokenType": {
+            "default": "",
+            "type": "string"
+          },
+          "user": {
+            "default": {
+              "email": "",
+              "name": "",
+              "picture": ""
+            },
+            "properties": {
+              "email": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "picture": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "email",
+              "name",
+              "picture"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "token",
+          "tokenType",
+          "scope",
+          "expiresIn",
+          "expiresAt",
+          "refreshToken",
+          "user"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "Input configuration for the GmailExtractor building block.",
+    "properties": {
+      "extraction": {
+        "description": "Optional: Provide to enable built-in LLM analysis.\nOmit entirely for raw emails only (for custom analysis patterns).",
+        "properties": {
+          "promptTemplate": {
+            "description": "Prompt template for the LLM extraction.\nSupports placeholders:\n- {{email.subject}} - Email subject line\n- {{email.date}} - Email date\n- {{email.from}} - Sender email\n- {{email.markdownContent}} - Full email content as markdown\n- {{email.snippet}} - Brief preview",
+            "type": "string"
+          },
+          "schema": true
+        },
+        "required": [
+          "promptTemplate",
+          "schema"
+        ],
+        "type": "object"
+      },
+      "gmailQuery": {
+        "description": "Gmail search query (e.g., \"from:DoNotReply@billpay.pge.com\")",
+        "type": "string"
+      },
+      "limit": {
+        "default": 100,
+        "description": "Maximum number of emails to fetch",
+        "type": "number"
+      },
+      "overrideAuth": {
+        "$ref": "#/$defs/Auth",
+        "asCell": [
+          "cell"
+        ],
+        "description": "Optional linked auth (overrides wish() default)"
+      },
+      "resolveInlineImages": {
+        "default": false,
+        "description": "Whether to resolve inline images (cid: references) to base64",
+        "type": "boolean"
+      },
+      "title": {
+        "default": "Email Items",
+        "description": "Display title for the extractor (shown in UI)",
+        "type": "string"
+      }
+    },
+    "required": [
+      "gmailQuery"
+    ],
+    "type": "object"
+  },
+  "pattern": "google/core/gmail-extractor.tsx",
+  "resultSchema": {
+    "$defs": {
+      "Email": {
+        "properties": {
+          "date": {
+            "type": "string"
+          },
+          "from": {
+            "type": "string"
+          },
+          "htmlContent": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "labelIds": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "markdownContent": {
+            "type": "string"
+          },
+          "plainText": {
+            "type": "string"
+          },
+          "snippet": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "summary": {
+            "default": "",
+            "type": "string"
+          },
+          "threadId": {
+            "type": "string"
+          },
+          "to": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "threadId",
+          "labelIds",
+          "snippet",
+          "subject",
+          "from",
+          "date",
+          "to",
+          "plainText",
+          "htmlContent",
+          "markdownContent",
+          "summary"
+        ],
+        "type": "object"
+      },
+      "JSXElement": {
+        "anyOf": [
+          {
+            "$ref": "https://commonfabric.org/schemas/vnode.json"
+          },
+          {
+            "$ref": "#/$defs/UIRenderable"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ]
+      },
+      "Output": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "$UI": {
+            "$ref": "https://commonfabric.org/schemas/vnode.json"
+          },
+          "authUI": {
+            "$ref": "https://commonfabric.org/schemas/vnode.json",
+            "description": "Auth UI component for managing Google OAuth connection"
+          },
+          "bgUpdater": {
+            "asCell": [
+              "stream",
+              "opaque"
+            ],
+            "description": "Handler to trigger email fetch from external patterns"
+          },
+          "emailCount": {
+            "description": "Number of emails imported",
+            "type": "number"
+          },
+          "emails": {
+            "description": "Array of imported emails",
+            "items": {
+              "$ref": "#/$defs/Email"
+            },
+            "type": "array"
+          },
+          "isReady": {
+            "description": "Whether auth is ready (has valid token)",
+            "type": "boolean"
+          },
+          "mentionable": {
+            "description": "Mentionables — email cards with NAME and summary for search indexing",
+            "items": {
+              "properties": {
+                "$NAME": {
+                  "type": "string"
+                },
+                "$UI": {
+                  "$ref": "https://commonfabric.org/schemas/vnode.json"
+                },
+                "summary": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "summary",
+                "$NAME",
+                "$UI"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "summary": {
+            "description": "Summary of container-level emails for hierarchical indexing",
+            "type": "string"
+          }
+        },
+        "required": [
+          "emails",
+          "mentionable",
+          "emailCount",
+          "summary",
+          "authUI",
+          "bgUpdater",
+          "isReady",
+          "$NAME",
+          "$UI"
+        ],
+        "type": "object"
+      },
+      "UIRenderable": {
+        "properties": {
+          "$UI": {
+            "$ref": "https://commonfabric.org/schemas/vnode.json"
+          }
+        },
+        "required": [
+          "$UI"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "Output of GmailExtractor.",
+    "properties": {
+      "addLabels": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "description": "Add labels to a message",
+        "properties": {
+          "labels": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "messageId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "messageId",
+          "labels"
+        ],
+        "type": "object"
+      },
+      "completedCount": {
+        "description": "Count of completed analyses",
+        "type": "number"
+      },
+      "emailCount": {
+        "description": "Count of emails fetched",
+        "type": "number"
+      },
+      "emails": {
+        "description": "Raw emails from Gmail",
+        "items": {
+          "$ref": "#/$defs/Email"
+        },
+        "type": "array"
+      },
+      "gmailImporter": {
+        "$ref": "#/$defs/Output",
+        "description": "Access to underlying GmailImporter (for advanced use)"
+      },
+      "isConnected": {
+        "description": "Whether Gmail is connected",
+        "type": "boolean"
+      },
+      "pendingCount": {
+        "description": "Count of pending analyses",
+        "type": "number"
+      },
+      "rawAnalyses": {
+        "description": "Analysis results (empty when extraction not provided)",
+        "items": {
+          "properties": {
+            "analysis": {
+              "properties": {
+                "error": {
+                  "type": "unknown"
+                },
+                "pending": {
+                  "type": "boolean"
+                },
+                "result": {
+                  "type": "unknown"
+                }
+              },
+              "type": "object"
+            },
+            "email": {
+              "$ref": "#/$defs/Email"
+            },
+            "emailDate": {
+              "type": "string"
+            },
+            "emailId": {
+              "type": "string"
+            },
+            "error": {
+              "type": "unknown"
+            },
+            "pending": {
+              "type": "boolean"
+            },
+            "result": {
+              "type": "unknown"
+            }
+          },
+          "required": [
+            "email",
+            "emailId",
+            "emailDate",
+            "analysis",
+            "pending",
+            "error"
+          ],
+          "type": "object"
+        },
+        "type": "array"
+      },
+      "refresh": {
+        "asCell": [
+          "stream"
+        ],
+        "description": "Refresh emails from Gmail",
+        "type": "unknown"
+      },
+      "removeLabels": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "description": "Remove labels from a message",
+        "properties": {
+          "labels": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "messageId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "messageId",
+          "labels"
+        ],
+        "type": "object"
+      },
+      "ui": {
+        "description": "UI bundle (JSX elements)",
+        "properties": {
+          "analysisProgressUI": {
+            "$ref": "#/$defs/JSXElement"
+          },
+          "authStatusUI": {
+            "$ref": "#/$defs/JSXElement"
+          },
+          "connectionStatusUI": {
+            "$ref": "#/$defs/JSXElement"
+          },
+          "previewUI": {
+            "$ref": "#/$defs/JSXElement"
+          }
+        },
+        "required": [
+          "authStatusUI",
+          "connectionStatusUI",
+          "analysisProgressUI",
+          "previewUI"
+        ],
+        "type": "object"
+      }
+    },
+    "required": [
+      "emails",
+      "emailCount",
+      "rawAnalyses",
+      "pendingCount",
+      "completedCount",
+      "isConnected",
+      "refresh",
+      "addLabels",
+      "removeLabels",
+      "ui",
+      "gmailImporter"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/google/extractors/berkeley-library.tsx/20260807T235141Z-M5LfnOzvH-8b90Cx.json
+++ b/packages/patterns/baselines/google/extractors/berkeley-library.tsx/20260807T235141Z-M5LfnOzvH-8b90Cx.json
@@ -1,0 +1,274 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "Auth": {
+        "properties": {
+          "expiresAt": {
+            "default": 0,
+            "type": "number"
+          },
+          "expiresIn": {
+            "default": 0,
+            "type": "number"
+          },
+          "refreshToken": {
+            "default": "",
+            "type": "string"
+          },
+          "scope": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "token": {
+            "default": "",
+            "type": "string"
+          },
+          "tokenType": {
+            "default": "",
+            "type": "string"
+          },
+          "user": {
+            "default": {
+              "email": "",
+              "name": "",
+              "picture": ""
+            },
+            "properties": {
+              "email": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "picture": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "email",
+              "name",
+              "picture"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "token",
+          "tokenType",
+          "scope",
+          "expiresIn",
+          "expiresAt",
+          "refreshToken",
+          "user"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "dismissedHolds": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "dueDateOverrides": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "asCell": [
+          "cell"
+        ],
+        "properties": {},
+        "type": "object"
+      },
+      "manuallyReturned": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "overrideAuth": {
+        "$ref": "#/$defs/Auth",
+        "asCell": [
+          "cell"
+        ]
+      },
+      "selectedItems": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "google/extractors/berkeley-library.tsx",
+  "resultSchema": {
+    "$defs": {
+      "ItemStatus": {
+        "enum": [
+          "hold_ready",
+          "checked_out",
+          "overdue",
+          "renewed",
+          "returned"
+        ]
+      },
+      "ItemType": {
+        "enum": [
+          "other",
+          "book",
+          "audiobook",
+          "dvd",
+          "magazine",
+          "ebook"
+        ]
+      },
+      "TrackedItem": {
+        "properties": {
+          "author": {
+            "type": "string"
+          },
+          "daysUntilDue": {
+            "type": "number"
+          },
+          "dueDate": {
+            "type": "string"
+          },
+          "emailDate": {
+            "type": "string"
+          },
+          "fineAmount": {
+            "type": "number"
+          },
+          "isManuallyReturned": {
+            "type": "boolean"
+          },
+          "itemType": {
+            "$ref": "#/$defs/ItemType"
+          },
+          "key": {
+            "type": "string"
+          },
+          "renewalsRemaining": {
+            "type": "number"
+          },
+          "status": {
+            "$ref": "#/$defs/ItemStatus"
+          },
+          "title": {
+            "type": "string"
+          },
+          "urgency": {
+            "$ref": "#/$defs/UrgencyLevel"
+          }
+        },
+        "required": [
+          "key",
+          "title",
+          "status",
+          "urgency",
+          "daysUntilDue",
+          "emailDate",
+          "isManuallyReturned"
+        ],
+        "type": "object"
+      },
+      "UrgencyLevel": {
+        "enum": [
+          "overdue",
+          "urgent_1day",
+          "warning_3days",
+          "notice_7days",
+          "ok"
+        ]
+      }
+    },
+    "description": "Berkeley Public Library book tracker. #berkeleyLibrary",
+    "properties": {
+      "$TILE_UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "checkedOutCount": {
+        "type": "number"
+      },
+      "dismissHold": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title"
+        ],
+        "type": "object"
+      },
+      "holdsReady": {
+        "items": {
+          "$ref": "#/$defs/TrackedItem"
+        },
+        "type": "array"
+      },
+      "holdsReadyCount": {
+        "type": "number"
+      },
+      "markAsReturned": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title"
+        ],
+        "type": "object"
+      },
+      "overdueCount": {
+        "type": "number"
+      },
+      "trackedItems": {
+        "items": {
+          "$ref": "#/$defs/TrackedItem"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "trackedItems",
+      "holdsReady",
+      "overdueCount",
+      "checkedOutCount",
+      "holdsReadyCount",
+      "markAsReturned",
+      "dismissHold",
+      "$TILE_UI"
+    ],
+    "tags": [
+      "berkeleylibrary"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/habit-tracker/habit-tracker.tsx/20260807T235141Z-W2TbHCwLoHtTgyg-.json
+++ b/packages/patterns/baselines/habit-tracker/habit-tracker.tsx/20260807T235141Z-W2TbHCwLoHtTgyg-.json
@@ -1,0 +1,205 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "Habit": {
+        "properties": {
+          "color": {
+            "default": "#3b82f6",
+            "type": "string"
+          },
+          "icon": {
+            "default": "✓",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "icon",
+          "color"
+        ],
+        "type": "object"
+      },
+      "HabitLog": {
+        "properties": {
+          "completed": {
+            "type": "boolean"
+          },
+          "date": {
+            "type": "string"
+          },
+          "habitName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "habitName",
+          "date",
+          "completed"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "habits": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/Habit"
+        },
+        "type": "array"
+      },
+      "logs": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/HabitLog"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "habits",
+      "logs"
+    ],
+    "type": "object"
+  },
+  "pattern": "habit-tracker/habit-tracker.tsx",
+  "resultSchema": {
+    "$defs": {
+      "Habit": {
+        "properties": {
+          "color": {
+            "default": "#3b82f6",
+            "type": "string"
+          },
+          "icon": {
+            "default": "✓",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "icon",
+          "color"
+        ],
+        "type": "object"
+      },
+      "HabitLog": {
+        "properties": {
+          "completed": {
+            "type": "boolean"
+          },
+          "date": {
+            "type": "string"
+          },
+          "habitName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "habitName",
+          "date",
+          "completed"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addHabit": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "icon": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "icon"
+        ],
+        "type": "object"
+      },
+      "deleteHabit": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "habit": {
+            "$ref": "#/$defs/Habit"
+          }
+        },
+        "required": [
+          "habit"
+        ],
+        "type": "object"
+      },
+      "habits": {
+        "items": {
+          "$ref": "#/$defs/Habit"
+        },
+        "type": "array"
+      },
+      "logs": {
+        "items": {
+          "$ref": "#/$defs/HabitLog"
+        },
+        "type": "array"
+      },
+      "summary": {
+        "type": "string"
+      },
+      "todayDate": {
+        "type": "string"
+      },
+      "toggleHabit": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "habitName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "habitName"
+        ],
+        "type": "object"
+      }
+    },
+    "required": [
+      "habits",
+      "logs",
+      "todayDate",
+      "summary",
+      "toggleHabit",
+      "addHabit",
+      "deleteHabit",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/lobby/main.tsx/20260807T235141Z-LRjjdS0thkLWVO7H.json
+++ b/packages/patterns/baselines/lobby/main.tsx/20260807T235141Z-LRjjdS0thkLWVO7H.json
@@ -1,0 +1,384 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "LobbyAdminBootstrapRole": {
+        "$ref": "#/$defs/LobbyAdminRoleAssignment",
+        "ifc": {
+          "addIntegrity": [
+            "lobby-admin"
+          ]
+        }
+      },
+      "LobbyAdminList": {
+        "ifc": {
+          "requiredIntegrity": [
+            "lobby-admin"
+          ],
+          "uiContract": {
+            "action": "TrustedLobbyAction",
+            "helper": "UiAction",
+            "requiredEventIntegrity": [
+              "TrustedLobbySurface"
+            ],
+            "trustedPattern": "TrustedLobbySurface"
+          },
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/lobby/main.tsx",
+              "moduleIdentity": "pNg1v-APlB7qMS2evaVd512znRNlzftQAYV6S955__Y",
+              "path": [
+                "commitTrustedLobbyAction"
+              ]
+            }
+          }
+        },
+        "items": {
+          "$ref": "#/$defs/LobbyAdminRole"
+        },
+        "type": "array"
+      },
+      "LobbyAdminRegistryStoredValue": {
+        "properties": {
+          "admins": {
+            "$ref": "#/$defs/LobbyAdminList"
+          },
+          "bootstrapAdmin": {
+            "$ref": "#/$defs/LobbyAdminBootstrapRole"
+          },
+          "everyoneIsAdmin": {
+            "$ref": "#/$defs/LobbyEveryoneAdminFlag"
+          }
+        },
+        "type": "object"
+      },
+      "LobbyAdminRegistryValue": {
+        "$ref": "#/$defs/LobbyAdminRegistryStoredValue"
+      },
+      "LobbyAdminRole": {
+        "$ref": "#/$defs/LobbyAdminRoleAssignment",
+        "ifc": {
+          "addIntegrity": [
+            "lobby-admin"
+          ]
+        }
+      },
+      "LobbyAdminRoleAssignment": {
+        "properties": {
+          "displayName": {
+            "type": "string"
+          },
+          "subject": {
+            "$ref": "#/$defs/LobbyProfile",
+            "asCell": [
+              "cell"
+            ]
+          }
+        },
+        "required": [
+          "subject",
+          "displayName"
+        ],
+        "type": "object"
+      },
+      "LobbyEveryoneAdminFlag": {
+        "ifc": {
+          "uiContract": {
+            "action": "TrustedLobbyAction",
+            "helper": "UiAction",
+            "requiredEventIntegrity": [
+              "TrustedLobbySurface"
+            ],
+            "trustedPattern": "TrustedLobbySurface"
+          },
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/lobby/main.tsx",
+              "moduleIdentity": "pNg1v-APlB7qMS2evaVd512znRNlzftQAYV6S955__Y",
+              "path": [
+                "commitTrustedLobbyAction"
+              ]
+            }
+          }
+        },
+        "type": "boolean"
+      },
+      "LobbyExternalProfileLink": {
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "label",
+          "url"
+        ],
+        "type": "object"
+      },
+      "LobbyParticipant": {
+        "properties": {
+          "name": {
+            "description": "Durable fallback label for policy rows if the live profile is offline.",
+            "type": "string"
+          },
+          "profile": {
+            "$ref": "#/$defs/LobbyProfile",
+            "asCell": [
+              "cell"
+            ]
+          }
+        },
+        "required": [
+          "profile",
+          "name"
+        ],
+        "type": "object"
+      },
+      "LobbyParticipantList": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/LobbyParticipant"
+        },
+        "type": "array"
+      },
+      "LobbyProfile": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "bio": {
+            "type": "string"
+          },
+          "externalLinks": {
+            "description": "Connector-facing identity hints retained on the stored profile link.",
+            "items": {
+              "$ref": "#/$defs/LobbyExternalProfileLink"
+            },
+            "type": "array"
+          },
+          "initialNameApplied": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "verifiedIdentities": {
+            "description": "Transport original assertion cells; consumers validate their integrity.",
+            "items": {
+              "asCell": [
+                "cell"
+              ],
+              "type": "unknown"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "LobbyRoster": {
+        "properties": {
+          "participants": {
+            "$ref": "#/$defs/LobbyParticipantList"
+          }
+        },
+        "required": [
+          "participants"
+        ],
+        "type": "object"
+      },
+      "LobbyRosterValue": {
+        "$ref": "#/$defs/LobbyRoster",
+        "default": {
+          "participants": []
+        }
+      }
+    },
+    "properties": {
+      "adminRegistry": {
+        "$ref": "#/$defs/LobbyAdminRegistryValue",
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ],
+        "description": "Shared durable trusted-admin policy."
+      },
+      "roster": {
+        "$ref": "#/$defs/LobbyRosterValue",
+        "description": "Shared durable presence list.",
+        "scope": "space"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "lobby/main.tsx",
+  "resultSchema": {
+    "$defs": {
+      "LobbyExternalProfileLink": {
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "label",
+          "url"
+        ],
+        "type": "object"
+      },
+      "LobbyParticipantView": {
+        "properties": {
+          "isAdmin": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "isAdmin"
+        ],
+        "type": "object"
+      },
+      "LobbyProfile": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "bio": {
+            "type": "string"
+          },
+          "externalLinks": {
+            "description": "Connector-facing identity hints retained on the stored profile link.",
+            "items": {
+              "$ref": "#/$defs/LobbyExternalProfileLink"
+            },
+            "type": "array"
+          },
+          "initialNameApplied": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "verifiedIdentities": {
+            "description": "Transport original assertion cells; consumers validate their integrity.",
+            "items": {
+              "type": "unknown"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "LobbyTrustedActionEvent": {
+        "properties": {
+          "detail": {
+            "properties": {
+              "checked": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "everyoneIsAdmin": {
+            "type": "boolean"
+          },
+          "profile": {
+            "$ref": "#/$defs/LobbyProfile",
+            "description": "Headless/test seam; real UI bindings supply profile cells as state."
+          }
+        },
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addSelf": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "Agent-facing action: add the active Fabric profile, with no payload."
+      },
+      "allParticipants": {
+        "description": "Agent-facing, profile-free snapshot for downstream processing.",
+        "items": {
+          "$ref": "#/$defs/LobbyParticipantView"
+        },
+        "type": "array"
+      },
+      "currentUserIsAdmin": {
+        "type": "boolean"
+      },
+      "everyoneIsAdmin": {
+        "type": "boolean"
+      },
+      "join": {
+        "$ref": "#/$defs/LobbyTrustedActionEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "participantCount": {
+        "type": "number"
+      },
+      "participants": {
+        "description": "Backward-compatible alias for `allParticipants`.",
+        "items": {
+          "$ref": "#/$defs/LobbyParticipantView"
+        },
+        "type": "array"
+      },
+      "removeParticipant": {
+        "$ref": "#/$defs/LobbyTrustedActionEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "setEveryoneIsAdmin": {
+        "$ref": "#/$defs/LobbyTrustedActionEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "toggleParticipantAdmin": {
+        "$ref": "#/$defs/LobbyTrustedActionEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      }
+    },
+    "required": [
+      "addSelf",
+      "allParticipants",
+      "participants",
+      "participantCount",
+      "currentUserIsAdmin",
+      "everyoneIsAdmin",
+      "join",
+      "removeParticipant",
+      "toggleParticipantAdmin",
+      "setEveryoneIsAdmin",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/lunch-poll/main.tsx/20260807T235141Z-BzywQ1dr1ae4Wexh.json
+++ b/packages/patterns/baselines/lunch-poll/main.tsx/20260807T235141Z-BzywQ1dr1ae4Wexh.json
@@ -1,0 +1,772 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "HistoryEntry": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "loggedBy": {
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/$defs/User",
+                "asCell": [
+                  "cell"
+                ]
+              }
+            ]
+          },
+          "loggedByName": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "votes": {
+            "items": {
+              "$ref": "#/$defs/VoteSnapshot"
+            },
+            "type": "array"
+          },
+          "wentAt": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "loggedByName",
+          "loggedBy",
+          "wentAt",
+          "votes"
+        ],
+        "type": "object"
+      },
+      "LunchProfile": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "Option": {
+        "properties": {
+          "addedByName": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "imageUrl": {
+            "description": "Persisted generated-art data URL (`\"\"` until the host's client generates\nand syncs it). Every viewer renders this stored value; generation only\nruns on the host's client for options where it is still empty.",
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "addedByName"
+        ],
+        "type": "object"
+      },
+      "ParticipantProfileDirectory": {
+        "properties": {
+          "participants": {
+            "default": [],
+            "items": {
+              "$ref": "#/$defs/ParticipantProfileLink"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "participants"
+        ],
+        "type": "object"
+      },
+      "ParticipantProfileDirectoryValue": {
+        "$ref": "#/$defs/ParticipantProfileDirectory",
+        "default": {
+          "participants": []
+        }
+      },
+      "ParticipantProfileLink": {
+        "properties": {
+          "name": {
+            "description": "Immutable Lunch Poll name used by the current name-keyed vote schema.",
+            "type": "string"
+          },
+          "profile": {
+            "$ref": "#/$defs/LunchProfile",
+            "asCell": [
+              "cell"
+            ],
+            "description": "Live canonical profile cell; compare it by identity with `equals()`."
+          }
+        },
+        "required": [
+          "name",
+          "profile"
+        ],
+        "type": "object"
+      },
+      "User": {
+        "properties": {
+          "avatar": {
+            "description": "Avatar URL or glyph, snapshotted from the joiner's shared profile.",
+            "type": "string"
+          },
+          "color": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "color"
+        ],
+        "type": "object"
+      },
+      "Vote": {
+        "properties": {
+          "castAt": {
+            "description": "When the vote was cast (ms epoch), stamped by `castVote`. Optional for\nvotes stored before this field existed — those count as not-today, so the\ncurrent-day filter hides them.",
+            "type": "number"
+          },
+          "optionId": {
+            "type": "string"
+          },
+          "voteType": {
+            "$ref": "#/$defs/VoteColor"
+          },
+          "voterName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "voterName",
+          "optionId",
+          "voteType"
+        ],
+        "type": "object"
+      },
+      "VoteColor": {
+        "enum": [
+          "green",
+          "yellow",
+          "red"
+        ]
+      },
+      "VoteSnapshot": {
+        "properties": {
+          "color": {
+            "$ref": "#/$defs/VoteColor"
+          },
+          "optionTitle": {
+            "type": "string"
+          },
+          "voter": {
+            "type": "string"
+          },
+          "voterLink": {
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/$defs/User",
+                "asCell": [
+                  "cell"
+                ]
+              }
+            ]
+          }
+        },
+        "required": [
+          "voter",
+          "voterLink",
+          "optionTitle",
+          "color"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "adminName": {
+        "default": "",
+        "scope": "space",
+        "type": "string"
+      },
+      "myName": {
+        "default": "",
+        "scope": "user",
+        "type": "string"
+      },
+      "options": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/Option"
+        },
+        "scope": "space",
+        "type": "array"
+      },
+      "participantProfiles": {
+        "$ref": "#/$defs/ParticipantProfileDirectoryValue",
+        "description": "Canonical live profile links for profile-backed users; guests are absent.",
+        "scope": "space"
+      },
+      "question": {
+        "default": "Where should we eat?",
+        "scope": "space",
+        "type": "string"
+      },
+      "users": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/User"
+        },
+        "scope": "space",
+        "type": "array"
+      },
+      "visits": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/HistoryEntry"
+        },
+        "scope": "space",
+        "type": "array"
+      },
+      "votes": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/Vote"
+        },
+        "scope": "space",
+        "type": "array"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "lunch-poll/main.tsx",
+  "resultSchema": {
+    "$defs": {
+      "AddOptionEvent": {
+        "properties": {
+          "title": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "CastVoteEvent": {
+        "properties": {
+          "optionId": {
+            "type": "string"
+          },
+          "voteType": {
+            "$ref": "#/$defs/VoteColor"
+          }
+        },
+        "required": [
+          "optionId",
+          "voteType"
+        ],
+        "type": "object"
+      },
+      "ClaimHostEvent": {
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object"
+      },
+      "ClearHistoryEvent": {
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object"
+      },
+      "ClearVoteEvent": {
+        "properties": {
+          "optionId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "optionId"
+        ],
+        "type": "object"
+      },
+      "HistoryEntry": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "loggedBy": {
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/$defs/User"
+              }
+            ]
+          },
+          "loggedByName": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "votes": {
+            "items": {
+              "$ref": "#/$defs/VoteSnapshot"
+            },
+            "type": "array"
+          },
+          "wentAt": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "loggedByName",
+          "loggedBy",
+          "wentAt",
+          "votes"
+        ],
+        "type": "object"
+      },
+      "JoinEvent": {
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "LogVisitEvent": {
+        "properties": {
+          "optionId": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "wentAt": {
+            "type": "number"
+          }
+        },
+        "type": "object"
+      },
+      "LunchProfile": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "Option": {
+        "properties": {
+          "addedByName": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "imageUrl": {
+            "description": "Persisted generated-art data URL (`\"\"` until the host's client generates\nand syncs it). Every viewer renders this stored value; generation only\nruns on the host's client for options where it is still empty.",
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "addedByName"
+        ],
+        "type": "object"
+      },
+      "ParticipantProfileLink": {
+        "properties": {
+          "name": {
+            "description": "Immutable Lunch Poll name used by the current name-keyed vote schema.",
+            "type": "string"
+          },
+          "profile": {
+            "$ref": "#/$defs/LunchProfile",
+            "description": "Live canonical profile cell; compare it by identity with `equals()`."
+          }
+        },
+        "required": [
+          "name",
+          "profile"
+        ],
+        "type": "object"
+      },
+      "PlaceStat": {
+        "properties": {
+          "greens": {
+            "type": "number"
+          },
+          "reds": {
+            "type": "number"
+          },
+          "title": {
+            "type": "string"
+          },
+          "visits": {
+            "type": "number"
+          },
+          "yellows": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "title",
+          "visits",
+          "greens",
+          "yellows",
+          "reds"
+        ],
+        "type": "object"
+      },
+      "RemoveHistoryEntryEvent": {
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
+      },
+      "RemoveOptionEvent": {
+        "properties": {
+          "optionId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "optionId"
+        ],
+        "type": "object"
+      },
+      "ResetVotesEvent": {
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object"
+      },
+      "SetOptionImageEvent": {
+        "properties": {
+          "imageUrl": {
+            "type": "string"
+          },
+          "optionId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "optionId",
+          "imageUrl"
+        ],
+        "type": "object"
+      },
+      "User": {
+        "properties": {
+          "avatar": {
+            "description": "Avatar URL or glyph, snapshotted from the joiner's shared profile.",
+            "type": "string"
+          },
+          "color": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "color"
+        ],
+        "type": "object"
+      },
+      "Vote": {
+        "properties": {
+          "castAt": {
+            "description": "When the vote was cast (ms epoch), stamped by `castVote`. Optional for\nvotes stored before this field existed — those count as not-today, so the\ncurrent-day filter hides them.",
+            "type": "number"
+          },
+          "optionId": {
+            "type": "string"
+          },
+          "voteType": {
+            "$ref": "#/$defs/VoteColor"
+          },
+          "voterName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "voterName",
+          "optionId",
+          "voteType"
+        ],
+        "type": "object"
+      },
+      "VoteColor": {
+        "enum": [
+          "green",
+          "yellow",
+          "red"
+        ]
+      },
+      "VoteSnapshot": {
+        "properties": {
+          "color": {
+            "$ref": "#/$defs/VoteColor"
+          },
+          "optionTitle": {
+            "type": "string"
+          },
+          "voter": {
+            "type": "string"
+          },
+          "voterLink": {
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/$defs/User"
+              }
+            ]
+          }
+        },
+        "required": [
+          "voter",
+          "voterLink",
+          "optionTitle",
+          "color"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addOption": {
+        "$ref": "#/$defs/AddOptionEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "adminName": {
+        "type": "string"
+      },
+      "castVote": {
+        "$ref": "#/$defs/CastVoteEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "claimHost": {
+        "$ref": "#/$defs/ClaimHostEvent",
+        "asCell": [
+          "stream"
+        ]
+      },
+      "clearHistory": {
+        "$ref": "#/$defs/ClearHistoryEvent",
+        "asCell": [
+          "stream"
+        ]
+      },
+      "clearMyVote": {
+        "$ref": "#/$defs/ClearVoteEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "historyCount": {
+        "type": "number"
+      },
+      "isAdmin": {
+        "type": "boolean"
+      },
+      "isJoined": {
+        "type": "boolean"
+      },
+      "joinAs": {
+        "$ref": "#/$defs/JoinEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "logVisit": {
+        "$ref": "#/$defs/LogVisitEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "mostRecentTitle": {
+        "type": "string"
+      },
+      "myName": {
+        "type": "string"
+      },
+      "optionCount": {
+        "type": "number"
+      },
+      "options": {
+        "items": {
+          "$ref": "#/$defs/Option"
+        },
+        "type": "array"
+      },
+      "participantProfiles": {
+        "items": {
+          "$ref": "#/$defs/ParticipantProfileLink"
+        },
+        "type": "array"
+      },
+      "placeStats": {
+        "items": {
+          "$ref": "#/$defs/PlaceStat"
+        },
+        "type": "array"
+      },
+      "question": {
+        "type": "string"
+      },
+      "recentVisits": {
+        "items": {
+          "$ref": "#/$defs/HistoryEntry"
+        },
+        "type": "array"
+      },
+      "removeHistoryEntry": {
+        "$ref": "#/$defs/RemoveHistoryEntryEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "removeOption": {
+        "$ref": "#/$defs/RemoveOptionEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "resetVotes": {
+        "$ref": "#/$defs/ResetVotesEvent",
+        "asCell": [
+          "stream"
+        ]
+      },
+      "setOptionImage": {
+        "$ref": "#/$defs/SetOptionImageEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "todayDate": {
+        "type": "string"
+      },
+      "todayVoteCount": {
+        "type": "number"
+      },
+      "todaysVotes": {
+        "items": {
+          "$ref": "#/$defs/Vote"
+        },
+        "type": "array"
+      },
+      "userCount": {
+        "type": "number"
+      },
+      "users": {
+        "items": {
+          "$ref": "#/$defs/User"
+        },
+        "type": "array"
+      },
+      "voteCount": {
+        "type": "number"
+      },
+      "voteHistoryCount": {
+        "type": "number"
+      },
+      "votes": {
+        "items": {
+          "$ref": "#/$defs/Vote"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "question",
+      "options",
+      "votes",
+      "users",
+      "participantProfiles",
+      "adminName",
+      "myName",
+      "userCount",
+      "optionCount",
+      "voteCount",
+      "todayDate",
+      "todaysVotes",
+      "todayVoteCount",
+      "historyCount",
+      "recentVisits",
+      "mostRecentTitle",
+      "voteHistoryCount",
+      "placeStats",
+      "isJoined",
+      "isAdmin",
+      "joinAs",
+      "claimHost",
+      "addOption",
+      "removeOption",
+      "castVote",
+      "clearMyVote",
+      "resetVotes",
+      "setOptionImage",
+      "logVisit",
+      "removeHistoryEntry",
+      "clearHistory",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/lunch-poll/participant-identity-card.tsx/20260807T235141Z-LqNBOGKrU45OKNLQ.json
+++ b/packages/patterns/baselines/lunch-poll/participant-identity-card.tsx/20260807T235141Z-LqNBOGKrU45OKNLQ.json
@@ -1,0 +1,240 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "LunchProfile": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ParticipantProfileDirectory": {
+        "properties": {
+          "participants": {
+            "default": [],
+            "items": {
+              "$ref": "#/$defs/ParticipantProfileLink"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "participants"
+        ],
+        "type": "object"
+      },
+      "ParticipantProfileDirectoryValue": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/ParticipantProfileDirectory"
+          },
+          {
+            "properties": {
+              "participants": {
+                "items": {
+                  "$ref": "#/$defs/ParticipantProfileLink"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "participants"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "ParticipantProfileLink": {
+        "properties": {
+          "name": {
+            "description": "Immutable Lunch Poll name used by the current name-keyed vote schema.",
+            "type": "string"
+          },
+          "profile": {
+            "$ref": "#/$defs/LunchProfile",
+            "asCell": [
+              "cell"
+            ],
+            "description": "Live canonical profile cell; compare it by identity with `equals()`."
+          }
+        },
+        "required": [
+          "name",
+          "profile"
+        ],
+        "type": "object"
+      },
+      "User": {
+        "properties": {
+          "avatar": {
+            "description": "Avatar URL or glyph, snapshotted from the joiner's shared profile.",
+            "type": "string"
+          },
+          "color": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "color"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "Inputs for the participant identity/admin controls.\n\nThe parent owns the durable user directory and viewer identity cells. This\npattern only owns local per-session UI state for the join draft and admin\ntakeover reveal.",
+    "properties": {
+      "adminName": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "description": "Shared admin name cell.",
+        "type": "string"
+      },
+      "myName": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "description": "Per-user current viewer name cell.",
+        "type": "string"
+      },
+      "participantProfiles": {
+        "$ref": "#/$defs/ParticipantProfileDirectoryValue",
+        "asCell": [
+          "cell"
+        ],
+        "description": "Object-wrapped directory of live canonical profile links."
+      },
+      "profile": {
+        "$ref": "#/$defs/LunchProfile",
+        "asCell": [
+          "cell"
+        ],
+        "description": "The viewer's resolved `#profile` cell, from the parent's top-level wish\n(or an injected cell in tests). Used only as the badge/`equals()` identity\n— never read for its name; the display name arrives as `profileName`.\nUndefined until it resolves (or when the viewer has no profile).",
+        "tags": [
+          "profile"
+        ]
+      },
+      "profileAvatar": {
+        "description": "The viewer's resolved avatar, from the parent's `#profileAvatar` wish.",
+        "tags": [
+          "profileavatar"
+        ],
+        "type": "string"
+      },
+      "profileName": {
+        "description": "The viewer's resolved display name, from the parent's top-level\n`#profileName` wish (or injected in tests). \"\" until it resolves; the join\ncard gates on this being non-empty and snapshots it into the roster.",
+        "tags": [
+          "profilename"
+        ],
+        "type": "string"
+      },
+      "profileSetupUI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json",
+        "description": "The `#profile` wish's built-in create/pick surface (`profileWish[UI]`),\nrendered by the parent's top-level wish and passed down so the card shows\nit in the no-profile state. Omitted in tests without a wish environment.",
+        "tags": [
+          "profile"
+        ]
+      },
+      "users": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "description": "Shared roster of participants who have joined.",
+        "items": {
+          "$ref": "#/$defs/User"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "users",
+      "myName",
+      "adminName",
+      "participantProfiles",
+      "profileName",
+      "profileAvatar"
+    ],
+    "type": "object"
+  },
+  "pattern": "lunch-poll/participant-identity-card.tsx",
+  "resultSchema": {
+    "$defs": {
+      "ClaimHostEvent": {
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object"
+      },
+      "JoinEvent": {
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "description": "Outputs for the participant identity/admin controls.\n\nInstantiate this sub-pattern by function call when the parent needs `me`,\n`isJoined`, `isAdmin`, or the bound streams. The `[UI]` value may then be\nembedded in the parent's layout.",
+    "properties": {
+      "$NAME": {
+        "description": "Human-readable pattern name.",
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json",
+        "description": "Static VNode rendering the join form and admin controls."
+      },
+      "claimHost": {
+        "$ref": "#/$defs/ClaimHostEvent",
+        "asCell": [
+          "stream"
+        ],
+        "description": "Bound stream that transfers admin ownership to the current viewer."
+      },
+      "isAdmin": {
+        "description": "Whether the current viewer currently owns admin actions.",
+        "type": "boolean"
+      },
+      "isJoined": {
+        "description": "Whether the current viewer has joined the participant roster.",
+        "type": "boolean"
+      },
+      "joinAs": {
+        "$ref": "#/$defs/JoinEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "description": "Bound stream that joins the current viewer and claims admin if first."
+      },
+      "me": {
+        "description": "Trimmed current viewer name resolved once for downstream sub-patterns.",
+        "type": "string"
+      },
+      "profileName": {
+        "description": "Current canonical profile display name, or empty for a guest/no profile.",
+        "type": "string"
+      }
+    },
+    "required": [
+      "me",
+      "isJoined",
+      "isAdmin",
+      "profileName",
+      "joinAs",
+      "claimHost",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/lunch-poll/poll-option-card.tsx/20260807T235141Z-nyswrtttx6op5FMr.json
+++ b/packages/patterns/baselines/lunch-poll/poll-option-card.tsx/20260807T235141Z-nyswrtttx6op5FMr.json
@@ -1,0 +1,239 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "CastVoteEvent": {
+        "properties": {
+          "optionId": {
+            "type": "string"
+          },
+          "voteType": {
+            "$ref": "#/$defs/VoteColor"
+          }
+        },
+        "required": [
+          "optionId",
+          "voteType"
+        ],
+        "type": "object"
+      },
+      "LogVisitEvent": {
+        "properties": {
+          "optionId": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "wentAt": {
+            "type": "number"
+          }
+        },
+        "type": "object"
+      },
+      "Option": {
+        "properties": {
+          "addedByName": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "imageUrl": {
+            "description": "Persisted generated-art data URL (`\"\"` until the host's client generates\nand syncs it). Every viewer renders this stored value; generation only\nruns on the host's client for options where it is still empty.",
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "addedByName"
+        ],
+        "type": "object"
+      },
+      "RemoveOptionEvent": {
+        "properties": {
+          "optionId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "optionId"
+        ],
+        "type": "object"
+      },
+      "SetOptionImageEvent": {
+        "properties": {
+          "imageUrl": {
+            "type": "string"
+          },
+          "optionId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "optionId",
+          "imageUrl"
+        ],
+        "type": "object"
+      },
+      "Vote": {
+        "properties": {
+          "castAt": {
+            "description": "When the vote was cast (ms epoch), stamped by `castVote`. Optional for\nvotes stored before this field existed — those count as not-today, so the\ncurrent-day filter hides them.",
+            "type": "number"
+          },
+          "optionId": {
+            "type": "string"
+          },
+          "voteType": {
+            "$ref": "#/$defs/VoteColor"
+          },
+          "voterName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "voterName",
+          "optionId",
+          "voteType"
+        ],
+        "type": "object"
+      },
+      "VoteColor": {
+        "enum": [
+          "green",
+          "yellow",
+          "red"
+        ]
+      }
+    },
+    "description": "Inputs for one rendered ranked option row.\n\nThe parent owns all durable and shared UI state. This pattern receives one\noption, current viewer/admin facts, shared per-session editor state, and the\nstreams it should emit for mutations. When rendering inside `options.map()`,\npass the resolved `me` value from the parent, not the raw `myName` PerUser\ncell.",
+    "properties": {
+      "castVote": {
+        "$ref": "#/$defs/CastVoteEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "description": "Parent-owned stream that toggles or records this viewer's vote."
+      },
+      "isAdmin": {
+        "description": "Whether the current viewer owns admin-only actions.",
+        "type": "boolean"
+      },
+      "isJoined": {
+        "description": "Whether the current viewer is allowed to vote.",
+        "type": "boolean"
+      },
+      "logVisit": {
+        "$ref": "#/$defs/LogVisitEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "description": "Parent-owned admin stream that records this option in visit history."
+      },
+      "me": {
+        "description": "Resolved current viewer name; required for per-option vote styling.",
+        "type": "string"
+      },
+      "option": {
+        "$ref": "#/$defs/Option",
+        "description": "Option record to render."
+      },
+      "rank": {
+        "description": "One-based display rank, or undefined while the parent ranking settles.",
+        "type": [
+          "number",
+          "undefined"
+        ]
+      },
+      "removeConfirmTarget": {
+        "asCell": [
+          "cell"
+        ],
+        "description": "Per-session option id awaiting admin remove confirmation.",
+        "type": [
+          "null",
+          "string",
+          "undefined"
+        ]
+      },
+      "removeOption": {
+        "$ref": "#/$defs/RemoveOptionEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "description": "Parent-owned admin stream that removes this option after confirmation."
+      },
+      "setOptionImage": {
+        "$ref": "#/$defs/SetOptionImageEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "description": "Parent-owned admin stream persisting this option's generated art."
+      },
+      "votes": {
+        "description": "Shared vote list used to compute this viewer's selected vote.",
+        "items": {
+          "$ref": "#/$defs/Vote"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "option",
+      "rank",
+      "me",
+      "isJoined",
+      "isAdmin",
+      "votes",
+      "removeConfirmTarget",
+      "castVote",
+      "removeOption",
+      "logVisit",
+      "setOptionImage"
+    ],
+    "type": "object"
+  },
+  "pattern": "lunch-poll/poll-option-card.tsx",
+  "resultSchema": {
+    "$defs": {
+      "GeneratedArtFetchState": {
+        "enum": [
+          "",
+          "stored",
+          "generated",
+          "pending",
+          "error",
+          "requested"
+        ]
+      }
+    },
+    "description": "Outputs for one rendered ranked option row.\n\nParents normally embed this sub-pattern with JSX.",
+    "properties": {
+      "$NAME": {
+        "description": "Human-readable pattern name, matching the option title.",
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json",
+        "description": "Static VNode rendering the complete option row."
+      },
+      "artSyncState": {
+        "$ref": "#/$defs/GeneratedArtFetchState",
+        "description": "Generated-art lifecycle for this row: `\"stored\"` once the option carries a\npersisted image (every viewer), the underlying fetch state while the host's\nclient is generating, and `\"\"` for non-hosts before anything is stored.\nPure read — persistence happens only through the host's explicit keep\naction (→ `setOptionImage`). Optional for the same reason as\n`GeneratedArtOutput.fetchState`: it is fetch-derived on the generating\npath, and a required declaration would gate boundary readers of\nnon-generating rows."
+      }
+    },
+    "required": [
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/notes/daily-journal.tsx/20260807T235141Z-W6R5Tcf-CBjw8k1v.json
+++ b/packages/patterns/baselines/notes/daily-journal.tsx/20260807T235141Z-W6R5Tcf-CBjw8k1v.json
@@ -1,0 +1,522 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "AnonymousType_1": {
+        "items": {
+          "$ref": "#/$defs/MentionablePiece"
+        },
+        "type": "array"
+      },
+      "AnonymousType_2": {
+        "items": {
+          "$ref": "#/$defs/NotePiece"
+        },
+        "type": "array"
+      },
+      "MentionablePiece": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "backlinks": {
+            "$ref": "#/$defs/AnonymousType_1"
+          },
+          "isHidden": {
+            "type": "boolean"
+          },
+          "mentioned": {
+            "$ref": "#/$defs/AnonymousType_1"
+          }
+        },
+        "required": [
+          "mentioned",
+          "backlinks"
+        ],
+        "type": "object"
+      },
+      "NotePiece": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "backlinks": {
+            "$ref": "#/$defs/AnonymousType_1"
+          },
+          "content": {
+            "type": "string"
+          },
+          "isHidden": {
+            "type": "boolean"
+          },
+          "parentNotebook": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/NotebookPiece"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "setTitle": {
+            "asCell": [
+              "stream"
+            ],
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "NotebookPiece": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "backlinks": {
+            "$ref": "#/$defs/AnonymousType_1"
+          },
+          "createNote": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "content": {
+                "type": "string"
+              },
+              "navigate": {
+                "type": "boolean"
+              },
+              "title": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "title",
+              "content"
+            ],
+            "type": "object"
+          },
+          "createNotebook": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "notesData": {
+                "items": {
+                  "properties": {
+                    "content": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "title",
+                    "content"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "title": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "title"
+            ],
+            "type": "object"
+          },
+          "createNotes": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "notesData": {
+                "items": {
+                  "properties": {
+                    "content": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "title",
+                    "content"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "notesData"
+            ],
+            "type": "object"
+          },
+          "isHidden": {
+            "type": "boolean"
+          },
+          "isNotebook": {
+            "type": "boolean"
+          },
+          "notes": {
+            "$ref": "#/$defs/AnonymousType_2"
+          },
+          "setTitle": {
+            "asCell": [
+              "stream"
+            ],
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "createNote",
+          "createNotes",
+          "setTitle",
+          "createNotebook"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "entries": {
+        "$ref": "#/$defs/AnonymousType_2",
+        "asCell": [
+          "cell"
+        ],
+        "default": []
+      },
+      "template": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "title": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "Daily Journal",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "notes/daily-journal.tsx",
+  "resultSchema": {
+    "$defs": {
+      "AnonymousType_1": {
+        "items": {
+          "$ref": "#/$defs/MentionablePiece"
+        },
+        "type": "array"
+      },
+      "AnonymousType_2": {
+        "items": {
+          "$ref": "#/$defs/NotePiece"
+        },
+        "type": "array"
+      },
+      "MentionablePiece": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "backlinks": {
+            "$ref": "#/$defs/AnonymousType_1"
+          },
+          "isHidden": {
+            "type": "boolean"
+          },
+          "mentioned": {
+            "$ref": "#/$defs/AnonymousType_1"
+          }
+        },
+        "required": [
+          "mentioned",
+          "backlinks"
+        ],
+        "type": "object"
+      },
+      "NotePiece": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "backlinks": {
+            "$ref": "#/$defs/AnonymousType_1"
+          },
+          "content": {
+            "type": "string"
+          },
+          "isHidden": {
+            "type": "boolean"
+          },
+          "parentNotebook": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/NotebookPiece"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "setTitle": {
+            "asCell": [
+              "stream"
+            ],
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "NotebookPiece": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "backlinks": {
+            "$ref": "#/$defs/AnonymousType_1"
+          },
+          "createNote": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "content": {
+                "type": "string"
+              },
+              "navigate": {
+                "type": "boolean"
+              },
+              "title": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "title",
+              "content"
+            ],
+            "type": "object"
+          },
+          "createNotebook": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "notesData": {
+                "items": {
+                  "properties": {
+                    "content": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "title",
+                    "content"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "title": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "title"
+            ],
+            "type": "object"
+          },
+          "createNotes": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "notesData": {
+                "items": {
+                  "properties": {
+                    "content": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "title",
+                    "content"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "notesData"
+            ],
+            "type": "object"
+          },
+          "isHidden": {
+            "type": "boolean"
+          },
+          "isNotebook": {
+            "type": "boolean"
+          },
+          "notes": {
+            "$ref": "#/$defs/AnonymousType_2"
+          },
+          "setTitle": {
+            "asCell": [
+              "stream"
+            ],
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "createNote",
+          "createNotes",
+          "setTitle",
+          "createNotebook"
+        ],
+        "type": "object"
+      },
+      "WeeklyRollup": {
+        "properties": {
+          "accomplishments": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "headline": {
+            "type": "string"
+          },
+          "mood": {
+            "type": "string"
+          },
+          "openThreads": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "themes": {
+            "items": {
+              "properties": {
+                "detail": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "detail"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "headline",
+          "themes",
+          "accomplishments",
+          "openThreads",
+          "mood"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "entries": {
+        "$ref": "#/$defs/AnonymousType_2"
+      },
+      "goToToday": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "isJournal": {
+        "type": "boolean"
+      },
+      "mentionable": {
+        "$ref": "#/$defs/AnonymousType_2"
+      },
+      "summary": {
+        "type": "string"
+      },
+      "template": {
+        "type": "string"
+      },
+      "title": {
+        "type": "string"
+      },
+      "weeklyRollup": {
+        "anyOf": [
+          {
+            "type": "undefined"
+          },
+          {
+            "$ref": "#/$defs/WeeklyRollup"
+          }
+        ]
+      }
+    },
+    "required": [
+      "title",
+      "entries",
+      "template",
+      "isJournal",
+      "summary",
+      "mentionable",
+      "goToToday",
+      "weeklyRollup",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/notes/note-md.tsx/20260807T235141Z-nvK6Zyg6duKlVh4o.json
+++ b/packages/patterns/baselines/notes/note-md.tsx/20260807T235141Z-nvK6Zyg6duKlVh4o.json
@@ -1,0 +1,498 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "AnonymousType_1": {
+        "items": {
+          "$ref": "#/$defs/MentionablePiece"
+        },
+        "type": "array"
+      },
+      "MentionablePiece": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "backlinks": {
+            "$ref": "#/$defs/AnonymousType_1"
+          },
+          "isHidden": {
+            "type": "boolean"
+          },
+          "mentioned": {
+            "$ref": "#/$defs/AnonymousType_1"
+          }
+        },
+        "required": [
+          "mentioned",
+          "backlinks"
+        ],
+        "type": "object"
+      },
+      "NotePiece": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "backlinks": {
+            "$ref": "#/$defs/AnonymousType_1"
+          },
+          "content": {
+            "type": "string"
+          },
+          "isHidden": {
+            "type": "boolean"
+          },
+          "parentNotebook": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/NotebookPiece"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "setTitle": {
+            "asCell": [
+              "stream"
+            ],
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "NotebookPiece": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "backlinks": {
+            "$ref": "#/$defs/AnonymousType_1"
+          },
+          "createNote": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "content": {
+                "type": "string"
+              },
+              "navigate": {
+                "type": "boolean"
+              },
+              "title": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "title",
+              "content"
+            ],
+            "type": "object"
+          },
+          "createNotebook": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "notesData": {
+                "items": {
+                  "properties": {
+                    "content": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "title",
+                    "content"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "title": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "title"
+            ],
+            "type": "object"
+          },
+          "createNotes": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "notesData": {
+                "items": {
+                  "properties": {
+                    "content": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "title",
+                    "content"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "notesData"
+            ],
+            "type": "object"
+          },
+          "isHidden": {
+            "type": "boolean"
+          },
+          "isNotebook": {
+            "type": "boolean"
+          },
+          "notes": {
+            "items": {
+              "$ref": "#/$defs/NotePiece"
+            },
+            "type": "array"
+          },
+          "setTitle": {
+            "asCell": [
+              "stream"
+            ],
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "createNote",
+          "createNotes",
+          "setTitle",
+          "createNotebook"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "content": {
+        "asCell": [
+          "cell"
+        ],
+        "description": "Writable content cell for checkbox updates",
+        "type": "string"
+      },
+      "note": {
+        "$ref": "#/$defs/NotePiece",
+        "default": {
+          "backlinks": [],
+          "content": "",
+          "title": ""
+        },
+        "description": "Cell reference to note data (title + content + backlinks)"
+      },
+      "sourceNoteRef": {
+        "$ref": "#/$defs/NotePiece",
+        "description": "Direct reference to source note for Edit navigation"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "notes/note-md.tsx",
+  "resultSchema": {
+    "$defs": {
+      "AnonymousType_1": {
+        "items": {
+          "$ref": "#/$defs/MentionablePiece"
+        },
+        "type": "array"
+      },
+      "MentionablePiece": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "backlinks": {
+            "$ref": "#/$defs/AnonymousType_1"
+          },
+          "isHidden": {
+            "type": "boolean"
+          },
+          "mentioned": {
+            "$ref": "#/$defs/AnonymousType_1"
+          }
+        },
+        "required": [
+          "mentioned",
+          "backlinks"
+        ],
+        "type": "object"
+      },
+      "NotePiece": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "backlinks": {
+            "$ref": "#/$defs/AnonymousType_1"
+          },
+          "content": {
+            "type": "string"
+          },
+          "isHidden": {
+            "type": "boolean"
+          },
+          "parentNotebook": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/NotebookPiece"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "setTitle": {
+            "asCell": [
+              "stream"
+            ],
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "NotebookPiece": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "backlinks": {
+            "$ref": "#/$defs/AnonymousType_1"
+          },
+          "createNote": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "content": {
+                "type": "string"
+              },
+              "navigate": {
+                "type": "boolean"
+              },
+              "title": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "title",
+              "content"
+            ],
+            "type": "object"
+          },
+          "createNotebook": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "notesData": {
+                "items": {
+                  "properties": {
+                    "content": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "title",
+                    "content"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "title": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "title"
+            ],
+            "type": "object"
+          },
+          "createNotes": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "notesData": {
+                "items": {
+                  "properties": {
+                    "content": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "title",
+                    "content"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "notesData"
+            ],
+            "type": "object"
+          },
+          "isHidden": {
+            "type": "boolean"
+          },
+          "isNotebook": {
+            "type": "boolean"
+          },
+          "notes": {
+            "items": {
+              "$ref": "#/$defs/NotePiece"
+            },
+            "type": "array"
+          },
+          "setTitle": {
+            "asCell": [
+              "stream"
+            ],
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "createNote",
+          "createNotes",
+          "setTitle",
+          "createNotebook"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$TILE_UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json",
+        "description": "Tile variant (CT-1764): minimal embedded UI for `<cf-render variant=\"tile\">`."
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "checkboxToggle": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "description": "Stream to toggle checkboxes in content",
+        "properties": {
+          "detail": {
+            "properties": {
+              "checked": {
+                "type": "boolean"
+              },
+              "index": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "index",
+              "checked"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "detail"
+        ],
+        "type": "object"
+      },
+      "goToEdit": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "Stream to navigate back to source note for editing"
+      },
+      "hasBacklinks": {
+        "description": "Whether backlinks section should be visible",
+        "type": "boolean"
+      },
+      "isHidden": {
+        "description": "Hidden from default-app piece list",
+        "enum": [
+          true
+        ],
+        "type": "boolean"
+      },
+      "isMentionable": {
+        "description": "Excluded from mentions autocomplete (notes in notebooks may be hidden but still mentionable)",
+        "enum": [
+          false
+        ],
+        "type": "boolean"
+      },
+      "note": {
+        "$ref": "#/$defs/NotePiece",
+        "description": "Passthrough note reference"
+      },
+      "processedContent": {
+        "description": "Processed content with wiki-links converted to markdown links",
+        "type": "string"
+      }
+    },
+    "required": [
+      "note",
+      "isHidden",
+      "isMentionable",
+      "processedContent",
+      "checkboxToggle",
+      "hasBacklinks",
+      "goToEdit",
+      "$NAME",
+      "$UI",
+      "$TILE_UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/notes/note.tsx/20260807T235141Z-40_zMsrJYaAleRzt.json
+++ b/packages/patterns/baselines/notes/note.tsx/20260807T235141Z-40_zMsrJYaAleRzt.json
@@ -1,0 +1,722 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "AnonymousType_1": {
+        "items": {
+          "$ref": "#/$defs/MentionablePiece"
+        },
+        "type": "array"
+      },
+      "AnonymousType_2": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/NotebookPiece"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "MentionablePiece": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "backlinks": {
+            "$ref": "#/$defs/AnonymousType_1"
+          },
+          "isHidden": {
+            "type": "boolean"
+          },
+          "mentioned": {
+            "$ref": "#/$defs/AnonymousType_1"
+          }
+        },
+        "required": [
+          "mentioned",
+          "backlinks"
+        ],
+        "type": "object"
+      },
+      "NotePiece": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "backlinks": {
+            "$ref": "#/$defs/AnonymousType_1"
+          },
+          "content": {
+            "type": "string"
+          },
+          "isHidden": {
+            "type": "boolean"
+          },
+          "parentNotebook": {
+            "$ref": "#/$defs/AnonymousType_2"
+          },
+          "setTitle": {
+            "asCell": [
+              "stream"
+            ],
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "NotebookPiece": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "backlinks": {
+            "$ref": "#/$defs/AnonymousType_1"
+          },
+          "createNote": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "content": {
+                "type": "string"
+              },
+              "navigate": {
+                "type": "boolean"
+              },
+              "title": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "title",
+              "content"
+            ],
+            "type": "object"
+          },
+          "createNotebook": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "notesData": {
+                "items": {
+                  "properties": {
+                    "content": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "title",
+                    "content"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "title": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "title"
+            ],
+            "type": "object"
+          },
+          "createNotes": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "notesData": {
+                "items": {
+                  "properties": {
+                    "content": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "title",
+                    "content"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "notesData"
+            ],
+            "type": "object"
+          },
+          "isHidden": {
+            "type": "boolean"
+          },
+          "isNotebook": {
+            "type": "boolean"
+          },
+          "notes": {
+            "items": {
+              "$ref": "#/$defs/NotePiece"
+            },
+            "type": "array"
+          },
+          "setTitle": {
+            "asCell": [
+              "stream"
+            ],
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "createNote",
+          "createNotes",
+          "setTitle",
+          "createNotebook"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "content": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "isHidden": {
+        "default": false,
+        "type": "boolean"
+      },
+      "linkPattern": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "description": "Pattern JSON for [[wiki-links]]. Defaults to creating new Notes.",
+        "type": "string"
+      },
+      "parentNotebook": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/NotebookPiece"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "asCell": [
+          "cell"
+        ],
+        "default": null,
+        "description": "Parent notebook reference. Set at creation, can be updated for moves."
+      },
+      "title": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "Untitled Note",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "notes/note.tsx",
+  "resultSchema": {
+    "$defs": {
+      "AnonymousType_1": {
+        "items": {
+          "$ref": "#/$defs/MentionablePiece"
+        },
+        "type": "array"
+      },
+      "AnonymousType_2": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/NotebookPiece"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "CellScope": {
+        "enum": [
+          "space",
+          "user",
+          "session"
+        ]
+      },
+      "FsProjection": {
+        "anyOf": [
+          {
+            "properties": {
+              "content": {
+                "type": "string"
+              },
+              "frontmatter": {
+                "additionalProperties": {
+                  "type": "unknown"
+                },
+                "properties": {},
+                "type": "object"
+              },
+              "type": {
+                "enum": [
+                  "text/markdown"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "content"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "content": {
+                "additionalProperties": {
+                  "type": "unknown"
+                },
+                "properties": {},
+                "type": "object"
+              },
+              "type": {
+                "enum": [
+                  "application/json"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "content"
+            ],
+            "type": "object"
+          },
+          {
+            "additionalProperties": {
+              "type": "unknown"
+            },
+            "properties": {
+              "type": {
+                "type": "undefined"
+              }
+            },
+            "type": "object"
+          }
+        ]
+      },
+      "MentionablePiece": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "backlinks": {
+            "$ref": "#/$defs/AnonymousType_1"
+          },
+          "isHidden": {
+            "type": "boolean"
+          },
+          "mentioned": {
+            "$ref": "#/$defs/AnonymousType_1"
+          }
+        },
+        "required": [
+          "mentioned",
+          "backlinks"
+        ],
+        "type": "object"
+      },
+      "NotePiece": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "backlinks": {
+            "$ref": "#/$defs/AnonymousType_1"
+          },
+          "content": {
+            "type": "string"
+          },
+          "isHidden": {
+            "type": "boolean"
+          },
+          "parentNotebook": {
+            "$ref": "#/$defs/AnonymousType_2"
+          },
+          "setTitle": {
+            "asCell": [
+              "stream"
+            ],
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "NotebookPiece": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "backlinks": {
+            "$ref": "#/$defs/AnonymousType_1"
+          },
+          "createNote": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "content": {
+                "type": "string"
+              },
+              "navigate": {
+                "type": "boolean"
+              },
+              "title": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "title",
+              "content"
+            ],
+            "type": "object"
+          },
+          "createNotebook": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "notesData": {
+                "items": {
+                  "properties": {
+                    "content": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "title",
+                    "content"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "title": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "title"
+            ],
+            "type": "object"
+          },
+          "createNotes": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "notesData": {
+                "items": {
+                  "properties": {
+                    "content": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "title",
+                    "content"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "notesData"
+            ],
+            "type": "object"
+          },
+          "isHidden": {
+            "type": "boolean"
+          },
+          "isNotebook": {
+            "type": "boolean"
+          },
+          "notes": {
+            "items": {
+              "$ref": "#/$defs/NotePiece"
+            },
+            "type": "array"
+          },
+          "setTitle": {
+            "asCell": [
+              "stream"
+            ],
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "createNote",
+          "createNotes",
+          "setTitle",
+          "createNotebook"
+        ],
+        "type": "object"
+      },
+      "Pattern": {
+        "properties": {
+          "argumentSchema": true,
+          "defaultScope": {
+            "$ref": "#/$defs/CellScope"
+          },
+          "resultSchema": true
+        },
+        "required": [
+          "argumentSchema",
+          "resultSchema"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "Represents a small #note a user took to remember some text.",
+    "properties": {
+      "$FS": {
+        "$ref": "#/$defs/FsProjection"
+      },
+      "$NAME": {
+        "type": "string"
+      },
+      "$TILE_UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json",
+        "description": "Tile variant (CT-1764): the minimal embedded UI used when a container\n(e.g. Record) renders this note via `<cf-render variant=\"tile\">`."
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "appendLink": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "piece": {
+            "$ref": "#/$defs/MentionablePiece"
+          }
+        },
+        "required": [
+          "piece"
+        ],
+        "type": "object"
+      },
+      "backlinks": {
+        "$ref": "#/$defs/AnonymousType_1"
+      },
+      "closeMenu": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "content": {
+        "type": "string"
+      },
+      "createNewNote": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "editContent": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "detail": {
+            "properties": {
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "detail"
+        ],
+        "type": "object"
+      },
+      "grep": {
+        "properties": {
+          "extraParams": {
+            "properties": {
+              "content": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "content"
+            ],
+            "type": "object"
+          },
+          "pattern": {
+            "$ref": "#/$defs/Pattern"
+          },
+          "useResultSchemaForObservation": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "pattern",
+          "extraParams"
+        ],
+        "type": "object"
+      },
+      "isEditingTitle": {
+        "type": "boolean"
+      },
+      "isHidden": {
+        "type": "boolean"
+      },
+      "mentioned": {
+        "$ref": "#/$defs/AnonymousType_1",
+        "default": []
+      },
+      "menuOpen": {
+        "type": "boolean"
+      },
+      "parentNotebook": {
+        "$ref": "#/$defs/AnonymousType_2",
+        "description": "Parent notebook reference, null if not in a notebook"
+      },
+      "setTitle": {
+        "asCell": [
+          "stream"
+        ],
+        "type": "string"
+      },
+      "startEditingTitle": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "stopEditingTitle": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "summary": {
+        "type": "string"
+      },
+      "title": {
+        "type": "string"
+      },
+      "toggleMenu": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "translate": {
+        "properties": {
+          "extraParams": {
+            "properties": {
+              "content": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "content"
+            ],
+            "type": "object"
+          },
+          "pattern": {
+            "$ref": "#/$defs/Pattern"
+          },
+          "useResultSchemaForObservation": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "pattern",
+          "extraParams"
+        ],
+        "type": "object"
+      }
+    },
+    "required": [
+      "title",
+      "content",
+      "summary",
+      "mentioned",
+      "backlinks",
+      "isHidden",
+      "grep",
+      "translate",
+      "editContent",
+      "setTitle",
+      "appendLink",
+      "createNewNote",
+      "parentNotebook",
+      "menuOpen",
+      "isEditingTitle",
+      "toggleMenu",
+      "closeMenu",
+      "startEditingTitle",
+      "stopEditingTitle",
+      "$NAME",
+      "$UI",
+      "$FS",
+      "$TILE_UI"
+    ],
+    "tags": [
+      "note"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/notes/notebook.tsx/20260807T235141Z-xYVoJQgUM6DkHyzY.json
+++ b/packages/patterns/baselines/notes/notebook.tsx/20260807T235141Z-xYVoJQgUM6DkHyzY.json
@@ -1,0 +1,728 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "AnonymousType_1": {
+        "items": {
+          "$ref": "#/$defs/MentionablePiece"
+        },
+        "type": "array"
+      },
+      "AnonymousType_2": {
+        "items": {
+          "$ref": "#/$defs/NotePiece"
+        },
+        "type": "array"
+      },
+      "AnonymousType_3": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/NotebookPiece"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "MentionablePiece": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "backlinks": {
+            "$ref": "#/$defs/AnonymousType_1"
+          },
+          "isHidden": {
+            "type": "boolean"
+          },
+          "mentioned": {
+            "$ref": "#/$defs/AnonymousType_1"
+          }
+        },
+        "required": [
+          "mentioned",
+          "backlinks"
+        ],
+        "type": "object"
+      },
+      "NotePiece": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "backlinks": {
+            "$ref": "#/$defs/AnonymousType_1"
+          },
+          "content": {
+            "type": "string"
+          },
+          "isHidden": {
+            "type": "boolean"
+          },
+          "parentNotebook": {
+            "$ref": "#/$defs/AnonymousType_3"
+          },
+          "setTitle": {
+            "asCell": [
+              "stream"
+            ],
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "NotebookPiece": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "backlinks": {
+            "$ref": "#/$defs/AnonymousType_1"
+          },
+          "createNote": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "content": {
+                "type": "string"
+              },
+              "navigate": {
+                "type": "boolean"
+              },
+              "title": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "title",
+              "content"
+            ],
+            "type": "object"
+          },
+          "createNotebook": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "notesData": {
+                "items": {
+                  "properties": {
+                    "content": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "title",
+                    "content"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "title": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "title"
+            ],
+            "type": "object"
+          },
+          "createNotes": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "notesData": {
+                "items": {
+                  "properties": {
+                    "content": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "title",
+                    "content"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "notesData"
+            ],
+            "type": "object"
+          },
+          "isHidden": {
+            "type": "boolean"
+          },
+          "isNotebook": {
+            "type": "boolean"
+          },
+          "notes": {
+            "$ref": "#/$defs/AnonymousType_2"
+          },
+          "setTitle": {
+            "asCell": [
+              "stream"
+            ],
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "createNote",
+          "createNotes",
+          "setTitle",
+          "createNotebook"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "isHidden": {
+        "default": false,
+        "type": "boolean"
+      },
+      "isNotebook": {
+        "default": true,
+        "type": "boolean"
+      },
+      "notes": {
+        "$ref": "#/$defs/AnonymousType_2",
+        "asCell": [
+          "cell"
+        ],
+        "default": []
+      },
+      "parentNotebook": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/NotebookPiece"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "asCell": [
+          "cell"
+        ],
+        "default": null,
+        "description": "Parent notebook reference. Set at creation, can be updated for moves."
+      },
+      "title": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "Notebook",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "notes/notebook.tsx",
+  "resultSchema": {
+    "$defs": {
+      "AnonymousType_1": {
+        "items": {
+          "$ref": "#/$defs/MentionablePiece"
+        },
+        "type": "array"
+      },
+      "AnonymousType_2": {
+        "items": {
+          "$ref": "#/$defs/NotePiece"
+        },
+        "type": "array"
+      },
+      "AnonymousType_3": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/NotebookPiece"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "MentionablePiece": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "backlinks": {
+            "$ref": "#/$defs/AnonymousType_1"
+          },
+          "isHidden": {
+            "type": "boolean"
+          },
+          "mentioned": {
+            "$ref": "#/$defs/AnonymousType_1"
+          }
+        },
+        "required": [
+          "mentioned",
+          "backlinks"
+        ],
+        "type": "object"
+      },
+      "NotePiece": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "backlinks": {
+            "$ref": "#/$defs/AnonymousType_1"
+          },
+          "content": {
+            "type": "string"
+          },
+          "isHidden": {
+            "type": "boolean"
+          },
+          "parentNotebook": {
+            "$ref": "#/$defs/AnonymousType_3"
+          },
+          "setTitle": {
+            "asCell": [
+              "stream"
+            ],
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "NotebookPiece": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "backlinks": {
+            "$ref": "#/$defs/AnonymousType_1"
+          },
+          "createNote": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "content": {
+                "type": "string"
+              },
+              "navigate": {
+                "type": "boolean"
+              },
+              "title": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "title",
+              "content"
+            ],
+            "type": "object"
+          },
+          "createNotebook": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "notesData": {
+                "items": {
+                  "properties": {
+                    "content": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "title",
+                    "content"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "title": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "title"
+            ],
+            "type": "object"
+          },
+          "createNotes": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "notesData": {
+                "items": {
+                  "properties": {
+                    "content": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "title",
+                    "content"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "notesData"
+            ],
+            "type": "object"
+          },
+          "isHidden": {
+            "type": "boolean"
+          },
+          "isNotebook": {
+            "type": "boolean"
+          },
+          "notes": {
+            "$ref": "#/$defs/AnonymousType_2"
+          },
+          "setTitle": {
+            "asCell": [
+              "stream"
+            ],
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "createNote",
+          "createNotes",
+          "setTitle",
+          "createNotebook"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "A #notebook that organizes notes into collections.",
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "backlinks": {
+        "$ref": "#/$defs/AnonymousType_1"
+      },
+      "cancelNewNestedNotebook": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "cancelNewNote": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "cancelNewNotebook": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "createAnotherNestedNotebookFromPrompt": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "createAnotherNoteFromPrompt": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "createNestedNotebookFromPrompt": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "createNote": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "content"
+        ],
+        "type": "object"
+      },
+      "createNoteFromPrompt": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "createNotebook": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "notesData": {
+            "items": {
+              "properties": {
+                "content": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "title",
+                "content"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title"
+        ],
+        "type": "object"
+      },
+      "createNotebookFromSelectionPrompt": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "createNotes": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "notesData": {
+            "items": {
+              "properties": {
+                "content": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "title",
+                "content"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "notesData"
+        ],
+        "type": "object"
+      },
+      "deleteSelected": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "deselectAllNotes": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "duplicateSelected": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "goToAllNotes": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "hasSelection": {
+        "type": "boolean"
+      },
+      "isEditingTitle": {
+        "type": "boolean"
+      },
+      "isHidden": {
+        "type": "boolean"
+      },
+      "isNotebook": {
+        "type": "boolean"
+      },
+      "noteCount": {
+        "type": "number"
+      },
+      "notes": {
+        "$ref": "#/$defs/AnonymousType_2"
+      },
+      "selectAllNotes": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "selectedCount": {
+        "type": "number"
+      },
+      "selectedNoteIndices": {
+        "items": {
+          "type": "number"
+        },
+        "type": "array"
+      },
+      "setTitle": {
+        "asCell": [
+          "stream"
+        ],
+        "type": "string"
+      },
+      "showNewNestedNotebookPrompt": {
+        "type": "boolean"
+      },
+      "showNewNoteModal": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "showNewNotePrompt": {
+        "type": "boolean"
+      },
+      "showNewNotebookModal": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "showNewNotebookPrompt": {
+        "type": "boolean"
+      },
+      "startEditTitle": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "stopEditTitle": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "summary": {
+        "type": "string"
+      },
+      "title": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "title",
+      "notes",
+      "noteCount",
+      "summary",
+      "isNotebook",
+      "isHidden",
+      "backlinks",
+      "createNote",
+      "createNotes",
+      "setTitle",
+      "createNotebook",
+      "selectAllNotes",
+      "deselectAllNotes",
+      "deleteSelected",
+      "duplicateSelected",
+      "showNewNoteModal",
+      "cancelNewNote",
+      "showNewNotebookModal",
+      "cancelNewNotebook",
+      "cancelNewNestedNotebook",
+      "startEditTitle",
+      "stopEditTitle",
+      "goToAllNotes",
+      "createNoteFromPrompt",
+      "createAnotherNoteFromPrompt",
+      "createNestedNotebookFromPrompt",
+      "createAnotherNestedNotebookFromPrompt",
+      "createNotebookFromSelectionPrompt",
+      "selectedNoteIndices",
+      "selectedCount",
+      "hasSelection",
+      "showNewNotePrompt",
+      "showNewNotebookPrompt",
+      "showNewNestedNotebookPrompt",
+      "isEditingTitle",
+      "$NAME",
+      "$UI"
+    ],
+    "tags": [
+      "notebook"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/reading-list/reading-item-detail.tsx/20260807T235141Z-7T_9IsWqvXttLoVy.json
+++ b/packages/patterns/baselines/reading-list/reading-item-detail.tsx/20260807T235141Z-7T_9IsWqvXttLoVy.json
@@ -1,0 +1,246 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "ItemStatus": {
+        "enum": [
+          "want",
+          "reading",
+          "finished",
+          "abandoned"
+        ]
+      },
+      "ItemType": {
+        "enum": [
+          "book",
+          "article",
+          "paper",
+          "video"
+        ]
+      }
+    },
+    "description": "Input for creating a new reading item detail piece",
+    "properties": {
+      "addedAt": {
+        "default": 0,
+        "type": "number"
+      },
+      "author": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "finishedAt": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null
+      },
+      "notes": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "rating": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "asCell": [
+          "cell"
+        ],
+        "default": null
+      },
+      "status": {
+        "$ref": "#/$defs/ItemStatus",
+        "asCell": [
+          "cell"
+        ],
+        "default": "want"
+      },
+      "title": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "type": {
+        "$ref": "#/$defs/ItemType",
+        "asCell": [
+          "cell"
+        ],
+        "default": "article"
+      },
+      "url": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "reading-list/reading-item-detail.tsx",
+  "resultSchema": {
+    "$defs": {
+      "ItemStatus": {
+        "enum": [
+          "want",
+          "reading",
+          "finished",
+          "abandoned"
+        ]
+      },
+      "ItemType": {
+        "enum": [
+          "book",
+          "article",
+          "paper",
+          "video"
+        ]
+      }
+    },
+    "description": "Output shape of the reading item piece - this is what gets stored in lists\n#book #article #reading",
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addedAt": {
+        "type": "number"
+      },
+      "author": {
+        "type": "string"
+      },
+      "finishedAt": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "notes": {
+        "type": "string"
+      },
+      "rating": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "setNotes": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "notes": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "notes"
+        ],
+        "type": "object"
+      },
+      "setRating": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "rating": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "rating"
+        ],
+        "type": "object"
+      },
+      "setStatus": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "status": {
+            "$ref": "#/$defs/ItemStatus"
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "type": "object"
+      },
+      "status": {
+        "$ref": "#/$defs/ItemStatus"
+      },
+      "summary": {
+        "type": "string"
+      },
+      "title": {
+        "type": "string"
+      },
+      "type": {
+        "$ref": "#/$defs/ItemType"
+      },
+      "url": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "title",
+      "author",
+      "url",
+      "type",
+      "status",
+      "rating",
+      "notes",
+      "summary",
+      "addedAt",
+      "finishedAt",
+      "setStatus",
+      "setRating",
+      "setNotes",
+      "$NAME",
+      "$UI"
+    ],
+    "tags": [
+      "book",
+      "article",
+      "reading"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/reading-list/reading-list.tsx/20260807T235141Z-B9HT5OdzizPCYaYa.json
+++ b/packages/patterns/baselines/reading-list/reading-list.tsx/20260807T235141Z-B9HT5OdzizPCYaYa.json
@@ -1,0 +1,454 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "ItemStatus": {
+        "enum": [
+          "want",
+          "reading",
+          "finished",
+          "abandoned"
+        ]
+      },
+      "ItemType": {
+        "enum": [
+          "book",
+          "article",
+          "paper",
+          "video"
+        ]
+      },
+      "ReadingItemDetailOutput": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "$UI": {
+            "$ref": "https://commonfabric.org/schemas/vnode.json"
+          },
+          "addedAt": {
+            "type": "number"
+          },
+          "author": {
+            "type": "string"
+          },
+          "finishedAt": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "notes": {
+            "type": "string"
+          },
+          "rating": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "setNotes": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "notes": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "notes"
+            ],
+            "type": "object"
+          },
+          "setRating": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "rating": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "rating"
+            ],
+            "type": "object"
+          },
+          "setStatus": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "status": {
+                "$ref": "#/$defs/ItemStatus"
+              }
+            },
+            "required": [
+              "status"
+            ],
+            "type": "object"
+          },
+          "status": {
+            "$ref": "#/$defs/ItemStatus"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "$ref": "#/$defs/ItemType"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "author",
+          "url",
+          "type",
+          "status",
+          "rating",
+          "notes",
+          "summary",
+          "addedAt",
+          "finishedAt",
+          "setStatus",
+          "setRating",
+          "setNotes",
+          "$NAME",
+          "$UI"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "items": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/ReadingItemDetailOutput"
+        },
+        "type": "array"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "reading-list/reading-list.tsx",
+  "resultSchema": {
+    "$defs": {
+      "ItemStatus": {
+        "enum": [
+          "want",
+          "reading",
+          "finished",
+          "abandoned"
+        ]
+      },
+      "ItemType": {
+        "enum": [
+          "book",
+          "article",
+          "paper",
+          "video"
+        ]
+      },
+      "ReadingItemDetailOutput": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "$UI": {
+            "$ref": "https://commonfabric.org/schemas/vnode.json"
+          },
+          "addedAt": {
+            "type": "number"
+          },
+          "author": {
+            "type": "string"
+          },
+          "finishedAt": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "notes": {
+            "type": "string"
+          },
+          "rating": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "setNotes": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "notes": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "notes"
+            ],
+            "type": "object"
+          },
+          "setRating": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "rating": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "rating"
+            ],
+            "type": "object"
+          },
+          "setStatus": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "properties": {
+              "status": {
+                "$ref": "#/$defs/ItemStatus"
+              }
+            },
+            "required": [
+              "status"
+            ],
+            "type": "object"
+          },
+          "status": {
+            "$ref": "#/$defs/ItemStatus"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "$ref": "#/$defs/ItemType"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "author",
+          "url",
+          "type",
+          "status",
+          "rating",
+          "notes",
+          "summary",
+          "addedAt",
+          "finishedAt",
+          "setStatus",
+          "setRating",
+          "setNotes",
+          "$NAME",
+          "$UI"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addItem": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "author": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "$ref": "#/$defs/ItemType"
+          }
+        },
+        "required": [
+          "title",
+          "author",
+          "type"
+        ],
+        "type": "object"
+      },
+      "currentFilter": {
+        "enum": [
+          "want",
+          "reading",
+          "finished",
+          "abandoned",
+          "all"
+        ]
+      },
+      "filteredCount": {
+        "type": "number"
+      },
+      "filteredItems": {
+        "items": {
+          "$ref": "#/$defs/ReadingItemDetailOutput"
+        },
+        "type": "array"
+      },
+      "items": {
+        "items": {
+          "$ref": "#/$defs/ReadingItemDetailOutput"
+        },
+        "type": "array"
+      },
+      "mentionable": {
+        "items": {
+          "$ref": "#/$defs/ReadingItemDetailOutput"
+        },
+        "type": "array"
+      },
+      "removeItem": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "item": {
+            "$ref": "#/$defs/ReadingItemDetailOutput"
+          }
+        },
+        "required": [
+          "item"
+        ],
+        "type": "object"
+      },
+      "setFilter": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "status": {
+            "enum": [
+              "want",
+              "reading",
+              "finished",
+              "abandoned",
+              "all"
+            ]
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "type": "object"
+      },
+      "summary": {
+        "type": "string"
+      },
+      "totalCount": {
+        "type": "number"
+      },
+      "updateItem": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "item": {
+            "$ref": "#/$defs/ReadingItemDetailOutput"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "rating": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "status": {
+            "$ref": "#/$defs/ItemStatus"
+          }
+        },
+        "required": [
+          "item"
+        ],
+        "type": "object"
+      }
+    },
+    "required": [
+      "items",
+      "mentionable",
+      "totalCount",
+      "currentFilter",
+      "filteredItems",
+      "filteredCount",
+      "summary",
+      "addItem",
+      "removeItem",
+      "setFilter",
+      "updateItem",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/record.tsx/20260807T235141Z-BOKG-LZYz4IXGa0R.json
+++ b/packages/patterns/baselines/record.tsx/20260807T235141Z-BOKG-LZYz4IXGa0R.json
@@ -1,0 +1,310 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "SubPieceEntry": {
+        "properties": {
+          "collapsed": {
+            "type": "boolean"
+          },
+          "label": {
+            "type": "string"
+          },
+          "note": {
+            "type": "string"
+          },
+          "piece": {
+            "type": "unknown"
+          },
+          "pinned": {
+            "type": "boolean"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "pinned",
+          "piece"
+        ],
+        "type": "object"
+      },
+      "TrashedSubPieceEntry": {
+        "properties": {
+          "collapsed": {
+            "type": "boolean"
+          },
+          "label": {
+            "type": "string"
+          },
+          "note": {
+            "type": "string"
+          },
+          "piece": {
+            "type": "unknown"
+          },
+          "pinned": {
+            "type": "boolean"
+          },
+          "trashedAt": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "trashedAt",
+          "type",
+          "pinned",
+          "piece"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "subPieces": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/SubPieceEntry"
+        },
+        "type": "array"
+      },
+      "title": {
+        "default": "",
+        "type": "string"
+      },
+      "trashedSubPieces": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/TrashedSubPieceEntry"
+        },
+        "type": "array"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "record.tsx",
+  "resultSchema": {
+    "$defs": {
+      "RecordOutput": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "$UI": {
+            "$ref": "https://commonfabric.org/schemas/vnode.json"
+          },
+          "addModule": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "description": "Adds a module of the named type to this record's sub-pieces.",
+            "properties": {
+              "initialData": {
+                "additionalProperties": {
+                  "type": "unknown"
+                },
+                "properties": {},
+                "type": "object"
+              },
+              "result": {
+                "type": "unknown"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
+          },
+          "getSummary": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "description": "Writes a structured summary of every module into the result cell.",
+            "properties": {
+              "result": {
+                "type": "unknown"
+              }
+            },
+            "type": "object"
+          },
+          "listModuleTypes": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "description": "Writes the list of addable module types into the result cell.",
+            "properties": {
+              "result": {
+                "type": "unknown"
+              }
+            },
+            "type": "object"
+          },
+          "parentRecord": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/RecordOutput"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Self-reference for sub-pieces to access their parent Record"
+          },
+          "removeModule": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "description": "Moves the module at the given index to the trash.",
+            "properties": {
+              "index": {
+                "type": "number"
+              },
+              "result": {
+                "type": "unknown"
+              }
+            },
+            "required": [
+              "index"
+            ],
+            "type": "object"
+          },
+          "setTitle": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "description": "Sets this record's title.",
+            "properties": {
+              "newTitle": {
+                "type": "string"
+              },
+              "result": {
+                "type": "unknown"
+              }
+            },
+            "required": [
+              "newTitle"
+            ],
+            "type": "object"
+          },
+          "subPieces": {
+            "default": [],
+            "items": {
+              "$ref": "#/$defs/SubPieceEntry"
+            },
+            "type": "array"
+          },
+          "title": {
+            "default": "",
+            "type": "string"
+          },
+          "trashedSubPieces": {
+            "default": [],
+            "items": {
+              "$ref": "#/$defs/TrashedSubPieceEntry"
+            },
+            "type": "array"
+          },
+          "updateModule": {
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ],
+            "description": "Sets a directly-settable field on the module at the given index.",
+            "properties": {
+              "field": {
+                "type": "string"
+              },
+              "index": {
+                "type": "number"
+              },
+              "result": {
+                "type": "unknown"
+              },
+              "value": {
+                "type": "unknown"
+              }
+            },
+            "required": [
+              "index",
+              "field",
+              "value"
+            ],
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "SubPieceEntry": {
+        "properties": {
+          "collapsed": {
+            "type": "boolean"
+          },
+          "label": {
+            "type": "string"
+          },
+          "note": {
+            "type": "string"
+          },
+          "piece": {
+            "type": "unknown"
+          },
+          "pinned": {
+            "type": "boolean"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "pinned",
+          "piece"
+        ],
+        "type": "object"
+      },
+      "TrashedSubPieceEntry": {
+        "properties": {
+          "collapsed": {
+            "type": "boolean"
+          },
+          "label": {
+            "type": "string"
+          },
+          "note": {
+            "type": "string"
+          },
+          "piece": {
+            "type": "unknown"
+          },
+          "pinned": {
+            "type": "boolean"
+          },
+          "trashedAt": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "trashedAt",
+          "type",
+          "pinned",
+          "piece"
+        ],
+        "type": "object"
+      }
+    },
+    "$ref": "#/$defs/RecordOutput"
+  }
+}

--- a/packages/patterns/baselines/scope-bug-ct1597-reduce/main.tsx/20260807T235141Z-lCg9n1Y9Ik1g1PbZ.json
+++ b/packages/patterns/baselines/scope-bug-ct1597-reduce/main.tsx/20260807T235141Z-lCg9n1Y9Ik1g1PbZ.json
@@ -1,0 +1,362 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "Option": {
+        "properties": {
+          "addedByName": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "addedByName"
+        ],
+        "type": "object"
+      },
+      "User": {
+        "properties": {
+          "color": {
+            "type": "string"
+          },
+          "joinedAt": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "color",
+          "joinedAt"
+        ],
+        "type": "object"
+      },
+      "Vote": {
+        "properties": {
+          "optionId": {
+            "type": "string"
+          },
+          "voteType": {
+            "$ref": "#/$defs/VoteColor"
+          },
+          "voterName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "voterName",
+          "optionId",
+          "voteType"
+        ],
+        "type": "object"
+      },
+      "VoteColor": {
+        "enum": [
+          "green",
+          "yellow",
+          "red"
+        ]
+      }
+    },
+    "properties": {
+      "adminName": {
+        "default": "",
+        "scope": "space",
+        "type": "string"
+      },
+      "joinName": {
+        "default": "",
+        "scope": "space",
+        "type": "string"
+      },
+      "myName": {
+        "default": "",
+        "scope": "space",
+        "type": "string"
+      },
+      "optionDraft": {
+        "default": "",
+        "scope": "space",
+        "type": "string"
+      },
+      "options": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/Option"
+        },
+        "scope": "space",
+        "type": "array"
+      },
+      "question": {
+        "default": "Where should we eat?",
+        "scope": "space",
+        "type": "string"
+      },
+      "users": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/User"
+        },
+        "scope": "space",
+        "type": "array"
+      },
+      "votes": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/Vote"
+        },
+        "scope": "space",
+        "type": "array"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "scope-bug-ct1597-reduce/main.tsx",
+  "resultSchema": {
+    "$defs": {
+      "AddOptionEvent": {
+        "properties": {
+          "title": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "CastVoteEvent": {
+        "properties": {
+          "optionId": {
+            "type": "string"
+          },
+          "voteType": {
+            "$ref": "#/$defs/VoteColor"
+          }
+        },
+        "required": [
+          "optionId",
+          "voteType"
+        ],
+        "type": "object"
+      },
+      "ClearVoteEvent": {
+        "properties": {
+          "optionId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "optionId"
+        ],
+        "type": "object"
+      },
+      "JoinEvent": {
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "Option": {
+        "properties": {
+          "addedByName": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "addedByName"
+        ],
+        "type": "object"
+      },
+      "RemoveOptionEvent": {
+        "properties": {
+          "optionId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "optionId"
+        ],
+        "type": "object"
+      },
+      "ResetVotesEvent": {
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object"
+      },
+      "User": {
+        "properties": {
+          "color": {
+            "type": "string"
+          },
+          "joinedAt": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "color",
+          "joinedAt"
+        ],
+        "type": "object"
+      },
+      "Vote": {
+        "properties": {
+          "optionId": {
+            "type": "string"
+          },
+          "voteType": {
+            "$ref": "#/$defs/VoteColor"
+          },
+          "voterName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "voterName",
+          "optionId",
+          "voteType"
+        ],
+        "type": "object"
+      },
+      "VoteColor": {
+        "enum": [
+          "green",
+          "yellow",
+          "red"
+        ]
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addOption": {
+        "$ref": "#/$defs/AddOptionEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "adminName": {
+        "type": "string"
+      },
+      "castVote": {
+        "$ref": "#/$defs/CastVoteEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "clearMyVote": {
+        "$ref": "#/$defs/ClearVoteEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "isAdmin": {
+        "type": "boolean"
+      },
+      "isJoined": {
+        "type": "boolean"
+      },
+      "joinAs": {
+        "$ref": "#/$defs/JoinEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "myName": {
+        "type": "string"
+      },
+      "optionCount": {
+        "type": "number"
+      },
+      "options": {
+        "items": {
+          "$ref": "#/$defs/Option"
+        },
+        "type": "array"
+      },
+      "question": {
+        "type": "string"
+      },
+      "removeOption": {
+        "$ref": "#/$defs/RemoveOptionEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "resetVotes": {
+        "$ref": "#/$defs/ResetVotesEvent",
+        "asCell": [
+          "stream"
+        ]
+      },
+      "userCount": {
+        "type": "number"
+      },
+      "users": {
+        "items": {
+          "$ref": "#/$defs/User"
+        },
+        "type": "array"
+      },
+      "voteCount": {
+        "type": "number"
+      },
+      "votes": {
+        "items": {
+          "$ref": "#/$defs/Vote"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "question",
+      "options",
+      "votes",
+      "users",
+      "adminName",
+      "myName",
+      "userCount",
+      "optionCount",
+      "voteCount",
+      "isJoined",
+      "isAdmin",
+      "joinAs",
+      "addOption",
+      "removeOption",
+      "castVote",
+      "clearMyVote",
+      "resetVotes",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/scoped-group-chat/main-plain-inputs.tsx/20260807T235141Z-I2xzQicEVi3vvXmq.json
+++ b/packages/patterns/baselines/scoped-group-chat/main-plain-inputs.tsx/20260807T235141Z-I2xzQicEVi3vvXmq.json
@@ -1,0 +1,258 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "ChatMessage": {
+        "properties": {
+          "author": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          },
+          "sentAt": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "author",
+          "body",
+          "sentAt"
+        ],
+        "type": "object"
+      },
+      "Conversation": {
+        "properties": {
+          "rooms": {
+            "default": [],
+            "items": {
+              "$ref": "#/$defs/Room"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "rooms"
+        ],
+        "type": "object"
+      },
+      "Room": {
+        "properties": {
+          "messages": {
+            "default": [],
+            "items": {
+              "$ref": "#/$defs/ChatMessage"
+            },
+            "type": "array"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "messages"
+        ],
+        "type": "object"
+      },
+      "SelectedRoom": {
+        "properties": {
+          "room": {
+            "$ref": "#/$defs/Room"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "properties": {
+      "conversation": {
+        "$ref": "#/$defs/Conversation",
+        "default": {
+          "rooms": []
+        },
+        "scope": "space"
+      },
+      "draft": {
+        "default": "",
+        "scope": "user",
+        "type": "string"
+      },
+      "name": {
+        "default": "",
+        "scope": "user",
+        "type": "string"
+      },
+      "newRoomName": {
+        "default": "",
+        "scope": "session",
+        "type": "string"
+      },
+      "selectedRoom": {
+        "$ref": "#/$defs/SelectedRoom",
+        "scope": "session"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "scoped-group-chat/main-plain-inputs.tsx",
+  "resultSchema": {
+    "$defs": {
+      "AddRoomEvent": {
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ChatMessage": {
+        "properties": {
+          "author": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          },
+          "sentAt": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "author",
+          "body",
+          "sentAt"
+        ],
+        "type": "object"
+      },
+      "Conversation": {
+        "properties": {
+          "rooms": {
+            "default": [],
+            "items": {
+              "$ref": "#/$defs/Room"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "rooms"
+        ],
+        "type": "object"
+      },
+      "Room": {
+        "properties": {
+          "messages": {
+            "default": [],
+            "items": {
+              "$ref": "#/$defs/ChatMessage"
+            },
+            "type": "array"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "messages"
+        ],
+        "type": "object"
+      },
+      "SelectRoomEvent": {
+        "properties": {
+          "room": {
+            "$ref": "#/$defs/Room"
+          }
+        },
+        "type": "object"
+      },
+      "SelectedRoom": {
+        "properties": {
+          "room": {
+            "$ref": "#/$defs/Room"
+          }
+        },
+        "type": "object"
+      },
+      "SendMessageEvent": {
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addRoom": {
+        "$ref": "#/$defs/AddRoomEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "conversation": {
+        "$ref": "#/$defs/Conversation",
+        "default": {
+          "rooms": []
+        },
+        "scope": "space"
+      },
+      "draft": {
+        "default": "",
+        "scope": "user",
+        "type": "string"
+      },
+      "messageCount": {
+        "type": "number"
+      },
+      "name": {
+        "default": "",
+        "scope": "user",
+        "type": "string"
+      },
+      "newRoomName": {
+        "default": "",
+        "scope": "session",
+        "type": "string"
+      },
+      "roomCount": {
+        "type": "number"
+      },
+      "selectRoom": {
+        "$ref": "#/$defs/SelectRoomEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "selectedRoom": {
+        "$ref": "#/$defs/SelectedRoom",
+        "scope": "session"
+      },
+      "sendMessage": {
+        "$ref": "#/$defs/SendMessageEvent",
+        "asCell": [
+          "stream"
+        ]
+      }
+    },
+    "required": [
+      "name",
+      "selectedRoom",
+      "conversation",
+      "draft",
+      "newRoomName",
+      "messageCount",
+      "roomCount",
+      "sendMessage",
+      "addRoom",
+      "selectRoom",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/scoped-group-chat/main-with-writable-inputs.tsx/20260807T235141Z-qLIZEotBNgJKZHlc.json
+++ b/packages/patterns/baselines/scoped-group-chat/main-with-writable-inputs.tsx/20260807T235141Z-qLIZEotBNgJKZHlc.json
@@ -1,0 +1,283 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "ChatMessage": {
+        "properties": {
+          "author": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          },
+          "sentAt": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "author",
+          "body",
+          "sentAt"
+        ],
+        "type": "object"
+      },
+      "Conversation": {
+        "properties": {
+          "rooms": {
+            "default": [],
+            "items": {
+              "$ref": "#/$defs/Room"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "rooms"
+        ],
+        "type": "object"
+      },
+      "Room": {
+        "properties": {
+          "messages": {
+            "default": [],
+            "items": {
+              "$ref": "#/$defs/ChatMessage"
+            },
+            "type": "array"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "messages"
+        ],
+        "type": "object"
+      },
+      "SelectedRoom": {
+        "properties": {
+          "room": {
+            "$ref": "#/$defs/Room"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "properties": {
+      "conversation": {
+        "$ref": "#/$defs/Conversation",
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ],
+        "default": {
+          "rooms": []
+        }
+      },
+      "draft": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "user"
+          }
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "name": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "user"
+          }
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "newRoomName": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "session"
+          }
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "selectedRoom": {
+        "$ref": "#/$defs/SelectedRoom",
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "session"
+          }
+        ]
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "scoped-group-chat/main-with-writable-inputs.tsx",
+  "resultSchema": {
+    "$defs": {
+      "AddRoomEvent": {
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ChatMessage": {
+        "properties": {
+          "author": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          },
+          "sentAt": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "author",
+          "body",
+          "sentAt"
+        ],
+        "type": "object"
+      },
+      "Conversation": {
+        "properties": {
+          "rooms": {
+            "default": [],
+            "items": {
+              "$ref": "#/$defs/Room"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "rooms"
+        ],
+        "type": "object"
+      },
+      "Room": {
+        "properties": {
+          "messages": {
+            "default": [],
+            "items": {
+              "$ref": "#/$defs/ChatMessage"
+            },
+            "type": "array"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "messages"
+        ],
+        "type": "object"
+      },
+      "SelectRoomEvent": {
+        "properties": {
+          "room": {
+            "$ref": "#/$defs/Room"
+          }
+        },
+        "type": "object"
+      },
+      "SelectedRoom": {
+        "properties": {
+          "room": {
+            "$ref": "#/$defs/Room"
+          }
+        },
+        "type": "object"
+      },
+      "SendMessageEvent": {
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addRoom": {
+        "$ref": "#/$defs/AddRoomEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "conversation": {
+        "$ref": "#/$defs/Conversation",
+        "default": {
+          "rooms": []
+        },
+        "scope": "space"
+      },
+      "draft": {
+        "default": "",
+        "scope": "user",
+        "type": "string"
+      },
+      "messageCount": {
+        "type": "number"
+      },
+      "name": {
+        "default": "",
+        "scope": "user",
+        "type": "string"
+      },
+      "newRoomName": {
+        "default": "",
+        "scope": "session",
+        "type": "string"
+      },
+      "roomCount": {
+        "type": "number"
+      },
+      "selectRoom": {
+        "$ref": "#/$defs/SelectRoomEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "selectedRoom": {
+        "$ref": "#/$defs/SelectedRoom",
+        "scope": "session"
+      },
+      "sendMessage": {
+        "$ref": "#/$defs/SendMessageEvent",
+        "asCell": [
+          "stream"
+        ]
+      }
+    },
+    "required": [
+      "name",
+      "selectedRoom",
+      "conversation",
+      "draft",
+      "newRoomName",
+      "messageCount",
+      "roomCount",
+      "sendMessage",
+      "addRoom",
+      "selectRoom",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/scoped-user-directory/main.tsx/20260807T235141Z-nU9Wsv8YtDsoJtrZ.json
+++ b/packages/patterns/baselines/scoped-user-directory/main.tsx/20260807T235141Z-nU9Wsv8YtDsoJtrZ.json
@@ -1,0 +1,161 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "Directory": {
+        "properties": {
+          "users": {
+            "default": [],
+            "items": {
+              "$ref": "#/$defs/User"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "users"
+        ],
+        "type": "object"
+      },
+      "User": {
+        "properties": {
+          "displayName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "displayName"
+        ],
+        "type": "object"
+      },
+      "UserPointer": {
+        "properties": {
+          "user": {
+            "$ref": "#/$defs/User"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "properties": {
+      "directory": {
+        "$ref": "#/$defs/Directory",
+        "default": {
+          "users": []
+        },
+        "scope": "space"
+      },
+      "me": {
+        "$ref": "#/$defs/UserPointer",
+        "scope": "user"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "scoped-user-directory/main.tsx",
+  "resultSchema": {
+    "$defs": {
+      "Directory": {
+        "properties": {
+          "users": {
+            "default": [],
+            "items": {
+              "$ref": "#/$defs/User"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "users"
+        ],
+        "type": "object"
+      },
+      "JoinAsEvent": {
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "RenameEvent": {
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "User": {
+        "properties": {
+          "displayName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "displayName"
+        ],
+        "type": "object"
+      },
+      "UserPointer": {
+        "properties": {
+          "user": {
+            "$ref": "#/$defs/User"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "directory": {
+        "$ref": "#/$defs/Directory",
+        "default": {
+          "users": []
+        },
+        "scope": "space"
+      },
+      "joinAs": {
+        "$ref": "#/$defs/JoinAsEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "me": {
+        "$ref": "#/$defs/UserPointer",
+        "scope": "user"
+      },
+      "rename": {
+        "$ref": "#/$defs/RenameEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "userCount": {
+        "type": "number"
+      }
+    },
+    "required": [
+      "directory",
+      "me",
+      "userCount",
+      "joinAs",
+      "rename",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/scrabble/scrabble.tsx/20260807T235141Z-ao4juxlRbO98X9CP.json
+++ b/packages/patterns/baselines/scrabble/scrabble.tsx/20260807T235141Z-ao4juxlRbO98X9CP.json
@@ -1,0 +1,470 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "GameEvent": {
+        "properties": {
+          "details": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "player": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "number"
+          },
+          "type": {
+            "enum": [
+              "join",
+              "submit",
+              "word",
+              "system"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "player",
+          "details",
+          "timestamp"
+        ],
+        "type": "object"
+      },
+      "Letter": {
+        "properties": {
+          "char": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "isBlank": {
+            "type": "boolean"
+          },
+          "points": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "char",
+          "points",
+          "id",
+          "isBlank"
+        ],
+        "type": "object"
+      },
+      "PlacedTile": {
+        "properties": {
+          "col": {
+            "type": "number"
+          },
+          "letter": {
+            "$ref": "#/$defs/Letter"
+          },
+          "row": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "letter",
+          "row",
+          "col"
+        ],
+        "type": "object"
+      },
+      "Player": {
+        "properties": {
+          "avatar": {
+            "description": "Avatar URL or glyph, snapshotted from the joiner's shared profile.",
+            "type": "string"
+          },
+          "color": {
+            "type": "string"
+          },
+          "joinedAt": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "profile": {
+            "asCell": [
+              "cell"
+            ],
+            "description": "Live profile cell — present for profile-joined players (the scoreboard\nrenders it via `<cf-profile-badge>`), absent for headless name-only joins\n(test seam), which fall back to `<cf-avatar>`.",
+            "properties": {
+              "avatar": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "score": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "name",
+          "color",
+          "score",
+          "joinedAt"
+        ],
+        "type": "object"
+      },
+      "PlayerRoster": {
+        "properties": {
+          "list": {
+            "items": {
+              "$ref": "#/$defs/Player"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "list"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "bag": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/Letter"
+        },
+        "type": "array"
+      },
+      "bagIndex": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ],
+        "default": 0,
+        "type": "number"
+      },
+      "board": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/PlacedTile"
+        },
+        "type": "array"
+      },
+      "gameEvents": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/GameEvent"
+        },
+        "type": "array"
+      },
+      "gameName": {
+        "default": "Scrabble Match",
+        "scope": "space",
+        "type": "string"
+      },
+      "message": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "session"
+          }
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "myName": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "user"
+          }
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "placed": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "user"
+          }
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/PlacedTile"
+        },
+        "type": "array"
+      },
+      "players": {
+        "$ref": "#/$defs/PlayerRoster",
+        "default": {
+          "list": []
+        },
+        "scope": "space"
+      },
+      "rack": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "user"
+          }
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/Letter"
+        },
+        "type": "array"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "scrabble/scrabble.tsx",
+  "resultSchema": {
+    "$defs": {
+      "GameEvent": {
+        "properties": {
+          "details": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "player": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "number"
+          },
+          "type": {
+            "enum": [
+              "join",
+              "submit",
+              "word",
+              "system"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "player",
+          "details",
+          "timestamp"
+        ],
+        "type": "object"
+      },
+      "Letter": {
+        "properties": {
+          "char": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "isBlank": {
+            "type": "boolean"
+          },
+          "points": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "char",
+          "points",
+          "id",
+          "isBlank"
+        ],
+        "type": "object"
+      },
+      "PlacedTile": {
+        "properties": {
+          "col": {
+            "type": "number"
+          },
+          "letter": {
+            "$ref": "#/$defs/Letter"
+          },
+          "row": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "letter",
+          "row",
+          "col"
+        ],
+        "type": "object"
+      },
+      "PlayerView": {
+        "properties": {
+          "avatar": {
+            "description": "Avatar URL or glyph, snapshotted from the joiner's shared profile.",
+            "type": "string"
+          },
+          "color": {
+            "type": "string"
+          },
+          "joinedAt": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "score": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "name",
+          "color",
+          "score",
+          "joinedAt"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "bag": {
+        "items": {
+          "$ref": "#/$defs/Letter"
+        },
+        "type": "array"
+      },
+      "bagIndex": {
+        "type": "number"
+      },
+      "board": {
+        "items": {
+          "$ref": "#/$defs/PlacedTile"
+        },
+        "type": "array"
+      },
+      "clearBoard": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "gameEvents": {
+        "items": {
+          "$ref": "#/$defs/GameEvent"
+        },
+        "type": "array"
+      },
+      "joinGame": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "joinWithName": {
+        "asCell": [
+          "stream"
+        ],
+        "type": "string"
+      },
+      "message": {
+        "type": "string"
+      },
+      "myName": {
+        "type": "string"
+      },
+      "placeTile": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "col": {
+            "type": "number"
+          },
+          "letterId": {
+            "type": "string"
+          },
+          "row": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "letterId",
+          "row",
+          "col"
+        ],
+        "type": "object"
+      },
+      "placed": {
+        "items": {
+          "$ref": "#/$defs/PlacedTile"
+        },
+        "type": "array"
+      },
+      "players": {
+        "items": {
+          "$ref": "#/$defs/PlayerView"
+        },
+        "type": "array"
+      },
+      "rack": {
+        "items": {
+          "$ref": "#/$defs/Letter"
+        },
+        "type": "array"
+      },
+      "resetGame": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "submitTurn": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      }
+    },
+    "required": [
+      "myName",
+      "board",
+      "bag",
+      "bagIndex",
+      "players",
+      "gameEvents",
+      "rack",
+      "placed",
+      "message",
+      "joinGame",
+      "joinWithName",
+      "placeTile",
+      "submitTurn",
+      "clearBoard",
+      "resetGame"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/scrabble/scrabble.tsx/20260810T184538Z-eVxzue5ODCUhwOGf.json
+++ b/packages/patterns/baselines/scrabble/scrabble.tsx/20260810T184538Z-eVxzue5ODCUhwOGf.json
@@ -1,0 +1,474 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "GameEvent": {
+        "properties": {
+          "details": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "player": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "number"
+          },
+          "type": {
+            "enum": [
+              "join",
+              "submit",
+              "word",
+              "system"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "player",
+          "details",
+          "timestamp"
+        ],
+        "type": "object"
+      },
+      "Letter": {
+        "properties": {
+          "char": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "isBlank": {
+            "type": "boolean"
+          },
+          "points": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "char",
+          "points",
+          "id",
+          "isBlank"
+        ],
+        "type": "object"
+      },
+      "PlacedTile": {
+        "properties": {
+          "col": {
+            "type": "number"
+          },
+          "letter": {
+            "$ref": "#/$defs/Letter"
+          },
+          "row": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "letter",
+          "row",
+          "col"
+        ],
+        "type": "object"
+      },
+      "Player": {
+        "properties": {
+          "avatar": {
+            "description": "Avatar URL or glyph, snapshotted from the joiner's shared profile.",
+            "type": "string"
+          },
+          "color": {
+            "type": "string"
+          },
+          "joinedAt": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "profile": {
+            "asCell": [
+              "cell"
+            ],
+            "description": "Live profile cell — present for profile-joined players (the scoreboard\nrenders it via `<cf-profile-badge>`), absent for headless name-only joins\n(test seam), which fall back to `<cf-avatar>`.",
+            "properties": {
+              "avatar": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "score": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "name",
+          "color",
+          "score",
+          "joinedAt"
+        ],
+        "type": "object"
+      },
+      "PlayerRoster": {
+        "properties": {
+          "list": {
+            "items": {
+              "$ref": "#/$defs/Player"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "list"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "bag": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/Letter"
+        },
+        "type": "array"
+      },
+      "bagIndex": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ],
+        "default": 0,
+        "type": "number"
+      },
+      "board": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/PlacedTile"
+        },
+        "type": "array"
+      },
+      "gameEvents": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/GameEvent"
+        },
+        "type": "array"
+      },
+      "gameName": {
+        "default": "Scrabble Match",
+        "scope": "space",
+        "type": "string"
+      },
+      "message": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "session"
+          }
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "myName": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "user"
+          }
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "placed": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "user"
+          }
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/PlacedTile"
+        },
+        "type": "array"
+      },
+      "players": {
+        "$ref": "#/$defs/PlayerRoster",
+        "default": {
+          "list": []
+        },
+        "scope": "space"
+      },
+      "rack": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "user"
+          }
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/Letter"
+        },
+        "type": "array"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "scrabble/scrabble.tsx",
+  "resultSchema": {
+    "$defs": {
+      "GameEvent": {
+        "properties": {
+          "details": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "player": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "number"
+          },
+          "type": {
+            "enum": [
+              "join",
+              "submit",
+              "word",
+              "system"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "player",
+          "details",
+          "timestamp"
+        ],
+        "type": "object"
+      },
+      "Letter": {
+        "properties": {
+          "char": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "isBlank": {
+            "type": "boolean"
+          },
+          "points": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "char",
+          "points",
+          "id",
+          "isBlank"
+        ],
+        "type": "object"
+      },
+      "PlacedTile": {
+        "properties": {
+          "col": {
+            "type": "number"
+          },
+          "letter": {
+            "$ref": "#/$defs/Letter"
+          },
+          "row": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "letter",
+          "row",
+          "col"
+        ],
+        "type": "object"
+      },
+      "PlayerView": {
+        "properties": {
+          "avatar": {
+            "description": "Avatar URL or glyph, snapshotted from the joiner's shared profile.",
+            "type": "string"
+          },
+          "color": {
+            "type": "string"
+          },
+          "joinedAt": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "score": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "name",
+          "color",
+          "score",
+          "joinedAt"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "bag": {
+        "items": {
+          "$ref": "#/$defs/Letter"
+        },
+        "type": "array"
+      },
+      "bagIndex": {
+        "type": "number"
+      },
+      "board": {
+        "items": {
+          "$ref": "#/$defs/PlacedTile"
+        },
+        "type": "array"
+      },
+      "clearBoard": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "tier": "wrapper"
+      },
+      "gameEvents": {
+        "items": {
+          "$ref": "#/$defs/GameEvent"
+        },
+        "type": "array"
+      },
+      "joinGame": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "tier": "wrapper"
+      },
+      "joinWithName": {
+        "asCell": [
+          "stream"
+        ],
+        "type": "string"
+      },
+      "message": {
+        "type": "string"
+      },
+      "myName": {
+        "type": "string"
+      },
+      "placeTile": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "col": {
+            "type": "number"
+          },
+          "letterId": {
+            "type": "string"
+          },
+          "row": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "letterId",
+          "row",
+          "col"
+        ],
+        "type": "object"
+      },
+      "placed": {
+        "items": {
+          "$ref": "#/$defs/PlacedTile"
+        },
+        "type": "array"
+      },
+      "players": {
+        "items": {
+          "$ref": "#/$defs/PlayerView"
+        },
+        "type": "array"
+      },
+      "rack": {
+        "items": {
+          "$ref": "#/$defs/Letter"
+        },
+        "type": "array"
+      },
+      "resetGame": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "tier": "wrapper"
+      },
+      "submitTurn": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "tier": "wrapper"
+      }
+    },
+    "required": [
+      "myName",
+      "board",
+      "bag",
+      "bagIndex",
+      "players",
+      "gameEvents",
+      "rack",
+      "placed",
+      "message",
+      "joinGame",
+      "joinWithName",
+      "placeTile",
+      "submitTurn",
+      "clearBoard",
+      "resetGame"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/self-improving-classifier.tsx/20260807T235141Z-5wVJ8qiymFqPkaxm.json
+++ b/packages/patterns/baselines/self-improving-classifier.tsx/20260807T235141Z-5wVJ8qiymFqPkaxm.json
@@ -1,0 +1,767 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "ClassifiableInput": {
+        "properties": {
+          "fields": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "properties": {},
+            "type": "object"
+          },
+          "id": {
+            "type": "string"
+          },
+          "receivedAt": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "receivedAt",
+          "fields"
+        ],
+        "type": "object"
+      },
+      "ClassificationResult": {
+        "properties": {
+          "classification": {
+            "type": "boolean"
+          },
+          "confidence": {
+            "type": "number"
+          },
+          "decidedBy": {
+            "enum": [
+              "user",
+              "rules",
+              "llm"
+            ]
+          },
+          "inputId": {
+            "type": "string"
+          },
+          "matchedRules": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "reasoning": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "inputId",
+          "classification",
+          "confidence",
+          "reasoning",
+          "decidedBy",
+          "matchedRules"
+        ],
+        "type": "object"
+      },
+      "ClassificationRule": {
+        "properties": {
+          "caseInsensitive": {
+            "type": "boolean"
+          },
+          "createdAt": {
+            "type": "number"
+          },
+          "evaluationCount": {
+            "type": "number"
+          },
+          "falseNegatives": {
+            "type": "number"
+          },
+          "falsePositives": {
+            "type": "number"
+          },
+          "id": {
+            "type": "string"
+          },
+          "isShared": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "pattern": {
+            "type": "string"
+          },
+          "precision": {
+            "type": "number"
+          },
+          "predicts": {
+            "type": "boolean"
+          },
+          "recall": {
+            "type": "number"
+          },
+          "sharedFrom": {
+            "type": "string"
+          },
+          "targetField": {
+            "type": "string"
+          },
+          "tier": {
+            "$ref": "#/$defs/Tier"
+          },
+          "trueNegatives": {
+            "type": "number"
+          },
+          "truePositives": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "targetField",
+          "pattern",
+          "caseInsensitive",
+          "predicts",
+          "precision",
+          "recall",
+          "tier",
+          "evaluationCount",
+          "truePositives",
+          "falsePositives",
+          "trueNegatives",
+          "falseNegatives",
+          "createdAt",
+          "isShared"
+        ],
+        "type": "object"
+      },
+      "ClassifierConfig": {
+        "properties": {
+          "autoClassifyThreshold": {
+            "type": "number"
+          },
+          "enableLLMFallback": {
+            "type": "boolean"
+          },
+          "harmAsymmetry": {
+            "enum": [
+              "fp",
+              "fn",
+              "equal"
+            ]
+          },
+          "minExamplesForRules": {
+            "type": "number"
+          },
+          "prefillThreshold": {
+            "type": "number"
+          },
+          "question": {
+            "type": "string"
+          },
+          "suggestionThreshold": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "question",
+          "minExamplesForRules",
+          "autoClassifyThreshold",
+          "prefillThreshold",
+          "suggestionThreshold",
+          "harmAsymmetry",
+          "enableLLMFallback"
+        ],
+        "type": "object"
+      },
+      "LabeledExample": {
+        "properties": {
+          "confidence": {
+            "type": "number"
+          },
+          "decidedBy": {
+            "enum": [
+              "user",
+              "auto",
+              "suggestion-accepted"
+            ]
+          },
+          "input": {
+            "$ref": "#/$defs/ClassifiableInput"
+          },
+          "interestingReason": {
+            "type": "string"
+          },
+          "isInteresting": {
+            "type": "boolean"
+          },
+          "label": {
+            "type": "boolean"
+          },
+          "labeledAt": {
+            "type": "number"
+          },
+          "originalPrediction": {
+            "type": "boolean"
+          },
+          "reasoning": {
+            "type": "string"
+          },
+          "wasCorrection": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "input",
+          "label",
+          "decidedBy",
+          "reasoning",
+          "confidence",
+          "labeledAt",
+          "wasCorrection",
+          "isInteresting"
+        ],
+        "type": "object"
+      },
+      "PendingClassification": {
+        "properties": {
+          "input": {
+            "$ref": "#/$defs/ClassifiableInput"
+          },
+          "result": {
+            "$ref": "#/$defs/ClassificationResult"
+          }
+        },
+        "required": [
+          "input",
+          "result"
+        ],
+        "type": "object"
+      },
+      "Tier": {
+        "enum": [
+          0,
+          1,
+          2,
+          3,
+          4
+        ]
+      }
+    },
+    "properties": {
+      "config": {
+        "$ref": "#/$defs/ClassifierConfig",
+        "asCell": [
+          "cell"
+        ],
+        "default": {
+          "autoClassifyThreshold": 0.85,
+          "enableLLMFallback": true,
+          "harmAsymmetry": "equal",
+          "minExamplesForRules": 5,
+          "prefillThreshold": 0.7,
+          "question": "",
+          "suggestionThreshold": 0.5
+        }
+      },
+      "currentItem": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/ClassifiableInput"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "asCell": [
+          "cell"
+        ],
+        "default": null
+      },
+      "examples": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/LabeledExample"
+        },
+        "type": "array"
+      },
+      "pendingClassifications": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/PendingClassification"
+        },
+        "type": "array"
+      },
+      "rules": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/ClassificationRule"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "config",
+      "examples",
+      "rules",
+      "pendingClassifications",
+      "currentItem"
+    ],
+    "type": "object"
+  },
+  "pattern": "self-improving-classifier.tsx",
+  "resultSchema": {
+    "$defs": {
+      "ClassifiableInput": {
+        "properties": {
+          "fields": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "properties": {},
+            "type": "object"
+          },
+          "id": {
+            "type": "string"
+          },
+          "receivedAt": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "receivedAt",
+          "fields"
+        ],
+        "type": "object"
+      },
+      "ClassificationResult": {
+        "properties": {
+          "classification": {
+            "type": "boolean"
+          },
+          "confidence": {
+            "type": "number"
+          },
+          "decidedBy": {
+            "enum": [
+              "user",
+              "rules",
+              "llm"
+            ]
+          },
+          "inputId": {
+            "type": "string"
+          },
+          "matchedRules": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "reasoning": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "inputId",
+          "classification",
+          "confidence",
+          "reasoning",
+          "decidedBy",
+          "matchedRules"
+        ],
+        "type": "object"
+      },
+      "ClassificationRule": {
+        "properties": {
+          "caseInsensitive": {
+            "type": "boolean"
+          },
+          "createdAt": {
+            "type": "number"
+          },
+          "evaluationCount": {
+            "type": "number"
+          },
+          "falseNegatives": {
+            "type": "number"
+          },
+          "falsePositives": {
+            "type": "number"
+          },
+          "id": {
+            "type": "string"
+          },
+          "isShared": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "pattern": {
+            "type": "string"
+          },
+          "precision": {
+            "type": "number"
+          },
+          "predicts": {
+            "type": "boolean"
+          },
+          "recall": {
+            "type": "number"
+          },
+          "sharedFrom": {
+            "type": "string"
+          },
+          "targetField": {
+            "type": "string"
+          },
+          "tier": {
+            "$ref": "#/$defs/Tier"
+          },
+          "trueNegatives": {
+            "type": "number"
+          },
+          "truePositives": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "targetField",
+          "pattern",
+          "caseInsensitive",
+          "predicts",
+          "precision",
+          "recall",
+          "tier",
+          "evaluationCount",
+          "truePositives",
+          "falsePositives",
+          "trueNegatives",
+          "falseNegatives",
+          "createdAt",
+          "isShared"
+        ],
+        "type": "object"
+      },
+      "ClassifierConfig": {
+        "properties": {
+          "autoClassifyThreshold": {
+            "type": "number"
+          },
+          "enableLLMFallback": {
+            "type": "boolean"
+          },
+          "harmAsymmetry": {
+            "enum": [
+              "fp",
+              "fn",
+              "equal"
+            ]
+          },
+          "minExamplesForRules": {
+            "type": "number"
+          },
+          "prefillThreshold": {
+            "type": "number"
+          },
+          "question": {
+            "type": "string"
+          },
+          "suggestionThreshold": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "question",
+          "minExamplesForRules",
+          "autoClassifyThreshold",
+          "prefillThreshold",
+          "suggestionThreshold",
+          "harmAsymmetry",
+          "enableLLMFallback"
+        ],
+        "type": "object"
+      },
+      "LabeledExample": {
+        "properties": {
+          "confidence": {
+            "type": "number"
+          },
+          "decidedBy": {
+            "enum": [
+              "user",
+              "auto",
+              "suggestion-accepted"
+            ]
+          },
+          "input": {
+            "$ref": "#/$defs/ClassifiableInput"
+          },
+          "interestingReason": {
+            "type": "string"
+          },
+          "isInteresting": {
+            "type": "boolean"
+          },
+          "label": {
+            "type": "boolean"
+          },
+          "labeledAt": {
+            "type": "number"
+          },
+          "originalPrediction": {
+            "type": "boolean"
+          },
+          "reasoning": {
+            "type": "string"
+          },
+          "wasCorrection": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "input",
+          "label",
+          "decidedBy",
+          "reasoning",
+          "confidence",
+          "labeledAt",
+          "wasCorrection",
+          "isInteresting"
+        ],
+        "type": "object"
+      },
+      "PendingClassification": {
+        "properties": {
+          "input": {
+            "$ref": "#/$defs/ClassifiableInput"
+          },
+          "result": {
+            "$ref": "#/$defs/ClassificationResult"
+          }
+        },
+        "required": [
+          "input",
+          "result"
+        ],
+        "type": "object"
+      },
+      "RuleSuggestion": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "pattern": {
+            "type": "string"
+          },
+          "predicts": {
+            "type": "boolean"
+          },
+          "reasoning": {
+            "type": "string"
+          },
+          "targetField": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "targetField",
+          "pattern",
+          "predicts",
+          "reasoning"
+        ],
+        "type": "object"
+      },
+      "Tier": {
+        "enum": [
+          0,
+          1,
+          2,
+          3,
+          4
+        ]
+      }
+    },
+    "description": "Self-improving binary classifier with LLM + regex rules. #classifier #learning",
+    "properties": {
+      "addRule": {
+        "$ref": "#/$defs/RuleSuggestion",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "config": {
+        "$ref": "#/$defs/ClassifierConfig"
+      },
+      "confirmClassification": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "inputId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "inputId"
+        ],
+        "type": "object"
+      },
+      "correctClassification": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "correctLabel": {
+            "type": "boolean"
+          },
+          "inputId": {
+            "type": "string"
+          },
+          "reasoning": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "inputId",
+          "correctLabel"
+        ],
+        "type": "object"
+      },
+      "dismissClassification": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "inputId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "inputId"
+        ],
+        "type": "object"
+      },
+      "examples": {
+        "items": {
+          "$ref": "#/$defs/LabeledExample"
+        },
+        "type": "array"
+      },
+      "pendingClassifications": {
+        "items": {
+          "$ref": "#/$defs/PendingClassification"
+        },
+        "type": "array"
+      },
+      "removeRule": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "ruleId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "ruleId"
+        ],
+        "type": "object"
+      },
+      "rules": {
+        "items": {
+          "$ref": "#/$defs/ClassificationRule"
+        },
+        "type": "array"
+      },
+      "stats": {
+        "properties": {
+          "autoClassified": {
+            "type": "number"
+          },
+          "correctionRate": {
+            "type": "number"
+          },
+          "negativeExamples": {
+            "type": "number"
+          },
+          "positiveExamples": {
+            "type": "number"
+          },
+          "totalExamples": {
+            "type": "number"
+          },
+          "totalRules": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "totalExamples",
+          "positiveExamples",
+          "negativeExamples",
+          "autoClassified",
+          "correctionRate",
+          "totalRules"
+        ],
+        "type": "object"
+      },
+      "submitItem": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "fields": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "properties": {},
+            "type": "object"
+          }
+        },
+        "required": [
+          "fields"
+        ],
+        "type": "object"
+      }
+    },
+    "required": [
+      "config",
+      "examples",
+      "rules",
+      "pendingClassifications",
+      "stats",
+      "submitItem",
+      "confirmClassification",
+      "correctClassification",
+      "dismissClassification",
+      "addRule",
+      "removeRule"
+    ],
+    "tags": [
+      "classifier",
+      "learning"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/self.tsx/20260807T235141Z-Avtr9K2fxUVHnM0a.json
+++ b/packages/patterns/baselines/self.tsx/20260807T235141Z-Avtr9K2fxUVHnM0a.json
@@ -1,0 +1,487 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "Neurotype": {
+        "properties": {
+          "detail": {
+            "additionalProperties": {
+              "type": [
+                "number",
+                "string"
+              ]
+            },
+            "properties": {},
+            "type": "object"
+          },
+          "recordedAt": {
+            "type": "number"
+          },
+          "result": {
+            "type": "string"
+          },
+          "source": {
+            "enum": [
+              "self-reported",
+              "assessed"
+            ]
+          },
+          "system": {
+            "$ref": "#/$defs/NeurotypeSystem"
+          }
+        },
+        "required": [
+          "system",
+          "result",
+          "source",
+          "recordedAt"
+        ],
+        "type": "object"
+      },
+      "NeurotypeSystem": {
+        "enum": [
+          "mbti",
+          "enneagram",
+          "big5",
+          "custom"
+        ]
+      },
+      "QAResponse": {
+        "properties": {
+          "answer": {
+            "type": "string"
+          },
+          "answeredAt": {
+            "type": "number"
+          },
+          "prompt": {
+            "type": "string"
+          },
+          "promptId": {
+            "type": "string"
+          },
+          "track": {
+            "enum": [
+              "meaning",
+              "neurotype",
+              "freeform"
+            ]
+          }
+        },
+        "required": [
+          "promptId",
+          "prompt",
+          "answer",
+          "track",
+          "answeredAt"
+        ],
+        "type": "object"
+      },
+      "SelfModel": {
+        "properties": {
+          "neurotypes": {
+            "items": {
+              "$ref": "#/$defs/Neurotype"
+            },
+            "type": "array"
+          },
+          "responses": {
+            "items": {
+              "$ref": "#/$defs/QAResponse"
+            },
+            "type": "array"
+          },
+          "values": {
+            "items": {
+              "$ref": "#/$defs/ValueCard"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "responses",
+          "values",
+          "neurotypes"
+        ],
+        "type": "object"
+      },
+      "Track": {
+        "enum": [
+          "open",
+          "scissor",
+          "closing"
+        ]
+      },
+      "ValueCard": {
+        "properties": {
+          "attendingTo": {
+            "type": "string"
+          },
+          "contextTags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "description": {
+            "type": "string"
+          },
+          "sourcePromptId": {
+            "type": "string"
+          },
+          "sourceTrack": {
+            "$ref": "#/$defs/Track"
+          },
+          "stance": {
+            "enum": [
+              "descriptive",
+              "aspirational",
+              "conflicted"
+            ]
+          },
+          "title": {
+            "type": "string"
+          },
+          "weight": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "title"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "selfModel": {
+        "$ref": "#/$defs/SelfModel",
+        "asCell": [
+          "cell"
+        ],
+        "default": {
+          "neurotypes": [],
+          "responses": [],
+          "values": []
+        },
+        "description": "Optional external Writable cell for the self-model.\nWhen provided the pattern uses this cell directly (useful for testing\nand for parent patterns that want to own the storage).\nWhen omitted the pattern creates and owns its own durable cell."
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "self.tsx",
+  "resultSchema": {
+    "$defs": {
+      "AddValueCardEvent": {
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "sourcePromptId": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "weight": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "title"
+        ],
+        "type": "object"
+      },
+      "Neurotype": {
+        "properties": {
+          "detail": {
+            "additionalProperties": {
+              "type": [
+                "number",
+                "string"
+              ]
+            },
+            "properties": {},
+            "type": "object"
+          },
+          "recordedAt": {
+            "type": "number"
+          },
+          "result": {
+            "type": "string"
+          },
+          "source": {
+            "enum": [
+              "self-reported",
+              "assessed"
+            ]
+          },
+          "system": {
+            "$ref": "#/$defs/NeurotypeSystem"
+          }
+        },
+        "required": [
+          "system",
+          "result",
+          "source",
+          "recordedAt"
+        ],
+        "type": "object"
+      },
+      "NeurotypeSystem": {
+        "enum": [
+          "mbti",
+          "enneagram",
+          "big5",
+          "custom"
+        ]
+      },
+      "QAResponse": {
+        "properties": {
+          "answer": {
+            "type": "string"
+          },
+          "answeredAt": {
+            "type": "number"
+          },
+          "prompt": {
+            "type": "string"
+          },
+          "promptId": {
+            "type": "string"
+          },
+          "track": {
+            "enum": [
+              "meaning",
+              "neurotype",
+              "freeform"
+            ]
+          }
+        },
+        "required": [
+          "promptId",
+          "prompt",
+          "answer",
+          "track",
+          "answeredAt"
+        ],
+        "type": "object"
+      },
+      "RecordNeurotypeEvent": {
+        "properties": {
+          "detail": {
+            "additionalProperties": {
+              "type": [
+                "number",
+                "string"
+              ]
+            },
+            "properties": {},
+            "type": "object"
+          },
+          "result": {
+            "type": "string"
+          },
+          "source": {
+            "enum": [
+              "self-reported",
+              "assessed"
+            ]
+          },
+          "system": {
+            "$ref": "#/$defs/NeurotypeSystem"
+          }
+        },
+        "required": [
+          "system",
+          "result",
+          "source"
+        ],
+        "type": "object"
+      },
+      "RecordResponseEvent": {
+        "properties": {
+          "answer": {
+            "type": "string"
+          },
+          "prompt": {
+            "type": "string"
+          },
+          "promptId": {
+            "type": "string"
+          },
+          "track": {
+            "enum": [
+              "meaning",
+              "neurotype",
+              "freeform"
+            ]
+          }
+        },
+        "required": [
+          "promptId",
+          "prompt",
+          "answer",
+          "track"
+        ],
+        "type": "object"
+      },
+      "RemoveNeurotypeEvent": {
+        "properties": {
+          "system": {
+            "$ref": "#/$defs/NeurotypeSystem"
+          }
+        },
+        "required": [
+          "system"
+        ],
+        "type": "object"
+      },
+      "RemoveValueCardEvent": {
+        "properties": {
+          "index": {
+            "description": "Zero-based index of the ValueCard to remove.",
+            "type": "number"
+          }
+        },
+        "required": [
+          "index"
+        ],
+        "type": "object"
+      },
+      "SelfModel": {
+        "properties": {
+          "neurotypes": {
+            "items": {
+              "$ref": "#/$defs/Neurotype"
+            },
+            "type": "array"
+          },
+          "responses": {
+            "items": {
+              "$ref": "#/$defs/QAResponse"
+            },
+            "type": "array"
+          },
+          "values": {
+            "items": {
+              "$ref": "#/$defs/ValueCard"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "responses",
+          "values",
+          "neurotypes"
+        ],
+        "type": "object"
+      },
+      "Track": {
+        "enum": [
+          "open",
+          "scissor",
+          "closing"
+        ]
+      },
+      "ValueCard": {
+        "properties": {
+          "attendingTo": {
+            "type": "string"
+          },
+          "contextTags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "description": {
+            "type": "string"
+          },
+          "sourcePromptId": {
+            "type": "string"
+          },
+          "sourceTrack": {
+            "$ref": "#/$defs/Track"
+          },
+          "stance": {
+            "enum": [
+              "descriptive",
+              "aspirational",
+              "conflicted"
+            ]
+          },
+          "title": {
+            "type": "string"
+          },
+          "weight": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "title"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "Private self-model — the user's values, neurotype, and reflective answers. #selfModel",
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addValueCard": {
+        "$ref": "#/$defs/AddValueCardEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "recordNeurotype": {
+        "$ref": "#/$defs/RecordNeurotypeEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "recordResponse": {
+        "$ref": "#/$defs/RecordResponseEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "removeNeurotype": {
+        "$ref": "#/$defs/RemoveNeurotypeEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "removeValueCard": {
+        "$ref": "#/$defs/RemoveValueCardEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "selfModel": {
+        "$ref": "#/$defs/SelfModel"
+      }
+    },
+    "required": [
+      "selfModel",
+      "recordNeurotype",
+      "addValueCard",
+      "recordResponse",
+      "removeNeurotype",
+      "removeValueCard",
+      "$NAME",
+      "$UI"
+    ],
+    "tags": [
+      "selfmodel"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/shopping-list.tsx/20260807T235141Z-hKraXKQuHExITFpi.json
+++ b/packages/patterns/baselines/shopping-list.tsx/20260807T235141Z-hKraXKQuHExITFpi.json
@@ -1,0 +1,185 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "ShoppingItem": {
+        "properties": {
+          "aisleOverride": {
+            "default": "",
+            "type": "string"
+          },
+          "aisleSeed": {
+            "default": 0,
+            "type": "number"
+          },
+          "done": {
+            "default": false,
+            "type": "boolean"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "done",
+          "aisleSeed",
+          "aisleOverride"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "items": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/ShoppingItem"
+        },
+        "type": "array"
+      },
+      "storeLayout": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "type": "string"
+      }
+    },
+    "required": [
+      "items",
+      "storeLayout"
+    ],
+    "type": "object"
+  },
+  "pattern": "shopping-list.tsx",
+  "resultSchema": {
+    "$defs": {
+      "ShoppingItem": {
+        "properties": {
+          "aisleOverride": {
+            "default": "",
+            "type": "string"
+          },
+          "aisleSeed": {
+            "default": 0,
+            "type": "number"
+          },
+          "done": {
+            "default": false,
+            "type": "boolean"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "done",
+          "aisleSeed",
+          "aisleOverride"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "Shopping list with AI-powered aisle sorting. #shoppingList",
+    "properties": {
+      "addItem": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream",
+          "stream"
+        ],
+        "properties": {
+          "detail": {
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "message"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "detail"
+        ],
+        "type": "object"
+      },
+      "addItemForOmnibot": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream",
+          "stream"
+        ],
+        "properties": {
+          "itemText": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "itemText"
+        ],
+        "type": "object"
+      },
+      "addItems": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream",
+          "stream"
+        ],
+        "properties": {
+          "itemNames": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "itemNames"
+        ],
+        "type": "object"
+      },
+      "doneCount": {
+        "type": "number"
+      },
+      "items": {
+        "items": {
+          "$ref": "#/$defs/ShoppingItem"
+        },
+        "type": "array"
+      },
+      "remainingCount": {
+        "type": "number"
+      },
+      "storeLayout": {
+        "type": "string"
+      },
+      "summary": {
+        "type": "string"
+      },
+      "totalCount": {
+        "type": "number"
+      }
+    },
+    "required": [
+      "items",
+      "summary",
+      "totalCount",
+      "doneCount",
+      "remainingCount",
+      "storeLayout",
+      "addItem",
+      "addItemForOmnibot",
+      "addItems"
+    ],
+    "tags": [
+      "shoppinglist"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/simple-list/simple-list.tsx/20260807T235141Z-WE4SkMQhyuq7cq9p.json
+++ b/packages/patterns/baselines/simple-list/simple-list.tsx/20260807T235141Z-WE4SkMQhyuq7cq9p.json
@@ -1,0 +1,158 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "SimpleListItem": {
+        "properties": {
+          "done": {
+            "default": false,
+            "type": "boolean"
+          },
+          "indented": {
+            "default": false,
+            "type": "boolean"
+          },
+          "text": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "text",
+          "indented",
+          "done"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "items": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/SimpleListItem"
+        },
+        "type": "array"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "simple-list/simple-list.tsx",
+  "resultSchema": {
+    "$defs": {
+      "SimpleListItem": {
+        "properties": {
+          "done": {
+            "default": false,
+            "type": "boolean"
+          },
+          "indented": {
+            "default": false,
+            "type": "boolean"
+          },
+          "text": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "text",
+          "indented",
+          "done"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addItem": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "text": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "text"
+        ],
+        "type": "object"
+      },
+      "deleteItem": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "index": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "index"
+        ],
+        "type": "object"
+      },
+      "items": {
+        "items": {
+          "$ref": "#/$defs/SimpleListItem"
+        },
+        "type": "array"
+      },
+      "setIndent": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "indented": {
+            "type": "boolean"
+          },
+          "index": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "index",
+          "indented"
+        ],
+        "type": "object"
+      },
+      "summary": {
+        "type": "string"
+      },
+      "toggleIndent": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "index": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "index"
+        ],
+        "type": "object"
+      }
+    },
+    "required": [
+      "items",
+      "summary",
+      "toggleIndent",
+      "setIndent",
+      "deleteItem",
+      "addItem",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/system/default-app-ben.tsx/20260807T235141Z-yzT6urh1pXfCnj3e.json
+++ b/packages/patterns/baselines/system/default-app-ben.tsx/20260807T235141Z-yzT6urh1pXfCnj3e.json
@@ -1,0 +1,107 @@
+{
+  "argumentSchema": {
+    "asCell": [
+      "opaque"
+    ]
+  },
+  "pattern": "system/default-app-ben.tsx",
+  "resultSchema": {
+    "$defs": {
+      "AnonymousType_1": {
+        "items": {
+          "$ref": "#/$defs/MentionablePiece"
+        },
+        "type": "array"
+      },
+      "MentionablePiece": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "backlinks": {
+            "$ref": "#/$defs/AnonymousType_1"
+          },
+          "isHidden": {
+            "type": "boolean"
+          },
+          "isMentionable": {
+            "type": "boolean"
+          },
+          "mentionable": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/AnonymousType_1"
+              },
+              {
+                "properties": {},
+                "type": "object"
+              }
+            ]
+          },
+          "mentioned": {
+            "$ref": "#/$defs/AnonymousType_1"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "additionalProperties": {
+      "type": "unknown"
+    },
+    "properties": {
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addPiece": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "piece": {
+            "$ref": "#/$defs/MentionablePiece"
+          }
+        },
+        "required": [
+          "piece"
+        ],
+        "type": "object"
+      },
+      "backlinksIndex": {
+        "properties": {
+          "mentionable": {
+            "anyOf": [
+              {
+                "type": "undefined"
+              },
+              {
+                "$ref": "#/$defs/AnonymousType_1"
+              }
+            ]
+          }
+        },
+        "required": [
+          "mentionable"
+        ],
+        "type": "object"
+      },
+      "fabUI": {
+        "type": "unknown"
+      },
+      "pieceRegistry": {
+        "$ref": "#/$defs/AnonymousType_1"
+      },
+      "sidebarUI": {
+        "type": "unknown"
+      }
+    },
+    "required": [
+      "backlinksIndex",
+      "fabUI",
+      "pieceRegistry",
+      "addPiece",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/system/default-app.tsx/20260807T235141Z-KwkEPiEZ0rhRYby5.json
+++ b/packages/patterns/baselines/system/default-app.tsx/20260807T235141Z-KwkEPiEZ0rhRYby5.json
@@ -1,0 +1,103 @@
+{
+  "argumentSchema": {
+    "asCell": [
+      "opaque"
+    ]
+  },
+  "pattern": "system/default-app.tsx",
+  "resultSchema": {
+    "$defs": {
+      "AnonymousType_3": {
+        "items": {
+          "$ref": "#/$defs/MentionablePiece"
+        },
+        "type": "array"
+      },
+      "MentionablePiece": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "backlinks": {
+            "$ref": "#/$defs/AnonymousType_3"
+          },
+          "isHidden": {
+            "type": "boolean"
+          },
+          "isMentionable": {
+            "type": "boolean"
+          },
+          "mentionable": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/AnonymousType_3"
+              },
+              {
+                "properties": {},
+                "type": "object"
+              }
+            ]
+          },
+          "mentioned": {
+            "$ref": "#/$defs/AnonymousType_3"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "additionalProperties": {
+      "type": "unknown"
+    },
+    "properties": {
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addPiece": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "piece": {
+            "$ref": "#/$defs/MentionablePiece"
+          }
+        },
+        "required": [
+          "piece"
+        ],
+        "type": "object"
+      },
+      "backlinksIndex": {
+        "properties": {
+          "mentionable": {
+            "anyOf": [
+              {
+                "type": "undefined"
+              },
+              {
+                "$ref": "#/$defs/AnonymousType_3"
+              }
+            ]
+          }
+        },
+        "required": [
+          "mentionable"
+        ],
+        "type": "object"
+      },
+      "pieceRegistry": {
+        "$ref": "#/$defs/AnonymousType_3"
+      },
+      "sidebarUI": {
+        "type": "unknown"
+      }
+    },
+    "required": [
+      "backlinksIndex",
+      "pieceRegistry",
+      "addPiece",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/system/home-ben.tsx/20260807T235141Z-CZOBbOqcsfMSgrzf.json
+++ b/packages/patterns/baselines/system/home-ben.tsx/20260807T235141Z-CZOBbOqcsfMSgrzf.json
@@ -1,0 +1,229 @@
+{
+  "argumentSchema": false,
+  "pattern": "system/home-ben.tsx",
+  "resultSchema": {
+    "$defs": {
+      "Favorite": {
+        "properties": {
+          "cell": {
+            "properties": {
+              "$NAME": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "spaceName": {
+            "type": "string"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "userTags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "cell",
+          "tags",
+          "userTags"
+        ],
+        "type": "object"
+      },
+      "JSXElement": {
+        "anyOf": [
+          {
+            "$ref": "https://commonfabric.org/schemas/vnode.json"
+          },
+          {
+            "$ref": "#/$defs/UIRenderable"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ]
+      },
+      "JournalEntry": {
+        "properties": {
+          "eventType": {
+            "type": "string"
+          },
+          "narrative": {
+            "type": "string"
+          },
+          "narrativePending": {
+            "type": "boolean"
+          },
+          "snapshot": {
+            "$ref": "#/$defs/JournalSnapshot"
+          },
+          "space": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "unknown"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "timestamp": {
+            "type": "number"
+          }
+        },
+        "type": "object"
+      },
+      "JournalSnapshot": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "schemaTag": {
+            "type": "string"
+          },
+          "valueExcerpt": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "SpaceEntry": {
+        "properties": {
+          "did": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "UIRenderable": {
+        "properties": {
+          "$UI": {
+            "$ref": "https://commonfabric.org/schemas/vnode.json"
+          }
+        },
+        "required": [
+          "$UI"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "enum": [
+          "Home"
+        ],
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "#/$defs/JSXElement"
+      },
+      "addFavorite": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "piece": {
+            "properties": {
+              "$NAME": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "spaceName": {
+            "type": "string"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "piece"
+        ],
+        "type": "object"
+      },
+      "addJournalEntry": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "entry": {
+            "$ref": "#/$defs/JournalEntry"
+          }
+        },
+        "required": [
+          "entry"
+        ],
+        "type": "object"
+      },
+      "defaultAppUrl": {
+        "type": "string"
+      },
+      "favorites": {
+        "items": {
+          "$ref": "#/$defs/Favorite"
+        },
+        "type": "array"
+      },
+      "journal": {
+        "items": {
+          "$ref": "#/$defs/JournalEntry"
+        },
+        "type": "array"
+      },
+      "removeFavorite": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "piece": {
+            "type": "unknown"
+          }
+        },
+        "required": [
+          "piece"
+        ],
+        "type": "object"
+      },
+      "spaces": {
+        "items": {
+          "$ref": "#/$defs/SpaceEntry"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "$NAME",
+      "$UI",
+      "favorites",
+      "journal",
+      "spaces",
+      "defaultAppUrl",
+      "addFavorite",
+      "removeFavorite",
+      "addJournalEntry"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/system/home.tsx/20260807T235141Z-xFfAsSS0O19Er1GO.json
+++ b/packages/patterns/baselines/system/home.tsx/20260807T235141Z-xFfAsSS0O19Er1GO.json
@@ -1,0 +1,871 @@
+{
+  "argumentSchema": {
+    "additionalProperties": false,
+    "properties": {},
+    "type": "object"
+  },
+  "pattern": "system/home.tsx",
+  "resultSchema": {
+    "$defs": {
+      "BackwardsCompatibleProfile": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "$UI": {
+            "type": "unknown"
+          },
+          "addElement": {
+            "$ref": "#/$defs/MutateProfileElementsEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "addExternalLink": {
+            "$ref": "#/$defs/MutateExternalProfileLinksEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "addPiece": {
+            "$ref": "#/$defs/MutateProfileElementsEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "avatar": {
+            "ifc": {
+              "addIntegrity": [
+                {
+                  "kind": "represents-principal",
+                  "subject": {
+                    "__ctCurrentPrincipal": true
+                  }
+                }
+              ],
+              "ownerPrincipal": {
+                "__ctCurrentPrincipal": true
+              },
+              "writeAuthorizedBy": {
+                "__ctWriterIdentityOf": {
+                  "file": "/packages/patterns/system/profile-home.tsx",
+                  "moduleIdentity": "Z_bIu7BuAKEy0ZkS0ORzKAslmhpjvUdaiyP1JVJX55U",
+                  "path": [
+                    "setAvatar"
+                  ]
+                }
+              }
+            },
+            "type": "string"
+          },
+          "bio": {
+            "default": "",
+            "ifc": {
+              "addIntegrity": [
+                {
+                  "kind": "represents-principal",
+                  "subject": {
+                    "__ctCurrentPrincipal": true
+                  }
+                }
+              ],
+              "ownerPrincipal": {
+                "__ctCurrentPrincipal": true
+              },
+              "writeAuthorizedBy": {
+                "__ctWriterIdentityOf": {
+                  "file": "/packages/patterns/system/profile-home.tsx",
+                  "moduleIdentity": "Z_bIu7BuAKEy0ZkS0ORzKAslmhpjvUdaiyP1JVJX55U",
+                  "path": [
+                    "setBio"
+                  ]
+                }
+              }
+            },
+            "type": "string"
+          },
+          "elements": {
+            "ifc": {
+              "addIntegrity": [
+                {
+                  "kind": "represents-principal",
+                  "subject": {
+                    "__ctCurrentPrincipal": true
+                  }
+                }
+              ],
+              "ownerPrincipal": {
+                "__ctCurrentPrincipal": true
+              },
+              "writeAuthorizedBy": {
+                "__ctWriterIdentityOf": {
+                  "file": "/packages/patterns/system/profile-home.tsx",
+                  "moduleIdentity": "Z_bIu7BuAKEy0ZkS0ORzKAslmhpjvUdaiyP1JVJX55U",
+                  "path": [
+                    "mutateElements"
+                  ]
+                }
+              }
+            },
+            "items": {
+              "$ref": "#/$defs/ProfileElement"
+            },
+            "type": "array"
+          },
+          "externalLinks": {
+            "default": [],
+            "ifc": {
+              "addIntegrity": [
+                {
+                  "kind": "represents-principal",
+                  "subject": {
+                    "__ctCurrentPrincipal": true
+                  }
+                }
+              ],
+              "ownerPrincipal": {
+                "__ctCurrentPrincipal": true
+              },
+              "writeAuthorizedBy": {
+                "__ctWriterIdentityOf": {
+                  "file": "/packages/patterns/system/profile-home.tsx",
+                  "moduleIdentity": "Z_bIu7BuAKEy0ZkS0ORzKAslmhpjvUdaiyP1JVJX55U",
+                  "path": [
+                    "mutateExternalProfileLinks"
+                  ]
+                }
+              }
+            },
+            "items": {
+              "$ref": "#/$defs/ExternalProfileLink"
+            },
+            "type": "array"
+          },
+          "initialNameApplied": {
+            "type": "string"
+          },
+          "isEditing": {
+            "default": false,
+            "type": "boolean"
+          },
+          "name": {
+            "ifc": {
+              "addIntegrity": [
+                {
+                  "kind": "represents-principal",
+                  "subject": {
+                    "__ctCurrentPrincipal": true
+                  }
+                }
+              ],
+              "ownerPrincipal": {
+                "__ctCurrentPrincipal": true
+              },
+              "writeAuthorizedBy": {
+                "__ctWriterIdentityOf": {
+                  "file": "/packages/patterns/system/profile-home.tsx",
+                  "moduleIdentity": "Z_bIu7BuAKEy0ZkS0ORzKAslmhpjvUdaiyP1JVJX55U",
+                  "path": [
+                    "setName"
+                  ]
+                }
+              }
+            },
+            "type": "string"
+          },
+          "publishVerifiedIdentities": {
+            "$ref": "#/$defs/MutateVerifiedIdentitiesEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "removeElement": {
+            "$ref": "#/$defs/MutateProfileElementsEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "removeExternalLink": {
+            "$ref": "#/$defs/MutateExternalProfileLinksEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "revokeVerifiedIdentities": {
+            "$ref": "#/$defs/MutateVerifiedIdentitiesEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "setAvatar": {
+            "$ref": "#/$defs/SetProfileAvatarEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "setBio": {
+            "$ref": "#/$defs/SetProfileBioEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "setName": {
+            "$ref": "#/$defs/SetProfileNameEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "toggleEditing": {
+            "asCell": [
+              "stream",
+              "opaque"
+            ]
+          },
+          "verifiedIdentities": {
+            "default": [],
+            "ifc": {
+              "addIntegrity": [
+                {
+                  "kind": "represents-principal",
+                  "subject": {
+                    "__ctCurrentPrincipal": true
+                  }
+                }
+              ],
+              "ownerPrincipal": {
+                "__ctCurrentPrincipal": true
+              },
+              "writeAuthorizedBy": {
+                "__ctWriterIdentityOf": {
+                  "file": "/packages/patterns/system/profile-home.tsx",
+                  "moduleIdentity": "Z_bIu7BuAKEy0ZkS0ORzKAslmhpjvUdaiyP1JVJX55U",
+                  "path": [
+                    "publishVerifiedIdentities"
+                  ]
+                }
+              }
+            },
+            "items": {
+              "$ref": "#/$defs/VerifiedExternalIdentity"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "$NAME",
+          "$UI",
+          "name",
+          "avatar",
+          "bio",
+          "externalLinks",
+          "verifiedIdentities",
+          "elements",
+          "setName",
+          "setAvatar",
+          "addElement",
+          "removeElement",
+          "isEditing",
+          "initialNameApplied"
+        ],
+        "type": "object"
+      },
+      "CreateProfileEvent": {
+        "properties": {
+          "detail": {
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "key": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "target": {
+            "properties": {
+              "value": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "ExternalIdentityAssertion": {
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "verifiedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "value",
+          "verifiedAt"
+        ],
+        "type": "object"
+      },
+      "ExternalProfileLink": {
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "label",
+          "url"
+        ],
+        "type": "object"
+      },
+      "Favorite": {
+        "properties": {
+          "cell": {
+            "properties": {
+              "$NAME": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "id": {
+            "type": "string"
+          },
+          "spaceName": {
+            "type": "string"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "userTags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "cell",
+          "tags",
+          "userTags"
+        ],
+        "type": "object"
+      },
+      "JournalEntry": {
+        "properties": {
+          "eventType": {
+            "type": "string"
+          },
+          "narrative": {
+            "type": "string"
+          },
+          "narrativePending": {
+            "type": "boolean"
+          },
+          "snapshot": {
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "schemaTag": {
+                "type": "string"
+              },
+              "valueExcerpt": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "space": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "unknown"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "timestamp": {
+            "type": "number"
+          }
+        },
+        "type": "object"
+      },
+      "MutateExternalProfileLinksEvent": {
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "MutateProfileElementsEvent": {
+        "properties": {
+          "catalogId": {
+            "type": "string"
+          },
+          "cell": true,
+          "patternUrl": {
+            "type": "string"
+          },
+          "pieceId": {
+            "type": "string"
+          },
+          "pieceSpace": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "userTags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "MutateVerifiedIdentitiesEvent": {
+        "properties": {
+          "identities": {
+            "items": {
+              "$ref": "#/$defs/VerifiedExternalIdentity"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ProfileElement": {
+        "properties": {
+          "cell": true,
+          "source": {
+            "enum": [
+              "piece",
+              "url",
+              "catalog"
+            ]
+          },
+          "tag": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "userTags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "cell",
+          "tag",
+          "userTags"
+        ],
+        "type": "object"
+      },
+      "SetProfileAvatarEvent": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "detail": {
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "key": {
+            "type": "string"
+          },
+          "target": {
+            "properties": {
+              "value": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "SetProfileBioEvent": {
+        "properties": {
+          "bio": {
+            "type": "string"
+          },
+          "detail": {
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "key": {
+            "type": "string"
+          },
+          "target": {
+            "properties": {
+              "value": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "SetProfileNameEvent": {
+        "properties": {
+          "detail": {
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "key": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "target": {
+            "properties": {
+              "value": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "SpaceEntry": {
+        "properties": {
+          "did": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "TrustedDefaultProfile": {
+        "anyOf": [
+          {
+            "type": "undefined"
+          },
+          {
+            "$ref": "#/$defs/BackwardsCompatibleProfile"
+          }
+        ]
+      },
+      "TrustedProfileLink": {
+        "$ref": "#/$defs/BackwardsCompatibleProfile",
+        "ifc": {
+          "addIntegrity": [
+            "profile-link"
+          ],
+          "uiContract": {
+            "action": "CreateProfile",
+            "helper": "UiAction",
+            "requiredEventIntegrity": [
+              "ProfileCreateSurface"
+            ],
+            "trustedPattern": "ProfileCreateSurface"
+          },
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/system/profile-create.tsx",
+              "moduleIdentity": "B_VWt7zYJWHbCSoxTT_h-8CyL5ay5yEPG4WvnlM-Pqk",
+              "path": [
+                "submitProfileCreation"
+              ]
+            }
+          }
+        }
+      },
+      "TrustedProfileList": {
+        "ifc": {
+          "addIntegrity": [
+            "profile-link"
+          ],
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/system/profile-create.tsx",
+              "moduleIdentity": "B_VWt7zYJWHbCSoxTT_h-8CyL5ay5yEPG4WvnlM-Pqk",
+              "path": [
+                "submitProfileCreation"
+              ]
+            }
+          }
+        },
+        "items": {
+          "$ref": "#/$defs/TrustedProfileLink"
+        },
+        "type": "array"
+      },
+      "TrustedProfileMru": {
+        "ifc": {
+          "addIntegrity": [
+            "profile-link"
+          ],
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/system/profile-create.tsx",
+              "moduleIdentity": "B_VWt7zYJWHbCSoxTT_h-8CyL5ay5yEPG4WvnlM-Pqk",
+              "path": [
+                "setMruProfile"
+              ]
+            }
+          }
+        },
+        "items": {
+          "$ref": "#/$defs/BackwardsCompatibleProfile",
+          "ifc": {
+            "addIntegrity": [
+              "profile-link"
+            ],
+            "uiContract": {
+              "action": "SetMruProfile",
+              "helper": "UiAction",
+              "requiredEventIntegrity": [
+                "ProfilePickerSurface"
+              ],
+              "trustedPattern": "ProfilePickerSurface"
+            },
+            "writeAuthorizedBy": {
+              "__ctWriterIdentityOf": {
+                "file": "/packages/patterns/system/profile-create.tsx",
+                "moduleIdentity": "B_VWt7zYJWHbCSoxTT_h-8CyL5ay5yEPG4WvnlM-Pqk",
+                "path": [
+                  "setMruProfile"
+                ]
+              }
+            }
+          }
+        },
+        "type": "array"
+      },
+      "VerifiedExternalIdentity": {
+        "$ref": "#/$defs/ExternalIdentityAssertion",
+        "ifc": {
+          "requiredIntegrity": [
+            "loom-verified-external-identity"
+          ]
+        }
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "type": "unknown"
+      },
+      "addFavorite": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "piece": {
+            "properties": {
+              "$NAME": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "spaceName": {
+            "type": "string"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "piece"
+        ],
+        "type": "object"
+      },
+      "addJournalEntry": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "entry": {
+            "$ref": "#/$defs/JournalEntry"
+          }
+        },
+        "required": [
+          "entry"
+        ],
+        "type": "object"
+      },
+      "addSpace": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "detail": {
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "message"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "detail"
+        ],
+        "type": "object"
+      },
+      "createProfile": {
+        "$ref": "#/$defs/CreateProfileEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "defaultAppUrl": {
+        "default": "",
+        "type": "string"
+      },
+      "defaultProfile": {
+        "$ref": "#/$defs/TrustedDefaultProfile"
+      },
+      "favorites": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/Favorite"
+        },
+        "type": "array"
+      },
+      "journal": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/JournalEntry"
+        },
+        "type": "array"
+      },
+      "mru": {
+        "$ref": "#/$defs/TrustedProfileMru",
+        "default": []
+      },
+      "profiles": {
+        "$ref": "#/$defs/TrustedProfileList",
+        "default": []
+      },
+      "removeFavorite": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "piece": {
+            "type": "unknown"
+          }
+        },
+        "type": "object"
+      },
+      "removeSpace": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "spaces": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/SpaceEntry"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "favorites",
+      "journal",
+      "spaces",
+      "defaultAppUrl",
+      "profiles",
+      "mru",
+      "createProfile",
+      "addFavorite",
+      "removeFavorite",
+      "addJournalEntry",
+      "addSpace",
+      "removeSpace",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/system/omnibox-fab.tsx/20260807T235141Z-4rOdMhrdacKO1Yw_.json
+++ b/packages/patterns/baselines/system/omnibox-fab.tsx/20260807T235141Z-4rOdMhrdacKO1Yw_.json
@@ -1,0 +1,313 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "AnonymousType_1": {
+        "items": {
+          "$ref": "#/$defs/MentionablePiece"
+        },
+        "type": "array"
+      },
+      "MentionablePiece": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "backlinks": {
+            "$ref": "#/$defs/AnonymousType_1"
+          },
+          "isHidden": {
+            "type": "boolean"
+          },
+          "isMentionable": {
+            "type": "boolean"
+          },
+          "mentionable": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/AnonymousType_1"
+              },
+              {
+                "properties": {},
+                "type": "object"
+              }
+            ]
+          },
+          "mentioned": {
+            "$ref": "#/$defs/AnonymousType_1"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "properties": {
+      "extraSystemPrompt": {
+        "type": "string"
+      },
+      "extraTools": true,
+      "mentionable": {
+        "$ref": "#/$defs/AnonymousType_1",
+        "asCell": [
+          "cell"
+        ]
+      }
+    },
+    "required": [
+      "mentionable",
+      "extraTools",
+      "extraSystemPrompt"
+    ],
+    "type": "object"
+  },
+  "pattern": "system/omnibox-fab.tsx",
+  "resultSchema": {
+    "$defs": {
+      "BuiltInLLMContent": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "items": {
+              "$ref": "#/$defs/BuiltInLLMContentPart"
+            },
+            "type": "array"
+          }
+        ]
+      },
+      "BuiltInLLMContentPart": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/BuiltInLLMTextPart"
+          },
+          {
+            "$ref": "#/$defs/BuiltInLLMImagePart"
+          },
+          {
+            "$ref": "#/$defs/BuiltInLLMToolCallPart"
+          },
+          {
+            "$ref": "#/$defs/BuiltInLLMToolResultPart"
+          }
+        ]
+      },
+      "BuiltInLLMImagePart": {
+        "properties": {
+          "image": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "image"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "image"
+        ],
+        "type": "object"
+      },
+      "BuiltInLLMMessage": {
+        "properties": {
+          "content": {
+            "$ref": "#/$defs/BuiltInLLMContent"
+          },
+          "role": {
+            "enum": [
+              "user",
+              "system",
+              "assistant",
+              "tool"
+            ]
+          }
+        },
+        "required": [
+          "role",
+          "content"
+        ],
+        "type": "object"
+      },
+      "BuiltInLLMTextPart": {
+        "properties": {
+          "text": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "text"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "text"
+        ],
+        "type": "object"
+      },
+      "BuiltInLLMToolCallPart": {
+        "properties": {
+          "input": {
+            "additionalProperties": true,
+            "properties": {},
+            "type": "object"
+          },
+          "toolCallId": {
+            "type": "string"
+          },
+          "toolName": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "tool-call"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "toolCallId",
+          "toolName",
+          "input"
+        ],
+        "type": "object"
+      },
+      "BuiltInLLMToolResultPart": {
+        "properties": {
+          "output": {
+            "anyOf": [
+              {
+                "properties": {
+                  "type": {
+                    "enum": [
+                      "text"
+                    ],
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "type": {
+                    "enum": [
+                      "json"
+                    ],
+                    "type": "string"
+                  },
+                  "value": true
+                },
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "type": "object"
+              }
+            ]
+          },
+          "toolCallId": {
+            "type": "string"
+          },
+          "toolName": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "tool-result"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "toolCallId",
+          "toolName",
+          "output"
+        ],
+        "type": "object"
+      },
+      "JSXElement": {
+        "anyOf": [
+          {
+            "$ref": "https://commonfabric.org/schemas/vnode.json"
+          },
+          {
+            "$ref": "#/$defs/UIRenderable"
+          },
+          {
+            "properties": {},
+            "type": "object"
+          }
+        ]
+      },
+      "UIRenderable": {
+        "properties": {
+          "$UI": {
+            "$ref": "https://commonfabric.org/schemas/vnode.json"
+          }
+        },
+        "required": [
+          "$UI"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "#/$defs/JSXElement"
+      },
+      "fabExpanded": {
+        "type": "boolean"
+      },
+      "messages": {
+        "items": {
+          "$ref": "#/$defs/BuiltInLLMMessage"
+        },
+        "type": "array"
+      },
+      "pinToChat": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "accumulate": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path",
+          "name",
+          "accumulate"
+        ],
+        "type": "object"
+      }
+    },
+    "required": [
+      "$NAME",
+      "messages",
+      "$UI",
+      "fabExpanded",
+      "pinToChat"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/system/profile-create.tsx/20260807T235141Z-SEDe7QT5L6UoJ4Wx.json
+++ b/packages/patterns/baselines/system/profile-create.tsx/20260807T235141Z-SEDe7QT5L6UoJ4Wx.json
@@ -1,0 +1,563 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "BackwardsCompatibleProfile": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "$UI": {
+            "type": "unknown"
+          },
+          "addElement": {
+            "$ref": "#/$defs/MutateProfileElementsEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "addExternalLink": {
+            "$ref": "#/$defs/MutateExternalProfileLinksEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "addPiece": {
+            "$ref": "#/$defs/MutateProfileElementsEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "avatar": {
+            "ifc": {
+              "addIntegrity": [
+                {
+                  "kind": "represents-principal",
+                  "subject": {
+                    "__ctCurrentPrincipal": true
+                  }
+                }
+              ],
+              "ownerPrincipal": {
+                "__ctCurrentPrincipal": true
+              },
+              "writeAuthorizedBy": {
+                "__ctWriterIdentityOf": {
+                  "file": "/packages/patterns/system/profile-home.tsx",
+                  "moduleIdentity": "Z_bIu7BuAKEy0ZkS0ORzKAslmhpjvUdaiyP1JVJX55U",
+                  "path": [
+                    "setAvatar"
+                  ]
+                }
+              }
+            },
+            "type": "string"
+          },
+          "bio": {
+            "default": "",
+            "ifc": {
+              "addIntegrity": [
+                {
+                  "kind": "represents-principal",
+                  "subject": {
+                    "__ctCurrentPrincipal": true
+                  }
+                }
+              ],
+              "ownerPrincipal": {
+                "__ctCurrentPrincipal": true
+              },
+              "writeAuthorizedBy": {
+                "__ctWriterIdentityOf": {
+                  "file": "/packages/patterns/system/profile-home.tsx",
+                  "moduleIdentity": "Z_bIu7BuAKEy0ZkS0ORzKAslmhpjvUdaiyP1JVJX55U",
+                  "path": [
+                    "setBio"
+                  ]
+                }
+              }
+            },
+            "type": "string"
+          },
+          "elements": {
+            "ifc": {
+              "addIntegrity": [
+                {
+                  "kind": "represents-principal",
+                  "subject": {
+                    "__ctCurrentPrincipal": true
+                  }
+                }
+              ],
+              "ownerPrincipal": {
+                "__ctCurrentPrincipal": true
+              },
+              "writeAuthorizedBy": {
+                "__ctWriterIdentityOf": {
+                  "file": "/packages/patterns/system/profile-home.tsx",
+                  "moduleIdentity": "Z_bIu7BuAKEy0ZkS0ORzKAslmhpjvUdaiyP1JVJX55U",
+                  "path": [
+                    "mutateElements"
+                  ]
+                }
+              }
+            },
+            "items": {
+              "$ref": "#/$defs/ProfileElement"
+            },
+            "type": "array"
+          },
+          "externalLinks": {
+            "default": [],
+            "ifc": {
+              "addIntegrity": [
+                {
+                  "kind": "represents-principal",
+                  "subject": {
+                    "__ctCurrentPrincipal": true
+                  }
+                }
+              ],
+              "ownerPrincipal": {
+                "__ctCurrentPrincipal": true
+              },
+              "writeAuthorizedBy": {
+                "__ctWriterIdentityOf": {
+                  "file": "/packages/patterns/system/profile-home.tsx",
+                  "moduleIdentity": "Z_bIu7BuAKEy0ZkS0ORzKAslmhpjvUdaiyP1JVJX55U",
+                  "path": [
+                    "mutateExternalProfileLinks"
+                  ]
+                }
+              }
+            },
+            "items": {
+              "$ref": "#/$defs/ExternalProfileLink"
+            },
+            "type": "array"
+          },
+          "initialNameApplied": {
+            "type": "string"
+          },
+          "isEditing": {
+            "default": false,
+            "type": "boolean"
+          },
+          "name": {
+            "ifc": {
+              "addIntegrity": [
+                {
+                  "kind": "represents-principal",
+                  "subject": {
+                    "__ctCurrentPrincipal": true
+                  }
+                }
+              ],
+              "ownerPrincipal": {
+                "__ctCurrentPrincipal": true
+              },
+              "writeAuthorizedBy": {
+                "__ctWriterIdentityOf": {
+                  "file": "/packages/patterns/system/profile-home.tsx",
+                  "moduleIdentity": "Z_bIu7BuAKEy0ZkS0ORzKAslmhpjvUdaiyP1JVJX55U",
+                  "path": [
+                    "setName"
+                  ]
+                }
+              }
+            },
+            "type": "string"
+          },
+          "publishVerifiedIdentities": {
+            "$ref": "#/$defs/MutateVerifiedIdentitiesEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "removeElement": {
+            "$ref": "#/$defs/MutateProfileElementsEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "removeExternalLink": {
+            "$ref": "#/$defs/MutateExternalProfileLinksEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "revokeVerifiedIdentities": {
+            "$ref": "#/$defs/MutateVerifiedIdentitiesEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "setAvatar": {
+            "$ref": "#/$defs/SetProfileAvatarEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "setBio": {
+            "$ref": "#/$defs/SetProfileBioEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "setName": {
+            "$ref": "#/$defs/SetProfileNameEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "toggleEditing": {
+            "asCell": [
+              "stream",
+              "opaque"
+            ]
+          },
+          "verifiedIdentities": {
+            "default": [],
+            "ifc": {
+              "addIntegrity": [
+                {
+                  "kind": "represents-principal",
+                  "subject": {
+                    "__ctCurrentPrincipal": true
+                  }
+                }
+              ],
+              "ownerPrincipal": {
+                "__ctCurrentPrincipal": true
+              },
+              "writeAuthorizedBy": {
+                "__ctWriterIdentityOf": {
+                  "file": "/packages/patterns/system/profile-home.tsx",
+                  "moduleIdentity": "Z_bIu7BuAKEy0ZkS0ORzKAslmhpjvUdaiyP1JVJX55U",
+                  "path": [
+                    "publishVerifiedIdentities"
+                  ]
+                }
+              }
+            },
+            "items": {
+              "$ref": "#/$defs/VerifiedExternalIdentity",
+              "asCell": [
+                "cell"
+              ]
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "$NAME",
+          "$UI",
+          "name",
+          "avatar",
+          "bio",
+          "externalLinks",
+          "verifiedIdentities",
+          "elements",
+          "setName",
+          "setAvatar",
+          "addElement",
+          "removeElement",
+          "isEditing",
+          "initialNameApplied"
+        ],
+        "type": "object"
+      },
+      "ExternalIdentityAssertion": {
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "verifiedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "value",
+          "verifiedAt"
+        ],
+        "type": "object"
+      },
+      "ExternalProfileLink": {
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "label",
+          "url"
+        ],
+        "type": "object"
+      },
+      "MutateExternalProfileLinksEvent": {
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "MutateProfileElementsEvent": {
+        "properties": {
+          "catalogId": {
+            "type": "string"
+          },
+          "cell": true,
+          "patternUrl": {
+            "type": "string"
+          },
+          "pieceId": {
+            "type": "string"
+          },
+          "pieceSpace": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "userTags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "MutateVerifiedIdentitiesEvent": {
+        "properties": {
+          "identities": {
+            "items": {
+              "$ref": "#/$defs/VerifiedExternalIdentity",
+              "asCell": [
+                "cell"
+              ]
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ProfileElement": {
+        "properties": {
+          "cell": true,
+          "source": {
+            "enum": [
+              "url",
+              "catalog",
+              "piece"
+            ]
+          },
+          "tag": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "userTags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "cell",
+          "tag",
+          "userTags"
+        ],
+        "type": "object"
+      },
+      "SetProfileAvatarEvent": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "detail": {
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "key": {
+            "type": "string"
+          },
+          "target": {
+            "properties": {
+              "value": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "SetProfileBioEvent": {
+        "properties": {
+          "bio": {
+            "type": "string"
+          },
+          "detail": {
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "key": {
+            "type": "string"
+          },
+          "target": {
+            "properties": {
+              "value": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "SetProfileNameEvent": {
+        "properties": {
+          "detail": {
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "key": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "target": {
+            "properties": {
+              "value": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "VerifiedExternalIdentity": {
+        "$ref": "#/$defs/ExternalIdentityAssertion",
+        "ifc": {
+          "requiredIntegrity": [
+            "loom-verified-external-identity"
+          ]
+        }
+      }
+    },
+    "properties": {
+      "defaultName": {
+        "type": "string"
+      },
+      "inputId": {
+        "type": "string"
+      },
+      "profiles": {
+        "asCell": [
+          "cell"
+        ],
+        "items": {
+          "$ref": "#/$defs/BackwardsCompatibleProfile"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "profiles"
+    ],
+    "type": "object"
+  },
+  "pattern": "system/profile-create.tsx",
+  "resultSchema": {
+    "$defs": {
+      "CreateProfileEvent": {
+        "properties": {
+          "detail": {
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "key": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "target": {
+            "properties": {
+              "value": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "createProfile": {
+        "$ref": "#/$defs/CreateProfileEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      }
+    },
+    "required": [
+      "createProfile",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/system/profile-home.tsx/20260807T235141Z-6imY7d0oB5R0_3w4.json
+++ b/packages/patterns/baselines/system/profile-home.tsx/20260807T235141Z-6imY7d0oB5R0_3w4.json
@@ -1,0 +1,497 @@
+{
+  "argumentSchema": {
+    "properties": {
+      "initialName": {
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "system/profile-home.tsx",
+  "resultSchema": {
+    "$defs": {
+      "ExternalIdentityAssertion": {
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "verifiedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "value",
+          "verifiedAt"
+        ],
+        "type": "object"
+      },
+      "ExternalProfileLink": {
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "label",
+          "url"
+        ],
+        "type": "object"
+      },
+      "MutateExternalProfileLinksEvent": {
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "MutateProfileElementsEvent": {
+        "properties": {
+          "catalogId": {
+            "type": "string"
+          },
+          "cell": true,
+          "patternUrl": {
+            "type": "string"
+          },
+          "pieceId": {
+            "type": "string"
+          },
+          "pieceSpace": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "userTags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "MutateVerifiedIdentitiesEvent": {
+        "properties": {
+          "identities": {
+            "items": {
+              "$ref": "#/$defs/VerifiedExternalIdentity"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ProfileElement": {
+        "properties": {
+          "cell": true,
+          "source": {
+            "enum": [
+              "catalog",
+              "url",
+              "piece"
+            ]
+          },
+          "tag": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "userTags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "cell",
+          "tag",
+          "userTags"
+        ],
+        "type": "object"
+      },
+      "SetProfileAvatarEvent": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "detail": {
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "key": {
+            "type": "string"
+          },
+          "target": {
+            "properties": {
+              "value": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "SetProfileBioEvent": {
+        "properties": {
+          "bio": {
+            "type": "string"
+          },
+          "detail": {
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "key": {
+            "type": "string"
+          },
+          "target": {
+            "properties": {
+              "value": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "SetProfileNameEvent": {
+        "properties": {
+          "detail": {
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "key": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "target": {
+            "properties": {
+              "value": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "VerifiedExternalIdentity": {
+        "$ref": "#/$defs/ExternalIdentityAssertion",
+        "ifc": {
+          "requiredIntegrity": [
+            "loom-verified-external-identity"
+          ]
+        }
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "type": "unknown"
+      },
+      "addElement": {
+        "$ref": "#/$defs/MutateProfileElementsEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "addExternalLink": {
+        "$ref": "#/$defs/MutateExternalProfileLinksEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "addPiece": {
+        "$ref": "#/$defs/MutateProfileElementsEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "avatar": {
+        "ifc": {
+          "addIntegrity": [
+            {
+              "kind": "represents-principal",
+              "subject": {
+                "__ctCurrentPrincipal": true
+              }
+            }
+          ],
+          "ownerPrincipal": {
+            "__ctCurrentPrincipal": true
+          },
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/system/profile-home.tsx",
+              "moduleIdentity": "Z_bIu7BuAKEy0ZkS0ORzKAslmhpjvUdaiyP1JVJX55U",
+              "path": [
+                "setAvatar"
+              ]
+            }
+          }
+        },
+        "type": "string"
+      },
+      "bio": {
+        "default": "",
+        "ifc": {
+          "addIntegrity": [
+            {
+              "kind": "represents-principal",
+              "subject": {
+                "__ctCurrentPrincipal": true
+              }
+            }
+          ],
+          "ownerPrincipal": {
+            "__ctCurrentPrincipal": true
+          },
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/system/profile-home.tsx",
+              "moduleIdentity": "Z_bIu7BuAKEy0ZkS0ORzKAslmhpjvUdaiyP1JVJX55U",
+              "path": [
+                "setBio"
+              ]
+            }
+          }
+        },
+        "type": "string"
+      },
+      "elements": {
+        "ifc": {
+          "addIntegrity": [
+            {
+              "kind": "represents-principal",
+              "subject": {
+                "__ctCurrentPrincipal": true
+              }
+            }
+          ],
+          "ownerPrincipal": {
+            "__ctCurrentPrincipal": true
+          },
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/system/profile-home.tsx",
+              "moduleIdentity": "Z_bIu7BuAKEy0ZkS0ORzKAslmhpjvUdaiyP1JVJX55U",
+              "path": [
+                "mutateElements"
+              ]
+            }
+          }
+        },
+        "items": {
+          "$ref": "#/$defs/ProfileElement"
+        },
+        "type": "array"
+      },
+      "externalLinks": {
+        "default": [],
+        "ifc": {
+          "addIntegrity": [
+            {
+              "kind": "represents-principal",
+              "subject": {
+                "__ctCurrentPrincipal": true
+              }
+            }
+          ],
+          "ownerPrincipal": {
+            "__ctCurrentPrincipal": true
+          },
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/system/profile-home.tsx",
+              "moduleIdentity": "Z_bIu7BuAKEy0ZkS0ORzKAslmhpjvUdaiyP1JVJX55U",
+              "path": [
+                "mutateExternalProfileLinks"
+              ]
+            }
+          }
+        },
+        "items": {
+          "$ref": "#/$defs/ExternalProfileLink"
+        },
+        "type": "array"
+      },
+      "initialNameApplied": {
+        "type": "string"
+      },
+      "isEditing": {
+        "default": false,
+        "type": "boolean"
+      },
+      "name": {
+        "ifc": {
+          "addIntegrity": [
+            {
+              "kind": "represents-principal",
+              "subject": {
+                "__ctCurrentPrincipal": true
+              }
+            }
+          ],
+          "ownerPrincipal": {
+            "__ctCurrentPrincipal": true
+          },
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/system/profile-home.tsx",
+              "moduleIdentity": "Z_bIu7BuAKEy0ZkS0ORzKAslmhpjvUdaiyP1JVJX55U",
+              "path": [
+                "setName"
+              ]
+            }
+          }
+        },
+        "type": "string"
+      },
+      "publishVerifiedIdentities": {
+        "$ref": "#/$defs/MutateVerifiedIdentitiesEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "removeElement": {
+        "$ref": "#/$defs/MutateProfileElementsEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "removeExternalLink": {
+        "$ref": "#/$defs/MutateExternalProfileLinksEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "revokeVerifiedIdentities": {
+        "$ref": "#/$defs/MutateVerifiedIdentitiesEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "setAvatar": {
+        "$ref": "#/$defs/SetProfileAvatarEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "setBio": {
+        "$ref": "#/$defs/SetProfileBioEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "setName": {
+        "$ref": "#/$defs/SetProfileNameEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "toggleEditing": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "verifiedIdentities": {
+        "default": [],
+        "ifc": {
+          "addIntegrity": [
+            {
+              "kind": "represents-principal",
+              "subject": {
+                "__ctCurrentPrincipal": true
+              }
+            }
+          ],
+          "ownerPrincipal": {
+            "__ctCurrentPrincipal": true
+          },
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/system/profile-home.tsx",
+              "moduleIdentity": "Z_bIu7BuAKEy0ZkS0ORzKAslmhpjvUdaiyP1JVJX55U",
+              "path": [
+                "publishVerifiedIdentities"
+              ]
+            }
+          }
+        },
+        "items": {
+          "$ref": "#/$defs/VerifiedExternalIdentity"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "name",
+      "avatar",
+      "bio",
+      "externalLinks",
+      "verifiedIdentities",
+      "elements",
+      "setName",
+      "setAvatar",
+      "setBio",
+      "addExternalLink",
+      "removeExternalLink",
+      "publishVerifiedIdentities",
+      "revokeVerifiedIdentities",
+      "addElement",
+      "removeElement",
+      "addPiece",
+      "toggleEditing",
+      "isEditing",
+      "initialNameApplied",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/system/profile-picker.tsx/20260807T235141Z-1pxX4OIuahXSSHDs.json
+++ b/packages/patterns/baselines/system/profile-picker.tsx/20260807T235141Z-1pxX4OIuahXSSHDs.json
@@ -1,0 +1,540 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "BackwardsCompatibleProfile": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "$UI": {
+            "type": "unknown"
+          },
+          "addElement": {
+            "$ref": "#/$defs/MutateProfileElementsEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "addExternalLink": {
+            "$ref": "#/$defs/MutateExternalProfileLinksEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "addPiece": {
+            "$ref": "#/$defs/MutateProfileElementsEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "avatar": {
+            "ifc": {
+              "addIntegrity": [
+                {
+                  "kind": "represents-principal",
+                  "subject": {
+                    "__ctCurrentPrincipal": true
+                  }
+                }
+              ],
+              "ownerPrincipal": {
+                "__ctCurrentPrincipal": true
+              },
+              "writeAuthorizedBy": {
+                "__ctWriterIdentityOf": {
+                  "file": "/packages/patterns/system/profile-home.tsx",
+                  "moduleIdentity": "Z_bIu7BuAKEy0ZkS0ORzKAslmhpjvUdaiyP1JVJX55U",
+                  "path": [
+                    "setAvatar"
+                  ]
+                }
+              }
+            },
+            "type": "string"
+          },
+          "bio": {
+            "default": "",
+            "ifc": {
+              "addIntegrity": [
+                {
+                  "kind": "represents-principal",
+                  "subject": {
+                    "__ctCurrentPrincipal": true
+                  }
+                }
+              ],
+              "ownerPrincipal": {
+                "__ctCurrentPrincipal": true
+              },
+              "writeAuthorizedBy": {
+                "__ctWriterIdentityOf": {
+                  "file": "/packages/patterns/system/profile-home.tsx",
+                  "moduleIdentity": "Z_bIu7BuAKEy0ZkS0ORzKAslmhpjvUdaiyP1JVJX55U",
+                  "path": [
+                    "setBio"
+                  ]
+                }
+              }
+            },
+            "type": "string"
+          },
+          "elements": {
+            "ifc": {
+              "addIntegrity": [
+                {
+                  "kind": "represents-principal",
+                  "subject": {
+                    "__ctCurrentPrincipal": true
+                  }
+                }
+              ],
+              "ownerPrincipal": {
+                "__ctCurrentPrincipal": true
+              },
+              "writeAuthorizedBy": {
+                "__ctWriterIdentityOf": {
+                  "file": "/packages/patterns/system/profile-home.tsx",
+                  "moduleIdentity": "Z_bIu7BuAKEy0ZkS0ORzKAslmhpjvUdaiyP1JVJX55U",
+                  "path": [
+                    "mutateElements"
+                  ]
+                }
+              }
+            },
+            "items": {
+              "$ref": "#/$defs/ProfileElement"
+            },
+            "type": "array"
+          },
+          "externalLinks": {
+            "default": [],
+            "ifc": {
+              "addIntegrity": [
+                {
+                  "kind": "represents-principal",
+                  "subject": {
+                    "__ctCurrentPrincipal": true
+                  }
+                }
+              ],
+              "ownerPrincipal": {
+                "__ctCurrentPrincipal": true
+              },
+              "writeAuthorizedBy": {
+                "__ctWriterIdentityOf": {
+                  "file": "/packages/patterns/system/profile-home.tsx",
+                  "moduleIdentity": "Z_bIu7BuAKEy0ZkS0ORzKAslmhpjvUdaiyP1JVJX55U",
+                  "path": [
+                    "mutateExternalProfileLinks"
+                  ]
+                }
+              }
+            },
+            "items": {
+              "$ref": "#/$defs/ExternalProfileLink"
+            },
+            "type": "array"
+          },
+          "initialNameApplied": {
+            "type": "string"
+          },
+          "isEditing": {
+            "default": false,
+            "type": "boolean"
+          },
+          "name": {
+            "ifc": {
+              "addIntegrity": [
+                {
+                  "kind": "represents-principal",
+                  "subject": {
+                    "__ctCurrentPrincipal": true
+                  }
+                }
+              ],
+              "ownerPrincipal": {
+                "__ctCurrentPrincipal": true
+              },
+              "writeAuthorizedBy": {
+                "__ctWriterIdentityOf": {
+                  "file": "/packages/patterns/system/profile-home.tsx",
+                  "moduleIdentity": "Z_bIu7BuAKEy0ZkS0ORzKAslmhpjvUdaiyP1JVJX55U",
+                  "path": [
+                    "setName"
+                  ]
+                }
+              }
+            },
+            "type": "string"
+          },
+          "publishVerifiedIdentities": {
+            "$ref": "#/$defs/MutateVerifiedIdentitiesEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "removeElement": {
+            "$ref": "#/$defs/MutateProfileElementsEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "removeExternalLink": {
+            "$ref": "#/$defs/MutateExternalProfileLinksEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "revokeVerifiedIdentities": {
+            "$ref": "#/$defs/MutateVerifiedIdentitiesEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "setAvatar": {
+            "$ref": "#/$defs/SetProfileAvatarEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "setBio": {
+            "$ref": "#/$defs/SetProfileBioEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "setName": {
+            "$ref": "#/$defs/SetProfileNameEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "toggleEditing": {
+            "asCell": [
+              "stream",
+              "opaque"
+            ]
+          },
+          "verifiedIdentities": {
+            "default": [],
+            "ifc": {
+              "addIntegrity": [
+                {
+                  "kind": "represents-principal",
+                  "subject": {
+                    "__ctCurrentPrincipal": true
+                  }
+                }
+              ],
+              "ownerPrincipal": {
+                "__ctCurrentPrincipal": true
+              },
+              "writeAuthorizedBy": {
+                "__ctWriterIdentityOf": {
+                  "file": "/packages/patterns/system/profile-home.tsx",
+                  "moduleIdentity": "Z_bIu7BuAKEy0ZkS0ORzKAslmhpjvUdaiyP1JVJX55U",
+                  "path": [
+                    "publishVerifiedIdentities"
+                  ]
+                }
+              }
+            },
+            "items": {
+              "$ref": "#/$defs/VerifiedExternalIdentity",
+              "asCell": [
+                "cell"
+              ]
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "$NAME",
+          "$UI",
+          "name",
+          "avatar",
+          "bio",
+          "externalLinks",
+          "verifiedIdentities",
+          "elements",
+          "setName",
+          "setAvatar",
+          "addElement",
+          "removeElement",
+          "isEditing",
+          "initialNameApplied"
+        ],
+        "type": "object"
+      },
+      "ExternalIdentityAssertion": {
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "verifiedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "value",
+          "verifiedAt"
+        ],
+        "type": "object"
+      },
+      "ExternalProfileLink": {
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "label",
+          "url"
+        ],
+        "type": "object"
+      },
+      "MutateExternalProfileLinksEvent": {
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "MutateProfileElementsEvent": {
+        "properties": {
+          "catalogId": {
+            "type": "string"
+          },
+          "cell": true,
+          "patternUrl": {
+            "type": "string"
+          },
+          "pieceId": {
+            "type": "string"
+          },
+          "pieceSpace": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "userTags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "MutateVerifiedIdentitiesEvent": {
+        "properties": {
+          "identities": {
+            "items": {
+              "$ref": "#/$defs/VerifiedExternalIdentity",
+              "asCell": [
+                "cell"
+              ]
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ProfileElement": {
+        "properties": {
+          "cell": true,
+          "source": {
+            "enum": [
+              "url",
+              "catalog",
+              "piece"
+            ]
+          },
+          "tag": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "userTags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "cell",
+          "tag",
+          "userTags"
+        ],
+        "type": "object"
+      },
+      "SetProfileAvatarEvent": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "detail": {
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "key": {
+            "type": "string"
+          },
+          "target": {
+            "properties": {
+              "value": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "SetProfileBioEvent": {
+        "properties": {
+          "bio": {
+            "type": "string"
+          },
+          "detail": {
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "key": {
+            "type": "string"
+          },
+          "target": {
+            "properties": {
+              "value": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "SetProfileNameEvent": {
+        "properties": {
+          "detail": {
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "key": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "target": {
+            "properties": {
+              "value": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "VerifiedExternalIdentity": {
+        "$ref": "#/$defs/ExternalIdentityAssertion",
+        "ifc": {
+          "requiredIntegrity": [
+            "loom-verified-external-identity"
+          ]
+        }
+      }
+    },
+    "properties": {
+      "defaultProfile": {
+        "anyOf": [
+          {
+            "type": "undefined"
+          },
+          {
+            "$ref": "#/$defs/BackwardsCompatibleProfile"
+          }
+        ],
+        "asCell": [
+          "cell"
+        ]
+      },
+      "mru": {
+        "asCell": [
+          "cell"
+        ],
+        "items": {
+          "$ref": "#/$defs/BackwardsCompatibleProfile"
+        },
+        "type": "array"
+      },
+      "profiles": {
+        "asCell": [
+          "cell"
+        ],
+        "items": {
+          "$ref": "#/$defs/BackwardsCompatibleProfile"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "profiles",
+      "defaultProfile",
+      "mru"
+    ],
+    "type": "object"
+  },
+  "pattern": "system/profile-picker.tsx",
+  "resultSchema": {
+    "properties": {
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      }
+    },
+    "required": [
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/system/quick-capture.tsx/20260807T235141Z-xMX6UR492BGoaoGz.json
+++ b/packages/patterns/baselines/system/quick-capture.tsx/20260807T235141Z-xMX6UR492BGoaoGz.json
@@ -1,0 +1,95 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "AnonymousType_1": {
+        "items": {
+          "$ref": "#/$defs/MentionablePiece"
+        },
+        "type": "array"
+      },
+      "MentionablePiece": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "backlinks": {
+            "$ref": "#/$defs/AnonymousType_1"
+          },
+          "isHidden": {
+            "type": "boolean"
+          },
+          "isMentionable": {
+            "type": "boolean"
+          },
+          "mentionable": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/AnonymousType_1"
+              },
+              {
+                "properties": {},
+                "type": "object"
+              }
+            ]
+          },
+          "mentioned": {
+            "$ref": "#/$defs/AnonymousType_1"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "properties": {
+      "pieceRegistry": {
+        "$ref": "#/$defs/AnonymousType_1",
+        "asCell": [
+          "cell"
+        ]
+      }
+    },
+    "required": [
+      "pieceRegistry"
+    ],
+    "type": "object"
+  },
+  "pattern": "system/quick-capture.tsx",
+  "resultSchema": {
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "capture": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "attachments": {
+            "items": {},
+            "type": "array"
+          },
+          "text": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "text"
+        ],
+        "type": "object"
+      },
+      "summary": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "summary",
+      "capture",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/todo-list/todo-list.tsx/20260807T235141Z-duiHwIulWUWpk1ec.json
+++ b/packages/patterns/baselines/todo-list/todo-list.tsx/20260807T235141Z-duiHwIulWUWpk1ec.json
@@ -1,0 +1,146 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "TodoItem": {
+        "properties": {
+          "done": {
+            "default": false,
+            "type": "boolean"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "done"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "items": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/TodoItem"
+        },
+        "type": "array"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "todo-list/todo-list.tsx",
+  "resultSchema": {
+    "$defs": {
+      "TodoItem": {
+        "properties": {
+          "done": {
+            "default": false,
+            "type": "boolean"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "done"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addItem": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title"
+        ],
+        "type": "object"
+      },
+      "archiveCompleted": {
+        "asCell": [
+          "stream"
+        ],
+        "type": "unknown"
+      },
+      "itemCount": {
+        "type": "number"
+      },
+      "items": {
+        "items": {
+          "$ref": "#/$defs/TodoItem"
+        },
+        "type": "array"
+      },
+      "mentionable": {
+        "items": {
+          "properties": {
+            "$NAME": {
+              "type": "string"
+            },
+            "$UI": {
+              "$ref": "https://commonfabric.org/schemas/vnode.json"
+            },
+            "summary": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "summary",
+            "$NAME",
+            "$UI"
+          ],
+          "type": "object"
+        },
+        "type": "array"
+      },
+      "removeItem": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "item": {
+            "$ref": "#/$defs/TodoItem"
+          }
+        },
+        "required": [
+          "item"
+        ],
+        "type": "object"
+      },
+      "summary": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "items",
+      "mentionable",
+      "itemCount",
+      "summary",
+      "addItem",
+      "removeItem",
+      "archiveCompleted",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/topics/main.tsx/20260807T235141Z-CA7Nublj63c_BFWy.json
+++ b/packages/patterns/baselines/topics/main.tsx/20260807T235141Z-CA7Nublj63c_BFWy.json
@@ -1,0 +1,1061 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "AddCommentEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Optional only so callers of the previous deployed schema\nremain valid; new callers must provide a non-blank name.",
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "body"
+        ],
+        "type": "object"
+      },
+      "AddLinkEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Optional only so callers of the previous deployed schema\nremain valid; new callers must provide a non-blank name.",
+            "type": "string"
+          },
+          "kind": {
+            "$ref": "#/$defs/TopicLinkKind"
+          },
+          "label": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "url",
+          "label"
+        ],
+        "type": "object"
+      },
+      "SetBodyEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Optional only so callers of the previous deployed schema\nremain valid; new callers must provide a non-blank name.",
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "body"
+        ],
+        "type": "object"
+      },
+      "TopicAuthor": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "kind": {
+            "enum": [
+              "person",
+              "agent"
+            ]
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "name"
+        ],
+        "type": "object"
+      },
+      "TopicComment": {
+        "properties": {
+          "author": {
+            "$ref": "#/$defs/TopicAuthor",
+            "description": "Snapshot taken at write time (profile enrichment comes later; never gate\nauthorship on a profile wish — CT-1879). Comments carry no minted id:\narray elements have stable entity identity; future editing addresses\nelements by reference (`equals()`), not by a synthetic key."
+          },
+          "authorName": {
+            "default": "",
+            "type": "string"
+          },
+          "body": {
+            "default": "",
+            "type": "string"
+          },
+          "sentAt": {
+            "default": 0,
+            "type": "number"
+          }
+        },
+        "required": [
+          "authorName",
+          "body",
+          "sentAt"
+        ],
+        "type": "object"
+      },
+      "TopicLink": {
+        "properties": {
+          "addedAt": {
+            "type": "number"
+          },
+          "addedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "kind": {
+            "$ref": "#/$defs/TopicLinkKind",
+            "default": "web"
+          },
+          "label": {
+            "default": "",
+            "type": "string"
+          },
+          "url": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "url",
+          "label"
+        ],
+        "type": "object"
+      },
+      "TopicLinkKind": {
+        "enum": [
+          "session",
+          "pr",
+          "topic",
+          "web"
+        ]
+      },
+      "TopicPiece": {
+        "properties": {
+          "$NAME": {
+            "default": "",
+            "description": "Like the other derived display fields, a cold retained sibling may not\nhave produced this path yet. Its persisted title remains authoritative.",
+            "type": [
+              "string",
+              "undefined"
+            ]
+          },
+          "addComment": {
+            "$ref": "#/$defs/AddCommentEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "addLink": {
+            "$ref": "#/$defs/AddLinkEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "body": {
+            "type": "string"
+          },
+          "bodyUpdatedAt": {
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "bodyUpdatedBy": {
+            "anyOf": [
+              {
+                "type": "undefined"
+              },
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              }
+            ]
+          },
+          "commentCount": {
+            "default": 0,
+            "description": "Cold mixed-version references can expose an unresolved computed path as\nexplicit undefined. Shape it to zero until the sibling starts.",
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "comments": {
+            "items": {
+              "$ref": "#/$defs/TopicComment"
+            },
+            "type": "array"
+          },
+          "createdAt": {
+            "type": "number"
+          },
+          "createdBy": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              {
+                "type": "undefined"
+              }
+            ],
+            "default": {
+              "kind": "person",
+              "name": ""
+            },
+            "description": "Mixed-version list projections can resolve an older sibling's absent\npath as undefined. Fabric shapes that absence to this inert legacy\nsentinel at the list boundary; newly computed non-empty authorship remains\na structured TopicAuthor."
+          },
+          "createdByName": {
+            "type": "string"
+          },
+          "crossrefs": {
+            "anyOf": [
+              {
+                "properties": {
+                  "referencedBy": {
+                    "items": {
+                      "$ref": "#/$defs/TopicReference"
+                    },
+                    "type": "array"
+                  },
+                  "refsOut": {
+                    "items": {
+                      "$ref": "#/$defs/TopicReference"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "refsOut",
+                  "referencedBy"
+                ],
+                "type": "object"
+              },
+              {
+                "type": "undefined"
+              }
+            ],
+            "default": {
+              "referencedBy": [],
+              "refsOut": []
+            },
+            "description": "This topic's own place in the board's prose graph, derived read-side\nfrom `mentionable` (the sibling pieces it links, resolved from the\nboard's own list). Both sets stay empty until `mentionable` is wired.\nOptional (2026-07-21 deploy): pieces healed before their `mentionable`\nlink exists carry a session-scoped crossrefs indirection that resolves\nundefined outside the minting session; the list projection must accept\nthat rather than fail argument validation."
+          },
+          "lastActivityAt": {
+            "default": 0,
+            "description": "Max of creation, comments, body saves, and link additions.",
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "links": {
+            "items": {
+              "$ref": "#/$defs/TopicLink"
+            },
+            "type": "array"
+          },
+          "setBody": {
+            "$ref": "#/$defs/SetBodyEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "body",
+          "comments",
+          "links",
+          "createdAt",
+          "createdByName",
+          "commentCount",
+          "lastActivityAt",
+          "addComment",
+          "addLink",
+          "setBody",
+          "$NAME"
+        ],
+        "type": "object"
+      },
+      "TopicReference": {
+        "properties": {
+          "$NAME": {
+            "default": "",
+            "description": "Like the other derived display fields, a cold retained sibling may not\nhave produced this path yet. Its persisted title remains authoritative.",
+            "type": [
+              "string",
+              "undefined"
+            ]
+          },
+          "addComment": {
+            "$ref": "#/$defs/AddCommentEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "addLink": {
+            "$ref": "#/$defs/AddLinkEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "body": {
+            "type": "string"
+          },
+          "bodyUpdatedAt": {
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "bodyUpdatedBy": {
+            "anyOf": [
+              {
+                "type": "undefined"
+              },
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              }
+            ]
+          },
+          "commentCount": {
+            "default": 0,
+            "description": "Cold mixed-version references can expose an unresolved computed path as\nexplicit undefined. Shape it to zero until the sibling starts.",
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "comments": {
+            "items": {
+              "$ref": "#/$defs/TopicComment"
+            },
+            "type": "array"
+          },
+          "createdAt": {
+            "type": "number"
+          },
+          "createdBy": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              {
+                "type": "undefined"
+              }
+            ],
+            "default": {
+              "kind": "person",
+              "name": ""
+            },
+            "description": "Mixed-version list projections can resolve an older sibling's absent\npath as undefined. Fabric shapes that absence to this inert legacy\nsentinel at the list boundary; newly computed non-empty authorship remains\na structured TopicAuthor."
+          },
+          "createdByName": {
+            "type": "string"
+          },
+          "lastActivityAt": {
+            "default": 0,
+            "description": "Max of creation, comments, body saves, and link additions.",
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "links": {
+            "items": {
+              "$ref": "#/$defs/TopicLink"
+            },
+            "type": "array"
+          },
+          "setBody": {
+            "$ref": "#/$defs/SetBodyEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "body",
+          "comments",
+          "links",
+          "createdAt",
+          "createdByName",
+          "commentCount",
+          "lastActivityAt",
+          "addComment",
+          "addLink",
+          "setBody",
+          "$NAME"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "myName": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "user"
+          }
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "topics": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/TopicPiece"
+        },
+        "type": "array"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "topics/main.tsx",
+  "resultSchema": {
+    "$defs": {
+      "AddCommentEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Optional only so callers of the previous deployed schema\nremain valid; new callers must provide a non-blank name.",
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "body"
+        ],
+        "type": "object"
+      },
+      "AddLinkEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Optional only so callers of the previous deployed schema\nremain valid; new callers must provide a non-blank name.",
+            "type": "string"
+          },
+          "kind": {
+            "$ref": "#/$defs/TopicLinkKind"
+          },
+          "label": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "url",
+          "label"
+        ],
+        "type": "object"
+      },
+      "AddTopicEvent": {
+        "properties": {
+          "agentName": {
+            "description": "The agent making this mutation. The authenticated principal remains the\nhuman whose identity key invoked the stream; this is the agent's explicit\ncontent-level signature under that shared principal. Optional only so\ncallers of the previous deployed schema remain valid; new callers must\nprovide a non-blank name.",
+            "type": "string"
+          },
+          "body": {
+            "description": "The topic's initial living-document body. A topic born with a body\nappears with it atomically — no reader observes the title-only halfway\nstate, and no follow-up `setBody` call is needed to finish a create\n(verb contract: the atomic-unit rule).",
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title"
+        ],
+        "type": "object"
+      },
+      "SetBodyEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Optional only so callers of the previous deployed schema\nremain valid; new callers must provide a non-blank name.",
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "body"
+        ],
+        "type": "object"
+      },
+      "TopicAuthor": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "kind": {
+            "enum": [
+              "person",
+              "agent"
+            ]
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "name"
+        ],
+        "type": "object"
+      },
+      "TopicComment": {
+        "properties": {
+          "author": {
+            "$ref": "#/$defs/TopicAuthor",
+            "description": "Snapshot taken at write time (profile enrichment comes later; never gate\nauthorship on a profile wish — CT-1879). Comments carry no minted id:\narray elements have stable entity identity; future editing addresses\nelements by reference (`equals()`), not by a synthetic key."
+          },
+          "authorName": {
+            "default": "",
+            "type": "string"
+          },
+          "body": {
+            "default": "",
+            "type": "string"
+          },
+          "sentAt": {
+            "default": 0,
+            "type": "number"
+          }
+        },
+        "required": [
+          "authorName",
+          "body",
+          "sentAt"
+        ],
+        "type": "object"
+      },
+      "TopicCrossref": {
+        "properties": {
+          "fid": {
+            "description": "The topic's own fid in tagged form (`fid1:…`); \"\" until known.",
+            "type": "string"
+          },
+          "referencedBy": {
+            "description": "Sibling topics whose prose mentions this topic's fid.",
+            "items": {
+              "$ref": "#/$defs/TopicPiece"
+            },
+            "type": "array"
+          },
+          "refsOut": {
+            "description": "Sibling topics whose fids this topic's prose mentions.",
+            "items": {
+              "$ref": "#/$defs/TopicPiece"
+            },
+            "type": "array"
+          },
+          "topic": {
+            "$ref": "#/$defs/TopicPiece"
+          }
+        },
+        "required": [
+          "fid",
+          "topic",
+          "refsOut",
+          "referencedBy"
+        ],
+        "type": "object"
+      },
+      "TopicIndexRef": {
+        "properties": {
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title"
+        ],
+        "type": "object"
+      },
+      "TopicIndexRow": {
+        "properties": {
+          "commentCount": {
+            "type": "number"
+          },
+          "createdAt": {
+            "type": "number"
+          },
+          "createdBy": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              {
+                "type": "undefined"
+              }
+            ],
+            "default": {
+              "kind": "person",
+              "name": ""
+            }
+          },
+          "lastActivityAt": {
+            "type": "number"
+          },
+          "referencedBy": {
+            "description": "Sibling topics whose prose mentions this topic's fid.",
+            "items": {
+              "$ref": "#/$defs/TopicIndexRef"
+            },
+            "type": "array"
+          },
+          "refsOut": {
+            "description": "Sibling topics whose fids this topic's prose mentions.",
+            "items": {
+              "$ref": "#/$defs/TopicIndexRef"
+            },
+            "type": "array"
+          },
+          "title": {
+            "type": "string"
+          },
+          "topic": {
+            "$ref": "#/$defs/TopicIndexRef"
+          }
+        },
+        "required": [
+          "topic",
+          "title",
+          "createdAt",
+          "commentCount",
+          "lastActivityAt",
+          "refsOut",
+          "referencedBy"
+        ],
+        "type": "object"
+      },
+      "TopicLink": {
+        "properties": {
+          "addedAt": {
+            "type": "number"
+          },
+          "addedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "kind": {
+            "$ref": "#/$defs/TopicLinkKind",
+            "default": "web"
+          },
+          "label": {
+            "default": "",
+            "type": "string"
+          },
+          "url": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "url",
+          "label"
+        ],
+        "type": "object"
+      },
+      "TopicLinkKind": {
+        "enum": [
+          "session",
+          "pr",
+          "topic",
+          "web"
+        ]
+      },
+      "TopicPiece": {
+        "properties": {
+          "$NAME": {
+            "default": "",
+            "description": "Like the other derived display fields, a cold retained sibling may not\nhave produced this path yet. Its persisted title remains authoritative.",
+            "type": [
+              "string",
+              "undefined"
+            ]
+          },
+          "addComment": {
+            "$ref": "#/$defs/AddCommentEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "addLink": {
+            "$ref": "#/$defs/AddLinkEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "body": {
+            "type": "string"
+          },
+          "bodyUpdatedAt": {
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "bodyUpdatedBy": {
+            "anyOf": [
+              {
+                "type": "undefined"
+              },
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              }
+            ]
+          },
+          "commentCount": {
+            "default": 0,
+            "description": "Cold mixed-version references can expose an unresolved computed path as\nexplicit undefined. Shape it to zero until the sibling starts.",
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "comments": {
+            "items": {
+              "$ref": "#/$defs/TopicComment"
+            },
+            "type": "array"
+          },
+          "createdAt": {
+            "type": "number"
+          },
+          "createdBy": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              {
+                "type": "undefined"
+              }
+            ],
+            "default": {
+              "kind": "person",
+              "name": ""
+            },
+            "description": "Mixed-version list projections can resolve an older sibling's absent\npath as undefined. Fabric shapes that absence to this inert legacy\nsentinel at the list boundary; newly computed non-empty authorship remains\na structured TopicAuthor."
+          },
+          "createdByName": {
+            "type": "string"
+          },
+          "crossrefs": {
+            "anyOf": [
+              {
+                "properties": {
+                  "referencedBy": {
+                    "items": {
+                      "$ref": "#/$defs/TopicReference"
+                    },
+                    "type": "array"
+                  },
+                  "refsOut": {
+                    "items": {
+                      "$ref": "#/$defs/TopicReference"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "refsOut",
+                  "referencedBy"
+                ],
+                "type": "object"
+              },
+              {
+                "type": "undefined"
+              }
+            ],
+            "default": {
+              "referencedBy": [],
+              "refsOut": []
+            },
+            "description": "This topic's own place in the board's prose graph, derived read-side\nfrom `mentionable` (the sibling pieces it links, resolved from the\nboard's own list). Both sets stay empty until `mentionable` is wired.\nOptional (2026-07-21 deploy): pieces healed before their `mentionable`\nlink exists carry a session-scoped crossrefs indirection that resolves\nundefined outside the minting session; the list projection must accept\nthat rather than fail argument validation."
+          },
+          "lastActivityAt": {
+            "default": 0,
+            "description": "Max of creation, comments, body saves, and link additions.",
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "links": {
+            "items": {
+              "$ref": "#/$defs/TopicLink"
+            },
+            "type": "array"
+          },
+          "setBody": {
+            "$ref": "#/$defs/SetBodyEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "body",
+          "comments",
+          "links",
+          "createdAt",
+          "createdByName",
+          "commentCount",
+          "lastActivityAt",
+          "addComment",
+          "addLink",
+          "setBody",
+          "$NAME"
+        ],
+        "type": "object"
+      },
+      "TopicReference": {
+        "properties": {
+          "$NAME": {
+            "default": "",
+            "description": "Like the other derived display fields, a cold retained sibling may not\nhave produced this path yet. Its persisted title remains authoritative.",
+            "type": [
+              "string",
+              "undefined"
+            ]
+          },
+          "addComment": {
+            "$ref": "#/$defs/AddCommentEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "addLink": {
+            "$ref": "#/$defs/AddLinkEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "body": {
+            "type": "string"
+          },
+          "bodyUpdatedAt": {
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "bodyUpdatedBy": {
+            "anyOf": [
+              {
+                "type": "undefined"
+              },
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              }
+            ]
+          },
+          "commentCount": {
+            "default": 0,
+            "description": "Cold mixed-version references can expose an unresolved computed path as\nexplicit undefined. Shape it to zero until the sibling starts.",
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "comments": {
+            "items": {
+              "$ref": "#/$defs/TopicComment"
+            },
+            "type": "array"
+          },
+          "createdAt": {
+            "type": "number"
+          },
+          "createdBy": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              {
+                "type": "undefined"
+              }
+            ],
+            "default": {
+              "kind": "person",
+              "name": ""
+            },
+            "description": "Mixed-version list projections can resolve an older sibling's absent\npath as undefined. Fabric shapes that absence to this inert legacy\nsentinel at the list boundary; newly computed non-empty authorship remains\na structured TopicAuthor."
+          },
+          "createdByName": {
+            "type": "string"
+          },
+          "lastActivityAt": {
+            "default": 0,
+            "description": "Max of creation, comments, body saves, and link additions.",
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "links": {
+            "items": {
+              "$ref": "#/$defs/TopicLink"
+            },
+            "type": "array"
+          },
+          "setBody": {
+            "$ref": "#/$defs/SetBodyEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "body",
+          "comments",
+          "links",
+          "createdAt",
+          "createdByName",
+          "commentCount",
+          "lastActivityAt",
+          "addComment",
+          "addLink",
+          "setBody",
+          "$NAME"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "Topics — a tracker over #topic pieces: durable units of shared attention\n(CT-1878). Deliberately minimal: no statuses, labels, or assignees; topics\nsort by last activity. Replaces Linear / GitHub issues / loose process docs\nfor the team; PR workflows stay in GitHub and arrive here as links.",
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addTopic": {
+        "$ref": "#/$defs/AddTopicEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "crossrefs": {
+        "default": [],
+        "description": "The prose reference graph over the board's own topics, one row per\n(non-null) entry of `topics`. Rows carry their topic, so consumers never\nneed to correlate by index — indices are not a stable address.",
+        "items": {
+          "$ref": "#/$defs/TopicCrossref"
+        },
+        "type": "array"
+      },
+      "index": {
+        "default": [],
+        "description": "Compact discovery index — the documented full-board survey surface: one\nreference-plus-summary row per (non-null) entry of `topics`. Everything\nreference-valued in a row is declared through the title-only\n`TopicIndexRef`, so one bounded read surveys the whole board.\n`crossrefs` stays as the UI's reference graph; it is not compact — each\nrow expands to full pieces — and is not the survey surface.",
+        "items": {
+          "$ref": "#/$defs/TopicIndexRow"
+        },
+        "type": "array"
+      },
+      "mentionable": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/TopicPiece"
+        },
+        "type": "array"
+      },
+      "myName": {
+        "type": "string"
+      },
+      "newTitle": {
+        "description": "Session-local draft for the footer composer (exposed for embedding and\nheadless driving, like the chat exemplar's drafts).",
+        "type": "string"
+      },
+      "setMyName": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "submitTopic": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "Submit the footer composer as the current viewer's canonical Profile."
+      },
+      "topicCount": {
+        "type": "number"
+      },
+      "topics": {
+        "items": {
+          "$ref": "#/$defs/TopicPiece"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "topics",
+      "mentionable",
+      "topicCount",
+      "crossrefs",
+      "index",
+      "addTopic",
+      "myName",
+      "setMyName",
+      "submitTopic",
+      "$NAME",
+      "$UI"
+    ],
+    "tags": [
+      "topic"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/topics/main.tsx/20260810T184538Z-mt3jbWmTMcsdG-lD.json
+++ b/packages/patterns/baselines/topics/main.tsx/20260810T184538Z-mt3jbWmTMcsdG-lD.json
@@ -1,0 +1,1063 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "AddCommentEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Optional only so callers of the previous deployed schema\nremain valid; new callers must provide a non-blank name.",
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "body"
+        ],
+        "type": "object"
+      },
+      "AddLinkEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Optional only so callers of the previous deployed schema\nremain valid; new callers must provide a non-blank name.",
+            "type": "string"
+          },
+          "kind": {
+            "$ref": "#/$defs/TopicLinkKind"
+          },
+          "label": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "url",
+          "label"
+        ],
+        "type": "object"
+      },
+      "SetBodyEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Optional only so callers of the previous deployed schema\nremain valid; new callers must provide a non-blank name.",
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "body"
+        ],
+        "type": "object"
+      },
+      "TopicAuthor": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "kind": {
+            "enum": [
+              "person",
+              "agent"
+            ]
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "name"
+        ],
+        "type": "object"
+      },
+      "TopicComment": {
+        "properties": {
+          "author": {
+            "$ref": "#/$defs/TopicAuthor",
+            "description": "Snapshot taken at write time (profile enrichment comes later; never gate\nauthorship on a profile wish — CT-1879). Comments carry no minted id:\narray elements have stable entity identity; future editing addresses\nelements by reference (`equals()`), not by a synthetic key."
+          },
+          "authorName": {
+            "default": "",
+            "type": "string"
+          },
+          "body": {
+            "default": "",
+            "type": "string"
+          },
+          "sentAt": {
+            "default": 0,
+            "type": "number"
+          }
+        },
+        "required": [
+          "authorName",
+          "body",
+          "sentAt"
+        ],
+        "type": "object"
+      },
+      "TopicLink": {
+        "properties": {
+          "addedAt": {
+            "type": "number"
+          },
+          "addedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "kind": {
+            "$ref": "#/$defs/TopicLinkKind",
+            "default": "web"
+          },
+          "label": {
+            "default": "",
+            "type": "string"
+          },
+          "url": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "url",
+          "label"
+        ],
+        "type": "object"
+      },
+      "TopicLinkKind": {
+        "enum": [
+          "session",
+          "pr",
+          "topic",
+          "web"
+        ]
+      },
+      "TopicPiece": {
+        "properties": {
+          "$NAME": {
+            "default": "",
+            "description": "Like the other derived display fields, a cold retained sibling may not\nhave produced this path yet. Its persisted title remains authoritative.",
+            "type": [
+              "string",
+              "undefined"
+            ]
+          },
+          "addComment": {
+            "$ref": "#/$defs/AddCommentEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "addLink": {
+            "$ref": "#/$defs/AddLinkEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "body": {
+            "type": "string"
+          },
+          "bodyUpdatedAt": {
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "bodyUpdatedBy": {
+            "anyOf": [
+              {
+                "type": "undefined"
+              },
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              }
+            ]
+          },
+          "commentCount": {
+            "default": 0,
+            "description": "Cold mixed-version references can expose an unresolved computed path as\nexplicit undefined. Shape it to zero until the sibling starts.",
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "comments": {
+            "items": {
+              "$ref": "#/$defs/TopicComment"
+            },
+            "type": "array"
+          },
+          "createdAt": {
+            "type": "number"
+          },
+          "createdBy": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              {
+                "type": "undefined"
+              }
+            ],
+            "default": {
+              "kind": "person",
+              "name": ""
+            },
+            "description": "Mixed-version list projections can resolve an older sibling's absent\npath as undefined. Fabric shapes that absence to this inert legacy\nsentinel at the list boundary; newly computed non-empty authorship remains\na structured TopicAuthor."
+          },
+          "createdByName": {
+            "type": "string"
+          },
+          "crossrefs": {
+            "anyOf": [
+              {
+                "properties": {
+                  "referencedBy": {
+                    "items": {
+                      "$ref": "#/$defs/TopicReference"
+                    },
+                    "type": "array"
+                  },
+                  "refsOut": {
+                    "items": {
+                      "$ref": "#/$defs/TopicReference"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "refsOut",
+                  "referencedBy"
+                ],
+                "type": "object"
+              },
+              {
+                "type": "undefined"
+              }
+            ],
+            "default": {
+              "referencedBy": [],
+              "refsOut": []
+            },
+            "description": "This topic's own place in the board's prose graph, derived read-side\nfrom `mentionable` (the sibling pieces it links, resolved from the\nboard's own list). Both sets stay empty until `mentionable` is wired.\nOptional (2026-07-21 deploy): pieces healed before their `mentionable`\nlink exists carry a session-scoped crossrefs indirection that resolves\nundefined outside the minting session; the list projection must accept\nthat rather than fail argument validation."
+          },
+          "lastActivityAt": {
+            "default": 0,
+            "description": "Max of creation, comments, body saves, and link additions.",
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "links": {
+            "items": {
+              "$ref": "#/$defs/TopicLink"
+            },
+            "type": "array"
+          },
+          "setBody": {
+            "$ref": "#/$defs/SetBodyEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "body",
+          "comments",
+          "links",
+          "createdAt",
+          "createdByName",
+          "commentCount",
+          "lastActivityAt",
+          "addComment",
+          "addLink",
+          "setBody",
+          "$NAME"
+        ],
+        "type": "object"
+      },
+      "TopicReference": {
+        "properties": {
+          "$NAME": {
+            "default": "",
+            "description": "Like the other derived display fields, a cold retained sibling may not\nhave produced this path yet. Its persisted title remains authoritative.",
+            "type": [
+              "string",
+              "undefined"
+            ]
+          },
+          "addComment": {
+            "$ref": "#/$defs/AddCommentEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "addLink": {
+            "$ref": "#/$defs/AddLinkEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "body": {
+            "type": "string"
+          },
+          "bodyUpdatedAt": {
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "bodyUpdatedBy": {
+            "anyOf": [
+              {
+                "type": "undefined"
+              },
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              }
+            ]
+          },
+          "commentCount": {
+            "default": 0,
+            "description": "Cold mixed-version references can expose an unresolved computed path as\nexplicit undefined. Shape it to zero until the sibling starts.",
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "comments": {
+            "items": {
+              "$ref": "#/$defs/TopicComment"
+            },
+            "type": "array"
+          },
+          "createdAt": {
+            "type": "number"
+          },
+          "createdBy": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              {
+                "type": "undefined"
+              }
+            ],
+            "default": {
+              "kind": "person",
+              "name": ""
+            },
+            "description": "Mixed-version list projections can resolve an older sibling's absent\npath as undefined. Fabric shapes that absence to this inert legacy\nsentinel at the list boundary; newly computed non-empty authorship remains\na structured TopicAuthor."
+          },
+          "createdByName": {
+            "type": "string"
+          },
+          "lastActivityAt": {
+            "default": 0,
+            "description": "Max of creation, comments, body saves, and link additions.",
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "links": {
+            "items": {
+              "$ref": "#/$defs/TopicLink"
+            },
+            "type": "array"
+          },
+          "setBody": {
+            "$ref": "#/$defs/SetBodyEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "body",
+          "comments",
+          "links",
+          "createdAt",
+          "createdByName",
+          "commentCount",
+          "lastActivityAt",
+          "addComment",
+          "addLink",
+          "setBody",
+          "$NAME"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "myName": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "user"
+          }
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "topics": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/TopicPiece"
+        },
+        "type": "array"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "topics/main.tsx",
+  "resultSchema": {
+    "$defs": {
+      "AddCommentEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Optional only so callers of the previous deployed schema\nremain valid; new callers must provide a non-blank name.",
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "body"
+        ],
+        "type": "object"
+      },
+      "AddLinkEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Optional only so callers of the previous deployed schema\nremain valid; new callers must provide a non-blank name.",
+            "type": "string"
+          },
+          "kind": {
+            "$ref": "#/$defs/TopicLinkKind"
+          },
+          "label": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "url",
+          "label"
+        ],
+        "type": "object"
+      },
+      "AddTopicEvent": {
+        "properties": {
+          "agentName": {
+            "description": "The agent making this mutation. The authenticated principal remains the\nhuman whose identity key invoked the stream; this is the agent's explicit\ncontent-level signature under that shared principal. Optional only so\ncallers of the previous deployed schema remain valid; new callers must\nprovide a non-blank name.",
+            "type": "string"
+          },
+          "body": {
+            "description": "The topic's initial living-document body. A topic born with a body\nappears with it atomically — no reader observes the title-only halfway\nstate, and no follow-up `setBody` call is needed to finish a create\n(verb contract: the atomic-unit rule).",
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title"
+        ],
+        "type": "object"
+      },
+      "SetBodyEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Optional only so callers of the previous deployed schema\nremain valid; new callers must provide a non-blank name.",
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "body"
+        ],
+        "type": "object"
+      },
+      "TopicAuthor": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "kind": {
+            "enum": [
+              "person",
+              "agent"
+            ]
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "name"
+        ],
+        "type": "object"
+      },
+      "TopicComment": {
+        "properties": {
+          "author": {
+            "$ref": "#/$defs/TopicAuthor",
+            "description": "Snapshot taken at write time (profile enrichment comes later; never gate\nauthorship on a profile wish — CT-1879). Comments carry no minted id:\narray elements have stable entity identity; future editing addresses\nelements by reference (`equals()`), not by a synthetic key."
+          },
+          "authorName": {
+            "default": "",
+            "type": "string"
+          },
+          "body": {
+            "default": "",
+            "type": "string"
+          },
+          "sentAt": {
+            "default": 0,
+            "type": "number"
+          }
+        },
+        "required": [
+          "authorName",
+          "body",
+          "sentAt"
+        ],
+        "type": "object"
+      },
+      "TopicCrossref": {
+        "properties": {
+          "fid": {
+            "description": "The topic's own fid in tagged form (`fid1:…`); \"\" until known.",
+            "type": "string"
+          },
+          "referencedBy": {
+            "description": "Sibling topics whose prose mentions this topic's fid.",
+            "items": {
+              "$ref": "#/$defs/TopicPiece"
+            },
+            "type": "array"
+          },
+          "refsOut": {
+            "description": "Sibling topics whose fids this topic's prose mentions.",
+            "items": {
+              "$ref": "#/$defs/TopicPiece"
+            },
+            "type": "array"
+          },
+          "topic": {
+            "$ref": "#/$defs/TopicPiece"
+          }
+        },
+        "required": [
+          "fid",
+          "topic",
+          "refsOut",
+          "referencedBy"
+        ],
+        "type": "object"
+      },
+      "TopicIndexRef": {
+        "properties": {
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title"
+        ],
+        "type": "object"
+      },
+      "TopicIndexRow": {
+        "properties": {
+          "commentCount": {
+            "type": "number"
+          },
+          "createdAt": {
+            "type": "number"
+          },
+          "createdBy": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              {
+                "type": "undefined"
+              }
+            ],
+            "default": {
+              "kind": "person",
+              "name": ""
+            }
+          },
+          "lastActivityAt": {
+            "type": "number"
+          },
+          "referencedBy": {
+            "description": "Sibling topics whose prose mentions this topic's fid.",
+            "items": {
+              "$ref": "#/$defs/TopicIndexRef"
+            },
+            "type": "array"
+          },
+          "refsOut": {
+            "description": "Sibling topics whose fids this topic's prose mentions.",
+            "items": {
+              "$ref": "#/$defs/TopicIndexRef"
+            },
+            "type": "array"
+          },
+          "title": {
+            "type": "string"
+          },
+          "topic": {
+            "$ref": "#/$defs/TopicIndexRef"
+          }
+        },
+        "required": [
+          "topic",
+          "title",
+          "createdAt",
+          "commentCount",
+          "lastActivityAt",
+          "refsOut",
+          "referencedBy"
+        ],
+        "type": "object"
+      },
+      "TopicLink": {
+        "properties": {
+          "addedAt": {
+            "type": "number"
+          },
+          "addedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "kind": {
+            "$ref": "#/$defs/TopicLinkKind",
+            "default": "web"
+          },
+          "label": {
+            "default": "",
+            "type": "string"
+          },
+          "url": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "url",
+          "label"
+        ],
+        "type": "object"
+      },
+      "TopicLinkKind": {
+        "enum": [
+          "session",
+          "pr",
+          "topic",
+          "web"
+        ]
+      },
+      "TopicPiece": {
+        "properties": {
+          "$NAME": {
+            "default": "",
+            "description": "Like the other derived display fields, a cold retained sibling may not\nhave produced this path yet. Its persisted title remains authoritative.",
+            "type": [
+              "string",
+              "undefined"
+            ]
+          },
+          "addComment": {
+            "$ref": "#/$defs/AddCommentEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "addLink": {
+            "$ref": "#/$defs/AddLinkEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "body": {
+            "type": "string"
+          },
+          "bodyUpdatedAt": {
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "bodyUpdatedBy": {
+            "anyOf": [
+              {
+                "type": "undefined"
+              },
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              }
+            ]
+          },
+          "commentCount": {
+            "default": 0,
+            "description": "Cold mixed-version references can expose an unresolved computed path as\nexplicit undefined. Shape it to zero until the sibling starts.",
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "comments": {
+            "items": {
+              "$ref": "#/$defs/TopicComment"
+            },
+            "type": "array"
+          },
+          "createdAt": {
+            "type": "number"
+          },
+          "createdBy": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              {
+                "type": "undefined"
+              }
+            ],
+            "default": {
+              "kind": "person",
+              "name": ""
+            },
+            "description": "Mixed-version list projections can resolve an older sibling's absent\npath as undefined. Fabric shapes that absence to this inert legacy\nsentinel at the list boundary; newly computed non-empty authorship remains\na structured TopicAuthor."
+          },
+          "createdByName": {
+            "type": "string"
+          },
+          "crossrefs": {
+            "anyOf": [
+              {
+                "properties": {
+                  "referencedBy": {
+                    "items": {
+                      "$ref": "#/$defs/TopicReference"
+                    },
+                    "type": "array"
+                  },
+                  "refsOut": {
+                    "items": {
+                      "$ref": "#/$defs/TopicReference"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "refsOut",
+                  "referencedBy"
+                ],
+                "type": "object"
+              },
+              {
+                "type": "undefined"
+              }
+            ],
+            "default": {
+              "referencedBy": [],
+              "refsOut": []
+            },
+            "description": "This topic's own place in the board's prose graph, derived read-side\nfrom `mentionable` (the sibling pieces it links, resolved from the\nboard's own list). Both sets stay empty until `mentionable` is wired.\nOptional (2026-07-21 deploy): pieces healed before their `mentionable`\nlink exists carry a session-scoped crossrefs indirection that resolves\nundefined outside the minting session; the list projection must accept\nthat rather than fail argument validation."
+          },
+          "lastActivityAt": {
+            "default": 0,
+            "description": "Max of creation, comments, body saves, and link additions.",
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "links": {
+            "items": {
+              "$ref": "#/$defs/TopicLink"
+            },
+            "type": "array"
+          },
+          "setBody": {
+            "$ref": "#/$defs/SetBodyEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "body",
+          "comments",
+          "links",
+          "createdAt",
+          "createdByName",
+          "commentCount",
+          "lastActivityAt",
+          "addComment",
+          "addLink",
+          "setBody",
+          "$NAME"
+        ],
+        "type": "object"
+      },
+      "TopicReference": {
+        "properties": {
+          "$NAME": {
+            "default": "",
+            "description": "Like the other derived display fields, a cold retained sibling may not\nhave produced this path yet. Its persisted title remains authoritative.",
+            "type": [
+              "string",
+              "undefined"
+            ]
+          },
+          "addComment": {
+            "$ref": "#/$defs/AddCommentEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "addLink": {
+            "$ref": "#/$defs/AddLinkEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "body": {
+            "type": "string"
+          },
+          "bodyUpdatedAt": {
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "bodyUpdatedBy": {
+            "anyOf": [
+              {
+                "type": "undefined"
+              },
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              }
+            ]
+          },
+          "commentCount": {
+            "default": 0,
+            "description": "Cold mixed-version references can expose an unresolved computed path as\nexplicit undefined. Shape it to zero until the sibling starts.",
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "comments": {
+            "items": {
+              "$ref": "#/$defs/TopicComment"
+            },
+            "type": "array"
+          },
+          "createdAt": {
+            "type": "number"
+          },
+          "createdBy": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              {
+                "type": "undefined"
+              }
+            ],
+            "default": {
+              "kind": "person",
+              "name": ""
+            },
+            "description": "Mixed-version list projections can resolve an older sibling's absent\npath as undefined. Fabric shapes that absence to this inert legacy\nsentinel at the list boundary; newly computed non-empty authorship remains\na structured TopicAuthor."
+          },
+          "createdByName": {
+            "type": "string"
+          },
+          "lastActivityAt": {
+            "default": 0,
+            "description": "Max of creation, comments, body saves, and link additions.",
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "links": {
+            "items": {
+              "$ref": "#/$defs/TopicLink"
+            },
+            "type": "array"
+          },
+          "setBody": {
+            "$ref": "#/$defs/SetBodyEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "body",
+          "comments",
+          "links",
+          "createdAt",
+          "createdByName",
+          "commentCount",
+          "lastActivityAt",
+          "addComment",
+          "addLink",
+          "setBody",
+          "$NAME"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "Topics — a tracker over #topic pieces: durable units of shared attention\n(CT-1878). Deliberately minimal: no statuses, labels, or assignees; topics\nsort by last activity. Replaces Linear / GitHub issues / loose process docs\nfor the team; PR workflows stay in GitHub and arrive here as links.",
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addTopic": {
+        "$ref": "#/$defs/AddTopicEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "crossrefs": {
+        "default": [],
+        "description": "The prose reference graph over the board's own topics, one row per\n(non-null) entry of `topics`. Rows carry their topic, so consumers never\nneed to correlate by index — indices are not a stable address.",
+        "items": {
+          "$ref": "#/$defs/TopicCrossref"
+        },
+        "type": "array"
+      },
+      "index": {
+        "default": [],
+        "description": "Compact discovery index — the documented full-board survey surface: one\nreference-plus-summary row per (non-null) entry of `topics`. Everything\nreference-valued in a row is declared through the title-only\n`TopicIndexRef`, so one bounded read surveys the whole board.\n`crossrefs` stays as the UI's reference graph; it is not compact — each\nrow expands to full pieces — and is not the survey surface.",
+        "items": {
+          "$ref": "#/$defs/TopicIndexRow"
+        },
+        "type": "array"
+      },
+      "mentionable": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/TopicPiece"
+        },
+        "type": "array"
+      },
+      "myName": {
+        "type": "string"
+      },
+      "newTitle": {
+        "description": "Session-local draft for the footer composer (exposed for embedding and\nheadless driving, like the chat exemplar's drafts).",
+        "type": "string"
+      },
+      "setMyName": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "deprecated": true,
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "submitTopic": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "Submit the footer composer as the current viewer's canonical Profile.",
+        "tier": "wrapper"
+      },
+      "topicCount": {
+        "type": "number"
+      },
+      "topics": {
+        "items": {
+          "$ref": "#/$defs/TopicPiece"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "topics",
+      "mentionable",
+      "topicCount",
+      "crossrefs",
+      "index",
+      "addTopic",
+      "myName",
+      "setMyName",
+      "submitTopic",
+      "$NAME",
+      "$UI"
+    ],
+    "tags": [
+      "topic"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/topics/topic.tsx/20260807T235141Z-QYT25fGPFURBgrju.json
+++ b/packages/patterns/baselines/topics/topic.tsx/20260807T235141Z-QYT25fGPFURBgrju.json
@@ -1,0 +1,825 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "AddCommentEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Optional only so callers of the previous deployed schema\nremain valid; new callers must provide a non-blank name.",
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "body"
+        ],
+        "type": "object"
+      },
+      "AddLinkEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Optional only so callers of the previous deployed schema\nremain valid; new callers must provide a non-blank name.",
+            "type": "string"
+          },
+          "kind": {
+            "$ref": "#/$defs/TopicLinkKind"
+          },
+          "label": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "url",
+          "label"
+        ],
+        "type": "object"
+      },
+      "SetBodyEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Optional only so callers of the previous deployed schema\nremain valid; new callers must provide a non-blank name.",
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "body"
+        ],
+        "type": "object"
+      },
+      "TopicAuthor": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "kind": {
+            "enum": [
+              "person",
+              "agent"
+            ]
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "name"
+        ],
+        "type": "object"
+      },
+      "TopicComment": {
+        "properties": {
+          "author": {
+            "$ref": "#/$defs/TopicAuthor",
+            "description": "Snapshot taken at write time (profile enrichment comes later; never gate\nauthorship on a profile wish — CT-1879). Comments carry no minted id:\narray elements have stable entity identity; future editing addresses\nelements by reference (`equals()`), not by a synthetic key."
+          },
+          "authorName": {
+            "default": "",
+            "type": "string"
+          },
+          "body": {
+            "default": "",
+            "type": "string"
+          },
+          "sentAt": {
+            "default": 0,
+            "type": "number"
+          }
+        },
+        "required": [
+          "authorName",
+          "body",
+          "sentAt"
+        ],
+        "type": "object"
+      },
+      "TopicLink": {
+        "properties": {
+          "addedAt": {
+            "type": "number"
+          },
+          "addedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "kind": {
+            "$ref": "#/$defs/TopicLinkKind",
+            "default": "web"
+          },
+          "label": {
+            "default": "",
+            "type": "string"
+          },
+          "url": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "url",
+          "label"
+        ],
+        "type": "object"
+      },
+      "TopicLinkKind": {
+        "enum": [
+          "pr",
+          "topic",
+          "session",
+          "web"
+        ]
+      },
+      "TopicReference": {
+        "properties": {
+          "$NAME": {
+            "default": "",
+            "description": "Like the other derived display fields, a cold retained sibling may not\nhave produced this path yet. Its persisted title remains authoritative.",
+            "type": [
+              "string",
+              "undefined"
+            ]
+          },
+          "addComment": {
+            "$ref": "#/$defs/AddCommentEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "addLink": {
+            "$ref": "#/$defs/AddLinkEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "body": {
+            "type": "string"
+          },
+          "bodyUpdatedAt": {
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "bodyUpdatedBy": {
+            "anyOf": [
+              {
+                "type": "undefined"
+              },
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              }
+            ]
+          },
+          "commentCount": {
+            "default": 0,
+            "description": "Cold mixed-version references can expose an unresolved computed path as\nexplicit undefined. Shape it to zero until the sibling starts.",
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "comments": {
+            "items": {
+              "$ref": "#/$defs/TopicComment"
+            },
+            "type": "array"
+          },
+          "createdAt": {
+            "type": "number"
+          },
+          "createdBy": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              {
+                "type": "undefined"
+              }
+            ],
+            "default": {
+              "kind": "person",
+              "name": ""
+            },
+            "description": "Mixed-version list projections can resolve an older sibling's absent\npath as undefined. Fabric shapes that absence to this inert legacy\nsentinel at the list boundary; newly computed non-empty authorship remains\na structured TopicAuthor."
+          },
+          "createdByName": {
+            "type": "string"
+          },
+          "lastActivityAt": {
+            "default": 0,
+            "description": "Max of creation, comments, body saves, and link additions.",
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "links": {
+            "items": {
+              "$ref": "#/$defs/TopicLink"
+            },
+            "type": "array"
+          },
+          "setBody": {
+            "$ref": "#/$defs/SetBodyEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "body",
+          "comments",
+          "links",
+          "createdAt",
+          "createdByName",
+          "commentCount",
+          "lastActivityAt",
+          "addComment",
+          "addLink",
+          "setBody",
+          "$NAME"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "body": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "description": "The topic's living document: durable conclusions get folded up into the\nbody; the comment thread below holds the deliberation.",
+        "type": "string"
+      },
+      "bodyUpdatedAt": {
+        "asCell": [
+          "cell"
+        ],
+        "default": 0,
+        "type": "number"
+      },
+      "bodyUpdatedBy": {
+        "$ref": "#/$defs/TopicAuthor",
+        "asCell": [
+          "cell"
+        ],
+        "default": {
+          "kind": "person",
+          "name": ""
+        }
+      },
+      "comments": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/TopicComment"
+        },
+        "type": "array"
+      },
+      "createdAt": {
+        "default": 0,
+        "type": "number"
+      },
+      "createdBy": {
+        "$ref": "#/$defs/TopicAuthor"
+      },
+      "createdByName": {
+        "default": "",
+        "type": "string"
+      },
+      "links": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/TopicLink"
+        },
+        "type": "array"
+      },
+      "mentionable": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "description": "The board's own topics list — the sibling set for this topic's derived\ncrossrefs and the mention universe for authoring. A reference to the\ntracker's array, wired at creation like `myName` (and backfillable as a\none-time link-bind on pieces created before it existed). Absent, the\ndetail page simply derives no connections.",
+        "items": {
+          "$ref": "#/$defs/TopicReference"
+        },
+        "type": "array"
+      },
+      "myName": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "user"
+          }
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "title": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "topics/topic.tsx",
+  "resultSchema": {
+    "$defs": {
+      "AddCommentEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Optional only so callers of the previous deployed schema\nremain valid; new callers must provide a non-blank name.",
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "body"
+        ],
+        "type": "object"
+      },
+      "AddLinkEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Optional only so callers of the previous deployed schema\nremain valid; new callers must provide a non-blank name.",
+            "type": "string"
+          },
+          "kind": {
+            "$ref": "#/$defs/TopicLinkKind"
+          },
+          "label": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "url",
+          "label"
+        ],
+        "type": "object"
+      },
+      "SetBodyEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Optional only so callers of the previous deployed schema\nremain valid; new callers must provide a non-blank name.",
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "body"
+        ],
+        "type": "object"
+      },
+      "TopicAuthor": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "kind": {
+            "enum": [
+              "person",
+              "agent"
+            ]
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "name"
+        ],
+        "type": "object"
+      },
+      "TopicComment": {
+        "properties": {
+          "author": {
+            "$ref": "#/$defs/TopicAuthor",
+            "description": "Snapshot taken at write time (profile enrichment comes later; never gate\nauthorship on a profile wish — CT-1879). Comments carry no minted id:\narray elements have stable entity identity; future editing addresses\nelements by reference (`equals()`), not by a synthetic key."
+          },
+          "authorName": {
+            "default": "",
+            "type": "string"
+          },
+          "body": {
+            "default": "",
+            "type": "string"
+          },
+          "sentAt": {
+            "default": 0,
+            "type": "number"
+          }
+        },
+        "required": [
+          "authorName",
+          "body",
+          "sentAt"
+        ],
+        "type": "object"
+      },
+      "TopicLink": {
+        "properties": {
+          "addedAt": {
+            "type": "number"
+          },
+          "addedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "kind": {
+            "$ref": "#/$defs/TopicLinkKind",
+            "default": "web"
+          },
+          "label": {
+            "default": "",
+            "type": "string"
+          },
+          "url": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "url",
+          "label"
+        ],
+        "type": "object"
+      },
+      "TopicLinkKind": {
+        "enum": [
+          "pr",
+          "topic",
+          "session",
+          "web"
+        ]
+      },
+      "TopicReference": {
+        "properties": {
+          "$NAME": {
+            "default": "",
+            "description": "Like the other derived display fields, a cold retained sibling may not\nhave produced this path yet. Its persisted title remains authoritative.",
+            "type": [
+              "string",
+              "undefined"
+            ]
+          },
+          "addComment": {
+            "$ref": "#/$defs/AddCommentEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "addLink": {
+            "$ref": "#/$defs/AddLinkEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "body": {
+            "type": "string"
+          },
+          "bodyUpdatedAt": {
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "bodyUpdatedBy": {
+            "anyOf": [
+              {
+                "type": "undefined"
+              },
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              }
+            ]
+          },
+          "commentCount": {
+            "default": 0,
+            "description": "Cold mixed-version references can expose an unresolved computed path as\nexplicit undefined. Shape it to zero until the sibling starts.",
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "comments": {
+            "items": {
+              "$ref": "#/$defs/TopicComment"
+            },
+            "type": "array"
+          },
+          "createdAt": {
+            "type": "number"
+          },
+          "createdBy": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              {
+                "type": "undefined"
+              }
+            ],
+            "default": {
+              "kind": "person",
+              "name": ""
+            },
+            "description": "Mixed-version list projections can resolve an older sibling's absent\npath as undefined. Fabric shapes that absence to this inert legacy\nsentinel at the list boundary; newly computed non-empty authorship remains\na structured TopicAuthor."
+          },
+          "createdByName": {
+            "type": "string"
+          },
+          "lastActivityAt": {
+            "default": 0,
+            "description": "Max of creation, comments, body saves, and link additions.",
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "links": {
+            "items": {
+              "$ref": "#/$defs/TopicLink"
+            },
+            "type": "array"
+          },
+          "setBody": {
+            "$ref": "#/$defs/SetBodyEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "body",
+          "comments",
+          "links",
+          "createdAt",
+          "createdByName",
+          "commentCount",
+          "lastActivityAt",
+          "addComment",
+          "addLink",
+          "setBody",
+          "$NAME"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "The complete result available when a Topic is instantiated directly.",
+    "properties": {
+      "$NAME": {
+        "default": "",
+        "description": "Like the other derived display fields, a cold retained sibling may not\nhave produced this path yet. Its persisted title remains authoritative.",
+        "type": [
+          "string",
+          "undefined"
+        ]
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addComment": {
+        "$ref": "#/$defs/AddCommentEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "addLink": {
+        "$ref": "#/$defs/AddLinkEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "body": {
+        "type": "string"
+      },
+      "bodyDraft": {
+        "type": "string"
+      },
+      "bodyUpdatedAt": {
+        "type": [
+          "number",
+          "undefined"
+        ]
+      },
+      "bodyUpdatedBy": {
+        "anyOf": [
+          {
+            "type": "undefined"
+          },
+          {
+            "$ref": "#/$defs/TopicAuthor"
+          }
+        ]
+      },
+      "cancelEditBody": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "commentCount": {
+        "default": 0,
+        "description": "Cold mixed-version references can expose an unresolved computed path as\nexplicit undefined. Shape it to zero until the sibling starts.",
+        "type": [
+          "number",
+          "undefined"
+        ]
+      },
+      "commentDraft": {
+        "description": "Session-local composer/edit state. These controls belong to a direct Topic\ninstance, not the shared TopicPiece projection used by the tracker's list.",
+        "type": "string"
+      },
+      "comments": {
+        "items": {
+          "$ref": "#/$defs/TopicComment"
+        },
+        "type": "array"
+      },
+      "createdAt": {
+        "type": "number"
+      },
+      "createdBy": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          {
+            "type": "undefined"
+          }
+        ],
+        "default": {
+          "kind": "person",
+          "name": ""
+        },
+        "description": "Mixed-version list projections can resolve an older sibling's absent\npath as undefined. Fabric shapes that absence to this inert legacy\nsentinel at the list boundary; newly computed non-empty authorship remains\na structured TopicAuthor."
+      },
+      "createdByName": {
+        "type": "string"
+      },
+      "crossrefs": {
+        "anyOf": [
+          {
+            "properties": {
+              "referencedBy": {
+                "items": {
+                  "$ref": "#/$defs/TopicReference"
+                },
+                "type": "array"
+              },
+              "refsOut": {
+                "items": {
+                  "$ref": "#/$defs/TopicReference"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "refsOut",
+              "referencedBy"
+            ],
+            "type": "object"
+          },
+          {
+            "type": "undefined"
+          }
+        ],
+        "default": {
+          "referencedBy": [],
+          "refsOut": []
+        },
+        "description": "This topic's own place in the board's prose graph, derived read-side\nfrom `mentionable` (the sibling pieces it links, resolved from the\nboard's own list). Both sets stay empty until `mentionable` is wired.\nOptional (2026-07-21 deploy): pieces healed before their `mentionable`\nlink exists carry a session-scoped crossrefs indirection that resolves\nundefined outside the minting session; the list projection must accept\nthat rather than fail argument validation."
+      },
+      "editingBody": {
+        "scope": "session",
+        "type": "boolean"
+      },
+      "lastActivityAt": {
+        "default": 0,
+        "description": "Max of creation, comments, body saves, and link additions.",
+        "type": [
+          "number",
+          "undefined"
+        ]
+      },
+      "linkKindDraft": {
+        "$ref": "#/$defs/TopicLinkKind"
+      },
+      "linkLabelDraft": {
+        "type": "string"
+      },
+      "linkUrlDraft": {
+        "type": "string"
+      },
+      "links": {
+        "items": {
+          "$ref": "#/$defs/TopicLink"
+        },
+        "type": "array"
+      },
+      "saveBody": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "setBody": {
+        "$ref": "#/$defs/SetBodyEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "startEditBody": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "submitComment": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI affordances as streams: composer submit, body edit lifecycle."
+      },
+      "submitLink": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "title": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "commentDraft",
+      "bodyDraft",
+      "editingBody",
+      "linkUrlDraft",
+      "linkLabelDraft",
+      "linkKindDraft",
+      "submitComment",
+      "startEditBody",
+      "saveBody",
+      "cancelEditBody",
+      "submitLink",
+      "$UI",
+      "title",
+      "body",
+      "comments",
+      "links",
+      "createdAt",
+      "createdByName",
+      "commentCount",
+      "lastActivityAt",
+      "addComment",
+      "addLink",
+      "setBody",
+      "$NAME"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/topics/topic.tsx/20260810T184539Z-QT516p3dnJusrW28.json
+++ b/packages/patterns/baselines/topics/topic.tsx/20260810T184539Z-QT516p3dnJusrW28.json
@@ -1,0 +1,830 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "AddCommentEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Optional only so callers of the previous deployed schema\nremain valid; new callers must provide a non-blank name.",
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "body"
+        ],
+        "type": "object"
+      },
+      "AddLinkEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Optional only so callers of the previous deployed schema\nremain valid; new callers must provide a non-blank name.",
+            "type": "string"
+          },
+          "kind": {
+            "$ref": "#/$defs/TopicLinkKind"
+          },
+          "label": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "url",
+          "label"
+        ],
+        "type": "object"
+      },
+      "SetBodyEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Optional only so callers of the previous deployed schema\nremain valid; new callers must provide a non-blank name.",
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "body"
+        ],
+        "type": "object"
+      },
+      "TopicAuthor": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "kind": {
+            "enum": [
+              "person",
+              "agent"
+            ]
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "name"
+        ],
+        "type": "object"
+      },
+      "TopicComment": {
+        "properties": {
+          "author": {
+            "$ref": "#/$defs/TopicAuthor",
+            "description": "Snapshot taken at write time (profile enrichment comes later; never gate\nauthorship on a profile wish — CT-1879). Comments carry no minted id:\narray elements have stable entity identity; future editing addresses\nelements by reference (`equals()`), not by a synthetic key."
+          },
+          "authorName": {
+            "default": "",
+            "type": "string"
+          },
+          "body": {
+            "default": "",
+            "type": "string"
+          },
+          "sentAt": {
+            "default": 0,
+            "type": "number"
+          }
+        },
+        "required": [
+          "authorName",
+          "body",
+          "sentAt"
+        ],
+        "type": "object"
+      },
+      "TopicLink": {
+        "properties": {
+          "addedAt": {
+            "type": "number"
+          },
+          "addedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "kind": {
+            "$ref": "#/$defs/TopicLinkKind",
+            "default": "web"
+          },
+          "label": {
+            "default": "",
+            "type": "string"
+          },
+          "url": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "url",
+          "label"
+        ],
+        "type": "object"
+      },
+      "TopicLinkKind": {
+        "enum": [
+          "pr",
+          "topic",
+          "session",
+          "web"
+        ]
+      },
+      "TopicReference": {
+        "properties": {
+          "$NAME": {
+            "default": "",
+            "description": "Like the other derived display fields, a cold retained sibling may not\nhave produced this path yet. Its persisted title remains authoritative.",
+            "type": [
+              "string",
+              "undefined"
+            ]
+          },
+          "addComment": {
+            "$ref": "#/$defs/AddCommentEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "addLink": {
+            "$ref": "#/$defs/AddLinkEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "body": {
+            "type": "string"
+          },
+          "bodyUpdatedAt": {
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "bodyUpdatedBy": {
+            "anyOf": [
+              {
+                "type": "undefined"
+              },
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              }
+            ]
+          },
+          "commentCount": {
+            "default": 0,
+            "description": "Cold mixed-version references can expose an unresolved computed path as\nexplicit undefined. Shape it to zero until the sibling starts.",
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "comments": {
+            "items": {
+              "$ref": "#/$defs/TopicComment"
+            },
+            "type": "array"
+          },
+          "createdAt": {
+            "type": "number"
+          },
+          "createdBy": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              {
+                "type": "undefined"
+              }
+            ],
+            "default": {
+              "kind": "person",
+              "name": ""
+            },
+            "description": "Mixed-version list projections can resolve an older sibling's absent\npath as undefined. Fabric shapes that absence to this inert legacy\nsentinel at the list boundary; newly computed non-empty authorship remains\na structured TopicAuthor."
+          },
+          "createdByName": {
+            "type": "string"
+          },
+          "lastActivityAt": {
+            "default": 0,
+            "description": "Max of creation, comments, body saves, and link additions.",
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "links": {
+            "items": {
+              "$ref": "#/$defs/TopicLink"
+            },
+            "type": "array"
+          },
+          "setBody": {
+            "$ref": "#/$defs/SetBodyEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "body",
+          "comments",
+          "links",
+          "createdAt",
+          "createdByName",
+          "commentCount",
+          "lastActivityAt",
+          "addComment",
+          "addLink",
+          "setBody",
+          "$NAME"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "body": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "description": "The topic's living document: durable conclusions get folded up into the\nbody; the comment thread below holds the deliberation.",
+        "type": "string"
+      },
+      "bodyUpdatedAt": {
+        "asCell": [
+          "cell"
+        ],
+        "default": 0,
+        "type": "number"
+      },
+      "bodyUpdatedBy": {
+        "$ref": "#/$defs/TopicAuthor",
+        "asCell": [
+          "cell"
+        ],
+        "default": {
+          "kind": "person",
+          "name": ""
+        }
+      },
+      "comments": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/TopicComment"
+        },
+        "type": "array"
+      },
+      "createdAt": {
+        "default": 0,
+        "type": "number"
+      },
+      "createdBy": {
+        "$ref": "#/$defs/TopicAuthor"
+      },
+      "createdByName": {
+        "default": "",
+        "type": "string"
+      },
+      "links": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/TopicLink"
+        },
+        "type": "array"
+      },
+      "mentionable": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "description": "The board's own topics list — the sibling set for this topic's derived\ncrossrefs and the mention universe for authoring. A reference to the\ntracker's array, wired at creation like `myName` (and backfillable as a\none-time link-bind on pieces created before it existed). Absent, the\ndetail page simply derives no connections.",
+        "items": {
+          "$ref": "#/$defs/TopicReference"
+        },
+        "type": "array"
+      },
+      "myName": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "user"
+          }
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "title": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "topics/topic.tsx",
+  "resultSchema": {
+    "$defs": {
+      "AddCommentEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Optional only so callers of the previous deployed schema\nremain valid; new callers must provide a non-blank name.",
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "body"
+        ],
+        "type": "object"
+      },
+      "AddLinkEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Optional only so callers of the previous deployed schema\nremain valid; new callers must provide a non-blank name.",
+            "type": "string"
+          },
+          "kind": {
+            "$ref": "#/$defs/TopicLinkKind"
+          },
+          "label": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "url",
+          "label"
+        ],
+        "type": "object"
+      },
+      "SetBodyEvent": {
+        "properties": {
+          "agentName": {
+            "description": "Explicit content-level signature for an agent using its human user's\nidentity key. Optional only so callers of the previous deployed schema\nremain valid; new callers must provide a non-blank name.",
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "body"
+        ],
+        "type": "object"
+      },
+      "TopicAuthor": {
+        "properties": {
+          "avatar": {
+            "type": "string"
+          },
+          "kind": {
+            "enum": [
+              "person",
+              "agent"
+            ]
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "name"
+        ],
+        "type": "object"
+      },
+      "TopicComment": {
+        "properties": {
+          "author": {
+            "$ref": "#/$defs/TopicAuthor",
+            "description": "Snapshot taken at write time (profile enrichment comes later; never gate\nauthorship on a profile wish — CT-1879). Comments carry no minted id:\narray elements have stable entity identity; future editing addresses\nelements by reference (`equals()`), not by a synthetic key."
+          },
+          "authorName": {
+            "default": "",
+            "type": "string"
+          },
+          "body": {
+            "default": "",
+            "type": "string"
+          },
+          "sentAt": {
+            "default": 0,
+            "type": "number"
+          }
+        },
+        "required": [
+          "authorName",
+          "body",
+          "sentAt"
+        ],
+        "type": "object"
+      },
+      "TopicLink": {
+        "properties": {
+          "addedAt": {
+            "type": "number"
+          },
+          "addedBy": {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          "kind": {
+            "$ref": "#/$defs/TopicLinkKind",
+            "default": "web"
+          },
+          "label": {
+            "default": "",
+            "type": "string"
+          },
+          "url": {
+            "default": "",
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "url",
+          "label"
+        ],
+        "type": "object"
+      },
+      "TopicLinkKind": {
+        "enum": [
+          "pr",
+          "topic",
+          "session",
+          "web"
+        ]
+      },
+      "TopicReference": {
+        "properties": {
+          "$NAME": {
+            "default": "",
+            "description": "Like the other derived display fields, a cold retained sibling may not\nhave produced this path yet. Its persisted title remains authoritative.",
+            "type": [
+              "string",
+              "undefined"
+            ]
+          },
+          "addComment": {
+            "$ref": "#/$defs/AddCommentEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "addLink": {
+            "$ref": "#/$defs/AddLinkEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "body": {
+            "type": "string"
+          },
+          "bodyUpdatedAt": {
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "bodyUpdatedBy": {
+            "anyOf": [
+              {
+                "type": "undefined"
+              },
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              }
+            ]
+          },
+          "commentCount": {
+            "default": 0,
+            "description": "Cold mixed-version references can expose an unresolved computed path as\nexplicit undefined. Shape it to zero until the sibling starts.",
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "comments": {
+            "items": {
+              "$ref": "#/$defs/TopicComment"
+            },
+            "type": "array"
+          },
+          "createdAt": {
+            "type": "number"
+          },
+          "createdBy": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TopicAuthor"
+              },
+              {
+                "type": "undefined"
+              }
+            ],
+            "default": {
+              "kind": "person",
+              "name": ""
+            },
+            "description": "Mixed-version list projections can resolve an older sibling's absent\npath as undefined. Fabric shapes that absence to this inert legacy\nsentinel at the list boundary; newly computed non-empty authorship remains\na structured TopicAuthor."
+          },
+          "createdByName": {
+            "type": "string"
+          },
+          "lastActivityAt": {
+            "default": 0,
+            "description": "Max of creation, comments, body saves, and link additions.",
+            "type": [
+              "number",
+              "undefined"
+            ]
+          },
+          "links": {
+            "items": {
+              "$ref": "#/$defs/TopicLink"
+            },
+            "type": "array"
+          },
+          "setBody": {
+            "$ref": "#/$defs/SetBodyEvent",
+            "additionalProperties": false,
+            "asCell": [
+              "stream"
+            ]
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "body",
+          "comments",
+          "links",
+          "createdAt",
+          "createdByName",
+          "commentCount",
+          "lastActivityAt",
+          "addComment",
+          "addLink",
+          "setBody",
+          "$NAME"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "The complete result available when a Topic is instantiated directly.",
+    "properties": {
+      "$NAME": {
+        "default": "",
+        "description": "Like the other derived display fields, a cold retained sibling may not\nhave produced this path yet. Its persisted title remains authoritative.",
+        "type": [
+          "string",
+          "undefined"
+        ]
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "addComment": {
+        "$ref": "#/$defs/AddCommentEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "addLink": {
+        "$ref": "#/$defs/AddLinkEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "body": {
+        "type": "string"
+      },
+      "bodyDraft": {
+        "type": "string"
+      },
+      "bodyUpdatedAt": {
+        "type": [
+          "number",
+          "undefined"
+        ]
+      },
+      "bodyUpdatedBy": {
+        "anyOf": [
+          {
+            "type": "undefined"
+          },
+          {
+            "$ref": "#/$defs/TopicAuthor"
+          }
+        ]
+      },
+      "cancelEditBody": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "tier": "wrapper"
+      },
+      "commentCount": {
+        "default": 0,
+        "description": "Cold mixed-version references can expose an unresolved computed path as\nexplicit undefined. Shape it to zero until the sibling starts.",
+        "type": [
+          "number",
+          "undefined"
+        ]
+      },
+      "commentDraft": {
+        "description": "Session-local composer/edit state. These controls belong to a direct Topic\ninstance, not the shared TopicPiece projection used by the tracker's list.",
+        "type": "string"
+      },
+      "comments": {
+        "items": {
+          "$ref": "#/$defs/TopicComment"
+        },
+        "type": "array"
+      },
+      "createdAt": {
+        "type": "number"
+      },
+      "createdBy": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/TopicAuthor"
+          },
+          {
+            "type": "undefined"
+          }
+        ],
+        "default": {
+          "kind": "person",
+          "name": ""
+        },
+        "description": "Mixed-version list projections can resolve an older sibling's absent\npath as undefined. Fabric shapes that absence to this inert legacy\nsentinel at the list boundary; newly computed non-empty authorship remains\na structured TopicAuthor."
+      },
+      "createdByName": {
+        "type": "string"
+      },
+      "crossrefs": {
+        "anyOf": [
+          {
+            "properties": {
+              "referencedBy": {
+                "items": {
+                  "$ref": "#/$defs/TopicReference"
+                },
+                "type": "array"
+              },
+              "refsOut": {
+                "items": {
+                  "$ref": "#/$defs/TopicReference"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "refsOut",
+              "referencedBy"
+            ],
+            "type": "object"
+          },
+          {
+            "type": "undefined"
+          }
+        ],
+        "default": {
+          "referencedBy": [],
+          "refsOut": []
+        },
+        "description": "This topic's own place in the board's prose graph, derived read-side\nfrom `mentionable` (the sibling pieces it links, resolved from the\nboard's own list). Both sets stay empty until `mentionable` is wired.\nOptional (2026-07-21 deploy): pieces healed before their `mentionable`\nlink exists carry a session-scoped crossrefs indirection that resolves\nundefined outside the minting session; the list projection must accept\nthat rather than fail argument validation."
+      },
+      "editingBody": {
+        "scope": "session",
+        "type": "boolean"
+      },
+      "lastActivityAt": {
+        "default": 0,
+        "description": "Max of creation, comments, body saves, and link additions.",
+        "type": [
+          "number",
+          "undefined"
+        ]
+      },
+      "linkKindDraft": {
+        "$ref": "#/$defs/TopicLinkKind"
+      },
+      "linkLabelDraft": {
+        "type": "string"
+      },
+      "linkUrlDraft": {
+        "type": "string"
+      },
+      "links": {
+        "items": {
+          "$ref": "#/$defs/TopicLink"
+        },
+        "type": "array"
+      },
+      "saveBody": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "tier": "wrapper"
+      },
+      "setBody": {
+        "$ref": "#/$defs/SetBodyEvent",
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ]
+      },
+      "startEditBody": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "tier": "wrapper"
+      },
+      "submitComment": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "description": "UI affordances as streams: composer submit, body edit lifecycle.",
+        "tier": "wrapper"
+      },
+      "submitLink": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ],
+        "tier": "wrapper"
+      },
+      "title": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "commentDraft",
+      "bodyDraft",
+      "editingBody",
+      "linkUrlDraft",
+      "linkLabelDraft",
+      "linkKindDraft",
+      "submitComment",
+      "startEditBody",
+      "saveBody",
+      "cancelEditBody",
+      "submitLink",
+      "$UI",
+      "title",
+      "body",
+      "comments",
+      "links",
+      "createdAt",
+      "createdByName",
+      "commentCount",
+      "lastActivityAt",
+      "addComment",
+      "addLink",
+      "setBody",
+      "$NAME"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/weekly-calendar/event.tsx/20260807T235141Z-2xJP5tyghQinGEjd.json
+++ b/packages/patterns/baselines/weekly-calendar/event.tsx/20260807T235141Z-2xJP5tyghQinGEjd.json
@@ -1,0 +1,219 @@
+{
+  "argumentSchema": {
+    "properties": {
+      "color": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "#fef08a",
+        "type": "string"
+      },
+      "date": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "endTime": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "10:00",
+        "type": "string"
+      },
+      "eventId": {
+        "default": "",
+        "type": "string"
+      },
+      "isHidden": {
+        "default": false,
+        "type": "boolean"
+      },
+      "notes": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "startTime": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "09:00",
+        "type": "string"
+      },
+      "title": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "Untitled Event",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "weekly-calendar/event.tsx",
+  "resultSchema": {
+    "$defs": {
+      "AnonymousType_1": {
+        "items": {
+          "$ref": "#/$defs/MentionablePiece"
+        },
+        "type": "array"
+      },
+      "MentionablePiece": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "backlinks": {
+            "$ref": "#/$defs/AnonymousType_1"
+          },
+          "isHidden": {
+            "type": "boolean"
+          },
+          "mentioned": {
+            "$ref": "#/$defs/AnonymousType_1"
+          }
+        },
+        "required": [
+          "mentioned",
+          "backlinks"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "Represents a calendar event with a date, time, and notes.",
+    "properties": {
+      "backlinks": {
+        "$ref": "#/$defs/AnonymousType_1"
+      },
+      "color": {
+        "type": "string"
+      },
+      "date": {
+        "type": "string"
+      },
+      "endTime": {
+        "type": "string"
+      },
+      "eventId": {
+        "type": "string"
+      },
+      "isHidden": {
+        "type": "boolean"
+      },
+      "notes": {
+        "type": "string"
+      },
+      "setColor": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "newColor": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "newColor"
+        ],
+        "type": "object"
+      },
+      "setDate": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "newDate": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "newDate"
+        ],
+        "type": "object"
+      },
+      "setNotes": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "newNotes": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "newNotes"
+        ],
+        "type": "object"
+      },
+      "setTime": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "newEndTime": {
+            "type": "string"
+          },
+          "newStartTime": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "newStartTime",
+          "newEndTime"
+        ],
+        "type": "object"
+      },
+      "setTitle": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "newTitle": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "newTitle"
+        ],
+        "type": "object"
+      },
+      "startTime": {
+        "type": "string"
+      },
+      "summary": {
+        "type": "string"
+      },
+      "title": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "title",
+      "date",
+      "startTime",
+      "endTime",
+      "color",
+      "notes",
+      "summary",
+      "isHidden",
+      "eventId",
+      "backlinks",
+      "setTitle",
+      "setDate",
+      "setTime",
+      "setColor",
+      "setNotes"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/weekly-calendar/weekly-calendar.tsx/20260807T235141Z-rlolelNJckVp0XbP.json
+++ b/packages/patterns/baselines/weekly-calendar/weekly-calendar.tsx/20260807T235141Z-rlolelNJckVp0XbP.json
@@ -1,0 +1,221 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "EventPiece": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "color": {
+            "type": "string"
+          },
+          "date": {
+            "type": "string"
+          },
+          "endTime": {
+            "type": "string"
+          },
+          "eventId": {
+            "type": "string"
+          },
+          "isHidden": {
+            "type": "boolean"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "startTime": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "properties": {
+      "events": {
+        "asCell": [
+          "cell"
+        ],
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/EventPiece"
+        },
+        "type": "array"
+      },
+      "isCalendar": {
+        "default": true,
+        "type": "boolean"
+      },
+      "isHidden": {
+        "default": false,
+        "type": "boolean"
+      },
+      "title": {
+        "default": "Weekly Calendar",
+        "type": "string"
+      }
+    },
+    "required": [
+      "events"
+    ],
+    "type": "object"
+  },
+  "pattern": "weekly-calendar/weekly-calendar.tsx",
+  "resultSchema": {
+    "$defs": {
+      "AnonymousType_1": {
+        "items": {
+          "$ref": "#/$defs/MentionablePiece"
+        },
+        "type": "array"
+      },
+      "EventPiece": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "color": {
+            "type": "string"
+          },
+          "date": {
+            "type": "string"
+          },
+          "endTime": {
+            "type": "string"
+          },
+          "eventId": {
+            "type": "string"
+          },
+          "isHidden": {
+            "type": "boolean"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "startTime": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "MentionablePiece": {
+        "properties": {
+          "$NAME": {
+            "type": "string"
+          },
+          "backlinks": {
+            "$ref": "#/$defs/AnonymousType_1"
+          },
+          "isHidden": {
+            "type": "boolean"
+          },
+          "mentioned": {
+            "$ref": "#/$defs/AnonymousType_1"
+          }
+        },
+        "required": [
+          "mentioned",
+          "backlinks"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "backlinks": {
+        "$ref": "#/$defs/AnonymousType_1"
+      },
+      "createEvent": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "date": {
+            "type": "string"
+          },
+          "endTime": {
+            "type": "string"
+          },
+          "startTime": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "date",
+          "startTime",
+          "endTime"
+        ],
+        "type": "object"
+      },
+      "eventCount": {
+        "type": "number"
+      },
+      "events": {
+        "items": {
+          "$ref": "#/$defs/EventPiece"
+        },
+        "type": "array"
+      },
+      "isCalendar": {
+        "type": "boolean"
+      },
+      "isHidden": {
+        "type": "boolean"
+      },
+      "mentionable": {
+        "items": {
+          "$ref": "#/$defs/EventPiece"
+        },
+        "type": "array"
+      },
+      "setTitle": {
+        "additionalProperties": false,
+        "asCell": [
+          "stream"
+        ],
+        "properties": {
+          "newTitle": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "newTitle"
+        ],
+        "type": "object"
+      },
+      "summary": {
+        "type": "string"
+      },
+      "title": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "title",
+      "events",
+      "mentionable",
+      "eventCount",
+      "summary",
+      "isCalendar",
+      "isHidden",
+      "backlinks",
+      "createEvent",
+      "setTitle",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/integration/multi-runtime-worker.ts
+++ b/packages/patterns/integration/multi-runtime-worker.ts
@@ -13,7 +13,10 @@ import {
   setBlindStructuralTarget,
   unmarkUiInputBlindWriteTx,
 } from "@commonfabric/runner";
-import { markRendererTrustedEvent } from "@commonfabric/runner/cfc";
+import {
+  markRendererTrustedEvent,
+  markRuntimeInjectedEventKeys,
+} from "@commonfabric/runner/cfc";
 import { Identity, type KeyPairRaw } from "@commonfabric/identity";
 import {
   initializePiecesController,
@@ -252,13 +255,19 @@ const handlers: Record<
   async send({ handler, event, trustedUi, idle: doIdle }) {
     const trusted = trustedUi as TrustedUiDescriptor | undefined;
     let eventValue: unknown = event ?? {};
+    // Keys this harness put in the event rather than the caller, declared to
+    // the send so a verb's closed event schema judges only the caller's own
+    // fields — the same declaration the html worker reconciler makes for the
+    // envelope it builds around a real DOM event.
+    let injectedKeys: readonly string[] | undefined;
     if (trusted) {
       // Equivalent of a genuine user interaction on a trusted surface: DOM
       // provenance plus the renderer-trusted mark the html worker reconciler
       // applies when delivering real DOM events.
+      const authored = isRecord(event) ? event : undefined;
       eventValue = {
         type: "click",
-        ...(isRecord(event) ? event : {}),
+        ...(authored ?? {}),
         provenance: {
           origin: "dom",
           trusted: true,
@@ -270,11 +279,20 @@ const handlers: Record<
         },
       };
       markRendererTrustedEvent(eventValue);
+      injectedKeys = markRuntimeInjectedEventKeys(
+        authored && Object.hasOwn(authored, "type")
+          ? ["provenance"]
+          : ["type", "provenance"],
+      );
     }
     const target = result();
     const { error } = await controller().runtime.editWithRetry(
       (tx) => {
-        target.key(handler as never).withTx(tx).send(eventValue as never);
+        target.key(handler as never).withTx(tx).send(
+          eventValue as never,
+          undefined,
+          { runtimeInjectedEventKeys: injectedKeys },
+        );
       },
     );
     if (error) {

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -285,8 +285,12 @@ export const recordRelevantSchemaWritePolicyInput = (
  * same-id retry collides on the handling's create-only receipt.
  *
  * `runtimeInjectedEventKeys` names payload keys the RUNTIME itself merged
- * into this send's event value (the LLM tool-call path injects a `result`
- * cell: `builtins/llm-dialog.ts` sends `{ ...input, result }`). The
+ * into this send's event value. Two paths inject: the LLM tool-call path
+ * adds a `result` cell (`builtins/llm-dialog.ts` sends `{ ...input, result }`),
+ * and the renderer builds a whole DOM-event envelope — `type`, `provenance`,
+ * the allowlisted key/modifier/button properties, `target`, `detail` — from
+ * the browser's event (`packages/html/src/event-envelope.ts` names that set,
+ * and the worker reconciler mints the subset actually present). The
  * dispatch-side closed-world gate exempts exactly these keys — and only
  * these — from an `additionalProperties: false` event schema. The marker is
  * PROVENANCE, not shape, and must stay unforgeable: it rides this
@@ -296,10 +300,13 @@ export const recordRelevantSchemaWritePolicyInput = (
  * send options itself and puts only `eventId` in them. In-process callers are
  * gated too: the value must be an
  * array MINTED by {@link markRuntimeInjectedEventKeys} — the stream-send
- * path drops any other value — and the mint lives in runner internals no
- * pattern compartment can import, so sandboxed pattern code holding a real
- * stream cell still cannot smuggle an undeclared key past closed-world by
- * passing a plain array here. Adding any data-expressible way to set it
+ * path drops any other value — and the mint reaches only host code that can
+ * import runner internals or `@commonfabric/runner/cfc`. A pattern
+ * compartment resolves neither: its module graph admits `commonfabric`,
+ * `commonfabric/cfc`, `commonfabric/schema` and `turndown` alone
+ * (`sandbox/runtime-module-policy.ts`), so sandboxed pattern code holding a
+ * real stream cell still cannot smuggle an undeclared key past closed-world
+ * by passing a plain array here. Adding any data-expressible way to set it
  * would reopen the accepted-and-ignored hole C5 closes.
  */
 export type StreamSendOptions = {
@@ -309,9 +316,10 @@ export type StreamSendOptions = {
 
 // The mint registry backing `runtimeInjectedEventKeys` (see
 // StreamSendOptions): membership here is the capability. Only code that can
-// call `markRuntimeInjectedEventKeys` — runner-internal modules and
-// same-package tests; never a pattern compartment, whose module graph cannot
-// import runner internals — can produce an array the send path accepts.
+// call `markRuntimeInjectedEventKeys` — runner-internal modules, same-package
+// tests, and the host packages that import it through
+// `@commonfabric/runner/cfc`; never a pattern compartment, whose module graph
+// resolves neither — can produce an array the send path accepts.
 const mintedRuntimeInjectedKeys = new WeakSet<readonly string[]>();
 
 /**

--- a/packages/runner/src/cfc/mod.ts
+++ b/packages/runner/src/cfc/mod.ts
@@ -254,6 +254,7 @@ export {
 } from "./sink-inventory.ts";
 export type { SinkMaxConfidentiality } from "./sink-inventory.ts";
 export { markRendererTrustedEvent } from "./ui-contract.ts";
+export { markRuntimeInjectedEventKeys } from "../cell.ts";
 export {
   cfcObjectSchemaIsClosed,
   INJECTION_SAFE_ATOM,

--- a/packages/schema-generator/src/event-closure.ts
+++ b/packages/schema-generator/src/event-closure.ts
@@ -1,0 +1,61 @@
+import type { SchemaDefinition } from "./interface.ts";
+
+type SchemaRecord = Record<string, unknown>;
+
+const asSchemaRecord = (value: unknown): SchemaRecord | undefined =>
+  typeof value === "object" && value !== null
+    ? value as SchemaRecord
+    : undefined;
+
+/**
+ * Close a verb EVENT schema's root: stamp `additionalProperties: false` so an
+ * undeclared field in a call payload is a typed rejection at dispatch, never
+ * silently stripped (verb contract design rule 1; the dispatch gate is C5's
+ * `closedWorldEventRejection`). Applied only where generation KNOWS the
+ * schema describes what a caller sends to a verb — the `Stream<E>` property
+ * formatter and the transformer-injected handler event schema — never to
+ * hand-authored schema literals, which stay author-owned.
+ *
+ * The stamp is position-scoped and conservative:
+ *
+ * - An inline object root gains the keyword directly.
+ * - A `$ref` root gains it BESIDE the reference (sibling keywords apply
+ *   conjunctively), so a shared `$defs` entry stays open at its other use
+ *   sites — the def itself is never mutated.
+ * - Anything that already declares `additionalProperties` — including a
+ *   `$ref` whose def does (an index-signature event is the author's organic
+ *   opt-out) — is left untouched: `false` beside a schema-valued constraint
+ *   would override it conjunctively.
+ * - Non-object roots (unions, primitives, `never`'s emission, booleans) are
+ *   left untouched; closure of a union event is out of scope, and
+ *   `never`-derived shapes must not read as intentional closure.
+ */
+export function closeVerbEventRoot(
+  schema: unknown,
+  definitions?: Record<string, SchemaDefinition | undefined>,
+): unknown {
+  const root = asSchemaRecord(schema);
+  if (root === undefined) return schema;
+  if (Object.hasOwn(root, "additionalProperties")) return schema;
+
+  if (root.type === "object") {
+    return { ...root, additionalProperties: false };
+  }
+
+  const ref = root.$ref;
+  if (typeof ref === "string" && ref.startsWith("#/$defs/")) {
+    const defName = ref.slice("#/$defs/".length);
+    const defs = asSchemaRecord(root.$defs) ??
+      (definitions as SchemaRecord | undefined);
+    const target = asSchemaRecord(defs?.[defName]);
+    if (
+      target !== undefined &&
+      target.type === "object" &&
+      !Object.hasOwn(target, "additionalProperties")
+    ) {
+      return { ...root, additionalProperties: false };
+    }
+  }
+
+  return schema;
+}

--- a/packages/schema-generator/src/formatters/common-fabric-formatter.ts
+++ b/packages/schema-generator/src/formatters/common-fabric-formatter.ts
@@ -18,6 +18,7 @@ import type {
 } from "@commonfabric/api";
 import type { GenerationContext, TypeFormatter } from "../interface.ts";
 import type { SchemaGenerator } from "../schema-generator.ts";
+import { closeVerbEventRoot } from "../event-closure.ts";
 import {
   detectWrapperViaNode,
   extractDefaultBrandPayloadValue,
@@ -653,10 +654,19 @@ export class CommonFabricFormatter implements TypeFormatter {
       if (typeof innerSchema === "boolean") {
         return this.applyWrapperSemantics(innerSchema, "Stream");
       }
-      return this.applyWrapperSemantics(
-        innerSchema as MutableJSONSchemaObj,
-        "Stream",
-      );
+      // The stream's own schema is what a caller SENDS — the verb's EVENT.
+      // Close its root (design rule 1: an undeclared field is a typed
+      // rejection at dispatch, never silently stripped). Position-scoped:
+      // a $ref root gains the keyword beside the reference, so the shared
+      // def stays open at data-position use sites. See closeVerbEventRoot
+      // for the guards (author index signatures, unions, never).
+      return closeVerbEventRoot(
+        this.applyWrapperSemantics(
+          innerSchema as MutableJSONSchemaObj,
+          "Stream",
+        ),
+        context.definitions,
+      ) as MutableJSONSchema;
     }
 
     // Cell<T>: disallow Cell<Stream<T>> to avoid ambiguous semantics

--- a/packages/schema-generator/src/index.ts
+++ b/packages/schema-generator/src/index.ts
@@ -1,5 +1,6 @@
 // Main API exports
 export { SchemaGenerator } from "./schema-generator.ts";
+export { closeVerbEventRoot } from "./event-closure.ts";
 
 // Public types for API consumers
 export type {

--- a/packages/schema-generator/test/stream-result.test.ts
+++ b/packages/schema-generator/test/stream-result.test.ts
@@ -109,7 +109,7 @@ interface SchemaRoot {
     expect(JSON.stringify(schema)).not.toContain("TopicRef");
   });
 
-  it("leaves the event schema open — closed-world emission is blocked on the update gate (C5)", async () => {
+  it("closes the event schema root — closed-world emission (C5, unblocked by #5302)", async () => {
     const schema = await schemaFor(`
 interface SchemaRoot {
   verb: Stream<{ title: string }>;
@@ -120,22 +120,57 @@ interface SchemaRoot {
       (asObjectSchema(schema).properties as Record<string, unknown>).verb,
     );
 
-    // The verb contract's design rule 1 wants EVENT schemas closed-world
-    // (`additionalProperties: false` — an undeclared field is a rejection,
-    // never ignored). Emitting it is currently BLOCKED: the pattern-update
-    // gate judges a stream property under its enclosing role, and for a verb
-    // arriving through a piece's ARGUMENT schema the argument-role
-    // additionalProperties rule refuses the open→closed direction against
-    // every recorded baseline ("additional properties accepted previously
-    // would now be rejected" — measured on calendar/calendar.tsx,
-    // lunch-poll/poll-option-card.tsx, notes/note.tsx). Landing the emission
-    // needs that migration step first; the sequencing finding is recorded in
-    // docs/history/plans/pattern-verb-contract-implementation.md (WS-C and
-    // Risks).
-    // Until then this pin makes the open event side an explicit decision, not
-    // an omission — dispatch-side enforcement (runner, C5) already honors a
-    // schema that declares the closure by hand.
-    expect(Object.hasOwn(verb, "additionalProperties")).toBe(false);
+    // The verb contract's design rule 1: EVENT schemas are closed-world —
+    // an undeclared field is a typed rejection at dispatch, never silently
+    // stripped. Emission was blocked until the update gate grew the
+    // verb-event-role rule (#5302): a boolean additionalProperties
+    // transition below a stream marker is free in both directions, so the
+    // open→closed migration no longer trips the argument-role refusal.
+    // The stamp is position-scoped (a $ref root gains the keyword beside
+    // the reference; shared defs stay open at data-position use sites) and
+    // guarded — author index signatures, unions, and never-derived shapes
+    // are untouched (see closeVerbEventRoot).
+    expect(verb.additionalProperties).toBe(false);
     expect(verb.type).toBe("object");
+  });
+
+  it("stamps the closure beside a $ref event, leaving the shared def open", async () => {
+    const schema = await schemaFor(`
+interface AddTopic {
+  title: string;
+}
+
+interface SchemaRoot {
+  verb: Stream<AddTopic>;
+  // The same type in a DATA position must stay open there.
+  draft: AddTopic;
+}
+`);
+    const root = asObjectSchema(schema);
+    const properties = root.properties as Record<string, unknown>;
+    const verb = asObjectSchema(properties.verb);
+    expect(verb.$ref).toBe("#/$defs/AddTopic");
+    expect(verb.additionalProperties).toBe(false);
+    // Position-scoped: the def itself and the data-position reference are
+    // untouched.
+    const defs = root.$defs as Record<string, unknown>;
+    expect(Object.hasOwn(asObjectSchema(defs.AddTopic), "additionalProperties"))
+      .toBe(false);
+    expect(
+      Object.hasOwn(asObjectSchema(properties.draft), "additionalProperties"),
+    )
+      .toBe(false);
+  });
+
+  it("leaves an index-signature event open — the author's organic opt-out", async () => {
+    const schema = await schemaFor(`
+interface SchemaRoot {
+  verb: Stream<{ title: string; [key: string]: unknown }>;
+}
+`);
+    const verb = asObjectSchema(
+      (asObjectSchema(schema).properties as Record<string, unknown>).verb,
+    );
+    expect(verb.additionalProperties).not.toBe(false);
   });
 });

--- a/packages/ts-transformers/src/transformers/schema-generator.ts
+++ b/packages/ts-transformers/src/transformers/schema-generator.ts
@@ -5,11 +5,13 @@ import {
   TransformationContext,
 } from "../core/mod.ts";
 import {
+  closeVerbEventRoot,
   type SchemaGenerationOptions,
   SchemaGenerator,
 } from "@commonfabric/schema-generator";
 import { numberFromExpression } from "@commonfabric/schema-generator/numeric-expression";
 import {
+  detectCallKind,
   getNodeText,
   getTypeFromTypeNodeWithFallback,
   visitEachChildWithJsx,
@@ -40,7 +42,34 @@ export class SchemaGeneratorTransformer extends HelpersOnlyTransformer {
       };
     };
 
+    // First toSchema argument of every handler-family call: the verb's EVENT
+    // schema, whose generated root gets closed-world stamping (design rule 1;
+    // the update-gate transition is legal via the verb-event-role rule,
+    // #5302). Membership is the provenance: only transformer-injected
+    // toSchema calls land here, so a hand-authored schema literal in the
+    // same position stays author-owned.
+    const verbEventSchemaCalls = new Set<ts.Node>();
+    const collectVerbEventSchemaCall = (node: ts.Node): void => {
+      if (!ts.isCallExpression(node) || node.arguments.length < 1) return;
+      const callee = node.expression;
+      const isHelperHandler = ts.isPropertyAccessExpression(callee) &&
+        ts.isIdentifier(callee.expression) &&
+        callee.expression.text === CF_HELPERS_IDENTIFIER &&
+        callee.name.text === "handler";
+      const isBuilderHandler = !isHelperHandler &&
+        (() => {
+          const kind = detectCallKind(node, checker);
+          return kind?.kind === "builder" && kind.builderName === "handler";
+        })();
+      if (!isHelperHandler && !isBuilderHandler) return;
+      const eventArg = node.arguments[0];
+      if (eventArg && isToSchemaNode(eventArg)) {
+        verbEventSchemaCalls.add(eventArg);
+      }
+    };
+
     const visit: ts.Visitor = (node) => {
+      collectVerbEventSchemaCall(node);
       if (isToSchemaNode(node)) {
         const typeArg = node.typeArguments[0]!;
         const typeArguments = ts.isTypeReferenceNode(typeArg)
@@ -156,9 +185,18 @@ export class SchemaGeneratorTransformer extends HelpersOnlyTransformer {
           );
         }
         finalSchema = resolvePolicyOfMarkers(finalSchema, context, node);
-        const emittedSchema = typeof finalSchema === "boolean"
+        let emittedSchema = typeof finalSchema === "boolean"
           ? finalSchema
           : { ...(finalSchema as Record<string, unknown>), ...optionsObj };
+        // A handler-family call's first schema is the verb's EVENT: close its
+        // root. Applied after the author-options spread so an explicit
+        // additionalProperties always wins (closeVerbEventRoot never
+        // overwrites a declared keyword, here or on a $ref'd def).
+        if (verbEventSchemaCalls.has(node)) {
+          emittedSchema = closeVerbEventRoot(emittedSchema) as
+            | boolean
+            | Record<string, unknown>;
+        }
         const schemaAst = createSchemaAst(emittedSchema, context.factory);
 
         // Wrap in `as const satisfies JSONSchema` so that schema-inference

--- a/packages/ts-transformers/test/fixtures/ast-transform/builder-arg-hoisted-nullish-selection.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/builder-arg-hoisted-nullish-selection.expected.jsx
@@ -21,7 +21,8 @@ const join = handler({
             type: "string"
         }
     },
-    required: ["name"]
+    required: ["name"],
+    additionalProperties: false
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -127,7 +128,8 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
                 }
             },
             required: ["name"],
-            asCell: ["stream"]
+            asCell: ["stream"],
+            additionalProperties: false
         }
     },
     required: ["boundJoin"]

--- a/packages/ts-transformers/test/fixtures/ast-transform/builder-arg-ternary-label.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/builder-arg-ternary-label.expected.jsx
@@ -18,7 +18,8 @@ const join = handler({
             type: "string"
         }
     },
-    required: ["name"]
+    required: ["name"],
+    additionalProperties: false
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -68,7 +69,8 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
                 }
             },
             required: ["name"],
-            asCell: ["stream"]
+            asCell: ["stream"],
+            additionalProperties: false
         }
     },
     required: ["boundJoin"]

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-builders.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-builders.expected.jsx
@@ -24,7 +24,8 @@ const addTodo = handler({
             type: "string"
         }
     },
-    required: ["add"]
+    required: ["add"],
+    additionalProperties: false
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-handler-both-inline.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-handler-both-inline.expected.jsx
@@ -29,7 +29,8 @@ export const incrementer = handler({
             type: "number"
         }
     },
-    required: ["amount"]
+    required: ["amount"],
+    additionalProperties: false
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-handler-event-only.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-handler-event-only.expected.jsx
@@ -26,7 +26,8 @@ export const incrementer = handler({
             type: "number"
         }
     },
-    required: ["amount"]
+    required: ["amount"],
+    additionalProperties: false
 } as const satisfies __cfHelpers.JSONSchema, false as const satisfies __cfHelpers.JSONSchema, (event: IncrementEvent, _state) => {
     console.log("increment by", event.amount);
 });

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-handler-inside-jsx.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-handler-inside-jsx.expected.jsx
@@ -37,7 +37,8 @@ export const result = (<div>
                 type: "number"
             }
         },
-        required: ["x", "y"]
+        required: ["x", "y"],
+        additionalProperties: false
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "object",
         properties: {

--- a/packages/ts-transformers/test/fixtures/closures/action-generic-event.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-generic-event.expected.jsx
@@ -24,7 +24,8 @@ const __cfHandler_1 = __cfHelpers.handler({
             type: "string"
         }
     },
-    required: ["data"]
+    required: ["data"],
+    additionalProperties: false
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -61,7 +62,8 @@ export default pattern((__cf_pattern_input) => {
     properties: {
         update: {
             $ref: "#/$defs/MyEvent",
-            asCell: ["stream"]
+            asCell: ["stream"],
+            additionalProperties: false
         }
     },
     required: ["update"],

--- a/packages/ts-transformers/test/fixtures/closures/action-with-event.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-with-event.expected.jsx
@@ -24,7 +24,8 @@ const __cfHandler_1 = __cfHelpers.handler({
             type: "string"
         }
     },
-    required: ["data"]
+    required: ["data"],
+    additionalProperties: false
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -60,7 +61,8 @@ export default pattern((__cf_pattern_input) => {
     properties: {
         update: {
             $ref: "#/$defs/MyEvent",
-            asCell: ["stream"]
+            asCell: ["stream"],
+            additionalProperties: false
         }
     },
     required: ["update"],

--- a/packages/ts-transformers/test/fixtures/closures/handler-destructured-params.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-destructured-params.expected.jsx
@@ -39,7 +39,8 @@ const __cfHandler_1 = __cfHelpers.handler({
             required: ["value", "items"]
         }
     },
-    required: ["detail"]
+    required: ["detail"],
+    additionalProperties: false
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {

--- a/packages/ts-transformers/test/fixtures/closures/handler-event-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-event-param.expected.jsx
@@ -26,7 +26,8 @@ const __cfHandler_1 = __cfHelpers.handler({
             required: ["value"]
         }
     },
-    required: ["detail"]
+    required: ["detail"],
+    additionalProperties: false
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {

--- a/packages/ts-transformers/test/fixtures/closures/helper-owned-handler-nested-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/helper-owned-handler-nested-captures.expected.jsx
@@ -78,7 +78,8 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
                 }
             },
             required: ["fileId", "content"],
-            asCell: ["stream"]
+            asCell: ["stream"],
+            additionalProperties: false
         }
     },
     required: ["fileId", "content", "savedContent", "onSaveFile"]
@@ -128,7 +129,8 @@ export default pattern((__cf_pattern_input) => {
                 }
             },
             required: ["fileId", "content"],
-            asCell: ["stream"]
+            asCell: ["stream"],
+            additionalProperties: false
         }
     },
     required: ["fileId", "content", "savedContent", "onSaveFile"]

--- a/packages/ts-transformers/test/fixtures/closures/hoisted-handler-preserves-capture-schemas.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/hoisted-handler-preserves-capture-schemas.expected.jsx
@@ -106,7 +106,8 @@ const __cfHandler_2 = __cfHelpers.handler({
             type: "string"
         }
     },
-    required: ["label"]
+    required: ["label"],
+    additionalProperties: false
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {

--- a/packages/ts-transformers/test/fixtures/closures/map-conditional-inline-handler-send.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-conditional-inline-handler-send.expected.jsx
@@ -34,7 +34,8 @@ const castVote = handler({
             "enum": ["single", "double"]
         }
     },
-    required: ["id", "step"]
+    required: ["id", "step"],
+    additionalProperties: false
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -109,6 +110,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     $ref: "#/$defs/VoteEvent",
     asCell: ["stream"],
+    additionalProperties: false,
     $defs: {
         VoteEvent: {
             type: "object",
@@ -138,7 +140,8 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
         },
         boundCastVote: {
             $ref: "#/$defs/VoteEvent",
-            asCell: ["stream"]
+            asCell: ["stream"],
+            additionalProperties: false
         }
     },
     required: ["item", "boundCastVote"],
@@ -208,7 +211,8 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
                 },
                 boundCastVote: {
                     $ref: "#/$defs/VoteEvent",
-                    asCell: ["stream"]
+                    asCell: ["stream"],
+                    additionalProperties: false
                 }
             },
             required: ["state", "boundCastVote"]

--- a/packages/ts-transformers/test/fixtures/closures/nested-map-fallback-receiver.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/nested-map-fallback-receiver.expected.jsx
@@ -28,7 +28,8 @@ const __cfHandler_1 = __cfHelpers.handler({
             type: "string"
         }
     },
-    required: ["name"]
+    required: ["name"],
+    additionalProperties: false
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -107,7 +108,8 @@ const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
                 }
             },
             required: ["name"],
-            asCell: ["stream"]
+            asCell: ["stream"],
+            additionalProperties: false
         }
     },
     required: ["p", "setAssign"]
@@ -140,7 +142,8 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
                         }
                     },
                     required: ["name"],
-                    asCell: ["stream"]
+                    asCell: ["stream"],
+                    additionalProperties: false
                 }
             },
             required: ["setAssign"]
@@ -225,7 +228,8 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
                         }
                     },
                     required: ["name"],
-                    asCell: ["stream"]
+                    asCell: ["stream"],
+                    additionalProperties: false
                 }
             },
             required: ["people", "setAssign"]

--- a/packages/ts-transformers/test/fixtures/handler-schema/complex-nested-types.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/complex-nested-types.expected.jsx
@@ -49,7 +49,8 @@ const userHandler = handler({
             "enum": ["create", "update", "delete"]
         }
     },
-    required: ["user", "action"]
+    required: ["user", "action"],
+    additionalProperties: false
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -109,7 +110,8 @@ const _updateTags = handler({
             required: ["tags"]
         }
     },
-    required: ["detail"]
+    required: ["detail"],
+    additionalProperties: false
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {

--- a/packages/ts-transformers/test/fixtures/handler-schema/date-types.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/date-types.expected.jsx
@@ -24,7 +24,8 @@ const timedHandler = handler({
             type: "object"
         }
     },
-    required: ["timestamp"]
+    required: ["timestamp"],
+    additionalProperties: false
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {

--- a/packages/ts-transformers/test/fixtures/handler-schema/identity-only-handler-default-array.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/identity-only-handler-default-array.expected.jsx
@@ -31,7 +31,8 @@ const removePiece = handler({
             asCell: ["comparable"]
         }
     },
-    required: ["piece"]
+    required: ["piece"],
+    additionalProperties: false
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {

--- a/packages/ts-transformers/test/fixtures/handler-schema/identity-only-handler-payload.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/identity-only-handler-payload.expected.jsx
@@ -25,7 +25,8 @@ const addPiece = handler({
             asCell: ["comparable"]
         }
     },
-    required: ["piece"]
+    required: ["piece"],
+    additionalProperties: false
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -56,7 +57,8 @@ const trackRecent = handler({
             asCell: ["comparable"]
         }
     },
-    required: ["piece"]
+    required: ["piece"],
+    additionalProperties: false
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {

--- a/packages/ts-transformers/test/fixtures/handler-schema/simple-handler-writable.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/simple-handler-writable.expected.jsx
@@ -24,7 +24,8 @@ const myHandler = handler({
             type: "number"
         }
     },
-    required: ["increment"]
+    required: ["increment"],
+    additionalProperties: false
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {

--- a/packages/ts-transformers/test/fixtures/handler-schema/simple-handler.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/simple-handler.expected.jsx
@@ -24,7 +24,8 @@ const myHandler = handler({
             type: "number"
         }
     },
-    required: ["increment"]
+    required: ["increment"],
+    additionalProperties: false
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {

--- a/packages/ts-transformers/test/fixtures/handler-schema/stream-declared-result.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/stream-declared-result.expected.jsx
@@ -30,7 +30,8 @@ const __cfHandler_1 = __cfHelpers.handler({
             type: "string"
         }
     },
-    required: ["title"]
+    required: ["title"],
+    additionalProperties: false
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -51,7 +52,8 @@ const __cfHandler_2 = __cfHelpers.handler({
             type: "string"
         }
     },
-    required: ["title"]
+    required: ["title"],
+    additionalProperties: false
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -94,11 +96,13 @@ export default pattern(() => {
     properties: {
         addTopic: {
             $ref: "#/$defs/AddTopic",
-            asCell: ["stream"]
+            asCell: ["stream"],
+            additionalProperties: false
         },
         touch: {
             $ref: "#/$defs/AddTopic",
-            asCell: ["stream"]
+            asCell: ["stream"],
+            additionalProperties: false
         }
     },
     required: ["addTopic", "touch"],

--- a/packages/ts-transformers/test/fixtures/handler-schema/unsupported-intersection-index.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/unsupported-intersection-index.expected.jsx
@@ -28,7 +28,8 @@ const removeItem = handler({
             type: "string"
         }
     },
-    required: ["key"]
+    required: ["key"],
+    additionalProperties: false
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     additionalProperties: true,

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-captures.expected.jsx
@@ -42,7 +42,8 @@ const __cfHandler_1 = __cfHelpers.handler({
             type: "string"
         }
     },
-    required: ["name"]
+    required: ["name"],
+    additionalProperties: false
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -169,7 +170,8 @@ const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
                 }
             },
             required: ["name"],
-            asCell: ["stream"]
+            asCell: ["stream"],
+            additionalProperties: false
         }
     },
     required: ["entry", "pushPath"]
@@ -202,7 +204,8 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
                         }
                     },
                     required: ["name"],
-                    asCell: ["stream"]
+                    asCell: ["stream"],
+                    additionalProperties: false
                 }
             },
             required: ["pushPath"]

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-default-input-local-chain-map-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-default-input-local-chain-map-capture.expected.jsx
@@ -50,7 +50,8 @@ const __cfHandler_1 = __cfHelpers.handler({
             type: "string"
         }
     },
-    required: ["name"]
+    required: ["name"],
+    additionalProperties: false
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -99,7 +100,8 @@ const __cfHandler_2 = __cfHelpers.handler({
             },
             required: ["id", "name", "type"]
         }
-    }
+    },
+    additionalProperties: false
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {}
@@ -221,7 +223,8 @@ const __cfHandler_3 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
                 }
             },
             required: ["name"],
-            asCell: ["stream"]
+            asCell: ["stream"],
+            additionalProperties: false
         }
     },
     required: ["item", "handleNavigateInto"]
@@ -242,7 +245,8 @@ const __cfHandler_4 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
                 }
             },
             required: ["item"],
-            asCell: ["stream"]
+            asCell: ["stream"],
+            additionalProperties: false
         }
     },
     required: ["item", "handleOpenFile"],
@@ -319,7 +323,8 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
                         }
                     },
                     required: ["name"],
-                    asCell: ["stream"]
+                    asCell: ["stream"],
+                    additionalProperties: false
                 },
                 handleOpenFile: {
                     type: "object",
@@ -329,7 +334,8 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
                         }
                     },
                     required: ["item"],
-                    asCell: ["stream"]
+                    asCell: ["stream"],
+                    additionalProperties: false
                 }
             },
             required: ["handleNavigateInto", "handleOpenFile"]

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-local-initializer-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-local-initializer-captures.expected.jsx
@@ -50,7 +50,8 @@ const __cfHandler_1 = __cfHelpers.handler({
             type: "string"
         }
     },
-    required: ["name"]
+    required: ["name"],
+    additionalProperties: false
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -244,7 +245,8 @@ const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
                 }
             },
             required: ["name"],
-            asCell: ["stream"]
+            asCell: ["stream"],
+            additionalProperties: false
         }
     },
     required: ["item", "pushPath"]
@@ -277,7 +279,8 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
                         }
                     },
                     required: ["name"],
-                    asCell: ["stream"]
+                    asCell: ["stream"],
+                    additionalProperties: false
                 }
             },
             required: ["pushPath"]

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/safe-context-and-jsx.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/safe-context-and-jsx.expected.jsx
@@ -108,7 +108,8 @@ const MyHandler = handler({
             type: "object",
             properties: {}
         }
-    }
+    },
+    additionalProperties: false
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -219,7 +220,8 @@ const MyHandler2 = handler({
             type: "object",
             properties: {}
         }
-    }
+    },
+    additionalProperties: false
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {

--- a/packages/ts-transformers/test/fixtures/schema-injection/builder-input-path-shrink.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/builder-input-path-shrink.expected.jsx
@@ -64,7 +64,8 @@ const handlerExplicit = handler({
             required: ["message"]
         }
     },
-    required: ["detail"]
+    required: ["detail"],
+    additionalProperties: false
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {

--- a/packages/ts-transformers/test/fixtures/schema-transform/pattern-with-types.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/pattern-with-types.expected.jsx
@@ -104,7 +104,8 @@ const addItem = handler // <
             required: ["message"]
         }
     },
-    required: ["detail"]
+    required: ["detail"],
+    additionalProperties: false
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {


### PR DESCRIPTION
## Why

C5 (#5246) shipped the dispatch gate but with nothing emitting `additionalProperties: false`, closed-world enforcement was a per-schema author opt-in — design rule 1's "an undeclared field is a typed rejection, never ignored" held only where someone hand-closed a schema, and the silent-strip failure class (the live board's discarded-`agentName`) stayed open everywhere else. #5302's verb-event-role rule made the open→closed transition legal; this PR does the emitting. **DO NOT MERGE until Berni nods at the skew policy** ([asked on #5302](https://github.com/commontoolsinc/labs/pull/5302#issuecomment-5172941621)) — the plan records emission landing under reject-on-collision, and his answer should precede the ship.

## What Changed

- **`closeVerbEventRoot`** (`packages/schema-generator/src/event-closure.ts`): the one closure rule, position-scoped and guarded — inline object roots gain the keyword directly; `$ref` roots gain it beside the reference so a shared def stays open at data-position use sites; anything already declaring `additionalProperties` (index signatures = the author's organic opt-out), unions, `never`-derived shapes, and booleans are untouched.
- **Surface 1 — handler `$event`** (what the dispatch gate reads): `SchemaGeneratorTransformer` stamps the generated literal when a `toSchema` call is the first argument of a handler-family call. Membership is the provenance: hand-authored schema literals in that position are never stamped.
- **Surface 2 — `Stream` property schemas** (what baselines record and `cf piece verbs` advertises): the Stream wrapper branch applies the same helper.
- `stream-result.test.ts` pins the closed side (plus $ref-position-scoping and the index-signature opt-out) where it pinned the open side; mapping spec §6.5 and behavior spec §12 rewritten; plan WS-C + Risks record the landing.
- 26 transformer fixture goldens regenerated (churn audited: only root closures and comma reflow); **64 fleet baselines re-recorded with zero compatibility refusals** — the #5302 rule carried the entire migration.

## Test plan

- schema-generator 55 ✓, ts-transformers 1132 ✓, runner 1127 ✓ (llm-dialog carve-out holds), piece ✓, CLI 123 ✓, topics pattern suites 53 ✓
- `deno task pattern-compat` — 336 patterns updatable, 0 refusals
- `deno task check-docs`, repo-wide `deno fmt --check` + `deno lint` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit closed‑world event schemas for verbs in `schema-generator` and `ts-transformers`. Event roots now include `additionalProperties: false`, so undeclared payload fields are rejected at the dispatch gate instead of being silently dropped.

- **New Features**
  - Added `closeVerbEventRoot` to close object roots; stamps beside `$ref` and skips schemas that already set `additionalProperties`, unions/never/booleans, and hand-authored literals.
  - Applied to two surfaces: pattern `Stream` property schemas and transformer-injected handler `$event` when `toSchema(...)` is the first handler arg.
  - Updated docs (mapping §6.5, behavior spec §12) and tests; regenerated transformer goldens and re-recorded baselines.

- **Migration**
  - No code changes required; 64 fleet baselines re-recorded with zero compatibility refusals.
  - To keep an event open, declare an index signature or set `additionalProperties` on the event type explicitly.

<sup>Written for commit 9fc61cddc792eaab1fa38541b7887fadca8530c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




---

## Custody and inherited context

Sequencing moved to the consolidated verbs plan (#5519); custody of rebases,
review responses and re-verification transferred from the author. **Merging
stays with Mike.** Recorded here because it is expensive to rediscover.

**State at handover:** gate-clear and current on main, both touched-package
suites plus `pattern-compat` green. Held for confirmation of the recorded
forward-skew policy — the one question the reviewer named open, answered by
recorded policy rather than by him.

### The skew fallback, if the answer is not "confirmed"

The load-bearing fact: **emission and enforcement are separable.** The schemas
record the contract; collision behavior lives in one function —
`closedWorldEventRejection` in `packages/runner/src/runner.ts`, one call site,
pinned by `scheduler-event-receipts.test.ts` and the CFC integrity suites. So:

- **Confirmed** → merges as-is.
- **Wants skew tolerance** — a version window, reject-only-on-non-widening,
  whatever is specified → this still merges unchanged and the answer lands as a
  gate amendment in that one function. No fleet churn, no golden churn. Worth
  raising in that conversation: the policy's local-first leg rests on the CLI
  pre-dispatch gate validating against deployed schemas, so a concern about
  non-CLI callers belongs in the gate rather than in emission.
- **Full retreat** — no closure until versioning machinery exists → revert the
  two stamps, regenerate goldens, re-record baselines (closed-to-open is free by
  design, for exactly this case), flip the pins back, restore the two spec
  sections. All mechanical. #5302 stays in every branch — inert without
  emission, and needed by any future attempt.

### Re-record lore

1. **Verify, then record.** After any rebase run plain `pattern-compat` and read
   the verdict before `--update`. Zero refusals is the invariant; a refusal is a
   semantic regression that `--update` would bury as a fresh baseline.
2. **Do not stack this PR's own baselines.** The 64 baseline files it adds are
   append-only timestamped JSONs. If contracts change again, delete this PR's
   additions and re-record rather than stacking — a contract hash that never
   existed on main should not persist.
3. **Audit golden churn by frequency, not by eye:**
   `git diff | grep '^+' | sort | uniq -c`. The legitimate signature is exactly
   two shapes — `additionalProperties: false` insertions and comma-reflowed
   `asCell: ["stream"],` lines. A third shape in the histogram is a real
   behavior change.
4. **The provenance guard is positional.** The transformer stamps only
   `arguments[0]` of handler-family calls. Any future re-ordering of handler
   arguments silently un-stamps, and the tell is fixture goldens losing the
   keyword — so never hand-edit the `schema-generation-handler-*` or
   `handler-schema/*` expected files.

### One inheritance that rides along

The `llm-dialog` carve-out (`runtimeInjectedEventKeys`) is what keeps the CFC
suites green under closed schemas. Its retirement is decided but unclaimed. It
blocks nothing here; the recorded direction is to deliver through receipts, after
which the marker machinery goes.

### Reconciliation with #5501

No ordering edge — a declared result rides a trailing options argument while
event stamping keys on `arguments[0]`. Whichever of the two lands second owes a
golden regeneration.
