### PR TITLE
test(runner): stage the list resume-preservation reload instead of ti…

### DIFF
--- a/docs/development/waiting-in-tests-rationale.md
+++ b/docs/development/waiting-in-tests-rationale.md
@@ -186,6 +186,29 @@ the test: the hold proves the recovery waits for the absence confirmation
 before writing, and it ends before any retry can accumulate against the
 withheld answer.
 
+## Sizing the auto-advance runaway ceiling
+
+Auto-advance turns a `src/` backoff into a hot loop whenever the condition it
+retries against cannot change — a withheld document, a commit that will be
+rejected the same way every round. Each round arms a fresh timer, the pump fires
+it on the next turn of the event loop, and the cycle allocates. Left to run it
+ends as a V8 out-of-memory abort, which names no test and leaves nothing to
+read.
+
+The ceiling therefore has to sit below the point where such a loop exhausts the
+heap, not at a round number far above it. Measured across the runner suite, the
+heaviest user of auto-advance, one test reaches 160 fires and every other one
+stays under a hundred, so a ceiling an order of magnitude above that separates a
+livelock from every healthy test while still tripping long before memory runs
+out. The error names the arming site that accounted for most of the fires, which
+is the frame worth having: in a stalled resume it is the storage layer's
+conflict repair or the memory server's refresh scheduler, and either one
+identifies the condition that cannot clear.
+
+A test that legitimately advances through many windows should say so with
+`clock.tick(ms)` rather than lean on the pump. One whose work logical time
+cannot pace at all belongs in `realClockFiles`.
+
 ## Why the runtime-client suite stays on the real clock
 
 `packages/runtime-client` keeps its unit tests on the real clock, and the

--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -386,12 +386,18 @@ logical time to zero and drops pending timers: one frozen clock wraps a whole
 grid tests) calls it from `beforeEach` to start each case from a known instant.
 
 One file stays on the real clock, listed with its reason in the runner preload's
