### PR TITLE
refactor(runner): the runtime serializes its own cells and artifacts

### DIFF
--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -101,6 +101,7 @@ import {
 } from "./cfc/metadata.ts";
 import { toURI } from "./uri-utils.ts";
 import { createRef } from "./create-ref.ts";
+import { flattenBuilderArtifacts } from "./storage-preflight.ts";
 import {
   type SigilLink,
   type SigilWriteRedirectLink,
@@ -483,6 +484,19 @@ declare module "@commonfabric/api" {
     getAsReactiveProxy(
       boundTarget?: (...args: unknown[]) => unknown,
     ): Reactive<T>;
+    /**
+     * Returns the sigil link naming this cell, or `null` when the cell has no
+     * full link yet (one that has not been created). This is how a cell reaches
+     * storage: the link is what stands in for it, and `hasEncodableForm()` asks
+     * for this member by name.
+     */
+    toSigilLinkOrNull(): SigilLink | null;
+    /**
+     * Answers the JSON protocol with the same link `toSigilLinkOrNull()` gives,
+     * so a cell embedded in a value being stringified reads as what it names.
+     * `packages/html`'s VDOM key generation depends on this. Nothing on the way
+     * to storage consults it.
+     */
     toJSON(): SigilLink | null;
     runtime: Runtime;
     tx: IExtendedStorageTransaction | undefined;
@@ -541,6 +555,7 @@ const cellMethods = new Set<
   "filterWithPattern",
   "flatMap",
   "flatMapWithPattern",
+  "toSigilLinkOrNull",
   "toJSON",
   "for",
   "asSchema",
@@ -1803,7 +1818,7 @@ export class CellImpl<T extends FabricValue>
       // unconverted, and the strict conversion would reject their
       // non-string-keyed internals.
       const comparable = normalizeForComparison && !isCellLink(candidate)
-        ? fabricFromNativeValue(candidate)
+        ? fabricFromNativeValue(flattenBuilderArtifacts(candidate))
         : candidate;
       return existing.some((element) => valueEqual(element, comparable));
     };
@@ -2865,7 +2880,7 @@ export class CellImpl<T extends FabricValue>
     return result;
   }
 
