### PR TITLE
refactor(cli): build the `cf acl` runtime the way every other command…

### DIFF
--- a/packages/cli/commands/acl.ts
+++ b/packages/cli/commands/acl.ts
@@ -1,11 +1,7 @@
 import { Command } from "@cliffy/command";
 import { Table } from "@cliffy/table";
-import {
-  getAcl,
-  removeAclEntry,
-  setAclEntry,
-  SpaceConfig,
-} from "../lib/acl.ts";
+import { getAcl, removeAclEntry, setAclEntry } from "../lib/acl.ts";
+import { parseSpaceOptions } from "./piece.ts";
 import { cliText } from "../lib/cli-name.ts";
 import { render } from "../lib/render.ts";
 import { isCapability } from "@commonfabric/memory";
@@ -95,39 +91,3 @@ export const acl = new Command()
     await removeAclEntry(config, did);
     render(`Removed ${did} from ACL`);
   });
-
-/**
- * Parse space-related options from command arguments
- */
-function parseSpaceOptions(
-  options: Record<string, string | undefined>,
-): SpaceConfig {
-  const apiUrl = options.apiUrl || Deno.env.get("CF_API_URL");
-  const identity = options.identity || Deno.env.get("CF_IDENTITY");
-  const space = options.space;
-
-  if (!apiUrl) {
-    render(
-      "Error: --api-url is required or set CF_API_URL environment variable",
-    );
-    Deno.exit(1);
-  }
-
-  if (!identity) {
-    render(
-      "Error: --identity is required or set CF_IDENTITY environment variable",
-    );
-    Deno.exit(1);
-  }
-
-  if (!space) {
-    render("Error: --space is required");
-    Deno.exit(1);
-  }
-
-  return {
-    apiUrl: new URL(apiUrl),
-    identityPath: identity,
-    space: space,
-  };
-}

--- a/packages/cli/lib/acl.ts
+++ b/packages/cli/lib/acl.ts
@@ -1,71 +1,29 @@
-import { createSession, isDID, Session } from "@commonfabric/identity";
-import { loadIdentity } from "./identity.ts";
-import {
-  ACLManager,
-  experimentalOptionsFromEnv,
-  Runtime,
-  runtimePresets,
-} from "@commonfabric/runner";
-import { StorageManager } from "@commonfabric/runner/storage/cache";
+import { ACLManager } from "@commonfabric/runner";
 import {
   ACL,
   ACLUser,
   type Capability,
   isACLUser,
 } from "@commonfabric/memory/acl";
+import { loadManager, type SpaceConfig } from "./piece.ts";
 import { throwOnSpaceAuthorizationError } from "./utils.ts";
-import { startVersionCheck } from "./version-check.ts";
 
