### PR TITLE
docs(plan): split verb results into a shared read model and its parts

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -58,3 +58,7 @@ a record: archive it to `docs/history/plans/` following the procedure in
   calling a verb adds — and at
   [CLI surface shape](cli-surface-shape.md) for the command surface and an
   additive path to it. Start here rather than at either part.
+- [Verb calls: working notes](verb-result-selection.md) holds the call-specific
+  investigation those documents do not carry: what produces a receipt and what
+  its existence proves, how a receipt's address is derived, and the error and
+  exit-status conventions. Sketches to draw from, not a settled contract.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -49,3 +49,8 @@ a record: archive it to `docs/history/plans/` following the procedure in
   [`../development/space-clone-rehearsal.md`](../development/space-clone-rehearsal.md).
   The plan stays live until the practice has been exercised on a real
   migration.
+- [Verb results: references, not expansions](verb-result-selection.md) makes a
+  verb's result render references as references instead of expanding them —
+  bounding the payload and keeping identity in-band — and adds the `cf
+  invocation get` reader that re-opens a settled outcome without re-executing
+  the verb.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -49,8 +49,12 @@ a record: archive it to `docs/history/plans/` following the procedure in
   [`../development/space-clone-rehearsal.md`](../development/space-clone-rehearsal.md).
   The plan stays live until the practice has been exercised on a real
   migration.
-- [Verb results: references, not expansions](verb-result-selection.md) makes a
-  verb's result render references as references instead of expanding them —
-  bounding the payload and keeping identity in-band — and adds the `cf
-  invocation get` reader that re-opens a settled outcome without re-executing
-  the verb.
+- [Reading Fabric data](fabric-read-model.md) is the umbrella for one model
+  across three concerns: everything addressable is a cell, so a verb's result
+  and a direct read are the same operation on different cells. It carries the
+  vocabulary and points at
+  [shaped reads and verb results](shaped-reads-and-verb-results.md) — the shared
+  read layer, how a shape says "an address here, a value there", and what
+  calling a verb adds — and at
+  [CLI surface shape](cli-surface-shape.md) for the command surface and an
+  additive path to it. Start here rather than at either part.

--- a/docs/plans/cli-surface-shape.md
+++ b/docs/plans/cli-surface-shape.md
@@ -1,0 +1,179 @@
+# CLI surface shape
+
+The **command surface**, one of the three concerns in
+[Reading Fabric data](fabric-read-model.md), which defines the shared model. The
+`cf` surface grew one command at a time and now expresses a model the code no
+longer has. That costs more than tidiness: the names imply distinctions the runtime
+does not make, which misdirects design work before it starts.
+
+This document is about the command surface, not the machinery underneath.
+Nothing here blocks [Shaped reads and verb results](shaped-reads-and-verb-results.md).
+
+## What the surface is for
+
+Every command serves exactly one of seven purposes. Sorting them this way is
+what makes the trouble visible.
+
+| Purpose | Commands |
+| --- | --- |
+| **Authoring** — work on source files, never touching a live space | `check`, `test`, `view` (pager), `init`, `deps update` |
+| **Identity and access** — who you are, and who may do what | `id` (new/did/derive/from-mnemonic), `acl` (ls/set/remove) |
+| **Live data** — reading and writing running state | `piece get`/`set`/`call`/`apply`/`link`/`step`/`verbs`/`inspect`, `wish` |
+| **Piece lifecycle** — deploying and managing running programs | `piece new`/`setsrc`/`getsrc`/`rm`/`ls`/`search`/`map`/`set-slug`/`recreate-root`/`set-home` |
+| **Rendering** — turning things into something to look at | `piece view` (terminal), `piece render` (HTML), `view` (source pager) |
+| **Storage forensics** — reading the database directly, offline | `inspect` (18 subcommands), `space` (clone/verify/reset/fingerprint) |
+| **Filesystem projection** — exposing cells as files | `fuse` (mount/unmount/status), `exec` |
+
+Four of these are coherent and want nothing: authoring, identity and access,
+storage forensics, and filesystem projection. The trouble is concentrated in the
+middle three.
+
+## Where it has accreted
+
+**`piece` carries four unrelated jobs.** Deploying a program, listing what is
+deployed, reading live data, and rendering a UI all hang off one word. Someone
+reading a value and someone deploying a pattern share a command prefix and
+nothing else.
+
+**Names imply distinctions the code does not make.**
+
+| Surface | What the name says | What it actually is |
+| --- | --- | --- |
+| `--piece` | a piece | any cell address — the function that fetches a piece's result returns the piece unchanged, and the read path checks nothing piece-specific |
+| `piece get` | reading a piece | reading a cell at a path |
+| `--input` | a mode you switch on | an address — it follows a link stored in the document to reach the arguments cell |
+| `--schema` | a type contract you must satisfy | a selection over the value, which also accepts a bare list of paths |
+
+The `--piece` case is not cosmetic. Believing the target had to be a piece is
+what made a verb's receipt look like it needed purpose-built read machinery,
+when it is an ordinary cell that any read already handles.
+
+**One word, two jobs — twice.** `piece inspect` examines a running piece, while
+`cf inspect` reads the database offline and has its own `piece` subcommand.
+Separately, `piece view` renders a piece's UI in the terminal while `view` is a
+pager for source files. `piece map` and `cf inspect graph` both draw the graph
+of entities and their connections — one live, one offline.
+
+**One capability, two commands.** `piece apply` writes a whole set of inputs;
+`piece set` writes at one path. Both target the same arguments cell.
+
+### The input spec is not a schema
+
+`--schema` is the most misleading name on the surface, and the one worth fixing
+first, because it shapes how people reason about the whole read model.
+
+A schema describes what data **is**. What this flag takes describes what the
+caller **wants back**. Same syntax, opposite direction — and four things follow
+from the mismatch:
+
+- **It accepts input that is not a schema at all.** `--schema
+  'title,createdBy.name'` is a list of paths.
+- **It is a strict subset, stripped of what gives a Fabric schema meaning.**
+  `asCell`, `default`, `scope`, and `ifc` are forbidden to callers; `$ref`,
+  `$defs`, and the combinators are unsupported. What remains is structure with
+  the semantics removed.
+- **It is about to carry keywords that are not JSON Schema.** Marking a position
+  as an address needs a projection-only keyword, which no schema dialect
+  defines.
+- **It misleads readers in practice.** "How is `topic.title` a schema? It's a
+  path" is the reasonable question of someone reading the flag's name and
+  finding it does not hold.
+
+The confusion is not that schemas are being used as queries. In this system they
+legitimately are — a subscription is a graph query whose selector is a schema,
+and that is why the *syntax* should stay schema-shaped, so a caller can lift a
+source schema and prune it into a request. The problem is narrower: this
+particular schema is output-directed and deliberately incomplete, and the name
+claims more than it delivers.
+
+**Rename the flag; keep the syntax.** `--shape` says what it is, covers both the
+concise and nested forms, and promises no validation. Doing it now is much
+cheaper than later: `piece call` does not have this flag yet, so adding it there
+as `--shape` and aliasing on `get` costs one deprecation on a flag that is still
+young. Adding it as `--schema` doubles the footprint of the wrong name.
+
+## What it should look like
+
+Reading is one operation reached from several starting points, so the surface
+wants one read command and distinct commands for the distinct ways of arriving:
+
+```
+# <read opts> = [--shape S] [--filter P] — the shared tail, identical everywhere
+
+cf get   <addr> [path]           <read opts>
+cf call  <addr> <verb> <payload> <read opts>
+cf wish  <query>                 <read opts>   # a query, not an address
+cf exec  <mountedFile> [args]    <read opts>   # reached through a filesystem mount
+
+cf set   <addr> [path]                         # writes; nothing to shape
+
+cf piece new|setsrc|getsrc|rm|ls|search|verbs|slug   # deploying and listing only
+cf space … | cf id … | cf acl … | cf fuse …
+cf inspect …                                          # offline forensics
+cf check | test | view | init | deps                  # working on source
+```
+
+Three properties earn their place.
+
+**One way to write an address.** An entity id (`of:fid1:…`), a slug, or a URL,
+with a suffix for navigating within it — `<addr>#argument` in place of the
+`--input` flag. An address printed by one command is accepted by the next
+without reshaping, which is not true today.
+
+**Arrivals stay separate; the tail is shared.** `get`, `call`, `wish`, and
+`exec` are genuinely different operations and none should absorb another.
+But all of them finish by turning a cell into structured output, so they take
+the same read options and an address renders the same way however you arrived at
+it. A command that returns data gets the whole tail, not a subset — a result
+worth shaping is a result worth filtering. `set` is the exception, because it
+writes rather than returns. Today each command grew its own output handling and
+they have drifted.
+
+**`piece` keeps only what is genuinely about pieces.** Deploying, updating,
+removing, listing, searching, slugs, and listing a piece's verbs. Reading and
+writing cells are not piece operations and stop presenting themselves as ones.
+
+`--shape` throughout, for the reasons above.
+
+## How to get there
+
+Additive, in dependency order. Nothing before step 5 removes or renames anything
+a caller depends on.
+
+1. **Factor out the shared read step** so a single implementation turns a cell
+   and a shape into structured output.
+2. **Give every arrival access to it** — `piece call` gains `--schema` and
+   `--filter`, `wish` gains them, and an address renders identically from each.
+3. **`--piece` accepts the `of:` address form**, so an emitted address composes
+   into the next command. This is where addressing stops being piece-flavoured
+   in practice.
+4. **Add positional addresses and the `#argument` suffix** beside the existing
+   flags, keeping both.
+5. **Add `cf get`/`set`/`call`** as aliases of the existing
+   implementations. Same code, honest names, both spellings working.
+6. **Deprecate the old spellings** once the new ones carry traffic.
+7. **Merge the duplicated nouns** — the two `inspect`s, the two `view`s, `piece
+   map` against `inspect graph`, and `apply` against `set`.
+
+Steps 1–5 are mechanical. Step 7 needs real decisions and belongs last, because
+each pair is two working commands whose merge changes behaviour rather than
+spelling.
+
+## Decisions this document does not make
+
+**`wish` stays its own command.** A wish is a query, not an address: it resolves
+to whatever satisfies it, and may match nothing. Folding it into a read over
+addresses would be a category error. It shares the output step, not the way you
+arrive.
+
+**`exec` runs something reached through a filesystem mount.** Whether that
+becomes an address form or stays its own command depends on how far the address
+grammar should reach into the filesystem projection.
+
+**`piece step` is not redundant with the `--step` flag.** A separate step
+process cannot carry its work into a later read in another process, so the
+standalone command and the flag are not interchangeable. Any merge has to
+preserve that.
+
+**`piece link` stays.** It writes a link with reactive-wiring meaning that a
+general value write does not express.

--- a/docs/plans/cli-surface-shape.md
+++ b/docs/plans/cli-surface-shape.md
@@ -81,7 +81,7 @@ The **concise** form is a different thing wearing the same flag:
 ```
 
 The concise form is a shorthand, and it exists because full schemas are verbose
-enough that nobody writes one to select two fields. It is modelled on
+enough that nobody writes one to select two fields. It is modeled on
 [`llm`'s schemas](https://llm.datasette.io/en/stable/schemas.html), which is
 worth recording so the next reader does not have to re-derive why it looks the
 way it does.
@@ -189,7 +189,7 @@ a caller depends on — steps 1–5 only add.
    map` against `inspect graph`, and `apply` against `set`.
 
 Steps 1–5 are mechanical. Step 7 needs real decisions and belongs last, because
-each pair is two working commands whose merge changes behaviour rather than
+each pair is two working commands whose merge changes behavior rather than
 spelling.
 
 **Each step carries its own documentation.** `--input`, `--piece`, and

--- a/docs/plans/cli-surface-shape.md
+++ b/docs/plans/cli-surface-shape.md
@@ -94,15 +94,20 @@ needing a justification as a schema dialect. A reader who sees
 `--schema title,createdBy.name@` and asks "how is that a schema?" is right, and
 will get righter.
 
-**Give the shorthand its own flag and leave `--schema` for full schemas.** That
-resolves the ambiguity rather than papering over it, and it leaves room for the
+**Give the concise syntax `--select` and leave `--schema` for full schemas.**
+That resolves the ambiguity rather than papering over it, and it leaves room for
+the
 shorthand to grow notation a schema does not need — a suffix meaning "give me
 the link at this path rather than its contents" is the obvious candidate, since
 that is the common case and spelling it in full is painful.
 
+`--select` is the name because it says what the syntax does, reads naturally
+with the address suffix (`--select 'topic@,topic.title'`), and leaves "shape"
+free as the word for what a caller asks for — covering both spellings rather
+than competing with one of them.
+
 Timing argues for doing it now: `piece call` does not have either form yet, so
-splitting them costs one deprecation on a flag that is still young. Naming the
-shorthand flag is open.
+splitting them costs one deprecation on a flag that is still young.
 
 **What a reader may not supply, in either syntax.** `asCell`, `default`,
 `scope`, and `ifc` stay the source's — they decide how a value is treated, not
@@ -123,7 +128,7 @@ Reading is one operation reached from several starting points, so the surface
 wants one read command and distinct commands for the distinct ways of arriving:
 
 ```
-# <read opts> = selection (--schema, or its shorthand) + --filter — identical everywhere
+# <read opts> = [--select S | --schema S] [--filter P] — identical everywhere
 
 cf get   <addr> [path]           <read opts>
 cf call  <addr> <verb> <payload> <read opts>
@@ -161,7 +166,7 @@ writing cells are not piece operations and stop presenting themselves as ones.
 they belong under `space`, and moving them is part of step 7 rather than
 something this shape decides.
 
-The same selection flags everywhere, split per the reasons above.
+`--select` and `--schema` everywhere, split per the reasons above.
 
 ## How to get there
 
@@ -170,8 +175,8 @@ a caller depends on — steps 1–5 only add.
 
 1. **Factor out the shared read step** so a single implementation turns a cell
    and a shape into structured output.
-2. **Give every arrival access to it** — `piece call` gains the selection and
-   filter flags, `wish` gains them, and an address renders identically from each.
+2. **Give every arrival access to it** — `piece call` gains `--select`,
+   `--schema` and `--filter`, `wish` gains them, and an address renders identically from each.
 3. **`--piece` accepts the `of:` address form**, so an emitted address composes
    into the next command. This is where addressing stops being piece-flavoured
    in practice.

--- a/docs/plans/cli-surface-shape.md
+++ b/docs/plans/cli-surface-shape.md
@@ -22,7 +22,7 @@ itself part of the problem.
 | **Live data** — reading and writing running state | `piece get`/`set`/`call`/`apply`/`link`/`step`/`verbs`/`inspect`, `wish` |
 | **Piece lifecycle** — deploying and managing running programs | `piece new`/`setsrc`/`getsrc`/`rm`/`ls`/`search`/`map`/`set-slug`/`recreate-root`/`set-home` |
 | **Rendering** — turning things into something to look at | `piece view` (terminal), `piece render` (HTML), `view` (source pager) |
-| **Storage forensics** — reading the database directly, offline | `inspect` (22 subcommands), `space` (clone/verify/reset/fingerprint) |
+| **Storage forensics** — reading the database directly, mostly offline (`inspect pull` fetches from a remote) | `inspect` (22 subcommands), `space` (clone/verify/reset/fingerprint) |
 | **Filesystem projection** — exposing cells as files | `fuse` (mount/unmount/status), `exec` |
 
 Four of these are coherent and want nothing: authoring, identity and access,
@@ -112,8 +112,10 @@ splitting them costs one deprecation on a flag that is still young.
 **What a reader may not supply, in either syntax.** `asCell`, `default`,
 `scope`, and `ifc` stay the source's — they decide how a value is treated, not
 which values come back. `$ref`, `$defs`, and the combinators are unsupported.
-Both checks run against the parsed projection whatever syntax produced it, so
-writing the full form does not unlock them.
+Neither syntax can express them, though not by the same route: the checks run
+when a full schema is parsed, while the concise form is held to an identifier
+grammar with no way to write a keyword. Writing the full form does not unlock
+them.
 
 That rule needs no carve-out for the address suffix. `asCell` carries a handle
 contract as well as a boundary, and a handle cannot cross a serialized channel —
@@ -178,7 +180,7 @@ a caller depends on — steps 1–5 only add.
 2. **Give every arrival access to it** — `piece call` gains `--select`,
    `--schema` and `--filter`, `wish` gains them, and an address renders identically from each.
 3. **`--piece` accepts the `of:` address form**, so an emitted address composes
-   into the next command. This is where addressing stops being piece-flavoured
+   into the next command. This is where addressing stops being piece-flavored
    in practice.
 4. **Add positional addresses and the `#argument` suffix** beside the existing
    flags, keeping both.

--- a/docs/plans/cli-surface-shape.md
+++ b/docs/plans/cli-surface-shape.md
@@ -86,13 +86,13 @@ enough that nobody writes one to select two fields. It is modelled on
 worth recording so the next reader does not have to re-derive why it looks the
 way it does.
 
-`llm` keeps both syntaxes under one flag, so one flag is demonstrably livable
-and "the shorthand is not a schema" is not on its own a reason to split. The
-reason to split anyway is that **our shorthand is growing notation that is not
-schema syntax at all** — a suffix marking a path as an address, below — and a
-separate flag gives that room without every addition needing a justification as
-a schema dialect. A reader who sees `--schema title,createdBy.name@` and asks
-"how is that a schema?" is right, and will get righter.
+`llm` keeps both syntaxes under one flag, so one flag is livable on its own
+terms. What makes the split worth it here is that **our shorthand is growing
+notation that is not schema syntax at all** — a suffix marking a path as an
+address, below — and a separate flag gives that room without each addition
+needing a justification as a schema dialect. A reader who sees
+`--schema title,createdBy.name@` and asks "how is that a schema?" is right, and
+will get righter.
 
 **Give the shorthand its own flag and leave `--schema` for full schemas.** That
 resolves the ambiguity rather than papering over it, and it leaves room for the

