### PR TITLE
test: name a return-value test `returns`, not `answers`

### DIFF
--- a/packages/runner/test/encodable-form.test.ts
+++ b/packages/runner/test/encodable-form.test.ts
@@ -35,17 +35,17 @@ function factoryArtifact(serialized: unknown): () => void {
 describe("encodable-form", () => {
   describe("replaceArtifacts()", () => {
     describe("values carrying no artifact", () => {
-      it("answers a record by identity", () => {
+      it("returns a record by identity", () => {
         const value = { a: 1, b: { c: [1, 2, 3] } };
         expect(flatten(value)).toBe(value);
       });
 
-      it("answers a nested array by identity", () => {
+      it("returns a nested array by identity", () => {
         const value = [{ a: 1 }, [2, [3]]];
         expect(flatten(value)).toBe(value);
       });
 
-      it("answers a value carrying a sparse hole by identity", () => {
+      it("returns a value carrying a sparse hole by identity", () => {
         const value = [1, , 3];
         const result = flatten(value);
         expect(result).toBe(value);
@@ -346,7 +346,7 @@ describe("encodable-form", () => {
   });
 
   describe("encodableFormOf()", () => {
-    it("answers what `toEncodableForm` returns", () => {
+    it("returns the result of `toEncodableForm`", () => {
       expect(encodableFormOf({ toEncodableForm: () => ({ a: 1 }) }))
         .toEqual({ a: 1 });
     });
@@ -374,7 +374,7 @@ describe("encodable-form", () => {
       expect(encodableFormOf(value)).toEqual({ saw: "self" });
     });
 
-    it("answers `undefined` for a value carrying neither name", () => {
+    it("returns `undefined` for a value carrying neither name", () => {
       expect(encodableFormOf({ a: 1 })).toBe(undefined);
     });
   });

--- a/packages/utils/test/arrays.test.ts
+++ b/packages/utils/test/arrays.test.ts
@@ -246,7 +246,7 @@ describe("arrays", () => {
           .toBe(false);
       });
 
-      it("answers rather than throwing for `null` and `undefined`", () => {
+      it("returns rather than throwing for `null` and `undefined`", () => {
         expect(isArrayWithOnlyIndexProperties(null))
           .toBe(false);
         expect(
@@ -255,7 +255,7 @@ describe("arrays", () => {
           .toBe(false);
       });
 
-      it("answers rather than throwing for a primitive", () => {
+      it("returns rather than throwing for a primitive", () => {
         expect(isArrayWithOnlyIndexProperties("abc"))
           .toBe(false);
         expect(isArrayWithOnlyIndexProperties(42))

--- a/packages/utils/test/objects.test.ts
+++ b/packages/utils/test/objects.test.ts
@@ -169,14 +169,14 @@ describe("objects", () => {
         expect(isInertPlainObject(Object.create(null))).toBe(false);
       });
 
-      it("answers rather than throwing for `null` and `undefined`", () => {
+      it("returns rather than throwing for `null` and `undefined`", () => {
         expect(isInertPlainObject(null)).toBe(false);
         expect(isInertPlainObject(undefined)).toBe(
           false,
         );
       });
 
-      it("answers rather than throwing for primitives", () => {
+      it("returns rather than throwing for primitives", () => {
         expect(isInertPlainObject("abc")).toBe(false);
         expect(isInertPlainObject(42)).toBe(false);
         expect(isInertPlainObject(true)).toBe(false);

--- a/packages/utils/test/types.test.ts
+++ b/packages/utils/test/types.test.ts
@@ -247,7 +247,7 @@ describe("types", () => {
       expect(isPlainObject(Object.create(null), true)).toBe(true);
     });
 
-    it("answers the same either way for everything else", () => {
+    it("returns the same either way for everything else", () => {
       class MyClass {}
       for (const value of [{}, { a: 1 }, [], new Date(), new MyClass(), null]) {
         expect(isPlainObject(value, false)).toBe(isPlainObject(value, true));

--- a/tasks/pattern-vintage-run.test.ts
+++ b/tasks/pattern-vintage-run.test.ts
@@ -2158,7 +2158,7 @@ describe("deciding when the next generation is due", () => {
     ])).toEqual([]);
   });
 
-  it("answers per test key", () => {
+  it("returns per test key", () => {
     expect(staleTestKeys([
       outcome("a/a.test.tsx", 0),
       outcome("b/b.test.tsx", 2),


### PR DESCRIPTION
`it("returns ...")` is how this repository names a test that pins what a
function hands back. A handful of tests had drifted to `it("answers ...")`
for that same job. This renames them, so the name of a return-value test
says the same thing everywhere.

## The count, for comparison

Occurrences of each opening verb across `*.ts` and `*.tsx`:

| Test name       | Before | After |
| --------------- | -----: | ----: |
| `it("returns …` |    794 |   805 |
| `it("answers …` |     13 |     2 |

So `returns` was already the convention by a factor of about sixty to one,
and eleven of the thirteen `answers` were the same idea under a different
word.

## The two that stay

Two are the _other_ sense of "answers" -- responding to a request, rather
than returning a value -- so renaming them to `returns` would say something
untrue:

* `packages/shell/test/device-link.test.ts` -- "answers exactly once, even
  on a double tap". The subject is a person answering a prompt; the test
  asserts on a recorded list of `answers`, and only the first one counts.
* `packages/toolshed/routes/shell/shell.test.ts` -- "answers an OPTIONS
  preflight". The route _responds to_ a preflight; it does not return one.
  The prose right below it in the same file already reads "the shell router
  answers with a 404".

## Files touched

* `packages/runner/test/encodable-form.test.ts` (5)
* `packages/utils/test/arrays.test.ts` (2)
* `packages/utils/test/objects.test.ts` (2)
* `packages/utils/test/types.test.ts` (1)
* `tasks/pattern-vintage-run.test.ts` (1)

One rename is more than a verb swap: "answers what `toEncodableForm`
returns" would have become "returns what `toEncodableForm` returns", so it
reads "returns the result of `toEncodableForm`" instead.

## Testing

Test names only; no test body, no source, no behavior change.

* `deno fmt --check` and `deno lint`, repo-wide -- both clean.
* `packages/utils` full suite -- 94 passed, 0 failed.
* `packages/runner/test/encodable-form.test.ts` -- 45 steps, 0 failed.
* `tasks/pattern-vintage-run.test.ts` -- 59 steps, 0 failed.

Checked as well that no rename collides with an existing test name in its
own `describe()` block.


## Coverage Baseline

This PR just changes string content of test cases.

ACCEPT_COVERAGE_DEBT: coverage-debt: packages/runner uncovered lines = 4757 lines


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes return-value test names to use `returns` instead of `answers`, aligning with the repo’s convention. Test names only; no logic or behavior changes.

- **Refactors**
  - Renamed `it("answers …")` to `it("returns …")` in tests across `packages/runner`, `packages/utils`, and `tasks`.
  - Kept two valid “answers” cases as-is (user answers a device-link prompt; route answers an OPTIONS preflight).

<sup>Written for commit ea5d2379fcf657a68ef4cc8fbae0681a20d6f0cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

