### PR TITLE
fix(runner): give a child run an owner other than whoever created it

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -43,6 +43,7 @@ decision is reversed or superseded).
 - [FUSE filesystem](fuse-filesystem/README.md)
 - [SQLite builtins](sqlite-builtin/README.md)
 - [Persistent scheduler state](persistent-scheduler-state.md)
+- [Runner child-run ownership](runner-child-run-ownership.md)
 - [Scheduler v2](scheduler-v2/README.md)
 - [Server-primary execution](server-side-execution/README.md)
 - [Verifiable execution](verifiable-execution/README.md)

--- a/docs/specs/runner-child-run-ownership.md
+++ b/docs/specs/runner-child-run-ownership.md
@@ -1,0 +1,63 @@
+# Runner child-run ownership
+
+> **Status**: Implemented; this spec governs the current behavior and is
+> updated with it.
+> **Companion**: [Scheduler v2](scheduler-v2/README.md) §7.6 defines the
+> lineage rules for work an event handler launches. This document covers the
+> children a pattern launches, which those rules do not reach.
+
+Running a pattern produces a *registration*: the scheduler actions the runner
+holds for that result cell, indexed by the result's key. Starting a result
+installs one; stopping it removes and cancels one.
+
+The registration is not part of any transaction. The writes a setup stages
+roll back when its transaction fails; the registration does not. A result is
+also reachable from more than one place: a nested pattern inside its parent, a
+list element inside its coordinator, and a page the user navigated to can all
+name the same result. These two facts decide the four rules below.
+
+## Releasing a child
+
+A pattern that launches a child registers a *release* for it, which runs when
+the launching pattern is torn down. A release stops the child's registration
+only when both of these hold:
+
+- The registration is the one this launch installed. A later attempt that
+  replaced it owns itself, so a release that no longer recognises what it
+  finds does nothing.
+- Nothing holds an independent lifetime for the result (below).
+
+## Independent lifetimes
+
+A result acquires a lifetime of its own when something starts it in its own
+right rather than as part of an enclosing pattern — `Runner.start`. Navigating
+to a nested result opens it as a page, which is the case this rule exists for.
+An enclosing pattern releasing such a result leaves it running; only stopping
+it directly ends it.
+
+A start that is still resolving may be about to acquire that lifetime and
+cannot say so yet, so a release declines while one is in flight. A start that
+then fails leaves the result registered until the runtime stops it, the same
+bound the scheduler accepts for a start that exhausts its retries.
+
+## Rolling back with the transaction
+
+A run stages its setup in a transaction and installs its registration outside
+one. When that transaction does not become durable, the registration is
+stopped: the piece would otherwise run against writes that never landed, and
+the memo that decides whether to materialize it again would describe a child
+that exists nowhere.
+
+A stale basis is the exception. A conflict or a local inconsistency is
+resolved by re-running the same work against fresher state, and that re-run
+reuses what is already there. [Settle
+outcomes](space-model/5-transactions.md) states the rule and names the
+classifier that draws the line.
+
+## Commit-gated starts
+
+A start gated on a commit has no registration until its callback installs one.
+Ownership of it begins when the start is scheduled, so stopping the result
+before that commit tombstones the pending start and the callback does not
+install it. Without this a piece the user stopped starts anyway, moments
+later.

--- a/docs/specs/scheduler-v2/README.md
+++ b/docs/specs/scheduler-v2/README.md
@@ -749,7 +749,9 @@ correctness comes from cancellation, not staging:
    Ownership of a commit-gated start begins when the start is scheduled, not
    when its post-commit callback installs it. Cancelling the parent or lineage
    before that commit tombstones the pending start, so the callback must not
-   install it. After installation, cancellation may stop only the exact local
+   install it; stopping the result key does the same, so a piece the user
+   stopped before the origin commit does not start afterwards. After
+   installation, cancellation may stop only the exact local
    registration installed by that attempt; if another attempt has replaced or
    won the same result key, its registration remains live. This prevents a
    receipt-losing duplicate from stopping the winner.