--- a/docs/plans/cli-surface-shape.md
+++ b/docs/plans/cli-surface-shape.md
@@ -11,8 +11,9 @@ Nothing here blocks [Shaped reads and verb results](shaped-reads-and-verb-result
 
 ## What the surface is for
 
-Every command serves exactly one of seven purposes. Sorting them this way is
-what makes the trouble visible.
+Sorting commands by what they are for makes the trouble visible. Seven
+purposes, and one command — `view` — genuinely straddles two of them, which is
+itself part of the problem.
 
 | Purpose | Commands |
 | --- | --- |
@@ -21,7 +22,7 @@ what makes the trouble visible.
 | **Live data** — reading and writing running state | `piece get`/`set`/`call`/`apply`/`link`/`step`/`verbs`/`inspect`, `wish` |
 | **Piece lifecycle** — deploying and managing running programs | `piece new`/`setsrc`/`getsrc`/`rm`/`ls`/`search`/`map`/`set-slug`/`recreate-root`/`set-home` |
 | **Rendering** — turning things into something to look at | `piece view` (terminal), `piece render` (HTML), `view` (source pager) |
-| **Storage forensics** — reading the database directly, offline | `inspect` (18 subcommands), `space` (clone/verify/reset/fingerprint) |
+| **Storage forensics** — reading the database directly, offline | `inspect` (22 subcommands), `space` (clone/verify/reset/fingerprint) |
 | **Filesystem projection** — exposing cells as files | `fuse` (mount/unmount/status), `exec` |
 
 Four of these are coherent and want nothing: authoring, identity and access,
@@ -50,12 +51,15 @@ when it is an ordinary cell that any read already handles.
 
 **One word, two jobs — twice.** `piece inspect` examines a running piece, while
 `cf inspect` reads the database offline and has its own `piece` subcommand.
-Separately, `piece view` renders a piece's UI in the terminal while `view` is a
+Separately, `piece view` prints an ASCII rendering of a piece while `view` is a
 pager for source files. `piece map` and `cf inspect graph` both draw the graph
 of entities and their connections — one live, one offline.
 
-**One capability, two commands.** `piece apply` writes a whole set of inputs;
-`piece set` writes at one path. Both target the same arguments cell.
+**Two commands, overlapping but not equivalent.** `piece apply` validates a
+whole input against `argumentSchema` and re-executes the pattern with it; `piece
+set` writes at one path. Both target the arguments cell, and the overlap invites
+merging them, but they are not the same operation — which is why any merge
+belongs in the last step rather than among the renames.
 
 ### The input spec is not a schema
 
@@ -107,7 +111,7 @@ cf exec  <mountedFile> [args]    <read opts>   # reached through a filesystem mo
 
 cf set   <addr> [path]                         # writes; nothing to shape
 
-cf piece new|setsrc|getsrc|rm|ls|search|verbs|slug   # deploying and listing only
+cf piece new|setsrc|getsrc|rm|ls|search|verbs|set-slug   # deploying and listing
 cf space … | cf id … | cf acl … | cf fuse …
 cf inspect …                                          # offline forensics
 cf check | test | view | init | deps                  # working on source
@@ -132,17 +136,20 @@ they have drifted.
 **`piece` keeps only what is genuinely about pieces.** Deploying, updating,
 removing, listing, searching, slugs, and listing a piece's verbs. Reading and
 writing cells are not piece operations and stop presenting themselves as ones.
+`recreate-root` and `set-home` are space-level operations sitting under `piece`;
+they belong under `space`, and moving them is part of step 7 rather than
+something this shape decides.
 
 `--shape` throughout, for the reasons above.
 
 ## How to get there
 
-Additive, in dependency order. Nothing before step 5 removes or renames anything
-a caller depends on.
+Additive, in dependency order. Nothing before step 6 removes or renames anything
+a caller depends on — steps 1–5 only add.
 
 1. **Factor out the shared read step** so a single implementation turns a cell
    and a shape into structured output.
-2. **Give every arrival access to it** — `piece call` gains `--schema` and
+2. **Give every arrival access to it** — `piece call` gains `--shape` and
    `--filter`, `wish` gains them, and an address renders identically from each.
 3. **`--piece` accepts the `of:` address form**, so an emitted address composes
    into the next command. This is where addressing stops being piece-flavoured

--- a/docs/plans/cli-surface-shape.md
+++ b/docs/plans/cli-surface-shape.md
@@ -81,11 +81,18 @@ The **concise** form is a different thing wearing the same flag:
 ```
 
 The concise form is a shorthand, and it exists because full schemas are verbose
-enough that nobody writes one to select two fields. That is a good reason for it
-to exist and a bad reason for it to share a flag with the thing it abbreviates.
-A reader who sees `--schema title,createdBy.name` and asks "how is that a
-schema?" has spotted the real problem: one flag, two syntaxes, one name that
-only describes one of them.
+enough that nobody writes one to select two fields. It is modelled on
+[`llm`'s schemas](https://llm.datasette.io/en/stable/schemas.html), which is
+worth recording so the next reader does not have to re-derive why it looks the
+way it does.
+
+`llm` keeps both syntaxes under one flag, so one flag is demonstrably livable
+and "the shorthand is not a schema" is not on its own a reason to split. The
+reason to split anyway is that **our shorthand is growing notation that is not
+schema syntax at all** — a suffix marking a path as an address, below — and a
+separate flag gives that room without every addition needing a justification as
+a schema dialect. A reader who sees `--schema title,createdBy.name@` and asks
+"how is that a schema?" is right, and will get righter.
 
 **Give the shorthand its own flag and leave `--schema` for full schemas.** That
 resolves the ambiguity rather than papering over it, and it leaves room for the
@@ -101,8 +108,14 @@ shorthand flag is open.
 `scope`, and `ifc` stay the source's — they decide how a value is treated, not
 which values come back. `$ref`, `$defs`, and the combinators are unsupported.
 Both checks run against the parsed projection whatever syntax produced it, so
-writing the full form does not unlock them. That is worth knowing before
-designing shorthand notation on top of `asCell`, since it is refused today.
+writing the full form does not unlock them.
+
+That rule needs no carve-out for the address suffix. `asCell` carries a handle
+contract as well as a boundary, and a handle cannot cross a serialized channel —
+so a reader supplying it would be asking for something the channel silently
+downgrades to an address. The suffix desugars to a projection-only `$link`
+instead; see
+[shaped reads](shaped-reads-and-verb-results.md) for the reasoning.
 
 ## What it should look like
 
@@ -173,6 +186,25 @@ a caller depends on — steps 1–5 only add.
 Steps 1–5 are mechanical. Step 7 needs real decisions and belongs last, because
 each pair is two working commands whose merge changes behaviour rather than
 spelling.
+
+**Each step carries its own documentation.** `--input`, `--piece`, and
+`piece get` appear across the tutorial, `packages/cli/README.md`, and the
+pattern documentation, so a single sweep at the end would leave every
+intermediate state wrong. What each step owes:
+
+| Step | Documentation owed |
+| --- | --- |
+| 2 | The read options gain a second host — `piece call`'s section in `packages/cli/README.md`, and [Verbs over the CLI](../common/verbs-over-the-cli.md), which is already stale |
+| 3 | Address forms wherever `--piece` is taught: the CLI README and the tutorial's workflow chapter |
+| 4 | `#argument` beside every `--input` example, in the same places |
+| 5 | The new spellings alongside the old ones everywhere both work |
+| 6 | Removal of the old spellings, once redirects have carried traffic |
+| 7 | Whatever the merges decide |
+
+**Old spellings stay as redirects, not errors, until step 6 has traffic behind
+it.** A deprecated spelling that still works costs a line of aliasing; one that
+fails costs every script and skill file that used it, including ones outside
+this repository.
 
 ## Decisions this document does not make
 

--- a/docs/plans/cli-surface-shape.md
+++ b/docs/plans/cli-surface-shape.md
@@ -43,7 +43,7 @@ nothing else.
 | `--piece` | a piece | any cell address — the function that fetches a piece's result returns the piece unchanged, and the read path checks nothing piece-specific |
 | `piece get` | reading a piece | reading a cell at a path |
 | `--input` | a mode you switch on | an address — it follows a link stored in the document to reach the arguments cell |
-| `--schema` | a type contract you must satisfy | a selection over the value, which also accepts a bare list of paths |
+| `--schema` | one input format | two — a full schema, and a concise path shorthand that is not a schema |
 
 The `--piece` case is not cosmetic. Believing the target had to be a piece is
 what made a verb's receipt look like it needed purpose-built read machinery,
@@ -61,40 +61,48 @@ set` writes at one path. Both target the arguments cell, and the overlap invites
 merging them, but they are not the same operation — which is why any merge
 belongs in the last step rather than among the renames.
 
-### The input spec is not a schema
+### One flag, two syntaxes
 
-`--schema` is the most misleading name on the surface, and the one worth fixing
-first, because it shapes how people reason about the whole read model.
+`--schema` takes two different things, and that is what makes it confusing —
+not that it takes a schema.
 
-A schema describes what data **is**. What this flag takes describes what the
-caller **wants back**. Same syntax, opposite direction — and four things follow
-from the mismatch:
+Schemas are queries here. The schema-on-read principle runs through the whole
+system: you describe the shape of the data you want, and that description
+decides what is loaded. A reader supplying a schema is doing exactly what a
+subscription does. So the flag's *full* form is a schema in good standing, and
+the syntax should stay schema-shaped so a caller can lift a source schema and
+prune it into a request.
 
-- **It accepts input that is not a schema at all.** `--schema
-  'title,createdBy.name'` is a list of paths.
-- **It is a strict subset, stripped of what gives a Fabric schema meaning.**
-  `asCell`, `default`, `scope`, and `ifc` are forbidden to callers; `$ref`,
-  `$defs`, and the combinators are unsupported. What remains is structure with
-  the semantics removed.
-- **It is about to carry keywords that are not JSON Schema.** Marking a position
-  as an address needs a projection-only keyword, which no schema dialect
-  defines.
-- **It misleads readers in practice.** "How is `topic.title` a schema? It's a
-  path" is the reasonable question of someone reading the flag's name and
-  finding it does not hold.
+The **concise** form is a different thing wearing the same flag:
 
-The confusion is not that schemas are being used as queries. In this system they
-legitimately are — a subscription is a graph query whose selector is a schema,
-and that is why the *syntax* should stay schema-shaped, so a caller can lift a
-source schema and prune it into a request. The problem is narrower: this
-particular schema is output-directed and deliberately incomplete, and the name
-claims more than it delivers.
+```
+--schema 'title,createdBy.name'                        # a path list
+--schema '{"properties":{"title":{"type":"string"}}}'  # a schema
+```
 
-**Rename the flag; keep the syntax.** `--shape` says what it is, covers both the
-concise and nested forms, and promises no validation. Doing it now is much
-cheaper than later: `piece call` does not have this flag yet, so adding it there
-as `--shape` and aliasing on `get` costs one deprecation on a flag that is still
-young. Adding it as `--schema` doubles the footprint of the wrong name.
+The concise form is a shorthand, and it exists because full schemas are verbose
+enough that nobody writes one to select two fields. That is a good reason for it
+to exist and a bad reason for it to share a flag with the thing it abbreviates.
+A reader who sees `--schema title,createdBy.name` and asks "how is that a
+schema?" has spotted the real problem: one flag, two syntaxes, one name that
+only describes one of them.
+
+**Give the shorthand its own flag and leave `--schema` for full schemas.** That
+resolves the ambiguity rather than papering over it, and it leaves room for the
+shorthand to grow notation a schema does not need — a suffix meaning "give me
+the link at this path rather than its contents" is the obvious candidate, since
+that is the common case and spelling it in full is painful.
+
+Timing argues for doing it now: `piece call` does not have either form yet, so
+splitting them costs one deprecation on a flag that is still young. Naming the
+shorthand flag is open.
+
+**What a reader may not supply, in either syntax.** `asCell`, `default`,
+`scope`, and `ifc` stay the source's — they decide how a value is treated, not
+which values come back. `$ref`, `$defs`, and the combinators are unsupported.
+Both checks run against the parsed projection whatever syntax produced it, so
+writing the full form does not unlock them. That is worth knowing before
+designing shorthand notation on top of `asCell`, since it is refused today.
 
 ## What it should look like
 
@@ -102,7 +110,7 @@ Reading is one operation reached from several starting points, so the surface
 wants one read command and distinct commands for the distinct ways of arriving:
 
 ```
-# <read opts> = [--shape S] [--filter P] — the shared tail, identical everywhere
+# <read opts> = selection (--schema, or its shorthand) + --filter — identical everywhere
 
 cf get   <addr> [path]           <read opts>
 cf call  <addr> <verb> <payload> <read opts>
@@ -140,7 +148,7 @@ writing cells are not piece operations and stop presenting themselves as ones.
 they belong under `space`, and moving them is part of step 7 rather than
 something this shape decides.
 
-`--shape` throughout, for the reasons above.
+The same selection flags everywhere, split per the reasons above.
 
 ## How to get there
 
@@ -149,8 +157,8 @@ a caller depends on — steps 1–5 only add.
 
 1. **Factor out the shared read step** so a single implementation turns a cell
    and a shape into structured output.
-2. **Give every arrival access to it** — `piece call` gains `--shape` and
-   `--filter`, `wish` gains them, and an address renders identically from each.
+2. **Give every arrival access to it** — `piece call` gains the selection and
+   filter flags, `wish` gains them, and an address renders identically from each.
 3. **`--piece` accepts the `of:` address form**, so an emitted address composes
    into the next command. This is where addressing stops being piece-flavoured
    in practice.

--- a/docs/plans/fabric-read-model.md
+++ b/docs/plans/fabric-read-model.md
@@ -1,0 +1,139 @@
+# Reading Fabric data: one model, several arrivals
+
+This is the umbrella for three concerns that share a model: **the read layer**,
+**calls** layered on it, and **the command surface**. Two documents cover them,
+since the first two are closely coupled and the third moves on its own timeline.
+
+- [Shaped reads and verb results](shaped-reads-and-verb-results.md) — **the read
+  layer, and calls.** How a read decides what to return, and what calling a verb
+  adds on top.
+- [CLI surface shape](cli-surface-shape.md) — **the command surface.** What it
+  should look like, and how to get there without breaking callers.
+
+It assumes no prior familiarity with the runtime. If you want the full
+background rather than the working vocabulary below,
+[the tutorial](../tutorial/README.md) covers cells in chapter 2, what a cell
+really is in chapter 8, and storage in chapter 9.
+
+## Orientation
+
+| Term | What it is |
+| --- | --- |
+| **Space** | A store of data, named by a cryptographic identifier. Everything lives in exactly one space. |
+| **Cell** | The unit of state — reactive, durable, and addressable. Behind each is a stored JSON document. |
+| **Address** | Where a cell lives: a space, an entity id such as `of:fid1:abc…`, and optionally a path inside the document. |
+| **Link** | A pointer from one cell to another, stored inline in a document. Following links is how one cell reaches another. |
+| **Pattern** | A user-authored program declaring state and, optionally, callable operations. Components run once to wire up reactive state, in the style of Solid.js. |
+| **Piece** | A running instance of a pattern in a space. What you address, read, and call. |
+| **Verb** | A piece's callable operation, invoked with `cf piece call`. |
+| **Receipt** | The cell the runtime writes when a verb finishes, holding whatever the verb returned. |
+| **Schema** | A description a cell carries of what it holds. The runtime reads it to decide what to fetch and how to treat each value. |
+| **Shape** | A description a *caller* supplies of what it wants back from a read. Written in schema syntax, but a request rather than a declaration. |
+
+Two ideas that carry most of the weight:
+
+**A cell is a point in a graph, not a self-contained record.** Its document
+holds values *and links to other cells*. Reading one without saying where to
+stop follows those links onward, and onward again, so an innocuous-looking read
+can return an enormous amount of unrelated data. That is the whole problem this
+work exists to solve.
+
+**Descriptions of data are queries here, not type annotations.** A cell's schema
+is what the runtime consults to decide which documents to load — reactivity is
+literally a subscription to a query whose selector is a schema. A caller's shape
+works the same way in the opposite direction: it becomes the set of paths
+fetched, so links outside it are never followed.
+
+Keeping those two apart matters. A **schema** declares what data *is* and
+belongs to the cell; a **shape** asks for what a caller *wants* and belongs to
+the read. They share a syntax and are routinely confused, including by the flag
+that carries them.
+
+## The model
+
+**Everything addressable is a cell.** A piece is a cell — the function that
+"gets a piece's result" returns the piece itself, and nothing in the read path
+checks whether the thing you addressed is a piece at all. A receipt is a cell.
+A piece's arguments are a cell, reached by following a link stored in its
+document. There is no separate "piece object" behind the address you hold.
+
+**Arrival is plural; reading is singular.** There are several genuinely
+different ways to end up holding a cell:
+
+| Arrival | What it does |
+| --- | --- |
+| `cf piece get <addr>` | addresses a cell directly |
+| `cf piece call <addr> <verb>` | runs a verb, then reads the receipt it wrote |
+| `cf wish <query>` | resolves a query to whatever satisfies it |
+| `cf exec <mountedFile>` | reaches a verb through a filesystem mount and runs it |
+
+None of these should absorb the others — a query is not an address, and running
+a verb is not reading. But all four end in the same place: you now hold a cell,
+and you want structured data out of it.
+
+That last step — **given a cell and a description of what you want, produce
+structured output** — is one operation. The description says which positions
+come back as values and which come back as addresses you can use later.
+
+## Why this matters
+
+The last step is not shared today, and the same note renders two different ways
+depending on how you reached it. Read it from the board that holds it:
+
+```json
+{ "title": "Notes", "body": "…" }
+```
+
+Create it with a verb and read it out of the call's result, and its `append`
+operation comes along as a raw internal pointer:
+
+```json
+{ "note": { "title": "Notes", "body": "…",
+            "append": { "/": { "link@1": { "id": "of:fid1:…", … } } } } }
+```
+
+Neither behaviour was designed. Each command grew its own output handling and
+they drifted.
+
+## What the model settles
+
+Three questions dissolve rather than needing answers.
+
+**How deep should a read follow links?** It does not traverse by depth at all. A
+read selects by path, so paths outside the selection are never followed however
+many hops away they sit.
+
+**What format should a verb's result use?** The one a read already uses. Inside
+the result, it *is* a read, on a different cell.
+
+**What makes a receipt special?** Nothing. It is an ordinary cell, distinguished
+only by being created without a schema — which is a defect rather than a
+property.
+
+## The three concerns
+
+**The read layer.** Given a cell and a description of what you want, return
+structured data. What is missing is a way for that description to say "give me
+an address here, a value there" — which is what preserves a created thing's
+identity instead of flattening it into a copy of its contents. Covered in
+[Shaped reads and verb results](shaped-reads-and-verb-results.md).
+
+**Calls, layered on it.** Running a verb writes a receipt; reading that receipt
+is an ordinary read. What belongs to the call is the surrounding envelope, safe
+retries, collecting a result later, and recovering an address when a response is
+lost. Same document as the read layer.
+
+**The command surface.** `piece` currently carries four unrelated jobs, two
+commands are named `inspect`, two are named `view`, `--piece` names a cell
+rather than a piece, and `--input` is an address disguised as a mode flag.
+Covered in [CLI surface shape](cli-surface-shape.md).
+
+## What follows from the split
+
+Reads and calls stop blocking each other. The read layer can be settled against
+`cf piece get`, which is where the load already is, and calls inherit it rather
+than specifying a parallel format.
+
+The command surface stops being a prerequisite. Sharing the read layer between
+commands requires no renaming, so the naming and structure questions can be
+argued on their own timeline instead of gating functional work.

--- a/docs/plans/fabric-read-model.md
+++ b/docs/plans/fabric-read-model.md
@@ -33,8 +33,8 @@ really is in chapter 8, and storage in chapter 9.
 | **Piece** | A running instance of a pattern in a space. What you address, read, and call. |
 | **Verb** | A piece's callable operation, invoked with `cf piece call`. |
 | **Receipt** | The cell the runtime writes when a verb finishes, holding whatever the verb returned. |
-| **Schema** | A description a cell carries of what it holds. The runtime reads it to decide what to fetch and how to treat each value. |
-| **Shape** | A description a *caller* supplies of what it wants back from a read. Written in schema syntax, but a request rather than a declaration. |
+| **Schema** | A description of data's shape. Schemas are queries here: the runtime reads one to decide which documents to load and how to treat each value. |
+| **Shape** | The schema supplied for one particular read — what this caller wants back. Written concisely or in full. |
 
 Two ideas that carry most of the weight:
 
@@ -44,16 +44,18 @@ stop follows those links onward, and onward again, so an innocuous-looking read
 can return an enormous amount of unrelated data. That is the whole problem this
 work exists to solve.
 
-**Descriptions of data are queries here, not type annotations.** A cell's schema
-is what the runtime consults to decide which documents to load — reactivity is
-literally a subscription to a query whose selector is a schema. A caller's shape
-works the same way in the opposite direction: it becomes the set of paths
-fetched, so links outside it are never followed.
+**Schemas are queries, not type annotations.** This is the schema-on-read
+principle the rest of the system runs on: you describe the shape of the data you
+want, and that description decides what gets loaded. Reactivity is a
+subscription to a query whose selector is a schema, and a read works the same
+way — the schema supplied becomes the set of paths fetched, so links outside it
+are never followed.
 
-Keeping those two apart matters. A **schema** declares what data *is* and
-belongs to the cell; a **shape** asks for what a caller *wants* and belongs to
-the read. They share a syntax and are routinely confused, including by the flag
-that carries them.
+A cell carries a schema and a reader supplies one. They are the same kind of
+artifact; what differs is **authority**, not direction. The cell's schema is
+authoritative for how a value is treated — whether it comes back as a handle,
+what it defaults to, which partition it reads, who may see it. The reader's
+selects among what is there.
 
 ## The model
 

--- a/docs/plans/fabric-read-model.md
+++ b/docs/plans/fabric-read-model.md
@@ -70,8 +70,8 @@ different ways to end up holding a cell:
 
 | Arrival | What it does |
 | --- | --- |
-| `cf piece get <addr>` | addresses a cell directly |
-| `cf piece call <addr> <verb>` | runs a verb, then reads the receipt it wrote |
+| `cf piece get --piece <addr>` | addresses a cell directly |
+| `cf piece call --piece <addr> <verb>` | runs a verb, then reads the receipt it wrote |
 | `cf wish <query>` | resolves a query to whatever satisfies it |
 | `cf exec <mountedFile>` | reaches a verb through a filesystem mount and runs it |
 

--- a/docs/plans/fabric-read-model.md
+++ b/docs/plans/fabric-read-model.md
@@ -100,7 +100,7 @@ operation comes along as a raw internal pointer:
             "append": { "/": { "link@1": { "id": "of:fid1:…", … } } } } }
 ```
 
-Neither behaviour was designed. Each command grew its own output handling and
+Neither behavior was designed. Each command grew its own output handling and
 they drifted.
 
 ## What the model settles

--- a/docs/plans/fabric-read-model.md
+++ b/docs/plans/fabric-read-model.md
@@ -10,6 +10,12 @@ since the first two are closely coupled and the third moves on its own timeline.
 - [CLI surface shape](cli-surface-shape.md) — **the command surface.** What it
   should look like, and how to get there without breaking callers.
 
+Call-specific investigation detail — what produces a receipt and what its
+existence proves, how its address is derived, the entity-URI change to
+`--piece`, error conventions and sequencing — is collected in
+[Verb calls: working notes](verb-result-selection.md). Sketches to draw from,
+not a settled contract.
+
 It assumes no prior familiarity with the runtime. If you want the full
 background rather than the working vocabulary below,
 [the tutorial](../tutorial/README.md) covers cells in chapter 2, what a cell

--- a/docs/plans/shaped-reads-and-verb-results.md
+++ b/docs/plans/shaped-reads-and-verb-results.md
@@ -438,47 +438,71 @@ unless noted.
   `{"/": {"link@1": …}}` — faithful, but the internal form rather than a
   declared one.
 
-## Open questions
+## What a receipt declares
 
-**What a receipt's schema should record.** The root container kind alone is
-enough for narrowing to engage; a verb's result is a record, so
-`{"type": "object"}` would do — assuming a non-record return is impossible,
-which the contract has not been checked for.
+A receipt carries a **descriptive** schema: the root container kind and the
+property names, derived from the value the runtime has just written and stored
+in the durable schema metadata in the same create-only transaction. That is what
+narrowing needs — a selector cannot be built without the root container kind —
+and it is the least a receipt can say and still be readable like any other cell.
 
-Recording the full structure — including which positions hold links — is what
-makes a reader's selection match a declaration rather than coincide with a
-runtime value, which is the second reason for giving receipts a schema at all.
-The cost is deriving it from the value at write time rather than writing a
-constant.
+It records nothing about which positions hold links. A link position in a source
+schema is spelled `asCell`, and `["cell"]` asserts a writable handle; writing
+that onto a document nothing can be written through would be a claim the receipt
+cannot honour.
 
-One detail either way: a link position in a source schema is spelled `asCell`,
-and `["cell"]` asserts a writable handle on a document nothing can be written
-through. Whether a receipt should say that, something narrower, or nothing about
-link positions, is open.
+Descriptive is not the end state. A schema derived from a value matches what
+happened to be written, where a schema derived from a declaration matches what
+the verb promises — and only the second lets a reader's selection be checked
+before the call rather than after. The declared source is a verb's own result
+type, which reaches the runtime on `module.resultSchema`; the receipt's schema
+slot then takes a better-sourced value rather than a migration.
 
-**What an invocation id is scoped to.** Nothing in a receipt's address
-identifies who called: a supplied id is hashed together with the stream link, so
-it is namespaced per verb binding but not by caller. An invocation id is
-therefore a read key shared by everyone using that verb in that space. Two
-callers picking the same id read one receipt, and a guessed id reads someone
-else's result.
+## An invocation id is scoped to a session
 
-The scope should be a **session**, not a principal. An identity separates
-nothing here — agents are directed to work under their human user's key rather
-than mint their own, so the collision that actually happens is two agents under
-one key. A session distinguishes them; a DID does not. A minted, unguessable
-session also closes the second half of the problem, which an identity cannot: a
-DID is public, so scoping by one would still leave an outcome's address
-computable by anyone who knows the piece, the verb, and a conventional id.
+Nothing in a receipt's address would otherwise identify who called: a supplied id
+is hashed together with the stream link, so it is namespaced per verb binding but
+not by caller. Unscoped, an invocation id is a read key shared by everyone using
+that verb in that space — two callers picking the same id read one receipt, and a
+guessed id reads someone else's result.
 
-Sharing an outcome deliberately is then done by passing its address, not by two
+The scope is a **session**, not a principal. An identity separates nothing here:
+agents are directed to work under their human user's key rather than mint their
+own, so the collision that actually happens is two agents under one key. A
+session distinguishes them; a DID does not. A minted, unguessable session also
+closes the second half of the problem, which an identity cannot — a DID is
+public, so scoping by one would still leave an outcome's address computable by
+anyone who knows the piece, the verb, and a conventional id.
+
+The session is minted explicitly rather than managed implicitly, so a caller
+always knows which session an outcome belongs to. Neither session identifier
+already in the tree serves: the storage session is minted per process and
+re-minted on close, so scoping by it would break same-id replay, which is the
+property the id exists for.
+
+Sharing an outcome deliberately is done by passing its address, not by two
 callers deriving the same id from a convention — which is unambiguous, and
 removes the only reason the shared key looked useful.
 
-What remains open is the mechanism. Neither session identifier in the tree
-serves: the storage session is minted per process and re-minted on close, so
-scoping by it would break same-id replay, which is the property the id exists
-for. That points at a new, caller-supplied session identity — minted explicitly
-rather than managed implicitly, so a caller always knows which session an
-outcome belongs to — and at the question of what an absent one means, since
-unscoped preserves today's behavior and today's collision.
+## Open questions
+
+**Whether a receipt's schema becomes declared-sourced.** The mechanism exists —
+a verb's declared result type can reach `module.resultSchema`, and the runtime
+already writes a result cell's schema from there. What is unsettled is whether
+that road is the one to take, given that an earlier attempt at result-schema
+emission was withdrawn for reasons that still hold about durable schemas and the
+compatibility gate.
+
+Until it is settled, a receipt for a verb returning anything reactive — which
+includes every verb returning a child piece — carries no schema at all, because
+the descriptive derivation runs only where the result is plain.
+
+**Whether a reactive compute needs an invocation id.** A pattern tool, unlike a
+handler, is a function of its inputs: the same inputs and the same action yield
+the same output by definition, so its outcome could be addressed by what it
+computed rather than by a name the caller chose. That would make deduplication a
+property of the computation instead of a convention the caller has to keep, and
+would leave the invocation id serving only the caller's own bookkeeping.
+
+Whether the two cases should share one mechanism or stay separate is open, and
+the answer decides whether a session scopes both or only handler calls.

--- a/docs/plans/shaped-reads-and-verb-results.md
+++ b/docs/plans/shaped-reads-and-verb-results.md
@@ -118,46 +118,18 @@ caller cannot do is introduce its own. A disjunction has no single answer to
 "return this subtree," so honouring one would mean picking a branch on the
 caller's behalf.
 
-### What a shape cannot yet say: which positions are addresses
+### Saying which positions are addresses
 
-Everything above selects *values*. What is missing is a way to say "at this
-position, give me the address rather than what is behind it."
+Everything above selects *values*. A shape also needs to say "at this position,
+give me the address rather than what is behind it."
 
 That is what preserves identity. If a verb creates a note and the result
 flattens it into its contents, the caller cannot then call a verb on that note —
 there is no address to pass along. If instead the position renders as an
 address, the next command can use it directly.
 
-Four spellings are available, and the choice is not cosmetic:
-
-| Spelling | Where the address comes from |
-| --- | --- |
-| Omission-driven (`--add-ids`) | positions the shape did not project |
-| Path list (`--id-for-paths`) | a second list, parallel to the shape |
-| Marked at the position | a keyword beside `properties`, inside the shape |
-| Selected as a field | a reserved name inside the selection set |
-| Suffixed in the shorthand | a marker on a path — `createdBy.user@` |
-
-The last is sugar rather than a rival: the shorthand desugars into a schema, so
-it needs one of the others underneath it. It is listed because the shorthand is
-where the common case actually gets typed, and a spelling nobody writes is not
-much of a win. Of the first four, two cannot do the job at all.
-
-**Omission-driven cannot express the case that motivates this.** A caller
-creating a topic usually wants its address *and* one field from it — the title,
-to confirm the write landed. That needs both from the same subtree. If the shape
-projects `topic.title`, then `topic` is on the path being traversed and renders
-as a value, so no address is produced. Address or field, not both.
-
-**A path list does not compose.** It is a second addressing language running
-beside the shape, and it cannot describe nested structure the way the shape can.
-It brings back path enumeration precisely where the shape exists to avoid it.
-
-The other two both work, and both express the motivating case. They differ in
-where the marker sits.
-
-**Marking at the position** puts a keyword beside `properties`, so a position
-can be descended into and rendered as an address at once:
+**A `$link` marker beside `properties`.** A position can be descended into and
+rendered as an address at once:
 
 ```json
 { "properties": {
@@ -165,43 +137,88 @@ can be descended into and rendered as an address at once:
                "properties": { "title": true } } } }
 ```
 
-**Selecting it as a field** puts a reserved name inside the selection set,
-alongside the fields that genuinely exist:
-
-```json
-{ "properties": {
-    "topic": { "properties": { "$id": true, "title": true } } } }
-```
-
-Either returns the same thing:
+returning
 
 ```json
 { "topic": { "$link": { "id": "of:fid1:…", "space": "did:key:…" },
              "title": "New topic" } }
 ```
 
-The second borrows GraphQL's selection sets, where `{ topic { id title } }`
-treats identity as a field you ask for rather than a special form. It needs one
-mechanism instead of two and composes at any depth with no rule about where a
-marker may sit. Its wrinkle is that our documents have no `id` field — identity
-lives on the link, not in the data — so the name is synthetic and sits in an
-allowlist beside names that are not. Only the idea transfers, not the syntax:
-the argument for schema-shaped shapes is that a caller can lift a source schema
-and prune it, which a different query syntax would break.
+**Semantics: link *instead of* contents.** A bare marker returns the address and
+nothing else. Address-plus-summary is spelled as two paths — `topic@,topic.title`
+— which merge by union into the shape above and render as one result carrying
+both. One rule, no special case: you get what you asked for, and asking for the
+link is not asking for the contents.
 
-Whichever wins, the marker must be **projection-only**, not a borrowed `asCell`.
-A reader is barred from supplying `asCell` by name, alongside `ifc`, in either
-syntax; reusing it would either breach that rule or give one keyword two
-meanings depending on who wrote it. That constraint binds the shorthand suffix
-too — reading `@` as "as cell" is the natural intuition, and it is the one
-spelling the current rules refuse.
+**The shorthand desugars one-to-one.** `createdBy.user@` rewrites the leaf in
+place to `{"user": {"$link": true}}` — an annotation on the position, not a
+structural change.
 
-The mechanism underneath already exists either way, and needs no new traversal
-machinery. A selector can be told to reject a position — load nothing there.
-Marked positions would get exactly that, composed into the same set of paths
-the projection already builds, so the address comes back without its target
-being loaded. The rejecting selector exists and is used at roughly nine gate
-sites in `traverse.ts`; wiring it into the projection's path mask is the work.
+#### Why this spelling
+
+Two decisions, and they are separable.
+
+**The name is `$link`, not `$id`.** Cells do have ids at one layer, but
+addresses are many-to-one over cells: a holder of an address cannot tell a
+canonical id from an alias, and nothing in normal use requires them to. What a
+caller needs is a link it can read next, not a claim about canonical identity.
+The rendered output already returns a link object, and the request vocabulary
+should match the response vocabulary. `$id` would also teach something false —
+our documents carry no `id` field, because identity lives on the link.
+
+**The placement is the position, not a field inside the selection set.** The
+link is physically stored in the *parent* document, on the edge — which is
+exactly why a list of marked addresses costs one document read. `$link: true`
+beside `properties` annotates where the data actually is. The alternative,
+borrowed from GraphQL's selection sets, puts a synthetic member inside the
+*child's* selection set, claiming the address is data belonging to a target
+that is never touched. GraphQL carries that off because its objects genuinely
+have `id` fields; ours do not. There is an implementation asymmetry too: the
+rejecting selector takes a positional instruction, so `$link: true` maps onto it
+directly, while a field spelling has to infer "load nothing here" from the
+absence of real members — fetch-suppression by omission rather than by
+statement. And the shorthand suffix would have to convert a leaf into a
+container selecting a synthetic member, rather than annotating it in place.
+
+**Two spellings were considered and rejected outright.** Deriving addresses from
+what a shape *omitted* cannot express the motivating case at all: projecting
+`topic.title` puts `topic` on the traversed path, so it renders as a value and
+no address is produced — address or field, never both. And a parallel path list
+alongside the shape is a second addressing language that cannot describe nested
+structure, reintroducing path enumeration precisely where the shape exists to
+avoid it.
+
+#### Why not `asCell`
+
+The marker is **projection-only**. Reusing `asCell` — the natural intuition,
+since `@` reads as "as cell" — fails for a reason beyond the rule that bars
+readers from supplying it.
+
+`asCell` bundles two things: a traversal boundary, and a *handle contract*. What
+comes back is a live cell — readable, writable, subscribable — and in a pattern,
+asking for `asCell` is often how an author signals intent to mutate. A read
+needs only the boundary and an address rendering.
+
+Over a serialized channel the handle half cannot be delivered at all. A cell
+does not cross a process boundary; the only faithful serialization of one is its
+link. So a reader-supplied `asCell` would be a request the channel silently
+degrades — a name promising handle semantics and delivering an address, which is
+the same defect this work exists to remove. `asCell` also spans five variants,
+only some of them boundaries; opening it to readers would import that whole
+surface, and a reader asserting `writeonly` in a read is nonsense that would
+then need refusing case by case.
+
+`$link` names exactly what a serialized read can return, leaves `asCell` meaning
+what it means in patterns, and keeps the rule that treatment keywords are never
+a reader's at full strength, with no carve-out.
+
+#### The mechanism already exists
+
+A selector can be told to reject a position — load nothing there. Marked
+positions get exactly that, composed into the same set of paths the projection
+already builds, so the address comes back without its target being loaded. The
+rejecting selector is used at roughly nine gate sites in `traverse.ts`; wiring
+it into the projection's path mask is the work.
 
 ### Collections are all or nothing
 
@@ -306,7 +323,16 @@ failing to engage rather than anything special about receipts:
   declaration — field names that happen to coincide, rather than a subtree of a
   declared structure.
 
-Giving the receipt cell a schema when it is created addresses both.
+Giving the receipt cell a schema addresses both. It goes in the durable schema
+metadata — `setMetaRaw("schema", …)`, the field `piece get` reads back through
+`asSchema` — not the schema argument to `getCell`, which seeds the link scope
+and the in-memory cell only. The receipt is minted before the handler runs, so
+there is no shape at that moment; it is written at result-write time, in the
+same create-only transaction, from the value the runtime is already holding.
+
+What is recorded is **descriptive**: what this receipt holds, never a contract
+constraining anything later. That is a safe thing for a write-once document,
+where description and authority cannot diverge.
 
 This is **not** the same as emitting a declared result schema for a verb, which
 is deferred to the Fabric-types stream design. That would be a published
@@ -382,23 +408,19 @@ unless noted.
 
 ## Open questions
 
-**Which spelling marks addresses in a shape.** Two of the four are ruled out
-above: omission-driven cannot express an address beside a summary field, and a
-path list does not compose. The live choice is between marking at the position
-and selecting identity as a field. The second is the smaller mechanism; the
-first keeps the selection set free of synthetic names. Decide before
-implementation, since the rendered output is identical either way and only the
-request syntax differs.
-
 **Whether a caller-supplied shape may fix the root container kind.** Narrowing
 keys on the *source* schema today. A caller's shape states the root kind too,
 and honouring it would let schema-less sources narrow. The rule barring caller
 metadata covers `ifc`/`asCell`/`scope`/`default`; root container kind is
-structure rather than metadata, so this may be a clean exception.
+structure rather than metadata, so this may be a clean exception. Largely moot
+if receipts carry a schema, since the receipt is the schema-less source that
+motivated the question.
 
-**Whether creating receipt cells with a schema is acceptable**, given the
-compatibility gate does not reach them and the Fabric-types work would supersede
-the source of that schema rather than the slot it fills.
+**What shape a receipt should declare.** A structural schema is enough for
+narrowing to engage — it only needs the root container kind. Whether that shape
+should also record which positions hold links, and in what encoding, is open:
+the obvious spelling is `asCell`, which would put a treatment keyword on a
+document nothing can be written through.
 
 **Invocation id namespace.** Nothing in a receipt's address identifies who
 called. A supplied id is hashed together with the stream link, so it is

--- a/docs/plans/shaped-reads-and-verb-results.md
+++ b/docs/plans/shaped-reads-and-verb-results.md
@@ -71,8 +71,22 @@ asymmetry is why.
 ```
 
 The concise form is sugar for the flat case; the full form is a JSON Schema
