### PR TITLE
refactor(runner): drop the unused per-module compile cache seam

### DIFF
--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -43,13 +43,12 @@ const logger = getLogger("module-record-compiler");
  * one parse per distinct body per process.
  *
  * Keying on the body (not the module's source `identity`) is deliberate: a
- * content-hash identity is a hash of the *authored source*, and the same
- * identity can map to *different* compiled bytes across compilation modes /
- * runtime versions (cf. the `recordCache` note in `compileSourcesToRecords`,
- * where a precompiled body and a bare-transpiled body share a content-hash key).
- * An identity key could therefore serve one body's parse for another; the body
- * fully determines the parse, so a body key is exact and cross-contamination is
- * impossible.
+ * content-hash identity is a hash of the *authored source*, so one identity can
+ * map to different compiled bytes across compilation modes and runtime
+ * versions — the CF-transformed body and the bare-transpiled body of the same
+ * source share a content-hash key. An identity key could therefore serve one
+ * body's parse for another; the body fully determines the parse, so a body key
+ * is exact and cross-contamination is impossible.
  *
  * The two maps are process-global and unbounded by design: one small
  * record-surface entry (export names + import specifiers) per distinct compiled
@@ -352,27 +351,6 @@ export function createWriteOnceExports(): Record<string, unknown> {
   });
 }
 
