### PR TITLE
test(runner): pin two properties that evicting documents has to preserve

### DIFF
--- a/packages/runner/test/replica-eviction-invariants.test.ts
+++ b/packages/runner/test/replica-eviction-invariants.test.ts
@@ -1,0 +1,234 @@
+// Two properties that hold today and that any change letting a space replica
+// drop documents has to preserve. A replica currently keeps every document it
+// pulls for as long as it is open; work to make it hand documents back has to
+// leave both of these standing.
+//
+// These are deliberately small and fast — they are meant to be the loop you run
+// while working on eviction, rather than a 100 KB suite whose failure you then
+// have to localize. Neither test knows anything about how eviction is
+// configured: they assert the behaviour a reader is entitled to, so they answer
+// the question whatever the mechanism turns out to be.
+//
+// What each one is a guard against:
+//
+//   1. A list projection whose element documents stop being read, and are then
+//      read again, has to rebuild. If the elements' documents were evicted when
+//      the list emptied, the restored list can come back with an empty
+//      aggregate.
+//   2. A commit that conflicts across two replicas has to settle. The waiting
+//      side advances only when a sync frame arrives, and a sync frame only
+//      arrives over a watch. If the watch behind the conflicted document were
+//      given up, this would wait forever rather than fail — the wait has no
+//      timer, by design.
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import type { OpaqueCell } from "@commonfabric/api";
+import { Identity } from "@commonfabric/identity";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import { type JSONSchema } from "../src/builder/types.ts";
+import { createBuilder } from "../src/builder/factory.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import type { Options } from "../src/storage/v2.ts";
+import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
+
+const signer = await Identity.fromPassphrase("replica eviction invariants");
+const space = signer.did();
+
+const numberSchema = { type: "number" } as const satisfies JSONSchema;
+const booleanSchema = { type: "boolean" } as const satisfies JSONSchema;
+const numberElementArgumentSchema = {
+  type: "object",
+  properties: { element: numberSchema },
+  required: ["element"],
+  additionalProperties: false,
+} as const satisfies JSONSchema;
+
+describe("a list projection survives its input emptying", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let tx: IExtendedStorageTransaction;
+  let lift: ReturnType<typeof createBuilder>["commonfabric"]["lift"];
+  let pattern: ReturnType<typeof createBuilder>["commonfabric"]["pattern"];
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    tx = runtime.edit();
+    const { commonfabric } = createTrustedBuilder(runtime);
+    ({ lift, pattern } = commonfabric);
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("rebuilds after the list is emptied and restored", async () => {
+    let predicateRuns = 0;
+    const isPositive = lift((value: number) => {
+      predicateRuns++;
+      return value > 0;
+    });
+    const predicate = pattern<{ element: number }, unknown>(
+      ({ element }) => isPositive(element),
+      numberElementArgumentSchema,
+      booleanSchema,
+    );
+    const filtered = pattern<{ values: number[] }>(({ values }) => ({
+      values,
+      positives: (values as unknown as OpaqueCell<number[]>)
+        // deno-lint-ignore no-explicit-any
+        .filterWithPattern(predicate as any, {}),
+    }));
+
+    const result = runtime.run(
+      tx,
+      filtered,
+      { values: [1, 2, 3] },
+      runtime.getCell(space, "eviction-filter", undefined, tx),
+    );
+    runtime.prepareTxForCommit(tx);
+    await tx.commit();
+    tx = runtime.edit();
+    await result.pull();
+    expect(result.key("positives").get()).toEqual([1, 2, 3]);
+
+    // Emptying the list stops every element run, so nothing reads their result
+    // documents any more.
+    // deno-lint-ignore no-explicit-any
+    result.withTx(tx).key("values").set(undefined as any);
+    runtime.prepareTxForCommit(tx);
+    await tx.commit();
+    tx = runtime.edit();
+    await result.pull();
+    expect(result.key("positives").get()).toEqual([]);
+
+    // Restoring it rebuilds the aggregate, and rebuilding it costs one run of
+    // the predicate per element. A replica that evicted the elements' result
+    // documents has to fetch them back, and a run that reads one before it
+    // arrives runs again once it does — so the count, not the aggregate, is
+    // what shows the waste. The aggregate below stays correct either way.
+    const runsBeforeRestore = predicateRuns;
+    result.withTx(tx).key("values").set([4, 5]);
+    runtime.prepareTxForCommit(tx);
+    await tx.commit();
+    tx = runtime.edit();
+    await result.pull();
+    expect(result.key("positives").get()).toEqual([4, 5]);
+    expect(predicateRuns - runsBeforeRestore).toBe(2);
+  });
+});
+
+// Two managers over one in-process server, so a commit on one can conflict with
+// a commit on the other.
+class SharedServerStorageManager extends EmulatedStorageManager {
+  static connectTo(
+    server: MemoryV2Server.Server,
+    options: Omit<Options, "memoryHost" | "spaceHostMap">,
+  ): SharedServerStorageManager {
+    const manager = new SharedServerStorageManager(
+      { ...options, memoryHost: new URL("memory://") },
+      () => server,
+    );
+    manager.sharedServer = server;
+    return manager;
+  }
+
+  private sharedServer!: MemoryV2Server.Server;
+
+  protected override server(): MemoryV2Server.Server {
+    return this.sharedServer;
+  }
+}
+
+describe("a cross-replica conflict settles", () => {
+  let server: MemoryV2Server.Server;
+  let storageA: SharedServerStorageManager;
+  let storageB: SharedServerStorageManager;
+  let rtA: Runtime;
+  let rtB: Runtime;
+
+  beforeEach(() => {
+    server = new MemoryV2Server.Server({
+      authorizeSessionOpen(message) {
+        const principal = (message.authorization as { principal?: unknown })
+          ?.principal;
+        return typeof principal === "string" ? principal : undefined;
+      },
+      sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
+    });
+    storageA = SharedServerStorageManager.connectTo(server, { as: signer });
+    storageB = SharedServerStorageManager.connectTo(server, { as: signer });
+    rtA = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storageA,
+    });
+    rtB = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storageB,
+    });
+  });
+
+  afterEach(async () => {
+    await rtB?.dispose();
+    await rtA?.dispose();
+    await storageB?.close();
+    await storageA?.close();
+    await server?.close();
+  });
+
+  it("resolves a stale commit instead of waiting forever", async () => {
+    const cause = "eviction-conflict";
+    const docA = rtA.getCell<{ v: string }>(space, cause, undefined);
+    {
+      const tx = rtA.edit();
+      docA.withTx(tx).set({ v: "v0" });
+      rtA.prepareTxForCommit(tx);
+      expect((await tx.commit()).error).toBeUndefined();
+      await storageA.synced();
+    }
+
+    // B catches up, then stages a write over a read taken at v0.
+    const docB = rtB.getCell<{ v: string }>(space, cause, undefined);
+    await docB.sync();
+    await docB.pull();
+    expect(docB.get()).toEqual({ v: "v0" });
+
+    const txB = rtB.edit();
+    docB.withTx(txB).get();
+    docB.withTx(txB).set({ v: "vB" });
+    rtB.prepareTxForCommit(txB);
+
+    // A moves the server on. B is deliberately not synced, so its read is now
+    // stale and its commit has to conflict.
+    {
+      const tx = rtA.edit();
+      docA.withTx(tx).set({ v: "v1" });
+      rtA.prepareTxForCommit(tx);
+      expect((await tx.commit()).error).toBeUndefined();
+      await storageA.synced();
+    }
+    expect(docB.get()).toEqual({ v: "v0" });
+
+    // Settling this needs a sync frame to reach B, which needs the watch behind
+    // the document. If that watch were gone the wait would never end — there is
+    // no timer on it — so this test hanging is the symptom, not a failure
+    // message.
+    const rejected = await txB.commit();
+    expect(rejected.error?.name).toBe("ConflictError");
+
+    // And B is left able to see the server's value rather than its stale one.
+    await docB.sync();
+    await docB.pull();
+    expect(docB.get()).toEqual({ v: "v1" });
+  });
+});