-object and is what expresses nested structure. `--filter` narrows array
-membership with a predicate and runs before projection.
+object and is what expresses nested structure.
+
+**`--filter` is the other axis.** A shape names paths; it cannot say "only the
+elements where `status == "open"`". That is `--filter`, a predicate over array
+elements. The two do not collapse into one, because **filtering runs before
+projection** — a predicate can inspect a field the result omits:
+
+```bash
+cf piece get ... topics --filter '.status == "open"' --shape 'title,id'
+```
+
+`status` decides membership and never appears in the output. A single mechanism
+would have to either leak the field or give up deciding on it. One constraint:
+combined with an inline schema rather than the concise form, `--filter` requires
+an array root, since the schema then describes the whole returned value rather
+than each item.
 
 There are two kinds of thing a caller's shape may **not** contain, for two
 different reasons (`FORBIDDEN_PROJECTION_KEYS` and
@@ -184,8 +198,13 @@ sites in `traverse.ts`; wiring it into the projection's path mask is the work.
 ### Collections are all or nothing
 
 A shape controls **depth** (how far in to go) and **width** (which fields to
-take), but not **cardinality** (how many elements of a list). A shape reaching a
-collection takes every element; there is no windowing or per-element limit.
+take). It does not control how many elements of a list come back: a shape
+reaching a collection takes every element that survives filtering.
+
+`--filter` is not an exception to this. It decides which elements are in the
+result at all, before any of the above applies; all-or-nothing governs how
+deeply each *surviving* element expands, not how many survive. What is missing
+is count-based windowing — "the first ten" — which no predicate expresses.
 
 Two things make that acceptable at the sizes this serves. Cost is roughly
 *things expanded × fields each × levels deep*, so cardinality only matters once
@@ -196,9 +215,11 @@ every address before deciding to ask for contents.
 
 The limit of that argument is the address list itself. Once a collection is
 large enough that rendering one address per element is the payload, seeing the
-count costs what the count was meant to protect against. Windowing becomes
-necessary there, and it has to window collections of **addresses**, not only
-expanded ones.
+count costs what the count was meant to protect against. A predicate covers much
+of this — filtering down is usually available, and is the answer whenever
+something discriminates the elements you want. Windowing is for when nothing
+does: ten thousand entries with no predicate that selects among them. It has to
+window collections of **addresses**, not only expanded ones.
 
 ### Pushing the shape into the fetch
 

--- a/docs/plans/shaped-reads-and-verb-results.md
+++ b/docs/plans/shaped-reads-and-verb-results.md
@@ -290,12 +290,14 @@ What genuinely belongs to the call, and to nothing else:
 Everything inside `result` is the read layer. A call should gain `--schema` and
 `--filter` by reusing the shared implementation, not by growing a second one.
 
-### The receipt is an ordinary cell created without a schema
+### Receipts carry a descriptive schema
 
-Receipts are created with no schema argument (`handleJavaScriptHandlerResult`,
-`packages/runner/src/runner.ts`), so the stored document carries an empty
-`schema` field. Two consequences follow, and both are the read layer's mechanisms
-failing to engage rather than anything special about receipts:
+A receipt is an ordinary cell, and like any other it should say what it holds.
+Today it does not: receipts are created with no schema argument
+(`handleJavaScriptHandlerResult`, `packages/runner/src/runner.ts`), so the
+stored document carries an empty `schema` field. Two consequences follow, and
+both are the read layer's mechanisms failing to engage rather than anything
+special about receipts:
 
 - The fetch narrowing above cannot engage, so a shape is applied after
   everything has been loaded.

--- a/docs/plans/shaped-reads-and-verb-results.md
+++ b/docs/plans/shaped-reads-and-verb-results.md
@@ -154,39 +154,19 @@ link is not asking for the contents.
 place to `{"user": {"$link": true}}` — an annotation on the position, not a
 structural change.
 
-#### Why this spelling
+#### Why the marker sits at the position
 
-Two decisions, and they are separable.
-
-**The name is `$link`, not `$id`.** Cells do have ids at one layer, but
-addresses are many-to-one over cells: a holder of an address cannot tell a
-canonical id from an alias, and nothing in normal use requires them to. What a
-caller needs is a link it can read next, not a claim about canonical identity.
-The rendered output already returns a link object, and the request vocabulary
-should match the response vocabulary. `$id` would also teach something false —
-our documents carry no `id` field, because identity lives on the link.
-
-**The placement is the position, not a field inside the selection set.** The
-link is physically stored in the *parent* document, on the edge — which is
+The link is physically stored in the *parent* document, on the edge — which is
 exactly why a list of marked addresses costs one document read. `$link: true`
-beside `properties` annotates where the data actually is. The alternative,
-borrowed from GraphQL's selection sets, puts a synthetic member inside the
-*child's* selection set, claiming the address is data belonging to a target
-that is never touched. GraphQL carries that off because its objects genuinely
-have `id` fields; ours do not. There is an implementation asymmetry too: the
-rejecting selector takes a positional instruction, so `$link: true` maps onto it
-directly, while a field spelling has to infer "load nothing here" from the
-absence of real members — fetch-suppression by omission rather than by
-statement. And the shorthand suffix would have to convert a leaf into a
-container selecting a synthetic member, rather than annotating it in place.
+beside `properties` annotates the position where the data actually is, and the
+rejecting selector takes a positional instruction, so the marker maps onto it
+directly.
 
-**Two spellings were considered and rejected outright.** Deriving addresses from
-what a shape *omitted* cannot express the motivating case at all: projecting
-`topic.title` puts `topic` on the traversed path, so it renders as a value and
-no address is produced — address or field, never both. And a parallel path list
-alongside the shape is a second addressing language that cannot describe nested
-structure, reintroducing path enumeration precisely where the shape exists to
-avoid it.
+The name says what the caller gets. Addresses are many-to-one over cells: a
+holder of one cannot tell a canonical id from an alias, and nothing in normal
+use requires them to. What comes back is a link to read next, not a claim about
+canonical identity — and the rendered output is a link object, so the request
+vocabulary matches the response.
 
 #### Why not `asCell`
 

--- a/docs/plans/shaped-reads-and-verb-results.md
+++ b/docs/plans/shaped-reads-and-verb-results.md
@@ -427,15 +427,29 @@ and `["cell"]` asserts a writable handle on a document nothing can be written
 through. Whether a receipt should say that, something narrower, or nothing about
 link positions, is open.
 
-**Should an invocation id be namespaced by its caller?** Nothing in a receipt's
-address identifies who called: a supplied id is hashed together with the stream
-link, so it is namespaced per verb binding but not by principal — no DID or
-session enters the hash. An invocation id is therefore a read key shared by
-everyone using that verb in that space. Two callers picking the same id read one
-receipt, and a guessed id reads someone else's result.
+**What an invocation id is scoped to.** Nothing in a receipt's address
+identifies who called: a supplied id is hashed together with the stream link, so
+it is namespaced per verb binding but not by caller. An invocation id is
+therefore a read key shared by everyone using that verb in that space. Two
+callers picking the same id read one receipt, and a guessed id reads someone
+else's result.
 
-Adding the caller's DID to that hash is mechanically cheap — identity into a
-hash that already exists. The cost is that it changes deduplication semantics
-and breaks deliberate id-sharing between agents, if that is worth keeping. The
-consequences and the three ways out are worked through in
-[Verb calls: working notes](verb-result-selection.md).
+The scope should be a **session**, not a principal. An identity separates
+nothing here — agents are directed to work under their human user's key rather
+than mint their own, so the collision that actually happens is two agents under
+one key. A session distinguishes them; a DID does not. A minted, unguessable
+session also closes the second half of the problem, which an identity cannot: a
+DID is public, so scoping by one would still leave an outcome's address
+computable by anyone who knows the piece, the verb, and a conventional id.
+
+Sharing an outcome deliberately is then done by passing its address, not by two
+callers deriving the same id from a convention — which is unambiguous, and
+removes the only reason the shared key looked useful.
+
+What remains open is the mechanism. Neither session identifier in the tree
+serves: the storage session is minted per process and re-minted on close, so
+scoping by it would break same-id replay, which is the property the id exists
+for. That points at a new, caller-supplied session identity — minted explicitly
+rather than managed implicitly, so a caller always knows which session an
+outcome belongs to — and at the question of what an absent one means, since
+unscoped preserves today's behavior and today's collision.

--- a/docs/plans/shaped-reads-and-verb-results.md
+++ b/docs/plans/shaped-reads-and-verb-results.md
@@ -258,6 +258,11 @@ This is why a cell's declared schema matters beyond type-checking: it is what
 lets a caller's shape become a fetch instruction instead of a filter applied
 after the fact.
 
+A caller's selection states the root kind too, so honouring it would let
+ambiguous-root sources narrow as well — but no case has been shown that needs
+it, and the source most likely to have wanted it is the receipt, which now
+carries its own schema.
+
 ### Defect: an unshaped read serializes live handles
 
 A read with no shape loads the value and serializes whatever objects it finds.
@@ -397,25 +402,31 @@ unless noted.
 
 ## Open questions
 
-**Whether a caller-supplied shape may fix the root container kind.** Narrowing
-keys on the *source* schema today. A caller's shape states the root kind too,
-and honouring it would let schema-less sources narrow. The rule barring caller
-metadata covers `ifc`/`asCell`/`scope`/`default`; root container kind is
-structure rather than metadata, so this may be a clean exception. Largely moot
-if receipts carry a schema, since the receipt is the schema-less source that
-motivated the question.
+**What a receipt's schema should record.** The root container kind alone is
+enough for narrowing to engage; a verb's result is a record, so
+`{"type": "object"}` would do — assuming a non-record return is impossible,
+which the contract has not been checked for.
 
-**What shape a receipt should declare.** A structural schema is enough for
-narrowing to engage — it only needs the root container kind. Whether that shape
-should also record which positions hold links, and in what encoding, is open:
-the obvious spelling is `asCell`, which would put a treatment keyword on a
-document nothing can be written through.
+Recording the full structure — including which positions hold links — is what
+makes a reader's selection match a declaration rather than coincide with a
+runtime value, which is the second reason for giving receipts a schema at all.
+The cost is deriving it from the value at write time rather than writing a
+constant.
 
-**Invocation id namespace.** Nothing in a receipt's address identifies who
-called. A supplied id is hashed together with the stream link, so it is
-namespaced per verb binding but not by principal — no DID or session enters the
-hash. An invocation id is therefore a read key shared by everyone using that
-verb in that space: two callers picking the same id read one receipt, and a
-guessed id reads someone else's result. Pre-existing, and reachable once
-receipts are read deliberately. The consequences and the three ways out are
-worked through in [Verb calls: working notes](verb-result-selection.md).
+One detail either way: a link position in a source schema is spelled `asCell`,
+and `["cell"]` asserts a writable handle on a document nothing can be written
+through. Whether a receipt should say that, something narrower, or nothing about
+link positions, is open.
+
+**Should an invocation id be namespaced by its caller?** Nothing in a receipt's
+address identifies who called: a supplied id is hashed together with the stream
+link, so it is namespaced per verb binding but not by principal — no DID or
+session enters the hash. An invocation id is therefore a read key shared by
+everyone using that verb in that space. Two callers picking the same id read one
+receipt, and a guessed id reads someone else's result.
+
+Adding the caller's DID to that hash is mechanically cheap — identity into a
+hash that already exists. The cost is that it changes deduplication semantics
+and breaks deliberate id-sharing between agents, if that is worth keeping. The
+consequences and the three ways out are worked through in
+[Verb calls: working notes](verb-result-selection.md).

--- a/docs/plans/shaped-reads-and-verb-results.md
+++ b/docs/plans/shaped-reads-and-verb-results.md
@@ -160,6 +160,35 @@ link is not asking for the contents.
 place to `{"user": {"$link": true}}` — an annotation on the position, not a
 structural change.
 
+#### What a rendered address contains
+
+The runtime's own link encoding is dispatched on an experimental option and
+mid-migration, so a caller reading it builds on something replaceable. A rendered
+address is therefore a **declared** shape, and the moment callers are told to
+`jq` a result, that shape is a public contract — the only choice is whether it is
+one we declared or one that leaked. The spelling follows `state-inspector`'s
+`annotate()`, which already projects stored values to `{ $link }` / `{ $ref }` /
+`"$stream"` for the same reason, though only its key name: that projection drops
+empty and absent fields where this one fills them.
+
+| Field | | Why |
+| --- | --- | --- |
+| `id` | always, **scheme included** | The scheme is the kind, and `of:` and `computed:` over one hash are different entities. Dropping it is a silent retarget |
+| `space` | always, filled in | Measured: the runtime emits it on some links and not others, so a consumer cannot rely on it. Filling it means no fallbacks in `jq`, and an address stays meaningful when copied out of context |
+| `scope` | always, defaulting `"space"` | Absence silently meaning `"space"` is a trap |
+| `path` | always, `[]` when empty | One shape, no optional-key branching |
+| `overwrite` | **dropped** | A write-redirect marker with no caller meaning. Measured on references and aliases alike, so it discriminates nothing |
+| `schema` | **omitted** | A rendered address has no use for one, and a single measured link carried an entire schema with its `$defs` — inlining would make a bounded result unbounded, which is the defect this exists to prevent |
+
+Every optional field becomes required with a filled default. That costs a few
+bytes per address and buys a shape callers index without defensive branching.
+The cost is worth naming: on a marked collection those bytes repeat per element,
+which is the case this design otherwise calls cheap. If that becomes the
+constraint, it is the windowing trigger already recorded under Deferred work.
+
+`cf inspect` remains the route to the raw stored form. A second output contract
+would undo the stability the first one exists to provide.
+
 #### Why the marker sits at the position
 
 The link is physically stored in the *parent* document, on the edge — which is

--- a/docs/plans/shaped-reads-and-verb-results.md
+++ b/docs/plans/shaped-reads-and-verb-results.md
@@ -90,9 +90,11 @@ storage partition to read, and who may see the data:
 They are the runtime's understanding of the value, not data stored in the cell,
 so they are not a caller's to assert.
 
-**Structural composition is unimplemented for caller shapes: `$ref`, `$defs`,
-`anyOf`/`oneOf`/`allOf`/`not`, and the conditional keywords.** These are the
-JSON Schema features for describing *possible* shapes — `$ref` points at a named
+**Structural composition is unimplemented for caller shapes** — sixteen keys,
+including `$ref`, `$defs`, `anyOf`/`oneOf`/`allOf`/`not`, the conditional
+keywords, `patternProperties`, `prefixItems`, `propertyNames`, and
+`contentSchema`. These are the JSON Schema features for describing *possible*
+shapes — `$ref` points at a named
 definition elsewhere in the document, and the combinators express "matches any
 of these." Source schemas use them constantly: every named interface becomes a
 `$ref` into `$defs`, and the projection resolves those while selecting. What a
@@ -174,9 +176,10 @@ wrote it.
 
 The mechanism underneath already exists either way, and needs no new traversal
 machinery. A selector can be told to reject a position — load nothing there.
-Marked positions get exactly that, composed into the same set of paths the
-projection already builds, so the address comes back without its target being
-loaded.
+Marked positions would get exactly that, composed into the same set of paths
+the projection already builds, so the address comes back without its target
+being loaded. The rejecting selector exists and is used at roughly nine gate
+sites in `traverse.ts`; wiring it into the projection's path mask is the work.
 
 ### Collections are all or nothing
 
@@ -369,9 +372,10 @@ compatibility gate does not reach them and the Fabric-types work would supersede
 the source of that schema rather than the slot it fills.
 
 **Invocation id namespace.** Nothing in a receipt's address identifies who
-called. The address is derived from the verb's graph position plus the caller's
-id string verbatim, so an invocation id is a read key shared by everyone using
-that verb in that space: two callers picking the same id read one receipt, and a
+called. A supplied id is hashed together with the stream link, so it is
+namespaced per verb binding but not by principal — no DID or session enters the
+hash. An invocation id is therefore a read key shared by everyone using that
+verb in that space: two callers picking the same id read one receipt, and a
 guessed id reads someone else's result. Pre-existing, and reachable once
 receipts are read deliberately. The consequences and the three ways out are
 worked through in [Verb calls: working notes](verb-result-selection.md).

