### PR TITLE
fix(runner): settle a transaction's callbacks when it is aborted

### DIFF
--- a/docs/specs/space-model/5-transactions.md
+++ b/docs/specs/space-model/5-transactions.md
@@ -24,6 +24,39 @@ to cells require a transaction context.
 4. **Commit**: `tx.commit()` attempts to persist changes
 5. **Abort**: `tx.abort()` discards changes (or automatic on error)
 
+### Settle Outcomes
+
+A transaction settles in one of three ways: its commit succeeds, its commit is
+rejected, or something aborts it. All three run the callbacks registered through
+`addCommitCallback`. A rejected commit and an abort both deliver an error to
+those callbacks, because both discard every write the transaction staged.
+
+Those callbacks are the compensation hook: they undo in-memory state that only
+makes sense if the transaction's writes became durable. Two rules govern one.
+
+A callback that undoes such state checks that the state is still the state this
+transaction established. Another transaction can reach the same deterministic
+address and take ownership before this one settles, and its bookkeeping matches
+durable writes of its own.
+
+Not every failure calls for compensation. A stale basis — a conflict, or a local
+inconsistency — is resolved by re-running the same work against fresh state, and
+that re-run may depend on the very bookkeeping a compensating callback would
+discard; undoing it there can stop the work converging at all.
+`storage/rejection.ts` classifies the outcomes, so a callback acts only on the
+ones no re-run follows.
+
+External side effects belong in the post-commit outbox instead, which runs only
+after a successful commit.
+
+Work that re-runs what another transaction already carries, so the two can be
+compared, wants none of this. The idempotency validator is the case that exists.
+Its callbacks would compensate for state belonging to the run it duplicates,
+which has already committed it, so it takes its transaction from
+`createDuplicateWorkTransaction` — a wrapper that drops settle callbacks rather
+than registering them, leaving nothing to take back when the transaction is
+discarded.
+
 ### Read-Your-Writes
 
 Within a transaction, reads reflect pending writes:

--- a/packages/runner/src/builtins/filter.ts
+++ b/packages/runner/src/builtins/filter.ts
@@ -38,6 +38,7 @@ import {
   scopedCell,
 } from "./scope-policy.ts";
 import { resolveOpPattern } from "./op-pattern-ref.ts";
