### PR TITLE
test(runner): make the flatMap contribution's coverage independent of…

### DIFF
--- a/docs/development/COVERAGE.md
+++ b/docs/development/COVERAGE.md
@@ -116,6 +116,27 @@ and therefore stricter — bar rather than failing anything. The instrumented
 statements are also the only lines this mechanism can speak to: a line the
 instrumentation cannot reach is not a line a pattern test could cover.
 
+## Coverage must not depend on the execution environment
+
+Whether a line counts as covered must not depend on how fast the machine ran,
+how the test files were distributed across shards, or any other property of the
+environment or configuration. A line that is covered on one run and uncovered
+on the next is a defect in the tests. It is not noise for the gate to absorb,
+and it is not something to wave through with an override.
+
+So when you find a line whose coverage moves with the environment — a branch
+guarded on elapsed wall-clock time, a line whose count changes when test files
+are redistributed across shards, a path that only some runs happen to take —
+write a test that covers that line reliably on every run and under every
+configuration. Extract the code into something a plain unit test can call
+directly if that is what it takes: a unit test that constructs the input it
+wants does not care how loaded the machine is or which shard it landed in.
+
+The
+[2026-07-28 investigation record](../history/development/coverage-ratchet-noise-2026-07-28.md)
+works through two real instances, and describes how to localize a group-level
+change down to the specific file and line so you know what to write a test for.
+
 ## Ratchet baselines and accepting debt
 
 The ratchet applies per source group and only to the groups a PR changes: for

--- a/docs/development/deno-coverage-guard-line-artifact.md
+++ b/docs/development/deno-coverage-guard-line-artifact.md
@@ -5,10 +5,10 @@ A one-line conditional guard — `if (cond) return …;`, `if (cond) throw …;`
 function runs but the guarded branch is never taken, even though the `cond`
 condition is evaluated on every call.
 