--- a/docs/plans/shaped-reads-and-verb-results.md
+++ b/docs/plans/shaped-reads-and-verb-results.md
@@ -1,0 +1,377 @@
+# Shaped reads and verb results
+
+The **read layer** and **calls**, two of the three concerns in
+[Reading Fabric data](fabric-read-model.md): the shared layer that turns a cell
+into structured output, and what calling a verb adds on top. Read that document
+first — this one uses its vocabulary. The third concern, the command surface, is
+[CLI surface shape](cli-surface-shape.md).
+
+## The shared read layer
+
+### The problem, concretely
+
+Ask a piece for one of its fields and you get back the data at that path:
+
+```bash
+cf piece get --piece <board> label
+→ "My board"
+```
+
+Simple, because a label is a string. But most interesting fields are not
+strings. A board holding notes stores each note as a **link** — a pointer to
+another cell — rather than a copy of it. So reading `notes` means the runtime
+has to decide how far to follow those pointers.
+
+Today it follows them all the way. Reading a list of ten notes returns every
+field of every note, plus every field of anything *those* notes point at, and so
+on until the graph runs out. Two things go wrong:
+
+- **The result is unbounded.** One read of a modest board produced over 300,000
+  tokens of output.
+- **Identity is destroyed.** You wanted to know *which* note was created so you
+  could act on it next. What you got is a copy of its contents, with no address
+  in it. There is nothing to pass to the following command.
+
+The fix is to let the caller say how far to go, and to say "give me the address
+here, not the contents."
+
+### A read is a cell plus a shape
+
+The unit of work is: *given a cell, and a description of what the caller wants
+back, produce structured output.* Every way of arriving at a cell ends here.
+
+That description is a **shape**. It names paths and returns the subtree at each
+one. `properties` acts as an allowlist — anything you do not name is dropped,
+unless you add `additionalProperties: true`.
+
+Naming paths is what makes a shape more than an output filter. Those same paths
+become the **selector**: the instruction sent to storage saying which documents
+to load. So a shape does not merely trim a result that was already fetched — it
+can stop the fetch from happening. Reshaping what comes back (renaming fields,
+computing values) is `jq`'s job, downstream, where the data is already local.
+
+**A shape is written in schema syntax, but it is a request rather than a
+contract.** Borrowing the syntax is deliberate — a caller can lift a source
+schema and prune it into a request — but the two point in opposite directions: a
+source schema declares what the data *is*, while a shape asks for what the
+caller *wants back*. A shape is also a strict subset, since the annotations that
+give a source schema its meaning are the source's to declare and the composition
+keywords are unsupported. The flag carrying it is spelled `--schema` today;
+[CLI surface shape](cli-surface-shape.md) proposes `--shape`, and this
+asymmetry is why.
+
+### What a shape can say today
+
+`--schema` accepts three forms (`packages/cli/README.md`, "Output Conventions"):
+
+```bash
+--schema 'title,createdBy.name'                       # concise: a list of paths
+--schema '{"properties":{"topic":{"properties":{"title":true}}}}'   # full form
+--schema @shape.json                                  # the full form, from a file
+```
+
+The concise form is sugar for the flat case; the full form is a JSON Schema
+object and is what expresses nested structure. `--filter` narrows array
+membership with a predicate and runs before projection.
+
+There are two kinds of thing a caller's shape may **not** contain, for two
+different reasons (`FORBIDDEN_PROJECTION_KEYS` and
+`UNSUPPORTED_PROJECTION_KEYS`, `packages/cli/lib/piece-get-transform.ts`).
+
+**Fabric metadata is the source's: `asCell`, `default`, `scope`, `ifc`.** These
+sit beside `type` inside a schema and say what the value at that position *is* —
+a handle rather than a plain value, a fallback when the document is absent, which
+storage partition to read, and who may see the data:
+
+```json
+"body": { "type": "string", "asCell": ["cell"], "default": "" }
+```
+
+They are the runtime's understanding of the value, not data stored in the cell,
+so they are not a caller's to assert.
+
+**Structural composition is unimplemented for caller shapes: `$ref`, `$defs`,
+`anyOf`/`oneOf`/`allOf`/`not`, and the conditional keywords.** These are the
+JSON Schema features for describing *possible* shapes — `$ref` points at a named
+definition elsewhere in the document, and the combinators express "matches any
+of these." Source schemas use them constantly: every named interface becomes a
+`$ref` into `$defs`, and the projection resolves those while selecting. What a
+caller cannot do is introduce its own. A disjunction has no single answer to
+"return this subtree," so honouring one would mean picking a branch on the
+caller's behalf.
+
+### What a shape cannot yet say: which positions are addresses
+
+Everything above selects *values*. What is missing is a way to say "at this
+position, give me the address rather than what is behind it."
+
+That is what preserves identity. If a verb creates a note and the result
+flattens it into its contents, the caller cannot then call a verb on that note —
+there is no address to pass along. If instead the position renders as an
+address, the next command can use it directly.
+
+Four spellings are available, and the choice is not cosmetic:
+
+| Spelling | Where the address comes from |
+| --- | --- |
+| Omission-driven (`--add-ids`) | positions the shape did not project |
+| Path list (`--id-for-paths`) | a second list, parallel to the shape |
+| Marked at the position | a keyword beside `properties`, inside the shape |
+| Selected as a field | a reserved name inside the selection set |
+
+Two of them cannot do the job.
+
+**Omission-driven cannot express the case that motivates this.** A caller
+creating a topic usually wants its address *and* one field from it — the title,
+to confirm the write landed. That needs both from the same subtree. If the shape
+projects `topic.title`, then `topic` is on the path being traversed and renders
+as a value, so no address is produced. Address or field, not both.
+
+**A path list does not compose.** It is a second addressing language running
+beside the shape, and it cannot describe nested structure the way the shape can.
+It brings back path enumeration precisely where the shape exists to avoid it.
+
+The other two both work, and both express the motivating case. They differ in
+where the marker sits.
+
+**Marking at the position** puts a keyword beside `properties`, so a position
+can be descended into and rendered as an address at once:
+
+```json
+{ "properties": {
+    "topic": { "$link": true,
+               "properties": { "title": true } } } }
+```
+
+**Selecting it as a field** puts a reserved name inside the selection set,
+alongside the fields that genuinely exist:
+
+```json
+{ "properties": {
+    "topic": { "properties": { "$id": true, "title": true } } } }
+```
+
+Either returns the same thing:
+
+```json
+{ "topic": { "$link": { "id": "of:fid1:…", "space": "did:key:…" },
+             "title": "New topic" } }
+```
+
+The second borrows GraphQL's selection sets, where `{ topic { id title } }`
+treats identity as a field you ask for rather than a special form. It needs one
+mechanism instead of two and composes at any depth with no rule about where a
+marker may sit. Its wrinkle is that our documents have no `id` field — identity
+lives on the link, not in the data — so the name is synthetic and sits in an
+allowlist beside names that are not. Only the idea transfers, not the syntax:
+the argument for schema-shaped shapes is that a caller can lift a source schema
+and prune it, which a different query syntax would break.
+
+Whichever wins, the marker must be **projection-only**, not a borrowed `asCell`.
+Callers are barred from supplying `asCell` by name, alongside `ifc`; reusing it
+would either breach that rule or give one keyword two meanings depending on who
+wrote it.
+
+The mechanism underneath already exists either way, and needs no new traversal
+machinery. A selector can be told to reject a position — load nothing there.
+Marked positions get exactly that, composed into the same set of paths the
+projection already builds, so the address comes back without its target being
+loaded.
+
+### Collections are all or nothing
+
+A shape controls **depth** (how far in to go) and **width** (which fields to
+take), but not **cardinality** (how many elements of a list). A shape reaching a
+collection takes every element; there is no windowing or per-element limit.
+
+Two things make that acceptable at the sizes this serves. Cost is roughly
+*things expanded × fields each × levels deep*, so cardinality only matters once
+something is expanded — a list of marked addresses costs one document however
+many entries it has, because the links are stored inline in the document being
+read. And that same property makes the choice an informed one: the caller sees
+every address before deciding to ask for contents.
+
+The limit of that argument is the address list itself. Once a collection is
+large enough that rendering one address per element is the payload, seeing the
+count costs what the count was meant to protect against. Windowing becomes
+necessary there, and it has to window collections of **addresses**, not only
+expanded ones.
+
+### Pushing the shape into the fetch
+
+The shape can bound network work, not just output size — but only under a
+condition worth understanding.
+
+When the runtime can build the selector *before* reading, the first storage
+request asks only for the paths the shape names, and linked documents outside
+that set are never loaded at all. Nothing is fetched and then discarded.
+
+Building that selector means settling one question first: **is the value being
+read an array or an object?** The same shape means different things either way.
+Against an object, `title` selects that object's `title` field. Against an array,
+it selects `title` from every element. Until that is known, the paths cannot
+become a selector, because the runtime does not know whether to apply them at the
+top level or one level down inside each element.
+
+The answer comes from the outermost `type` in the cell's **declared schema** —
+its *root container kind*. When the source carries no schema, or its outermost
+type is a union such as "array or null", or is otherwise ambiguous, the runtime
+falls back to loading the value first and shaping it afterwards. The projection
+still returns the right answer; it just pays full loading before narrowing.
+
+This is why a cell's declared schema matters beyond type-checking: it is what
+lets a caller's shape become a fetch instruction instead of a filter applied
+after the fact.
+
+### Defect: an unshaped read serializes live handles
+
+A read with no shape loads the value and serializes whatever objects it finds.
+Some of those objects are live runtime handles rather than data — a verb is
+represented by a stream handle that holds a reference back to the runtime. So an
+unshaped read of any cell containing a verb emits the scheduler: event queues,
+handler tables, and a circular reference back to the runtime, around 16–17 KB
+for an otherwise two-field result.
+
+This affects cells that *do* declare their schema, not only ones that do not:
+declaring a position as a stream does not prevent it, because the source schema
+governs what is read rather than what is printed. It is independent of
+everything else here and worth fixing on its own — a verb's rendered form should
+be a marker, not its implementation.
+
+## Calls, layered on the read layer
+
+### What a call adds
+
+When you call a verb, the runtime runs it and writes whatever it returned into a
+new cell called the **receipt**. Reading the result of a call is therefore
+reading that cell — an ordinary read, on a different starting point.
+
+What genuinely belongs to the call, and to nothing else:
+
+- **The envelope** — the `invocation` id, `status`, the receipt's address, and
+  whether this attempt was deduplicated.
+- **Safe retries** — calling again with the same invocation id returns the
+  original outcome instead of running the verb a second time.
+- **Collecting later** — dispatching without waiting, then picking the result up
+  afterwards.
+- **Recovering an address** — deriving where a receipt lives from the piece, the
+  verb, and an invocation id the caller chose in advance, for when the response
+  was lost.
+
+Everything inside `result` is the read layer. A call should gain `--schema` and
+`--filter` by reusing the shared implementation, not by growing a second one.
+
+### The receipt is an ordinary cell created without a schema
+
+Receipts are created with no schema argument (`handleJavaScriptHandlerResult`,
+`packages/runner/src/runner.ts`), so the stored document carries an empty
+`schema` field. Two consequences follow, and both are the read layer's mechanisms
+failing to engage rather than anything special about receipts:
+
+- The fetch narrowing above cannot engage, so a shape is applied after
+  everything has been loaded.
+- A caller's shape is matched against the runtime value rather than against a
+  declaration — field names that happen to coincide, rather than a subtree of a
+  declared structure.
+
+Giving the receipt cell a schema when it is created addresses both.
+
+This is **not** the same as emitting a declared result schema for a verb, which
+is deferred to the Fabric-types stream design. That would be a published
+contract: compared across pattern versions by the schema compatibility gate, and
+permanent once shipped. A receipt's schema is per-invocation and describes what
+that one receipt holds. The gate compares only a pattern's argument and result
+schemas between two versions (`assertPatternSchemasBackwardCompatible`,
+`packages/piece/src/schema-compatibility.ts`) and never reaches a receipt, so no
+permanence obligation attaches. When declared result schemas do arrive, the same
+slot takes a better-sourced value — a change to one argument, not a migration.
+
+Discoverability is a separate gap that this does not address: a caller still
+cannot learn a verb's result shape before calling it, and the interim answer
+remains prose in the verb's description.
+
+### What dissolves, and what survives
+
+`cf piece get` already reads a receipt — its target is a cell, a receipt is a
+cell, and `--schema` projects it correctly. Once `--piece` accepts the `of:`
+address form, reading a receipt directly is an ordinary read and needs no
+command of its own.
+
+What survives as genuinely verb-specific is **reconstruction**: turning a piece,
+a verb, and a caller-chosen invocation id into an address, for when the response
+was lost and no address was kept. That is deriving an address, not reading one,
+and it is what earns a verb-aware command.
+
+## Measured facts
+
+Recorded so they are not re-derived. Observed against a running local server
+unless noted.
+
+**Addressing**
+
+- The function that fetches a piece's result returns the piece unchanged
+  (`PieceManager.getResult`, `packages/piece/src/manager.ts`) — a piece *is* its
+  result cell, and the read path checks nothing piece-specific. Its counterpart
+  `getArgument` follows a link stored in the document and throws when absent,
+  making it the only piece-shaped operation of the pair.
+- `cf piece get` against a receipt address returns its value, and
+  `--schema note.title` projects it to `{"note": {"title": …}}`.
+
+**Documents and links**
+
+- A piece's stored document is `{argument, internal, patternIdentity,
+  patternSetupIdentity, schema, value}`. A plain-data target is `{result,
+  value}`; a bare indirection is `{value}`. `patternIdentity` is therefore a
+  positive marker that a link points at a piece — at the cost of reading it.
+- A stored link carries `{id, path, scope}`, plus sometimes `space` and
+  sometimes a schema. `overwrite: "redirect"` appears on links to children and
+  links to plain fields alike, so it distinguishes nothing.
+- A link to a child piece has an empty `path`; a link to a field within a
+  document carries one. Observed across two fixtures at every link position,
+  including a field deliberately declared as a cell over plain data, whose link
+  carried a path and whose target had no `patternIdentity`.
+- One link was measured carrying an entire result schema with its `$defs`, which
+  is why a rendered address must never inline a schema.
+
+**Schemas**
+
+- A verb declared as `Stream<Event, Result>` compiles the event type and drops
+  the result type. The emitted property is the event schema plus
+  `asCell: ["stream"]` — nothing describes the result.
+- `asCell` is not one concept: `["cell"]`, `["stream"]`, `["opaque"]`,
+  `["readonly"]`, and `["writeonly"]` all appear, and only some are boundaries.
+  A writable array places `asCell` on the array itself, leaving its items plain.
+- A sub-pattern instance cannot be declared as a cell — it lacks the cell
+  surface — while a cell handle cannot be declared as its plain type. So the
+  cell wrapper is expressible for exactly the values that are *not* child
+  pieces.
+- Of the shipped patterns, four verbs declare a result type and one returns a
+  reference.
+
+## Open questions
+
+**Which spelling marks addresses in a shape.** Two of the four are ruled out
+above: omission-driven cannot express an address beside a summary field, and a
+path list does not compose. The live choice is between marking at the position
+and selecting identity as a field. The second is the smaller mechanism; the
+first keeps the selection set free of synthetic names. Decide before
+implementation, since the rendered output is identical either way and only the
+request syntax differs.
+
+**Whether a caller-supplied shape may fix the root container kind.** Narrowing
+keys on the *source* schema today. A caller's shape states the root kind too,
+and honouring it would let schema-less sources narrow. The rule barring caller
+metadata covers `ifc`/`asCell`/`scope`/`default`; root container kind is
+structure rather than metadata, so this may be a clean exception.
+
+**Whether creating receipt cells with a schema is acceptable**, given the
+compatibility gate does not reach them and the Fabric-types work would supersede
+the source of that schema rather than the slot it fills.
+
+**Invocation id namespace.** Nothing in a receipt's address identifies who
+called. The address is derived from the verb's graph position plus the caller's
+id string verbatim, so an invocation id is a read key shared by everyone using
+that verb in that space: two callers picking the same id read one receipt, and a
+guessed id reads someone else's result. Pre-existing, and reachable once
+receipts are read deliberately. The consequences and the three ways out are
+worked through in [Verb calls: working notes](verb-result-selection.md).

--- a/docs/plans/shaped-reads-and-verb-results.md
+++ b/docs/plans/shaped-reads-and-verb-results.md
@@ -50,15 +50,15 @@ to load. So a shape does not merely trim a result that was already fetched — i
 can stop the fetch from happening. Reshaping what comes back (renaming fields,
 computing values) is `jq`'s job, downstream, where the data is already local.
 
-**A shape is written in schema syntax, but it is a request rather than a
-contract.** Borrowing the syntax is deliberate — a caller can lift a source
-schema and prune it into a request — but the two point in opposite directions: a
-source schema declares what the data *is*, while a shape asks for what the
-caller *wants back*. A shape is also a strict subset, since the annotations that
-give a source schema its meaning are the source's to declare and the composition
-keywords are unsupported. The flag carrying it is spelled `--schema` today;
-[CLI surface shape](cli-surface-shape.md) proposes `--shape`, and this
-asymmetry is why.
+**A shape is a schema, supplied for one read.** This is schema-on-read: a cell
+carries a schema and a reader supplies one, and they are the same kind of
+artifact. What differs is authority — the source's schema governs how a value is
+treated, the reader's selects among what is there. A caller can lift a source
+schema and prune it into a request, which is why the syntax is shared.
+
+What a reader supplies is a strict subset, though: the annotations that decide
+how a value is treated stay the source's, and the composition keywords are
+unsupported. Both restrictions hold whichever syntax the reader writes in.
 
 ### What a shape can say today
 
@@ -88,9 +88,11 @@ combined with an inline schema rather than the concise form, `--filter` requires
 an array root, since the schema then describes the whole returned value rather
 than each item.
 
-There are two kinds of thing a caller's shape may **not** contain, for two
+There are two kinds of thing a reader's schema may **not** contain, for two
 different reasons (`FORBIDDEN_PROJECTION_KEYS` and
-`UNSUPPORTED_PROJECTION_KEYS`, `packages/cli/lib/piece-get-transform.ts`).
+`UNSUPPORTED_PROJECTION_KEYS`, `packages/cli/lib/piece-get-transform.ts`). Both
+are checked against the parsed projection regardless of which syntax produced
+it, so writing the full form does not unlock them.
 
 **Fabric metadata is the source's: `asCell`, `default`, `scope`, `ifc`.** These
 sit beside `type` inside a schema and say what the value at that position *is* —
@@ -134,8 +136,12 @@ Four spellings are available, and the choice is not cosmetic:
 | Path list (`--id-for-paths`) | a second list, parallel to the shape |
 | Marked at the position | a keyword beside `properties`, inside the shape |
 | Selected as a field | a reserved name inside the selection set |
+| Suffixed in the shorthand | a marker on a path — `createdBy.user@` |
 
-Two of them cannot do the job.
+The last is sugar rather than a rival: the shorthand desugars into a schema, so
+it needs one of the others underneath it. It is listed because the shorthand is
+where the common case actually gets typed, and a spelling nobody writes is not
+much of a win. Of the first four, two cannot do the job at all.
 
 **Omission-driven cannot express the case that motivates this.** A caller
 creating a topic usually wants its address *and* one field from it — the title,
@@ -184,9 +190,11 @@ the argument for schema-shaped shapes is that a caller can lift a source schema
 and prune it, which a different query syntax would break.
 
 Whichever wins, the marker must be **projection-only**, not a borrowed `asCell`.
-Callers are barred from supplying `asCell` by name, alongside `ifc`; reusing it
-would either breach that rule or give one keyword two meanings depending on who
-wrote it.
+A reader is barred from supplying `asCell` by name, alongside `ifc`, in either
+syntax; reusing it would either breach that rule or give one keyword two
+meanings depending on who wrote it. That constraint binds the shorthand suffix
+too — reading `@` as "as cell" is the natural intuition, and it is the one
+spelling the current rules refuse.
 
 The mechanism underneath already exists either way, and needs no new traversal
 machinery. A selector can be told to reject a position — load nothing there.

--- a/docs/plans/shaped-reads-and-verb-results.md
+++ b/docs/plans/shaped-reads-and-verb-results.md
@@ -97,8 +97,17 @@ than each item.
 There are two kinds of thing a reader's schema may **not** contain, for two
 different reasons (`FORBIDDEN_PROJECTION_KEYS` and
 `UNSUPPORTED_PROJECTION_KEYS`, `packages/cli/lib/piece-get-transform.ts`). Both
-are checked against the parsed projection regardless of which syntax produced
-it, so writing the full form does not unlock them.
+are checked when a full schema is parsed — the inline and `@file` forms. The
+concise form reaches neither check; what keeps it from expressing them is its
+identifier grammar, which has no way to write a keyword at all. So the two
+syntaxes agree on what they unlock, but by two different mechanisms rather than
+one shared guard.
+
+That distinction matters for anything that *becomes* meaningful later. A key in
+neither set is carried through and ignored rather than refused, so giving it a
+meaning changes behavior for a schema that already contains it, with no error
+ever having been raised. Reserving a key before it means something is what turns
+that into refuse-then-meaningful.
 
 **Fabric metadata is the source's: `asCell`, `default`, `scope`, `ifc`.** These
 sit beside `type` inside a schema and say what the value at that position *is* —
@@ -446,10 +455,20 @@ in the durable schema metadata in the same create-only transaction. That is what
 narrowing needs — a selector cannot be built without the root container kind —
 and it is the least a receipt can say and still be readable like any other cell.
 
+**It covers plain results only.** Deriving a shape needs a settled value, and a
+result holding anything reactive does not have one at the moment the receipt is
+written. So a verb returning a child piece — the case this design exists to
+serve — gets a receipt with no schema, and a selection over it matches a runtime
+value rather than a declaration. What that costs is bounded: a `$link` marker
+still renders an address and still suppresses the fetch, because a rejecting
+selector short-circuits before a source schema is consulted. What is lost is
+narrowing on field selection, and any check of a selection before the call. The
+open question below is how that gap closes.
+
 It records nothing about which positions hold links. A link position in a source
 schema is spelled `asCell`, and `["cell"]` asserts a writable handle; writing
 that onto a document nothing can be written through would be a claim the receipt
-cannot honour.
+cannot honor.
 
 Descriptive is not the end state. A schema derived from a value matches what
 happened to be written, where a schema derived from a declaration matches what

--- a/docs/plans/shaped-reads-and-verb-results.md
+++ b/docs/plans/shaped-reads-and-verb-results.md
@@ -62,16 +62,22 @@ unsupported. Both restrictions hold whichever syntax the reader writes in.
 
 ### What a shape can say today
 
-`--schema` accepts three forms (`packages/cli/README.md`, "Output Conventions"):
+There are two syntaxes, and today both ride `--schema`
+(`packages/cli/README.md`, "Output Conventions"):
 
 ```bash
---schema 'title,createdBy.name'                       # concise: a list of paths
+--select 'title,createdBy.name'                       # concise: a list of paths
 --schema '{"properties":{"topic":{"properties":{"title":true}}}}'   # full form
 --schema @shape.json                                  # the full form, from a file
 ```
 
 The concise form is sugar for the flat case; the full form is a JSON Schema
 object and is what expresses nested structure.
+[CLI surface shape](cli-surface-shape.md) proposes giving them separate flags —
+`--select` for the concise syntax, `--schema` for full schemas — and this
+document writes them that way throughout. The measured facts at the end use
+`--schema` for both, because that is the flag the measurements were taken
+against.
 
 **`--filter` is the other axis.** A shape names paths; it cannot say "only the
 elements where `status == "open"`". That is `--filter`, a predicate over array
@@ -79,7 +85,7 @@ elements. The two do not collapse into one, because **filtering runs before
 projection** — a predicate can inspect a field the result omits:
 
 ```bash
-cf piece get ... topics --filter '.status == "open"' --shape 'title,id'
+cf piece get ... topics --filter '.status == "open"' --select 'title,id'
 ```
 
 `status` decides membership and never appears in the output. A single mechanism
@@ -150,7 +156,7 @@ nothing else. Address-plus-summary is spelled as two paths — `topic@,topic.tit
 both. One rule, no special case: you get what you asked for, and asking for the
 link is not asking for the contents.
 
-**The shorthand desugars one-to-one.** `createdBy.user@` rewrites the leaf in
+**The concise syntax desugars one-to-one.** `createdBy.user@` rewrites the leaf in
 place to `{"user": {"$link": true}}` — an annotation on the position, not a
 structural change.
 
@@ -287,8 +293,9 @@ What genuinely belongs to the call, and to nothing else:
   verb, and an invocation id the caller chose in advance, for when the response
   was lost.
 
-Everything inside `result` is the read layer. A call should gain `--schema` and
-`--filter` by reusing the shared implementation, not by growing a second one.
+Everything inside `result` is the read layer. A call should gain `--select`,
+`--schema` and `--filter` by reusing the shared implementation, not by growing a
+second one.
 
 ### Receipts carry a descriptive schema
 

--- a/docs/plans/shaped-reads-and-verb-results.md
+++ b/docs/plans/shaped-reads-and-verb-results.md
@@ -195,6 +195,14 @@ The cost is worth naming: on a marked collection those bytes repeat per element,
 which is the case this design otherwise calls cheap. If that becomes the
 constraint, it is the windowing trigger already recorded under Deferred work.
 
+**`$link` in the output shares a namespace with the fields beside it**, so a
+document holding a field genuinely named `$link` renders ambiguously. That is
+accepted rather than solved. The request side has position to disambiguate — a
+marker sits beside `properties`, where a property name cannot — but the response
+side has no escape story, and inventing one costs every consumer a rule to apply
+on every read for a field name nothing in the system produces. A caller who hits
+it can read the position without the marker and address it a level up.
+
 `cf inspect` remains the route to the raw stored form. A second output contract
 would undo the stability the first one exists to provide.
 
@@ -460,8 +468,10 @@ result holding anything reactive does not have one at the moment the receipt is
 written. So a verb returning a child piece — the case this design exists to
 serve — gets a receipt with no schema, and a selection over it matches a runtime
 value rather than a declaration. What that costs is bounded: a `$link` marker
-still renders an address and still suppresses the fetch, because a rejecting
-selector short-circuits before a source schema is consulted. What is lost is
+*on a link position* still renders an address and still suppresses the fetch,
+because a rejecting selector short-circuits before a source schema is consulted.
+A marker below a link is a separate matter — the rejection has to propagate up
+through the containers holding it, which is its own piece of work. What is lost is
 narrowing on field selection, and any check of a selection before the call. The
 open question below is how that gap closes.
 

--- a/docs/plans/shaped-reads-and-verb-results.md
+++ b/docs/plans/shaped-reads-and-verb-results.md
@@ -263,20 +263,23 @@ ambiguous-root sources narrow as well — but no case has been shown that needs
 it, and the source most likely to have wanted it is the receipt, which now
 carries its own schema.
 
-### Defect: an unshaped read serializes live handles
+### An unshaped read emits the internal encoding
 
-A read with no shape loads the value and serializes whatever objects it finds.
-Some of those objects are live runtime handles rather than data — a verb is
-represented by a stream handle that holds a reference back to the runtime. So an
-unshaped read of any cell containing a verb emits the scheduler: event queues,
-handler tables, and a circular reference back to the runtime, around 16–17 KB
-for an otherwise two-field result.
+A read with no selection returns whatever the value serializes to, and a verb
+position serializes to the runtime's own link envelope:
 
-This affects cells that *do* declare their schema, not only ones that do not:
-declaring a position as a stream does not prevent it, because the source schema
-governs what is read rather than what is printed. It is independent of
-everything else here and worth fixing on its own — a verb's rendered form should
-be a marker, not its implementation.
+```json
+{ "createNote": { "/": { "link@1": { "id": "of:fid1:…",
+                                     "space": "did:key:…",
+                                     "path": [], "scope": "space" } } } }
+```
+
+That is faithful — a verb is a channel, and a link is the only thing about it
+that crosses a process boundary — but it is not a contract. The envelope is the
+runtime's internal form, still selected by an experimental option
+(`modernCellRep`), so a caller reading it builds on an encoding that can be
+replaced underneath them. A declared shape is what turns the same information
+into something a caller may depend on, which is why a rendered address has one.
 
 ## Calls, layered on the read layer
 
