### PR TITLE
Cloud spend breakdown

### DIFF
--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -373,6 +373,12 @@ runs out even though nothing about the usage changed. How much of a grant is lef
 is not in the billing export: Google publishes it only in the console's billing
 credits page.
 
+A grant may also arrive in monthly tranches that land on a few days rather than
+spreading across the month. The rate window is a fortnight, so it either covers
+those days or it does not, and the projection steps up or down as they pass out
+of it. The month-to-date figure in the header carries whatever has landed so far
+and is the one to read when a tranche is due but has not arrived.
+
 ### `OPENAI_ADMIN_KEY`
 
 Powers the OpenAI share of **model spend**. Needs an organization **Admin** key —

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -331,16 +331,42 @@ the prior month's tail until it covers 14 days or reaches the first available
 billing day. The chart shows up to 45 finished UTC days and highlights the part
 used for the estimate.
 
-A day is finished when the export has stopped adding to it, which the tile reads
-from the export's own progress: a day counts as finished once a later day's usage
-has been written since that day was last written to. This matters because the
-export lands a day's usage in batches and goes on adding to a day well into the
-following one, so a day it has not finished holds only part of that day's cost.
-Such a day belongs in the month-to-date total, where it is a running figure, and
-not in the rate behind the projection or at the end of the chart, where it would
-read as spend falling away. When the export has finished no day for more than
-four days the tile goes gray and says how far behind it is, rather than
+Which days are finished matters, because the export lands a day's usage in
+batches spread over the day or two after it ends, and works on several days at
+once. A day it has not finished holds only part of that day's cost. Such a day
+belongs in the month-to-date total, where it is a running figure, and not in the
+rate behind the projection or at the end of the chart, where it would read as
+spend falling away.
+
+Nothing in the export marks a day as complete, so the tile establishes it two
+ways at once, and a day has to satisfy both.
+
+The first is how much of the day the export has accounted for. Alongside cost,
+the query totals the billable time on each day's usage — the seconds of instance,
+disk, and other metered life the export has recorded. A running fleet books close
+to the same amount every day, and unlike cost it does not move when a promotion
+or a price change lands, so a day holding less than half of the day before it is
+one the export is still filling in. A fleet that really does shrink trips this
+for the day it shrinks on, and then the days after it stand against the new level
+and the window moves on.
+
+The second is how long the export has had. It records when it last added a
+material batch to each day, which the tile turns into how long the export is
+currently taking to finish with a day. That figure is measured from the export's
+own record across the window rather than assumed here, so it follows an export
+that speeds up or slows down. A day is finished once the export has had that long
+since the day ended. The newest day in the window is never finished, because the
+export has written nothing after it to show it has moved past it.
+
+Each check covers where the other is blind. Billable time alone would accept a
+day the export happens to be most of the way through; elapsed time alone would
+accept a day the export has fallen behind on. When no day passes both for more
+than four days the tile goes gray and says how far behind it is, rather than
 projecting a month from stale history.
+
+Both checks read only the export's `regular` rows. Invoice adjustments and
+rounding corrections arrive weeks after the fact and carry no usage, so counting
+them would make a long-closed day look freshly written.
 
 A promotional credit is finite, so the spend the tile reports rises when a grant
 runs out even though nothing about the usage changed. How much of a grant is left

--- a/packages/dashboard/tiles/gcp-spend.test.ts
+++ b/packages/dashboard/tiles/gcp-spend.test.ts
@@ -67,17 +67,26 @@ const DAY = 86_400_000;
 const TABLE = "billing-proj.billing.gcp_billing_export_v1_XXXX";
 
 // One row per day, in the shape the query returns: the day, its cost before
-// credits, the credit that came off it (negative, as the export records it), and
-// the seconds-epoch time the export last added to that day. These fixtures export
-// each day eight hours in, so every day but the newest has a later day written
-// after it, which is what marks a day finished.
-const exportedAt = (day: string) => (Date.parse(`${day}T08:00:00Z`) / 1000);
+// credits, the credit that came off it (negative, as the export records it), the
+// billable time the export has recorded for it, and the seconds-epoch time the
+// export last added a material batch to it.
+//
+// The billable time a fleet books in a full day. A day holding a small part of
+// this is one the export has yet to fill in.
+const FULL_DAY = 400 * 86_400;
+// A day the export is partway through. Well under half of a full day, which is
+// the share the tile reads as unfinished.
+const PART_DAY = FULL_DAY / 4;
+// These fixtures have the export finish each day eight hours after the day ends,
+// so that is the settling time the tile measures from them.
+const settledAt = (day: string) => Date.parse(`${day}T00:00:00Z`) / 1000 + 32 * 3600;
 
 function dailyRows(
   first: string,
   last: string,
   amount: (day: string) => number,
   credit: (day: string) => number = () => 0,
+  metered: (day: string) => number = () => FULL_DAY,
 ): string[][] {
   const rows: string[][] = [];
   for (
@@ -90,7 +99,8 @@ function dailyRows(
       day,
       String(amount(day)),
       String(credit(day)),
-      String(exportedAt(day)),
+      String(metered(day)),
+      String(settledAt(day)),
     ]);
   }
   return rows;
