### PR TITLE
perf: stop re-walking values the write path already knows are mutable

### DIFF
--- a/docs/history/development/performance/2026-08-fabric-value-validation-cost.md
+++ b/docs/history/development/performance/2026-08-fabric-value-validation-cost.md
@@ -1,0 +1,103 @@
+---
+status: historical
+created: 2026-08-04
+archived: 2026-08-04
+reason: "Investigation record for the write-path validation slowdown visible on the benchmarks dashboard from 2026-07-29."
+---
+
+# Where the write path's validation time went, August 2026
+
+## What was measured
+
+Apple M5 Max, Deno 2.9.4 (the `mise.toml` pin), medians of repeated runs of
+two benchmarks:
+
+- `Cell.set() - depth: very deep (20 levels)` in
+  `packages/runner/test/cell-set.bench.ts`
+- `Cell push - array append schemaless (100x)` in
+  `packages/runner/test/cell.bench.ts`
+
+Runs alternated between two worktrees so that machine drift could not favour
+either side. Numbers below are the reported per-iteration average, in
+microseconds.
+
+| | Cell.set very deep | Cell push |
+|---|---|---|
+| `main` at `54bfa33fb` | 23959 | 47107 |
+| with the two changes described here | 16064 | 27212 |
+| `main` with the inertness checks deleted outright | 22375 | 41013 |
+
+The third row is the diagnostic upper bound: `isInertPlainObject()` cut back to
+the bare prototype comparison it replaced, and the per-index descriptor loop
+removed from `isInertArray()`. Both benchmarks land well below it, because the
+larger of the two changes removes work that predates those checks.
+
+## What the time was actually going to
+
+Counting predicate calls for one iteration of each benchmark:
+
+- `Cell.set` very deep: 49780 calls to `isInertPlainObject()`, walking 97498
+  keys, for a value of 41 objects and 82 keys. About 500 calls per `set()`.
+- `Cell push`: 5354 calls to `isInertArray()`, walking 358754 index keys.
+
+Attributing those calls by stack, 461 of every 502 in the first case and 5250
+of 5354 in the second arrive by the same route: `cloneHelper()` asks
+`canReturnAsIs()` whether a value can be passed through as-is,
+`canReturnAsIs()` asks `isDeepFrozenFabricValue()`, and that function
+evaluated `isFabricValue(value) && isDeepFrozen(value)`. `isFabricValue()` is
+an uncached recursive membership walk of the whole subtree, and `cloneHelper()`
+recurses, so the walk ran once per node per level: quadratic in the depth of
+the value. Every one of those walks was thrown away, because the value handed
+to the write path is mutable and so was never going to be deep-frozen.
+
+Swapping the two conjuncts fixes it. `isDeepFrozen()` answers in constant time
+for anything not frozen at its root and memoizes every subtree it does walk, so
+with it first the membership walk only runs for a value that could still answer
+`true`.
+
+## What each primitive costs
+
+Measured on the two- and three-key objects the `Cell.set` benchmark builds
+(three objects per iteration, twenty keys in total):
+
+| Operation | Cost for three objects |
+|---|---|
+| prototype comparison | 24 ns |
+| `Object.keys()` | 17 ns |
+| `Object.getOwnPropertyNames()` | 17 ns |
+| `Object.getOwnPropertySymbols()` | 39 ns |
+| `Object.entries()` | 59 ns |
+| `Object.assign()` into a fresh object | 59 ns |
+| `Reflect.ownKeys()` | 279 ns |
+| `Object.getOwnPropertyDescriptor()` per key | 228 ns |
+| `Object.getOwnPropertyDescriptors()` | 1100 ns |
+
+`Reflect.ownKeys()` is the outlier: it costs roughly what all three of the
+single-purpose key reads cost together, several times over, and its cost is
+per call rather than per key. Asking the three narrower questions separately —
+enumerable string keys, all string keys, symbol keys — is what
+`isInertPlainObject()` now does.
+
+The bulk `Object.getOwnPropertyDescriptors()` is five times the price of
+fetching the same descriptors one at a time, so the per-key call stays.
+Descriptors are the only way JavaScript answers "is this an accessor", and
+inertness turns on that question, so one descriptor per own key is the floor
+for the check as specified.
+
+## What did not work
+
+Fusing validation into the copy loop — taking each own key once, reading its
+descriptor, and building the clone from the value already in that descriptor —
+measured *slower* than validating and then copying with `Object.assign()`: 664
+ns against 602 ns for the same three objects. The copy is not where the time
+goes. `Object.assign()` runs inside the engine at 59 ns for three objects,
+while the descriptor walk it would fold into costs 228 ns and happens either
+way. The same held for arrays: a fused copy-and-check loop measured 2.4 µs
+against 2.5 µs for the separate loops, an improvement of well under the
+per-element descriptor cost it cannot avoid.
+
+The `Cell push` benchmark spends only about 7 ms of its roughly 43 ms in the
+push loop; the rest is runtime construction, the initial `set()`, and disposal.
+The array validation cost is spread across all of it rather than concentrated
+in the loop, which is why loop-only profiling of that benchmark understates it
+by an order of magnitude.

