### PR TITLE
fix(integration): drive the page from the browser fills, and fix pier…

### DIFF
--- a/docs/development/DEPENDENCIES.md
+++ b/docs/development/DEPENDENCIES.md
@@ -456,9 +456,12 @@ boundary:
 | Start and acknowledge screencast frames | `packages/integration/page.ts` | Raw page protocol bindings |
 | Capture a Deno inspector CPU profile | `packages/cli/support/profiling/inspector-protocol-client.ts` | Chrome DevTools Protocol over the inspector WebSocket |
 
-The pierce strategy retains the repository's existing selector semantics. It
-searches elements inside open shadow roots and excludes matching elements in
-the light DOM. Immediate `$` and `$$` calls perform one query. A
+The pierce strategy searches the whole page: everything a native query matches
+in the light DOM, plus every element inside an open shadow root at any depth. It
+walks in document order and searches an element's shadow tree as soon as it
+reaches that element. One traversal definition is serialized into each in-page
+resolver, so an immediate query and a wait for the same selector settle on the
+same elements. Immediate `$` and `$$` calls perform one query. A
 `waitForSelector` call observes DOM, selector state, and shadow-root changes in
 the page and resolves when a match appears. The event-driven wait has no
 elapsed-time deadline. Protocol shadow-root notifications cover roots attached
@@ -482,7 +485,8 @@ deno fmt --check
 deno lint
 ```
 
-The focused integration test covers native and shadow-root selection, dynamic
+The focused integration test covers native, light-DOM, and shadow-root
+selection, agreement between the immediate queries and the wait, dynamic
 element and selector-state changes, shadow roots attached after a wait starts,
 browser lifecycle compatibility, interaction callbacks, transformed element
 coordinates, and the default typing delay.

--- a/docs/development/debugging/integration-test-diagnostics.md
+++ b/docs/development/debugging/integration-test-diagnostics.md
@@ -9,8 +9,9 @@ What the failure probe contains, and where each piece lives:
 
 - **Fill phase ledger** (`__cfFillDiag`, in
   [`cfc-browser-helpers.ts`](../../../packages/patterns/integration/cfc-browser-helpers.ts))
-  — per-selector progress through the fill (found → visible → filled →
-  committed), naming the exact await that hung.
+  — per-selector progress through the fill (settled → found → visible → filled
+  → committed), naming the exact await that hung. A fill on a page that never
+  exposes `commonfabric.viewSettled` stops at the settle and says so.
 - **Host/bound-cell state** (`readCfInputProbe`, same file) — whether the
   `cf-input` host has a bound cell and a pending commit, alongside DOM
   value/visibility/disabled.

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -234,6 +234,11 @@ One line per archived document; each document's header carries the fuller
 
 ### Investigations, journals, and working notes
 
+- [2026-08-lunch-poll-join-name-fill-timeout.md](development/debugging/2026-08-lunch-poll-join-name-fill-timeout.md)
+  — why the lunch poll's intermittent `#lp-join-name` fill timeout is not a
+  fill-helper problem: the field never renders because the "Continue as guest"
+  handler's write does not reach the rendered view, and settling the view before
+  the fill does not change it. Includes a local reproduction, August 2026.
 - [cf-harness Loom migration notes](packages/cf-harness/docs/LOOM_MIGRATION_NOTES.md)
   — April 2026 pre-integration assessment of Loom's Codex batch and interactive paths.
 - [bug3-suggestion-alias-verification-2026-07.md](packages/patterns/bug3-suggestion-alias-verification-2026-07.md)

