### PR TITLE
dashboard: point the prod-errors pop-out at the logs explorer itself

### DIFF
--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -420,7 +420,7 @@ it.
 | `COMMON_TOOLS_URL` | common.tools | override the public-site URL (e.g. the `www` host if the apex redirects). |
 | `DASHBOARD_REPO` | CI tiles, github users | which repo the CI tiles read. Its owner is the organization the **github users** tile reads (default `commontoolsinc/labs`). |
 | `DASHBOARD_CACHE_DIR` | server caches | directory for all persistent dashboard cache files (default: the platform temp directory). |
-| `SIGNOZ_UI_URL` | prod errors | browser-facing SigNoz URL for the "logs" pop-out. Defaults to `SIGNOZ_URL` when that is a public `https://` URL; set it when the server reaches SigNoz over an in-cluster URL a browser can't. |
+| `SIGNOZ_UI_URL` | prod errors, dau | browser-facing SigNoz URL for the explorer pop-outs: **prod errors** links to `/logs/logs-explorer` and **dau** to `/traces-explorer` under it. Defaults to `SIGNOZ_URL` when that is a public `https://` URL. An in-cluster `http://` URL, which a browser cannot reach, leaves both tiles with no pop-out at all, so set this whenever the server reaches SigNoz over one. |
 | `PROD_SERVICE` | prod errors, dau | the `service.name` production reports under in SigNoz, which both trace-reading tiles scope to. Defaults to `toolshed-production`. A name outside `[A-Za-z0-9._-]` is ignored, since it lands inside a query expression. |
 | `DAU_EXCLUDE_DIDS` | dau | comma-separated identity DIDs to leave out of the count — the server's own identity, `MEMORY_SERVICE_DIDS`, background services. Until it is set the count is an upper bound. See [dau](#dau) below. |
 

--- a/packages/dashboard/tiles/prod-errors.test.ts
+++ b/packages/dashboard/tiles/prod-errors.test.ts
@@ -118,7 +118,7 @@ Deno.test("prod errors: an empty result set -> unknown, and non-finite counts ar
   assertEquals(none.status, "unknown");
   assertEquals(none.value, "—");
   assertEquals(none.sub, "no toolshed-production spans");
-  assertEquals(none.href, "https://signoz.example/logs"); // still drills through
+  assertEquals(none.href, "https://signoz.example/logs/logs-explorer"); // still drills through
 
   // A bucket whose count is not a number is no bucket at all.
   const junk = await withFetch(
@@ -177,11 +177,11 @@ Deno.test("prod errors: the drill link prefers SIGNOZ_UI_URL over an in-cluster 
     withFetch(() => ok([]), () => prodErrors.collect(ctx(env)));
 
   const ui = await collect({ ...ENV, SIGNOZ_UI_URL: "https://ui.example/" });
-  assertEquals(ui.href, "https://ui.example/logs"); // trailing slash trimmed
+  assertEquals(ui.href, "https://ui.example/logs/logs-explorer"); // trailing slash trimmed
   assertEquals(ui.hint, "logs ↗");
 
   // No UI url, but the query url is public https -> the browser can use it too.
-  assertEquals((await collect(ENV)).href, "https://signoz.example/logs");
+  assertEquals((await collect(ENV)).href, "https://signoz.example/logs/logs-explorer");
 
   // An in-cluster url the browser can't reach, and no UI url -> no link at all.
   const inCluster = await collect({ SIGNOZ_URL: "http://signoz.svc:8080", SIGNOZ_API_KEY: "k" });

--- a/packages/dashboard/tiles/prod-errors.ts
+++ b/packages/dashboard/tiles/prod-errors.ts
@@ -97,7 +97,7 @@ export const prodErrors: Tile = {
     // prefers SIGNOZ_UI_URL and only falls back to SIGNOZ_URL when it's public https.
     const service = serviceName(ctx.env);
     const uiBase = ctx.env("SIGNOZ_UI_URL") ?? (base.startsWith("https://") ? base : undefined);
-    const drill = uiBase ? { href: `${uiBase.replace(/\/$/, "")}/logs`, hint: "logs ↗" } : {};
+    const drill = uiBase ? { href: `${uiBase.replace(/\/$/, "")}/logs/logs-explorer`, hint: "logs ↗" } : {};
 
     let trend: { total: Map<number, number>; err: Map<number, number> };
     try {


### PR DESCRIPTION
The prod errors tile's pop-out link was built as `<signoz>/logs`. That is not a page in the SigNoz UI; the logs explorer lives one level down, at `/logs/logs-explorer`. Send the link there so it lands on the view that lists the error records behind the tile's rate, and update the two tests that pinned the old path.

The env-var table also described `SIGNOZ_UI_URL` as belonging to prod errors alone, and named neither pop-out destination. The dau tile reads the same variable for its own traces-explorer link, so list both tiles, name both paths, and say plainly what happens when it is unset while `SIGNOZ_URL` is an in-cluster `http://` address: the fallback is refused because a browser cannot reach that host, and both tiles then render with no pop-out at all rather than a broken one.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the prod errors tile pop-out to open the SigNoz logs explorer at `/logs/logs-explorer` so it lands on the error list. Updates tests and README to note `SIGNOZ_UI_URL` is used by both prod errors and dau, and that an in-cluster `http://` `SIGNOZ_URL` disables pop-outs unless `SIGNOZ_UI_URL` is set.

<sup>Written for commit 3ffb05e91ceadb4541aaf8d9372ab9814ecc1ccc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

