### PR TITLE
refactor(runner): one storage provider interface, and drop the dead m…

### DIFF
--- a/docs/specs/server-side-execution/README.md
+++ b/docs/specs/server-side-execution/README.md
@@ -897,7 +897,7 @@ An initial prototype may connect through the `loopback` transport
 cannot transfer through a raw `Engine` shortcut.
 
 The production design is an **executor-grade provider** implementing
-`IStorageProviderWithReplica` (`packages/runner/src/storage/interface.ts`)
+`IStorageProvider` (`packages/runner/src/storage/interface.ts`)
 that (a) reads through the engine's read pool directly (the request
 dispatch in `packages/memory/v2/server.ts`) with MessageChannel batching, (b)
 commits through the server's canonical validated apply path, and (c) receives

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -83,7 +83,7 @@ import {
 import type { Runtime } from "./runtime.ts";
 import type {
   IExtendedStorageTransaction,
-  IStorageProviderWithReplica,
+  IStorageProvider,
   IStorageSubscription,
   MemorySpace,
   URI,
@@ -763,10 +763,10 @@ type SchedulerRehydrationSubscriptionOptions = {
       readonly PersistedSchedulerObservationSnapshot[]
     >;
     addressesCurrentAtOrBelow?: NonNullable<
-      IStorageProviderWithReplica["areSchedulerAddressesCurrentAtOrBelow"]
+      IStorageProvider["areSchedulerAddressesCurrentAtOrBelow"]
     >;
     hasPendingWriteOverlapping?: NonNullable<
-      IStorageProviderWithReplica["schedulerHasPendingWriteOverlapping"]
+      IStorageProvider["schedulerHasPendingWriteOverlapping"]
     >;
   };
   // The owning pattern instance for this reader, set unconditionally (not only

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -42,7 +42,6 @@ import type {
   DID,
   IExtendedStorageTransaction,
   IStorageManager,
-  IStorageProvider,
   MemorySpace,
   URI,
 } from "./storage/interface.ts";
@@ -169,7 +168,7 @@ Error.stackTraceLimit = 500;
 
 export const DEFAULT_MAX_RETRIES = 5;
 
-export type { IExtendedStorageTransaction, IStorageProvider, MemorySpace };
+export type { IExtendedStorageTransaction, MemorySpace };
 
 export interface ConsoleHandlerOutput {
   method: ConsoleMethod;

--- a/packages/runner/src/storage/cache.deno.ts
+++ b/packages/runner/src/storage/cache.deno.ts
@@ -5,12 +5,7 @@ import { EmulatedStorageManager } from "./v2-emulate.ts";
 export { EmulatedStorageManager } from "./v2-emulate.ts";
 export { EmulatedStorageManager as StorageManagerEmulator } from "./v2-emulate.ts";
 export { SelectorTracker } from "./selector-tracker.ts";
-export {
-  defaultSettings,
-  type Options,
-  type SessionFactory,
-  watchIdForEntry,
-} from "./v2.ts";
+export { type Options, type SessionFactory, watchIdForEntry } from "./v2.ts";
 
 export class StorageManager extends V2Storage.StorageManager {
   static override open(options: V2Storage.Options): V2Storage.StorageManager {

--- a/packages/runner/src/storage/cache.ts
+++ b/packages/runner/src/storage/cache.ts
@@ -2,12 +2,7 @@ export * from "@commonfabric/memory/interface";
 import * as V2Storage from "./v2.ts";
 
 export { SelectorTracker } from "./selector-tracker.ts";
-export {
-  defaultSettings,
-  type Options,
-  type SessionFactory,
-  watchIdForEntry,
-} from "./v2.ts";
+export { type Options, type SessionFactory, watchIdForEntry } from "./v2.ts";
 
 export class StorageManager {
   static open(options: V2Storage.Options): V2Storage.StorageManager {

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -141,7 +141,7 @@ export interface IStorageManager extends IStorageSubscriptionCapability {
    * Open a new connection to the storage provider associated with the given
    * space.
    */
-  open(space: MemorySpace): IStorageProviderWithReplica;
+  open(space: MemorySpace): IStorageProvider;
 
   /**
    * Record a runtime-learned HTTP or HTTPS host hint for a space
@@ -323,18 +323,6 @@ export interface IStorageManager extends IStorageSubscriptionCapability {
 
 export interface IRemoteStorageProviderSettings {
   /**
-   * Number of subscriptions remote storage provider is allowed to have per
-   * space.
-   */
-  maxSubscriptionsPerSpace: number;
-
-  /**
-   * Amount of milliseconds we will spend waiting on WS connection before we
-   * abort.
-   */
-  connectionTimeout: number;
-
-  /**
    * EXPERIMENTAL (default off): allow more than one watch-refresh round trip
    * to be in flight per space at once, up to a bounded window
    * (`CONCURRENT_WATCH_REFRESH_WINDOW`). By default watch acquisition is strict
@@ -347,12 +335,6 @@ export interface IRemoteStorageProviderSettings {
    * docs/development/EXPERIMENTAL_OPTIONS.md.
    */
   experimentalConcurrentWatchRefresh?: boolean;
-}
-
-export interface LocalStorageOptions {
-  as: Signer;
-  id?: string;
-  settings?: IRemoteStorageProviderSettings;
 }
 
 export interface IStorageProvider {
@@ -384,15 +366,7 @@ export interface IStorageProvider {
    */
   destroy(): Promise<void>;
 
-  /**
-   * Get the storage provider's replica.
-   *
-   * @returns The storage provider's replica.
-   */
-  getReplica(): string | undefined;
-}
-
-export interface IStorageProviderWithReplica extends IStorageProvider {
+  /** The replica holding this space's documents. */
   replica: ISpaceReplica;
 
   /** Establish the authenticated space session without reading entity values. */

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -77,7 +77,7 @@ import type {
   ISpaceReplica,
   IStorageManager,
   IStorageNotification,
-  IStorageProviderWithReplica,
+  IStorageProvider,
   IStorageSubscription,
   IStorageTransaction,
   IStorageTransactionInconsistent,
@@ -630,11 +630,6 @@ export interface Options {
   spaceIdentity?: Signer;
 }
 
-export const defaultSettings: IRemoteStorageProviderSettings = {
-  maxSubscriptionsPerSpace: 50_000,
-  connectionTimeout: 30_000,
-};
-
 /**
  * Max concurrent watch-refresh round trips per space when
  * `experimentalConcurrentWatchRefresh` is on. Bounds how many requests a
@@ -931,7 +926,7 @@ export class StorageManager implements IStorageManager {
     this.id = options.id ?? crypto.randomUUID();
     this.#sessionId = this.id;
     this.as = options.as;
-    this.#settings = options.settings ?? defaultSettings;
+    this.#settings = options.settings ?? {};
     this.#sessionFactory = sessionFactory;
     if (options.spaceIdentity) {
       this.registerSpaceIdentity(options.spaceIdentity);
@@ -1008,7 +1003,7 @@ export class StorageManager implements IStorageManager {
     this.#spaceIdentities.set(identity.did() as MemorySpace, identity);
   }
 
-  open(space: MemorySpace): IStorageProviderWithReplica {
+  open(space: MemorySpace): IStorageProvider {
     let provider = this.#providers.get(space);
     if (!provider) {
       // Session principal drives user/session scoped storage. Even when we have
@@ -1775,7 +1770,7 @@ type ProviderSyncRequest = {
  */
 type TelemetrySink = { submit(marker: RuntimeTelemetryMarker): void };
 
-class Provider implements IStorageProviderWithReplica {
+class Provider implements IStorageProvider {
   replica: SpaceReplica;
   #syncRequests = new Map<string, ProviderSyncRequest>();
   #destroyed = false;
@@ -1987,10 +1982,6 @@ class Provider implements IStorageProviderWithReplica {
       this.options.routeState.generation++;
     }
     await this.replica.closeNow();
-  }
-
-  getReplica(): string | undefined {
-    return this.options.space;
   }
 }
 

--- a/packages/runner/test/memory-v2-concurrent-watch-refresh.test.ts
+++ b/packages/runner/test/memory-v2-concurrent-watch-refresh.test.ts
@@ -18,8 +18,7 @@ import {
   type SessionSync,
   type SessionSyncUpsert,
 } from "@commonfabric/memory/v2";
-import type { IStorageProviderWithReplica } from "../src/storage/interface.ts";
-import { defaultSettings } from "../src/storage/v2.ts";
+import type { IStorageProvider } from "../src/storage/interface.ts";
 import {
   ScriptedSessionTransport,
   type ScriptedTransportMessage,
@@ -34,7 +33,7 @@ const space = signer.did();
 // the concurrency test proves the observed max equals this.
 const WINDOW = 8;
 
-type TestProvider = IStorageProviderWithReplica & {
+type TestProvider = IStorageProvider & {
   get(uri: URI): EntityDocument | undefined;
   sync(
     uri: URI,
@@ -150,7 +149,6 @@ function makeProvider(concurrent: boolean) {
     as: signer,
     memoryHost: new URL(`memory://concurrent-refresh-${concurrent}`),
     settings: {
-      ...defaultSettings,
       experimentalConcurrentWatchRefresh: concurrent,
     },
   }, new SingleSessionFactory(transport));

--- a/packages/runner/test/memory-v2-lazy-session.test.ts
+++ b/packages/runner/test/memory-v2-lazy-session.test.ts
@@ -326,7 +326,7 @@ describe("Memory v2 entity identifier capabilities", () => {
     });
 
     try {
-      expect(provider.getReplica()).toBe(space);
+      expect(provider.replica.did()).toBe(space);
       expect(await provider.listEntityIds!()).toBeUndefined();
       expect(await provider.listEntityIdPage!()).toBeUndefined();
       expect(await provider.entityIdExists!("of:fid1:missing-capability"))

--- a/packages/runner/test/memory-v2-reconnect-race.test.ts
+++ b/packages/runner/test/memory-v2-reconnect-race.test.ts
@@ -11,7 +11,7 @@ import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import { StorageManager as CutoverStorageManager } from "../src/storage/cache.deno.ts";
 import type {
-  IStorageProviderWithReplica,
+  IStorageProvider,
   StorageNotification,
 } from "../src/storage/interface.ts";
 import {
@@ -29,7 +29,7 @@ const signer = await Identity.fromPassphrase("memory-v2-reconnect-race");
 const space = signer.did();
 const DOCUMENT_MIME = "application/json" as const;
 
-type TestProvider = IStorageProviderWithReplica & {
+type TestProvider = IStorageProvider & {
   get(uri: URI): EntityDocument | undefined;
   send(
     batch: { uri: URI; value: EntityDocument | undefined }[],

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -42,7 +42,7 @@ import { applyPatch } from "../../memory/v2/patch.ts";
 import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import type { AppliedCommit } from "@commonfabric/memory/v2/engine";
 import type {
-  IStorageProviderWithReplica,
+  IStorageProvider,
   StorageNotification,
 } from "../src/storage/interface.ts";
 import { setConflictAdmissionMode } from "../src/storage/v2.ts";
@@ -70,7 +70,7 @@ const DOCS = {
 } as const;
 type DocKey = keyof typeof DOCS;
 
-type TestProvider = IStorageProviderWithReplica & {
+type TestProvider = IStorageProvider & {
   get(uri: URI): EntityDocument | undefined;
 };
 

--- a/packages/runner/test/memory-v2-sync-under-pending.test.ts
+++ b/packages/runner/test/memory-v2-sync-under-pending.test.ts
@@ -7,7 +7,7 @@ import {
   type SessionSyncUpsert,
 } from "@commonfabric/memory/v2";
 import type {
-  IStorageProviderWithReplica,
+  IStorageProvider,
   StorageNotification,
 } from "../src/storage/interface.ts";
 import {
@@ -30,7 +30,7 @@ const foreignSpace = (await Identity.fromPassphrase(
 )).did();
 const DOCUMENT_MIME = "application/json" as const;
 
-type TestProvider = IStorageProviderWithReplica & {
+type TestProvider = IStorageProvider & {
   get(uri: URI): EntityDocument | undefined;
   sync(
     uri: URI,

--- a/packages/runner/test/memory-v2-watch-refresh-race.test.ts
+++ b/packages/runner/test/memory-v2-watch-refresh-race.test.ts
@@ -7,7 +7,7 @@ import {
   type SessionSync,
   type SessionSyncUpsert,
 } from "@commonfabric/memory/v2";
-import type { IStorageProviderWithReplica } from "../src/storage/interface.ts";
+import type { IStorageProvider } from "../src/storage/interface.ts";
 import {
   ScriptedSessionTransport,
   type ScriptedTransportMessage,
@@ -18,7 +18,7 @@ import {
 const signer = await Identity.fromPassphrase("memory-v2-watch-refresh-race");
 const space = signer.did();
 
-type TestProvider = IStorageProviderWithReplica & {
+type TestProvider = IStorageProvider & {
   get(uri: URI): EntityDocument | undefined;
   sync(
     uri: URI,

--- a/packages/runner/test/memory-v2-watch-remove-coverage.test.ts
+++ b/packages/runner/test/memory-v2-watch-remove-coverage.test.ts
@@ -13,7 +13,7 @@ import {
   type SessionSync,
   type SessionSyncUpsert,
 } from "@commonfabric/memory/v2";
-import type { IStorageProviderWithReplica } from "../src/storage/interface.ts";
+import type { IStorageProvider } from "../src/storage/interface.ts";
 import {
   ScriptedSessionTransport,
   type ScriptedTransportMessage,
@@ -24,7 +24,7 @@ import {
 const signer = await Identity.fromPassphrase("memory-v2-watch-remove-coverage");
 const space = signer.did();
 
-type TestProvider = IStorageProviderWithReplica & {
+type TestProvider = IStorageProvider & {
   get(uri: URI): EntityDocument | undefined;
   sync(
     uri: URI,

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -53,10 +53,7 @@ import {
   stripSigilCfcLabelViews,
 } from "@commonfabric/runner/cfc";
 import { NameSchema, rendererVDOMSchema } from "@commonfabric/runner/schemas";
-import {
-  defaultSettings,
-  StorageManager,
-} from "../../runner/src/storage/cache.ts";
+import { StorageManager } from "../../runner/src/storage/cache.ts";
 import {
   getMetaLink,
   KeepAsCell,
@@ -537,7 +534,6 @@ export class RuntimeProcessor {
       // watch-refresh round trips up to a bounded window. Off unless the host
       // set it; the default is strict single-flight.
       settings: {
-        ...defaultSettings,
         experimentalConcurrentWatchRefresh:
           data.concurrentWatchRefresh === true,
       },


### PR DESCRIPTION
…embers around it

The storage provider contract was split across two interfaces. A base `IStorageProvider` declared four members, and `IStorageProviderWithReplica` extended it with the replica handle and the whole set of optional capabilities the runner actually calls. There is only one implementation of either, the `Provider` class in the memory v2 storage module, and every real consumer named the extended variant: the storage manager's `open()` return type, the runner, and every storage test. The base tier survived only as a type re-export from `runtime.ts` that nothing imported, so the split bought no substitutability and instead made a reader ask which of the two tiers a given site meant.

This merges the extended interface's members into `IStorageProvider` and deletes the extended name. Every reference is a rename; no member changes type, so what each consumer sees is unchanged. The `runtime.ts` re-export of the base tier goes with it, since it existed only to publish a name no one asked for.

Collapsing the two tiers exposed dead members that the split had kept out of each other's sight, and this removes them in the same pass.

`IRemoteStorageProviderSettings` declared two required numeric fields, `maxSubscriptionsPerSpace` and `connectionTimeout`. Both were supplied by `defaultSettings` and by every settings object built from it, and neither was ever read. The names promise behavior the code does not have: no subscription cap is enforced, and no connect attempt is abandoned after the stated interval. Declaring them meant each construction site had to carry two numbers forward, and a reader had to work out from their absence that they do nothing. Both are deleted, leaving the settings object as the carrier for the experimental concurrent watch-refresh flag, which is the one field anything reads.

That left `defaultSettings` as the empty object with all its apparatus intact: two re-exports through the public storage entry points, two spread sites, and a fallback. Spreading an empty object into a settings literal contributes nothing, so both call sites were writing a spread under an override and reading as though a set of defaults were being layered beneath it when none were. Both spreads are gone and the literals now say what they always meant, the fallback for a caller that supplies no settings is written inline, and the name and its two exports are deleted. Nothing has to look up what the storage defaults are in order to learn that there are none.

`getReplica()` did not return a replica. It returned the provider's space DID string, and its declared type said so. While the contract was split the mismatch was easy to miss; merging the tiers put the method directly above the `replica` field, which holds an actual `ISpaceReplica`, and made two similar names with unrelated types adjacent. The method had no production caller anywhere in the repository. Its one use was a single assertion in the entity-identifier capability test, checking that a provider knows its space. That assertion now reads the space from the replica instead. The two routes give the same value: a provider builds its replica by passing its own options through, the replica stores that space in a readonly field, and `did()` reads the field with no session or network work. So the test still checks what it checked, without a method that existed only to be checked.

`LocalStorageOptions` is deleted as well. It had no references anywhere in the repository.

The server-side-execution spec named the extended interface as the contract an executor-grade provider would implement, and is updated to the collapsed name. The runner README already described `open()` as returning `IStorageProvider`, which the collapse makes true.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unify the storage provider contract under `IStorageProvider` and remove dead settings, types, and methods to simplify the runner API. No runtime behavior changes.

- **Refactors**
  - Merged `IStorageProviderWithReplica` into `IStorageProvider`; `open()` now returns `IStorageProvider`.
  - Removed unused `IRemoteStorageProviderSettings` fields `maxSubscriptionsPerSpace` and `connectionTimeout`; deleted `defaultSettings` and spreads; fallbacks are inline.
  - Deleted `getReplica()`; tests now read `provider.replica.did()`. Removed `LocalStorageOptions`.
  - Dropped unused type re-export from `runtime.ts`; cleaned up `cache.ts`/`cache.deno.ts` exports.
  - Updated docs to reference `IStorageProvider`.

- **Migration**
  - Replace `IStorageProviderWithReplica` imports/usages with `IStorageProvider`.
  - Stop importing or spreading `defaultSettings`; pass `settings: { experimentalConcurrentWatchRefresh?: boolean }` only when needed.

<sup>Written for commit 05383190bc4c3a35942ae138ab5491cd0d8632d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

