### PR TITLE
docs(lunch-poll): record the Estuary source migration and its traps

### DIFF
--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -87,6 +87,9 @@ One line per archived document; each document's header carries the fuller
 
 ### Audits and reports
 
+- [estuary-source-migration-2026-08-04.md](packages/patterns/lunch-poll/estuary-source-migration-2026-08-04.md)
+  — rehearsal and live `setsrc` moving the Estuary lunch poll onto the mainline
+  pattern, August 2026.
 - [cf-view-language-coverage-2026-07.md](packages/cli/cf-view-language-coverage-2026-07.md)
   — active-repository syntax inventory and `cf view` support snapshot, July
   2026.

--- a/docs/history/packages/patterns/lunch-poll/estuary-source-migration-2026-08-04.md
+++ b/docs/history/packages/patterns/lunch-poll/estuary-source-migration-2026-08-04.md
@@ -1,0 +1,86 @@
+---
+status: historical
+created: 2026-08-04
+archived: 2026-08-04
+reason: "Record of the rehearsal and live source update that moved the Estuary lunch poll onto the mainline pattern."
+---
+
+# Migrating the Estuary lunch poll onto the mainline source
+
+Record of a `setsrc` against a populated production space, rehearsed on a clone
+first. The live counterpart is
+[`packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md`](../../../../../packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md).
+
+## What was changed
+
+The Estuary lunch poll ran a source lineage that existed in no commit on any
+branch. It carried a restaurant-hours feature — a `restaurant-availability.ts`
+module plus `checkRestaurantHours`, `availabilityRefresh`,
+`availabilityLastRequestedAt` and `restaurantSearchContext` inputs — and lacked
+`participantProfiles`. The authored source survived only inside the deployed
+piece, from which it was recovered before the update.
+
+The update replaced that source with `packages/patterns/lunch-poll/main.tsx` at
+commit `c97de0181555adf7351cc78b339263792e1221fd`, the commit Estuary itself
+runs, confirmed from its `/api/meta`. Dropping the restaurant-hours feature was
+the accepted cost.
+
+- Piece: `fid1:S2MlU76VbKBRTtFt_hgPyi9MB04ti9yKN08G2IJJUW4` in space `team-lunch`
+- Space DID: `did:key:z6MkhAKxuP8cXuDNjyUJ2xgmjjgENQGm7zzo5Tg3V7vyYnzr`
+- Source ref before: `cf:pattern:6L3o4uBafChxKHyi5OSt-nbQoN3FIRmw_YVK1dVkhwk`
+- Source ref after: `cf:pattern:dTg2Hp4JCJbEGWO_2KVmrN_GKww7RG2FEzrQ6nvMopo`
+
+## Why a rehearsal was required
+
+The compatibility checker rejected the transition, naming two removals:
+
+```
+Pattern schemas are not backward compatible:
+- argument.availabilityLastRequestedAt: existing argument field was removed
+- result.applyRestaurantSearchContext: existing result field was removed
+```
+
+A rejected compatibility check on a populated space is one of the conditions
+that makes a rehearsal mandatory. The update went through with
+`--dangerously-allow-incompatible-schema`.
+
+Getting the snapshot took a person with host access. Estuary's whole-space dump
+endpoint is off, so the snapshot came from `VACUUM INTO` run on the host against
+the live store.
+
+## Rehearsal result
+
+Two passes against a clone, resetting the clone between them, produced identical
+outcomes: 150270 → 150656 commits, 153163 → 154179 revisions, 708 entities
+added, one removed, two changed.
+
+The removed entity was `stream of:fid1:6p8kfS4w8LxrVjaXTg9BUaTPDHwNFQ03I9mOpzevTME`,
+the handler behind the "Enable daily checks" button — the restaurant-hours
+feature being dropped. `cf space verify --expect-migration` exits non-zero on any
+removal, so the gate fired on both passes and the removal had to be identified
+before the run could be judged.
+
+The two changed entities were the piece and one owned cell. No free cell
+changed, so no authored content was overwritten. Write churn peaked at 275
+commits per minute and returned to zero within two minutes on both passes.
+
+## What the poll kept and lost
+
+Kept: five options, ten participants, forty votes, no visits, the question and
+the host name, all byte-identical to the pre-update values.
+
+Lost: the `joinedAt` timestamp on all ten participant records. The mainline
+`User` type does not declare that field. Rolling the source back restores the
+restaurant-hours feature but not those timestamps, since nothing rewrites a
+field the forward migration dropped.
+
+Production matched the rehearsal's prediction field for field.
+
+## A CLI limitation found on the way
+
+`cf piece set --input` cannot write any field of this pattern on this build. It
+fails with `updated input does not match its schema: myName: value does not
+match type string`, whether or not the calling identity has joined, and
+including on a write to `myName` itself. The read path materializes `myName` as
+`""`. This closes the documented Option B state-copy loop for this pattern;
+seeding through the pattern's own handlers still works.

--- a/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
+++ b/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
@@ -32,7 +32,7 @@ now an ordinary `PerSpace` cell — can all be copied to another piece via the C
 ## The live pieces
 
 Two hosts run the poll, at different paces. **These are deployment pointers, not
-stable identifiers — current as of 2026-08-03.** A piece is tied to one
+stable identifiers — current as of 2026-08-04.** A piece is tied to one
 space/server and can be reset, wedged, or lost; if one 404s, `inspect` fails, or
 it stops responding, re-establish it (see "Recovering" below) and update this
 block.
