### PR TITLE
feat(dashboard): give each tile status a texture, and reload local pa…

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -65,7 +65,7 @@
     "initialize-db": "deno run --allow-env --allow-read --allow-write --allow-ffi --allow-net=github.com,release-assets.githubusercontent.com,jsr.io packages/memory/scripts/initialize-db.ts",
     "integration": "./tasks/integration.ts",
     "demo": "./tasks/demo.ts",
-    "dashboard": "deno run --allow-net --allow-run=deno,git --allow-read --allow-write --allow-env packages/dashboard/server.ts",
+    "dashboard": "deno run --allow-net --allow-run=deno --allow-read --allow-write --allow-env packages/dashboard/server.ts",
     "profile": "./scripts/restart-local-dev.sh --inspect-brk",
     "cf-profile": "ROOT=\"$(pwd)\" && cd \"$INIT_CWD\" && deno run -A \"$ROOT/packages/cli/support/profiling/cf-profile.ts\"",
     "cf-inspect-brk": "bash -lc 'ROOT=\"$(pwd)\" && cd \"$INIT_CWD\" && CF_CLI_NAME=cf deno run --inspect-brk --allow-net --allow-ffi --allow-read --allow-write --allow-env --allow-run \"$ROOT/packages/cli/mod.ts\" \"$@\"' --",

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -37,7 +37,7 @@ dashboard/
   favicon.ts    runtime status priority and access to generated PNG favicon copies
   favicon-png.generated.ts  generated runtime PNG favicon copies
   favicon-artwork.ts  build/test-only SVG source for those favicon copies
-  version.ts    Git commit used as the browser/server compatibility version
+  version.ts    the browser/server compatibility version a page reloads on
   render.ts     renderTile(view) + the page shell/CSS
   server.ts     generic runtime: scheduler, SSE, route mounting, page assembly
   registry.ts   THE ONE REGISTRATION POINT — the array of tiles
@@ -77,11 +77,17 @@ snapshot for that source and shows the combined list in gray with the error.
 Each event connection receives the current tile snapshot before it waits for
 new collections. The browser reconciles that snapshot by tile ID, leaving
 unchanged elements, focus, and scroll positions in place. Routine data updates
-never navigate the page. The server uses the current Git commit as its
-compatibility version. Local development reads the checked-out commit from Git.
-A deployed image receives the commit that its publishing workflow checked out.
-An unattended display reloads when it reconnects to a server running a
-different commit.
+never navigate the page. The page shell — the styles and the client script —
+arrives only with a full page load, so the server hands the browser a
+compatibility version and the page reloads itself as soon as the server reports
+a different one. A deployed image uses the commit its publishing workflow
+checked out, which is fixed for the life of the image, so every display on that
+image agrees. A server started from a checkout reports the moment it started
+instead, because the code under it changes between one start and the next: a
+watched restart therefore pulls every open page onto the code that restart is
+serving, and the version in the page source says which start served it.
+An unattended display reloads when it reconnects to a server reporting a
+different version.
 
 The tab favicon follows the most urgent visible tile. It is red when any tile is
 red, orange when there are no red tiles but at least one orange tile, and green
@@ -142,6 +148,14 @@ little in between worth manufacturing. Red has to stay rare and trustworthy: if
 tiles sit red or amber most of the time, people stop seeing them, and a board
 everyone has learned to ignore is worse than no board. A tile earns a color
 change; it never reaches for one to get attention.
+
+Each signal carries a texture behind the tile as well as a color, so a state is
+legible without depending on color alone. A gray tile is covered in a grid of
+tiny dots, an amber tile in wavy lines, and a red tile in zig-zags. Green tiles
+are left plain, which is the calm the rest of the wall is measured against.
+Every texture fades out down the tile: it is whole for the tile's top fifth,
+thins from there, and is gone four fifths of the way down, which leaves the
+sub line and the foot of a chart on plain color.
 
 Think about how a tile makes someone feel before you think about what it
 measures. Prefer an honest gray "unknown" over a false green — a tile that

