### PR TITLE
fix(patterns): wait for a stable click-target box before dispatching

### DIFF
--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -155,6 +155,19 @@ why it belongs in the predicate that tags the control. Whether the control is
 declines it. A test that needs a control enabled before clicking says so with
 `waitForDisabled(page, selector, false)`.
 
+A control has to be rendered when the predicate tags it, but that alone does
+not make the click that follows safe. The trusted click measures the control's
+box a few protocol round trips after the tag, and in that window the surface the
+control sits in can still be settling: a join card's profile surface toggles
+display through its entrance, or a re-render relays out the region. The box can
+therefore move or vanish, and `DOM.getBoxModel` returns nothing for an element
+with no box, which the click reports as "Unable to get stable box model to click
+on". So after tagging, `clickMarked` holds until the tagged control's bounding
+box is unchanged across two consecutive animation frames before it dispatches.
+That wait is frame-driven and drops its baseline whenever the box disappears, so
+a control hidden partway through is picked up once it returns rather than clicked
+mid-shift; the stuck-condition net bounds a box that never settles.
+
 Waiting for a click's effect carries the same requirement, for the same reason.
 Nothing in an integration test holds a UI subscription, so between one check and
 the next nothing drives the page. A rendering the page has to produce for

--- a/packages/patterns/integration/cfc-browser-helpers.test.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.test.ts
@@ -825,4 +825,65 @@ describe("CFC browser helpers", () => {
       await presentationPage.close();
     }
   });
+
+  it("waits for a marked target's shifting box to settle before clicking", async () => {
+    await page.evaluate((clickTargetAttr: string) => {
+      const host = document.createElement("div");
+      const root = host.attachShadow({ mode: "open" });
+      const button = document.createElement("button");
+      button.id = "shifting-guest-button";
+      button.textContent = "Continue as guest";
+      root.append(button);
+      document.body.append(host);
+
+      let clicked = false;
+      button.addEventListener("click", () => {
+        clicked = true;
+      }, { once: true });
+
+      // The control is laid out when the helper marks it, but its surface then
+      // goes display:none for a spell as the join card's entrance settles — the
+      // way the real profile surface toggles display through its transition.
+      // While the marked control has no layout box, DOM.getBoxModel returns
+      // nothing, so a click that measures the box once throws "Unable to get
+      // stable box model to click on"; a click that waits for the box to settle
+      // clicks the control once its surface returns. The shift lands between the
+      // mark and the click, a window with no view settle to sequence against, so
+      // the fixture hides on the mark and restores on a timer that outlasts a
+      // single mark->click round trip. The restore states when the surface
+      // returns, not how long to wait for it: the helper's wait ends on the
+      // return, bounded only by the stuck-condition net.
+      const observer = new MutationObserver(() => {
+        if (!button.hasAttribute(clickTargetAttr)) return;
+        observer.disconnect();
+        button.style.display = "none";
+        setTimeout(() => {
+          button.style.display = "";
+        }, 1000);
+      });
+      observer.observe(button, {
+        attributes: true,
+        attributeFilter: [clickTargetAttr],
+      });
+
+      (globalThis as typeof globalThis & {
+        commonfabric: { viewSettled: () => Promise<void> };
+      }).commonfabric = { viewSettled: () => Promise.resolve() };
+      (globalThis as typeof globalThis & {
+        __shiftingClicked: () => boolean;
+      }).__shiftingClicked = () => clicked;
+    }, { args: [CLICK_TARGET_ATTR] });
+
+    await clickCfButton(page, "#shifting-guest-button");
+
+    const clicked = await page.evaluate(() =>
+      (globalThis as typeof globalThis & {
+        __shiftingClicked: () => boolean;
+      }).__shiftingClicked()
+    );
+    assert(
+      clicked,
+      "the click never reached the target after its hidden surface returned",
+    );
+  });
 });

--- a/packages/patterns/integration/cfc-browser-helpers.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.ts
@@ -892,6 +892,70 @@ export async function clickNthCfButton(
   await clickMarked(page, token);
 }
 
