### PR TITLE
refactor(cli): one flag vocabulary and one parser for cf fuse mount

### DIFF
--- a/packages/cli/commands/fuse.ts
+++ b/packages/cli/commands/fuse.ts
@@ -3,8 +3,8 @@ import { basename, resolve } from "@std/path";
 import ports from "@commonfabric/ports" with { type: "json" };
 import {
   buildBackgroundSupervisorDenoArgs,
-  buildDenoArgs,
   buildFuseBinaryArgs,
+  buildFuseChildDenoArgs,
   defaultStateDir,
   ensureExecShim,
   fuseMod,
@@ -399,7 +399,7 @@ export const fuse = new Command()
       });
     } else {
       spawnCmd = "deno";
-      spawnArgs = buildDenoArgs({
+      spawnArgs = buildFuseChildDenoArgs({
         modPath: fuseMod(import.meta.url),
         ...mountFlags,
       });

--- a/packages/cli/commands/main.ts
+++ b/packages/cli/commands/main.ts
@@ -136,46 +136,32 @@ export const main = new Command()
       .description(
         "Internal: supervise a background FUSE child process.",
       )
-      .arguments("<mountpoint:string>")
-      .option("--api-url <url:string>", "URL of the fabric instance.")
-      .option("--identity <path:string>", "Path to an identity keyfile.")
-      .option("--exec-cli <path:string>", "Path to the cf exec shim.")
-      .option("--log-file <path:string>", "Path to the FUSE child log file.")
-      .option("--debug", "Enable FUSE debug output.")
-      .option("--allow-other", "Pass allow_other through to the FUSE child.")
-      .option("--noattrcache", "Pass noattrcache through to the FUSE child.")
-      .option(
-        "--attrcache-timeout <seconds:string>",
-        "Pass attrcache-timeout through to the FUSE child.",
-      )
-      .option("--cfc-mode <mode:string>", "FUSE-side CFC mode.")
-      .option("--cfc-annotations", "Publish CFC annotation xattrs.")
-      .option(
-        "--cfc-xattr-namespace <namespace:string>",
-        "CFC xattr namespace.",
-      )
-      .option("--cfc-writeback-xattrs", "Enable CFC writeback xattrs.")
-      .option(
-        "--cfc-writeback-state <path:string>",
-        "CFC writeback state path.",
-      )
-      .option(
-        "--dangerously-allow-incompatible-schema",
-        "Allow incompatible source schema updates.",
-      )
-      .option("--state-path <path:string>", "Mount state file to update.")
-      .option(
-        "--supervisor-status <path:string>",
-        "Child readiness and heartbeat status file.",
-      )
-      .option("-s, --space <name:string>", "Space(s) to connect.", {
-        collect: true,
-      })
-      .action(async (options, mountpoint) => {
-        const { fuseSupervisorOptions, runFuseSupervisor } = await import(
+      .usage("<mountpoint> [options]")
+      // The supervisor argv is parsed once, by the same parser the deno
+      // entrypoint uses, so the compiled binary and `deno run` accept exactly
+      // the same flags.
+      .useRawArgs()
+      .action(async (_options: unknown, ...rawArgs: unknown[]) => {
+        const supervisorArgs = rawArgs.map((arg) => String(arg));
+        const { parseSupervisorArgs, supervisorHelp } = await import(
+          "../lib/fuse-mount-flags.ts"
+        );
+        let parsed;
+        try {
+          parsed = parseSupervisorArgs(supervisorArgs);
+        } catch (error) {
+          throw new ValidationError(
+            error instanceof Error ? error.message : String(error),
+          );
+        }
+        if (parsed.help) {
+          console.log(supervisorHelp());
+          return;
+        }
+        const { runFuseSupervisor } = await import(
           "../lib/fuse-supervisor.ts"
         );
-        await runFuseSupervisor(fuseSupervisorOptions(options, mountpoint));
+        await runFuseSupervisor(parsed.options);
       }),
   )
   .command("completion", completion)

--- a/packages/cli/lib/fuse-mount-flags.ts
+++ b/packages/cli/lib/fuse-mount-flags.ts
@@ -1,0 +1,311 @@
+/**
+ * The mount flag vocabulary shared by every `cf fuse mount` spawn path.
+ *
+ * A mount travels through up to three processes: the `cf fuse mount` command
+ * spawns a supervisor, and the supervisor spawns the FUSE child that owns
+ * libfuse. Each hop passes the mount flags along on the command line, and the
+ * spawned process may be either a `deno run` of a module or a subcommand of the
+ * compiled `cf` binary. The tables below name each flag once, and both the argv
+ * builders and the supervisor's argv parser read them.
+ */
+
+/** Mount flags the FUSE daemon accepts. */
+export interface FuseMountFlags {
+  mountpoint: string;
+  apiUrl: string;
+  identity: string;
+  execCli: string;
+  logFile?: string;
+  spaces?: string[];
+  debug?: boolean;
+  allowOther?: boolean;
+  noattrcache?: boolean;
+  attrcacheTimeout?: string;
+  cfcMode?: string;
+  cfcAnnotations?: boolean;
+  cfcXattrNamespace?: string;
+  cfcWritebackXattrs?: boolean;
+  cfcWritebackState?: string;
+  dangerouslyAllowIncompatibleSchema?: boolean;
+  supervisorStatusPath?: string;
+}
+
+/**
+ * Mount flags the supervisor accepts: everything the daemon takes, plus the
+ * mount state file the supervisor fills in once it knows the child's PID.
+ */
+export interface FuseSupervisorFlags extends FuseMountFlags {
+  statePath?: string;
+}
+
+/** How a flag carries its field's value on the command line. */
+type FlagArity =
+  /** Present with a following value when the field is set. */
+  | "value"
+  /** Present without a value when the field is true. */
+  | "switch"
+  /** Repeated once per element of the field's array. */
+  | "repeated";
+
+interface FlagSpec {
+  flag: string;
+  arity: FlagArity;
+  /** Single-dash form the supervisor parser also accepts. */
+  alias?: string;
+  /** Placeholder for the value in help output. */
+  valueLabel?: string;
+  help: string;
+}
+
+/**
+ * One spec per flag field. Keying by field name makes a field with no spec a
+ * type error, so a new mount flag reaches every hop or fails to compile.
+ */
+type FlagSpecs<Flags> = {
+  readonly [Field in keyof Required<Omit<Flags, "mountpoint">>]: FlagSpec;
+};
+
+const MOUNT_FLAG_SPECS: FlagSpecs<FuseMountFlags> = {
+  apiUrl: {
+    flag: "--api-url",
+    arity: "value",
+    valueLabel: "<url>",
+    help: "URL of the fabric instance",
+  },
+  identity: {
+    flag: "--identity",
+    arity: "value",
+    valueLabel: "<path>",
+    help: "Path to an identity keyfile",
+  },
+  execCli: {
+    flag: "--exec-cli",
+    arity: "value",
+    valueLabel: "<path>",
+    help: "Path to the cf exec shim",
+  },
+  logFile: {
+    flag: "--log-file",
+    arity: "value",
+    valueLabel: "<path>",
+    help: "Path to the FUSE child log file",
+  },
+  debug: {
+    flag: "--debug",
+    arity: "switch",
+    help: "Enable FUSE debug output",
+  },
+  allowOther: {
+    flag: "--allow-other",
+    arity: "switch",
+    help: "Pass allow_other through to the FUSE child",
+  },
+  noattrcache: {
+    flag: "--noattrcache",
+    arity: "switch",
+    help: "Pass noattrcache through to the FUSE child",
+  },
+  attrcacheTimeout: {
+    flag: "--attrcache-timeout",
+    arity: "value",
+    valueLabel: "<seconds>",
+    help: "Pass attrcache-timeout through to the FUSE child",
+  },
+  cfcMode: {
+    flag: "--cfc-mode",
+    arity: "value",
+    valueLabel: "<mode>",
+    help: "FUSE-side CFC mode",
+  },
+  cfcAnnotations: {
+    flag: "--cfc-annotations",
+    arity: "switch",
+    help: "Publish CFC annotation xattrs",
+  },
+  cfcXattrNamespace: {
+    flag: "--cfc-xattr-namespace",
+    arity: "value",
+    valueLabel: "<ns>",
+    help: "CFC xattr namespace",
+  },
+  cfcWritebackXattrs: {
+    flag: "--cfc-writeback-xattrs",
+    arity: "switch",
+    help: "Enable CFC writeback xattrs",
+  },
+  cfcWritebackState: {
+    flag: "--cfc-writeback-state",
+    arity: "value",
+    valueLabel: "<path>",
+    help: "CFC writeback state path",
+  },
+  dangerouslyAllowIncompatibleSchema: {
+    flag: "--dangerously-allow-incompatible-schema",
+    arity: "switch",
+    help: "Allow incompatible source schema updates",
+  },
+  supervisorStatusPath: {
+    flag: "--supervisor-status",
+    arity: "value",
+    valueLabel: "<path>",
+    help: "Child readiness and heartbeat status file",
+  },
+  spaces: {
+    flag: "--space",
+    arity: "repeated",
+    alias: "-s",
+    valueLabel: "<name>",
+    help: "Space(s) to connect",
+  },
+};
+
+const SUPERVISOR_FLAG_SPECS: FlagSpecs<FuseSupervisorFlags> = {
+  ...MOUNT_FLAG_SPECS,
+  statePath: {
+    flag: "--state-path",
+    arity: "value",
+    valueLabel: "<path>",
+    help: "Mount state file to update with child PID",
+  },
+};
+
+function encodeFlags(
+  flags: FuseSupervisorFlags,
+  specs: Record<string, FlagSpec>,
+): string[] {
+  const values = flags as unknown as Record<string, unknown>;
+  const args: string[] = [];
+  for (const [field, spec] of Object.entries(specs)) {
+    const value = values[field];
+    switch (spec.arity) {
+      case "switch":
+        if (value) args.push(spec.flag);
+        break;
+      case "value":
+        if (value) args.push(spec.flag, String(value));
+        break;
+      case "repeated":
+        for (const item of (value as string[] | undefined) ?? []) {
+          args.push(spec.flag, item);
+        }
+        break;
+    }
+  }
+  return args;
+}
+
+/** Encode the mount flags the FUSE daemon accepts. */
+export function mountFlagArgs(flags: FuseMountFlags): string[] {
+  return encodeFlags(flags, MOUNT_FLAG_SPECS);
+}
+
+/** Encode the mount flags the supervisor accepts. */
+export function supervisorFlagArgs(flags: FuseSupervisorFlags): string[] {
+  return encodeFlags(flags, SUPERVISOR_FLAG_SPECS);
+}
+
+export interface ParsedSupervisorArgs {
+  options: FuseSupervisorFlags;
+  help: boolean;
+}
+
+const SUPERVISOR_FLAG_LOOKUP: ReadonlyMap<
+  string,
+  { field: string; spec: FlagSpec }
+> = new Map(
+  Object.entries(SUPERVISOR_FLAG_SPECS).flatMap(([field, spec]) => {
+    const entries: [string, { field: string; spec: FlagSpec }][] = [
+      [spec.flag, { field, spec }],
+    ];
+    if (spec.alias) entries.push([spec.alias, { field, spec }]);
+    return entries;
+  }),
+);
+
+/** Decode a supervisor argv into the flags the supervisor runs with. */
+export function parseSupervisorArgs(rawArgs: string[]): ParsedSupervisorArgs {
+  const options: FuseSupervisorFlags = {
+    mountpoint: "",
+    apiUrl: "",
+    identity: "",
+    execCli: "",
+    logFile: "",
+    spaces: [],
+  };
+  const values = options as unknown as Record<string, unknown>;
+  let help = false;
+
+  for (let i = 0; i < rawArgs.length; i++) {
+    const arg = rawArgs[i];
+    if (arg === "--help" || arg === "-h") {
+      help = true;
+      continue;
+    }
+    const match = SUPERVISOR_FLAG_LOOKUP.get(arg);
+    if (match) {
+      switch (match.spec.arity) {
+        case "switch":
+          values[match.field] = true;
+          break;
+        case "value":
+          values[match.field] = requireValue(rawArgs, ++i, arg);
+          break;
+        case "repeated":
+          (values[match.field] as string[]).push(
+            requireValue(rawArgs, ++i, arg),
+          );
+          break;
+      }
+      continue;
+    }
+    if (arg.startsWith("-")) {
+      throw new Error(`Unknown fuse supervisor option: ${arg}`);
+    }
+    if (options.mountpoint) {
+      throw new Error(`Unexpected fuse supervisor argument: ${arg}`);
+    }
+    options.mountpoint = arg;
+  }
+
+  if (!help && !options.mountpoint) {
+    throw new Error("Missing mountpoint for fuse supervisor.");
+  }
+
+  return { options, help };
+}
+
+function requireValue(args: string[], index: number, flag: string): string {
+  const value = args[index];
+  if (value === undefined) {
+    throw new Error(`Missing value for ${flag}`);
+  }
+  return value;
+}
+
+/** Column the help descriptions start at, counted from the line start. */
+const HELP_DESCRIPTION_COLUMN = 34;
+
+function helpLine(label: string, help: string): string {
+  const labelled = `  ${label}`;
+  if (labelled.length + 1 > HELP_DESCRIPTION_COLUMN) {
+    return `${labelled}\n${" ".repeat(HELP_DESCRIPTION_COLUMN)}${help}`;
+  }
+  return `${labelled.padEnd(HELP_DESCRIPTION_COLUMN)}${help}`;
+}
+
+export function supervisorHelp(): string {
+  const lines = Object.values(SUPERVISOR_FLAG_SPECS).map((spec) => {
+    const flags = spec.alias ? `${spec.alias}, ${spec.flag}` : spec.flag;
+    const label = spec.valueLabel ? `${flags} ${spec.valueLabel}` : flags;
+    return helpLine(label, spec.help);
+  });
+  lines.push(helpLine("-h, --help", "Show this help"));
+
+  return `Usage: fuse-supervisor <mountpoint> [options]
+
+Internal: supervise a background FUSE child process.
+
+Options:
+${lines.join("\n")}
+`;
+}

--- a/packages/cli/lib/fuse-supervisor.ts
+++ b/packages/cli/lib/fuse-supervisor.ts
@@ -5,26 +5,15 @@ import {
   type MountStateEntry,
   writeMountStateFile,
 } from "./fuse.ts";
+import {
+  type FuseSupervisorFlags,
+  mountFlagArgs,
+  parseSupervisorArgs,
+  supervisorHelp,
+} from "./fuse-mount-flags.ts";
 
-export interface FuseSupervisorOptions {
-  mountpoint: string;
-  apiUrl: string;
-  identity: string;
-  execCli: string;
-  logFile: string;
-  spaces: string[];
-  debug?: boolean;
-  allowOther?: boolean;
-  noattrcache?: boolean;
-  attrcacheTimeout?: string;
-  cfcMode?: string;
-  cfcAnnotations?: boolean;
-  cfcXattrNamespace?: string;
-  cfcWritebackXattrs?: boolean;
-  cfcWritebackState?: string;
-  dangerouslyAllowIncompatibleSchema?: boolean;
-  statePath?: string;
-  supervisorStatusPath?: string;
+/** The mount flags the supervisor runs with, plus its injectable surroundings. */
+export interface FuseSupervisorOptions extends FuseSupervisorFlags {
   importMetaUrl?: string;
   command?: FuseCommandConstructor;
   execPath?: string;
@@ -37,55 +26,6 @@ export interface FuseSupervisorOptions {
   addSignalListener?: (signal: Deno.Signal, handler: () => void) => void;
   removeSignalListener?: (signal: Deno.Signal, handler: () => void) => void;
   supervisorPid?: number;
-}
-
-/** Parsed command flags used to launch a FUSE supervisor. */
-export interface FuseSupervisorCliOptions {
-  apiUrl?: string;
-  identity?: string;
-  execCli?: string;
-  logFile?: string;
-  space?: string[];
-  debug?: boolean;
-  allowOther?: boolean;
-  noattrcache?: boolean;
-  attrcacheTimeout?: string;
-  cfcMode?: string;
-  cfcAnnotations?: boolean;
-  cfcXattrNamespace?: string;
-  cfcWritebackXattrs?: boolean;
-  cfcWritebackState?: string;
-  dangerouslyAllowIncompatibleSchema?: boolean;
-  statePath?: string;
-  supervisorStatus?: string;
-}
-
-/** Convert CLI command options into the supervisor's runtime contract. */
-export function fuseSupervisorOptions(
-  options: FuseSupervisorCliOptions,
-  mountpoint: string,
-): FuseSupervisorOptions {
-  return {
-    mountpoint,
-    apiUrl: options.apiUrl ?? "",
-    identity: options.identity ?? "",
-    execCli: options.execCli ?? "",
-    logFile: options.logFile ?? "",
-    spaces: options.space ?? [],
-    debug: options.debug,
-    allowOther: options.allowOther,
-    noattrcache: options.noattrcache,
-    attrcacheTimeout: options.attrcacheTimeout,
-    cfcMode: options.cfcMode,
-    cfcAnnotations: options.cfcAnnotations,
-    cfcXattrNamespace: options.cfcXattrNamespace,
-    cfcWritebackXattrs: options.cfcWritebackXattrs,
-    cfcWritebackState: options.cfcWritebackState,
-    dangerouslyAllowIncompatibleSchema:
-      options.dangerouslyAllowIncompatibleSchema,
-    statePath: options.statePath,
-    supervisorStatusPath: options.supervisorStatus,
-  };
 }
 
 export interface FuseCommandConstructor {
@@ -113,59 +53,20 @@ export function buildFuseChildCommand(
   const execBase = basename(execPath);
   const isCompiledBinary = execBase !== "deno" && execBase !== "deno.exe";
 
+  // The child is the daemon, so it receives the daemon's flags only: the mount
+  // state file stays with this process.
   if (isCompiledBinary) {
-    const args = ["fuse-daemon", options.mountpoint];
-    if (options.apiUrl) args.push("--api-url", options.apiUrl);
-    if (options.identity) args.push("--identity", options.identity);
-    if (options.execCli) args.push("--exec-cli", options.execCli);
-    if (options.logFile) args.push("--log-file", options.logFile);
-    if (options.debug) args.push("--debug");
-    if (options.allowOther) args.push("--allow-other");
-    if (options.noattrcache) args.push("--noattrcache");
-    if (options.attrcacheTimeout) {
-      args.push("--attrcache-timeout", options.attrcacheTimeout);
-    }
-    if (options.cfcMode) args.push("--cfc-mode", options.cfcMode);
-    if (options.cfcAnnotations) args.push("--cfc-annotations");
-    if (options.cfcXattrNamespace) {
-      args.push("--cfc-xattr-namespace", options.cfcXattrNamespace);
-    }
-    if (options.cfcWritebackXattrs) args.push("--cfc-writeback-xattrs");
-    if (options.cfcWritebackState) {
-      args.push("--cfc-writeback-state", options.cfcWritebackState);
-    }
-    if (options.dangerouslyAllowIncompatibleSchema) {
-      args.push("--dangerously-allow-incompatible-schema");
-    }
-    if (options.supervisorStatusPath) {
-      args.push("--supervisor-status", options.supervisorStatusPath);
-    }
-    for (const space of options.spaces) args.push("--space", space);
-    return { command: execPath, args };
+    return {
+      command: execPath,
+      args: ["fuse-daemon", options.mountpoint, ...mountFlagArgs(options)],
+    };
   }
 
   return {
     command: execPath,
     args: buildFuseChildDenoArgs({
+      ...options,
       modPath: fuseMod(options.importMetaUrl ?? import.meta.url),
-      mountpoint: options.mountpoint,
-      apiUrl: options.apiUrl,
-      identity: options.identity,
-      execCli: options.execCli,
-      logFile: options.logFile,
-      spaces: options.spaces,
-      debug: options.debug,
-      allowOther: options.allowOther,
-      noattrcache: options.noattrcache,
-      attrcacheTimeout: options.attrcacheTimeout,
-      cfcMode: options.cfcMode,
-      cfcAnnotations: options.cfcAnnotations,
-      cfcXattrNamespace: options.cfcXattrNamespace,
-      cfcWritebackXattrs: options.cfcWritebackXattrs,
-      cfcWritebackState: options.cfcWritebackState,
-      dangerouslyAllowIncompatibleSchema:
-        options.dangerouslyAllowIncompatibleSchema,
-      supervisorStatusPath: options.supervisorStatusPath,
     }),
   };
 }
@@ -281,133 +182,6 @@ export async function cleanupFuseChild(
   await child.status.catch(() => undefined);
 }
 
-export interface ParsedSupervisorArgs {
-  options: FuseSupervisorOptions;
-  help: boolean;
-}
-
-export function parseSupervisorArgs(
-  rawArgs: string[],
-): ParsedSupervisorArgs {
-  const options: FuseSupervisorOptions = {
-    mountpoint: "",
-    apiUrl: "",
-    identity: "",
-    execCli: "",
-    logFile: "",
-    spaces: [],
-  };
-  let help = false;
-
-  for (let i = 0; i < rawArgs.length; i++) {
-    const arg = rawArgs[i];
-    switch (arg) {
-      case "--help":
-      case "-h":
-        help = true;
-        break;
-      case "--api-url":
-        options.apiUrl = requireValue(rawArgs, ++i, arg);
-        break;
-      case "--identity":
-        options.identity = requireValue(rawArgs, ++i, arg);
-        break;
-      case "--exec-cli":
-        options.execCli = requireValue(rawArgs, ++i, arg);
-        break;
-      case "--log-file":
-        options.logFile = requireValue(rawArgs, ++i, arg);
-        break;
-      case "--debug":
-        options.debug = true;
-        break;
-      case "--allow-other":
-        options.allowOther = true;
-        break;
-      case "--noattrcache":
-        options.noattrcache = true;
-        break;
-      case "--attrcache-timeout":
-        options.attrcacheTimeout = requireValue(rawArgs, ++i, arg);
-        break;
-      case "--cfc-mode":
-        options.cfcMode = requireValue(rawArgs, ++i, arg);
-        break;
-      case "--cfc-annotations":
-        options.cfcAnnotations = true;
-        break;
-      case "--cfc-xattr-namespace":
-        options.cfcXattrNamespace = requireValue(rawArgs, ++i, arg);
-        break;
-      case "--cfc-writeback-xattrs":
-        options.cfcWritebackXattrs = true;
-        break;
-      case "--cfc-writeback-state":
-        options.cfcWritebackState = requireValue(rawArgs, ++i, arg);
-        break;
-      case "--dangerously-allow-incompatible-schema":
-        options.dangerouslyAllowIncompatibleSchema = true;
-        break;
-      case "--state-path":
-        options.statePath = requireValue(rawArgs, ++i, arg);
-        break;
-      case "--supervisor-status":
-        options.supervisorStatusPath = requireValue(rawArgs, ++i, arg);
-        break;
-      case "--space":
-      case "-s":
-        options.spaces.push(requireValue(rawArgs, ++i, arg));
-        break;
-      default:
-        if (arg.startsWith("-")) {
-          throw new Error(`Unknown fuse supervisor option: ${arg}`);
-        }
-        if (options.mountpoint) {
-          throw new Error(`Unexpected fuse supervisor argument: ${arg}`);
-        }
-        options.mountpoint = arg;
-    }
-  }
-
-  return { options, help };
-}
-
-function requireValue(args: string[], index: number, flag: string): string {
-  const value = args[index];
-  if (value === undefined) {
-    throw new Error(`Missing value for ${flag}`);
-  }
-  return value;
-}
-
-export function supervisorHelp(): string {
-  return `Usage: fuse-supervisor <mountpoint> [options]
-
-Internal: supervise a background FUSE child process.
-
-Options:
-  --api-url <url>                 URL of the fabric instance
-  --identity <path>               Path to an identity keyfile
-  --exec-cli <path>               Path to the cf exec shim
-  --log-file <path>               Path to the FUSE child log file
-  --debug                         Enable FUSE debug output
-  --allow-other                   Pass allow_other through to the FUSE child
-  --noattrcache                   Pass noattrcache through to the FUSE child
-  --attrcache-timeout <seconds>   Pass attrcache-timeout through to the FUSE child
-  --cfc-mode <mode>               FUSE-side CFC mode
-  --cfc-annotations               Publish CFC annotation xattrs
-  --cfc-xattr-namespace <ns>      CFC xattr namespace
-  --cfc-writeback-xattrs          Enable CFC writeback xattrs
-  --cfc-writeback-state <path>    CFC writeback state path
-  --dangerously-allow-incompatible-schema
-                                  Allow incompatible source schema updates
-  --state-path <path>             Mount state file to update with child PID
-  --supervisor-status <path>      Child readiness and heartbeat status file
-  -s, --space <name>              Space(s) to connect
-  -h, --help                      Show this help
-`;
-}
-
 /**
  * Writes the mount state file. This process spawned the FUSE child, so it is the
  * only one that knows both PIDs, and it writes the file once and completely.
@@ -444,9 +218,6 @@ if (import.meta.main) {
     if (help) {
       console.log(supervisorHelp());
       Deno.exit(0);
-    }
-    if (!options.mountpoint) {
-      throw new Error("Missing mountpoint for fuse supervisor.");
     }
     await runFuseSupervisor(options);
   } catch (error) {

--- a/packages/cli/lib/fuse.ts
+++ b/packages/cli/lib/fuse.ts
@@ -9,6 +9,12 @@ import {
   SEPARATOR,
 } from "@std/path";
 import { cliName } from "./cli-name.ts";
+import {
+  type FuseMountFlags,
+  type FuseSupervisorFlags,
+  mountFlagArgs,
+  supervisorFlagArgs,
+} from "./fuse-mount-flags.ts";
 
 export interface MountStateEntry {
   pid: number;
@@ -21,37 +27,17 @@ export interface MountStateEntry {
   logFile?: string;
 }
 
-export interface FuseChildDenoArgsOptions {
+export interface FuseChildDenoArgsOptions extends FuseMountFlags {
   modPath: string;
-  mountpoint: string;
-  apiUrl: string;
-  identity: string;
-  execCli: string;
-  logFile?: string;
-  spaces?: string[];
-  debug?: boolean;
-  allowOther?: boolean;
-  noattrcache?: boolean;
-  attrcacheTimeout?: string;
-  cfcMode?: string;
-  cfcAnnotations?: boolean;
-  cfcXattrNamespace?: string;
-  cfcWritebackXattrs?: boolean;
-  cfcWritebackState?: string;
-  dangerouslyAllowIncompatibleSchema?: boolean;
-  supervisorStatusPath?: string;
 }
 
 export interface BackgroundSupervisorDenoArgsOptions
-  extends Omit<FuseChildDenoArgsOptions, "modPath"> {
+  extends FuseSupervisorFlags {
   cliModPath: string;
-  statePath?: string;
 }
 
-export interface FuseBinaryArgsOptions
-  extends Omit<FuseChildDenoArgsOptions, "modPath"> {
+export interface FuseBinaryArgsOptions extends FuseSupervisorFlags {
   subcommand: "fuse-daemon" | "fuse-supervisor";
-  statePath?: string;
 }
 
 export async function canonicalizeMountLookupPath(
@@ -615,7 +601,7 @@ exec "${Deno.execPath()}" run --allow-net --allow-ffi --allow-read --allow-write
 export function buildFuseChildDenoArgs(
   opts: FuseChildDenoArgsOptions,
 ): string[] {
-  const args = [
+  return [
     "run",
     "--unstable-ffi",
     "--allow-ffi",
@@ -625,123 +611,38 @@ export function buildFuseChildDenoArgs(
     "--allow-net",
     opts.modPath,
     opts.mountpoint,
+    ...mountFlagArgs(opts),
   ];
-
-  if (opts.apiUrl) args.push("--api-url", opts.apiUrl);
-  if (opts.identity) args.push("--identity", opts.identity);
-  if (opts.execCli) args.push("--exec-cli", opts.execCli);
-  if (opts.logFile) args.push("--log-file", opts.logFile);
-  if (opts.debug) args.push("--debug");
-  if (opts.allowOther) args.push("--allow-other");
-  if (opts.noattrcache) args.push("--noattrcache");
-  if (opts.attrcacheTimeout) {
-    args.push("--attrcache-timeout", opts.attrcacheTimeout);
-  }
-  if (opts.cfcMode) args.push("--cfc-mode", opts.cfcMode);
-  if (opts.cfcAnnotations) args.push("--cfc-annotations");
-  if (opts.cfcXattrNamespace) {
-    args.push("--cfc-xattr-namespace", opts.cfcXattrNamespace);
-  }
-  if (opts.cfcWritebackXattrs) args.push("--cfc-writeback-xattrs");
-  if (opts.cfcWritebackState) {
-    args.push("--cfc-writeback-state", opts.cfcWritebackState);
-  }
-  if (opts.dangerouslyAllowIncompatibleSchema) {
-    args.push("--dangerously-allow-incompatible-schema");
-  }
-  if (opts.supervisorStatusPath) {
-    args.push("--supervisor-status", opts.supervisorStatusPath);
-  }
-  for (const space of opts.spaces ?? []) args.push("--space", space);
-
-  return args;
 }
 
 /**
  * Build the args for the compiled cf binary's direct FUSE entry points. The
  * compiled binary takes the mountpoint and mount flags directly, where a
- * deno invocation needs a script path and permission flags first.
+ * deno invocation needs a script path and permission flags first. Only the
+ * supervisor entry point takes the mount state file; the daemon never sees it.
  */
 export function buildFuseBinaryArgs(opts: FuseBinaryArgsOptions): string[] {
-  const args = [opts.subcommand, opts.mountpoint];
-
-  if (opts.apiUrl) args.push("--api-url", opts.apiUrl);
-  if (opts.identity) args.push("--identity", opts.identity);
-  if (opts.debug) args.push("--debug");
-  if (opts.allowOther) args.push("--allow-other");
-  if (opts.noattrcache) args.push("--noattrcache");
-  if (opts.attrcacheTimeout) {
-    args.push("--attrcache-timeout", opts.attrcacheTimeout);
-  }
-  if (opts.cfcMode) args.push("--cfc-mode", opts.cfcMode);
-  if (opts.cfcAnnotations) args.push("--cfc-annotations");
-  if (opts.cfcXattrNamespace) {
-    args.push("--cfc-xattr-namespace", opts.cfcXattrNamespace);
-  }
-  if (opts.cfcWritebackXattrs) args.push("--cfc-writeback-xattrs");
-  if (opts.cfcWritebackState) {
-    args.push("--cfc-writeback-state", opts.cfcWritebackState);
-  }
-  if (opts.dangerouslyAllowIncompatibleSchema) {
-    args.push("--dangerously-allow-incompatible-schema");
-  }
-  if (opts.execCli) args.push("--exec-cli", opts.execCli);
-  if (opts.logFile) args.push("--log-file", opts.logFile);
-  if (opts.statePath) args.push("--state-path", opts.statePath);
-  if (opts.supervisorStatusPath) {
-    args.push("--supervisor-status", opts.supervisorStatusPath);
-  }
-  for (const space of opts.spaces ?? []) args.push("--space", space);
-
-  return args;
+  return [
+    opts.subcommand,
+    opts.mountpoint,
+    ...(opts.subcommand === "fuse-supervisor"
+      ? supervisorFlagArgs(opts)
+      : mountFlagArgs(opts)),
+  ];
 }
 
 /** Build the deno subprocess args for running the non-FFI FUSE supervisor. */
 export function buildBackgroundSupervisorDenoArgs(
   opts: BackgroundSupervisorDenoArgsOptions,
 ): string[] {
-  const args = [
+  const permissions = ["--allow-run"];
+  if (opts.statePath) permissions.push(`--allow-write=${opts.statePath}`);
+
+  return [
     "run",
-    "--allow-run",
+    ...permissions,
     opts.cliModPath,
     opts.mountpoint,
+    ...supervisorFlagArgs(opts),
   ];
-
-  if (opts.statePath) {
-    args.splice(2, 0, `--allow-write=${opts.statePath}`);
-    args.push("--state-path", opts.statePath);
-  }
-
-  if (opts.apiUrl) args.push("--api-url", opts.apiUrl);
-  if (opts.identity) args.push("--identity", opts.identity);
-  if (opts.execCli) args.push("--exec-cli", opts.execCli);
-  if (opts.logFile) args.push("--log-file", opts.logFile);
-  if (opts.debug) args.push("--debug");
-  if (opts.allowOther) args.push("--allow-other");
-  if (opts.noattrcache) args.push("--noattrcache");
-  if (opts.attrcacheTimeout) {
-    args.push("--attrcache-timeout", opts.attrcacheTimeout);
-  }
-  if (opts.cfcMode) args.push("--cfc-mode", opts.cfcMode);
-  if (opts.cfcAnnotations) args.push("--cfc-annotations");
-  if (opts.cfcXattrNamespace) {
-    args.push("--cfc-xattr-namespace", opts.cfcXattrNamespace);
-  }
-  if (opts.cfcWritebackXattrs) args.push("--cfc-writeback-xattrs");
-  if (opts.cfcWritebackState) {
-    args.push("--cfc-writeback-state", opts.cfcWritebackState);
-  }
-  if (opts.dangerouslyAllowIncompatibleSchema) {
-    args.push("--dangerously-allow-incompatible-schema");
-  }
-  if (opts.supervisorStatusPath) {
-    args.push("--supervisor-status", opts.supervisorStatusPath);
-  }
-  for (const space of opts.spaces ?? []) args.push("--space", space);
-
-  return args;
-}
-
-export function buildDenoArgs(opts: FuseChildDenoArgsOptions): string[] {
-  return buildFuseChildDenoArgs(opts);
 }

--- a/packages/cli/test/fuse.test.ts
+++ b/packages/cli/test/fuse.test.ts
@@ -16,7 +16,6 @@ import {
 } from "../commands/fuse.ts";
 import {
   buildBackgroundSupervisorDenoArgs,
-  buildDenoArgs,
   buildFuseBinaryArgs,
   buildFuseChildDenoArgs,
   ensureExecShim,
@@ -38,12 +37,13 @@ import {
 import {
   buildFuseChildCommand,
   cleanupFuseChild,
-  fuseSupervisorOptions,
-  parseSupervisorArgs,
   recordFuseMountState,
   runFuseSupervisor,
-  supervisorHelp,
 } from "../lib/fuse-supervisor.ts";
+import {
+  parseSupervisorArgs,
+  supervisorHelp,
+} from "../lib/fuse-mount-flags.ts";
 import { writeFailedSupervisorStartupStatus } from "../../fuse/mod.ts";
 import { withEnv } from "./utils.ts";
 
@@ -1046,9 +1046,9 @@ describe("isAlive", () => {
   });
 });
 
-describe("buildDenoArgs", () => {
+describe("buildFuseChildDenoArgs", () => {
   it("builds minimal args", () => {
-    const args = buildDenoArgs({
+    const args = buildFuseChildDenoArgs({
       modPath: "/path/to/mod.ts",
       mountpoint: "/mnt",
       apiUrl: "",
@@ -1069,7 +1069,7 @@ describe("buildDenoArgs", () => {
   });
 
   it("includes api-url and identity when provided", () => {
-    const args = buildDenoArgs({
+    const args = buildFuseChildDenoArgs({
       modPath: "/mod.ts",
       mountpoint: "/mnt",
       apiUrl: "http://localhost:8000",
@@ -1085,7 +1085,7 @@ describe("buildDenoArgs", () => {
   });
 
   it("omits api-url, identity, and exec-cli when empty", () => {
-    const args = buildDenoArgs({
+    const args = buildFuseChildDenoArgs({
       modPath: "/mod.ts",
       mountpoint: "/mnt",
       apiUrl: "",
@@ -1098,7 +1098,7 @@ describe("buildDenoArgs", () => {
   });
 
   it("passes CFC mount options through to the daemon", () => {
-    const args = buildDenoArgs({
+    const args = buildFuseChildDenoArgs({
       modPath: "/mod.ts",
       mountpoint: "/mnt",
       apiUrl: "",
@@ -1125,7 +1125,7 @@ describe("buildDenoArgs", () => {
   });
 
   it("passes noattrcache through to the daemon", () => {
-    const args = buildDenoArgs({
+    const args = buildFuseChildDenoArgs({
       modPath: "/mod.ts",
       mountpoint: "/mnt",
       apiUrl: "",
@@ -1138,7 +1138,7 @@ describe("buildDenoArgs", () => {
   });
 
   it("passes attrcache-timeout through to the daemon", () => {
-    const args = buildDenoArgs({
+    const args = buildFuseChildDenoArgs({
       modPath: "/mod.ts",
       mountpoint: "/mnt",
       apiUrl: "",
@@ -1155,7 +1155,7 @@ describe("buildDenoArgs", () => {
   it("forwards an attrcache-timeout of zero to the daemon", () => {
     // "0" selects untuned caching in the daemon and must survive every
     // forwarding layer even though the layers test the field for truthiness.
-    const args = buildDenoArgs({
+    const args = buildFuseChildDenoArgs({
       modPath: "/mod.ts",
       mountpoint: "/mnt",
       apiUrl: "",
@@ -1195,7 +1195,7 @@ describe("buildDenoArgs", () => {
   });
 
   it("omits NFS cache mount options when unset", () => {
-    const args = buildDenoArgs({
+    const args = buildFuseChildDenoArgs({
       modPath: "/mod.ts",
       mountpoint: "/mnt",
       apiUrl: "",
@@ -1229,45 +1229,6 @@ describe("FUSE supervisor command construction", () => {
       new Error("status path unavailable"),
       () => Promise.reject(new Error("write failed")),
     )).resolves.toBeUndefined();
-  });
-
-  it("maps CLI options into the supervisor contract", () => {
-    expect(fuseSupervisorOptions({
-      apiUrl: "http://localhost:8000",
-      identity: "/tmp/id.key",
-      execCli: "/tmp/cf-exec",
-      logFile: "/tmp/cf-fuse.log",
-      space: ["home", "work"],
-      allowOther: true,
-      noattrcache: true,
-      attrcacheTimeout: "2",
-      cfcMode: "observe",
-      cfcAnnotations: true,
-      cfcXattrNamespace: "both",
-      cfcWritebackXattrs: true,
-      cfcWritebackState: "/tmp/cfc.json",
-      dangerouslyAllowIncompatibleSchema: true,
-      statePath: "/tmp/state.json",
-      supervisorStatus: "/tmp/status.json",
-    }, "/mnt")).toEqual({
-      mountpoint: "/mnt",
-      apiUrl: "http://localhost:8000",
-      identity: "/tmp/id.key",
-      execCli: "/tmp/cf-exec",
-      logFile: "/tmp/cf-fuse.log",
-      spaces: ["home", "work"],
-      allowOther: true,
-      noattrcache: true,
-      attrcacheTimeout: "2",
-      cfcMode: "observe",
-      cfcAnnotations: true,
-      cfcXattrNamespace: "both",
-      cfcWritebackXattrs: true,
-      cfcWritebackState: "/tmp/cfc.json",
-      dangerouslyAllowIncompatibleSchema: true,
-      statePath: "/tmp/state.json",
-      supervisorStatusPath: "/tmp/status.json",
-    });
   });
 
   it("builds a background supervisor invocation that does not load libfuse", () => {
@@ -1783,6 +1744,53 @@ describe("parseSupervisorArgs", () => {
   it("rejects unknown options", () => {
     expect(() => parseSupervisorArgs(["/mnt", "--nosuchflag"]))
       .toThrow("Unknown fuse supervisor option: --nosuchflag");
+  });
+
+  it("rejects an argv that names no mountpoint", () => {
+    expect(() => parseSupervisorArgs(["--debug"]))
+      .toThrow("Missing mountpoint for fuse supervisor.");
+  });
+
+  it("round-trips every flag both supervisor argv builders emit", () => {
+    // The builders and this parser read one flag table, and this is the
+    // property that table exists for: a flag the command sets survives the hop
+    // into the supervisor whichever entrypoint runs it.
+    const flags = {
+      mountpoint: "/mnt",
+      apiUrl: "http://localhost:8000",
+      identity: "/tmp/id.key",
+      execCli: "/tmp/cf-exec",
+      logFile: "/tmp/cf-fuse.log",
+      spaces: ["home", "work"],
+      debug: true,
+      allowOther: true,
+      noattrcache: true,
+      attrcacheTimeout: "0",
+      cfcMode: "observe",
+      cfcAnnotations: true,
+      cfcXattrNamespace: "both",
+      cfcWritebackXattrs: true,
+      cfcWritebackState: "/tmp/cfc.json",
+      dangerouslyAllowIncompatibleSchema: true,
+      statePath: "/tmp/state.json",
+      supervisorStatusPath: "/tmp/state.json.child-status",
+    };
+
+    const cliModPath = "/repo/packages/cli/lib/fuse-supervisor.ts";
+    const denoArgs = buildBackgroundSupervisorDenoArgs({
+      cliModPath,
+      ...flags,
+    });
+    expect(
+      parseSupervisorArgs(denoArgs.slice(denoArgs.indexOf(cliModPath) + 1))
+        .options,
+    ).toEqual(flags);
+
+    const binaryArgs = buildFuseBinaryArgs({
+      subcommand: "fuse-supervisor",
+      ...flags,
+    });
+    expect(parseSupervisorArgs(binaryArgs.slice(1)).options).toEqual(flags);
   });
 
   it("reports help without requiring a mountpoint", () => {
@@ -2305,7 +2313,7 @@ describe("fuse unmount", () => {
 
 describe("debug flag forwarding", () => {
   it("survives every forwarding layer", () => {
-    const args = buildDenoArgs({
+    const args = buildFuseChildDenoArgs({
       modPath: "/mod.ts",
       mountpoint: "/mnt",
       apiUrl: "",
@@ -2363,7 +2371,7 @@ describe("debug flag forwarding", () => {
   });
 
   it("omits --debug from every layer when unset", () => {
-    const args = buildDenoArgs({
+    const args = buildFuseChildDenoArgs({
       modPath: "/mod.ts",
       mountpoint: "/mnt",
       apiUrl: "",

--- a/packages/cli/test/main-command.test.ts
+++ b/packages/cli/test/main-command.test.ts
@@ -213,6 +213,29 @@ describe("main command", () => {
     );
   });
 
+  it("shows the supervisor's own help for the direct supervisor entry point", async () => {
+    // The subcommand forwards its raw argv to the supervisor's parser, so the
+    // compiled binary and a direct `deno run` of the supervisor answer with the
+    // same flags and the same help.
+    const { code, stdout } = await cf("fuse-supervisor --help");
+
+    expect(code).toBe(0);
+    expect(stdout.join("\n")).toContain(
+      "Usage: fuse-supervisor <mountpoint> [options]",
+    );
+    expect(stdout.join("\n")).toContain("--supervisor-status <path>");
+  });
+
+  it("rejects an unknown flag on the direct supervisor entry point", async () => {
+    const { code, stdout, stderr } = await cf("fuse-supervisor /mnt --json");
+
+    expect(code).not.toBe(0);
+    expect(stdout).toEqual([]);
+    expect(stripAnsi(stderr.join("\n"))).toContain(
+      "Unknown fuse supervisor option: --json",
+    );
+  });
+
   it("keeps rejection help off stdout when --json is unsupported", async () => {
     const { code, stdout, stderr } = await cf("acl --json");
 


### PR DESCRIPTION
The mount flags `cf fuse mount` accepts travel through as many as three processes. The command spawns a supervisor, the supervisor spawns the FUSE child that owns libfuse, and each hop passes the flags along on a command line. Each hop also has two forms: a mount started from the compiled `cf` binary runs a subcommand of that binary, where a mount started from a checkout runs `deno run` on a module.

Every hop hand-wrote the whole flag list. Three near-identical option interfaces named the same fourteen fields. Four separate chains of `if` statements pushed the same flags onto an argv array. The supervisor argv was then read back by two complete parsers: a Cliffy option list in the CLI's command tree, used when the compiled binary runs `cf fuse-supervisor`, and a hand-rolled switch statement with its own copy of the help text, used when the supervisor module is run directly. Adding a flag meant editing all of them, and the recent history of these files is a run of changes that had to.

The vocabulary now lives in one table, in the new module packages/cli/lib/fuse-mount-flags.ts. Each entry names the field that carries a flag, the flag it becomes on a command line, and whether it takes a value, repeats, or stands alone. The table is keyed by field name and typed against the flags interface, so a field with no entry fails to compile. The four argv builders share one encoder over that table, and the three option interfaces collapse to `FuseMountFlags`, which is what the daemon accepts, and `FuseSupervisorFlags`, which is the same set plus the mount state file that only the supervisor sees.

The second supervisor parser is gone. The `cf fuse-supervisor` subcommand takes its arguments raw and hands them to the same parser the module's own entrypoint uses, which is what the neighbouring `cf fuse-daemon` subcommand already does. That deletes the Cliffy option list, the interface that mirrored its output, and the function that renamed each field back. The help text is generated from the table and reproduces the layout the hand-written text produced. Two small differences come with this on an internal subcommand nothing types by hand: it no longer accepts `--flag=value`, which no spawner in the repository uses, and an unknown flag is now reported by the supervisor's parser, wrapped as a Cliffy validation error so stderr carries the message and stdout stays empty. The rule that an argv must name a mountpoint moved into the parser, which both entrypoints had been checking separately.

`buildDenoArgs`, an alias that only forwarded to `buildFuseChildDenoArgs`, is deleted in favour of the name it forwarded to.

The tests assert the round trip the shared table exists for: what either supervisor argv builder emits parses back to the flags that went in. The `cf fuse-supervisor` subcommand is covered end to end for its help output and for rejecting an unknown flag.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the `cf fuse mount` flag vocabulary and parsing across the CLI, supervisor, and daemon. Removes duplicate option lists and argv builders, makes flags/help identical between the compiled binary and `deno run`, and improves error reporting.

- **Refactors**
  - Added `packages/cli/lib/fuse-mount-flags.ts` with one table-driven spec, `FuseMountFlags`/`FuseSupervisorFlags`, encoders (`mountFlagArgs`, `supervisorFlagArgs`), a shared parser (`parseSupervisorArgs`), and `supervisorHelp`.
  - `cf fuse-supervisor` now forwards raw argv to the shared parser; the hand-written Cliffy option list and duplicate parser/help were removed.
  - Consolidated argv builders: `buildFuseChildDenoArgs`, `buildFuseBinaryArgs`, `buildBackgroundSupervisorDenoArgs`, and `buildFuseChildCommand` use the shared encoders; removed `buildDenoArgs`.
  - Parser behavior tweaks: rejects `--flag=value`, reports unknown flags via a wrapped Cliffy validation error (stderr only), and enforces a required mountpoint.
  - Tests cover round-tripping between builders and parser, supervisor help output, and rejecting unknown flags; updated existing tests to use `buildFuseChildDenoArgs`.

<sup>Written for commit 0132969f5cea4b0a77c0940ca827c59d79cf0ec1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

