### PR TITLE
dashboard: report a benchmark change at the size it actually is

### DIFF
--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -542,14 +542,24 @@ Notes:
   CPU's line. Any sample isolated by those breaks appears as a point. A CPU
   with one sample also appears as a point until another sample can form a line.
   A large rise reads as a fold multiplier (`▲44×`) once it passes 4x. This
-  avoids a long percentage. The trend is a robust
-  **daily-median Theil–Sen** fit: the sub-daily samples are first collapsed to one
-  median per calendar day, then the trend is the median of the pairwise log-slopes
-  between days, projected across the day span. The daily median absorbs within-day
-  spikes, the median-of-slopes tolerates roughly a third of the days being outliers,
-  and working per calendar day (not per sample or per millisecond) keeps it
-  time-aware without letting two noisy runs a few hours apart blow up the slope —
-  which is what naive per-millisecond weighting does. With fewer than 7 distinct
+  avoids a long percentage. The trend is the difference between the start and
+  the end of whichever of **two robust fits** describes the samples more
+  closely, measured on the samples themselves rather than extended past them.
+  The first fit is a run of **flat levels meeting at change points**, which is
+  the shape a series takes when a change lands and shifts it. Levels are
+  medians, so a lone spike moves none of them, and a boundary counts as a change
+  point only when the two levels either side sit more than 4 standard errors of
+  their difference apart, with at least 3 samples supporting each — so noise
+  produces no levels, and one stray sample is not a level. The second fit is a
+  **straight line** through the median of the pairwise log-slopes, which is the
+  shape a series takes when it drifts, and it answers when its total deviation
+  is at least a tenth smaller. Reporting the difference across the fit rather
+  than a slope extended over the window means a shift reads at its true size
+  wherever in the window it sits: a shift in the newest samples is the one worth
+  catching soonest, and a slope through it would report a fraction of it. The
+  samples are first grouped into at most 64 equal-sized runs, each replaced by
+  its median, which bounds the change-point search and gives every group the
+  same weight however unevenly the runs arrive. With fewer than 7 distinct
   days in the window the trend is marked new: there is too little data to claim one.
   The window is capped by the 90-day artifact retention, so it shows at most ~45
   days and only as far back as the job has run.

--- a/packages/dashboard/tiles.test.ts
+++ b/packages/dashboard/tiles.test.ts
@@ -602,10 +602,10 @@ Deno.test("benchmark: fewer than a week of days claims no trend", () => {
   assertEquals(trendPct(t([100, 500, 2000]), [100, 500, 2000]), 0);
 });
 
