### PR TITLE
docs(execution): consequence-flush deadline — latency-bounded waves on the exhaustion machinery

### DIFF
--- a/docs/specs/server-side-execution/serving-loop.md
+++ b/docs/specs/server-side-execution/serving-loop.md
@@ -215,8 +215,11 @@ mid-wave belong to the NEXT wave — natural double-buffering, no timers):
     - watermark doc := n
   hand external effects to the outbox (post-commit; see §5)
 
-on wave budget exhaustion (a cascade that will not quiesce within the
-scheduler's pass budget): commit the wave anyway — the in-memory state is
+on wave budget exhaustion — EITHER trigger (deadline RULED, owner
+2026-08-04): (a) a cascade that will not quiesce within the
+scheduler's pass budget, or (b) the CONSEQUENCE-FLUSH DEADLINE — a
+wave still running at T_flush commits what is sealed so far. ONE
+mechanism for both: commit the wave anyway — the in-memory state is
 a consistent snapshot — count wavesBudgetExhausted, and advance W NOT AT
 ALL: an exhausted wave's commit carries no watermark movement
 (`derivedThrough` stays at the current W). Continuation waves carry the
@@ -228,6 +231,44 @@ effect re-fires.
 on idle (no dirty work, no queued events) for IDLE_PARK_MS:
   park per activation policy
 ```
+
+**The deadline is the MULTI-USER LATENCY bound.** Without it, one
+user's heavy demanded fan-out delays every other user's consequence
+visibility in the same batch — head-of-line blocking ACROSS users,
+because the whole input batch commits once at the batch's derived
+closure. With it, a consequence is visible within roughly
+2·T_flush + push even while the wave behind it keeps deriving.
+Light waves never reach the deadline and stay single-commit — the
+zero-delta case, which is why this is a trigger on the EXISTING
+exhaustion machinery rather than a new commit topology. T_flush is
+a policy knob (order 50–100 ms), tuned in Phase 6 with the other
+budgets; `wavesBudgetExhausted` counts both triggers, and the
+amplification budget's inspection rule treats deadline flushes
+under load as a legitimate re-baseline reason (testing.md §4).
+
+**Sealing order makes the first flush worth flushing**: events and
+their handler consequences MUST seal ahead of deep demanded
+recomputes. The loop already behaves this way — events run eagerly,
+derivations are demanded pulls — this sentence pins it so an
+implementation does not reorder. Per-stream `eventWatermark` still
+advances for events fully processed in an exhausted wave, and
+`consequenceOf` carries them, so overlay echoes retire on the FIRST
+flush (speculation.md §4) even when W lags to quiescence.
+
+**Considered and RECORDED as the fallback, not built** (owner,
+2026-08-04): the two-tier WRITE-CLASS split — every wave committing
+its non-re-derivable tier (handler consequences, `eventWatermark`
+advances, effect intents, cascade entries) ahead of a re-derivable
+tier. It buys constant consequence latency at a CONSTANT 2×
+amplification floor plus a steady-state consistency seam between
+consequences and their derived views; the deadline buys the same
+latency bound load-adaptively on machinery that already exists and
+is model-verified (C10). Adopt the split ONLY if Phase 3's
+propagation gate (≤300 ms p50, testing.md §5) fails under realistic
+fan-out with the deadline alone — and if adopting, split by WRITE
+CLASS (the §3d conflict seam, which makes the second tier
+drop-only and keeps the watermark-with-consequences atomicity),
+never by "handlers vs reactive".
 
 Rules:
 

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -59,6 +59,17 @@ settledness (T1/T4/T6, C4), the effect channel with LT8's window
 (T2, C1-LT8), cross-space carriage end to end (T4, cluster B,
 C2/C2-dedupe).
 
+Delta 2026-08-04 — the consequence-flush deadline (serving-loop
+§3): both new binding sentences are covered without a new
+instrument. The flush SEMANTICS (commit-early, W pinned,
+continuation completes, exactly-once across the boundary) are
+trigger-agnostic and C10-verified — the clockless model's count
+budget is the deadline's proxy — and the sealing-order MUST is the
+same property family (C1/C10's event-first processing). The
+`T_flush` VALUE is a Phase 6 implementation gate alongside the
+other budgets. The recorded write-class fallback is not built —
+no instrument owed unless it is ever adopted.
+
 ## 3. The owed register (every genuine orphan, with its trigger)
 
 Nothing here blocks Phase 1. Each item names the instrument


### PR DESCRIPTION
## Why

The one-commit-per-wave rule couples every user's consequence visibility to the whole batch's derived closure — one user's heavy fan-out head-of-line-blocks another user's trivial click. Reviewing the alternatives (separate handler/reactive commits; short waves) concluded: the split buys constant consequence latency at a constant 2× amplification floor plus a steady-state consistency seam, while the SAME latency bound is available load-adaptively from machinery the spec already has and the model already verifies — the budget-exhaustion early commit. This PR generalizes that clause's trigger with a consequence-flush deadline (owner ruling, 2026-08-04) instead of changing the commit topology.

## What Changed

- serving-loop §3: the exhaustion clause gains trigger (b) — the consequence-flush deadline (`T_flush`, order 50–100 ms, Phase 6 tunes it); the latency rationale stated (visibility ≈ 2·T_flush + push; light waves stay single-commit, zero delta); the sealing-order MUST (events + consequences seal ahead of deep demanded recomputes — pins what the loop already does); and the write-class split RECORDED as the fallback, adopted only if Phase 3's ≤300 ms p50 propagation gate fails under realistic fan-out with the deadline alone — and by write class (the §3d seam), never "handlers vs reactive".
- verification-coverage.md §2: dated delta — the flush semantics are trigger-agnostic and C10-verified (the clockless model's count budget is the deadline's proxy); the sealing-order MUST is the same property family; `T_flush`'s value is a Phase 6 implementation gate. No new instrument owed.

Prior PRs in the series: #5269 (the v2 spec), #5313 (the executable model). The in-flight stage train (#5339, #5349, stage C) rebases over this once it lands.

## Test plan

Docs-only; the deadline's semantics are covered by the existing model property C10 (`cd packages/spec-model && deno task test`, 18/18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce a consequence-flush deadline in the serving loop to bound multi-user consequence latency without changing the one-commit-per-wave model. Also pin sealing order and update verification coverage; docs only.

- **New Features**
  - Add `T_flush` deadline as a second exhaustion trigger: commit sealed state at the deadline with W pinned; continuation waves finish derivations.
  - Bound consequence visibility to roughly 2·`T_flush` + push; light waves do not hit the deadline and remain single-commit.
  - Require sealing order: events and handler consequences seal before deep demanded recomputes so the first flush advances event watermarks and clears echoes.
  - Record (not implement) a write-class split as a fallback only if the Phase 3 propagation gate fails; split by write class, not “handlers vs reactive”.
  - Update verification coverage: semantics are trigger-agnostic and already covered by C10; `T_flush` value is a Phase 6 tuning gate; no new instrumentation.

<sup>Written for commit b97765b47af0b98e93d8422f02f1093346a79ab4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

