### PR TITLE
refactor(runner): remove the vestigial isolate hosting layer from the…

### DIFF
--- a/docs/specs/module-loading.md
+++ b/docs/specs/module-loading.md
@@ -838,8 +838,8 @@ This spec supplies the stable implementation identity that
 - Verification: [`verifyCompiledModuleBody`][c8] and [`verifyModuleGraph`][c8],
   over the shared [`classifyModuleItems`][c9] core.
 - SES lockdown and source-map registration: [`ensureSESInitialized`][c10],
-  [`SESRuntime.loadSourceMapLazy`][c10]; the shared invoke isolate the harness
-  calls into is [`SESRuntime.getIsolate`][c10].
+  [`SESRuntime.loadSourceMapLazy`][c10]; the error-mapping entry point the
+  harness invokes pattern functions through is [`SESRuntime.exec`][c10].
 - Debug-only source annotation: [`annotateFunctionDebugMetadata`][c11] via
   [`getExternalSourceLocation`][c11].
 - Scheduler fingerprints: [`schedulerImplementationFingerprint`][c12] and

--- a/docs/specs/sandboxing/SES_SANDBOXING_SPEC.md
+++ b/docs/specs/sandboxing/SES_SANDBOXING_SPEC.md
@@ -1436,15 +1436,16 @@ source-map bytes — which the compile cache stores and syncs — by roughly 65%
 
 **What exists today.** The shipped surface is `SESRuntime`
 (`packages/runner/src/sandbox/ses-runtime.ts`) over `SourceMapParser`
-(`packages/js-compiler/source-map.ts`): `loadSourceMap` / `loadSourceMapLazy`
-register maps by filename, `mapPosition` resolves one coordinate, `parseStack`
-rewrites a whole stack, and `mapThrownError` does that once per error —
-`materializeHostVisibleStack`, then `parseStack`, then a `markErrorStackMapped`
-marker, because `parseStack` is **not idempotent**: per-module maps are
-registered under the same module path that mapped frames carry as their source,
-so re-parsing an already-mapped stack would look the now-authored coordinates up
-again and corrupt them. `Engine` re-exports `parseStack` / `mapPosition`, and the
-scheduler's diagnostics share the same marker helpers.
+(`packages/js-compiler/source-map.ts`): `loadSourceMapLazy` registers a map by
+filename as a provider that runs on first lookup, `mapPosition` resolves one
+coordinate, `parseStack` rewrites a whole stack, and `mapThrownError` does that
+once per error — `materializeHostVisibleStack`, then `parseStack`, then a
+`markErrorStackMapped` marker, because `parseStack` is **not idempotent**:
+per-module maps are registered under the same module path that mapped frames
+carry as their source, so re-parsing an already-mapped stack would look the
+now-authored coordinates up again and corrupt them. `Engine` re-exports
+`parseStack` / `mapPosition`, and the scheduler's diagnostics share the same
+marker helpers.
 
 §8.4.1 describes the interface shape that surface already satisfies. The
 `ErrorMappingOptions` / `MappedError` / execution-wrapper designs in §8.4.2–§8.4.3
