### PR TITLE
refactor(runner): delete the single-implementation Harness interface

### DIFF
--- a/docs/specs/content-addressed-action-identity.md
+++ b/docs/specs/content-addressed-action-identity.md
@@ -28,7 +28,7 @@ Phase 3 shipped in two PRs:
   `writeAuthorizedBy` claims keep verifying without a `verifiedLoadId`.
 - **E2 (legacy machinery deletion)**: every loadId surface is gone — frame
   threading, side tables, `seedVerifiedLoadIds`, per-load registry
-  partitions and capture walks, the loadId-scoped `Harness` methods, the
+  partitions and capture walks, the loadId-scoped `Engine` methods, the
   CFC `implementationRef`×`verifiedLoadId` arm (provenance is the only
   source of `kind: "verified"`), `FunctionCache`, and the prewarm walk. New
   `writeAuthorizedBy` claims are stamped with `moduleIdentity` only. What
@@ -555,7 +555,7 @@ canary test compiling+resolving with `$implRef` stripped.
 - `harness/executable-registry.ts`: ~everything string-keyed (§4);
   `function-cache.ts` re-keyed or deleted.
 - `cfc/implementation-identity.ts`: loadId/ref plumbing → provenance WeakMap;
-  `Harness` interface loses `getVerifiedLoadId`, `getVerifiedFunctionInLoad`,
+  `Engine` loses `getVerifiedLoadId`, `getVerifiedFunctionInLoad`,
   `isVerifiedSourceInLoad`, `getVerifiedBundleId`, `getVerifiedBindingMetadata`,
   `registerVerifiedFunction`, `getExecutableFunction`, `associatePattern`.
 - `runner.ts`: `resolveJavaScriptFunction` ref path, `discoverAndCacheFunctions`,
@@ -614,7 +614,7 @@ canary test compiling+resolving with `$implRef` stripped.
    session-lifetime, per-engine content-addressed implementation index
    (`ExecutableRegistry.verifiedImplementationsByEntryRef`, populated by
    `Engine.recordModuleProvenance`, surfaced as
-   `Harness.getVerifiedImplementation`, consulted by `resolveByImplRef` after
+   `Engine.getVerifiedImplementation`, consulted by `resolveByImplRef` after
    the bounded artifact index misses). Chosen over refcount pinning (piece
    lifecycle is fuzzy; high complexity) and a WeakRef shadow (fails exactly in
    the post-eviction-GC scenario it must cover). Memory is bounded by the set

--- a/docs/specs/sandboxing/SES_SANDBOXING_SPEC.md
+++ b/docs/specs/sandboxing/SES_SANDBOXING_SPEC.md
@@ -2118,13 +2118,11 @@ Build a new sandbox subsystem that separates:
 - minimal ambient globals for Compartments
 - trusted runtime-module exports registered as `cf:runtime/` records
 
-Initial implementation can migrate logic from the current harness runtime-module
-surface, but the target module split should live under `packages/runner/src/sandbox/`.
+The target module split should live under `packages/runner/src/sandbox/`.
 
 **Likely files:**
 - new `packages/runner/src/sandbox/runtime-modules.ts`
 - new `packages/runner/src/sandbox/compartment-globals.ts`
-- `packages/runner/src/harness/runtime-modules.ts` (migration source)
 
 ### Phase 4: Runner Integration
 

--- a/packages/runner/README.md
+++ b/packages/runner/README.md
@@ -826,7 +826,8 @@ The Runtime coordinates several core services:
 - **PatternManager**: Loads, compiles, and caches pattern definitions
 - **ModuleRegistry**: Manages module registration and retrieval for patterns
 - **Runner**: Executes patterns and manages their lifecycle