### PR DESCRIPTION
A space replica keeps every document it pulls for as long as it is open. Work to make it hand documents back has to leave the rest of the runner standing, and two properties in particular are easy to break without noticing, because neither is asserted anywhere small enough to run in a fix loop.

A list projection whose element documents stop being read, and are then read again, has to rebuild — and rebuilding costs one run of the element pattern per element. A replica that dropped those documents has to fetch them back, and a run that reads one before it arrives runs a second time once it does. The aggregate stays correct either way, so the run count is what shows the waste; asserting the values alone would miss it.

A commit that conflicts across two replicas has to settle. The waiting side advances only when a sync frame arrives, and a sync frame only arrives over a watch. Give up the watch behind the conflicted document and this waits forever rather than failing — the wait has no timer, by design — so the symptom is a hung test rather than a message.

Neither test knows how eviction might be configured. They assert what a reader is entitled to, so they answer the question whatever mechanism is tried. Both are small and fast, which is the point: they are meant to be the loop you run while working on eviction, rather than a suite whose failure you then have to localize.

Both pass today. Verified against a prototype that evicts documents, where the first fails on the run count and the second hangs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add replica-eviction invariants tests in packages/runner/test/replica-eviction-invariants.test.ts to pin behavior needed when space replicas start dropping documents. They catch wasted predicate reruns in list projections and ensure cross-replica conflicts resolve instead of hanging.

- Verifies a list projection rebuilds once per element after the list is emptied and restored by asserting the predicate run count.
- Verifies a stale commit across two replicas returns a ConflictError and the replica then reads the server value, proving the document watch stays active.

<sup>Written for commit afd078460f91efe3b5fb92188432ff3c2308d0d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

NEW_COVERAGE_BASELINE