@@ -1465,7 +1466,10 @@ The existing shared surface is the right baseline:
 ```typescript
 // Shown at module scope.
 interface StackMapper {
-  loadSourceMap(filename: string, sourceMap: SourceMap): void;
+  loadSourceMapLazy(
+    filename: string,
+    provider: () => SourceMap | undefined,
+  ): void;
   mapPosition(
     filename: string,
     line: number,
@@ -1513,8 +1517,8 @@ interface MappedError {
 
 Required behavior:
 
-- if `filename` and `sourceMap` are present, the shared mapper loads that map
-  before parsing the stack
+- if `filename` and `sourceMap` are present, the shared mapper registers that
+  map under `filename` before parsing the stack
 - `mappedStack` is the formatted post-classification stack shown to users or
   logs
 - `patternLocation` comes from the first `pattern` frame after classification
@@ -1532,7 +1536,7 @@ function mapError(
   options: ErrorMappingOptions = {},
 ): MappedError {
   if (options.filename && options.sourceMap) {
-    mapper.loadSourceMap(options.filename, options.sourceMap);
+    mapper.loadSourceMapLazy(options.filename, () => options.sourceMap);
   }
 
   return classifyAndFormatMappedError(mapper, error, options);
@@ -2620,8 +2624,9 @@ in review or incident work should be added here with a class and a status.
   build exposes no `ModuleSource`/`StaticModuleRecord` constructor
 - **Import hooks**: `resolveHook` and `importNowHook`, the callbacks a
   Compartment uses to resolve a specifier and fetch its record
-- **SESIsolate**: Runtime component that creates and manages Compartments with globals injection
-- **SESRuntime**: Runtime harness that integrates SESIsolate into the pattern execution pipeline
+- **SESRuntime**: Runtime harness that owns the shared source-map state,
+  evaluates callbacks in the shared callback Compartment, and maps the stacks of
+  errors thrown by the pattern execution pipeline
 
 ---
 

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -1126,7 +1126,7 @@ export class Engine extends EventTarget {
           verify: false, // already verified at compile time
         });
       } catch (error) {
-        // Module evaluation runs outside an isolate `exec`, so errors thrown
+        // Module evaluation runs outside an `exec` call, so errors thrown
         // at module scope would otherwise surface with a censored (empty) or
         // raw-coordinate stack. Materialize + source-map it here (once),
         // matching how invoked-function errors are mapped.
@@ -1415,19 +1415,18 @@ export class Engine extends EventTarget {
     });
   }
 
-  // Invokes a function that should've came from this isolate (unverifiable).
-  // We use this to hook into the isolate's source mapping functionality.
+  // Invokes a function that should've came from this SES runtime
+  // (unverifiable). We use this to hook into its source mapping functionality.
   invoke(fn: () => any): any {
     // Scheduler dictates this is a synchronous function,
     // and if we have functions from this source, this should already
     // be set up.
-    // Some tests invoke values outside of this isolate, so just
+    // Some tests invoke values outside of this SES runtime, so just
     // execute and return if runtime internals have not been initialized.
     if (!this.runtimeInternals && !this.sesRuntime) {
       return fn();
     }
-    return this.getSESRuntime().getIsolate("__engine-invoke__").value(fn)
-      .invoke().inner();
+    return this.getSESRuntime().exec(fn);
   }
 
   getInvocation(source: string): HarnessedFunction {

--- a/packages/runner/src/sandbox/mod.ts
+++ b/packages/runner/src/sandbox/mod.ts
@@ -2,7 +2,6 @@ export { createModuleCompartmentGlobals } from "./compartment-globals.ts";
 export {
   ensureSESLockdown,
   evaluateCallbackSourceInSES,
-  SESIsolate,
   SESRuntime,
   type SESRuntimeOptions,
 } from "./ses-runtime.ts";

--- a/packages/runner/src/sandbox/ses-runtime.ts
+++ b/packages/runner/src/sandbox/ses-runtime.ts
@@ -1,16 +1,13 @@
-import type { JsScript, SourceMap } from "@commonfabric/js-compiler";
+import type { SourceMap } from "@commonfabric/js-compiler";
 import {
   type MappedPosition,
   SourceMapParser,
 } from "@commonfabric/js-compiler/source-map";
-import { getLogger } from "@commonfabric/utils/logger";
 import "ses";
 import { createCallbackCompartmentGlobals } from "./compartment-globals.ts";
 import { restoreErrorIsError } from "./error-taming.ts";
 import { hardenVerifiedFunction } from "./function-hardening.ts";
 import { sanitizeLocaleMethods } from "./locale-taming.ts";
-
-const logger = getLogger("ses-runtime");
 
 export interface SESRuntimeOptions {
   globals?: Record<string, unknown>;
@@ -21,13 +18,6 @@ export interface SESRuntimeOptions {
 interface SESCompartmentLike {
   evaluate(source: string): unknown;
   globalThis?: object;
-}
-
-export interface JsValue {
-  invoke(...args: unknown[]): JsValue;
-  inner(): unknown;
-  asObject(): object;
-  isObject(): boolean;
 }
 
 class SESInternals {
@@ -47,10 +37,6 @@ class SESInternals {
     } catch (e: unknown) {
       throw this.mapThrownError(e);
     }
-  }
-
-  loadSourceMap(filename: string, sourceMap: SourceMap) {
-    this.sourceMaps.load(filename, sourceMap);
   }
 
   loadSourceMapLazy(filename: string, provider: () => SourceMap | undefined) {
@@ -99,127 +85,25 @@ class SESInternals {
   }
 }
 
-class SESJsValue implements JsValue {
-  constructor(
-    private internals: SESInternals,
-    private value: unknown,
-  ) {}
-
-  invoke(...args: unknown[]): SESJsValue {
-    if (typeof this.value !== "function") {
-      throw new Error("Cannot invoke non function");
-    }
-    const result = this.internals.exec(() =>
-      Reflect.apply(
-        this.value as (...args: unknown[]) => unknown,
-        undefined,
-        args,
-      )
-    );
-    return new SESJsValue(this.internals, result);
-  }
-
-  inner(): unknown {
-    return this.value;
-  }
-
-  asObject(): object {
-    if (!this.isObject()) {
-      throw new Error("Value is not an object");
-    }
-    return this.value as object;
-  }
-
-  isObject(): boolean {
-    return !!(this.value && typeof this.value === "object");
-  }
-}
-
-export class SESIsolate {
-  private globals: Record<string, unknown>;
-  private internals: SESInternals;
-
-  constructor(
-    private options: SESRuntimeOptions = {},
-    internals?: SESInternals,
-  ) {
-    this.internals = internals ?? new SESInternals(options);
-    this.globals = { ...(options.globals ?? {}) };
-    ensureSESInitialized(!!options.lockdown);
-  }
-
-  execute(input: string | JsScript): SESJsValue {
-    logger.timeStart("execute");
-    try {
-      const { js, filename, sourceMap } = typeof input === "string"
-        ? { js: input, filename: "NO-NAME.js" }
-        : input;
-
-      if (filename && sourceMap) {
-        this.internals.loadSourceMap(filename, sourceMap);
-      }
-
-      logger.timeStart("execute", "createCompartment");
-      let compartment;
-      try {
-        compartment = createCompartment(this.globals);
-      } finally {
-        logger.timeEnd("execute", "createCompartment");
-      }
-
-      logger.timeStart("execute", "compartmentEvaluate");
-      try {
-        const result = this.internals.exec(() => compartment.evaluate(js));
-        return new SESJsValue(this.internals, result);
-      } finally {
-        logger.timeEnd("execute", "compartmentEvaluate");
-      }
-    } finally {
-      logger.timeEnd("execute");
-    }
-  }
-
-  value<T>(value: T): SESJsValue {
-    return new SESJsValue(this.internals, value);
-  }
-
-  mapPosition(
-    filename: string,
-    line: number,
-    column: number,
-  ): MappedPosition | null {
-    return this.internals.mapPosition(filename, line, column);
-  }
-
-  parseStack(stack: string): string {
-    return this.internals.parseStack(stack);
-  }
-
-  clear(): void {
-    this.internals.clear();
-  }
-}
-
 export class SESRuntime extends EventTarget {
   private internals: SESInternals;
-  private isolates = new Map<string, SESIsolate>();
   private callbackEvaluator: SESCallbackEvaluator;
 
-  constructor(private options: SESRuntimeOptions = {}) {
+  constructor(options: SESRuntimeOptions = {}) {
     super();
     this.internals = new SESInternals(options);
     this.callbackEvaluator = new SESCallbackEvaluator(options);
   }
 
-  getIsolate(key: string): SESIsolate {
-    const existing = this.isolates.get(key);
-    if (existing) {
-      return existing;
-    }
-
-    const isolate = new SESIsolate(this.options, this.internals);
-    this.isolates.set(key, isolate);
-    return isolate;
+  /**
+   * Call `callback` and source-map the stack of whatever it throws — or of the
+   * rejection, when it returns a promise. Mapping happens once per error (see
+   * `SESInternals.mapThrownError`). The scheduler runs each action through
+   * `Engine.invoke`, which lands here, so an error raised in pattern code
+   * reaches the scheduler carrying authored coordinates.
+   */
+  exec<T>(callback: () => T): T {
+    return this.internals.exec(callback);
   }
 
   mapPosition(
@@ -232,22 +116,12 @@ export class SESRuntime extends EventTarget {
 
   /**
    * Register a source map under `filename` so {@link mapPosition} (and stack
-   * parsing) can translate bundle coordinates back to original sources. The
-   * module-record loader composes a per-load bundle map from the per-module maps
-   * and registers it here; {@link SESIsolate.execute} registers one implicitly
-   * for a single-script evaluation.
-   */
-  loadSourceMap(filename: string, sourceMap: SourceMap): void {
-    this.internals.loadSourceMap(filename, sourceMap);
-  }
-
-  /**
-   * Deferred variant of {@link loadSourceMap}: `provider` runs (once) on the
-   * first lookup that needs `filename`. The ESM boot path registers its
-   * composed bundle/per-module maps this way — composition is a per-segment
-   * VLQ transcode over every module, and its only consumers (error mapping,
-   * debug `fn.src` resolution) are on-demand, so boots that never look up a
-   * frame never pay it (CT-1819).
+   * parsing) can translate bundle coordinates back to original sources.
+   * `provider` runs (once) on the first lookup that needs `filename`. The ESM
+   * boot path registers its composed bundle/per-module maps this way —
+   * composition is a per-segment VLQ transcode over every module, and its only
+   * consumers (error mapping, debug `fn.src` resolution) are on-demand, so
+   * boots that never look up a frame never pay it (CT-1819).
    */
   loadSourceMapLazy(
     filename: string,
@@ -263,7 +137,7 @@ export class SESRuntime extends EventTarget {
   /**
    * Materialize + source-map a thrown error's stack (once — see
    * `SESInternals.mapThrownError`). Used by the engine for errors that escape
-   * module evaluation outside an isolate `exec` (e.g. `loadModuleGraph`).
+   * module evaluation outside an {@link exec} call (e.g. `loadModuleGraph`).
    */
   mapThrownError(error: unknown): unknown {
     return this.internals.mapThrownError(error);
@@ -276,7 +150,6 @@ export class SESRuntime extends EventTarget {
   clear(): void {
     this.internals.clear();
     this.callbackEvaluator.clear();
-    this.isolates.clear();
   }
 }
 

--- a/packages/runner/test/runtime.test.ts
+++ b/packages/runner/test/runtime.test.ts
@@ -11,20 +11,6 @@ import { getRuntimeModuleExports } from "../src/sandbox/runtime-modules.ts";
 const signer = await Identity.fromPassphrase("test operator");
 
 describe("SESRuntime", () => {
-  it("creates distinct isolates per key and resets them on clear", () => {
-    const runtime = new SESRuntime({ lockdown: true });
-
-    const alpha = runtime.getIsolate("alpha");
-    const beta = runtime.getIsolate("beta");
-
-    expect(alpha).not.toBe(beta);
-
-    runtime.clear();
-
-    const alphaAfterClear = runtime.getIsolate("alpha");
-    expect(alphaAfterClear).not.toBe(alpha);
-  });
-
   it("clears cached callback creators on runtime.clear", () => {
     const runtime = new SESRuntime({ lockdown: true });
 

--- a/packages/runner/test/ses-runtime-source-maps.test.ts
+++ b/packages/runner/test/ses-runtime-source-maps.test.ts
@@ -3,31 +3,11 @@ import { expect } from "@std/expect";
 import { SESRuntime } from "../src/sandbox/ses-runtime.ts";
 import { identitySourceMap } from "@commonfabric/js-compiler/source-map";
 
-// The runner-facing source-map surface of the SES runtime. The module-graph boot
-// path registers DEFERRED providers (CT-1819), but the eager chain stays
-// load-bearing: `SESIsolate.execute` registers a per-script map directly, and an
-// explicit registration must win over any pending provider for the same name.
+// The runner-facing source-map surface of the SES runtime: the module-graph boot
+// path registers deferred providers (CT-1819), and both coordinate lookup and
+// stack parsing read what those providers materialize. The provider semantics
+// themselves belong to `SourceMapParser` and are covered by its own tests.
 describe("SESRuntime source-map registration", () => {
-  it("eager loads resolve immediately and supersede lazy providers", () => {
-    const runtime = new SESRuntime();
-    let providerCalls = 0;
-    runtime.loadSourceMapLazy("m.js", () => {
-      providerCalls++;
-      return identitySourceMap(3, "/id/stale.tsx");
-    });
-    runtime.loadSourceMap("m.js", identitySourceMap(3, "/id/fresh.tsx"));
-
-    const pos = runtime.mapPosition("m.js", 2, 0);
-    expect(pos?.source).toBe("/id/fresh.tsx");
-    expect(pos?.line).toBe(2);
-    // The pending provider was displaced without ever running.
-    expect(providerCalls).toBe(0);
-    // Stack parsing rides the same registry.
-    expect(runtime.parseStack("    at fn (m.js:3:0)")).toContain(
-      "/id/fresh.tsx:3:0",
-    );
-  });
-
   it("lazy providers materialize once, on first lookup", () => {
     const runtime = new SESRuntime();
     let providerCalls = 0;
@@ -39,5 +19,18 @@ describe("SESRuntime source-map registration", () => {
     expect(runtime.mapPosition("lazy.js", 1, 0)?.source).toBe("/id/lazy.tsx");
     runtime.mapPosition("lazy.js", 2, 0);
     expect(providerCalls).toBe(1);
+  });
+
+  it("stack parsing rides the same registry as coordinate lookup", () => {
+    const runtime = new SESRuntime();
+    runtime.loadSourceMapLazy(
+      "m.js",
+      () => identitySourceMap(3, "/id/authored.tsx"),
+    );
+
+    expect(runtime.mapPosition("m.js", 2, 0)?.source).toBe("/id/authored.tsx");
+    expect(runtime.parseStack("    at fn (m.js:3:0)")).toContain(
+      "/id/authored.tsx:3:0",
+    );
   });
 });


### PR DESCRIPTION
… SES runtime

The SES runtime carried a value-marshalling and isolate-hosting layer from the era when the runner hosted several named JavaScript isolates. `SESRuntime` kept a string-keyed map of `SESIsolate`s, each of which wrapped a compartment and could evaluate a source string; values crossing the boundary were wrapped in `SESJsValue`, which implemented the `JsValue` interface with `invoke`, `inner`, `asObject`, and `isObject`.

None of that structure was doing any work. Every isolate the map could hand out shared one `SESInternals` and one set of options, so distinct keys could not produce distinct behavior even in principle. `SESIsolate.execute` had no callers at all, in production or in tests. The map itself had exactly one production caller: `Engine.invoke`, which always asked for the same fixed key and then ran `getIsolate(key).value(fn).invoke().inner()` — a chain that allocates two wrapper objects per scheduler action invocation to reach `SESInternals.exec(fn)`, which is the one thing it actually wanted (run the function and source-map the stack of anything it throws, once).

This removes the `JsValue` interface, the `SESJsValue` class, the `SESIsolate` class, and the keyed isolate map, and gives `SESRuntime` a direct `exec<T>(callback: () => T): T` that delegates to `SESInternals.exec`. `Engine.invoke` calls it. The callback compartment is untouched: it always lived on `SESCallbackEvaluator`, which the isolate layer only forwarded to.

Lockdown initialization is unaffected. The `SESIsolate` constructor called `ensureSESInitialized`, but the engine already calls `ensureSESLockdown()` immediately before constructing its `SESRuntime`, and the callback evaluator initializes lockdown for its own compartment.

Removing the isolate layer also strands the eager half of source-map registration, so this drops that too. `SESRuntime` offered both an eager `loadSourceMap`, which stores a composed map immediately, and a deferred `loadSourceMapLazy`, which stores a provider that runs the first time a lookup needs the filename. `SESIsolate.execute` was the eager form's only caller, registering a map for a single-script evaluation. The engine's two remaining registration sites are deferred by design and could not use the eager form regardless: composing a bundle map is a per-segment VLQ transcode over every module in the graph, and its only consumers — error mapping and debug `fn.src` resolution — are on demand, so a boot that never looks up a frame should never pay for the composition. Neither site holds a finished map; each holds the inputs to compose one. So `SESRuntime.loadSourceMap` and the `SESInternals.loadSourceMap` behind it go as well.

`SourceMapParser.load` stays. It is the underlying registration primitive in js-compiler, `loadLazy` is defined in terms of the same store, and its precedence rule — an explicit map supersedes a pending provider for the same filename — is covered directly by that package's own tests.

Tests follow the same reasoning. The case asserting that two isolate keys yield two isolate objects is deleted rather than rewritten, because the concept it tested no longer exists. The case asserting that an eager registration displaces a pending provider is deleted because it duplicates the js-compiler test named above at the layer that owns the behavior. That case also asserted something this package should still guard, that stack parsing reads the same registry registration writes to, so that becomes its own test over the deferred path. The test covering what `SESRuntime.clear()` does to the callback-creator cache is unchanged.

`SESIsolate` was never exported from the runner package index, so the only export to remove is the one from the sandbox barrel.

Documentation that named the removed pieces is updated in the same change. The module-loading spec's citation index now points at `SESRuntime.exec` instead of `SESRuntime.getIsolate`. In the SES sandboxing spec, the glossary describes `SESRuntime` on its own terms instead of as a wrapper around `SESIsolate`, and the §8.4 summary and §8.4.1 `StackMapper` baseline — both of which claim to describe the surface that exists today — now name `loadSourceMapLazy`. The unbuilt §8.4.2 `mapError` design, which optionally registers a caller-supplied map before parsing a stack, keeps that behavior and expresses it through the deferred call.

`evaluateFunctionSourceInSES` and `evaluateCallbackSourceInSES` stay where they are. They are used only by tests and a benchmark, but they call module-private helpers, so moving them to a test helper would mean exporting more of this module's internals than it removes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the isolate/value-wrapping layer from `SESRuntime` and added a direct `exec` entry point used by `Engine.invoke`; eager source-map registration was dropped in favor of `loadSourceMapLazy` for on-demand composition.

- **Refactors**
  - Removed `JsValue`, `SESJsValue`, `SESIsolate`, and the keyed isolate map.
  - Added `SESRuntime.exec<T>(callback)` delegating to `SESInternals.exec`; `Engine.invoke` now calls `sesRuntime.exec(fn)`.
  - Removed `SESRuntime.loadSourceMap`; kept `loadSourceMapLazy` for deferred map composition and lookups.
  - Lockdown and the callback Compartment remain unchanged; error stacks still map once per error.
  - Updated docs to reference `SESRuntime.exec` and `loadSourceMapLazy`; removed `SESIsolate` from `sandbox/mod.ts`.
  - Tests: removed isolate-key and eager supersede cases; added a deferred path test to ensure stack parsing uses the same registry; kept the `clear()` callback-creator cache test.

- **Migration**
  - Replace `getIsolate(...).value(fn).invoke().inner()` with `sesRuntime.exec(fn)`.
  - Replace `loadSourceMap(filename, map)` with `loadSourceMapLazy(filename, () => map)`.

<sup>Written for commit e1ef5aafbf3fa4c89dfcb787ab923aff034ded6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