@@ -864,7 +866,12 @@ phase E).
 **Computation-launched children are outside I10.** Computations are
 idempotent and re-runnable; their children converge through deterministic
 ids and normal re-runs, and orphaned registrations are bounded by the same
-retry budget. (The exhausted-retry zombie is accepted as pre-existing; the
+retry budget. The runner is nonetheless stricter for the launches it can tie
+to a transaction: a child whose setup transaction does not become durable has
+its registration stopped rather than left for a re-run to converge over, since
+the bookkeeping a coordinator keeps would otherwise make that re-run skip the
+staging the child needs. [Runner child-run
+ownership](../runner-child-run-ownership.md) states the rules. (The exhausted-retry zombie is accepted as pre-existing; the
 implementation should leave a watch-this comment at the retry-exhaustion
 sites.)
 

--- a/packages/runner/src/builtins/filter.ts
+++ b/packages/runner/src/builtins/filter.ts
@@ -348,7 +348,7 @@ export function filter(
     if (list === undefined) {
       probeScoped(() => resultWithLog.set([]));
       for (const entry of elementRuns.values()) {
-        runtime.runner.stop(entry.resultCell);
+        runtime.runner.releaseChild(entry.resultCell, undefined);
       }
       elementRuns.clear();
       return;
@@ -420,7 +420,7 @@ export function filter(
         // Link the new result cells to the pattern cell too
         setPatternCell(boundResultCell, parentCell.key("pattern"));
 
-        addCancel(() => runtime.runner.stop(resultCell));
+        addCancel(() => runtime.runner.releaseChild(resultCell, undefined));
         const entry = { resultCell, lastIndex: i };
         elementRuns.set(elementKey, entry);
         rollback.created(elementKey, entry);

--- a/packages/runner/src/builtins/flatmap.ts
+++ b/packages/runner/src/builtins/flatmap.ts
@@ -354,7 +354,7 @@ export function flatMap(
     if (list === undefined) {
       probeScoped(() => resultWithLog.set([]));
       for (const entry of elementRuns.values()) {
-        runtime.runner.stop(entry.resultCell);
+        runtime.runner.releaseChild(entry.resultCell, undefined);
       }
       elementRuns.clear();
       return;
@@ -423,7 +423,7 @@ export function flatMap(
         );
         // Link the new result cells to the pattern cell too
         setPatternCell(boundResultCell, parentCell.key("pattern"));
-        addCancel(() => runtime.runner.stop(resultCell));
+        addCancel(() => runtime.runner.releaseChild(resultCell, undefined));
         const entry = { resultCell, lastIndex: i };
         elementRuns.set(elementKey, entry);
         rollback.created(elementKey, entry);

--- a/packages/runner/src/builtins/map.ts
+++ b/packages/runner/src/builtins/map.ts
@@ -338,7 +338,7 @@ export function map(
     if (list === undefined) {
       probeScoped(() => resultWithLog.set([]));
       for (const entry of elementRuns.values()) {
-        runtime.runner.stop(entry.resultCell);
+        runtime.runner.releaseChild(entry.resultCell, undefined);
       }
       elementRuns.clear();
       return;
@@ -406,7 +406,7 @@ export function map(
         setResultCell(boundResultCell, parentCell);
         // Link the new result cells to the pattern cell too
         setPatternCell(boundResultCell, parentCell.key("pattern"));
-        addCancel(() => runtime.runner.stop(resultCell));
+        addCancel(() => runtime.runner.releaseChild(resultCell, undefined));
         const entry = { resultCell, lastIndex: i };
         elementRuns.set(elementKey, entry);
         rollback.created(elementKey, entry);

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -90,6 +90,10 @@ import type {
   URI,
 } from "./storage/interface.ts";
 import { TransactionWrapper } from "./storage/extended-storage-transaction.ts";
+import {
+  isConflictRejection,
+  isStorageTransactionInconsistent,
+} from "./storage/rejection.ts";
 import { ignoreReadForScheduling } from "./scheduler.ts";
 import {
   machineryRead,
@@ -196,6 +200,9 @@ type StartAttempt = {
   readonly schedulePatternUpdate: boolean;
   readonly generationsByDoc: Map<string, number>;
   readonly preResolutionStopKeys: Set<string>;
+  // The result this attempt resolved to, which a link start only learns by
+  // following the link.
+  targetKey?: `${MemorySpace}/${CellScope}/${URI}`;
 };
 
 // The debug-name builders reuse the action's already-computed
@@ -1167,6 +1174,19 @@ export class Runner {
   // for the system-wide commit precondition.
   private locallyCommittedHandlerResultStarts = new Set<
     `${MemorySpace}/${CellScope}/${URI}`
+  >();
+  // Results started in their own right rather than as part of an enclosing
+  // pattern, which is what navigating to a nested result does. An enclosing
+  // pattern releasing such a result leaves it running; only stopping it
+  // directly ends it.
+  private independentlyStartedResults = new Set<
+    `${MemorySpace}/${CellScope}/${URI}`
+  >();
+  // Commit-gated starts that have not installed a registration yet, indexed by
+  // result so an explicit stop can tombstone them before installation.
+  private pendingDeferredStarts = new Map<
+    `${MemorySpace}/${CellScope}/${URI}`,
+    Set<DeferredCancelOwnership>
   >();
   // Map whose key is the result cell's full key, and whose values are a hash
   // of the pattern's encodable form -- what `writeJavaScriptActionResult`
@@ -2159,13 +2179,47 @@ export class Runner {
     this.activeStartAttempts.add(attempt);
     this.trackStartAttempt(attempt, startKey);
     try {
-      return this.doStart(resultCell, new Set(), attempt).finally(() => {
-        this.finishStartAttempt(attempt);
-      });
+      return this.doStart(resultCell, new Set(), attempt)
+        .then((started) => {
+          // This start gives the result a lifetime of its own, so an enclosing
+          // pattern releasing it later leaves it running.
+          const target = attempt.targetKey;
+          if (started && target !== undefined && this.cancels.has(target)) {
+            this.independentlyStartedResults.add(target);
+          }
+          return started;
+        })
+        .finally(() => {
+          this.finishStartAttempt(attempt);
+        });
     } catch (error) {
       this.finishStartAttempt(attempt);
       return Promise.reject(error);
     }
+  }
+
+  /**
+   * Releases a child an enclosing pattern is done with. Stops only the exact
+   * registration this invocation installed — a later attempt that replaced it
+   * owns itself — and leaves a result that has a lifetime of its own running.
+   */
+  releaseChild<T>(
+    resultCell: Cell<T>,
+    installedCancel: Cancel | undefined,
+  ): void {
+    const key = this.getDocKey(resultCell);
+    if (installedCancel !== undefined) {
+      if (this.cancels.get(key) !== installedCancel) return;
+    } else if (!this.cancels.has(key)) return;
+    if (this.independentlyStartedResults.has(key)) return;
+    // A start still resolving may be about to give this result a lifetime of
+    // its own, and it cannot say so until it finishes. Declining here keeps a
+    // page that is still opening from being closed by its parent. An attempt
+    // that then fails leaves the result registered until the runtime stops it,
+    // which is the same bound the scheduler already accepts for a start that
+    // exhausts its retries.
+    if ((this.activeStartAttemptsByDoc.get(key)?.size ?? 0) > 0) return;
+    this.stop(resultCell);
   }
 
   /**
@@ -2773,6 +2827,7 @@ export class Runner {
       : resultCell;
 
     const key = this.getDocKey(rootCell);
+    attempt.targetKey = key;
     // Step 2: Already started? Return success
     if (this.cancels.has(key)) return Promise.resolve(true);
 
@@ -2997,13 +3052,51 @@ export class Runner {
     resultCell: Cell<T>,
   ): DeferredCancelOwnership {
     const key = this.getDocKey(resultCell);
-    return useDeferredCancelOwnership((installedCancel) => {
+    const base = useDeferredCancelOwnership((installedCancel) => {
       // A result key can be stopped and restarted while deferred startup is
       // re-entering runner code. Only stop if this attempt's exact cancel
       // registration is still current; a later replacement owns itself.
       if (this.cancels.get(key) !== installedCancel) return;
       this.stop(resultCell);
     });
+    // Ownership of a commit-gated start begins when the start is scheduled,
+    // not when its callback installs it, so a stop before that commit has to
+    // reach the pending start and tombstone it. The entry goes as soon as the
+    // start settles either way: it installed a registration, which owns itself
+    // from then on, or it was cancelled.
+    const ownership: DeferredCancelOwnership = {
+      cancel: () => {
+        unregister();
+        base.cancel();
+      },
+      isCancelled: base.isCancelled,
+      markInstalled: (registration) => {
+        unregister();
+        return base.markInstalled(registration);
+      },
+    };
+    const unregister = () => {
+      const pending = this.pendingDeferredStarts.get(key);
+      if (pending === undefined) return;
+      pending.delete(ownership);
+      if (pending.size === 0) this.pendingDeferredStarts.delete(key);
+    };
+    let pending = this.pendingDeferredStarts.get(key);
+    if (pending === undefined) {
+      pending = new Set();
+      this.pendingDeferredStarts.set(key, pending);
+    }
+    pending.add(ownership);
+    return ownership;
+  }
+
+  private cancelPendingDeferredStarts(
+    key: `${MemorySpace}/${CellScope}/${URI}`,
+  ): void {
+    const pending = this.pendingDeferredStarts.get(key);
+    if (pending === undefined) return;
+    this.pendingDeferredStarts.delete(key);
+    for (const ownership of pending) ownership.cancel();
   }
 
   private startAfterSuccessfulCommit<T = any>(
@@ -3258,6 +3351,24 @@ export class Runner {
           this.pullCellOnceAfterSuccessfulCommit(tx, resultCell);
         }
       }
+    }
+
+    // The setup writes are staged in this transaction; the registration is
+    // not, so a transaction that does not become durable would otherwise leave
+    // a piece running over writes that never landed. A stale basis is the
+    // exception: the re-run that follows reuses what is already there.
+    if (installedCancel !== undefined) {
+      const startedCancel = installedCancel;
+      tx.addCommitCallback((_settledTx, result) => {
+        if (!result.error) return;
+        if (
+          isConflictRejection(result.error) ||
+          isStorageTransactionInconsistent(result.error)
+        ) {
+          return;
+        }
+        this.releaseChild(resultCell, startedCancel);
+      });
     }
 
     if (!providedTx) {
@@ -4055,6 +4166,8 @@ export class Runner {
    */
   stop<T>(resultCell: Cell<T>): void {
     const key = this.getDocKey(resultCell);
+    this.independentlyStartedResults.delete(key);
+    this.cancelPendingDeferredStarts(key);
     if ((this.activeStartAttemptsByDoc.get(key)?.size ?? 0) > 0) {
       this.startGenerationByDoc.set(
         key,
@@ -4180,6 +4293,11 @@ export class Runner {
     this.lifecycleEpoch++;
     this.resumeSnapshotsBySpace.clear();
     this.resumeSnapshotLoads.clear();
+    this.independentlyStartedResults.clear();
+    for (const key of [...this.pendingDeferredStarts.keys()]) {
+      this.cancelPendingDeferredStarts(key);
+    }
+    this.pendingDeferredStarts.clear();
     // Cancel all tracked operations
     for (const cancel of this.allCancels) {
       try {
@@ -5384,7 +5502,7 @@ export class Runner {
         undefined,
         resultCell,
       );
-      addCancel(() => this.stop(resultCell));
+      addCancel(() => this.releaseChild(resultCell, undefined));
 
       tx.addCommitCallback((_committedTx, result) => {
         if (!result.error) return;
@@ -6760,11 +6878,17 @@ export class Runner {
         parentResultCell.space,
       );
     }
-    this.run(tx, patternImpl, inputs, childResultCell, {
-      awaitSyncBeforeInitialRun: defersInitialRunUntilSynced(
-        schedulerRehydration,
-      ),
-    });
+    const childRun = this.runWithStartOwnership(
+      tx,
+      patternImpl,
+      inputs,
+      childResultCell,
+      {
+        awaitSyncBeforeInitialRun: defersInitialRunUntilSynced(
+          schedulerRehydration,
+        ),
+      },
+    );
 
     if (sendToBindings) {
       sendValueToBinding(
@@ -6777,10 +6901,9 @@ export class Runner {
       );
     }
 
-    // TODO(seefeld): Make sure to not cancel after a pattern is elevated to a
-    // piece, e.g. via navigateTo. Nothing is cancelling right now, so leaving
-    // this as TODO.
-    addCancel(() => this.stop(childResultCell));
+    addCancel(() =>
+      this.releaseChild(childResultCell, childRun.installedCancel)
+    );
   }
 }
 

--- a/packages/runner/test/child-run-ownership.test.ts
+++ b/packages/runner/test/child-run-ownership.test.ts
@@ -1,0 +1,351 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import type { OpaqueCell } from "@commonfabric/api";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import type { Cell } from "../src/cell.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+import { Runtime } from "../src/runtime.ts";
+
+// The four guarantees a child run carries beyond "whoever created it stops it".
+// Each drives the public API only: a parent pattern, a child reached through
+// it, and start/stop/abort in the order that distinguishes the cases.
+
+const signer = await Identity.fromPassphrase("child run ownership");
+const space = signer.did();
+
+function key(cell: Cell<unknown>) {
+  const link = cell.getAsNormalizedFullLink();
+  return `${link.space}/${link.scope}/${link.id}` as const;
+}
+
+describe("child run ownership", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("rolls back a nested child when its parent transaction aborts", async () => {
+    const { lift, pattern } = createTrustedBuilder(runtime).commonfabric;
+    const Child = pattern<{ value: number }>(({ value }) => ({
+      doubled: lift((input: number) => input * 2)(value),
+    }));
+    const Parent = pattern<{ value: number }>(({ value }) => ({
+      child: Child({ value }),
+    }));
+    const tx = runtime.edit();
+    const parent = runtime.getCell(
+      space,
+      "aborted nested child parent",
+      undefined,
+      tx,
+    );
+    const before = new Set(runtime.runner.cancels.keys());
+    runtime.run(tx, Parent, { value: 3 }, parent);
+    const created = [...runtime.runner.cancels.keys()].filter((k) =>
+      !before.has(k)
+    );
+    expect(created.length).toBeGreaterThanOrEqual(2);
+
+    expect(tx.abort("parent setup rejected").error).toBeUndefined();
+    await runtime.idle();
+
+    expect(created.filter((k) => runtime.runner.cancels.has(k))).toEqual([]);
+  });
+
+  it("keeps a directly started nested child after its parent stops", async () => {
+    const { lift, pattern } = createTrustedBuilder(runtime).commonfabric;
+    const Child = pattern<{ value: number }>(({ value }) => ({
+      doubled: lift((input: number) => input * 2)(value),
+    }));
+    const Parent = pattern<{ value: number }>(({ value }) => ({
+      child: Child({ value }),
+    }));
+    const tx = runtime.edit();
+    const parent = runtime.getCell<{ child: { doubled: number } }>(
+      space,
+      "directly started nested child parent",
+      undefined,
+      tx,
+    );
+    const result = runtime.run(tx, Parent, { value: 3 }, parent);
+    expect((await tx.commit()).error).toBeUndefined();
+    await runtime.idle();
+    expect(await result.pull()).toEqual({ child: { doubled: 6 } });
+    const child = result.key("child").resolveAsCell() as Cell<
+      { doubled: number }
+    >;
+
+    const directStart = runtime.start(child);
+    runtime.runner.stop(parent);
+
+    await expect(directStart).resolves.toBe(true);
+    expect(runtime.runner.cancels.has(key(child))).toBe(true);
+    runtime.runner.stop(child);
+  });
+
+  it("keeps a directly started map child after its parent stops", async () => {
+    const { lift, pattern } = createTrustedBuilder(runtime).commonfabric;
+    const op = pattern(({ element }: { element: number }) =>
+      lift((value: number) => value)(element)
+    );
+    const Parent = pattern<{ values?: number[] }>(({ values }) => {
+      const list = values as unknown as OpaqueCell<number[]>;
+      return {
+        values,
+        out: list.mapWithPattern(
+          op as unknown as Parameters<typeof list.mapWithPattern>[0],
+          {},
+        ),
+      };
+    });
+    const tx = runtime.edit();
+    const parent = runtime.getCell<Record<string, unknown>>(
+      space,
+      "directly started map child parent",
+      undefined,
+      tx,
+    );
+    let child: Cell<unknown> | undefined;
+    const capture = (args: unknown[]) => {
+      const options = args[4] as
+        | { doNotUpdateOnPatternChange?: boolean }
+        | undefined;
+      if (child === undefined && options?.doNotUpdateOnPatternChange === true) {
+        child = args[3] as Cell<unknown>;
+      }
+    };
+    const runner = runtime.runner as unknown as Record<string, unknown>;
+    const originalRun = runtime.runner.run;
+    const originalRunChild = runner.runChild as
+      | ((...args: unknown[]) => unknown)
+      | undefined;
+    runtime.runner.run = ((...args: unknown[]) => {
+      capture(args);
+      return Reflect.apply(originalRun, runtime.runner, args);
+    }) as typeof runtime.runner.run;
+    if (originalRunChild !== undefined) {
+      runner.runChild = (...args: unknown[]) => {
+        capture(args);
+        return Reflect.apply(originalRunChild, runtime.runner, args);
+      };
+    }
+    try {
+      runtime.run(tx, Parent, { values: [1] }, parent);
+      expect((await tx.commit()).error).toBeUndefined();
+      await runtime.idle();
+      await parent.pull();
+    } finally {
+      runtime.runner.run = originalRun;
+      if (originalRunChild !== undefined) runner.runChild = originalRunChild;
+    }
+    expect(child).toBeDefined();
+
+    const directStart = runtime.start(child!);
+    runtime.runner.stop(parent);
+
+    await expect(directStart).resolves.toBe(true);
+    expect(runtime.runner.cancels.has(key(child!))).toBe(true);
+    runtime.runner.stop(child!);
+  });
+
+  it("tombstones a pending commit-gated start on an explicit stop", async () => {
+    const { lift, pattern } = createTrustedBuilder(runtime).commonfabric;
+    const Piece = pattern<{ value: number }>(({ value }) => ({
+      doubled: lift((input: number) => input * 2)(value),
+    }));
+    const tx = runtime.edit();
+    tx.tx.immediate = true;
+    (tx.tx as { deferRunnerStartUntilCommit?: boolean })
+      .deferRunnerStartUntilCommit = true;
+    const result = runtime.getCell<Record<string, unknown>>(
+      space,
+      "stopped before its deferred start",
+      undefined,
+      tx,
+    );
+    runtime.run(tx, Piece, { value: 3 }, result.withTx(tx));
+
+    runtime.runner.stop(result);
+    expect((await tx.commit()).error).toBeUndefined();
+    await runtime.idle();
+
+    expect(runtime.runner.cancels.has(key(result))).toBe(false);
+  });
+
+  it("tombstones a pending commit-gated start when the runtime stops", async () => {
+    const { lift, pattern } = createTrustedBuilder(runtime).commonfabric;
+    const Piece = pattern<{ value: number }>(({ value }) => ({
+      doubled: lift((input: number) => input * 2)(value),
+    }));
+    const tx = runtime.edit();
+    tx.tx.immediate = true;
+    (tx.tx as { deferRunnerStartUntilCommit?: boolean })
+      .deferRunnerStartUntilCommit = true;
+    const result = runtime.getCell<Record<string, unknown>>(
+      space,
+      "stopped by teardown before its deferred start",
+      undefined,
+      tx,
+    );
+    runtime.run(tx, Piece, { value: 3 }, result.withTx(tx));
+
+    runtime.runner.stopAll();
+    expect((await tx.commit()).error).toBeUndefined();
+    await runtime.idle();
+
+    expect(runtime.runner.cancels.has(key(result))).toBe(false);
+  });
+
+  it("keeps a child whose setup transaction fails on a stale basis", async () => {
+    const { lift, pattern } = createTrustedBuilder(runtime).commonfabric;
+    const Child = pattern<{ value: number }>(({ value }) => ({
+      doubled: lift((input: number) => input * 2)(value),
+    }));
+    const Parent = pattern<{ value: number }>(({ value }) => ({
+      child: Child({ value }),
+    }));
+    const tx = runtime.edit();
+    const parent = runtime.getCell(
+      space,
+      "stale basis parent",
+      undefined,
+      tx,
+    );
+    const before = new Set(runtime.runner.cancels.keys());
+    runtime.run(tx, Parent, { value: 3 }, parent);
+    const created = [...runtime.runner.cancels.keys()].filter((k) =>
+      !before.has(k)
+    );
+    expect(created.length).toBeGreaterThanOrEqual(2);
+
+    // A conflict is resolved by re-running against fresher state, and that
+    // re-run reuses what is already registered.
+    (tx.tx as unknown as { commit: () => Promise<unknown> }).commit = () =>
+      Promise.resolve({
+        error: { name: "ConflictError", message: "stale basis" },
+      });
+    await tx.commit();
+    await runtime.idle();
+
+    expect(created.filter((k) => runtime.runner.cancels.has(k)))
+      .toEqual(created);
+    for (const cell of [parent]) runtime.runner.stop(cell);
+  });
+
+  it("declines to release a registration it does not own", async () => {
+    const { lift, pattern } = createTrustedBuilder(runtime).commonfabric;
+    const Piece = pattern<{ value: number }>(({ value }) => ({
+      doubled: lift((input: number) => input * 2)(value),
+    }));
+    const tx = runtime.edit();
+    const result = runtime.getCell<Record<string, unknown>>(
+      space,
+      "released by a stale owner",
+      undefined,
+      tx,
+    );
+    runtime.run(tx, Piece, { value: 3 }, result);
+    expect((await tx.commit()).error).toBeUndefined();
+    await runtime.idle();
+    expect(runtime.runner.cancels.has(key(result))).toBe(true);
+
+    // A release naming a registration that is no longer current belongs to an
+    // attempt something else replaced, so it leaves the live one alone.
+    runtime.runner.releaseChild(result, () => {});
+
+    expect(runtime.runner.cancels.has(key(result))).toBe(true);
+    runtime.runner.stop(result);
+  });
+
+  it("keeps a child started before its parent stops", async () => {
+    const { lift, pattern } = createTrustedBuilder(runtime).commonfabric;
+    const Child = pattern<{ value: number }>(({ value }) => ({
+      doubled: lift((input: number) => input * 2)(value),
+    }));
+    const Parent = pattern<{ value: number }>(({ value }) => ({
+      child: Child({ value }),
+    }));
+    const tx = runtime.edit();
+    const parent = runtime.getCell<{ child: { doubled: number } }>(
+      space,
+      "child started before its parent stops",
+      undefined,
+      tx,
+    );
+    const result = runtime.run(tx, Parent, { value: 3 }, parent);
+    expect((await tx.commit()).error).toBeUndefined();
+    await runtime.idle();
+    const child = result.key("child").resolveAsCell() as Cell<
+      { doubled: number }
+    >;
+
+    // The start settles first, so the release consults the recorded lifetime
+    // rather than an attempt still in flight.
+    await expect(runtime.start(child)).resolves.toBe(true);
+    runtime.runner.stop(parent);
+
+    expect(runtime.runner.cancels.has(key(child))).toBe(true);
+    const update = runtime.edit();
+    child.getArgumentCell()!.withTx(update).key("value").set(5);
+    expect((await update.commit()).error).toBeUndefined();
+    expect(await child.pull()).toEqual({ doubled: 10 });
+    runtime.runner.stop(child);
+  });
+
+  it("stops tracking a commit-gated start once it installs", async () => {
+    const { lift, pattern } = createTrustedBuilder(runtime).commonfabric;
+    const Piece = pattern<{ value: number }>(({ value }) => ({
+      doubled: lift((input: number) => input * 2)(value),
+    }));
+    const tx = runtime.edit();
+    tx.tx.immediate = true;
+    (tx.tx as { deferRunnerStartUntilCommit?: boolean })
+      .deferRunnerStartUntilCommit = true;
+    const result = runtime.getCell<Record<string, unknown>>(
+      space,
+      "deferred start that installs",
+      undefined,
+      tx,
+    );
+    runtime.run(tx, Piece, { value: 3 }, result.withTx(tx));
+
+    const pending = (runtime.runner as unknown as {
+      pendingDeferredStarts: Map<string, Set<unknown>>;
+    }).pendingDeferredStarts;
+    expect(pending.size).toBe(1);
+
+    expect((await tx.commit()).error).toBeUndefined();
+    await runtime.idle();
+
+    // The installed registration owns itself from here, so nothing is left
+    // waiting to be tombstoned.
+    expect(runtime.runner.cancels.has(key(result))).toBe(true);
+    expect(pending.size).toBe(0);
+    runtime.runner.stop(result);
+  });
+
+  it("declines to release a result that has no registration", () => {
+    const result = runtime.getCell<Record<string, unknown>>(
+      space,
+      "released while never started",
+    );
+    expect(runtime.runner.cancels.has(key(result))).toBe(false);
+
+    runtime.runner.releaseChild(result, undefined);
+
+    expect(runtime.runner.cancels.has(key(result))).toBe(false);
+  });
+});


### PR DESCRIPTION
A running pattern holds a registration: the scheduler actions the runner keeps for that result. Until now one rule governed all of them — whoever created a child stops it — and that rule is wrong in four ways, because a registration is not part of any transaction and a result is reachable from more than one place.

A result someone opened in its own right was stopped by the pattern that happened to create it. Drilling into a detail view from a list and then stopping the list closed the open view. Record the results that a start opened directly, and have a release leave those running. A start still resolving cannot say yet that it is about to become such an owner, so a release declines while one is in flight; a start that then fails leaves the result registered until the runtime stops it, the bound the scheduler already accepts for a start that exhausts its retries.

A release also stopped whatever it found under the result's key rather than the registration it installed, so a later attempt that replaced it was stopped by the earlier one's cleanup. Release the exact registration or nothing.

A run staged its setup in a transaction but installed its registration outside one, so a transaction that never became durable left a piece running over writes that vanished. Stop such a registration when its transaction fails, except on a stale basis, where the re-run that follows reuses what is there.

A commit-gated start was reachable only once its callback installed it, so stopping the piece first let it start moments later anyway. Index pending starts by result and tombstone them on an explicit stop.

Specify all four, which until now existed only as behavior, and amend the scheduler specification where it describes ownership of a commit-gated start and the convergence of computation-launched children.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce explicit child-run ownership so parents only stop the registration they installed, and user-started/navigated children keep running. Also roll back orphaned registrations when setup transactions fail and prevent commit-gated starts from installing after a stop; docs/specs and tests added.

- **Bug Fixes**
  - Keep directly started results running when a parent releases; decline releases while a start is in flight.
  - Only stop the exact registration installed by the attempt; do nothing if it was replaced.
  - Roll back registrations when their setup transaction fails to commit (except stale-basis/conflict/inconsistency retries).
  - Tombstone pending commit-gated starts on explicit stop or runtime teardown so they don’t install after the commit.

<sup>Written for commit d13cd4cf02e11dbe0a286ea748089d48ecf874f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