-Most of this is expected. V8 collects coverage at block (byte-range)
-granularity rather than per line: the guard's body (`throw …`, `return …`,
-`continue`) is its own range with its own execution count, and a branch that is
-never taken legitimately has a count of 0. The V8 blog post
+This is expected. V8 collects coverage at block (byte-range) granularity rather
+than per line: the guard's body (`throw …`, `return …`, `continue`) is its own
+range with its own execution count, and a branch that is never taken legitimately
+has a count of 0. The V8 blog post
 ["JavaScript code coverage"](https://v8.dev/blog/javascript-code-coverage)
 describes this directly — "block coverage could detect that the `else` branch …
 is never executed." A whole-line hit count is a projection of those block ranges
@@ -16,13 +16,8 @@ onto lines, and the blog does not specify how that projection should work; it is
 the coverage tool's job. When a single line holds both the executed condition and
 the un-taken body, projecting it to 0 is a defensible choice, not a bug.
 
-One projection behaviour is not defensible, and it is the only part worth
-reporting upstream: a trailing comment on the guard line flips the reported line
-count from 0 to 1, even though a comment changes nothing about what executes. The
-reproduction below isolates it.
-
 This note records the behaviour because several deliberately-unreachable
-invariant guards in the runtime are marked uncovered solely because of it.
+invariant guards in the runtime are marked uncovered by it.
 
 ## Where it bites us
 
@@ -50,21 +45,16 @@ These conditions are evaluated on every call, but their branches are not taken
 in single-space, healthy-transaction tests, so deno reports each guard line as
 uncovered.
 
-## Isolating the line-attribution quirk
+## Reproduction
 
 ```ts
 // guard.ts
-function noComment(x: unknown): number {
+function guarded(x: unknown): number {
   if (!x) throw new Error("e");
   return 1;
 }
-function withComment(x: unknown): number {
-  if (!x) throw new Error("e"); // a trailing comment
-  return 1;
-}
 if (import.meta.main) {
-  noComment({}); // truthy argument: the `if (!x)` branch is never taken
-  withComment({});
+  guarded({}); // truthy argument: the `if (!x)` branch is never taken
 }
 ```
 
@@ -73,52 +63,23 @@ deno run --coverage=cov guard.ts
 deno coverage cov --lcov | grep '^DA:'
 ```
 
-Observed on deno 2.8.3:
-
 ```
 DA:2,0   // if (!x) throw new Error("e");
 DA:3,1   // return 1;
-DA:6,1   // if (!x) throw new Error("e"); // a trailing comment
-DA:7,1   // return 1;
 ```
 
-`noComment` and `withComment` contain identical executable code and are each
-called once with a truthy argument. Line 2 (no trailing comment) is reported as
-0 hits; line 6 (the same statement with a trailing comment) is reported as 1
-hit. A comment cannot change what executes, so the difference is purely a
-line-attribution artifact: deno credits the line to whatever byte range ends it
-— the untaken branch statement when nothing follows, the covered trailing
-comment when one does.
-
-## Expected vs actual
-
-The block-level fact — the un-taken `throw` executes 0 times — is correct and
-expected. The defect is only in how that projects onto a line count:
-
-- Expected: two lines containing identical executable code report the same line
-  hit count.
-- Actual: line 2 reports 0 hits while line 6 — the same statement with a
-  trailing comment — reports 1. A comment, which does not execute, decides the
-  count.
-
-## Reporting upstream
-
-Only the trailing-comment line-attribution flip is worth reporting; the un-taken
-branch reporting 0 hits is documented V8 block-granularity behaviour and should
-not be filed as a bug. A search of deno's open issues found no existing report of
-comment-sensitive line coverage or `deno coverage` line attribution. The closest
-match, [denoland/deno#9865](https://github.com/denoland/deno/issues/9865)
-("`deno coverage` line and branch counts are incorrect"), is closed and covers a
-different case — off-by-one line and branch counts around an `if`/`else` block,
-not a comment changing a line's hit count — so a focused report on the
-comment-sensitivity would not duplicate it.
+Line 2 holds both the condition, which is evaluated, and the `throw`, which is
+not reached. The line count reports the un-taken range.
 
 ## Impact and handling
 
-We do not work around this with trailing comments — that would make a comment
-load-bearing for coverage. The affected guards are left as plain one-liners.
-Writing each invariant guard on a single line keeps the artifact to one line per
-guard rather than three (the `if`, the body, and the closing brace of a block
-form). The remaining uncovered guard lines are tracked here rather than chased
-with contrived error-injection tests, since the branches are unreachable by
-construction.
+The affected guards are left as plain one-liners. Writing each invariant guard
+on a single line keeps the artifact to one line per guard rather than three (the
+`if`, the body, and the closing brace of a block form). The uncovered guard
+lines are tracked here rather than chased with contrived error-injection tests,
+since the branches are unreachable by construction.
+
+A guard line is the one case where an uncovered line is expected to stay
+uncovered. Everywhere else, a line whose coverage moves between runs or between
+shard layouts is a defect in the tests — see
+[COVERAGE.md](COVERAGE.md) for what to do about it.

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -275,6 +275,10 @@ One line per archived document; each document's header carries the fuller
 - [2026-07-binary-artifact-transfer.md](development/performance/2026-07-binary-artifact-transfer.md)
   — binary artifact file and byte transfer snapshot before the per-binary
   workflow split, July 2026.
+- [coverage-ratchet-noise-2026-07-28.md](development/coverage-ratchet-noise-2026-07-28.md)
+  — why a rename-only pull request owed coverage debt: a wall-clock-guarded
+  diagnostic and a shard re-partition each moved the `packages/runner`
+  uncovered-line count with no change to that package, July 2026.
 - [scoped-cells-field-notes.md](development/scoped-cells-field-notes.md) —
   field journal from the first scoped-cell patterns.
 - [2026-07-02-convergence-evidence-appendix.md](plans/2026-07-02-convergence-evidence-appendix.md)

--- a/docs/history/development/coverage-ratchet-noise-2026-07-28.md
+++ b/docs/history/development/coverage-ratchet-noise-2026-07-28.md
@@ -1,0 +1,268 @@
+---
+status: historical
+created: 2026-07-29
+archived: 2026-07-29
+reason: "Investigation record: why PR #5128, a type-rename-only change, had to accept coverage debt. The date in the filename is the day of the CI runs it analyses."
+---
+
+# Why a rename-only pull request owed coverage debt, July 2026
+
+## Conclusion
+
+[PR #5128](https://github.com/commontoolsinc/labs/pull/5128) renamed two
+TypeScript type aliases and changed no executable code, yet the coverage ratchet
+reported `packages/runner` at 6898 uncovered lines against a `main` baseline of
+6896, so the author accepted the debt with an override.
+
+The pull request did not add those two lines. Its coverage of `packages/runner`
+was identical, line for line, to the `main` run immediately before its baseline.
+The baseline had dropped by two lines because a different pull request landed on
+`main` in the twelve minutes between when #5128 last merged `main` and when its
+coverage job ran.
+
+Underneath that, the metric itself is far noisier than the gate's zero-line
+tolerance. Across five hours of `main` runs on 2026-07-28 the
+`packages/runner` count took four distinct values — 6896, 6898, 6935, 6937 —
+with no change to any source file in that package. Two independent mechanisms
+produce the swing, and both are described below.
+
+## What the numbers actually were
+
+The gate compares a pull request against the newest non-cold `main` run, not
+against a run of the pull request's own merge base. The relevant runs, in order:
+
+| Time (UTC) | `main` commit | Landed pull request | `packages/runner` uncovered |
+| --- | --- | --- | ---: |
+| 21:21 | `704d3108` | #5122 | 6909 |
+| 21:51 | `8be27e5c` | #5094 | 6937 |
+| 21:58 | `62d16cc2` | #5124 | 6898 |
+| 22:06 | `fc9572aa` | #5129 | 6896 |
+| 23:00–23:11 | three runs | — | 6896 |
+| 23:15 | `2567081a` | #5126 | 6935 |
+
+A `pull_request` run does not test the pull request's own head. It checks out
+`refs/pull/N/merge`, GitHub's synthetic merge of that head onto `main`, so the
+`main` commit a run was measured on top of is that merge commit's **first
+parent** — not the pull request's merge base, which can be hundreds of commits
+back. For PR #5128 the tested tree was `6f5e5449`, whose first parent is
+`8be27e5c`: the run that measured 6937.
+
+PR #5128's own coverage job measured 6898. Against the `main` it was tested on
+top of it was 39 lines *better*. Against the baseline the gate chose,
+`fc9572aa`, it was 2 lines worse.
+
+Joining the 159 LCOV shard reports from each run and differencing them per file
+gives the exact accounting. Comparing PR #5128's run to the `62d16cc2` `main`
+run: zero files differ. Comparing it to the `fc9572aa` baseline: exactly two
+lines differ, in two files the pull request never touched.
+
+- `packages/runner/src/builtins/fetch-utils.ts:69`
+- `packages/runner/src/builtins/flatmap.ts:128`
+
+## Mechanism one: adding any runner test file re-partitions the shards
+
+`tasks/select-runner-test-files.ts` splits `packages/runner/test/*.test.ts`
+across five shards by round-robin over the sorted filename list. Inserting one
+file moves every alphabetically later file into a different shard.
+
+PR #5129, which landed at 22:06 and became #5128's baseline, added
+`packages/runner/test/fake-clock-lockdown-classification.test.ts`. That name
+sorts before every `fetch-*` and `list-*` test, so 294 of the suite's 505 test
+files changed shard. Both of the two lines above sit in code that those tests
+drive.
+
+The two lines then moved for different reasons.
+
+### `fetch-utils.ts:69` — a line-attribution artifact, not a behavior change
+
+The line is the `} else {` of a two-branch conditional:
+
+```ts
+// Shown for illustration only.
+if (Object.keys(normalizedOptions).length > 0) {   // line 67
+  inputsOnly.options = normalizedOptions;          // line 68
+} else {                                           // line 69
+  delete inputsOnly.options;                       // line 70
+}
+```
+
+The else branch ran exactly once in every run examined — line 70 reports one
+hit in all of them. What changed is which shard process ran it. V8 collects
+coverage as byte ranges, and a process that takes only one of the two branches
+reports the other as an uncovered range whose boundary falls on line 69. So a
+shard that only takes the if branch reports `DA:69,0`, and a shard that only
+takes the else branch also reports `DA:69,0`. The join sums per-line counts
+across shards, and zero plus zero is zero, so the line scores as uncovered even
+though both branches demonstrably executed. After the re-partition both
+workloads landed in the same process, which reported `DA:69,11`, and the line
+scored as covered.
+
+Raw evidence, one shard report each:
+
+```text
+main 704d3108, shard runner-1 (if branch only)      DA:67,10  DA:68,10  DA:69,0   DA:70,0
+main 704d3108, shard runner-4 (else branch only)    DA:67,0   DA:68,0   DA:69,0   DA:70,1
+main 2567081a, shard runner-1 (both, one process)   DA:67,11  DA:68,10  DA:69,11  DA:70,1
+```
+
+This is the cross-shard form of a single-process artifact. In one process a
+guard line reads as uncovered because its branch is not taken, which is
+expected: V8 counts byte ranges, and a whole-line count is a projection of them.
+Here the branch *is* taken, in a different process, and summing the shard
+reports loses that fact.
+
+deno fixed this attribution. On 2.8.1, the version pinned when this ran, and on
+2.8.3, a process that takes only the if arm reports the `} else {` line as 0
+hits; on 2.9.4 it reports the count of the arm that ran, so summing the shards no
+longer loses the else branch. Reduced case, `if (n > 0) { … } else { … }` called
+once with a positive argument, lines 3 to 7:
+
+```text
+deno 2.8.3   DA:3,1  DA:4,1  DA:5,0  DA:6,0  DA:7,0
+deno 2.9.4   DA:3,1  DA:4,1  DA:5,1  DA:6,0  DA:7,0
+```
+
+### The sibling artifact, fixed in the same release
+
+Through 2.8.x a trailing comment on a guard line changed that line's reported
+count, which a comment cannot justify since it does not execute. The live note
+on guard-line coverage carried this reproduction, and it is kept here because
+the behaviour it isolates no longer occurs:
+
+```ts
+// guard.ts
+function noComment(x: unknown): number {
+  if (!x) throw new Error("e");
+  return 1;
+}
+function withComment(x: unknown): number {
+  if (!x) throw new Error("e"); // a trailing comment
+  return 1;
+}
+if (import.meta.main) {
+  noComment({}); // truthy argument: the `if (!x)` branch is never taken
+  withComment({});
+}
+```
+
+```text
+deno 2.8.3   DA:2,0  DA:3,1  DA:6,1  DA:7,1
+deno 2.9.4   DA:2,0  DA:3,1  DA:6,0  DA:7,1
+```
+
+`noComment` and `withComment` hold identical executable code and are each called
+once with a truthy argument. On 2.8.3 the commented form reported 1 hit and the
+uncommented form 0, because deno credited the line to whatever byte range ended
+it — the un-taken branch statement when nothing followed, the covered trailing
+comment when one did. On 2.9.4 both report 0. What survives on every version is
+the first line of each pair: a guard whose branch is never taken reads as
+uncovered, by design.
+
+Searching deno's issues while this stood found no existing report of either
+artifact. The closest,
+[denoland/deno#9865](https://github.com/denoland/deno/issues/9865), is closed
+and covers off-by-one line and branch counts around an `if`/`else` block rather
+than either of these. Both were fixed upstream before a report was filed.
+
+### `flatmap.ts:128` — a real difference in what the tests did
+
+The line is the array arm of the `contribute` callback the flatMap builtin hands
+to the resume republisher. Before the re-partition it executed zero times across
+the entire suite; afterwards it executed 47 times in one shard. The number of
+`contribute` calls changed as well, from 31 to 47. So here the tests genuinely
+took a different path once their grouping into processes changed — the flatMap
+resume and republish tests are sensitive to what else shares their process.
+
+## Mechanism two: a wall-clock branch in traverse.ts, worth 39 lines
+
+This one was already diagnosed, in the description of
+[PR #5087](https://github.com/commontoolsinc/labs/pull/5087) on the same day.
+It is repeated here because it was still live afterwards, and because it is the
+larger of the two sources of movement in this group.
+
+`packages/runner/src/traverse.ts` ends each traversal with a diagnostic guarded
+on elapsed time:
+
+```ts
+// Shown for illustration only.
+const elapsed = logger.timeEnd("traverse") ?? 0;
+if (elapsed > 100) {
+  // ... assemble and log a slow-traverse warning, reading
+  // this.schemaTracker.size and this.schemaTracker.totalValues
+}
+```
+
+Whether that branch is ever taken during a CI run depends on how loaded the
+machine was. In the runs examined it fired once or twice across a whole run, or
+not at all, always from a pattern-integration shard:
+
+```text
+main 8be27e5c   no shard fired      39 lines uncovered
+PR  #5128       pattern-integration-3 and -4 fired once each   covered
+main fc9572aa   pattern-integration-4 fired twice              covered
+```
+
+The block is 32 lines, and it is the only caller of `MapSet.size` and
+`MapSet.totalValues`, which are another 7 lines. So one timing-dependent branch
+decides 39 lines of the `packages/runner` total. That is the 6896 versus 6935
+step in the table above: the 23:15 run landed PR #5126, which touches only
+`packages/cli` and `docs/tutorial`, and `packages/runner` rose by exactly 39.
+
+## Why the gate cannot absorb this
+
+The ratchet's tolerance is zero lines. The measurement's own run-to-run spread
+in this one group is 39 lines from the traverse branch, plus a few more whenever
+the runner test file list changes. A rename-only pull request has no way to
+influence either.
+
+Seven of the sixty most recently merged pull requests carry a coverage override
+in their descriptions, spread across `packages/runner`, `packages/cli`,
+`packages/toolshed`, and `packages/memory`. Two of them accept `packages/runner`
+at 6948, which is the traverse swing being paid for rather than fixed.
+
+An accepted override does not raise the baseline value for later pull requests.
+`applyBaselineOverrides` in `tasks/ci-check-lib.ts` truncates the metric's
+sample timeline to start at the overriding commit, and the baseline is still the
+newest non-cold sample in what remains. So an override forgives one pull request
+and discards older history for that metric; it does not pin the number.
+
+## What removes each cause
+
+Policy is that coverage does not depend on wall-clock performance or on how the
+tests were sharded, so the fix for each of these is a test that covers the line
+on every run and under every configuration — not a looser gate and not an
+override. [COVERAGE.md](../../development/COVERAGE.md) states the policy.
+
+- `flatmap.ts` is fixed. The contribution the flatMap builtin hands to the
+  resume republisher is now a named export, and `resume-republish-unit.test.ts`
+  drives all three of its arms — array, scalar, and still-pending — through
+  the real republisher with hand-built inputs. The array arm no longer waits
+  for a resume that happens to produce an array-valued element result.
+- The slow-traverse diagnostic is fixed, in
+  [PR #5108](https://github.com/commontoolsinc/labs/pull/5108). The field
+  assembly moved into a function a unit test can call, and the threshold
+  comparison moved off the call site into a method the tests drive from both
+  sides — 150ms reports, 5ms is silent, and the boundary is pinned exactly at
+  100ms silent and 101ms reporting. Leaving the comparison at the call site
+  would not have been enough: an `if` whose body never runs marks the `if` line
+  uncovered too, so one line would have kept flapping, and against a
+  zero-tolerance ratchet a one-line swing fails a pull request exactly as a
+  39-line swing does.
+- `fetch-utils.ts:69` is fixed, by the toolchain rather than by this
+  repository. deno 2.9.4 corrects the line attribution that produced it: on
+  2.8.3 a process taking only one arm of a two-arm conditional reports the
+  boundary line as 0 hits, and on 2.9.4 it reports the count of the arm that
+  ran. The pin moved to 2.9.4 the day after this investigation, so summing the
+  shard reports no longer loses that branch.
+
+## How to reproduce this analysis
+
+Download the `coverage-profile-*` artifacts from the pull request's run and from
+the `main` runs on either side of it, then for each run join every shard's LCOV
+into one map from source line to total hits and difference the resulting
+uncovered-line sets per file. The per-file difference localizes a whole-group
+change of a few lines to the exact file and line numbers, which the pull request
+comment cannot do. Reading the individual shard reports for that file then
+distinguishes a real behavior change from a line-attribution artifact: if some
+shard reports a hit on the branch body while the branch's own line sums to zero,
+the code ran and the accounting lost it.

--- a/packages/runner/src/builtins/flatmap.ts
+++ b/packages/runner/src/builtins/flatmap.ts
@@ -38,7 +38,10 @@ import {
   scopedCell,
 } from "./scope-policy.ts";
 import { resolveOpPattern } from "./op-pattern-ref.ts";
-import { createResumeRepublisher } from "./resume-republish.ts";
+import {
+  createResumeRepublisher,
+  type ElementContribution,
+} from "./resume-republish.ts";
 import { createResumeRecovery } from "./resume-recover.ts";
 import {
   linkResolutionProbe,
@@ -49,6 +52,21 @@ import { listElementLink } from "./list-element-link.ts";
 import { getLogger } from "@commonfabric/utils/logger";
 
 const logger = getLogger("runner.flatmap", { enabled: true, level: "warn" });
+
+// Rebuild the flattened list from the per-element results: spread an array
+// result one level deep, push a defined scalar directly, and treat an undefined
+// result as still streaming in. forEach over the array skips holes, so sparse
+// per-element results densify here. See resume-republish.ts for the convergence
+// machinery.
+export const flatMapContribution: ElementContribution = (
+  elemResult,
+  _inputElement,
+  out,
+) => {
+  if (Array.isArray(elemResult)) elemResult.forEach((v) => out.push(v));
+  else if (elemResult !== undefined) out.push(elemResult);
+  else return "pending";
+};
 
 /**
  * Implementation of built-in flatMap module. Like map, this is called once at
@@ -109,11 +127,6 @@ export function flatMap(
     logger,
   });
 
-  // Rebuild the flattened list from the per-element results: spread an array
-  // result one level deep, push a defined scalar directly, and treat an undefined
-  // result as still streaming in. forEach over the array skips holes, so sparse
-  // per-element results densify here. See resume-republish.ts for the convergence
-  // machinery.
   const { awaitPendingThenRepublish } = createResumeRepublisher({
     runtime,
     logger,
@@ -124,11 +137,7 @@ export function flatMap(
     elementRuns,
     aggregateNoun: "flatMap result",
     elementNoun: "result",
-    contribute: (elemResult, _inputElement, out) => {
-      if (Array.isArray(elemResult)) elemResult.forEach((v) => out.push(v));
-      else if (elemResult !== undefined) out.push(elemResult);
-      else return "pending";
-    },
+    contribute: flatMapContribution,
   });
 
   // Hold the durable list while the input list itself confirms. On a resume

--- a/packages/runner/test/resume-republish-unit.test.ts
+++ b/packages/runner/test/resume-republish-unit.test.ts
@@ -8,12 +8,18 @@ import {
   createResumeRepublisher,
   type ElementContribution,
 } from "../src/builtins/resume-republish.ts";
+import { flatMapContribution } from "../src/builtins/flatmap.ts";
 
 // Focused coverage for the shared resume-republish machinery
 // (src/builtins/resume-republish.ts), driving the straggler and guard arms that
 // the end-to-end resume tests (list-resume-preserve.test.ts and friends) cannot
 // reach deterministically: the still-pending re-defer, the input/result guards,
 // the editWithRetry error arm, and the rejected-sync catch.
+//
+// The same harness drives each builtin's own contribution through the real
+// republisher, so every arm of a contribution is covered by a plain unit test
+// rather than by whichever end-to-end resume happens to produce that shape of
+// per-element result on a given run.
 //
 // The republisher's only real collaborators are the cells it reads and writes,
 // the runtime's editWithRetry, and the storage manager's trackUntilSettled. Each
@@ -339,6 +345,59 @@ describe("resume-republish unit", () => {
     await drain(tracked);
     // The rejected sync skips the rebuild entirely; the container is untouched.
     expect(result.setValues.length).toBe(0);
+  });
+});
+
+describe("flatMap contribution", () => {
+  it("spreads an array result one level deep and densifies its holes", async () => {
+    const inputs = [new FakeCell("e0", null), new FakeCell("e1", null)];
+    // A sparse per-element result: index 1 is a hole, which forEach steps over.
+    const sparse: unknown[] = [];
+    sparse[0] = "a";
+    sparse[2] = "c";
+    const results = [
+      new FakeCell("r0", ["x", ["y"]]),
+      new FakeCell("r1", sparse),
+    ];
+    const result = new FakeCell("container", [0, 1]);
+    const { runtime, tracked } = makeRuntime();
+    const rr = makeRepublisher({
+      result,
+      inputsList: inputs,
+      elementRuns: runsFor(inputs, results),
+      runtime,
+      contribute: flatMapContribution,
+    });
+
+    rr.awaitPendingThenRepublish(results as unknown as Cell<any>[]);
+    await drain(tracked);
+
+    // One level of spreading: the nested array survives as a single element,
+    // and the hole contributes nothing, so the output is dense.
+    expect(result.setValues.length).toBe(1);
+    expect(result.setValues[0]).toEqual(["x", ["y"], "a", "c"]);
+  });
+
+  it("pushes a defined scalar result and skips a settled-undefined one", async () => {
+    const inputs = [new FakeCell("e0", null), new FakeCell("e1", null)];
+    // Element 1 reads undefined, but it is in the awaited set, so it has
+    // settled: flatMap skips it rather than holding the aggregate for it.
+    const results = [new FakeCell("r0", 7), new FakeCell("r1", undefined)];
+    const result = new FakeCell("container", [0, 1]);
+    const { runtime, tracked } = makeRuntime();
+    const rr = makeRepublisher({
+      result,
+      inputsList: inputs,
+      elementRuns: runsFor(inputs, results),
+      runtime,
+      contribute: flatMapContribution,
+    });
+
+    rr.awaitPendingThenRepublish(results as unknown as Cell<any>[]);
+    await drain(tracked);
+
+    expect(result.setValues.length).toBe(1);
+    expect(result.setValues[0]).toEqual([7]);
   });
 });
 


### PR DESCRIPTION
… sharding

A pull request that renamed two TypeScript type aliases, changed no executable code, and touched nothing in packages/runner beyond an export name still had to accept coverage debt: the ratchet reported that group at 6898 uncovered lines against a main baseline of 6896. It did not add those two lines. Joining the per-shard LCOV reports from its run and from the main runs on either side shows its coverage was identical, line for line, to the main run before the baseline; the baseline had dropped by two because another pull request landed in the twelve minutes between when the branch last merged main and when its coverage job ran.

One of those two lines is the array arm of the contribution the flatMap builtin hands to the resume republisher. It was covered only by whichever end-to-end resume test happened to produce an array-valued element result on a given run — 47 executions in one run, none in the next, with no source change. Runner tests are split across shards by round-robin over the sorted filename list, so adding one test file anywhere alphabetically earlier moves most of the suite into different processes, and the resume tests behave differently depending on what shares their process.

Coverage that depends on how the tests were sharded, or on how fast the machine ran, is a defect in the tests rather than noise for the gate to absorb. Hoist the contribution to a named export and drive all three of its arms through the real republisher in the existing unit test: an array result spread one level deep with its holes skipped, a defined scalar pushed directly, and a still-streaming undefined result reported as pending. That test builds its own inputs, so it covers the same lines on every run and under every shard layout. The contribution's code is unchanged; only its position in the file is.

COVERAGE.md gains that rule as policy, so the next person who finds a line whose coverage moves with the environment writes a test for it instead of reaching for a baseline override.

Reduce the guard-line coverage note to what is still true while here. Most of it documented two line-attribution artifacts that deno 2.9.4 fixed: a trailing comment changing a guard line's reported count, and a process taking only one arm of a two-arm conditional reporting the line holding the block boundary as zero. The pin now names 2.9.4, and live documentation is meant to be forward-looking rather than an account of what the repository used to see, so the note keeps only the behaviour that survives on every version — a guard whose branch is never taken reads as uncovered, by design — and the two reproductions move into the record with the rest of the era's evidence.

The investigation itself is recorded under docs/history, indexed in that tree's README, with the per-line evidence, the run-to-run spread of the metric, and the method for localizing a group-level change down to a specific file and line. It also documents the larger source of movement in the same group, a traversal diagnostic guarded on elapsed wall-clock time that decided 39 lines depending on how loaded the machine was, which PR #5108 has since fixed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `packages/runner` coverage deterministic by exporting the `flatMap` contribution and testing all paths through the resume republisher, removing sharding- and timing-dependent coverage noise. Also documents the policy that coverage must not depend on the environment, updates the guard-line note for deno 2.9.4, and adds an investigation record.

- **Bug Fixes**
  - Exported `flatMapContribution` from `packages/runner/src/builtins/flatmap.ts` and wired it into `createResumeRepublisher`; no runtime behavior change.
  - Added unit tests in `packages/runner/test/resume-republish-unit.test.ts` that drive array spread, defined scalar, and pending undefined paths through the real republisher to stabilize coverage across shard layouts.

<sup>Written for commit 791d3f4c51b8799b52d632d9ba2eff2e33577da4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