--- a/docs/history/development/debugging/2026-08-lunch-poll-join-name-fill-timeout.md
+++ b/docs/history/development/debugging/2026-08-lunch-poll-join-name-fill-timeout.md
@@ -1,0 +1,129 @@
+---
+status: historical
+created: 2026-08-03
+archived: 2026-08-03
+reason: "Investigation finding: the lunch-poll join-name fill timeout is not a fill-helper problem."
+---
+
+# The lunch poll's join-name fill timeout is not in the fill helper
+
+`packages/patterns/integration/lunch-poll-vote.test.ts` intermittently fails
+with `Timed out filling cf input "#lp-join-name"`, on either the host's fill or
+the guest's. The obvious reading is that `fillCfInput` gives up too early, or
+watches the DOM when it should be driving the page. That reading is wrong, and
+this record exists so the next person does not spend the effort a second time
+rebuilding the fill helper.
+
+## What the failure probe says
+
+The helper's own failure probe is decisive. From a CI run on `main`:
+
+```text
+"fill": { "attempts": 605, "phase": "no-element" },
+"pendingIpc": [],
+```
+
+605 evaluations across the five-minute safety net, every one of them finding no
+element at all, with nothing in flight to the worker. The predicate was never
+starved of re-evaluations: 605 over 300 seconds is exactly the cadence of the
+timer backstop in `packages/integration/utils.ts`.
+
+## Driving the page does not help
+
+The natural fix is to make the fill ask the view to settle before it reads the
+DOM, because asking the worker whether it is idle is what queues runnable pull
+work, and an integration test holds no UI subscription that would otherwise
+start it. That reasoning is sound in general, and the text waits in
+`packages/patterns/integration/cfc-browser-helpers.ts` rely on it.
+
+It does not fix this failure. With the settle in place the same test still fails
+the same way:
+
+```text
+"fill": { "attempts": 60, "phase": "no-element" },
+"pendingIpc": [],
+```
+
+Sixty attempts, each of which drove a full settle, and the field was absent for
+every one. The control genuinely never renders, so no amount of driving the page
+will surface it.
+
+## Where the fault actually is
+
+`#lp-join-name` renders only under the `showManualEntry` branch of
+`packages/patterns/lunch-poll/participant-identity-card.tsx`, and that branch is
+gated on one per-session cell:
+
+```text
+const useCustomName = Writable.perSession.of<boolean>(false);
+const showManualEntry = computed(() => useCustomName.get());
+```
+
+The only thing that sets it is the `#lp-guest-button` handler,
+`onClick={() => useCustomName.set(true)}`. So the failure means that clicking
+"Continue as guest" did not produce the manual-entry branch.
+
+The click did reach the worker: the failing probe records one completed
+`ipc/cell:send`, which is the handler dispatch. The worker then reported itself
+idle — `pendingIpc` empty, and sixty subsequent idle round-trips all resolving —
+while the rendered view never showed the branch that cell drives. The gap is
+between the handler's write and the rendered view, not in how the test waits for
+it.
+
+Two leads worth pulling, in order:
+
+- The failing probe records `ipc/vdom:mount` twice and `ipc/vdom:unmount` once.
+  Confirm the piece's vdom is still mounted at the point of failure; the probe
+  also reports an empty `hostTagName`, which is consistent with the card not
+  being in the document at all.
+- The card's own comment notes that `hasProfile` is a cross-space computed value
+  with a transient empty-name window, and that `showProfileSetup` (which renders
+  the guest button) and `showProfileJoin` swap as it resolves. Establish whether
+  the handler's write lands while that swap is in flight, and whether the write
+  is observed by the recomputation that produces the branch.
+
+## Reproducing it
+
+It reproduced once locally, on the first run of this test in a fresh working
+copy, and not since. Start the local dev servers for the copy with its port
+offset, then point the test at them:
+
+```text
+API_URL=http://localhost:<toolshed-port> FRONTEND_URL=http://localhost:<shell-port> \
+  LOG_LEVEL=warn deno test --trace-leaks -A ./integration/lunch-poll-vote.test.ts
+```
+
+A failing run takes the full five-minute bound and a passing one finishes in
+under ten seconds, so the two are easy to tell apart while iterating.
+
+There is no reliable reproduction yet. These attempts did not produce one, and
+each rules something out:
+
+- The click and the field it should reveal, driven on one browser for ten
+  consecutive navigations: ten passes. The step is not fragile on its own.
+- The same, on two browsers booted against the piece concurrently, for eight
+  navigations and sixteen clicks: sixteen passes. Concurrency between the two
+  browsers is not sufficient either, and the field appeared immediately every
+  time rather than late.
+- The whole test against freshly restarted shell and toolshed processes: passes.
+  The compile cache is keyed per space and every run takes a fresh space UUID,
+  so restarting the servers does not make the run colder.
+- The whole test under enough busy loops to saturate every core: passes. Plain
+  CPU starvation is not the trigger.
+
+What the one failure had that none of these did was a first-ever boot in the
+copy, so the shell's own dev-server transform cache was cold and the browser's
+boot was much slower. That points at a slow-boot window rather than at load as
+such, and it matches this test's `beforeAll` comment about cold compiles wedging
+the worker event loop. Confirming it means catching a failure with the worker
+instrumented to say whether the handler's write to the per-session cell actually
+landed, which needs the failure to be summonable first.
+
+## What was changed on the strength of this
+
+Nothing in the pattern or the runtime. The fill helpers were changed for two
+reasons that stand on their own and are not this flake: they now drive the page
+rather than only watching it, matching the text waits beside them, and they now
+re-resolve the control after asking the host to commit, because a commit that
+re-renders the host leaves the typed value on a detached input and an empty live
+field could report a successful fill.

--- a/packages/integration/astral-adapter.ts
+++ b/packages/integration/astral-adapter.ts
@@ -5,6 +5,16 @@ import {
   type WaitForSelectorOptions,
 } from "@astral/astral";
 
