### PR TITLE
feat(runner): let a test turn doc-visit diagnostics on

### DIFF
--- a/docs/development/CONFIGURATION.md
+++ b/docs/development/CONFIGURATION.md
@@ -236,6 +236,29 @@ longer exist.
 
 ---
 
+## Runner diagnostics
+
+Environment toggles read by `packages/runner` when it starts. None of them
+change what a traversal computes; they decide what it records about itself.
+All are off by default, and each is read once, so a process picks up a change
+to the environment only on restart.
+
+A test therefore cannot switch one on by setting the variable. For doc-visit
+diagnostics, call `setTraverseDiagnostics(true)` from
+`packages/runner/src/traverse.ts`, which overrides the variable for the process
+and is read again at the start of every traversal; pass `undefined` to hand the
+decision back to the environment. For captures, construct a
+`TraverseCaptureRecorder` directly, as `traverse-replay.test.ts` does — the
+variables only decide whether the module installs one of its own on startup.
+
+| Var | Default | Notes |
+|---|---|---|
+| `CF_TRAVERSE_DIAGNOSTICS` | _(unset)_ | Set to exactly `1` to count, for each traversal, how many times it visited each doc and how many distinct doc-and-path pairs it reached. Only the slow-traverse warning reads those counts. Without this, that warning reports `uniqueDocs=0`, `uniquePaths=0`, and `topDocs=n/a`. It is off by default because the tracking builds a string and touches a `Map` and a `Set` on every schema visit, which is measurable on large traversals. |
+| `CF_TRAVERSE_CAPTURE` | _(unset)_ | Path to write a traverse fixture to. Every `SchemaObjectTraverser.traverse()` call is recorded in order, along with the value of each doc it visited, and written to that path periodically and on unload. `packages/runner/test/traverse-replay/replay.ts` replays a fixture against a read-only transaction; `packages/runner/src/traverse-recorder.ts` documents the fidelity limits, of which the important one is that a doc written during the run replays with its earliest captured value. |
+| `CF_TRAVERSE_CAPTURE_MAX` | `20000` | How many invocations one capture records before it stops. Anything that is not a finite number above zero falls back to the default. Read only when `CF_TRAVERSE_CAPTURE` is set. |
+
+---
+
 ## Experimental flags
 
 [`docs/development/EXPERIMENTAL_OPTIONS.md`](./EXPERIMENTAL_OPTIONS.md) is the

--- a/docs/development/COVERAGE.md
+++ b/docs/development/COVERAGE.md
@@ -137,6 +137,61 @@ The
 works through two real instances, and describes how to localize a group-level
 change down to the specific file and line so you know what to write a test for.
 