-- **Harness**: Provides the execution environment for pattern code
+- **Engine** (`runtime.harness`): Provides the execution environment for pattern
+  code
 
 All services receive the Runtime instance as a dependency, enabling proper
 isolation and testability without global state.

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -4,7 +4,6 @@ import {
   type CompiledModuleArtifact,
   type EvaluateResult,
   type Exports,
-  type Harness,
   type HarnessedFunction,
   type ResolvedFabricPin,
   type RuntimeProgram,
@@ -166,7 +165,7 @@ export interface EngineOptions {
   hideInternalStackFrames?: boolean;
 }
 
-export class Engine extends EventTarget implements Harness {
+export class Engine extends EventTarget {
   private runtimeInternals: RuntimeInternals | undefined;
   private compilerInternals: CompilerInternals | undefined;
   private ctRuntime: Runtime;

--- a/packages/runner/src/harness/index.ts
+++ b/packages/runner/src/harness/index.ts
@@ -1,7 +1,6 @@
 export { Engine, EngineProgramResolver } from "./engine.ts";
 export type { EngineOptions } from "./engine.ts";
 export type {
-  Harness,
   HarnessedFunction,
   RuntimeProgram,
   TypeScriptHarnessProcessOptions,

--- a/packages/runner/src/harness/runtime-modules.ts
+++ b/packages/runner/src/harness/runtime-modules.ts
@@ -1,7 +1,0 @@
-export type { RuntimeModuleIdentifier } from "../sandbox/runtime-modules.ts";
-export {
-  getRuntimeModuleExports as getExports,
-  getRuntimeModuleTypes as getTypes,
-  isRuntimeModuleIdentifier,
-  RuntimeModuleIdentifiers,
-} from "../sandbox/runtime-modules.ts";

--- a/packages/runner/src/harness/types.ts
+++ b/packages/runner/src/harness/types.ts
@@ -1,17 +1,7 @@
-import type {
-  Program,
-  ProgramResolver,
-  Source,
-} from "@commonfabric/js-compiler";
+import type { Program } from "@commonfabric/js-compiler";
 import type { PatternCoverageSpan } from "@commonfabric/ts-transformers";
-import type { PatternCoverageCollector } from "../pattern-coverage.ts";
 import type { MemorySpace } from "../runtime.ts";
-import type {
-  CachedCompiledModule,
-  CompiledModuleGraph,
-  HoistRegistrationSink,
-} from "../sandbox/module-record-compiler.ts";
-import type { UnsafeHostTrustOptions } from "../unsafe-host-trust.ts";
+import type { HoistRegistrationSink } from "../sandbox/module-record-compiler.ts";
 
 export type HarnessedFunction = (input: any) => void;
 
@@ -143,93 +133,4 @@ export interface EvaluateResult {
    * and indexes it for synchronous by-identity resolution.
    */
   registrationsByIdentity?: HoistRegistrationSink;
-}
-
-// A `Harness` wraps a flow of compiling, bundling, and executing typescript.
-export interface Harness extends EventTarget {
-  // Compile + evaluate a program through the ESM module-record path,
-  // returning the entry exports plus the per-module export map.
-  compileAndEvaluateModules(
-    program: RuntimeProgram,
-    options?: TypeScriptHarnessProcessOptions,
-  ): Promise<EvaluateResult>;
-
-  // Compile a program to a verified ESM record graph, returning the graph plus
-  // the per-module cache descriptors (in content-identity space). Split from
-  // evaluation so a caller can write the descriptors to the content-addressed
-  // cache between compile and evaluate.
-  compileToRecordGraph(
-    program: RuntimeProgram,
-    options?: TypeScriptHarnessProcessOptions,
-  ): Promise<{
-    id: string;
-    graph: CompiledModuleGraph;
-    mainSpecifier: string;
-    entryIdentity: string;
-    modules: CacheableModule[];
-    resolvedPins: ResolvedFabricPin[];
-  }>;
-
-  // Evaluate a verified ESM record graph produced by `compileToRecordGraph`.
-  evaluateRecordGraph(
-    id: string,
-    graph: CompiledModuleGraph,
-    mainSpecifier: string,
-    files: Source[],
-  ): EvaluateResult;
-
-  // Warm load: build + verify + evaluate a pattern directly from cached compiled
-  // modules (by content identity) — no TS source, no resolve, no recompile.
-  evaluateCachedModules(
-    modules: readonly CachedCompiledModule[],
-    entryIdentity: string,
-    options?: {
-      sourceFiles?: Source[];
-      trustedBodies?: boolean;
-      patternCoverage?: PatternCoverageCollector;
-    },
-  ): Promise<EvaluateResult>;
-
-  // Cold recovery: recompile cacheable modules from the stored (already-resolved,
-  // inject-transformed) source set — e.g. after a runtimeVersion bump.
-  compileResolvedToRecordGraph(
-    resolvedFiles: Source[],
-    entryFilename: string,
-    options?: {
-      fabricImports?: FabricImportOptions;
-      patternCoverage?: PatternCoverageCollector;
-    },
-  ): Promise<{ modules: CacheableModule[]; entryIdentity: string }>;
-
-  // Resolves a `ProgramResolver` into a `Program` using the engine's
-  // configuration.
-  resolve(
-    source: ProgramResolver,
-  ): Promise<Program>;
-
-  invoke(fn: () => any): any;
-
-  getInvocation(source: string): HarnessedFunction;
-
-  // Resolve a verified implementation function by its content-addressed
-  // `{ identity, symbol }` entry ref — the strong (session-lifetime) index
-  // behind serialized `$implRef`s. Unlike the bounded artifact index this
-  // never evicts, so a `$implRef`-only graph stays resolvable for as long as
-  // its module was verified-evaluated in this session.
-  getVerifiedImplementation?(
-    identity: string,
-    symbol: string,
-  ): HarnessedFunction | undefined;
-
-  unsafeTrustHostValue(
-    value: unknown,
-    options: UnsafeHostTrustOptions,
-  ): void;
-
-  // Translate a bundle-prefixed source path (`/<programHash>/<authoredPath>`, as
-  // returned by `mapPosition`) into the reload-stable canonical source
-  // `cf:module/<moduleHash>/<authoredPath>`, keeping the authored path for
-  // debuggability. Returns undefined for built-in / non-program sources, so
-  // callers fall back to the raw value.
-  canonicalModuleSource?(source: string): string | undefined;
 }


### PR DESCRIPTION
The runner declared a `Harness` interface describing the flow of compiling, bundling, and executing TypeScript: eight required methods, two optional ones, and `extends EventTarget`. `Engine` was its only implementation, and no code anywhere in the repository ever referred to the interface. Every consumer types against the concrete `Engine` instead: `Runtime` declares its property as `readonly harness: Engine`, and the one place that genuinely wants a structural harness shape, `canonicalizingMapPosition` in `builder/module.ts`, writes its own inline type with `mapPosition` and `canonicalModuleSource` rather than importing the interface. The re-export from `harness/index.ts` was therefore dead public surface, and the two optional members were speculative: `Engine` always defines both, and the callers that reach them do so through `Engine` or through that local structural type.

An interface with one implementation and no consumers costs more than it earns. It has to be kept in step with the class by hand, and when it drifts nothing notices, because an `implements` clause only asserts that the class is assignable to the interface. It never constrains a call site, and it never narrows or widens the class's own inferred member types. Removing it changes no behavior and loses no type checking.

This deletes the interface, drops `implements Harness` and its type import from `Engine`, and removes the export. The genuinely shared data types in `harness/types.ts` stay: `HarnessedFunction`, `RuntimeProgram`, `TypeScriptHarnessProcessOptions`, `EvaluateResult`, `CacheableModule`, and the rest all have real importers. Six imports that only the interface used are gone with it.

Also deleted: `harness/runtime-modules.ts`, a seven-line pass-through that re-exported `sandbox/runtime-modules.ts` under shortened names. Nothing imported it, it was not listed in the package's exports map, and the sandbox module it forwarded to is what callers already use.

The live specifications that named these are updated in the same change. Three places in the content-addressed action identity spec described methods on the `Harness` interface; they now name `Engine`, which is where those methods lived and where the surviving one still lives. The SES sandboxing spec listed the deleted file as a migration source for a phase whose migration has since happened, so that reference is dropped. The runner's README listed `Harness` among the core services alongside `Scheduler`, `PatternManager`, and the others, every one of which names a real exported class; that entry now names `Engine` and points at the `runtime.harness` property it is reached through.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the unused `Harness` interface and reference the concrete `Engine` instead. No behavior changes; docs and README now point to `Engine`.

- **Refactors**
  - Deleted `Harness` and the `implements Harness` clause in `Engine`; removed its export. Kept shared types like `HarnessedFunction`, `RuntimeProgram`, `TypeScriptHarnessProcessOptions`, `EvaluateResult`, and `CacheableModule`.
  - Removed `packages/runner/src/harness/runtime-modules.ts` pass-through; use `packages/runner/src/sandbox/runtime-modules.ts` directly.
  - Updated specs to name `Engine` where `Harness` was referenced and dropped an outdated migration note. README now lists `Engine` (`runtime.harness`). 

- **Migration**
  - If you imported or referenced `Harness`, switch to `Engine`.

<sup>Written for commit 67b62c9e4f2eb1c594ec0f9b8fef33f4a6a1a461. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

