### PR TITLE
fix(runner): getOwnPropertyDescriptor must answer about OWN properties

### DIFF
--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -625,7 +625,25 @@ export function createQueryResultProxy<T>(
       }
       const readTx = runtime.readTx(tx);
       const current = readTx.readValueOrThrow(link, SHAPE_READ) as typeof value;
-      if ((isRecord(current) || Array.isArray(current)) && prop in current) {
+      // `Object.hasOwn`, not `in`: this trap answers about OWN properties, and
+      // `in` walks the prototype chain. Because the underlying value is an
+      // ordinary `Object.prototype`-rooted record, `in` reported every member of
+      // `Object.prototype` -- `toString`, `valueOf`, `constructor`, `__proto__`
+      // -- as an own property of the proxy, while `ownKeys` (which uses
+      // `Reflect.ownKeys`) listed none of them. Two traps describing the same
+      // value disagreed by construction, so every consumer that reasons about a
+      // read-back value's shape was being told it carries names it does not.
+      //
+      // That is not academic: `unsafeObjectKeyIn()` refuses a `FabricValue`
+      // carrying own `__proto__`/`constructor` and tests with `Object.hasOwn()`,
+      // so writing a read-back record back to a cell was rejected for a key the
+      // record never had, and every read-modify-write against a cell failed
+      // (loom CT-1949). The `has` trap below keeps `in` -- there it is correct,
+      // being the `in` operator's own trap.
+      if (
+        (isRecord(current) || Array.isArray(current)) &&
+        Object.hasOwn(current, prop)
+      ) {
         return {
           configurable: true,
           enumerable: true,

--- a/packages/runner/test/query-result-proxy-enumeration.test.ts
+++ b/packages/runner/test/query-result-proxy-enumeration.test.ts
@@ -300,4 +300,82 @@ describe("CT-1240: query result proxy enumeration", () => {
       popFrame(frame);
     }
   });
+  // A trap that answers about OWN properties must not consult the prototype
+  // chain. It used to use `in`, so every member of `Object.prototype` came back
+  // as an own property of the proxy while `ownKeys` listed none of them -- two
+  // traps describing the same value, disagreeing. Downstream that made a
+  // read-back record unwritable: `unsafeObjectKeyIn()` refuses a `FabricValue`
+  // with own `__proto__`/`constructor` and asks with `Object.hasOwn()`, so
+  // writing a record back to a cell was rejected over keys it never had
+  // (loom CT-1949).
+  it("getOwnPropertyDescriptor does not report inherited names as own", () => {
+    const cell = runtime.getCell<{ a: number }>(
+      space,
+      "test-own-descriptor-not-inherited",
+      undefined,
+      tx,
+    );
+    cell.set({ a: 1 });
+
+    const proxy = createQueryResultProxy<{ a: number }>(
+      runtime,
+      tx,
+      cell.getAsNormalizedFullLink(),
+      0,
+      true,
+    );
+
+    // The two names the FabricValue boundary reserves, plus enough of
+    // `Object.prototype` to show this is about inheritance generally and not a
+    // special case for those two.
+    for (
+      const inherited of [
+        "__proto__",
+        "constructor",
+        "toString",
+        "valueOf",
+        "hasOwnProperty",
+        "isPrototypeOf",
+        "propertyIsEnumerable",
+        "toLocaleString",
+      ]
+    ) {
+      expect(Object.hasOwn(proxy, inherited)).toBe(false);
+      expect(Object.getOwnPropertyDescriptor(proxy, inherited)).toBe(undefined);
+    }
+
+    // A name that is genuinely absent stays absent, and a real own key is
+    // still reported -- so the fix narrowed the answer without emptying it.
+    expect(Object.hasOwn(proxy, "definitelyNotAKeyAnywhere")).toBe(false);
+    expect(Object.hasOwn(proxy, "a")).toBe(true);
+
+    // The two traps now agree, which is the property that was violated.
+    for (const key of Reflect.ownKeys(proxy)) {
+      expect(Object.hasOwn(proxy, key as string)).toBe(true);
+    }
+  });
+
+  // `in` IS the `has` trap's own operator, so inherited names SHOULD answer
+  // true there. Pinned so a future cleanup does not "fix" both traps alike.
+  it("the `in` operator still sees inherited names", () => {
+    const cell = runtime.getCell<{ a: number }>(
+      space,
+      "test-in-operator-still-inherits",
+      undefined,
+      tx,
+    );
+    cell.set({ a: 1 });
+
+    const proxy = createQueryResultProxy<{ a: number }>(
+      runtime,
+      tx,
+      cell.getAsNormalizedFullLink(),
+      0,
+      true,
+    );
+
+    expect("toString" in proxy).toBe(true);
+    expect("a" in proxy).toBe(true);
+    expect("definitelyNotAKeyAnywhere" in proxy).toBe(false);
+  });
 });