+import { trackListSetupRollback } from "./list-element-rollback.ts";
 import { createResumeRepublisher } from "./resume-republish.ts";
 import { createResumeRecovery } from "./resume-recover.ts";
 import {
@@ -170,6 +171,7 @@ export function filter(
   });
 
   const reconcile: Action = (tx: IExtendedStorageTransaction) => {
+    const rollback = trackListSetupRollback(tx, runtime, elementRuns);
     const elementAwaitSync = resumeBatchAwaitSync;
     // Identity-only list materialization (mirrors map.ts:163-188): read `op`
     // through the schema, but build element cells from the raw slot links
@@ -208,6 +210,10 @@ export function filter(
     ]);
 
     if (!result || result.getAsNormalizedFullLink().scope !== outputScope) {
+      const previousResult = result;
+      rollback.resultReplaced(() => {
+        result = previousResult;
+      });
       const resultSchema = listResultSchema();
       // CT-1623: identify the result container by the reserved output spot
       // (stable, program-independent). See map.ts for rationale.
@@ -368,6 +374,7 @@ export function filter(
 
       if (elementRuns.has(elementKey)) {
         const existing = elementRuns.get(elementKey)!;
+        const previousIndex = existing.lastIndex;
         if (argumentUsage.usesIndex && existing.lastIndex !== i) {
           runtime.runner.run(
             tx,
@@ -381,6 +388,7 @@ export function filter(
           );
         }
         existing.lastIndex = i;
+        if (previousIndex !== i) rollback.indexChanged(existing, previousIndex);
       } else {
         const resultCell = runtime.getCell(
           parentCell.space,
@@ -404,7 +412,9 @@ export function filter(
         setPatternCell(resultCell, parentCell.key("pattern"));
 
         addCancel(() => runtime.runner.stop(resultCell));
-        elementRuns.set(elementKey, { resultCell, lastIndex: i });
+        const entry = { resultCell, lastIndex: i };
+        elementRuns.set(elementKey, entry);
+        rollback.created(elementKey, entry);
 
         // An element first seen after the resume batch cleared, while the space
         // may still be syncing: its inline op write rode on this reconcile's

--- a/packages/runner/src/builtins/flatmap.ts
+++ b/packages/runner/src/builtins/flatmap.ts
@@ -38,6 +38,7 @@ import {
   scopedCell,
 } from "./scope-policy.ts";
 import { resolveOpPattern } from "./op-pattern-ref.ts";
+import { trackListSetupRollback } from "./list-element-rollback.ts";
 import {
   createResumeRepublisher,
   type ElementContribution,
@@ -181,6 +182,7 @@ export function flatMap(
   };
 
   const reconcile: Action = (tx: IExtendedStorageTransaction) => {
+    const rollback = trackListSetupRollback(tx, runtime, elementRuns);
     const elementAwaitSync = resumeBatchAwaitSync;
     // Identity-only list materialization (mirrors map.ts:163-188): read `op`
     // through the schema, but build element cells from the raw slot links
@@ -218,6 +220,10 @@ export function flatMap(
     ]);
 
     if (!result || result.getAsNormalizedFullLink().scope !== outputScope) {
+      const previousResult = result;
+      rollback.resultReplaced(() => {
+        result = previousResult;
+      });
       const resultSchema = listResultSchema();
       // CT-1623: identify the result container by the reserved output spot
       // (stable, program-independent). See map.ts for rationale.
@@ -374,6 +380,7 @@ export function flatMap(
 
       if (elementRuns.has(elementKey)) {
         const existing = elementRuns.get(elementKey)!;
+        const previousIndex = existing.lastIndex;
         if (argumentUsage.usesIndex && existing.lastIndex !== i) {
           runtime.runner.run(
             tx,
@@ -387,6 +394,7 @@ export function flatMap(
           );
         }
         existing.lastIndex = i;
+        if (previousIndex !== i) rollback.indexChanged(existing, previousIndex);
       } else {
         const resultCell = runtime.getCell(
           parentCell.space,
@@ -407,7 +415,9 @@ export function flatMap(
         // Link the new result cells to the pattern cell too
         setPatternCell(resultCell, parentCell.key("pattern"));
         addCancel(() => runtime.runner.stop(resultCell));
-        elementRuns.set(elementKey, { resultCell, lastIndex: i });
+        const entry = { resultCell, lastIndex: i };
+        elementRuns.set(elementKey, entry);
+        rollback.created(elementKey, entry);
 
         // An element first seen after the resume batch cleared, while the space
         // may still be syncing: its inline op write rode on this reconcile's

--- a/packages/runner/src/builtins/list-element-rollback.ts
+++ b/packages/runner/src/builtins/list-element-rollback.ts
@@ -1,0 +1,122 @@
+import type { Cell } from "../cell.ts";
+import type { Runtime } from "../runtime.ts";
+import {
+  isConflictRejection,
+  isStorageTransactionInconsistent,
+} from "../storage/rejection.ts";
+import type { IExtendedStorageTransaction } from "../storage/interface.ts";
+
+/**
+ * The per-element bookkeeping a list coordinator keeps across reconciles.
+ */
+export type ElementRun = {
+  resultCell: Cell<any>;
+  lastIndex: number;
+};
+
+export interface ListSetupRollback {
+  /** An entry this reconcile added to the coordinator's element map. */
+  created(elementKey: string, entry: ElementRun): void;
+  /** An index this reconcile moved, with the value it moved away from. */
+  indexChanged(entry: ElementRun, previousIndex: number): void;
+  /** A result container this reconcile installed, with a restore for the old one. */
+  resultReplaced(restore: () => void): void;
+}
+
+/**
+ * Undo a reconcile's in-memory bookkeeping when its transaction does not become
+ * durable.
+ *
+ * A reconcile records an element's result cell and index in plain memory while
+ * writing that element's setup through its transaction. The memory survives a
+ * transaction that is rejected or aborted, so the next reconcile finds the entry,
+ * reuses it, and never re-runs the setup whose writes are gone. The element then
+ * has no pattern and reads as undefined for as long as the coordinator lives.
+ *
+ * A stale basis is the exception. A conflict or a local inconsistency re-runs
+ * the same reconcile against fresh state, and that re-run is what converges;
+ * it reuses this bookkeeping and re-issues only the writes it still needs.
+ * Tearing the bookkeeping down under it makes each attempt rebuild the elements
+ * it just discarded, and the reconcile stops converging altogether. Every other
+ * outcome — an abort, a terminal or permanent refusal, a transport failure —
+ * has no such re-run behind it, so the record has to go.
+ *
+ * Each undo checks that the state it is about to revert is still the state this
+ * reconcile installed. An overlapping reconcile that has already moved the same
+ * entry owns it, and its bookkeeping matches durable writes of its own.
+ */
+export function trackListSetupRollback(
+  tx: IExtendedStorageTransaction,
+  runtime: Runtime,
+  elementRuns: Map<string, ElementRun>,
+): ListSetupRollback {
+  const created = new Map<string, ElementRun>();
+  const indexChanges = new Map<
+    ElementRun,
+    { from: number; to: number }
+  >();
+  const resultRestores: Array<() => void> = [];
+  let registered = false;
+
+  const registerRollback = (): void => {
+    if (registered) return;
+    registered = true;
+    tx.addCommitCallback((_settledTx, result) => {
+      if (!result.error) return;
+      if (
+        isConflictRejection(result.error) ||
+        isStorageTransactionInconsistent(result.error)
+      ) {
+        return;
+      }
+      const errors: unknown[] = [];
+      for (const [elementKey, entry] of created) {
+        if (elementRuns.get(elementKey) !== entry) continue;
+        elementRuns.delete(elementKey);
+        indexChanges.delete(entry);
+        try {
+          runtime.runner.stop(entry.resultCell);
+        } catch (error) {
+          errors.push(error);
+        }
+      }
+      for (const [entry, { from, to }] of indexChanges) {
+        if (entry.lastIndex === to) entry.lastIndex = from;
+      }
+      for (const restore of resultRestores) {
+        try {
+          restore();
+        } catch (error) {
+          errors.push(error);
+        }
+      }
+      if (errors.length === 1) throw errors[0];
+      if (errors.length > 1) {
+        throw new AggregateError(
+          errors,
+          "Multiple list element rollbacks failed",
+        );
+      }
+    });
+  };
+
+  return {
+    created(elementKey, entry) {
+      created.set(elementKey, entry);
+      registerRollback();
+    },
+    indexChanged(entry, previousIndex) {
+      const existing = indexChanges.get(entry);
+      if (existing) {
+        existing.to = entry.lastIndex;
+      } else {
+        indexChanges.set(entry, { from: previousIndex, to: entry.lastIndex });
+      }
+      registerRollback();
+    },
+    resultReplaced(restore) {
+      resultRestores.push(restore);
+      registerRollback();
+    },
+  };
+}

--- a/packages/runner/src/builtins/map.ts
+++ b/packages/runner/src/builtins/map.ts
@@ -46,6 +46,7 @@ import {
   machineryRead,
 } from "../storage/reactivity-log.ts";
 import { resolveOpPattern } from "./op-pattern-ref.ts";
+import { trackListSetupRollback } from "./list-element-rollback.ts";
 import { getLogger } from "@commonfabric/utils/logger";
 
 const logger = getLogger("runner.map", { enabled: true, level: "warn" });
@@ -149,6 +150,7 @@ export function map(
   };
 
   const reconcile: Action = (tx: IExtendedStorageTransaction) => {
+    const rollback = trackListSetupRollback(tx, runtime, elementRuns);
     // Captured before the loop consumes it: this reconcile's element runs use
     // the current value; the flag is cleared only once a non-empty resume batch
     // has been processed (below), so a transient empty first reconcile doesn't
@@ -198,6 +200,10 @@ export function map(
     const argumentUsage = inferListOpArgumentUsage(opPattern);
 
     if (!result || result.getAsNormalizedFullLink().scope !== listScope) {
+      const previousResult = result;
+      rollback.resultReplaced(() => {
+        result = previousResult;
+      });
       const resultSchema = listResultSchema(opPattern.resultSchema);
       // CT-1623: identify the result container by the reserved output spot —
       // the fully-resolved write-redirect target the runner supplies as the
@@ -354,6 +360,7 @@ export function map(
 
       if (elementRuns.has(elementKey)) {
         const existing = elementRuns.get(elementKey)!;
+        const previousIndex = existing.lastIndex;
         if (argumentUsage.usesIndex && existing.lastIndex !== i) {
           runtime.runner.run(
             tx,
@@ -367,6 +374,7 @@ export function map(
           );
         }
         existing.lastIndex = i;
+        if (previousIndex !== i) rollback.indexChanged(existing, previousIndex);
         newArrayValue[i] = exposedResultCell(runtime, tx, existing.resultCell);
       } else {
         const resultCell = runtime.getCell(
@@ -390,7 +398,9 @@ export function map(
         // Link the new result cells to the pattern cell too
         setPatternCell(resultCell, parentCell.key("pattern"));
         addCancel(() => runtime.runner.stop(resultCell));
-        elementRuns.set(elementKey, { resultCell, lastIndex: i });
+        const entry = { resultCell, lastIndex: i };
+        elementRuns.set(elementKey, entry);
+        rollback.created(elementKey, entry);
         newArrayValue[i] = exposedResultCell(runtime, tx, resultCell);
       }
     }

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -1359,10 +1359,10 @@ export class CellImpl<T extends FabricValue>
   set(
     newValue: AnyCellWrapping<T> | T,
     /**
-     * Internal-only commit callback. This runs after this transaction's final
-     * commit result, including failure, so it must remain non-effectful. Use
-     * the post-commit outbox for external side effects that must happen only
-     * after success.
+     * Internal-only settle callback. This runs once this transaction reaches
+     * its final outcome, which includes a rejected commit and an abort, so it
+     * must remain non-effectful. Use the post-commit outbox for external side
+     * effects that must happen only after success.
      */
     onCommit?: (tx: IExtendedStorageTransaction) => void,
     /**

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -5387,9 +5387,19 @@ export class Runner {
       addCancel(() => this.stop(resultCell));
 
       tx.addCommitCallback((_committedTx, result) => {
-        if (result.error) {
-          this.stop(resultCell);
+        if (!result.error) return;
+        // Stopping the child is only half of the rollback: this memo of what
+        // the result cell holds decides whether the next run materializes the
+        // child again. A rejected commit rolls the child's links back and the
+        // notification for that rollback clears the memo, but an abort settles
+        // without reaching storage, so clear it here. Left set, the memo makes
+        // the next run treat the pattern as unchanged and skip a child that
+        // now exists nowhere. Cleared ahead of the stop, so a materialization
+        // that stopping re-enters keeps the memo it writes.
+        if (this.resultPatternCache.get(cacheKey) === resultPatternKey) {
+          this.resultPatternCache.delete(cacheKey);
         }
+        this.stop(resultCell);
       });
       this.pullCellOnceAfterSuccessfulCommit(tx, resultCell);
     }

--- a/packages/runner/src/scheduler/run.ts
+++ b/packages/runner/src/scheduler/run.ts
@@ -14,6 +14,7 @@ import {
   isStorageTransactionInconsistent,
   isTerminalRejection,
 } from "../storage/rejection.ts";
+import { createDuplicateWorkTransaction } from "../storage/extended-storage-transaction.ts";
 import { sortAndCompactPaths } from "../reactive-dependencies.ts";
 import {
   MAX_ACTION_RUN_TRACE_HISTORY,
@@ -898,7 +899,9 @@ function recordOptionalActionRunDiagnostics(
       runIdempotencyRecheck(
         {
           idempotencyViolations: state.idempotencyViolations,
-          createTx: () => state.runtime.edit(),
+          // The recheck re-runs the action only to compare its writes with the
+          // run that already happened, then throws the transaction away.
+          createTx: () => createDuplicateWorkTransaction(state.runtime.edit()),
           invoke: (fn) => state.runtime.harness.invoke(fn),
           getActionId: state.getActionId,
           getActionTelemetryInfo: state.getActionTelemetryInfo,

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -40,6 +40,7 @@ import type {
   SqliteOperation,
 } from "@commonfabric/memory/v2";
 import type { MergeableOpDelta } from "./mergeable-ops.ts";
+import { TransactionAborted } from "./transaction-errors.ts";
 import {
   getDirectTransactionReactivityLog,
   getTransactionReadActivities,
@@ -1752,7 +1753,14 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     this.#cfcState.prepare = { status: "unprepared" };
     this.#cfcState.dereferenceTraces = [];
     this.#cfcState.structureContainers = [];
-    return this.tx.abort(reason);
+    const result = this.tx.abort(reason);
+    // An abort is a terminal outcome, and it discards the staged writes the
+    // same way a rejected commit does. Settle callbacks compensate for writes
+    // that did not become durable, so they run here as well.
+    if (!result.error) {
+      this.runCommitCallbacks({ error: TransactionAborted(reason) });
+    }
+    return result;
   }
 
   private runCommitCallbacks(result: Result<Unit, CommitError>): void {
@@ -1972,6 +1980,14 @@ export interface TransactionWrapperOptions {
    * wrapped transaction.
    */
   childCellTx?: IExtendedStorageTransaction;
+
+  /**
+   * If true, drops settle callbacks instead of registering them. For work that
+   * duplicates what another transaction already carries: the state such a
+   * callback would compensate for belongs to the original, so this transaction
+   * has nothing to take back when it ends.
+   */
+  discardSettleCallbacks?: boolean;
 }
 
 /**
@@ -2343,8 +2359,25 @@ export class TransactionWrapper implements IExtendedStorageTransaction {
       result: Result<Unit, CommitError>,
     ) => void,
   ): void {
+    if (this.options.discardSettleCallbacks === true) return;
     return this.wrapped.addCommitCallback(callback);
   }
+}
+
+/**
+ * Create a transaction wrapper for work that re-runs what another transaction
+ * already carries, so the two can be compared, and is discarded afterwards.
+ *
+ * The re-run registers the same settle callbacks the original did. Those
+ * callbacks undo in-memory state on the way to a transaction that did not
+ * become durable, and here the state belongs to the original run, which has
+ * already committed it — so this wrapper drops them rather than letting the
+ * discard tear down live state the original owns.
+ */
+export function createDuplicateWorkTransaction(
+  tx: IExtendedStorageTransaction,
+): TransactionWrapper {
+  return new TransactionWrapper(tx, { discardSettleCallbacks: true });
 }
 
 /**

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -1330,19 +1330,27 @@ export interface IExtendedStorageTransaction extends IStorageTransaction {
   hasPendingPostCommitEffects(): boolean;
 
   /**
-   * Add a callback to be called when the transaction commit completes.
-   * The callback receives the transaction as a parameter and is called
-   * regardless of whether the commit succeeded or failed.
+   * Add a callback to be called when the transaction settles. The callback
+   * receives the transaction as a parameter and is called regardless of
+   * whether the commit succeeded or failed. `abort()` settles the transaction
+   * too, and delivers a `StorageTransactionAborted` error to the callback: the
+   * writes it staged are discarded either way, so a callback that compensates
+   * a failed commit describes the rollback an abort performs as well.
    *
    * Internal-only hook. Callbacks may run after failed commits and therefore
    * must not perform external side effects or release external requests. Use
    * the CFC post-commit outbox for effectful work that should happen only after
    * a successful commit.
    *
-   * Note: Callbacks are called synchronously after commit completes.
+   * A callback that undoes in-memory state must check that the state it is
+   * about to undo is still the state this transaction established. Another
+   * transaction can reach the same deterministic address and take ownership
+   * before this one settles.
+   *
+   * Note: Callbacks are called synchronously after the transaction settles.
    * If a callback throws, the error is logged but doesn't affect other callbacks.
    *
-   * @param callback - Function to call after commit
+   * @param callback - Function to call when the transaction settles
    */
   addCommitCallback(
     callback: (

--- a/packages/runner/test/cell-callbacks.test.ts
+++ b/packages/runner/test/cell-callbacks.test.ts
@@ -129,7 +129,7 @@ describe("Cell commit callbacks", () => {
     expect(callOrder).toEqual([1, 2]);
   });
 
-  it("should not call callback if transaction fails", () => {
+  it("should call callback when the transaction is aborted", () => {
     const cell = runtime.getCell<number>(
       space,
       "callback-fail-test",
@@ -137,16 +137,18 @@ describe("Cell commit callbacks", () => {
       tx,
     );
 
-    let callbackCalled = false;
+    const statuses: string[] = [];
 
-    cell.set(42, () => {
-      callbackCalled = true;
+    cell.set(42, (settledTx) => {
+      statuses.push(settledTx.status().status);
     });
 
-    // Abort the transaction instead of committing
+    // An abort discards the staged writes exactly as a rejected commit does,
+    // and the callback exists to compensate for writes that did not become
+    // durable. It reports the same errored transaction either way.
     tx.abort("test abort");
 
-    expect(callbackCalled).toBe(false);
+    expect(statuses).toEqual(["error"]);
   });
 
   it("should call callback when commit returns an error", async () => {

--- a/packages/runner/test/child-pattern-start-ownership.test.ts
+++ b/packages/runner/test/child-pattern-start-ownership.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+
+// A computation that returns a pattern launches a child piece under an address
+// derived from the computation's own result cell. Every later run of that
+// computation reaches the same address and hands the running child a new
+// pattern identity rather than installing a registration of its own, so one
+// registration is shared by every run. Stopping that registration is what
+// recovers the child when a run's setup does not become durable: the next run
+// finds nothing registered and materializes the child again. A compensation
+// narrowed to the run that installed the registration would recover nothing
+// here, because the runs that follow install none.
+
+const signer = await Identity.fromPassphrase("child pattern start ownership");
+const space = signer.did();
+
+type TransactMessage = { requestId: string };
+type TransactResponse = {
+  type: "response";
+  requestId: string;
+  ok?: unknown;
+  error?: { name: string; message: string };
+};
+type TestMemoryServer = {
+  transact(message: TransactMessage): Promise<TransactResponse>;
+};
+
+// Hold the first commit whose payload mentions a marker, and decide its outcome
+// later. Every other commit passes through, so the runs that follow the held one
+// settle while it waits.
+function holdCommitCarrying(
+  storageManager: ReturnType<typeof StorageManager.emulate>,
+  marker: string,
+): {
+  held: Promise<void>;
+  reject(): void;
+  restore(): void;
+} {
+  const server = (storageManager as unknown as { server(): TestMemoryServer })
+    .server();
+  const original = server.transact.bind(server);
+  const held = Promise.withResolvers<void>();
+  const release = Promise.withResolvers<void>();
+  let holding = false;
+
+  server.transact = (message) => {
+    if (!holding && JSON.stringify(message).includes(marker)) {
+      holding = true;
+      held.resolve();
+      return release.promise.then(() => ({
+        type: "response" as const,
+        requestId: message.requestId,
+        error: {
+          name: "ConflictError",
+          message: "forced child ownership test conflict",
+        },
+      }));
+    }
+    return original(message);
+  };
+
+  return {
+    held: held.promise,
+    reject: () => release.resolve(),
+    restore: () => {
+      server.transact = original;
+    },
+  };
+}
+
+describe("a computation-produced child", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+  });
+
+  afterEach(async () => {
+    await runtime.dispose();
+    await storageManager.close();
+  });
+
+  it("converges after a superseded setup commit is rejected", async () => {
+    const { cell, lift, pattern } = createTrustedBuilder(runtime).commonfabric;
+    const childPattern = pattern<{ source: number }>(({ source }) => ({
+      doubled: lift((value: number) => value * 2)(source),
+    }));
+    const produceChild = lift((source: number) => childPattern({ source }));
+    const rootPattern = pattern(() => {
+      const source = cell(1);
+      return { source, child: produceChild(source) };
+    });
+
+    const setupTx = runtime.edit();
+    const rootCell = runtime.getCell<{ source: number; child: unknown }>(
+      space,
+      "child ownership root",
+      undefined,
+      setupTx,
+    );
+    const root = runtime.run(setupTx, rootPattern, {}, rootCell);
+    await setupTx.commit();
+    await runtime.idle();
+    const stopReading = root.key("child").sink(() => {});
+
+    try {
+      await runtime.idle();
+      const registrationsWithChild = runtime.runner.cancels.size;
+      expect(registrationsWithChild).toBeGreaterThan(1);
+
+      // The run that hands the child the pattern for source 2 has its commit
+      // held. The run for source 3 supersedes it and commits normally.
+      const supersededRun = holdCommitCarrying(
+        storageManager,
+        "/patternIdentity",
+      );
+      try {
+        const bumpTx = runtime.edit();
+        root.key("source").withTx(bumpTx).set(2);
+        await bumpTx.commit();
+        await supersededRun.held;
+
+        // The third write only has to reach the local replica for the
+        // computation to re-run. Its commit queues behind the held one, so
+        // awaiting it here would deadlock.
+        const thirdTx = runtime.edit();
+        root.key("source").withTx(thirdTx).set(3);
+        const thirdCommit = thirdTx.commit();
+        await runtime.idle();
+
+        supersededRun.reject();
+        expect((await thirdCommit).error).toBeUndefined();
+        await runtime.idle();
+      } finally {
+        supersededRun.restore();
+      }
+
+      await runtime.idle();
+      await root.pull();
+
+      expect(runtime.runner.cancels.size).toBe(registrationsWithChild);
+      expect(root.key("child").key("doubled").get()).toBe(6);
+    } finally {
+      stopReading();
+    }
+  });
+});

--- a/packages/runner/test/list-element-rollback.test.ts
+++ b/packages/runner/test/list-element-rollback.test.ts
@@ -1,0 +1,514 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { Identity } from "@commonfabric/identity";
+import type { Cell } from "../src/cell.ts";
+import { Runtime as RuntimeClass } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+import type { Runtime } from "../src/runtime.ts";
+import {
+  type ElementRun,
+  trackListSetupRollback,
+} from "../src/builtins/list-element-rollback.ts";
+import type {
+  CommitError,
+  IExtendedStorageTransaction,
+  Result,
+  Unit,
+} from "../src/storage/interface.ts";
+
+// A reconcile's element bookkeeping is plain memory that has to follow the fate
+// of the transaction carrying the matching setup writes. These drive the
+// rollback directly, so each settle outcome and each ownership case is reached
+// on its own rather than through whichever one a coordinator happens to hit.
+
+type SettleableTx = IExtendedStorageTransaction & {
+  settle(result: Result<Unit, CommitError>): void;
+  callbackCount(): number;
+};
+
+function createSettleableTx(): SettleableTx {
+  const callbacks: Array<
+    (tx: IExtendedStorageTransaction, result: Result<Unit, CommitError>) => void
+  > = [];
+  const tx = {
+    addCommitCallback(
+      callback: (
+        tx: IExtendedStorageTransaction,
+        result: Result<Unit, CommitError>,
+      ) => void,
+    ): void {
+      callbacks.push(callback);
+    },
+    settle(result: Result<Unit, CommitError>): void {
+      for (const callback of callbacks) callback(tx as SettleableTx, result);
+    },
+    callbackCount: () => callbacks.length,
+  };
+  return tx as unknown as SettleableTx;
+}
+
+function createStoppingRuntime(): {
+  runtime: Runtime;
+  stopped: Cell<any>[];
+  failOn(cell: Cell<any>, error: Error): void;
+} {
+  const stopped: Cell<any>[] = [];
+  const failures = new Map<Cell<any>, Error>();
+  const runtime = {
+    runner: {
+      stop(cell: Cell<any>) {
+        stopped.push(cell);
+        const failure = failures.get(cell);
+        if (failure) throw failure;
+      },
+    },
+  };
+  return {
+    runtime: runtime as unknown as Runtime,
+    stopped,
+    failOn: (cell, error) => failures.set(cell, error),
+  };
+}
+
+function elementCell(name: string): Cell<any> {
+  return { toString: () => name } as unknown as Cell<any>;
+}
+
+const aborted: Result<Unit, CommitError> = {
+  error: {
+    name: "StorageTransactionAborted",
+    message: "aborted",
+    reason: new Error("aborted"),
+  },
+};
+const conflict: Result<Unit, CommitError> = {
+  error: { name: "ConflictError", message: "conflict" } as CommitError,
+};
+const inconsistent: Result<Unit, CommitError> = {
+  error: {
+    name: "StorageTransactionInconsistent",
+    message: "stale basis",
+  } as CommitError,
+};
+const committed: Result<Unit, CommitError> = { ok: {} };
+
+describe("list element rollback", () => {
+  it("registers nothing until a reconcile installs something", () => {
+    const tx = createSettleableTx();
+    const elementRuns = new Map<string, ElementRun>();
+    trackListSetupRollback(tx, createStoppingRuntime().runtime, elementRuns);
+
+    expect(tx.callbackCount()).toBe(0);
+  });
+
+  it("drops a created entry and stops its piece when the setup aborts", () => {
+    const tx = createSettleableTx();
+    const { runtime, stopped } = createStoppingRuntime();
+    const elementRuns = new Map<string, ElementRun>();
+    const rollback = trackListSetupRollback(tx, runtime, elementRuns);
+
+    const entry: ElementRun = { resultCell: elementCell("a"), lastIndex: 0 };
+    elementRuns.set("a", entry);
+    rollback.created("a", entry);
+
+    tx.settle(aborted);
+
+    expect(elementRuns.has("a")).toBe(false);
+    expect(stopped).toEqual([entry.resultCell]);
+  });
+
+  it("keeps everything when the setup commits", () => {
+    const tx = createSettleableTx();
+    const { runtime, stopped } = createStoppingRuntime();
+    const elementRuns = new Map<string, ElementRun>();
+    const rollback = trackListSetupRollback(tx, runtime, elementRuns);
+
+    const entry: ElementRun = { resultCell: elementCell("a"), lastIndex: 0 };
+    elementRuns.set("a", entry);
+    rollback.created("a", entry);
+
+    tx.settle(committed);
+
+    expect(elementRuns.get("a")).toBe(entry);
+    expect(stopped).toEqual([]);
+  });
+
+  for (
+    const [label, outcome] of [
+      ["a conflict", conflict],
+      ["a local inconsistency", inconsistent],
+    ] as const
+  ) {
+    it(`keeps everything through ${label}, which re-runs instead`, () => {
+      const tx = createSettleableTx();
+      const { runtime, stopped } = createStoppingRuntime();
+      const elementRuns = new Map<string, ElementRun>();
+      const rollback = trackListSetupRollback(tx, runtime, elementRuns);
+
+      const entry: ElementRun = { resultCell: elementCell("a"), lastIndex: 2 };
+      elementRuns.set("a", entry);
+      rollback.created("a", entry);
+      entry.lastIndex = 5;
+      rollback.indexChanged(entry, 2);
+      let restored = false;
+      rollback.resultReplaced(() => {
+        restored = true;
+      });
+
+      tx.settle(outcome);
+
+      // The re-run reuses this bookkeeping; discarding it would make each
+      // attempt rebuild what the last one threw away.
+      expect(elementRuns.get("a")).toBe(entry);
+      expect(entry.lastIndex).toBe(5);
+      expect(stopped).toEqual([]);
+      expect(restored).toBe(false);
+    });
+  }
+
+  it("leaves an entry a later reconcile replaced", () => {
+    const tx = createSettleableTx();
+    const { runtime, stopped } = createStoppingRuntime();
+    const elementRuns = new Map<string, ElementRun>();
+    const rollback = trackListSetupRollback(tx, runtime, elementRuns);
+
+    const entry: ElementRun = { resultCell: elementCell("a"), lastIndex: 0 };
+    elementRuns.set("a", entry);
+    rollback.created("a", entry);
+
+    const replacement: ElementRun = {
+      resultCell: elementCell("a-replacement"),
+      lastIndex: 0,
+    };
+    elementRuns.set("a", replacement);
+
+    tx.settle(aborted);
+
+    expect(elementRuns.get("a")).toBe(replacement);
+    expect(stopped).toEqual([]);
+  });
+
+  it("restores an index it moved", () => {
+    const tx = createSettleableTx();
+    const elementRuns = new Map<string, ElementRun>();
+    const rollback = trackListSetupRollback(
+      tx,
+      createStoppingRuntime().runtime,
+      elementRuns,
+    );
+
+    const entry: ElementRun = { resultCell: elementCell("a"), lastIndex: 1 };
+    elementRuns.set("a", entry);
+    entry.lastIndex = 4;
+    rollback.indexChanged(entry, 1);
+
+    tx.settle(aborted);
+
+    expect(entry.lastIndex).toBe(1);
+  });
+
+  it("keeps the first index it moved away from across two moves", () => {
+    const tx = createSettleableTx();
+    const elementRuns = new Map<string, ElementRun>();
+    const rollback = trackListSetupRollback(
+      tx,
+      createStoppingRuntime().runtime,
+      elementRuns,
+    );
+
+    const entry: ElementRun = { resultCell: elementCell("a"), lastIndex: 1 };
+    elementRuns.set("a", entry);
+    entry.lastIndex = 4;
+    rollback.indexChanged(entry, 1);
+    entry.lastIndex = 7;
+    rollback.indexChanged(entry, 4);
+
+    tx.settle(aborted);
+
+    expect(entry.lastIndex).toBe(1);
+  });
+
+  it("leaves an index a later reconcile moved again", () => {
+    const tx = createSettleableTx();
+    const elementRuns = new Map<string, ElementRun>();
+    const rollback = trackListSetupRollback(
+      tx,
+      createStoppingRuntime().runtime,
+      elementRuns,
+    );
+
+    const entry: ElementRun = { resultCell: elementCell("a"), lastIndex: 1 };
+    elementRuns.set("a", entry);
+    entry.lastIndex = 4;
+    rollback.indexChanged(entry, 1);
+    // A later reconcile owns the entry now, and its index matches writes of
+    // its own.
+    entry.lastIndex = 9;
+
+    tx.settle(aborted);
+
+    expect(entry.lastIndex).toBe(9);
+  });
+
+  it("restores a result container it installed", () => {
+    const tx = createSettleableTx();
+    const rollback = trackListSetupRollback(
+      tx,
+      createStoppingRuntime().runtime,
+      new Map<string, ElementRun>(),
+    );
+
+    let container: string | undefined = "installed";
+    const previous = undefined;
+    rollback.resultReplaced(() => {
+      container = previous;
+    });
+
+    tx.settle(aborted);
+
+    expect(container).toBeUndefined();
+  });
+
+  it("does not restore an index belonging to an entry it dropped", () => {
+    const tx = createSettleableTx();
+    const { runtime } = createStoppingRuntime();
+    const elementRuns = new Map<string, ElementRun>();
+    const rollback = trackListSetupRollback(tx, runtime, elementRuns);
+
+    const entry: ElementRun = { resultCell: elementCell("a"), lastIndex: 3 };
+    elementRuns.set("a", entry);
+    rollback.created("a", entry);
+    entry.lastIndex = 6;
+    rollback.indexChanged(entry, 3);
+
+    tx.settle(aborted);
+
+    // The entry is gone, so its index is not restored to a slot it no longer
+    // occupies.
+    expect(elementRuns.has("a")).toBe(false);
+    expect(entry.lastIndex).toBe(6);
+  });
+
+  it("surfaces a single failing stop", () => {
+    const tx = createSettleableTx();
+    const { runtime, failOn } = createStoppingRuntime();
+    const elementRuns = new Map<string, ElementRun>();
+    const rollback = trackListSetupRollback(tx, runtime, elementRuns);
+
+    const entry: ElementRun = { resultCell: elementCell("a"), lastIndex: 0 };
+    elementRuns.set("a", entry);
+    rollback.created("a", entry);
+    const failure = new Error("stop failed");
+    failOn(entry.resultCell, failure);
+
+    expect(() => tx.settle(aborted)).toThrow(failure);
+    expect(elementRuns.has("a")).toBe(false);
+  });
+
+  it("surfaces a failing container restore", () => {
+    const tx = createSettleableTx();
+    const rollback = trackListSetupRollback(
+      tx,
+      createStoppingRuntime().runtime,
+      new Map<string, ElementRun>(),
+    );
+
+    const failure = new Error("restore failed");
+    rollback.resultReplaced(() => {
+      throw failure;
+    });
+
+    expect(() => tx.settle(aborted)).toThrow(failure);
+  });
+
+  it("runs the remaining rollbacks after a container restore throws", () => {
+    const tx = createSettleableTx();
+    const { runtime, stopped } = createStoppingRuntime();
+    const elementRuns = new Map<string, ElementRun>();
+    const rollback = trackListSetupRollback(tx, runtime, elementRuns);
+
+    const entry: ElementRun = { resultCell: elementCell("a"), lastIndex: 0 };
+    elementRuns.set("a", entry);
+    rollback.created("a", entry);
+    rollback.resultReplaced(() => {
+      throw new Error("first restore failed");
+    });
+    let secondRestored = false;
+    rollback.resultReplaced(() => {
+      secondRestored = true;
+    });
+
+    expect(() => tx.settle(aborted)).toThrow();
+
+    expect(stopped).toEqual([entry.resultCell]);
+    expect(secondRestored).toBe(true);
+  });
+
+  it("aggregates several failing rollbacks and still runs them all", () => {
+    const tx = createSettleableTx();
+    const { runtime, failOn, stopped } = createStoppingRuntime();
+    const elementRuns = new Map<string, ElementRun>();
+    const rollback = trackListSetupRollback(tx, runtime, elementRuns);
+
+    const first: ElementRun = { resultCell: elementCell("a"), lastIndex: 0 };
+    const second: ElementRun = { resultCell: elementCell("b"), lastIndex: 1 };
+    elementRuns.set("a", first);
+    elementRuns.set("b", second);
+    rollback.created("a", first);
+    rollback.created("b", second);
+    failOn(first.resultCell, new Error("first stop failed"));
+    failOn(second.resultCell, new Error("second stop failed"));
+
+    let thrown: unknown;
+    try {
+      tx.settle(aborted);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(AggregateError);
+    expect((thrown as AggregateError).errors.length).toBe(2);
+    expect(stopped.length).toBe(2);
+    expect(elementRuns.size).toBe(0);
+  });
+});
+
+// The coordinators install their result container and create their first
+// element in one reconcile. When that reconcile's transaction is discarded,
+// both records have to go: the container so the next reconcile re-links it, and
+// the element so the next reconcile re-runs a setup whose writes are gone.
+
+const coordinatorSigner = await Identity.fromPassphrase(
+  "list element rollback coordinators",
+);
+const coordinatorSpace = coordinatorSigner.did();
+
+type ListOp =
+  | "mapWithPattern"
+  | "filterWithPattern"
+  | "flatMapWithPattern";
+
+describe("a list coordinator whose first reconcile is discarded", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: RuntimeClass;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: coordinatorSigner });
+    runtime = new RuntimeClass({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+  });
+
+  afterEach(async () => {
+    await runtime.dispose();
+    await storageManager.close();
+  });
+
+  // Abort the transaction carrying the first per-element setup, at the moment
+  // it is committed, so the reconcile runs to completion and then loses
+  // everything it staged.
+  function abortFirstElementSetup(): {
+    restore(): void;
+    aborted(): boolean;
+  } {
+    const originalRun = runtime.runner.run;
+    let didAbort = false;
+    let setups = 0;
+    runtime.runner.run = ((...args: Parameters<typeof originalRun>) => {
+      const run = Reflect.apply(originalRun, runtime.runner, args);
+      const options = args[4] as
+        | { doNotUpdateOnPatternChange?: boolean }
+        | undefined;
+      if (options?.doNotUpdateOnPatternChange !== true) return run;
+      setups++;
+      if (setups === 1) {
+        const childTx = args[0];
+        if (childTx === undefined) {
+          throw new Error("element setup had no transaction");
+        }
+        const originalCommit = childTx.commit.bind(childTx);
+        childTx.commit = (() => {
+          expect(childTx.abort("abort the first element setup").error)
+            .toBeUndefined();
+          didAbort = true;
+          return originalCommit();
+        }) as typeof childTx.commit;
+      }
+      return run;
+    }) as typeof runtime.runner.run;
+    return {
+      restore: () => {
+        runtime.runner.run = originalRun;
+      },
+      aborted: () => didAbort,
+    };
+  }
+
+  async function runListPattern(
+    listOp: ListOp,
+    opBody: (element: any) => any,
+    label: string,
+  ): Promise<Cell<any>> {
+    const { cell, lift, pattern } = createTrustedBuilder(runtime).commonfabric;
+    const operation = pattern<{ element: number }>(({ element }) =>
+      lift(opBody)(element)
+    );
+    const parentPattern = pattern(() => {
+      // Non-empty from the start, so one reconcile installs the container and
+      // creates the element together.
+      const items = cell<number[]>([3]);
+      return {
+        items,
+        derived: (items as unknown as Record<string, any>)[listOp](
+          operation,
+          {},
+        ),
+      };
+    });
+    const setupTx = runtime.edit();
+    const parent = runtime.getCell<{ items: number[]; derived: unknown }>(
+      coordinatorSpace,
+      label,
+      undefined,
+      setupTx,
+    );
+    const result = runtime.run(setupTx, parentPattern, {}, parent);
+    expect((await setupTx.commit()).error).toBeUndefined();
+    return result;
+  }
+
+  for (
+    const [name, listOp, opBody, expected] of [
+      ["map", "mapWithPattern", (value: number) => value * 2, [6]],
+      ["filter", "filterWithPattern", (value: number) => value > 1, [3]],
+      ["flatMap", "flatMapWithPattern", (value: number) => [value, value], [
+        3,
+        3,
+      ]],
+    ] as const
+  ) {
+    it(`rebuilds a ${name} element and its container`, async () => {
+      const abort = abortFirstElementSetup();
+      try {
+        const result = await runListPattern(
+          listOp,
+          opBody,
+          `discarded first reconcile ${name}`,
+        );
+        const stopReading = result.key("derived").sink(() => {});
+        try {
+          await runtime.scheduler.idleWithPendingCommits();
+          expect(abort.aborted()).toBe(true);
+          expect(await result.key("derived").pull()).toEqual([...expected]);
+        } finally {
+          stopReading();
+        }
+      } finally {
+        abort.restore();
+      }
+    });
+  }
+});

--- a/packages/runner/test/transaction-abort-settlement.test.ts
+++ b/packages/runner/test/transaction-abort-settlement.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+import type { EventHandler } from "../src/scheduler/types.ts";
+import type { CommitError } from "../src/storage/interface.ts";
+
+// A transaction settles in one of three ways: its commit succeeds, its commit
+// is rejected, or it is aborted. All three end the transaction and decide the
+// fate of the writes it staged, so all three reach the callbacks registered to
+// compensate for writes that did not become durable.
+//
+// Work that re-runs what another transaction already carries is the exception,
+// because it never attempted the work its callbacks describe. The idempotency
+// recheck is the one that exists: it re-runs each computation against a
+// throwaway transaction to compare the writes, then aborts it, and takes that
+// transaction from createDuplicateWorkTransaction so it registers no callbacks
+// to settle.
+
+const signer = await Identity.fromPassphrase("transaction abort settlement");
+const space = signer.did();
+
+describe("an aborted transaction", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+  });
+
+  afterEach(async () => {
+    await runtime.dispose();
+    await storageManager.close();
+  });
+
+  it("settles its callbacks with an aborted outcome", () => {
+    const cell = runtime.getCell<{ value: number }>(
+      space,
+      "abort settles callbacks",
+      undefined,
+    );
+    const tx = runtime.edit();
+    cell.withTx(tx).set({ value: 1 });
+
+    const outcomes: (CommitError | undefined)[] = [];
+    tx.addCommitCallback((_settledTx, result) => {
+      outcomes.push(result.error);
+    });
+
+    tx.abort("aborted by test");
+
+    expect(outcomes.length).toBe(1);
+    expect(outcomes[0]?.name).toBe("StorageTransactionAborted");
+  });
+
+  it("settles its callbacks exactly once", async () => {
+    const cell = runtime.getCell<{ value: number }>(
+      space,
+      "abort settles once",
+      undefined,
+    );
+    const tx = runtime.edit();
+    cell.withTx(tx).set({ value: 1 });
+
+    let settlements = 0;
+    tx.addCommitCallback(() => {
+      settlements++;
+    });
+
+    tx.abort("aborted by test");
+    const commit = await tx.commit();
+
+    expect(commit.error).toBeDefined();
+    expect(settlements).toBe(1);
+  });
+
+  it("drops a follow-up event sent by a handler that then throws", async () => {
+    const setupTx = runtime.edit();
+    const origin = runtime.getCell<unknown>(
+      space,
+      "abort lineage origin stream",
+      undefined,
+      setupTx,
+    );
+    const followUp = runtime.getCell<unknown>(
+      space,
+      "abort lineage follow-up stream",
+      undefined,
+      setupTx,
+    );
+    const delivered = runtime.getCell<unknown[]>(
+      space,
+      "abort lineage delivered payloads",
+      undefined,
+      setupTx,
+    );
+    origin.withTx(setupTx).set({ $stream: true });
+    followUp.withTx(setupTx).set({ $stream: true });
+    delivered.withTx(setupTx).set([]);
+    await setupTx.commit();
+
+    let errors = 0;
+    runtime.scheduler.onError(() => {
+      errors++;
+    });
+
+    // The origin handler's transaction is aborted when the handler throws, so
+    // its writes never become durable. The follow-up it sent describes work
+    // that depends on those writes.
+    const originHandler: EventHandler = (handlerTx) => {
+      runtime.scheduler.queueEvent(
+        followUp.getAsNormalizedFullLink(),
+        "follow-up payload",
+        undefined,
+        undefined,
+        false,
+        { originTx: handlerTx },
+      );
+      throw new Error("origin handler failed after sending a follow-up");
+    };
+    const followUpHandler: EventHandler = (handlerTx, event: unknown) => {
+      const current = delivered.withTx(handlerTx).get();
+      delivered.withTx(handlerTx).set([...current, event]);
+    };
+
+    runtime.scheduler.addEventHandler(
+      originHandler,
+      origin.getAsNormalizedFullLink(),
+    );
+    runtime.scheduler.addEventHandler(
+      followUpHandler,
+      followUp.getAsNormalizedFullLink(),
+    );
+
+    // An origin left unsettled parks its follow-up at the head of the queue
+    // with no wake source, so idle() never resolves and the failure surfaces as
+    // an unresolved promise rather than as the assertions below.
+    runtime.scheduler.queueEvent(origin.getAsNormalizedFullLink(), {});
+    await runtime.idle();
+    await runtime.idle();
+
+    expect(errors).toBe(1);
+    expect(delivered.get()).toEqual([]);
+  });
+
+  it("leaves a child alone when the idempotency recheck aborts", async () => {
+    const { cell, lift, pattern } = createTrustedBuilder(runtime).commonfabric;
+    const childPattern = pattern<{ source: number }>(({ source }) => ({
+      doubled: lift((value: number) => value * 2)(source),
+    }));
+    const produceChild = lift((source: number) => childPattern({ source }));
+    const rootPattern = pattern(() => {
+      const source = cell(3);
+      return { source, child: produceChild(source) };
+    });
+
+    const setupTx = runtime.edit();
+    const rootCell = runtime.getCell<{ source: number; child: unknown }>(
+      space,
+      "recheck child survival root",
+      undefined,
+      setupTx,
+    );
+    const root = runtime.run(setupTx, rootPattern, {}, rootCell);
+    await setupTx.commit();
+    await runtime.idle();
+    const stopReading = root.key("child").sink(() => {});
+
+    try {
+      await runtime.idle();
+      const registrations = runtime.runner.cancels.size;
+      expect(await root.key("child").key("doubled").pull()).toBe(6);
+
+      // Every computation now runs a second time against a throwaway
+      // transaction that is aborted. The child belongs to the run that
+      // committed, and has to survive that abort untouched.
+      runtime.scheduler.enableIdempotencyCheck();
+      try {
+        const bumpTx = runtime.edit();
+        root.key("source").withTx(bumpTx).set(5);
+        expect((await bumpTx.commit()).error).toBeUndefined();
+        await runtime.scheduler.idleWithPendingCommits();
+      } finally {
+        runtime.scheduler.disableIdempotencyCheck();
+      }
+
+      expect(runtime.runner.cancels.size).toBe(registrations);
+      expect(await root.key("child").key("doubled").pull()).toBe(10);
+    } finally {
+      stopReading();
+    }
+  });
+});

--- a/packages/runner/test/transactional-setup-ownership.test.ts
+++ b/packages/runner/test/transactional-setup-ownership.test.ts
@@ -1,0 +1,231 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { Identity } from "@commonfabric/identity";
+import { getMetaLink } from "../src/link-utils.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { Action } from "../src/scheduler.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+
+const signer = await Identity.fromPassphrase("transactional setup ownership");
+const space = signer.did();
+
+describe("transactional setup ownership", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+  });
+
+  afterEach(async () => {
+    await runtime.dispose();
+    await storageManager.close();
+  });
+
+  // Two runs of one computation overlap: the first materializes the child and
+  // then aborts, while the second commits in between. Only the first run
+  // materializes anything — the second finds the pattern unchanged and writes no
+  // child setup at all — so the aborting run is the one that installed the
+  // registration and the memo, and it is the one that has to take them back. The
+  // requirement is that the child comes back and stays reactive, not that any
+  // particular bookkeeping survives the abort untouched.
+  it("keeps a shared child reactive when a newer setup commits first", async () => {
+    type RegistrationKey = Parameters<typeof runtime.runner.cancels.has>[0];
+    const internals = runtime.runner as unknown as {
+      resultPatternCache: Map<RegistrationKey, string>;
+    };
+    const originalEdit = runtime.edit.bind(runtime);
+    type TestTx = ReturnType<typeof originalEdit>;
+    type CommitResult = Awaited<ReturnType<TestTx["commit"]>>;
+    type HeldCommit = {
+      tx: TestTx;
+      commit: TestTx["commit"];
+      promise: Promise<CommitResult>;
+      resolve: (result: CommitResult) => void;
+      result?: CommitResult;
+    };
+    const firstCaptured = Promise.withResolvers<void>();
+    const secondCaptured = Promise.withResolvers<void>();
+    const held: HeldCommit[] = [];
+    let sourceAction: Action | undefined;
+
+    runtime.edit = ((...args: Parameters<typeof originalEdit>) => {
+      const tx = originalEdit(...args);
+      const originalCommit = tx.commit.bind(tx);
+      tx.commit = (() => {
+        const action = tx.tx.sourceAction;
+        if (
+          held.length >= 2 || action === undefined ||
+          internals.resultPatternCache.size === 0 ||
+          (sourceAction !== undefined && action !== sourceAction)
+        ) {
+          return originalCommit();
+        }
+        const completion = Promise.withResolvers<CommitResult>();
+        held.push({
+          tx,
+          commit: originalCommit,
+          promise: completion.promise,
+          resolve: completion.resolve,
+        });
+        if (held.length === 1) {
+          sourceAction = action as Action;
+          firstCaptured.resolve();
+        } else {
+          secondCaptured.resolve();
+        }
+        return completion.promise;
+      }) as typeof tx.commit;
+      return tx;
+    }) as typeof runtime.edit;
+
+    try {
+      const { lift, pattern } = createTrustedBuilder(runtime).commonfabric;
+      const childPattern = pattern<{ value: number }>(({ value }) => ({
+        doubled: lift((input: number) => input * 2)(value),
+      }));
+      const makeChild = lift(({ value }: { value: number }) =>
+        childPattern({ value })
+      );
+      const parentPattern = pattern<{ value: number }>(({ value }) => ({
+        child: makeChild({ value }),
+      }));
+      const setupTx = runtime.edit();
+      const parent = runtime.getCell(
+        space,
+        "same-pattern child owner",
+        undefined,
+        setupTx,
+      );
+      const result = runtime.run(
+        setupTx,
+        parentPattern,
+        { value: 3 },
+        parent,
+      );
+      expect((await setupTx.commit()).error).toBeUndefined();
+      const initialPull = result.pull();
+
+      await firstCaptured.promise;
+      if (sourceAction === undefined) {
+        throw new Error("action transaction had no source");
+      }
+      await runtime.scheduler.run(sourceAction);
+      await secondCaptured.promise;
+
+      const cacheKey = [...internals.resultPatternCache.keys()][0];
+      expect(cacheKey).toBeDefined();
+      const newerCommit = await held[1].commit();
+      expect(newerCommit.error).toBeUndefined();
+      held[1].result = newerCommit;
+      held[1].resolve(newerCommit);
+      expect(held[0].tx.abort("the original setup aborted").error)
+        .toBeUndefined();
+      const abortedCommit = await held[0].commit();
+      held[0].result = abortedCommit;
+      held[0].resolve(abortedCommit);
+      await initialPull;
+
+      const child = result.key("child").resolveAsCell();
+      expect(await child.key("doubled").pull()).toBe(6);
+      const argumentLink = getMetaLink(child, "argument");
+      expect(argumentLink).toBeDefined();
+      const updateTx = runtime.edit();
+      runtime.getCellFromLink<{ value: number }>(
+        argumentLink!,
+        undefined,
+        updateTx,
+      ).set({ value: 4 });
+      expect((await updateTx.commit()).error).toBeUndefined();
+      await runtime.scheduler.idleWithPendingCommits();
+      expect(await child.key("doubled").pull()).toBe(8);
+      runtime.runner.stop(parent);
+    } finally {
+      runtime.edit = originalEdit;
+      for (const heldCommit of held) {
+        if (heldCommit.result !== undefined) continue;
+        if (heldCommit.tx.status().status === "ready") {
+          heldCommit.tx.abort("shared child ownership test finished");
+        }
+        const result = await heldCommit.commit();
+        heldCommit.result = result;
+        heldCommit.resolve(result);
+      }
+      await Promise.all(held.map(({ promise }) => promise));
+    }
+  });
+
+  it("produces a mapped result after its child setup aborts", async () => {
+    const { cell, lift, pattern } = createTrustedBuilder(runtime).commonfabric;
+    const operation = pattern<{ element: number }>(({ element }) =>
+      lift((value: number) => value * 2)(element)
+    );
+    const parentPattern = pattern(() => {
+      const items = cell<number[]>([]);
+      return {
+        items,
+        mapped: (items as unknown as {
+          mapWithPattern(
+            operation: unknown,
+            params: Record<string, never>,
+          ): unknown;
+        }).mapWithPattern(operation, {}),
+      };
+    });
+    const setupTx = runtime.edit();
+    const parent = runtime.getCell<{
+      items: number[];
+      mapped: number[];
+    }>(space, "aborted map child setup", undefined, setupTx);
+    const result = runtime.run(setupTx, parentPattern, {}, parent);
+    expect((await setupTx.commit()).error).toBeUndefined();
+    const stopReading = result.key("mapped").sink(() => {});
+    await runtime.scheduler.idleWithPendingCommits();
+
+    const originalRun = runtime.runner.run;
+    let firstSetupAborted = false;
+    let childSetups = 0;
+    runtime.runner.run = ((...args: Parameters<typeof originalRun>) => {
+      const run = Reflect.apply(originalRun, runtime.runner, args);
+      const options = args[4] as
+        | { doNotUpdateOnPatternChange?: boolean }
+        | undefined;
+      if (options?.doNotUpdateOnPatternChange !== true) return run;
+
+      childSetups++;
+      if (childSetups === 1) {
+        const childTx = args[0];
+        if (childTx === undefined) {
+          throw new Error("map child setup had no transaction");
+        }
+        const originalCommit = childTx.commit.bind(childTx);
+        childTx.commit = (() => {
+          expect(childTx.abort("abort the first map child setup").error)
+            .toBeUndefined();
+          firstSetupAborted = true;
+          return originalCommit();
+        }) as typeof childTx.commit;
+      }
+      return run;
+    }) as typeof runtime.runner.run;
+
+    try {
+      const updateTx = runtime.edit();
+      result.key("items").withTx(updateTx).set([1]);
+      expect((await updateTx.commit()).error).toBeUndefined();
+      await runtime.scheduler.idleWithPendingCommits();
+
+      expect(firstSetupAborted).toBe(true);
+      expect(await result.key("mapped").pull()).toEqual([2]);
+    } finally {
+      runtime.runner.run = originalRun;
+      stopReading();
+    }
+  });
+});


### PR DESCRIPTION
A transaction ends in one of three ways: its commit succeeds, its commit is rejected, or something aborts it. All three decide the fate of the writes it staged, and the last two discard them. This runtime registers callbacks on a transaction to compensate for writes that never became durable, and it keeps ordinary in-memory bookkeeping alongside those writes: records of which child computations were started, which list elements were created, and where each one sits. Only the two commit outcomes ran those callbacks. An abort discarded the writes and told nobody.

The bookkeeping then describes work that no longer exists. A later pass consults it, concludes the work is already done, and skips it, so the affected computations never produce a value again. The same silence stalls the event queue outright: work sent by an aborted transaction waits for a confirmation that can never arrive.

Dispatch the settle callbacks from abort(), carrying a StorageTransactionAborted error. Every callback already distinguishes a successful commit from a failed one, so an abort arrives as the failure it is and no callback needed changing. The stalled queue is the clearest case. A handler that sends an event and then throws has its transaction aborted, so the speculation lineage never learns the origin failed and leaves that origin's record pending. An aborted transaction also never builds a commit, so it never records a per-space commit sequence, and the follow-up event therefore does not count as landing in the origin's space. It parks at the head of the queue waiting for a confirmation that cannot come, and the scheduler stops dispatching events from that point onwards. This brings the implementation in line with what the scheduler specification already describes: a failed origin cancels its undispatched descendants and stops the pieces it started locally.

This does change a stated contract, so the statement of it moves too. The callback registration documented itself as running when a commit completes, and a test asserted that an abort skipped it while the neighbouring test asserted that a rejected commit reached it. That asymmetry has no basis: both outcomes discard the staged writes, which is the only thing a compensating callback cares about. The callback is now documented as a settle callback, and the test asserts that an abort delivers the same errored transaction a rejected commit does.

Two pieces of bookkeeping then need to roll back with their transaction.

A computation that returns a pattern memoizes what it materialized into the result cell, and the compensation for a failed setup stops the child. A rejected commit clears that memo through the notification for its rollback, but an abort never reaches storage, so the memo survived. The next run then treated the pattern as unchanged and skipped a child that no longer existed anywhere.

A list coordinator records each element's result cell and index in plain memory while writing that element's setup through the reconcile's transaction. When the transaction does not become durable the setup writes disappear and the record stays, so the next reconcile finds the entry, reuses it, and never re-runs the setup. The element has no pattern from then on, and reads as undefined for as long as the coordinator lives. The result container and the per-element index have the same problem. Undoing an element run deletes the entry and stops the element's piece; stopping it is what lets a later reconcile register the element again, because the element cell id is deterministic and a piece left registered makes that reconcile skip the setup exactly as the stale entry did. map, filter and flatMap share the bookkeeping and now share the rollback.

Every undo first checks that the state is still the state this transaction installed, so an attempt that has already been superseded leaves the newer state alone.

A stale basis is the exception, and it has to be. A conflict or a local inconsistency re-runs the same work against fresh state, and that re-run is what converges; it reuses the bookkeeping and re-issues only the writes it still needs. Discarding the bookkeeping under it makes every attempt rebuild what the previous attempt just discarded, and the work then never converges at all — a flat-map appending during its resume window spins until it exhausts memory. Every other outcome has no such re-run behind it, so the record has to go. The rejection classifier the storage layer already exposes draws that line.

The shared hashtag resolver in wish was audited for the same shape and does not have it. Its reference count is balanced by the wish's cancel group rather than by a transaction, and its shared cell is repopulated by its own action rather than by per-transaction setup writes.

The tests cover the settle outcome itself, the follow-up event that must now be dropped rather than parked forever, a mapped element that must reappear after its setup aborts, and two overlapping runs of one computation where the older one aborts after the newer commits. That last case pins behaviour that is easy to get wrong in the opposite direction. Only the first run materializes the child: the second finds the pattern unchanged and writes no child setup at all, so the aborting run is the run that installed both the registration and the memo, and taking them back is what lets a later run rebuild a child whose setup writes are gone. The requirement is that the child comes back and stays reactive, not that any particular bookkeeping survives the abort untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run settle callbacks when a transaction is aborted and roll back in-memory child/list bookkeeping so aborted work doesn’t leak or stall the scheduler. Idempotency rechecks now use a duplicate-work transaction that discards settle callbacks.

- **Bug Fixes**
  - `abort()` now settles callbacks via `addCommitCallback`, delivering a `StorageTransactionAborted` error; docs/spec updated to call them “settle” callbacks.
  - Fixed scheduler deadlock: follow-up events from aborted origins are dropped instead of parking at the head of the queue.
  - Child pattern setups: clear the result-pattern memo and stop the child on failed setup (including abort) so the next run rematerializes it.
  - Lists: added `trackListSetupRollback` and wired it into `map`, `filter`, and `flatMap` to undo created entries, index moves, and result-container swaps when the transaction isn’t durable; skips rollback on conflict/inconsistency and only reverts state still owned by the settling tx.
  - Idempotency rechecks switched to `createDuplicateWorkTransaction`, which discards settle callbacks so the throwaway run can abort without tearing down live state.

- **Migration**
  - If you use `addCommitCallback`, expect it to run on abort as well. Keep callbacks non-effectful, verify ownership before undoing in-memory state, and rely on the rejection classifier to ignore stale-basis retries. Use `createDuplicateWorkTransaction` for duplicate-work cases (like idempotency checks) to suppress settle callbacks.

<sup>Written for commit 0ee393b3e5506c44d6d0e98feb9698aa78093b66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

