### PR TITLE
docs: finish the charm-to-piece rename in four live documents

### DIFF
--- a/docs/features/shared-identity.md
+++ b/docs/features/shared-identity.md
@@ -25,7 +25,7 @@ counting users.
 
 Only to deliberately act *as the local dev server's own identity* — i.e. for
 operator/admin tasks on your own localhost where the caller must match toolshed's
-dev identity (e.g. `add-admin-charm`, the background-charm-service operator,
+dev identity (e.g. `add-admin-piece`, the background piece service operator,
 deploying system home patterns). For everything else — your personal identity,
 normal pattern dev, and any shared or remote server — use `id new`.
 

--- a/docs/specs/server-side-execution/README.md
+++ b/docs/specs/server-side-execution/README.md
@@ -276,7 +276,7 @@ discovered mid-rebuild. Five placement classes:
 | **Pure structural** | `map`, `filter`, `flatmap`, `if-else`/`when`/`unless`, `inspect-conf-label`, `wish` (the `list-*` modules, `op-pattern-ref` and `scope-policy` are helper modules, not registered built-ins — builtins.md §1) | server | yes — free to discard |
 | **Deferred** | `stream-data` | disabled in the v2 interim (unused today; the low-latency UI it promises likely wants a different mechanism — owner, 2026-08-02) | — |
 | **Effectful / network** | `fetch` (`fetchData`), `fetch-program`, `llm` (`generateText`/`generateObject`), `llm-dialog`, `sqlite*` | **server only** | **never** — speculation reads through to the last committed result |
-| **Compile / instantiate** | `compile-and-run` (charm creation, incl. from handlers) | server (sandboxed worker; toolshed already compiles) | no |
+| **Compile / instantiate** | `compile-and-run` (piece creation, incl. from handlers) | server (sandboxed worker; toolshed already compiles) | no |
 | **Client-enacted effect** | `navigate-to` | server *computes*, client *enacts* (§3.7) | echo allowed (navigate optimistically, reconcile) |
 
 Why effectful nodes are server-only rather than merely server-preferred:

--- a/docs/specs/server-side-execution/builtins.md
+++ b/docs/specs/server-side-execution/builtins.md
@@ -57,7 +57,7 @@ rule); streaming partial commits.
 
 ## 3. Compile / instantiate — server-side, sandboxed
 
-`compile-and-run`: compiles + instantiates patterns (charm creation),
+`compile-and-run`: compiles + instantiates patterns (piece creation),
 including when invoked from a handler's consequences. Runs in the
 SpaceServer's runtime; compilation itself already happens server-side in
 toolshed — reuse that path. Async work stays on the post-commit outbox

--- a/docs/specs/server-side-execution/runtime-mapping.md
+++ b/docs/specs/server-side-execution/runtime-mapping.md
@@ -83,7 +83,7 @@ Status legend:
 | 35 | Resumed-start machinery: per-doc rehydration snapshots, sync-holds, rehydration barrier | `runner.ts:3216-3395`, `scheduler/facade.ts:680-803`, barrier `scheduler/work-oracle.ts:79-86` | serving-loop §3b, §6 | CHANGED |
 | 36 | Runtime teardown ordering: settle pointer commits, updater dispose, scheduler dispose | `runtime.ts:1343-1424`, `runner.ts:3900-3924` | README §4 (teardown O(1) budget) | COVERED |
 
-### 1e. Results that are patterns (charm creation from computation)
+### 1e. Results that are patterns (piece creation from computation)
 
 | # | behavior | today (anchor) | v2 doc § | status |
 | --- | --- | --- | --- | --- |


### PR DESCRIPTION
"Charm" was the name this codebase used for a running instance of a pattern before that concept was renamed to "piece". The rename landed in stages, and the sweeps that carried it through the documentation left four live documents still using the old word. Nothing about the system changed; these are the last places where the prose describes it by a name the code no longer uses.

Three of them are server-side-execution specs, where "charm creation" described what `compile-and-run` and result-as-pattern instantiation produce. Those become "piece creation", which matches the surrounding prose in the same files (builtins.md already says "Instantiated pieces join the space's graph").

The fourth is the shared-identity feature document, which listed two examples of operator tasks that must run as the local dev server's own identity. Both names were stale rather than merely old-fashioned: the task is now `add-admin-piece`, defined in packages/background-piece- service, and the service that was called the background charm service is now the background piece service, living at packages/background-piece- service. The replacement wording matches how the same two examples are already written in docs/development/LOCAL_DEV_SERVERS.md.

Documents under docs/history/ keep the vocabulary of their era and are left alone. Two source files also contain the word — a Scrabble word list and a Frankenstein text fixture — where it is ordinary English and has nothing to do with the runtime concept.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finish the rename from “charm” to “piece” in four live docs to align terminology with the codebase. Updates `compile-and-run` references to “piece creation” and fixes shared-identity examples to `add-admin-piece` and “background piece service”.

<sup>Written for commit 07233db2f39d5dbcd4da1a65eefe1b3a8c32eb48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