-/** Per-module compiled artifact, cacheable by module hash (Phase 4). */
-export interface CompiledModuleArtifact {
-  exports: string[];
-  compiled: string;
-}
-
-/**
- * Cache of compiled module artifacts keyed by content-addressed module hash.
- * Because the hash already folds in the transitive import closure, a cached
- * artifact is valid as long as its key matches — editing one file invalidates
- * only that module (and its importers, whose hashes change).
- *
- * The cache assumes the fixed compiler options used by this adapter (CommonJS,
- * ES2023, esModuleInterop). A caller sharing one cache across differing
- * compiler options would need to fold an options tag into the key.
- */
-export interface ModuleRecordCache {
-  get(moduleHash: string): CompiledModuleArtifact | undefined;
-  set(moduleHash: string, artifact: CompiledModuleArtifact): void;
-}
-
 export interface CompileSourcesOptions {
   /**
    * Names exported by each bare runtime module specifier (e.g.
@@ -381,8 +359,6 @@ export interface CompileSourcesOptions {
    */
   runtimeModules?: Record<string, string[]>;
   runtimeFingerprint?: string;
-  /** Optional per-module compiled-artifact cache, keyed by module hash. */
-  recordCache?: ModuleRecordCache;
   /**
    * Pre-compiled CommonJS body per source name. When provided (e.g. from
    * `TypeScriptCompiler.compileToModules`, which runs the full CF transformer
@@ -659,23 +635,12 @@ export function compileSourcesToRecords(
     const sourceMap = options.precompiledSourceMaps?.get(source.name);
     if (sourceMap) moduleSourceMaps.set(specifier, sourceMap);
     const precompiled = options.precompiledBodies?.get(source.name);
-    let exportNames: string[];
+    const exportNames = resolveFullExports(source.name);
     let compiled: string;
-    // A precompiled (CF-transformed) body is authoritative. Do NOT consult or
-    // populate the shared cache: it may hold a bare-transpiled body under the
-    // same content-hash key (different compilation mode), which must not mix.
-    const cached = precompiled === undefined
-      ? options.recordCache?.get(moduleHash)
-      : undefined;
     if (precompiled !== undefined) {
-      exportNames = resolveFullExports(source.name);
       compiled = precompiled;
-    } else if (cached) {
-      exportNames = cached.exports;
-      compiled = cached.compiled;
     } else {
       const { ts: tsc } = compilerStack();
-      exportNames = resolveFullExports(source.name);
       compiled = tsc.transpileModule(source.contents, {
         fileName: source.name,
         compilerOptions: {
@@ -684,7 +649,6 @@ export function compileSourcesToRecords(
           esModuleInterop: true,
         },
       }).outputText;
-      options.recordCache?.set(moduleHash, { exports: exportNames, compiled });
     }
 
     // Runtime imports are exactly the `require()` calls in the compiled output.

--- a/packages/runner/test/module-record-compiler.test.ts
+++ b/packages/runner/test/module-record-compiler.test.ts
@@ -2,11 +2,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
 import type { Source } from "@commonfabric/js-compiler";
-import {
-  type CompiledModuleArtifact,
-  compileSourcesToRecords,
-  type ModuleRecordCache,
-} from "../src/sandbox/module-record-compiler.ts";
+import { compileSourcesToRecords } from "../src/sandbox/module-record-compiler.ts";
 import {
   importModuleGraphNow,
   runtimeModuleRecords,
@@ -17,21 +13,6 @@ import { ensureCompilerStack } from "../src/harness/deferred-compiler-stack.ts";
 // These tests drive the sync parse internals directly (below the async flow
 // boundaries that normally load the deferred compiler stack), so load it here.
 await ensureCompilerStack();
-
-class MapRecordCache implements ModuleRecordCache {
-  store = new Map<string, CompiledModuleArtifact>();
-  hits = 0;
-  misses = 0;
-  get(hash: string): CompiledModuleArtifact | undefined {
-    const v = this.store.get(hash);
-    if (v) this.hits++;
-    else this.misses++;
-    return v;
-  }
-  set(hash: string, artifact: CompiledModuleArtifact): void {
-    this.store.set(hash, artifact);
-  }
-}
 
 function files(map: Record<string, string>): Source[] {
   return Object.entries(map).map(([name, contents]) => ({ name, contents }));
@@ -201,59 +182,18 @@ export const ok = (): number => 7;`,
     expect(ns.value).toBe("hi world");
   });
 
-  it("populates the per-module cache on a miss and reuses it on a hit", () => {
-    const sources = files({ "/main.ts": `export const x = () => 1;` });
-    const cache = new MapRecordCache();
-
-    compileSourcesToRecords(sources, { recordCache: cache });
-    expect(cache.misses).toBe(1);
-    expect(cache.store.size).toBe(1);
-
-    // Second compile of identical sources hits the cache (no recompile).
-    compileSourcesToRecords(sources, { recordCache: cache });
-    expect(cache.hits).toBe(1);
-  });
-
-  it("prefers a precompiled body over a cached (bare-transpiled) one", () => {
+  it("uses a precompiled body instead of the bare transpile", () => {
     const sources = files({
       "/main.ts": `export const run = (): number => 1;`,
     });
-    const cache = new MapRecordCache();
-    // Seed the cache with a stale bare-transpiled artifact.
-    compileSourcesToRecords(sources, { recordCache: cache });
-    expect(cache.store.size).toBe(1);
-
-    // With a precompiled body provided, the cache must be ignored (different
-    // compilation mode) and the precompiled body used.
+    // A body distinguishable from what transpiling the source would produce.
     const precompiledBodies = new Map([[
       "/main.ts",
       `Object.defineProperty(exports, "__esModule", { value: true });\nexports.run = () => 99;`,
     ]]);
+
     const { records, specifierByPath } = compileSourcesToRecords(sources, {
-      recordCache: cache,
       precompiledBodies,
-    });
-    const ns = importModuleGraphNow(specifierByPath.get("/main.ts")!, {
-      records,
-    }) as { run(): number };
-    expect(ns.run()).toBe(99);
-  });
-
-  it("uses the cached compiled artifact (cache is authoritative on hit)", () => {
-    const sources = files({
-      "/main.ts": `export const run = (): number => 1;`,
-    });
-    // Pre-seed the cache with a sentinel artifact so we can prove it is used.
-    const cache = new MapRecordCache();
-    const { specifierByPath: probe } = compileSourcesToRecords(sources);
-    const hash = probe.get("/main.ts")!.replace("cf:module/", "");
-    cache.store.set(hash, {
-      exports: ["run"],
-      compiled: `exports.run = function () { return 99; };`,
-    });
-
-    const { records, specifierByPath } = compileSourcesToRecords(sources, {
-      recordCache: cache,
     });
     const ns = importModuleGraphNow(specifierByPath.get("/main.ts")!, {
       records,


### PR DESCRIPTION
`compileSourcesToRecords` accepted an injectable `recordCache`: a get/set store of per-module compiled artifacts keyed by content-addressed module hash, so a caller could skip the bare `ts.transpileModule` fallback on a repeat compile. It was added alongside the ESM loader work and was then superseded by the durable content-addressed compilation cache, which is what production actually uses: the pattern manager reads and writes the per-space compiled set through `compilation-cache/cell-cache.ts` and hands cached bodies back as `precompiledBodies`.

Nothing ever registered a `recordCache`. The only production caller of `compileSourcesToRecords` is the Engine, which always passes a precompiled body for every authored module, and the cache branch only ran for a module with no precompiled body — so the seam was unreachable twice over, and the bare-transpile fallback it accelerated is itself a standalone/test-path convenience. The repeat-compile cost on the warm path is now absorbed by the process-global body-keyed parse memo higher up in the same file.

This removes the `ModuleRecordCache` interface, the sandbox-local `CompiledModuleArtifact` it stored, the `recordCache` option, and the consult/populate branches in the compile loop. The bare-transpile fallback stays, just uncached. Note this is not the `CompiledModuleArtifact` exported from the runner's public entry point — that one lives in `harness/types.ts`, describes a compiled body plus its side artifacts, and is untouched.

Two comment and test consequences:

The doc comment on the export parse memo explained its body key by pointing at the `recordCache` note for the underlying fact — that one content-hash identity can map to different compiled bytes across compilation modes. That fact still decides the memo's key, so the comment now states it directly instead of citing a note that no longer exists.

Of the three deleted cache tests, one also happened to be the only unit coverage anywhere that a precompiled body is used in place of the bare transpile. That branch is the production path, so it keeps a focused test of its own rather than losing coverage with the cache.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused per-module compile cache from `compileSourcesToRecords` to simplify the runner with no change to production behavior. The bare-transpile fallback remains, but we no longer cache it since production uses `precompiledBodies` and a process-global parse memo.

- **Refactors**
  - Removed `recordCache` option, `ModuleRecordCache`, sandbox-local `CompiledModuleArtifact`, and cache get/set branches.
  - Updated the parse-memo comment to explain the body-based key directly.
  - Deleted cache-related tests and kept a focused test that a precompiled body is used instead of the bare transpile.

<sup>Written for commit 2e49c2342ceae35fed81ecb902db1f77a968d042. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

