### PR TITLE
Revert "runner: treat fabric special objects as leaves when inlining data URI…"

### DIFF
--- a/packages/runner/src/data-uri.ts
+++ b/packages/runner/src/data-uri.ts
@@ -26,7 +26,6 @@
 import {
   FabricInstance,
   FabricPrimitive,
-  FabricSpecialObject,
   type FabricValue,
 } from "@commonfabric/data-model/fabric-value";
 import { isRecord } from "@commonfabric/utils/types";
@@ -136,12 +135,15 @@ export function dataUriFromValueWithResolvedLinks(
 /**
  * Find any data: URI links and inline them.
  *
- * A `FabricSpecialObject` is a leaf, matching the treatment
- * {@link dataUriFromValueWithResolvedLinks} gives it on the way in: the walk
- * hands one back by reference rather than descending into its enumerable own
- * properties, and a link path that continues into one resolves to
- * `undefined`. The link check runs ahead of that leaf check, so a link
- * carried as a fabric instance still inlines.
+ * TODO(danfuzz): This `isRecord`-gated walk has no `FabricSpecialObject`
+ * guard: after the link check, a non-link `FabricPrimitive`/`FabricInstance`
+ * falls into the `Object.entries` descent, which walks it by enumerable own
+ * props instead of treating it as a leaf. An instance with no enumerable
+ * props happens to pass through by reference, but the copy-on-write branch
+ * (`{ ...value }`) silently flattens any instance whose entry inlines
+ * differently into a plain object. The payload walk
+ * (`dataValue[path.shift()]`) indexes into decoded content with the same
+ * blindness.
  *
  * @param value - The value to find and inline data: URI links in.
  * @returns The value with any data: URI links inlined.
@@ -184,20 +186,17 @@ export function findAndInlineDataUriLinks(value: any): any {
           });
           return findAndInlineDataUriLinks(newSigilLink);
         }
-        if (path.length === 0) break;
-        if (dataValue instanceof FabricSpecialObject) {
-          // The remaining path names nothing inside a leaf.
-          return undefined;
+        if (path.length > 0) {
+          dataValue = dataValue[path.shift()!];
+        } else {
+          break;
         }
-        dataValue = dataValue[path.shift()!];
       }
 
       return dataValue;
     } else {
       return value;
     }
-  } else if (value instanceof FabricSpecialObject) {
-    return value;
   } else if (Array.isArray(value)) {
     let next: any[] | undefined;
     for (let index = 0; index < value.length; index++) {

--- a/packages/runner/test/data-uri-inlining.test.ts
+++ b/packages/runner/test/data-uri-inlining.test.ts
@@ -1,8 +1,6 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { entityRefToString } from "@commonfabric/data-model/cell-rep";
-import { FabricError } from "@commonfabric/data-model/fabric-instances";
-import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "../src/runtime.ts";
@@ -243,100 +241,6 @@ describe("data URI inlining", () => {
       expect(findAndInlineDataUriLinks(42)).toBe(42);
       expect(findAndInlineDataUriLinks(true)).toBe(true);
       expect(findAndInlineDataUriLinks(null)).toBe(null);
-    });
-
-    it("keeps a fabric instance whose own property holds a link intact", () => {
-      const dataURI = dataUriFromValueWithResolvedLinks("inline me");
-      const causeLink = {
-        "/": {
-          [LINK_V1_TAG]: {
-            id: dataURI,
-            path: [],
-          },
-        },
-      };
-      // `cause` is an enumerable own property of the error, and here it holds
-      // a link that inlines.
-      const error = new FabricError({
-        type: "Error",
-        message: "boom",
-        stack: undefined,
-        cause: causeLink,
-      });
-      const value = { error, sibling: causeLink };
-
-      const result = findAndInlineDataUriLinks(value);
-      expect(result).not.toBe(value);
-      expect(result.sibling).toBe("inline me");
-      expect(result.error).toBe(error);
-      expect(result.error.cause).toBe(causeLink);
-    });
-
-    it("keeps a fabric primitive intact when a sibling inlines", () => {
-      const dataURI = dataUriFromValueWithResolvedLinks("inline me");
-      const bytes = new FabricBytes(new Uint8Array([1, 2, 3]));
-      const value = {
-        bytes,
-        sibling: {
-          "/": {
-            [LINK_V1_TAG]: {
-              id: dataURI,
-              path: [],
-            },
-          },
-        },
-      };
-
-      const result = findAndInlineDataUriLinks(value);
-      expect(result.sibling).toBe("inline me");
-      expect(result.bytes).toBe(bytes);
-    });
-
-    it("resolves a path continuing into a fabric instance to undefined", () => {
-      const error = new FabricError({
-        type: "Error",
-        message: "boom",
-        stack: undefined,
-        cause: undefined,
-      });
-      const dataURI = dataUriFromValueWithResolvedLinks({ error });
-
-      // `message` is an own property of the decoded instance and `deepClone`
-      // is inherited from its prototype. Neither is addressable content.
-      for (const segment of ["message", "deepClone"]) {
-        const link = {
-          "/": {
-            [LINK_V1_TAG]: {
-              id: dataURI,
-              path: ["error", segment],
-            },
-          },
-        };
-
-        expect(findAndInlineDataUriLinks(link)).toBe(undefined);
-      }
-    });
-
-    it("returns a fabric instance addressed by the whole payload path", () => {
-      const error = new FabricError({
-        type: "Error",
-        message: "boom",
-        stack: undefined,
-        cause: undefined,
-      });
-      const dataURI = dataUriFromValueWithResolvedLinks({ nested: { error } });
-      const link = {
-        "/": {
-          [LINK_V1_TAG]: {
-            id: dataURI,
-            path: ["nested", "error"],
-          },
-        },
-      };
-
-      const result = findAndInlineDataUriLinks(link);
-      expect(result).toBeInstanceOf(FabricError);
-      expect(result.message).toBe("boom");
     });
 
     it("should deeply traverse nested structures", () => {


### PR DESCRIPTION
Reverts commontoolsinc/labs#5305

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the change that treated fabric special objects as leaves during data: URI inlining, restoring the previous traversal in `packages/runner`.

- **Refactors**
  - Remove `FabricSpecialObject` guard in `findAndInlineDataUriLinks`, resuming descent into enumerable own properties.
  - Delete tests that assumed leaf semantics for fabric instances/primitives.

<sup>Written for commit 3dc2c12ba72b4fee93b243f8be4aa39bc51b05fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

NEW_COVERAGE_BASELINE