-export interface SpaceConfig {
-  apiUrl: URL;
-  identityPath: string;
-  space: string;
-}
-
-// Create an identity and session from configuration.
-async function loadSession(config: SpaceConfig): Promise<Session> {
-  const identity = await loadIdentity(config.identityPath);
-  return isDID(config.space)
-    ? createSession({
-      identity,
-      spaceDid: config.space,
-    })
-    : createSession({
-      identity,
-      spaceName: config.space,
-    });
-}
-
-// Creates a Runtime instance for ACL operations
-export async function createRuntime(
+// Open the space and hand an ACLManager to `run`. The ACL document is
+// addressed by the space DID and read through the ACLManager, so the space
+// cell's contents are never needed here and their sync is deferred.
+async function withAcl<T>(
   config: SpaceConfig,
-  session: Session,
-): Promise<Runtime> {
-  // Shared first-party posture for client runtimes against a deployed API
-  // (CT-1814).
-  const runtime = new Runtime(runtimePresets.remoteClient({
-    apiUrl: config.apiUrl,
-    storageManager: StorageManager.open({
-      as: session.as,
-      memoryHost: new URL(config.apiUrl),
-      spaceIdentity: session.spaceIdentity,
-    }),
-    experimental: experimentalOptionsFromEnv(Deno.env.get),
-  }));
-
-  // The server's commit rides the health response the check below already
-  // fetches; only cf's own local resolution (baked metadata or git) runs
-  // concurrently here, and finish() settles it on both paths so no
-  // subprocess op outlives a thrown error.
-  const versionCheck = startVersionCheck();
-  const healthy = await runtime.healthCheck();
-  await versionCheck.finish(runtime.serverGitSha, config.apiUrl);
-  if (!healthy) {
-    throw new Error(`Could not connect to "${config.apiUrl.toString()}".`);
-  }
-
-  await runtime.storageManager.synced();
-  return runtime;
+  run: (acl: ACLManager) => Promise<T>,
+): Promise<T> {
+  const manager = await loadManager({ ...config, deferSpaceCellSync: true });
+  await using runtime = manager.runtime;
+  const space = manager.getSpace();
+  const result = await run(new ACLManager(runtime, space));
+  // Checked AFTER the ACL access, which is what pulls the space and records any
+  // denial. A denied write already rejects above; this also fails a read that
+  // otherwise collapses to a silent "no ACL".
+  throwOnSpaceAuthorizationError(runtime.storageManager, space);
+  return result;
 }
 
 // Add or update an ACL entry for a DID
@@ -75,14 +33,7 @@ export async function setAclEntry(
   capability: Capability,
 ): Promise<void> {
   const userDid = userToACLUser(user);
-  const session = await loadSession(config);
-  await using runtime = await createRuntime(config, session);
-  const aclManager = new ACLManager(runtime, session.space);
-  await aclManager.set(userDid, capability);
-  // Checked AFTER the ACL access, which is what pulls the space and records any
-  // denial. A denied write already rejects above; this also fails a read that
-  // otherwise collapses to a silent "no ACL".
-  throwOnSpaceAuthorizationError(runtime.storageManager, session.space);
+  await withAcl(config, (acl) => acl.set(userDid, capability));
 }
 
 // Remove an ACL entry for a DID
@@ -91,23 +42,14 @@ export async function removeAclEntry(
   user: string,
 ): Promise<void> {
   const userDid = userToACLUser(user);
-  const session = await loadSession(config);
-  await using runtime = await createRuntime(config, session);
-  const aclManager = new ACLManager(runtime, session.space);
-  await aclManager.remove(userDid);
-  throwOnSpaceAuthorizationError(runtime.storageManager, session.space);
+  await withAcl(config, (acl) => acl.remove(userDid));
 }
 
 // Get the current ACL for a space
 export async function getAcl(
   config: SpaceConfig,
 ): Promise<ACL | null> {
-  const session = await loadSession(config);
-  await using runtime = await createRuntime(config, session);
-  const aclManager = new ACLManager(runtime, session.space);
-  const acl = await aclManager.get();
-  throwOnSpaceAuthorizationError(runtime.storageManager, session.space);
-  return acl;
+  return await withAcl(config, (acl) => acl.get());
 }
 
 // Use "ANYONE" on the command line to map to "*"

--- a/packages/cli/test/acl-command.test.ts
+++ b/packages/cli/test/acl-command.test.ts
@@ -1,0 +1,36 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { cf, stripAnsi, withEnv } from "./utils.ts";
+
+function errorText(stderr: string[]): string {
+  return stderr.map(stripAnsi).join("\n");
+}
+
+describe("cf acl", () => {
+  it("reads the space options its environment declarations map", async () => {
+    // `--api-url` and `--identity` reach the option parser through the
+    // command's `CF_API_URL` and `CF_IDENTITY` declarations, so the only
+    // option left unset is the one with no environment fallback.
+    await withEnv("CF_API_URL", "https://toolshed.test", async () => {
+      await withEnv("CF_IDENTITY", "/nonexistent/identity.key", async () => {
+        const { code, stderr } = await cf("acl ls");
+        expect(code).toBe(1);
+        expect(errorText(stderr)).toContain(
+          'Missing required option: "--space".',
+        );
+      });
+    });
+  });
+
+  it("reports a missing identity on stderr and exits non-zero", async () => {
+    await withEnv("CF_API_URL", undefined, async () => {
+      await withEnv("CF_IDENTITY", undefined, async () => {
+        const { code, stderr } = await cf("acl ls");
+        expect(code).toBe(1);
+        expect(errorText(stderr)).toContain(
+          'Missing required option: "--identity", or "CF_IDENTITY".',
+        );
+      });
+    });
+  });
+});

--- a/packages/cli/test/runtime-creation.test.ts
+++ b/packages/cli/test/runtime-creation.test.ts
@@ -1,49 +1,14 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { createSession, Identity } from "@commonfabric/identity";
+import { Identity } from "@commonfabric/identity";
 import { PieceManager } from "@commonfabric/piece";
 import { Runtime } from "@commonfabric/runner";
-import { createRuntime as createAclRuntime } from "../lib/acl.ts";
 import { loadManager } from "../lib/piece.ts";
 import { withEnv } from "./utils.ts";
 
 const AUTO_UPDATE_ENV = "EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE";
 
 describe("CLI runtime creation", () => {
-  it("applies deployed-client options to the ACL runtime", async () => {
-    const identity = await Identity.fromPassphrase("acl runtime creation test");
-    const session = await createSession({
-      identity,
-      spaceName: "acl-runtime-creation",
-    });
-    const originalHealthCheck = Runtime.prototype.healthCheck;
-    let created: Runtime | undefined;
-    Runtime.prototype.healthCheck = function () {
-      created = this;
-      return Promise.resolve(false);
-    };
-
-    await withEnv(AUTO_UPDATE_ENV, "true", async () => {
-      try {
-        await expect(createAclRuntime({
-          apiUrl: new URL("https://toolshed.test"),
-          identityPath: "unused",
-          space: "unused",
-        }, session)).rejects.toThrow("Could not connect");
-        expect(created?.apiUrl.href).toBe("https://toolshed.test/");
-        expect(created?.experimental.systemPatternAutoUpdate).toBe(true);
-      } finally {
-        Runtime.prototype.healthCheck = originalHealthCheck;
-        if (created) {
-          await (created.storageManager as unknown as {
-            closeNow(): Promise<void>;
-          }).closeNow();
-          await created.dispose();
-        }
-      }
-    });
-  });
-
   it("applies deployed-client options to the piece-manager runtime", async () => {
     const identity = await Identity.fromPassphrase(
       "piece runtime creation test",


### PR DESCRIPTION
… does

Every command group in the CLI that talks to a deployed fabric resolves `--identity`, `--api-url`, and `--space` into a space configuration and then builds a remote-client runtime through `lib/piece.ts`. That is how `cf piece`, `cf deps`, `cf wish`, and `cf exec` all work. `cf acl` alone carried a private copy of the whole stack: a second exported type also called `SpaceConfig` but with different field names and an already-parsed URL, its own session construction, its own runtime construction repeating the same remote-client preset plus storage-manager open plus health check, and its own option parser inside the command file.

Two copies of one construction cost more than the lines they occupy. A test existed for no other reason than to police them: it replaced `Runtime.prototype.healthCheck` twice over, once per construction, to assert that both applied the same deployed-client options. Any change to how a client runtime is built had to be made twice and kept in step by hand. The acl copy had already drifted: its option parser re-read `CF_API_URL` and `CF_IDENTITY` straight from the environment even though the command's own environment declarations already map both onto options, and it reported a missing option by printing a sentence to standard output and calling exit, where every other command raises the validation error that prints usage and the failing option to standard error.

The acl functions now call `loadManager` and take the runtime and space from the piece manager it returns, and the command imports the shared option parser the way `cf deps` already does. `loadManager` is asked to defer the space-cell sync, because the ACL document is addressed by the space identifier and read through `ACLManager`, so the space cell's contents are never needed here.

Two behavioral notes. `loadManager` checks for a space authorization error of its own once the space session is open, which is earlier than the acl functions did; the check after the ACL access is kept, because that access is what pulls the space and records a denial that a read would otherwise turn into a silent "no ACL". A missing option now produces the usage text and the error line on standard error rather than a sentence on standard output; the exit code is still 1, and the acl integration script always passes complete arguments.

The parity half of the runtime-creation test is gone with the second construction it guarded. A new test covers what the deleted option parser used to do by hand: with the environment variables set, `cf acl ls` reports only `--space` as missing, which is only true if the command's environment declarations really do reach the shared parser.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored `cf acl` to build its runtime via the shared remote-client stack (`loadManager`) like the rest of the CLI, removing duplicate session/runtime and option parsing code and aligning behavior.

- **Refactors**
  - Use `loadManager` from `lib/piece.ts` to get the runtime and space, deferring space-cell sync; ACL reads/writes go through `ACLManager`, with early auth check plus a post-ACL check to avoid silent “no ACL”.
  - Remove private `SpaceConfig`, custom session/runtime builders, and the local option parser; import the shared `parseSpaceOptions` from `commands/piece.ts`.
  - Replace the ACL runtime parity test with a focused env-mapping test for `cf acl ls`; keep runtime-creation coverage via the piece manager.

- **Bug Fixes**
  - Options now flow through the shared parser: `CF_API_URL` and `CF_IDENTITY` are respected; when unset, only `--space` is reported missing.
  - Missing-option errors now print usage and the error on stderr and exit with code 1, matching other commands.

<sup>Written for commit 0b7a11cc99b93a1f27e0629d5a73fa6ef7918ea5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

