### PR TITLE
fix(runner): read a value's encodable form through `Reflect.apply`

### DIFF
--- a/packages/runner/src/encodable-form.ts
+++ b/packages/runner/src/encodable-form.ts
@@ -56,17 +56,18 @@ export function hasEncodableForm(value: unknown): boolean {
  * Produces the encodable form of a value that has one, or `undefined` for a
  * value that does not. Ask `hasEncodableForm()` to tell those apart from a
  * value whose encodable form is itself `undefined`.
- *
- * Invoked through `Reflect.apply`, not through the method's own `.call`. A
- * `Reactive` is a proxy over a cell that answers a method name with a proxy
- * over that method, and reading `.call` off THAT goes back through the proxy
- * and comes out as data navigation rather than as `Function.prototype.call`.
- * `Reflect.apply` reaches the function's own call behavior instead of reading
- * a property off it, so it holds for a proxied method as well as a plain one.
  */
 export function encodableFormOf(value: unknown): unknown {
   const method = encodableFormMethod(value);
-  return method === undefined ? undefined : Reflect.apply(method, value, []);
+  if (method === undefined) return undefined;
+
+  // `Reflect.apply`, and not the method's own `.call`. A proxy answers each
+  // property read however it likes, so a proxied function can report `typeof
+  // "function"` while what its `.call` yields is not callable at all.
+  // `Reflect.apply` reaches a function's call behavior directly rather than
+  // reading a property off it, which holds whether the method in hand arrived
+  // plain or through a proxy.
+  return Reflect.apply(method, value, []);
 }
 
 /**

--- a/packages/runner/src/encodable-form.ts
+++ b/packages/runner/src/encodable-form.ts
@@ -56,9 +56,17 @@ export function hasEncodableForm(value: unknown): boolean {
  * Produces the encodable form of a value that has one, or `undefined` for a
  * value that does not. Ask `hasEncodableForm()` to tell those apart from a
  * value whose encodable form is itself `undefined`.
+ *
+ * Invoked through `Reflect.apply`, not through the method's own `.call`. A
+ * `Reactive` is a proxy over a cell that answers a method name with a proxy
+ * over that method, and reading `.call` off THAT goes back through the proxy
+ * and comes out as data navigation rather than as `Function.prototype.call`.
+ * `Reflect.apply` reaches the function's own call behavior instead of reading
+ * a property off it, so it holds for a proxied method as well as a plain one.
  */
 export function encodableFormOf(value: unknown): unknown {
-  return encodableFormMethod(value)?.call(value);
+  const method = encodableFormMethod(value);
+  return method === undefined ? undefined : Reflect.apply(method, value, []);
 }
 
 /**

--- a/packages/runner/test/encodable-form.test.ts
+++ b/packages/runner/test/encodable-form.test.ts
@@ -1,14 +1,22 @@
-import { describe, it } from "@std/testing/bdd";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
 import { fabricFromNativeValue } from "@commonfabric/data-model/fabric-value";
 import { dataUriFromValue } from "@commonfabric/data-model/data-uri-codec";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 
 import {
   encodableFormOf,
   hasEncodableForm,
   replaceArtifacts,
 } from "../src/encodable-form.ts";
+import { createRef } from "../src/create-ref.ts";
+import { Runtime } from "../src/runtime.ts";
+import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
+
+const signer = await Identity.fromPassphrase("test operator");
+const space = signer.did();
 
 /**
  * The walk under test, with the copy callback ignored -- what a caller that
@@ -374,8 +382,83 @@ describe("encodable-form", () => {
       expect(encodableFormOf(value)).toEqual({ saw: "self" });
     });
 
+    it("invokes a member that only `Reflect.apply` can call", () => {
+      // A `Reactive` is a proxy over a cell, and it answers a method name with
+      // a PROXY over that method. Reading `.call` off that goes back through
+      // the proxy as data navigation and comes out uncallable, so the invoke
+      // has to reach the function's own call behavior rather than a property
+      // of it.
+      const method = new Proxy(function () {
+        return { invoked: true };
+      }, {
+        get: (_target, prop) =>
+          prop === "call" ? { notAFunction: true } : undefined,
+      });
+      expect(encodableFormOf({ toEncodableForm: method }))
+        .toEqual({ invoked: true });
+    });
+
     it("returns `undefined` for a value carrying neither name", () => {
       expect(encodableFormOf({ a: 1 })).toBe(undefined);
+    });
+  });
+
+  describe("a cell and the reactive that stands for it", () => {
+    let runtime: Runtime;
+    let storageManager: ReturnType<typeof StorageManager.emulate>;
+    let tx: IExtendedStorageTransaction;
+
+    beforeEach(() => {
+      storageManager = StorageManager.emulate({ as: signer });
+      runtime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager,
+      });
+      tx = runtime.edit();
+    });
+
+    afterEach(async () => {
+      await tx.commit();
+      await runtime?.dispose();
+      await storageManager?.close();
+    });
+
+    /** A cell, and the `Reactive` proxy a pattern holds it through. */
+    function subjects() {
+      const cell = runtime.getCell<{ value: number }>(
+        space,
+        "encodable-form-cell",
+        undefined,
+        tx,
+      );
+      cell.set({ value: 42 });
+      return { cell, reactive: cell.getAsReactiveProxy() };
+    }
+
+    it("both return the link the cell names", () => {
+      const { cell, reactive } = subjects();
+      expect(hasEncodableForm(cell)).toBe(true);
+      expect(hasEncodableForm(reactive)).toBe(true);
+      expect(encodableFormOf(cell)).toEqual(cell.toSigilLinkOrNull());
+      expect(encodableFormOf(reactive)).toEqual(cell.toSigilLinkOrNull());
+    });
+
+    it("derive one id, whichever of the two a graph holds", () => {
+      // A `Reactive` answers its methods through a proxy, so the invoke has to
+      // hold for a proxied method too. When it does not, deriving an id over a
+      // graph carrying one fails outright rather than answering differently.
+      const { cell, reactive } = subjects();
+      expect(createRef({ held: reactive }, "cause").toString())
+        .toBe(createRef({ held: cell }, "cause").toString());
+    });
+
+    it("are left alone by the walk, being no builder's artifacts", () => {
+      // Neither is a plain object, so the walk does not descend into one. What
+      // stands in for a cell is `replaceArtifacts`'s `replaceOther` hook, whose
+      // caller knows an `isCell()` when it holds one.
+      const { cell, reactive } = subjects();
+      const held = { cell, reactive };
+      expect(flatten(held)).toBe(held);
     });
   });
 });

