### PR TITLE
docs: write down which spelling of English this repository uses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,8 +126,9 @@ change a subsystem you have not worked on before.
 Three obligations that are easy to miss:
 
 - `docs/README.md` governs everything this repository writes down. It says how
-  to write a comment in code, how to write documentation, and where a new
-  document belongs. Read it before you write either.
+  to write a comment in code, how to write documentation, which spelling of
+  English both use, and where a new document belongs. Read it before you write
+  either.
 - `docs/development/EXPERIMENTAL_OPTIONS.md` is the central registry of every
   experimental flag. Read it before adding, changing, or removing a flag, and
   update it in the same change.

--- a/docs/README.md
+++ b/docs/README.md
@@ -92,6 +92,37 @@ created as live documents and archived later. A plan you intend to execute
 starts in `docs/plans/` (a pending plan is live) and is archived when it is
 done.
 
+## Spelling
+
+Prose written here — comments, documents, error and log messages, test
+descriptions — uses American spellings: `behavior`, `color`, `center`,
+`serialize`, `analyze`, `gray`.
+
+This is standardization and nothing more. It makes no claim about which
+variety of English is better, and it asks nothing of how anyone writes
+anywhere else. It exists because a tree that spells a word two ways is a tree
+where searching for one spelling finds only part of what is there, and where a
+reader's attention catches on the seam instead of the content. One spelling
+per word is the whole of the benefit.
+
+The variety is the one already in overwhelming use in these files rather than
+a preference imposed on them: `behavior` outnumbers `behaviour` by more than
+twenty to one, and `center` outnumbers `centre` by more than two hundred. The
+convention mostly describes the repository, and writing it down is a way to
+keep it that way.
+
+Two things it does not reach:
+
+- **Quoted external material.** A dependency's name, a message relayed from
+  another system, a specification's wording, and the contents of a data file
+  keep whatever spelling they arrived with. Repeating a name accurately
+  outranks spelling it consistently.
+- **Identifiers already established in the codebase.** `cancelled` is spelled
+  that way across several hundred sites, exported names among them. Changing
+  it is a rename with real blast radius, not a spelling fix. Match the
+  surrounding code when extending a vocabulary like that, and treat any change
+  to it as the code change it is.
+
 ## Map of this tree
 
 - [`why.md`](why.md) — the short statement of what Common Fabric is for and

--- a/docs/README.md
+++ b/docs/README.md
@@ -98,30 +98,16 @@ Prose written here — comments, documents, error and log messages, test
 descriptions — uses American spellings: `behavior`, `color`, `center`,
 `serialize`, `analyze`, `gray`.
 
-This is standardization and nothing more. It makes no claim about which
-variety of English is better, and it asks nothing of how anyone writes
-anywhere else. It exists because a tree that spells a word two ways is a tree
-where searching for one spelling finds only part of what is there, and where a
-reader's attention catches on the seam instead of the content. One spelling
-per word is the whole of the benefit.
+This is standardization rather than a claim about which English is better: one
+spelling per word means a search for a word finds all of it, and this is the
+variety already in overwhelming use in these files.
 
-The variety is the one already in overwhelming use in these files rather than
-a preference imposed on them: `behavior` outnumbers `behaviour` by more than
-twenty to one, and `center` outnumbers `centre` by more than two hundred. The
-convention mostly describes the repository, and writing it down is a way to
-keep it that way.
-
-Two things it does not reach:
-
-- **Quoted external material.** A dependency's name, a message relayed from
-  another system, a specification's wording, and the contents of a data file
-  keep whatever spelling they arrived with. Repeating a name accurately
-  outranks spelling it consistently.
-- **Identifiers already established in the codebase.** `cancelled` is spelled
-  that way across several hundred sites, exported names among them. Changing
-  it is a rename with real blast radius, not a spelling fix. Match the
-  surrounding code when extending a vocabulary like that, and treat any change
-  to it as the code change it is.
+Two carve-outs. Material quoted from outside — a dependency's name, a message
+relayed from another system, a specification's wording, a data file's contents
+— keeps whatever spelling it arrived with. And an identifier vocabulary
+already established in the codebase, `cancelled` among them, is a rename
+rather than a spelling fix: match the surrounding code, and treat a change to
+it as the code change it is.
 
 ## Map of this tree
 


### PR DESCRIPTION
Nothing in `docs/`, `AGENTS.md`, `.claude/rules/`, or `skills/` said which
variety of English this repository writes in, and the tree has been drifting.
This adds a short `## Spelling` section to `docs/README.md`, which is the
document that already governs both comments in code and documents.

## Why this is descriptive rather than imposed

Counting across `packages/` and `docs/`, excluding `docs/history/`:

| | British | American |
| --- | ---: | ---: |
| `behaviour` / `behavior` | 37 | 901 |
| `colour` / `color` | 106 | 4999 |
| `centre` / `center` | 7 | 1461 |
| `analyse` / `analyze` | 2 | 357 |
| `serialise` / `serialize` | 1 | 176 |
| `grey` / `gray` | 21 | 435 |
| `defence` / `defense` | 7 | 60 |
| `recognise` / `recognize` | 5 | 74 |

The convention already holds by a wide margin everywhere it is uncontested.
Writing it down keeps it that way rather than establishing something new.

## How it is framed

The section states outright that this is standardization, that it makes no
claim about which variety of English is better, and that it asks nothing of
how anyone writes anywhere else. The argument given is the practical one: a
tree that spells a word two ways is a tree where searching for one spelling
finds only part of what is there, and where a reader's attention catches on
the seam instead of the content.

## The two carve-outs

- **Quoted external material.** Dependency names, messages relayed from other
  systems, specification wording, and data-file contents keep the spelling
  they arrived with. Repeating a name accurately outranks spelling it
  consistently.
- **Identifiers already established here.** `cancelled` is the one place the
  British form is in the majority — 237 against 61 — and it is overwhelmingly
  identifiers rather than prose: `isCancelled`, `bootstrapQueryCancelled`,
  `isRunCancelled`, exported names among them. Changing that is a rename with
  real blast radius, not a spelling fix, so the section says to match the
  surrounding code and treat any change to it as the code change it is.

This is deliberately a note and not a sweep. No existing spelling is changed
by this pull request.

`AGENTS.md` gains one clause on the `docs/README.md` bullet it already
carries, so the pointer names spelling alongside comments and documents.

## Verification

`deno fmt --check`, `deno task check-docs` (all 523 blocks), and
`deno task check-skill-facts` pass. Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0154rxhW7tcMxQ8QLvHSxbCZ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented the repository spelling convention: use American English in prose across comments, docs, messages, and tests, with carve-outs for quoted external material and established identifiers like “cancelled”. Added a Spelling section to `docs/README.md` (rationale trimmed to one sentence) and updated `AGENTS.md` to point to it; docs-only, no existing text was changed.

<sup>Written for commit 2fa3964523f686c1fd9fe3e492b88ac8b6cbe417. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