-Deno.test("benchmark: Theil–Sen trend ignores a lone spike", () => {
+Deno.test("benchmark: the trend ignores a lone spike", () => {
   const flat = [100, 100, 100, 100, 100, 100, 100, 100];
   const spiked = [...flat];
-  spiked[3] = 400; // a 4x outlier — least squares would flag it, the median slope doesn't
+  spiked[3] = 400; // a 4x outlier — a median level does not move to meet it
   const times = flat.map((_, i) => i * 86_400_000);
   assertEquals(trendStatus(trendPct(times, spiked)), "good");
 });

--- a/packages/dashboard/tiles/benchmark.test.ts
+++ b/packages/dashboard/tiles/benchmark.test.ts
@@ -2816,9 +2816,10 @@ Deno.test("benchmark: trend classification — flat or falling good, a rise warn
   assertEquals(st([100, 120, 140, 160, 180, 200, 240]), "bad");
 });
 
-Deno.test("benchmark: a whole day's samples collapse to that day's median before the trend is taken", () => {
+Deno.test("benchmark: a lone spike is not a level, so the trend stays flat", () => {
   // Seven days, three samples each, all at 100 apart from one spike of 10000 in
-  // the middle of day 3. The day's median is still 100, so the trend stays flat.
+  // the middle of day 3. One sample cannot carry a level of its own, so the
+  // series reads as the single level it is.
   const times: number[] = [], values: number[] = [];
   for (let d = 0; d < 7; d++) {
     for (let s = 0; s < 3; s++) {
@@ -2829,6 +2830,81 @@ Deno.test("benchmark: a whole day's samples collapse to that day's median before
   assertEquals(trendPct(times, values), 0);
   // Values at or below zero are not timings and are left out entirely.
   assertEquals(trendPct([...times, 7 * DAY], [...values, 0]), 0);
+});
+
+// Twenty-one samples spread over seven days, stepping from `before` to `after`
+// at `at`, each nudged by a fixed amount that repeats without a pattern the fit
+// can follow. The nudge keeps the samples from agreeing exactly, so the trend
+// runs its change-point search rather than reading the two ends directly.
+function steppedSeries(
+  at: number,
+  before: number,
+  after: number,
+): { times: number[]; values: number[] } {
+  const times: number[] = [], values: number[] = [];
+  for (let i = 0; i < 21; i++) {
+    times.push(Math.floor(i / 3) * DAY + (i % 3) * HOUR);
+    values.push((i < at ? before : after) * (1 + ((i * 7919) % 13 - 6) / 1000));
+  }
+  return { times, values };
+}
+
+Deno.test("benchmark: the same rise reads the same wherever it falls in the window", () => {
+  // The old fit ran a line through the samples and reported its rise across the
+  // window, so a step read large in the middle and almost vanished at either
+  // end. The size of the step is what it is wherever it landed.
+  for (const at of [3, 6, 10, 15, 18]) {
+    const { times, values } = steppedSeries(at, 100, 105);
+    const pct = trendPct(times, values);
+    assert(
+      Math.abs(pct - 0.05) < 0.01,
+      `a 5% step at sample ${at} read as ${(pct * 100).toFixed(1)}%`,
+    );
+    assertEquals(trendStatus(pct), "warn");
+  }
+});
+
+Deno.test("benchmark: a rise in the newest samples is reported at its full size", () => {
+  // The freshest regression is the one worth catching soonest, and it has the
+  // fewest samples behind it.
+  const { times, values } = steppedSeries(18, 100, 130);
+  const pct = trendPct(times, values);
+  assert(
+    Math.abs(pct - 0.30) < 0.02,
+    `a 30% step in the last three samples read as ${(pct * 100).toFixed(1)}%`,
+  );
+  assertEquals(trendStatus(pct), "bad");
+});
+
+Deno.test("benchmark: a fall reads as a fall of its own size", () => {
+  const { times, values } = steppedSeries(10, 125, 100);
+  const pct = trendPct(times, values);
+  assert(
+    Math.abs(pct + 0.20) < 0.01,
+    `a 20% drop read as ${(pct * 100).toFixed(1)}%`,
+  );
+  assertEquals(trendStatus(pct), "good");
+});
+
+Deno.test("benchmark: a series that only wobbles reads flat", () => {
+  const { times, values } = steppedSeries(21, 100, 100);
+  assertEquals(trendPct(times, values), 0);
+  assertEquals(trendStatus(trendPct(times, values)), "good");
+});
+
+Deno.test("benchmark: a steady climb reads as the whole of its rise", () => {
+  // No step to find, so the straight line describes the series and answers with
+  // its rise from the first sample to the last.
+  const times: number[] = [], values: number[] = [];
+  for (let i = 0; i < 21; i++) {
+    times.push(Math.floor(i / 3) * DAY + (i % 3) * HOUR);
+    values.push(100 * Math.pow(1.30, i / 20));
+  }
+  const pct = trendPct(times, values);
+  assert(
+    Math.abs(pct - 0.30) < 0.02,
+    `a 30% climb read as ${(pct * 100).toFixed(1)}%`,
+  );
 });
 
 Deno.test("benchmark: fewer than a week of days claims no trend", () => {

--- a/packages/dashboard/tiles/benchmark.test.ts
+++ b/packages/dashboard/tiles/benchmark.test.ts
@@ -2892,6 +2892,24 @@ Deno.test("benchmark: a series that only wobbles reads flat", () => {
   assertEquals(trendStatus(trendPct(times, values)), "good");
 });
 
+Deno.test("benchmark: more samples than the fit reads are grouped, and the rise survives", () => {
+  // A 45-day window holds several hundred runs, more than the fit reads
+  // directly, so they are grouped into equal-sized runs first. A step three
+  // quarters of the way along still reports at its own size afterwards, and the
+  // grouping does not smear it across the boundary it falls on.
+  const times: number[] = [], values: number[] = [];
+  for (let i = 0; i < 260; i++) {
+    times.push(Math.floor(i / 6) * DAY + (i % 6) * 4 * HOUR);
+    values.push((i < 195 ? 100 : 118) * (1 + ((i * 7919) % 13 - 6) / 1000));
+  }
+  const pct = trendPct(times, values);
+  assert(
+    Math.abs(pct - 0.18) < 0.01,
+    `an 18% step among 260 samples read as ${(pct * 100).toFixed(1)}%`,
+  );
+  assertEquals(trendStatus(pct), "warn");
+});
+
 Deno.test("benchmark: a steady climb reads as the whole of its rise", () => {
   // No step to find, so the straight line describes the series and answers with
   // its rise from the first sample to the last.

--- a/packages/dashboard/trend.ts
+++ b/packages/dashboard/trend.ts
@@ -4,6 +4,17 @@ const DAY_MS = 86_400_000;
 const MIN_TREND_DAYS = 7;
 const UP_PCT = 0.05;
 const RAPID_PCT = 0.20;
+// Samples the level fit reads, after grouping. Bounds the change-point search,
+// which is quadratic in the sample count.
+const LEVEL_SAMPLE_CAP = 64;
+// Samples either side of a change point, so each level rests on three or more.
+const MIN_SEGMENT = 3;
+// How far apart two neighbouring levels must sit, in standard errors of their
+// difference, for the boundary between them to count as a change point.
+const CHANGE_POINT_SIGMAS = 4;
+// How much smaller the straight line's total deviation must be for it to
+// describe the series instead of the levels.
+const LINE_PREFERENCE_MARGIN = 0.1;
 
 const median = (values: number[]): number => {
   const sorted = [...values].sort((a, b) => a - b);
@@ -21,34 +32,147 @@ export function distinctTrendDays(times: number[], values: number[]): number {
   return days.size;
 }
 
-// Overall trend as the fractional change of a robust fit across the displayed
-// range (+0.2 means the fit ends 20% higher than it starts).
-//
-// Sub-daily samples become one median value per calendar day. The fit is the
-// median of every pairwise log slope between those daily values, projected over
-// the complete day span. `times` must be ascending.
-export function trendPct(times: number[], values: number[]): number {
-  const byDay = new Map<number, number[]>();
-  for (let i = 0; i < values.length; i++) {
-    if (values[i] <= 0) continue;
-    const day = Math.floor(times[i] / DAY_MS);
-    const samples = byDay.get(day);
-    if (samples) samples.push(values[i]);
-    else byDay.set(day, [values[i]]);
+// Groups the samples into at most `LEVEL_SAMPLE_CAP` equal-sized runs and takes
+// each run's median. Grouping by count rather than by clock keeps every group
+// carrying the same weight however unevenly the samples arrive.
+function groupedSamples(values: number[]): number[] {
+  if (values.length <= LEVEL_SAMPLE_CAP) return values;
+  const grouped: number[] = [];
+  for (let group = 0; group < LEVEL_SAMPLE_CAP; group++) {
+    const from = Math.round(group * values.length / LEVEL_SAMPLE_CAP);
+    const to = Math.round((group + 1) * values.length / LEVEL_SAMPLE_CAP);
+    if (to > from) grouped.push(median(values.slice(from, to)));
   }
-  const days = [...byDay.keys()].sort((a, b) => a - b);
-  if (days.length < MIN_TREND_DAYS) return 0;
-  const daily = days.map((day) => median(byDay.get(day)!));
-  const slopes: number[] = [];
-  for (let i = 0; i < days.length; i++) {
-    for (let j = i + 1; j < days.length; j++) {
-      slopes.push(
-        (Math.log(daily[j]) - Math.log(daily[i])) / (days[j] - days[i]),
-      );
+  return grouped;
+}
+
+// The typical size of a sample-to-sample move, read from the differences
+// between neighbours. A level change contributes one difference however large
+// it is, so the median of them describes the noise around the levels.
+function noiseScale(logs: number[]): number {
+  if (logs.length < 2) return 0;
+  const steps: number[] = [];
+  for (let i = 1; i < logs.length; i++) {
+    steps.push(Math.abs(logs[i] - logs[i - 1]));
+  }
+  return 1.4826 * median(steps) / Math.SQRT2;
+}
+
+function insertSorted(sorted: number[], value: number): void {
+  let low = 0, high = sorted.length;
+  while (low < high) {
+    const mid = (low + high) >> 1;
+    if (sorted[mid] < value) low = mid + 1;
+    else high = mid;
+  }
+  sorted.splice(low, 0, value);
+}
+
+function medianOfSorted(sorted: number[]): number {
+  const middle = sorted.length >> 1;
+  return sorted.length % 2
+    ? sorted[middle]
+    : (sorted[middle - 1] + sorted[middle]) / 2;
+}
+
+// Splits `[from, to)` at the boundary whose two sides sit furthest apart, then
+// splits each side the same way, collecting the boundaries into `into`. A
+// boundary counts only when the gap between the two medians clears
+// `CHANGE_POINT_SIGMAS` standard errors, so noise alone does not produce one.
+function collectChangePoints(
+  logs: number[],
+  scale: number,
+  from: number,
+  to: number,
+  into: number[],
+): void {
+  const length = to - from;
+  if (length < 2 * MIN_SEGMENT) return;
+  const leftMedians: number[] = new Array(length + 1).fill(0);
+  const left: number[] = [];
+  for (let taken = 0; taken < length; taken++) {
+    insertSorted(left, logs[from + taken]);
+    leftMedians[taken + 1] = medianOfSorted(left);
+  }
+  const rightMedians: number[] = new Array(length + 1).fill(0);
+  const right: number[] = [];
+  for (let taken = length - 1; taken >= 0; taken--) {
+    insertSorted(right, logs[from + taken]);
+    rightMedians[taken] = medianOfSorted(right);
+  }
+  let bestSplit = -1;
+  let bestGap = 0;
+  for (let split = MIN_SEGMENT; split <= length - MIN_SEGMENT; split++) {
+    const gap = Math.abs(rightMedians[split] - leftMedians[split]);
+    const floor = CHANGE_POINT_SIGMAS * scale *
+      Math.sqrt(1 / split + 1 / (length - split));
+    if (gap > floor && gap > bestGap) {
+      bestGap = gap;
+      bestSplit = from + split;
     }
   }
+  if (bestSplit < 0) return;
+  into.push(bestSplit);
+  collectChangePoints(logs, scale, from, bestSplit, into);
+  collectChangePoints(logs, scale, bestSplit, to, into);
+}
+
+// The median of every pairwise slope between samples, by position in the
+// series.
+function medianSlope(logs: number[]): number {
+  const slopes: number[] = [];
+  for (let i = 0; i < logs.length; i++) {
+    for (let j = i + 1; j < logs.length; j++) {
+      slopes.push((logs[j] - logs[i]) / (j - i));
+    }
+  }
+  return slopes.length ? median(slopes) : 0;
+}
+
+// Overall change as the fractional difference between the start and the end of
+// a robust fit (+0.2 means the fit ends 20% higher than it starts).
+//
+// Two fits describe the series and the closer one answers. The first is a set
+// of flat levels meeting at change points, which is the shape a series takes
+// when something lands and shifts it. The second is a straight line through the
+// median pairwise slope, which is the shape a series takes when it drifts. Each
+// reports the difference between its own value at the last sample and at the
+// first, so a shift reads at its true size wherever in the window it sits.
+//
+// Sub-zero values are not timings and take no part. Fewer than
+// `MIN_TREND_DAYS` distinct days reads flat. `times` must be ascending.
+export function trendPct(times: number[], values: number[]): number {
+  if (distinctTrendDays(times, values) < MIN_TREND_DAYS) return 0;
+  const logs = groupedSamples(values.filter((value) => value > 0))
+    .map((value) => Math.log(value));
+  if (logs.length < 2) return 0;
+  // A scale of zero means most neighbours agree exactly. The search then treats
+  // any daylight between two levels as real, and still asks for `MIN_SEGMENT`
+  // samples either side of the boundary, so a single stray sample is not one.
+  const scale = noiseScale(logs);
+  const changePoints: number[] = [];
+  collectChangePoints(logs, scale, 0, logs.length, changePoints);
+  // The search reports each boundary as it splits, which is widest-gap first.
+  changePoints.sort((a, b) => a - b);
+  const edges = [0, ...changePoints, logs.length];
+  const levels = edges.slice(0, -1).map((start, index) =>
+    median(logs.slice(start, edges[index + 1]))
+  );
+  let levelDeviation = 0;
+  for (let edge = 0; edge < levels.length; edge++) {
+    for (let i = edges[edge]; i < edges[edge + 1]; i++) {
+      levelDeviation += Math.abs(logs[i] - levels[edge]);
+    }
+  }
+  const slope = medianSlope(logs);
+  const intercept = median(logs.map((log, index) => log - slope * index));
+  let lineDeviation = 0;
+  for (let i = 0; i < logs.length; i++) {
+    lineDeviation += Math.abs(logs[i] - (intercept + slope * i));
+  }
+  const byLine = lineDeviation < levelDeviation * (1 - LINE_PREFERENCE_MARGIN);
   return Math.expm1(
-    median(slopes) * (days[days.length - 1] - days[0]),
+    byLine ? slope * (logs.length - 1) : levels[levels.length - 1] - levels[0],
   );
 }
 

--- a/packages/dashboard/trend.ts
+++ b/packages/dashboard/trend.ts
@@ -50,7 +50,6 @@ function groupedSamples(values: number[]): number[] {
 // between neighbours. A level change contributes one difference however large
 // it is, so the median of them describes the noise around the levels.
 function noiseScale(logs: number[]): number {
-  if (logs.length < 2) return 0;
   const steps: number[] = [];
   for (let i = 1; i < logs.length; i++) {
     steps.push(Math.abs(logs[i] - logs[i - 1]));
@@ -140,12 +139,14 @@ function medianSlope(logs: number[]): number {
 // first, so a shift reads at its true size wherever in the window it sits.
 //
 // Sub-zero values are not timings and take no part. Fewer than
-// `MIN_TREND_DAYS` distinct days reads flat. `times` must be ascending.
+// `MIN_TREND_DAYS` distinct days reads flat, which also means the fits below
+// always have that many samples to read: a distinct day needs a sample above
+// zero to count, and grouping only ever thins a longer series. `times` must be
+// ascending.
 export function trendPct(times: number[], values: number[]): number {
   if (distinctTrendDays(times, values) < MIN_TREND_DAYS) return 0;
   const logs = groupedSamples(values.filter((value) => value > 0))
     .map((value) => Math.log(value));
-  if (logs.length < 2) return 0;
   // A scale of zero means most neighbours agree exactly. The search then treats
   // any daylight between two levels as real, and still asks for `MIN_SEGMENT`
   // samples either side of the boundary, so a single stray sample is not one.


### PR DESCRIPTION
The trend behind the benchmarks tile, the per-benchmark drill-down at `/bench`, and the CI job-duration history all came from one fit: collapse the samples to a median per calendar day, take the median of the pairwise log-slopes between those days, and multiply that slope by the number of days in the window. That models the series as a straight line. The series is not a straight line. Performance on main is flat until something lands and shifts it, then flat again at the new level, so what the fit is asked to describe is a step.

Running a line through a step and reporting its rise across the whole window makes the answer depend on where in the window the step happens to sit rather than on how big the step is. Measured against steps of a known size, the old fit reported a 5% step as 0.7% when it landed in the first tenth of the window, as 6.6% in the middle, and as 0.5% in the last twentieth. It was accurate only for a step about three quarters of the way along. Both ends of that range are bad in their own way: a step in the newest samples is the one worth catching soonest and it read at a tenth of its size, and a step in the middle read a third too large.

The drill-down showed this at full strength. On real recorded history, a benchmark that had genuinely slowed by a factor of 8.6 in the newest samples was reported as having risen 3.1%, and a benchmark that had genuinely improved by 22% was reported as flat.

Two fits now describe the series and the closer of the two answers. The first is a run of flat levels meeting at change points, found by splitting at the boundary whose two sides sit furthest apart and then splitting each side the same way. Levels are medians, so a lone spike moves none of them, and a boundary counts only when the two levels either side sit more than four standard errors of their difference apart with at least three samples supporting each, so noise produces no levels and a single stray sample is not one. The second fit is the straight line that was there before, which still describes a series that genuinely drifts, and it answers when its total deviation is at least a tenth smaller. Each fit reports the difference between its own value at the last sample and at the first, measured on the samples rather than extended past them.

Against the same known steps the new fit reports between 5.0% and 5.6% wherever in the window the step sits, and on 200 series that carry noise and no change at all it reports exactly flat in the median case. Against recorded history it puts the index shift on one runner at 4.8% where a direct measurement of the same window gives 4.2%, against the old fit's 3.5%; it puts the 8.6-fold benchmark at 761% and the 22% improvement at -20%.

Samples are grouped into at most 64 equal-sized runs, each replaced by its median, before either fit reads them. That bounds the change-point search, which is quadratic in the sample count, and it gives every group the same weight however unevenly the runs arrive — which grouping by calendar day did not, since a day with one run counted for as much as a day with six.

The reporting threshold, the seven-distinct-days floor below which a series is marked new, and the labels are all unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make benchmark trends step-aware so we report the true size of a change, wherever it falls in the window. Improves the dashboard tile, `/bench` drill‑down, and CI job-duration history, especially for fresh regressions and lone spikes.

- **New Features**
  - Two robust fits: flat levels with change points, and a straight line; use the closer fit (line only if ≥10% less deviation).
  - Report the start→end change on the chosen fit, not a projected slope.
  - Robustness: levels are medians; change points need 4σ separation with ≥3 samples per side, so spikes don’t create fake levels.
  - Preprocess by grouping into ≤64 equal-sized runs and taking medians; ignore non‑positive values; still requires ≥7 distinct days; thresholds and labels unchanged.
  - Updated README and tests for steps anywhere in the window, fresh regressions, improvements, lone spikes, drifts, flat series, plus the high‑sample grouping path (e.g., 260 samples).

- **Refactors**
  - Removed unreachable short‑series guards and clarified the invariant in code comments.

<sup>Written for commit de37ff5e1685a0163ae52894430165a55297380e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