+/**
+ * How `$`, `$$`, and `waitForSelector` resolve a selector.
+ *
+ * `native` hands the selector to the page's own `querySelector`, which stops at
+ * every shadow boundary. `pierce` matches everything `native` matches, in the
+ * light DOM, and in addition every element inside an open shadow root at any
+ * depth. A pierce query walks the page in document order and searches an
+ * element's shadow tree as soon as it reaches that element, so the first match
+ * is the first one in the rendered page.
+ */
 export type QueryStrategy = "native" | "pierce";
 
 export type SelectorOptions = {
@@ -285,7 +295,7 @@ export async function queryAllPierce(
       bindings,
       () =>
         bindings.Runtime.callFunctionOn({
-          functionDeclaration: contentPierceQuerySelector.toString(),
+          functionDeclaration: pierceDeclaration(contentPierceQuerySelector),
           objectId: remote.objectId,
           arguments: [
             { value: selector },
@@ -351,7 +361,9 @@ export async function waitForPierceSelector(
         bindings,
         () =>
           bindings.Runtime.callFunctionOn({
-            functionDeclaration: contentWaitForPierceSelector.toString(),
+            functionDeclaration: pierceDeclaration(
+              contentWaitForPierceSelector,
+            ),
             objectId: remote.objectId,
             arguments: [
               { value: selector },
@@ -392,29 +404,58 @@ export async function waitForPierceSelector(
   }
 }
 
-function contentPierceQuerySelector(
-  this: Document | Element,
+// The single definition of what a pierce selector matches. It runs in the page,
+// serialized into every in-page function that resolves one, so an immediate
+// query and a wait for the same selector settle on the same elements.
+//
+// The walk is document order over `root`'s descendants, entering an element's
+// open shadow tree as soon as it reaches that element, and entering `root`'s own
+// shadow tree first when `root` is an element. `root` itself is never a match,
+// which is how `querySelector` scopes a search to an element.
+function collectPierceMatches(
+  root: Document | Element,
   selector: string,
   firstOnly: boolean,
 ): Element[] {
   const matches: Element[] = [];
 
-  const visit = (root: Document | Element | ShadowRoot): boolean => {
-    for (const element of root.querySelectorAll("*")) {
-      const shadowRoot = element.shadowRoot;
-      if (!shadowRoot) continue;
-
-      for (const match of shadowRoot.querySelectorAll(selector)) {
-        matches.push(match);
+  const visit = (node: Document | Element | ShadowRoot): boolean => {
+    if (node instanceof Element && node.shadowRoot) {
+      if (visit(node.shadowRoot)) return true;
+    }
+    for (const element of node.querySelectorAll("*")) {
+      if (element.matches(selector)) {
+        matches.push(element);
         if (firstOnly) return true;
       }
-      if (visit(shadowRoot) && firstOnly) return true;
+      if (element.shadowRoot && visit(element.shadowRoot)) return true;
     }
     return false;
   };
 
-  visit(this);
+  visit(root);
   return matches;
+}
+
+// Build the `functionDeclaration` for an in-page function that resolves a pierce
+// selector. The traversal's source is declared in the enclosing scope, so the
+// serialized function's call to `collectPierceMatches` binds to it in the page
+// the same way it binds to the module-scope function here.
+function pierceDeclaration(
+  contentFunction: (this: Document | Element, ...args: never[]) => unknown,
+): string {
+  return `function (...args) {
+    const collectPierceMatches = ${collectPierceMatches.toString()};
+    return (${contentFunction.toString()}).apply(this, args);
+  }`;
+}
+
+function contentPierceQuerySelector(
+  this: Document | Element,
+  selector: string,
+  firstOnly: boolean,
+): Element[] {
+  return collectPierceMatches(this, selector, firstOnly);
 }
 
 function contentWaitForPierceSelector(
@@ -455,27 +496,8 @@ function contentWaitForPierceSelector(
     }).navigation;
     let finished = false;
 
-    const findMatch = (): Element | undefined => {
-      const visit = (
-        root: Document | Element | ShadowRoot,
-      ): Element | undefined => {
-        if (root instanceof Element && root.shadowRoot) {
-          const match = root.shadowRoot.querySelector(selector);
-          if (match) return match;
-          const nestedMatch = visit(root.shadowRoot);
-          if (nestedMatch) return nestedMatch;
-        }
-        for (const element of root.querySelectorAll("*")) {
-          const shadowRoot = element.shadowRoot;
-          if (!shadowRoot) continue;
-          const match = shadowRoot.querySelector(selector);
-          if (match) return match;
-          const nestedMatch = visit(shadowRoot);
-          if (nestedMatch) return nestedMatch;
-        }
-      };
-      return visit(this);
-    };
+    const findMatch = (): Element | undefined =>
+      collectPierceMatches(this, selector, true)[0];
 
     let state = stateOwner[stateKey];
     if (!state) {

--- a/packages/integration/page.ts
+++ b/packages/integration/page.ts
@@ -340,7 +340,11 @@ export class Page extends EventTarget {
     await this.afterNavigation?.();
   }
 
-  // Passthru of `@astral/astral`'s `Page#waitForSelector`
+  // Passthru of `@astral/astral`'s `Page#waitForSelector`.
+  //
+  // With `strategy: "pierce"` the wait is driven by page events and takes no
+  // timeout, and it resolves against the same elements `$` with that strategy
+  // returns: light-DOM elements and elements inside open shadow roots alike.
   async waitForSelector(
     selector: string,
     options?: WaitForSelectorOptions & SelectorOptions,

--- a/packages/integration/presentation/interactions.ts
+++ b/packages/integration/presentation/interactions.ts
@@ -6,16 +6,30 @@ import type { PresentationConfig } from "./config.ts";
 
 const controllers = new WeakMap<Page, PresentationInteractions>();
 
-const cfInputIsFillable = (
+// Settle the view, then report whether `selector` resolves to a fillable input.
+// The settle drives the page rather than watching it: asking the worker whether
+// it is idle queues runnable pull work that nothing else would start, so a
+// control that only the page's own pending work renders arrives on a settling
+// check and not on one that reads the DOM alone.
+//
+// Rendered, not on-screen: the fill scrolls the control into view once this
+// resolves, so its viewport position here does not bear on whether it can be
+// filled.
+const settledCfInputIsFillable = async (
   probe: ProbeApi,
   selector: string,
-): boolean => {
+): Promise<boolean> => {
+  const settle = (globalThis as typeof globalThis & {
+    commonfabric?: { viewSettled?: () => Promise<void> };
+  }).commonfabric?.viewSettled;
+  if (!settle) return false;
+  await settle();
   const element = probe.collect(selector)[0];
   if (!element) return false;
   const input = element instanceof HTMLInputElement
     ? element
     : element.shadowRoot?.querySelector("input");
-  return input instanceof HTMLInputElement && probe.isVisible(input) &&
+  return input instanceof HTMLInputElement && probe.isRendered(input) &&
     !input.disabled && !input.readOnly;
 };
 
@@ -83,6 +97,12 @@ export class PresentationInteractions {
     selector: string,
     value: string,
   ): Promise<void> {
+    // Settle before resolving the handle. A pierce-strategy wait is driven by
+    // DOM events and carries no bound of its own, so it would sit forever on a
+    // control that only the page's pending work renders.
+    await waitForCondition(this.#page, settledCfInputIsFillable, {
+      args: [selector],
+    });
     const host = await this.#page.waitForSelector(selector, {
       strategy: "pierce",
     });
@@ -91,9 +111,6 @@ export class PresentationInteractions {
         ? element
         : element.shadowRoot?.querySelector("input");
       input?.scrollIntoView({ block: "center", inline: "center" });
-    });
-    await waitForCondition(this.#page, cfInputIsFillable, {
-      args: [selector],
     });
     await this.#moveCursorToElement(host);
     const focused = await host.evaluate((element: Element) => {
@@ -121,12 +138,12 @@ export class PresentationInteractions {
       throw new Error(`"${selector}" did not resolve to a fillable input`);
     }
     await this.#page.keyboard.type(value);
-    const committed = await host.evaluate(
+    const outcome = await host.evaluate(
       async (element: Element, value: string) => {
         const input = element instanceof HTMLInputElement
           ? element
           : element.shadowRoot?.querySelector("input");
-        if (!(input instanceof HTMLInputElement)) return false;
+        if (!(input instanceof HTMLInputElement)) return "replaced";
         input.dispatchEvent(
           new Event("change", { bubbles: true, composed: true }),
         );
@@ -143,11 +160,25 @@ export class PresentationInteractions {
         await new Promise((resolve) =>
           requestAnimationFrame(() => requestAnimationFrame(resolve))
         );
-        return input.value === value;
+        // A commit that re-renders the host replaces the control. The input this
+        // fill typed into is then detached and still holds the typed text, so
+        // resolve it again and require the same node before reading the value
+        // off it.
+        const liveInput = element instanceof HTMLInputElement
+          ? element
+          : element.shadowRoot?.querySelector("input");
+        if (!element.isConnected || liveInput !== input) return "replaced";
+        return input.value === value ? "committed" : "value-mismatch";
       },
       { args: [value] },
     );
-    if (!committed) {
+    if (outcome === "replaced") {
+      throw new Error(
+        `the control behind "${selector}" was replaced while committing ` +
+          `"${value}"`,
+      );
+    }
+    if (outcome !== "committed") {
       throw new Error(
         `presentation typing did not commit "${value}" to "${selector}"`,
       );

--- a/packages/integration/test/astral-adapter.test.ts
+++ b/packages/integration/test/astral-adapter.test.ts
@@ -117,7 +117,7 @@ Deno.test("ElementHandle pierce waits observe their own shadow root", async () =
 
       const lightTarget = document.createElement("button");
       lightTarget.id = "scoped-light-target";
-      lightTarget.className = "scoped-target";
+      lightTarget.className = "scoped-light";
       host.append(lightTarget);
       document.body.append(host);
     });
@@ -143,6 +143,77 @@ Deno.test("ElementHandle pierce waits observe their own shadow root", async () =
       await (await target).getAttribute("id"),
       "scoped-shadow-target",
     );
+  } finally {
+    await closeTestBrowser(page, browser);
+  }
+});
+
+Deno.test("pierce selectors resolve light-DOM elements", async () => {
+  const browser = await launch({ headless: true });
+  const astralPage = await browser.newPage();
+  const page = new Page(astralPage, { timeout: 10_000 });
+
+  try {
+    await page.evaluate(() => {
+      const lightTarget = document.createElement("button");
+      lightTarget.className = "pierce-target";
+      lightTarget.textContent = "light";
+      document.body.append(lightTarget);
+
+      const host = document.createElement("section");
+      host.id = "pierce-shadow-host";
+      const root = host.attachShadow({ mode: "open" });
+      const shadowTarget = document.createElement("button");
+      shadowTarget.className = "pierce-target";
+      shadowTarget.textContent = "shadow";
+      root.append(shadowTarget);
+      document.body.append(host);
+
+      const scope = document.createElement("main");
+      scope.id = "pierce-scope";
+      document.body.append(scope);
+    });
+
+    const firstTarget = await page.$(".pierce-target", { strategy: "pierce" });
+    assertEquals(await firstTarget?.innerText(), "light");
+
+    const targets = await page.$$(".pierce-target", { strategy: "pierce" });
+    assertEquals(
+      await Promise.all(targets.map((target) => target.innerText())),
+      ["light", "shadow"],
+    );
+
+    const awaitedTarget = await page.waitForSelector(".pierce-target", {
+      strategy: "pierce",
+    });
+    assertEquals(await awaitedTarget.innerText(), "light");
+
+    const host = await page.waitForSelector("#pierce-shadow-host");
+    const hostTarget = await host.$(".pierce-target", { strategy: "pierce" });
+    assertEquals(await hostTarget?.innerText(), "shadow");
+
+    const lateTarget = page.waitForSelector("#late-light-target", {
+      strategy: "pierce",
+    });
+    await page.evaluate(() => {
+      const target = document.createElement("button");
+      target.id = "late-light-target";
+      target.textContent = "late light";
+      document.body.append(target);
+    });
+    assertEquals(await (await lateTarget).innerText(), "late light");
+
+    const scope = await page.waitForSelector("#pierce-scope");
+    const scopedTarget = scope.waitForSelector("#scoped-late-light-target", {
+      strategy: "pierce",
+    });
+    await page.evaluate(() => {
+      const target = document.createElement("button");
+      target.id = "scoped-late-light-target";
+      target.textContent = "scoped late light";
+      document.getElementById("pierce-scope")!.append(target);
+    });
+    assertEquals(await (await scopedTarget).innerText(), "scoped late light");
   } finally {
     await closeTestBrowser(page, browser);
   }
@@ -1005,15 +1076,15 @@ Deno.test("Page preserves Common Tools behavior on published Astral", async () =
     const nativeTarget = await page.$(".target");
     assertEquals(await nativeTarget?.innerText(), "light");
 
-    const firstShadowTarget = await page.$(".target", {
+    const firstPierceTarget = await page.$(".target", {
       strategy: "pierce",
     });
-    assertEquals(await firstShadowTarget?.innerText(), "outer");
+    assertEquals(await firstPierceTarget?.innerText(), "light");
 
-    const shadowTargets = await page.$$(".target", { strategy: "pierce" });
+    const pierceTargets = await page.$$(".target", { strategy: "pierce" });
     assertEquals(
-      await Promise.all(shadowTargets.map((target) => target.innerText())),
-      ["outer", "inner"],
+      await Promise.all(pierceTargets.map((target) => target.innerText())),
+      ["light", "outer", "inner"],
     );
 
     const queryRoot = await page.waitForSelector("#query-root");

--- a/packages/patterns/integration/cfc-browser-helpers.test.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.test.ts
@@ -1,5 +1,14 @@
-import { Browser, type Page } from "@commonfabric/integration";
-import { assert, assertEquals } from "@std/assert";
+import {
+  Browser,
+  installPresentationInteractions,
+  type Page,
+} from "@commonfabric/integration";
+import {
+  assert,
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "@std/assert";
 import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 import {
   CLICK_TARGET_ATTR,
@@ -7,11 +16,27 @@ import {
   clickCfButtonsConcurrently,
   clickNthCfButton,
   clickTrustedAction,
+  fillCfInput,
   waitForSettledText,
 } from "./cfc-browser-helpers.ts";
 
 /** One element's live click marks, in attribute order. */
 type MarkProbe = { clicks: number; marksAtClick: string[]; marks: string[] };
+
+/** Presentation config with every demo delay removed. */
+const testPresentationConfig = {
+  enabled: true,
+  outputDir: ".",
+  videoFileName: "unused.mp4",
+  viewport: { width: 1280, height: 720 },
+  typingDelayMs: 0,
+  cursorTravelMs: 0,
+  cursorSettleMs: 0,
+  clickPulseMs: 0,
+  postResultHoldMs: 0,
+  jpegQuality: 85,
+  keepFrames: false,
+} as const;
 
 describe("CFC browser helpers", () => {
   let browser: Browser;
@@ -462,5 +487,342 @@ describe("CFC browser helpers", () => {
     );
     assertEquals(result.marksAtClick.length, 2);
     assertEquals(result.marks, ["held-by-another-click"]);
+  });
+
+  it("drives the page to settle before filling a cf input", async () => {
+    await page.evaluate(() => {
+      const host = document.createElement("div");
+      host.id = "settling-fill-input";
+      Object.assign(host.style, {
+        display: "block",
+        height: "40px",
+        width: "240px",
+      });
+      const root = host.attachShadow({ mode: "open" });
+      const input = document.createElement("input");
+      Object.assign(input.style, {
+        display: "block",
+        height: "32px",
+        width: "200px",
+      });
+      root.append(input);
+      document.body.append(host);
+
+      let settleCalls = 0;
+      (globalThis as typeof globalThis & {
+        commonfabric: { viewSettled: () => Promise<void> };
+      }).commonfabric = {
+        viewSettled: () => {
+          settleCalls++;
+          return Promise.resolve();
+        },
+      };
+      (globalThis as typeof globalThis & {
+        __settlingFillResult: () => { settleCalls: number; value?: string };
+      }).__settlingFillResult = () => ({
+        settleCalls,
+        value: host.shadowRoot?.querySelector("input")?.value,
+      });
+    });
+
+    await fillCfInput(page, "#settling-fill-input", "Bob");
+
+    const result = await page.evaluate(() =>
+      (globalThis as typeof globalThis & {
+        __settlingFillResult: () => { settleCalls: number; value?: string };
+      }).__settlingFillResult()
+    );
+    assertEquals(result.value, "Bob");
+    assert(
+      result.settleCalls > 0,
+      "the fill read the DOM without asking the view to settle, so it only " +
+        "watches the page instead of driving it",
+    );
+  });
+
+  it("fills a cf input that only pending page work renders", async () => {
+    await page.evaluate(() => {
+      (globalThis as typeof globalThis & {
+        commonfabric: { viewSettled: () => Promise<void> };
+      }).commonfabric = {
+        viewSettled: () => {
+          if (!document.querySelector("#pending-work-input")) {
+            const host = document.createElement("div");
+            host.id = "pending-work-input";
+            Object.assign(host.style, {
+              display: "block",
+              height: "40px",
+              width: "240px",
+            });
+            const root = host.attachShadow({ mode: "open" });
+            const input = document.createElement("input");
+            Object.assign(input.style, {
+              display: "block",
+              height: "32px",
+              width: "200px",
+            });
+            root.append(input);
+            document.body.append(host);
+          }
+          return Promise.resolve();
+        },
+      };
+    });
+
+    await fillCfInput(page, "#pending-work-input", "Bob");
+
+    const value = await page.evaluate(() =>
+      document.querySelector("#pending-work-input")?.shadowRoot
+        ?.querySelector("input")?.value
+    );
+    assertEquals(value, "Bob");
+  });
+
+  it("fills the live input when a commit replaces the one it typed into", async () => {
+    await page.evaluate(() => {
+      const host = document.createElement("div") as HTMLDivElement & {
+        commit: () => Promise<void>;
+      };
+      host.id = "replacing-commit-input";
+      Object.assign(host.style, {
+        display: "block",
+        height: "40px",
+        width: "240px",
+      });
+      const root = host.attachShadow({ mode: "open" });
+      const makeInput = () => {
+        const input = document.createElement("input");
+        Object.assign(input.style, {
+          display: "block",
+          height: "32px",
+          width: "200px",
+        });
+        return input;
+      };
+      root.append(makeInput());
+      document.body.append(host);
+
+      // The first commit re-renders the control, as a Lit host does when the
+      // committed cell value flows back into its template. Later commits leave
+      // it in place, so the fill converges on the replacement.
+      let replaced = false;
+      host.commit = () => {
+        if (!replaced) {
+          replaced = true;
+          root.querySelector("input")?.remove();
+          root.append(makeInput());
+        }
+        return Promise.resolve();
+      };
+
+      (globalThis as typeof globalThis & {
+        commonfabric: { viewSettled: () => Promise<void> };
+      }).commonfabric = { viewSettled: () => Promise.resolve() };
+    });
+
+    await fillCfInput(page, "#replacing-commit-input", "Bob");
+
+    const value = await page.evaluate(() =>
+      document.querySelector("#replacing-commit-input")?.shadowRoot
+        ?.querySelector("input")?.value
+    );
+    assertEquals(value, "Bob");
+  });
+
+  it("settles pending page work before presentation typing resolves its input", async () => {
+    const presentationPage = await browser.newPage();
+    const presentation = installPresentationInteractions(
+      presentationPage,
+      testPresentationConfig,
+      { label: "Bob", color: "#0891b2" },
+    );
+    try {
+      await presentationPage.evaluate(() => {
+        // The shell's own controls sit inside shadow roots, so the target hangs
+        // off one.
+        const view = document.createElement("div");
+        view.id = "pending-presentation-view";
+        const viewRoot = view.attachShadow({ mode: "open" });
+        document.body.append(view);
+        (globalThis as typeof globalThis & {
+          commonfabric: { viewSettled: () => Promise<void> };
+        }).commonfabric = {
+          viewSettled: () => {
+            if (!viewRoot.querySelector("#pending-presentation-input")) {
+              const host = document.createElement("div");
+              host.id = "pending-presentation-input";
+              Object.assign(host.style, {
+                display: "block",
+                height: "40px",
+                width: "240px",
+              });
+              const root = host.attachShadow({ mode: "open" });
+              const input = document.createElement("input");
+              Object.assign(input.style, {
+                display: "block",
+                height: "32px",
+                width: "200px",
+              });
+              root.append(input);
+              viewRoot.append(host);
+            }
+            return Promise.resolve();
+          },
+        };
+      });
+
+      await fillCfInput(presentationPage, "#pending-presentation-input", "Bob");
+
+      const value = await presentationPage.evaluate(() =>
+        document.querySelector("#pending-presentation-view")?.shadowRoot
+          ?.querySelector("#pending-presentation-input")?.shadowRoot
+          ?.querySelector("input")?.value
+      );
+      assertEquals(value, "Bob");
+    } finally {
+      presentation.uninstall();
+      await presentationPage.close();
+    }
+  });
+
+  it("drives the page to settle before presentation typing", async () => {
+    const presentationPage = await browser.newPage();
+    const presentation = installPresentationInteractions(
+      presentationPage,
+      testPresentationConfig,
+      { label: "Bob", color: "#0891b2" },
+    );
+    try {
+      await presentationPage.evaluate(() => {
+        // The shell's own controls sit inside shadow roots, so the target hangs
+        // off one.
+        const view = document.createElement("div");
+        view.id = "settling-presentation-view";
+        const viewRoot = view.attachShadow({ mode: "open" });
+        document.body.append(view);
+        const host = document.createElement("div");
+        host.id = "settling-presentation-input";
+        Object.assign(host.style, {
+          display: "block",
+          height: "40px",
+          width: "240px",
+        });
+        const root = host.attachShadow({ mode: "open" });
+        const input = document.createElement("input");
+        Object.assign(input.style, {
+          display: "block",
+          height: "32px",
+          width: "200px",
+        });
+        root.append(input);
+        viewRoot.append(host);
+
+        let settleCalls = 0;
+        (globalThis as typeof globalThis & {
+          commonfabric: { viewSettled: () => Promise<void> };
+        }).commonfabric = {
+          viewSettled: () => {
+            settleCalls++;
+            return Promise.resolve();
+          },
+        };
+        (globalThis as typeof globalThis & {
+          __settlingPresentationResult: () => {
+            settleCalls: number;
+            value?: string;
+          };
+        }).__settlingPresentationResult = () => ({
+          settleCalls,
+          value: input.value,
+        });
+      });
+
+      await fillCfInput(
+        presentationPage,
+        "#settling-presentation-input",
+        "Bob",
+      );
+
+      const result = await presentationPage.evaluate(() =>
+        (globalThis as typeof globalThis & {
+          __settlingPresentationResult: () => {
+            settleCalls: number;
+            value?: string;
+          };
+        }).__settlingPresentationResult()
+      );
+      assertEquals(result.value, "Bob");
+      assert(
+        result.settleCalls > 0,
+        "presentation typing resolved its control without asking the view to " +
+          "settle, so it only watches the page instead of driving it",
+      );
+    } finally {
+      presentation.uninstall();
+      await presentationPage.close();
+    }
+  });
+
+  it("reports a control a presentation commit replaced", async () => {
+    const presentationPage = await browser.newPage();
+    const presentation = installPresentationInteractions(
+      presentationPage,
+      testPresentationConfig,
+      { label: "Bob", color: "#0891b2" },
+    );
+    try {
+      await presentationPage.evaluate(() => {
+        // The shell's own controls sit inside shadow roots, so the target hangs
+        // off one.
+        const view = document.createElement("div");
+        const viewRoot = view.attachShadow({ mode: "open" });
+        document.body.append(view);
+        const host = document.createElement("div") as HTMLDivElement & {
+          commit: () => Promise<void>;
+        };
+        host.id = "replaced-presentation-input";
+        Object.assign(host.style, {
+          display: "block",
+          height: "40px",
+          width: "240px",
+        });
+        const root = host.attachShadow({ mode: "open" });
+        const makeInput = () => {
+          const input = document.createElement("input");
+          Object.assign(input.style, {
+            display: "block",
+            height: "32px",
+            width: "200px",
+          });
+          return input;
+        };
+        root.append(makeInput());
+        viewRoot.append(host);
+        host.commit = () => {
+          root.querySelector("input")?.remove();
+          root.append(makeInput());
+          return Promise.resolve();
+        };
+
+        (globalThis as typeof globalThis & {
+          commonfabric: { viewSettled: () => Promise<void> };
+        }).commonfabric = { viewSettled: () => Promise.resolve() };
+      });
+
+      // The typed value survives on the detached control, so a verification
+      // that reads it reports a fill that never reached the live field.
+      const error = await assertRejects(
+        () =>
+          fillCfInput(presentationPage, "#replaced-presentation-input", "Bob"),
+        Error,
+      );
+      assertStringIncludes(
+        (error.cause as Error).message,
+        "was replaced while committing",
+      );
+    } finally {
+      presentation.uninstall();
+      await presentationPage.close();
+    }
   });
 });

--- a/packages/patterns/integration/cfc-browser-helpers.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.ts
@@ -148,10 +148,14 @@ const viewSettledReady = (): boolean =>
     commonfabric?: { viewSettled?: () => Promise<void> };
   }).commonfabric?.viewSettled === "function";
 
-// Fill the input behind `selector`, then report whether the value took. Mirrors
-// the prior poll predicate: a not-yet-ready field (absent, hidden, disabled,
-// read-only) reports false without dispatching anything, so a re-check on the
-// next DOM mutation retries the fill; a ready field is filled once and verified.
+// Settle the view, then fill the input behind `selector` and report whether the
+// value took. The settle drives the page rather than watching it: asking the
+// worker whether it is idle queues runnable pull work that nothing else would
+// start, so a field that only the page's own pending work renders arrives on a
+// settling check and not on one that reads the DOM alone. A not-yet-ready field
+// (absent, hidden, disabled, read-only) reports false without dispatching
+// anything, so a re-check on the next DOM mutation retries the fill; a ready
+// field is filled once and verified.
 //
 // Each invocation keeps a progress ledger on `globalThis.__cfFillDiag`
 // (per selector): which phase it reached and when. waitForCondition never
@@ -177,7 +181,7 @@ const fillAndVerify = async (
   }).__cfFillDiag ??= {});
   const diag: FillDiag = {
     attempts: (registry[selector]?.attempts ?? 0) + 1,
-    phase: "collecting",
+    phase: "settling",
     phaseAt: Date.now(),
     startedAt: Date.now(),
   };
@@ -186,6 +190,18 @@ const fillAndVerify = async (
     diag.phase = name;
     diag.phaseAt = Date.now();
   };
+
+  // The ledger is written above this point so that a page which never exposes
+  // `viewSettled` names that in the failure probe.
+  const settle = (globalThis as typeof globalThis & {
+    commonfabric?: { viewSettled?: () => Promise<void> };
+  }).commonfabric?.viewSettled;
+  if (!settle) {
+    phase("no-settle");
+    return false;
+  }
+  await settle();
+  phase("settled");
 
   const element = probe.collect(selector)[0];
   if (!element) {
@@ -245,7 +261,23 @@ const fillAndVerify = async (
     requestAnimationFrame(() => requestAnimationFrame(resolve))
   );
 
-  diag.lastInputValue = input.value;
+  // A commit that re-renders the host replaces the control. The input this fill
+  // typed into is then detached and still holds the typed text, so resolve the
+  // selector again and require the same nodes before reading the value off it.
+  // A replaced control reports false, and the next page pulse fills the control
+  // that took its place.
+  const liveElement = probe.collect(selector)[0];
+  const liveInput = liveElement instanceof HTMLInputElement
+    ? liveElement
+    : liveElement?.shadowRoot?.querySelector("input");
+  diag.lastInputValue = liveInput instanceof HTMLInputElement
+    ? liveInput.value
+    : undefined;
+  if (liveElement !== element || liveInput !== input) {
+    phase("target-replaced");
+    return false;
+  }
+
   const verified = input.value === nextValue;
   phase(verified ? "verified" : "value-mismatch");
   return verified;


### PR DESCRIPTION
…ce matching

The browser fill helpers resolved their target by reading the DOM and nothing else. Asking the worker whether it is idle is what queues runnable pull work, and an integration test holds no UI subscription that would otherwise start it, so a purely observing wait can sit on a page whose next rendering is ready to be produced. Settle before resolving, in the plain fill and in the presentation fill that takes over while a demo recording is active. This matches the text waits in the same file, which already settle for that reason.

Verification read the input reference captured before the commit. Asking the host component to commit can re-render it and replace the control, leaving that reference detached but still holding the typed text, so an empty live field could report a successful fill. Resolve again after committing and require the same nodes: the plain fill hands the retry back to the waiter and converges on the replacement, and the presentation fill reports the replacement instead of claiming success. The fill also writes its phase ledger before looking for `viewSettled`, so a page that never exposes it names that in the failure probe rather than stalling silently.

Underneath those helpers, the package resolved a shadow-piercing selector in two places that disagreed about elements in the light DOM. The resolver behind `waitForSelector(selector, { strategy: "pierce" })` only ever asked shadow roots for a match, so a selector whose only match was a light-DOM element matched nothing at all. The resolver handed to `waitForCondition` predicates walks every element and tests it, so the same selector matched there. A test whose target sat outside a shadow root therefore passed its `waitForCondition` step and then sat in the pierce wait that followed. Those waits are driven by page events and reject a caller-supplied deadline, so the symptom was an unexplained multi-minute hang, with no error and no diagnostic, until the enclosing test's own bound expired.

Make pierce mean what its name says: everything a native query matches, plus everything inside an open shadow root at any depth. The walk is document order over the root's descendants, entering an element's shadow tree as soon as it reaches that element. That is the order the predicate-side resolver already used, so the two now return the same elements in the same order, and the shell integration helper that scans for a clickable host agrees with both. There is now one definition of that walk, and its source is serialized into the page alongside each in-page resolver that calls it, so the immediate `$` and `$$` queries and the event-driven wait cannot drift apart again. Sharing it also settles a second disagreement between the pair: an element-scoped `$` used to skip the root element's own shadow tree, which the element-scoped wait had always searched.

The new tests cover what the fills must do to the page — ask the view to settle rather than only watch it, fill a control that only a settle renders, converge on the control a commit put in place of the one it typed into, and report such a replacement rather than claim success — and what a pierce selector must match, including a light-DOM target that does not exist when the wait begins and one scoped to an element. Every one of them fails against the previous behavior. The presentation cases assert rather than rely on a stall, because the wait they exercise carries no bound and a regression would otherwise hang the suite instead of reporting anything. Two existing adapter assertions described the old light-DOM exclusion and change with it.

The record in `docs/history` covers a failure this does not fix: the lunch poll's intermittent `#lp-join-name` fill timeout. It reproduces with all of the above in place, with the settle having run sixty times and the field still absent, so the control genuinely never renders. The field is gated on one per-session cell whose sole writer is the "Continue as guest" handler; the click reaches the worker, the worker reports itself idle, and the rendered view never shows the branch that cell drives. The gap is between the handler's write and the view, not in how the test waits. There is no reliable reproduction yet, and the record says so rather than overstating a rate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drive the browser fills by settling the view before resolving inputs, and unify pierce selector semantics so `$`, `$$`, and `waitForSelector({ strategy: "pierce" })` agree on light DOM and shadow DOM matches. This removes fill starvation and fixes hangs caused by mismatched pierce queries.

- **Bug Fixes**
  - Fills: call `commonfabric.viewSettled()` before resolving, then re-resolve after commit to detect replaced controls; presentation fill reports replacements; phase ledger now logs before settle (shows “no-settle”).
  - Pierce selectors: now match light DOM plus open shadow roots in document order; one shared traversal is serialized into the page for `$`, `$$`, and `waitForSelector`; element-scoped queries include the root’s own shadow tree.
  - Tests/Docs: added coverage for settle-before-fill, commit replacement, and pierce-light-DOM cases; updated debugging notes; added a history record explaining the lunch-poll `#lp-join-name` timeout is not a fill-helper issue.

<sup>Written for commit ad7543a26b35ee0ec18b7d52f0b67041c6d2c15c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

