### PR TITLE
docs(specs): PendingStacks wording tracks the shipped CT-1910 repair

### DIFF
--- a/docs/specs/memory-v2/tla/PendingStacks.tla
+++ b/docs/specs/memory-v2/tla/PendingStacks.tla
@@ -39,10 +39,12 @@
 (*                   overlaps p, plus always the top-of-stack layer.       *)
 (*                                                                         *)
 (*   BasisMode - where the staleness scan for a pending read starts:       *)
-(*       "maxdep"    shipped semantics: the resolution seq of the highest  *)
-(*                   recorded dependency (CT-1910's over-advance).         *)
-(*       "confirmed" planned repair: the reader's confirmed basis, with    *)
-(*                   the reader's own session excluded from the scan.      *)
+(*       "maxdep"    legacy: served only to pending reads that carry no    *)
+(*                   basisSeq; scans from the resolution seq of the        *)
+(*                   highest recorded dependency (CT-1910's over-advance). *)
+(*       "confirmed" CT-1910 repair, shipped: clients declare basisSeq     *)
+(*                   and the scan runs from that confirmed basis with the  *)
+(*                   reader's own session excluded.                        *)
 (***************************************************************************)
 EXTENDS Naturals, Sequences, FiniteSets
 

--- a/docs/specs/memory-v2/tla/PendingStacks_Current.cfg
+++ b/docs/specs/memory-v2/tla/PendingStacks_Current.cfg
@@ -1,5 +1,7 @@
-\* Shipped semantics: full-stack dependency recording (#4606), staleness scan
-\* based at the highest dependency's resolution seq.
+\* Legacy shape, kept as the regression witness: full-stack dependency
+\* recording (#4606), staleness scan based at the highest dependency's
+\* resolution seq. This is the path servers still serve to pending reads
+\* that carry no basisSeq.
 \* EXPECTED: ReadCoherence VIOLATED (CT-1910 pending-read basis over-advance).
 SPECIFICATION Spec
 CHECK_DEADLOCK FALSE

--- a/docs/specs/memory-v2/tla/PendingStacks_Repaired.cfg
+++ b/docs/specs/memory-v2/tla/PendingStacks_Repaired.cfg
@@ -1,6 +1,10 @@
-\* Full-stack dependency recording plus the CT-1910 repair: the pending-read
-\* staleness scan runs from the reader's confirmed basis, excluding only the
-\* reader's own session. EXPECTED: all invariants HOLD.
+\* Full-stack dependency recording plus the CT-1910 repair (shipped): the
+\* pending-read staleness scan runs from the reader's declared confirmed
+\* basis. The model excludes the reader's whole session from the scan; the
+\* shipped SQL exclusion is predecessor-restricted (own-session commits with
+\* local_seq below the reader's), and the two coincide on every
+\* FIFO-reachable state of this model (see tla/README.md, "Scope of the
+\* certification"). EXPECTED: all invariants HOLD.
 SPECIFICATION Spec
 CHECK_DEADLOCK FALSE
 CONSTANTS


### PR DESCRIPTION
## Summary

Comment-only updates to the PendingStacks TLA+ model and its configs; no modes, formulas, or config constants change.

- `PendingStacks.tla` — the `BasisMode` header now matches the README table: `"maxdep"` is the legacy path served only to pending reads that carry no `basisSeq`; `"confirmed"` is the CT-1910 repair, shipped (clients declare `basisSeq` and the scan runs from that confirmed basis). Comment-box alignment preserved.
- `PendingStacks_Current.cfg` — no longer claims to be "shipped semantics"; it is the legacy shape kept as the regression witness — the path servers still serve to `basisSeq`-less pending readers. EXPECTED-violation line unchanged.
- `PendingStacks_Repaired.cfg` — notes the repair is shipped and replaces the "excluding only the reader's own session" claim with the accurate model/SQL relationship: the model excludes the reader's whole session, the shipped SQL exclusion is predecessor-restricted (own-session commits with `local_seq` below the reader's), and the two coincide on every FIFO-reachable state of the model (see `tla/README.md`, "Scope of the certification").

Wording verified against the code side before editing: `v2.ts` (clients always emit `basisSeq`), `engine.ts` (confirmed-basis scan with the legacy fallback, and the predecessor-restricted SQL exclusion). Forward-looking per the live-doc rules — describes what each mode is, not what used to be planned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns PendingStacks TLA+ comments and configs with the shipped CT-1910 repair, clarifying BasisMode semantics and the legacy vs repaired paths. No changes to modes, formulas, or config constants; wording only.

- **Refactors**
  - PendingStacks.tla: BasisMode header now states `"maxdep"` is legacy (only when no `basisSeq`), and `"confirmed"` is the shipped repair (scan from confirmed basis with own-session exclusion).
  - Configs: PendingStacks_Current.cfg labeled as the legacy regression witness; PendingStacks_Repaired.cfg notes the repair is shipped and clarifies model vs SQL exclusion (whole-session vs predecessor-restricted) and their equivalence on FIFO-reachable states.

<sup>Written for commit b6e2424d88a95d3d3f9fc1e4a23f3c6c00a7079b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