--- a/packages/data-model/src/deep-freeze.ts
+++ b/packages/data-model/src/deep-freeze.ts
@@ -266,7 +266,15 @@ export function isDeepFrozenFabricValue(value: unknown): value is FabricValue {
     return true;
   }
 
-  const result = isFabricValue(value) && isDeepFrozen(value);
+  // The frozen-ness question goes first because it is the cheap one, and a
+  // `false` from it settles the conjunction. `isDeepFrozen()` answers in
+  // constant time for anything not frozen at its root, and memoizes every
+  // subtree it does walk; `isFabricValue()` walks the whole tree afresh on
+  // every call. With the walk second, a mutable tree -- what the write path
+  // hands this function at every level of its own recursion -- costs one
+  // `Object.isFrozen()` call rather than a full membership walk of its
+  // subtree.
+  const result = isDeepFrozen(value) && isFabricValue(value);
 
   if (result && typeof value === "object" && value !== null) {
     deepFrozenFabricValueCache.add(value);

--- a/packages/utils/src/objects.ts
+++ b/packages/utils/src/objects.ts
@@ -81,8 +81,8 @@ export function isInertPlainObject(
   // accessor carries `get` / `set` where a data property carries `value`. The
   // keys walked here are every own key, the two reads above having established
   // that there are no others.
-  for (let i = 0; i < keys.length; i++) {
-    const descriptor = Object.getOwnPropertyDescriptor(value, keys[i]!)!;
+  for (const key of keys) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key)!;
     if (!("value" in descriptor)) {
       return false;
     }

--- a/packages/utils/src/objects.ts
+++ b/packages/utils/src/objects.ts
@@ -60,17 +60,30 @@ export function isInertPlainObject(
     return false;
   }
 
-  // A single pass over the own keys checks all three requirements: each key
-  // must be a string (`Reflect.ownKeys()` yields symbol keys too, which a
-  // count-based comparison would need a second key walk to exclude), and its
-  // descriptor must be enumerable and carry `value` (an accessor answers
-  // `get` / `set` instead).
-  for (const key of Reflect.ownKeys(value)) {
-    if (typeof key !== "string") {
-      return false;
-    }
-    const descriptor = Object.getOwnPropertyDescriptor(value, key)!;
-    if (!descriptor.enumerable || !("value" in descriptor)) {
+  // Three key reads settle the two *key* requirements. `Object.keys()` is the
+  // enumerable string keys; `Object.getOwnPropertyNames()` is those plus the
+  // non-enumerable ones, so equal lengths mean every string key is enumerable;
+  // and no symbol keys means `Object.getOwnPropertySymbols()` is empty. This
+  // sits on the hot write path, and each of the three has an engine fast path
+  // that `Reflect.ownKeys()` -- which would answer both questions at once --
+  // does not: the three together cost a fraction of the one.
+  const keys = Object.keys(value);
+
+  if (Object.getOwnPropertyNames(value).length !== keys.length) {
+    return false;
+  }
+
+  if (Object.getOwnPropertySymbols(value).length !== 0) {
+    return false;
+  }
+
+  // The remaining requirement is data-ness, which only a descriptor answers: an
+  // accessor carries `get` / `set` where a data property carries `value`. The
+  // keys walked here are every own key, the two reads above having established
+  // that there are no others.
+  for (let i = 0; i < keys.length; i++) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, keys[i]!)!;
+    if (!("value" in descriptor)) {
       return false;
     }
   }

--- a/packages/utils/test/objects.test.ts
+++ b/packages/utils/test/objects.test.ts
@@ -204,7 +204,7 @@ describe("objects", () => {
       ).toBe(false);
     });
 
-    it("answers for a `Proxy` that disowns a key it reported", () => {
+    it("returns `false` for a `Proxy` that disowns a key it reported", () => {
       // A proxy whose `ownKeys()` names a key its `getOwnPropertyDescriptor()`
       // then answers `undefined` for. Inertness cannot be established, so the
       // answer is `false`; only a trap that throws on its own account takes

--- a/packages/utils/test/objects.test.ts
+++ b/packages/utils/test/objects.test.ts
@@ -203,5 +203,20 @@ describe("objects", () => {
         isInertPlainObject(new Proxy(withSymbol, {})),
       ).toBe(false);
     });
+
+    it("answers for a `Proxy` that disowns a key it reported", () => {
+      // A proxy whose `ownKeys()` names a key its `getOwnPropertyDescriptor()`
+      // then answers `undefined` for. Inertness cannot be established, so the
+      // answer is `false`; only a trap that throws on its own account takes
+      // this check off its "answers rather than throws" contract.
+      const ghosted = new Proxy({ a: 1 }, {
+        ownKeys: () => ["a", "ghost"],
+        getOwnPropertyDescriptor: (target, key) =>
+          key === "ghost"
+            ? undefined
+            : Object.getOwnPropertyDescriptor(target, key),
+      });
+      expect(isInertPlainObject(ghosted)).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
Writing a value into a cell got slower over the last week, visibly so on the benchmarks dashboard. The proximate cause was the plain-object arm of the fabric type check, which grew from a single prototype comparison into a walk of every own key with a property descriptor fetched for each one. That walk buys something real -- it is what rejects symbol keys, non-enumerable string keys, and accessor-backed properties, none of which a fabric record can carry -- so the fix is not to give any of it back.

Counting the calls showed the walk was not the whole story. One `Cell.set()` of a twenty-level value, 41 objects and 82 keys in all, ran the plain-object check about five hundred times. Roughly nine in ten of those calls arrived by one route: `cloneHelper()` asks `canReturnAsIs()` whether it may pass a value through untouched, `canReturnAsIs()` asks `isDeepFrozenFabricValue()`, and that function evaluated `isFabricValue(value) && isDeepFrozen(value)`. `isFabricValue()` is an uncached recursive membership walk of the whole subtree, and `cloneHelper()` recurses, so the subtree was re-validated once per node per level -- quadratic in the depth of the value. Every one of those walks was discarded, because the value the write path is holding is mutable and so was never going to be deep-frozen at all.

So this swaps the two conjuncts. `isDeepFrozen()` answers in constant time for anything not frozen at its root, and memoizes each subtree it does walk; `isFabricValue()` starts from nothing every time. With the cheap, memoized question first, the membership walk runs only for a value that could still answer `true`. The conjunction's value is unchanged, and both operands are free of observable side effects, so no caller sees a difference.

The second change makes the check itself cheaper without weakening it. `Reflect.ownKeys()` answers "every own key, strings and symbols alike" in one call, but it has no engine fast path and costs about as much per call as the three single-purpose key reads cost in total for a small object. Asking the narrower questions separately -- `Object.keys()` for the enumerable string keys, `Object.getOwnPropertyNames()` whose length must match to rule out a non-enumerable one, and `Object.getOwnPropertySymbols()` which must be empty -- answers the same two questions for a fraction of the price. The per-key descriptor stays, because a descriptor is the only thing that distinguishes a data property from an accessor, and that distinction is the point of the check.

One behavioural detail improves as a side effect. Handed a proxy whose `ownKeys()` names a key that its `getOwnPropertyDescriptor()` then disowns, the check used to read a property off `undefined` and throw a `TypeError`; it now answers `false`, which is what its "answers rather than throws" contract says it should do. A test pins that.

Measured with the pinned Deno on an Apple M5 Max, alternating between worktrees so machine drift could not favour either side: `Cell.set() - depth: very deep (20 levels)` goes from 23959 to 16064 microseconds, and `Cell push - array append schemaless (100x)` from 47107 to
27212. Both land below where deleting the inertness checks outright would put them, because the quadratic re-validation predates those checks. The investigation record, including what was tried and did not pay off, is in docs/history/development/performance/.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up write-path validation by checking frozen-ness first and using cheaper key reads for plain objects. Cell.set (20 levels) drops 23959→16064 µs; Cell push (100x) drops 47107→27212 µs.

- **Refactors**
  - `packages/data-model/src/deep-freeze.ts`: in `isDeepFrozenFabricValue`, evaluate `isDeepFrozen(value) && isFabricValue(value)` in that order to short-circuit on mutable values and avoid quadratic re-walks.
  - `packages/utils/src/objects.ts`: replace `Reflect.ownKeys()` with `Object.keys()`, `Object.getOwnPropertyNames()`, and `Object.getOwnPropertySymbols()`; keep per-key descriptors to confirm data properties.

- **Bug Fixes**
  - Proxies that list a key but return no descriptor now result in `false` instead of a throw; test added in `packages/utils/test/objects.test.ts`.

<sup>Written for commit a70e6f245b2a193aa61c110bcff9b8c297fe956b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