-`realClockFiles` list. It is a resume test whose reload holds each per-element
-child document back by a delay to open the resume window it observes; that delay
-is a frozen test-file timer, and the resuming runtime's pull/idle machinery
-blocks on the deliveries it gates, so the resume deadlocks. That is an honest
-exception: the clock it needs is the real one, and its own sleeps are the honest
-way to wait.
+`realClockFiles` list. It is a resume test that holds the per-element documents
+in its transport so the coordinator reconciles while they are absent, which is
+the state it exists to observe. A commit carrying a read of a withheld document
+is rejected as stale, and the catch-up the rejection waits on cannot arrive
+while the hold is on, so the retry cycle repeats until the test releases it.
+Real time paces that cycle; auto-advance fires each round's timer as soon as it
+is armed, and the loop allocates until the process runs out of heap. A hold that
+spans a reconcile therefore needs the real clock; a shorter one, that no retry
+outlives, does not. The test itself waits on transport edges, never on a delay.
+[The rationale
+document](waiting-in-tests-rationale.md#the-runner-clock-retired-exemptions-and-converted-waits)
+works that retry loop through in full.
 
 Other entries have been retired from that list as the deadlines and test
 designs behind them were fixed. [The rationale
@@ -405,6 +411,14 @@ positive-delay `setTimeout` written in test code freezes before and after the
 first `Runtime` exists. How the harness reads frames that lockdown's error
 taming would otherwise blank is in [the rationale
 document](waiting-in-tests-rationale.md#how-the-runner-clock-classifies-timers-across-ses-lockdown).
+
+When auto-advance runs away, the harness stops the test rather than letting the
+process die: past a fixed number of fires within one test it throws, naming the
+arming site that accounted for most of them. That is a runaway detector rather
+than a wait with a deadline — a healthy test never approaches the count, and
+what it reports is a livelock. Where the ceiling sits and why is in [the
+rationale
+document](waiting-in-tests-rationale.md#sizing-the-auto-advance-runaway-ceiling).
 
 One consequence is worth stating because it is easy to trip over. A test that
 guards a wait with its own wall-clock deadline — a `setTimeout(reject, ms)` — has

--- a/packages/runner/test/clock-preload.ts
+++ b/packages/runner/test/clock-preload.ts
@@ -16,11 +16,18 @@ installFakeClock({
   // Test files kept on the real clock for now. These should be converted to use
   // a fake clock. // TODO: convert these tests to a fake clock
   realClockFiles: [
-    // The sibling resume test: its reload storage manager holds each per-element
-    // child document back by a real delay to open the resume window it observes,
-    // and the resuming runtime's pull/idle machinery blocks on those deliveries.
-    // Under the fake clock the delay is a frozen test-file timer that pull/idle
-    // wait on, so the resume deadlocks; the real clock delivers them as intended.
+    // Holds the resume's per-element documents in the transport so the
+    // coordinator reconciles while they are absent. A commit carrying a read of
+    // a withheld document is rejected as stale, and the catch-up the rejection
+    // waits on cannot arrive while the hold is on, so the retry cycle repeats;
+    // real time paces it until the test releases the hold, but auto-advance
+    // fires each cycle's timer as soon as it is armed and the loop allocates
+    // until the process runs out of heap. Same shape as the retry loop recorded
+    // for `list-resume-container-defer` in
+    // `docs/development/waiting-in-tests-rationale.md`, and the reason that
+    // suite's holds are bounded. This one's hold spans a reconcile, which is the state it
+    // exists to observe, so it needs the real clock. The test itself waits on
+    // transport edges, never on a delay.
     "list-resume-preserve",
   ],
 });

--- a/packages/runner/test/list-resume-preserve.test.ts
+++ b/packages/runner/test/list-resume-preserve.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import type { Signer } from "@commonfabric/memory/interface";
@@ -31,72 +31,104 @@ import {
 // that genuinely settles falsy/undefined is still excluded — convergence, not
 // freeze).
 //
-// The window is timing-dependent, so this test forces it deterministically: a
-// loopback transport delays delivery of the per-element predicate documents
-// (boolean-valued) relative to everything else, modeling a real reload where the
-// per-element results rehydrate after the aggregate container has loaded. The
-// container's `kept` entries are `{ keep, label }` objects, so the boolean
-// predicate documents are cleanly separable from the container document. The
-// test asserts that the `kept` list is never observed as empty or a strict
-// shrink during the resume window.
+// The reload is staged in the transport rather than timed. A resume asks
+// storage for two batches of documents: the aggregate's own container together
+// with the input list, and, behind it, the per-element runs. Both are held. The
+// test lets the coordinator run once against nothing, releases the container
+// batch, lets it reconcile while the per-element batch is still withheld, and
+// only then releases that. Each step waits on an edge the transport reports, so
+// the sequence is the same on every run.
+//
+// Delaying the second batch on a timer instead cannot promise that sequence.
+// The coordinator's resume work and the delivery are then ordered by whatever
+// the event loop did on that run, so the window is wide, narrow or closed by
+// luck and the assertions below check a different scenario each time.
 
 const signer = await Identity.fromPassphrase("list resume preserve");
 const space = signer.did();
 
-// Per-element result docs are separated from the aggregate container by the
-// schema type their query carries. A `filter` predicate result is a boolean and
-// its sync carries `"type":"boolean"`; a `flatMap` op result here is a number
-// (the container's own query carries no scalar item type, only `asCell` slots),
-// so the two builtins pass distinct matchers below.
-const FILTER_CHILD_DOC = /"type":"boolean"/;
-const FLATMAP_CHILD_DOC = /"type":"number"/;
+// Which batch a sync belongs to, read off the schemas it carries. The
+// per-element batch carries the run argument's schema, whose sole required
+// property is `element`; it is recognized first, because it also mentions the
+// aggregate. The top-level batch carries the pattern's own result schema, whose
+// required property is the aggregate's key.
+const PER_ELEMENT_BATCH = /"required":\["element"\]/;
+const TOP_LEVEL_BATCH = /"required":\["(?:kept|values)"\]/;
 
-// How long the reload's storage manager holds back each per-element child
-// document before delivering it, which is what opens the resume window the
-// tests observe. The resuming runtime's pull/idle machinery blocks on these
-// deliveries, so this file runs on the real clock (see the `realClockFiles`
-// note in `test/clock-preload.ts`).
-const CHILD_DELAY_MS = 80;
-
-function delayingLoopback(
-  server: MemoryV2Server.Server,
-  childDelayMs: number,
-  childDoc: RegExp,
-  onDelay: () => void,
-): MemoryV2Client.Transport {
-  const inner = MemoryV2Client.loopback(server);
-  return {
-    send: (p: string) => inner.send(p),
-    close: () => inner.close(),
-    setReceiver: (r: (p: string) => void) => {
-      inner.setReceiver((payload: string) => {
-        if (childDelayMs > 0 && childDoc.test(payload)) {
-          onDelay();
-          setTimeout(() => r(payload), childDelayMs);
-        } else {
-          r(payload);
-        }
-      });
-    },
-    setCloseReceiver: (r: (e?: Error) => void) => inner.setCloseReceiver?.(r),
-  };
+/**
+ * A transport gate that holds the two resume batches and releases them on the
+ * test's word, in the order a reload delivers them.
+ *
+ * Each stage exposes a promise that resolves the first time a document of that
+ * stage is held back. That is the edge the test waits on: the storage layer has
+ * answered, so the batch is known to exist and to be withheld, rather than the
+ * test guessing at when it might turn up.
+ */
+class ResumeBatchGate {
+  readonly #held: [string[], string[]] = [[], []];
+  readonly #open: [boolean, boolean] = [false, false];
+  readonly #resolve: [(() => void) | undefined, (() => void) | undefined];
+  #deliver: (payload: string) => void = () => {};
+  /** Resolves once a top-level document has been held back. */
+  readonly topHeld: Promise<void>;
+  /** Resolves once a per-element document has been held back. */
+  readonly elementsHeld: Promise<void>;
+  constructor() {
+    let resolveTop!: () => void;
+    let resolveElements!: () => void;
+    this.topHeld = new Promise<void>((resolve) => {
+      resolveTop = resolve;
+    });
+    this.elementsHeld = new Promise<void>((resolve) => {
+      resolveElements = resolve;
+    });
+    this.#resolve = [resolveTop, resolveElements];
+  }
+  #stageOf(payload: string): 0 | 1 | undefined {
+    if (PER_ELEMENT_BATCH.test(payload)) return 1;
+    if (TOP_LEVEL_BATCH.test(payload)) return 0;
+    return undefined;
+  }
+  wrap(inner: MemoryV2Client.Transport): MemoryV2Client.Transport {
+    return {
+      send: (payload: string) => inner.send(payload),
+      close: () => inner.close(),
+      setReceiver: (receive: (payload: string) => void) => {
+        this.#deliver = receive;
+        inner.setReceiver((payload: string) => {
+          const stage = this.#stageOf(payload);
+          if (stage === undefined || this.#open[stage]) {
+            receive(payload);
+            return;
+          }
+          this.#held[stage].push(payload);
+          this.#resolve[stage]?.();
+          this.#resolve[stage] = undefined;
+        });
+      },
+      setCloseReceiver: (r: (e?: Error) => void) => inner.setCloseReceiver?.(r),
+    };
+  }
+  /** How many documents of a stage are currently held back. */
+  heldCount(stage: 0 | 1): number {
+    return this.#held[stage].length;
+  }
+  /** Open a stage and flush every document it holds. */
+  release(stage: 0 | 1): void {
+    this.#open[stage] = true;
+    for (const payload of this.#held[stage].splice(0)) this.#deliver(payload);
+  }
 }
 
-class DelayingSessionFactory implements SessionFactory {
+class GatedSessionFactory implements SessionFactory {
   constructor(
     private readonly getServer: () => MemoryV2Server.Server,
-    private readonly childDelayMs: number,
-    private readonly childDoc: RegExp,
-    private readonly onDelay: () => void,
+    private readonly gate?: ResumeBatchGate,
   ) {}
   async create(spaceId: string, sgnr?: Signer) {
+    const base = MemoryV2Client.loopback(this.getServer());
     const client = await MemoryV2Client.connect({
-      transport: delayingLoopback(
-        this.getServer(),
-        this.childDelayMs,
-        this.childDoc,
-        this.onDelay,
-      ),
+      transport: this.gate ? this.gate.wrap(base) : base,
     });
     const session = await client.mount(
       spaceId,
@@ -107,42 +139,39 @@ class DelayingSessionFactory implements SessionFactory {
   }
 }
 
-class DelayingStorageManager extends StorageManager {
+class GatedStorageManager extends StorageManager {
   static make(
     as: Identity,
     server: MemoryV2Server.Server,
-    childDelayMs: number,
-    childDoc: RegExp,
-    onDelay: () => void = () => {},
-  ): DelayingStorageManager {
-    return new DelayingStorageManager(
+    gate?: ResumeBatchGate,
+  ): GatedStorageManager {
+    return new GatedStorageManager(
       { as, memoryHost: new URL("memory://") } as Options,
       server,
-      childDelayMs,
-      childDoc,
-      onDelay,
+      gate,
     );
   }
   private constructor(
     options: Options,
     server: MemoryV2Server.Server,
-    childDelayMs: number,
-    childDoc: RegExp,
-    onDelay: () => void,
+    gate?: ResumeBatchGate,
   ) {
-    super(
-      options,
-      new DelayingSessionFactory(
-        () => server,
-        childDelayMs,
-        childDoc,
-        onDelay,
-      ),
-    );
+    super(options, new GatedSessionFactory(() => server, gate));
   }
   override registerSpaceHost(): boolean {
     return false;
   }
+}
+
+function makeServer(): MemoryV2Server.Server {
+  return new MemoryV2Server.Server({
+    authorizeSessionOpen(message) {
+      const principal = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof principal === "string" ? principal : undefined;
+    },
+    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
+  });
 }
 
 const PROGRAM: RuntimeProgram = {
@@ -177,135 +206,148 @@ const labelsOf = (v: unknown): string[] | null =>
     ? null
     : ["<non-array>"];
 
-describe("list builtin resume preservation", () => {
-  let server: MemoryV2Server.Server;
-  let sm1: DelayingStorageManager;
-  let sm2: DelayingStorageManager;
-  let delayed: number;
+/**
+ * Build the aggregate in a first runtime, then resume in a second runtime
+ * behind the batch gate: release the container and input list, let the
+ * coordinator reconcile while the per-element runs are still held, then
+ * release those and let it converge. Asserts that the aggregate converges to
+ * the durable value and was never observed empty or shrunk on the way, and that
+ * the window was genuinely open — a run that never held a batch back fails
+ * rather than passing vacuously.
+ */
+async function runResumePreservation<T>(
+  program: RuntimeProgram,
+  items: readonly unknown[],
+  cellId: string,
+  resultKey: string,
+  shapeOf: (value: unknown) => T[] | null,
+  expected: T[],
+): Promise<void> {
+  const server = makeServer();
+  const sm1 = GatedStorageManager.make(signer, server);
+  const gate = new ResumeBatchGate();
+  const sm2 = GatedStorageManager.make(signer, server, gate);
 
-  beforeEach(() => {
-    delayed = 0;
-    server = new MemoryV2Server.Server({
-      authorizeSessionOpen(message) {
-        const principal = (message.authorization as { principal?: unknown })
-          ?.principal;
-        return typeof principal === "string" ? principal : undefined;
-      },
-      sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
-    });
-    sm1 = DelayingStorageManager.make(signer, server, 0, FILTER_CHILD_DOC);
-    sm2 = DelayingStorageManager.make(
-      signer,
-      server,
-      CHILD_DELAY_MS,
-      FILTER_CHILD_DOC,
-      () => delayed++,
-    );
+  // CREATE (runtime A): build the durable, non-empty aggregate.
+  const rt1 = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager: sm1,
   });
-  afterEach(async () => {
-    await sm1?.close();
-    await sm2?.close();
-    await server?.close();
+  const compiled = await rt1.patternManager.compilePattern(program, { space });
+  const tx0 = rt1.edit();
+  const rc1 = rt1.getCell<Record<string, unknown>>(
+    space,
+    cellId,
+    compiled.resultSchema,
+    tx0,
+  );
+  rt1.run(tx0, compiled, { items }, rc1);
+  await tx0.commit();
+  // pull() reads to quiescence and settled() waits for the scheduler, storage
+  // sync and any async builtin work; both converge internally, so no pump loop.
+  await rc1.pull();
+  await rt1.settled();
+  await rt1.patternManager.flushCompileCacheWrites();
+  await sm1.synced();
+  expect(shapeOf(rc1.key(resultKey).getAsQueryResult())).toEqual(expected);
+  // The second runtime reads what this one wrote, and the test closes the
+  // store itself once both are done.
+  await rt1.dispose({ closeStorage: false });
+
+  // RELOAD (runtime B): cold cache, both resume batches held.
+  const rt2 = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager: sm2,
   });
-
-  it("preserves a durable filter result while per-element children resync", async () => {
-    // CREATE (runtime A): build the durable, non-empty filtered list.
-    const rt1 = new Runtime({
-      apiUrl: new URL(import.meta.url),
-      storageManager: sm1,
-    });
-    const compiled1 = await rt1.patternManager.compilePattern(PROGRAM, {
+  const trajectory: (T[] | null)[] = [];
+  try {
+    await rt2.patternManager.compilePattern(program, { space });
+    const tx = rt2.edit();
+    const rc2 = rt2.getCell<Record<string, unknown>>(
       space,
-    });
-    const tx0 = rt1.edit();
-    const rc1 = rt1.getCell<{ kept: { label: string }[] }>(
-      space,
-      "lr-result",
-      compiled1.resultSchema,
-      tx0,
+      cellId,
+      compiled.resultSchema,
+      tx,
     );
-    const h1 = rt1.run(tx0, compiled1, { items: ITEMS }, rc1);
-    await tx0.commit();
-    for (let k = 0; k < 10; k++) {
-      await h1.pull();
-      await rt1.idle();
-    }
-    await rt1.patternManager.flushCompileCacheWrites();
-    await sm1.synced();
-    expect(
-      (rc1.key("kept").getAsQueryResult() ?? []).map((x: { label: string }) =>
-        x.label
-      ),
-    ).toEqual(EXPECTED);
-    await rt1.dispose({ closeStorage: false });
+    await tx.commit();
 
-    // RELOAD (runtime B): cold cache, with per-element predicate documents
-    // delivered late so the container loads before the children.
-    const rt2 = new Runtime({
-      apiUrl: new URL(import.meta.url),
-      storageManager: sm2,
+    const cancel = rc2.key(resultKey).sink((v) => {
+      trajectory.push(shapeOf(v));
     });
-    const trajectory: (string[] | null)[] = [];
     try {
-      await rt2.patternManager.compilePattern(PROGRAM, { space });
-      const tx = rt2.edit();
-      const rc2 = rt2.getCell<{ kept: { label: string }[] }>(
-        space,
-        "lr-result",
-        compiled1.resultSchema,
-        tx,
-      );
-      await tx.commit();
+      // Start reads documents from both batches, so it is kicked off here and
+      // awaited at the end: the window has to be open while it runs.
+      const starting = rt2.start(rc2);
 
-      const cancel = rc2.key("kept").sink((v) => {
-        trajectory.push(labelsOf(v));
-      });
+      // Let the coordinator run once against a container that has not loaded
+      // at all, which is the state a reload starts from, before handing it the
+      // top-level batch.
+      await gate.topHeld;
+      expect(gate.heldCount(0)).toBeGreaterThan(0);
+      await rt2.idle();
+      gate.release(0);
 
-      const started = await rt2.start(rc2);
-      expect(started).toBe(true);
+      // The window. The container now holds its durable value and the
+      // coordinator reconciles against it while the per-element runs are still
+      // withheld. idle() drives the scheduler to quiescence without blocking on
+      // those documents the way pull() would.
+      await gate.elementsHeld;
+      await rt2.idle();
+      expect(gate.heldCount(1)).toBeGreaterThan(0);
+      trajectory.push(shapeOf(rc2.key(resultKey).get()));
 
-      for (let k = 0; k < 24; k++) {
-        await rc2.pull();
-        await rt2.idle();
-        trajectory.push(labelsOf(rc2.key("kept").get()));
-      }
-      cancel();
+      gate.release(1);
+      expect(await starting).toBe(true);
 
-      // Self-check: the harness only exercises the bug if it actually deferred
-      // some per-element documents. If the storage payload shape changes so the
-      // matcher no longer fires, fail loudly rather than pass vacuously.
-      expect(delayed).toBeGreaterThan(0);
-
-      const finalLabels = (rc2.key("kept").getAsQueryResult() ?? []).map(
-        (x: { label: string }) => x.label,
-      );
-      // Converges to the durable value.
-      expect(finalLabels).toEqual(EXPECTED);
-
-      // Never transiently emptied or shrunk during the resume window. On
-      // failure the offending values (the empty/partial snapshots) are shown;
-      // the full trajectory is logged for context.
-      const shrank = trajectory.filter(
-        (t) => t !== null && t.length > 0 && t.length < EXPECTED.length,
-      );
-      const empties = trajectory.filter((t) => t !== null && t.length === 0);
-      if (shrank.length > 0 || empties.length > 0) {
-        console.log("kept trajectory:", JSON.stringify(trajectory));
-      }
-      expect(empties).toEqual([]);
-      expect(shrank).toEqual([]);
+      // Converge: pull() re-reads to quiescence now that the children have
+      // landed, and settled() flushes the reconcile their arrival triggers.
+      await rc2.pull();
+      await rt2.settled();
+      trajectory.push(shapeOf(rc2.key(resultKey).get()));
     } finally {
-      await rt2.dispose({ closeStorage: false });
+      await rt2.idle();
+      cancel();
     }
+
+    // Converges to the durable value.
+    expect(shapeOf(rc2.key(resultKey).getAsQueryResult())).toEqual(expected);
+
+    // Never transiently emptied or shrunk during the resume window. On failure
+    // the offending values (the empty/partial snapshots) are shown; the full
+    // trajectory is logged for context.
+    const observed = trajectory.filter((t): t is T[] => t !== null);
+    const shrank = observed.filter(
+      (t) => t.length > 0 && t.length < expected.length,
+    );
+    const empties = observed.filter((t) => t.length === 0);
+    if (shrank.length > 0 || empties.length > 0) {
+      console.log(`${resultKey} trajectory:`, JSON.stringify(trajectory));
+    }
+    expect(empties).toEqual([]);
+    expect(shrank).toEqual([]);
+  } finally {
+    await rt2.dispose({ closeStorage: false });
+    await sm1.close();
+    await sm2.close();
+    await server.close();
+  }
+}
+
+describe("list builtin resume preservation", () => {
+  it("preserves a durable filter result while per-element children resync", async () => {
+    await runResumePreservation(
+      PROGRAM,
+      ITEMS,
+      "lr-result",
+      "kept",
+      labelsOf,
+      EXPECTED,
+    );
   });
 });
 
-// The flatMap mirror. The op result is a number, so each per-element result
-// doc's sync carries `"type":"number"`, which the aggregate container's own
-// slot-link query does not — that is the matcher the reload uses to deliver the
-// per-element results late. Each element carries a distinct `n` so the skip test
-// can assert exactly which element is omitted; the per-test self-check on the
-// delayed count guards against the matcher drifting if the payload shape moves.
+// The flatMap mirror. Each element carries a distinct `n` so the skip test can
+// assert exactly which element is omitted.
 const FLATMAP_ITEMS = [
   { keep: true, n: 1, label: "a" },
   { keep: true, n: 2, label: "b" },
@@ -387,138 +429,35 @@ const numbersOf = (v: unknown): number[] | null =>
   Array.isArray(v) ? (v as number[]) : v == null ? null : [NaN];
 
 describe("flatMap builtin resume preservation", () => {
-  let server: MemoryV2Server.Server;
-  let sm1: DelayingStorageManager;
-  let sm2: DelayingStorageManager;
-  let delayed: number;
-
-  beforeEach(() => {
-    delayed = 0;
-    server = new MemoryV2Server.Server({
-      authorizeSessionOpen(message) {
-        const principal = (message.authorization as { principal?: unknown })
-          ?.principal;
-        return typeof principal === "string" ? principal : undefined;
-      },
-      sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
-    });
-    sm1 = DelayingStorageManager.make(signer, server, 0, FLATMAP_CHILD_DOC);
-    sm2 = DelayingStorageManager.make(
-      signer,
-      server,
-      CHILD_DELAY_MS,
-      FLATMAP_CHILD_DOC,
-      () => delayed++,
-    );
-  });
-  afterEach(async () => {
-    await sm1?.close();
-    await sm2?.close();
-    await server?.close();
-  });
-
-  async function runFlatMapResume(
-    program: RuntimeProgram,
-    items: typeof FLATMAP_ITEMS,
-    expected: number[],
-  ): Promise<void> {
-    // CREATE (runtime A): build the durable, non-empty flattened list.
-    const rt1 = new Runtime({
-      apiUrl: new URL(import.meta.url),
-      storageManager: sm1,
-    });
-    const compiled1 = await rt1.patternManager.compilePattern(program, {
-      space,
-    });
-    const tx0 = rt1.edit();
-    const rc1 = rt1.getCell<{ values: number[] }>(
-      space,
-      "fm-result",
-      compiled1.resultSchema,
-      tx0,
-    );
-    const h1 = rt1.run(tx0, compiled1, { items }, rc1);
-    await tx0.commit();
-    for (let k = 0; k < 10; k++) {
-      await h1.pull();
-      await rt1.idle();
-    }
-    await rt1.patternManager.flushCompileCacheWrites();
-    await sm1.synced();
-    expect(rc1.key("values").getAsQueryResult() ?? []).toEqual(expected);
-    await rt1.dispose({ closeStorage: false });
-
-    // RELOAD (runtime B): cold cache, per-element result docs delivered late so
-    // the container loads before the children.
-    const rt2 = new Runtime({
-      apiUrl: new URL(import.meta.url),
-      storageManager: sm2,
-    });
-    const trajectory: (number[] | null)[] = [];
-    try {
-      await rt2.patternManager.compilePattern(program, { space });
-      const tx = rt2.edit();
-      const rc2 = rt2.getCell<{ values: number[] }>(
-        space,
-        "fm-result",
-        compiled1.resultSchema,
-        tx,
-      );
-      await tx.commit();
-
-      const cancel = rc2.key("values").sink((v) => {
-        trajectory.push(numbersOf(v));
-      });
-
-      const started = await rt2.start(rc2);
-      expect(started).toBe(true);
-
-      for (let k = 0; k < 24; k++) {
-        await rc2.pull();
-        await rt2.idle();
-        trajectory.push(numbersOf(rc2.key("values").get()));
-      }
-      cancel();
-
-      // Self-check: fail loudly if the matcher stopped firing, rather than pass
-      // vacuously.
-      expect(delayed).toBeGreaterThan(0);
-
-      const finalValues = rc2.key("values").getAsQueryResult() ?? [];
-      // Converges to the durable value.
-      expect(finalValues).toEqual(expected);
-
-      // Never transiently emptied or shrunk during the resume window.
-      const shrank = trajectory.filter(
-        (t) => t !== null && t.length > 0 && t.length < expected.length,
-      );
-      const empties = trajectory.filter((t) => t !== null && t.length === 0);
-      if (shrank.length > 0 || empties.length > 0) {
-        console.log("values trajectory:", JSON.stringify(trajectory));
-      }
-      expect(empties).toEqual([]);
-      expect(shrank).toEqual([]);
-    } finally {
-      await rt2.dispose({ closeStorage: false });
-    }
-  }
-
   it("preserves a durable flatMap result while per-element children resync", async () => {
-    await runFlatMapResume(FLATMAP_PROGRAM, FLATMAP_ITEMS, FLATMAP_EXPECTED);
+    await runResumePreservation(
+      FLATMAP_PROGRAM,
+      FLATMAP_ITEMS,
+      "fm-result",
+      "values",
+      numbersOf,
+      FLATMAP_EXPECTED,
+    );
   });
 
   it("skips a flatMap element that settles undefined without dropping the list", async () => {
-    await runFlatMapResume(
+    await runResumePreservation(
       FLATMAP_SKIP_PROGRAM,
       FLATMAP_ITEMS,
+      "fm-skip-result",
+      "values",
+      numbersOf,
       FLATMAP_SKIP_EXPECTED,
     );
   });
 
   it("spreads a flatMap element whose op returns an array across a resume", async () => {
-    await runFlatMapResume(
+    await runResumePreservation(
       FLATMAP_SPREAD_PROGRAM,
       FLATMAP_ITEMS,
+      "fm-spread-result",
+      "values",
+      numbersOf,
       FLATMAP_SPREAD_EXPECTED,
     );
   });

--- a/packages/test-support/test/clock-preload.ts
+++ b/packages/test-support/test/clock-preload.ts
@@ -59,7 +59,19 @@ interface Timer {
   args: unknown[];
   kind: Kind;
   interval?: number;
+  // Where a production timer was armed, so a runaway can name it. Undefined
+  // when the stack carried no frame outside this file.
+  site: string | undefined;
 }
+
+// How many production timers one test may auto-advance through before the pump
+// calls it a livelock. A backoff the real clock would pace re-arms as fast as
+// the event loop turns here, so a retry that cannot succeed never stops. The
+// ceiling has to sit below the point where that loop exhausts the heap,
+// otherwise V8 aborts the process first and no test is named. Across the runner
+// suite — the heaviest user of auto-advance — one test reaches 160 fires and
+// every other one stays under a hundred.
+const AUTO_ADVANCE_LIMIT = 2_000;
 
 /** Which behavior a package's preload selects. */
 export type FakeClockMode = "auto-advance" | "freeze-all";
@@ -131,14 +143,20 @@ function currentStack(): string {
 }
 
 // The immediate caller of setTimeout: the first stack frame outside this file.
-// A frame in a `test/` directory (or a `.test.ts` file) is test code.
-function callerIsTest(): boolean {
+function callerFrame(): string | undefined {
   const stack = currentStack();
   for (const line of stack.split("\n").slice(1)) {
     if (line.includes(HARNESS_FILE)) continue;
-    return /\/test\//.test(line) || /\.test\.ts/.test(line);
+    // Stack lines arrive as `    at <site>`; the caller is the site itself.
+    return line.trim().replace(/^at /, "");
   }
-  return false;
+  return undefined;
+}
+
+// A frame in a `test/` directory (or a `.test.ts` file) is test code.
+function frameIsTest(frame: string | undefined): boolean {
+  return frame !== undefined &&
+    (/\/test\//.test(frame) || /\.test\.ts/.test(frame));
 }
 
 function freezeAround(
@@ -220,15 +238,35 @@ function freezeAround(
     };
     const nextProd = (limit: number) => nextTimer(limit, true);
     let autoCount = 0;
+    // Fires per arming site, so a runaway names the timer that dominated it
+    // rather than whichever one happened to be last.
+    const autoBySite = new Map<string, number>();
+    const busiestSite = (): string => {
+      let worst = "an unrecorded site";
+      let most = 0;
+      for (const [site, count] of autoBySite) {
+        if (count > most) {
+          most = count;
+          worst = `${site} (${count} of them)`;
+        }
+      }
+      return worst;
+    };
     const autoAdvance = () => {
       autoScheduled = false;
       if (ticking) return;
       const next = nextProd(Infinity);
       if (!next) return;
-      if (++autoCount > 200_000) {
+      const site = next.site ?? "an unrecorded site";
+      autoBySite.set(site, (autoBySite.get(site) ?? 0) + 1);
+      if (++autoCount > AUTO_ADVANCE_LIMIT) {
         throw new Error(
-          "clock auto-advance runaway: a production timer keeps re-arming. " +
-            "This test likely needs explicit clock.tick(ms) control.",
+          `clock auto-advance runaway: ${AUTO_ADVANCE_LIMIT} production ` +
+            `timers fired in this test, most of them armed at ${busiestSite()}. ` +
+            "A backoff the real clock would pace re-arms as fast as the event " +
+            "loop turns here, so a retry that cannot succeed never stops. Give " +
+            "the test explicit clock.tick(ms) control, or list its file in the " +
+            "preload's realClockFiles.",
         );
       }
       elapsed = next.fireAt;
@@ -290,12 +328,36 @@ function freezeAround(
       const id = seq++;
       const ms = Number(delay) || 0;
       if (ms <= 0) {
-        timers.set(id, { id, cb, fireAt: elapsed, args, kind: "zero" });
+        timers.set(id, {
+          id,
+          cb,
+          fireAt: elapsed,
+          args,
+          kind: "zero",
+          site: undefined,
+        });
         scheduleKick();
-      } else if (!config.autoAdvance || callerIsTest()) {
-        timers.set(id, { id, cb, fireAt: elapsed + ms, args, kind: "test" });
+        return id;
+      }
+      const site = callerFrame();
+      if (!config.autoAdvance || frameIsTest(site)) {
+        timers.set(id, {
+          id,
+          cb,
+          fireAt: elapsed + ms,
+          args,
+          kind: "test",
+          site,
+        });
       } else {
-        timers.set(id, { id, cb, fireAt: elapsed + ms, args, kind: "prod" });
+        timers.set(id, {
+          id,
+          cb,
+          fireAt: elapsed + ms,
+          args,
+          kind: "prod",
+          site,
+        });
         scheduleAuto();
       }
       return id;
@@ -307,7 +369,8 @@ function freezeAround(
     ): number => {
       const id = seq++;
       const ms = Math.max(1, Number(delay) || 0);
-      const kind: Kind = (!config.autoAdvance || callerIsTest())
+      const site = callerFrame();
+      const kind: Kind = (!config.autoAdvance || frameIsTest(site))
         ? "test"
         : "prod";
       timers.set(id, {
@@ -317,6 +380,7 @@ function freezeAround(
         args,
         kind,
         interval: ms,
+        site,
       });
       if (kind === "prod") scheduleAuto();
       return id;


### PR DESCRIPTION
…ming it

`list-resume-preserve.test.ts` opens its resume window by delaying storage documents on an 80 ms timer, and the file sits on the real clock so that delay elapses. The window is then as wide as 80 ms of wall time happens to make it on the machine of the day: the coordinator's resume work and the delivery race, and whether the per-element documents arrive before, during or after the reconcile the test is written to observe is decided by scheduling rather than by the test.

The matcher picks the wrong documents as well. It selects syncs by the element's own type, and the input list's item schema spells those fields out too, so it withholds the container and the input list along with the children it means to delay.

The reload is now staged in the transport. A resume asks storage for two batches — the aggregate's container with the input list, and the per-element runs behind it — and both are held. The coordinator runs once against nothing, the container batch is released, it reconciles while the per-element batch is still withheld, and only then is that released. Every wait is a transport edge or a settled runtime, and no timers remain in the file.

The file still needs the real clock, but for a different reason than the one recorded, so that reason is corrected in the preload and in the waiting guidance. A commit carrying a read of a withheld document is rejected as stale, and the catch-up the rejection waits on cannot arrive while the hold is on — the retry loop already written up for `list-resume-container-defer`. Real time paces that cycle until the hold is released; auto-advance fires each round's timer as soon as it is armed, and the loop allocates until the process runs out of heap. A hold short enough that no retry outlives it does not need the exemption; this one's hold has to span a reconcile, which is the state it exists to observe.

That failure mode reaches any test that withholds a document, and it arrives as a V8 out-of-memory abort naming no test, because the shared harness's runaway ceiling of 200,000 fires sits far above the point where the heap runs out. The ceiling is now 2,000 and the error names the arming site that accounted for most of the fires. Measured across the runner suite, the heaviest user of auto-advance, one test reaches 160 fires and every other one stays under a hundred, so the ceiling separates a livelock from every healthy test while still tripping long before memory runs out. The sizing goes in the rationale document.

Two of the four cases in the rewritten file no longer detect a deliberately removed preservation guard, where the timer-based version detected three. The window those two need is a per-element write reverted by a preempted commit, which the old test reached only because its documents were delayed rather than withheld: the pump's `pull()` could complete during the window, and a held document blocks it. Both `resume-append-exclusion` tests fail when the guard is removed, for filter and for flatMap, so the suite keeps that coverage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the resume-preservation tests deterministic by staging reload batches in the transport instead of timing them, and add an auto‑advance runaway ceiling to stop livelocks before OOM. Fix per‑element document matching and update docs and clock preload rationale.

- **Refactors**
  - `packages/runner/test/list-resume-preserve.test.ts`: replace 80 ms delays with a `ResumeBatchGate` that holds two batches (container+input, then per‑element) and releases them in order; tests wait on transport edges and remove timers; stays on the real clock with corrected rationale.
  - Extract gated storage/session setup and a generic `runResumePreservation` used for filter and flatMap; assert convergence and that the list is never empty or shrunk during the window.
  - Coverage note: two cases no longer trip when the guard is removed; coverage remains via the `resume-append-exclusion` tests.

- **Test Harness**
  - `packages/test-support/test/clock-preload.ts`: track timer arming sites and cap auto‑advance at 2,000; throw with the busiest arming site to identify livelocks before the process runs out of memory.
  - `packages/runner/test/clock-preload.ts`: update the `realClockFiles` entry for `list-resume-preserve` with the new retry-loop reasoning.
  - Docs: add guidance on real‑clock exemptions and on sizing the auto‑advance ceiling in `docs/development/waiting-in-tests*.md`.

<sup>Written for commit 27815dc50ed30fb92a28ead6b8e777c3dae4569f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