--- a/packages/dashboard/deno.jsonc
+++ b/packages/dashboard/deno.jsonc
@@ -4,7 +4,7 @@
     "@resvg/resvg-js": "npm:@resvg/resvg-js@2.6.2"
   },
   "tasks": {
-    "watch": "deno run --watch --allow-net --allow-run=deno,git --allow-read --allow-write --allow-env server.ts",
+    "watch": "deno run --watch --allow-net --allow-run=deno --allow-read --allow-write --allow-env server.ts",
     "test": "deno run --allow-env --allow-read --allow-write --allow-run test/runner.ts",
     // Resvg's Linux loader checks the C library through Node's process report,
     // which reads CPU, network-interface, and hostname information.

--- a/packages/dashboard/render.test.ts
+++ b/packages/dashboard/render.test.ts
@@ -78,7 +78,7 @@ Deno.test("renderTile: an absent value/sub/hint/aside renders nothing rather tha
   const html = renderTile(view());
   assertEquals(
     html,
-    `<div class="tile good"><p class="lbl"><span class="dot green"></span> labs ci<span class="spacer"></span></p></div>`,
+    `<div class="tile good"><div class="texture"></div><p class="lbl"><span class="dot green"></span> labs ci<span class="spacer"></span></p></div>`,
   );
 });
 
@@ -223,7 +223,7 @@ Deno.test("shell: the freshness age and the refresh interval reach both the text
   assertStringIncludes(html, `link.dataset.focusKey === focusedKey`);
 });
 