-  toJSON(): SigilLink | null {
+  toSigilLinkOrNull(): SigilLink | null {
     // Return null when no link exists (cell hasn't been created yet)
     if (!this.hasFullLink()) {
       return null;
@@ -2873,6 +2888,17 @@ export class CellImpl<T extends FabricValue>
 
     // Use sigil link format which includes space for cross-space references
     return createSigilLinkFromParsedLink(this.link);
+  }
+
+  toJSON(): SigilLink | null {
+    // The JSON protocol's name for the same link. `generateKey()` in
+    // `packages/html/src/worker/keying.ts` stringifies render nodes to key
+    // them, and a cell inside one has to come out as the link it names for a
+    // key to be stable across renders.
+    //
+    // It carries no weight on the way to storage: what a cell reaches storage
+    // as is read from `toSigilLinkOrNull()` by name.
+    return this.toSigilLinkOrNull();
   }
 
   get __debugValue(): T {

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -17,6 +17,7 @@ import type { JSONSchemaObj } from "@commonfabric/api";
 import { ContextualFlowControl } from "./cfc.ts";
 import { isCellScope, scopeRank } from "./scope.ts";
 import { createRef } from "./create-ref.ts";
+import { flattenBuilderArtifacts } from "./storage-preflight.ts";
 import {
   CellImpl,
   isCell,
@@ -397,11 +398,17 @@ export function diffAndUpdate(
       ...allowMutableTransactionRead,
     },
   };
+  // A builder artifact -- a module, a handler, a pattern, the factory carrying
+  // a module's members -- has no fabric representation, so the runtime replaces
+  // it with its encodable form before the value reaches the data model. This is
+  // the raw write path, reached by `Cell.set()` and the collection operations;
+  // the pattern-driven paths (a run's result, its argument) do the same at
+  // their own boundaries.
   const changes = normalizeAndDiff(
     runtime,
     tx,
     link,
-    newValue,
+    flattenBuilderArtifacts(newValue),
     context,
     readOptions,
     { seen: new Map(), nextAnchorId: anchorIds },

--- a/packages/runner/src/encodable-form.ts
+++ b/packages/runner/src/encodable-form.ts
@@ -9,13 +9,14 @@ import { isPlainObject } from "@commonfabric/utils/types";
  *
  * - `toEncodableForm`, carried by every builder artifact -- a module, a
  *   handler, a pattern, and the factory that carries a module's members.
- * - `toJSON`, the JSON protocol's name. A `Cell` answers only this one, for
- *   which it is how the cell becomes a link; a builder artifact answers it too,
- *   delegating (see `builder/json-member.ts`).
+ * - `toSigilLinkOrNull`, carried by a `Cell`, for which producing the link it
+ *   names IS how it reaches storage.
  *
- * Preferring the first is the point: what the runtime wants is the encodable
- * form, and `toJSON` names a protocol rather than that. The fallback is what
- * keeps a value whose only serializer IS the JSON one -- a `Cell` -- answering.
+ * Both are the runtime's OWN names, and that is the point. Asking by name
+ * rather than by class is what lets this module stay a leaf -- naming `Cell`
+ * here would mean importing the runtime's core, and the graph already runs the
+ * other way. Neither name is a public protocol, so no value acquires an
+ * encodable form by carrying a member it defined for some other purpose.
  */
 function encodableFormMethod(value: unknown): (() => unknown) | undefined {
   if (
@@ -25,12 +26,15 @@ function encodableFormMethod(value: unknown): (() => unknown) | undefined {
     return undefined;
   }
 
-  const artifact = value as { toEncodableForm?: unknown; toJSON?: unknown };
-  if (typeof artifact.toEncodableForm === "function") {
-    return artifact.toEncodableForm as () => unknown;
+  const named = value as {
+    toEncodableForm?: unknown;
+    toSigilLinkOrNull?: unknown;
+  };
+  if (typeof named.toEncodableForm === "function") {
+    return named.toEncodableForm as () => unknown;
   }
-  return typeof artifact.toJSON === "function"
-    ? artifact.toJSON as () => unknown
+  return typeof named.toSigilLinkOrNull === "function"
+    ? named.toSigilLinkOrNull as () => unknown
     : undefined;
 }
 
@@ -40,7 +44,9 @@ function encodableFormMethod(value: unknown): (() => unknown) | undefined {
  * Deliberately BROADER than the walk's own test (`hasOwnEncodableForm`): this
  * accepts either name and an inherited member, because its callers ask about a
  * specific value they already hold -- a pattern, a cell -- rather than sifting
- * an arbitrary graph. The walk cannot afford either latitude; see there.
+ * an arbitrary graph. A cell answers here through an inherited member, that
+ * being where a class puts its methods. The walk cannot afford either latitude;
+ * see there.
  */
 export function hasEncodableForm(value: unknown): boolean {
   return encodableFormMethod(value) !== undefined;
@@ -69,8 +75,22 @@ const IN_PROGRESS = Symbol("IN_PROGRESS");
 type OnCopy = (copy: unknown, original: unknown) => void;
 
 /**
+ * Asked about each value the walk would otherwise pass through untouched,
+ * and answers what should stand in its place -- the value itself to leave it
+ * alone. This is how a caller says what ELSE has no fabric representation: a
+ * `Cell`, whose encodable form is the link it stands for. Recognizing one takes
+ * `isCell()`, and that lives in the runtime's core rather than here, so the
+ * knowledge arrives as a function instead of as an import.
+ */
+type ReplaceOther = (value: object | AnyFunction) => unknown;
+
+/** Shorthand for the callable shape the walk reaches. */
+type AnyFunction = (...args: never[]) => unknown;
+
+/**
  * Replaces every builder artifact reachable from `value` with its encodable
- * form, yielding a value the data model can represent.
+ * form, yielding a value the data model can represent. `replaceOther` extends
+ * that to values the walk does not descend into (see `ReplaceOther`).
  *
  * A builder artifact carries its serializer as a `toEncodableForm` method (see
  * `builder/module.ts` and `builder/pattern.ts`). A method is a function-valued
@@ -104,14 +124,19 @@ type OnCopy = (copy: unknown, original: unknown) => void;
  * the cycle or an artifact still raw inside the partial result: an ancestor is
  * answered as itself, so a copy's cycle edge points at the original.
  */
-export function replaceArtifacts<T>(value: T, onCopy: OnCopy): T {
-  return replace(value, new Map(), onCopy) as T;
+export function replaceArtifacts<T>(
+  value: T,
+  onCopy: OnCopy,
+  replaceOther: ReplaceOther = (value) => value,
+): T {
+  return replace(value, new Map(), onCopy, replaceOther) as T;
 }
 
 function replace(
   value: unknown,
   seen: Map<object, unknown>,
   onCopy: OnCopy,
+  replaceOther: ReplaceOther,
 ): unknown {
   if (value === null) return value;
   const isFunction = typeof value === "function";
@@ -127,10 +152,12 @@ function replace(
   // the builder, and a function that is not an artifact has no fabric
   // representation for the conversion to find either way.
   if (isFunction) {
-    if (!hasOwnEncodableForm(value)) return value;
+    if (!hasOwnEncodableForm(value)) {
+      return replaced(value, replaceOther, seen, onCopy);
+    }
     seen.set(value, IN_PROGRESS);
     return copied(
-      replace(value.toEncodableForm(), seen, onCopy),
+      replace(value.toEncodableForm(), seen, onCopy, replaceOther),
       value,
       seen,
       onCopy,
@@ -141,36 +168,57 @@ function replace(
   // is only ever descended into.
   const isArray = Array.isArray(value);
   if (!isArray && !isPlainObject(value, false)) {
-    // Anything else -- a `Cell`, a `FabricInstance`, a `Date` -- is the
-    // conversion's to interpret, and carries no builder artifact.
+    // Anything else -- a `FabricInstance`, a `Date` -- carries no builder
+    // artifact, and is the conversion's to interpret unless `replaceOther`
+    // claims it. A `Cell` is what that hook is for: the walk cannot name one
+    // from here, and the conversion has no representation for it either.
     //
     // A null-prototype object is excluded too -- hence the `false` argument
     // to `isPlainObject()`. It is not a fabric record, so it is not the
     // walk's to rewrite. That is not the same as the conversion refusing one:
-    // `native-type-tags.ts` answers it `Object`, and upgrades it to
-    // `HasToJSON` when it carries a callable one. Whether to accept it is the
+    // `native-type-tags.ts` answers it `Object`. Whether to accept it is the
     // conversion's question, asked of the value as it stands.
-    return value;
+    return replaced(value, replaceOther, seen, onCopy);
   }
 
   seen.set(value, IN_PROGRESS);
   let flattened: unknown;
   if (isArray) {
-    flattened = replaceInElements(value, seen, onCopy);
+    flattened = replaceInElements(value, seen, onCopy, replaceOther);
   } else if (hasOwnEncodableForm(value)) {
     // The artifact's OWN method is what gets called, rather than the
     // serializer it delegates to: the method a copy carries is closed over the
     // artifact the copy was made from, and that original is what the
     // serialized form describes.
-    flattened = replace(value.toEncodableForm(), seen, onCopy);
+    flattened = replace(value.toEncodableForm(), seen, onCopy, replaceOther);
   } else {
     flattened = replaceInEntries(
       value as Record<string, unknown>,
       seen,
       onCopy,
+      replaceOther,
     );
   }
   return copied(flattened, value, seen, onCopy);
+}
+
+/**
+ * Helper for `replace()`, which offers a value the walk does not descend into
+ * to `replaceOther` and records whatever comes back.
+ *
+ * The replacement is NOT descended into. What the hook answers stands for the
+ * value itself -- a link, say -- rather than being a container the walk has any
+ * further claim on.
+ */
+function replaced(
+  value: object | AnyFunction,
+  replaceOther: ReplaceOther,
+  seen: Map<object, unknown>,
+  onCopy: OnCopy,
+): unknown {
+  const replacement = replaceOther(value);
+  if (replacement === value) return value;
+  return copied(replacement, value, seen, onCopy);
 }
 
 /**
@@ -201,6 +249,7 @@ function replaceInElements(
   value: readonly unknown[],
   seen: Map<object, unknown>,
   onCopy: OnCopy,
+  replaceOther: ReplaceOther,
 ): readonly unknown[] {
   // Read each element ONCE, and build any copy from what was read -- the
   // array counterpart of the entries `replaceInEntries` materializes, for the
@@ -221,7 +270,7 @@ function replaceInElements(
     // a hole here too.
     if (!(i in value)) continue;
     const element = value[i];
-    const flattened = replace(element, seen, onCopy);
+    const flattened = replace(element, seen, onCopy, replaceOther);
     replaced[i] = flattened;
     if (flattened !== element) changed = true;
   }
@@ -232,6 +281,7 @@ function replaceInEntries(
   value: Record<string, unknown>,
   seen: Map<object, unknown>,
   onCopy: OnCopy,
+  replaceOther: ReplaceOther,
 ): Record<string, unknown> {
   // Read each member ONCE, and build any copy from what was read: reading a
   // second time to copy would run an accessor twice and keep the second
@@ -241,7 +291,7 @@ function replaceInEntries(
   let result: Record<string, unknown> | undefined;
   for (let i = 0; i < entries.length; i++) {
     const [key, element] = entries[i];
-    const flattened = replace(element, seen, onCopy);
+    const flattened = replace(element, seen, onCopy, replaceOther);
     if (flattened === element) continue;
     result ??= Object.fromEntries(entries);
     result[key] = flattened;

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -49,6 +49,7 @@ import {
   type Cell,
   createCell,
   internCellLinkSchema,
+  isCell,
   schemaCellScope,
 } from "./cell.ts";
 import { createRef, EntityId } from "./create-ref.ts";
@@ -599,6 +600,17 @@ type RuntimeSetupOptions = {
 
 function isMemorySpaceDID(value: string): boolean {
   return /^did:[^:]+:.+/.test(value);
+}
+
+/**
+ * Helper for `Runtime.getImmutableCell()`, which tells the storage preflight
+ * what a `Cell` stands for -- the sigil link naming it -- and leaves everything
+ * else to the walk. A cell has no fabric representation of its own, so one
+ * reached anywhere inside a value bound for the data model has to become its
+ * link first.
+ */
+function cellAsLink(value: object | ((...args: never[]) => unknown)): unknown {
+  return isCell(value) ? value.toSigilLinkOrNull() : value;
 }
 
 /**
@@ -2000,17 +2012,24 @@ export class Runtime {
     tx?: IExtendedStorageTransaction,
     cfcLabelView?: CfcLabelView,
   ): Cell<any> {
-    // Not `dataUriFromValueWithResolvedLinks()`: its link-rewriting walk is unwanted here
-    // (this data is immutable as given). `fabricFromNativeValue()` converts
-    // what callers actually pass -- notably `Cell`s, which become sigil
-    // links via their `toJSON()` -- into an encodable `FabricValue`.
-    // Builder artifacts are replaced HERE rather than at each caller. This is
-    // the designed intake, and the callers are many: raw and JavaScript node
-    // inputs, wish candidates, schema defaults. Covering them one at a time was
-    // tried and is whack-a-mole -- each site that is missed fails as a
-    // rejection at the conversion, or worse as a cleanup error that masks it.
+    // Not `dataUriFromValueWithResolvedLinks()`: its link-rewriting walk is
+    // unwanted here (this data is immutable as given).
+    //
+    // Builder artifacts become their encodable form and cells become sigil
+    // links HERE rather than at each caller. Neither has a fabric
+    // representation, so both have to go before the value reaches
+    // `fabricFromNativeValue()`. This is the designed intake, and the callers
+    // are many: raw and JavaScript node inputs, wish candidates, schema
+    // defaults. Covering them one at a time was tried and is whack-a-mole --
+    // each site that is missed fails as a rejection at the conversion, or worse
+    // as a cleanup error that masks it.
+    //
+    // One walk covers both. A cell is a leaf to it -- what stands in for a cell
+    // is the link it names, not a container to descend into -- and an
+    // artifact's encodable form is walked in turn, so a cell inside one is
+    // reached as well.
     const asDataURI = dataUriFromValue(
-      fabricFromNativeValue(flattenBuilderArtifacts(data)),
+      fabricFromNativeValue(flattenBuilderArtifacts(data, cellAsLink)),
     );
     return createCell(
       this,

--- a/packages/runner/src/storage-preflight.ts
+++ b/packages/runner/src/storage-preflight.ts
@@ -3,7 +3,8 @@ import { replaceArtifacts } from "./encodable-form.ts";
 
 /**
  * Replaces every builder artifact reachable from `value` with its encodable
- * form, on the way into the data model.
+ * form, on the way into the data model. `replaceOther` extends that to values
+ * the walk does not descend into; see `ReplaceOther` in `encodable-form.ts`.
  *
  * The walk itself is `replaceArtifacts`; this names the one thing a storage
  * boundary adds to it -- carrying trust and the content-addressed entry ref
@@ -20,6 +21,9 @@ import { replaceArtifacts } from "./encodable-form.ts";
  * original. A copy of a trusted artifact being trusted is the property the
  * side tables exist to preserve; not carrying it was the bug.
  */
-export function flattenBuilderArtifacts<T>(value: T): T {
-  return replaceArtifacts(value, noteDerivedCopy);
+export function flattenBuilderArtifacts<T>(
+  value: T,
+  replaceOther?: (value: object | ((...args: never[]) => unknown)) => unknown,
+): T {
+  return replaceArtifacts(value, noteDerivedCopy, replaceOther);
 }

--- a/packages/runner/test/cell-links.test.ts
+++ b/packages/runner/test/cell-links.test.ts
@@ -83,7 +83,26 @@ describe("getAsLink method", () => {
     expect(linkRefPayload(link).path).toEqual(["nested", "value"]);
   });
 
-  it("should return sigil format for both getAsLink and toJSON", () => {
+  it("should stringify as the link it names, nested or not", () => {
+    // `generateKey()` in `packages/html/src/worker/keying.ts` keys render nodes
+    // by stringifying them, so a cell inside one has to come out as its link
+    // for the key to be stable across renders. Without the member the
+    // stringify walks a cell's own members into the runtime and dies on the
+    // cycle -- which that function catches, silently keying by a fallback.
+    const cell = runtime.getCell<{ value: number }>(
+      space,
+      "cell-json-print-test",
+      undefined,
+      tx,
+    );
+    cell.set({ value: 42 });
+
+    const link = cell.toSigilLinkOrNull();
+    expect(JSON.parse(JSON.stringify(cell))).toEqual(link);
+    expect(JSON.parse(JSON.stringify({ held: cell }))).toEqual({ held: link });
+  });
+
+  it("should return sigil format for both getAsLink and toSigilLinkOrNull", () => {
     const cell = runtime.getCell<{ value: number }>(
       space,
       "getAsLink-json-test",
@@ -93,19 +112,19 @@ describe("getAsLink method", () => {
     cell.set({ value: 42 });
 
     const link = cell.getAsLink();
-    const json = cell.toJSON();
+    const sigilLink = cell.toSigilLinkOrNull();
 
     // getAsLink returns sigil format
     expect(link).toHaveProperty("/");
     expect(linkRefPayload(link)).toBeDefined();
 
-    // toJSON now also returns sigil format (includes space for cross-space references)
-    expect(json).not.toBeNull();
-    const jsonPayload = linkRefPayload(json as SigilLink);
-    expect(jsonPayload.id).toBeDefined();
-    expect(jsonPayload.path).toEqual([]);
-    // Verify space is included for cross-space resolution
-    expect(jsonPayload.space).toEqual(space);
+    // So does the link a cell reaches storage as, space included so a
+    // cross-space reference resolves.
+    expect(sigilLink).not.toBeNull();
+    const payload = linkRefPayload(sigilLink as SigilLink);
+    expect(payload.id).toBeDefined();
+    expect(payload.path).toEqual([]);
+    expect(payload.space).toEqual(space);
   });
 
   it("should create relative links with base parameter - same document", () => {

--- a/packages/runner/test/data-updating.test.ts
+++ b/packages/runner/test/data-updating.test.ts
@@ -1262,11 +1262,6 @@ describe("data-updating", () => {
         cell.set([new Date(1234)]);
         cell.addUnique(new Date(1234));
         expect((cell.getRaw() as unknown[]).length).toBe(1);
-
-        // A toJSON-backed candidate likewise matches its normalized form.
-        cell.set(["hello"]);
-        cell.addUnique({ toJSON: () => "hello" });
-        expect((cell.getRaw() as unknown[]).length).toBe(1);
       } finally {
         popFrame(frame);
       }

--- a/packages/runner/test/doc-map.test.ts
+++ b/packages/runner/test/doc-map.test.ts
@@ -178,26 +178,4 @@ describe("cell-map", () => {
       expect(retrievedCell.equals(c)).toBe(true);
     });
   });
-
-  describe("cells as JSON", () => {
-    it("should serialize the entity ID", () => {
-      const c = runtime.getCell<{ value: number }>(
-        space,
-        "test-json",
-        undefined,
-        tx,
-      );
-      c.set({ value: 42 });
-
-      // toJSON returns sigil format with space for cross-space resolution
-      const json = JSON.parse(JSON.stringify(c));
-      expect(json["/"]).toBeDefined();
-      expect(json["/"][LINK_V1_TAG]).toBeDefined();
-      expect(json["/"][LINK_V1_TAG].id).toContain(
-        entityRefToString(c.entityId),
-      );
-      expect(json["/"][LINK_V1_TAG].path).toEqual([]);
-      expect(json["/"][LINK_V1_TAG].space).toEqual(space);
-    });
-  });
 });

--- a/packages/runner/test/encodable-form.test.ts
+++ b/packages/runner/test/encodable-form.test.ts
@@ -192,7 +192,7 @@ describe("encodable-form", () => {
         // optimization, and skipping it is a loud rejection.
         const value = { tools: { send: { handler: artifact({ ok: true }) } } };
         expect(() => fabricFromNativeValue(value))
-          .toThrow(/function per se/);
+          .toThrow(/Not representable as a `FabricValue`: function/);
       });
     });
 
@@ -298,11 +298,17 @@ describe("encodable-form", () => {
       expect(hasEncodableForm({ toEncodableForm: () => ({}) })).toBe(true);
     });
 
-    it("returns true for a value carrying only `toJSON`", () => {
-      // A `Cell` answers only this name -- it is how a cell becomes a link --
-      // and a cell is not a builder artifact. Dropping the fallback would stop
-      // every such value producing a form at all.
-      expect(hasEncodableForm({ toJSON: () => ({}) })).toBe(true);
+    it("returns true for a value carrying only `toSigilLinkOrNull`", () => {
+      // A `Cell` answers this name -- the link is what stands in for a cell on
+      // the way to storage -- and a cell is not a builder artifact.
+      expect(hasEncodableForm({ toSigilLinkOrNull: () => ({}) })).toBe(true);
+    });
+
+    it("returns false for a value carrying only `toJSON`", () => {
+      // The JSON protocol's name gets no standing here. A cell carries it too,
+      // for `JSON.stringify`, and reading storage's answer off it would mean
+      // every value bearing the protocol's member answered as well.
+      expect(hasEncodableForm({ toJSON: () => ({}) })).toBe(false);
     });
 
     it("returns true for an INHERITED member", () => {
@@ -327,7 +333,8 @@ describe("encodable-form", () => {
     });
 
     it("returns false for a non-callable member of either name", () => {
-      expect(hasEncodableForm({ toEncodableForm: 1, toJSON: 2 })).toBe(false);
+      expect(hasEncodableForm({ toEncodableForm: 1, toSigilLinkOrNull: 2 }))
+        .toBe(false);
     });
 
     it("returns false for `null` and for a primitive", () => {
@@ -344,16 +351,15 @@ describe("encodable-form", () => {
         .toEqual({ a: 1 });
     });
 
-    it("falls back to `toJSON` when that is the only name", () => {
-      expect(encodableFormOf({ toJSON: () => ({ b: 2 }) })).toEqual({ b: 2 });
+    it("falls back to `toSigilLinkOrNull` when that is the only name", () => {
+      expect(encodableFormOf({ toSigilLinkOrNull: () => ({ b: 2 }) }))
+        .toEqual({ b: 2 });
     });
 
     it("prefers `toEncodableForm` when a value carries both", () => {
-      // A builder artifact carries both, and `toJSON` merely delegates. The
-      // order is what makes the runtime ask by the name that means it.
       const value = {
         toEncodableForm: () => ({ preferred: true }),
-        toJSON: () => ({ preferred: false }),
+        toSigilLinkOrNull: () => ({ preferred: false }),
       };
       expect(encodableFormOf(value)).toEqual({ preferred: true });
     });

--- a/packages/runner/test/favorites-row-stored-shape.test.ts
+++ b/packages/runner/test/favorites-row-stored-shape.test.ts
@@ -3,6 +3,7 @@ import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { fromFileUrl } from "@std/path/from-file-url";
 
+import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "../src/runtime.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
@@ -203,7 +204,7 @@ describe("a stored favorite row instantiates in favorites-manager", () => {
 
     // Sanity: the row is live before the swap, so a failure below is the swap's
     // re-stage and not a mis-seeded fixture.
-    expect(JSON.stringify(managerCell.getAsQueryResult()))
+    expect(toCompactDebugString(managerCell.getAsQueryResult()))
       .not.toContain("No favorites yet.");
 
     // The swap. Identity is content-addressed, so v2 has to differ in SOURCE —
@@ -241,7 +242,7 @@ describe("a stored favorite row instantiates in favorites-manager", () => {
     expect(
       (managerCell.getAsQueryResult() as Record<string, unknown>)["$NAME"],
     ).toBe("Favorites Manager v2");
-    expect(JSON.stringify(managerCell.getAsQueryResult()))
+    expect(toCompactDebugString(managerCell.getAsQueryResult()))
       .not.toContain("No favorites yet.");
   });
 });

--- a/packages/runner/test/link-utils.test.ts
+++ b/packages/runner/test/link-utils.test.ts
@@ -228,9 +228,9 @@ describe("link-utils", () => {
       });
     });
 
-    it("should parse toJSON to normalized links", () => {
+    it("should parse a cell's sigil link to normalized links", () => {
       const cell = runtime.getCell(space, "test");
-      const result = parseLink(cell.toJSON(), cell);
+      const result = parseLink(cell.toSigilLinkOrNull(), cell);
 
       expect(result).toEqual({
         id: expect.stringContaining("of:"),

--- a/packages/runner/test/patterns-regressions.test.ts
+++ b/packages/runner/test/patterns-regressions.test.ts
@@ -266,7 +266,7 @@ describe("Pattern Runner - Regressions", () => {
     tx = runtime.edit();
   });
 
-  it("normalizes nested toJSON values before raw runner writes in v2", async () => {
+  it("normalizes nested builder artifacts before raw runner writes in v2", async () => {
     await commitTx();
     await runtime.dispose();
     await storageManager.close();
@@ -281,13 +281,15 @@ describe("Pattern Runner - Regressions", () => {
     tx = runtime.edit();
     bindBuilder();
 
+    // Shaped like a builder artifact: a function carrying its own
+    // `toEncodableForm`, which is the member the write path keys on.
     const initialRecipe = Object.assign(() => {}, {
-      toJSON() {
+      toEncodableForm() {
         return { name: "initial recipe" };
       },
     });
     const resultRecipe = Object.assign(() => {}, {
-      toJSON() {
+      toEncodableForm() {
         return { name: "result recipe" };
       },
     });
@@ -297,7 +299,7 @@ describe("Pattern Runner - Regressions", () => {
       resultSchema: {},
       derivedInternalCells: [{
         partialCause: "recipe",
-        schema: { default: initialRecipe.toJSON() },
+        schema: { default: initialRecipe.toEncodableForm() },
       }],
       result: {
         internalRecipe: {

--- a/packages/runner/test/result-projection-value-equality.test.ts
+++ b/packages/runner/test/result-projection-value-equality.test.ts
@@ -1,7 +1,10 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
-import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
+import {
+  FabricBytes,
+  FabricEpochNsec,
+} from "@commonfabric/data-model/fabric-primitives";
 
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
 import { Runtime } from "../src/runtime.ts";
@@ -81,7 +84,7 @@ describe("result projection", () => {
       ({
         argumentSchema: { type: "object", properties: {} } as const,
         resultSchema: undefined,
-        result: { tag, when: { toJSON: () => "2020-01-01" } },
+        result: { tag, when: new Date("2020-01-01T00:00:00.000Z") },
         nodes: [],
       }) as unknown as Pattern;
 
@@ -107,7 +110,8 @@ describe("result projection", () => {
       const raw = runtime.getCell(space, "native-result", undefined)
         .getRaw() as { tag: number; when: unknown };
       expect(raw.tag).toBe(2);
-      expect(raw.when).toBe("2020-01-01");
+      expect(raw.when).toBeInstanceOf(FabricEpochNsec);
+      expect((raw.when as FabricEpochNsec).value).toBe(1577836800000000000n);
     } finally {
       await runtime.dispose();
       await storage.close();


### PR DESCRIPTION
A value on its way into the data model may hold two things the model has no
representation for: a builder artifact, and a `Cell`. The runtime replaces both
itself, at the boundaries where they arrive, rather than leaving either to be
recognized by the duck-typed `toJSON` protocol on the way through.

Artifacts already worked this way at the pattern-driven boundaries. This adds
the two that were missing.

## What changes

- **`diffAndUpdate()`** — the raw write funnel behind `Cell.set()` and the
  collection operations — now runs the artifact walk. `addUnique()`'s dedup
  comparison normalizes the same way, so a candidate is compared in the form a
  write would store it in.
- **`Runtime.getImmutableCell()`** now turns cells into links. Its entity id is
  derived from the bytes of what it is given, so a cell reaching the conversion
  unreplaced is a document that cannot be named. Its own comment already said
  as much: "`fabricFromNativeValue()` converts what callers actually pass --
  notably `Cell`s, which become sigil links via their `toJSON()`".

One walk covers both. `replaceArtifacts()` takes a `replaceOther` hook for the
values it does not descend into, and `getImmutableCell` supplies the cell
knowledge: `isCell()` lives in the runtime's core, and `encodable-form.ts` is a
leaf that the import graph reaches from the other direction.

A `Cell` also gains `toSigilLinkOrNull()`, and `hasEncodableForm()` asks for
THAT name rather than `toJSON`. Both names it now reads are the runtime's own,
so no value acquires an encodable form by carrying a member the JSON protocol
happens to share. `Cell.toJSON()` remains, delegating, for `JSON.stringify`.

## Why it is inert, measured

An A/B harness runs 25 probes across this tree and `main`: six
pattern-serialization encodings, seven raw cell writes, nine
`getImmutableCell` entity ids, plus liveness and provenance. **Every one is
byte-identical.**

Suites: full workspace passing; `packages/runner` 1133 passed / 0 failed, the
same count as `main`. `deno fmt --check`, `deno lint`, `deno task check`, and
the eight standalone gates are green.

## What this unblocks

`data-model` can stop honoring `toJSON()` in `fabricFromNativeValue()`, which
is the point of the exercise. That is the follow-on PR, stacked on this one.

## One thing found in passing, and left alone

`convertCellsToLinks()` is not the walk for this job. It treats a SHARED
reference as a cycle, so a pattern graph's repeated empty `path: []` comes back
rewritten as a back-link into the first occurrence. It also converts
query-result proxies that the conversion had been rejecting. Both are harmless
where it is used today, its one caller feeding it event values rather than a
graph, so this changes nothing about it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The runtime now serializes builder artifacts and `Cell`s at storage boundaries, replacing them with their encodable forms/links before values hit the data model. This removes reliance on duck-typed `toJSON` and keeps behavior unchanged.

- **Refactors**
  - `diffAndUpdate()` now flattens builder artifacts; `addUnique()` compares candidates in their normalized, stored form.
  - `Runtime.getImmutableCell()` replaces embedded `Cell`s with sigil links via a single walk that also flattens artifacts.
  - Added `Cell.toSigilLinkOrNull()`; `toJSON()` delegates for `JSON.stringify` only.
  - `hasEncodableForm()` now checks `toEncodableForm` or `toSigilLinkOrNull` (no `toJSON` fallback); the walk accepts a `replaceOther` hook to handle values it doesn’t descend into.
  - No behavior change: A/B probes are byte-identical and all tests in `packages/runner` pass.

<sup>Written for commit 367233c3fd06cb96f6c6127cb6bec4efcfff5dea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



---

NEW_COVERAGE_BASELINE

The ratchet reports `packages/runner` uncovered +1. Attributed from CI's own
LCOV artifacts — every `coverage-profile-*` from this run and from the base
`main` run, merged by max hits, diffed per file:

- **427 lines newly uncovered, 407 newly covered** in `packages/runner` — a
  wash, and the same churn appears in `packages/llm`, `packages/memory`, and
  `packages/ts-transformers`, none of which this branch touches.
- Intersecting this branch's added source lines with that merged profile gives
  **zero** uncovered added lines.

The churn is shard re-partitioning. The runner suite is sharded five ways and
balanced on the `test-timing-*` artifacts; this branch changes per-file test
timings (a step removed from `doc-map.test.ts`, one added to
`cell-links.test.ts`), so the shards divide differently and incidental coverage
of untouched files moves with them.

(The reconstruction above does not reproduce the gate's arithmetic exactly —
it counts 4588 → 4608 where the gate counts 4783 → 4784 — so treat the wash and
the zero as the findings, not the absolute totals.)
