### PR TITLE
refactor(memory): delete the leftover v2 wire shapes and the dead syn…

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -662,10 +662,6 @@ the per-epic implementation notes).
 > Two neighbours in the same handshake are related but are not runtime-toggleable
 > experimental flags:
 >
-> - **`syncSchemaTable`** is the older, index-keyed predecessor of
->   `syncSchemaTableV2`. It is hardwired to `false` in `getMemoryProtocolFlags`
->   and has no config function; it is effectively dead and can be deleted from
->   the protocol types once no peer negotiates it.
 > - **`sqliteCommitRowLabelEval`** is a build-inherent capability, hardwired to
 >   `true`, advertising that this build's engine evaluates row-label rules at
 >   commit time. It is not configuration: an older server that lacks the

--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -141,8 +141,7 @@ connection.
 in [Session Sync Payload](#423-session-sync-payload). It defaults to `false`
 when absent. The server sends compact sync payloads only when both peers
 advertise the capability; otherwise it sends the historical fully expanded
-shape. The older `syncSchemaTable` flag names an incompatible, index-keyed draft
-and does not enable the v2 encoding.
+shape.
 
 `entityIdListing` advertises support for `entity-id.list`. It defaults to
 `false` when absent. A client must not send the request unless the server

--- a/packages/memory/test/v2-test.ts
+++ b/packages/memory/test/v2-test.ts
@@ -139,7 +139,6 @@ describe("memory v2 flags", () => {
       modernCellRep: false,
       persistentSchedulerState: false,
       commitPreconditions: false,
-      syncSchemaTable: false,
       // Build-inherent capability, not configuration: always advertised.
       sqliteCommitRowLabelEval: true,
       pendingReadStacks: true,
@@ -158,7 +157,6 @@ describe("memory v2 flags", () => {
       modernCellRep: true,
       persistentSchedulerState: true,
       commitPreconditions: true,
-      syncSchemaTable: false,
       sqliteCommitRowLabelEval: true,
       pendingReadStacks: true,
       entityIdListing: true,
@@ -179,7 +177,6 @@ describe("memory v2 flags", () => {
         modernCellRep: true,
         persistentSchedulerState: true,
         commitPreconditions: true,
-        syncSchemaTable: true,
         syncSchemaTableV2: true,
         sqliteCommitRowLabelEval: true,
         pendingReadStacks: true,
@@ -191,7 +188,6 @@ describe("memory v2 flags", () => {
         modernCellRep: true,
         persistentSchedulerState: false,
         commitPreconditions: false,
-        syncSchemaTable: false,
         syncSchemaTableV2: false,
         // A peer without commit-time sqlite row-label evaluation stays
         // compatible — the capability only gates the runner's write-gate
@@ -212,7 +208,6 @@ describe("parseMemoryProtocolFlags", () => {
       modernCellRep: true,
       persistentSchedulerState: false,
       commitPreconditions: false,
-      syncSchemaTable: false,
       syncSchemaTableV2: false,
       sqliteCommitRowLabelEval: false,
       pendingReadStacks: false,
@@ -224,7 +219,6 @@ describe("parseMemoryProtocolFlags", () => {
       modernCellRep: false,
       persistentSchedulerState: false,
       commitPreconditions: false,
-      syncSchemaTable: false,
       syncSchemaTableV2: false,
       sqliteCommitRowLabelEval: false,
       pendingReadStacks: false,
@@ -243,7 +237,6 @@ describe("parseMemoryProtocolFlags", () => {
         modernCellRep: false,
         persistentSchedulerState: true,
         commitPreconditions: false,
-        syncSchemaTable: false,
         syncSchemaTableV2: false,
         sqliteCommitRowLabelEval: false,
         pendingReadStacks: false,
@@ -263,27 +256,6 @@ describe("parseMemoryProtocolFlags", () => {
         modernCellRep: false,
         persistentSchedulerState: false,
         commitPreconditions: true,
-        syncSchemaTable: false,
-        syncSchemaTableV2: false,
-        sqliteCommitRowLabelEval: false,
-        pendingReadStacks: false,
-        entityIdListing: false,
-        entityIdPagination: false,
-        entityIdLookup: false,
-      },
-    );
-  });
-
-  it("accepts the legacy syncSchemaTable key", () => {
-    assertEquals(
-      parseMemoryProtocolFlags({
-        syncSchemaTable: true,
-      }),
-      {
-        modernCellRep: false,
-        persistentSchedulerState: false,
-        commitPreconditions: false,
-        syncSchemaTable: true,
         syncSchemaTableV2: false,
         sqliteCommitRowLabelEval: false,
         pendingReadStacks: false,
@@ -303,7 +275,6 @@ describe("parseMemoryProtocolFlags", () => {
         modernCellRep: false,
         persistentSchedulerState: false,
         commitPreconditions: false,
-        syncSchemaTable: false,
         syncSchemaTableV2: true,
         sqliteCommitRowLabelEval: false,
         pendingReadStacks: false,
@@ -323,7 +294,6 @@ describe("parseMemoryProtocolFlags", () => {
         modernCellRep: false,
         persistentSchedulerState: false,
         commitPreconditions: false,
-        syncSchemaTable: false,
         syncSchemaTableV2: false,
         sqliteCommitRowLabelEval: true,
         pendingReadStacks: false,
@@ -343,7 +313,6 @@ describe("parseMemoryProtocolFlags", () => {
         modernCellRep: false,
         persistentSchedulerState: false,
         commitPreconditions: false,
-        syncSchemaTable: false,
         syncSchemaTableV2: false,
         sqliteCommitRowLabelEval: false,
         pendingReadStacks: true,
@@ -361,7 +330,6 @@ describe("parseMemoryProtocolFlags", () => {
         modernCellRep: false,
         persistentSchedulerState: false,
         commitPreconditions: false,
-        syncSchemaTable: false,
         syncSchemaTableV2: false,
         sqliteCommitRowLabelEval: false,
         pendingReadStacks: false,
@@ -382,7 +350,6 @@ describe("parseMemoryProtocolFlags", () => {
         modernCellRep: false,
         persistentSchedulerState: false,
         commitPreconditions: false,
-        syncSchemaTable: false,
         syncSchemaTableV2: false,
         sqliteCommitRowLabelEval: false,
         pendingReadStacks: false,
@@ -403,7 +370,6 @@ describe("parseMemoryProtocolFlags", () => {
     assertEquals(parseMemoryProtocolFlags("modernCellRep"), null);
     assertEquals(parseMemoryProtocolFlags([true]), null);
     assertEquals(parseMemoryProtocolFlags({ modernCellRep: "true" }), null);
-    assertEquals(parseMemoryProtocolFlags({ syncSchemaTable: "true" }), null);
     assertEquals(parseMemoryProtocolFlags({ syncSchemaTableV2: "true" }), null);
     assertEquals(
       parseMemoryProtocolFlags({ sqliteCommitRowLabelEval: "true" }),

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -24,7 +24,6 @@ export type BranchName = string;
 export type SessionId = string;
 export type SessionToken = string;
 export type CellScope = "space" | "user" | "session";
-export type JobId = `job:${string}`;
 export type Reference = string & {
   readonly __memoryV2Reference: unique symbol;
 };
@@ -261,19 +260,6 @@ export type ClientCommit = {
   };
 };
 
-export type SessionOpenArgs = {
-  sessionId?: SessionId;
-  seenSeq?: number;
-  sessionToken?: SessionToken;
-};
-
-export type SessionOpenCommand = {
-  cmd: "session.open";
-  id: JobId;
-  protocol: typeof MEMORY_PROTOCOL;
-  args: SessionOpenArgs;
-};
-
 export type SessionOpenResult = {
   sessionId: SessionId;
   sessionToken: SessionToken;
@@ -288,8 +274,6 @@ export type MemoryProtocolFlags = {
   modernCellRep: boolean;
   persistentSchedulerState: boolean;
   commitPreconditions: boolean;
-  /** Legacy CT-1775 draft capability: index-keyed per-frame schema table. */
-  syncSchemaTable: boolean;
   /** Hash-keyed per-frame schema table. */
   syncSchemaTableV2: boolean;
   /**
@@ -330,7 +314,6 @@ export type WireMemoryProtocolFlags = {
   modernCellRep?: boolean;
   persistentSchedulerState?: boolean;
   commitPreconditions?: boolean;
-  syncSchemaTable?: boolean;
   syncSchemaTableV2?: boolean;
   sqliteCommitRowLabelEval?: boolean;
   pendingReadStacks?: boolean;
@@ -836,15 +819,6 @@ export type V2Error = {
 
 export type V2Result<Value> = { ok: Value } | { error: V2Error };
 
-export type TaskReturn<Result> = {
-  the: "task/return";
-  of: JobId;
-  is: Result;
-};
-
-export type Receipt<Result> = TaskReturn<Result>;
-export type LegacyClientMessage = SessionOpenCommand;
-export type LegacyServerMessage = TaskReturn<V2Result<unknown>>;
 export type ClientMessage =
   | HelloMessage
   | SessionOpenRequest
@@ -931,7 +905,6 @@ export const getMemoryProtocolFlags = (): MemoryProtocolFlags => ({
   modernCellRep: getModernCellRepConfig(),
   persistentSchedulerState: getPersistentSchedulerStateConfig(),
   commitPreconditions: getCommitPreconditionsConfig(),
-  syncSchemaTable: false,
   // A build-inherent capability, not configuration: this build's engine always
   // evaluates row-label rules at commit (sqlite/commit-eval.ts), so it always
   // advertises the fact. Peers that see it absent (an older server) keep their
@@ -995,14 +968,6 @@ export const parseMemoryProtocolFlags = (
     return null;
   }
 
-  const syncSchemaTable = value.syncSchemaTable;
-  if (
-    syncSchemaTable !== undefined &&
-    typeof syncSchemaTable !== "boolean"
-  ) {
-    return null;
-  }
-
   const syncSchemaTableV2 = value.syncSchemaTableV2;
   if (
     syncSchemaTableV2 !== undefined &&
@@ -1055,7 +1020,6 @@ export const parseMemoryProtocolFlags = (
     modernCellRep: modernCellRep === true,
     persistentSchedulerState: persistentSchedulerState === true,
     commitPreconditions: commitPreconditions === true,
-    syncSchemaTable: syncSchemaTable === true,
     syncSchemaTableV2: syncSchemaTableV2 === true,
     // Absent (an older peer) parses to false: the capability must be
     // POSITIVELY advertised for the runner to relax its write gate.
@@ -1078,7 +1042,6 @@ export const wireMemoryProtocolFlags = (
   modernCellRep: flags.modernCellRep,
   persistentSchedulerState: flags.persistentSchedulerState,
   commitPreconditions: flags.commitPreconditions,
-  syncSchemaTable: flags.syncSchemaTable,
   syncSchemaTableV2: flags.syncSchemaTableV2,
   sqliteCommitRowLabelEval: flags.sqliteCommitRowLabelEval,
   pendingReadStacks: flags.pendingReadStacks,


### PR DESCRIPTION
…cSchemaTable flag

The memory v2 protocol module carried three leftovers from earlier drafts of the wire protocol. Each one declares a message or a capability that no peer can produce and no peer can consume, so reading the module gives a misleading picture of what actually travels over the connection.

The first leftover is `SessionOpenCommand`, together with its `SessionOpenArgs` payload. It describes a session-open request shaped as an invocation, with a `cmd` field naming the operation and an `args` object carrying the session identifier and token. The protocol now opens a session with `SessionOpenRequest` instead, which is tagged by a `type` field and carries a session descriptor. The server's client-message parser has no branch that looks at a `cmd` field, and the client only ever sends the `type`-tagged shape. The authorization invocation that the live session-open request embeds does use a `cmd` field, but it is an unrelated structure read as an untyped record and validated field by field, so it never referred to these types.

The second leftover is `TaskReturn`, a `task/return` result envelope, along with its three aliases `Receipt`, `LegacyClientMessage`, and `LegacyServerMessage`. Nothing in the codebase emits or parses a `task/return` message. Deleting these also orphans `JobId`, the identifier type the two shapes used, so that goes with them.

The third leftover is the `syncSchemaTable` protocol flag. It is the older, index-keyed predecessor of `syncSchemaTableV2`, which keys the same per-frame schema table by hash instead. It has no configuration function and is hardwired to `false` where the flags are built, so this build can never advertise it, and the server decides whether to compress sync payloads by looking only at `syncSchemaTableV2`. Despite that, the flag was still declared on both the internal and the wire flag types, validated on parse, stored on every parsed flags object, and written back out on every handshake.

Removing the flag from the wire type is compatible in both directions. An absent optional wire field already parses as `false`, so a peer running an older build sees this build's handshake exactly as it would have before. In the other direction, an older peer that still sends `syncSchemaTable: true` now has the key ignored as unrecognized, which produces the same outcome as before: the value was parsed but never consulted.

There is one narrow behavior change. A handshake carrying a non-boolean `syncSchemaTable` value was previously rejected outright, because the parser type-checked the field. That key is now unrecognized, and unrecognized keys are ignored, so such a handshake is accepted and the garbage value is discarded. This matches how every other key the protocol does not define is treated.

The flag registry in `docs/development/EXPERIMENTAL_OPTIONS.md` and the handshake section of `docs/specs/memory-v2/04-protocol.md` both described the flag; both are updated here. On the test side, the flag is dropped from the flag fixtures, and the two tests that existed solely to pin its parsing are deleted. The per-connection negotiation test that opens a handshake advertising the old flag is kept: it now exercises the path where an unrecognized key arrives and the connection falls back to uncompressed sync payloads.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove unused legacy memory v2 wire shapes and the dead `syncSchemaTable` flag to match the live protocol and simplify handshakes. Backwards compatible; non-boolean `syncSchemaTable` is now ignored instead of rejecting the handshake.

- **Refactors**
  - Removed `SessionOpenCommand`/`SessionOpenArgs`, `TaskReturn` (and aliases), and `JobId`.
  - Dropped `syncSchemaTable` from internal and wire flag types; `syncSchemaTableV2` remains.
  - Updated protocol docs and trimmed tests that only pinned the old flag parsing.

- **Migration**
  - Handshakes stay compatible with older peers; absent optional fields parse as `false`.
  - A non-boolean `syncSchemaTable` key is now ignored rather than rejecting the handshake.

<sup>Written for commit 755350321a52e3e3e3794bf327a7ec2f68b0400a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