+### Diagnostics that fire on wall-clock time
+
+The slow-traverse report in `packages/runner/src/traverse.ts` was one of those
+instances. It logged a traversal's counters only when that traversal had taken
+more than 100 milliseconds of real time, so it ran on a loaded machine and did
+not run on an idle one. Thirty-nine lines moved with the load: the body of the
+report, plus the two `MapSet` getters that nothing but the report called.
+Several unrelated pull requests spent an `ACCEPT_COVERAGE_DEBT` marker on the
+result.
+
+Write such a diagnostic so that the elapsed time reaches it as a parameter,
+rather than having the reporting code measure the time for itself. Put the
+threshold comparison and the report together in a function that takes the
+elapsed time, and call that function from the timed path every time, with no
+condition around the call. That is what `maybeReportSlowTraverse()` does now.
+Every line of the diagnostic then runs on every machine, and the clock decides
+nothing except which way the comparison inside goes.
+
+A test reaches the report by choosing the elapsed time. It can call the
+function directly with a time over the threshold, or it can pin the clock the
+timed path reads, which also proves that the path still reaches the
+diagnostic. The `SchemaObjectTraverser slow-traverse reporting` cases in
+`packages/runner/test/traverse.test.ts` are the worked example of the second.
+They replace `performance.now` — what `logger.timeStart` and `timeEnd` read —
+for the length of one traversal, and advance it from a store read, because
+`traverse()` is synchronous and a test cannot step a clock from outside a call
+that never yields. That the traversal really did read the store is asserted, so
+a traversal that stopped reading could not pass the test vacuously.
+
+The fake clock that a package's test task preloads does not cover a branch like
+this one, and cannot. It replaces `performance.now` with logical time, and
+logical time moves only when a positive-delay timer fires. A synchronous call
+arms no timers, so a span timed around synchronous work measures exactly zero:
+under the runner package's preload, `elapsed > 100` is deterministically false
+in every test in the package. The `clock.tick(ms)` control is asynchronous and
+advances nothing until it is awaited, so there is no way to move logical time
+from inside a synchronous call either. A test that wants a chosen elapsed time
+therefore replaces `performance.now` outright, saving and restoring it rather
+than assuming it is the native one, since the preload already owns that
+property. That is also why the movement was collected by the
+pattern-integration jobs rather than by the runner suite: their coverage comes
+from a browser worker, which a Deno `--preload` never reaches.
+
+Leaving the threshold comparison behind at the call site does not reduce the
+movement to nothing. The lines inside a guard are covered only on a run that
+took the branch, so a call site of the form
+`if (elapsed > SLOW_TRAVERSE_MS) report(...)` keeps its reporting line moving
+from one run to the next, and one line of movement fails the ratchet exactly as
+thirty-nine did. Do not reason from what the `if` line itself reports either.
+That count is a projection of V8's block ranges onto lines: it differs between
+the one-line and the braced form of the same guard, and it changed between deno
+2.8.3 and the pinned 2.9.4, which now credits a braced guard's line with the
+condition's own count. See
+[deno coverage: one-line guard reported uncovered when its branch is not taken](deno-coverage-guard-line-artifact.md).
+
 ## Ratchet baselines and accepting debt
 
 The ratchet applies per source group and only to the groups a PR changes: for

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -1088,7 +1088,8 @@ sweep does not mistake them for missing experimental flags:
   (forward the web worker's console to the main thread), `telemetryEnabled`
   (browser OpenTelemetry), `showDebuggerView`, `themePreference`.
 - **Runner diagnostics** (environment): `CF_TRAVERSE_CAPTURE`,
-  `CF_TRAVERSE_CAPTURE_MAX`, `CF_TRAVERSE_DIAGNOSTICS`.
+  `CF_TRAVERSE_CAPTURE_MAX`, `CF_TRAVERSE_DIAGNOSTICS`. What each one does is in
+  [the configuration reference](./CONFIGURATION.md#runner-diagnostics).
 - **CLI controls** (environment): `CF_EXEC_SHEBANG`, `CF_CLI_TRACE_TIMINGS`,
   `CF_PROFILE_DONE_MARKER`.
 - **Operational and build toggles**: `MEMORY_ACL_MODE` (`off` / `observe` /

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -639,6 +639,23 @@ const TRAVERSE_DIAGNOSTICS: boolean = (() => {
   }
 })();
 
+let traverseDiagnosticsOverride: boolean | undefined;
+
+/**
+ * Sets doc-visit diagnostics for this process, above whatever
+ * `CF_TRAVERSE_DIAGNOSTICS` said. Passing `undefined` hands the decision back
+ * to the environment. A traversal reads the setting when it starts, so a
+ * change applies from the next traversal on.
+ */
+export function setTraverseDiagnostics(enabled: boolean | undefined): void {
+  traverseDiagnosticsOverride = enabled;
+}
+
+/** Whether doc-visit diagnostics are collected. */
+export function traverseDiagnosticsEnabled(): boolean {
+  return traverseDiagnosticsOverride ?? TRAVERSE_DIAGNOSTICS;
+}
+
 /**
  * Identity-memoized `ContextualFlowControl.resolveSchemaRefs()` with an
  * interned result. `$ref` resolution mints a fresh schema per call, which
@@ -2891,6 +2908,9 @@ export class SchemaObjectTraverser<V extends FabricValue>
   // Track per-doc visit counts and unique paths
   private docVisits = new Map<string, number>();
   private uniquePaths = new Set<string>();
+  // Read once per traversal, so one traversal collects and reports the same
+  // way throughout.
+  private diagnostics = traverseDiagnosticsEnabled();
   private maxDepth = 0;
   private currentDepth = 0;
   // Memoization cache for traverseWithSchema: key → result
@@ -2962,6 +2982,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
     this.getDocAtPathCalls = 0;
     this.docVisits.clear();
     this.uniquePaths.clear();
+    this.diagnostics = traverseDiagnosticsEnabled();
     this.maxDepth = 0;
     this.currentDepth = 0;
     this.schemaMemoHits = 0;
@@ -3038,7 +3059,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
       `maxDepth=${this.maxDepth}`,
       `schemaMemo=${this.activeMemo.size}`,
       `schemaMemoHits=${this.schemaMemoHits}`,
-      TRAVERSE_DIAGNOSTICS
+      this.diagnostics
         ? `topDocs=${topDocs}`
         : "topDocs=n/a (set CF_TRAVERSE_DIAGNOSTICS=1)",
     ]);
@@ -3135,7 +3156,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
     this.currentDepth++;
     if (this.currentDepth > this.maxDepth) this.maxDepth = this.currentDepth;
     const docId = doc.address.id;
-    if (TRAVERSE_DIAGNOSTICS) {
+    if (this.diagnostics) {
       // Per-visit doc/path tracking for the slow-traverse log; the string
       // building is too hot to leave on by default (see TRAVERSE_DIAGNOSTICS).
       this.docVisits.set(docId, (this.docVisits.get(docId) ?? 0) + 1);

--- a/packages/runner/test/traverse.test.ts
+++ b/packages/runner/test/traverse.test.ts
@@ -27,6 +27,7 @@ import {
   PointerCycleTracker,
   SchemaObjectTraverser,
   schemaTrackerCoversSelector,
+  setTraverseDiagnostics,
   type TraversalContext,
 } from "../src/traverse.ts";
 import { StoreObjectManager } from "../src/storage/query.ts";
@@ -4212,6 +4213,13 @@ describe("MapSet size and totalValues", () => {
 
     expect(mapSet.size).toBe(2);
     expect(mapSet.totalValues).toBe(3);
+    expect(mapSet.get("a")).toEqual(new Set(["one", "two"]));
+    expect(mapSet.get("absent")).toBeUndefined();
+
+    // Emptying a key drops the key, so both counts fall.
+    mapSet.deleteValue("b", "three");
+    expect(mapSet.size).toBe(1);
+    expect(mapSet.totalValues).toBe(2);
   });
 
   it("counts keys and values in the hash-dedup mode", () => {
@@ -4228,6 +4236,11 @@ describe("MapSet size and totalValues", () => {
 
     expect(mapSet.size).toBe(2);
     expect(mapSet.totalValues).toBe(3);
+
+    // Dropping a key takes the values it held with it.
+    mapSet.delete("a");
+    expect(mapSet.size).toBe(1);
+    expect(mapSet.totalValues).toBe(1);
   });
 });
 
@@ -4348,5 +4361,100 @@ describe("SchemaObjectTraverser slow-traverse reporting", () => {
     // without a test noticing.
     expect(traverseWithElapsed(100).warnings).toEqual([]);
     expect(traverseWithElapsed(101).warnings.length).toBe(1);
+  });
+
+  // Runs a slow traversal over a container that links into `targetCount`
+  // separate docs, linking target `i` exactly `i + 1` times, so every target
+  // ends with a different visit count. Ids are long enough to be truncated in
+  // the report.
+  function traverseLinkingIntoManyDocs(targetCount: number): string[] {
+    const docUri = "of:slow-traverse-many-container" as URI;
+    const targetUri = (i: number) =>
+      `of:slow-traverse-linked-document-${i}` as URI;
+    const properties: Record<string, JSONSchema> = {};
+    const docValue: Record<string, FabricValue> = {};
+    for (let i = 0; i < targetCount; i++) {
+      for (let link = 0; link <= i; link++) {
+        docValue[`p${i}_${link}`] = {
+          "/": { [LINK_V1_TAG]: { id: targetUri(i), path: ["name"] } },
+        };
+        properties[`p${i}_${link}`] = { type: "string" };
+      }
+    }
+
+    let now = 1000;
+    const store = new ClockAdvancingStore(() => {
+      now += 150;
+    });
+    for (let i = 0; i < targetCount; i++) {
+      const of = targetUri(i) as Entity;
+      store.set(`${of}/${type}`, {
+        the: type,
+        of,
+        is: { value: { name: `name-${i}` } },
+        cause: hashOf({ the: type, of }),
+        since: 1,
+      });
+    }
+    store.set(`${docUri}/${type}`, {
+      the: type,
+      of: docUri as Entity,
+      is: { value: docValue },
+      cause: hashOf({ the: type, of: docUri as Entity }),
+      since: 2,
+    });
+
+    const traverser = getTraverser(store, {
+      path: ["value"],
+      schema: { type: "object", properties },
+    });
+    const doc: IMemorySpaceValueAttestation = {
+      address: { space: "did:null:null", id: docUri, type, path: ["value"] },
+      value: docValue,
+    };
+
+    const warnings: string[] = [];
+    const savedWarn = console.warn;
+    const savedNow = performance.now;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.map((arg) => String(arg)).join(" "));
+    };
+    Reflect.set(performance, "now", () => now);
+    setTraverseDiagnostics(true);
+    try {
+      traverser.traverse(doc);
+    } finally {
+      setTraverseDiagnostics(undefined);
+      Reflect.set(performance, "now", savedNow);
+      console.warn = savedWarn;
+    }
+    return warnings;
+  }
+
+  it("names the five most-visited docs when diagnostics are on", () => {
+    const warnings = traverseLinkingIntoManyDocs(6);
+
+    expect(warnings.length).toBe(1);
+    // Six targets plus the container were visited, and all seven are counted.
+    expect(warnings[0]).toContain("uniqueDocs=7");
+
+    const listed = /topDocs=(.*)$/.exec(warnings[0])![1].trim().split(" ");
+    // Seven docs were visited and five are named: the field is capped.
+    expect(listed.length).toBe(5);
+    // Each entry is an id cut to its first 20 characters, then its count.
+    for (const entry of listed) {
+      expect(entry).toMatch(/^.{20}\.\.=\d+$/);
+    }
+    // Most-visited first. Target `i` was linked `i + 1` times, so the two
+    // least-visited targets are the ones the cap dropped.
+    const counts = listed.map((entry) => Number(entry.split("=")[1]));
+    expect(counts).toEqual([...counts].sort((a, b) => b - a));
+    expect(counts).not.toContain(1);
+    expect(counts).not.toContain(2);
+  });
+
+  it("collects nothing when diagnostics are off", () => {
+    // The default, and what every job that measures coverage runs under.
+    expect(traverseWithElapsed(150).warnings[0]).toContain("uniqueDocs=0");
   });
 });


### PR DESCRIPTION
`CF_TRAVERSE_DIAGNOSTICS` is read once, when `traverse.ts` loads, into a module constant no other module can see. Setting the variable from inside a test does nothing, so everything the flag guards was unreachable in-process: the per-visit doc and path tracking, and the branch of the slow-traverse report that names the most-visited docs. That code ships, and no test had ever run it.

`setTraverseDiagnostics()` overrides the variable for the process, in the shape `storage/v2.ts` already uses for `CF_CONFLICT_ADMISSION`: an override that wins over the environment, and `undefined` to hand the decision back. A traversal reads the setting once, when it starts, into an instance field, so the per-visit check stays a field read rather than a call, and one traversal collects and reports the same way from beginning to end.

The report's `topDocs` field now has a test. It builds a container linking into six separate docs, linking target `i` exactly `i + 1` times so every target ends with a different visit count, and asserts what the format promises: five docs named out of the seven visited, most-visited first, each id cut to its first 20 characters. The assertions read the field's structure rather than pinning exact visit counts, which are a property of how the traversal happens to walk links and would otherwise turn an unrelated traversal change into a failure here. Verified by mutation: sorting ascending, raising the five-doc cap, truncating at a different width, and ignoring the flag in the report each fail the test.

One thing the test documents by pinning it: ids sharing a 20-character prefix are indistinguishable in `topDocs`, which is what the six targets here look like. The counts still tell them apart.

The `MapSet` counter tests gain the retrieval and removal behavior they sat next to: `get()` returns the values held under a key and `undefined` for a key never written, and emptying or dropping a key lowers both counts. The reference-equality return in `get()` had no test reaching it.

Two documents change with it.

The configuration reference had never described these variables. They appeared only as three names in the experimental-options registry, in the appendix listing toggles that are out of scope there — an appendix that points at the configuration reference for them, which did not mention them, so the only description of what any of them does was a comment in the code that reads it. It now covers all three: what each turns on, what the output looks like without it, the capture default of 20000 invocations and what happens to a value outside that shape, that a change to the environment takes effect only on restart, and how a test reaches each one instead. The appendix entry links to that section.

COVERAGE.md gains the wall-clock case as the worked instance of the rule that coverage must not depend on the execution environment. The slow-traverse report gated its body on a traversal taking more than 100 milliseconds of real time, so 39 lines moved between covered and uncovered with the load on the machine and nothing else; the code side of that is fixed, and this is the writeup, so that the next diagnostic of this shape is written correctly rather than found by the ratchet. Three findings are recorded because none are derivable from the source: a preloaded fake clock cannot cover such a branch, since it replaces `performance.now` with logical time that a synchronous traversal never advances — measured at zero across a busy loop, with `clock.tick()` advancing nothing until awaited; a test that pins the clock must therefore save and restore `performance.now` rather than assume the native one; and what a guard line itself reports is a projection of V8's block ranges onto lines that differs between the one-line and the braced form, and that deno 2.9.4 changed, now crediting a braced guard's line with the condition's own count where 2.8.3 reported zero.

It lands as a subsection of the environment policy that #5336 wrote, next to the investigation record that policy cites, so the rule and the worked case read as one region.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let tests enable doc-visit diagnostics in `packages/runner` and make slow-traverse reporting testable without relying on wall-clock time. Adds a process-level override and new tests for the `topDocs` output.

- New Features
  - Added `setTraverseDiagnostics(enabled | undefined)`; traversal reads the setting once at start.
  - Guarded doc/path tracking via an instance field (`this.diagnostics`) instead of a module constant.
  - Added a test for the slow-traverse `topDocs` field (checks format, ordering, and cap) using a deterministic `performance.now` override.
  - Extended `MapSet` tests to cover `get()`, emptying keys, and deletion count updates.

- Refactors
  - Routed slow-traverse reporting through a function called unconditionally with elapsed time, removing wall-clock–based coverage gaps.
  - Docs: added a “Runner diagnostics” section to `CONFIGURATION.md` for `CF_TRAVERSE_DIAGNOSTICS`, `CF_TRAVERSE_CAPTURE`, and `CF_TRAVERSE_CAPTURE_MAX` (defaults, how tests enable them, restart behavior); linked from `EXPERIMENTAL_OPTIONS.md`. Added a coverage write-up on timing-based diagnostics and fake-clock pitfalls in `COVERAGE.md`.

<sup>Written for commit 85bf4a1e8a6f6b579a828de828a8e3b8e54227c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

