### PR TITLE
toolshed: report why an LLM request failed, and to whom it belongs

### DIFF
--- a/docs/features/llm-testing.md
+++ b/docs/features/llm-testing.md
@@ -65,6 +65,49 @@ addMockObjectResponse(
 
 Mock responses are **one-time use** — they're consumed when matched.
 
+## Testing the toolshed route against a mock model
+
+The mock mode above intercepts the client's `fetch`, so it never reaches the
+route handler. To exercise the route's own handling of a response — an empty
+answer, a provider that turns the request down, a stream that stops early —
+drive `generateText` with a stand-in language model instead.
+
+`findModel` reads the exported `MODELS` registry in
+`packages/toolshed/routes/ai/llm/models.ts`, and that registry is a plain
+mutable object. A test registers a model under a name of its own, runs the
+generation, and takes the entry back out afterwards:
+
+```ts
+// Shown for illustration only.
+MODELS["mock:test-model"] = {
+  model: new MockLanguageModelV4({ doStream: { stream } }),
+  name: "mock:test-model",
+  capabilities: { /* the fields the route reads */ },
+  aliases: [],
+};
+try {
+  await generateText({ model: "mock:test-model", messages });
+} finally {
+  delete MODELS["mock:test-model"];
+}
+```
+
+Two properties of the AI SDK shape what these tests can assert.
+
+A request that fails **after it has started** does not reject. The SDK reports
+it as an `{ type: "error", error }` part carried inside the response stream and
+passes it to the `onError` callback. Reading only `textStream` therefore yields
+an empty response and no sign of the failure, so a test that wants to see the
+provider's complaint has to look at what the route does with `onError`, not at
+whether `streamText` threw.
+
+The SDK retries a failure it considers retryable — a 408, 409, 429, or any 5xx
+— sleeping between attempts, and reports the exhausted attempts wrapped in a
+`RetryError` that carries no status of its own. Both routes ask for a single
+attempt with `maxRetries: 0`, so a mock can fail with any status and the
+failure comes straight back. A test that sets its own `maxRetries` gets the
+sleeps and the wrapper too.
+
 ## Conversation Fixtures
 
 For multi-turn or complex LLM interactions, use **conversation fixtures** —
@@ -165,8 +208,10 @@ in `beforeEach` to reset between tests.
 | File | What it tests |
 |------|--------------|
 | `packages/llm/src/client.test.ts` | Guard behavior, mock mode API, fixture loading |
-| `packages/toolshed/routes/ai/llm/generateText.test.ts` | JSON mode config, response cleaning |
+| `packages/toolshed/routes/ai/llm/generateText.test.ts` | JSON mode config, response cleaning, failure reporting against a mock model |
 | `packages/toolshed/routes/ai/llm/generateObject.test.ts` | Model resolution, error paths |
+| `packages/toolshed/routes/ai/llm/llm.status.test.ts` | The HTTP status a failed generation answers with, through the real router |
+| `packages/toolshed/routes/ai/llm/errors.test.ts` | Sorting a failure into a status, including shapes the routes cannot produce |
 | `packages/runner/test/llm-pattern-smoke.test.ts` | generateText, generateObject, and tool-calling through runtime |
 | `packages/runner/test/llm-conversation-fixture.test.ts` | Multi-turn conversations and tool chains via fixtures |
 

--- a/packages/llm/src/client.test.ts
+++ b/packages/llm/src/client.test.ts
@@ -7,6 +7,7 @@ import {
   type ConversationFixture,
   disableMockMode,
   enableMockMode,
+  failureHint,
   LLMClient,
   LLMStreamError,
   loadConversationFixture,
@@ -590,6 +591,45 @@ describe("mock response gate", () => {
       expect(response.content).toBe("ungated");
     } finally {
       resetMockMode();
+    }
+  });
+});
+
+describe("failureHint", () => {
+  const PARAMETERS = "messages, prompt, model, etc.";
+
+  // The hint is the first thing a developer reads in the console when a
+  // request fails, and for most of a working day the failure is not theirs.
+  // Each status class has to send them to the right place.
+
+  it("sends a rate-limited caller away to wait rather than to their arguments", () => {
+    for (const status of [429, 503]) {
+      const hint = failureHint(status, PARAMETERS);
+      expect(hint).toContain("again later");
+      expect(hint).not.toContain(PARAMETERS);
+    }
+  });
+
+  it("tells a caller a server failure was not their doing", () => {
+    for (const status of [500, 502, 504]) {
+      const hint = failureHint(status, PARAMETERS);
+      expect(hint).toContain("was not the problem");
+      expect(hint).not.toContain(PARAMETERS);
+    }
+  });
+
+  it("names the arguments to check when the request was rejected", () => {
+    for (const status of [400, 422]) {
+      expect(failureHint(status, PARAMETERS)).toContain(PARAMETERS);
+    }
+  });
+
+  it("claims nothing about a status it does not recognise", () => {
+    for (const status of [401, 403, 404, 418]) {
+      const hint = failureHint(status, PARAMETERS);
+      expect(hint).not.toContain(PARAMETERS);
+      expect(hint).not.toContain("again later");
+      expect(hint).not.toContain("was not the problem");
     }
   });
 });

--- a/packages/llm/src/client.ts
+++ b/packages/llm/src/client.ts
@@ -314,6 +314,25 @@ export interface ConversationFixture {
   responses: ConversationFixtureEntry[];
 }
 
