### PR TITLE
fix(cli): narrow initial piece get transform pull

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -163,11 +163,19 @@ remains the ordinary successful `null` CLI response, as does a valid projected
 null.
 
 Both transforms run as a short-lived computed pattern in the caller's session.
-The runtime's list filter/map builtins therefore handle CFC exactly as authored
-pattern expressions do: predicate observations label array membership,
-projection reads propagate labels, and filtered elements retain their source
-links. Projection map/lift nodes construct the requested shape from a
-source-schema-selected read rather than returning a widening identity alias.
+When the declared source schema fixes the root container shape, the pattern
+constructs its first storage read from the union of predicate-observed and
+projected paths. Structurally declared properties, including local `$ref` item
+schemas, are pruned to that union: predicate-only fields can decide membership
+without appearing in the result, and omitted linked subgraphs are not hydrated.
+Schema-less or root-union sources retain a value-shape read before the transform
+because their array/object projection semantics cannot be established from the
+declaration. Ambiguous source-schema compositions remain intact and can retain a
+wider selector. The runtime's list filter/map builtins therefore handle CFC
+exactly as authored pattern expressions do: predicate observations label array
+membership, projection reads propagate labels, and filtered elements retain
+their source links. Projection map/lift nodes construct the requested shape from
+a source-schema-selected read rather than returning a widening identity alias.
 Nested non-stream Cell handles are materialized before the predicate/projection
 JavaScript runs; stream handles remain capabilities. The source cell's schema
 remains authoritative for Common Fabric metadata. A caller cannot introduce or

