### PR TITLE
refactor: make a diagnostic message transform a plain function

### DIFF
--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -2869,15 +2869,16 @@ trusted-name lists).
 
 ## 18. Diagnostics Message Transformation (Optional Consumer Layer)
 
-Diagnostic message transformers are exported separately from AST transform
-pipeline. Current built-in behavior:
+Diagnostic message transformation is exported separately from AST transform
+pipeline. A diagnostic message transform is a plain function taking a
+TypeScript diagnostic message and returning either a replacement message or
+null when it does not apply. Current built-in behavior:
 
-- `ReactiveErrorTransformer` rewrites TypeScript messages matching
+- `createReactiveErrorTransformer` builds a transform that rewrites TypeScript
+  messages matching
   `"Property 'get' does not exist on type 'OpaqueCell<...>'"` into user-facing
   guidance about unnecessary `.get()`.
-- optional `verbose` mode appends original TypeScript message.
-- `CompositeDiagnosticTransformer` returns the first matching transformer
-  result.
+- its optional `verbose` argument appends the original TypeScript message.
 
 ## 19. Current Known Limits (Observed)
 

--- a/packages/js-compiler/test/typescript.errors.test.ts
+++ b/packages/js-compiler/test/typescript.errors.test.ts
@@ -65,10 +65,8 @@ describe("CompilationError message flattening", () => {
   });
 
   it("applies a message transformer over the flattened text", () => {
-    const transformer: DiagnosticMessageTransformer = {
-      transform: (message) =>
-        message.includes("assignable") ? `friendly: ${message}` : null,
-    };
+    const transformer: DiagnosticMessageTransformer = (message) =>
+      message.includes("assignable") ? `friendly: ${message}` : null;
     const chain: DiagnosticMessageChain = {
       messageText: "Type 'A' is not assignable to type 'B'.",
       category: ts.DiagnosticCategory.Error,
@@ -227,10 +225,8 @@ describe("Checker", () => {
     const checker = new Checker(
       programFor({ "/ok.ts": "export const x: number = 1;" }),
       {
-        messageTransformer: {
-          transform: (message) =>
-            message.includes("manufactured") ? `clearer: ${message}` : null,
-        },
+        messageTransformer: (message) =>
+          message.includes("manufactured") ? `clearer: ${message}` : null,
       },
     );
     expect(() => checker.check([chainDiagnostic("manufactured emit failure")]))

--- a/packages/js-compiler/typescript/diagnostics/errors.ts
+++ b/packages/js-compiler/typescript/diagnostics/errors.ts
@@ -32,17 +32,11 @@ function flattenDiagnosticMessageText(
 }
 
 /**
- * Interface for transforming diagnostic error messages.
- * Implementations can convert confusing TypeScript errors into clearer messages.
+ * Rewrites a diagnostic error message, converting confusing TypeScript errors
+ * into clearer ones. Takes the original TypeScript diagnostic message and
+ * returns the replacement, or null when no rewrite applies.
  */
-export interface DiagnosticMessageTransformer {
-  /**
-   * Transform a diagnostic message.
-   * @param message The original TypeScript diagnostic message
-   * @returns Transformed message, or null if no transformation applies
-   */
-  transform(message: string): string | null;
-}
+export type DiagnosticMessageTransformer = (message: string) => string | null;
 
 export interface ErrorDetails {
   readonly diagnostic: Diagnostic;
@@ -107,7 +101,7 @@ export class CompilationError {
 
     // Apply custom message transformer if configured
     if (messageTransformer) {
-      const transformed = messageTransformer.transform(message);
+      const transformed = messageTransformer(message);
       if (transformed !== null) {
         return { type: "ERROR", message: transformed };
       }

--- a/packages/runner/src/harness/compiler-stack.ts
+++ b/packages/runner/src/harness/compiler-stack.ts
@@ -21,8 +21,8 @@ import ts from "typescript";
 export { ts };
 export {
   CommonFabricTransformerPipeline,
+  createReactiveErrorTransformer,
   isLegacyInjectedEnvelope,
-  ReactiveErrorTransformer,
   transformCfDirective,
 } from "@commonfabric/ts-transformers";
 export {

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -399,10 +399,8 @@ export class Engine extends EventTarget {
           getTransformedProgram: options.getTransformedProgram
             ? (nextProgram) => options.getTransformedProgram?.(nextProgram)
             : undefined,
-          diagnosticMessageTransformer: new (compilerStack()
-            .ReactiveErrorTransformer)({
-            verbose: options.verboseErrors,
-          }),
+          diagnosticMessageTransformer: compilerStack()
+            .createReactiveErrorTransformer(options.verboseErrors),
           beforeTransformers: (program) => {
             const pipeline = new (compilerStack()
               .CommonFabricTransformerPipeline)({

--- a/packages/ts-transformers/src/diagnostics/error-message-transformer.ts
+++ b/packages/ts-transformers/src/diagnostics/error-message-transformer.ts
@@ -7,44 +7,22 @@
  */
 
 /**
- * Interface for transforming diagnostic error messages.
- */
-export interface DiagnosticMessageTransformer {
-  /**
-   * Transform a diagnostic message.
-   * @param message The original TypeScript diagnostic message
-   * @returns Transformed message, or null if no transformation applies
-   */
-  transform(message: string): string | null;
-}
-
-/**
- * Options for the Reactive error transformer.
- */
-export interface ReactiveErrorTransformerOptions {
-  /**
-   * When true, appends the original TypeScript error to the transformed message.
-   * Useful for debugging.
-   */
-  verbose?: boolean;
-}
-
-/**
- * Transforms confusing Reactive-related TypeScript errors into clear, actionable messages.
+ * Builds a transform for confusing Reactive-related TypeScript errors, turning
+ * them into clear, actionable messages.
  *
  * For example, transforms:
  *   "Property 'get' does not exist on type 'OpaqueCell<number> & number'"
  * Into:
  *   "Unnecessary .get() call on a reactive value. This value can be accessed directly..."
+ *
+ * The returned transform yields null for a message it does not rewrite. Under
+ * `verbose` a rewritten message also carries the original TypeScript error,
+ * which helps when debugging.
  */
-export class ReactiveErrorTransformer implements DiagnosticMessageTransformer {
-  private verbose: boolean;
-
-  constructor(options: ReactiveErrorTransformerOptions = {}) {
-    this.verbose = options.verbose ?? false;
-  }
-
-  transform(message: string): string | null {
+export function createReactiveErrorTransformer(
+  verbose = false,
+): (message: string) => string | null {
+  return (message: string) => {
     // Detect .get() called on OpaqueCell/Reactive types
     // TypeScript error: "Property 'get' does not exist on type 'OpaqueCell<...> & ...'"
     const match = message.match(
@@ -58,35 +36,12 @@ export class ReactiveErrorTransformer implements DiagnosticMessageTransformer {
         `and results from computed() and lift() don't need .get(). ` +
         `Only Writable<T> requires .get() to read values.`;
 
-      if (this.verbose) {
+      if (verbose) {
         return `${clarification}\n\nOriginal TypeScript error: ${message}`;
       }
       return clarification;
     }
 
     return null; // No transformation applies
-  }
-}
-
-/**
- * Combines multiple diagnostic message transformers.
- * Returns the first successful transformation, or null if none apply.
- */
-export class CompositeDiagnosticTransformer
-  implements DiagnosticMessageTransformer {
-  private transformers: DiagnosticMessageTransformer[];
-
-  constructor(transformers: DiagnosticMessageTransformer[]) {
-    this.transformers = transformers;
-  }
-
-  transform(message: string): string | null {
-    for (const transformer of this.transformers) {
-      const result = transformer.transform(message);
-      if (result !== null) {
-        return result;
-      }
-    }
-    return null;
-  }
+  };
 }

--- a/packages/ts-transformers/src/diagnostics/mod.ts
+++ b/packages/ts-transformers/src/diagnostics/mod.ts
@@ -1,6 +1,1 @@
-export {
-  CompositeDiagnosticTransformer,
-  type DiagnosticMessageTransformer,
-  ReactiveErrorTransformer,
-  type ReactiveErrorTransformerOptions,
-} from "./error-message-transformer.ts";
+export { createReactiveErrorTransformer } from "./error-message-transformer.ts";

--- a/packages/ts-transformers/src/mod.ts
+++ b/packages/ts-transformers/src/mod.ts
@@ -34,9 +34,4 @@ export {
 } from "./transformers/mod.ts";
 export { ClosureTransformer } from "./closures/transformer.ts";
 export { CommonFabricTransformerPipeline } from "./cf-pipeline.ts";
-export {
-  CompositeDiagnosticTransformer,
-  type DiagnosticMessageTransformer,
-  ReactiveErrorTransformer,
-  type ReactiveErrorTransformerOptions,
-} from "./diagnostics/mod.ts";
+export { createReactiveErrorTransformer } from "./diagnostics/mod.ts";

--- a/packages/ts-transformers/test/error-message-transformer.test.ts
+++ b/packages/ts-transformers/test/error-message-transformer.test.ts
@@ -1,17 +1,14 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import {
-  CompositeDiagnosticTransformer,
-  ReactiveErrorTransformer,
-} from "../src/diagnostics/mod.ts";
+import { createReactiveErrorTransformer } from "../src/diagnostics/mod.ts";
 
-describe("ReactiveErrorTransformer", () => {
+describe("createReactiveErrorTransformer", () => {
   it("transforms .get() on OpaqueCell error to clear message", () => {
-    const transformer = new ReactiveErrorTransformer();
+    const transform = createReactiveErrorTransformer();
     const originalMessage =
       "Property 'get' does not exist on type 'OpaqueCell<number> & number'.";
 
-    const result = transformer.transform(originalMessage);
+    const result = transform(originalMessage);
 
     expect(result).not.toBeNull();
     expect(result).toContain("Unnecessary .get() call");
@@ -20,11 +17,11 @@ describe("ReactiveErrorTransformer", () => {
   });
 
   it("includes original error in verbose mode", () => {
-    const transformer = new ReactiveErrorTransformer({ verbose: true });
+    const transform = createReactiveErrorTransformer(true);
     const originalMessage =
       "Property 'get' does not exist on type 'OpaqueCell<number> & number'.";
 
-    const result = transformer.transform(originalMessage);
+    const result = transform(originalMessage);
 
     expect(result).not.toBeNull();
     expect(result).toContain("Unnecessary .get() call");
@@ -33,51 +30,23 @@ describe("ReactiveErrorTransformer", () => {
   });
 
   it("returns null for unrelated errors", () => {
-    const transformer = new ReactiveErrorTransformer();
+    const transform = createReactiveErrorTransformer();
     const unrelatedMessage =
       "Type 'string' is not assignable to type 'number'.";
 
-    const result = transformer.transform(unrelatedMessage);
+    const result = transform(unrelatedMessage);
 
     expect(result).toBeNull();
   });
 
   it("handles complex OpaqueCell types", () => {
-    const transformer = new ReactiveErrorTransformer();
+    const transform = createReactiveErrorTransformer();
     const complexMessage =
       "Property 'get' does not exist on type 'OpaqueCell<{ items: string[]; count: number }> & { items: string[]; count: number }'.";
 
-    const result = transformer.transform(complexMessage);
+    const result = transform(complexMessage);
 
     expect(result).not.toBeNull();
     expect(result).toContain("Unnecessary .get() call");
-  });
-});
-
-describe("CompositeDiagnosticTransformer", () => {
-  it("returns first successful transformation", () => {
-    const transformer1 = new ReactiveErrorTransformer();
-    const transformer2 = {
-      transform: (msg: string) =>
-        msg.includes("foo") ? "transformed foo" : null,
-    };
-    const composite = new CompositeDiagnosticTransformer([
-      transformer1,
-      transformer2,
-    ]);
-
-    // First transformer matches
-    const opaqueResult = composite.transform(
-      "Property 'get' does not exist on type 'OpaqueCell<number> & number'.",
-    );
-    expect(opaqueResult).toContain("Unnecessary .get() call");
-
-    // Second transformer matches
-    const fooResult = composite.transform("some foo error");
-    expect(fooResult).toBe("transformed foo");
-
-    // Neither matches
-    const noMatch = composite.transform("unrelated error");
-    expect(noMatch).toBeNull();
   });
 });


### PR DESCRIPTION
Rewriting a confusing TypeScript diagnostic into a clearer one was built as a plugin surface. There was an interface with a single `transform` method, one class implementing it (a single regular expression match producing one canned message about unnecessary `.get()` calls on reactive values), and a second class whose whole job was to chain several implementations together and return the first result that applied.

None of that generality was ever used. The one production caller constructs the one implementation and hands it to the compiler. The chaining class had no production caller at all, and no second implementation ever existed for it to chain. The interface itself was declared twice, once in js-compiler and once in ts-transformers, with identical shape, so a reader had to work out which of the two declarations any given mention referred to.

The interface described a function that had been spelled as an object: one method, no state, no other members. This replaces it with a function type declared once, in js-compiler:

    export type DiagnosticMessageTransformer = (message: string) => string | null

`CompilationError`, `CompilerError` and `Checker` keep taking the same optional value; they call it directly instead of reaching for a `.transform` member. The duplicate declaration in ts-transformers is gone, and the chaining class along with it. What ts-transformers now exports is a factory, `createReactiveErrorTransformer(verbose)`, that returns the rewriting function.

The two packages deliberately share no dependency edge — neither one's deno.jsonc imports the other, and they meet only where the runner wires them together. So ts-transformers does not import the type: its factory's return type is written out structurally, and the runner's assignment is what checks the two spell the same signature.

Section 18 of the ts-transformers current-behavior specification described both classes; it now describes the function form.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified diagnostic message transformation by replacing the class-based plugin surface with a single function type and a small factory. This removes unused code and a duplicate interface while keeping the same `.get()` guidance.

- **Refactors**
  - Define `DiagnosticMessageTransformer = (message: string) => string | null` once in `js-compiler`, and call it directly in error handling.
  - Replace `ReactiveErrorTransformer` and `CompositeDiagnosticTransformer` with `createReactiveErrorTransformer(verbose)` in `@commonfabric/ts-transformers`; remove the duplicate interface.
  - Update runner wiring to use the factory; refresh tests and spec section 18.

- **Migration**
  - Replace `new ReactiveErrorTransformer({ verbose })` with `createReactiveErrorTransformer(verbose)` and pass the returned function where a `DiagnosticMessageTransformer` is expected.
  - Stop importing `CompositeDiagnosticTransformer` and the `DiagnosticMessageTransformer` interface from `@commonfabric/ts-transformers`.

<sup>Written for commit e5e1c7123d56a478aba703ff12168f9877967dc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