+/**
+ * What a failed request points at, read off its status. The service reports a
+ * request the caller has to change apart from a provider that was busy or
+ * broken, so the hint follows the status rather than blaming the caller for
+ * everything.
+ */
+function failureHint(status: number, parameters: string): string {
+  if (status === 429 || status === 503) {
+    return "The model provider is busy. Make the request again later.";
+  }
+  if (status >= 500) {
+    return "The LLM service or the model provider failed. The request was not the problem.";
+  }
+  if (status === 400 || status === 422) {
+    return `The LLM server or the model provider rejected the request. Check that you're passing the correct parameters (${parameters})`;
+  }
+  return "The LLM service turned the request down.";
+}
+
 function extractMessageText(
   content: unknown,
 ): string {
@@ -517,7 +536,7 @@ export class LLMClient {
       console.error(
         `%c[generateObject Error]%c HTTP ${response.status}\n` +
           `Response: ${errorText}\n` +
-          `%cCommon cause: Check that you're passing the correct parameters (messages, schema, model, etc.)`,
+          `%c${failureHint(response.status, "messages, schema, model, etc.")}`,
         "color: red; font-weight: bold",
         "color: inherit",
         "color: gray; font-style: italic",
@@ -620,7 +639,7 @@ export class LLMClient {
       console.error(
         `%c[generateText Error]%c HTTP ${response.status}\n` +
           `Response: ${errorText}\n` +
-          `%cCommon cause: Check that you're passing the correct parameters (messages, prompt, model, etc.)`,
+          `%c${failureHint(response.status, "messages, prompt, model, etc.")}`,
         "color: red; font-weight: bold",
         "color: inherit",
         "color: gray; font-style: italic",

--- a/packages/llm/src/client.ts
+++ b/packages/llm/src/client.ts
@@ -320,7 +320,7 @@ export interface ConversationFixture {
  * broken, so the hint follows the status rather than blaming the caller for
  * everything.
  */
-function failureHint(status: number, parameters: string): string {
+export function failureHint(status: number, parameters: string): string {
   if (status === 429 || status === 503) {
     return "The model provider is busy. Make the request again later.";
   }

--- a/packages/toolshed/routes/ai/llm/errors.test.ts
+++ b/packages/toolshed/routes/ai/llm/errors.test.ts
@@ -1,0 +1,81 @@
+import { assertEquals } from "@std/assert";
+import { APICallError, InvalidPromptError, RetryError } from "ai";
+
+import env from "@/env.ts";
+import {
+  httpStatusForError,
+  LLMRequestError,
+  LLMUpstreamError,
+} from "./errors.ts";
+
+if (env.ENV !== "test") {
+  throw new Error("ENV must be 'test'");
+}
+
+function providerFailure(statusCode: number): APICallError {
+  return new APICallError({
+    message: "provider said no",
+    url: "https://provider.example/v1/messages",
+    requestBodyValues: {},
+    statusCode,
+  });
+}
+
+// The routes ask the AI SDK for a single attempt, so these two shapes do not
+// reach the classifier from them. They are what the classifier sees if a call
+// site ever asks for retries again, and the status has to survive the wrapping
+// either way.
+Deno.test("a status survives a retry wrapper", () => {
+  const wrapped = new RetryError({
+    message: "Failed after 3 attempts",
+    reason: "maxRetriesExceeded",
+    errors: [providerFailure(500), providerFailure(429)],
+  });
+  assertEquals(httpStatusForError(wrapped), 429);
+});
+
+Deno.test("a status survives a chain of causes", () => {
+  const wrapped = new Error("wrapped", {
+    cause: new Error("wrapped again", { cause: providerFailure(503) }),
+  });
+  assertEquals(httpStatusForError(wrapped), 503);
+});
+
+Deno.test("a cycle among causes does not trap the search", () => {
+  const outer: { cause?: unknown } = new Error("outer");
+  outer.cause = outer;
+  assertEquals(httpStatusForError(outer), 500);
+});
+
+// The AI SDK raises these over what the caller sent, before any provider is
+// asked. Reporting them against the provider would send the caller looking in
+// the wrong place.
+Deno.test("a request the SDK would not send is the caller's mistake", () => {
+  assertEquals(
+    httpStatusForError(
+      new InvalidPromptError({
+        prompt: {},
+        message: "messages must not be empty",
+      }),
+    ),
+    400,
+  );
+});
+
+Deno.test("the error types carry their own classification", () => {
+  assertEquals(httpStatusForError(new LLMRequestError("bad")), 400);
+  assertEquals(httpStatusForError(new LLMUpstreamError("down")), 502);
+  assertEquals(
+    httpStatusForError(new LLMUpstreamError("busy", { upstreamStatus: 429 })),
+    429,
+  );
+});
+
+Deno.test("an error from nowhere in particular is this service's", () => {
+  assertEquals(
+    httpStatusForError(new TypeError("undefined is not a function")),
+    500,
+  );
+  assertEquals(httpStatusForError("a string"), 500);
+  assertEquals(httpStatusForError(undefined), 500);
+});

--- a/packages/toolshed/routes/ai/llm/errors.ts
+++ b/packages/toolshed/routes/ai/llm/errors.ts
@@ -1,0 +1,156 @@
+import * as HttpStatusCodes from "stoker/http-status-codes";
+import {
+  AISDKError,
+  APICallError,
+  InvalidArgumentError,
+  InvalidDataContentError,
+  InvalidMessageRoleError,
+  InvalidPromptError,
+  InvalidToolInputError,
+  MessageConversionError,
+  RetryError,
+  UnsupportedFunctionalityError,
+} from "ai";
+
+/**
+ * The caller asked for something this service does not offer, or for a
+ * combination it cannot serve. The caller has to change the request for it to
+ * succeed.
+ */
+export class LLMRequestError extends Error {
+  override readonly name = "LLMRequestError";
+}
+
+/**
+ * A service these routes call failed: a model provider, or the annotation
+ * service behind the feedback route. `upstreamStatus` is the HTTP status that
+ * service answered with, where it answered at all.
+ */
+export class LLMUpstreamError extends Error {
+  override readonly name = "LLMUpstreamError";
+  readonly upstreamStatus: number | undefined;
+
+  constructor(
+    message: string,
+    options?: { cause?: unknown; upstreamStatus?: number },
+  ) {
+    super(message, options);
+    this.upstreamStatus = options?.upstreamStatus;
+  }
+}
+
+/**
+ * Digs the HTTP status out of a failure a provider call reported. A retried
+ * call reports the attempts wrapped in a `RetryError`, which carries no status
+ * of its own, so the wrapper and any chain of causes are opened up to reach
+ * the call that carries one.
+ */
+export function upstreamStatusOf(error: unknown): number | undefined {
+  const seen = new Set<unknown>();
+  let current = error;
+  while (current !== null && current !== undefined && !seen.has(current)) {
+    seen.add(current);
+    if (APICallError.isInstance(current)) {
+      return current.statusCode;
+    }
+    if (RetryError.isInstance(current)) {
+      current = current.lastError;
+      continue;
+    }
+    current = (current as { cause?: unknown }).cause;
+  }
+  return undefined;
+}
+
+/**
+ * The AI SDK errors raised over what the caller sent, before any provider was
+ * asked. They name a message, a content part, a tool definition or a setting
+ * that this service built the request out of.
+ */
+function isRequestSideSdkError(error: unknown): boolean {
+  return InvalidPromptError.isInstance(error) ||
+    InvalidDataContentError.isInstance(error) ||
+    InvalidMessageRoleError.isInstance(error) ||
+    MessageConversionError.isInstance(error) ||
+    InvalidArgumentError.isInstance(error) ||
+    InvalidToolInputError.isInstance(error) ||
+    UnsupportedFunctionalityError.isInstance(error);
+}
+
+// Anthropic answers 529 when a model is overloaded. It is not a registered
+// status, and it means what 503 means.
+const PROVIDER_OVERLOADED = 529;
+
+export type LLMErrorStatus =
+  | typeof HttpStatusCodes.BAD_REQUEST
+  | typeof HttpStatusCodes.TOO_MANY_REQUESTS
+  | typeof HttpStatusCodes.INTERNAL_SERVER_ERROR
+  | typeof HttpStatusCodes.BAD_GATEWAY
+  | typeof HttpStatusCodes.SERVICE_UNAVAILABLE
+  | typeof HttpStatusCodes.GATEWAY_TIMEOUT;
+
+function statusForUpstream(upstreamStatus: number | undefined): LLMErrorStatus {
+  // The service never answered, or answered in a way that carried no status:
+  // a connection that failed, a response that could not be read.
+  if (upstreamStatus === undefined) {
+    return HttpStatusCodes.BAD_GATEWAY;
+  }
+  // The service is asking for the request to be made again later, and waiting
+  // is the caller's to do, so these reach the caller as themselves.
+  if (upstreamStatus === HttpStatusCodes.TOO_MANY_REQUESTS) {
+    return HttpStatusCodes.TOO_MANY_REQUESTS;
+  }
+  if (
+    upstreamStatus === HttpStatusCodes.SERVICE_UNAVAILABLE ||
+    upstreamStatus === PROVIDER_OVERLOADED
+  ) {
+    return HttpStatusCodes.SERVICE_UNAVAILABLE;
+  }
+  // The exchange with the service ran out of time.
+  if (upstreamStatus === HttpStatusCodes.REQUEST_TIMEOUT) {
+    return HttpStatusCodes.GATEWAY_TIMEOUT;
+  }
+  // A 5xx is the service breaking on a request it accepted.
+  if (upstreamStatus >= 500) {
+    return HttpStatusCodes.BAD_GATEWAY;
+  }
+  // Any other 4xx says the request this service sent was wrong. Where it was
+  // wrong in what it carried, the caller wrote that: a prompt past the context
+  // window, a schema the model will not accept.
+  if (
+    upstreamStatus === HttpStatusCodes.BAD_REQUEST ||
+    upstreamStatus === HttpStatusCodes.REQUEST_TOO_LONG ||
+    upstreamStatus === HttpStatusCodes.UNPROCESSABLE_ENTITY
+  ) {
+    return HttpStatusCodes.BAD_REQUEST;
+  }
+  // Where it was wrong in any other way — a key the service rejected, an
+  // account it will not bill, a model named here that it does not carry — this
+  // service is the one that has to change, and the caller can only report it.
+  return HttpStatusCodes.INTERNAL_SERVER_ERROR;
+}
+
+/**
+ * The status to answer a failed generation with. A caller distinguishes a
+ * request it should change from one it should repeat later from one it can do
+ * nothing about, and only the status tells it which it has.
+ */
+export function httpStatusForError(error: unknown): LLMErrorStatus {
+  if (error instanceof LLMRequestError || isRequestSideSdkError(error)) {
+    return HttpStatusCodes.BAD_REQUEST;
+  }
+  if (error instanceof LLMUpstreamError) {
+    return statusForUpstream(error.upstreamStatus);
+  }
+  const upstreamStatus = upstreamStatusOf(error);
+  if (upstreamStatus !== undefined) {
+    return statusForUpstream(upstreamStatus);
+  }
+  // The provider was asked and what came back could not be used: a response
+  // that failed to parse, a stream that broke its own protocol, an object that
+  // never satisfied the schema.
+  if (AISDKError.isInstance(error)) {
+    return HttpStatusCodes.BAD_GATEWAY;
+  }
+  return HttpStatusCodes.INTERNAL_SERVER_ERROR;
+}

--- a/packages/toolshed/routes/ai/llm/generateObject.ts
+++ b/packages/toolshed/routes/ai/llm/generateObject.ts
@@ -2,6 +2,7 @@ import {
   type LLMGenerateObjectRequest,
   type LLMGenerateObjectResponse,
 } from "@commonfabric/llm/types";
+import { LLMRequestError } from "./errors.ts";
 import { findModel } from "./models.ts";
 import {
   generateObject as generateObjectCore,
@@ -21,11 +22,25 @@ export async function generateObject(
       string,
       unknown
     >;
-    const modelConfig = findModel(
-      params.model ?? DEFAULT_GENERATE_OBJECT_MODELS,
-    );
+    const modelName = params.model ?? DEFAULT_GENERATE_OBJECT_MODELS;
+    const modelConfig = findModel(modelName);
+    if (!modelConfig) {
+      throw new LLMRequestError(`Unsupported model: ${modelName}`);
+    }
     const ajv = new Ajv({ allErrors: true, strict: false });
-    const validator = ajv.compile(providerSchema);
+    // The schema comes from the caller, and Ajv rejects one it cannot compile:
+    // an unknown type, a reference to nothing, a keyword given the wrong shape.
+    let validator;
+    try {
+      validator = ajv.compile(providerSchema);
+    } catch (error) {
+      throw new LLMRequestError(
+        `Schema cannot be compiled: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        { cause: error },
+      );
+    }
 
     const activeSpan = trace.getActiveSpan();
     const spanId = activeSpan?.spanContext().spanId;
@@ -74,6 +89,10 @@ export async function generateObject(
         },
       }),
       maxOutputTokens: params.maxTokens,
+      // The AI SDK otherwise sleeps and sends the request again twice before
+      // reporting a failure, and reports it wrapped in an error that carries
+      // no status. One attempt leaves the decision to retry with the caller.
+      maxRetries: 0,
       // Registering a telemetry integration turns span collection on for every
       // AI SDK call. This route has never emitted AI SDK spans, so it opts out.
       telemetry: { isEnabled: false },

--- a/packages/toolshed/routes/ai/llm/generateText.test.ts
+++ b/packages/toolshed/routes/ai/llm/generateText.test.ts
@@ -1,12 +1,22 @@
-import { assertEquals, assertThrows } from "@std/assert";
+import {
+  assert,
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+  assertThrows,
+} from "@std/assert";
 import { describe, it } from "@std/testing/bdd";
+import { APICallError, type LanguageModel } from "ai";
+import { MockLanguageModelV4 } from "ai/test";
 import { GOOGLE_SEARCH_NATIVE_MODEL_TOOL } from "@commonfabric/llm/types";
 import env from "@/env.ts";
 import {
   applyNativeModelTools,
   cleanJsonResponse,
   configureJsonMode,
+  generateText,
 } from "./generateText.ts";
+import { MODELS } from "./models.ts";
 
 if (env.ENV !== "test") {
   throw new Error("ENV must be 'test'");
@@ -345,5 +355,276 @@ describe("applyNativeModelTools", () => {
       Error,
       "Native model tool 'google_search' conflicts with an existing tool definition",
     );
+  });
+});
+
+// The AI SDK reports a request that fails after it starts as an `error` part
+// carried inside the response stream, not as a rejection, and the text side of
+// that stream drops every part that is not text. A reader that only collects
+// text therefore sees an empty response with no trace of the provider's
+// complaint. These tests run generations against a mock model to check that
+// the provider's complaint reaches the caller.
+
+const MOCK_MODEL_NAME = "mock:test-model";
+
+/**
+ * Registers `model` under a name that `findModel` resolves, runs `body`, then
+ * takes the registration back out of the shared model list.
+ */
+async function withMockModel(
+  model: LanguageModel,
+  body: () => Promise<void>,
+): Promise<void> {
+  MODELS[MOCK_MODEL_NAME] = {
+    model,
+    name: MOCK_MODEL_NAME,
+    capabilities: {
+      contextWindow: 1000,
+      maxOutputTokens: 100,
+      streaming: true,
+      systemPrompt: true,
+      stopSequences: true,
+      prefill: false,
+      images: false,
+      reasoning: false,
+    },
+    aliases: [],
+  };
+  try {
+    await body();
+  } finally {
+    delete MODELS[MOCK_MODEL_NAME];
+  }
+}
+
+/**
+ * A model that turns down the request the way a provider does when it rejects
+ * one outright. The error is marked as not retryable so the generation reports
+ * it rather than retrying behind the test's back.
+ */
+function rejectingModel(): LanguageModel {
+  return new MockLanguageModelV4({
+    doStream: () => {
+      throw new APICallError({
+        message: "Overloaded",
+        url: "https://provider.example/v1/messages",
+        requestBodyValues: {},
+        statusCode: 529,
+        responseBody: '{"type":"error","error":{"type":"overloaded_error"}}',
+        isRetryable: false,
+      });
+    },
+  });
+}
+
+/**
+ * A model that answers without writing any text, which is what happens when a
+ * model spends its whole output budget before producing a first token.
+ */
+function silentModel(): LanguageModel {
+  return new MockLanguageModelV4({
+    doStream: {
+      stream: new ReadableStream({
+        start(controller) {
+          controller.enqueue({ type: "stream-start", warnings: [] });
+          controller.enqueue({
+            type: "finish",
+            finishReason: { unified: "length", raw: "max_tokens" },
+            usage: {
+              inputTokens: {
+                total: 7,
+                noCache: 7,
+                cacheRead: 0,
+                cacheWrite: 0,
+              },
+              outputTokens: { total: 0, text: 0, reasoning: 0 },
+            },
+          });
+          controller.close();
+        },
+      }),
+    },
+  });
+}
+
+/**
+ * A model that writes part of an answer and then fails, which is what happens
+ * when a connection drops partway through a response.
+ */
+function truncatingModel(): LanguageModel {
+  return new MockLanguageModelV4({
+    doStream: {
+      stream: new ReadableStream({
+        start(controller) {
+          controller.enqueue({ type: "stream-start", warnings: [] });
+          controller.enqueue({ type: "text-start", id: "1" });
+          controller.enqueue({
+            type: "text-delta",
+            id: "1",
+            delta: "Half an ans",
+          });
+          controller.enqueue({
+            type: "error",
+            error: new Error("connection reset"),
+          });
+          controller.close();
+        },
+      }),
+    },
+  });
+}
+
+/**
+ * A model that fails with `payload` in place of an error. The AI SDK passes a
+ * stream's error part through untouched, so whatever a provider put there is
+ * what the reporting code has to render.
+ */
+function failingWithPayload(payload: unknown): LanguageModel {
+  return new MockLanguageModelV4({
+    doStream: {
+      stream: new ReadableStream({
+        start(controller) {
+          controller.enqueue({ type: "stream-start", warnings: [] });
+          controller.enqueue({ type: "error", error: payload });
+          controller.close();
+        },
+      }),
+    },
+  });
+}
+
+/** Reads a streaming generation's response body into one line per chunk. */
+async function readStreamLines(stream: ReadableStream): Promise<string[]> {
+  const lines: string[] = [];
+  const decoder = new TextDecoder();
+  let pending = "";
+  for await (const chunk of stream) {
+    pending += decoder.decode(chunk as Uint8Array, { stream: true });
+    const parts = pending.split("\n");
+    pending = parts.pop() ?? "";
+    lines.push(...parts.filter((line) => line !== ""));
+  }
+  if (pending !== "") lines.push(pending);
+  return lines;
+}
+
+describe("generateText failure reporting", () => {
+  it("reports the provider's failure for a non-streaming request", async () => {
+    await withMockModel(rejectingModel(), async () => {
+      const error = await assertRejects(
+        () =>
+          generateText({
+            model: MOCK_MODEL_NAME,
+            messages: [{ role: "user", content: "hi" }],
+          }),
+        Error,
+      );
+
+      assertStringIncludes(error.message, MOCK_MODEL_NAME);
+      assertStringIncludes(error.message, "Overloaded");
+      assertStringIncludes(error.message, "HTTP status 529");
+      assert(
+        APICallError.isInstance(error.cause),
+        "the provider's error should stay reachable as the cause",
+      );
+      // The response body is reported through the cause, which the log
+      // records, rather than through the message, which reaches the client.
+      assertEquals(
+        (error.cause as APICallError).responseBody,
+        '{"type":"error","error":{"type":"overloaded_error"}}',
+      );
+    });
+  });
+
+  it("reports the finish reason when a response carries no text", async () => {
+    await withMockModel(silentModel(), async () => {
+      const error = await assertRejects(
+        () =>
+          generateText({
+            model: MOCK_MODEL_NAME,
+            messages: [{ role: "user", content: "hi" }],
+          }),
+        Error,
+      );
+
+      assertStringIncludes(error.message, MOCK_MODEL_NAME);
+      assertStringIncludes(error.message, "finish reason: length");
+      assertStringIncludes(error.message, "output tokens: 0");
+    });
+  });
+
+  it("fails rather than returning an answer that was cut short", async () => {
+    await withMockModel(truncatingModel(), async () => {
+      const error = await assertRejects(
+        () =>
+          generateText({
+            model: MOCK_MODEL_NAME,
+            messages: [{ role: "user", content: "hi" }],
+          }),
+        Error,
+      );
+
+      assertStringIncludes(error.message, MOCK_MODEL_NAME);
+      assertStringIncludes(error.message, "connection reset");
+    });
+  });
+
+  it("spells out a failure the provider reported as a plain object", async () => {
+    const payload = { type: "overloaded_error", message: "Overloaded" };
+    await withMockModel(failingWithPayload(payload), async () => {
+      const error = await assertRejects(
+        () =>
+          generateText({
+            model: MOCK_MODEL_NAME,
+            messages: [{ role: "user", content: "hi" }],
+          }),
+        Error,
+      );
+
+      assertStringIncludes(error.message, JSON.stringify(payload));
+      assertEquals(error.message.includes("[object Object]"), false);
+    });
+  });
+
+  it("survives a failure reported without a value", async () => {
+    await withMockModel(failingWithPayload(null), async () => {
+      const error = await assertRejects(
+        () =>
+          generateText({
+            model: MOCK_MODEL_NAME,
+            messages: [{ role: "user", content: "hi" }],
+          }),
+        Error,
+      );
+
+      // The description of the failure must not itself fail; a TypeError from
+      // this code would replace the report with its own stack.
+      assertEquals(error instanceof TypeError, false);
+      assertStringIncludes(error.message, MOCK_MODEL_NAME);
+    });
+  });
+
+  it("reports the provider's failure on a streaming request", async () => {
+    await withMockModel(rejectingModel(), async () => {
+      const result = await generateText({
+        model: MOCK_MODEL_NAME,
+        messages: [{ role: "user", content: "hi" }],
+        stream: true,
+      });
+      assert(result.stream, "a streaming request should return a stream");
+      const lines = await readStreamLines(result.stream);
+
+      assertEquals(lines.length, 1);
+      const event = JSON.parse(lines[0]);
+      assertEquals(event.type, "error");
+      assertStringIncludes(event.error, MOCK_MODEL_NAME);
+      assertStringIncludes(event.error, "Overloaded");
+      assertStringIncludes(event.error, "HTTP status 529");
+      assertEquals(
+        lines.some((line) => line.includes('"finish"')),
+        false,
+        "a failed stream should not report itself finished",
+      );
+    });
   });
 });

--- a/packages/toolshed/routes/ai/llm/generateText.ts
+++ b/packages/toolshed/routes/ai/llm/generateText.ts
@@ -1,4 +1,12 @@
-import { jsonSchema, ModelMessage, stepCountIs, streamText, tool } from "ai";
+import {
+  type FinishReason,
+  jsonSchema,
+  type LanguageModelUsage,
+  ModelMessage,
+  stepCountIs,
+  streamText,
+  tool,
+} from "ai";
 import { trace } from "@opentelemetry/api";
 import {
   type LLMNativeModelToolId,
@@ -6,6 +14,11 @@ import {
   type LLMRequest,
 } from "@commonfabric/llm/types";
 import { type BuiltInLLMMessage } from "@commonfabric/api";
+import {
+  LLMRequestError,
+  LLMUpstreamError,
+  upstreamStatusOf,
+} from "./errors.ts";
 import { findModel, type ModelConfig } from "./models.ts";
 import { normalizeSchemaForProvider } from "./schema.ts";
 import {
@@ -149,19 +162,101 @@ export function applyNativeModelTools(
   };
   for (const toolId of nativeModelToolIds) {
     if (tools[toolId] !== undefined) {
-      throw new Error(
+      throw new LLMRequestError(
         `Native model tool '${toolId}' conflicts with an existing tool definition`,
       );
     }
     const factory = modelConfig.nativeModelToolFactories?.[toolId];
     if (factory === undefined) {
-      throw new Error(
+      throw new LLMRequestError(
         `Native model tool '${toolId}' is not supported by model '${modelConfig.name}'`,
       );
     }
     tools[toolId] = factory();
   }
   streamParams.tools = tools;
+}
+
+// A description ends up in an HTTP response body as well as in the log, so
+// cap it. A provider states a failure in a few hundred characters, but a proxy
+// in front of one can answer with a whole HTML page.
+const MAX_ERROR_DESCRIPTION_CHARS = 1000;
+
+function truncateDescription(text: string): string {
+  return text.length > MAX_ERROR_DESCRIPTION_CHARS
+    ? `${text.slice(0, MAX_ERROR_DESCRIPTION_CHARS)}… (truncated)`
+    : text;
+}
+
+/**
+ * Renders a failure the AI SDK recorded as one line of text. An HTTP status
+ * separates a request the provider turned down from a rate limit or an
+ * outage. The provider's response body is left out: it reaches the log
+ * through the cause of the error this description goes into.
+ */
+function describeStreamError(error: unknown): string {
+  if (typeof error !== "object" || error === null) {
+    return truncateDescription(String(error));
+  }
+  if (!(error instanceof Error)) {
+    // A provider can report a failure as a plain object lifted out of the
+    // response rather than as an error.
+    try {
+      return truncateDescription(JSON.stringify(error));
+    } catch {
+      return truncateDescription(String(error));
+    }
+  }
+  const { statusCode } = error as { statusCode?: unknown };
+  const status = typeof statusCode === "number"
+    ? `; HTTP status ${statusCode}`
+    : "";
+  return `${error.name}: ${truncateDescription(error.message)}${status}`;
+}
+
+/**
+ * Wraps a recorded stream failure for the caller to throw. The description
+ * goes in the message because the message is all that reaches the client:
+ * `llm.handlers.ts` puts it in the response body and drops the cause. The
+ * cause carries the provider's own error, whose fields the log records.
+ */
+function streamFailureError(failure: unknown, modelName: string): Error {
+  return new LLMUpstreamError(
+    `LLM request to ${modelName} failed: ${describeStreamError(failure)}`,
+    { cause: failure, upstreamStatus: upstreamStatusOf(failure) },
+  );
+}
+
+// Reasons a response holds no text that say what the caller asked for rather
+// than that the provider failed: an output budget spent before the first
+// token, a turn the model answered with tool calls, a filter that refused the
+// content. This route returns text alone, so a turn of tool calls arrives here
+// as an empty response.
+const CALLER_OWNED_FINISH_REASONS: ReadonlySet<FinishReason> = new Set(
+  ["length", "tool-calls", "content-filter"],
+);
+
+/**
+ * Describes a response that carried neither text nor a failure. The finish
+ * reason says where it came from and the token counts show whether the model
+ * wrote anything at all.
+ */
+async function emptyResponseError(
+  llmStream: {
+    finishReason: PromiseLike<FinishReason>;
+    totalUsage: PromiseLike<LanguageModelUsage>;
+  },
+  modelName: string,
+): Promise<Error> {
+  const finishReason = await llmStream.finishReason;
+  const usage = await llmStream.totalUsage;
+  const message = `No text in the response from ${modelName} ` +
+    `(finish reason: ${finishReason}, ` +
+    `input tokens: ${usage.inputTokens ?? "unknown"}, ` +
+    `output tokens: ${usage.outputTokens ?? "unknown"})`;
+  return CALLER_OWNED_FINISH_REASONS.has(finishReason)
+    ? new LLMRequestError(message)
+    : new LLMUpstreamError(message);
 }
 
 async function readNativeModelToolResults(
@@ -200,12 +295,14 @@ export async function generateText(
   const modelConfig = findModel(params.model!);
   if (!modelConfig) {
     console.error("Unsupported model:", params.model);
-    throw new Error(`Unsupported model: ${params.model}`);
+    throw new LLMRequestError(`Unsupported model: ${params.model}`);
   }
 
   // Groq models don't support streaming in JSON mode
   if (params.mode && params.stream && params.model?.startsWith("groq:")) {
-    throw new Error("Groq models don't support streaming in JSON mode");
+    throw new LLMRequestError(
+      "Groq models don't support streaming in JSON mode",
+    );
   }
 
   // Since our BuiltInLLMMessage types are now aligned with Vercel AI SDK, no conversion needed
@@ -219,6 +316,12 @@ export async function generateText(
     abortSignal: params.abortSignal,
     telemetry: { isEnabled: true },
     maxOutputTokens: params.maxTokens,
+    // The AI SDK otherwise sleeps and sends the request again twice before
+    // reporting a failure, holding the caller's connection open meanwhile and
+    // replacing the provider's answer with a wrapper that carries no status.
+    // One attempt, reported as it happened, leaves the decision to retry with
+    // the caller, who now has a status to make it on.
+    maxRetries: 0,
     stopWhen: stepCountIs(8), // TODO(bf): low limit to prevent runaway process
   };
 
@@ -298,6 +401,19 @@ export async function generateText(
   streamParams.runtimeContext = runtimeContext;
   streamParams.telemetry = { isEnabled: true, includeRuntimeContext };
 
+  // Anything that goes wrong once the request is under way — a provider
+  // rejecting it, a rate limit, a connection dropping mid-response, a stream
+  // that ends without a finish chunk — reaches the caller as an `error` part
+  // inside the stream instead of as a rejection. Both `textStream` and the
+  // parts of `fullStream` read below drop those parts, so record the first
+  // one here. Both paths then fail on it, including when text had already
+  // arrived: a response cut short is reported rather than passed off as a
+  // whole one.
+  let streamFailure: unknown;
+  streamParams.onError = ({ error }) => {
+    streamFailure ??= error;
+  };
+
   // This is where the LLM API call is made
   const llmStream = await streamText(streamParams);
 
@@ -325,8 +441,12 @@ export async function generateText(
       result += delta;
     }
 
+    if (streamFailure !== undefined) {
+      throw streamFailureError(streamFailure, modelConfig.name);
+    }
+
     if (!result) {
-      throw new Error("No response from LLM");
+      throw await emptyResponseError(llmStream, modelConfig.name);
     }
 
     // Clean up JSON responses when mode is enabled
@@ -433,6 +553,12 @@ export async function generateText(
               ),
             );
           }
+        }
+
+        // Check before reading `finishReason`, which reports a failed stream
+        // as a generic "no output generated" rejection that has lost the cause.
+        if (streamFailure !== undefined) {
+          throw streamFailureError(streamFailure, modelConfig.name);
         }
 
         // Only add stop token if not in JSON mode to avoid breaking JSON structure

--- a/packages/toolshed/routes/ai/llm/llm.handlers.ts
+++ b/packages/toolshed/routes/ai/llm/llm.handlers.ts
@@ -6,6 +6,7 @@ import type {
   GenerateTextRoute,
   GetModelsRoute,
 } from "./llm.routes.ts";
+import { httpStatusForError, LLMUpstreamError } from "./errors.ts";
 import { ALIAS_NAMES, ModelList, MODELS, TASK_MODELS } from "./models.ts";
 import { CacheItem, hashKey, loadFromCache, saveToCache } from "./cache.ts";
 import type { Context } from "@hono/hono";
@@ -27,6 +28,25 @@ const removeNonCacheableFields = (
   // No guarantee that `messages` exists here.
   return rest as unknown as CacheItem;
 };
+
+/**
+ * Reads the request body as JSON. A body that is not JSON at all reaches the
+ * framework as a failure with no status of its own, so it is caught here.
+ */
+async function readJsonBody(
+  c: Context,
+): Promise<{ ok: true; payload: any } | { ok: false; error: string }> {
+  try {
+    return { ok: true, payload: await c.req.json() };
+  } catch (error) {
+    return {
+      ok: false,
+      error: `Request body is not JSON: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    };
+  }
+}
 
 /**
  * Validates that the model and JSON mode settings are compatible
@@ -118,7 +138,11 @@ export const getModels: AppRouteHandler<GetModelsRoute> = (c) => {
  * Generates text using specified LLM model or task
  */
 export const generateText: AppRouteHandler<GenerateTextRoute> = async (c) => {
-  const payload = await c.req.json();
+  const body = await readJsonBody(c);
+  if (!body.ok) {
+    return c.json({ error: body.error }, HttpStatusCodes.BAD_REQUEST);
+  }
+  const payload = body.payload;
   if (!isLLMRequest(payload)) {
     return c.json(
       {
@@ -227,7 +251,7 @@ export const generateText: AppRouteHandler<GenerateTextRoute> = async (c) => {
   } catch (error) {
     console.error("Error in generateText:", error);
     const message = error instanceof Error ? error.message : "Unknown error";
-    return c.json({ error: message }, HttpStatusCodes.BAD_REQUEST);
+    return c.json({ error: message }, httpStatusForError(error));
   }
 };
 
@@ -236,7 +260,11 @@ export const generateText: AppRouteHandler<GenerateTextRoute> = async (c) => {
  * Submits user feedback on an LLM response to Phoenix
  */
 export const submitFeedback: AppRouteHandler<FeedbackRoute> = async (c) => {
-  const payload = await c.req.json();
+  const body = await readJsonBody(c);
+  if (!body.ok) {
+    return c.json({ error: body.error }, HttpStatusCodes.BAD_REQUEST);
+  }
+  const payload = body.payload;
 
   try {
     const phoenixPayload = {
@@ -261,21 +289,34 @@ export const submitFeedback: AppRouteHandler<FeedbackRoute> = async (c) => {
       body: JSON.stringify(phoenixPayload),
     };
 
-    const response = await fetch(
-      `${env.CFTS_AI_LLM_PHOENIX_API_URL}/span_annotations?sync=false`,
-      phoenixAnnotationPayload,
-    );
+    let response: Response;
+    try {
+      response = await fetch(
+        `${env.CFTS_AI_LLM_PHOENIX_API_URL}/span_annotations?sync=false`,
+        phoenixAnnotationPayload,
+      );
+    } catch (error) {
+      throw new LLMUpstreamError(
+        `Phoenix API unreachable: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        { cause: error },
+      );
+    }
 
     if (!response.ok) {
-      const errorText = await response.text();
-      throw new Error(`Phoenix API error: ${response.status} ${errorText}`);
+      const errorText = await response.text().catch(() => "");
+      throw new LLMUpstreamError(
+        `Phoenix API error: ${response.status} ${errorText}`,
+        { upstreamStatus: response.status },
+      );
     }
 
     return c.json({ success: true }, HttpStatusCodes.OK);
   } catch (error) {
     console.error("Error submitting feedback:", error);
     const message = error instanceof Error ? error.message : "Unknown error";
-    return c.json({ error: message }, HttpStatusCodes.BAD_REQUEST);
+    return c.json({ error: message }, httpStatusForError(error));
   }
 };
 
@@ -286,7 +327,11 @@ export const submitFeedback: AppRouteHandler<FeedbackRoute> = async (c) => {
 export const generateObject: AppRouteHandler<GenerateObjectRoute> = async (
   c,
 ) => {
-  const payload = await c.req.json();
+  const body = await readJsonBody(c);
+  if (!body.ok) {
+    return c.json({ error: body.error }, HttpStatusCodes.BAD_REQUEST);
+  }
+  const payload = body.payload;
 
   if (!payload.messages || !payload.schema) {
     const missing = [
@@ -341,6 +386,6 @@ export const generateObject: AppRouteHandler<GenerateObjectRoute> = async (
   } catch (error) {
     console.error("Error in generateObject:", error);
     const message = error instanceof Error ? error.message : "Unknown error";
-    return c.json({ error: message }, HttpStatusCodes.BAD_REQUEST);
+    return c.json({ error: message }, httpStatusForError(error));
   }
 };

--- a/packages/toolshed/routes/ai/llm/llm.routes.ts
+++ b/packages/toolshed/routes/ai/llm/llm.routes.ts
@@ -20,6 +20,56 @@ import {
 
 const tags = ["AI Language Models"];
 
+const ErrorSchema = z.object({ error: z.string() });
+
+// The shape stoker's validation hook answers with, which differs from the one
+// the handlers write.
+const ValidationErrorSchema = z.object({
+  success: z.boolean(),
+  error: z.object({
+    name: z.string(),
+    issues: z.array(z.record(z.string(), z.any())),
+  }),
+});
+
+/**
+ * The ways a request to these routes fails, told apart by status so a caller
+ * knows whether to change the request, repeat it later, or report the service
+ * as broken. A streaming request that fails once its response body has begun
+ * cannot use any of these: its status is already 200 and the failure arrives
+ * as an `error` event in the stream.
+ */
+const failureResponses = {
+  [HttpStatusCodes.BAD_REQUEST]: jsonContent(
+    ErrorSchema,
+    "The request names something this service does not offer, asks for more than the model can produce, or carries something the model refused.",
+  ),
+  [HttpStatusCodes.UNPROCESSABLE_ENTITY]: jsonContent(
+    ValidationErrorSchema,
+    "The request body does not match the schema for this route.",
+  ),
+  [HttpStatusCodes.TOO_MANY_REQUESTS]: jsonContent(
+    ErrorSchema,
+    "The model provider is rate limiting these requests. Make the request again later.",
+  ),
+  [HttpStatusCodes.INTERNAL_SERVER_ERROR]: jsonContent(
+    ErrorSchema,
+    "This service is misconfigured, or failed for a reason it does not recognise.",
+  ),
+  [HttpStatusCodes.BAD_GATEWAY]: jsonContent(
+    ErrorSchema,
+    "The model provider failed, or answered with something this service could not use.",
+  ),
+  [HttpStatusCodes.SERVICE_UNAVAILABLE]: jsonContent(
+    ErrorSchema,
+    "The model provider is overloaded. Make the request again later.",
+  ),
+  [HttpStatusCodes.GATEWAY_TIMEOUT]: jsonContent(
+    ErrorSchema,
+    "The exchange with the model provider ran out of time.",
+  ),
+} as const;
+
 const NativeModelToolIdSchema = z.enum(LLM_NATIVE_MODEL_TOOL_IDS);
 
 const TextPartSchema = z.object({
@@ -245,16 +295,7 @@ export const generateText = createRoute({
       description:
         "Generated text response. NOTE: If you make a request with `stream: true`, the server answers with a `text/event-stream` of newline-delimited JSON events instead of a single message object; the message is assembled from the `text-delta` events as they arrive.",
     },
-    [HttpStatusCodes.BAD_REQUEST]: {
-      content: {
-        "application/json": {
-          schema: z.object({
-            error: z.string(),
-          }),
-        },
-      },
-      description: "Invalid request parameters",
-    },
+    ...failureResponses,
   },
 });
 
@@ -293,16 +334,7 @@ export const feedback = createRoute({
       }),
       "Feedback submitted successfully",
     ),
-    [HttpStatusCodes.BAD_REQUEST]: {
-      content: {
-        "application/json": {
-          schema: z.object({
-            error: z.string(),
-          }),
-        },
-      },
-      description: "Invalid request parameters",
-    },
+    ...failureResponses,
   },
 });
 
@@ -353,16 +385,7 @@ export const generateObject = createRoute({
       }),
       "Generated object",
     ),
-    [HttpStatusCodes.BAD_REQUEST]: jsonContent(
-      z.object({
-        error: z.string(),
-      }).openapi({
-        example: {
-          error: "idea is missing",
-        },
-      }),
-      "Invalid request parameters",
-    ),
+    ...failureResponses,
   },
 });
 

--- a/packages/toolshed/routes/ai/llm/llm.status.test.ts
+++ b/packages/toolshed/routes/ai/llm/llm.status.test.ts
@@ -1,0 +1,235 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { APICallError, type LanguageModel } from "ai";
+import { MockLanguageModelV4 } from "ai/test";
+
+import env from "@/env.ts";
+import createApp from "@/lib/create-app.ts";
+import router from "@/routes/ai/llm/llm.index.ts";
+import { MODELS } from "@/routes/ai/llm/models.ts";
+
+if (env.ENV !== "test") {
+  throw new Error("ENV must be 'test'");
+}
+
+// A caller acts on the status before it reads the body: a request it must
+// change, one it should make again later, and one this service or a provider
+// broke all call for different handling. These drive the real router so the
+// status a caller sees is what is asserted.
+
+const app = createApp().route("/", router);
+
+const MOCK_MODEL_NAME = "mock:status-model";
+
+/** A model that turns the request down the way a provider does. */
+function rejectingWith(statusCode: number, message: string): LanguageModel {
+  return new MockLanguageModelV4({
+    doStream: () => {
+      throw new APICallError({
+        message,
+        url: "https://provider.example/v1/messages",
+        requestBodyValues: {},
+        statusCode,
+        responseBody: `{"error":"${message}"}`,
+      });
+    },
+  });
+}
+
+/** A model that answers without writing any text. */
+function silentModel(): LanguageModel {
+  return new MockLanguageModelV4({
+    doStream: {
+      stream: new ReadableStream({
+        start(controller) {
+          controller.enqueue({ type: "stream-start", warnings: [] });
+          controller.enqueue({
+            type: "finish",
+            finishReason: { unified: "length", raw: "max_tokens" },
+            usage: {
+              inputTokens: {
+                total: 1,
+                noCache: 1,
+                cacheRead: 0,
+                cacheWrite: 0,
+              },
+              outputTokens: { total: 0, text: 0, reasoning: 0 },
+            },
+          });
+          controller.close();
+        },
+      }),
+    },
+  });
+}
+
+/**
+ * Registers `model` under a name that `findModel` resolves, runs `body`, then
+ * takes the registration back out of the shared model list.
+ */
+async function withMockModel<T>(
+  model: LanguageModel | undefined,
+  body: () => Promise<T>,
+): Promise<T> {
+  if (model) {
+    MODELS[MOCK_MODEL_NAME] = {
+      model,
+      name: MOCK_MODEL_NAME,
+      capabilities: {
+        contextWindow: 1000,
+        maxOutputTokens: 100,
+        streaming: true,
+        systemPrompt: true,
+        stopSequences: true,
+        prefill: false,
+        images: false,
+        reasoning: false,
+      },
+      aliases: [],
+    };
+  }
+  try {
+    return await body();
+  } finally {
+    delete MODELS[MOCK_MODEL_NAME];
+  }
+}
+
+/** Posts a body and reads back the status and the error it carried. */
+async function post(
+  path: string,
+  requestBody: unknown,
+): Promise<{ status: number; error: string }> {
+  const response = await app.request(path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: typeof requestBody === "string"
+      ? requestBody
+      : JSON.stringify(requestBody),
+  });
+  const body = await response.json();
+  return { status: response.status, error: body.error ?? "" };
+}
+
+function statusFor(
+  model: LanguageModel | undefined,
+  requestedModel = MOCK_MODEL_NAME,
+  extraRequestFields: Record<string, unknown> = {},
+): Promise<{ status: number; error: string }> {
+  return withMockModel(model, () =>
+    post("/api/ai/llm", {
+      model: requestedModel,
+      messages: [{ role: "user", content: "hi" }],
+      cache: false,
+      ...extraRequestFields,
+    }));
+}
+
+Deno.test("a provider outage is not reported as the caller's mistake", async () => {
+  const { status, error } = await statusFor(
+    rejectingWith(500, "Internal server error"),
+  );
+  assertEquals(status, 502);
+  assertStringIncludes(error, "Internal server error");
+});
+
+Deno.test("a rate limit is passed along so the caller can wait", async () => {
+  const { status } = await statusFor(
+    rejectingWith(429, "Rate limit exceeded"),
+  );
+  assertEquals(status, 429);
+});
+
+Deno.test("a provider timeout is reported as a gateway timeout", async () => {
+  const { status } = await statusFor(rejectingWith(408, "Request timeout"));
+  assertEquals(status, 504);
+});
+
+Deno.test("a request the provider refused stays the caller's to fix", async () => {
+  const { status } = await statusFor(
+    rejectingWith(400, "prompt is too long: 300000 tokens > 200000 maximum"),
+  );
+  assertEquals(status, 400);
+});
+
+Deno.test("an overloaded provider is reported as temporary", async () => {
+  const { status } = await statusFor(rejectingWith(529, "Overloaded"));
+  assertEquals(status, 503);
+});
+
+Deno.test("a key the provider rejected is this service's to fix", async () => {
+  const { status } = await statusFor(rejectingWith(401, "invalid x-api-key"));
+  assertEquals(status, 500);
+});
+
+Deno.test("an output budget spent before the first token is the caller's", async () => {
+  const { status, error } = await statusFor(silentModel());
+  assertEquals(status, 400);
+  assertStringIncludes(error, "finish reason: length");
+});
+
+Deno.test("a model this service does not carry is the caller's mistake", async () => {
+  const { status, error } = await statusFor(undefined, "mock:no-such-model");
+  assertEquals(status, 400);
+  assertStringIncludes(error, "Unknown model 'mock:no-such-model'");
+});
+
+Deno.test("a tool the model cannot serve is the caller's mistake", async () => {
+  const { status, error } = await statusFor(
+    rejectingWith(500, "unreached"),
+    MOCK_MODEL_NAME,
+    { nativeModelToolIds: ["google_search"] },
+  );
+  assertEquals(status, 400);
+  assertStringIncludes(error, "is not supported by model");
+});
+
+// A body sent as JSON is parsed by the route's own validator, which answers
+// its own 400 before the handler runs. A body sent as anything else reaches
+// the handler unparsed.
+Deno.test("a body that is not JSON is the caller's mistake", async () => {
+  const response = await app.request("/api/ai/llm", {
+    method: "POST",
+    headers: { "Content-Type": "text/plain" },
+    body: "hello",
+  });
+  assertEquals(response.status, 400);
+  assertStringIncludes((await response.json()).error, "not JSON");
+});
+
+Deno.test("a body that does not match the schema is reported as unprocessable", async () => {
+  const { status } = await post("/api/ai/llm", { messages: "not an array" });
+  assertEquals(status, 422);
+});
+
+Deno.test("a schema that cannot compile is the caller's mistake", async () => {
+  const { status, error } = await withMockModel(
+    rejectingWith(500, "unreached"),
+    () =>
+      post("/api/ai/llm/generateObject", {
+        messages: [{ role: "user", content: "hi" }],
+        schema: { type: "notatype" },
+        model: MOCK_MODEL_NAME,
+        cache: false,
+      }),
+  );
+  assertEquals(status, 400);
+  assertStringIncludes(error, "Schema cannot be compiled");
+});
+
+Deno.test("a model generateObject does not carry is the caller's mistake", async () => {
+  const response = await app.request("/api/ai/llm/generateObject", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      messages: [{ role: "user", content: "hi" }],
+      schema: { type: "object" },
+      model: "mock:no-such-model",
+      cache: false,
+    }),
+  });
+  assertEquals(response.status, 400);
+  assertStringIncludes(
+    (await response.json()).error,
+    "Unsupported model: mock:no-such-model",
+  );
+});


### PR DESCRIPTION
Production logs carried a steady trickle of "Error in generateText: Error: No response from LLM" with nothing to act on, and the routes answered every failure with 400 Bad Request. Between them, a provider outage, a rate limit, a rejected API key, a prompt past the context window and a genuinely malformed request were indistinguishable, and the pair of them told the caller the fault was theirs.

## Why the message said nothing

The Vercel AI SDK's streamText does not reject when a request fails after it has started. It delivers the failure as an error part carried inside the response stream and hands it to the onError callback. The text side of that stream drops every part that is not a text delta, so the non-streaming path accumulated an empty string and threw a message that said only that the string was empty. The streaming path ignored those parts as well, then read the finish reason, which rejects with a generic "no output generated" that has likewise lost the cause.

Record the first failure the stream reports, and report it from both paths. The message now names the model, the provider's message and its HTTP status, and the provider's own error stays reachable as the cause, whose fields the log records. A response that carries neither text nor a failure is a different situation and says so, naming the finish reason and the token counts.

A stream that fails partway through is now an error even when some text had already arrived, rather than a truncated answer presented as a whole one.

Describing a failure must not itself fail. A provider that reports one as a plain object rather than as an error is spelled out rather than rendered "[object Object]", and one reported with no value at all no longer reaches a property read on null.

## Why the status said the wrong thing

Sorting failures needs the provider's status to survive, and it did not. The SDK sends a failed request again twice before reporting anything, sleeping between attempts, for exactly the failures that matter most here: 408, 409, 429, and every 5xx. What it then reports is not the provider's answer but a wrapper carrying no status at all. So both routes held the caller's connection open through several seconds of waiting and then told them to try again later, in a form that could not be read. Both routes now ask once. The decision to ask again belongs to the caller, who now has a status to make it on. Where such a wrapper appears anyway, the search for a status opens it and follows the chain of causes underneath.

Two error types then carry the distinction from where a failure is raised to where the response is written: one for a request naming something the service does not offer, one for a service these routes call. errors.ts states the judgement in each case. A rate limit is passed along, and so is an overloaded provider, because waiting is the caller's to do. A provider objecting to what the request contained stays a 400, because this service built that request out of the caller's payload and the caller can shorten a prompt or change a schema. A provider rejecting a key or refusing to bill an account is answering a request this service got wrong, so that is a 500. A provider that failed to answer usefully at all is a 502.

Several failures the caller owns were reported against the provider, or against the service. Half the AI SDK's errors are raised over what the caller sent before any provider is asked, and those are named. A schema Ajv cannot compile comes straight from the caller. A response that stopped at the output limit, or that the model spent on tool calls, or that a content filter refused, says what the caller asked for. A body sent without a JSON content type reaches the handler unparsed. generateObject also reached into an unresolved model config and failed with a TypeError on a model name it did not carry; it now reports the name.

Reaching the annotation service behind the feedback route can fail before any response exists, which is that service failing.

The routes now declare the 422 their own validator answers with, and say that a streaming response cannot carry any of these statuses, since its status is fixed at 200 before the failure happens.

## Elsewhere

The client logged the same "check that you're passing the correct parameters" hint for every failed request. That hint now follows the status, so a provider outage no longer sends a developer looking through their own arguments.

The tests drive generateText and the real router against stand-in language models registered in the model registry, which is the first time that registry is used that way; the language-model testing document describes the technique and the properties of the SDK that shape it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve LLM error reporting and HTTP statuses so callers know whether to fix the request, retry later, or report an outage. Streaming and non‑streaming now surface the model, provider message, and status, and keep the provider error as the cause.

- **New Features**
  - Classify failures via `errors.ts` and return accurate statuses: 400, 422, 429, 500, 502, 503, 504; streaming emits an `error` event rather than returning truncated text.
  - Capture provider failures from the SDK stream (`onError`), including model name, provider message, and HTTP status; empty responses report finish reason and token usage; one attempt per request (`maxRetries: 0`); `LLMClient` console hint now follows status.
  - Routes and OpenAPI advertise upstream‑aware failures; handlers reject non‑JSON bodies with 400; feedback route propagates Phoenix failures with correct statuses.

- **Bug Fixes**
  - Treat truncated streams as errors; render provider error payloads safely (no “[object Object]” or null derefs).
  - `generateObject`: unknown models and Ajv compile errors return 400 with the requested model name; native tool conflicts/unsupported tools now return 400; block Groq JSON‑mode streaming with a clear 400.

<sup>Written for commit 2cd5cae0454d8d11b03a3d2a590892a976d66684. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