+// Hold until the element carrying the click mark `selector` has a settled
+// layout box: rendered — laid out, not display:none or visibility:hidden — with
+// an unchanged bounding rect across two consecutive animation frames. Between
+// marking a control and dispatching its trusted click, the surface it sits in
+// can still be settling: a join card's profile surface toggles display through
+// its entrance, and a re-render can relayout the region. The box the click
+// measures a few round trips after the mark may therefore have moved or gone,
+// and `DOM.getBoxModel` returns nothing for an element with no box — which the
+// click reports as "Unable to get stable box model to click on". Waiting here
+// for the box to stop shifting means the click measures a box that is present
+// and where it was. The wait drives itself off the frame signal and drops its
+// baseline whenever the box disappears, so a control hidden partway through is
+// picked up once it returns rather than clicked mid-shift; the stuck-condition
+// net in `waitForCondition` bounds a box that never settles.
+const clickTargetBoxStable = async (
+  probe: ProbeApi,
+  selector: string,
+): Promise<boolean> => {
+  const measure = ():
+    | { x: number; y: number; width: number; height: number }
+    | null => {
+    const target = probe.collect(selector)[0] as HTMLElement | undefined;
+    if (!target || !probe.isRendered(target)) return null;
+    const { x, y, width, height } = target.getBoundingClientRect();
+    return { x, y, width, height };
+  };
+  const nextFrame = (): Promise<void> =>
+    new Promise((resolve) => requestAnimationFrame(() => resolve()));
+
+  let previous = measure();
+  await nextFrame();
+  let current = measure();
+  while (
+    previous === null || current === null ||
+    previous.x !== current.x || previous.y !== current.y ||
+    previous.width !== current.width || previous.height !== current.height
+  ) {
+    previous = current;
+    await nextFrame();
+    current = measure();
+  }
+  return true;
+};
+
+// Hold until the marked control at `selector` has a settled layout box — see
+// `clickTargetBoxStable` — so the trusted click that follows measures a box
+// that is present and unmoving. Shared by every helper whose click routes
+// through `clickMarked`.
+async function waitForStableClickTarget(
+  page: Page,
+  selector: string,
+): Promise<void> {
+  try {
+    await waitForCondition(page, clickTargetBoxStable, { args: [selector] });
+  } catch (cause) {
+    const probe = await readTextProbe(page, selector).catch(() => undefined);
+    throw new Error(
+      `Marked click target ${selector} never presented a stable box. ` +
+        `Last probe: ${toIndentedDebugString(probe)}`,
+      { cause },
+    );
+  }
+}
+
 /**
  * Resolve the element whose click marks contain `token` and click it, then
  * clear that mark.
@@ -904,13 +968,16 @@ export async function clickMarked(
   page: Page,
   token: string,
 ): Promise<void> {
+  const markSelector = `[${CLICK_TARGET_ATTR}~="${token}"]`;
   try {
-    const clickTarget = await page.waitForSelector(
-      `[${CLICK_TARGET_ATTR}~="${token}"]`,
-      {
-        strategy: "pierce",
-      },
-    );
+    const clickTarget = await page.waitForSelector(markSelector, {
+      strategy: "pierce",
+    });
+    // The mark resolves the target the instant it is laid out, but the click
+    // measures its box a few round trips later. Hold until that box has stopped
+    // shifting, so the click does not race a surface that is still settling and
+    // fail to get a stable box model.
+    await waitForStableClickTarget(page, markSelector);
     await clickTarget.click();
   } finally {
     await clearClickMark(page, token).catch(() => {});


### PR DESCRIPTION
The CFC click helpers tag a control the moment it is laid out, then dispatch a trusted click that measures the control's box a few protocol round trips later. When the surface the control sits in is still settling — a join card's profile surface toggling display through its entrance, or a re-render relaying out the region — the box can move or vanish in that window. astral measures the box once, and DOM.getBoxModel returns nothing for an element with no box, so the click throws "Unable to get stable box model to click on". This is the intermittent failure the lunch-poll two-browser vote test hit at its first join-card click, and every clickCfButton in that test shared the exposure.

This is a different window from the exact-control settle landed in #5169: that fix guarantees the marked element is the one that received its handler; this one guarantees the marked element's box is still measurable when the click dispatches. Both races live between the mark and the click.

After resolving the marked target and before dispatching, clickMarked now holds until the target's bounding box is unchanged across two consecutive animation frames. The wait is frame-driven, drops its baseline whenever the box disappears — so a control hidden partway through is picked up once it returns rather than clicked mid-shift — and is bounded only by waitForCondition's stuck-condition net. Because every CFC click routes through clickMarked, this covers clickCfButton, clickCfButtonsConcurrently, clickNthCfButton, clickTrustedAction, and the note-button helpers. The wait adds no view settle, so the "no settle between a group's marks and its clicks" invariant is unchanged. Waiting for a present, stable rect cannot regress a passing test: no test clicks a target whose box is still moving, since such a click already lands at the wrong point.

The change ships with a regression test that reproduces the race deterministically: a marked control whose surface goes display:none for a spell once the mark lands, then returns. The shift lands between the mark and the click, a window with no view settle to sequence against, so the fixture uses a timer rather than a settlement step. Without the wait the helpers measure the box once and throw; with it the control is clicked once its box settles. waiting-in-tests.md gains a paragraph describing the tag-to-click window and the stability wait that closes it.

Deflaked by Hixie's agent (Claude Opus 4.8).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wait for a stable layout box before dispatching trusted clicks to marked targets, preventing intermittent “Unable to get stable box model to click on” errors during surface transitions. This deflakes affected tests by clicking only after the element’s box is present and unmoving.

- **Bug Fixes**
  - `clickMarked` now waits until the target’s bounding rect is unchanged across two animation frames (baseline resets if the box disappears; bounded by `waitForCondition`).
  - Covers all CFC click helpers: `clickCfButton`, `clickCfButtonsConcurrently`, `clickNthCfButton`, `clickTrustedAction`, and note-button helpers.
  - Added a deterministic regression test that hides the target’s surface (`display:none`) between mark and click and verifies the click after return.
  - Updated docs to describe the tag-to-click window and the new stability wait.

<sup>Written for commit 03d6494dc69b1f6607b68eebd0b3abe4db435ae0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

