### PR TITLE
refactor(cli): type the invocation engine against the real runner types

### DIFF
--- a/docs/plans/pattern-verb-contract-implementation.md
+++ b/docs/plans/pattern-verb-contract-implementation.md
@@ -958,8 +958,8 @@ Size M, mostly parallel. `packages/cli`, `skills/cf`.
   commit is durable on the server, and a later same-id call deduplicates
   against the create-only receipt and returns the original outcome, so the
   readback's confirmation can be fetched at any time. Handler sends only: a
-  tool's result is delivered by this process, and the receipt-less
-  set-fallback dispatch leaves nothing to read back — both refuse the flag.
+  tool's result is delivered by this process rather than read back from a
+  receipt, so a tool run refuses the flag.
   `--wait <seconds>` is a caller-chosen patience bound on the default wait,
   not a correctness timeout: one clearable deadline racing the outermost
   await (no polling, no bound anywhere inside the settlement path), and on

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -1,5 +1,12 @@
-import type { CellScope, JSONSchema } from "@commonfabric/api";
-import { encodeJsonPointer } from "@commonfabric/runner";
+import type { CellScope, JSONSchema, Pattern } from "@commonfabric/api";
+import type { PieceManager } from "@commonfabric/piece";
+import {
+  type Cell,
+  encodeJsonPointer,
+  type IExtendedStorageTransaction,
+  type MemorySpace,
+  type NormalizedFullLink,
+} from "@commonfabric/runner";
 import { isInstance } from "@commonfabric/utils/types";
 import {
   localRefTarget,
@@ -23,108 +30,12 @@ export interface CliRuntimeErrorRecord {
   space?: string;
 }
 
-export interface CallableTransactionStatus {
-  status: string;
-  error?: Error;
-}
-
-export interface CallableTransactionLike {
-  status?: () => CallableTransactionStatus;
-  commit?: () => Promise<unknown>;
-  /** The handling's receipt address (runner: tx.handlingReceiptLink) — on
-   * success this handling's outcome, on a receipt-exists collision the
-   * winner's original (verb contract WS-D). */
-  handlingReceiptLink?: {
-    id: string;
-    space: string;
-    scope?: CellScope;
-    path?: readonly (string | number)[];
-  };
-}
-
-export interface CallableCellLike {
-  schema?: JSONSchema;
-  get: () => unknown;
-  getRaw?: () => unknown;
-  asSchemaFromLinks?: () => CallableCellLike;
-  key: (segment: string) => CallableCellLike;
-  pull?: () => Promise<unknown>;
-  getAsNormalizedFullLink?: () => {
-    scope?: CellScope;
-    id?: string;
-    space?: string;
-    path?: readonly (string | number)[];
-  };
-  /** Resolve through stored links to the concrete backing cell (runner:
-   * Cell.resolveAsCell). `getAsNormalizedFullLink` alone reports the cell's
-   * own address — receipt id plus path — even where the stored value is a
-   * link into another document; resolving first is what tells the two
-   * apart. */
-  resolveAsCell?: () => CallableCellLike;
-  send?: (
-    value: unknown,
-    onCommit?: (tx: CallableTransactionLike) => void,
-    sendOptions?: { eventId?: string },
-  ) => void;
-}
-
-export interface CallablePieceIoLike {
-  getCell: () => Promise<CallableCellLike>;
-  set: (value: unknown, path?: (string | number)[]) => Promise<void>;
-}
-
-export interface CallableRuntimeLike {
-  [CF_RUNTIME_ERROR_LOG]?: CliRuntimeErrorRecord[];
-  storageManager?: { synced: () => Promise<void> };
-  idle: () => Promise<void>;
-  // Drain to full quiescence: scheduler idle, storage synced, and every
-  // in-flight async builtin (an LLM call, a fetch) finished. This is how a tool
-  // whose result arrives asynchronously is awaited without polling or a
-  // deadline. Optional so lightweight test doubles can omit it.
-  settled?: () => Promise<void>;
-  edit: () => CallableTransactionLike;
-  getCell: (
-    space: string,
-    id: string,
-    schema: JSONSchema | undefined,
-    tx: CallableTransactionLike,
-    scope?: CellScope,
-  ) => CallableCellLike;
-  run: (
-    tx: CallableTransactionLike,
-    pattern: unknown,
-    input: unknown,
-    resultCell: CallableCellLike,
-  ) => { sink?: (fn: (value: unknown) => void) => (() => void) | void } | void;
-  prepareTxForCommit?: (tx: CallableTransactionLike) => void;
-  /** Open a cell at a normalized link — the receipt readback path. */
-  getCellFromLink?: (
-    link: NonNullable<CallableTransactionLike["handlingReceiptLink"]>,
-    schema?: JSONSchema,
-    tx?: CallableTransactionLike,
-  ) => CallableCellLike;
-}
-
-export interface CallableManagerLike {
-  runtime: CallableRuntimeLike;
-  synced: () => Promise<void>;
-  getSpace?: () => string;
-}
-
-export interface CallablePieceLike {
-  input: CallablePieceIoLike;
-  result: CallablePieceIoLike;
-  getCell?: () => { pull?: () => Promise<unknown> };
-}
-
 export interface CallableResolution {
-  callableCell: CallableCellLike;
+  callableCell: Cell<any>;
   callableKind: CallableKind;
   cellKey: string;
-  cellProp: "input" | "result";
-  manager: CallableManagerLike;
-  piece: CallablePieceLike;
-  space: string;
+  manager: PieceManager;
+  space: MemorySpace;
 }
 
 /** The phases a handler invocation passes through, reported on early exit so
@@ -217,24 +128,23 @@ export interface ExecutedCallable {
   outputText?: string;
   /** Present for handler sends carrying a caller-supplied invocation id. */
   invocation?: InvocationOutcome;
-  /** The tool result cell's address, when the runtime exposes it — the handle
-   * a caller can revisit later instead of re-running the tool (verb contract
-   * Part 2, docs/plans/pattern-verb-contract.md). Handlers gain their
-   * equivalent with the invocation protocol's caller-supplied ids. */
+  /** The tool result cell's address — the handle a caller can revisit later
+   * instead of re-running the tool (verb contract Part 2,
+   * docs/plans/pattern-verb-contract.md). Handlers gain their equivalent with
+   * the invocation protocol's caller-supplied ids. */
   resultRef?: CallableResultRef;
-}
-
-interface CallablePatternLike extends Record<string, unknown> {
-  argumentSchema?: JSONSchema;
-  resultSchema?: JSONSchema;
 }
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
-function asCallablePattern(value: unknown): CallablePatternLike | undefined {
+/** Read a tool callable's stored `pattern` slot as the pattern the runner
+ * will run. Only the record shape is checked here; a record missing the
+ * schemas reaches `runtime.run` the same way any malformed stored pattern
+ * does. */
+function asCallablePattern(value: unknown): Pattern | undefined {
   if (!isRecord(value)) return undefined;
-  return value as CallablePatternLike;
+  return value as Pattern;
 }
 
 function asExtraParams(value: unknown): Record<string, unknown> {
@@ -464,28 +374,28 @@ function mergeToolInput(
 
 export function detectCallableKind(
   callableValue: unknown,
-  callableCell: CallableCellLike,
+  callableCell: Cell<any>,
 ): CallableKind | null {
   let resolvedValue = callableValue;
   try {
-    resolvedValue = callableCell?.getRaw?.() ?? callableCell?.get?.() ??
+    resolvedValue = callableCell.getRaw() ?? callableCell.get() ??
       callableValue;
   } catch {
     resolvedValue = callableValue;
   }
 
   const callableKind =
-    classifyCallableEntry(callableValue, callableCell?.schema) ??
-      classifyCallableEntry(resolvedValue, callableCell?.schema) ??
-      classifyCallableEntry(callableCell, callableCell?.schema);
+    classifyCallableEntry(callableValue, callableCell.schema) ??
+      classifyCallableEntry(resolvedValue, callableCell.schema) ??
+      classifyCallableEntry(callableCell, callableCell.schema);
   if (callableKind) {
     return callableKind;
   }
 
   try {
-    const pattern = callableCell.key("pattern").getRaw?.() ??
-      callableCell.key("pattern").get?.();
-    const extraParams = callableCell.key("extraParams").get?.();
+    const pattern = callableCell.key("pattern").getRaw() ??
+      callableCell.key("pattern").get();
+    const extraParams = callableCell.key("extraParams").get();
     if (pattern !== undefined && extraParams !== undefined) {
       return "tool";
     }
@@ -497,7 +407,7 @@ export function detectCallableKind(
 }
 
 export function callableCommandSpec(
-  callableCell: CallableCellLike,
+  callableCell: Cell<any>,
   callableKind: CallableKind,
 ): ExecCommandSpec {
   if (callableKind === "handler") {
@@ -509,11 +419,11 @@ export function callableCommandSpec(
   }
 
   const pattern = asCallablePattern(
-    callableCell.key("pattern").getRaw?.() ??
+    callableCell.key("pattern").getRaw() ??
       callableCell.key("pattern").get(),
   );
   const extraParams = asExtraParams(
-    callableCell.key("extraParams").get?.(),
+    callableCell.key("extraParams").get(),
   );
 
   return {
@@ -528,43 +438,28 @@ export function callableCommandSpec(
 }
 
 /** Normalize a receipt/backing link into the `links` dictionary's value
- * shape. Absent scope on a normalized link means the space scope (the same
- * rule `resultRef` applies); the path rides along only when the link points
- * below the backing document's root. */
-function toInvocationResultLink(link: {
-  id: string;
-  space: string;
-  scope?: CellScope;
-  path?: readonly (string | number)[];
-}): InvocationResultLink {
+ * shape. The path rides along only when the link points below the backing
+ * document's root. */
+function toInvocationResultLink(
+  link: NormalizedFullLink,
+): InvocationResultLink {
   return {
     space: link.space,
     id: link.id,
-    scope: link.scope ?? "space",
-    ...(link.path !== undefined && link.path.length > 0
-      ? { path: [...link.path] }
-      : {}),
+    scope: link.scope,
+    ...(link.path.length > 0 ? { path: [...link.path] } : {}),
   };
 }
 
 /** Two normalized links address the same backing document iff id, space,
- * and scope (absent = space) all agree; a differing path alone is just a
- * position inside the same doc, which needs no link of its own. */
+ * and scope all agree; a differing path alone is just a position inside the
+ * same doc, which needs no link of its own. */
 function sameBackingDocument(
-  a: { id: string; space: string; scope?: CellScope },
-  b: { id: string; space: string; scope?: CellScope },
+  a: NormalizedFullLink,
+  b: NormalizedFullLink,
 ): boolean {
-  return a.id === b.id && a.space === b.space &&
-    (a.scope ?? "space") === (b.scope ?? "space");
+  return a.id === b.id && a.space === b.space && a.scope === b.scope;
 }
-
-/** The shape a backing address takes on its way into the dictionary. */
-type BackingLink = {
-  id: string;
-  space: string;
-  scope?: CellScope;
-  path?: readonly (string | number)[];
-};
 
 /**
  * Walk a settled result's backing links into the `{ "/path": <link> }`
@@ -600,26 +495,14 @@ type BackingLink = {
  * owns verbs is the case that proves the point — the stream on that piece is
  * a live object whose `runtime`/`scheduler` graph refers back to itself, and
  * walking into it exhausted the stack.
- *
- * A receipt cell that cannot resolve links (no `resolveAsCell` /
- * `getAsNormalizedFullLink`) degrades to the receipt-root entry alone rather
- * than guessing.
  */
 export function collectInvocationResultLinks(
-  receiptLink: NonNullable<CallableTransactionLike["handlingReceiptLink"]>,
-  receiptCell: CallableCellLike | undefined,
+  receiptLink: NormalizedFullLink,
+  receiptCell: Cell<any>,
   value: unknown,
 ): Record<string, InvocationResultLink> {
-  if (receiptCell === undefined) {
-    return { "/": toInvocationResultLink(receiptLink) };
-  }
-
-  const resolvedRoot = receiptCell.resolveAsCell?.() ?? receiptCell;
-  const rootLink = resolvedRoot.getAsNormalizedFullLink?.();
-  const rootBacking: BackingLink =
-    rootLink?.id !== undefined && rootLink.space !== undefined
-      ? rootLink as BackingLink
-      : receiptLink;
+  const resolvedRoot = receiptCell.resolveAsCell();
+  const rootBacking = resolvedRoot.getAsNormalizedFullLink();
   const links: Record<string, InvocationResultLink> = {
     "/": toInvocationResultLink(rootBacking),
   };
@@ -628,10 +511,10 @@ export function collectInvocationResultLinks(
   }
 
   const walk = (
-    cell: CallableCellLike,
+    cell: Cell<any>,
     val: unknown,
     pathSegments: string[],
-    base: { id: string; space: string; scope?: CellScope },
+    base: NormalizedFullLink,
   ): void => {
     // A non-plain object is not part of the result's JSON: it is a live
     // runtime object the readback surfaced (a stream on a returned piece,
@@ -645,23 +528,20 @@ export function collectInvocationResultLinks(
       : Object.keys(val);
     for (const key of keys) {
       const childValue = (val as Record<string, unknown>)[key];
-      let child: CallableCellLike;
+      let child: Cell<any>;
       try {
         child = cell.key(key);
       } catch {
         continue; // Not addressable as a cell — nothing to annotate.
       }
-      const resolved = child.resolveAsCell?.() ?? child;
-      const childLink = resolved.getAsNormalizedFullLink?.();
+      const resolved = child.resolveAsCell();
+      const childLink = resolved.getAsNormalizedFullLink();
       const segments = [...pathSegments, key];
-      if (
-        childLink?.id !== undefined && childLink.space !== undefined &&
-        !sameBackingDocument(childLink as BackingLink, base)
-      ) {
+      if (!sameBackingDocument(childLink, base)) {
         links[encodeJsonPointer(["", ...segments])] = toInvocationResultLink(
-          childLink as BackingLink,
+          childLink,
         );
-        walk(resolved, childValue, segments, childLink as BackingLink);
+        walk(resolved, childValue, segments, childLink);
       } else {
         // Same backing document — no entry — but descendants are still read
         // from the RESOLVED cell: a same-doc link can redirect to another
@@ -681,133 +561,110 @@ export async function executeResolvedCallable(
   deps: CallableExecutionDeps = {},
 ): Promise<ExecutedCallable> {
   if (resolved.callableKind === "handler") {
-    const send = resolved.callableCell.send;
-    if (typeof send === "function") {
-      // Before anything is dispatched, and so before the invocation id can be
-      // spent on a handling that would run with no event. An absent payload
-      // is normalized to `{}` against an object schema (D5), so what goes out
-      // is what the gate judged.
-      const dispatchInput = assertVerbInputSatisfiesSchema(
-        resolved.cellKey,
-        input,
-        resolved.callableCell.schema,
-      );
-      const runtimeErrors = runtimeErrorLog(resolved.manager.runtime);
-      const errorCountBefore = runtimeErrors.length;
-      const invocationId = deps.invocationId;
-      if (deps.skipReadback && invocationId === undefined) {
-        // Refused before dispatch: skipping the readback is only sound when
-        // a later same-id call can fetch the outcome, and that needs the id.
-        throw new Error("--no-wait requires an invocation id");
-      }
-      deps.onPhase?.("dispatched");
-      const tx = await new Promise<CallableTransactionLike>(
-        (resolve, reject) => {
-          try {
-            send.call(
-              resolved.callableCell,
-              dispatchInput,
-              resolve,
-              invocationId !== undefined
-                ? { eventId: invocationId }
-                : undefined,
-            );
-          } catch (error) {
-            reject(error);
+    // Before anything is dispatched, and so before the invocation id can be
+    // spent on a handling that would run with no event. An absent payload
+    // is normalized to `{}` against an object schema (D5), so what goes out
+    // is what the gate judged.
+    const dispatchInput = assertVerbInputSatisfiesSchema(
+      resolved.cellKey,
+      input,
+      resolved.callableCell.schema,
+    );
+    const runtimeErrors = runtimeErrorLog(resolved.manager.runtime);
+    const errorCountBefore = runtimeErrors.length;
+    const invocationId = deps.invocationId;
+    if (deps.skipReadback && invocationId === undefined) {
+      // Refused before dispatch: skipping the readback is only sound when
+      // a later same-id call can fetch the outcome, and that needs the id.
+      throw new Error("--no-wait requires an invocation id");
+    }
+    deps.onPhase?.("dispatched");
+    const tx = await new Promise<IExtendedStorageTransaction>(
+      (resolve, reject) => {
+        try {
+          if (invocationId !== undefined) {
+            resolved.callableCell.send(dispatchInput, resolve, {
+              eventId: invocationId,
+            });
+          } else {
+            resolved.callableCell.send(dispatchInput, resolve);
           }
-        },
+        } catch (error) {
+          reject(error);
+        }
+      },
+    );
+    // Acknowledgment is transaction-local (verb contract, Settlement): the
+    // commit callback above fires on THIS handling's final commit. Awaiting
+    // runtime.idle()/manager.synced() here instead would hold an
+    // already-committed write hostage to every derived recomputation it
+    // triggered elsewhere in the graph.
+    deps.onPhase?.("committed");
+
+    const txStatus = tx.status();
+    const deduplicated = txStatus.status === "error" &&
+      "precondition" in txStatus.error &&
+      txStatus.error.precondition === "receipt-exists";
+    if (txStatus.status === "error" && !deduplicated) {
+      const latestRuntimeError = runtimeErrors.slice(errorCountBefore).at(-1)
+        ?.message;
+      throw new Error(
+        `Handler "${resolved.cellKey}" failed: ${
+          latestRuntimeError ?? errorMessage(txStatus.error)
+        }`,
       );
-      // Acknowledgment is transaction-local (verb contract, Settlement): the
-      // commit callback above fires on THIS handling's final commit. Awaiting
-      // runtime.idle()/manager.synced() here instead would hold an
-      // already-committed write hostage to every derived recomputation it
-      // triggered elsewhere in the graph.
-      deps.onPhase?.("committed");
+    }
 
-      const txStatus = tx?.status?.();
-      const deduplicated = txStatus?.status === "error" &&
-        (txStatus.error as { precondition?: string } | undefined)
-            ?.precondition === "receipt-exists";
-      if (txStatus?.status === "error" && !deduplicated) {
-        const latestRuntimeError = runtimeErrors.slice(errorCountBefore).at(-1)
-          ?.message;
-        throw new Error(
-          `Handler "${resolved.cellKey}" failed: ${
-            latestRuntimeError ?? errorMessage(txStatus.error)
-          }`,
-        );
-      }
+    if (invocationId === undefined) return {};
 
-      if (invocationId === undefined) return {};
-
-      if (deps.skipReadback) {
-        // --no-wait's exit point: the commit is acknowledged, so the
-        // handling — and on a collision, the original one — is durable on
-        // the server and survives this process. Only the readback
-        // (sync + read of the outcome) is skipped; a later same-id call
-        // retrieves it by deduplicating against the create-only receipt.
-        return {
-          invocation: {
-            id: invocationId,
-            status: "committed",
-            ...(deduplicated ? { deduplicated: true } : {}),
-          },
-        };
-      }
-
-      // Read the handling's outcome back off its receipt. On a receipt-exists
-      // collision this is the ORIGINAL handling's receipt — same id, same
-      // outcome, no re-execution — so a retry settles as a success.
-      deps.onPhase?.("readback");
-      let result: unknown;
-      let links: Record<string, InvocationResultLink> | undefined;
-      const link = tx?.handlingReceiptLink;
-      const getCellFromLink = resolved.manager.runtime.getCellFromLink;
-      if (link && typeof getCellFromLink === "function") {
-        const receipt = getCellFromLink.call(resolved.manager.runtime, link);
-        const value = typeof receipt.pull === "function"
-          ? await receipt.pull()
-          : receipt.get();
-        // A value-less verb's receipt is an empty record — existence-only.
-        if (
-          value !== undefined &&
-          !(isRecord(value) && Object.keys(value).length === 0)
-        ) {
-          result = value;
-        }
-        if (deps.showLinks) {
-          // After readback, off the same receipt the result came from: the
-          // links annotate exactly the value the caller is holding.
-          links = collectInvocationResultLinks(link, receipt, result);
-        }
-      }
-
+    if (deps.skipReadback) {
+      // --no-wait's exit point: the commit is acknowledged, so the
+      // handling — and on a collision, the original one — is durable on
+      // the server and survives this process. Only the readback
+      // (sync + read of the outcome) is skipped; a later same-id call
+      // retrieves it by deduplicating against the create-only receipt.
       return {
         invocation: {
           id: invocationId,
-          status: "settled",
+          status: "committed",
           ...(deduplicated ? { deduplicated: true } : {}),
-          ...(result !== undefined ? { result } : {}),
-          ...(links !== undefined ? { links } : {}),
         },
       };
     }
 
-    if (deps.skipReadback) {
-      // This handler dispatches through a plain data write, outside the
-      // invocation receipt protocol — there is no per-handling commit
-      // acknowledgement to wait for and no receipt a later same-id call
-      // could read the outcome back from.
-      throw new Error(
-        `--no-wait is not available for "${resolved.cellKey}": ` +
-          "this callable dispatches without an invocation receipt",
-      );
+    // Read the handling's outcome back off its receipt. On a receipt-exists
+    // collision this is the ORIGINAL handling's receipt — same id, same
+    // outcome, no re-execution — so a retry settles as a success.
+    deps.onPhase?.("readback");
+    let result: unknown;
+    let links: Record<string, InvocationResultLink> | undefined;
+    const link = tx.handlingReceiptLink;
+    if (link) {
+      const receipt = resolved.manager.runtime.getCellFromLink<any>(link);
+      const value = await receipt.pull();
+      // A value-less verb's receipt is an empty record — existence-only.
+      if (
+        value !== undefined &&
+        !(isRecord(value) && Object.keys(value).length === 0)
+      ) {
+        result = value;
+      }
+      if (deps.showLinks) {
+        // After readback, off the same receipt the result came from: the
+        // links annotate exactly the value the caller is holding.
+        links = collectInvocationResultLinks(link, receipt, result);
+      }
     }
-    await resolved.piece[resolved.cellProp].set(input, [resolved.cellKey]);
-    await resolved.manager.runtime.idle();
-    await resolved.manager.synced();
 
-    return {};
+    return {
+      invocation: {
+        id: invocationId,
+        status: "settled",
+        ...(deduplicated ? { deduplicated: true } : {}),
+        ...(result !== undefined ? { result } : {}),
+        ...(links !== undefined ? { links } : {}),
+      },
+    };
   }
 
   if (deps.skipReadback) {
@@ -821,18 +678,18 @@ export async function executeResolvedCallable(
   }
 
   const pattern = asCallablePattern(
-    resolved.callableCell.key("pattern").getRaw?.() ??
+    resolved.callableCell.key("pattern").getRaw() ??
       resolved.callableCell.key("pattern").get(),
   );
   const extraParams = asExtraParams(
-    resolved.callableCell.key("extraParams").get?.(),
+    resolved.callableCell.key("extraParams").get(),
   );
   const runtime = resolved.manager.runtime;
   const runtimeErrors = runtimeErrorLog(runtime);
   const errorCountBefore = runtimeErrors.length;
   const tx = runtime.edit();
-  const resultScope = resolved.callableCell.getAsNormalizedFullLink?.().scope;
-  const resultCell = runtime.getCell(
+  const resultScope = resolved.callableCell.getAsNormalizedFullLink().scope;
+  const resultCell = runtime.getCell<unknown>(
     resolved.space,
     deps.uuid?.() ?? crypto.randomUUID(),
     pattern?.resultSchema,
@@ -850,22 +707,17 @@ export async function executeResolvedCallable(
   // change, including the server-pushed writeback of an async tool's result.
   let sinkValue: unknown;
   let hasSinkValue = false;
-  const cancelSink = typeof running?.sink === "function"
-    ? running.sink((value) => {
-      if (value !== undefined) {
-        sinkValue = value;
-        hasSinkValue = true;
-      }
-    })
-    : undefined;
+  const cancelSink = running.sink((value) => {
+    if (value !== undefined) {
+      sinkValue = value;
+      hasSinkValue = true;
+    }
+  });
 
   let outputValue: unknown;
   try {
     await runtime.idle();
-    runtime.prepareTxForCommit?.(tx);
-    if (typeof tx.commit !== "function") {
-      throw new Error("Callable runtime transaction is not committable");
-    }
+    runtime.prepareTxForCommit(tx);
     await tx.commit();
 
     // Drain the tool to a fully settled state — scheduler idle, storage synced,
@@ -874,22 +726,14 @@ export async function executeResolvedCallable(
     // async tool's LLM/fetch call is awaited to completion here, with no poll
     // interval under it and no deadline over it. `settled()` normalizes a failed
     // builtin to "settled", so a broken tool converges here rather than hanging.
-    if (typeof runtime.settled === "function") {
-      await runtime.settled();
-    } else {
-      await runtime.idle();
-      await resolved.manager.synced();
-      await runtime.storageManager?.synced();
-    }
+    await runtime.settled();
 
     if (hasSinkValue) {
       outputValue = sinkValue;
     } else {
       // Fully settled with nothing on the sink: read once (a server-pushed value
       // can land without re-triggering the local effect).
-      outputValue = typeof resultCell.pull === "function"
-        ? await resultCell.pull()
-        : resultCell.get();
+      outputValue = await resultCell.pull();
       if (outputValue === undefined) {
         // The tool ran to a fully settled state without producing a result.
         // Keep the caller's contract of a defined result or an explicit
@@ -905,25 +749,20 @@ export async function executeResolvedCallable(
       }
     }
   } finally {
-    cancelSink?.();
+    cancelSink();
   }
 
-  // The result cell's durable address rides along when the runtime exposes
-  // it: today the cell is otherwise unlinked — reachable by nobody once this
-  // process exits (a named defect in the verb-contract design). Handing the
-  // address back is the smallest honest handle.
-  const resultLink = resultCell.getAsNormalizedFullLink?.();
+  // The result cell's durable address rides along: today the cell is
+  // otherwise unlinked — reachable by nobody once this process exits (a named
+  // defect in the verb-contract design). Handing the address back is the
+  // smallest honest handle.
+  const resultLink = resultCell.getAsNormalizedFullLink();
   return {
     outputText: JSON.stringify(outputValue, null, 2),
-    ...(resultLink?.id && resultLink?.space
-      ? {
-        resultRef: {
-          space: resultLink.space,
-          id: resultLink.id,
-          // Absent scope on a normalized link means the space scope.
-          scope: resultLink.scope ?? "space",
-        },
-      }
-      : {}),
+    resultRef: {
+      space: resultLink.space,
+      id: resultLink.id,
+      scope: resultLink.scope,
+    },
   };
 }

--- a/packages/cli/lib/exec.ts
+++ b/packages/cli/lib/exec.ts
@@ -1,18 +1,17 @@
 import type { PieceManager } from "@commonfabric/piece";
 import {
+  PieceController,
   type PiecePatternRef,
   PiecesController,
 } from "@commonfabric/piece/ops";
+import type { Cell } from "@commonfabric/runner";
 import { basename, dirname, join, relative, resolve } from "@std/path";
 import {
   type MountedCallablePath,
   parseMountedCallablePath,
 } from "../../fuse/callable-path.ts";
 import {
-  type CallableCellLike,
   callableCommandSpec,
-  type CallableManagerLike,
-  type CallablePieceLike,
   type CallableResultRef,
   detectCallableKind,
 } from "./callable.ts";
@@ -40,22 +39,22 @@ export interface MountedPieceMeta {
 export interface ResolvedMountedCallableFile {
   absPath: string;
   callablePath: MountedCallablePath;
-  callableCell: CallableCellLike;
+  callableCell: Cell<any>;
   commandSpec: ExecCommandSpec;
-  manager: CallableManagerLike;
+  manager: PieceManager;
   mount: { entry: MountStateEntry; path: string };
-  piece: CallablePieceLike;
+  piece: PieceController;
   pieceId: string;
   pieceMeta: MountedPieceMeta;
 }
 
 export interface ExecDependencies {
   stateDir?: string;
-  loadManager?: (config: SpaceConfig) => Promise<CallableManagerLike>;
+  loadManager?: (config: SpaceConfig) => Promise<PieceManager>;
   loadPiece?: (
-    manager: CallableManagerLike,
+    manager: PieceManager,
     pieceId: string,
-  ) => Promise<CallablePieceLike>;
+  ) => Promise<PieceController>;
   stat?: (path: string) => Promise<Deno.FileInfo>;
   readDir?: (path: string) => AsyncIterable<Deno.DirEntry>;
   delay?: (ms: number) => Promise<void>;
@@ -81,13 +80,10 @@ export interface ResolveMountedCallableOptions {
 }
 
 async function defaultLoadPiece(
-  manager: CallableManagerLike,
+  manager: PieceManager,
   pieceId: string,
-): Promise<CallablePieceLike> {
-  return await new PiecesController(manager as unknown as PieceManager).get(
-    pieceId,
-    true,
-  );
+): Promise<PieceController> {
+  return await new PiecesController(manager).get(pieceId, true);
 }
 
 async function readMountedPieceMeta(
@@ -266,26 +262,19 @@ export async function resolveMountedCallableFile(
 
   await assertMountedCallableFileExists(canonicalAbsPath, deps);
   const pieceMeta = await readMountedPieceMeta(canonicalAbsPath, callablePath);
-  const manager = deps.loadManager
-    ? await deps.loadManager({
-      apiUrl: mount.entry.apiUrl,
-      identity: mount.entry.identity,
-      space: callablePath.spaceName,
-      ...(options.jsonOutput ? { jsonOutput: true } : {}),
-    })
-    : await loadManager({
-      apiUrl: mount.entry.apiUrl,
-      identity: mount.entry.identity,
-      space: callablePath.spaceName,
-      ...(options.jsonOutput ? { jsonOutput: true } : {}),
-    }) as unknown as CallableManagerLike;
+  const manager = await (deps.loadManager ?? loadManager)({
+    apiUrl: mount.entry.apiUrl,
+    identity: mount.entry.identity,
+    space: callablePath.spaceName,
+    ...(options.jsonOutput ? { jsonOutput: true } : {}),
+  });
   const piece = await (deps.loadPiece ?? defaultLoadPiece)(
     manager,
     pieceMeta.id,
   );
-  const rootCell = await piece[callablePath.cellProp].getCell();
-  const childCell = rootCell.key(callablePath.cellKey);
-  const callableCell = childCell.asSchemaFromLinks?.() ?? childCell;
+  const rootCell: Cell<any> = await piece[callablePath.cellProp].getCell();
+  const callableCell = rootCell.key(callablePath.cellKey)
+    .asSchemaFromLinks<any>();
   const actualKind = detectCallableKind(undefined, callableCell);
   if (actualKind !== callablePath.callableKind) {
     throw new Error(
@@ -322,10 +311,8 @@ export async function executeMountedCallableFile(
       callableCell: resolved.callableCell,
       callableKind: resolved.callablePath.callableKind,
       cellKey: resolved.callablePath.cellKey,
-      cellProp: resolved.callablePath.cellProp,
       manager: resolved.manager,
-      piece: resolved.piece,
-      space: resolved.manager.getSpace?.() ?? resolved.callablePath.spaceName,
+      space: resolved.manager.getSpace(),
     },
     commandSpec: resolved.commandSpec,
     rawArgs,
@@ -340,12 +327,9 @@ export async function executeMountedCallableFile(
 
   // Auto-step: trigger reactive recomputation after handler execution.
   // Skip if --help was shown — no mutation occurred.
-  if (!result.helpText && typeof resolved.piece.getCell === "function") {
+  if (!result.helpText) {
     try {
-      const pieceCell = resolved.piece.getCell();
-      if (typeof pieceCell.pull === "function") {
-        await pieceCell.pull();
-      }
+      await resolved.piece.getCell().pull();
       await resolved.manager.synced();
     } catch {
       // Auto-step is best-effort; the handler already executed successfully.

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -14,6 +14,7 @@ import {
   isCellResult,
   isReadableCell,
   isSlugAddress,
+  type MemorySpace,
   NAME,
   Runtime,
   runtimePresets,
@@ -1342,7 +1343,7 @@ function getCallableValue(rootValue: unknown, callableName: string): unknown {
 async function tryResolvePieceCallableAt(
   piece: any,
   manager: any,
-  space: string,
+  space: MemorySpace,
   callableName: string,
   cellProp: "input" | "result",
 ): Promise<ResolvedPieceCallable | null> {
@@ -1360,10 +1361,8 @@ async function tryResolvePieceCallableAt(
     callableCell,
     callableKind,
     cellKey: callableName,
-    cellProp,
     commandSpec: callableCommandSpec(callableCell, callableKind),
     manager,
-    piece,
     space,
   };
 }
@@ -1400,7 +1399,7 @@ function probeForcedStreamCell(cell: any, name: string): any | null {
 async function tryResolvePieceHandler(
   piece: any,
   manager: any,
-  space: string,
+  space: MemorySpace,
   callableName: string,
 ): Promise<ResolvedPieceCallable | null> {
   const pieceCell = piece.getCell?.();
@@ -1427,13 +1426,11 @@ async function tryResolvePieceHandler(
     callableCell: streamCell,
     callableKind: "handler",
     cellKey: callableName,
-    cellProp: "result",
     // The link-derived cell still carries whatever payload schema the piece
     // does publish, which the forced stream cast does not; keep using it for
     // the command spec so `--help` and input validation are unaffected.
     commandSpec: callableCommandSpec(linkDerivedCell, "handler"),
     manager,
-    piece,
     space,
   };
 }
@@ -1441,7 +1438,7 @@ async function tryResolvePieceHandler(
 async function tryResolveLivePieceToolCallable(
   piece: any,
   manager: any,
-  space: string,
+  space: MemorySpace,
   callableName: string,
   pieceScope?: PieceConfig["pieceScope"],
 ): Promise<any | null> {
@@ -1484,7 +1481,7 @@ async function loadPieceForCallables(
 ): Promise<{
   manager: any;
   piece: any;
-  space: string;
+  space: MemorySpace;
   resolvedConfig: Awaited<ReturnType<typeof resolvePieceConfigWithManager>>;
 }> {
   const manager = await (deps.loadManager ?? loadManager)(config);

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -2,7 +2,8 @@ import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { dirname, join } from "@std/path";
 import type { JSONSchema } from "@commonfabric/api";
-import { PiecesController } from "@commonfabric/piece/ops";
+import type { PieceManager } from "@commonfabric/piece";
+import { PieceController, PiecesController } from "@commonfabric/piece/ops";
 import {
   type ExecCommandSpec,
   normalizeCallableInputForExecution,
@@ -1969,12 +1970,14 @@ describe("mounted callable resolution and execution", () => {
 
     // Commit, then drain to a fully settled state, then read the result cell
     // once. No poll loop and no deadline: `settled()` awaits the tool's async
-    // work to completion.
+    // work to completion. The trailing sync is the auto-step that follows
+    // every mounted invocation.
     expect(harness.tracker.events).toEqual([
       "run",
       "idle",
       "commit",
       "settled",
+      "manager.synced",
     ]);
     expect(JSON.parse(result.outputText!)).toEqual({ echoed: "tea" });
   });
@@ -2036,6 +2039,7 @@ describe("mounted callable resolution and execution", () => {
       "idle",
       "commit",
       "settled",
+      "manager.synced",
     ]);
     expect(JSON.parse(result.outputText!)).toEqual({ echoed: "from-sink" });
   });
@@ -2829,10 +2833,17 @@ function createExecHarness(options: {
     pull: () => Promise.resolve(state.pullValue ?? state.value),
     key: (_key: string) => resultCell,
     asSchemaFromLinks: () => resultCell,
+    getAsNormalizedFullLink: () => ({
+      id: "of:tool-result-cell",
+      space: "did:key:test-home",
+      scope: "space",
+      path: [],
+    }),
   };
 
   const piece = {
     id: options.pieceId,
+    getCell: () => ({ pull: () => Promise.resolve() }),
     input: {
       getCell: () => Promise.resolve(rootCell),
       set: (value: unknown, path?: (string | number)[]) => {
@@ -2869,6 +2880,7 @@ function createExecHarness(options: {
           return Promise.resolve();
         },
       }),
+      prepareTxForCommit: () => {},
       getCell: (
         space: string,
         _id: string,
@@ -2913,7 +2925,13 @@ function createExecHarness(options: {
     },
   };
 
-  return { manager, piece, tracker };
+  // The doubles implement the slice of the manager and piece surfaces the
+  // invocation engine exercises; the cast is at this seam alone.
+  return {
+    manager: manager as unknown as PieceManager,
+    piece: piece as unknown as PieceController,
+    tracker,
+  };
 }
 
 function createMockCell(
@@ -2939,6 +2957,12 @@ function createMockCell(
       options?.onSchemaFromLinks?.();
       return cell;
     },
+    getAsNormalizedFullLink: () => ({
+      id: "of:mock-cell",
+      space: "did:key:test-home",
+      scope: "space",
+      path: [],
+    }),
     send: options?.send,
     isStream: options?.isStream,
     key: (key: string) => {

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -2,8 +2,8 @@ import { describe, it } from "@std/testing/bdd";
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import { expect } from "@std/expect";
 import type { JSONSchema } from "@commonfabric/api";
+import type { Cell, NormalizedFullLink } from "@commonfabric/runner";
 import {
-  type CallableCellLike,
   CF_RUNTIME_ERROR_LOG,
   collectInvocationResultLinks,
   normalizeAbsentVerbPayload,
@@ -1074,11 +1074,7 @@ function createPieceCallableHarness(options: {
   neverCommit?: boolean;
   /** Replace the readback receipt cell wholesale — for --show-links tests,
    * whose receipt must support key()/resolveAsCell link traversal. */
-  receiptCell?: CallableCellLike;
-  /** Omit the stream cell's `send`: the dispatch falls back to a plain data
-   * write, the path with no per-handling commit acknowledgement and no
-   * receipt — the shape --no-wait must refuse. */
-  withoutSend?: boolean;
+  receiptCell?: Cell<any>;
 }) {
   const tracker = {
     handlerWrites: [] as Array<{
@@ -1122,14 +1118,14 @@ function createPieceCallableHarness(options: {
     callableSchema,
     {
       scope: options.callableScope,
-      ...(options.callableKind === "handler" && !options.withoutSend
+      ...(options.callableKind === "handler"
         ? {
           send: (
             value: unknown,
             onCommit?: (
               tx: {
                 status: () => { status: string; error?: Error };
-                handlingReceiptLink?: { id: string; space: string };
+                handlingReceiptLink?: NormalizedFullLink;
               },
             ) => void,
             sendOptions?: { eventId?: string },
@@ -1160,10 +1156,10 @@ function createPieceCallableHarness(options: {
                     ),
                   }
                   : { status: "done" },
-              handlingReceiptLink: {
+              handlingReceiptLink: mockLink({
                 id: "of:receipt-1",
                 space: "did:key:test-home",
-              },
+              }),
             });
           },
         }
@@ -1246,6 +1242,8 @@ function createPieceCallableHarness(options: {
       edit: () => ({
         commit: async () => {},
       }),
+      prepareTxForCommit: () => {},
+      settled: () => Promise.resolve(),
       getCell: (
         _space: string,
         _id: string,
@@ -2336,35 +2334,6 @@ describe("piece call wait control", () => {
     expect(harness.tracker.toolRunPattern).toBeUndefined();
   });
 
-  it("refuses --no-wait for a handler that dispatches without a receipt", async () => {
-    const harness = createPieceCallableHarness({
-      callableKind: "handler",
-      cellKey: "recordMessage",
-      inputSchema: {
-        type: "object",
-        properties: {
-          message: { type: "string" },
-        },
-      },
-      withoutSend: true,
-    });
-
-    await expect(
-      executePieceCallable(config, "recordMessage", ["--message", "hi"], {
-        loadManager: () => Promise.resolve(harness.manager),
-        loadPiece: () => Promise.resolve(harness.piece),
-        invocationId: "inv-set-fallback-no-wait",
-        skipReadback: true,
-      }),
-    ).rejects.toThrow(
-      /--no-wait is not available for "recordMessage": this callable dispatches without an invocation receipt/,
-    );
-
-    // Refused before the data write: the set-fallback dispatch would leave
-    // nothing a later same-id call could read an outcome back from.
-    expect(harness.tracker.handlerWrites).toEqual([]);
-  });
-
   it("carries the furthest phase as status for an unsettled invocation", () => {
     expect(invocationJson({ id: "inv-1", status: "dispatched" })).toEqual({
       invocation: "inv-1",
@@ -2419,6 +2388,28 @@ interface MockLinkedNode {
   children?: Record<string, MockLinkedNode>;
 }
 
+/** The full normalized link a real cell reports for a mock document: the
+ * space scope and a root path are what a runner-minted link carries when the
+ * fixture leaves them out. */
+function mockLink(
+  doc: MockLinkedDoc,
+  path: (string | number)[] = doc.path ?? [],
+): NormalizedFullLink {
+  return {
+    id: doc.id,
+    space: doc.space,
+    scope: doc.scope ?? "space",
+    path,
+  } as unknown as NormalizedFullLink;
+}
+
+/** A partial cell double, cast at the seam where the invocation engine takes
+ * it. Every member the engine reaches for is present; the rest of `Cell` is
+ * not. */
+function mockCell(members: Record<string, unknown>): Cell<any> {
+  return members as unknown as Cell<any>;
+}
+
 /**
  * A receipt cell whose key()/resolveAsCell traversal mirrors the runner's:
  * `key(segment)` reports the ENCLOSING doc's address extended by the segment
@@ -2431,67 +2422,56 @@ interface MockLinkedNode {
  * Unresolved wrappers refuse traversal outright (`key()` hands back a
  * barren cell), pinning that the collector reads descendants from RESOLVED
  * cells only — a same-document link can redirect elsewhere, and children
- * live under its target.
+ * live under its target. The barren cell reports the receipt's own address,
+ * so descending through one by mistake shows up as a missing entry rather
+ * than a foreign document.
  */
 function linkedReceiptCell(
   receiptDoc: MockLinkedDoc,
   value: unknown,
   root: MockLinkedNode = {},
-): CallableCellLike {
-  const barren: CallableCellLike = {
+): Cell<any> {
+  const barren: Cell<any> = mockCell({
     get: () => undefined,
+    resolveAsCell: () => barren,
+    getAsNormalizedFullLink: () => mockLink(receiptDoc),
     key: () => barren,
-  };
+  });
   const build = (
     node: MockLinkedNode,
     doc: MockLinkedDoc,
     pathInDoc: (string | number)[],
-  ): CallableCellLike => {
-    const cell: CallableCellLike = {
+  ): Cell<any> => {
+    const cell: Cell<any> = mockCell({
       get: () => value,
       pull: () => Promise.resolve(value),
       resolveAsCell: () => cell,
-      getAsNormalizedFullLink: () => ({
-        id: doc.id,
-        space: doc.space,
-        scope: doc.scope,
-        path: pathInDoc,
-      }),
+      getAsNormalizedFullLink: () => mockLink(doc, pathInDoc),
       key: (segment: string) => {
         const childNode = node.children?.[segment] ?? {};
         const resolved = childNode.doc
           ? build(childNode, childNode.doc, childNode.doc.path ?? [])
           : build(childNode, doc, [...pathInDoc, segment]);
-        return {
+        return mockCell({
           get: () => undefined,
           key: () => barren,
           resolveAsCell: () => resolved,
-          getAsNormalizedFullLink: () => ({
-            id: doc.id,
-            space: doc.space,
-            scope: doc.scope,
-            path: [...pathInDoc, segment],
-          }),
-        };
+          getAsNormalizedFullLink: () => mockLink(doc, [...pathInDoc, segment]),
+        });
       },
-    };
+    });
     return cell;
   };
   const resolvedRoot = root.doc
     ? build(root, root.doc, root.doc.path ?? [])
     : build(root, receiptDoc, receiptDoc.path ?? []);
-  return {
+  return mockCell({
     get: () => value,
     pull: () => Promise.resolve(value),
     key: () => barren,
     resolveAsCell: () => resolvedRoot,
-    getAsNormalizedFullLink: () => ({
-      id: receiptDoc.id,
-      space: receiptDoc.space,
-      scope: receiptDoc.scope,
-      path: receiptDoc.path ?? [],
-    }),
-  };
+    getAsNormalizedFullLink: () => mockLink(receiptDoc),
+  });
 }
 
 /**
@@ -2506,15 +2486,11 @@ function recordingReceiptCell(
   doc: MockLinkedDoc,
   requested: string[],
   path: string[] = [],
-): CallableCellLike {
-  const cell: CallableCellLike = {
+): Cell<any> {
+  const cell: Cell<any> = mockCell({
     get: () => undefined,
     resolveAsCell: () => cell,
-    getAsNormalizedFullLink: () => ({
-      id: doc.id,
-      space: doc.space,
-      path,
-    }),
+    getAsNormalizedFullLink: () => mockLink(doc, path),
     key: (segment: string) => {
       if (requested.length >= 32) {
         throw new Error("fake cell budget exhausted");
@@ -2523,12 +2499,13 @@ function recordingReceiptCell(
       requested.push(next.join("/"));
       return recordingReceiptCell(doc, requested, next);
     },
-  };
+  });
   return cell;
 }
 
 describe("collectInvocationResultLinks", () => {
-  const receiptLink = { id: "of:receipt-1", space: "did:key:test-home" };
+  const receiptDoc = { id: "of:receipt-1", space: "did:key:test-home" };
+  const receiptLink = mockLink(receiptDoc);
   const receiptRef = {
     space: "did:key:test-home",
     id: "of:receipt-1",
@@ -2537,7 +2514,7 @@ describe("collectInvocationResultLinks", () => {
 
   it("yields just the receipt for a plain-JSON-only result", () => {
     const value = { total: 3, tags: ["a", "b"], nested: { deep: true } };
-    const cell = linkedReceiptCell(receiptLink, value);
+    const cell = linkedReceiptCell(receiptDoc, value);
     expect(collectInvocationResultLinks(receiptLink, cell, value)).toEqual({
       "/": receiptRef,
     });
@@ -2548,7 +2525,7 @@ describe("collectInvocationResultLinks", () => {
     // address as a child (key() throws) contributes no link and must not
     // abort the walk — its addressable siblings still annotate.
     const value = { weird: { x: 1 }, comment: { body: "hi" } };
-    const inner = linkedReceiptCell(receiptLink, value, {
+    const inner = linkedReceiptCell(receiptDoc, value, {
       children: {
         comment: { doc: { id: "of:comment-1", space: "did:key:test-home" } },
       },
@@ -2556,15 +2533,15 @@ describe("collectInvocationResultLinks", () => {
     // Wrap the RESOLVED root: the outer wrapper is deliberately unresolved
     // (its own key() refuses traversal), so the throwing key must shadow the
     // cell the walk actually descends through.
-    const innerRoot = inner.resolveAsCell!();
-    const cell: CallableCellLike = {
+    const innerRoot = inner.resolveAsCell();
+    const cell: Cell<any> = mockCell({
       ...innerRoot,
       resolveAsCell: () => cell,
       key: (segment: string) => {
         if (segment === "weird") throw new Error("not addressable");
-        return innerRoot.key!(segment);
+        return innerRoot.key(segment);
       },
-    };
+    });
     expect(collectInvocationResultLinks(receiptLink, cell, value)).toEqual({
       "/": receiptRef,
       "/comment": {
@@ -2580,7 +2557,7 @@ describe("collectInvocationResultLinks", () => {
       comment: { body: "hi", author: { name: "b" } },
       count: 1,
     };
-    const cell = linkedReceiptCell(receiptLink, value, {
+    const cell = linkedReceiptCell(receiptDoc, value, {
       children: {
         comment: {
           doc: { id: "of:comment-1", space: "did:key:test-home" },
@@ -2618,7 +2595,7 @@ describe("collectInvocationResultLinks", () => {
 
   it("addresses an array element reference by its index", () => {
     const value = { items: [{ t: "inline" }, { t: "linked" }] };
-    const cell = linkedReceiptCell(receiptLink, value, {
+    const cell = linkedReceiptCell(receiptDoc, value, {
       children: {
         items: {
           children: {
@@ -2639,7 +2616,7 @@ describe("collectInvocationResultLinks", () => {
 
   it("keeps the sub-document path of a link below a doc's root", () => {
     const value = { pick: { t: "third entry" } };
-    const cell = linkedReceiptCell(receiptLink, value, {
+    const cell = linkedReceiptCell(receiptDoc, value, {
       children: {
         pick: {
           doc: {
@@ -2665,7 +2642,7 @@ describe("collectInvocationResultLinks", () => {
 
   it("escapes pointer-special characters in path keys (RFC 6901)", () => {
     const value = { "a/b": { linked: true } };
-    const cell = linkedReceiptCell(receiptLink, value, {
+    const cell = linkedReceiptCell(receiptDoc, value, {
       children: {
         "a/b": { doc: { id: "of:odd-key", space: "did:key:test-home" } },
       },
@@ -2687,7 +2664,7 @@ describe("collectInvocationResultLinks", () => {
     // receipt it was read through — and the receipt address stays available
     // under the reserved bare key (pointer keys always start with "/", so
     // no result path can collide with it).
-    const cell = linkedReceiptCell(receiptLink, 42, {
+    const cell = linkedReceiptCell(receiptDoc, 42, {
       doc: { id: "of:answer-1", space: "did:key:test-home" },
     });
     expect(collectInvocationResultLinks(receiptLink, cell, 42)).toEqual({
@@ -2698,7 +2675,7 @@ describe("collectInvocationResultLinks", () => {
 
   it("rebases children of a reference-backed root onto its document", () => {
     const value = { body: "hi", author: { name: "b" } };
-    const cell = linkedReceiptCell(receiptLink, value, {
+    const cell = linkedReceiptCell(receiptDoc, value, {
       doc: { id: "of:comment-1", space: "did:key:test-home" },
       children: {
         author: { doc: { id: "of:author-1", space: "did:key:test-home" } },
@@ -2728,16 +2705,14 @@ describe("collectInvocationResultLinks", () => {
       scope: "session" as const,
     };
     expect(
-      collectInvocationResultLinks(scoped, linkedReceiptCell(scoped, {}), {}),
+      collectInvocationResultLinks(
+        mockLink(scoped),
+        linkedReceiptCell(scoped, {}),
+        {},
+      ),
     ).toEqual({
       "/": { space: "did:key:test-home", id: "of:receipt-2", scope: "session" },
     });
-  });
-
-  it("degrades to the root entry alone without a receipt cell to walk", () => {
-    expect(
-      collectInvocationResultLinks(receiptLink, undefined, { a: { b: 1 } }),
-    ).toEqual({ "/": receiptRef });
   });
 
   it("addresses no path inside a live (non-plain) object in the result", () => {
@@ -2771,7 +2746,7 @@ describe("collectInvocationResultLinks", () => {
     const requested: string[] = [];
     const links = collectInvocationResultLinks(
       receiptLink,
-      recordingReceiptCell(receiptLink, requested),
+      recordingReceiptCell(receiptDoc, requested),
       value,
     );
     // The stream itself is addressed — it is a property of the result and
@@ -2797,7 +2772,7 @@ describe("collectInvocationResultLinks", () => {
     const requested: string[] = [];
     const links = collectInvocationResultLinks(
       receiptLink,
-      recordingReceiptCell(receiptLink, requested),
+      recordingReceiptCell(receiptDoc, requested),
       new FakeRuntime(),
     );
     expect(requested).toEqual([]);

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -286,9 +286,10 @@ export const recordRelevantSchemaWritePolicyInput = (
  * these — from an `additionalProperties: false` event schema. The marker is
  * PROVENANCE, not shape, and must stay unforgeable: it rides this
  * in-process options argument, never the event value, so no remote or CLI
- * caller can express it — payloads are plain data, and the CLI's send
- * surface (`CallableCellLike.send`, packages/cli/lib/callable.ts) forwards
- * only `eventId`. In-process callers are gated too: the value must be an
+ * caller can express it — payloads are plain data, and the CLI's invocation
+ * engine (`executeResolvedCallable`, packages/cli/lib/callable.ts) builds the
+ * send options itself and puts only `eventId` in them. In-process callers are
+ * gated too: the value must be an
  * array MINTED by {@link markRuntimeInjectedEventKeys} — the stream-send
  * path drops any other value — and the mint lives in runner internals no
  * pattern compartment can import, so sandboxed pattern code holding a real

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -32,7 +32,7 @@ export type {
 export * from "./interface.ts";
 export { raw } from "./module.ts";
 export type { Cell, Stream } from "./cell.ts";
-export type { NormalizedLink } from "./link-types.ts";
+export type { NormalizedFullLink, NormalizedLink } from "./link-types.ts";
 export { encodeJsonPointer } from "./link-types.ts";
 export type { SigilLink, URI } from "./sigil-types.ts";
 export {


### PR DESCRIPTION
The CLI's callable invocation engine — what `cf piece call` and `cf exec` run — was written against a set of hand-written interfaces that re-described the runner's own surfaces: CallableCellLike shadowed Cell, CallableRuntimeLike shadowed Runtime, CallableManagerLike shadowed PieceManager, and so on for the transaction, the piece, and the piece's input/result accessors. Almost every member on those interfaces was declared optional, with a comment explaining that the optionality existed so lightweight test doubles could leave members out.

That optionality was fiction. Only one implementation ever reaches the engine in production, and it is the real runner object, where every one of those members is required. The engine paid for the fiction twice over. It paid at each call site, with guards asking whether a method the real type always has happens to exist — `getRaw?.()`, `resolveAsCell?.()`, `settled?`, `typeof tx.commit !== "function"`, and about twenty more. It paid at the boundaries, where a real PieceManager had to be cast through `unknown` on the way in and a real piece controller on the way out, because the shadow types and the real ones had no assignability relationship. The layer was also still growing: the verb-contract work added `handlingReceiptLink`, `getCellFromLink` and `settled` to it, each a fresh re-declaration of something the runner already declares.

This deletes the seven shadow interfaces and types the engine against `Cell`, `Runtime`, `PieceManager`, `PieceController`, `IExtendedStorageTransaction` and `NormalizedFullLink` directly. The guards that asked about members the real types require are gone, as are the two `as unknown as` casts in `resolveMountedCallableFile`. Where the shadow link shape declared `id`, `space` and `scope` optional, the real normalized link requires all three, so the presence tests and the `scope ?? "space"` defaults in the `--show-links` walk go too, along with the local BackingLink shape that existed to describe them.

Two behaviours the shadow types kept alive are removed because they were unreachable:

  - The handler branch tested whether the callable cell had a `send` method and, when it did not, fell back to writing the payload into the piece's input or result cell as plain data. Every callable cell the resolvers produce is a real Cell, and `send` is a method on every Cell, so the fallback could not run. Its `--no-wait` refusal message went with it.
  - The tool branch had an alternative drain (idle, then manager sync, then storage sync) for a runtime without `settled()`. `Runtime.settled()` is not optional.

With the data-write fallback gone, nothing in the engine reads the piece or the cell it was resolved on, so `piece` and `cellProp` leave CallableResolution; `cf exec` keeps its own `piece` field for the auto-step that follows an invocation. `space` on that record becomes `MemorySpace` rather than a plain string, which is what `Runtime.getCell` wants and what `PieceManager.getSpace` returns.

The test doubles now cast once where they are constructed instead of implementing a maintained parallel vocabulary, and gain the few members the dropped guards used to skip over: `resolveAsCell` on the barren receipt cell, `prepareTxForCommit` and `settled` on the fake runtimes, `getCell` on the fake piece, and `getAsNormalizedFullLink` on the fake cells. Two `cf exec` event assertions grow a trailing `manager.synced`: the fake piece previously had no `getCell`, so the auto-step silently skipped, and the doubles now model what a real piece does.

Also exports `NormalizedFullLink` from the runner's index — it is the return type of the public `Cell.getAsNormalizedFullLink`, so a consumer holding one could not name it — and updates the `StreamSendOptions` comment in the runner, which cited the deleted `CallableCellLike.send` as the reason no CLI caller can express `runtimeInjectedEventKeys`. The guarantee is unchanged: the engine builds the send-options object itself and puts only `eventId` in it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the CLI invocation engine to use the real runner types, removing seven shadow interfaces and optional guards. This simplifies handler/tool execution, eliminates unreachable paths, and adds a public export for `NormalizedFullLink`.

- **Refactors**
  - Type the engine directly against `Cell`, `Runtime`, `PieceManager`, `PieceController`, `IExtendedStorageTransaction`, and `NormalizedFullLink`; remove `Callable*Like` types.
  - Drop optional checks and unreachable branches: the handler data-write fallback and the non-`settled()` drain.
  - Use normalized links end-to-end: enforce scope (no `scope ?? "space"`), and walk `--show-links` using resolved cells.
  - Streamline `cf exec`: the engine no longer reads the piece/cell; auto-step now pulls the piece cell and then runs `manager.synced`.

- **New Features**
  - Export `NormalizedFullLink` from `@commonfabric/runner`.

<sup>Written for commit e0a5aa970538b3ab501b4a32a961b6a5ce0ea398. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

