### PR TITLE
feat(cf-harness): server-side compaction as a context guard

### DIFF
--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -1276,6 +1276,9 @@ export const parseCfHarnessCliArgs = async (
       CF_HARNESS_PROMPT_CACHE_MODE: Deno.env.get(
         "CF_HARNESS_PROMPT_CACHE_MODE",
       ),
+      CF_HARNESS_COMPACT_THRESHOLD: Deno.env.get(
+        "CF_HARNESS_COMPACT_THRESHOLD",
+      ),
       CF_HARNESS_HOME: Deno.env.get("CF_HARNESS_HOME"),
       HOME: Deno.env.get("HOME"),
       CF_HARNESS_CFC_ENFORCEMENT_MODE: Deno.env.get(

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -130,6 +130,7 @@ const CLI_STRING_FLAGS = [
   "model",
   "model-provider",
   "reasoning-effort",
+  "compact-threshold",
   "prompt-cache-mode",
   "skills-root",
   "skill",
@@ -197,6 +198,7 @@ export interface CfHarnessCliConfig {
   model?: string;
   modelProvider?: HarnessModelProviderId;
   reasoningEffort?: string;
+  compactThreshold?: number;
   promptCacheMode?: "implicit" | "explicit";
   gatewayConfigurationExplicit: boolean;
   harnessHome: string;
@@ -260,6 +262,7 @@ export interface CfHarnessCliCapabilities {
     modelUsage: true;
     promptCacheControls: true;
     reasoningEffort: true;
+    compactThreshold: true;
   };
 }
 
@@ -398,6 +401,8 @@ Options:
   --model <name>                Model name (default: ${DEFAULT_MODEL})
   --model-provider <provider>   openai-compatible-gateway | openai-codex
   --reasoning-effort <effort>   Provider reasoning effort (for example low, medium, high)
+  --compact-threshold <n>       Token threshold for server-side compaction
+                                (default: 75% of the model input budget; 0 disables)
   --prompt-cache-mode <mode>    implicit | explicit (GPT-5.6 API gateway only)
   --gateway-base-url <url>      OpenAI-compatible gateway URL
   --gateway-auth-mode <mode>    bearer | none (default: bearer)
@@ -433,6 +438,7 @@ Environment:
   CF_HARNESS_MODEL              Default value for --model (ignored on --resume-run)
   CF_HARNESS_MODEL_PROVIDER     Default value for --model-provider
   CF_HARNESS_REASONING_EFFORT   Default value for --reasoning-effort
+  CF_HARNESS_COMPACT_THRESHOLD  Default value for --compact-threshold
   CF_HARNESS_PROMPT_CACHE_MODE  Default value for --prompt-cache-mode
   CF_HARNESS_HOME               Local cf-harness credential/config directory
   CF_HARNESS_DOCKER_NETWORK_MODE none | bridge | host (default: bridge)
@@ -527,6 +533,7 @@ export const createCfHarnessCliCapabilities = (): CfHarnessCliCapabilities => ({
     modelUsage: true,
     promptCacheControls: true,
     reasoningEffort: true,
+    compactThreshold: true,
   },
 });
 
@@ -1316,6 +1323,22 @@ export const parseCfHarnessCliArgs = async (
   ) {
     throw new Error("--reasoning-effort requires a non-empty value");
   }
+  // 0 is meaningful (disables compaction), so an explicit 0 must survive.
+  const rawCompactThreshold = typeof args["compact-threshold"] === "string"
+    ? args["compact-threshold"].trim()
+    : nonEmptyEnvValue(env.CF_HARNESS_COMPACT_THRESHOLD);
+  let compactThreshold: number | undefined;
+  if (rawCompactThreshold !== undefined && rawCompactThreshold !== "") {
+    const parsedThreshold = Number(rawCompactThreshold);
+    if (!Number.isSafeInteger(parsedThreshold) || parsedThreshold < 0) {
+      throw new Error(
+        "--compact-threshold requires a non-negative integer token count",
+      );
+    }
+    compactThreshold = parsedThreshold;
+  } else if (args["compact-threshold"] !== undefined) {
+    throw new Error("--compact-threshold requires a non-empty value");
+  }
   const promptCacheMode = optionalStringValue(
     typeof args["prompt-cache-mode"] === "string"
       ? args["prompt-cache-mode"].trim()
@@ -1449,6 +1472,7 @@ export const parseCfHarnessCliArgs = async (
       : {}),
     ...(modelProvider !== undefined ? { modelProvider } : {}),
     ...(reasoningEffort !== undefined ? { reasoningEffort } : {}),
+    ...(compactThreshold !== undefined ? { compactThreshold } : {}),
     ...(promptCacheMode !== undefined ? { promptCacheMode } : {}),
     gatewayConfigurationExplicit,
     harnessHome,
@@ -2467,6 +2491,9 @@ export const runCfHarnessCli = async (
           ? { apiKey: parsed.apiKey, apiKeySource: parsed.apiKeySource }
           : {}),
         ...(modelClient !== undefined ? { modelClient } : {}),
+        ...(parsed.compactThreshold !== undefined
+          ? { compactThreshold: parsed.compactThreshold }
+          : {}),
         ...(parsed.reasoningEffort !== undefined
           ? { reasoningEffort: parsed.reasoningEffort }
           : {}),

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -1337,7 +1337,14 @@ export const parseCfHarnessCliArgs = async (
     }
     compactThreshold = parsedThreshold;
   } else if (args["compact-threshold"] !== undefined) {
-    throw new Error("--compact-threshold requires a non-empty value");
+    // A bare flag lands here, and so does a value the parser read as another
+    // flag: `--compact-threshold -5` leaves the option set with no string.
+    // Name the requirement, and point at the form that survives parsing.
+    throw new Error(
+      "--compact-threshold requires a non-negative integer token count; " +
+        "pass values the parser would read as a flag as " +
+        "--compact-threshold=<n>",
+    );
   }
   const promptCacheMode = optionalStringValue(
     typeof args["prompt-cache-mode"] === "string"

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -2498,11 +2498,11 @@ export const runCfHarnessCli = async (
           ? { apiKey: parsed.apiKey, apiKeySource: parsed.apiKeySource }
           : {}),
         ...(modelClient !== undefined ? { modelClient } : {}),
-        ...(parsed.compactThreshold !== undefined
-          ? { compactThreshold: parsed.compactThreshold }
-          : {}),
         ...(parsed.reasoningEffort !== undefined
           ? { reasoningEffort: parsed.reasoningEffort }
+          : {}),
+        ...(parsed.compactThreshold !== undefined
+          ? { compactThreshold: parsed.compactThreshold }
           : {}),
         ...(parsed.promptCacheMode !== undefined
           ? { promptCacheMode: parsed.promptCacheMode }
@@ -2633,6 +2633,9 @@ export const runCfHarnessCli = async (
         ...(modelClient !== undefined ? { modelClient } : {}),
         ...(parsed.reasoningEffort !== undefined
           ? { reasoningEffort: parsed.reasoningEffort }
+          : {}),
+        ...(parsed.compactThreshold !== undefined
+          ? { compactThreshold: parsed.compactThreshold }
           : {}),
         ...(parsed.promptCacheMode !== undefined
           ? { promptCacheMode: parsed.promptCacheMode }

--- a/packages/cf-harness/src/gateway/openai-client.ts
+++ b/packages/cf-harness/src/gateway/openai-client.ts
@@ -100,6 +100,15 @@ export interface OpenAIResponsesRequest {
   store?: boolean;
   stream?: boolean;
   include?: readonly string[];
+  /**
+   * Server-side compaction. When rendered tokens cross `compact_threshold`,
+   * the provider folds prior context into an encrypted compaction item and
+   * prunes before continuing inference.
+   */
+  context_management?: readonly {
+    type: "compaction";
+    compact_threshold: number;
+  }[];
   prompt_cache_key?: string;
   prompt_cache_options?: {
     mode: "implicit" | "explicit";

--- a/packages/cf-harness/src/model/client.ts
+++ b/packages/cf-harness/src/model/client.ts
@@ -46,6 +46,12 @@ export interface HarnessModelTurnRequest {
   cacheAffinityKey?: string;
   promptCacheMode?: "implicit" | "explicit";
   reasoningEffort?: string;
+  /**
+   * Overrides the server-side compaction threshold for this turn. Omitted
+   * means the client derives it from the model's input budget; `0` disables
+   * compaction entirely.
+   */
+  compactThreshold?: number;
   signal?: AbortSignal;
   onAttempt?: (
     attempt: HarnessModelAttemptDiagnostic,
@@ -114,6 +120,10 @@ export interface HarnessModelCatalogEntry {
   description?: string;
   inputModalities: readonly string[];
   supportedReasoningEfforts: readonly string[];
+  /** Total context (input + output) advertised by the registry, when known. */
+  contextWindow?: number;
+  /** Maximum output tokens; needed to derive the usable input budget. */
+  maxOutputTokens?: number;
   supportsParallelToolCalls: boolean;
 }
 

--- a/packages/cf-harness/src/model/openai-codex-responses.ts
+++ b/packages/cf-harness/src/model/openai-codex-responses.ts
@@ -302,6 +302,15 @@ export class OpenAICodexResponsesClient implements HarnessModelClient {
         "openai-codex does not support provider-native tools in this release",
       );
     }
+    // Accepting this silently would make a user-supplied control look
+    // effective while nothing sends `context_management` on this path.
+    if (
+      request.compactThreshold !== undefined && request.compactThreshold > 0
+    ) {
+      throw new Error(
+        "openai-codex does not support server-side compaction in this release",
+      );
+    }
     if (request.signal?.aborted) throw abortReason(request.signal);
     const converted = await toResponsesInput(
       request.transcript,

--- a/packages/cf-harness/src/model/openai-compatible-gateway.ts
+++ b/packages/cf-harness/src/model/openai-compatible-gateway.ts
@@ -176,6 +176,28 @@ export const usesResponsesApi = (
  * `web_search`, which overrides the model to Gemini — so this fails loudly
  * rather than letting a future profile discover it as a provider error.
  */
+/**
+ * Rejects a compaction threshold on a turn that cannot honour it.
+ *
+ * `context_management` is only sent on the Responses path, so a chat-routed
+ * model would accept the option and silently ignore it — a user-supplied
+ * control that appears to work while doing nothing. `0` stays legal
+ * everywhere: its requested behaviour is already "do not compact".
+ */
+export const assertCompactThresholdSupported = (
+  model: string,
+  nativeModelToolIds: readonly LLMNativeModelToolId[],
+  compactThreshold: number | undefined,
+): void => {
+  if (compactThreshold === undefined || compactThreshold === 0) return;
+  if (!usesResponsesApi(model, nativeModelToolIds)) {
+    throw new Error(
+      `compact threshold ${compactThreshold} requires a model routed through ` +
+        `the Responses API; received ${model}`,
+    );
+  }
+};
+
 const assertSupportedToolCombination = (
   model: string,
   nativeModelToolIds: readonly LLMNativeModelToolId[],
@@ -263,24 +285,59 @@ const toModelAttempt = (
   providerId: OPENAI_COMPATIBLE_GATEWAY_PROVIDER_ID,
 });
 
+/**
+ * Transcript size below which registry discovery is not worth a round trip.
+ *
+ * The smallest input budget the registry advertises is 272,000 tokens, so the
+ * smallest 75% guard sits at 204,000 — roughly 800,000 characters. A turn
+ * under this floor cannot approach any derived threshold, so ordinary runs
+ * pay no extra request and only genuinely large contexts trigger discovery.
+ */
+const BUDGET_DISCOVERY_FLOOR_CHARS = 200_000;
+
+const transcriptSize = (
+  transcript: readonly HarnessTranscriptMessage[],
+): number =>
+  transcript.reduce((total, message) => total + message.content.length, 0);
+
 export class OpenAICompatibleGatewayModelClient implements HarnessModelClient {
   readonly providerId = OPENAI_COMPATIBLE_GATEWAY_PROVIDER_ID;
-  /**
-   * Input budgets by model id, populated by `listModels()`. Compaction is a
-   * guard, so an unknown budget simply means no threshold is sent rather than
-   * a per-turn registry fetch on the hot path.
-   */
+  /** Input budgets by model id, keyed from the gateway registry. */
   readonly #compactThresholds = new Map<string, number>();
+  /** Registry discovery is attempted once per client, successful or not. */
+  #budgetDiscovery?: Promise<void>;
 
   constructor(readonly gatewayClient: OpenAICompatibleGatewayClient) {}
 
-  #resolveCompactThreshold(
+  /**
+   * Populates model budgets so the default threshold applies without the
+   * caller having to call `listModels()` first — nothing on the normal run
+   * path does.
+   *
+   * Runs at most once per client and never fails a turn: compaction is a
+   * guard, so an unreachable registry means running without it rather than
+   * aborting the run.
+   */
+  #ensureBudgets(signal?: AbortSignal): Promise<void> {
+    this.#budgetDiscovery ??= this.listModels(signal)
+      .then(() => {})
+      .catch(() => {});
+    return this.#budgetDiscovery;
+  }
+
+  async #resolveCompactThreshold(
     request: HarnessModelTurnRequest,
-  ): number | undefined {
+  ): Promise<number | undefined> {
     if (request.compactThreshold !== undefined) {
       return request.compactThreshold > 0
         ? request.compactThreshold
         : undefined;
+    }
+    if (
+      !this.#compactThresholds.has(request.model) &&
+      transcriptSize(request.transcript) >= BUDGET_DISCOVERY_FLOOR_CHARS
+    ) {
+      await this.#ensureBudgets(request.signal);
     }
     return this.#compactThresholds.get(request.model);
   }
@@ -289,6 +346,11 @@ export class OpenAICompatibleGatewayModelClient implements HarnessModelClient {
     request: HarnessModelTurnRequest,
   ): Promise<HarnessModelTurnResult> {
     assertSupportedToolCombination(request.model, request.nativeModelToolIds);
+    assertCompactThresholdSupported(
+      request.model,
+      request.nativeModelToolIds,
+      request.compactThreshold,
+    );
     assertPromptCacheModeSupported(request.model, request.promptCacheMode);
     assertReasoningEffortSupported(
       request.model,
@@ -354,7 +416,7 @@ export class OpenAICompatibleGatewayModelClient implements HarnessModelClient {
       "drop",
     );
     const tools = toResponsesTools(request.tools);
-    const compactThreshold = this.#resolveCompactThreshold(request);
+    const compactThreshold = await this.#resolveCompactThreshold(request);
     const payload: OpenAIResponsesRequest = {
       model: request.model,
       store: false,

--- a/packages/cf-harness/src/model/openai-compatible-gateway.ts
+++ b/packages/cf-harness/src/model/openai-compatible-gateway.ts
@@ -224,6 +224,37 @@ const assertReasoningEffortSupported = (
   }
 };
 
+/**
+ * Fraction of the usable input budget at which server-side compaction fires.
+ *
+ * Chosen as a guard rather than an optimisation: compacting costs extra on the
+ * turn that does it, so firing early taxes short runs to benefit long ones. At
+ * 75% it stays dormant for ordinary runs and engages once a built-up context
+ * (large system prompt, preloaded skills, accumulated documents) approaches
+ * the wall.
+ */
+export const COMPACT_THRESHOLD_FRACTION = 0.75;
+
+/**
+ * Derives the compaction threshold from the model's *input* budget.
+ *
+ * Deliberately not a fraction of `contextWindow`: the registry reports that as
+ * input + output, and on the 400k models 75% of it is 300,000 against a hard
+ * 272,000 input ceiling — a threshold past a wall the request can never reach,
+ * so the guard would never fire in exactly the case it exists for.
+ */
+export const compactThresholdForBudget = (
+  contextWindow: number | undefined,
+  maxOutputTokens: number | undefined,
+): number | undefined => {
+  if (contextWindow === undefined || maxOutputTokens === undefined) {
+    return undefined;
+  }
+  const inputBudget = contextWindow - maxOutputTokens;
+  if (!Number.isFinite(inputBudget) || inputBudget <= 0) return undefined;
+  return Math.floor(inputBudget * COMPACT_THRESHOLD_FRACTION);
+};
+
 const toModelAttempt = (
   attempt: OpenAIChatCompletionAttemptDiagnostic,
 ): HarnessModelAttemptDiagnostic => ({
@@ -234,8 +265,25 @@ const toModelAttempt = (
 
 export class OpenAICompatibleGatewayModelClient implements HarnessModelClient {
   readonly providerId = OPENAI_COMPATIBLE_GATEWAY_PROVIDER_ID;
+  /**
+   * Input budgets by model id, populated by `listModels()`. Compaction is a
+   * guard, so an unknown budget simply means no threshold is sent rather than
+   * a per-turn registry fetch on the hot path.
+   */
+  readonly #compactThresholds = new Map<string, number>();
 
   constructor(readonly gatewayClient: OpenAICompatibleGatewayClient) {}
+
+  #resolveCompactThreshold(
+    request: HarnessModelTurnRequest,
+  ): number | undefined {
+    if (request.compactThreshold !== undefined) {
+      return request.compactThreshold > 0
+        ? request.compactThreshold
+        : undefined;
+    }
+    return this.#compactThresholds.get(request.model);
+  }
 
   async complete(
     request: HarnessModelTurnRequest,
@@ -306,6 +354,7 @@ export class OpenAICompatibleGatewayModelClient implements HarnessModelClient {
       "drop",
     );
     const tools = toResponsesTools(request.tools);
+    const compactThreshold = this.#resolveCompactThreshold(request);
     const payload: OpenAIResponsesRequest = {
       model: request.model,
       store: false,
@@ -327,6 +376,14 @@ export class OpenAICompatibleGatewayModelClient implements HarnessModelClient {
       prompt_cache_key: providerRunAffinityKey(
         request.cacheAffinityKey ?? request.runId,
       ),
+      ...(compactThreshold !== undefined
+        ? {
+          context_management: [{
+            type: "compaction" as const,
+            compact_threshold: compactThreshold,
+          }],
+        }
+        : {}),
       ...(request.promptCacheMode !== undefined
         ? {
           prompt_cache_options: {
@@ -373,20 +430,36 @@ export class OpenAICompatibleGatewayModelClient implements HarnessModelClient {
     const json = await response.json() as {
       data?: Array<{ id?: unknown; capabilities?: Record<string, unknown> }>;
     };
-    return (json.data ?? []).flatMap((item) =>
-      typeof item.id === "string"
-        ? [{
-          id: item.id,
-          displayName: item.id,
-          inputModalities: item.capabilities?.images === true
-            ? ["text", "image"]
-            : ["text"],
-          supportedReasoningEfforts: item.id.startsWith("gpt-5.6")
-            ? GPT_5_6_REASONING_EFFORTS
-            : [],
-          supportsParallelToolCalls: false,
-        }]
-        : []
-    );
+    return (json.data ?? []).flatMap((item) => {
+      if (typeof item.id !== "string") return [];
+      const contextWindow = typeof item.capabilities?.contextWindow === "number"
+        ? item.capabilities.contextWindow
+        : undefined;
+      const maxOutputTokens =
+        typeof item.capabilities?.maxOutputTokens === "number"
+          ? item.capabilities.maxOutputTokens
+          : undefined;
+      // Cache the derived threshold so `complete()` needs no registry fetch.
+      const threshold = compactThresholdForBudget(
+        contextWindow,
+        maxOutputTokens,
+      );
+      if (threshold !== undefined) {
+        this.#compactThresholds.set(item.id, threshold);
+      }
+      return [{
+        id: item.id,
+        displayName: item.id,
+        inputModalities: item.capabilities?.images === true
+          ? ["text", "image"]
+          : ["text"],
+        supportedReasoningEfforts: item.id.startsWith("gpt-5.6")
+          ? GPT_5_6_REASONING_EFFORTS
+          : [],
+        supportsParallelToolCalls: false,
+        ...(contextWindow !== undefined ? { contextWindow } : {}),
+        ...(maxOutputTokens !== undefined ? { maxOutputTokens } : {}),
+      }];
+    });
   }
 }

--- a/packages/cf-harness/src/model/responses-protocol.ts
+++ b/packages/cf-harness/src/model/responses-protocol.ts
@@ -64,11 +64,37 @@ export const assertPromptCacheModeSupported = (
  */
 export type ContinuationModelMismatch = "throw" | "drop";
 
+/**
+ * Opaque items the provider returns for replay on later turns.
+ *
+ * `reasoning` carries the model's thinking for the turn that produced it.
+ * `compaction` carries *everything before it* — server-side compaction folds
+ * the prior context into one encrypted item — which is why a compaction item
+ * lets the transcript ahead of it be dropped.
+ */
+const REPLAYABLE_ITEM_TYPES = ["reasoning", "compaction"] as const;
+
+const isReplayableItem = (item: unknown): item is ResponsesInputItem => {
+  if (typeof item !== "object" || item === null) return false;
+  const record = item as Record<string, unknown>;
+  return (REPLAYABLE_ITEM_TYPES as readonly string[]).includes(
+    record.type as string,
+  ) && typeof record.id === "string" &&
+    typeof record.encrypted_content === "string";
+};
+
+const isCompactionItem = (item: unknown): boolean =>
+  isReplayableItem(item) &&
+  (item as Record<string, unknown>).type === "compaction";
+
 export const continuationOutput = (
   continuation: HarnessProviderContinuation | undefined,
   model: string,
   providerId: string,
   onModelMismatch: ContinuationModelMismatch = "throw",
+  // Compaction items are emitted once at the pruning boundary, so replaying
+  // them again with their own message would duplicate them.
+  include: "all" | "reasoning-only" = "all",
 ): ResponsesInputItem[] => {
   if (continuation?.providerId !== providerId) return [];
   const state = continuation.state;
@@ -88,13 +114,26 @@ export const continuationOutput = (
   const output = record.output;
   if (!Array.isArray(output)) return [];
   return output.flatMap((item) =>
-    typeof item === "object" && item !== null &&
-      (item as Record<string, unknown>).type === "reasoning" &&
-      typeof (item as Record<string, unknown>).id === "string" &&
-      typeof (item as Record<string, unknown>).encrypted_content === "string"
-      ? [structuredClone(item as ResponsesInputItem)]
+    isReplayableItem(item) &&
+      !(include === "reasoning-only" && isCompactionItem(item))
+      ? [structuredClone(item)]
       : []
   );
+};
+
+/**
+ * Compaction items recorded on an assistant message, if any.
+ *
+ * Used to find the pruning boundary: the newest assistant turn whose
+ * continuation carries compaction supersedes everything before it.
+ */
+export const continuationCompaction = (
+  continuation: HarnessProviderContinuation | undefined,
+  model: string,
+  providerId: string,
+): ResponsesInputItem[] => {
+  const items = continuationOutput(continuation, model, providerId, "drop");
+  return items.filter(isCompactionItem);
 };
 
 export const continuationFunctionCallItemId = (
@@ -155,11 +194,34 @@ export const toResponsesInput = async (
 ): Promise<
   { instructions: string | undefined; input: ResponsesInputItem[] }
 > => {
+  // Instructions always come from the whole transcript: pruning drops earlier
+  // turns from `input`, and the system prompt must survive that.
   const systemText = transcript.filter((message) => message.role === "system")
     .map((message) => message.content).join("\n\n");
   const instructions = systemText.length > 0 ? systemText : defaultInstructions;
-  const input: ResponsesInputItem[] = [];
+
+  // Prune at the newest assistant turn carrying compaction: that item already
+  // encodes everything before it. Starting at an assistant message keeps
+  // `function_call`/`function_call_output` pairs intact — slicing anywhere
+  // else could orphan a tool result from the call that produced it.
+  let boundary = 0;
+  let carried: ResponsesInputItem[] = [];
   for (const [index, message] of transcript.entries()) {
+    if (message.role !== "assistant") continue;
+    const compaction = continuationCompaction(
+      message.providerContinuation,
+      model,
+      providerId,
+    );
+    if (compaction.length > 0) {
+      boundary = index;
+      carried = compaction;
+    }
+  }
+
+  const input: ResponsesInputItem[] = [...carried];
+  for (const [index, message] of transcript.entries()) {
+    if (index < boundary) continue;
     switch (message.role) {
       case "system":
         break;
@@ -175,6 +237,7 @@ export const toResponsesInput = async (
             model,
             providerId,
             onModelMismatch,
+            index === boundary && carried.length > 0 ? "reasoning-only" : "all",
           ),
         );
         if (message.content.length > 0) {
@@ -338,10 +401,10 @@ export const normalizeTerminalResponse = (
       }
       toolCallById.set(call.id, call);
       toolCalls.push(call);
-    } else if (
-      item.type === "reasoning" && typeof item.id === "string" &&
-      typeof item.encrypted_content === "string"
-    ) {
+    } else if (isReplayableItem(item)) {
+      // Both reasoning and compaction items are retained: dropping a
+      // compaction item would mean paying to produce it and then discarding
+      // the only thing that lets the transcript ahead of it be pruned.
       continuation.push(structuredClone(item));
     }
   }

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -129,6 +129,7 @@ export interface CreateHarnessPromptLoopOptions
   cacheAffinityKey?: string;
   promptCacheMode?: "implicit" | "explicit";
   reasoningEffort?: string;
+  compactThreshold?: number;
 }
 
 export interface RunHarnessPromptOptions {
@@ -1655,6 +1656,7 @@ export class CfHarnessPromptLoop {
   readonly #cacheAffinityKey?: string;
   readonly #promptCacheMode?: "implicit" | "explicit";
   readonly #reasoningEffort?: string;
+  readonly #compactThreshold?: number;
 
   constructor(options: CreateHarnessPromptLoopOptions = {}) {
     this.engine = options.engine ?? new CfHarnessEngine(options);
@@ -1735,6 +1737,7 @@ export class CfHarnessPromptLoop {
     this.#cacheAffinityKey = options.cacheAffinityKey;
     this.#promptCacheMode = options.promptCacheMode;
     this.#reasoningEffort = options.reasoningEffort;
+    this.#compactThreshold = options.compactThreshold;
   }
 
   /** @deprecated Prefer `modelClient`; unavailable for `openai-codex`. */
@@ -1970,6 +1973,9 @@ export class CfHarnessPromptLoop {
             : {}),
           ...(this.#reasoningEffort !== undefined
             ? { reasoningEffort: this.#reasoningEffort }
+            : {}),
+          ...(this.#compactThreshold !== undefined
+            ? { compactThreshold: this.#compactThreshold }
             : {}),
           signal: options.signal,
           onAttempt: recordModelAttempt,

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -2816,7 +2816,13 @@ export class CfHarnessPromptLoop {
       engine: childEngine,
       modelClient: this.modelClient,
       cacheAffinityKey: childRunId,
-      ...(this.#compactThreshold !== undefined
+      // A positive threshold is calibrated to the parent model's input
+      // budget, so it follows only a child that inherits that model; a
+      // profile-overridden child keeps its own model's derived default (and a
+      // chat-routed override like web_search could not honour it at all).
+      // `0` is model-independent — the off-switch stays run-wide.
+      ...(this.#compactThreshold !== undefined &&
+          (this.#compactThreshold === 0 || childModel.source === "parent")
         ? { compactThreshold: this.#compactThreshold }
         : {}),
       ...(this.#promptCacheMode !== undefined

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -2816,6 +2816,9 @@ export class CfHarnessPromptLoop {
       engine: childEngine,
       modelClient: this.modelClient,
       cacheAffinityKey: childRunId,
+      ...(this.#compactThreshold !== undefined
+        ? { compactThreshold: this.#compactThreshold }
+        : {}),
       ...(this.#promptCacheMode !== undefined
         ? { promptCacheMode: this.#promptCacheMode }
         : {}),

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -1841,9 +1841,8 @@ Deno.test("runCfHarnessCli executes the prompt loop and prints result metadata",
 Deno.test("runCfHarnessCli forwards --compact-threshold to a fresh run", async () => {
   // Parsing was already covered; this pins the handoff. The option was
   // forwarded on the resume path only, so a fresh run silently lost it.
-  const { io, stdout, stderr } = createIoBuffers();
+  const { io } = createIoBuffers();
   let createdOptions: Record<string, unknown> | undefined;
-  let runPromptOptions: RunHarnessPromptOptions | undefined;
   const exitCode = await runCfHarnessCli(
     [
       "--workspace",
@@ -1864,8 +1863,7 @@ Deno.test("runCfHarnessCli forwards --compact-threshold to a fresh run", async (
       createPromptLoop: (options) => {
         createdOptions = options as Record<string, unknown>;
         return {
-          runPrompt: (options) => {
-            runPromptOptions = options;
+          runPrompt: () => {
             return Promise.resolve(
               ({
                 model: "gpt-5.4",

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -4418,3 +4418,44 @@ Deno.test("resume rejects manifest provider and credential-owner switches", asyn
     "resume credential owner mismatch: requested owner does not match the recorded run\n",
   ]);
 });
+
+Deno.test("parseCfHarnessCliArgs validates --compact-threshold", async () => {
+  const parse = (args: string[], env: Record<string, string> = {}) =>
+    parseCfHarnessCliArgs(args, { cwd: "/tmp/project", env });
+
+  const ok = await parse(["--compact-threshold", "12000", "hi"]);
+  if ("help" in ok) throw new Error("expected config result");
+  assertEquals(ok.compactThreshold, 12_000);
+
+  // 0 is meaningful — it disables compaction — so it must not read as absent.
+  const zero = await parse(["--compact-threshold", "0", "hi"]);
+  if ("help" in zero) throw new Error("expected config result");
+  assertEquals(zero.compactThreshold, 0);
+
+  const omitted = await parse(["hi"]);
+  if ("help" in omitted) throw new Error("expected config result");
+  assertEquals(omitted.compactThreshold, undefined);
+
+  const fromEnv = await parse(["hi"], { CF_HARNESS_COMPACT_THRESHOLD: "9000" });
+  if ("help" in fromEnv) throw new Error("expected config result");
+  assertEquals(fromEnv.compactThreshold, 9_000);
+
+  // Every rejection names the requirement. `--compact-threshold -5` is the
+  // subtle one: the parser reads `-5` as a separate flag, so the option
+  // arrives with no string value and must not report merely "non-empty".
+  for (
+    const args of [
+      ["--compact-threshold", "abc", "hi"],
+      ["--compact-threshold", "1.5", "hi"],
+      ["--compact-threshold=-5", "hi"],
+      ["--compact-threshold", "-5", "hi"],
+      ["--compact-threshold", "hi"],
+    ]
+  ) {
+    await assertRejects(
+      () => parse(args),
+      Error,
+      "--compact-threshold requires a non-negative integer token count",
+    );
+  }
+});

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -1838,6 +1838,72 @@ Deno.test("runCfHarnessCli executes the prompt loop and prints result metadata",
   assertEquals(stderr, []);
 });
 
+Deno.test("runCfHarnessCli forwards --compact-threshold to a fresh run", async () => {
+  // Parsing was already covered; this pins the handoff. The option was
+  // forwarded on the resume path only, so a fresh run silently lost it.
+  const { io, stdout, stderr } = createIoBuffers();
+  let createdOptions: Record<string, unknown> | undefined;
+  let runPromptOptions: RunHarnessPromptOptions | undefined;
+  const exitCode = await runCfHarnessCli(
+    [
+      "--workspace",
+      "/tmp/project",
+      "--focus-root",
+      "packages/cf-harness",
+      "--prompt",
+      "Inspect the workspace",
+      "--model",
+      "gpt-5.4",
+      "--compact-threshold",
+      "12000",
+      "--print-transcript",
+    ],
+    {
+      io,
+      env: { CF_HARNESS_API_KEY: "test-key" },
+      createPromptLoop: (options) => {
+        createdOptions = options as Record<string, unknown>;
+        return {
+          runPrompt: (options) => {
+            runPromptOptions = options;
+            return Promise.resolve(
+              ({
+                model: "gpt-5.4",
+                finalAssistantText: "Inspection complete.",
+                transcript: [
+                  { role: "user", content: "Inspect the workspace" },
+                  { role: "assistant", content: "Inspection complete." },
+                ],
+                modelTurns: 1,
+                runState: {
+                  runId: "run-cli",
+                  status: "completed",
+                  createdAt: "2026-04-15T22:00:00.000Z",
+                  updatedAt: "2026-04-15T22:00:01.000Z",
+                  cfcEnforcementMode: "disabled",
+                  currentDir: "/workspace",
+                  artifactRoot: "/tmp/project/.cf-harness-artifacts/run-cli",
+                  transcriptPath:
+                    "/tmp/project/.cf-harness-artifacts/run-cli/transcript.json",
+                  runReportPath:
+                    "/tmp/project/.cf-harness-artifacts/run-cli/run-report.json",
+                  policyEvents: [],
+                  toolOutputs: [],
+                },
+              }) satisfies HarnessPromptLoopResult,
+            );
+          },
+          runTranscript: () =>
+            Promise.reject(new Error("unexpected resume path")),
+        };
+      },
+    },
+  );
+
+  assertEquals(exitCode, 0);
+  assertEquals(createdOptions?.compactThreshold, 12_000);
+});
+
 Deno.test("runCfHarnessCli passes image attachments to the prompt loop", async () => {
   const workspace = await Deno.makeTempDir();
   await Deno.writeFile(join(workspace, "capture.png"), ONE_PIXEL_PNG);

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -1902,6 +1902,88 @@ Deno.test("runCfHarnessCli forwards --compact-threshold to a fresh run", async (
   assertEquals(createdOptions?.compactThreshold, 12_000);
 });
 
+Deno.test("runCfHarnessCli reads CF_HARNESS_COMPACT_THRESHOLD from the process environment", async () => {
+  // Every other CLI test injects `env`, which bypasses the default projection
+  // built from `Deno.env.get` — exactly where this variable was missing:
+  // documented and parsed, but never populated in a real run.
+  const projected = [
+    "CF_HARNESS_COMPACT_THRESHOLD",
+    "CF_HARNESS_API_KEY",
+    "CF_HARNESS_MODEL",
+    "CF_HARNESS_MODEL_PROVIDER",
+    "CF_HARNESS_REASONING_EFFORT",
+    "CF_HARNESS_PROMPT_CACHE_MODE",
+    "CF_HARNESS_GATEWAY_BASE_URL",
+    "CF_HARNESS_GATEWAY_AUTH_MODE",
+  ];
+  const saved = new Map(projected.map((name) => [name, Deno.env.get(name)]));
+  for (const name of projected) Deno.env.delete(name);
+  Deno.env.set("CF_HARNESS_API_KEY", "test-key");
+  Deno.env.set("CF_HARNESS_COMPACT_THRESHOLD", "9000");
+  try {
+    const { io } = createIoBuffers();
+    let createdOptions: Record<string, unknown> | undefined;
+    const exitCode = await runCfHarnessCli(
+      [
+        "--workspace",
+        "/tmp/project",
+        "--focus-root",
+        "packages/cf-harness",
+        "--prompt",
+        "Inspect the workspace",
+        "--model",
+        "gpt-5.4",
+        "--print-transcript",
+      ],
+      {
+        io,
+        createPromptLoop: (options) => {
+          createdOptions = options as Record<string, unknown>;
+          return {
+            runPrompt: () => {
+              return Promise.resolve(
+                ({
+                  model: "gpt-5.4",
+                  finalAssistantText: "Inspection complete.",
+                  transcript: [
+                    { role: "user", content: "Inspect the workspace" },
+                    { role: "assistant", content: "Inspection complete." },
+                  ],
+                  modelTurns: 1,
+                  runState: {
+                    runId: "run-cli",
+                    status: "completed",
+                    createdAt: "2026-04-15T22:00:00.000Z",
+                    updatedAt: "2026-04-15T22:00:01.000Z",
+                    cfcEnforcementMode: "disabled",
+                    currentDir: "/workspace",
+                    artifactRoot: "/tmp/project/.cf-harness-artifacts/run-cli",
+                    transcriptPath:
+                      "/tmp/project/.cf-harness-artifacts/run-cli/transcript.json",
+                    runReportPath:
+                      "/tmp/project/.cf-harness-artifacts/run-cli/run-report.json",
+                    policyEvents: [],
+                    toolOutputs: [],
+                  },
+                }) satisfies HarnessPromptLoopResult,
+              );
+            },
+            runTranscript: () =>
+              Promise.reject(new Error("unexpected resume path")),
+          };
+        },
+      },
+    );
+    assertEquals(exitCode, 0);
+    assertEquals(createdOptions?.compactThreshold, 9_000);
+  } finally {
+    for (const [name, value] of saved) {
+      if (value === undefined) Deno.env.delete(name);
+      else Deno.env.set(name, value);
+    }
+  }
+});
+
 Deno.test("runCfHarnessCli passes image attachments to the prompt loop", async () => {
   const workspace = await Deno.makeTempDir();
   await Deno.writeFile(join(workspace, "capture.png"), ONE_PIXEL_PNG);

--- a/packages/cf-harness/test/openai-compaction.test.ts
+++ b/packages/cf-harness/test/openai-compaction.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "@std/assert";
+import { assert, assertEquals, assertRejects } from "@std/assert";
 import { OpenAICompatibleGatewayClient } from "../src/gateway/openai-client.ts";
 import {
   compactThresholdForBudget,
@@ -307,4 +307,139 @@ Deno.test("a compaction from another model is not replayed", async () => {
   // compaction must neither replay nor prune the transcript behind it.
   assertEquals(input.filter((i) => i.type === "compaction").length, 0);
   assert(JSON.stringify(input).includes("early contents"));
+});
+
+// ---------------------------------------------------------------------------
+// The default must work on the normal run path, with no primed catalog.
+// ---------------------------------------------------------------------------
+
+const bigTranscript = (): HarnessTranscriptMessage[] => [
+  { role: "user", content: "x".repeat(250_000) },
+];
+
+Deno.test("the default threshold applies without any listModels() call", async () => {
+  const captured: Captured[] = [];
+  // Nothing primes the catalog here: this is what a real run does.
+  const client = clientWith(captured, [
+    registry([{
+      id: MODEL,
+      capabilities: { contextWindow: 1_050_000, maxOutputTokens: 128_000 },
+    }]),
+    completed([]),
+  ]);
+
+  await client.complete(turn({ transcript: bigTranscript() }));
+
+  assertEquals(captured[0].url, `${GATEWAY}/v1/models`);
+  assertEquals(captured[1].body.context_management, [{
+    type: "compaction",
+    compact_threshold: 691_500,
+  }]);
+});
+
+Deno.test("discovery is attempted once, then reused", async () => {
+  const captured: Captured[] = [];
+  const client = clientWith(captured, [
+    registry([{
+      id: MODEL,
+      capabilities: { contextWindow: 1_050_000, maxOutputTokens: 128_000 },
+    }]),
+    completed([]),
+  ]);
+
+  await client.complete(turn({ transcript: bigTranscript() }));
+  await client.complete(turn({ transcript: bigTranscript() }));
+
+  const listCalls = captured.filter((c) => c.url.endsWith("/v1/models")).length;
+  assertEquals(listCalls, 1, "discovery must not repeat per turn");
+});
+
+Deno.test("small turns pay no discovery round trip", async () => {
+  const captured: Captured[] = [];
+  const client = clientWith(captured, [completed([])]);
+
+  // Nothing this small can approach any registry-derived threshold.
+  await client.complete(turn());
+
+  assertEquals(captured.length, 1);
+  assertEquals(captured[0].url, `${GATEWAY}/v1/responses`);
+  assertEquals(captured[0].body.context_management, undefined);
+});
+
+Deno.test("an unreachable registry degrades instead of failing the run", async () => {
+  const captured: Captured[] = [];
+  let call = 0;
+  const client = new OpenAICompatibleGatewayModelClient(
+    new OpenAICompatibleGatewayClient({
+      baseUrl: GATEWAY,
+      authMode: "none",
+      fetchFn: (input, init) => {
+        captured.push({
+          url: String(input),
+          body: init?.body
+            ? JSON.parse(String(init.body)) as Record<string, unknown>
+            : {},
+        });
+        call += 1;
+        // Discovery fails; the completion that follows must still succeed.
+        if (String(input).endsWith("/v1/models")) {
+          return Promise.resolve(new Response("nope", { status: 503 }));
+        }
+        return Promise.resolve(
+          new Response(JSON.stringify(completed([])), { status: 200 }),
+        );
+      },
+    }),
+  );
+
+  const result = await client.complete(turn({ transcript: bigTranscript() }));
+  assertEquals(result.assistant.content, "");
+  // Compaction is a guard, so losing it is not worth failing a run over.
+  const last = captured[captured.length - 1];
+  assertEquals(last.body.context_management, undefined);
+  assert(call >= 2);
+});
+
+// ---------------------------------------------------------------------------
+// Unsupported paths must fail loudly rather than ignore the option.
+// ---------------------------------------------------------------------------
+
+Deno.test("a positive threshold on a chat-routed model is rejected", async () => {
+  const client = clientWith([], [completed([])]);
+  await assertRejects(
+    () =>
+      client.complete(turn({
+        model: "gemini-3.5-flash",
+        compactThreshold: 5_000,
+      })),
+    Error,
+    "requires a model routed through the Responses API",
+  );
+});
+
+Deno.test("a positive threshold with native tools is rejected", async () => {
+  const client = clientWith([], [completed([])]);
+  await assertRejects(
+    () =>
+      client.complete(turn({
+        nativeModelToolIds: ["google_search"],
+        compactThreshold: 5_000,
+      })),
+    Error,
+    "cannot combine provider-native tools",
+  );
+});
+
+Deno.test("0 stays harmless on unsupported paths", async () => {
+  const captured: Captured[] = [];
+  const client = clientWith(captured, [{
+    choices: [{ index: 0, message: { role: "assistant", content: "ok" } }],
+  }]);
+  // Its requested behaviour is already "do not compact", so it need not throw.
+  const result = await client.complete(turn({
+    model: "gemini-3.5-flash",
+    compactThreshold: 0,
+  }));
+  assertEquals(result.assistant.content, "ok");
+  assertEquals(captured[0].url, `${GATEWAY}/v1/chat/completions`);
 });

--- a/packages/cf-harness/test/openai-compaction.test.ts
+++ b/packages/cf-harness/test/openai-compaction.test.ts
@@ -1,0 +1,310 @@
+import { assert, assertEquals } from "@std/assert";
+import { OpenAICompatibleGatewayClient } from "../src/gateway/openai-client.ts";
+import {
+  compactThresholdForBudget,
+  OpenAICompatibleGatewayModelClient,
+} from "../src/model/openai-compatible-gateway.ts";
+import { toResponsesInput } from "../src/model/responses-protocol.ts";
+import type { HarnessModelTurnRequest } from "../src/model/client.ts";
+import type { HarnessTranscriptMessage } from "../src/contracts/transcript.ts";
+
+const GATEWAY = "https://gateway.test";
+const PROVIDER = "openai-compatible-gateway";
+const MODEL = "gpt-5.6-terra";
+
+interface Captured {
+  url: string;
+  body: Record<string, unknown>;
+}
+
+const clientWith = (captured: Captured[], bodies: unknown[]) => {
+  let call = 0;
+  return new OpenAICompatibleGatewayModelClient(
+    new OpenAICompatibleGatewayClient({
+      baseUrl: GATEWAY,
+      authMode: "none",
+      fetchFn: (input, init) => {
+        captured.push({
+          url: String(input),
+          body: init?.body
+            ? JSON.parse(String(init.body)) as Record<string, unknown>
+            : {},
+        });
+        const body = bodies[Math.min(call, bodies.length - 1)];
+        call += 1;
+        return Promise.resolve(
+          new Response(JSON.stringify(body), { status: 200 }),
+        );
+      },
+    }),
+  );
+};
+
+const turn = (
+  overrides: Partial<HarnessModelTurnRequest> = {},
+): HarnessModelTurnRequest => ({
+  model: MODEL,
+  transcript: [{ role: "user", content: "Go." }],
+  tools: [],
+  nativeModelToolIds: [],
+  runId: "run-compaction",
+  ...overrides,
+});
+
+const completed = (output: unknown[]) => ({
+  id: "resp_1",
+  object: "response",
+  status: "completed",
+  output,
+});
+
+const compactionItem = (id = "cmp_1") => ({
+  type: "compaction",
+  id,
+  encrypted_content: `encrypted-${id}`,
+});
+
+const registry = (models: Array<Record<string, unknown>>) => ({
+  object: "list",
+  data: models,
+});
+
+// ---------------------------------------------------------------------------
+// Threshold policy
+// ---------------------------------------------------------------------------
+
+Deno.test("the threshold is 75% of the input budget, not of context window", () => {
+  // gpt-5.6 family: 1,050,000 total - 128,000 output = 922,000 input.
+  assertEquals(compactThresholdForBudget(1_050_000, 128_000), 691_500);
+  // The 400k models are the trap: 75% of contextWindow is 300,000, which is
+  // ABOVE the hard 272,000 input ceiling, so the guard would never fire.
+  assertEquals(compactThresholdForBudget(400_000, 128_000), 204_000);
+  assert(204_000 < 400_000 - 128_000, "threshold must sit under the input cap");
+});
+
+Deno.test("an unknown budget yields no threshold rather than a guess", () => {
+  assertEquals(compactThresholdForBudget(undefined, 128_000), undefined);
+  assertEquals(compactThresholdForBudget(1_050_000, undefined), undefined);
+  // Degenerate registry data must not produce a negative or zero threshold.
+  assertEquals(compactThresholdForBudget(1_000, 1_000), undefined);
+  assertEquals(compactThresholdForBudget(1_000, 2_000), undefined);
+});
+
+Deno.test("compaction is sent once the registry budget is known", async () => {
+  const captured: Captured[] = [];
+  // Order matches the call sequence below: completion, registry, completion.
+  const client = clientWith(captured, [
+    completed([]),
+    registry([{
+      id: MODEL,
+      capabilities: { contextWindow: 1_050_000, maxOutputTokens: 128_000 },
+    }]),
+    completed([]),
+  ]);
+
+  // Before discovery there is no budget, so no threshold is asserted.
+  await client.complete(turn());
+  assertEquals(captured[0].body.context_management, undefined);
+
+  const models = await client.listModels();
+  assertEquals(models[0].contextWindow, 1_050_000);
+  assertEquals(models[0].maxOutputTokens, 128_000);
+
+  await client.complete(turn());
+  assertEquals(captured[2].body.context_management, [{
+    type: "compaction",
+    compact_threshold: 691_500,
+  }]);
+});
+
+Deno.test("a per-request threshold overrides, and 0 disables", async () => {
+  const captured: Captured[] = [];
+  const client = clientWith(captured, [
+    registry([{
+      id: MODEL,
+      capabilities: { contextWindow: 1_050_000, maxOutputTokens: 128_000 },
+    }]),
+    completed([]),
+  ]);
+  await client.listModels();
+
+  await client.complete(turn({ compactThreshold: 5_000 }));
+  assertEquals(captured[1].body.context_management, [{
+    type: "compaction",
+    compact_threshold: 5_000,
+  }]);
+
+  await client.complete(turn({ compactThreshold: 0 }));
+  assertEquals(captured[2].body.context_management, undefined);
+});
+
+// ---------------------------------------------------------------------------
+// Retention and pruning
+// ---------------------------------------------------------------------------
+
+Deno.test("a compaction item is retained rather than dropped", async () => {
+  const captured: Captured[] = [];
+  const client = clientWith(captured, [
+    completed([
+      compactionItem(),
+      {
+        type: "message",
+        id: "msg_1",
+        role: "assistant",
+        status: "completed",
+        content: [{ type: "output_text", text: "done", annotations: [] }],
+      },
+    ]),
+  ]);
+
+  const result = await client.complete(turn());
+  const state = result.assistant.providerContinuation?.state as {
+    output: Array<Record<string, unknown>>;
+  };
+  assertEquals(
+    state.output.filter((o) => o.type === "compaction").length,
+    1,
+    "dropping it would mean paying for compaction and discarding the result",
+  );
+});
+
+const compactedTranscript = (): HarnessTranscriptMessage[] => [
+  { role: "system", content: "Be careful." },
+  { role: "user", content: "Read both files." },
+  // Superseded by the compaction below.
+  {
+    role: "assistant",
+    content: "Reading the first.",
+    toolCalls: [{
+      id: "call-early",
+      type: "function",
+      function: { name: "read_file", arguments: "{}" },
+    }],
+  },
+  {
+    role: "tool",
+    toolCallId: "call-early",
+    toolName: "read_file",
+    content: "early contents",
+  },
+  // The compaction boundary.
+  {
+    role: "assistant",
+    content: "Reading the second.",
+    toolCalls: [{
+      id: "call-late",
+      type: "function",
+      function: { name: "read_file", arguments: "{}" },
+    }],
+    providerContinuation: {
+      providerId: PROVIDER,
+      state: {
+        version: 1,
+        sourceModel: MODEL,
+        output: [
+          compactionItem(),
+          {
+            type: "reasoning",
+            id: "rs_1",
+            encrypted_content: "encrypted-rs_1",
+          },
+        ],
+      },
+    },
+  },
+  {
+    role: "tool",
+    toolCallId: "call-late",
+    toolName: "read_file",
+    content: "late contents",
+  },
+];
+
+Deno.test("pruning drops superseded turns but keeps tool pairs intact", async () => {
+  const { instructions, input } = await toResponsesInput(
+    compactedTranscript(),
+    MODEL,
+    PROVIDER,
+    "gateway Responses",
+    undefined,
+    "drop",
+  );
+
+  // The system prompt must survive pruning — it is sent every turn.
+  assertEquals(instructions, "Be careful.");
+
+  const types = input.map((i) => i.type ?? `role:${i.role}`);
+  assertEquals(types[0], "compaction");
+  // Everything before the boundary is gone: no early user turn, and crucially
+  // no orphaned function_call_output whose function_call was pruned away.
+  const callIds = input.flatMap((i) =>
+    typeof i.call_id === "string" ? [i.call_id] : []
+  );
+  assertEquals(callIds.includes("call-early"), false);
+  assert(!JSON.stringify(input).includes("early contents"));
+
+  // Every function_call_output still has its matching function_call.
+  const calls = new Set(
+    input.filter((i) => i.type === "function_call").map((i) => i.call_id),
+  );
+  for (const item of input.filter((i) => i.type === "function_call_output")) {
+    assert(
+      calls.has(item.call_id),
+      `orphaned tool result for ${String(item.call_id)}`,
+    );
+  }
+  assert(JSON.stringify(input).includes("late contents"));
+});
+
+Deno.test("the boundary's compaction item is emitted exactly once", async () => {
+  const { input } = await toResponsesInput(
+    compactedTranscript(),
+    MODEL,
+    PROVIDER,
+    "gateway Responses",
+    undefined,
+    "drop",
+  );
+  assertEquals(input.filter((i) => i.type === "compaction").length, 1);
+  // Its reasoning sibling still replays — only the compaction is deduplicated.
+  assertEquals(input.filter((i) => i.type === "reasoning").length, 1);
+});
+
+Deno.test("a transcript with no compaction is unchanged", async () => {
+  const plain: HarnessTranscriptMessage[] = [
+    { role: "system", content: "Be careful." },
+    { role: "user", content: "Go." },
+    { role: "assistant", content: "Working." },
+  ];
+  const { input } = await toResponsesInput(
+    plain,
+    MODEL,
+    PROVIDER,
+    "gateway Responses",
+    undefined,
+    "drop",
+  );
+  assertEquals(input.filter((i) => i.type === "compaction").length, 0);
+  assertEquals(input.length, 2);
+});
+
+Deno.test("a compaction from another model is not replayed", async () => {
+  const foreign = compactedTranscript();
+  const boundary = foreign[4] as {
+    providerContinuation: { state: { sourceModel: string } };
+  };
+  boundary.providerContinuation.state.sourceModel = "gpt-5.6-sol";
+
+  const { input } = await toResponsesInput(
+    foreign,
+    MODEL,
+    PROVIDER,
+    "gateway Responses",
+    undefined,
+    "drop",
+  );
+  // Encrypted state is bound to the model that produced it, so a mismatched
+  // compaction must neither replay nor prune the transcript behind it.
+  assertEquals(input.filter((i) => i.type === "compaction").length, 0);
+  assert(JSON.stringify(input).includes("early contents"));
+});

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -6932,3 +6932,74 @@ Deno.test("CfHarnessPromptLoop applies the compaction threshold to delegated wor
     );
   }
 });
+
+Deno.test("CfHarnessPromptLoop keeps a positive threshold off profile-overridden child models", async () => {
+  // web_search overrides the child model, so the parent's number — calibrated
+  // to the parent model's input budget — must not follow it there: on the
+  // chat-routed override it would be rejected outright, and on any other it
+  // would be the wrong model's threshold. `0` still propagates: the
+  // off-switch is run-wide.
+  for (
+    const { threshold, expectedChild } of [
+      { threshold: 12_000, expectedChild: undefined },
+      { threshold: 0, expectedChild: 0 },
+    ]
+  ) {
+    const childSeen: (number | undefined)[] = [];
+    let parentTurns = 0;
+    const modelClient: HarnessModelClient = {
+      providerId: "test-provider",
+      complete: (request) => {
+        if (request.model !== "gpt-5.6-terra") {
+          childSeen.push(request.compactThreshold);
+          return Promise.resolve({
+            assistant: { role: "assistant", content: "child done" },
+          });
+        }
+        parentTurns += 1;
+        return Promise.resolve({
+          assistant: parentTurns === 1
+            ? {
+              role: "assistant" as const,
+              content: "",
+              toolCalls: [{
+                id: `call-web-search-${threshold}`,
+                type: "function" as const,
+                function: {
+                  name: "delegate_task",
+                  arguments: JSON.stringify({
+                    goal: "Find the latest release notes.",
+                    profile: "web_search",
+                  }),
+                },
+              }],
+            }
+            : { role: "assistant" as const, content: "parent done" },
+        });
+      },
+    };
+    const loop = new CfHarnessPromptLoop({
+      modelClient,
+      compactThreshold: threshold,
+      allowedToolIds: ["delegate_task"],
+      allowedSubagentProfiles: ["web_search"],
+      engine: new CfHarnessEngine({
+        sandboxRuntime: new FakeSandboxRuntime(),
+        runId: `run-override-compaction-${threshold}`,
+        model: "gpt-5.6-terra",
+        cfcEnforcementMode: "disabled",
+      }),
+    });
+
+    await loop.runPrompt({ prompt: "Delegate and continue." });
+
+    assert(childSeen.length >= 1, "expected at least one child turn");
+    assertEquals(
+      childSeen.every((value) => value === expectedChild),
+      true,
+      `child turns should carry compactThreshold ${expectedChild}, saw ${
+        JSON.stringify(childSeen)
+      }`,
+    );
+  }
+});

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -6868,3 +6868,67 @@ Deno.test("CfHarnessPromptLoop includes prompt slot context on policy events", a
     "write_file requires direct-command authorization in enforce-explicit",
   );
 });
+
+Deno.test("CfHarnessPromptLoop applies the compaction threshold to delegated work", async () => {
+  // A run-wide setting has to reach children too. Without this, `0` would
+  // disable compaction in the parent while children fall back to the derived
+  // default and compact anyway.
+  for (const threshold of [12_000, 0]) {
+    const seen: (number | undefined)[] = [];
+    let parentTurns = 0;
+    const modelClient: HarnessModelClient = {
+      providerId: "test-provider",
+      complete: (request) => {
+        seen.push(request.compactThreshold);
+        if (request.model !== "gpt-5.6-terra") {
+          return Promise.resolve({
+            assistant: { role: "assistant", content: "child done" },
+          });
+        }
+        parentTurns += 1;
+        return Promise.resolve({
+          assistant: parentTurns === 1
+            ? {
+              role: "assistant" as const,
+              content: "",
+              toolCalls: [{
+                id: `call-delegate-${threshold}`,
+                type: "function" as const,
+                function: {
+                  name: "delegate_task",
+                  arguments: JSON.stringify({
+                    goal: "Do the isolated part.",
+                    profile: "default",
+                  }),
+                },
+              }],
+            }
+            : { role: "assistant" as const, content: "parent done" },
+        });
+      },
+    };
+    const loop = new CfHarnessPromptLoop({
+      modelClient,
+      compactThreshold: threshold,
+      allowedToolIds: ["delegate_task"],
+      allowedSubagentProfiles: ["default"],
+      engine: new CfHarnessEngine({
+        sandboxRuntime: new FakeSandboxRuntime(),
+        runId: `run-child-compaction-${threshold}`,
+        model: "gpt-5.6-terra",
+        cfcEnforcementMode: "disabled",
+      }),
+    });
+
+    await loop.runPrompt({ prompt: "Delegate and continue." });
+
+    assert(seen.length >= 2, "expected a parent turn and a child turn");
+    assertEquals(
+      seen.every((value) => value === threshold),
+      true,
+      `every turn should carry compactThreshold ${threshold}, saw ${
+        JSON.stringify(seen)
+      }`,
+    );
+  }
+});


### PR DESCRIPTION
Adopts OpenAI's [server-side compaction](https://developers.openai.com/api/docs/guides/compaction) on the Responses path — the second of the two settings from [*How enabling two settings tripled our scores on the ARC-AGI-3 benchmark*](https://openai.com/index/how-two-settings-tripled-our-arc-agi-3-scores/). The first, retained reasoning, cf-harness already does.

## Background: reasoning tokens and compaction

OpenAI found GPT-5.6 Sol scoring **13.3%** on the ARC-AGI-3 public set, and **38.3%** with two API settings enabled — with **6× fewer output tokens**. The cause was the harness, not the model: it *"discarded private reasoning after every move and later removed older actions once the running history exceeded its window."* The model kept a record of *what* it had done, but lost *why*, so it re-derived each game's rules before acting.

The two settings address the two halves of that loss:

**1. Retained reasoning — already in cf-harness.** Reasoning tokens are the model's private thinking for a turn. By default they are discarded once the turn ends. Preserving them means the next turn builds on prior conclusions instead of re-deriving them. cf-harness does this the ZDR-compatible way: `store: false` with `include: ["reasoning.encrypted_content"]`, replaying the encrypted items through `providerContinuation`. The alternative in the docs — [`previous_response_id` chaining](https://developers.openai.com/api/docs/guides/conversation-state) — requires server-side persistence and is unavailable to a Zero Data Retention org.

**2. Compaction — this PR.** Rolling truncation drops the oldest turns outright; compaction *"summarizes older context instead of dropping it"*, folding prior context — including prior reasoning — into a single encrypted item.

The two mechanisms are the same shape, which matters for the implementation. A compaction item and a reasoning item are both `{id, type, encrypted_content}` and both replay through the same continuation seam. That is precisely why the retention filter here had to widen to cover both: it previously matched `type === "reasoning"` only, so a compaction item was dropped silently.

One consequence worth stating, because it cost me an investigation: **compaction spends output budget** to emit its item. With a small `max_output_tokens` there is no room for it and the API returns an opaque `server_error` rather than a budget error. cf-harness never sets `max_output_tokens`, so this does not affect us — but it makes compaction look broken upstream if you test it with a tight ceiling.

## Threshold: 75% of the input budget

Derived from the gateway registry and cached by `listModels()`; when the catalog has not been primed, the client discovers budgets lazily once the transcript is large enough to matter (a one-time fetch gated at 200k characters, so ordinary runs pay nothing). `--compact-threshold <n>` overrides it; `0` disables.

Deliberately **not** 75% of `contextWindow`. The registry reports that as input + output, and on the 400k models 75% of it is 300,000 against a hard 272,000 input ceiling — verified live:

```
gpt-5.2 @300k tokens -> Input tokens exceed the configured limit of 272000 tokens.
```

That threshold would sit past a wall the request can never reach, so the guard would never fire in the one case it exists for.

## Why 75% rather than something aggressive

This is a **guard, not an optimisation**. The compacting turn costs more than the turn it replaces, so a low threshold taxes every short run to benefit long ones. At 75% it stays dormant for ordinary runs and engages once a built-up context — large system prompt, preloaded skills, accumulated documents — approaches the limit.

The gap *above* the threshold is not slack either — it is the guard's working room. Verified live: compaction cannot **rescue** a request that has already overshot the input cap. Sending ~300k tokens into the 272k cap returns `400 context_length_exceeded` with or without `context_management` — the cap check runs first, so compaction only pre-empts. The crossing turn itself must still fit, and the 25% between threshold and cap (68k tokens on the 400k models) is the single-turn headroom that absorbs it. A higher fraction would shrink exactly the margin the guard depends on.

## Two pieces that make it work

**Compaction items are retained.** They are shaped `{id, type, encrypted_content}`, structurally identical to reasoning items, so the previous filter dropped them silently. Enabling `context_management` without this would pay to produce compaction and then discard the only thing that makes it useful.

**Input is pruned at the compaction boundary.** The [compaction guide](https://developers.openai.com/api/docs/guides/compaction) calls client-side pruning a *"latency tip"*: *"you can drop items that came before the most recent compaction item"*. For us it is mandatory — measured **+14%** without it, worse than not compacting at all. The tip reads as optional because the guide assumes `previous_response_id` chaining, which ZDR rules out for us; with a stateless input array, not pruning means re-sending the full transcript *and* paying for the compaction item.

Pruning starts at an assistant message so `function_call`/`function_call_output` pairs stay intact — slicing anywhere else can orphan a tool result from the call that produced it. Instructions are still built from the whole transcript, so the system prompt survives pruning.

## Verification

**Live, end to end**, against the stage gateway on a Loom-shaped transcript (84 KB system prompt built from Loom's real skills, document-scale tool output). Run exactly as shipped — no manual `listModels()` call; the client discovered budgets lazily, derived the threshold, and did its own pruning:

```
gpt-5.4-nano: contextWindow=400000 maxOut=128000   -> threshold 204,000
turn 11: in=206574  compaction_items=1     <- crosses threshold
turn 12: in=60899   compaction_items=0     <- pruned
```

Whole-run totals from the same transcript: **1,383,892 vs 1,708,676 baseline input tokens — −19%**, matching the −21.5% an offline replay predicted.

**Suite:** 594 passed, 0 failed. New tests cover the threshold policy (including the 400k trap), retention, pruning with tool-pair integrity, single emission of the boundary item, cross-model rejection, lazy budget discovery (one fetch, gated by transcript size, degrades to no compaction if the registry is unreachable), CLI/child-loop propagation (including the real environment projection, with no injected `env`), and the no-compaction case.

**Child loops:** an explicit positive threshold follows only children that inherit the parent model — a profile-overridden child (e.g. `web_search`'s chat-routed Gemini) keeps its own model's derived default instead of a number calibrated to the wrong budget. `0` propagates unconditionally: the off-switch is model-independent.

## Notes for review

- Benefit scales with run length; a run that ends immediately after compacting is net negative. That is the cost of it being a guard.
- Compaction cannot save a turn that jumps from below the threshold straight past the input cap (verified above). A single tool output adding >68k tokens (~270 KB of text) in one turn still fails; client-side truncation would be the remedy and is out of scope here.
- Measured on synthetic-but-real-shaped data: the content, prompt and message shapes come from real runs, but the 13-turn sequence was assembled because the model gave up after 3 documents.
- An earlier investigation of mine concluded compaction was broken upstream. That was wrong — it was an artifact of a test harness passing `max_output_tokens: 64`, which leaves no budget for the compaction item and yields an opaque `server_error`. cf-harness never sets `max_output_tokens`, so production was never affected.

## References

- [OpenAI — Compaction](https://developers.openai.com/api/docs/guides/compaction) — `context_management`, `compact_threshold`, and the ZDR note that server-side compaction is compatible with `store: false`
- [OpenAI — Conversation state](https://developers.openai.com/api/docs/guides/conversation-state) — `previous_response_id` chaining, the alternative we cannot use
- [OpenAI — How enabling two settings tripled our scores on the ARC-AGI-3 benchmark](https://openai.com/index/how-two-settings-tripled-our-arc-agi-3-scores/) — 13.3% → 38.3%, 6× fewer output tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds server-side context compaction on the OpenAI Responses path in `cf-harness` to guard when input nears the model’s budget. Also improves `--compact-threshold` CLI validation with clearer errors.

- **New Features**
  - Sends `context_management: [{ type: "compaction", compact_threshold: N }]` once input reaches the threshold. Default N is 75% of the model’s input budget (contextWindow − maxOutputTokens) from the registry and cached by `listModels()`; if unknown, nothing is sent. Per-turn override via `compactThreshold`; `0` disables.
  - Retains `compaction` items and prunes at the newest assistant message that carries them, preserving `function_call`/`function_call_output` pairs. Compaction is emitted once; reasoning still replays; compaction from other models is ignored.
  - CLI and options: adds `--compact-threshold` and `CF_HARNESS_COMPACT_THRESHOLD`; programmatic `compactThreshold` on `CreateHarnessPromptLoopOptions` and `HarnessModelTurnRequest`. Tests cover threshold policy, pruning, retention, dedupe, cross-model rejection, and no-compaction.

- **Bug Fixes**
  - `--compact-threshold` parsing now names the requirement when rejected (e.g., `--compact-threshold -5`) and points to `--compact-threshold=<n>`. Tests cover valid counts, zero (disables), env/omitted cases, and each rejection path.

<sup>Written for commit c8b3abe9bdcc8f589b6d3fd0ceb8da37f4a96bf7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

