### PR TITLE
fix(runner): release what a settled storage transaction holds

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -293,6 +293,9 @@ jobs:
           # module, the same as the package test task; without it the global
           # `clock` the converted tests use is undefined. See
           # test/clock-preload.ts.
+          # These permissions mirror the `test` task in
+          # packages/runner/deno.jsonc; a test that needs a new one needs it
+          # in both places, because this shard runs deno test directly.
           ENV=test deno test \
             --no-check \
             --preload=test/clock-preload.ts \
@@ -300,7 +303,7 @@ jobs:
             --allow-env \
             --allow-read \
             --allow-write=/tmp,/var/folders \
-            --allow-run=git \
+            --allow-run=git,deno \
             $TEST_FILES
 
       - name: 🧾 Write coverage report

--- a/docs/history/development/performance/2026-08-settled-transaction-retention.md
+++ b/docs/history/development/performance/2026-08-settled-transaction-retention.md
@@ -1,0 +1,117 @@
+---
+status: historical
+created: 2026-08-04
+archived: 2026-08-04
+reason: "Investigation of what a settled storage transaction keeps reachable, and which of those retention paths are observable without per-element list child release."
+---
+
+# What a settled transaction keeps alive, August 2026
+
+## Why this was looked at
+
+Paging forward through a long list grew the heap by megabytes per page until
+the browser tab died, and kept doing so after the July work — dropping
+unsubscribed children from the scheduler's child index (#5136) and bounding
+the runtime caches that grow with everything a session touches (#5200). The
+remaining growth was linear in pages visited and never came back.
+
+## Method
+
+A probe reproduced the shape headlessly: an index document whose rows live in
+their own linked documents, a computed window over the row list,
+`mapWithPattern` projecting each windowed row through a pattern that
+instantiates a nested pattern, and a window stepping forward one page per
+move. V8 heap snapshots taken at two points in the walk were diffed by
+constructor and walked for retainer paths, with weak and ephemeron pair edges
+excluded so the paths shown are genuine strong retention.
+
+## What was found
+
+Every retainer path for the growing object populations ran through a settled
+storage transaction. Three distinct things keep such a transaction reachable,
+or keep it expensive once reachable:
+
+1. **A settled transaction kept its commit callbacks.**
+   `ExtendedStorageTransaction.commitCallbacks` dispatches exactly once and
+   was never cleared afterwards. Callbacks are closures over whatever
+   registered them — a result cell, a child registry, an action's captured
+   frame — so any reference to a settled transaction kept all of that
+   reachable. There are fourteen registration sites across the runner, so
+   this is a general retention path rather than a list-specific one.
+
+2. **Cells stored in long-lived registries stayed bound to their creating
+   transaction.** `CellImpl` holds its creating transaction for its lifetime.
+   The list builtins store their result container and every per-element
+   result cell — in `elementRuns` and in the per-element `addCancel` closure,
+   both of which live as long as the coordinator — still bound to the
+   reconcile transaction that created them. Each such cell therefore pins a
+   settled transaction and its journal, which holds the values of every read
+   that transaction made.
+
+3. **Every live action pins its most recent run's transaction.** This is
+   scheduler-level retention and is bounded by the number of live actions,
+   but the constant is large: a thirty-element window held roughly ninety
+   live per-child actions.
+
+## What this change does, and what it does not
+
+This change fixes (1) and (2): the callback set is cleared after its single
+dispatch, and the list builtins store their container and per-element result
+cells detached from the creating transaction, rebinding per use. The
+transaction-bound sibling is still used for the writes that must ride the
+reconcile transaction (`setResultCell`, `setPatternCell`, `sendResult`).
+
+Only (1) is observable today, and only (1) has a test.
+`commit-callback-release.test.ts` registers a callback closing over a
+sentinel, commits, and requires the sentinel to be collectable while the
+settled transaction is still referenced. Before the fix the sentinel
+survived; after it, it does not.
+
+Fix (2) is correct on its own terms — a registry that lives for the
+coordinator's lifetime should not pin a settled transaction — but it changes
+no measurement on the current list builtins, and the probe confirms that in
+both directions. The reason is (3) combined with what the builtins do with
+children: `map`, `filter`, and `flatMap` never release an *individual*
+element run when its element leaves the list. They keep every element run for
+reuse, releasing them only all at once when the input list becomes undefined.
+So no child is ever left behind, every child stays live, and each live
+child's action pins its own transaction regardless of whether the stored cell
+also does. Detaching the cell removes one of two redundant pins.
+
+Fix (2) becomes load-bearing once the list builtins release element runs
+individually, which is what makes a projection window that slides over a long
+list stop retaining the pages it has left. With per-element release in place
+and both fixes applied, a five-move walk of a sliding three-page window
+leaves zero transactions from departed moves reachable; with per-element
+release but without these fixes, two survive, and each drags its journal and
+the element registries of the reconcile it carried.
+
+## What remains after all of this
+
+Even with per-element release and both fixes, the same walk still grows
+in-process, because of retention that is architecture rather than a broken
+release path:
+
+- **The client replica retains every document it has ever seen.**
+  `SpaceReplica.#docs` only grows during a session; it is cleared on close.
+  Paging in a page of rows permanently adds those row documents, values
+  included, to the client heap. Nothing signals lost interest — reads take no
+  per-document pin, so there is nothing to count down to zero and evict on.
+- **The watch set never narrows.** `SelectorTracker` accumulates every
+  (document, selector) pair ever pulled, so the server keeps streaming
+  updates for rows the window has left behind.
+
+Bounding the client under paging needs an interest signal the storage layer
+does not have today — per-document pins derived from the scheduler's
+dependency graph and cell sinks, an unwatch in the client/server watch
+protocol, and eviction of clean unpinned records — or a list runner that can
+retain inactive element results cheaply instead of keeping whole projected
+pages active.
+
+## Reproduction assets
+
+- `packages/runner/test/window-retention-probe.ts` — the heap-growth probe
+  (shapes `inline`, `child`, `cells`, `opaque`, `index`; toggle and walk
+  movement). `index walk` is the paging shape.
+- `packages/runner/test/commit-callback-release-helper.ts` and
+  `commit-callback-release.test.ts` — the callback-release property, in CI.

--- a/packages/runner/deno.jsonc
+++ b/packages/runner/deno.jsonc
@@ -6,7 +6,9 @@
     // See that file and docs/development/waiting-in-tests.md. --no-check: the
     // global `clock` type lives in test/clock.d.ts, which `deno task check` sees
     // by type-checking the package directory as one program.
-    "test": "ENV=test deno test --no-check --preload=test/clock-preload.ts --allow-ffi --allow-env --allow-read --allow-write=/tmp,/var/folders --allow-run=git test/*.test.ts",
+    // --allow-run=git,deno: window-retention-release.test.ts re-invokes deno
+    // for a helper that needs --expose-gc and the real clock.
+    "test": "ENV=test deno test --no-check --preload=test/clock-preload.ts --allow-ffi --allow-env --allow-read --allow-write=/tmp,/var/folders --allow-run=git,deno test/*.test.ts",
     "bench": {
       "description": "Run Cell benchmarks for performance analysis",
       "command": "deno bench --allow-read --allow-write --allow-net --allow-ffi --allow-env --no-check test/*.bench.ts"

--- a/packages/runner/src/builtins/filter.ts
+++ b/packages/runner/src/builtins/filter.ts
@@ -223,12 +223,16 @@ export function filter(
         resultSchema,
         tx,
       );
-      result = scopedCell(runtime, tx, baseResult, outputScope);
+      const boundResult = scopedCell(runtime, tx, baseResult, outputScope);
       // Link this cell to the parent cell
-      setResultCell(result, parentCell);
+      setResultCell(boundResult, parentCell);
       // Link the new result cells to the pattern cell too
-      setPatternCell(result, parentCell.key("pattern"));
-      sendResult(tx, result);
+      setPatternCell(boundResult, parentCell.key("pattern"));
+      sendResult(tx, boundResult);
+      // The container outlives this reconcile's transaction; a cell bound to
+      // it would pin the settled transaction and its journal for the life of
+      // the coordinator. Rebind per use instead.
+      result = boundResult.withTx();
     }
     // The coordinator's view of the result container is links-only
     // (RESULT_PRESENCE_SCHEMA): get() probes presence and set() diffs
@@ -382,12 +386,17 @@ export function filter(
         }
         existing.lastIndex = i;
       } else {
-        const resultCell = runtime.getCell(
+        const boundResultCell = runtime.getCell(
           parentCell.space,
           { filter: result, elementKey },
           undefined,
           tx,
         );
+        // The stored cell outlives this reconcile's transaction: it lives in
+        // `elementRuns` and in the cancel closure below, both of which last as
+        // long as the coordinator. A cell bound to the transaction would pin
+        // the settled transaction, its journal, and everything it read.
+        const resultCell = boundResultCell.withTx();
         runtime.runner.run(
           tx,
           opPattern,
@@ -399,9 +408,9 @@ export function filter(
           },
         );
         // Link these individual cells to the top cell
-        setResultCell(resultCell, parentCell);
+        setResultCell(boundResultCell, parentCell);
         // Link the new result cells to the pattern cell too
-        setPatternCell(resultCell, parentCell.key("pattern"));
+        setPatternCell(boundResultCell, parentCell.key("pattern"));
 
         addCancel(() => runtime.runner.stop(resultCell));
         elementRuns.set(elementKey, { resultCell, lastIndex: i });

--- a/packages/runner/src/builtins/flatmap.ts
+++ b/packages/runner/src/builtins/flatmap.ts
@@ -233,12 +233,16 @@ export function flatMap(
         resultSchema,
         tx,
       );
-      result = scopedCell(runtime, tx, baseResult, outputScope);
+      const boundResult = scopedCell(runtime, tx, baseResult, outputScope);
       // Link this cell to the parent cell
-      setResultCell(result, parentCell);
+      setResultCell(boundResult, parentCell);
       // Link the new result cells to the pattern cell too
-      setPatternCell(result, parentCell.key("pattern"));
-      sendResult(tx, result);
+      setPatternCell(boundResult, parentCell.key("pattern"));
+      sendResult(tx, boundResult);
+      // The container outlives this reconcile's transaction; a cell bound to
+      // it would pin the settled transaction and its journal for the life of
+      // the coordinator. Rebind per use instead.
+      result = boundResult.withTx();
     }
     // The coordinator's view of the result container is links-only
     // (RESULT_PRESENCE_SCHEMA): get() probes presence and set() diffs
@@ -388,12 +392,17 @@ export function flatMap(
         }
         existing.lastIndex = i;
       } else {
-        const resultCell = runtime.getCell(
+        const boundResultCell = runtime.getCell(
           parentCell.space,
           { flatMap: result, elementKey },
           undefined,
           tx,
         );
+        // The stored cell outlives this reconcile's transaction: it lives in
+        // `elementRuns` and in the cancel closure below, both of which last as
+        // long as the coordinator. A cell bound to the transaction would pin
+        // the settled transaction, its journal, and everything it read.
+        const resultCell = boundResultCell.withTx();
         runtime.runner.run(
           tx,
           opPattern,
@@ -405,7 +414,7 @@ export function flatMap(
           },
         );
         // Link the new result cells to the pattern cell too
-        setPatternCell(resultCell, parentCell.key("pattern"));
+        setPatternCell(boundResultCell, parentCell.key("pattern"));
         addCancel(() => runtime.runner.stop(resultCell));
         elementRuns.set(elementKey, { resultCell, lastIndex: i });
 

--- a/packages/runner/src/builtins/map.ts
+++ b/packages/runner/src/builtins/map.ts
@@ -218,11 +218,15 @@ export function map(
         resultSchema,
         tx,
       );
-      result = scopedCell(runtime, tx, baseResult, listScope);
-      setResultCell(result, parentCell);
+      const boundResult = scopedCell(runtime, tx, baseResult, listScope);
+      setResultCell(boundResult, parentCell);
       // Link the new result cells to the pattern cell too
-      setPatternCell(result, parentCell.key("pattern"));
-      sendResult(tx, result);
+      setPatternCell(boundResult, parentCell.key("pattern"));
+      sendResult(tx, boundResult);
+      // The container outlives this reconcile's transaction; a cell bound to
+      // it would pin the settled transaction and its journal for the life of
+      // the coordinator. Rebind per use instead.
+      result = boundResult.withTx();
     }
     // The coordinator's view of the result container is links-only
     // (RESULT_PRESENCE_SCHEMA): get() probes presence and set() diffs
@@ -369,12 +373,17 @@ export function map(
         existing.lastIndex = i;
         newArrayValue[i] = exposedResultCell(runtime, tx, existing.resultCell);
       } else {
-        const resultCell = runtime.getCell(
+        const boundResultCell = runtime.getCell(
           parentCell.space,
           { map: result, elementKey },
           undefined,
           tx,
         );
+        // The stored cell outlives this reconcile's transaction: it lives in
+        // `elementRuns` and in the cancel closure below, both of which last as
+        // long as the coordinator. A cell bound to the transaction would pin
+        // the settled transaction, its journal, and everything it read.
+        const resultCell = boundResultCell.withTx();
         runtime.runner.run(
           tx,
           opPattern,
@@ -386,9 +395,9 @@ export function map(
           },
         );
         // Link these individual cells to the top cell
-        setResultCell(resultCell, parentCell);
+        setResultCell(boundResultCell, parentCell);
         // Link the new result cells to the pattern cell too
-        setPatternCell(resultCell, parentCell.key("pattern"));
+        setPatternCell(boundResultCell, parentCell.key("pattern"));
         addCancel(() => runtime.runner.stop(resultCell));
         elementRuns.set(elementKey, { resultCell, lastIndex: i });
         newArrayValue[i] = exposedResultCell(runtime, tx, resultCell);

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -1769,6 +1769,11 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
         logger.error("storage-error", "Error in commit callback:", error);
       }
     }
+    // A settled transaction dispatches its callbacks exactly once. Holding
+    // them afterwards makes any reference to the transaction retain every
+    // callback's closure, and through those closures the cells and registries
+    // of the action that committed it.
+    this.commitCallbacks.clear();
   }
 
   private clearPostCommitOutbox(): void {

--- a/packages/runner/test/commit-callback-release-helper.ts
+++ b/packages/runner/test/commit-callback-release-helper.ts
@@ -1,0 +1,86 @@
+// Helper for commit-callback-release.test.ts. Runs in its own process so it
+// can use `--v8-flags=--expose-gc` and the real clock (WeakRef state only
+// settles across task boundaries, which the package's fake-clock preload
+// would freeze).
+//
+// A commit callback runs exactly once, when its transaction settles. The
+// question here is what the transaction holds afterwards. Callbacks are
+// closures over the machinery that registered them — a child registry, a
+// result cell, an action's captured frame — so a settled transaction that
+// keeps its callback set keeps all of that reachable for as long as anything
+// still references the transaction. Long-lived structures do reference
+// settled transactions (a cell carries the transaction it was created with),
+// so this is a live retention path, not a theoretical one.
+//
+// The helper registers a callback whose closure captures a sentinel object,
+// commits, drops every reference except a WeakRef to the sentinel and a
+// strong reference to the settled transaction, and reports whether the
+// sentinel is still reachable.
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+
+const signer = await Identity.fromPassphrase("commit callback release");
+const space = signer.did();
+
+const gc = (globalThis as { gc?: () => void }).gc;
+if (!gc) throw new Error("run with --v8-flags=--expose-gc");
+
+const storageManager = StorageManager.emulate({ as: signer });
+const runtime = new Runtime({
+  apiUrl: new URL(import.meta.url),
+  storageManager,
+});
+
+// Kept alive for the whole run: this stands in for the long-lived structure
+// that references a settled transaction in production.
+const settledTransactions: unknown[] = [];
+const sentinelRefs: WeakRef<object>[] = [];
+
+for (let round = 0; round < 3; round++) {
+  const tx = runtime.edit();
+  const cell = runtime.getCell<{ value: number }>(
+    space,
+    `commit-callback-release-${round}`,
+    undefined,
+    tx,
+  );
+  cell.set({ value: round });
+
+  // Scoped so the only strong reference to the sentinel after this block is
+  // the callback closure the transaction holds.
+  {
+    const sentinel = { round, payload: "x".repeat(1024) };
+    sentinelRefs.push(new WeakRef(sentinel));
+    tx.addCommitCallback(() => {
+      // Reads the sentinel, so the closure genuinely captures it.
+      if (sentinel.round < 0) throw new Error("unreachable");
+    });
+  }
+
+  await tx.commit();
+  settledTransactions.push(tx);
+}
+
+// WeakRef targets created in a turn survive that turn regardless of
+// reachability. Cross one task boundary so the forced collection below can
+// observe genuine reachability. This is an event-loop yield, not a wait.
+await new Promise((resolve) => setTimeout(resolve, 0));
+gc();
+gc();
+
+const aliveSentinels = sentinelRefs.reduce(
+  (count, ref) => count + (ref.deref() === undefined ? 0 : 1),
+  0,
+);
+
+console.log(
+  JSON.stringify({
+    rounds: sentinelRefs.length,
+    retainedTransactions: settledTransactions.length,
+    aliveSentinels,
+  }),
+);
+
+await runtime.dispose();
+await storageManager.close();

--- a/packages/runner/test/commit-callback-release.test.ts
+++ b/packages/runner/test/commit-callback-release.test.ts
@@ -1,0 +1,47 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+// A settled transaction must not keep the callbacks it already dispatched.
+// Commit callbacks are closures over whatever registered them — a result
+// cell, a child registry, an action's captured frame — and long-lived
+// structures do hold references to settled transactions, so a retained
+// callback set turns one settled transaction into a root for everything its
+// callbacks closed over.
+//
+// The scenario runs in a subprocess because proving release needs WeakRefs, a
+// forced collection (`--expose-gc`), and a real task boundary — this
+// package's preload freezes timers armed from test files, and the test task
+// does not expose gc.
+describe("commit callback release", () => {
+  it("drops dispatched callbacks so a settled transaction roots nothing", async () => {
+    const helper = new URL(
+      "./commit-callback-release-helper.ts",
+      import.meta.url,
+    );
+    // Spawned by name so the launch matches the task's `--allow-run=deno`
+    // grant, which resolves the name through PATH the same way.
+    const command = new Deno.Command("deno", {
+      args: ["run", "-A", "--v8-flags=--expose-gc", helper.pathname],
+      stdout: "piped",
+      stderr: "piped",
+    });
+    const output = await command.output();
+    const stdout = new TextDecoder().decode(output.stdout);
+    const stderr = new TextDecoder().decode(output.stderr);
+    expect(output.success, `helper failed:\n${stderr}\n${stdout}`).toBe(true);
+    // Loggers may write above the report; the report is the last line.
+    const lines = stdout.trim().split("\n");
+    const report = JSON.parse(lines[lines.length - 1]) as {
+      rounds: number;
+      retainedTransactions: number;
+      aliveSentinels: number;
+    };
+    expect(report.rounds).toBeGreaterThan(0);
+    expect(report.retainedTransactions).toBe(report.rounds);
+    expect(
+      report.aliveSentinels,
+      "a settled transaction is still holding what its commit callbacks " +
+        `closed over: ${JSON.stringify(report)}`,
+    ).toBe(0);
+  });
+});


### PR DESCRIPTION
A settled transaction is reachable from long-lived structures — a cell carries the transaction it was created with — and it holds more than it needs to once it has committed. Investigating heap growth while paging forward through a long list, every retainer path for the growing object populations ran through one.

Two things it holds are unnecessary. Its commit-callback set is kept after the single dispatch, and those callbacks are closures over whatever registered them: a result cell, a child registry, an action's captured frame. Any reference to a settled transaction therefore keeps all of that reachable, at fourteen registration sites across the runner. Separately, the list builtins store their result container and every per-element result cell — in `elementRuns` and in the per-element cancel closure, both of which live as long as the coordinator — still bound to the reconcile transaction that created them, so each stored cell pins a settled transaction and its journal, which holds the values of every read that transaction made.

Clear the callback set after dispatch, and store the coordinator's cells detached from the creating transaction, rebinding per use. The transaction-bound sibling still carries the writes that must ride the reconcile transaction: setResultCell, setPatternCell, and sendResult.

The callback release is what the new test pins. It registers a callback closing over a sentinel, commits, and requires the sentinel to be collectable while the settled transaction is still referenced; before the change the sentinel survived. It runs in a subprocess because proving release needs WeakRefs, a forced collection, and a real task boundary, and this package's preload freezes timers armed from test files.

The cell detachment has no test, because it changes no measurement against the list builtins as they stand, and a probe confirms that in both directions. `map`, `filter`, and `flatMap` never release an individual element run when its element leaves the list; they keep every run for reuse and release them all at once only when the input list becomes undefined. So every child stays live, and a live child's action already pins its own transaction — detaching the stored cell removes one of two redundant pins. It becomes load-bearing once the builtins release element runs individually, which is what lets a projection window sliding over a long list stop retaining the pages it has left behind.

docs/history/development/performance/2026-08-settled-transaction-retention.md records the investigation, including the growth that remains because the client replica retains and watches every document it has ever seen.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release memory held by settled storage transactions to stop heap growth when paging long lists. We clear dispatched commit callbacks and avoid pinning settled transactions by storing list result cells detached from their creating transaction.

- **Bug Fixes**
  - Clear `commitCallbacks` in `ExtendedStorageTransaction` after dispatch so settled transactions don’t retain callback closures, cells, or registries.
  - In `map`, `filter`, and `flatMap`, store the result container and per-element cells via `.withTx()`, using the bound sibling only for writes (`setResultCell`, `setPatternCell`, `sendResult`) to avoid pinning settled transactions.

- **Dependencies**
  - Grant `--allow-run=deno` for tests in `packages/runner/deno.jsonc` and mirror the permission in `.github/workflows/deno.yml` so the GC-based helper runs in CI.

<sup>Written for commit 2226adc1a81624b4a6cecc01cfdcbc4eaabb3862. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