### PR DESCRIPTION
## Why

The query-result proxy's `getOwnPropertyDescriptor` trap tested membership with `prop in current`, and **`in` walks the prototype chain**. Because the underlying value is an ordinary `Object.prototype`-rooted record, the trap synthesized a descriptor for every member of `Object.prototype` — `toString`, `valueOf`, `constructor`, `__proto__` — so `Object.hasOwn(proxy, "toString")` answered `true`. The `ownKeys` trap directly above it uses `Reflect.ownKeys()` and listed none of them.

Two traps describing the same value, disagreeing by construction. Every consumer that reasons about a read-back value's shape was being told it carries names it does not.

That isn't academic. `unsafeObjectKeyIn()` (#5264) refuses a `FabricValue` carrying own `__proto__`/`constructor`, and it asks with `Object.hasOwn()`. So **writing a read-back record back to a cell was refused for a key the record never had** — which breaks read-modify-write against a cell generally, for any consumer.

It took down every Loom state-cell push for three days ([CT-1949](https://linear.app/common-tools/issue/CT-1949)), and because the error names the data model rather than the proxy, it read as a data problem for most of that time. Loom's own defensive fix is [loom#4672](https://github.com/commontoolsinc/loom/pull/4672); this is the underlying cause.

Measured before the fix, against a live toolshed:

| name | `Object.hasOwn` | in `ownKeys` |
|---|---|---|
| `__proto__` | true | no |
| `constructor` | true | no |
| `toString` | true | no |
| `valueOf` | true | no |
| `hasOwnProperty` | true | no |
| `apiUrl` | true | **yes** ← a real own key |
| `definitelyNotAKeyAnywhere` | false | no |

## What Changed

One line: `prop in current` → `Object.hasOwn(current, prop)`, which is the question this trap owes its caller.

**The `has` trap keeps `in`**, and a test now pins that — `has` *is* the `in` operator's own trap, so inherited names *should* answer true there. Conflating the two is what went wrong, so the distinction is worth holding in place against a future cleanup that "fixes" both alike.

## Test plan

- Two cases added to `query-result-proxy-enumeration.test.ts`: one asserting inherited names are not reported as own (and that the two traps now agree), one pinning that `in` still sees them.
- **Verified non-vacuous** — the new case fails with the change backed out.
- **Supported suite is green**: `cd packages/runner && deno task test` — **1146 passed / 0 failed** (6012 steps), and all Runner Test CI shards pass.

  _Correction:_ an earlier revision of this description reported "1026 passed / 120 failed, unchanged with and without the commit" and called those 120 pre-existing timing-sensitive failures. That diagnosis was wrong. The runner suite requires `--preload=test/clock-preload.ts`; without it the global `clock` is undefined and the suite fails en masse. I had run it unsupported, so I was comparing two broken runs. The no-regression conclusion happened to hold, but the evidence for it did not — the green supported run above is the real result.

## Draft because

The fix direction seems clear to me, but it's a core proxy trap and the call on whether this is the right layer is yours. The alternative — having `unsafeObjectKeyIn()` consult `ownKeys` instead of `Object.hasOwn()` — closes this particular blast radius but leaves the proxy misreporting to every other consumer, so it looks like compensating rather than fixing. Happy to be told otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the query-result proxy to only report own properties in `getOwnPropertyDescriptor`, aligning with `Reflect.ownKeys` and restoring safe read-modify-write to cells. Resolves false positives for inherited names like `__proto__` and `constructor` (CT-1949).

- **Bug Fixes**
  - Switched `prop in current` to `Object.hasOwn(current, prop)` in `getOwnPropertyDescriptor`; the `has` trap still uses `in`.
  - Added tests pinning that inherited `Object.prototype` names aren’t reported as own, real own keys are, both traps agree, and `in` still sees inherited names.
  - Verified the runner test suite passes with the change.

<sup>Written for commit e33cbd683fa7b97614d47e96e27434c31564f728. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