@@ -104,6 +114,7 @@ const earlyMonthRows = (credit: (day: string) => number = () => 0) =>
     "2026-01-10",
     (day) => day === "2026-01-10" ? 5 : day.startsWith("2026-01") ? 20 : 10,
     credit,
+    (day) => day === "2026-01-10" ? PART_DAY : FULL_DAY,
   );
 
 Deno.test(
@@ -188,7 +199,18 @@ Deno.test(
       sql,
       "DATE(usage_start_time) <= CURRENT_DATE()",
     );
-    assertStringIncludes(sql, "GROUP BY day ORDER BY day");
+    assertStringIncludes(sql, "ORDER BY money.day");
+    // Billable time and export progress, which mark a day as finished. Both read
+    // usage alone: invoice adjustments carry none and land weeks late.
+    assertStringIncludes(
+      sql,
+      "SUM(IF(usage.unit = 'seconds', usage.amount, 0)) AS metered",
+    );
+    assertStringIncludes(sql, "cost_type = 'regular'");
+    assertStringIncludes(
+      sql,
+      "MAX(IF(metered >= 0.01 * day_metered, export_time, NULL))",
+    );
   },
 );
 
@@ -263,7 +285,13 @@ Deno.test(
             "2025-12-31",
             () => 10,
           ),
-          ["2026-01-01", "7", "0", String(exportedAt("2026-01-01"))],
+          [
+            "2026-01-01",
+            "7",
+            "0",
+            String(PART_DAY),
+            String(settledAt("2026-01-01")),
+          ],
         ],
       ),
       () => gcpSpend.collect(ctx({ GCP_BILLING_TABLE: TABLE })),
@@ -338,10 +366,11 @@ Deno.test(
     const { result } = await withFetch(
       bigQueryStub([
         ...dailyRows("2026-01-01", "2026-01-07", () => 20),
-        // The export's newest write touched both of these days, so it has
-        // finished neither, and each holds part of a day's cost so far.
-        ["2026-01-08", "5", "0", String(exportedAt("2026-01-10"))],
-        ["2026-01-09", "5", "0", String(exportedAt("2026-01-10"))],
+        // The export has each of these days a quarter written, so it has
+        // finished neither, and each holds part of a day's cost so far. It has
+        // had long enough with both, which on its own would pass them.
+        ["2026-01-08", "5", "0", String(PART_DAY), String(settledAt("2026-01-08"))],
+        ["2026-01-09", "5", "0", String(PART_DAY), String(settledAt("2026-01-09"))],
       ]),
       () => gcpSpend.collect(ctx({ GCP_BILLING_TABLE: TABLE })),
     );
@@ -354,6 +383,60 @@ Deno.test(
       '<span class="hmtd">$150 MTD</span>',
     );
     assertEquals(result.duration, 7 * DAY);
+  },
+);
+
+Deno.test(
+  "cloud spend: a full day the export has not had long enough with waits",
+  async () => {
+    // Every day here holds a full day's billable time, so how much of each day
+    // the export has accounted for says nothing. What separates them is that
+    // this export takes a day and a half to finish with a day, which it has had
+    // for 2026-01-07 and has not had for the two days after it.
+    const slow = (day: string) => String(Date.parse(`${day}T00:00:00Z`) / 1000 + 60 * 3600);
+    const { result } = await withFetch(
+      bigQueryStub(
+        dailyRows("2026-01-01", "2026-01-09", () => 20)
+          .map((row) => [...row.slice(0, 4), slow(row[0])]),
+      ),
+      () => gcpSpend.collect(ctx({ GCP_BILLING_TABLE: TABLE })),
+    );
+
+    // Seven days at $20 rate the month at $620, and all nine days count towards
+    // the month-to-date total. Rating every day the export has touched would
+    // read the same $620 off days two of which are not all there.
+    assertEquals(result.value, "~$620/mo");
+    assertEquals(result.aside, '<span class="hmtd">$180 MTD</span>');
+    assertEquals(result.duration, 7 * DAY);
+  },
+);
+
+Deno.test(
+  "cloud spend: a fleet that shrinks for good stops reading as unfinished",
+  async () => {
+    // Two thirds of the fleet goes away on 2026-01-05 and never comes back.
+    // That day holds a third of the billable time of the day before it, which
+    // is what a day the export is still writing looks like, so it cannot end
+    // the rate window. Every day after it stands against the new level, so the
+    // window still reaches 2026-01-09 and the tile rates the month on the fleet
+    // it has now, rather than stalling on one that is not coming back.
+    const { result } = await withFetch(
+      bigQueryStub(
+        dailyRows(
+          "2026-01-01",
+          "2026-01-10",
+          (day) => day >= "2026-01-05" ? 6 : 20,
+          () => 0,
+          (day) => day >= "2026-01-05" ? FULL_DAY / 3 : FULL_DAY,
+        ),
+      ),
+      () => gcpSpend.collect(ctx({ GCP_BILLING_TABLE: TABLE })),
+    );
+
+    // Four days at $20 and five at $6 rate the month: $110 / 9 * 31 = $379.
+    assertEquals(result.value, "~$379/mo");
+    assertEquals(result.aside, '<span class="hmtd">$116 MTD</span>');
+    assertEquals(result.duration, 9 * DAY);
   },
 );
 