@@ -399,6 +402,12 @@ unless noted.
   pieces.
 - Of the shipped patterns, four verbs declare a result type and one returns a
   reference.
+
+**Rendering**
+
+- An unshaped read renders a verb position as the runtime's link envelope,
+  `{"/": {"link@1": …}}` — faithful, but the internal form rather than a
+  declared one.
 
 ## Open questions
 

--- a/docs/plans/shaped-reads-and-verb-results.md
+++ b/docs/plans/shaped-reads-and-verb-results.md
@@ -121,7 +121,7 @@ definition elsewhere in the document, and the combinators express "matches any
 of these." Source schemas use them constantly: every named interface becomes a
 `$ref` into `$defs`, and the projection resolves those while selecting. What a
 caller cannot do is introduce its own. A disjunction has no single answer to
-"return this subtree," so honouring one would mean picking a branch on the
+"return this subtree," so honoring one would mean picking a branch on the
 caller's behalf.
 
 ### Saying which positions are addresses
@@ -258,7 +258,7 @@ This is why a cell's declared schema matters beyond type-checking: it is what
 lets a caller's shape become a fetch instruction instead of a filter applied
 after the fact.
 
-A caller's selection states the root kind too, so honouring it would let
+A caller's selection states the root kind too, so honoring it would let
 ambiguous-root sources narrow as well — but no case has been shown that needs
 it, and the source most likely to have wanted it is the receipt, which now
 carries its own schema.

--- a/docs/plans/verb-result-selection.md
+++ b/docs/plans/verb-result-selection.md
@@ -345,11 +345,24 @@ handler bodies run, so effects outside the transaction happen twice.
 piece + verb + id into an address, bounded only by CFC labels and cell scope,
 never by authorship.
 
-| Option | Effect | Cost |
-| --- | --- | --- |
-| Document the shared read key; require collision-resistant ids | Cheapest | Relies on compliance; guessed-id reads remain |
-| Namespace the event id by caller DID | Makes the read key per-caller | Changes dedup semantics; breaks deliberate cross-agent id sharing |
-| Keep the shared key, stop treating unguessability as privacy | Honest about what the address proves | Needs explicit authorization on receipt reads; does not address aliasing |
+The scope is a **session**, not a principal. A DID separates nothing: agents
+work under their human user's key rather than mint their own, so the collision
+that happens in practice is two agents under one key. A session distinguishes
+them, and because it is minted rather than derived it is also unguessable —
+which a DID is not, so identity scoping would have left an address computable
+from a piece, a verb, and a conventional id.
+
+Deliberate sharing then moves to passing the address rather than two callers
+deriving one id from a convention. That is unambiguous, and it removes the only
+thing the shared key was good for.
+
+What is unresolved is the mechanism, not the direction. Neither session
+identifier already in the tree serves: the storage session is minted per process
+and re-minted on close, so scoping by it would break the same-id replay the id
+exists for; `cf-harness`'s is durable but is harness state, and not every caller
+is that harness. A new caller-supplied session identity is wanted — minted
+explicitly, so a caller always knows which session an outcome belongs to —
+along with a decision about what an absent one means.
 
 Pre-existing (WS-D), but reading receipts deliberately makes it reachable. The exposure is entirely
 in caller-chosen ids — and the human-friendly convention

--- a/docs/plans/verb-result-selection.md
+++ b/docs/plans/verb-result-selection.md
@@ -1,0 +1,791 @@
+# Verb results: references, not expansions
+
+This plan makes two things work from the CLI:
+
+1. Call a verb that creates or returns a piece, then use that piece in the next
+   command — without the response expanding to an unbounded document.
+2. Re-read an earlier invocation's outcome without running the verb again.
+
+The core change is one sentence: **a result renders references as references,
+instead of expanding them into their values.** Everything else follows from it.
+
+This continues the identity work from
+[Pattern verb contract — implementation plan](pattern-verb-contract-implementation.md)
+(WS-F), which shipped `--show-links` and left the selection interface open. The
+user-facing surface it changes is
+[Verbs over the CLI](../common/verbs-over-the-cli.md).
+
+## Orientation
+
+Skip this if you already work with patterns and the `cf` CLI.
+
+| Term | What it is |
+| --- | --- |
+| **Pattern** | A user-authored program — a `.tsx` module, roughly a Solid.js component. Declares reactive state and, optionally, callables. |
+| **Piece** | A *running instance* of a pattern, living in a space. The thing you address and call. |
+| **Space** | A store identified by a DID. Every cell lives in exactly one space. |
+| **Cell** | The reactive unit of storage. Its **backing document** is the storage record behind it. |
+| **Link** | A pointer to a cell — `{ space, id, scope, path? }`. Identity, not value. |
+| **Verb** | A piece's callable surface: a `Stream<Event, Result>` property in the pattern's output, invoked with `cf piece call`. |
+| **Handler** (or `action`) | The function body that runs when a verb is invoked. |
+| **Invocation** | One call to one verb. Its id is the idempotency key: replaying a settled id returns the original outcome instead of executing again. |
+| **Receipt** | The durable cell the runtime writes when a handler dispatch settles. Carries the handler's return value, or `{}` when there is nothing to return. |
+| **`of:`** | The URI scheme on an entity id (`of:fid1:<hash>`). The English preposition, from the memory protocol's fact record — `the` (type) / `of` (entity) / `is` (value) — so an entity id names the subject a fact is *of*. `of:` is the unkinded default. |
+| **`computed:`** | The same slot, marking an entity whose contents are re-derivable. Not independently addressable. |
+
+### What a verb looks like
+
+```tsx
+// Shown at module scope.
+
+interface NoteOutput {
+  title: string;
+}
+
+interface AddNoteEvent {
+  title: string;
+}
+
+interface AddNoteResult {
+  /** The note this call created — the piece itself, not a minted identifier. */
+  note: NoteOutput;
+}
+
+// A verb is a `Stream` property on a pattern's output. Its result type is the
+// second parameter; a verb that returns nothing stays `Stream<Event>`.
+interface BoardOutput {
+  addNote: Stream<AddNoteEvent, AddNoteResult>;
+}
+
+// `Note` is a pattern, so calling it produces a PIECE — a running instance with
+// its own identity — rather than a plain object.
+const Note = pattern<{ title: string }, NoteOutput>(({ title }) => ({ title }));
+
+// The implementation of the verb `BoardOutput` declares above. `action` takes
+// the SAME two type parameters as the `Stream` — event in, result out — and the
+// body must return that result type. `Stream<E, R>` and `Stream<E>` are
+// deliberately not interchangeable, so a declared result cannot be dropped
+// silently on assignment.
+//
+// A real pattern creates this inside `pattern(…)` and returns it as `addNote`,
+// alongside the state it mutates; it is standalone here to keep the example to
+// the parts this plan is about.
+export const addNote = action<AddNoteEvent, AddNoteResult>(({ title }) => {
+  const note = Note({ title });
+  // Return the piece itself. Patterns return references; rendering identity as
+  // an address is the client's job.
+  return { note };
+});
+```
+
+`return { note }` hands back **the piece**, not an identifier for it. Patterns
+deliberately never mint id fields — a pattern-authored id is a copy of runtime
+state that can go stale.
+
+## The problem
+
+**Expansion destroys identity and bounds nothing.** Today the CLI reads a
+result by materializing it, so `{ note }` comes back as the note's full value:
+
+```json
+{ "invocation": "0f4c…", "status": "settled",
+  "result": { "note": { "title": "Notes", "…": "…" } } }
+```
+
+The address is gone — you cannot call a verb on that note — and the payload
+grows with the transitive closure of everything the result references. The same
+shape produced over 300k tokens when a headless caller reads a board through
+`topics.crossrefs` ([pattern-verb-contract.md](pattern-verb-contract.md),
+"Discovery"). Recovering the address then took a side-car annotation plus two
+tools; step 5 of `packages/cli/integration/verbs-over-the-cli.sh`:
+
+```bash
+NOTE_ID=$(echo "$LINKED" | jq -r '.links["/note"].id // empty' | sed 's/^of://')
+```
+
+**And there is no durable readback.** The result exists in the invocation
+receipt, but the only way to re-read it is to re-invoke with the same id — which
+returns the original outcome, but re-runs the handler body, so effects outside
+the transaction repeat.
+
+## Goals and non-goals
+
+1. One call returns every value the verb produced **and** identity for
+   everything it referenced, bounded by the result's own declared shape.
+2. A returned child's address composes into the next `cf piece call --piece`.
+3. A settled outcome can be re-read without re-executing the verb.
+4. A lost response can be recovered, given the piece, the verb, and an
+   invocation id the caller chose in advance.
+5. Callers depend on a **declared** output shape, not on the runtime's internal
+   encoding, which is mid-migration.
+
+Non-goals: server-side filtering, selection languages, projection flags,
+changes to what patterns return, invocation listing, and batching (see Deferred
+work — it is the answer to O(N) fan-out, and it is not this plan).
+
+## Decision summary
+
+| What you want | How |
+| --- | --- |
+| A child's address, to call it next | It is in the result, at its natural path |
+| The values the verb computed | Also in the result, inline |
+| A specific field | `jq` — the result is a normal JSON document |
+| The content behind a reference | A second call against that address, or `--depth` |
+| A settled outcome, again | `cf invocation get <handle>` |
+| An outcome whose response was lost | `cf invocation get --piece --verb --invocation` |
+| Certainty about an uncertain commit | Same-id `cf piece call` replay — not a readback |
+
+There are **no selection flags**, and none are needed: with identity in-band,
+`jq` reaches it like any other field. `--show-links` exists today only because
+expansion destroyed the identity it annotates back on; it goes away with the
+expansion.
+
+## The result contract
+
+### References render as references
+
+A reference in a result renders as a `$link` node rather than its value:
+
+```json
+{
+  "invocation": "create-note-7",
+  "status": "settled",
+  "receipt": { "$link": { "id": "of:fid1:…", "space": "did:key:…", "scope": "space", "path": [] } },
+  "result": {
+    "note": { "$link": { "id": "of:fid1:…", "space": "did:key:…", "scope": "space", "path": [] } },
+    "writtenAt": "2026-08-04T…"
+  }
+}
+```
+
+`writtenAt` is inline because the handler computed it. `note` is a link because
+it is a separate entity with its own identity. **Both of the verb contract's
+stated payoffs — the address of a created child, and fields only the handler
+could produce — arrive in one round trip.** What defers is content belonging to
+a different document.
+
+### Except where a reference is useless to the caller
+
+**Expand what the caller cannot address; link what they can.**
+
+A `computed:` reference is not usefully addressable, and the reason is sharper
+than it first looks. A node the classifier marks `kind: "computed"` gets **two
+binds over the same hash preimage**, differing only by scheme: a *value bind* at
+`computed:fid1:<h>`, where the child's value actually lives, and an *identity
+bind* at `of:fid1:<h>`, which the runner uses "purely as the `resultFor` CAUSE —
+a stable coordinate, never read for a value." The runner states the consequence
+outright: **reading the `of:` one returns `undefined` for a healthy piece**
+(`instantiatePatternNode`, `packages/runner/src/runner.ts`).
+
+So handing a caller a `computed:` link hands them something `--piece` cannot
+take, and handing them its `of:` sibling hands them an address that reads empty.
+There is no third option. Computed references therefore **expand** — they are
+part of the value, not a boundary in it.
+
+An `of:` entity that is not one of those coordinate siblings is stable and
+independently identified, so a link suffices.
+
+This also gives the scheme-stripping hazard a concrete symptom: normalizing
+`computed:fid1:<h>` to `of:fid1:<h>` does not fail loudly — it silently
+addresses the coordinate and reads `undefined`.
+
+**Which nodes get a computed kind is the classifier's call.** It is a property of
+the node, decided per instantiation, and not something a caller — or this CLI —
+can predict from the shape of the pattern that produced it. The rendering rule
+therefore keys on the **scheme it observes** in the link, which is the only
+thing it needs and the only thing it can rely on.
+
+**Where the decision is made.** Not in the selector — `SchemaPathSelector` is
+`{ path, schema }` and nothing more, the schema is content-hashed and shipped
+through a schema-ref table, and `traverse.ts` never imports `entity-kind.ts`. A
+declarative kind gate would be a wire change across api → traverse →
+schema-hash → memory-v2 → server.
+
+It is made in **CLI code instead**, where the information is plainly available:
+read shallow, `getRaw()`, and inspect each parsed link's `id` — the scheme is
+right there. Expand only the `computed:` ones, with one more shallow sync each.
+
+If a declarative gate is ever wanted, there is a precedent to copy rather than
+invent: `canFollowScopedLink` (`traverse.ts` / `scope.ts`) already refuses a
+follow based on a property of the *target* rather than the shape at the
+position. A kind gate would sit in the same place and read the same object.
+
+### Depth, for when you want content
+
+`--depth N` follows up to N **`of:` hops**. Computed links are transparent and
+do not count — they are not boundaries.
+
+**Default 0**, on an asymmetry: depth 0 is bounded by the result's own shape,
+which the pattern author declared and published. Depth ≥ 1 is bounded by data
+the author never declared, and a single child can be arbitrarily large. At 0 you
+can always ask for more; a depth-1 default has already spent the payload before
+you can decline it.
+
+Depth counts *reference hops*, not JSON nesting — plain nested objects cost
+nothing. It is per-call, not per-path; per-path would be a selection language.
+
+**Depth 0 needs no runtime change.** The shallow fetch already exists — a
+schema-less `sync()` is the rejecting selector, and `getRawUntyped`
+(`cell.ts`) resolves links without entering `SchemaObjectTraverser`, so it
+cannot pull a child. Depth 0 is therefore *stop materializing*, not *change the
+fetch*: sync the receipt, read `getRaw()`, render the stored links.
+`followPointer`'s own comment states the property being relied on — "a
+rejecting-selector sync delivers only the root doc, so a link can point at a doc
+no selector ever walked."
+
+Each hop above 0, and each `computed:` expansion, is one more shallow sync
+issued from CLI code, where the target's scheme is visible on the parsed link.
+
+### Fan-out must be bounded and asked for
+
+Hidden N+1 traversal makes cost unpredictable. The rule is that a command's
+network work is **bounded and proportional to what the caller asked for** — not
+that it is always exactly one request.
+
+That distinction matters because **today's read already fans out, invisibly.**
+The sync is shallow: `StorageManager.syncCell` sends `schema: schema ?? false`
+(`storage/v2.ts`), and `schema: false` is `REJECTING_SELECTOR` — a traverser
+built with it follows no references. The expansion comes *afterwards*, from
+`.get()` / `.pull()`: a schema-less cell resolves to a `true` schema, the client
+walks the value, and every absent target hits `reportMissingLinkTarget`
+(`traverse.ts`) → `Runtime.ensureLinkedDocLoaded`, which **kicks a fresh sync
+per missing document** and re-runs the reader on arrival.
+
+So the status quo is one sync per referenced document, unbounded by the result's
+shape. This plan replaces that with one shallow read plus, at most, one hop per
+`computed:` reference — bounded by the pattern's own derived graph and by a
+depth the caller names. It reduces fan-out rather than introducing it.
+
+## The `$link` shape
+
+Wherever CLI output carries a reference, it emits one **declared** shape rather
+than the runtime's internal encoding, which is dispatched on `modernCellRep`
+and mid-migration (`cell-rep.ts`: legacy `{ "/": { "link@1": … } }` versus a
+modern `FabricLink`). Owning a shape is not optional — the moment callers are
+told to `jq` a result, *some* shape becomes a public contract. The only choice
+is whether it is one we declared or one that leaked.
+
+Spelling follows `state-inspector`'s `annotate()`, which already projects stored
+values to `{ $link }` / `{ $ref }` / `"$stream"` for the same reason.
+
+| Field | Default | Why |
+| --- | --- | --- |
+| `id` | always, **scheme included** | The scheme is part of the identity: `of:` and `computed:` over one hash are different entities. Dropping it is a silent retarget |
+| `space` | always, **filled in** | Measured: the runtime does not always emit it — present on some links, absent on others — so a consumer cannot rely on it. Filling it means no `// "…"` fallbacks in jq, and a link stays meaningful when copied out of context |
+| `scope` | always, defaulting `"space"` | `toInvocationResultLink` already does this. Absence silently meaning `"space"` is a trap |
+| `path` | always, `[]` when empty | Uniformity: one shape, no optional-key branching |
+| `overwrite` | **dropped** | A runtime write-redirect marker with no caller meaning. Measured present on every observed link |
+| `schema` | `true`, **never inlined** | Measured: a cell link can carry a full JSON Schema with `$defs`. Inlining would make a bounded result unbounded — the defect this plan exists to fix |
+
+Every optional field becomes required with a filled default. That costs a few
+bytes and buys a shape callers index without defensive branching.
+
+The same discipline applies one level up, to the envelope around the result.
+`deduplicated` is the exception that proves it: it is optional and **only ever
+appears as `true`**, because `invocationJson`
+(`packages/cli/commands/piece.ts`) spreads
+`...(outcome.deduplicated ? { deduplicated: true } : {})`, so the key's absence
+*is* the false case. That is an existing contract this plan does not change —
+but never emit `"deduplicated": false`, which no code path produces and which a
+caller branching on key presence would misread.
+
+**`cf inspect` remains the route to the raw stored form.** This plan adds no
+`--raw`: a second output contract would undo the stability the first one exists
+to provide, and `cf inspect` already owns "what is actually stored."
+
+## What using it looks like
+
+Create a note and address it, with no side-car annotation and no `sed`:
+
+```bash
+R=$(cf piece call --piece "$BOARD" createNote '{"title":"Notes"}')
+
+# The address is in the result, at its natural path. Note the bracket form:
+# `$` is a variable sigil in jq, so `.result.note.$link` is a syntax error.
+NOTE=$(echo "$R" | jq -r '.result.note["$link"].id')
+
+cf piece call --piece "$NOTE" append '{"text":"second line"}'
+```
+
+Fields the handler computed need no second call — they were never behind a
+reference:
+
+```bash
+echo "$R" | jq -r '.result.writtenAt'
+```
+
+Ask for the note's *contents* in the same call instead of following the link:
+
+```bash
+cf piece call --depth 1 --piece "$BOARD" createNote '{"title":"Notes"}'
+```
+
+Re-read that invocation later, without running the verb again:
+
+```bash
+cf invocation get "$(echo "$R" | jq -r '.receipt["$link"].id')"
+```
+
+Or, having dispatched detached and lost the response — recovering from the id
+you chose:
+
+```bash
+cf piece call --no-wait --invocation my-id-7 --piece "$BOARD" createNote '{"title":"Notes"}'
+cf invocation get --piece "$BOARD" --verb createNote --invocation my-id-7 --await
+```
+
+## Reading a receipt
+
+### What produces one
+
+Only JavaScript handler dispatches.
+`handleJavaScriptHandlerResult` (`packages/runner/src/runner.ts`) mints the
+receipt cell **unconditionally at its top**, before any branching, and all three
+downstream sub-paths share that one cell: the receipt-only branch writes it, the
+`deferForNavigate` branch is the **sole** caller of
+`setupDeferredHandlerResultPattern` (the navigateTo case, not the reactive one),
+and ordinary reactive results go through `runWithStartOwnership`. Other
+`{ resultFor: … }` cells in the same file take a resolved output-redirect spot
+as cause and are **not** receipts — do not pattern-match on `resultFor` alone.
+
+Tools take a different path — `runtime.run` into a fresh result cell, surfaced
+as `resultRef` — and produce no receipt.
+
+Publication also requires `commitPreconditions`, on by default and not
+env-reachable
+([EXPERIMENTAL_OPTIONS.md](../development/EXPERIMENTAL_OPTIONS.md)). When the
+runtime produces none, the response omits `receipt` — absent, never fabricated.
+
+**Not every receipt comes from `cf piece call`.** Shell clicks,
+background-piece-service runs, and pattern-internal chains all dispatch handlers
+and write receipts with deterministic ids: `queueSchedulerEvent`
+(`packages/runner/src/scheduler/events.ts`, behind the `queueEvent` facade) sets
+`id = args.eventId ?? mintEventId(eventLink, originTx)`. So the unit read here
+is **a handler dispatch someone can name** — which is why it earns a top-level
+noun rather than living under `cf piece`.
+
+**Why `cf invocation`, not `cf receipt`.** CFC single-use grants write a
+*consumption receipt* under the reserved `grant:cfc:` scheme
+(`packages/runner/src/cfc/grants.ts`), deliberately avoiding the `resultFor`
+idiom so `noteSystemWrite` gates it. `cf receipt` would be ambiguous between the
+two and invite the expectation that it reads the policy-state kind.
+
+### What its existence proves
+
+Settlement — not that the handler ran. Two cases with opposite behavior:
+
+- **The handler throws.** The error is rethrown out of
+  `invokeJavaScriptImplementation` and never reaches `postRun`, so no receipt is
+  written. At readback, failure is indistinguishable from never having happened.
+- **The argument fails validation** (`isValidArgument` false). The handler does
+  not run, but `result` stays `undefined` and `postRun(undefined)` runs anyway,
+  writing `{}` — exactly the shape a value-less success writes.
+
+`cf piece call` catches the second in its pre-dispatch payload gate, so CLI
+callers see a refusal that does not spend the id. Other dispatchers may not.
+
+| Question | Answer |
+| --- | --- |
+| Did this invocation settle? | yes |
+| What value is in the receipt? | yes |
+| Did the handler fail? | no — failure and absence look alike |
+| Did the handler body run? | no — validation non-runs write `{}` |
+| Was this attempt deduplicated? | no — that belongs to the attempt |
+| What invocations ran on this piece? | no — receipts are not enumerable |
+
+This is result readback, not invocation history.
+
+### How addresses are derived
+
+The reconstruction handle (step 4) must reproduce this exactly.
+
+```text
+receipt address = getCell(patternResultCell.space, { resultFor: cause })
+cause           = { ...inputs, $event: tx.dispatchedEventId }
+```
+
+`inputs` is the handler node's bound closure. The receipt lives in the **pattern
+result cell's space**, not necessarily the caller's, and is created with **no
+scope argument**, so receipts are space-scoped today.
+
+Two handles:
+
+1. **Direct:** `cf invocation get <receipt-id>`, taking `--space`, `--identity`
+   and the other addressing options as `--piece` does. It accepts exactly what
+   the `receipt` field's `$link.id` emits, prefix included — and needs no dependency on the
+   `entityIdFrom` fix, because the reader builds a link and loads it via
+   `getCellFromLink`, whose `toURI` returns an already-schemed URI verbatim.
+   **Do not route the receipt handle through `entityIdFrom` for symmetry with
+   `--piece`; that imports the bug.** Slugs do not apply — a receipt is not a
+   piece.
+2. **Reconstruction:** `cf invocation get --piece <p> --verb <v> --invocation
+   <id>`. Required, not convenient: goal 4 cannot use form 1, because the
+   address came back only in the response that was lost. This form inherits
+   `--piece`'s address forms, slugs included.
+
+**The highest-risk item in this plan:** the CLI must not duplicate the runner's
+cause-building logic. Byte-identical addressing is required across replicas, and
+reaching the handler node's `inputs` from a stream cell is runner-internal. The
+runner should export `receiptLinkFor(streamCell, eventId) ->
+NormalizedFullLink | undefined`.
+
+The reader loads that link through `runtime.getCellFromLink(link)` and `pull()`,
+the same path `executeResolvedCallable` already uses. A raw storage read would
+bypass the CFC checks attached to the stored result.
+
+### Waiting, and detached calls
+
+A detached caller knows the receipt address before the receipt exists, so the
+reader **subscribes and wakes when it appears**; it must not poll
+(AGENTS.md, "Avoid timeouts, retry loops, and sleeps";
+[waiting-in-tests.md](../development/waiting-in-tests.md)). `--wait <seconds>`
+bounds a caller's own patience, as on `cf piece call`.
+
+`tx.handlingReceiptLink` is published at commit time, so `--no-wait` returns
+`receipt` in its response. It also returns the invocation id — minted or
+supplied — both on stdout and, once, on stderr at the dispatch phase before any
+network work. So collect-later does **not** require supplying an id. Supplying
+one buys something narrower: it is known *before* the call, so it survives
+losing the process's output entirely.
+
+### Retry versus readback
+
+| What the caller knows | Correct action |
+| --- | --- |
+| The invocation committed or settled | `cf invocation get` |
+| Uncertain whether the commit happened, or whether the handler failed | Repeat `cf piece call` with the same `--invocation` id |
+| Response lost; piece, verb and caller-chosen id retained | Reconstructed `cf invocation get` |
+| No caller-chosen id retained | Recovery is not guaranteed |
+
+An absent receipt cannot distinguish never-dispatched, not-yet-committed,
+threw, expired, or wrong-handle. Under uncertainty only same-id replay safely
+finishes the work.
+
+### What a repeated read costs
+
+Each `cf` invocation is a separate process with a **cold replica** —
+`loadManager` builds a `runtimePresets.remoteClient` runtime over a remote
+`StorageManager`, and nothing persists between runs. Expect process start,
+session setup, a connection, and a sync; the walkthrough's `--verbose` output
+puts `initial_sync → dispatched` around 400ms against a warm local toolshed.
+
+So: **ask broadly once.** One read returns the whole envelope. Repeated reads
+are for questions you did not anticipate — recovery, detached collection, a
+follow-up from another process — not a read-per-field idiom. A readback remains
+far cheaper than the same-id replay it replaces, which pays all of the above
+plus a handler execution and a refused commit.
+
+## Errors and output conventions
+
+This plan inherits `packages/cli/README.md` §"Output Conventions" rather than
+restating them: **stdout carries command output only, with hints and diagnostics
+on stderr**, and **`-q/--quiet` suppresses the hint and next-step blocks**
+without touching the log floor, deliberately, because consumers parse `--quiet`
+runs' stderr for runtime warnings.
+
+stdout is always the Invocation JSON. Nothing narrows it to a bare value, so
+no envelope field is ever displaced onto stderr and no rule is needed for
+where it lands.
+
+What this plan *adds* to stderr is one thing: the list of paths that could not be
+expanded for a reason other than depth (below). That is advice about what you did
+not get, and stdout already carries the honest answer in the form of a `$link`,
+so **`--quiet` suppresses it** — the same test `resultRef` applies, where a value
+is advisory until the protocol carries it on stdout.
+
+Unchanged: the `invocation: <id>` line announced once on stderr at dispatch,
+before any network work, so a caller whose process dies still holds the id.
+
+### Exit status
+
+Removing the selection flags removed most of the error surface with them —
+there is no longer a "settled but the selection matched nothing" state, because
+there is no selection. What remains is three cases.
+
+**`cf piece call` is unchanged.** A refused or failed call reports on stderr with
+the existing `invocation: <id> phase: <phase>` line and exits non-zero. A settled
+call exits zero.
+
+**`cf invocation get` reports the read.** Zero when it found the receipt,
+non-zero when it did not — it is read-only, so there is no duplicate-write
+hazard in saying so. The message is "no receipt at this address" and must **not**
+claim the invocation never happened: absence cannot distinguish collected,
+never-created, failed, and wrong-handle.
+
+**An unfollowable hop degrades to a link, except when it cannot.** A `$link` at
+a position means "not expanded here" — uniformly, whether depth ran out, the kind
+rule kept it, or a hop failed to read. That uniformity is deliberate: no marker
+field, no shape variance, and the caller still gets the address, which is the
+part it can act on. Paths that failed *for a reason other than depth* are named
+on stderr, since depth running out is expected and an unreadable target is not.
+
+The exception is a **`computed:` expansion that fails**. There the caller is left
+holding a link it cannot address and cannot read, with no recourse — so that one
+fails loudly rather than degrading silently.
+
+## Teaching `--piece` the entity URI
+
+`--piece` gains the entity-URI form, so an address emitted by one command is
+accepted by the next without reshaping. This is the one change here that reaches
+beyond the CLI, and it is a bug fix rather than a new capability.
+
+`isSlugAddress` is `!value.includes(":")`, so the input forms are unambiguous:
+
+| Form | Example | `--piece` today | After | Denotes |
+| --- | --- | --- | --- | --- |
+| Slug | `my-board` | accepted | unchanged | a **stable name** that redirects; reassignable |
+| Bare hash | `fid1:…` | accepted | unchanged | a hash — **not a complete identity** |
+| Entity URI | `of:fid1:…` | **throws** | **accepted** | this entity, in its stored spelling |
+| Kinded URI | `computed:fid1:…` | throws | **refused, by name** | a *different* entity from the `of:` one over the same hash |
+
+**Why the prefixed form throws today.** `--piece` reaches `entityIdFrom` and
+thence `FabricHash.fromString`, which splits on the first colon and
+base64-decodes the rest — so `of:fid1:<b64>` parses as tag `of` with hash
+`fid1:<b64>`, and the colon is not valid base64url. It surfaces as a decode
+error, which is why it has never been reported as a missing feature.
+
+**The change.** Accept an `of:` scheme at `entityIdFrom`
+(`packages/runner/src/create-ref.ts`) and **refuse `computed:` rather than strip
+it** — stripping would rename an id to its `of:` sibling, a different entity.
+`pageIdForRouting` (`packages/runtime-client/backends/runtime-processor.ts`)
+already implements exactly that shape; lift it rather than write a third copy.
+
+Not one layer lower: `FabricHash.fromString` has non-entity users
+(`packages/memory/fact.ts` parses a cause with it), and `of:` is a URI scheme,
+not a hash tag. `entityIdFrom` is the entity-specific wrapper and the right seam.
+
+**One fix reaches everyone.** Every path turning an address string into a cell
+goes through `entityIdFrom`: the CLI, the shell (`runtime-processor`, four call
+sites), the background piece service, and slug resolution. That breadth is a
+reason to make the change carefully, not a reason to avoid it — the alternative
+is the CLI hand-stripping on its own, which is the eleventh copy of a conversion
+that already exists ten times.
+
+**Safety.** Additive: strings that threw now resolve, and nothing that already
+worked changes spelling or meaning. Three things to verify rather than assume:
+
+1. **`computed:` throws, not strips** — coercing renames an id to a different
+   entity.
+2. **String-keyed lookups get audited.** Once two spellings resolve, anything
+   keying on the *raw input* has two keys per entity. The cell layer keys on the
+   normalized URI and is fine; CLI-level raw-string comparisons are where to look.
+3. **The existing workarounds stay correct**, since stripping `of:` from an
+   already-bare id is a no-op.
+
+**What stays out of scope.** Ten hand-rolled prefix conversions exist across
+nine files in five packages — `lib-shell`, `patterns` (three files, two in
+user-space pattern code), `fuse`, `state-inspector` (two inside embedded browser
+JS), and `runtime-client` — running in **both** directions. Removing them is
+follow-up cleanup on a separate review path, and nothing here depends on it.
+
+**A bare hash is not a complete identity**, which is why the emitted form keeps
+its scheme. An entity's kind lives only there and the hash preimage is kind-free
+([computed-cell-identity.md](../specs/computed-cell-identity.md)), so stripping
+to `fid1:<h>` discards the distinction and re-resolving silently defaults to the
+`of:` sibling.
+
+## Other constraints
+
+**No result schema is emitted.** `Stream<Event, Result>` carries a real
+TypeScript result type, but the generator prepends `asCell: ["stream"]` to the
+inner schema
+([ts_to_json_schema_mapping.md](../specs/schema-generator/ts_to_json_schema_mapping.md)
+§6.2) and that inner schema is the **event's** (§6.5), so the result type has
+nowhere to go. Emission (C3) was built, proven, and withdrawn before merge
+because the coming Fabric-types stream evolution is expected to replace the
+shape. Two costs are inherited: result shapes have no update-gate protection,
+and a caller cannot discover a result's shape before calling. It is also why
+schema-driven narrowing of the *fetch* is not straightforwardly available.
+
+**Receipts have no retention bound.** Permanent and unlinked today — which
+[pattern-verb-contract.md](pattern-verb-contract.md) names as a defect in
+waiting: "deterministic addressing without linkage is how storage becomes
+permanent and invisible at once." This plan creates the first dependency on
+reading them later, so it owns two things: state the window honestly as
+unbounded, and **fail legibly on absence** — "no receipt at this address", never
+a claim the invocation never happened, because absence cannot distinguish
+collected, never-created, failed, or wrong-handle.
+
+## Open questions
+
+### Traversal mechanics — answered, pending owner confirmation
+
+Investigated against the code; **not yet confirmed by the `traverse.ts` owner**,
+so treat as strong rather than final.
+
+**A shallow read exists, and we already use it.** `StorageManager.syncCell`
+sends `schema: schema ?? false`, and `schema: false` is `REJECTING_SELECTOR`
+(`packages/data-model/src/schema-utils.ts`) — a traverser built with it follows
+no references. Combined with `getRawUntyped`, which never enters
+`SchemaObjectTraverser`, that is the whole depth-0 mechanism, with three in-tree
+precedents (ACL bootstrap, the sync path, conflict-retry doc pull). Note
+`READ_NON_RECURSIVE_FOR_SCHEDULING` is *not* it — that governs conflict and
+invalidation granularity, not link following.
+
+**Bandwidth is genuinely bounded**, so the strong claim is available. One
+caveat: the **meta closure** still travels — cfc / result / pattern / argument /
+internal docs via `loadMetaLinkedDocs`, each tracked with the rejecting
+selector. Bounded, but not zero.
+
+**`asCell` is the wrong lever, and would have burned us.** `traverseCells` is
+`context.includeMeta`; the server passes `true` and the client `false`, and
+`traversePointerWithSchema` guards its `asCell` early-return behind
+`!this.traverseCells` — with a comment saying so outright: "For the memory
+system, where we do traverse cells, we will still walk into these objects
+regardless of the schema flag." So `asCell` narrows only what the *client*
+materializes; the server sends the closure anyway. This also explains why the
+spike's hand-written `asCell` schemas returned `undefined` — wrong lever, not
+wrong syntax.
+
+**Kind-conditional traversal is not expressible declaratively**, but is
+expressible in CLI code — see "Except where a reference is useless to the
+caller".
+
+**What still needs the owner's eye:** whether the meta closure is large enough
+in practice to weaken the bounded claim, and whether a declarative kind gate
+alongside `canFollowScopedLink` is worth the wire change later.
+
+### Is the invocation id namespace per-user? — owner: Berni
+
+**The finding: nothing in a receipt's address identifies the caller.** `inputs`
+is graph structure, identical for every caller; `$event` is the caller's string
+verbatim (`resolveInvocationId` applies no namespacing); scope is a symbolic tag,
+not a user identifier; and the payload is excluded by design — which is what lets
+a same-id retry replay instead of execute.
+
+So an invocation id is a **read key shared per (space, verb binding)**, and it is
+the read, not the write, that this breaks.
+
+**Consequence 1: two callers sharing an id read one receipt.** Both resolve the
+same address, both get the same bytes, and one is reading an answer to the
+other's request. Nothing in the response says so, because the receipt records
+what happened *under an id*, not *to a request*. It bites four ways: no caller
+can verify a result is its own; the confusion propagates, since a caller holding
+someone else's child address operates on that piece next; async reads strip the
+last signal, because `deduplicated` belongs to an attempt and is not in the
+receipt, so **the reader this plan adds cannot diagnose it**; and retrying
+replays the same outcome forever. Concurrency adds a secondary effect — both
+handler bodies run, so effects outside the transaction happen twice.
+
+**Consequence 2: a guessed id reads someone else's result.** Reconstruction turns
+piece + verb + id into an address, bounded only by CFC labels and cell scope,
+never by authorship.
+
+| Option | Effect | Cost |
+| --- | --- | --- |
+| Document the shared read key; require collision-resistant ids | Cheapest | Relies on compliance; guessed-id reads remain |
+| Namespace the event id by caller DID | Makes the read key per-caller | Changes dedup semantics; breaks deliberate cross-agent id sharing |
+| Keep the shared key, stop treating unguessability as privacy | Honest about what the address proves | Needs explicit authorization on receipt reads; does not address aliasing |
+
+Pre-existing (WS-D), but this plan makes it reachable. The exposure is entirely
+in caller-chosen ids — and the human-friendly ones current documentation teaches
+(`add-comment-1`, `create-note-7`) are what two agents following one convention
+derive *systematically*.
+
+### Confirm the `$link` defaults — proposed above
+
+The table in "The `$link` shape" is a proposal. Confirm or amend before
+implementation: this is the surface that absorbs the `modernCellRep` migration
+on callers' behalf, and changing it later is the breakage it exists to prevent.
+
+**The key name deserves a second look.** `$link` matches `$stream` and `$NAME`,
+and the `$` guards against a pattern author having a field literally called
+`link`. But it costs jq ergonomics on the exact path this design optimizes for:
+`$` is a variable sigil in jq, so every expression needs the bracket form —
+`.result.note["$link"].id`, never `.result.note.$link.id`, which is a syntax
+error. A bare `link` would read better and collide worse. Worth deciding
+deliberately, since ergonomics was part of the argument for declaring a shape at
+all.
+
+### Should `--piece` accept a `$link`? — leave open
+
+It would close most of the canonical-locator gap, since `$link` carries
+everything but host. Two things stop it here: a path-bearing `$link` still does
+not name a piece, and JSON as a shell argument quotes badly. Nothing is blocked
+meanwhile — same-space composition is `jq -r '…["$link"].id'`, cross-space adds
+`--space`.
+
+## Migration
+
+**`result` changes shape.** This is the breaking part, and it is deliberate: a
+mode would leave the unbounded default reachable, which is the defect. Known
+consumers are `packages/cli/integration/verbs-over-the-cli.sh` and the CLI
+tests; both are updated in the same change. Any external script reading
+`result.<ref>.<field>` gets a `$link` instead and must either use `--depth 1` or
+follow the address.
+
+**`--show-links` is deleted.** With identity in-band it has no job. It has no
+consumers outside the walkthrough and CLI tests.
+
+**Sequenced so each step is separately reviewable:**
+
+1. **`$link` rendering and the shape** — the projection, its defaults, and the
+   receipt as a top-level field.
+2. **`--piece` accepts the entity URI** — the `entityIdFrom` change, refusing
+   `computed:`. Lands before step 3 because step 3's acceptance test is
+   `cf piece call --piece "$(… | jq -r '.result.note["$link"].id')"`, which
+   cannot pass until `--piece` takes the emitted form. Independently testable:
+   the same id works with and without its scheme.
+3. **Reference rendering** — stop expanding `of:` references; expand
+   `computed:`. Mechanically this is *stop materializing*: read the receipt
+   through the shallow path and render `getRaw()`, then follow only computed
+   links. `collectInvocationResultLinks` (`packages/cli/lib/callable.ts`) is
+   worth reusing here — it already walks a result and produces exactly this
+   identity map, but today it walks the *already-materialized* value, so it adds
+   identity **on top of** the payload. Rebuilding that walk on the shallow read
+   is what converts it from an annotation into a bound. Replacing the
+   walkthrough's `jq | sed` with a `$link` read is the acceptance test.
+4. **`--depth`** — the follow mechanism.
+5. **`cf invocation get`** — direct handle, then reconstruction with the
+   runner-exported `receiptLinkFor`.
+
+Step 3 is where the wire contract changes, so it is the one to land alone. The
+receipt reader does not depend on step 2: it loads through `getCellFromLink`,
+not `entityIdFrom`, so the prefixed form already works there.
+
+## Documentation this plan owes
+
+- [Verbs over the CLI](../common/verbs-over-the-cli.md) is **already stale**:
+  its `plainResultReceipts` note describes a default that has since flipped
+  (`packages/runner/src/runtime.ts` sets it `??= true`). It documents the
+  `--show-links` shape, and its examples teach hand-written invocation ids —
+  which the namespace question may make actively harmful advice.
+- `packages/cli/README.md` §"Output Conventions" is the source this plan
+  inherits its stdout/stderr rules from; it gains the `$link` contract.
+
+## Deferred work
+
+- **Batching.** The answer to O(N) fan-out — resolving many references in one
+  request. A parent's **compact index** (one row per child carrying a reference
+  plus summary fields, per the verb contract's Discovery section) already covers
+  the designed case in one read, and composes well here: the row's reference
+  renders as a `$link` while its summary fields render inline. Batching is for
+  the ad-hoc and exploratory cases an index does not anticipate.
+- **A canonical locator** carrying host, space, id, scope and path in one string.
+- **A local receipt cache.** Receipts are unusually good targets: `markCreateOnly`
+  makes them **write-once**, so a cached copy cannot go stale, and addressing is
+  deterministic. Three constraints decide it: identity-keyed (values inherit CFC
+  labels), confidential at rest (the CLI persists nothing today), and it must not
+  outlive server retention.
+- **A retention policy** and the linked receipt collection that would make expiry
+  distinguishable from error.
+- **Removing the ten hand-rolled `of:` conversions.**
+
+## Why the main alternatives were rejected
+
+| Alternative | Why not |
+| --- | --- |
+| Keep expanding, add a side-car links map | Discovery costs the full payload, identity and value live in parallel structures, and the map is flag-gated — so callers need foresight to keep a handle |
+| Add flags that select a link or an id out of the result | Unnecessary once identity is in-band; `jq` reaches it like any other field, and a flag would freeze one access pattern into the CLI |
+| Value projection (`--schema`, `--filter`) | Same reason — and there is no result schema for a caller to discover what to select |
+| Depth-limit expanded values instead of linking | Fidelity would depend on nesting depth, and identity would still be lost |
+| Handle-then-poke, a round trip per field | Untenable when each read is a process plus round trip |
+| Inline `@ID` annotation beside values | Cannot annotate a scalar, which can be its own document — the case where results are simplest. Replacing the node with a link is uniform |
+| Have patterns mint id fields | A pattern-authored fid is derived from runtime-only surface, reads `""` while unresolved, and goes stale |
+| Emit the raw runtime link encoding | It is dispatched on `modernCellRep` and mid-migration; exporting it makes every script a casualty of the flip |
+| Use an `asCell`-bearing read schema to bound the fetch | `asCell` is a *client materialization* boundary, not a fetch boundary — `traversePointerWithSchema` skips its early-return when `traverseCells` is set, which is exactly the server's configuration. The fetch boundary is the selector's schema |
+| A `--raw` escape hatch | A second output contract undoes the first one's stability; `cf inspect` owns the stored form |
+| Derive receipt addresses in the CLI | Byte-identical addressing would become a hand-maintained two-place invariant |
+| Address receipts by invocation id alone | The cause includes the handler's bound closure |
+| Put readback under `cf piece` | Any named handler dispatch has a receipt, not only CLI piece calls |
+| Name it `cf receipt` | CFC already has a different consumption-receipt concept |

