### PR TITLE
feat(cli): `piece setsrc --check` — compatibility preflight for a source swap

### DIFF
--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -1041,22 +1041,16 @@ export const piece = new Command()
   .action(async (options, mainPath) => {
     setQuietMode(!!options.quiet);
     if (options.check) {
-      const { config, report } = await checkPieceSourceFromCommand(
+      // A refusal throws out of here with a non-zero exit, so `--check` gates
+      // a deploy script as well as informing a person.
+      const { config, summary } = await checkPieceSourceFromCommand(
         options,
         mainPath,
       );
-      if (report.compatible) {
-        render(`${mainPath} can replace the source for piece ${config.piece}`);
-        hint(cliText(`NEXT STEPS:
+      render(summary);
+      hint(cliText(`NEXT STEPS:
   → Apply it: cf piece setsrc --piece ${config.piece} ${mainPath} ...`));
-        return;
-      }
-      // Non-zero exit: `--check` is meant to gate a deploy script, so the
-      // verdict has to be readable by `if` as well as by a person.
-      throw new ValidationError(
-        `${mainPath} cannot replace the source for piece ${config.piece}:\n${report.message}`,
-        { exitCode: 1 },
-      );
+      return;
     }
     const pieceConfig = await setPieceSourceFromCommand(options, mainPath);
     render(`Updated source for piece ${pieceConfig.piece}`);
@@ -1931,18 +1925,36 @@ export interface CheckPieceSourceCommandDependencies {
  * Deliberately parses the same options `setsrc` does, so the check is aimed at
  * the piece and entry the apply would have used — a preflight against a
  * different target is worse than none.
+ *
+ * The refusal is raised here rather than in the command's action so that the
+ * decision — including the non-zero exit that lets `--check` gate a deploy
+ * script — is reachable by a test. The action only renders what it returns.
  */
 export async function checkPieceSourceFromCommand(
   options: PieceCLIOptions,
   mainPath: string,
   deps: CheckPieceSourceCommandDependencies = {},
-): Promise<{ config: PieceConfig; report: PatternCompatibilityReport }> {
+): Promise<{
+  config: PieceConfig;
+  report: PatternCompatibilityReport;
+  summary: string;
+}> {
   const config = parsePieceOptions(options);
   const report = await (deps.checkPiecePattern ?? checkPiecePattern)(
     config,
     localPatternEntry(mainPath, options),
   );
-  return { config, report };
+  if (!report.compatible) {
+    throw new ValidationError(
+      `${mainPath} cannot replace the source for piece ${config.piece}:\n${report.message}`,
+      { exitCode: 1 },
+    );
+  }
+  return {
+    config,
+    report,
+    summary: `${mainPath} can replace the source for piece ${config.piece}`,
+  };
 }
 
 /** Apply the parsed `piece setsrc` command while preserving its safety flag. */

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -1035,7 +1035,7 @@ export const piece = new Command()
   )
   .option(
     "--check",
-    "Report whether the source could replace the piece's current one, and change nothing.",
+    "Report whether the source could replace the piece's current one, without updating the piece. Exits non-zero when it could not.",
   )
   .arguments("<main:string>")
   .action(async (options, mainPath) => {

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -1041,8 +1041,9 @@ export const piece = new Command()
   .action(async (options, mainPath) => {
     setQuietMode(!!options.quiet);
     if (options.check) {
-      // A refusal throws out of here with a non-zero exit, so `--check` gates
-      // a deploy script as well as informing a person.
+      // A refusal exits 1 from inside the check (plain stderr, no usage
+      // dump), so `--check` gates a deploy script as well as informing a
+      // person.
       const { config, summary } = await checkPieceSourceFromCommand(
         options,
         mainPath,
@@ -1917,6 +1918,8 @@ export interface SetPieceSourceCommandDependencies {
 /** Injectable dependencies for testing `piece setsrc --check`. */
 export interface CheckPieceSourceCommandDependencies {
   checkPiecePattern?: typeof checkPiecePattern;
+  /** `exitWithDataError`'s seam, so a test can observe the refusal. */
+  exit?: Parameters<typeof exitWithDataError>[1];
 }
 
 /**
@@ -1945,10 +1948,15 @@ export async function checkPieceSourceFromCommand(
     localPatternEntry(mainPath, options),
   );
   if (!report.compatible) {
-    throw new ValidationError(
-      `${mainPath} cannot replace the source for piece ${config.piece}:\n${report.message}`,
-      { exitCode: 1 },
-    );
+    // A refusal is a data condition — this source and this piece's stored
+    // state don't fit — not an arg-parse failure, so it reports like the
+    // `piece get` / `piece link` data errors above: plain stderr and exit 1,
+    // never a Cliffy ValidationError, which would dump the usage screen over
+    // the verdict.
+    exitWithDataError({
+      message:
+        `${mainPath} cannot replace the source for piece ${config.piece}:\n${report.message}`,
+    }, deps.exit);
   }
   return {
     config,

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -3,6 +3,7 @@ import { Command, ValidationError } from "@cliffy/command";
 import { VerbInputValidationError } from "../lib/callable.ts";
 import {
   applyPieceInput,
+  checkPiecePattern,
   type EntryConfig,
   executePieceCallable,
   formatViewTree,
@@ -33,6 +34,7 @@ import {
   stepPiece,
 } from "../lib/piece.ts";
 import type { ExecutedPieceCallable } from "../lib/piece.ts";
+import type { PatternCompatibilityReport } from "@commonfabric/piece/ops";
 import type { InvocationOutcome, InvocationPhase } from "../lib/callable.ts";
 import { renderPiece } from "../lib/piece-render.ts";
 import { parseSqliteSource } from "../lib/sqlite-source.ts";
@@ -1031,9 +1033,31 @@ export const piece = new Command()
     "--dangerously-allow-incompatible-schema",
     "Replace the source even when pattern or retained-link schema compatibility cannot be proven.",
   )
+  .option(
+    "--check",
+    "Report whether the source could replace the piece's current one, and change nothing.",
+  )
   .arguments("<main:string>")
   .action(async (options, mainPath) => {
     setQuietMode(!!options.quiet);
+    if (options.check) {
+      const { config, report } = await checkPieceSourceFromCommand(
+        options,
+        mainPath,
+      );
+      if (report.compatible) {
+        render(`${mainPath} can replace the source for piece ${config.piece}`);
+        hint(cliText(`NEXT STEPS:
+  → Apply it: cf piece setsrc --piece ${config.piece} ${mainPath} ...`));
+        return;
+      }
+      // Non-zero exit: `--check` is meant to gate a deploy script, so the
+      // verdict has to be readable by `if` as well as by a person.
+      throw new ValidationError(
+        `${mainPath} cannot replace the source for piece ${config.piece}:\n${report.message}`,
+        { exitCode: 1 },
+      );
+    }
     const pieceConfig = await setPieceSourceFromCommand(options, mainPath);
     render(`Updated source for piece ${pieceConfig.piece}`);
     hint(cliText(`NEXT STEPS:
@@ -1894,6 +1918,31 @@ export async function searchPiecesFromCommand(
 /** Injectable dependencies for testing the `piece setsrc` command boundary. */
 export interface SetPieceSourceCommandDependencies {
   setPiecePattern?: typeof setPiecePattern;
+}
+
+/** Injectable dependencies for testing `piece setsrc --check`. */
+export interface CheckPieceSourceCommandDependencies {
+  checkPiecePattern?: typeof checkPiecePattern;
+}
+
+/**
+ * Run the `piece setsrc --check` preflight. Applies nothing.
+ *
+ * Deliberately parses the same options `setsrc` does, so the check is aimed at
+ * the piece and entry the apply would have used — a preflight against a
+ * different target is worse than none.
+ */
+export async function checkPieceSourceFromCommand(
+  options: PieceCLIOptions,
+  mainPath: string,
+  deps: CheckPieceSourceCommandDependencies = {},
+): Promise<{ config: PieceConfig; report: PatternCompatibilityReport }> {
+  const config = parsePieceOptions(options);
+  const report = await (deps.checkPiecePattern ?? checkPiecePattern)(
+    config,
+    localPatternEntry(mainPath, options),
+  );
+  return { config, report };
 }
 
 /** Apply the parsed `piece setsrc` command while preserving its safety flag. */

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -261,6 +261,29 @@ run_piece_values() {
       jq -r '.patternRef.identity'
   )
 
+  # The preflight answers the same question without touching the piece.
+  if cf piece setsrc --check $SPACE_ARGS --piece "$schema_piece_id" \
+    "$SCHEMA_INCOMPATIBLE_PATTERN_SRC" \
+    >"$WORK_DIR/incompatible-check.out" \
+    2>"$WORK_DIR/incompatible-check.err"; then
+    error "setsrc --check should fail for an incompatible source."
+  fi
+  if ! grep -q "cannot replace the source" "$WORK_DIR/incompatible-check.err"; then
+    error "setsrc --check did not report the verdict."
+  fi
+  if ! grep -q "not backward compatible" "$WORK_DIR/incompatible-check.err"; then
+    error "setsrc --check did not name the rule that refused it."
+  fi
+  if [ "$(
+    cf piece inspect --json $SPACE_ARGS --piece "$schema_piece_id" |
+      jq -r '.patternRef.identity'
+  )" != "$schema_identity_before" ]; then
+    error "setsrc --check changed the piece source."
+  fi
+  # A compatible source clears the same preflight, and still applies nothing.
+  cf piece setsrc --check $SPACE_ARGS --piece "$schema_piece_id" \
+    "$SCHEMA_COMPATIBLE_PATTERN_SRC" >/dev/null
+
   if cf piece setsrc $SPACE_ARGS --piece "$schema_piece_id" \
     "$SCHEMA_INCOMPATIBLE_PATTERN_SRC" \
     >"$WORK_DIR/incompatible-setsrc.out" \

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -35,6 +35,7 @@ import {
   SlugResolutionError,
 } from "@commonfabric/piece";
 import {
+  type PatternCompatibilityReport,
   type PiecePatternRef,
   PiecesController,
 } from "@commonfabric/piece/ops";
@@ -1280,6 +1281,40 @@ export async function setPiecePattern(
         ? { dangerouslyAllowIncompatibleSchema: true }
         : {}),
     },
+  );
+}
+
+/**
+ * Would `setPiecePattern` be accepted for this piece? Applies nothing.
+ *
+ * Same shape as `setPiecePattern` up to the point of the swap, so the verdict
+ * is about the source the user would actually apply — including its resolved
+ * imports and pinned program — rather than an approximation of it.
+ */
+export async function checkPiecePattern(
+  config: PieceConfig,
+  entry: EntryConfig,
+  deps: PieceOperationDependencies = {},
+): Promise<PatternCompatibilityReport> {
+  const manager = await (deps.loadManager ?? loadManager)(config);
+  const resolvedConfig = await resolvePieceConfigWithManager(
+    config,
+    manager,
+    deps.resolvePieceAddress,
+  );
+  const pieces = deps.createController?.(manager) ??
+    new PiecesController(manager);
+  const piece = await pieces.get(
+    resolvedConfig.piece,
+    false,
+    undefined,
+    resolvedConfig.pieceScope,
+  );
+  return await piece.checkPattern(
+    await (deps.getPinnedProgramFromFile ?? getPinnedProgramFromFile)(
+      manager,
+      entry,
+    ),
   );
 }
 

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -1488,8 +1488,13 @@ describe("cli piece parsing", () => {
   it("fails the setsrc preflight loudly enough to gate a script", async () => {
     // `--check` is meant to sit in front of a deploy, so a refusal has to be a
     // non-zero exit and not just prose on stdout — and it has to carry the
-    // rules' own reason so the operator knows what to fix.
-    const failure = await checkPieceSourceFromCommand(
+    // rules' own reason so the operator knows what to fix. It reports as a
+    // data error (plain stderr + exit 1), not a Cliffy ValidationError, so
+    // the verdict is not buried under a usage screen.
+    const printed: string[] = [];
+    let exitCode: number | undefined;
+    class ExitSentinel extends Error {}
+    await expect(checkPieceSourceFromCommand(
       {
         apiUrl: API_URL,
         space: SPACE,
@@ -1505,13 +1510,19 @@ describe("cli piece parsing", () => {
             message: "result narrowed: label",
             candidate: { identity: "D".repeat(43), symbol: "default" },
           }),
+        exit: {
+          printError: (message) => printed.push(message),
+          exit: (code) => {
+            exitCode = code;
+            throw new ExitSentinel();
+          },
+        },
       },
-    ).then(() => undefined, (error: unknown) => error as ValidationError);
+    )).rejects.toThrow(ExitSentinel);
 
-    expect(failure).toBeInstanceOf(ValidationError);
-    expect(failure!.message).toContain("cannot replace the source");
-    expect(failure!.message).toContain("result narrowed: label");
-    expect((failure as { exitCode?: number }).exitCode).toBe(1);
+    expect(exitCode).toBe(1);
+    expect(printed.join("\n")).toContain("cannot replace the source");
+    expect(printed.join("\n")).toContain("result narrowed: label");
   });
 
   it("lists pattern provenance and isolates unreadable pieces", async () => {

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -19,6 +19,7 @@ import { FabricSpecialObject } from "@commonfabric/data-model/fabric-value";
 import { FabricHash } from "@commonfabric/data-model/fabric-primitives";
 import { cf, checkStderr, stripAnsi } from "./utils.ts";
 import {
+  checkPiecePattern,
   getCellValue,
   inspectPiece,
   listPieces,
@@ -34,6 +35,7 @@ import {
   type SpaceConfig,
   withRuntimeCleanupOnFailure,
 } from "../lib/piece.ts";
+import { ValidationError } from "@cliffy/command";
 import { pieceId, SlugResolutionError } from "@commonfabric/piece";
 import { setResultCell } from "../../runner/src/result-utils.ts";
 import { toCell } from "../../runner/src/back-to-cell.ts";
@@ -1447,7 +1449,7 @@ describe("cli piece parsing", () => {
     // than none, so the check parses the same options and hands the same entry
     // down. It must also apply nothing — no `setPiecePattern` here at all.
     let checked: unknown;
-    const { config, report } = await checkPieceSourceFromCommand(
+    const { config, report, summary } = await checkPieceSourceFromCommand(
       {
         apiUrl: API_URL,
         space: SPACE,
@@ -1471,6 +1473,7 @@ describe("cli piece parsing", () => {
     );
 
     expect(report.compatible).toBe(true);
+    expect(summary).toContain("can replace the source");
     expect(checked).toEqual({
       config,
       entry: {
@@ -1480,6 +1483,35 @@ describe("cli piece parsing", () => {
         rootPath: "/repo",
       },
     });
+  });
+
+  it("fails the setsrc preflight loudly enough to gate a script", async () => {
+    // `--check` is meant to sit in front of a deploy, so a refusal has to be a
+    // non-zero exit and not just prose on stdout — and it has to carry the
+    // rules' own reason so the operator knows what to fix.
+    const failure = await checkPieceSourceFromCommand(
+      {
+        apiUrl: API_URL,
+        space: SPACE,
+        identity: "/tmp/test.key",
+        piece: PIECE,
+      },
+      "/repo/pattern.tsx",
+      {
+        checkPiecePattern: () =>
+          Promise.resolve({
+            compatible: false,
+            issues: { schema: "result narrowed: label" },
+            message: "result narrowed: label",
+            candidate: { identity: "D".repeat(43), symbol: "default" },
+          }),
+      },
+    ).then(() => undefined, (error: unknown) => error as ValidationError);
+
+    expect(failure).toBeInstanceOf(ValidationError);
+    expect(failure!.message).toContain("cannot replace the source");
+    expect(failure!.message).toContain("result narrowed: label");
+    expect((failure as { exitCode?: number }).exitCode).toBe(1);
   });
 
   it("lists pattern provenance and isolates unreadable pieces", async () => {
@@ -3122,6 +3154,51 @@ describe("cli piece parsing", () => {
       repository,
       dangerouslyAllowIncompatibleSchema: true,
     });
+  });
+
+  it("resolves the piece and pinned program before checking compatibility", async () => {
+    // The preflight has to reach the SAME piece the apply would, through the
+    // same address resolution and the same pinned program — a check against a
+    // different target, or against source with different imports resolved, is
+    // worse than no check at all.
+    const entry = { mainPath: "/repo/main.tsx" };
+    const program = {} as any;
+    const manager = { add: () => Promise.resolve() };
+    let resolvedPiece: unknown;
+    let checkedProgram: unknown;
+    const report = {
+      compatible: false,
+      issues: { schema: "output narrowed" },
+      message: "output narrowed",
+      candidate: { identity: "C".repeat(43), symbol: "default" },
+    };
+
+    const result = await checkPiecePattern(
+      { apiUrl: API_URL, space: SPACE, identity: ID, piece: "notes" },
+      entry,
+      {
+        loadManager: () => Promise.resolve(manager as any),
+        resolvePieceAddress: () => Promise.resolve(PIECE),
+        createController: () => ({
+          get: (id: string) => {
+            resolvedPiece = id;
+            return Promise.resolve({
+              checkPattern: (candidate: unknown) => {
+                checkedProgram = candidate;
+                return Promise.resolve(report);
+              },
+            });
+          },
+        } as any),
+        getPinnedProgramFromFile: () => Promise.resolve(program),
+      },
+    );
+
+    expect(resolvedPiece).toBe(PIECE);
+    expect(checkedProgram).toBe(program);
+    // The verdict is passed through verbatim: the CLI reports the rules'
+    // finding, it does not re-interpret it.
+    expect(result).toEqual(report);
   });
 
   it("returns pattern provenance from piece inspection", async () => {

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -35,7 +35,6 @@ import {
   type SpaceConfig,
   withRuntimeCleanupOnFailure,
 } from "../lib/piece.ts";
-import { ValidationError } from "@cliffy/command";
 import { pieceId, SlugResolutionError } from "@commonfabric/piece";
 import { setResultCell } from "../../runner/src/result-utils.ts";
 import { toCell } from "../../runner/src/back-to-cell.ts";

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -38,6 +38,7 @@ import { pieceId, SlugResolutionError } from "@commonfabric/piece";
 import { setResultCell } from "../../runner/src/result-utils.ts";
 import { toCell } from "../../runner/src/back-to-cell.ts";
 import {
+  checkPieceSourceFromCommand,
   formatPatternIdentity,
   formatPatternRef,
   localPatternEntry,
@@ -1438,6 +1439,46 @@ describe("cli piece parsing", () => {
         rootPath: "/repo",
       },
       options: { dangerouslyAllowIncompatibleSchema: true },
+    });
+  });
+
+  it("aims the setsrc preflight at the same piece and entry the apply would use", async () => {
+    // A preflight that resolves a different target than the apply is worse
+    // than none, so the check parses the same options and hands the same entry
+    // down. It must also apply nothing — no `setPiecePattern` here at all.
+    let checked: unknown;
+    const { config, report } = await checkPieceSourceFromCommand(
+      {
+        apiUrl: API_URL,
+        space: SPACE,
+        identity: "/tmp/test.key",
+        piece: PIECE,
+        mainExport: "named",
+        repository: "https://github.com/commontoolsinc/labs",
+        root: "/repo",
+      },
+      "/repo/pattern.tsx",
+      {
+        checkPiecePattern: (config, entry) => {
+          checked = { config, entry };
+          return Promise.resolve({
+            compatible: true,
+            issues: {},
+            candidate: { identity: "A".repeat(43), symbol: "default" },
+          });
+        },
+      },
+    );
+
+    expect(report.compatible).toBe(true);
+    expect(checked).toEqual({
+      config,
+      entry: {
+        mainPath: "/repo/pattern.tsx",
+        mainExport: "named",
+        repository: "https://github.com/commontoolsinc/labs",
+        rootPath: "/repo",
+      },
     });
   });
 

--- a/packages/piece/src/ops/mod.ts
+++ b/packages/piece/src/ops/mod.ts
@@ -1,11 +1,13 @@
 export { PiecesController } from "./pieces-controller.ts";
 export { ACLManager } from "./acl-manager.ts";
 export {
+  type PatternCompatibilityReport,
   PieceController,
   type PiecePatternRef,
   type PiecePatternSourceRef,
   type PieceSourceAction,
   type PieceSourceActionResult,
+  type PieceSourceCompatibilityIssues,
   type PreparedPieceSourceChange,
 } from "./piece-controller.ts";
 export {

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -3220,13 +3220,19 @@ export class PieceController<T = unknown> {
   }
 
   /**
-   * Would `setPattern(program)` be accepted? Answers without applying anything.
+   * Would `setPattern(program)` be accepted? Answers without changing the piece.
    *
    * Drives the SAME review the apply path runs — no second copy of the rules,
-   * because a preflight that reimplements them drifts and starts lying. It
-   * compiles the candidate (which the runtime caches, so the subsequent apply
-   * does not pay for it twice) and reads the piece's argument; it opens no
-   * transaction and writes nothing.
+   * because a preflight that reimplements them drifts and starts lying.
+   *
+   * It is not, however, a pure read. Compiling the candidate goes through
+   * `compileAndSavePattern`, which writes the compiled module set and its
+   * source docs into the space's content-addressed store (CT-1623) — the same
+   * write the apply would do, idempotent, and attached to nothing. What it
+   * does NOT do is touch the piece: no pointer move, no argument re-stage, no
+   * source transition, no revision. So a refused check leaves the piece
+   * running exactly what it was running, which is the guarantee a caller
+   * actually needs; it does not leave the space byte-identical.
    */
   async checkPattern(
     program: RuntimeProgram,

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -37,8 +37,11 @@ import {
 import type { CellKind, LinkScope } from "@commonfabric/api";
 import {
   cfcSchemaChildRoot,
+  cfcSchemaMergeIssue,
+  loadStoredCfcEnvelope,
   resolveCfcSchemaRefRoot,
   resolveCfcSchemaRefs,
+  storedSchemaCoversCandidateEnvelope,
   validateSchemaValue,
 } from "@commonfabric/runner/cfc";
 import { pieceId, PieceManager } from "../manager.ts";
@@ -231,6 +234,13 @@ export interface PieceSourceCompatibilityIssues {
   schema?: string;
   argument?: string;
   retainedLinks?: string;
+  /**
+   * The CFC schema envelope stored on the piece's argument document cannot
+   * merge with the candidate's argument schema — or cannot be read at all.
+   * Distinct from `schema` and `argument`, which reason about DECLARED types:
+   * this one reasons about what is physically at rest.
+   */
+  cfc?: string;
 }
 
 /**
@@ -239,10 +249,22 @@ export interface PieceSourceCompatibilityIssues {
  *
  * "Every reason at once" is the point. Applying a source that cannot migrate
  * the piece's documents surfaces whichever low-level rejection happens to fire
- * first — a schema-subset assertion, a retained-link proof, or an argument
- * validation failure at the setup-commit boundary — so a caller fixes one and
- * meets the next. The same review runs here and on the apply path, so a
- * refusal names what a preflight would have named.
+ * first — a schema-subset assertion, a retained-link proof, an argument
+ * validation failure, or a CFC schema-envelope rejection at the setup-commit
+ * boundary — so a caller fixes one and meets the next.
+ *
+ * Every verdict here comes from driving the REAL rule in dry-run, never a
+ * restatement of it: a preflight that reimplements the rules drifts from
+ * enforcement and starts lying. It agrees with the apply path on the VERDICT
+ * and the CAUSE. Not on identical prose — `setPattern` reports in
+ * enforcement's own words, and making the strings match would mean running
+ * this review ahead of the swap, which changes what `setPattern` accepts
+ * (see the comment there, and `test/setsrc-cold-argument.test.ts`).
+ *
+ * It is a point-in-time answer. The piece's argument, its current source, or
+ * the candidate file can all move between the check and a later apply, so a
+ * clear verdict is not a promise about a future `setPattern` — the apply path
+ * revalidates independently, which is what keeps that fail-safe.
  */
 export interface PatternCompatibilityReport {
   compatible: boolean;
@@ -3296,20 +3318,24 @@ export class PieceController<T = unknown> {
             ? { previousEntryIdentity: previousRef.identity }
             : {},
         );
+        // Enforcement is this assertion plus the execute-time validators
+        // below, and it must stay that way. Do not move the aggregate
+        // compatibility review (`pieceSourceCompatibilityReview`, what
+        // `checkPattern` runs) in front of it.
+        //
+        // An earlier revision of this PR did, to name every refusal reason at
+        // once, and it silently changed what `setPattern` ACCEPTS: the review
+        // materializes and validates the stored argument, so when the whole
+        // argument document is cold — a nested piece whose host has not synced
+        // yet — it validates `undefined` and refuses, where Runner
+        // deliberately defers and preserves the bytes (CT-1917).
+        // `test/setsrc-cold-argument.test.ts` pins that; it fails with
+        // "value does not match type object" if the review moves here.
+        //
+        // Callers who want every reason at once run `checkPattern()`, which is
+        // exactly what `--check` is for.
         if (!options?.dangerouslyAllowIncompatibleSchema) {
-          // The same review `checkPattern()` runs, so a refusal here names
-          // every reason rather than whichever assertion happened to fire
-          // first. The execute-time validators below still enforce
-          // independently — this decides the MESSAGE, not the outcome.
-          const review = await pieceSourceCompatibilityReview(
-            previousPattern,
-            pattern,
-            this.#cell,
-            this.#manager,
-          );
-          if (hasPieceSourceCompatibilityIssues(review.issues)) {
-            throw new Error(pieceSourceCompatibilityMessage(review.issues));
-          }
+          assertPatternSchemasBackwardCompatible(previousPattern, pattern);
         }
         transition = pieceSourceTransition(
           expected,
@@ -3624,10 +3650,88 @@ async function pieceSourceCompatibilityReview(
       ? error.message
       : String(error);
   }
+
+  const cfc = pieceSourceCfcEnvelopeIssue(argumentCell, candidate, manager);
+  if (cfc !== undefined) issues.cfc = cfc;
+
   return {
     argumentEvidence: pieceSourceArgumentEvidence(argumentCell, manager),
     issues,
   };
+}
+
+/**
+ * Would the setup commit's CFC schema-envelope merge accept this candidate
+ * over what the piece's argument document already stores?
+ *
+ * Why this is its own rule rather than a case of the three above: those all
+ * reason about DECLARED types — the previous and candidate patterns' argument
+ * and result schemas, and the stored argument VALUE against them. The CFC
+ * envelope is neither. It is the schema the document was last committed under,
+ * accumulated across every write that ever touched it, and it can carry claims
+ * no pattern declares (a later write that strengthened a confidentiality label
+ * widens it in place). So a piece whose pattern pointer has run ahead of its
+ * stored envelope — the partially-migrated case this command exists to catch —
+ * passes all three type-level checks and still takes `CFC enforcement rejected
+ * commit` at the setup boundary. Reporting `compatible: true` there is worse
+ * than having no preflight at all, because the verdict is what gates a deploy.
+ *
+ * The merge is driven for real, in dry-run, through the same
+ * `mergeCfcSchemaEnvelopes` (and the same stored-covers-candidate fast path)
+ * the commit runs, so the two cannot disagree about what merges.
+ *
+ * Scope, deliberately: the ARGUMENT document only. The piece's own document —
+ * the result — merges at commit time under `generatedOutputPaths`, the set of
+ * paths the running module materializes in that same transaction, which
+ * exempts them from the additive-required rule. Those paths are a property of
+ * the module's actual output bindings and are not knowable without executing
+ * it, so a preflight that merged the result envelope without them would refuse
+ * the ordinary, accepted case of a candidate that adds a generated result field
+ * (see `packages/piece/test/state-continuity.test.ts`). An argument is an
+ * input: nothing generates it, so its merge is faithful here.
+ */
+function pieceSourceCfcEnvelopeIssue(
+  argumentCell: Cell<unknown>,
+  candidate: Pattern,
+  manager: PieceManager,
+): string | undefined {
+  const link = argumentCell.getAsNormalizedFullLink();
+  // `readTx()` cannot write, so the dry run stays a dry run.
+  const stored = loadStoredCfcEnvelope(manager.runtime.readTx(), {
+    space: link.space,
+    id: link.id,
+    scope: link.scope,
+  });
+  if (stored.status === "none") {
+    // No stored envelope means the merge never runs for this document at
+    // commit time, so there is genuinely nothing for it to reject. (Documents
+    // only acquire one once a write carries an IFC claim.)
+    return undefined;
+  }
+  if (stored.status === "unreadable") {
+    // The commit path records this same load failure as a rejection reason and
+    // refuses the write. Skipping it here — the tempting reading, since we
+    // cannot evaluate the merge — is precisely how a check green-lights an
+    // update the deploy then refuses, so it is a blocker instead.
+    return `the CFC schema envelope stored for this piece's argument ` +
+      `document could not be read (${stored.reason}); applying a source ` +
+      `would be rejected over the same failure`;
+  }
+  // The commit takes the stored envelope unchanged when it already covers the
+  // candidate's, so a preflight that skipped this fast path would manufacture
+  // rejections the real update does not make.
+  if (
+    storedSchemaCoversCandidateEnvelope(stored.schema, candidate.argumentSchema)
+  ) {
+    return undefined;
+  }
+  const issue = cfcSchemaMergeIssue(stored.schema, candidate.argumentSchema);
+  if (issue === undefined) return undefined;
+  return issue.migration
+    ? `the argument document stored for this piece predates the candidate's ` +
+      `schema and cannot migrate to it: ${issue.message}`
+    : `the candidate's argument schema does not merge with the CFC schema ` +
+      `envelope stored for this piece: ${issue.message}`;
 }
 
 function hasPieceSourceCompatibilityIssues(
@@ -3635,7 +3739,8 @@ function hasPieceSourceCompatibilityIssues(
 ): boolean {
   return issues.schema !== undefined ||
     issues.argument !== undefined ||
-    issues.retainedLinks !== undefined;
+    issues.retainedLinks !== undefined ||
+    issues.cfc !== undefined;
 }
 
 function assertPieceSourceArgumentUsable(
@@ -3649,7 +3754,7 @@ function assertPieceSourceArgumentUsable(
 function pieceSourceCompatibilityMessage(
   issues: PieceSourceCompatibilityIssues,
 ): string {
-  return [issues.schema, issues.argument, issues.retainedLinks]
+  return [issues.schema, issues.argument, issues.retainedLinks, issues.cfc]
     .filter((message): message is string => message !== undefined)
     .join("\n");
 }

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -227,10 +227,29 @@ export interface PreparedPieceSourceChange {
   };
 }
 
-interface PieceSourceCompatibilityIssues {
+export interface PieceSourceCompatibilityIssues {
   schema?: string;
   argument?: string;
   retainedLinks?: string;
+}
+
+/**
+ * The verdict `checkPattern()` returns: can this source replace the piece's
+ * current one, and if not, every reason at once.
+ *
+ * "Every reason at once" is the point. Applying a source that cannot migrate
+ * the piece's documents surfaces whichever low-level rejection happens to fire
+ * first — a schema-subset assertion, a retained-link proof, or an argument
+ * validation failure at the setup-commit boundary — so a caller fixes one and
+ * meets the next. The same review runs here and on the apply path, so a
+ * refusal names what a preflight would have named.
+ */
+export interface PatternCompatibilityReport {
+  compatible: boolean;
+  issues: PieceSourceCompatibilityIssues;
+  /** Every issue joined, or `undefined` when compatible. */
+  message?: string;
+  candidate: { identity: string; symbol: string };
 }
 
 export type PieceSourceActionResult =
@@ -3200,6 +3219,45 @@ export class PieceController<T = unknown> {
     }
   }
 
+  /**
+   * Would `setPattern(program)` be accepted? Answers without applying anything.
+   *
+   * Drives the SAME review the apply path runs — no second copy of the rules,
+   * because a preflight that reimplements them drifts and starts lying. It
+   * compiles the candidate (which the runtime caches, so the subsequent apply
+   * does not pay for it twice) and reads the piece's argument; it opens no
+   * transaction and writes nothing.
+   */
+  async checkPattern(
+    program: RuntimeProgram,
+  ): Promise<PatternCompatibilityReport> {
+    const { pattern: previousPattern, ref: previousRef } = await this
+      .#loadCurrentPattern();
+    const candidate = await compileProgram(this.#manager, program, {
+      previousEntryIdentity: previousRef.identity,
+    });
+    const candidateRef = this.#manager.runtime.patternManager
+      .getArtifactEntryRef(candidate);
+    if (candidateRef === undefined) {
+      throw new Error("the candidate source has no pattern identity");
+    }
+    const review = await pieceSourceCompatibilityReview(
+      previousPattern,
+      candidate,
+      this.#cell,
+      this.#manager,
+    );
+    const compatible = !hasPieceSourceCompatibilityIssues(review.issues);
+    return {
+      compatible,
+      issues: review.issues,
+      candidate: candidateRef,
+      ...(compatible
+        ? {}
+        : { message: pieceSourceCompatibilityMessage(review.issues) }),
+    };
+  }
+
   async setPattern(
     program: RuntimeProgram,
     options?: {
@@ -3233,7 +3291,19 @@ export class PieceController<T = unknown> {
             : {},
         );
         if (!options?.dangerouslyAllowIncompatibleSchema) {
-          assertPatternSchemasBackwardCompatible(previousPattern, pattern);
+          // The same review `checkPattern()` runs, so a refusal here names
+          // every reason rather than whichever assertion happened to fire
+          // first. The execute-time validators below still enforce
+          // independently — this decides the MESSAGE, not the outcome.
+          const review = await pieceSourceCompatibilityReview(
+            previousPattern,
+            pattern,
+            this.#cell,
+            this.#manager,
+          );
+          if (hasPieceSourceCompatibilityIssues(review.issues)) {
+            throw new Error(pieceSourceCompatibilityMessage(review.issues));
+          }
         }
         transition = pieceSourceTransition(
           expected,

--- a/packages/piece/test/pattern-compatibility-check.test.ts
+++ b/packages/piece/test/pattern-compatibility-check.test.ts
@@ -7,6 +7,7 @@ import {
   type RuntimeProgram,
 } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { readStoredCfcMetadata } from "@commonfabric/runner/cfc";
 import { PieceManager } from "../src/manager.ts";
 import { PiecesController } from "../src/ops/pieces-controller.ts";
 
@@ -119,6 +120,74 @@ function narrowedOutputProgram(): RuntimeProgram {
   };
 }
 
+/**
+ * The CFC-labelled variants below exist because the three rules above all
+ * reason about DECLARED types, and a fourth thing decides whether the setup
+ * commit lands: the CFC schema envelope physically stored on the piece's
+ * argument document. That envelope accumulates across every write the document
+ * ever took, so it can carry claims no pattern ever declared — and the merge
+ * against it rejects independently of every type-level check.
+ *
+ * A confidentiality label is what makes a document CFC-relevant at all
+ * (without one, nothing stores an envelope and the merge never runs). It is
+ * also the least entangled choice: an ownership label would demand matching
+ * `represents-principal` integrity on every write, so these cases would fail
+ * authorization before ever reaching the merge.
+ */
+const CFC_PRELUDE = [
+  "import { Confidential, NAME, pattern } from 'commonfabric';",
+  "const ATOM = {",
+  "  type: 'https://commonfabric.org/cfc/atom/Resource',",
+  "  class: 'SetsrcCompatibilityCheck',",
+  "  subject: 'did:example:declared',",
+  "} as const;",
+  "type Label = readonly [typeof ATOM];",
+];
+
+/** The atom the pattern declares, as it lands in the stored envelope. */
+const DECLARED_ATOM = {
+  type: "https://commonfabric.org/cfc/atom/Resource",
+  class: "SetsrcCompatibilityCheck",
+  subject: "did:example:declared",
+} as const;
+
+/** An atom NO version of the pattern declares — only a later write carries it. */
+const EXTRA_ATOM = {
+  type: "https://commonfabric.org/cfc/atom/Resource",
+  class: "SetsrcCompatibilityCheck",
+  subject: "did:example:extra",
+} as const;
+
+/**
+ * A CFC-labelled piece, in two revisions whose declared contracts are
+ * IDENTICAL down to the label. Keeping them identical is what isolates the
+ * envelope: any ifc difference between the two patterns is caught by the
+ * contract proof instead (`argument.seed: ifc changed`), which would make a
+ * CFC-envelope case pass for the wrong reason.
+ */
+function labelledProgram(label: string): RuntimeProgram {
+  return {
+    main: "/main.tsx",
+    files: [{
+      name: "/main.tsx",
+      contents: [
+        ...CFC_PRELUDE,
+        "interface Args { seed: Confidential<string, Label>; }",
+        "export default pattern<Args, { label: string }>(",
+        "  ({ seed }) => ({",
+        "    [NAME]: 'Compatibility check',",
+        `    label: ${label},`,
+        "  }),",
+        ");",
+        "",
+      ].join("\n"),
+    }],
+  };
+}
+
+const labelledBase = () => labelledProgram("seed");
+const labelledNext = () => labelledProgram("`seen:${seed}`");
+
 describe("setsrc compatibility preflight", () => {
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;
@@ -199,10 +268,16 @@ describe("setsrc compatibility preflight", () => {
       .toBe("seen:hello");
   });
 
-  it("agrees with the apply path, and names the same reason", async () => {
-    // The contract that keeps the preflight honest. Both run the same review,
-    // so a source the check refuses is refused by `setPattern` FOR THE SAME
-    // STATED REASON — otherwise the preflight is advice nobody can act on.
+  it("agrees with the apply path on the verdict and the cause", async () => {
+    // The contract that keeps the preflight honest: a source the check refuses
+    // is refused by `setPattern`, for the same underlying reason.
+    //
+    // Agreement is on the VERDICT and the CAUSE, deliberately not on identical
+    // prose. Enforcement lives on the apply path and reports in its own words;
+    // the check reports the review's. An earlier revision of this PR made the
+    // strings identical by running the review ahead of the swap, and that
+    // silently changed what `setPattern` accepts (see
+    // setsrc-cold-argument.test.ts). Message equality is not worth that.
     const piece = await livePiece();
     const report = await piece.checkPattern(incompatibleProgram());
     expect(report.compatible).toBe(false);
@@ -211,8 +286,162 @@ describe("setsrc compatibility preflight", () => {
       () => undefined,
       (error: unknown) => error as Error,
     );
-    expect(applied).toBeInstanceOf(Error);
-    expect(applied!.message).toBe(report.message);
+    // Refused on both paths. The check explains why in the review's words; the
+    // apply path reports in enforcement's, so only the verdict is compared.
+    expect(applied).toBeDefined();
+    expect(report.message).toContain("required");
+  });
+
+  /**
+   * A live CFC-labelled piece whose stored argument envelope has been widened
+   * past what any revision of the pattern declares.
+   *
+   * This is not a contrived shape: an envelope is the union of every write's
+   * claims, and strengthening a label is always allowed, so any later writer
+   * that presents a broader confidentiality leaves the document carrying more
+   * than the pattern does. The piece is then partially migrated — its pattern
+   * pointer is behind its own document — and that is the state where the three
+   * type-level rules all pass and the setup commit still refuses.
+   */
+  const pieceWithWidenedEnvelope = async () => {
+    const piece = await pieces.create(labelledBase(), {
+      input: { seed: "hello" },
+    });
+    await runtime.idle();
+    const argument = manager.getArgument(piece.getCell());
+    const { error } = await runtime.editWithRetry((tx) => {
+      argument.withTx(tx).asSchema({
+        type: "object",
+        properties: {
+          seed: {
+            type: "string",
+            ifc: { confidentiality: [DECLARED_ATOM, EXTRA_ATOM] },
+          },
+        },
+      } as never).set({ seed: "hello" } as never);
+    });
+    expect(
+      error?.message,
+      "the fixture could not widen the stored envelope, so the case below " +
+        "would pass for want of a merge to fail rather than because the " +
+        "check works",
+    ).toBeUndefined();
+    await runtime.idle();
+    return piece;
+  };
+
+  it("clears a CFC-labelled piece whose stored envelope still matches", async () => {
+    // The control for the two cases below. Carrying a CFC envelope at all must
+    // not make a piece un-swappable — otherwise the new rule reads as "any
+    // labelled piece is incompatible" and operators learn to ignore it.
+    const piece = await pieces.create(labelledBase(), {
+      input: { seed: "hello" },
+    });
+    await runtime.idle();
+
+    const report = await piece.checkPattern(labelledNext());
+    expect(report.compatible).toBe(true);
+    expect(report.issues).toEqual({});
+  });
+
+  it("refuses a source the piece's stored CFC envelope cannot merge with", async () => {
+    const piece = await pieceWithWidenedEnvelope();
+    const report = await piece.checkPattern(labelledNext());
+
+    // Isolation is the claim: the contract proof, the stored-argument
+    // validation and the retained-link proof ALL pass here — the two patterns
+    // are identical and the stored value is a plain string. Only the envelope
+    // rejects, so a check that stopped at the declared types would report this
+    // source as safe to deploy.
+    expect(report.issues.schema).toBe(undefined);
+    expect(report.issues.argument).toBe(undefined);
+    expect(report.issues.retainedLinks).toBe(undefined);
+    expect(report.compatible).toBe(false);
+    expect(report.issues.cfc).toBeDefined();
+    // The reason is the merge's own words, not a paraphrase invented here —
+    // it is the same sentence the commit rejection carries.
+    expect(report.message).toContain("confidentiality cannot be weakened");
+    expect(report.message).toContain("/seed");
+  });
+
+  it("predicts a real commit rejection, not a gate of its own", async () => {
+    // The property that makes the verdict worth acting on. The override exists
+    // precisely to bypass the preflight, so driving the apply path THROUGH it
+    // reaches the enforcement layer itself: CFC still refuses the commit, over
+    // the same weakening. The check is reporting something real.
+    const piece = await pieceWithWidenedEnvelope();
+    const report = await piece.checkPattern(labelledNext());
+    expect(report.compatible).toBe(false);
+
+    // The storage layer aborts with its own rejection shape rather than an
+    // `Error`, so read the message off it directly — the point is WHOSE
+    // rejection this is, and it is CFC enforcement's.
+    const forced = await piece.setPattern(labelledNext(), {
+      dangerouslyAllowIncompatibleSchema: true,
+    }).then(
+      () => undefined,
+      (error: unknown) => (error as { message?: string })?.message,
+    );
+    expect(forced).toContain("CFC enforcement rejected commit");
+    expect(forced).toContain("confidentiality cannot be weakened at /seed");
+
+    // And without the override, the apply path refuses too — naming the same
+    // cause in enforcement's own words. Agreement is on the verdict and the
+    // cause, not on identical prose: making the strings match would mean
+    // running the review ahead of the swap, which changes what `setPattern`
+    // accepts (see setsrc-cold-argument.test.ts).
+    const applied = await piece.setPattern(labelledNext()).then(
+      () => undefined,
+      (error: unknown) =>
+        error instanceof Error ? error.message : JSON.stringify(error),
+    );
+    expect(applied).toBeDefined();
+    // Both name the same underlying cause, in their own words. (The apply path
+    // may reject with a bare CFC rejection object rather than an `Error`, so
+    // compare text rather than asserting a type.)
+    expect(report.message).toContain("confidentiality cannot be weakened");
+    expect(applied).toContain("confidentiality cannot be weakened");
+  });
+
+  it("refuses a piece whose stored CFC envelope cannot be read at all", async () => {
+    // An envelope that exists but will not load is the tempting thing to skip:
+    // there is no merge to run, so "not applicable" reads as the honest
+    // answer. It is not — the commit path records that same load failure as a
+    // rejection reason and refuses the write, so skipping it green-lights a
+    // swap the deploy then rejects.
+    const piece = await pieces.create(labelledBase(), {
+      input: { seed: "hello" },
+    });
+    await runtime.idle();
+
+    // Serve a different schema at the content address the metadata names.
+    const link = manager.getArgument(piece.getCell())
+      .getAsNormalizedFullLink();
+    const metadata = readStoredCfcMetadata(runtime.readTx(), {
+      space: link.space,
+      id: link.id,
+      scope: link.scope,
+    });
+    expect(
+      metadata?.schemaHash,
+      "the labelled fixture stored no CFC envelope, so there is nothing for " +
+        "this case to poison",
+    ).toBeDefined();
+    const { error } = await runtime.editWithRetry((tx) => {
+      tx.writeOrThrow({
+        space: link.space,
+        id: `cid:${metadata!.schemaHash}` as typeof link.id,
+        type: "application/json",
+        path: [],
+      }, { value: { type: "string" } });
+    });
+    expect(error?.message).toBeUndefined();
+    await runtime.idle();
+
+    const report = await piece.checkPattern(labelledNext());
+    expect(report.compatible).toBe(false);
+    expect(report.message).toContain("could not be read");
+    expect(report.message).toContain("hash mismatch");
   });
 
   it("still lets the dangerous override through", async () => {

--- a/packages/piece/test/pattern-compatibility-check.test.ts
+++ b/packages/piece/test/pattern-compatibility-check.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { createSession, Identity } from "@commonfabric/identity";
-import { Runtime, type RuntimeProgram } from "@commonfabric/runner";
+import {
+  getPatternIdentityRef,
+  Runtime,
+  type RuntimeProgram,
+} from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { PieceManager } from "../src/manager.ts";
 import { PiecesController } from "../src/ops/pieces-controller.ts";
@@ -12,9 +16,12 @@ import { PiecesController } from "../src/ops/pieces-controller.ts";
 // a schema-subset assertion, a retained-link proof, or an argument validation
 // failure at the setup-commit boundary. Fix one, meet the next.
 //
-// `checkPattern()` answers the question up front and applies nothing. It runs
-// the SAME review the apply path runs (`pieceSourceCompatibilityReview`), which
-// is the property worth pinning: a preflight that reimplements the rules drifts
+// `checkPattern()` answers the question up front without changing the piece.
+// (It is not a pure read — compiling the candidate writes content-addressed
+// artifacts into the space — but it moves no pointer and re-stages nothing.)
+// It runs the SAME review the apply path runs
+// (`pieceSourceCompatibilityReview`), which is the property worth pinning: a
+// preflight that reimplements the rules drifts
 // from enforcement and becomes a liar. So these cases assert the two verdicts
 // agree, not merely that each is individually plausible.
 
@@ -169,10 +176,17 @@ describe("setsrc compatibility preflight", () => {
     const piece = await livePiece();
     await runtime.idle();
     const before = JSON.stringify(piece.getCell().getAsQueryResult());
+    const refBefore = getPatternIdentityRef(piece.getCell());
 
     await piece.checkPattern(incompatibleProgram());
     await runtime.idle();
 
+    // The piece is what must be untouched. (The check is not a pure read: it
+    // compiles the candidate, which writes content-addressed artifacts into
+    // the space. Those are attached to nothing — the POINTER is the thing a
+    // caller cares about, so assert it directly rather than inferring it from
+    // the rendered result.)
+    expect(getPatternIdentityRef(piece.getCell())).toEqual(refBefore);
     expect(JSON.stringify(piece.getCell().getAsQueryResult())).toBe(before);
 
     // And the piece still accepts a compatible source afterwards: the refused

--- a/packages/piece/test/pattern-compatibility-check.test.ts
+++ b/packages/piece/test/pattern-compatibility-check.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { createSession, Identity } from "@commonfabric/identity";
+import { Runtime, type RuntimeProgram } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { PieceManager } from "../src/manager.ts";
+import { PiecesController } from "../src/ops/pieces-controller.ts";
+
+// `cf piece setsrc <main>` replaces the source of a LIVE piece. Until now the
+// only way to learn whether a source could be applied was to attempt it, and
+// what came back was whichever low-level rejection happened to surface first —
+// a schema-subset assertion, a retained-link proof, or an argument validation
+// failure at the setup-commit boundary. Fix one, meet the next.
+//
+// `checkPattern()` answers the question up front and applies nothing. It runs
+// the SAME review the apply path runs (`pieceSourceCompatibilityReview`), which
+// is the property worth pinning: a preflight that reimplements the rules drifts
+// from enforcement and becomes a liar. So these cases assert the two verdicts
+// agree, not merely that each is individually plausible.
+
+const signer = await Identity.fromPassphrase("pattern compatibility check");
+
+/** The piece's current source: one optional input, one output. */
+function baseProgram(): RuntimeProgram {
+  return {
+    main: "/main.tsx",
+    files: [{
+      name: "/main.tsx",
+      contents: [
+        "import { NAME, pattern } from 'commonfabric';",
+        "export default pattern<{ seed?: string }, { label: string }>(",
+        "  ({ seed }) => ({",
+        "    [NAME]: 'Compatibility check',",
+        "    label: seed ?? 'unset',",
+        "  }),",
+        ");",
+        "",
+      ].join("\n"),
+    }],
+  };
+}
+
+/** A later revision of the same contract: accepted. */
+function compatibleProgram(): RuntimeProgram {
+  return {
+    main: "/main.tsx",
+    files: [{
+      name: "/main.tsx",
+      contents: [
+        "import { NAME, pattern } from 'commonfabric';",
+        "export default pattern<{ seed?: string }, { label: string }>(",
+        "  ({ seed }) => ({",
+        "    [NAME]: 'Compatibility check',",
+        "    label: seed ?? 'still unset',",
+        "  }),",
+        ");",
+        "",
+      ].join("\n"),
+    }],
+  };
+}
+
+/**
+ * Demands an input the stored argument does not carry and cannot default.
+ * This is the shape that bricked home roots on estuary: a required field with
+ * no default cannot migrate documents written before it existed.
+ */
+function incompatibleProgram(): RuntimeProgram {
+  return {
+    main: "/main.tsx",
+    files: [{
+      name: "/main.tsx",
+      contents: [
+        "import { NAME, pattern } from 'commonfabric';",
+        "export default pattern<{ required: number }, { label: string }>(",
+        "  ({ required }) => ({",
+        "    [NAME]: 'Compatibility check',",
+        "    label: String(required),",
+        "  }),",
+        ");",
+        "",
+      ].join("\n"),
+    }],
+  };
+}
+
+/**
+ * Narrows the declared OUTPUT type, which the argument/result subset proof
+ * rejects. The stored argument stays valid, so this isolates the contract rule
+ * from the stored-argument rule.
+ */
+function narrowedOutputProgram(): RuntimeProgram {
+  return {
+    main: "/main.tsx",
+    files: [{
+      name: "/main.tsx",
+      contents: [
+        "import { NAME, pattern } from 'commonfabric';",
+        "export default pattern<{ seed?: string }, { label: number }>(",
+        "  () => ({",
+        "    [NAME]: 'Compatibility check',",
+        "    label: 7,",
+        "  }),",
+        ");",
+        "",
+      ].join("\n"),
+    }],
+  };
+}
+
+describe("setsrc compatibility preflight", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let manager: PieceManager;
+  let pieces: PiecesController;
+
+  beforeEach(async () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("http://toolshed.test"),
+      storageManager,
+    });
+    manager = new PieceManager(
+      await createSession({
+        identity: signer,
+        spaceName: `pattern-compat-check-${crypto.randomUUID()}`,
+      }),
+      runtime,
+    );
+    await manager.synced();
+    pieces = new PiecesController(manager);
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  const livePiece = async () =>
+    await pieces.create(baseProgram(), { seed: "hello" });
+
+  it("clears a source that can replace the current one", async () => {
+    const piece = await livePiece();
+    const report = await piece.checkPattern(compatibleProgram());
+
+    expect(report.compatible).toBe(true);
+    expect(report.message).toBe(undefined);
+    expect(report.issues).toEqual({});
+    // The verdict names the source it judged, so a caller can tell which
+    // revision was cleared.
+    expect(report.candidate.identity).toBeDefined();
+  });
+
+  it("refuses a source whose contract the stored argument cannot satisfy", async () => {
+    const piece = await livePiece();
+    const report = await piece.checkPattern(incompatibleProgram());
+
+    expect(report.compatible).toBe(false);
+    expect(report.message).toBeDefined();
+    // The reason is the rule's own words, not a paraphrase invented here.
+    expect(report.message).toContain("required");
+  });
+
+  it("changes nothing — a refused check leaves the piece applying its old source", async () => {
+    const piece = await livePiece();
+    await runtime.idle();
+    const before = JSON.stringify(piece.getCell().getAsQueryResult());
+
+    await piece.checkPattern(incompatibleProgram());
+    await runtime.idle();
+
+    expect(JSON.stringify(piece.getCell().getAsQueryResult())).toBe(before);
+
+    // And the piece still accepts a compatible source afterwards: the refused
+    // check left no half-applied state behind to trip over.
+    await piece.setPattern(compatibleProgram());
+    await runtime.idle();
+    expect((piece.getCell().getAsQueryResult() as { label?: string }).label)
+      .toBe("still unset");
+  });
+
+  it("agrees with the apply path, and names the same reason", async () => {
+    // The contract that keeps the preflight honest. Both run the same review,
+    // so a source the check refuses is refused by `setPattern` FOR THE SAME
+    // STATED REASON — otherwise the preflight is advice nobody can act on.
+    const piece = await livePiece();
+    const report = await piece.checkPattern(incompatibleProgram());
+    expect(report.compatible).toBe(false);
+
+    const applied = await piece.setPattern(incompatibleProgram()).then(
+      () => undefined,
+      (error: unknown) => error as Error,
+    );
+    expect(applied).toBeInstanceOf(Error);
+    expect(applied!.message).toBe(report.message);
+  });
+
+  it("still lets the dangerous override through", async () => {
+    // `--dangerously-allow-incompatible-schema` exists for the case where the
+    // operator knows better than the proof, and this new pre-check must not
+    // become a second gate that ignores it.
+    //
+    // The override covers the CONTRACT proof, not the stored argument: a
+    // candidate the argument cannot satisfy is still refused downstream at
+    // setup (that is #5207's validation, independent of this change). So the
+    // case to pin is a contract-only break — a narrowed output type, which the
+    // subset proof rejects while the stored argument stays perfectly valid.
+    const piece = await livePiece();
+    expect((await piece.checkPattern(narrowedOutputProgram())).compatible)
+      .toBe(false);
+
+    await piece.setPattern(narrowedOutputProgram(), {
+      dangerouslyAllowIncompatibleSchema: true,
+    });
+    await runtime.idle();
+    expect((piece.getCell().getAsQueryResult() as { label?: unknown }).label)
+      .toBe(7);
+  });
+});

--- a/packages/piece/test/pattern-compatibility-check.test.ts
+++ b/packages/piece/test/pattern-compatibility-check.test.ts
@@ -188,6 +188,38 @@ function labelledProgram(label: string): RuntimeProgram {
 const labelledBase = () => labelledProgram("seed");
 const labelledNext = () => labelledProgram("`seen:${seed}`");
 
+/**
+ * A revision declaring a STRONGER label than the piece's stored envelope
+ * carries: the stored envelope no longer covers the candidate's, so the fast
+ * path is skipped and the real merge runs — and strengthening is exactly what
+ * a merge accepts.
+ */
+function strengthenedProgram(): RuntimeProgram {
+  return {
+    main: "/main.tsx",
+    files: [{
+      name: "/main.tsx",
+      contents: [
+        ...CFC_PRELUDE,
+        "const EXTRA = {",
+        "  type: 'https://commonfabric.org/cfc/atom/Resource',",
+        "  class: 'SetsrcCompatibilityCheck',",
+        "  subject: 'did:example:extra',",
+        "} as const;",
+        "type Stronger = readonly [typeof ATOM, typeof EXTRA];",
+        "interface Args { seed: Confidential<string, Stronger>; }",
+        "export default pattern<Args, { label: string }>(",
+        "  ({ seed }) => ({",
+        "    [NAME]: 'Compatibility check',",
+        "    label: seed,",
+        "  }),",
+        ");",
+        "",
+      ].join("\n"),
+    }],
+  };
+}
+
 describe("setsrc compatibility preflight", () => {
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;
@@ -329,6 +361,29 @@ describe("setsrc compatibility preflight", () => {
     await runtime.idle();
     return piece;
   };
+
+  it("does not blame the envelope for a merge that actually succeeds", async () => {
+    // The stored envelope does not COVER a candidate that strengthens its
+    // label, so the fast path is skipped and the real merge runs. Strengthening
+    // is what a merge accepts, so the envelope must not appear as a reason.
+    //
+    // Worth pinning separately from the "still matches" control: that case
+    // returns early without ever consulting the merge, so it cannot tell a
+    // working merge from one that is never reached. Here the merge runs and
+    // has to come back clean.
+    const piece = await pieces.create(labelledBase(), {
+      input: { seed: "hello" },
+    });
+    await runtime.idle();
+
+    const report = await piece.checkPattern(strengthenedProgram());
+
+    expect(report.issues.cfc).toBe(undefined);
+    // The contract proof is entitled to object to the changed label — this is
+    // only asserting that the envelope check does not pile on a second,
+    // spurious reason for the same edit.
+    expect(report.issues.schema ?? "").not.toContain("envelope");
+  });
 
   it("clears a CFC-labelled piece whose stored envelope still matches", async () => {
     // The control for the two cases below. Carrying a CFC envelope at all must

--- a/packages/piece/test/pattern-compatibility-check.test.ts
+++ b/packages/piece/test/pattern-compatibility-check.test.ts
@@ -40,7 +40,11 @@ function baseProgram(): RuntimeProgram {
   };
 }
 
-/** A later revision of the same contract: accepted. */
+/**
+ * A later revision of the same contract: accepted. Its output is observably
+ * different for the same stored argument, so applying it proves the swap
+ * happened AND that the argument survived it.
+ */
 function compatibleProgram(): RuntimeProgram {
   return {
     main: "/main.tsx",
@@ -51,7 +55,7 @@ function compatibleProgram(): RuntimeProgram {
         "export default pattern<{ seed?: string }, { label: string }>(",
         "  ({ seed }) => ({",
         "    [NAME]: 'Compatibility check',",
-        "    label: seed ?? 'still unset',",
+        "    label: `seen:${seed ?? 'unset'}`,",
         "  }),",
         ");",
         "",
@@ -137,7 +141,7 @@ describe("setsrc compatibility preflight", () => {
   });
 
   const livePiece = async () =>
-    await pieces.create(baseProgram(), { seed: "hello" });
+    await pieces.create(baseProgram(), { input: { seed: "hello" } });
 
   it("clears a source that can replace the current one", async () => {
     const piece = await livePiece();
@@ -172,11 +176,13 @@ describe("setsrc compatibility preflight", () => {
     expect(JSON.stringify(piece.getCell().getAsQueryResult())).toBe(before);
 
     // And the piece still accepts a compatible source afterwards: the refused
-    // check left no half-applied state behind to trip over.
+    // check left no half-applied state behind to trip over. The new output
+    // proves the swap landed; `hello` inside it proves the stored argument
+    // came through unchanged.
     await piece.setPattern(compatibleProgram());
     await runtime.idle();
     expect((piece.getCell().getAsQueryResult() as { label?: string }).label)
-      .toBe("still unset");
+      .toBe("seen:hello");
   });
 
   it("agrees with the apply path, and names the same reason", async () => {

--- a/packages/piece/test/setsrc-cold-argument.test.ts
+++ b/packages/piece/test/setsrc-cold-argument.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { createSession, Identity } from "@commonfabric/identity";
+import {
+  getPatternIdentityRef,
+  Runtime,
+  type RuntimeProgram,
+} from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { PieceManager } from "../src/manager.ts";
+import { PiecesController } from "../src/ops/pieces-controller.ts";
+
+// CT-1917 at the `cf piece setsrc` boundary: a slot the piece cannot READ right
+// now is not a slot holding the wrong value.
+//
+// A piece's argument document is not always resident. A nested piece's argument
+// lives in its HOST's document, so while the host has not synced the whole
+// argument reads as nothing. Runner deliberately DEFERS that state rather than
+// failing it: `applySetupState` preserves the stored bytes and lets the swap
+// proceed, because refusing would make every such piece un-updatable for
+// reasons that have nothing to do with its stored value.
+// `packages/runner/test/pattern-update-argument-validation.test.ts` pins the
+// same deferral one layer down ("defers an argument doc that reads NOTHING on
+// the in-place path").
+//
+// `setPattern` has to inherit that deferral, and there is one specific way to
+// lose it: running the aggregate compatibility review BEFORE the swap. That
+// review materializes the stored argument and validates it against the
+// candidate's schema, and it cannot tell a cold document from a wrong one — over
+// a cold document it validates `undefined` and refuses. An earlier revision of
+// PR #5311 did exactly that, to name every incompatibility at once, and a
+// reviewer found it by execution: two revisions with IDENTICAL schemas carrying
+// a required field, which `main` swaps happily, were refused with "updated
+// arguments do not match the candidate schema: value does not match type
+// object".
+//
+// So enforcement stays where it was: `assertPatternSchemasBackwardCompatible`
+// plus the execute-time validators, all of which defer a cold read. Whatever
+// else `setPattern` does with the aggregate review, it must not be allowed to
+// decide ACCEPTANCE — and this case is the guard on that, failing the moment it
+// is put back in front of the swap.
+//
+// Every other case in this package supplies a WARM argument, which is why the
+// regression got through — a warm argument validates fine either way.
+
+const signer = await Identity.fromPassphrase("setsrc cold argument");
+
+/**
+ * Two revisions whose argument schemas are IDENTICAL, each carrying a REQUIRED
+ * object field. Identical schemas are what isolates the argument check: the
+ * contract proof (`assertPatternSchemasBackwardCompatible`) has nothing to
+ * complain about, so the only rule that can refuse this swap is one that reads
+ * the stored argument. `required` with no default is what makes the read
+ * decisive — validating `undefined` against it cannot pass.
+ *
+ * `marker` is the only difference, so a successful swap is observable in the
+ * piece's own output rather than inferred.
+ */
+function registryProgram(marker: string): RuntimeProgram {
+  return {
+    main: "/main.tsx",
+    files: [{
+      name: "/main.tsx",
+      contents: [
+        "import { NAME, pattern } from 'commonfabric';",
+        "interface Args { registry: { label: string } }",
+        "export default pattern<Args, { marker: string }>(",
+        "  () => ({",
+        "    [NAME]: 'Cold argument',",
+        `    marker: ${JSON.stringify(marker)},`,
+        "  }),",
+        ");",
+        "",
+      ].join("\n"),
+    }],
+  };
+}
+
+describe("setsrc over a cold argument document", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let manager: PieceManager;
+  let pieces: PiecesController;
+
+  beforeEach(async () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("http://toolshed.test"),
+      storageManager,
+    });
+    manager = new PieceManager(
+      await createSession({
+        identity: signer,
+        spaceName: `setsrc-cold-argument-${crypto.randomUUID()}`,
+      }),
+      runtime,
+    );
+    await manager.synced();
+    pieces = new PiecesController(manager);
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("applies a candidate whose stored argument cannot be read right now", async () => {
+    const piece = await pieces.create(registryProgram("v1"), {
+      input: { registry: { label: "hello" } },
+    });
+    await runtime.idle();
+    const before = getPatternIdentityRef(piece.getCell());
+
+    // Repoint the piece's argument at a document nothing has ever written, the
+    // same way the runner's CT-1917 case does. The read succeeds and yields
+    // NOTHING — which is the state under test — rather than erroring, so the
+    // review downstream sees `undefined` where a live host would later supply
+    // the real argument.
+    const cold = runtime.getCell<Record<string, unknown>>(
+      piece.getCell().space,
+      "setsrc-cold-argument-doc",
+    );
+    const { error: retargetError } = await runtime.editWithRetry((tx) => {
+      piece.getCell().withTx(tx).setMetaRaw(
+        "argument",
+        cold.getAsWriteRedirectLink({ base: piece.getCell() }),
+      );
+    });
+    expect(
+      retargetError?.message,
+      "the fixture could not repoint the argument, so the case below would " +
+        "run against a WARM argument and pass without testing anything",
+    ).toBeUndefined();
+    await runtime.idle();
+
+    // Guard the fixture itself. If this ever reads a value, the case has gone
+    // warm and its verdict means nothing.
+    const argument = manager.getArgument(piece.getCell());
+    await argument.sync();
+    expect(
+      argument.asSchema(undefined).get(),
+      "the argument document is readable, so this is no longer the cold case",
+    ).toBeUndefined();
+
+    // The contract: the swap is ACCEPTED. A cold slot is deferred, not failed.
+    await piece.setPattern(registryProgram("v2"));
+    await runtime.idle();
+
+    expect(
+      getPatternIdentityRef(piece.getCell())?.identity,
+      "the pattern pointer did not move, so the swap was refused over an " +
+        "argument the piece merely could not read (CT-1917)",
+    ).not.toBe(before?.identity);
+    expect(
+      (piece.getCell().getAsQueryResult() as { marker?: string }).marker,
+    ).toBe("v2");
+  });
+});

--- a/packages/runner/src/cfc/mod.ts
+++ b/packages/runner/src/cfc/mod.ts
@@ -229,10 +229,7 @@ export type {
 } from "./prepare.ts";
 export { readStoredCfcMetadata } from "./metadata.ts";
 export { cfcSchemaMergeIssue } from "./schema-merge.ts";
-export type {
-  CfcSchemaMergeIssue,
-  MergeCfcSchemaEnvelopeOptions,
-} from "./schema-merge.ts";
+export type { CfcSchemaMergeIssue } from "./schema-merge.ts";
 export {
   createSinkRequestPolicyInput,
   recordSinkRequestPolicyInput,

--- a/packages/runner/src/cfc/mod.ts
+++ b/packages/runner/src/cfc/mod.ts
@@ -216,14 +216,23 @@ export {
   flowLabelWorkExists,
   flowReadExcluded,
   gatedSinkRequestExists,
+  loadStoredCfcEnvelope,
   prepareBoundaryCommit,
+  storedSchemaCoversCandidateEnvelope,
 } from "./prepare.ts";
 export type {
   CfcPrefixBoundSource,
   CfcPrefixProvenanceSummary,
   CfcPrefixProvenanceWrite,
   CfcPrepareInstrumentation,
+  StoredCfcEnvelope,
 } from "./prepare.ts";
+export { readStoredCfcMetadata } from "./metadata.ts";
+export { cfcSchemaMergeIssue } from "./schema-merge.ts";
+export type {
+  CfcSchemaMergeIssue,
+  MergeCfcSchemaEnvelopeOptions,
+} from "./schema-merge.ts";
 export {
   createSinkRequestPolicyInput,
   recordSinkRequestPolicyInput,

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -4582,6 +4582,73 @@ export const loadSchemaDocument = (
   return schema;
 };
 
+/**
+ * The stored CFC schema envelope at rest for one document, as the commit path
+ * sees it.
+ *
+ * Why one function: this is the gatherer BOTH the real commit path (the merge
+ * loop in `prepareBoundaryCommit` below) and the `cf piece setsrc --check`
+ * preflight call, so the two cannot disagree about what a document carries or
+ * about what counts as a failure. The failure taxonomy is part of the
+ * contract:
+ *
+ * - `none` — the document stores no CFC metadata, so the envelope merge never
+ *   runs for it at commit time and there is genuinely nothing to reject.
+ * - `loaded` — the metadata's `schemaHash` resolved to a content-verified
+ *   schema document; `metadata` rides along for callers (the commit path) that
+ *   also need the stored label map.
+ * - `unreadable` — metadata EXISTS but its envelope cannot be loaded (missing
+ *   cid document, content-hash mismatch). The commit path records `reason` and
+ *   rejects the write in enforcing modes, so a preflight must report it as a
+ *   blocker and never as "nothing stored" — treating it as absent is exactly
+ *   how a check green-lights an update the real commit then refuses.
+ *
+ * A metadata READ failure (the transaction itself erroring) still propagates:
+ * that is an operational failure of the caller's transaction, not a property
+ * of the document, and both paths fail loudly on it today.
+ */
+export type StoredCfcEnvelope =
+  | { readonly status: "none" }
+  | {
+    readonly status: "loaded";
+    readonly schema: JSONSchema;
+    readonly metadata: CfcMetadata;
+  }
+  | { readonly status: "unreadable"; readonly reason: string };
+
+export const loadStoredCfcEnvelope = (
+  tx: IExtendedStorageTransaction,
+  target: {
+    space: MemorySpace;
+    id: string;
+    scope?: Parameters<typeof normalizeCellScope>[0];
+  },
+  type: MediaType = "application/json",
+): StoredCfcEnvelope => {
+  const metadata = storedMetadataFor(
+    tx,
+    target.space,
+    target.id as URI,
+    normalizeCellScope(target.scope),
+    type,
+  );
+  if (metadata === undefined) return { status: "none" };
+  try {
+    return {
+      status: "loaded",
+      schema: loadSchemaDocument(tx, target.space, metadata.schemaHash),
+      metadata,
+    };
+  } catch (error) {
+    return {
+      status: "unreadable",
+      reason: error instanceof Error
+        ? error.message
+        : `schema load failed for ${target.id}`,
+    };
+  }
+};
+
 // Union of confidentiality (and integrity) atoms across every non-internal labeled read in the
 // transaction, resolved from stored labels the same way verifyInputRequirements
 // resolves them. Transaction-global by design — deliberately NOT scoped to a
@@ -5392,30 +5459,25 @@ export const prepareBoundaryCommit = (
       if (flowJoinIsCrossSpace) crossSpaceEligible?.add(entry);
       return entry;
     };
-    const existing = storedMetadataFor(
-      tx,
-      space,
-      id,
-      scope,
-      "application/json",
-    );
+    // ONE gatherer decides what this document stores — the same function the
+    // `setsrc --check` preflight calls — so the commit path and the preflight
+    // cannot drift apart on whether an unreadable envelope counts as "nothing
+    // stored". `unreadable` records the load failure as a rejection reason
+    // exactly as the inline catches here always did.
+    const stored = loadStoredCfcEnvelope(tx, { space, id, scope });
+    if (stored.status === "unreadable") {
+      reasons.push(stored.reason);
+      continue;
+    }
+    const existing = stored.status === "loaded" ? stored.metadata : undefined;
     let storedSchema: JSONSchema | undefined;
     let mergedSchema = schema;
-    if (existing !== undefined && undefinedCandidate) {
+    if (stored.status === "loaded" && undefinedCandidate) {
+      storedSchema = stored.schema;
+      mergedSchema = storedSchema;
+    } else if (stored.status === "loaded") {
+      storedSchema = stored.schema;
       try {
-        storedSchema = loadSchemaDocument(tx, space, existing.schemaHash);
-        mergedSchema = storedSchema;
-      } catch (error) {
-        reasons.push(
-          error instanceof Error
-            ? error.message
-            : `schema load failed for ${id}`,
-        );
-        continue;
-      }
-    } else if (existing !== undefined) {
-      try {
-        storedSchema = loadSchemaDocument(tx, space, existing.schemaHash);
         mergedSchema = schemasEqualIgnoringWriterStamp(storedSchema, schema) ||
             storedSchemaCoversCandidateEnvelope(storedSchema, schema)
           ? storedSchema
@@ -5427,8 +5489,9 @@ export const prepareBoundaryCommit = (
         // token so the default-root runnability backstop can key on THIS class
         // (recoverable by rolling forward) and leave every other CFC rejection
         // fail-closed. Only the recorded reason is tagged; the human-readable
-        // message is preserved verbatim after the token. A plain schema-load or
-        // other merge failure records its bare message as before.
+        // message is preserved verbatim after the token. Schema-LOAD failures
+        // are handled above by the shared gatherer and record their bare
+        // message as before.
         reasons.push(
           error instanceof CfcSchemaMigrationError
             ? `${CFC_SCHEMA_MIGRATION_INCOMPATIBLE_REASON}: ${error.message}`

--- a/packages/runner/src/cfc/schema-merge.ts
+++ b/packages/runner/src/cfc/schema-merge.ts
@@ -634,10 +634,9 @@ export interface CfcSchemaMergeIssue {
 export const cfcSchemaMergeIssue = (
   existing: JSONSchema,
   candidate: JSONSchema,
-  options: MergeCfcSchemaEnvelopeOptions = {},
 ): CfcSchemaMergeIssue | undefined => {
   try {
-    mergeCfcSchemaEnvelopes(existing, candidate, options);
+    mergeCfcSchemaEnvelopes(existing, candidate);
     return undefined;
   } catch (error) {
     if (error instanceof CfcSchemaMigrationError) {

--- a/packages/runner/src/cfc/schema-merge.ts
+++ b/packages/runner/src/cfc/schema-merge.ts
@@ -602,3 +602,50 @@ export const mergeCfcSchemaEnvelopes = (
   assertNoDivergentIfcBranches(candidate);
   return internSchema(mergeSchemaNode(existing, candidate, "", [], options));
 };
+
+/** Why a stored envelope and a candidate envelope cannot be merged. */
+export interface CfcSchemaMergeIssue {
+  /** The merge's own human-readable reason, verbatim. */
+  message: string;
+  /**
+   * True when the rejection is the additive-required migration class — an old
+   * document predating a now-required field that declares no default. This is
+   * the class the runnability backstop rolls forward on
+   * (see {@link CfcSchemaMigrationError}); everything else is a hard
+   * incompatibility that no roll-forward recovers.
+   */
+  migration: boolean;
+}
+
+/**
+ * Would {@link mergeCfcSchemaEnvelopes} accept this candidate over this stored
+ * envelope? `undefined` means yes.
+ *
+ * Why this exists: replacing a live piece's pattern source used to discover an
+ * unmergeable envelope only by attempting the swap and taking a low-level
+ * rejection from the setup commit. That is the failure `cf piece setsrc
+ * --check` is supposed to predict, so the preflight drives THIS seam — the
+ * same merge the commit runs, called in dry-run — rather than a second
+ * implementation of the rules that would drift out of agreement with
+ * enforcement and start green-lighting swaps the deploy then refuses.
+ *
+ * Pure: no transaction, no writes, because the merge itself is.
+ */
+export const cfcSchemaMergeIssue = (
+  existing: JSONSchema,
+  candidate: JSONSchema,
+  options: MergeCfcSchemaEnvelopeOptions = {},
+): CfcSchemaMergeIssue | undefined => {
+  try {
+    mergeCfcSchemaEnvelopes(existing, candidate, options);
+    return undefined;
+  } catch (error) {
+    if (error instanceof CfcSchemaMigrationError) {
+      return { message: error.message, migration: true };
+    }
+    return {
+      message: error instanceof Error ? error.message : String(error),
+      migration: false,
+    };
+  }
+};

--- a/packages/runner/test/cfc-cid-schema-verify.test.ts
+++ b/packages/runner/test/cfc-cid-schema-verify.test.ts
@@ -1,7 +1,10 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
-import { loadSchemaDocument } from "../src/cfc/prepare.ts";
+import {
+  loadSchemaDocument,
+  loadStoredCfcEnvelope,
+} from "../src/cfc/prepare.ts";
 import type { JSONSchema } from "../src/builder/types.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 
@@ -45,5 +48,93 @@ describe("cid schema document verification", () => {
     expect(() =>
       loadSchemaDocument(fakeTxReturning(poisoned), space, taggedHashString)
     ).toThrow(/hash mismatch/);
+  });
+});
+
+// `loadStoredCfcEnvelope` is the ONE gatherer of a document's stored CFC schema
+// envelope: the commit path's merge loop and the `cf piece setsrc --check`
+// preflight both call it, so its three outcomes ARE the shared failure
+// taxonomy. `unreadable` in particular has to stay its own state — the commit
+// records it as a rejection reason and refuses the write, so a caller that
+// mistook it for "no envelope" would green-light an update the real commit
+// then rejects.
+const fakeTxOverDocuments = (
+  documents: Record<string, unknown>,
+): IExtendedStorageTransaction =>
+  ({
+    readOrThrow: (target: { id: string }) => documents[target.id],
+  }) as unknown as IExtendedStorageTransaction;
+
+const envelopeTarget = { space, id: "of:doc", scope: "space" } as const;
+
+const metadataNaming = (schemaHash: string) => ({
+  cfc: { version: 1, schemaHash, labelMap: { version: 1, entries: [] } },
+});
+
+describe("stored CFC envelope gathering", () => {
+  it("reports a document with no stored metadata as none", () => {
+    expect(
+      loadStoredCfcEnvelope(
+        fakeTxOverDocuments({ "of:doc": { value: 1 } }),
+        envelopeTarget,
+      ),
+    ).toEqual({ status: "none" });
+  });
+
+  it("loads and verifies the envelope the metadata names", () => {
+    const { schema, taggedHashString } = internSchema(
+      { type: "object", properties: { a: { type: "string" } } } as JSONSchema,
+      true,
+    );
+    const result = loadStoredCfcEnvelope(
+      fakeTxOverDocuments({
+        "of:doc": metadataNaming(taggedHashString),
+        [`cid:${taggedHashString}`]: { value: schema },
+      }),
+      envelopeTarget,
+    );
+
+    expect(result.status).toBe("loaded");
+    if (result.status === "loaded") {
+      expect(result.schema).toEqual(schema);
+      // The metadata rides along for the commit path, which also needs the
+      // stored label map.
+      expect(result.metadata.schemaHash).toBe(taggedHashString);
+    }
+  });
+
+  it("reports a missing envelope document as unreadable, not as none", () => {
+    const result = loadStoredCfcEnvelope(
+      fakeTxOverDocuments({ "of:doc": metadataNaming("missing-hash") }),
+      envelopeTarget,
+    );
+
+    expect(result.status).toBe("unreadable");
+    if (result.status === "unreadable") {
+      expect(result.reason).toContain("missing or unreadable");
+    }
+  });
+
+  it("reports a poisoned envelope document as unreadable", () => {
+    const { taggedHashString } = internSchema(
+      { type: "object", properties: { a: { type: "string" } } } as JSONSchema,
+      true,
+    );
+    const poisoned = internSchema(
+      { type: "string", ifc: { confidentiality: [] } } as JSONSchema,
+      true,
+    ).schema;
+    const result = loadStoredCfcEnvelope(
+      fakeTxOverDocuments({
+        "of:doc": metadataNaming(taggedHashString),
+        [`cid:${taggedHashString}`]: { value: poisoned },
+      }),
+      envelopeTarget,
+    );
+
+    expect(result.status).toBe("unreadable");
+    if (result.status === "unreadable") {
+      expect(result.reason).toContain("hash mismatch");
+    }
   });
 });

--- a/packages/runner/test/cfc-schema-merge.test.ts
+++ b/packages/runner/test/cfc-schema-merge.test.ts
@@ -1197,19 +1197,4 @@ describe("cfcSchemaMergeIssue", () => {
     expect(issue?.migration).toBe(false);
     expect(issue?.message).toContain("confidentiality cannot be weakened");
   });
-
-  it("passes generated-output paths through to the merge", () => {
-    // Same additive-required shape as above, but declared a generated output:
-    // the module materializes it in the same transaction, so there is no older
-    // value to preserve and the merge accepts it. The preflight has to see the
-    // same answer the commit does, options included.
-    expect(cfcSchemaMergeIssue({
-      type: "object",
-      properties: { a: { type: "string" } },
-    }, {
-      type: "object",
-      properties: { a: { type: "string" }, b: { type: "string" } },
-      required: ["b"],
-    }, { generatedOutputPaths: [[]] })).toBe(undefined);
-  });
 });

--- a/packages/runner/test/cfc-schema-merge.test.ts
+++ b/packages/runner/test/cfc-schema-merge.test.ts
@@ -1,7 +1,10 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import type { JSONSchemaObj } from "../src/builder/types.ts";
-import { mergeCfcSchemaEnvelopes } from "../src/cfc/schema-merge.ts";
+import {
+  cfcSchemaMergeIssue,
+  mergeCfcSchemaEnvelopes,
+} from "../src/cfc/schema-merge.ts";
 import { storedSchemaCoversCandidateEnvelope } from "../src/cfc/prepare.ts";
 
 describe("mergeCfcSchemaEnvelopes", () => {
@@ -1147,5 +1150,66 @@ describe("storedSchemaCoversCandidateEnvelope (merge-skip decision)", () => {
       items: { type: "number" },
     } as const;
     expect(storedSchemaCoversCandidateEnvelope(stored, candidate)).toBe(false);
+  });
+});
+
+// `cfcSchemaMergeIssue` is the dry-run seam over the SAME merge: `cf piece
+// setsrc --check` asks it whether a candidate envelope would be accepted
+// rather than attempting the swap and taking a low-level commit rejection.
+// What it must not do is reimplement the rules, so these cases pin that its
+// verdict is the merge's own — including the message, verbatim.
+describe("cfcSchemaMergeIssue", () => {
+  it("reports no issue when the merge succeeds", () => {
+    expect(cfcSchemaMergeIssue({
+      type: "object",
+      properties: { a: { type: "string" } },
+    }, {
+      type: "object",
+      properties: { a: { type: "string" } },
+    })).toBe(undefined);
+  });
+
+  it("discriminates the additive-required migration class", () => {
+    // The class the runnability backstop rolls forward on: an old document
+    // predating a now-required field that declares no default. A caller has to
+    // be able to tell it apart from a hard incompatibility, because only this
+    // one is recoverable.
+    const issue = cfcSchemaMergeIssue({
+      type: "object",
+      properties: { a: { type: "string" } },
+    }, {
+      type: "object",
+      properties: { a: { type: "string" }, b: { type: "string" } },
+      required: ["b"],
+    });
+    expect(issue?.migration).toBe(true);
+    expect(issue?.message).toContain("needs a default");
+  });
+
+  it("reports a weakened ifc claim as a hard incompatibility", () => {
+    const issue = cfcSchemaMergeIssue({
+      type: "object",
+      properties: { a: { type: "string", ifc: { confidentiality: ["x"] } } },
+    }, {
+      type: "object",
+      properties: { a: { type: "string", ifc: { confidentiality: ["y"] } } },
+    });
+    expect(issue?.migration).toBe(false);
+    expect(issue?.message).toContain("confidentiality cannot be weakened");
+  });
+
+  it("passes generated-output paths through to the merge", () => {
+    // Same additive-required shape as above, but declared a generated output:
+    // the module materializes it in the same transaction, so there is no older
+    // value to preserve and the merge accepts it. The preflight has to see the
+    // same answer the commit does, options included.
+    expect(cfcSchemaMergeIssue({
+      type: "object",
+      properties: { a: { type: "string" } },
+    }, {
+      type: "object",
+      properties: { a: { type: "string" }, b: { type: "string" } },
+      required: ["b"],
+    }, { generatedOutputPaths: [[]] })).toBe(undefined);
   });
 });


### PR DESCRIPTION
## Why

`cf piece setsrc <main>` replaces the pattern source of a **live** piece. Until
now the only way to learn whether a source could be applied was to attempt it,
and what came back was whichever low-level rejection surfaced first — a
schema-subset assertion, a retained-link proof, an argument validation failure,
or a CFC envelope rejection at the setup-commit boundary. Fix one, meet the
next.

That class cost a production incident on estuary: home roots and profile pieces
pinned to patterns that could not migrate their existing documents. #4967 and
#4977 added runtime *repairs*. This is the other half — knowing **beforehand**
whether a given source can be applied to a given piece.

## What Changed

`PieceController.checkPattern()` answers that without touching the piece;
`setsrc` grows `--check` to expose it, exiting non-zero when refused so it can
gate a deploy script. The report names every reason at once instead of the
first one to throw. (It is not a pure read: compiling the candidate persists
content-addressed compiled modules and source docs, per CT-1623 — but the piece
itself is never changed.)

The design constraint is **no second copy of the rules** — a preflight that
reimplements compatibility drifts from enforcement and becomes a liar. So the
check drives `pieceSourceCompatibilityReview()`, the review `changeSource`
already uses for detach/restore/follow, which runs the real
`assertPatternSchemasBackwardCompatible`, the real argument validation against
the candidate schema, and the real retained-link assertion. To that review this
PR adds a CFC envelope check: a dry-run of the real `mergeCfcSchemaEnvelopes`
against the piece's stored argument envelope, with an unreadable envelope
treated as a blocker. This is the class behind the estuary incident — type-level
checks all pass while the stored documents cannot migrate — and the test suite
proves the false green: a swap every schema check clears is rejected by the
real commit path with `CFC enforcement rejected commit`, and the check now
predicts it.

**`setPattern` itself is unchanged from `main` — byte for byte, on purpose.**
An earlier revision ran the aggregate review ahead of the swap, and that broke
CT-1917 cold-argument deferral: the review materializes and validates the
argument, so a deferred/unreadable argument validates as `undefined` and the
swap is refused where the apply path deliberately defers. The check is an
advisory path beside enforcement, not in front of it.
`packages/piece/test/setsrc-cold-argument.test.ts` pins this (verified red
against the broken revision).

## What the check guarantees — and what it does not

The contract is agreement on **verdict and stated cause**: a source the check
refuses is refused by the apply path, for the same reason. Two honest limits:

- **Result envelopes are not checked.** The CFC check covers the stored
  *argument* document only. The piece's own result document merges at commit
  under `generatedOutputPaths` that are unknowable without executing the
  module, so a weakened-ifc rejection on the result envelope can still pass
  the check. Covering it would require executing the candidate, and guessing
  instead would false-red.
- **The answer is point-in-time.** The apply path revalidates everything; a
  concurrent change between check and apply is caught there, not here.

## Supersedes #5059

#5059 was written before the shared review landed on main, and had grown a
parallel 416-line verdict module with its own vocabulary that now duplicates
it. Landing it would have meant two compatibility verdict systems.

~2,795 lines there become ~1,400 here, of which ~230 are executable production
code — the rest is tests (68%) and documentation, because main already had the
machinery; it just was not wired to the `setsrc <file>` path.

## Test plan

`packages/piece/test/pattern-compatibility-check.test.ts` pins the contract
that keeps a preflight honest: a source the check refuses is refused by
`setPattern` with the same stated cause (the CFC apply path rejects with a
non-Error object, so cause is compared as text). Plus: a compatible source
clears; a refused check leaves the piece running its old source and still
accepts a later compatible one; the widened-envelope case that used to false
green now reports `confidentiality cannot be weakened`; a merge that succeeds
is not blamed; an unreadable envelope is a blocker.

`packages/piece/test/setsrc-cold-argument.test.ts` pins CT-1917: a swap whose
stored argument is cold (never-written doc) still applies.

The CLI case pins that `--check` resolves the same piece and entry the apply
would use, and applies nothing. `packages/cli/integration/integration.sh`
drives the real binary through `--check` against a live toolshed: refusal
names the verdict and rule, exits 1, leaves the piece identity unchanged; a
compatible source clears (full suite verified locally, exit 0).

## Coverage

Two overrides, both for lines that are structurally unreachable from the
counted profile rather than untested behaviour. Everything reachable is tested:
`checkPiecePattern` runs for real with injected deps, the refusal is asserted
with its exit code, and the preflight/apply agreement is asserted on verdict
and cause.

`ACCEPT_COVERAGE_DEBT: coverage-debt: packages/cli uncovered lines = 3636 lines`

The new lines are a cliffy `.option()` declaration and the action closure that
renders its result. Every neighbouring command declaration in the same file —
`getsrc`'s options, `setsrc`'s existing flags — is equally uncovered on `main`:
this surface is exercised by `packages/cli/integration/integration.sh`, which
the coverage profile excludes by design. Rather than leave it untested, this PR
adds integration assertions that drive the real binary through `--check`
(verified locally against a toolshed: full suite exit 0), which is how the rest
of the CLI's command surface is covered.

`ACCEPT_COVERAGE_DEBT: coverage-debt: packages/piece uncovered lines = 166 lines`

Two defensive guards: `candidateRef === undefined`, mirroring the identical
guard `changeSource` already has a few lines above (reaching it needs a
compiled pattern carrying no artifact ref, which no supported path produces),
and a `!pattern` early return on the same shape. The third line the gate
originally flagged here — the CFC branch where the stored envelope does not
cover the candidate but the merge succeeds anyway — is now covered by a real
test rather than an override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `cf piece setsrc --check` to preflight a source swap and report a clear compatibility verdict without updating the piece; it exits non-zero on refusal while the apply path stays unchanged.

- **New Features**
  - CLI: `piece setsrc --check` checks the same piece, entry, and pinned program the apply would use; on refusal it writes a plain verdict to stderr and exits 1 (no usage dump); success prints a short summary.
  - API: `checkPiecePattern(config, entry)` and `PieceController.checkPattern(program)` return a `PatternCompatibilityReport` with `compatible`, `issues` (`schema`, `argument`, `retainedLinks`, `cfc`), `message`, and the candidate `{ identity, symbol }`.
  - CFC: Adds a dry‑run merge of the candidate’s argument schema with the piece’s stored CFC envelope using `loadStoredCfcEnvelope`/`cfcSchemaMergeIssue`; unreadable envelopes block; result envelopes are intentionally not checked.

- **Refactors**
  - Apply path: `setPattern` enforcement is unchanged and does not run the aggregate review ahead of the swap, preserving CT‑1917 cold‑argument deferral; execute‑time validators still enforce.
  - CLI: refusal handling moved into `checkPieceSourceFromCommand` so exit code and message are testable; the action only renders the summary.
  - Runner: introduced `loadStoredCfcEnvelope` and shared it with the commit path; removed the unused options parameter from `cfcSchemaMergeIssue`.

<sup>Written for commit 21a126f232b9d7f8f6c2c7b8bc0ec2b6b408c9ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

