### PR TITLE
test: deterministically cover two lines that CI covered only by timin…

### DIFF
--- a/packages/runner/test/pattern-binding.test.ts
+++ b/packages/runner/test/pattern-binding.test.ts
@@ -71,6 +71,29 @@ describe("pattern-binding", () => {
       expect(testCell.getAsQueryResult()).toEqual({ value: 42 });
     });
 
+    it("resolves the argument cell from the result cell's meta link when argumentCellLink is undefined", () => {
+      const testCell = runtime.getCell<{ value: number }>(
+        space,
+        "argument meta link fallback 1",
+        undefined,
+        tx,
+      );
+      testCell.set({ value: 0 });
+
+      const argumentCell = getMetaCell(testCell, "argument", tx);
+      argumentCell.set({ input: 0 });
+      testCell.setMetaRaw(
+        "argument",
+        argumentCell.getAsWriteRedirectLink({ base: testCell }),
+      );
+
+      sendValueToBinding(tx, testCell, undefined, {
+        $alias: { cell: "argument", path: ["input"] },
+      }, 42);
+
+      expect(argumentCell.getAsQueryResult()).toEqual({ input: 42 });
+    });
+
     it("should handle array bindings", () => {
       const testCell = runtime.getCell<{ arr: number[] }>(
         space,

--- a/packages/toolshed/routes/storage/memory/memory.handlers.test.ts
+++ b/packages/toolshed/routes/storage/memory/memory.handlers.test.ts
@@ -1,0 +1,93 @@
+import { afterAll, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import {
+  decodeMemoryBoundary,
+  encodeMemoryBoundary,
+  getMemoryProtocolFlags,
+  MEMORY_PROTOCOL,
+} from "@commonfabric/memory/v2";
+import {
+  attachMemorySocketPipeline,
+  bufferTextMessagesUntilNegotiated,
+} from "./memory.handlers.ts";
+import { memoryServer } from "../memory.ts";
+
+const HELLO = encodeMemoryBoundary({
+  type: "hello",
+  protocol: MEMORY_PROTOCOL,
+  flags: getMemoryProtocolFlags(),
+});
+
+class FakeSocket extends EventTarget {
+  readyState: number = WebSocket.OPEN;
+  readonly sent: string[] = [];
+
+  send(payload: string): void {
+    this.sent.push(payload);
+  }
+
+  close(): void {}
+}
+
+// Runs the pipeline the way `subscribe` does: deliver the first message
+// through the socket while it is OPEN, set the readyState the send callback
+// will observe, attach, and resolve once the pipeline hands the negotiated
+// socket off. The hello reply is sent while the pipeline awaits
+// `connection.receive(firstMessage)`, so it has been attempted by the time
+// the handoff happens. Closing the socket afterwards releases the pipeline's
+// memory-server connection.
+const runHelloThroughPipeline = async (
+  fake: FakeSocket,
+  readyStateAtReply: number,
+): Promise<void> => {
+  const socket = fake as unknown as WebSocket;
+  const negotiation = bufferTextMessagesUntilNegotiated(socket);
+  const handedOff = Promise.withResolvers<void>();
+  const handoff = negotiation.handoff;
+  negotiation.handoff = (handlers) => {
+    handoff(handlers);
+    handedOff.resolve();
+  };
+
+  fake.dispatchEvent(new MessageEvent("message", { data: HELLO }));
+  const firstMessage = await negotiation.firstMessage;
+  expect(firstMessage).toBe(HELLO);
+
+  fake.readyState = readyStateAtReply;
+  expect(attachMemorySocketPipeline(socket, negotiation, firstMessage!)).toBe(
+    true,
+  );
+  await handedOff.promise;
+  fake.dispatchEvent(new CloseEvent("close"));
+};
+
+describe("memory.handlers", () => {
+  // The toolshed `memoryServer` is a module-level singleton constructed when
+  // memory.ts is imported. Deno isolates each test file's module graph, so
+  // this instance is owned by this file alone. Closing it releases its
+  // resources.
+  afterAll(async () => {
+    await memoryServer.close();
+  });
+
+  describe("attachMemorySocketPipeline", () => {
+    it("sends the hello reply while the socket is OPEN", async () => {
+      const fake = new FakeSocket();
+
+      await runHelloThroughPipeline(fake, WebSocket.OPEN);
+
+      expect(fake.sent.length).toBe(1);
+      const reply = decodeMemoryBoundary<{ type: string }>(fake.sent[0]);
+      expect(reply.type).toBe("hello.ok");
+    });
+
+    it("drops server messages once the socket has left OPEN", async () => {
+      const fake = new FakeSocket();
+
+      await runHelloThroughPipeline(fake, WebSocket.CLOSED);
+
+      expect(fake.sent).toEqual([]);
+    });
+  });
+});

--- a/packages/toolshed/routes/storage/memory/memory.handlers.ts
+++ b/packages/toolshed/routes/storage/memory/memory.handlers.ts
@@ -140,7 +140,7 @@ export const bufferTextMessagesUntilNegotiated = (
 // `memwrite-trace.ts`.
 let memwriteConnSeq = 0;
 
-const attachMemorySocketPipeline = (
+export const attachMemorySocketPipeline = (
   socket: WebSocket,
   negotiation: ReturnType<typeof bufferTextMessagesUntilNegotiated>,
   firstMessage: string,


### PR DESCRIPTION
…g luck

The coverage-debt gate is a ratchet: for each source group a pull request changes, the uncovered-line count must not rise above the count from the latest main run. Two lines were executed only when test scheduling happened to race a particular way. A main run that got lucky recorded a baseline below the count normal runs produce, and later pull requests then failed the gate without having changed those packages. PR #5332 hit this: its packages/runner baseline was two lines below the usual value.

packages/runner/src/pattern-binding.ts: sendValueToBinding falls back to reading the argument cell link from the result cell's "argument" meta field when the caller passes argumentCellLink as undefined. Every existing unit test passed an explicit link, so the fallback ran only when reached indirectly elsewhere. Add a case that registers an argument cell in the meta field the way the runner does, passes undefined, and asserts the value lands in that argument cell.

packages/toolshed/routes/storage/memory/memory.handlers.ts: the memory websocket pipeline's send callback drops server-to-client messages once the socket has left the OPEN state. That branch ran only when a server push raced a socket close. Export attachMemorySocketPipeline and drive it directly with a fake socket: the hello arrives while the socket is OPEN, then its readyState reports CLOSED before the pipeline attaches, so the case models the race it names rather than an impossible socket history. The server's reply is produced while the pipeline awaits the first receive, so the drop branch runs on every execution, with no race. A companion case that leaves the socket OPEN asserts the reply is sent, pinning both sides of the guard. The negotiation handoff serves as the completion signal, so the test waits on an event rather than polling, and the module-singleton memory server is closed from afterAll, so the cleanup cannot be displaced by a later test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make coverage checks deterministic by adding tests that always exercise two previously race‑dependent branches and exporting a helper needed to drive the memory socket pipeline in tests. This prevents false coverage-debt gate failures on unrelated PRs.

- **Bug Fixes**
  - Runner: add a test that uses the result cell’s "argument" meta link when `argumentCellLink` is undefined, verifying the value is written to the argument cell.
  - Toolshed memory: export `attachMemorySocketPipeline` and add tests with a fake WebSocket to assert the hello reply is sent when OPEN and dropped after CLOSED; close the module‑singleton memory server in `afterAll`.

<sup>Written for commit e46270d684ec4aec825b387e757ca71aeb7b2126. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