@@ -375,15 +458,17 @@ Deno.test(
   async () => {
     for (
       const rows of [
-        [["2026-01-09", "not-a-number", "0", "1767000000"]],
-        [["not-a-day", "10", "0", "1767000000"]],
-        [["2026-99-99", "10", "0", "1767000000"]],
-        [["2026-01-11", "10", "0", "1767000000"]],
-        [["2026-01-09", null, "0", "1767000000"]],
-        [["2026-01-09", "10", "not-a-number", "1767000000"]],
-        [["2026-01-09", "10", null, "1767000000"]],
-        [["2026-01-09", "10", "0", "not-a-number"]],
-        [["2026-01-09", "10", "0", null]],
+        [["2026-01-09", "not-a-number", "0", "86400", "1767000000"]],
+        [["not-a-day", "10", "0", "86400", "1767000000"]],
+        [["2026-99-99", "10", "0", "86400", "1767000000"]],
+        [["2026-01-11", "10", "0", "86400", "1767000000"]],
+        [["2026-01-09", null, "0", "86400", "1767000000"]],
+        [["2026-01-09", "10", "not-a-number", "86400", "1767000000"]],
+        [["2026-01-09", "10", null, "86400", "1767000000"]],
+        [["2026-01-09", "10", "0", "not-a-number", "1767000000"]],
+        [["2026-01-09", "10", "0", null, "1767000000"]],
+        [["2026-01-09", "10", "0", "86400", "not-a-number"]],
+        [["2026-01-09", "10", "0", "86400", null]],
       ] as (string | null)[][][]
     ) {
       const { result } = await withFetch(

--- a/packages/dashboard/tiles/gcp-spend.ts
+++ b/packages/dashboard/tiles/gcp-spend.ts
@@ -5,14 +5,31 @@
 // it reaches into available prior-month history, up to a 14-day total. Cost from
 // a day the export is still writing contributes only to the month-to-date total.
 //
-// The export lands a day's usage in batches, and goes on adding to a day well
-// into the following one, so a day it has not finished reads as a fall in spend
-// and would drag down any rate measured over it. A day counts as finished once
-// the export has written a later day's usage since it last wrote that day's,
-// because the export works forward through usage and does not return to a day it
-// has left behind. The chart and the rate window both end at the newest finished
-// day, and an export that has finished no day in several days grays the tile
-// rather than projecting from stale history.
+// The export lands a day's usage in batches spread over the day or two after it
+// ends, and works on several days at once, so a day it has not finished holds
+// only part of that day's cost and would drag down any rate measured over it.
+// Nothing in the export marks a day as complete, so the tile establishes it two
+// ways at once, each covering where the other is blind.
+//
+// The first is how much of the day the export has accounted for. Alongside cost,
+// the query totals the billable time on a day's usage — the seconds of instance,
+// disk, and other metered life the export has recorded. A running fleet books
+// close to the same amount every day, and unlike cost it does not move when a
+// promotion or a price change lands, so a day holding a small fraction of the
+// day before it is one the export is still filling in.
+//
+// The second is how long the export has had. It reports when it last added a
+// material batch to each day, which the tile turns into how long the export
+// currently takes to finish with a day. That measurement comes from the export's
+// own record over the window rather than a figure assumed here, so it tracks an
+// export that speeds up or slows down. A day is finished once the export has had
+// that long since the day ended.
+//
+// Billable time alone would accept a day the export happens to be most of the way
+// through, and elapsed time alone would accept a day the export has fallen behind
+// on. A day has to satisfy both. The chart and the rate window end at the newest
+// day that does, and an export that has finished no day in several days grays the
+// tile rather than projecting from stale history.
 //
 // The tile uses the BigQuery REST API, without bq or gcloud. It authenticates as
 // the workload's service account in GKE, or with GCP_SA_KEY locally. That account
@@ -27,24 +44,51 @@ const GCP_COLOR = "#4285f4";
 // reporting. The export normally finishes a day within a day or two of it
 // ending, so this much silence is a broken export rather than a slow one.
 const MAX_EXPORT_LAG_DAYS = 4;
+// The share of a day's billable time that makes an export batch a material one.
+// The export closes a day with a long tail of tiny corrections, and timing it by
+// those would read every day as settling days after it really did.
+const SETTLE_SHARE = 0.01;
+// The share of the previous day's billable time a day holds once the export has
+// filled it in. The export passes through half to two thirds of a day in the
+// hours after that day ends, and a fleet that shrinks overnight still books far
+// more than this, so the mark separates the two.
+const MIN_DAY_COVERAGE = 0.5;
 
 // Daily cost, credit, and export progress for the trailing UTC days and today.
 // A usage row carries its credits as a repeated field of negative amounts,
 // covering promotions, committed- and sustained-use discounts, and the free tier,
-// so what the account pays for that row is the two added together. The latest
-// export_time of a day's rows is when the export last added to that day.
+// so what the account pays for that row is the two added together.
+//
+// `metered` is the billable time on the day's usage, which is what tells a day
+// the export has filled in from one it is still writing. `settled` is when the
+// export last added a material batch to the day. Both read only `regular` rows:
+// invoice adjustments and rounding corrections arrive weeks later, carry no
+// usage, and would otherwise make a long-closed day look freshly written.
 // Grouping in BigQuery keeps the response small even when the export has many
 // rows per service.
-const sqlFor = (table: string) =>
-  `SELECT FORMAT_DATE('%F', DATE(usage_start_time)) AS day, ` +
-  `SUM(cost) AS cost, ` +
-  `IFNULL(SUM((SELECT SUM(credit.amount) FROM UNNEST(credits) AS credit)), 0) ` +
-  `AS credits, UNIX_SECONDS(MAX(export_time)) AS exported ` +
-  `FROM \`${table}\` ` +
-  `WHERE DATE(usage_start_time) >= ` +
-  `DATE_SUB(CURRENT_DATE(), INTERVAL ${SPEND_HISTORY_DAYS} DAY) ` +
-  `AND DATE(usage_start_time) <= CURRENT_DATE() ` +
-  `GROUP BY day ORDER BY day`;
+const sqlFor = (table: string) => {
+  const window = `DATE(usage_start_time) >= ` +
+    `DATE_SUB(CURRENT_DATE(), INTERVAL ${SPEND_HISTORY_DAYS} DAY) ` +
+    `AND DATE(usage_start_time) <= CURRENT_DATE()`;
+  return `WITH batches AS (` +
+    `SELECT FORMAT_DATE('%F', DATE(usage_start_time)) AS day, export_time, ` +
+    `SUM(IF(usage.unit = 'seconds', usage.amount, 0)) AS metered ` +
+    `FROM \`${table}\` WHERE ${window} AND cost_type = 'regular' ` +
+    `GROUP BY day, export_time), ` +
+    `shares AS (SELECT day, export_time, metered, ` +
+    `SUM(metered) OVER (PARTITION BY day) AS day_metered FROM batches), ` +
+    `progress AS (SELECT day, ANY_VALUE(day_metered) AS metered, ` +
+    `UNIX_SECONDS(MAX(IF(metered >= ${SETTLE_SHARE} * day_metered, ` +
+    `export_time, NULL))) AS settled FROM shares GROUP BY day), ` +
+    `money AS (SELECT FORMAT_DATE('%F', DATE(usage_start_time)) AS day, ` +
+    `SUM(cost) AS cost, ` +
+    `IFNULL(SUM((SELECT SUM(credit.amount) FROM UNNEST(credits) AS credit)), 0) ` +
+    `AS credits FROM \`${table}\` WHERE ${window} GROUP BY day) ` +
+    `SELECT money.day, money.cost, money.credits, ` +
+    `IFNULL(progress.metered, 0) AS metered, ` +
+    `IFNULL(progress.settled, 0) AS settled ` +
+    `FROM money LEFT JOIN progress USING (day) ORDER BY money.day`;
+};
 
 // The billing table is `project.dataset.table`; the query runs in that project,
 // where the service account holds Job User.
@@ -64,7 +108,8 @@ function amount(cell: string | undefined): number {
 
 interface DailyCost {
   paid: number; // cost after credits
-  exported: number; // when the export last added to this day, in seconds
+  metered: number; // billable time the export has recorded for this day
+  settled: number; // when the export last added a material batch, in seconds
 }
 
 interface DailyCostHistory {
@@ -91,33 +136,67 @@ function dailyCosts(
     const time = dayTime(day);
     const cost = amount(row[1]);
     const credit = amount(row[2]);
-    const exported = amount(row[3]);
+    const metered = amount(row[3]);
+    const settled = amount(row[4]);
     if (
       time === null ||
       time < first ||
       time > today ||
       !Number.isFinite(cost) ||
       !Number.isFinite(credit) ||
-      !Number.isFinite(exported)
+      !Number.isFinite(metered) ||
+      !Number.isFinite(settled)
     ) {
       throw new Error("billing history has an unexpected shape");
     }
-    parsed.set(day, { paid: cost + credit, exported });
+    parsed.set(day, { paid: cost + credit, metered, settled });
     oldest = Math.min(oldest, time);
   }
 
-  // The newest day the export has finished with: walking back from the newest
-  // day, the first one the export stopped adding to before it wrote a later day.
+  // Days the export has accounted for, by the billable time on them. The day
+  // before is the comparison because it is the older of the two, so it is the
+  // one the export has had longer to finish. The oldest day in the window has
+  // nothing before it and is far enough back to take as filled in.
   const days = [...parsed.keys()].sort();
-  let laterExport = -Infinity;
+  const filled = new Set<string>();
+  for (const [index, day] of days.entries()) {
+    const before = index === 0 ? undefined : parsed.get(days[index - 1]);
+    if (
+      before === undefined ||
+      parsed.get(day)!.metered >= MIN_DAY_COVERAGE * before.metered
+    ) {
+      filled.add(day);
+    }
+  }
+
+  // How long the export is currently taking to finish with a day, from its own
+  // record of when it last added a material batch to each day it has accounted
+  // for. Days it is still filling in are left out: their last batch says how far
+  // the export has got with them, not how long it needs. A stretch where the
+  // export ran late holds this up for as long as it stays in the window, which
+  // is the honest reading of an export that has been running late.
+  let settlingMs = 0;
+  for (const day of filled) {
+    settlingMs = Math.max(
+      settlingMs,
+      parsed.get(day)!.settled * 1000 - (dayTime(day)! + DAY_MS),
+    );
+  }
+
+  // The newest day the export has accounted for and has had that long with.
+  // The last day in the window is never it: the export has written nothing
+  // after that day, so there is no sign it has moved past it, and a window
+  // holding one day says nothing about how long the export takes.
   let last: number | undefined;
-  for (let index = days.length - 1; index >= 0; index--) {
-    const exported = parsed.get(days[index])!.exported;
-    if (exported < laterExport) {
-      last = dayTime(days[index])!;
+  for (let index = days.length - 2; index >= 0; index--) {
+    const time = dayTime(days[index])!;
+    if (
+      filled.has(days[index]) &&
+      now.getTime() - (time + DAY_MS) >= settlingMs
+    ) {
+      last = time;
       break;
     }
-    laterExport = Math.max(laterExport, exported);
   }
   if (last === undefined) return null;
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improves the cloud spend projection by correctly identifying finished billing days to prevent underrating recent spend. Uses billable time and export settle time instead of trusting “yesterday.”

- **Bug Fixes**
  - Updated the BigQuery query to include per-day metered seconds and the last material batch time; reads only `regular` rows to ignore late adjustments.
  - Rewrote finished-day logic: a day must have enough billable time compared to the prior day and have waited the measured settle time; the newest day never counts; gray state when no day passes both for >4 days.
  - Added tests for partial days, slow exports, and shrinking fleets; updated fixtures to include `metered` and `settled` columns.
  - Expanded `packages/dashboard/README.md` to document the new method and how monthly credit tranches can step the projection while MTD reflects actual landed credits.

<sup>Written for commit 2df48cd31ff06aba54b7890ca8aea22f729a4ff2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

