### PR TITLE
refactor(ts-transformers): make the cross-stage state a required fiel…

### DIFF
--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -88,6 +88,13 @@ pipeline from `CFC_TRANSFORMER_STAGE_SPECS`. Every stage shares:
   is the sole owner of cross-transformer communication. It replaced the
   formerly-separate registry fields on `TransformationOptions`.
 
+A stage reaches that instance as `context.state`. `TransformationContext`
+resolves it once in its constructor — taking the caller's `options.state` when
+one is supplied and creating a fresh instance otherwise — and stores the result
+back into its own `options`, so a nested context built from those options joins
+the same run. Every registry a stage reads through `context.state` is therefore
+present; no stage handles a missing one.
+
 `CrossStageState` organizes its registries into three deliberate families
 (mirroring the TypeScript compiler's `NodeLinks` pattern):
 

--- a/packages/ts-transformers/src/ast/type-building.ts
+++ b/packages/ts-transformers/src/ast/type-building.ts
@@ -451,9 +451,9 @@ export function expressionToTypeNode(
     // type arguments (`Default<string, .ts";`).
     const clonedTypeNode = cloneTypeNodeDeepForEmission(
       declaredTypeNode,
-      context.options.state?.typeRegistry,
+      context.state.typeRegistry,
     );
-    context.options.state?.typeRegistry?.set(clonedTypeNode, type);
+    context.state.typeRegistry.set(clonedTypeNode, type);
     return clonedTypeNode;
   }
 
@@ -462,12 +462,12 @@ export function expressionToTypeNode(
   const type = inferWidenedTypeFromExpression(
     expr,
     context.checker,
-    context.options.state?.typeRegistry,
+    context.state.typeRegistry,
   );
   return typeToTypeNodeWithRegistry(
     type,
     context,
-    context.options.state?.typeRegistry,
+    context.state.typeRegistry,
   );
 }
 
@@ -750,7 +750,7 @@ export function buildTypeElementsFromCaptureTree(
         inferWidenedTypeFromExpression(
           childNode.expression,
           checker,
-          context.options.state?.typeRegistry,
+          context.state.typeRegistry,
         ),
         propName,
       );
@@ -877,7 +877,7 @@ export function buildTypeElementsFromCaptureTree(
         {
           factory,
           checker,
-          typeRegistry: context.options.state?.typeRegistry,
+          typeRegistry: context.state.typeRegistry,
         },
       );
     }