@@ -60,15 +60,20 @@ piece:  fid1:S2MlU76VbKBRTtFt_hgPyi9MB04ti9yKN08G2IJJUW4
 url:    https://estuary.saga-castor.ts.net/team-lunch/fid1:S2MlU76VbKBRTtFt_hgPyi9MB04ti9yKN08G2IJJUW4
 ```
 
-Two things make this piece unlike the `rapids` one:
+Its deployed source is this checkout's `main.tsx`. Two things still make this
+piece unlike the `rapids` one:
 
-- **Its deployed source is a different lineage from this checkout.** It defines
-  `checkRestaurantHours`, `availabilityRefresh`, `availabilityLastRequestedAt`
-  and `restaurantSearchContext` inputs that the source here does not, and it
-  lacks `participantProfiles`. Deploying this checkout's `main.tsx` over it
-  would strand that restaurant-hours feature. Combined with the populated space,
-  that makes any update here rehearsal-grade — see
+- **Its space holds real data, so an update here is rehearsal-grade.** Rehearse
+  against a clone before any `setsrc` the compatibility checker rejects — see
   [`docs/development/space-clone-rehearsal.md`](../../../docs/development/space-clone-rehearsal.md).
+  Estuary serves production, so its whole-space dump endpoint is off and the
+  snapshot has to be taken on the host itself. The space DID is
+  `did:key:z6MkhAKxuP8cXuDNjyUJ2xgmjjgENQGm7zzo5Tg3V7vyYnzr`, and reaching the
+  host needs a key in the infra repository's `ssh_authorized_keys`.
+
+  ```bash
+  sqlite3 <store>/engine-v3/engine-v3/<did>.sqlite "VACUUM INTO '<destination>'"
+  ```
 - **Its space cannot be enumerated from a current checkout.** The stored
   home/registry pattern imports `safeDateNow`, which this API no longer exports,
   so `cf piece ls -s team-lunch` fails to compile it and exits non-zero with an
@@ -162,6 +167,17 @@ can shift the causal chain and orphan old data. Don't refactor the input
 interface casually against a piece you care about.
 
 ## Option B — copy the state into your own piece
+
+> **Note:** the copy loop below writes with `cf piece set --input`, which
+> validates the whole input object on every write. Every field fails on this
+> pattern with
+> `updated input does not match its schema: myName: value does not
+> match type string`,
+> including a write to `myName` itself. The pattern's `myName` is `PerUser`, and
+> the read path materializes it as `""` while the write path's validation does
+> not see a string there. Joining first does not change this. Seed a piece
+> through the pattern's own handlers instead — `joinAs`, then `addOption` for
+> each option.
 
 To get your **own** instance seeded with the current data (e.g. to experiment
 without touching the shared poll):

--- a/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
+++ b/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
@@ -60,8 +60,9 @@ piece:  fid1:S2MlU76VbKBRTtFt_hgPyi9MB04ti9yKN08G2IJJUW4
 url:    https://estuary.saga-castor.ts.net/team-lunch/fid1:S2MlU76VbKBRTtFt_hgPyi9MB04ti9yKN08G2IJJUW4
 ```
 
-Its deployed source is this checkout's `main.tsx`. Two things still make this
-piece unlike the `rapids` one:
+Its deployed source is the mainline pattern, but this host is redeployed rarely,
+so expect it to lag this checkout. `cf piece inspect` reports the source ref it
+is actually on. Two things still make this piece unlike the `rapids` one:
 
 - **Its space holds real data, so an update here is rehearsal-grade.** Rehearse
   against a clone before any `setsrc` the compatibility checker rejects — see


### PR DESCRIPTION
The lunch poll on Estuary was running a pattern source that existed in no commit on any branch. It carried a restaurant-hours feature — a restaurant-availability module plus the checkRestaurantHours, availabilityRefresh, availabilityLastRequestedAt and restaurantSearchContext inputs — and lacked participantProfiles. The authored source survived only inside the deployed piece.

That piece has now been moved onto the mainline pattern, dropping the restaurant-hours feature deliberately. The compatibility checker rejected the transition, naming the removal of the availabilityLastRequestedAt argument and the applyRestaurantSearchContext result, so the update needed the explicit incompatible-schema flag. A rejected compatibility check against a populated space is one of the conditions that makes a clone rehearsal mandatory; two passes against a clone produced identical outcomes before the live attempt.

DEPLOY-AND-SHARE.md described the old lineage, which would now send the next operator looking for inputs that are gone. Its Estuary block is rewritten to describe what is deployed there, and gains the two facts that were expensive to recover: the space DID, and that a snapshot has to be taken on the host with VACUUM INTO because the whole-space dump endpoint is off in production.

The rehearsal also turned up a CLI limitation worth warning about, since the documented state-copy procedure depends on it. On this build, cf piece set --input cannot write any field of this pattern: the whole-object validation reports that myName is not a string, even though the read path materializes it as an empty string, and joining first does not change it.

The migration itself is a point-in-time record rather than a description of the current system, so it lands under docs/history following the layout and metadata rules in that tree's README.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented the Estuary lunch‑poll migration to the mainline pattern and tightened operator notes to avoid risky updates. Clarifies the dropped restaurant‑hours feature, the required clone rehearsal, that Estuary’s deployed source may lag this checkout, and a CLI limitation.

- **Migration**
  - Added `docs/history/packages/patterns/lunch-poll/estuary-source-migration-2026-08-04.md` recording the rehearsal and live `setsrc`, what changed, and what was kept.
  - Updated `packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md` for Estuary:
    - Deployed source follows the mainline but may lag; verify with `cf piece inspect`.
    - Rehearse against a clone if compatibility fails; restaurant‑hours inputs were removed.
    - Take whole‑space snapshots on the host with SQLite `VACUUM INTO`; space DID included for admins.
    - Warned that `cf piece set --input` fails validation on this pattern; seed via handlers (`joinAs`, `addOption`) instead.
  - Linked the record in `docs/history/README.md`.

<sup>Written for commit 761be650930b61451f2d3f7adea23de1bb5f87bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