--- a/docs/plans/verb-result-selection.md
+++ b/docs/plans/verb-result-selection.md
@@ -31,7 +31,7 @@ pattern, piece, verb, receipt, schema, and shape. Four more terms appear here:
 | **Handler** (or `action`) | The function body that runs when a verb is invoked. |
 | **Invocation** | One call to one verb. Its id is the idempotency key: replaying a settled id returns the original outcome instead of executing again. |
 | **`of:`** | The URI scheme on an entity id (`of:fid1:<hash>`). From the memory protocol's fact record — `the` (type) / `of` (entity) / `is` (value) — so an entity id names the subject a fact is *of*. The unkinded default. |
-| **`computed:`** | The same slot, marking an entity whose contents are re-derivable. Not independently addressable. |
+| **`computed:`** | The same slot, marking an entity whose contents are re-derivable. Reduced to a bare hash it aliases its `of:` sibling, which is a different entity — the reason `--piece` must refuse it rather than strip it. |
 
 ## The call-specific problem
 
@@ -77,7 +77,9 @@ Losing that address is the case these notes do not solve; see
 Only JavaScript handler dispatches.
 `handleJavaScriptHandlerResult` (`packages/runner/src/runner.ts`) mints the
 receipt cell **unconditionally at its top**, before any branching, and all three
-downstream sub-paths share that one cell: the receipt-only branch writes it, the
+downstream sub-paths resolve to that one address — a second `Cell` object is
+minted later for it, so the sharing is address-level, not object-level: the
+receipt-only branch writes it, the
 `deferForNavigate` branch is the **sole** caller of
 `setupDeferredHandlerResultPattern` (the navigateTo case, not the reactive one),
 and ordinary reactive results go through `runWithStartOwnership`. Other
@@ -96,10 +98,12 @@ runtime produces none, the response omits `receipt` — absent, never fabricated
 background-piece-service runs, and pattern-internal chains all dispatch handlers
 and write receipts with deterministic ids: `queueSchedulerEvent`
 (`packages/runner/src/scheduler/events.ts`, behind the `queueEvent` facade) sets
-`id = args.eventId ?? mintEventId(eventLink, originTx)`. So the unit is **a
-handler dispatch someone can name**, not a CLI call — which is what
-reconstruction has to address, since the dispatch it recovers may never have
-come from a terminal.
+`id = args.eventId ?? mintEventId(eventLink, originTx)`. The fallback branch is
+a per-transaction key plus a sequence, or a random UUID — so those receipts are
+**not** re-derivable, and only dispatches that supply an id are nameable at all.
+That bounds any recovery scheme to callers who chose an id in advance, and is a
+reason to prefer fixing replay in the runner over deriving addresses in a
+client: replay safety helps every dispatch, nameable or not.
 
 **Should recovery ever get a name, `invocation` not `receipt`.** CFC single-use grants write a
 *consumption receipt* under the reserved `grant:cfc:` scheme
@@ -145,6 +149,19 @@ cause           = { ...inputs, $event: tx.dispatchedEventId }
 result cell's space**, not necessarily the caller's, and is created with **no
 scope argument**, so receipts are space-scoped today.
 
+**`$event` is not the caller's id.** A caller-supplied id is bound to the stream
+it was sent to before it becomes an event id: `scopeCallerEventId`
+(`packages/runner/src/scheduler/event-identity.ts`) hashes
+`{caller, id, path, space}` — the id string plus the stream link — into
+`evt:caller:<hash>`, and `Cell.send` routes every supplied id through it. That
+binding is deliberate: two verbs sharing input bindings must not collide on one
+receipt. The hash is deterministic across processes, so a retry from a fresh CLI
+invocation derives the same id — which is what makes any re-derivation scheme
+possible at all.
+
+Where no id is supplied, `mintEventId` produces `evt:<per-transaction key>:<seq>`
+or `evt:<random uuid>:<id>`. Those are not re-derivable.
+
 Holding the address already, a caller needs nothing verb-aware: a receipt is a
 cell and reading it is an ordinary read. Deriving the address without it is the
 deferred case below.
@@ -161,8 +178,9 @@ reader **subscribes and wakes when it appears**; it must not poll
 [waiting-in-tests.md](../development/waiting-in-tests.md)). `--wait <seconds>`
 bounds a caller's own patience, as on `cf piece call`.
 
-`tx.handlingReceiptLink` is published at commit time, so `--no-wait` returns
-`receipt` in its response. It also returns the invocation id — minted or
+`tx.handlingReceiptLink` is published at commit time, so `--no-wait` *can*
+return `receipt` — that is what migration step 2 adds. Today its exit returns
+`{id, status: "committed", deduplicated?}` and no receipt field. It also returns the invocation id — minted or
 supplied — both on stdout and, once, on stderr at the dispatch phase before any
 network work. So collect-later does **not** require supplying an id. Supplying
 one buys something narrower: it is known *before* the call, so it survives
@@ -262,8 +280,8 @@ Not one layer lower: `FabricHash.fromString` has non-entity users
 (`packages/memory/fact.ts` parses a cause with it), and `of:` is a URI scheme,
 not a hash tag. `entityIdFrom` is the entity-specific wrapper and the right seam.
 