-Deno.test("shell: live data and runtime settings keep the Git commit version", () => {
+Deno.test("shell: live data and runtime settings keep the compatibility version", () => {
   const first = shell(
     `<div class="tile good">first</div>`,
     "",
@@ -290,6 +290,24 @@ Deno.test("shell: the browser runs the viewer-time formatter", () => {
     localizeUpdate < compareMarkup,
     "live updates are localized before their markup is compared",
   );
+});
+
+Deno.test("shell: the texture fades out towards the bottom of its own tile", () => {
+  const html = shell(renderTile(view({ status: "bad" }), "labs-ci"), "", 0, 30_000, TEST_VERSION, "bad");
+  assertStringIncludes(html, `<div class="texture"></div>`);
+  // Measured against the tile: whole for its top fifth, gone four fifths down.
+  assertStringIncludes(
+    html,
+    ".texture{position:absolute;inset:0;z-index:-1;overflow:hidden;mask-image:linear-gradient(to bottom,#000 20%,transparent 80%)}",
+  );
+  // Measured against the turned frame the texture is drawn in.
+  assertStringIncludes(
+    html,
+    ".texture::before{content:\"\";position:absolute;inset:-100%;transform:rotate(30deg)}",
+  );
+  for (const status of ["unknown", "warn", "bad"]) {
+    assertStringIncludes(html, `.tile.${status} .texture::before{`);
+  }
 });
 
 Deno.test("shell: server-measured red age changes the favicon after one hour", () => {

--- a/packages/dashboard/render.ts
+++ b/packages/dashboard/render.ts
@@ -15,6 +15,44 @@ const PAINT_STATUS_FAVICON = paintStatusFavicon.toString();
 
 export const FAVICON_CRY_AFTER_MS = 60 * 60 * 1000;
 
+/**
+ * A tiling background image of one stroked path, for the texture that sits
+ * behind a tile's flat colour wash. The tile is 48 by 24 CSS pixels and the
+ * path is drawn in that coordinate space.
+ */
+function strokeTexture(path: string, stroke: string): string {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" ` +
+    `width="48" height="24" viewBox="0 0 48 24">` +
+    `<path d="${path}" fill="none" stroke="${stroke}" stroke-width="1"/></svg>`;
+  return `url("data:image/svg+xml,${encodeURIComponent(svg)}")`;
+}
+
+const WAVE_TEXTURE = strokeTexture(
+  "M0 12q6-8 12 0t12 0t12 0t12 0",
+  "rgba(224,168,82,.13)",
+);
+const ZIGZAG_TEXTURE = strokeTexture(
+  "M0 18l12-12 12 12 12-12 12 12",
+  "rgba(226,80,74,.13)",
+);
+// Two copies of the same dot grid make a triangular lattice, where each dot has
+// six neighbours at one distance rather than a square lattice's four near ones
+// and four far ones. The copies are one dot spacing apart across, one spacing
+// times the square root of three apart down, and the second copy is shifted by
+// half of each. That puts its dots above the midpoint of the gap between two
+// dots of the first copy, one spacing away from both, and the same distance
+// again from the two below.
+const DOT_SPACING_PX = 16;
+const DOT_ROW_PX = DOT_SPACING_PX * Math.sqrt(3);
+const DOT_TEXTURE = [
+  `background-image:radial-gradient(rgba(124,130,140,.15) 1px,transparent 1px),`,
+  `radial-gradient(rgba(124,130,140,.15) 1px,transparent 1px);`,
+  `background-position:0 0,${DOT_SPACING_PX / 2}px ${
+    (DOT_ROW_PX / 2).toFixed(2)
+  }px;`,
+  `background-size:${DOT_SPACING_PX}px ${DOT_ROW_PX.toFixed(2)}px`,
+].join("");
+
 type ViewerTimeElement = Pick<HTMLTimeElement, "dateTime" | "textContent">;
 
 /** Replace marked absolute timestamps with the viewer's local wall-clock time. */
@@ -62,7 +100,11 @@ export function renderTile(v: TileView, id?: string, wide = false): string {
       durationTag(v.duration)
     }</div>`
     : (v.extra ?? "");
-  const inner = `${header}${big}${sub}${body}`;
+  // The status texture is painted by this empty layer rather than by the tile,
+  // because the texture is turned on an angle and drawn past every edge, while
+  // the fade that thins it towards the bottom is measured against the tile.
+  // Those are two frames of reference, so they need two boxes.
+  const inner = `<div class="texture"></div>${header}${big}${sub}${body}`;
   if (!v.href) return `<div class="${cls}"${key}>${inner}</div>`;
   const tgt = /^https?:/.test(v.href) ? ` target="_blank" rel="noopener"` : "";
   return `<a class="${cls}"${key} href="${
@@ -89,12 +131,27 @@ ${faviconLink(status)}
   .badge{font-size:11px;color:#62d18d;border:1px solid rgba(67,197,116,.4);border-radius:6px;padding:2px 8px;margin-left:8px}
   .live{font-size:12px;color:#9aa0ab}
   .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:12px;margin-bottom:12px}
-  .tile{background:#16181d;border:1px solid #23262d;border-radius:12px;padding:14px 16px}
+  .tile{background:#16181d;border:1px solid #23262d;border-radius:12px;padding:14px 16px;position:relative;isolation:isolate;overflow:hidden}
   .tile.wide{margin-bottom:12px}
   .tile.good,.tile.wide.good{border-color:rgba(67,197,116,.34);background:rgba(67,197,116,.08)}
   .tile.warn,.tile.wide.warn{border-color:rgba(224,168,82,.42);background:rgba(224,168,82,.09)}
   .tile.bad,.tile.wide.bad{border-color:rgba(226,80,74,.5);background:rgba(226,80,74,.11)}
   .tile.unknown,.tile.wide.unknown{border-color:#2f333c}
+  /* Each status carries a texture as well as a colour, so the wall reads at a
+     glance and without relying on colour alone: dots for gray, waves for
+     amber, zig-zags for red. The waves run across the zig-zags, a quarter turn
+     from the angle the others take. The texture layer covers the tile and sits
+     above the colour wash and below the content. It carries the fade: whole
+     for the top fifth of the tile, thinning from there, and gone four fifths
+     of the way down. Inside it the texture is turned on an angle and drawn
+     past all four edges, so the turned corners still reach the tile's. The
+     fade is measured against the tile and the texture is drawn in the turned
+     frame, which is why they are two boxes rather than one. */
+  .texture{position:absolute;inset:0;z-index:-1;overflow:hidden;mask-image:linear-gradient(to bottom,#000 20%,transparent 80%)}
+  .texture::before{content:"";position:absolute;inset:-100%;transform:rotate(30deg)}
+  .tile.unknown .texture::before{${DOT_TEXTURE}}
+  .tile.warn .texture::before{background-image:${WAVE_TEXTURE};background-size:48px 24px;transform:rotate(120deg)}
+  .tile.bad .texture::before{background-image:${ZIGZAG_TEXTURE};background-size:48px 24px}
   .lbl{font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:#878d97;margin:0 0 7px;display:flex;align-items:center;gap:7px}
   .lbl .spacer{flex:1}
   .drill{font-size:10px;color:#6f757f;letter-spacing:0;text-transform:none}

--- a/packages/dashboard/server.test.ts
+++ b/packages/dashboard/server.test.ts
@@ -6,7 +6,6 @@
 import {
   assert,
   assertEquals,
-  assertMatch,
   assertRejects,
   assertStringIncludes,
 } from "@std/assert";
@@ -1089,7 +1088,13 @@ Deno.test("sse: /events opens a stream, tick pushes new tile markup, disconnect 
   assertEquals(await chunk(reader), ": connected\n\n");
   assertEquals(clients.size, 1);
   const initial = updateFromEvent(await chunk(reader));
-  assertMatch(initial.shellVersion, /^[0-9a-f]{40}$/);
+  // The page reloads itself when these two disagree, so the version the stream
+  // reports has to be the one the page it is feeding was built with.
+  const page = await (await handle(req("/"))).text();
+  assertStringIncludes(
+    page,
+    `const SHELL_VERSION = ${JSON.stringify(initial.shellVersion)};`,
+  );
   assert(initial.ageSeconds >= 0);
   assert(["good", "warn", "bad"].includes(initial.faviconStatus));
   assert(Object.hasOwn(initial, "faviconRedSince"));

--- a/packages/dashboard/version.test.ts
+++ b/packages/dashboard/version.test.ts
@@ -1,73 +1,49 @@
-import { assertEquals, assertStringIncludes, assertThrows } from "@std/assert";
-import { currentGitCommit, dashboardVersion } from "./version.ts";
+import {
+  assertEquals,
+  assertNotEquals,
+  assertStringIncludes,
+  assertThrows,
+} from "@std/assert";
+import { dashboardVersion, processStartVersion } from "./version.ts";
 
-const FIRST_COMMIT = "1".repeat(40);
-const SECOND_COMMIT = "a".repeat(40);
-const encoder = new TextEncoder();
+const DEPLOYED_COMMIT = "1".repeat(40);
+const START = new Date("2026-08-05T07:15:34.820Z");
+const LATER_START = new Date("2026-08-05T07:15:34.821Z");
 
 Deno.test("dashboard version uses the deployed image commit", () => {
   assertEquals(
     dashboardVersion(
-      (name) => name === "DASHBOARD_GIT_COMMIT" ? FIRST_COMMIT : undefined,
+      (name) => name === "DASHBOARD_GIT_COMMIT" ? DEPLOYED_COMMIT : undefined,
       () => {
-        throw new Error("Git must not run for a deployed image");
+        throw new Error("A deployed image must not read the clock");
       },
     ),
-    FIRST_COMMIT,
+    DEPLOYED_COMMIT,
   );
 });
 
-Deno.test("dashboard version reads the current commit for local development", () => {
+Deno.test("dashboard version reports the start time when no commit is deployed", () => {
   assertEquals(
-    dashboardVersion(() => undefined, () => SECOND_COMMIT),
-    SECOND_COMMIT,
+    dashboardVersion(() => undefined, () => START),
+    "local-2026-08-05T07:15:34.820Z",
   );
 });
 
-Deno.test("dashboard version rejects missing or abbreviated commits", () => {
-  for (const version of ["", "abc123", "g".repeat(40)]) {
+Deno.test("dashboard version rejects a missing or abbreviated commit", () => {
+  for (const commit of ["", "abc123", "g".repeat(40)]) {
     assertThrows(
-      () => dashboardVersion(() => version, () => FIRST_COMMIT),
+      () => dashboardVersion(() => commit, () => START),
       Error,
-      "Dashboard Git commit must be a full 40-character lowercase hash.",
+      "Dashboard deployment commit must be a full 40-character lowercase hash.",
     );
   }
 });
 
-Deno.test("local dashboard version matches the checked-out commit", () => {
-  const result = new Deno.Command("git", {
-    args: ["rev-parse", "--verify", "HEAD^{commit}"],
-    cwd: new URL("../../", import.meta.url),
-    stdout: "piped",
-  }).outputSync();
-  assertEquals(result.success, true);
-  assertEquals(
-    dashboardVersion(() => undefined),
-    new TextDecoder().decode(result.stdout).trim(),
+Deno.test("a start a millisecond later is a different version", () => {
+  assertNotEquals(
+    processStartVersion(START),
+    processStartVersion(LATER_START),
   );
-});
-
-Deno.test("dashboard version reports Git command failures", () => {
-  for (
-    const [stderr, message] of [
-      [
-        "fatal: not a git repository",
-        "Could not read the dashboard Git commit: fatal: not a git repository",
-      ],
-      ["", "Could not read the dashboard Git commit."],
-    ]
-  ) {
-    assertThrows(
-      () =>
-        currentGitCommit(() => ({
-          success: false,
-          stdout: new Uint8Array(),
-          stderr: encoder.encode(stderr),
-        })),
-      Error,
-      message,
-    );
-  }
 });
 
 Deno.test("dashboard image requires the publishing workflow commit", async () => {

--- a/packages/dashboard/version.ts
+++ b/packages/dashboard/version.ts
@@ -1,48 +1,33 @@
 type Environment = (name: string) => string | undefined;
-type ReadGitCommit = () => string;
-interface GitCommandOutput {
-  success: boolean;
-  stdout: Uint8Array;
-  stderr: Uint8Array;
-}
-type RunGitCommand = () => GitCommandOutput;
+type Clock = () => Date;
 
-const decoder = new TextDecoder();
-const REPOSITORY_ROOT = new URL("../../", import.meta.url);
-const GIT_COMMIT_PATTERN = /^[0-9a-f]{40}$/;
+const COMMIT_PATTERN = /^[0-9a-f]{40}$/;
 
-export function currentGitCommit(
-  runGit: RunGitCommand = () =>
-    new Deno.Command("git", {
-      args: ["rev-parse", "--verify", "HEAD^{commit}"],
-      cwd: REPOSITORY_ROOT,
-      stdout: "piped",
-      stderr: "piped",
-    }).outputSync(),
-): string {
-  const result = runGit();
-  if (!result.success) {
-    const detail = decoder.decode(result.stderr).trim();
+function validCommit(value: string): string {
+  if (!COMMIT_PATTERN.test(value)) {
     throw new Error(
-      `Could not read the dashboard Git commit${detail ? `: ${detail}` : "."}`,
-    );
-  }
-  return decoder.decode(result.stdout).trim();
-}
-
-function validGitCommit(value: string): string {
-  if (!GIT_COMMIT_PATTERN.test(value)) {
-    throw new Error(
-      "Dashboard Git commit must be a full 40-character lowercase hash.",
+      "Dashboard deployment commit must be a full 40-character lowercase hash.",
     );
   }
   return value;
 }
 
+/**
+ * The version a server started from a checkout reports, for a server whose code
+ * changes under it between starts. Two starts are further apart than the
+ * millisecond this records, so a page held open across a restart sees a version
+ * it did not load with and reloads onto the code now being served. The time is
+ * readable in the page source, which says when the server serving it started.
+ */
+export function processStartVersion(startedAt: Date): string {
+  return `local-${startedAt.toISOString()}`;
+}
+
 export function dashboardVersion(
   env: Environment = Deno.env.get,
-  readGitCommit: ReadGitCommit = currentGitCommit,
+  now: Clock = () => new Date(),
 ): string {
   const deployedCommit = env("DASHBOARD_GIT_COMMIT");
-  return validGitCommit(deployedCommit ?? readGitCommit());
+  if (deployedCommit !== undefined) return validCommit(deployedCommit);
+  return processStartVersion(now());
 }


### PR DESCRIPTION
…ges on restart

The wall separated a tile's state from its neighbours' with colour and nothing else: a green wash, an amber wash, a red wash, and the plain dark panel for an unknown one. That is fragile. Anyone who does not separate those hues easily reads four near-identical dark panels, and the washes are faint enough that a projector, a camera, or a screen at a bad angle can flatten the difference away for everyone.

Each of the three states worth noticing now carries a texture behind its contents as well. A gray tile is covered in a grid of tiny dots, an amber tile in wavy lines, and a red tile in zig-zags. Green tiles stay plain, so the calm state remains the quietest thing on the board.

The dots sit on a triangular lattice, built from two copies of one dot grid offset by half a cell, with the cell as tall as the dot spacing times the square root of three. That puts every dot the same distance from all six of its neighbours, which reads as texture rather than as the rows and columns a square grid falls into. The waves and the zig-zags are each one stroked path in a small inline SVG tile, built by a shared helper so both are drawn in the same coordinate space and repeat seamlessly in both directions. Every texture is stroked in its own status colour at low opacity, and the amber waves run a quarter turn from the angle the red zig-zags take, so the two are told apart by direction as well as by shape.

The texture turns 30 degrees so that none of it lines up with the type, and it fades down the tile: whole for the top fifth, thinning from there, and gone four fifths of the way down, which leaves the sub line and the foot of a chart on plain colour. Those two demands pull in different directions. A mask applies in a box's own frame, before that box is turned, and the texture has to be drawn well past all four edges for the turned corners to still reach the tile's. So each tile carries a texture layer that covers it exactly and holds the fade, and the turned, oversized painting happens inside that layer, clipped to it. Each frame of reference gets the box it needs.

Turning up any of this in a browser that already had the page open exposed a second problem. The page shell — the styles and the client script — reaches the browser only on a full page load; everything that arrives afterwards over the event stream is tile markup, which the client swaps into place without navigating. So a change to the CSS can only reach an open page by making it reload, and the one thing that makes it reload is the server reporting a compatibility version different from the one the page loaded with. That version was the repository's HEAD commit, read once at startup, which is the wrong thing to measure for a server running out of a checkout: editing a file under a watched restart left HEAD alone, so the version matched and the open page kept the old styles while quietly receiving new tile markup.

A server started from a checkout now reports the moment it started. Every restart is therefore a version change, and every open page reloads onto the code that restart is serving; read the version in the page source and it says which run of the server built the page in front of you. A deployed image is unaffected, keeping the commit its publishing workflow supplies through the environment, which is fixed for the life of the image, so displays on one image still agree with each other. Nothing in the dashboard runtime shells out to Git any more, so the local tasks drop that permission; the published image never granted it.

The event-stream test asserted the shape of the version rather than the property that matters. It now checks that the version the stream reports is the one embedded in the page that stream is feeding, which is what the reload comparison depends on.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds status textures to dashboard tiles for better readability, and changes the local compatibility version so open pages reload after a server restart while deployed images stay pinned to their commit.

- **New Features**
  - Tile textures in `packages/dashboard`: dots for gray/unknown, waves for amber/warn, zig-zags for red; green stays plain.
  - Texture is a rotated, low-opacity layer that fades out by 80% of the tile height; seamless via inline SVG/gradients.

- **Refactors**
  - Compatibility version: deployments use `DASHBOARD_GIT_COMMIT`; local runs use `local-<process-start-ISO>`. No Git shell-outs.
  - Dropped `--allow-run=git` from `deno.jsonc` tasks; updated tests to compare the stream’s version to the page’s version.
  - Render adds a `.texture` layer; CSS and tests updated accordingly.

<sup>Written for commit 27acaa18c11b8d428841ddbb5024edf6de166944. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