--- a/packages/cli/lib/piece-get-transform.ts
+++ b/packages/cli/lib/piece-get-transform.ts
@@ -704,6 +704,9 @@ function walkSchemaRoot<T>(
   ancestors.add(schema);
   const documentRoot = schema.$defs !== undefined ? schema : root;
   try {
+    // A reference is the source shape for this heuristic. Resolve it before
+    // inspecting sibling keywords so a broken reference cannot lend false
+    // shape authority through, for example, a sibling `type`.
     if (schema.$ref !== undefined) {
       try {
         return walkSchemaRoot(
@@ -721,6 +724,9 @@ function walkSchemaRoot<T>(
     }
 
     const types = schemaTypes(schema);
+    // An explicit `type` is the authoritative root-shape signal here.
+    // Combinators are conjunctive with it, so contradictory branch types
+    // cannot expand the root shapes it declares.
     if (types.length > 0) return behavior.fromTypes(types);
 
     const alternatives = [...schema.anyOf ?? [], ...schema.oneOf ?? []];
@@ -1512,6 +1518,11 @@ export async function derivePieceGetValue(
     const outputValue = outputCell.get();
     const recorded = errors.slice(errorCountBefore);
     if (recorded.length > 0) {
+      // Translate the array-shape errors emitted by the runner filter/map
+      // builtins into CLI-level messages. Keep these matches in sync with
+      // packages/runner/src/builtins/{filter,map}.ts; the mismatch regression
+      // test in piece-get-transform.test.ts guards this package-boundary
+      // coupling.
       if (
         transform.filter !== undefined &&
         recorded.some((error) =>

--- a/packages/cli/lib/piece-get-transform.ts
+++ b/packages/cli/lib/piece-get-transform.ts
@@ -686,67 +686,107 @@ function schemaIsArray(schema: JSONSchema | undefined): boolean {
 
 type SchemaRootKind = "array" | "non-array" | "unknown";
 
+interface SchemaRootWalkBehavior<T> {
+  unknown: T;
+  fromTypes: (types: string[]) => T;
+  fromAlternatives: (values: T[]) => T;
+  fromAllOf: (values: T[]) => T;
+  unresolvedRef: (error: unknown) => T;
+}
+
+function walkSchemaRoot<T>(
+  schema: JSONSchema | undefined,
+  behavior: SchemaRootWalkBehavior<T>,
+  root: JSONSchema = schema ?? true,
+  ancestors = new Set<object>(),
+): T {
+  if (!isRecord(schema) || ancestors.has(schema)) return behavior.unknown;
+  ancestors.add(schema);
+  const documentRoot = schema.$defs !== undefined ? schema : root;
+  try {
+    if (schema.$ref !== undefined) {
+      try {
+        return walkSchemaRoot(
+          ContextualFlowControl.resolveSchemaRefsOrThrow(
+            schema,
+            documentRoot,
+          ),
+          behavior,
+          documentRoot,
+          ancestors,
+        );
+      } catch (error) {
+        return behavior.unresolvedRef(error);
+      }
+    }
+
+    const types = schemaTypes(schema);
+    if (types.length > 0) return behavior.fromTypes(types);
+
+    const alternatives = [...schema.anyOf ?? [], ...schema.oneOf ?? []];
+    if (alternatives.length > 0) {
+      return behavior.fromAlternatives(
+        alternatives.map((option) =>
+          walkSchemaRoot(option, behavior, documentRoot, ancestors)
+        ),
+      );
+    }
+
+    if (schema.allOf !== undefined) {
+      return behavior.fromAllOf(
+        schema.allOf.map((option) =>
+          walkSchemaRoot(option, behavior, documentRoot, ancestors)
+        ),
+      );
+    }
+    return behavior.unknown;
+  } finally {
+    ancestors.delete(schema);
+  }
+}
+
 /**
  * Classify a root container only when the declared schema makes its shape
  * unambiguous. This is intentionally conservative: an unknown shape falls
  * back to inspecting the value so schema-less and union-shaped cells retain
  * their existing projection semantics.
+ *
+ * @internal Exported for focused root-shape tests.
  */
-/** @internal Exported for focused root-shape tests. */
 export function schemaRootKind(
   schema: JSONSchema | undefined,
   root: JSONSchema = schema ?? true,
   ancestors = new Set<object>(),
 ): SchemaRootKind {
-  if (!isRecord(schema) || ancestors.has(schema)) return "unknown";
-  ancestors.add(schema);
-  const documentRoot = schema.$defs !== undefined ? schema : root;
-  try {
-    const types = schemaTypes(schema);
-    if (types.length > 0) {
-      const hasArray = types.includes("array");
-      if (!hasArray) return "non-array";
-      return types.every((type) => type === "array") ? "array" : "unknown";
-    }
-
-    if (schema.$ref !== undefined) {
-      try {
-        return schemaRootKind(
-          ContextualFlowControl.resolveSchemaRefsOrThrow(
-            schema,
-            documentRoot,
-          ),
-          documentRoot,
-          ancestors,
+  return walkSchemaRoot(
+    schema,
+    {
+      unknown: "unknown",
+      fromTypes: (types) => {
+        const hasArray = types.includes("array");
+        if (!hasArray) return "non-array";
+        return types.every((type) => type === "array") ? "array" : "unknown";
+      },
+      fromAlternatives: (kinds) => {
+        const first = kinds[0];
+        return first !== "unknown" && kinds.every((kind) => kind === first)
+          ? first
+          : "unknown";
+      },
+      fromAllOf: (values) => {
+        const kinds = new Set(
+          values.filter((kind) => kind !== "unknown"),
         );
-      } catch {
-        return "unknown";
-      }
-    }
-
-    const alternatives = [...schema.anyOf ?? [], ...schema.oneOf ?? []];
-    if (alternatives.length > 0) {
-      const kinds = alternatives.map((option) =>
-        schemaRootKind(option, documentRoot, ancestors)
-      );
-      const first = kinds[0];
-      return first !== "unknown" && kinds.every((kind) => kind === first)
-        ? first
-        : "unknown";
-    }
-
-    if (schema.allOf !== undefined) {
-      const kinds = new Set(
-        schema.allOf.map((option) =>
-          schemaRootKind(option, documentRoot, ancestors)
-        ).filter((kind) => kind !== "unknown"),
-      );
-      return kinds.size === 1 ? [...kinds][0] : "unknown";
-    }
-    return "unknown";
-  } finally {
-    ancestors.delete(schema);
-  }
+        return kinds.size === 1 ? [...kinds][0] : "unknown";
+      },
+      // Root classification is an optimization only. A broken reference must
+      // not prevent the existing value-shaped fallback from reporting the
+      // source schema problem through the normal projection path.
+      unresolvedRef: () => "unknown",
+    },
+    root,
+    ancestors,
+  );
 }
 
 function schemaAtArrayItem(
@@ -861,37 +901,27 @@ export function schemaMayBeArray(
   root: JSONSchema = schema ?? true,
   ancestors = new Set<object>(),
 ): boolean {
-  if (!isRecord(schema)) return false;
-  if (ancestors.has(schema)) return false;
-  ancestors.add(schema);
-  const documentRoot = schema.$defs !== undefined ? schema : root;
-  try {
-    if (schema.$ref !== undefined) {
-      let resolved: JSONSchema;
-      try {
-        resolved = ContextualFlowControl.resolveSchemaRefsOrThrow(
-          schema,
-          documentRoot,
-        );
-      } catch (error) {
+  return walkSchemaRoot(
+    schema,
+    {
+      unknown: false,
+      fromTypes: (types) => types.includes("array"),
+      fromAlternatives: (values) => values.some(Boolean),
+      fromAllOf: (values) => values.some(Boolean),
+      // Unlike root classification, concise-path alignment cannot safely
+      // continue without resolving the schema that determines array traversal.
+      unresolvedRef: (error) => {
         throw new PieceGetTransformError(
           `Could not resolve source schema reference for --schema: ${
             error instanceof Error ? error.message : String(error)
           }`,
           { cause: error },
         );
-      }
-      return schemaMayBeArray(resolved, documentRoot, ancestors);
-    }
-    if (schemaTypes(schema).includes("array")) return true;
-    return [
-      ...schema.anyOf ?? [],
-      ...schema.oneOf ?? [],
-      ...schema.allOf ?? [],
-    ].some((option) => schemaMayBeArray(option, documentRoot, ancestors));
-  } finally {
-    ancestors.delete(schema);
-  }
+      },
+    },
+    root,
+    ancestors,
+  );
 }
 
 function alignConciseProjectionMask(
@@ -1480,10 +1510,31 @@ export async function derivePieceGetValue(
     await outputCell.pull();
     await runtime.idle();
     const outputValue = outputCell.get();
-    const recorded = errors.slice(errorCountBefore).at(-1);
-    if (recorded !== undefined) {
+    const recorded = errors.slice(errorCountBefore);
+    if (recorded.length > 0) {
+      if (
+        transform.filter !== undefined &&
+        recorded.some((error) =>
+          error.message === "filter currently only supports arrays"
+        )
+      ) {
+        throw new PieceGetTransformError(
+          "--filter can only be applied to an array",
+        );
+      }
+      if (
+        projection?.projectsArrayItems &&
+        recorded.some((error) =>
+          error.message === "map currently only supports arrays"
+        )
+      ) {
+        throw new PieceGetTransformError(
+          "--schema can only project array items from an array value",
+        );
+      }
+      const lastError = recorded.at(-1)!;
       throw new PieceGetTransformError(
-        `Could not apply piece get transform: ${recorded.message}`,
+        `Could not apply piece get transform: ${lastError.message}`,
       );
     }
     deps.onOutputCell?.(outputCell);

--- a/packages/cli/lib/piece-get-transform.ts
+++ b/packages/cli/lib/piece-get-transform.ts
@@ -684,6 +684,71 @@ function schemaIsArray(schema: JSONSchema | undefined): boolean {
   return schemaTypes(schema).includes("array");
 }
 
+type SchemaRootKind = "array" | "non-array" | "unknown";
+
+/**
+ * Classify a root container only when the declared schema makes its shape
+ * unambiguous. This is intentionally conservative: an unknown shape falls
+ * back to inspecting the value so schema-less and union-shaped cells retain
+ * their existing projection semantics.
+ */
+/** @internal Exported for focused root-shape tests. */
+export function schemaRootKind(
+  schema: JSONSchema | undefined,
+  root: JSONSchema = schema ?? true,
+  ancestors = new Set<object>(),
+): SchemaRootKind {
+  if (!isRecord(schema) || ancestors.has(schema)) return "unknown";
+  ancestors.add(schema);
+  const documentRoot = schema.$defs !== undefined ? schema : root;
+  try {
+    const types = schemaTypes(schema);
+    if (types.length > 0) {
+      const hasArray = types.includes("array");
+      if (!hasArray) return "non-array";
+      return types.every((type) => type === "array") ? "array" : "unknown";
+    }
+
+    if (schema.$ref !== undefined) {
+      try {
+        return schemaRootKind(
+          ContextualFlowControl.resolveSchemaRefsOrThrow(
+            schema,
+            documentRoot,
+          ),
+          documentRoot,
+          ancestors,
+        );
+      } catch {
+        return "unknown";
+      }
+    }
+
+    const alternatives = [...schema.anyOf ?? [], ...schema.oneOf ?? []];
+    if (alternatives.length > 0) {
+      const kinds = alternatives.map((option) =>
+        schemaRootKind(option, documentRoot, ancestors)
+      );
+      const first = kinds[0];
+      return first !== "unknown" && kinds.every((kind) => kind === first)
+        ? first
+        : "unknown";
+    }
+
+    if (schema.allOf !== undefined) {
+      const kinds = new Set(
+        schema.allOf.map((option) =>
+          schemaRootKind(option, documentRoot, ancestors)
+        ).filter((kind) => kind !== "unknown"),
+      );
+      return kinds.size === 1 ? [...kinds][0] : "unknown";
+    }
+    return "unknown";
+  } finally {
+    ancestors.delete(schema);
+  }
+}
+
 function schemaAtArrayItem(
   schema: JSONSchema | undefined,
 ): JSONSchema | undefined {
@@ -978,7 +1043,21 @@ export function selectSourceSchema(
     return source;
   }
   if (source.$ref !== undefined) {
-    return source;
+    if (source.$ref.startsWith("#/") && source.$defs === undefined) {
+      return source;
+    }
+    try {
+      return selectSourceSchema(
+        ContextualFlowControl.resolveSchemaRefsOrThrow(source, source),
+        mask,
+        purpose,
+      );
+    } catch {
+      // A malformed or unsupported source reference is not projection's job
+      // to reinterpret. Preserve the declared selector and let the runtime
+      // report the underlying schema problem.
+      return source;
+    }
   }
   if (
     source.anyOf !== undefined || source.oneOf !== undefined ||
@@ -1178,8 +1257,11 @@ export async function derivePieceGetValue(
     return await sourceValueCell.pull();
   }
 
-  const sourceValue = await sourceValueCell.pull();
-  if (transform.filter !== undefined && !Array.isArray(sourceValue)) {
+  const rootKind = schemaRootKind(sourceSchema);
+  const sourceIsArray = rootKind === "unknown"
+    ? Array.isArray(await sourceValueCell.pull())
+    : rootKind === "array";
+  if (transform.filter !== undefined && !sourceIsArray) {
     throw new PieceGetTransformError(
       "--filter can only be applied to an array",
     );
@@ -1187,7 +1269,7 @@ export async function derivePieceGetValue(
   const projection = resolveProjection(
     transform.projection,
     sourceSchema,
-    Array.isArray(sourceValue),
+    sourceIsArray,
   );
   const sourceItemSchema = schemaAtArrayItem(sourceSchema);
   const predicateItemMask = transform.filter === undefined

--- a/packages/cli/test/piece-get-transform.test.ts
+++ b/packages/cli/test/piece-get-transform.test.ts
@@ -291,6 +291,21 @@ describe("cf piece get transforms", () => {
     expect(schemaRootKind(cyclic as JSONSchema)).toBe("unknown");
   });
 
+  it("falls back conservatively when a source reference cannot resolve", () => {
+    const broken: JSONSchema = {
+      $ref: "#/$defs/Missing",
+      $defs: {},
+    };
+    const mask = {
+      type: "object" as const,
+      properties: { id: true as const },
+      additionalProperties: false as const,
+    };
+
+    expect(schemaRootKind(broken)).toBe("unknown");
+    expect(selectSourceSchema(broken, mask)).toBe(broken);
+  });
+
   it("merges predicate reads through aligned array masks", () => {
     expect(mergeMasks(
       {
@@ -1602,6 +1617,38 @@ describe("cf piece get transforms", () => {
     await expect(derivePieceGetValue(runtime, space, source, {
       filter: parsePieceGetFilter(".id == 1"),
     })).rejects.toThrow("--filter can only be applied to an array");
+  });
+
+  it("reports schema/value root mismatches with CLI-level errors", async () => {
+    const tx = runtime.edit();
+    const nullSource = runtime.getCell(
+      space,
+      "declared-array-null-filter-source",
+      { type: "array", items: { type: "object" } },
+      tx,
+    );
+    nullSource.set(null as never);
+    const objectSource = runtime.getCell(
+      space,
+      "declared-array-object-projection-source",
+      { type: "array", items: { type: "object" } },
+      tx,
+    );
+    objectSource.set({ id: 1 } as never);
+    expect((await tx.commit()).ok).toBeDefined();
+
+    await expect(derivePieceGetValue(runtime, space, nullSource, {
+      filter: parsePieceGetFilter("true"),
+    })).rejects.toThrow(/^--filter can only be applied to an array$/);
+    await expect(derivePieceGetValue(runtime, space, nullSource, {
+      filter: parsePieceGetFilter("true"),
+      projection: await parsePieceGetProjection("id"),
+    })).rejects.toThrow(/^--filter can only be applied to an array$/);
+    await expect(derivePieceGetValue(runtime, space, objectSource, {
+      projection: await parsePieceGetProjection("id"),
+    })).rejects.toThrow(
+      /^--schema can only project array items from an array value$/,
+    );
   });
 
   it("reports runtime predicate failures as transform errors", async () => {

--- a/packages/cli/test/piece-get-transform.test.ts
+++ b/packages/cli/test/piece-get-transform.test.ts
@@ -264,6 +264,17 @@ describe("cf piece get transforms", () => {
     ).toThrow("Could not resolve source schema reference for --schema");
   });
 
+  it("treats an explicit root type as authoritative over combinators", () => {
+    expect(schemaMayBeArray({
+      type: "object",
+      anyOf: [{ type: "array" }],
+    })).toBe(false);
+    expect(schemaMayBeArray({
+      type: "object",
+      allOf: [{ type: "array" }],
+    })).toBe(false);
+  });
+
   it("classifies only unambiguous declared root shapes", () => {
     const cyclic: Record<string, unknown> = {};
     cyclic.allOf = [cyclic];
@@ -303,6 +314,7 @@ describe("cf piece get transforms", () => {
     };
 
     expect(schemaRootKind(broken)).toBe("unknown");
+    expect(schemaRootKind({ ...broken, type: "array" })).toBe("unknown");
     expect(selectSourceSchema(broken, mask)).toBe(broken);
   });
 
@@ -1617,6 +1629,23 @@ describe("cf piece get transforms", () => {
     await expect(derivePieceGetValue(runtime, space, source, {
       filter: parsePieceGetFilter(".id == 1"),
     })).rejects.toThrow("--filter can only be applied to an array");
+  });
+
+  it("treats an unset declared array as empty for filtering", async () => {
+    const tx = runtime.edit();
+    const unsetSource = runtime.getCell(
+      space,
+      "declared-array-unset-filter-source",
+      { type: "array", items: { type: "object" } },
+      tx,
+    );
+    expect((await tx.commit()).ok).toBeDefined();
+
+    expect(
+      await derivePieceGetValue(runtime, space, unsetSource, {
+        filter: parsePieceGetFilter("true"),
+      }),
+    ).toEqual([]);
   });
 
   it("reports schema/value root mismatches with CLI-level errors", async () => {

--- a/packages/cli/test/piece-get-transform.test.ts
+++ b/packages/cli/test/piece-get-transform.test.ts
@@ -12,6 +12,7 @@ import {
   parsePieceGetProjection,
   PieceGetTransformError,
   schemaMayBeArray,
+  schemaRootKind,
   selectSourceSchema,
 } from "../lib/piece-get-transform.ts";
 
@@ -263,6 +264,33 @@ describe("cf piece get transforms", () => {
     ).toThrow("Could not resolve source schema reference for --schema");
   });
 
+  it("classifies only unambiguous declared root shapes", () => {
+    const cyclic: Record<string, unknown> = {};
+    cyclic.allOf = [cyclic];
+
+    expect(schemaRootKind(undefined)).toBe("unknown");
+    expect(schemaRootKind({ type: "array" })).toBe("array");
+    expect(schemaRootKind({ type: "object" })).toBe("non-array");
+    expect(schemaRootKind({ type: ["array", "null"] })).toBe("unknown");
+    expect(schemaRootKind({
+      $ref: "#/$defs/List",
+      $defs: { List: { type: "array" } },
+    })).toBe("array");
+    expect(schemaRootKind({
+      anyOf: [{ type: "array" }, { type: "array" }],
+    })).toBe("array");
+    expect(schemaRootKind({
+      oneOf: [{ type: "array" }, { type: "object" }],
+    })).toBe("unknown");
+    expect(schemaRootKind({
+      allOf: [{}, { type: "object" }],
+    })).toBe("non-array");
+    expect(schemaRootKind({
+      allOf: [{ type: "array" }, { type: "object" }],
+    })).toBe("unknown");
+    expect(schemaRootKind(cyclic as JSONSchema)).toBe("unknown");
+  });
+
   it("merges predicate reads through aligned array masks", () => {
     expect(mergeMasks(
       {
@@ -286,6 +314,50 @@ describe("cf piece get transforms", () => {
         additionalProperties: false,
       },
     });
+  });
+
+  it("narrows referenced source schemas without dropping Fabric metadata", () => {
+    const source: JSONSchema = {
+      $ref: "#/$defs/Item",
+      $defs: {
+        Item: {
+          type: "object",
+          scope: "user",
+          ifc: { confidentiality: ["item-secret"] },
+          properties: {
+            visible: {
+              type: "string",
+              ifc: { confidentiality: ["field-secret"] },
+            },
+            omitted: { type: "string" },
+          },
+          required: ["visible", "omitted"],
+        },
+      },
+    };
+    const selected = selectSourceSchema(source, {
+      type: "object",
+      properties: { visible: true },
+      additionalProperties: false,
+    });
+
+    expect(selected).toMatchObject({
+      type: "object",
+      scope: "user",
+      ifc: { confidentiality: ["item-secret"] },
+      properties: {
+        visible: {
+          type: "string",
+          ifc: {
+            confidentiality: ["item-secret", "field-secret"],
+          },
+        },
+      },
+      required: ["visible"],
+      additionalProperties: false,
+    });
+    expect(Object.keys((selected as { properties: object }).properties))
+      .toEqual(["visible"]);
   });
 
   it("collapses overlapping concise paths without exposing siblings", async () => {
@@ -432,6 +504,100 @@ describe("cf piece get transforms", () => {
       { title: "Second" },
       { title: "Third" },
     ]);
+  });
+
+  it("narrows the initial source selector to predicate and projection fields", async () => {
+    const tx = runtime.edit();
+    const detailsSchema = {
+      type: "object",
+      properties: {
+        body: { type: "string" },
+        comments: { type: "array", items: { type: "string" } },
+      },
+      required: ["body", "comments"],
+    } as const satisfies JSONSchema;
+    const itemSchema = {
+      type: "object",
+      properties: {
+        id: { type: "number" },
+        title: { type: "string" },
+        status: { type: "string" },
+        details: { ...detailsSchema, asCell: ["cell"] },
+      },
+      required: ["id", "title", "status", "details"],
+    } as const satisfies JSONSchema;
+    const sourceSchema = {
+      type: "array",
+      items: { $ref: "#/$defs/Item" },
+      $defs: { Item: itemSchema },
+    } as const satisfies JSONSchema;
+    const unavailableDetails = runtime.getCell(
+      space,
+      "initial-selector-unavailable-details",
+      detailsSchema,
+      tx,
+    );
+    const source = runtime.getCell(
+      space,
+      "initial-selector-transform-source",
+      sourceSchema,
+      tx,
+    );
+    source.set([{
+      id: 1,
+      title: "First",
+      status: "open",
+      details: unavailableDetails as never,
+    }]);
+    expect((await tx.commit()).ok).toBeDefined();
+
+    const sourceRead = runtime.getCell(
+      space,
+      "initial-selector-transform-source",
+      sourceSchema,
+    );
+    const sourceId = sourceRead.getAsNormalizedFullLink().id;
+    const provider = storageManager.open(space);
+    const originalSync = provider.sync.bind(provider);
+    const sourceSelectors: unknown[] = [];
+    const syncedUris: string[] = [];
+    provider.sync = ((uri, selector, scope) => {
+      syncedUris.push(uri);
+      if (uri === sourceId) sourceSelectors.push(selector?.schema);
+      return originalSync(uri, selector, scope);
+    }) as typeof provider.sync;
+
+    expect(
+      await derivePieceGetValue(runtime, space, sourceRead, {
+        filter: parsePieceGetFilter('.status == "open"'),
+        projection: await parsePieceGetProjection("id,title"),
+      }),
+    ).toEqual([{ id: 1, title: "First" }]);
+    const initialSelector = sourceSelectors.at(0) as {
+      type?: string;
+      items?: {
+        properties?: Record<string, unknown>;
+        required?: string[];
+        additionalProperties?: boolean;
+      };
+    };
+    expect(initialSelector.type).toBe("array");
+    expect(Object.keys(initialSelector.items?.properties ?? {}).sort()).toEqual(
+      [
+        "id",
+        "status",
+        "title",
+      ],
+    );
+    expect(initialSelector.items?.required).toEqual([
+      "id",
+      "title",
+      "status",
+    ]);
+    expect(initialSelector.items?.additionalProperties).toBe(false);
+    expect(syncedUris).not.toContain(
+      unavailableDetails.getAsNormalizedFullLink().id,
+    );
   });
 
   it("filters and projects through a linked array slot", async () => {

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -250,10 +250,14 @@ nested container, concise projection still applies its field mask across
 encountered arrays to prevent sibling disclosure; use an explicit schema for a
 fixed output contract. The two flags compose as filter-then-project. Both run
 through runtime filter/map/lift nodes, which construct projected values from
-source-schema-selected reads, so CFC behavior is the same as a computed pattern
-expression. Source schema metadata is authoritative; projection schemas cannot
-supply `ifc`, `asCell`, `scope`, or `default`. See `packages/cli/README.md` for
-the exact syntax and supported schema subset.
+source-schema-selected reads. A declared root shape and structurally selectable
+properties make the initial read the union of predicate and projection paths, so
+omitted linked subgraphs are not hydrated; ambiguous compositions can retain a
+wider selector, and schema-less or root-union sources need a value-shape read
+first. CFC behavior is the same as a computed pattern expression. Source schema
+metadata is authoritative; projection schemas cannot supply `ifc`, `asCell`,
+`scope`, or `default`. See `packages/cli/README.md` for the exact syntax and
+supported schema subset.
 
 For `piece call`, options before the callable name configure `piece call`.
 Arguments after the callable name configure the invoked handler or tool. The


### PR DESCRIPTION
## Summary

- derive an unambiguous source root shape from its declared schema before running piece get transforms
- push the union of filter-observed and projected paths into the first source selector
- resolve local $ref-backed item schemas for selection while preserving source IFC, scope, defaults, and other Fabric metadata
- document the conservative fallback for schema-less, root-union, and ambiguous composed schemas

The selector regression uses a fresh $ref-backed array view. It verifies that predicate-only status is available for filtering but absent from the id/title result, and that an omitted unavailable linked details document is never synchronized.

Linear: https://linear.app/common-tools/issue/CT-1931/cf-piece-get-push-filterschema-selection-into-the-initial-pull

## Validation

- mise exec -- deno test -A packages/cli/test/piece-get-transform.test.ts (45 steps passed)
- mise exec -- deno task check-skill-facts
- mise exec -- deno fmt --check
- mise exec -- deno lint
- full CLI suite: 1668 passed; two unrelated color-mode assertions failed and reproduce when color-mode.test.ts is run alone

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Narrows the initial selector for `piece get` to the union of filter and projection fields when the source schema fixes the root shape, preventing unnecessary linked hydration and improving sync correctness. Implements Linear CT-1931 with conservative schema-root detection and clearer CLI errors.

- **Bug Fixes**
  - Initial pull narrowing: build the first read from predicate+projection paths; predicate-only fields don’t appear; linked docs outside the union aren’t synced; resolve local `$ref` item schemas for selection while preserving `ifc`, `scope`, `default`, and `asCell`.
  - Root shape classification: new `schemaRootKind` walk where explicit `type` wins; only unambiguous roots are classified; ambiguous `anyOf`/`oneOf`/`allOf` keep a wider selector; unresolved/external `$ref` leave the selector intact for projection.
  - Array handling and errors: detect arrays from the declared schema when clear, otherwise inspect the value; treat an unset declared array as empty; translate runner errors to CLI messages (“--filter can only be applied to an array”, “--schema can only project array items from an array value”); emit “Could not resolve source schema reference for --schema” when a referenced item schema can’t resolve.

<sup>Written for commit cf3fd9646f3096a2587aac5d06a4f013ac6d8d26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