-**One fix reaches everyone.** Every path turning an address string into a cell
-goes through `entityIdFrom`: the CLI, the shell (`runtime-processor`, four call
+**One fix reaches most callers.** The address-string paths that matter here go
+through `entityIdFrom`: the CLI, the shell (`runtime-processor`, four call
 sites), the background piece service, and slug resolution. That breadth is a
 reason to make the change carefully, not a reason to avoid it — the alternative
 is the CLI hand-stripping on its own, which is the eleventh copy of a conversion
@@ -281,9 +299,11 @@ worked changes spelling or meaning. Three things to verify rather than assume:
    already-bare id is a no-op.
 
 **What stays out of scope.** Ten hand-rolled prefix conversions exist across
-nine files in five packages — `lib-shell`, `patterns` (three files, two in
+eleven files in five packages — `lib-shell`, `patterns` (three files, two in
 user-space pattern code), `fuse`, `state-inspector` (two inside embedded browser
-JS), and `runtime-client` — running in **both** directions. Removing them is
+JS), and `runtime-client` (three) — running in **both** directions, with roughly
+eight more hand-rolled sites outside those packages in `shell`, `toolshed`,
+`memory`, and `runner`. Removing them is
 follow-up cleanup on a separate review path, and nothing here depends on it.
 
 **A bare hash is not a complete identity**, which is why the emitted form keeps
@@ -297,10 +317,15 @@ to `fid1:<h>` discards the distinction and re-resolving silently defaults to the
 ### Is the invocation id namespace per-user? — owner: Berni
 
 **The finding: nothing in a receipt's address identifies the caller.** `inputs`
-is graph structure, identical for every caller; `$event` is the caller's string
-verbatim (`resolveInvocationId` applies no namespacing); scope is a symbolic tag,
-not a user identifier; and the payload is excluded by design — which is what lets
-a same-id retry replay instead of execute.
+is graph structure, identical for every caller; scope is a symbolic tag, not a
+user identifier; and the payload is excluded by design — which is what lets a
+same-id retry replay instead of execute.
+
+`$event` *is* namespaced, but not by principal: `scopeCallerEventId` hashes the
+supplied id together with the stream link, so the same id sent to two different
+verbs yields two receipts. What the hash does not contain is any identity — no
+DID, no session — so two callers passing the same id to the same verb still
+compute one address, and a guessed id still computes it from public inputs.
 
 So an invocation id is a **read key shared per (space, verb binding)**, and it is
 the read, not the write, that this breaks.
@@ -327,9 +352,9 @@ never by authorship.
 | Keep the shared key, stop treating unguessability as privacy | Honest about what the address proves | Needs explicit authorization on receipt reads; does not address aliasing |
 
 Pre-existing (WS-D), but reading receipts deliberately makes it reachable. The exposure is entirely
-in caller-chosen ids — and the human-friendly ones current documentation teaches
-(`add-comment-1`, `create-note-7`) are what two agents following one convention
-derive *systematically*.
+in caller-chosen ids — and the human-friendly convention
+[Verbs over the CLI](../common/verbs-over-the-cli.md) teaches (`add-comment-1`,
+`add-1`) is what two agents following it derive *systematically*.
 
 ## Migration
 
@@ -352,8 +377,8 @@ layer's call, not this half's.
    receipt exists.
 3. **Receipt cells created with a schema**, so a shape over a receipt matches a
    declaration and can be pushed into the read.
-4. **`piece call` gains `--schema`/`--filter`** by reusing the shared read
-   implementation rather than growing a second output path.
+4. **`piece call` gains the read options** — `--shape`/`--filter` — by reusing
+   the shared read implementation rather than growing a second output path.
 
 Reading a receipt directly needs no step of its own: it is an ordinary cell
 read, reachable once step 1 lands. Step 4 depends on the read layer having a
@@ -370,9 +395,10 @@ so without the address it is unreachable.
 **Why this is narrower than it sounds.** Three ways to want an outcome you do
 not have, and only the third is unserved:
 
-- *Dispatched detached.* `--no-wait` already returns the receipt address on
-  stdout and the invocation id on stderr, before any network work. The address
-  was handed over; keeping it is the answer.
+- *Dispatched detached.* `--no-wait` returns the invocation id on stderr before
+  any network work, and once migration step 2 lands it returns the receipt
+  address too. Keeping that address is the answer — but this bullet is
+  conditional on step 2, not on today's behaviour.
 - *Lost the response, verb has no effects outside its transaction.* Replaying
   with the same invocation id returns the original outcome. The body re-runs and
   loses the create-only race, so the commit is refused and nothing is duplicated.
@@ -426,6 +452,9 @@ first condition arrives on its own.
 - **Collection windowing.** Carried by the read layer; see
   [Shaped reads and verb results](shaped-reads-and-verb-results.md).
 - **A canonical locator** carrying host, space, id, scope and path in one string.
+  This absorbs the question of whether `--piece` should accept a rendered
+  address directly: a path-bearing one does not name a piece, so the locator is
+  where that belongs rather than the `--piece` parser.
 - **A local receipt cache.** `markCreateOnly` makes a receipt **write-once** and
   its address deterministic, so the *document* is safely cacheable. Its rendered
   value is not: the receipt holds links into live cells, so a materialized copy
@@ -435,6 +464,7 @@ first condition arrives on its own.
   and it must not outlive server retention.
 - **A retention policy** and the linked receipt collection that would make expiry
   distinguishable from error.
-- **Removing the ten hand-rolled `of:` conversions.**
+- **Removing the hand-rolled `of:` conversions** — a dozen in the packages
+  inventoried above, plus more outside them.
 - **Recovering an outcome whose address was lost** — discussed above, with its
   three options and the condition that would make it worth building.

--- a/docs/plans/verb-result-selection.md
+++ b/docs/plans/verb-result-selection.md
@@ -377,8 +377,9 @@ layer's call, not this half's.
    receipt exists.
 3. **Receipt cells created with a schema**, so a shape over a receipt matches a
    declaration and can be pushed into the read.
-4. **`piece call` gains the read options** — selection and filter — by reusing
-   the shared read implementation rather than growing a second output path.
+4. **`piece call` gains the read options** — `--select`, `--schema`, `--filter`
+   — by reusing the shared read implementation rather than growing a second
+   output path.
 
 Reading a receipt directly needs no step of its own: it is an ordinary cell
 read, reachable once step 1 lands. Step 4 depends on the read layer having a

--- a/docs/plans/verb-result-selection.md
+++ b/docs/plans/verb-result-selection.md
@@ -1,338 +1,74 @@
-# Verb results: references, not expansions
+# Verb calls: working notes
 
-This plan makes two things work from the CLI:
+**Sketches and investigation notes, not a plan.** The design lives in
+[Reading Fabric data](fabric-read-model.md) and the two documents it points at:
+[Shaped reads and verb results](shaped-reads-and-verb-results.md) for the read
+layer and what a call adds to it, and [CLI surface shape](cli-surface-shape.md)
+for the command surface.
 
-1. Call a verb that creates or returns a piece, then use that piece in the next
-   command — without the response expanding to an unbounded document.
-2. Re-read an earlier invocation's outcome without running the verb again.
+What is kept here is call-specific detail those documents do not carry: what
+produces a receipt and what its existence proves, how a receipt's address is
+derived, the entity-URI change to `--piece`, error and
+exit-status conventions, sequencing, and deferred work. Draw from it; do not
+treat it as a settled contract.
 
-The core change is one sentence: **a result renders references as references,
-instead of expanding them into their values.** Everything else follows from it.
+Anything about how a result *renders* — which positions are references, how a
+shape bounds a read — has moved. A verb result is the shared read layer applied
+to the receipt cell, not a contract of its own.
 
 This continues the identity work from
 [Pattern verb contract — implementation plan](pattern-verb-contract-implementation.md)
-(WS-F), which shipped `--show-links` and left the selection interface open. The
-user-facing surface it changes is
+(WS-F). The user-facing surface it changes is
 [Verbs over the CLI](../common/verbs-over-the-cli.md).
 
 ## Orientation
 
-Skip this if you already work with patterns and the `cf` CLI.
+[Reading Fabric data](fabric-read-model.md) defines space, cell, address, link,
+pattern, piece, verb, receipt, schema, and shape. Four more terms appear here:
 
 | Term | What it is |
 | --- | --- |
-| **Pattern** | A user-authored program — a `.tsx` module, roughly a Solid.js component. Declares reactive state and, optionally, callables. |
-| **Piece** | A *running instance* of a pattern, living in a space. The thing you address and call. |
-| **Space** | A store identified by a DID. Every cell lives in exactly one space. |
-| **Cell** | The reactive unit of storage. Its **backing document** is the storage record behind it. |
-| **Link** | A pointer to a cell — `{ space, id, scope, path? }`. Identity, not value. |
-| **Verb** | A piece's callable surface: a `Stream<Event, Result>` property in the pattern's output, invoked with `cf piece call`. |
 | **Handler** (or `action`) | The function body that runs when a verb is invoked. |
 | **Invocation** | One call to one verb. Its id is the idempotency key: replaying a settled id returns the original outcome instead of executing again. |
-| **Receipt** | The durable cell the runtime writes when a handler dispatch settles. Carries the handler's return value, or `{}` when there is nothing to return. |
-| **`of:`** | The URI scheme on an entity id (`of:fid1:<hash>`). The English preposition, from the memory protocol's fact record — `the` (type) / `of` (entity) / `is` (value) — so an entity id names the subject a fact is *of*. `of:` is the unkinded default. |
+| **`of:`** | The URI scheme on an entity id (`of:fid1:<hash>`). From the memory protocol's fact record — `the` (type) / `of` (entity) / `is` (value) — so an entity id names the subject a fact is *of*. The unkinded default. |
 | **`computed:`** | The same slot, marking an entity whose contents are re-derivable. Not independently addressable. |
 
-### What a verb looks like
+## The call-specific problem
 
-```tsx
-// Shown at module scope.
-
-interface NoteOutput {
-  title: string;
-}
-
-interface AddNoteEvent {
-  title: string;
-}
-
-interface AddNoteResult {
-  /** The note this call created — the piece itself, not a minted identifier. */
-  note: NoteOutput;
-}
-
-// A verb is a `Stream` property on a pattern's output. Its result type is the
-// second parameter; a verb that returns nothing stays `Stream<Event>`.
-interface BoardOutput {
-  addNote: Stream<AddNoteEvent, AddNoteResult>;
-}
-
-// `Note` is a pattern, so calling it produces a PIECE — a running instance with
-// its own identity — rather than a plain object.
-const Note = pattern<{ title: string }, NoteOutput>(({ title }) => ({ title }));
-
-// The implementation of the verb `BoardOutput` declares above. `action` takes
-// the SAME two type parameters as the `Stream` — event in, result out — and the
-// body must return that result type. `Stream<E, R>` and `Stream<E>` are
-// deliberately not interchangeable, so a declared result cannot be dropped
-// silently on assignment.
-//
-// A real pattern creates this inside `pattern(…)` and returns it as `addNote`,
-// alongside the state it mutates; it is standalone here to keep the example to
-// the parts this plan is about.
-export const addNote = action<AddNoteEvent, AddNoteResult>(({ title }) => {
-  const note = Note({ title });
-  // Return the piece itself. Patterns return references; rendering identity as
-  // an address is the client's job.
-  return { note };
-});
-```
-
-`return { note }` hands back **the piece**, not an identifier for it. Patterns
-deliberately never mint id fields — a pattern-authored id is a copy of runtime
-state that can go stale.
-
-## The problem
-
-**Expansion destroys identity and bounds nothing.** Today the CLI reads a
-result by materializing it, so `{ note }` comes back as the note's full value:
-
-```json
-{ "invocation": "0f4c…", "status": "settled",
-  "result": { "note": { "title": "Notes", "…": "…" } } }
-```
-
-The address is gone — you cannot call a verb on that note — and the payload
-grows with the transitive closure of everything the result references. The same
-shape produced over 300k tokens when a headless caller reads a board through
-`topics.crossrefs` ([pattern-verb-contract.md](pattern-verb-contract.md),
-"Discovery"). Recovering the address then took a side-car annotation plus two
-tools; step 5 of `packages/cli/integration/verbs-over-the-cli.sh`:
-
-```bash
-NOTE_ID=$(echo "$LINKED" | jq -r '.links["/note"].id // empty' | sed 's/^of://')
-```
-
-**And there is no durable readback.** The result exists in the invocation
+**There is no durable readback.** A verb's result exists in the invocation
 receipt, but the only way to re-read it is to re-invoke with the same id — which
-returns the original outcome, but re-runs the handler body, so effects outside
-the transaction repeat.
+returns the original outcome, yet re-runs the handler body, so effects outside
+the transaction repeat. A caller that dispatched detached, or that lost the
+response, holds no address at all, and nothing in the receipt is enumerable.
 
-## Goals and non-goals
+## What it looks like
 
-1. One call returns every value the verb produced **and** identity for
-   everything it referenced, bounded by the result's own declared shape.
-2. A returned child's address composes into the next `cf piece call --piece`.
-3. A settled outcome can be re-read without re-executing the verb.
-4. A lost response can be recovered, given the piece, the verb, and an
-   invocation id the caller chose in advance.
-5. Callers depend on a **declared** output shape, not on the runtime's internal
-   encoding, which is mid-migration.
-
-Non-goals: server-side filtering, selection languages, projection flags,
-changes to what patterns return, invocation listing, and batching (see Deferred
-work — it is the answer to O(N) fan-out, and it is not this plan).
-
-## Decision summary
-
-| What you want | How |
-| --- | --- |
-| A child's address, to call it next | It is in the result, at its natural path |
-| The values the verb computed | Also in the result, inline |
-| A specific field | `jq` — the result is a normal JSON document |
-| The content behind a reference | A second call against that address, or `--depth` |
-| A settled outcome, again | `cf invocation get <handle>` |
-| An outcome whose response was lost | `cf invocation get --piece --verb --invocation` |
-| Certainty about an uncertain commit | Same-id `cf piece call` replay — not a readback |
-
-There are **no selection flags**, and none are needed: with identity in-band,
-`jq` reaches it like any other field. `--show-links` exists today only because
-expansion destroyed the identity it annotates back on; it goes away with the
-expansion.
-
-## The result contract
-
-### References render as references
-
-A reference in a result renders as a `$link` node rather than its value:
-
-```json
-{
-  "invocation": "create-note-7",
-  "status": "settled",
-  "receipt": { "$link": { "id": "of:fid1:…", "space": "did:key:…", "scope": "space", "path": [] } },
-  "result": {
-    "note": { "$link": { "id": "of:fid1:…", "space": "did:key:…", "scope": "space", "path": [] } },
-    "writtenAt": "2026-08-04T…"
-  }
-}
-```
-
-`writtenAt` is inline because the handler computed it. `note` is a link because
-it is a separate entity with its own identity. **Both of the verb contract's
-stated payoffs — the address of a created child, and fields only the handler
-could produce — arrive in one round trip.** What defers is content belonging to
-a different document.
-
-### Except where a reference is useless to the caller
-
-**Expand what the caller cannot address; link what they can.**
-
-A `computed:` reference is not usefully addressable, and the reason is sharper
-than it first looks. A node the classifier marks `kind: "computed"` gets **two
-binds over the same hash preimage**, differing only by scheme: a *value bind* at
-`computed:fid1:<h>`, where the child's value actually lives, and an *identity
-bind* at `of:fid1:<h>`, which the runner uses "purely as the `resultFor` CAUSE —
-a stable coordinate, never read for a value." The runner states the consequence
-outright: **reading the `of:` one returns `undefined` for a healthy piece**
-(`instantiatePatternNode`, `packages/runner/src/runner.ts`).
-
-So handing a caller a `computed:` link hands them something `--piece` cannot
-take, and handing them its `of:` sibling hands them an address that reads empty.
-There is no third option. Computed references therefore **expand** — they are
-part of the value, not a boundary in it.
-
-An `of:` entity that is not one of those coordinate siblings is stable and
-independently identified, so a link suffices.
-
-This also gives the scheme-stripping hazard a concrete symptom: normalizing
-`computed:fid1:<h>` to `of:fid1:<h>` does not fail loudly — it silently
-addresses the coordinate and reads `undefined`.
-
-**Which nodes get a computed kind is the classifier's call.** It is a property of
-the node, decided per instantiation, and not something a caller — or this CLI —
-can predict from the shape of the pattern that produced it. The rendering rule
-therefore keys on the **scheme it observes** in the link, which is the only
-thing it needs and the only thing it can rely on.
-
-**Where the decision is made.** Not in the selector — `SchemaPathSelector` is
-`{ path, schema }` and nothing more, the schema is content-hashed and shipped
-through a schema-ref table, and `traverse.ts` never imports `entity-kind.ts`. A
-declarative kind gate would be a wire change across api → traverse →
-schema-hash → memory-v2 → server.
-
-It is made in **CLI code instead**, where the information is plainly available:
-read shallow, `getRaw()`, and inspect each parsed link's `id` — the scheme is
-right there. Expand only the `computed:` ones, with one more shallow sync each.
-
-If a declarative gate is ever wanted, there is a precedent to copy rather than
-invent: `canFollowScopedLink` (`traverse.ts` / `scope.ts`) already refuses a
-follow based on a property of the *target* rather than the shape at the
-position. A kind gate would sit in the same place and read the same object.
-
-### Depth, for when you want content
-
-`--depth N` follows up to N **`of:` hops**. Computed links are transparent and
-do not count — they are not boundaries.
-
-**Default 0**, on an asymmetry: depth 0 is bounded by the result's own shape,
-which the pattern author declared and published. Depth ≥ 1 is bounded by data
-the author never declared, and a single child can be arbitrarily large. At 0 you
-can always ask for more; a depth-1 default has already spent the payload before
-you can decline it.
-
-Depth counts *reference hops*, not JSON nesting — plain nested objects cost
-nothing. It is per-call, not per-path; per-path would be a selection language.
-
-**Depth 0 needs no runtime change.** The shallow fetch already exists — a
-schema-less `sync()` is the rejecting selector, and `getRawUntyped`
-(`cell.ts`) resolves links without entering `SchemaObjectTraverser`, so it
-cannot pull a child. Depth 0 is therefore *stop materializing*, not *change the
-fetch*: sync the receipt, read `getRaw()`, render the stored links.
-`followPointer`'s own comment states the property being relied on — "a
-rejecting-selector sync delivers only the root doc, so a link can point at a doc
-no selector ever walked."
-
-Each hop above 0, and each `computed:` expansion, is one more shallow sync
-issued from CLI code, where the target's scheme is visible on the parsed link.
-
-### Fan-out must be bounded and asked for
-
-Hidden N+1 traversal makes cost unpredictable. The rule is that a command's
-network work is **bounded and proportional to what the caller asked for** — not
-that it is always exactly one request.
-
-That distinction matters because **today's read already fans out, invisibly.**
-The sync is shallow: `StorageManager.syncCell` sends `schema: schema ?? false`
-(`storage/v2.ts`), and `schema: false` is `REJECTING_SELECTOR` — a traverser
-built with it follows no references. The expansion comes *afterwards*, from
-`.get()` / `.pull()`: a schema-less cell resolves to a `true` schema, the client
-walks the value, and every absent target hits `reportMissingLinkTarget`
-(`traverse.ts`) → `Runtime.ensureLinkedDocLoaded`, which **kicks a fresh sync
-per missing document** and re-runs the reader on arrival.
-
-So the status quo is one sync per referenced document, unbounded by the result's
-shape. This plan replaces that with one shallow read plus, at most, one hop per
-`computed:` reference — bounded by the pattern's own derived graph and by a
-depth the caller names. It reduces fan-out rather than introducing it.
-
-## The `$link` shape
-
-Wherever CLI output carries a reference, it emits one **declared** shape rather
-than the runtime's internal encoding, which is dispatched on `modernCellRep`
-and mid-migration (`cell-rep.ts`: legacy `{ "/": { "link@1": … } }` versus a
-modern `FabricLink`). Owning a shape is not optional — the moment callers are
-told to `jq` a result, *some* shape becomes a public contract. The only choice
-is whether it is one we declared or one that leaked.
-
-Spelling follows `state-inspector`'s `annotate()`, which already projects stored
-values to `{ $link }` / `{ $ref }` / `"$stream"` for the same reason.
-
-| Field | Default | Why |
-| --- | --- | --- |
-| `id` | always, **scheme included** | The scheme is part of the identity: `of:` and `computed:` over one hash are different entities. Dropping it is a silent retarget |
-| `space` | always, **filled in** | Measured: the runtime does not always emit it — present on some links, absent on others — so a consumer cannot rely on it. Filling it means no `// "…"` fallbacks in jq, and a link stays meaningful when copied out of context |
-| `scope` | always, defaulting `"space"` | `toInvocationResultLink` already does this. Absence silently meaning `"space"` is a trap |
-| `path` | always, `[]` when empty | Uniformity: one shape, no optional-key branching |
-| `overwrite` | **dropped** | A runtime write-redirect marker with no caller meaning. Measured present on every observed link |
-| `schema` | `true`, **never inlined** | Measured: a cell link can carry a full JSON Schema with `$defs`. Inlining would make a bounded result unbounded — the defect this plan exists to fix |
-
-Every optional field becomes required with a filled default. That costs a few
-bytes and buys a shape callers index without defensive branching.
-
-The same discipline applies one level up, to the envelope around the result.
-`deduplicated` is the exception that proves it: it is optional and **only ever
-appears as `true`**, because `invocationJson`
-(`packages/cli/commands/piece.ts`) spreads
-`...(outcome.deduplicated ? { deduplicated: true } : {})`, so the key's absence
-*is* the false case. That is an existing contract this plan does not change —
-but never emit `"deduplicated": false`, which no code path produces and which a
-caller branching on key presence would misread.
-
-**`cf inspect` remains the route to the raw stored form.** This plan adds no
-`--raw`: a second output contract would undo the stability the first one exists
-to provide, and `cf inspect` already owns "what is actually stored."
-
-## What using it looks like
-
-Create a note and address it, with no side-car annotation and no `sed`:
+Calling a verb with an id the caller chose, so the outcome stays recoverable:
 
 ```bash
-R=$(cf piece call --piece "$BOARD" createNote '{"title":"Notes"}')
-
-# The address is in the result, at its natural path. Note the bracket form:
-# `$` is a variable sigil in jq, so `.result.note.$link` is a syntax error.
-NOTE=$(echo "$R" | jq -r '.result.note["$link"].id')
-
-cf piece call --piece "$NOTE" append '{"text":"second line"}'
+cf piece call --piece <board> --invocation create-note-7 \
+  createNote '{"title":"Notes"}'
 ```
 
-Fields the handler computed need no second call — they were never behind a
-reference:
+The envelope carries the address of the cell holding this outcome. Field
+spellings are the read layer's, not settled here:
+
+```text
+{ invocation: "create-note-7",
+  status:     "settled",
+  receipt:    <address of the cell holding this outcome>,
+  result:     <what the verb returned, rendered by the read layer> }
+```
+
+Keeping that address means the result can be re-read later without running the
+verb again — an ordinary read, since a receipt is an ordinary cell:
 
 ```bash
-echo "$R" | jq -r '.result.writtenAt'
+cf piece get --piece of:fid1:...
 ```
 
-Ask for the note's *contents* in the same call instead of following the link:
-
-```bash
-cf piece call --depth 1 --piece "$BOARD" createNote '{"title":"Notes"}'
-```
-
-Re-read that invocation later, without running the verb again:
-
-```bash
-cf invocation get "$(echo "$R" | jq -r '.receipt["$link"].id')"
-```
-
-Or, having dispatched detached and lost the response — recovering from the id
-you chose:
-
-```bash
-cf piece call --no-wait --invocation my-id-7 --piece "$BOARD" createNote '{"title":"Notes"}'
-cf invocation get --piece "$BOARD" --verb createNote --invocation my-id-7 --await
-```
+Losing that address is the case these notes do not solve; see
+[Recovering a lost outcome](#recovering-a-lost-outcome--deferred).
 
 ## Reading a receipt
 
@@ -360,11 +96,12 @@ runtime produces none, the response omits `receipt` — absent, never fabricated
 background-piece-service runs, and pattern-internal chains all dispatch handlers
 and write receipts with deterministic ids: `queueSchedulerEvent`
 (`packages/runner/src/scheduler/events.ts`, behind the `queueEvent` facade) sets
-`id = args.eventId ?? mintEventId(eventLink, originTx)`. So the unit read here
-is **a handler dispatch someone can name** — which is why it earns a top-level
-noun rather than living under `cf piece`.
+`id = args.eventId ?? mintEventId(eventLink, originTx)`. So the unit is **a
+handler dispatch someone can name**, not a CLI call — which is what
+reconstruction has to address, since the dispatch it recovers may never have
+come from a terminal.
 
-**Why `cf invocation`, not `cf receipt`.** CFC single-use grants write a
+**Should recovery ever get a name, `invocation` not `receipt`.** CFC single-use grants write a
 *consumption receipt* under the reserved `grant:cfc:` scheme
 (`packages/runner/src/cfc/grants.ts`), deliberately avoiding the `resultFor`
 idiom so `noteSystemWrite` gates it. `cf receipt` would be ambiguous between the
@@ -397,7 +134,7 @@ This is result readback, not invocation history.
 
 ### How addresses are derived
 
-The reconstruction handle (step 4) must reproduce this exactly.
+Any scheme for re-deriving a receipt's address has to reproduce this exactly.
 
 ```text
 receipt address = getCell(patternResultCell.space, { resultFor: cause })
@@ -408,30 +145,13 @@ cause           = { ...inputs, $event: tx.dispatchedEventId }
 result cell's space**, not necessarily the caller's, and is created with **no
 scope argument**, so receipts are space-scoped today.
 
-Two handles:
+Holding the address already, a caller needs nothing verb-aware: a receipt is a
+cell and reading it is an ordinary read. Deriving the address without it is the
+deferred case below.
 
-1. **Direct:** `cf invocation get <receipt-id>`, taking `--space`, `--identity`
-   and the other addressing options as `--piece` does. It accepts exactly what
-   the `receipt` field's `$link.id` emits, prefix included — and needs no dependency on the
-   `entityIdFrom` fix, because the reader builds a link and loads it via
-   `getCellFromLink`, whose `toURI` returns an already-schemed URI verbatim.
-   **Do not route the receipt handle through `entityIdFrom` for symmetry with
-   `--piece`; that imports the bug.** Slugs do not apply — a receipt is not a
-   piece.
-2. **Reconstruction:** `cf invocation get --piece <p> --verb <v> --invocation
-   <id>`. Required, not convenient: goal 4 cannot use form 1, because the
-   address came back only in the response that was lost. This form inherits
-   `--piece`'s address forms, slugs included.
-
-**The highest-risk item in this plan:** the CLI must not duplicate the runner's
-cause-building logic. Byte-identical addressing is required across replicas, and
-reaching the handler node's `inputs` from a stream cell is runner-internal. The
-runner should export `receiptLinkFor(streamCell, eventId) ->
-NormalizedFullLink | undefined`.
-
-The reader loads that link through `runtime.getCellFromLink(link)` and `pull()`,
-the same path `executeResolvedCallable` already uses. A raw storage read would
-bypass the CFC checks attached to the stored result.
+Either way the reader loads the link through `runtime.getCellFromLink(link)` and
+`pull()`, the same path `executeResolvedCallable` already uses. A raw storage
+read would bypass the CFC checks attached to the stored result.
 
 ### Waiting, and detached calls
 
@@ -452,9 +172,9 @@ losing the process's output entirely.
 
 | What the caller knows | Correct action |
 | --- | --- |
-| The invocation committed or settled | `cf invocation get` |
+| The invocation settled, and its receipt address was kept | Read that address — an ordinary read |
 | Uncertain whether the commit happened, or whether the handler failed | Repeat `cf piece call` with the same `--invocation` id |
-| Response lost; piece, verb and caller-chosen id retained | Reconstructed `cf invocation get` |
+| Response lost, including the receipt address | Replay, or accept the loss — see the deferred section |
 | No caller-chosen id retained | Recovery is not guaranteed |
 
 An absent receipt cannot distinguish never-dispatched, not-yet-committed,
@@ -477,7 +197,7 @@ plus a handler execution and a refused commit.
 
 ## Errors and output conventions
 
-This plan inherits `packages/cli/README.md` §"Output Conventions" rather than
+These notes inherit `packages/cli/README.md` §"Output Conventions" rather than
 restating them: **stdout carries command output only, with hints and diagnostics
 on stderr**, and **`-q/--quiet` suppresses the hint and next-step blocks**
 without touching the log floor, deliberately, because consumers parse `--quiet`
@@ -487,41 +207,29 @@ stdout is always the Invocation JSON. Nothing narrows it to a bare value, so
 no envelope field is ever displaced onto stderr and no rule is needed for
 where it lands.
 
-What this plan *adds* to stderr is one thing: the list of paths that could not be
-expanded for a reason other than depth (below). That is advice about what you did
-not get, and stdout already carries the honest answer in the form of a `$link`,
-so **`--quiet` suppresses it** — the same test `resultRef` applies, where a value
-is advisory until the protocol carries it on stdout.
+Advisory notices about what a read could not materialize belong to the read
+layer and follow its conventions, not a call-specific rule.
 
 Unchanged: the `invocation: <id>` line announced once on stderr at dispatch,
 before any network work, so a caller whose process dies still holds the id.
 
 ### Exit status
 
-Removing the selection flags removed most of the error surface with them —
-there is no longer a "settled but the selection matched nothing" state, because
-there is no selection. What remains is three cases.
+Two call-specific cases. Failures inside a shaped read report under the read
+layer's rules.
 
 **`cf piece call` is unchanged.** A refused or failed call reports on stderr with
 the existing `invocation: <id> phase: <phase>` line and exits non-zero. A settled
 call exits zero.
 
-**`cf invocation get` reports the read.** Zero when it found the receipt,
-non-zero when it did not — it is read-only, so there is no duplicate-write
-hazard in saying so. The message is "no receipt at this address" and must **not**
-claim the invocation never happened: absence cannot distinguish collected,
-never-created, failed, and wrong-handle.
+**A read that finds no receipt says so, and no more.** The message is "no
+receipt at this address" and must **not** claim the invocation never happened:
+absence cannot distinguish collected, never-created, failed, and wrong-handle.
 
-**An unfollowable hop degrades to a link, except when it cannot.** A `$link` at
-a position means "not expanded here" — uniformly, whether depth ran out, the kind
-rule kept it, or a hop failed to read. That uniformity is deliberate: no marker
-field, no shape variance, and the caller still gets the address, which is the
-part it can act on. Paths that failed *for a reason other than depth* are named
-on stderr, since depth running out is expected and an unreadable target is not.
-
-The exception is a **`computed:` expansion that fails**. There the caller is left
-holding a link it cannot address and cannot read, with no recourse — so that one
-fails loudly rather than degrading silently.
+One property worth carrying into the read layer's design: a position that could
+not be materialized should still yield its address rather than an error, so a
+caller retains the part it can act on. Whether that degradation is uniform, and
+what is named on stderr, is the read layer's call.
 
 ## Teaching `--piece` the entity URI
 
@@ -584,66 +292,7 @@ its scheme. An entity's kind lives only there and the hash preimage is kind-free
 to `fid1:<h>` discards the distinction and re-resolving silently defaults to the
 `of:` sibling.
 
-## Other constraints
-
-**No result schema is emitted.** `Stream<Event, Result>` carries a real
-TypeScript result type, but the generator prepends `asCell: ["stream"]` to the
-inner schema
-([ts_to_json_schema_mapping.md](../specs/schema-generator/ts_to_json_schema_mapping.md)
-§6.2) and that inner schema is the **event's** (§6.5), so the result type has
-nowhere to go. Emission (C3) was built, proven, and withdrawn before merge
-because the coming Fabric-types stream evolution is expected to replace the
-shape. Two costs are inherited: result shapes have no update-gate protection,
-and a caller cannot discover a result's shape before calling. It is also why
-schema-driven narrowing of the *fetch* is not straightforwardly available.
-
-**Receipts have no retention bound.** Permanent and unlinked today — which
-[pattern-verb-contract.md](pattern-verb-contract.md) names as a defect in
-waiting: "deterministic addressing without linkage is how storage becomes
-permanent and invisible at once." This plan creates the first dependency on
-reading them later, so it owns two things: state the window honestly as
-unbounded, and **fail legibly on absence** — "no receipt at this address", never
-a claim the invocation never happened, because absence cannot distinguish
-collected, never-created, failed, or wrong-handle.
-
 ## Open questions
-
-### Traversal mechanics — answered, pending owner confirmation
-
-Investigated against the code; **not yet confirmed by the `traverse.ts` owner**,
-so treat as strong rather than final.
-
-**A shallow read exists, and we already use it.** `StorageManager.syncCell`
-sends `schema: schema ?? false`, and `schema: false` is `REJECTING_SELECTOR`
-(`packages/data-model/src/schema-utils.ts`) — a traverser built with it follows
-no references. Combined with `getRawUntyped`, which never enters
-`SchemaObjectTraverser`, that is the whole depth-0 mechanism, with three in-tree
-precedents (ACL bootstrap, the sync path, conflict-retry doc pull). Note
-`READ_NON_RECURSIVE_FOR_SCHEDULING` is *not* it — that governs conflict and
-invalidation granularity, not link following.
-
-**Bandwidth is genuinely bounded**, so the strong claim is available. One
-caveat: the **meta closure** still travels — cfc / result / pattern / argument /
-internal docs via `loadMetaLinkedDocs`, each tracked with the rejecting
-selector. Bounded, but not zero.
-
-**`asCell` is the wrong lever, and would have burned us.** `traverseCells` is
-`context.includeMeta`; the server passes `true` and the client `false`, and
-`traversePointerWithSchema` guards its `asCell` early-return behind
-`!this.traverseCells` — with a comment saying so outright: "For the memory
-system, where we do traverse cells, we will still walk into these objects
-regardless of the schema flag." So `asCell` narrows only what the *client*
-materializes; the server sends the closure anyway. This also explains why the
-spike's hand-written `asCell` schemas returned `undefined` — wrong lever, not
-wrong syntax.
-
-**Kind-conditional traversal is not expressible declaratively**, but is
-expressible in CLI code — see "Except where a reference is useless to the
-caller".
-
-**What still needs the owner's eye:** whether the meta closure is large enough
-in practice to weaken the bounded claim, and whether a declarative kind gate
-alongside `canFollowScopedLink` is worth the wire change later.
 
 ### Is the invocation id namespace per-user? — owner: Berni
 
@@ -663,7 +312,7 @@ what happened *under an id*, not *to a request*. It bites four ways: no caller
 can verify a result is its own; the confusion propagates, since a caller holding
 someone else's child address operates on that piece next; async reads strip the
 last signal, because `deduplicated` belongs to an attempt and is not in the
-receipt, so **the reader this plan adds cannot diagnose it**; and retrying
+receipt, so **a reader of receipts cannot diagnose it**; and retrying
 replays the same outcome forever. Concurrency adds a secondary effect — both
 handler bodies run, so effects outside the transaction happen twice.
 
@@ -677,81 +326,94 @@ never by authorship.
 | Namespace the event id by caller DID | Makes the read key per-caller | Changes dedup semantics; breaks deliberate cross-agent id sharing |
 | Keep the shared key, stop treating unguessability as privacy | Honest about what the address proves | Needs explicit authorization on receipt reads; does not address aliasing |
 
-Pre-existing (WS-D), but this plan makes it reachable. The exposure is entirely
+Pre-existing (WS-D), but reading receipts deliberately makes it reachable. The exposure is entirely
 in caller-chosen ids — and the human-friendly ones current documentation teaches
 (`add-comment-1`, `create-note-7`) are what two agents following one convention
 derive *systematically*.
 
-### Confirm the `$link` defaults — proposed above
-
-The table in "The `$link` shape" is a proposal. Confirm or amend before
-implementation: this is the surface that absorbs the `modernCellRep` migration
-on callers' behalf, and changing it later is the breakage it exists to prevent.
-
-**The key name deserves a second look.** `$link` matches `$stream` and `$NAME`,
-and the `$` guards against a pattern author having a field literally called
-`link`. But it costs jq ergonomics on the exact path this design optimizes for:
-`$` is a variable sigil in jq, so every expression needs the bracket form —
-`.result.note["$link"].id`, never `.result.note.$link.id`, which is a syntax
-error. A bare `link` would read better and collide worse. Worth deciding
-deliberately, since ergonomics was part of the argument for declaring a shape at
-all.
-
-### Should `--piece` accept a `$link`? — leave open
-
-It would close most of the canonical-locator gap, since `$link` carries
-everything but host. Two things stop it here: a path-bearing `$link` still does
-not name a piece, and JSON as a shell argument quotes badly. Nothing is blocked
-meanwhile — same-space composition is `jq -r '…["$link"].id'`, cross-space adds
-`--space`.
-
 ## Migration
 
-**`result` changes shape.** This is the breaking part, and it is deliberate: a
-mode would leave the unbounded default reachable, which is the defect. Known
-consumers are `packages/cli/integration/verbs-over-the-cli.sh` and the CLI
-tests; both are updated in the same change. Any external script reading
-`result.<ref>.<field>` gets a `$link` instead and must either use `--depth 1` or
-follow the address.
+**`result` changes shape** when the read layer lands, since a reference stops
+arriving as its expanded value. Known consumers are
+`packages/cli/integration/verbs-over-the-cli.sh` and the CLI tests, which assert
+on expanded fields today and are updated in the same change. `--show-links`
+becomes redundant once references render in band — it exists to annotate
+identity back onto a payload that destroyed it — but retiring it is the read
+layer's call, not this half's.
 
-**`--show-links` is deleted.** With identity in-band it has no job. It has no
-consumers outside the walkthrough and CLI tests.
+**The call-specific steps, each separately reviewable:**
 
-**Sequenced so each step is separately reviewable:**
+1. **`--piece` accepts the entity URI** — the `entityIdFrom` change, refusing
+   `computed:`. Independently testable: the same id works with and without its
+   scheme. Everything that composes an emitted address into a following command
+   waits on this.
+2. **`receipt` as a top-level envelope field**, published from
+   `tx.handlingReceiptLink` so a detached caller holds an address before the
+   receipt exists.
+3. **Receipt cells created with a schema**, so a shape over a receipt matches a
+   declaration and can be pushed into the read.
+4. **`piece call` gains `--schema`/`--filter`** by reusing the shared read
+   implementation rather than growing a second output path.
 
-1. **`$link` rendering and the shape** — the projection, its defaults, and the
-   receipt as a top-level field.
-2. **`--piece` accepts the entity URI** — the `entityIdFrom` change, refusing
-   `computed:`. Lands before step 3 because step 3's acceptance test is
-   `cf piece call --piece "$(… | jq -r '.result.note["$link"].id')"`, which
-   cannot pass until `--piece` takes the emitted form. Independently testable:
-   the same id works with and without its scheme.
-3. **Reference rendering** — stop expanding `of:` references; expand
-   `computed:`. Mechanically this is *stop materializing*: read the receipt
-   through the shallow path and render `getRaw()`, then follow only computed
-   links. `collectInvocationResultLinks` (`packages/cli/lib/callable.ts`) is
-   worth reusing here — it already walks a result and produces exactly this
-   identity map, but today it walks the *already-materialized* value, so it adds
-   identity **on top of** the payload. Rebuilding that walk on the shallow read
-   is what converts it from an annotation into a bound. Replacing the
-   walkthrough's `jq | sed` with a `$link` read is the acceptance test.
-4. **`--depth`** — the follow mechanism.
-5. **`cf invocation get`** — direct handle, then reconstruction with the
-   runner-exported `receiptLinkFor`.
+Reading a receipt directly needs no step of its own: it is an ordinary cell
+read, reachable once step 1 lands. Step 4 depends on the read layer having a
+factored implementation to reuse; steps 1–3 do not. Recovering an outcome whose
+address was lost is deliberately absent — see below.
 
-Step 3 is where the wire contract changes, so it is the one to land alone. The
-receipt reader does not depend on step 2: it loads through `getCellFromLink`,
-not `entityIdFrom`, so the prefixed form already works there.
+## Recovering a lost outcome — deferred
 
-## Documentation this plan owes
+**The problem.** A verb settled, and the caller no longer has its receipt
+address — the process died, output was lost, or a detached dispatch was never
+collected. The outcome exists and is durable, but nothing enumerates receipts,
+so without the address it is unreachable.
+
+**Why this is narrower than it sounds.** Three ways to want an outcome you do
+not have, and only the third is unserved:
+
+- *Dispatched detached.* `--no-wait` already returns the receipt address on
+  stdout and the invocation id on stderr, before any network work. The address
+  was handed over; keeping it is the answer.
+- *Lost the response, verb has no effects outside its transaction.* Replaying
+  with the same invocation id returns the original outcome. The body re-runs and
+  loses the create-only race, so the commit is refused and nothing is duplicated.
+- *Lost the response, verb has effects outside its transaction.* Replay would
+  re-send the mail or re-spend the model call. This is the case with no answer.
+
+**Option A — derive the address in the client.** Rebuild the cause from piece,
+verb, and a caller-chosen invocation id, per "How addresses are derived" above.
+The cost is coupling: addressing must be byte-identical across replicas, and a
+handler node's bound `inputs` are runner-internal, so the runner would have to
+export something like `receiptLinkFor(streamCell, eventId)` purely to serve this.
+Duplicating the cause-building in a client instead would create a two-place
+invariant that silently breaks addressing when either side drifts.
+
+**Option B — make replay safe instead.** If the harm is a re-executed effectful
+body, the fix may belong in the runner rather than the client: the receipt cell
+is minted unconditionally at the top of a dispatch, before any branching, so its
+address is known before the body runs. Checking for an existing receipt there
+would let a replay return the original outcome without re-executing — and would
+cover shell clicks, background-service runs, and pattern-internal chains, not
+only callers holding a terminal.
+
+**Option C — keep the address.** Treat the receipt address as the thing worth
+persisting, and make losing it the caller's problem to avoid. Costs nothing and
+is what the detached path already assumes.
+
+**When to revisit.** When a verb exists whose body has effects outside its
+transaction *and* whose caller cannot retain the address. Until both hold,
+Option C covers the ground and Option B is the better place to spend if the
+first condition arrives on its own.
+
+## Documentation owed
 
 - [Verbs over the CLI](../common/verbs-over-the-cli.md) is **already stale**:
   its `plainResultReceipts` note describes a default that has since flipped
   (`packages/runner/src/runtime.ts` sets it `??= true`). It documents the
   `--show-links` shape, and its examples teach hand-written invocation ids —
   which the namespace question may make actively harmful advice.
-- `packages/cli/README.md` §"Output Conventions" is the source this plan
-  inherits its stdout/stderr rules from; it gains the `$link` contract.
+- `packages/cli/README.md` §"Output Conventions" is the source these notes
+  inherit their stdout/stderr rules from. It also carries the projection and
+  filter contract the read layer extends.
 
 ## Deferred work
 
@@ -761,31 +423,18 @@ not `entityIdFrom`, so the prefixed form already works there.
   the designed case in one read, and composes well here: the row's reference
   renders as a `$link` while its summary fields render inline. Batching is for
   the ad-hoc and exploratory cases an index does not anticipate.
+- **Collection windowing.** Carried by the read layer; see
+  [Shaped reads and verb results](shaped-reads-and-verb-results.md).
 - **A canonical locator** carrying host, space, id, scope and path in one string.
-- **A local receipt cache.** Receipts are unusually good targets: `markCreateOnly`
-  makes them **write-once**, so a cached copy cannot go stale, and addressing is
-  deterministic. Three constraints decide it: identity-keyed (values inherit CFC
-  labels), confidential at rest (the CLI persists nothing today), and it must not
-  outlive server retention.
+- **A local receipt cache.** `markCreateOnly` makes a receipt **write-once** and
+  its address deterministic, so the *document* is safely cacheable. Its rendered
+  value is not: the receipt holds links into live cells, so a materialized copy
+  goes stale the moment a referenced child changes. Cache the links, never the
+  materialization. Three further constraints decide it: identity-keyed (values
+  inherit CFC labels), confidential at rest (the CLI persists nothing today),
+  and it must not outlive server retention.
 - **A retention policy** and the linked receipt collection that would make expiry
   distinguishable from error.
 - **Removing the ten hand-rolled `of:` conversions.**
-
-## Why the main alternatives were rejected
-
-| Alternative | Why not |
-| --- | --- |
-| Keep expanding, add a side-car links map | Discovery costs the full payload, identity and value live in parallel structures, and the map is flag-gated — so callers need foresight to keep a handle |
-| Add flags that select a link or an id out of the result | Unnecessary once identity is in-band; `jq` reaches it like any other field, and a flag would freeze one access pattern into the CLI |
-| Value projection (`--schema`, `--filter`) | Same reason — and there is no result schema for a caller to discover what to select |
-| Depth-limit expanded values instead of linking | Fidelity would depend on nesting depth, and identity would still be lost |
-| Handle-then-poke, a round trip per field | Untenable when each read is a process plus round trip |
-| Inline `@ID` annotation beside values | Cannot annotate a scalar, which can be its own document — the case where results are simplest. Replacing the node with a link is uniform |
-| Have patterns mint id fields | A pattern-authored fid is derived from runtime-only surface, reads `""` while unresolved, and goes stale |
-| Emit the raw runtime link encoding | It is dispatched on `modernCellRep` and mid-migration; exporting it makes every script a casualty of the flip |
-| Use an `asCell`-bearing read schema to bound the fetch | `asCell` is a *client materialization* boundary, not a fetch boundary — `traversePointerWithSchema` skips its early-return when `traverseCells` is set, which is exactly the server's configuration. The fetch boundary is the selector's schema |
-| A `--raw` escape hatch | A second output contract undoes the first one's stability; `cf inspect` owns the stored form |
-| Derive receipt addresses in the CLI | Byte-identical addressing would become a hand-maintained two-place invariant |
-| Address receipts by invocation id alone | The cause includes the handler's bound closure |
-| Put readback under `cf piece` | Any named handler dispatch has a receipt, not only CLI piece calls |
-| Name it `cf receipt` | CFC already has a different consumption-receipt concept |
+- **Recovering an outcome whose address was lost** — discussed above, with its
+  three options and the condition that would make it worth building.

--- a/docs/plans/verb-result-selection.md
+++ b/docs/plans/verb-result-selection.md
@@ -377,7 +377,7 @@ layer's call, not this half's.
    receipt exists.
 3. **Receipt cells created with a schema**, so a shape over a receipt matches a
    declaration and can be pushed into the read.
-4. **`piece call` gains the read options** — `--shape`/`--filter` — by reusing
+4. **`piece call` gains the read options** — selection and filter — by reusing
    the shared read implementation rather than growing a second output path.
 
 Reading a receipt directly needs no step of its own: it is an ordinary cell

--- a/docs/plans/verb-result-selection.md
+++ b/docs/plans/verb-result-selection.md
@@ -399,7 +399,7 @@ not have, and only the third is unserved:
 - *Dispatched detached.* `--no-wait` returns the invocation id on stderr before
   any network work, and once migration step 2 lands it returns the receipt
   address too. Keeping that address is the answer — but this bullet is
-  conditional on step 2, not on today's behaviour.
+  conditional on step 2, not on today's behavior.
 - *Lost the response, verb has no effects outside its transaction.* Replaying
   with the same invocation id returns the original outcome. The body re-runs and
   loses the create-only race, so the commit is refused and nothing is duplicated.

--- a/docs/plans/verb-result-selection.md
+++ b/docs/plans/verb-result-selection.md
@@ -142,7 +142,7 @@ Any scheme for re-deriving a receipt's address has to reproduce this exactly.
 
 ```text
 receipt address = getCell(patternResultCell.space, { resultFor: cause })
-cause           = { ...inputs, $event: tx.dispatchedEventId }
+cause           = { ...inputs, $event: tx.dispatchedEventId ?? <random uuid> }
 ```
 
 `inputs` is the handler node's bound closure. The receipt lives in the **pattern
@@ -159,8 +159,10 @@ receipt. The hash is deterministic across processes, so a retry from a fresh CLI
 invocation derives the same id — which is what makes any re-derivation scheme
 possible at all.
 
-Where no id is supplied, `mintEventId` produces `evt:<per-transaction key>:<seq>`
-or `evt:<random uuid>:<id>`. Those are not re-derivable.
+Where no id is supplied, `mintEventId` produces
+`evt:<per-transaction key>:<seq>:<stream link id>` or
+`evt:<random uuid>:<stream link id>`. Both end in the stream link's id, and
+neither is re-derivable.
 
 Holding the address already, a caller needs nothing verb-aware: a receipt is a
 cell and reading it is an ordinary read. Deriving the address without it is the
@@ -178,12 +180,14 @@ reader **subscribes and wakes when it appears**; it must not poll
 [waiting-in-tests.md](../development/waiting-in-tests.md)). `--wait <seconds>`
 bounds a caller's own patience, as on `cf piece call`.
 
-`tx.handlingReceiptLink` is published at commit time, so `--no-wait` *can*
-return `receipt` — that is what migration step 2 adds. Today its exit returns
-`{id, status: "committed", deduplicated?}` and no receipt field. It also returns the invocation id — minted or
-supplied — both on stdout and, once, on stderr at the dispatch phase before any
-network work. So collect-later does **not** require supplying an id. Supplying
-one buys something narrower: it is known *before* the call, so it survives
+`tx.handlingReceiptLink` is set during handling — before the commit, and only
+when receipts are enabled — so `--no-wait` *can* return `receipt`; that is what
+migration step 2 adds. Today its exit returns
+`{invocation, status: "committed", deduplicated?}` and no receipt field. It also
+returns the invocation id — minted or supplied — both on stdout and, once, on
+stderr at the dispatch phase. So collect-later does **not** require supplying an
+id. Supplying one buys something narrower: it is known *before* the call, so it
+survives
 losing the process's output entirely.
 
 ### Retry versus readback
@@ -228,8 +232,10 @@ where it lands.
 Advisory notices about what a read could not materialize belong to the read
 layer and follow its conventions, not a call-specific rule.
 
-Unchanged: the `invocation: <id>` line announced once on stderr at dispatch,
-before any network work, so a caller whose process dies still holds the id.
+Unchanged: the `invocation: <id>` line announced once on stderr at the dispatch
+phase, so a caller whose process dies past that point still holds the id. Note
+what that does and does not survive: dispatch comes after the initial sync, so
+the id outlives a lost commit but not a sync that never completes.
 
 ### Exit status
 


### PR DESCRIPTION
## Why

A verb's result and a direct read were being designed as two contracts. They are
one operation on different cells: a receipt is an ordinary cell, and nothing in
the read path checks piece-ness — `PieceManager.getResult` is the identity
function, and `cf piece get` reads a receipt address today without modification.

Designing them apart was expensive in ways that only show up as wasted work: a
`--depth` axis specified to bound a traversal that selects by path and therefore
never counts hops; four questions drafted for the `traverse.ts` owner that stop
applying once that's understood; and a result format specified for verbs that
the shared read path should own — the incident motivating all of it (a board read
past 300k tokens) was a `get`, not a call.

The restructure lets the read layer be settled against `cf piece get`, where the
load already is, with calls inheriting it. It also takes the command surface off
the critical path, since sharing a read step between commands requires no
renaming.

## What Changed

Docs only. Four files, ~1,300 lines.

| File | |
| --- | --- |
| `fabric-read-model.md` (147) | **Read this one cold.** The model, the vocabulary, and why three concerns split into two documents. |
| `shaped-reads-and-verb-results.md` (455) | The shared read layer and what a call adds. Carries the measured facts and the two remaining open questions. |
| `cli-surface-shape.md` (231) | The command surface: seven purposes, where it accreted, a target shape, an additive path that renames nothing before step 6. |
| `verb-result-selection.md` (484) | Reduced from a plan to working notes — call-specific detail the others don't carry. |

## What review settled

- **Schemas are queries** (Berni). The docs had framed a source schema and a
  reader's as opposites, which contradicts schema-on-read. Rewritten across all
  three; the naming problem relocated to one flag carrying two syntaxes, so
  `--select` takes the concise form and `--schema` keeps full schemas.
- **Address marking** (Ben). A `$link` marker beside `properties`, not a
  borrowed `asCell` — which carries a handle contract that can't cross a
  serialized channel.
- **Receipts carry a descriptive schema** (Ben), distinct from the declared
  result schema deferred to Fabric-types; the compatibility gate never reaches a
  receipt.
- **Invocation ids scope to a session, not a principal** (Berni). A DID
  separates nothing when agents work under their human's key, and a minted
  session is also unguessable, which a DID is not.

Two questions remain open, both in the read-layer document: what a receipt's
schema should record, and the mechanism for session scoping.

## Test plan

`deno task check-docs`, `check-conflict-markers`, `check-skill-facts` — all pass.
No code changes; `docs/` is excluded from `deno fmt`.

Runtime claims were measured against a local server rather than inferred, and
the evidence is in the read-layer document's "Measured facts". One claim was
retired when #5410 landed mid-review: the unshaped-read handle leak is fixed
(17,024 bytes → 976 on the same fixture), so that section now records what
remains true — an unshaped read emits the runtime's internal link encoding,
which is faithful but is not a contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