--- a/packages/ts-transformers/src/closures/strategies/action-strategy.ts
+++ b/packages/ts-transformers/src/closures/strategies/action-strategy.ts
@@ -147,17 +147,15 @@ export function transformActionCall(
   // Note: The action call has type `ModuleFactory<T, Stream<void>>`, but the finalCall
   // is `handler(...)({...})` which CALLS the factory. We need the return type of that call,
   // which is `Reactive<Stream<void>>`.
-  const typeRegistry = context.options.state?.typeRegistry;
-  if (typeRegistry) {
-    // Get the type of the original action call (ModuleFactory<T, Stream<void>>)
-    const actionType = checker.getTypeAtLocation(actionCall);
-    // Get the call signature to find what type is returned when calling the factory
-    const callSignatures = actionType.getCallSignatures();
-    if (callSignatures.length > 0) {
-      const callReturnType = callSignatures[0]!.getReturnType();
-      // This should be Reactive<Stream<void>> - the type of calling handler(...)({...})
-      registerSyntheticCallType(finalCall, callReturnType, typeRegistry);
-    }
+  const typeRegistry = context.state.typeRegistry;
+  // Get the type of the original action call (ModuleFactory<T, Stream<void>>)
+  const actionType = checker.getTypeAtLocation(actionCall);
+  // Get the call signature to find what type is returned when calling the factory
+  const callSignatures = actionType.getCallSignatures();
+  if (callSignatures.length > 0) {
+    const callReturnType = callSignatures[0]!.getReturnType();
+    // This should be Reactive<Stream<void>> - the type of calling handler(...)({...})
+    registerSyntheticCallType(finalCall, callReturnType, typeRegistry);
   }
 
   return finalCall;

--- a/packages/ts-transformers/src/closures/strategies/array-method-policy.ts
+++ b/packages/ts-transformers/src/closures/strategies/array-method-policy.ts
@@ -85,10 +85,10 @@ function hasSharedReactiveCollectionProvenance(
     context.checker,
     {
       ...options,
-      typeRegistry: context.options.state?.typeRegistry,
+      typeRegistry: context.state.typeRegistry,
       logger: context.options.logger,
-      syntheticReactiveCollectionRegistry: context.options.state
-        ?.syntheticReactiveCollectionRegistry,
+      syntheticReactiveCollectionRegistry: context.state
+        .syntheticReactiveCollectionRegistry,
     },
   );
 }
@@ -127,7 +127,7 @@ export function shouldTransformArrayMethod(
   const targetType = getTypeAtLocationWithFallback(
     mapTarget,
     context.checker,
-    context.options.state?.typeRegistry,
+    context.state.typeRegistry,
     context.options.logger,
   );
   const receiverKind = classifyReactiveReceiverKind(

--- a/packages/ts-transformers/src/closures/strategies/array-method-transform.ts
+++ b/packages/ts-transformers/src/closures/strategies/array-method-transform.ts
@@ -202,20 +202,18 @@ function createPatternCallWithParams(
   );
 
   const { checker } = context;
-  const typeRegistry = context.options.state?.typeRegistry;
+  const typeRegistry = context.state.typeRegistry;
   let resultTypeNode: ts.TypeNode | undefined;
 
   if (callback.type) {
     resultTypeNode = callback.type;
-    if (typeRegistry) {
-      const type = getTypeAtLocationWithFallback(
-        callback.type,
-        checker,
-        typeRegistry,
-      );
-      if (type) {
-        typeRegistry.set(callback.type, type);
-      }
+    const type = getTypeAtLocationWithFallback(
+      callback.type,
+      checker,
+      typeRegistry,
+    );
+    if (type) {
+      typeRegistry.set(callback.type, type);
     }
   } else {
     const signature = checker.getSignatureFromDeclaration(callback);
@@ -304,10 +302,8 @@ function createPatternCallWithParams(
     methodCall,
   );
 
-  if (typeRegistry) {
-    const mapResultType = context.checker.getTypeAtLocation(methodCall);
-    registerSyntheticCallType(mapWithPatternCall, mapResultType, typeRegistry);
-  }
+  const mapResultType = context.checker.getTypeAtLocation(methodCall);
+  registerSyntheticCallType(mapWithPatternCall, mapResultType, typeRegistry);
 
   return mapWithPatternCall;
 }

--- a/packages/ts-transformers/src/closures/strategies/array-method-utils.ts
+++ b/packages/ts-transformers/src/closures/strategies/array-method-utils.ts
@@ -275,10 +275,10 @@ function createAliasExpressionAsLiftApplied(
   // The type comes from info.symbol which was captured from the original
   // binding element. Without this registration, createLiftAppliedCall cannot
   // determine the correct result type for the synthetic lift-applied call.
-  if (context.options.state?.typeRegistry && info.symbol) {
+  if (info.symbol) {
     const symbolType = checker.getTypeOfSymbol(info.symbol);
     if (symbolType) {
-      context.options.state?.typeRegistry.set(elementAccess, symbolType);
+      context.state.typeRegistry.set(elementAccess, symbolType);
     }
   }
 

--- a/packages/ts-transformers/src/closures/strategies/lift-applied-strategy.ts
+++ b/packages/ts-transformers/src/closures/strategies/lift-applied-strategy.ts
@@ -405,7 +405,7 @@ export function transformLiftAppliedCall(
     return undefined;
   }
   const inputCall = node;
-  const { factory, checker, options } = context;
+  const { factory, checker, state } = context;
 
   // Extract callback
   const liftAppliedArgs = getLiftAppliedInputAndCallback(inputCall, checker);
@@ -431,7 +431,7 @@ export function transformLiftAppliedCall(
     callback.body,
     captureExpressions,
     checker,
-    options.state?.typeRegistry,
+    state.typeRegistry,
   );
 
   // Recursively transform the callback body first
@@ -476,7 +476,7 @@ export function transformLiftAppliedCall(
     captureExpressions,
     factory,
     checker,
-    options.state?.typeRegistry,
+    state.typeRegistry,
   );
 
   // Initialize PatternBuilder
@@ -511,8 +511,8 @@ export function transformLiftAppliedCall(
     // bare refs and carries the registry association onto the rewritten node.
     resultTypeNode = qualifyCommonFabricTypeRefs(
       callback.type,
-      options.state?.typeRegistry?.get(callback.type),
-      { checker, factory, typeRegistry: options.state?.typeRegistry },
+      state.typeRegistry.get(callback.type),
+      { checker, factory, typeRegistry: state.typeRegistry },
     );
   } else if (signature) {
     // Infer from callback signature
@@ -537,7 +537,7 @@ export function transformLiftAppliedCall(
           factory,
           sourceFile: context.sourceFile,
         },
-        options.state?.typeRegistry,
+        state.typeRegistry,
       );
     }
   }
@@ -582,7 +582,7 @@ export function transformLiftAppliedCall(
   const capabilityAnalysis = getCapabilityAnalysis(
     newCallback,
     checker,
-    options.state?.typeRegistry,
+    state.typeRegistry,
   );
   const inputParamSummary = capabilityAnalysis.firstParameter;
   if (inputParamSummary) {
@@ -592,7 +592,7 @@ export function transformLiftAppliedCall(
       getTypeFromTypeNodeWithFallback(
         inputTypeNode,
         checker,
-        options.state?.typeRegistry,
+        state.typeRegistry,
       ),
       false,
       checker,
@@ -633,15 +633,13 @@ export function transformLiftAppliedCall(
   );
 
   // Register the type of the call expression itself
-  if (options.state?.typeRegistry) {
-    registerLiftAppliedCallType(
-      rebuiltCall,
-      resultTypeNode,
-      resultType,
-      checker,
-      options.state?.typeRegistry,
-    );
-  }
+  registerLiftAppliedCallType(
+    rebuiltCall,
+    resultTypeNode,
+    resultType,
+    checker,
+    state.typeRegistry,
+  );
 
   return rebuiltCall;
 }

--- a/packages/ts-transformers/src/closures/utils/schema-factory.ts
+++ b/packages/ts-transformers/src/closures/utils/schema-factory.ts
@@ -28,7 +28,7 @@ export function createArrayMethodCallbackSchema(
   context: TransformationContext,
 ): ts.TypeNode {
   const { checker, factory } = context;
-  const typeRegistry = context.options.state?.typeRegistry;
+  const typeRegistry = context.state.typeRegistry;
 
   // 1. Determine element type
   let elemTypeNode: ts.TypeNode;
@@ -123,7 +123,7 @@ export function createHandlerStateSchema(
   context: TransformationContext,
 ): ts.TypeNode {
   const { checker, factory } = context;
-  const typeRegistry = context.options.state?.typeRegistry;
+  const typeRegistry = context.state.typeRegistry;
 
   // Try explicit annotation first
   if (stateParam) {
@@ -202,7 +202,7 @@ export function createLiftAppliedInputSchema(
     {
       factory,
       checker,
-      typeRegistry: context.options.state?.typeRegistry,
+      typeRegistry: context.state.typeRegistry,
     },
   );
 }
@@ -227,7 +227,7 @@ export function createHandlerEventSchema(
   context: TransformationContext,
 ): ts.TypeNode {
   const { factory, checker } = context;
-  const typeRegistry = context.options.state?.typeRegistry;
+  const typeRegistry = context.state.typeRegistry;
   const eventParam = callback.parameters[0];
 
   // If no event parameter exists, use never type (will generate false schema)

--- a/packages/ts-transformers/src/core/context.ts
+++ b/packages/ts-transformers/src/core/context.ts
@@ -46,6 +46,13 @@ export class TransformationContext {
   readonly factory: ts.NodeFactory;
   readonly sourceFile: ts.SourceFile;
   readonly options: TransformationOptions;
+  /**
+   * The cross-transformer communication registries every stage in this run
+   * shares. Either injected through `options.state` or created here; the same
+   * instance is stored back into `this.options.state` so a nested
+   * `TransformationContext` built from these options joins the same run.
+   */
+  readonly state: CrossStageState;
   readonly cfHelpers: CFHelpers;
   readonly diagnostics: TransformationDiagnostic[] = [];
   readonly tsContext: ts.TransformationContext;
@@ -60,10 +67,11 @@ export class TransformationContext {
       factory: this.factory,
       sourceFile: this.sourceFile,
     });
+    this.state = config.options?.state ?? new CrossStageState();
     this.options = {
       ...DEFAULT_OPTIONS,
       ...config.options,
-      state: config.options?.state ?? new CrossStageState(),
+      state: this.state,
     };
   }
 
@@ -96,14 +104,12 @@ export class TransformationContext {
    * shared CrossStageState so the duplicates collapse to one. The file name is
    * part of the key because that state is shared across every file in a
    * compilation, and the range is a file-relative offset that would otherwise
-   * collide between files. With no shared state present it falls back to
-   * reporting unconditionally.
+   * collide between files.
    */
   reportDiagnosticOnce(input: DiagnosticInput): void {
     const { start, length } = this.resolveDiagnosticRange(input.node);
     const key = `${this.sourceFile.fileName}:${input.type}:${start}:${length}`;
-    const state = this.options.state;
-    if (state && !state.markDiagnosticReported(key)) {
+    if (!this.state.markDiagnosticReported(key)) {
       return;
     }
     this.reportDiagnostic(input);
@@ -156,7 +162,7 @@ export class TransformationContext {
    * array method callback scopes.
    */
   markAsArrayMethodCallback(node: ts.Node): void {
-    this.options.state?.markArrayMethodCallback(node);
+    this.state.markArrayMethodCallback(node);
     this.invalidateReactiveAnalysisCaches();
   }
 
@@ -164,7 +170,7 @@ export class TransformationContext {
    * Check if a node is an array method callback created by ClosureTransformer.
    */
   isArrayMethodCallback(node: ts.Node): boolean {
-    return this.options.state?.isArrayMethodCallback(node) ?? false;
+    return this.state.isArrayMethodCallback(node);
   }
 
   /**
@@ -173,7 +179,7 @@ export class TransformationContext {
    * authored nodes with original parent chains in pattern context.
    */
   markAsSyntheticComputeCallback(node: ts.Node): void {
-    this.options.state?.markSyntheticComputeCallback(node);
+    this.state.markSyntheticComputeCallback(node);
     this.invalidateReactiveAnalysisCaches();
   }
 
@@ -181,16 +187,16 @@ export class TransformationContext {
    * Check if a node is a synthetic compute wrapper callback.
    */
   isSyntheticComputeCallback(node: ts.Node): boolean {
-    return this.options.state?.isSyntheticComputeCallback(node) ?? false;
+    return this.state.isSyntheticComputeCallback(node);
   }
 
   markSyntheticComputeOwnedSubtree(node: ts.Node): void {
-    this.options.state?.markSyntheticComputeOwnedSubtree(node);
+    this.state.markSyntheticComputeOwnedSubtree(node);
     this.invalidateReactiveAnalysisCaches();
   }
 
   isSyntheticComputeOwnedNode(node: ts.Node): boolean {
-    return this.options.state?.isSyntheticComputeOwnedNode(node) ?? false;
+    return this.state.isSyntheticComputeOwnedNode(node);
   }
 
   /**
@@ -200,16 +206,14 @@ export class TransformationContext {
    * the `nodeLinks.schemaInjected` docs in core/mod.ts (CT-1621).
    */
   markSchemaInjected(node: ts.Node): void {
-    this.options.state?.markSchemaInjected(node);
+    this.state.markSchemaInjected(node);
   }
 
   /**
-   * Whether SchemaInjection has already finalized this node. Returns false
-   * when no state is present (so a missing registry never suppresses a real
-   * first-pass injection).
+   * Whether SchemaInjection has already finalized this node.
    */
   isSchemaInjected(node: ts.Node): boolean {
-    return this.options.state?.isSchemaInjected(node) ?? false;
+    return this.state.isSchemaInjected(node);
   }
 
   /**
@@ -220,7 +224,7 @@ export class TransformationContext {
    * consumers are schema-injection + the schema generator.
    */
   recordSchemaHint(node: ts.Node, hint: SchemaHint): void {
-    this.options.state?.recordSchemaHint(node, hint);
+    this.state.recordSchemaHint(node, hint);
   }
 
   /**
@@ -228,7 +232,7 @@ export class TransformationContext {
    * node (handles visitor-replaced nodes). Returns undefined when absent.
    */
   lookupSchemaHint(node: ts.Node): SchemaHint | undefined {
-    return this.options.state?.lookupSchemaHint(node);
+    return this.state.lookupSchemaHint(node);
   }
 
   /**
@@ -241,7 +245,7 @@ export class TransformationContext {
     fn: ts.Node,
     summary: FunctionCapabilitySummary,
   ): void {
-    this.options.state?.recordCapabilitySummary(fn, summary);
+    this.state.recordCapabilitySummary(fn, summary);
   }
 
   /**
@@ -251,7 +255,7 @@ export class TransformationContext {
   lookupCapabilitySummary(
     fn: ts.Node,
   ): FunctionCapabilitySummary | undefined {
-    return this.options.state?.lookupCapabilitySummary(fn);
+    return this.state.lookupCapabilitySummary(fn);
   }
 
   markSyntheticReactiveCollectionDeclaration(node: ts.Node): void {
@@ -265,7 +269,7 @@ export class TransformationContext {
     if (!symbol) {
       return;
     }
-    this.options.state?.markSyntheticReactiveCollection(symbol);
+    this.state.markSyntheticReactiveCollection(symbol);
     this.invalidateReactiveAnalysisCaches();
   }
 

--- a/packages/ts-transformers/src/core/transformers.ts
+++ b/packages/ts-transformers/src/core/transformers.ts
@@ -122,6 +122,10 @@ export interface TransformationOptions {
    * Single owner of the pipeline's cross-transformer communication registries
    * (typeRegistry, schemaHints, the marker sets, etc.). Replaces the formerly
    * separate registry fields. See `CrossStageState`.
+   *
+   * This is the injection point for a caller that wants several runs to share
+   * one set of registries. A `TransformationContext` built without one creates
+   * its own and stores it back here, so `context.state` is always present.
    */
   readonly state?: CrossStageState;
   /**

--- a/packages/ts-transformers/src/lift/transformer.ts
+++ b/packages/ts-transformers/src/lift/transformer.ts
@@ -131,17 +131,15 @@ function finalizeLoweredCall(
     originalNode,
   );
 
-  if (context.options.state?.typeRegistry) {
-    const originalType = context.options.state?.typeRegistry.get(originalNode);
-    if (originalType) {
-      registerLiftAppliedCallType(
-        preservedVisitedCall,
-        undefined,
-        originalType,
-        checker,
-        context.options.state?.typeRegistry,
-      );
-    }
+  const originalType = context.state.typeRegistry.get(originalNode);
+  if (originalType) {
+    registerLiftAppliedCallType(
+      preservedVisitedCall,
+      undefined,
+      originalType,
+      checker,
+      context.state.typeRegistry,
+    );
   }
 
   setParentPointers(preservedVisitedCall, originalNode.parent);

--- a/packages/ts-transformers/src/transformers/builtins/lift-applied.ts
+++ b/packages/ts-transformers/src/transformers/builtins/lift-applied.ts
@@ -219,7 +219,7 @@ export function createLiftAppliedCall(
     factory,
     tsContext,
     context.checker,
-    context.options.state?.typeRegistry,
+    context.state.typeRegistry,
   );
 
   // Callback arrow: source-map-range only (emit-safe position carry). See
@@ -292,15 +292,13 @@ export function createLiftAppliedCall(
   // Register the type of the call expression itself in the typeRegistry
   // so that type inference works correctly for synthetic nodes. The
   // result type is the value the callback returns.
-  if (context.options.state?.typeRegistry && context.checker) {
-    registerLiftAppliedCallType(
-      liftAppliedCall,
-      resultTypeNode,
-      undefined, // resultType not available in this code path
-      context.checker,
-      context.options.state?.typeRegistry,
-    );
-  }
+  registerLiftAppliedCallType(
+    liftAppliedCall,
+    resultTypeNode,
+    undefined, // resultType not available in this code path
+    context.checker,
+    context.state.typeRegistry,
+  );
 
   // Maintain parent chains and compute-wrapper ownership for later passes that
   // revisit synthetic lift-applied callbacks after post-closure lowering.
@@ -342,7 +340,7 @@ function buildInputTypeNode(
     {
       factory,
       checker: context.checker,
-      typeRegistry: context.options.state?.typeRegistry,
+      typeRegistry: context.state.typeRegistry,
     },
   );
 }
@@ -359,7 +357,7 @@ function buildResultTypeNode(
   const resultType = getTypeAtLocationWithFallback(
     expression,
     checker,
-    context.options.state?.typeRegistry,
+    context.state.typeRegistry,
   );
 
   // If we couldn't get a type, fallback to unknown
@@ -379,6 +377,6 @@ function buildResultTypeNode(
       factory,
       sourceFile: context.sourceFile,
     },
-    context.options.state?.typeRegistry,
+    context.state.typeRegistry,
   );
 }

--- a/packages/ts-transformers/src/transformers/cfc-policy-authoring.ts
+++ b/packages/ts-transformers/src/transformers/cfc-policy-authoring.ts
@@ -821,7 +821,7 @@ export class CfcPolicyAuthoringTransformer extends Transformer {
         });
       }
     }
-    context.options.state?.recordPolicyManifests(
+    context.state.recordPolicyManifests(
       sourceFile.fileName,
       manifests,
     );

--- a/packages/ts-transformers/src/transformers/destructuring-lowering.ts
+++ b/packages/ts-transformers/src/transformers/destructuring-lowering.ts
@@ -144,7 +144,7 @@ export function getStaticDefaultTypeNode(
       {
         factory,
         checker: context.checker,
-        typeRegistry: context.options.state?.typeRegistry,
+        typeRegistry: context.state.typeRegistry,
       },
     );
   }

--- a/packages/ts-transformers/src/transformers/expression-rewrite/emitters/binary-expression.ts
+++ b/packages/ts-transformers/src/transformers/expression-rewrite/emitters/binary-expression.ts
@@ -152,14 +152,12 @@ export const emitBinaryExpression: Emitter = ({
         cfHelpers: context.cfHelpers,
       });
 
-      if (context.options.state?.typeRegistry) {
-        const resultType = context.checker.getTypeAtLocation(expression);
-        registerSyntheticCallType(
-          whenCall,
-          resultType,
-          context.options.state?.typeRegistry,
-        );
-      }
+      const resultType = context.checker.getTypeAtLocation(expression);
+      registerSyntheticCallType(
+        whenCall,
+        resultType,
+        context.state.typeRegistry,
+      );
 
       return whenCall;
     }
@@ -202,14 +200,12 @@ export const emitBinaryExpression: Emitter = ({
         cfHelpers: context.cfHelpers,
       });
 
-      if (context.options.state?.typeRegistry) {
-        const resultType = context.checker.getTypeAtLocation(expression);
-        registerSyntheticCallType(
-          unlessCall,
-          resultType,
-          context.options.state?.typeRegistry,
-        );
-      }
+      const resultType = context.checker.getTypeAtLocation(expression);
+      registerSyntheticCallType(
+        unlessCall,
+        resultType,
+        context.state.typeRegistry,
+      );
 
       return unlessCall;
     }

--- a/packages/ts-transformers/src/transformers/expression-rewrite/emitters/conditional-expression.ts
+++ b/packages/ts-transformers/src/transformers/expression-rewrite/emitters/conditional-expression.ts
@@ -184,14 +184,12 @@ export const emitConditionalExpression: Emitter = ({
     },
   });
 
-  if (context.options.state?.typeRegistry) {
-    const resultType = context.checker.getTypeAtLocation(expression);
-    registerSyntheticCallType(
-      ifElseCall,
-      resultType,
-      context.options.state?.typeRegistry,
-    );
-  }
+  const resultType = context.checker.getTypeAtLocation(expression);
+  registerSyntheticCallType(
+    ifElseCall,
+    resultType,
+    context.state.typeRegistry,
+  );
 
   return ifElseCall;
 };

--- a/packages/ts-transformers/src/transformers/expression-rewrite/rewrite-helpers.ts
+++ b/packages/ts-transformers/src/transformers/expression-rewrite/rewrite-helpers.ts
@@ -142,7 +142,7 @@ export function createReactiveWrapperForExpression(
     resultTypeNode = typeToTypeNodeWithRegistry(
       resultType,
       { checker, factory, sourceFile },
-      context.options.state?.typeRegistry,
+      context.state.typeRegistry,
     );
   } catch {
     resultTypeNode = undefined;
@@ -199,9 +199,9 @@ export function createReactiveWrapperForExpression(
   );
 
   // Register types for both the TypeNode and the lift-applied CallExpression
-  if (resultTypeNode && resultType && context.options.state?.typeRegistry) {
-    context.options.state?.typeRegistry.set(resultTypeNode, resultType);
-    context.options.state?.typeRegistry.set(liftAppliedCall, resultType);
+  if (resultTypeNode && resultType) {
+    context.state.typeRegistry.set(resultTypeNode, resultType);
+    context.state.typeRegistry.set(liftAppliedCall, resultType);
   }
 
   // CRITICAL: Set parent pointers and connect to parent chain

--- a/packages/ts-transformers/src/transformers/expression-site-policy.ts
+++ b/packages/ts-transformers/src/transformers/expression-site-policy.ts
@@ -937,7 +937,7 @@ function arrayMethodCallbackValueResolvesToCollection(
     getTypeAtLocationWithFallback(
       expression,
       context.checker,
-      context.options.state?.typeRegistry,
+      context.state.typeRegistry,
       context.options.logger,
     ),
     context.checker,

--- a/packages/ts-transformers/src/transformers/mergeable-push-validation.ts
+++ b/packages/ts-transformers/src/transformers/mergeable-push-validation.ts
@@ -97,7 +97,7 @@ export class MergeablePushValidationTransformer extends HelpersOnlyTransformer {
     const byCollection = new Map<string, MergeablePushMisuse>();
     analyzeFunctionCapabilities(callback, {
       checker: context.checker,
-      typeRegistry: context.options.state?.typeRegistry,
+      typeRegistry: context.state.typeRegistry,
       mergeablePushMisuseSink: (finding) => {
         const key = JSON.stringify([finding.rootName, ...finding.path]);
         const existing = byCollection.get(key);

--- a/packages/ts-transformers/src/transformers/pattern-body-reactive-root-lowering.ts
+++ b/packages/ts-transformers/src/transformers/pattern-body-reactive-root-lowering.ts
@@ -126,9 +126,7 @@ function registerReplacementType(
   original: ts.Node,
   context: TransformationContext,
 ): void {
-  const typeRegistry = context.options.state?.typeRegistry;
-  if (!typeRegistry) return;
-
+  const typeRegistry = context.state.typeRegistry;
   const originalType = getTypeAtLocationWithFallback(
     original,
     context.checker,

--- a/packages/ts-transformers/src/transformers/pattern-callback-transform.ts
+++ b/packages/ts-transformers/src/transformers/pattern-callback-transform.ts
@@ -89,12 +89,9 @@ export function registerCapabilitySummary(
   interprocedural: boolean,
   defaultsByParamName?: ReadonlyMap<string, readonly CapabilityParamDefault[]>,
 ): void {
-  // No cross-stage state → nowhere to record; skip the analysis work entirely.
-  if (!context.options.state) return;
-
   const summary = analyzeFunctionCapabilities(callback, {
     checker: context.checker,
-    typeRegistry: context.options.state?.typeRegistry,
+    typeRegistry: context.state.typeRegistry,
     interprocedural,
   });
 

--- a/packages/ts-transformers/src/transformers/reactive-variable-for.ts
+++ b/packages/ts-transformers/src/transformers/reactive-variable-for.ts
@@ -648,7 +648,7 @@ function shouldAddReactiveFor(
   const type = getTypeAtLocationWithFallback(
     expression,
     context.checker,
-    context.options.state?.typeRegistry,
+    context.state.typeRegistry,
     context.options.logger,
   );
   return isCellLikeType(type, context.checker);
@@ -726,9 +726,9 @@ function isReactiveArrayMethodCall(
       allowImplicitReactiveParameters: false,
       allowReactiveArrayCallbackParameters: false,
       sameScope: getEnclosingFunctionLikeDeclaration(call),
-      typeRegistry: context.options.state?.typeRegistry,
-      syntheticReactiveCollectionRegistry: context.options.state
-        ?.syntheticReactiveCollectionRegistry,
+      typeRegistry: context.state.typeRegistry,
+      syntheticReactiveCollectionRegistry: context.state
+        .syntheticReactiveCollectionRegistry,
       logger: context.options.logger,
     },
   ) || isExplicitReactiveCall(target.expression, context);
@@ -761,7 +761,7 @@ function shouldRetargetReactiveReference(
   const type = getTypeAtLocationWithFallback(
     target,
     context.checker,
-    context.options.state?.typeRegistry,
+    context.state.typeRegistry,
     context.options.logger,
   );
   if (type) {
@@ -898,7 +898,7 @@ function shouldUseStreamCause(
   const type = getTypeAtLocationWithFallback(
     target,
     context.checker,
-    context.options.state?.typeRegistry,
+    context.state.typeRegistry,
     context.options.logger,
   );
   return isStreamLikeType(type, context.checker);

--- a/packages/ts-transformers/src/transformers/schema-generator.ts
+++ b/packages/ts-transformers/src/transformers/schema-generator.ts
@@ -22,9 +22,8 @@ export class SchemaGeneratorTransformer extends HelpersOnlyTransformer {
   transform(context: TransformationContext): ts.SourceFile {
     const schemaGenerator = new SchemaGenerator();
     const { sourceFile, tsContext: transformation, checker } = context;
-    const { logger, state } = context.options;
-    const typeRegistry = state?.typeRegistry;
-    const schemaHints = state?.schemaHints;
+    const { logger } = context.options;
+    const { typeRegistry, schemaHints } = context.state;
     const writerIdentityForSourceFile = (fileName: string) => {
       const moduleIdentities = context.options.moduleIdentities;
       const moduleIdentity = moduleIdentities?.get(fileName);
@@ -77,7 +76,7 @@ export class SchemaGeneratorTransformer extends HelpersOnlyTransformer {
         // below and inside the schema-generator package. The uses don't collide
         // because they key on different node-kinds; no split needed.
         let type: ts.Type;
-        if (typeRegistry && typeRegistry.has(node)) {
+        if (typeRegistry.has(node)) {
           type = typeRegistry.get(node)!;
         } else {
           // Use fallback to handle synthetic TypeNodes that may be in the registry
@@ -150,14 +149,12 @@ export class SchemaGeneratorTransformer extends HelpersOnlyTransformer {
         let finalSchema: unknown = typeof schema === "boolean"
           ? schema
           : { ...(schema as Record<string, unknown>), ...optionsObj };
-        if (schemaHints) {
-          finalSchema = attachUiContractFromSchemaHints(
-            finalSchema,
-            node,
-            schemaTypeArg,
-            schemaHints,
-          );
-        }
+        finalSchema = attachUiContractFromSchemaHints(
+          finalSchema,
+          node,
+          schemaTypeArg,
+          schemaHints,
+        );
         if (writeAuthorizedByIdentity && typeof finalSchema !== "boolean") {
           finalSchema = attachWriteAuthorizedByMarker(
             finalSchema as Record<string, unknown>,
@@ -241,7 +238,7 @@ function resolvePolicyOfMarkers(
         : undefined);
     let manifests = sourceEntry === undefined
       ? undefined
-      : context.options.state?.getPolicyManifests().get(sourceEntry[0]);
+      : context.state.getPolicyManifests().get(sourceEntry[0]);
     if (sourceEntry !== undefined && manifests === undefined) {
       const definingSource = context.program.getSourceFile(sourceEntry[0]);
       if (definingSource !== undefined) {
@@ -250,7 +247,7 @@ function resolvePolicyOfMarkers(
             definingSource,
             sourceEntry[1],
           );
-          context.options.state?.recordPolicyManifests(
+          context.state.recordPolicyManifests(
             sourceEntry[0],
             manifests,
           );

--- a/packages/ts-transformers/src/transformers/schema-injection.ts
+++ b/packages/ts-transformers/src/transformers/schema-injection.ts
@@ -243,7 +243,7 @@ function findCapabilitySummaryForParameter(
   const summary = options?.includeNestedCallbacks
     ? analyzeFunctionCapabilities(fn, {
       checker: options.checker,
-      typeRegistry: context?.options.state?.typeRegistry,
+      typeRegistry: context?.state.typeRegistry,
       includeNestedCallbacks: true,
       summaryCache: context
         ? capabilitySummaryMemoFor(context).nested
@@ -253,7 +253,7 @@ function findCapabilitySummaryForParameter(
     ? (context.lookupCapabilitySummary(fn) ??
       analyzeFunctionCapabilities(fn, {
         checker: context.checker,
-        typeRegistry: context.options.state?.typeRegistry,
+        typeRegistry: context.state.typeRegistry,
         summaryCache: capabilitySummaryMemoFor(context).fallback,
       }))
     : analyzeFunctionCapabilities(fn, {
@@ -330,7 +330,7 @@ function applyCapabilitySummaryToArgument(
     baseType = getTypeFromTypeNodeWithFallback(
       baseTypeNode,
       checker,
-      context?.options.state?.typeRegistry,
+      context?.state.typeRegistry,
     );
   }
 
@@ -390,7 +390,7 @@ function applyCapabilitySummaryToParameter(
     baseType = getTypeFromTypeNodeWithFallback(
       baseTypeNode,
       checker,
-      context?.options.state?.typeRegistry,
+      context?.state.typeRegistry,
     );
   }
 
@@ -559,7 +559,7 @@ function collectFunctionSchemaTypeNodes(
   const unwrappedReturnExpr = returnExpr
     ? unwrapExpression(returnExpr)
     : undefined;
-  const uiContractHint = context?.options.state?.schemaHints &&
+  const uiContractHint = context &&
       unwrappedReturnExpr &&
       ts.isObjectLiteralExpression(unwrappedReturnExpr)
     ? propagateUiContractHintsFromObjectLiteral(
@@ -1111,7 +1111,7 @@ function applyIdentityArrayItemSchemaHints(
   identityPaths: readonly (readonly string[])[],
   context: TransformationContext,
 ): void {
-  if (!context.options.state?.schemaHints || identityPaths.length === 0) return;
+  if (identityPaths.length === 0) return;
 
   const grouped = new Map<string, boolean>();
   for (const path of identityPaths) {
@@ -2009,7 +2009,7 @@ function propagateUiContractHintsFromObjectLiteral(
 ):
   | UiContractHint
   | undefined {
-  if (!context.options.state?.schemaHints || !resultNode) {
+  if (!resultNode) {
     return undefined;
   }
 
@@ -3039,7 +3039,7 @@ function handlePatternSchemaInjection(
 export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
   transform(context: TransformationContext): ts.SourceFile {
     const { sourceFile, tsContext: transformation, checker } = context;
-    const typeRegistry = context.options.state?.typeRegistry;
+    const typeRegistry = context.state.typeRegistry;
 
     const visit = (node: ts.Node): ts.Node => {
       // Single idempotency guard: if SchemaInjection already finalized this
@@ -3405,9 +3405,9 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
             context,
             {
               explicitArgumentTypeNode: argumentType,
-              explicitArgumentTypeValue: typeRegistry?.get(argumentType),
+              explicitArgumentTypeValue: typeRegistry.get(argumentType),
               explicitResultTypeNode: resultType,
-              explicitResultTypeValue: typeRegistry?.get(resultType),
+              explicitResultTypeValue: typeRegistry.get(resultType),
               applyExplicitArgumentCapabilitySummary: true,
             },
           );
@@ -3573,7 +3573,7 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
               typeRegistry,
               firstArgument.arguments,
             );
-            if (narrowedArgumentTypeValue && typeRegistry) {
+            if (narrowedArgumentTypeValue) {
               typeRegistry.set(inputSchema, narrowedArgumentTypeValue);
             }
             // smr only (see prependSchemaArguments for the rationale).
@@ -3612,9 +3612,9 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
             context,
             {
               explicitArgumentTypeNode: argumentType,
-              explicitArgumentTypeValue: typeRegistry?.get(argumentType),
+              explicitArgumentTypeValue: typeRegistry.get(argumentType),
               explicitResultTypeNode: resultType,
-              explicitResultTypeValue: typeRegistry?.get(resultType),
+              explicitResultTypeValue: typeRegistry.get(resultType),
             },
           );
           if (!resolved) {
@@ -3664,7 +3664,7 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
                 typeRegistry,
               ),
               explicitArgumentTypeNode: argumentType,
-              explicitArgumentTypeValue: typeRegistry?.get(argumentType),
+              explicitArgumentTypeValue: typeRegistry.get(argumentType),
             },
           );
           if (!resolved) {

--- a/packages/ts-transformers/src/transformers/type-shrinking.ts
+++ b/packages/ts-transformers/src/transformers/type-shrinking.ts
@@ -1775,7 +1775,7 @@ export function validateShrinkCoverage(
         shrunk,
         checker,
         context.sourceFile,
-        context.options.state?.typeRegistry,
+        context.state.typeRegistry,
       ) ?? ts.factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword);
 
       validateShrinkCoverage(
@@ -1804,13 +1804,13 @@ export function validateShrinkCoverage(
         baseTypeNode,
         checker,
         context.sourceFile,
-        context.options.state?.typeRegistry,
+        context.state.typeRegistry,
       ) ?? ts.factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword);
       const shrunkElementNode = getArrayElementTypeNode(
         shrunk,
         checker,
         context.sourceFile,
-        context.options.state?.typeRegistry,
+        context.state.typeRegistry,
       );
 
       validateShrinkCoverage(
@@ -3091,7 +3091,7 @@ export function applyShrinkAndWrap(
         factory,
         checker,
         baseType,
-        context?.options.state?.typeRegistry,
+        context?.state.typeRegistry,
       )
       : applyCapabilityDefaultsToTypeNode(
         baseTypeNode,
@@ -3129,7 +3129,7 @@ export function applyShrinkAndWrap(
       factory,
       checker,
       baseType,
-      context?.options.state?.typeRegistry,
+      context?.state.typeRegistry,
     )
     : identityPaths.length > 0
     ? applyIdentityOnlyPathsToTypeNode(
@@ -3140,7 +3140,7 @@ export function applyShrinkAndWrap(
       factory,
       checker,
       baseType,
-      context?.options.state?.typeRegistry,
+      context?.state.typeRegistry,
     )
     : baseTypeNode;
   let shrunk: ts.TypeNode | undefined;
@@ -3170,7 +3170,7 @@ export function applyShrinkAndWrap(
         checker,
         sourceFile,
         factory,
-        context?.options.state?.typeRegistry,
+        context?.state.typeRegistry,
         fullShapePaths,
       );
       const nodeDriven = buildShrunkTypeNodeFromTypeNode(
@@ -3178,7 +3178,7 @@ export function applyShrinkAndWrap(
         retainedPaths,
         factory,
         checker,
-        context?.options.state?.typeRegistry,
+        context?.state.typeRegistry,
         fullShapePaths,
       );
       shrunk = choosePreferredShrinkCandidate(
@@ -3199,7 +3199,7 @@ export function applyShrinkAndWrap(
         retainedPaths,
         factory,
         checker,
-        context?.options.state?.typeRegistry,
+        context?.state.typeRegistry,
         fullShapePaths,
       );
       const typeDriven = baseType && identityPaths.length === 0
@@ -3209,7 +3209,7 @@ export function applyShrinkAndWrap(
           checker,
           sourceFile,
           factory,
-          context?.options.state?.typeRegistry,
+          context?.state.typeRegistry,
           fullShapePaths,
         )
         : undefined;
@@ -3236,7 +3236,7 @@ export function applyShrinkAndWrap(
       factory,
       checker,
       baseType,
-      context?.options.state?.typeRegistry,
+      context?.state.typeRegistry,
     );
     shrunk = next;
   }
@@ -3269,7 +3269,7 @@ export function applyShrinkAndWrap(
     factory,
     checker,
     sourceFile,
-    context?.options.state?.typeRegistry,
+    context?.state.typeRegistry,
   );
 
   if (!shouldWrap) {

--- a/packages/ts-transformers/test/closures/array-method-utils-coverage.test.ts
+++ b/packages/ts-transformers/test/closures/array-method-utils-coverage.test.ts
@@ -48,10 +48,9 @@ function testContext(checker: ts.TypeChecker): TransformationContext {
     checker,
     factory: ts.factory,
     tsContext: { factory: ts.factory } as ts.TransformationContext,
-    options: {
-      state: {
-        typeRegistry: new WeakMap<ts.Node, ts.Type>(),
-      },
+    options: {},
+    state: {
+      typeRegistry: new WeakMap<ts.Node, ts.Type>(),
     },
     markAsSyntheticComputeCallback: () => {},
     cfHelpers: {

--- a/packages/ts-transformers/test/destructuring-lowering-coverage.test.ts
+++ b/packages/ts-transformers/test/destructuring-lowering-coverage.test.ts
@@ -47,10 +47,9 @@ function testContext(checker: ts.TypeChecker): TransformationContext {
   return {
     checker,
     factory: ts.factory,
-    options: {
-      state: {
-        typeRegistry: new WeakMap<ts.Node, ts.Type>(),
-      },
+    options: {},
+    state: {
+      typeRegistry: new WeakMap<ts.Node, ts.Type>(),
     },
     cfHelpers: {
       getHelperExpr: (name: string) => ts.factory.createIdentifier(name),

--- a/packages/ts-transformers/test/destructuring-lowering.test.ts
+++ b/packages/ts-transformers/test/destructuring-lowering.test.ts
@@ -48,10 +48,9 @@ function testContext(checker: ts.TypeChecker): TransformationContext {
   return {
     checker,
     factory: ts.factory,
-    options: {
-      state: {
-        typeRegistry: new WeakMap<ts.Node, ts.Type>(),
-      },
+    options: {},
+    state: {
+      typeRegistry: new WeakMap<ts.Node, ts.Type>(),
     },
     cfHelpers: {
       getHelperExpr: (name: string) => ts.factory.createIdentifier(name),

--- a/packages/ts-transformers/test/lift-applied/create-lift-applied-call.test.ts
+++ b/packages/ts-transformers/test/lift-applied/create-lift-applied-call.test.ts
@@ -57,9 +57,8 @@ Deno.test("createLiftAppliedCall keeps fallback refs synced when names collide",
       checker,
       sourceFile: source,
       cfHelpers,
-      options: {
-        state: new CrossStageState(),
-      },
+      options: {},
+      state: new CrossStageState(),
     } as any;
 
     const rootIdentifier = factory.createIdentifier("_v1");

--- a/packages/ts-transformers/test/type-shrinking-coverage.test.ts
+++ b/packages/ts-transformers/test/type-shrinking-coverage.test.ts
@@ -164,10 +164,9 @@ function createContext(sourceFile: ts.SourceFile): {
   const context = {
     sourceFile,
     factory: ts.factory,
-    options: {
-      state: {
-        typeRegistry: new WeakMap<ts.Node, ts.Type>(),
-      },
+    options: {},
+    state: {
+      typeRegistry: new WeakMap<ts.Node, ts.Type>(),
     },
     reportDiagnostic: (d: CollectedDiagnostic) => {
       diagnostics.push({

--- a/packages/ts-transformers/test/type-shrinking-flap-coverage.test.ts
+++ b/packages/ts-transformers/test/type-shrinking-flap-coverage.test.ts
@@ -149,10 +149,9 @@ function createContext(sourceFile: ts.SourceFile): {
   const context = {
     sourceFile,
     factory: ts.factory,
-    options: {
-      state: {
-        typeRegistry: new WeakMap<ts.Node, ts.Type>(),
-      },
+    options: {},
+    state: {
+      typeRegistry: new WeakMap<ts.Node, ts.Type>(),
     },
     reportDiagnostic: (d: CollectedDiagnostic) => {
       diagnostics.push({


### PR DESCRIPTION
…d on the transformation context

The pipeline's cross-transformer registries live in a single `CrossStageState` object, reached through `TransformationOptions.state`. That field was typed as optional, but nothing could ever observe it missing: the only place a `TransformationContext` is built is `Transformer.toFactory`, and the context constructor already defaulted the field to a fresh `CrossStageState` whenever the caller did not supply one. The pipeline goes further and pre-populates it so every stage in a run shares one instance.

The optional type was still doing damage. Every consumer had to write `context.options.state?.typeRegistry`, which is 92 call sites across 18 files, and the resulting code grew branches that defended against a state that cannot be absent. Two of those branches were load-bearing lies: `reportDiagnosticOnce` documented that "with no shared state present it falls back to reporting unconditionally", and `registerCapabilitySummary` opened with an early return that skipped the whole interprocedural capability analysis on the grounds that there was "nowhere to record" it. Neither can run. A reader has no way to tell that from the code, so both read as real behavior that has to be preserved.

The context now carries a `readonly state: CrossStageState` field, resolved once in the constructor and stored back into `this.options.state` so the options bag a caller passes on still names the same instance. Consumers read `context.state.X` directly. `TransformationOptions.state` stays optional because it is the injection point: the pipeline and the test helpers use it to hand several runs one shared set of registries.

With the type no longer optional, the guards that only existed to tolerate a missing registry are unreachable, and this removes them: the `reportDiagnosticOnce` fallback and its doc sentence, the `registerCapabilitySummary` early return, and the `if (typeRegistry)` / `if (schemaHints)` wrappers in the lift lowering, the closure strategies, the expression-rewrite emitters, schema injection and schema generation. `typeRegistry` and `schemaHints` are non-optional fields on `CrossStageState`, initialized to `WeakMap`s at construction, so each of those conditions was constant-true. Where a helper takes an optional context (type-shrinking, parts of schema-injection) one level of optional chaining remains, on the context rather than on the state.

Behavior is unchanged. The test helpers that hand-build a stand-in context through a cast now set `state` alongside `options`, matching the shape of a real context.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the cross-stage pipeline state a required field on `TransformationContext`, remove dead null checks, and switch all reads to `context.state`. This simplifies the transformer code and keeps behavior unchanged.

- **Refactors**
  - Added `readonly state: CrossStageState` to `TransformationContext`; resolved once from `options.state` or created, then written back to `options.state` to share across nested contexts.
  - Replaced `context.options.state?.…` with `context.state.…` across the `ts-transformers` codebase; removed unreachable guards like `if (typeRegistry)`/`if (schemaHints)`.
  - Deleted misleading fallbacks and early returns (e.g., `reportDiagnosticOnce` “no shared state” note and `registerCapabilitySummary` short-circuit).
  - Kept `TransformationOptions.state` optional as the injection point for sharing registries; updated docs to clarify `context.state` behavior.

- **Migration**
  - If you construct contexts manually (e.g., in tests), set a `state` on the context (and/or pass `options.state`), and read registries from `context.state` instead of `context.options.state?.…`.

<sup>Written for commit ffcab0535fd72561313d58137d986aa6d6a15f4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