--- a/packages/runner/test/encodable-form.test.ts
+++ b/packages/runner/test/encodable-form.test.ts
@@ -443,13 +443,30 @@ describe("encodable-form", () => {
       expect(encodableFormOf(reactive)).toEqual(cell.toSigilLinkOrNull());
     });
 
-    it("derive one id, whichever of the two a graph holds", () => {
-      // An id is derived from a value's encodable form, and a `Reactive`
-      // answers its methods through a proxy -- so the two stand for one cell
-      // here exactly as they do at every other reader of that form.
+    it("derive the id their own link derives as plain data", () => {
+      // An id is derived from a value's encodable form, so the reference is the
+      // link itself written out as data -- a value that reaches `createRef`
+      // through none of the cell or proxy machinery. Comparing the two subjects
+      // only to each other would hold just as well if BOTH moved; comparing
+      // each to the link pins where they land, without naming a hash that a
+      // later change to link shape would have to come back and edit.
       const { cell, reactive } = subjects();
-      expect(createRef({ held: reactive }, "cause").toString())
-        .toBe(createRef({ held: cell }, "cause").toString());
+      const idOf = (held: unknown) => createRef({ held }, "cause").toString();
+      const link = idOf(cell.toSigilLinkOrNull());
+
+      expect(idOf(cell)).toBe(link);
+      expect(idOf(reactive)).toBe(link);
+
+      // And the comparison discriminates: a different cell's link is a
+      // different id, so the three above do not agree merely by being ids.
+      const other = runtime.getCell<{ value: number }>(
+        space,
+        "encodable-form-other-cell",
+        undefined,
+        tx,
+      );
+      other.set({ value: 42 });
+      expect(idOf(other.toSigilLinkOrNull())).not.toBe(link);
     });
 
     it("are left alone by the walk, being no builder's artifacts", () => {

--- a/packages/runner/test/encodable-form.test.ts
+++ b/packages/runner/test/encodable-form.test.ts
@@ -382,7 +382,7 @@ describe("encodable-form", () => {
       expect(encodableFormOf(value)).toEqual({ saw: "self" });
     });
 
-    it("invokes a member that only `Reflect.apply` can call", () => {
+    it("returns the result of a member only `Reflect.apply` can call", () => {
       // A `Reactive` is a proxy over a cell, and it answers a method name with
       // a PROXY over that method. Reading `.call` off that goes back through
       // the proxy as data navigation and comes out uncallable, so the invoke
@@ -391,8 +391,8 @@ describe("encodable-form", () => {
       const method = new Proxy(function () {
         return { invoked: true };
       }, {
-        get: (_target, prop) =>
-          prop === "call" ? { notAFunction: true } : undefined,
+        get: (target, prop) =>
+          prop === "call" ? { notAFunction: true } : Reflect.get(target, prop),
       });
       expect(encodableFormOf({ toEncodableForm: method }))
         .toEqual({ invoked: true });
@@ -444,9 +444,9 @@ describe("encodable-form", () => {
     });
 
     it("derive one id, whichever of the two a graph holds", () => {
-      // A `Reactive` answers its methods through a proxy, so the invoke has to
-      // hold for a proxied method too. When it does not, deriving an id over a
-      // graph carrying one fails outright rather than answering differently.
+      // An id is derived from a value's encodable form, and a `Reactive`
+      // answers its methods through a proxy -- so the two stand for one cell
+      // here exactly as they do at every other reader of that form.
       const { cell, reactive } = subjects();
       expect(createRef({ held: reactive }, "cause").toString())
         .toBe(createRef({ held: cell }, "cause").toString());


### PR DESCRIPTION
`encodableFormOf()` was `encodableFormMethod(value)?.call(value)`, and a
`Reactive` — a proxy over a cell — answers a method name with a **proxy over
that method**. Reading `.call` off that goes back through the proxy as data
navigation and comes out as an object, so the invoke throws
`?.call is not a function`. `typeof` still reports `"function"`, which is why
`hasEncodableForm()` says yes about the very value `encodableFormOf()` cannot
serve.

The reachable consequence is `createRef()`. `create-ref.ts` asks both questions
in sequence, so deriving an entity id over any graph holding a `Reactive` throws
outright. Measured over the same graph with a fixed cause:

| tree | `createRef({ held: reactive }, "cause")` |
| --- | --- |
| before the two-name lookup existed, when the read was a direct `obj.toJSON()` call | `fid1:MrktnKz2swoT0_6p-A4a7TqNzbmcQpXPacuGyTEhQms` |
| `main` | throws `?.call is not a function` |
| this branch | `fid1:MrktnKz2swoT0_6p-A4a7TqNzbmcQpXPacuGyTEhQms` |

That is also the id derived from the cell itself, so no id moves.

`Reflect.apply` reaches the function's own call behavior rather than reading a
property off it, which is what holds for a proxied method as well as a plain one.

## Coverage

Nothing covered this. A proxied method never reached the lookup anywhere in the
workspace suite — established by instrumenting the lookup and running it, and
corroborated by the fact that the runner suite would be red if one had.

Three cases now reach it: the proxied-method invoke on its own, and a real cell
alongside the `Reactive` standing for it, deriving one id between them. All three
verified red against a `.call` invoke.

## Verification

Runner 1147/0. `fmt`, `lint`, `check`, `check-docs`, `check-no-waitfor`,
`check-conflict-markers`, `check-skill-facts` all green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `encodableFormOf()` to invoke encodable-form methods with `Reflect.apply`, so proxied methods from `Reactive` work. This removes the "?.call is not a function" error and restores `createRef()` over graphs containing `Reactive`, with no ID changes.

- **Bug Fixes**
  - Invoke via `Reflect.apply(method, value, [])` to avoid proxy `.call` traps.
  - Tests: realistic proxied method; cell and its `Reactive` return the same encodable form; ID derivation is pinned to the cell link as plain data (with a second cell to prove discrimination).

<sup>Written for commit aeb2532ce5833d1073a461c1a77bca83a5cc3cc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

