### PR TITLE
refactor(html): delete the VDOM ops nothing emits, and the surface ar…

### DIFF
--- a/packages/html/deno.jsonc
+++ b/packages/html/deno.jsonc
@@ -11,12 +11,10 @@
   "exports": {
     ".": "./src/index.ts",
     "./client": "./src/client.ts",
-    "./utils": "./src/utils.ts",
     "./jsx-runtime": "./src/jsx-runtime.ts",
     "./jsx-dev-runtime": "./src/jsx-dev-runtime.ts",
     "./mock-doc": "./src/mock-doc.ts",
     "./worker": "./src/worker/mod.ts",
-    "./main": "./src/main/mod.ts",
     "./vdom-ops": "./src/vdom-ops.ts",
     "./debug": "./src/debug.ts"
   },

--- a/packages/html/src/main/applicator.ts
+++ b/packages/html/src/main/applicator.ts
@@ -170,18 +170,8 @@ export class DomApplicator {
         }
         break;
 
-      case "move-child":
-        if (!this.moveChild(op.parentId, op.childId, op.beforeId)) {
-          this.deferChildInsert(op.parentId, op.childId, op.beforeId);
-        }
-        break;
-
       case "remove-node":
         this.removeNode(op.nodeId);
-        break;
-
-      case "set-attrs":
-        this.setAttrs(op.nodeId, op.attrs);
         break;
     }
   }
@@ -209,17 +199,6 @@ export class DomApplicator {
    */
   setContainer(container: HTMLElement): void {
     this.nodes.set(CONTAINER_NODE_ID, container);
-  }
-
-  /**
-   * Mount the rendered tree into a parent element.
-   * @deprecated Use setContainer instead - content is now inserted directly.
-   */
-  mountInto(parent: HTMLElement, rootId: number): void {
-    const root = this.nodes.get(rootId);
-    if (root) {
-      parent.appendChild(root);
-    }
   }
 
   /**
@@ -488,15 +467,6 @@ export class DomApplicator {
     return true;
   }
 
-  private moveChild(
-    parentId: number,
-    childId: number,
-    beforeId: number | null,
-  ): boolean {
-    // Move is the same as insert - insertBefore handles it
-    return this.insertChild(parentId, childId, beforeId);
-  }
-
   private deferChildInsert(
     parentId: number,
     childId: number,
@@ -639,19 +609,4 @@ export class DomApplicator {
       this.collectDescendantNodeIds(childId, into);
     }
   }
-
-  private setAttrs(nodeId: number, attrs: Record<string, unknown>): void {
-    for (const [key, value] of Object.entries(attrs)) {
-      this.setProp(nodeId, key, value);
-    }
-  }
-}
-
-/**
- * Create a new DOM applicator.
- */
-export function createDomApplicator(
-  options: DomApplicatorOptions,
-): DomApplicator {
-  return new DomApplicator(options);
 }

--- a/packages/html/src/main/mod.ts
+++ b/packages/html/src/main/mod.ts
@@ -5,10 +5,10 @@
  * VDomOp operations from the worker thread to the actual DOM.
  */
 
-export { createDomApplicator, DomApplicator } from "./applicator.ts";
+export { DomApplicator } from "./applicator.ts";
 export type { DomApplicatorOptions } from "./applicator.ts";
 
-export { createVDomRenderer, renderVDom, VDomRenderer } from "./renderer.ts";
+export { VDomRenderer } from "./renderer.ts";
 export { provideElementSpace, SPACE_CONTEXT_KEY } from "./space-context.ts";
 export type { VDomRendererOptions } from "./renderer.ts";
 

--- a/packages/html/src/main/renderer.ts
+++ b/packages/html/src/main/renderer.ts
@@ -301,34 +301,3 @@ export class VDomRenderer {
     );
   }
 }
-
-/**
- * Create a new VDomRenderer.
- */
-export function createVDomRenderer(options: VDomRendererOptions): VDomRenderer {
-  return new VDomRenderer(options);
-}
-
-/**
- * Convenience function to render a cell into a container.
- * Returns a cancel function to stop rendering.
- *
- * @param container - The DOM element to render into
- * @param cellRef - The cell reference to render
- * @param options - Renderer options
- * @returns A cancel function
- */
-export async function renderVDom(
-  container: HTMLElement,
-  cellRef: CellRef,
-  options: VDomRendererOptions,
-): Promise<() => Promise<void>> {
-  const renderer = createVDomRenderer(options);
-  const cancel = await renderer.render(container, cellRef);
-
-  // Return a cancel function that also disposes the renderer
-  return async () => {
-    await cancel();
-    await renderer.dispose();
-  };
-}

--- a/packages/html/src/vdom-ops.ts
+++ b/packages/html/src/vdom-ops.ts
@@ -105,31 +105,11 @@ export interface InsertChildOp {
 }
 
 /**
- * Move an existing child to a new position.
- * If beforeId is null, moves to the end.
- */
-export interface MoveChildOp {
-  op: "move-child";
-  parentId: number;
-  childId: number;
-  beforeId: number | null;
-}
-
-/**
  * Remove a node from the DOM.
  */
 export interface RemoveNodeOp {
   op: "remove-node";
   nodeId: number;
-}
-
-/**
- * Set multiple attributes at once (optimization for initial render).
- */
-export interface SetAttrsOp {
-  op: "set-attrs";
-  nodeId: number;
-  attrs: Record<string, JSONValue>;
 }
 
 /**
@@ -145,9 +125,7 @@ export type VDomOp =
   | RemoveEventOp
   | SetBindingOp
   | InsertChildOp
-  | MoveChildOp
-  | RemoveNodeOp
-  | SetAttrsOp;
+  | RemoveNodeOp;
 
 /**
  * A batch of VDOM operations to be applied atomically.
@@ -161,43 +139,4 @@ export interface VDomBatch {
 
   /** Optional: the root node ID for this render tree */
   rootId?: number;
-}
-
-/**
- * Type guard for VDomOp.
- */
-export function isVDomOp(value: unknown): value is VDomOp {
-  if (typeof value !== "object" || value === null) {
-    return false;
-  }
-  const op = (value as VDomOp).op;
-  return (
-    op === "create-element" ||
-    op === "create-text" ||
-    op === "update-text" ||
-    op === "set-prop" ||
-    op === "remove-prop" ||
-    op === "set-event" ||
-    op === "remove-event" ||
-    op === "set-binding" ||
-    op === "insert-child" ||
-    op === "move-child" ||
-    op === "remove-node" ||
-    op === "set-attrs"
-  );
-}
-
-/**
- * Type guard for VDomBatch.
- */
-export function isVDomBatch(value: unknown): value is VDomBatch {
-  if (typeof value !== "object" || value === null) {
-    return false;
-  }
-  const batch = value as VDomBatch;
-  return (
-    typeof batch.batchId === "number" &&
-    Array.isArray(batch.ops) &&
-    batch.ops.every(isVDomOp)
-  );
 }

--- a/packages/html/src/worker/keying.ts
+++ b/packages/html/src/worker/keying.ts
@@ -129,11 +129,3 @@ export function generateChildKeys(children: readonly unknown[]): string[] {
 
   return keys;
 }
-
-/**
- * Check if two keys represent the same node identity.
- * Used for determining if a node can be reused vs recreated.
- */
-export function keysMatch(oldKey: string, newKey: string): boolean {
-  return oldKey === newKey;
-}

--- a/packages/html/src/worker/mod.ts
+++ b/packages/html/src/worker/mod.ts
@@ -7,7 +7,7 @@
  */
 
 export { WorkerReconciler } from "./reconciler.ts";
-export { generateChildKeys, generateKey, keysMatch } from "./keying.ts";
+export { generateChildKeys, generateKey } from "./keying.ts";
 export type {
   BindingCellRef,
   ChildNodeState,

--- a/packages/html/test/main-applicator.test.ts
+++ b/packages/html/test/main-applicator.test.ts
@@ -11,7 +11,7 @@ import {
   assertNotStrictEquals,
   assertStrictEquals,
 } from "@std/assert";
-import { createDomApplicator } from "../src/main/applicator.ts";
+import { DomApplicator } from "../src/main/applicator.ts";
 import type { DomEventMessage } from "../src/main/events.ts";
 import type { VDomBatch } from "../src/vdom-ops.ts";
 import { $conn, type CellRef } from "@commonfabric/runtime-client";
@@ -156,7 +156,7 @@ function createMockDocument() {
 Deno.test("DomApplicator - create elements", async (t) => {
   await t.step("creates an element from create-element op", () => {
     const doc = createMockDocument();
-    const applicator = createDomApplicator({
+    const applicator = new DomApplicator({
       document: doc,
       runtimeClient: createMockRuntimeClient(),
       onEvent: () => {},
@@ -176,7 +176,7 @@ Deno.test("DomApplicator - create elements", async (t) => {
 
   await t.step("creates a text node from create-text op", () => {
     const doc = createMockDocument();
-    const applicator = createDomApplicator({
+    const applicator = new DomApplicator({
       document: doc,
       runtimeClient: createMockRuntimeClient(),
       onEvent: () => {},
@@ -196,7 +196,7 @@ Deno.test("DomApplicator - create elements", async (t) => {
 
   await t.step("creates multiple elements in one batch", () => {
     const doc = createMockDocument();
-    const applicator = createDomApplicator({
+    const applicator = new DomApplicator({
       document: doc,
       runtimeClient: createMockRuntimeClient(),
       onEvent: () => {},
@@ -221,7 +221,7 @@ Deno.test("DomApplicator - create elements", async (t) => {
 
   await t.step("updates text nodes without DOM globals", () => {
     const doc = createMockDocument();
-    const applicator = createDomApplicator({
+    const applicator = new DomApplicator({
       document: doc,
       runtimeClient: createMockRuntimeClient(),
       onEvent: () => {},
@@ -250,7 +250,7 @@ Deno.test("DomApplicator - create elements", async (t) => {
 Deno.test("DomApplicator - child operations", async (t) => {
   await t.step("inserts child at end", () => {
     const doc = createMockDocument();
-    const applicator = createDomApplicator({
+    const applicator = new DomApplicator({
       document: doc,
       runtimeClient: createMockRuntimeClient(),
       onEvent: () => {},
@@ -274,7 +274,7 @@ Deno.test("DomApplicator - child operations", async (t) => {
 
   await t.step("inserts child before another", () => {
     const doc = createMockDocument();
-    const applicator = createDomApplicator({
+    const applicator = new DomApplicator({
       document: doc,
       runtimeClient: createMockRuntimeClient(),
       onEvent: () => {},
@@ -301,7 +301,7 @@ Deno.test("DomApplicator - child operations", async (t) => {
     "replays insert when child is created later in the batch",
     () => {
       const doc = createMockDocument();
-      const applicator = createDomApplicator({
+      const applicator = new DomApplicator({
         document: doc,
         runtimeClient: createMockRuntimeClient(),
         onEvent: () => {},
@@ -328,7 +328,7 @@ Deno.test("DomApplicator - child operations", async (t) => {
     "does not replay stale placement after child moves elsewhere",
     () => {
       const doc = createMockDocument();
-      const applicator = createDomApplicator({
+      const applicator = new DomApplicator({
         document: doc,
         runtimeClient: createMockRuntimeClient(),
         onEvent: () => {},
@@ -362,7 +362,7 @@ Deno.test("DomApplicator - child operations", async (t) => {
     "waits for beforeId to attach before replaying placement",
     () => {
       const doc = createMockDocument();
-      const applicator = createDomApplicator({
+      const applicator = new DomApplicator({
         document: doc,
         runtimeClient: createMockRuntimeClient(),
         onEvent: () => {},
@@ -392,34 +392,11 @@ Deno.test("DomApplicator - child operations", async (t) => {
     },
   );
 
-  await t.step("replays deferred move-child when nodes appear", () => {
-    const doc = createMockDocument();
-    const applicator = createDomApplicator({
-      document: doc,
-      runtimeClient: createMockRuntimeClient(),
-      onEvent: () => {},
-    });
-
-    applicator.applyBatch({
-      batchId: 1,
-      ops: [
-        { op: "move-child", parentId: 1, childId: 2, beforeId: null },
-        { op: "create-element", nodeId: 1, tagName: "div" },
-        { op: "create-element", nodeId: 2, tagName: "span" },
-      ],
-    });
-
-    const parent = applicator.getNode(1) as unknown as {
-      childNodes: Array<{ tagName: string }>;
-    };
-    assertEquals(parent.childNodes.map((child) => child.tagName), ["SPAN"]);
-  });
-
   await t.step(
     "does not replay insert after child is removed before creation",
     () => {
       const doc = createMockDocument();
-      const applicator = createDomApplicator({
+      const applicator = new DomApplicator({
         document: doc,
         runtimeClient: createMockRuntimeClient(),
         onEvent: () => {},
@@ -448,7 +425,7 @@ Deno.test("DomApplicator - child operations", async (t) => {
 
   await t.step("drops pending inserts that target removed descendants", () => {
     const doc = createMockDocument();
-    const applicator = createDomApplicator({
+    const applicator = new DomApplicator({
       document: doc,
       runtimeClient: createMockRuntimeClient(),
       onEvent: () => {},
@@ -484,7 +461,7 @@ Deno.test("DomApplicator - child operations", async (t) => {
     "appends pending insert when only beforeId anchor is removed",
     () => {
       const doc = createMockDocument();
-      const applicator = createDomApplicator({
+      const applicator = new DomApplicator({
         document: doc,
         runtimeClient: createMockRuntimeClient(),
         onEvent: () => {},
@@ -520,9 +497,9 @@ Deno.test("DomApplicator - child operations", async (t) => {
     },
   );
 
-  await t.step("moves child to new position", () => {
+  await t.step("re-inserting an attached child moves it", () => {
     const doc = createMockDocument();
-    const applicator = createDomApplicator({
+    const applicator = new DomApplicator({
       document: doc,
       runtimeClient: createMockRuntimeClient(),
       onEvent: () => {},
@@ -544,7 +521,7 @@ Deno.test("DomApplicator - child operations", async (t) => {
     // Move first child to end
     applicator.applyBatch({
       batchId: 2,
-      ops: [{ op: "move-child", parentId: 1, childId: 2, beforeId: null }],
+      ops: [{ op: "insert-child", parentId: 1, childId: 2, beforeId: null }],
     });
 
     const parent = applicator.getNode(1) as any;
@@ -556,7 +533,7 @@ Deno.test("DomApplicator - child operations", async (t) => {
 
   await t.step("removes a node", () => {
     const doc = createMockDocument();
-    const applicator = createDomApplicator({
+    const applicator = new DomApplicator({
       document: doc,
       runtimeClient: createMockRuntimeClient(),
       onEvent: () => {},
@@ -584,7 +561,7 @@ Deno.test("DomApplicator - child operations", async (t) => {
   await t.step("removes listeners from removed descendants", () => {
     const doc = createMockDocument();
     const events: DomEventMessage[] = [];
-    const applicator = createDomApplicator({
+    const applicator = new DomApplicator({
       document: doc,
       runtimeClient: createMockRuntimeClient(),
       onEvent: (msg) => events.push(msg),
@@ -642,7 +619,7 @@ Deno.test("DomApplicator - event handling", async (t) => {
   await t.step("sets event listener and dispatches events", () => {
     const doc = createMockDocument();
     const events: DomEventMessage[] = [];
-    const applicator = createDomApplicator({
+    const applicator = new DomApplicator({
       document: doc,
       runtimeClient: createMockRuntimeClient(),
       onEvent: (msg) => events.push(msg),
@@ -674,7 +651,7 @@ Deno.test("DomApplicator - event handling", async (t) => {
   await t.step("serializes data-ui dataset markers with trusted events", () => {
     const doc = createMockDocument();
     const events: DomEventMessage[] = [];
-    const applicator = createDomApplicator({
+    const applicator = new DomApplicator({
       document: doc,
       runtimeClient: createMockRuntimeClient(),
       onEvent: (msg) => events.push(msg),
@@ -698,9 +675,10 @@ Deno.test("DomApplicator - event handling", async (t) => {
       ops: [
         { op: "create-element", nodeId: 1, tagName: "button" },
         {
-          op: "set-attrs",
+          op: "set-prop",
           nodeId: 1,
-          attrs: { "data-ui-action": "SubmitDirectCommand" },
+          key: "data-ui-action",
+          value: "SubmitDirectCommand",
         },
         { op: "set-event", nodeId: 1, eventType: "click", handlerId: 42 },
       ],
@@ -717,7 +695,7 @@ Deno.test("DomApplicator - event handling", async (t) => {
   await t.step("attests nearest trusted UI pattern provenance", () => {
     const doc = createMockDocument();
     const events: DomEventMessage[] = [];
-    const applicator = createDomApplicator({
+    const applicator = new DomApplicator({
       document: doc,
       runtimeClient: createMockRuntimeClient(),
       onEvent: (msg) => events.push(msg),
@@ -741,18 +719,23 @@ Deno.test("DomApplicator - event handling", async (t) => {
       ops: [
         { op: "create-element", nodeId: 1, tagName: "section" },
         {
-          op: "set-attrs",
+          op: "set-prop",
           nodeId: 1,
-          attrs: {
-            "data-ui-pattern": "TrustedDirectCommandSurface",
-            "data-ui-event-integrity": "TrustedDirectCommandSurface",
-          },
+          key: "data-ui-pattern",
+          value: "TrustedDirectCommandSurface",
+        },
+        {
+          op: "set-prop",
+          nodeId: 1,
+          key: "data-ui-event-integrity",
+          value: "TrustedDirectCommandSurface",
         },
         { op: "create-element", nodeId: 2, tagName: "button" },
         {
-          op: "set-attrs",
+          op: "set-prop",
           nodeId: 2,
-          attrs: { "data-ui-action": "SubmitDirectCommand" },
+          key: "data-ui-action",
+          value: "SubmitDirectCommand",
         },
         {
           op: "insert-child",
@@ -783,7 +766,7 @@ Deno.test("DomApplicator - event handling", async (t) => {
   await t.step("removes event listener", () => {
     const doc = createMockDocument();
     const events: DomEventMessage[] = [];
-    const applicator = createDomApplicator({
+    const applicator = new DomApplicator({
       document: doc,
       runtimeClient: createMockRuntimeClient(),
       onEvent: (msg) => events.push(msg),
@@ -812,7 +795,7 @@ Deno.test("DomApplicator - event handling", async (t) => {
   await t.step("replaces event handler when setting same event type", () => {
     const doc = createMockDocument();
     const events: DomEventMessage[] = [];
-    const applicator = createDomApplicator({
+    const applicator = new DomApplicator({
       document: doc,
       runtimeClient: createMockRuntimeClient(),
       onEvent: (msg) => events.push(msg),
@@ -851,7 +834,7 @@ Deno.test("DomApplicator - cell bindings", async (t) => {
 
   await t.step("does not replace a binding for the same cell ref", () => {
     const doc = createMockDocument();
-    const applicator = createDomApplicator({
+    const applicator = new DomApplicator({
       document: doc,
       runtimeClient: createMockRuntimeClient(),
       onEvent: () => {},
@@ -893,7 +876,7 @@ Deno.test("DomApplicator - cell bindings", async (t) => {
 Deno.test("DomApplicator - batch with rootId", async (t) => {
   await t.step("tracks root node ID", () => {
     const doc = createMockDocument();
-    const applicator = createDomApplicator({
+    const applicator = new DomApplicator({
       document: doc,
       runtimeClient: createMockRuntimeClient(),
       onEvent: () => {},
@@ -912,7 +895,7 @@ Deno.test("DomApplicator - batch with rootId", async (t) => {
 
   await t.step("updates root when rootId changes", () => {
     const doc = createMockDocument();
-    const applicator = createDomApplicator({
+    const applicator = new DomApplicator({
       document: doc,
       runtimeClient: createMockRuntimeClient(),
       onEvent: () => {},
@@ -935,33 +918,10 @@ Deno.test("DomApplicator - batch with rootId", async (t) => {
   });
 });
 
-Deno.test("DomApplicator - mountInto", async (t) => {
-  await t.step("mounts root into parent element", () => {
-    const doc = createMockDocument();
-    const applicator = createDomApplicator({
-      document: doc,
-      runtimeClient: createMockRuntimeClient(),
-      onEvent: () => {},
-    });
-
-    applicator.applyBatch({
-      batchId: 1,
-      ops: [{ op: "create-element", nodeId: 1, tagName: "div" }],
-      rootId: 1,
-    });
-
-    const container = doc.createElement("section") as unknown as HTMLElement;
-    applicator.mountInto(container, 1);
-
-    assertEquals((container as any).childNodes.length, 1);
-    assertEquals((container as any).childNodes[0].tagName, "DIV");
-  });
-});
-
 Deno.test("DomApplicator - setContainer", async (t) => {
   await t.step("registers container element with CONTAINER_NODE_ID (0)", () => {
     const doc = createMockDocument();
-    const applicator = createDomApplicator({
+    const applicator = new DomApplicator({
       document: doc,
       runtimeClient: createMockRuntimeClient(),
       onEvent: () => {},
@@ -976,7 +936,7 @@ Deno.test("DomApplicator - setContainer", async (t) => {
 
   await t.step("allows inserting children directly into container", () => {
     const doc = createMockDocument();
-    const applicator = createDomApplicator({
+    const applicator = new DomApplicator({
       document: doc,
       runtimeClient: createMockRuntimeClient(),
       onEvent: () => {},
@@ -1003,7 +963,7 @@ Deno.test("DomApplicator - dispose", async (t) => {
   await t.step("cleans up all nodes and listeners", () => {
     const doc = createMockDocument();
     const events: DomEventMessage[] = [];
-    const applicator = createDomApplicator({
+    const applicator = new DomApplicator({
       document: doc,
       runtimeClient: createMockRuntimeClient(),
       onEvent: (msg) => events.push(msg),
@@ -1032,7 +992,7 @@ Deno.test("DomApplicator - error handling", async (t) => {
   await t.step("continues processing batch after operation error", () => {
     const doc = createMockDocument();
     const errors: Error[] = [];
-    const applicator = createDomApplicator({
+    const applicator = new DomApplicator({
       document: doc,
       runtimeClient: createMockRuntimeClient(),
       onEvent: () => {},
@@ -1069,7 +1029,7 @@ Deno.test("DomApplicator - bindings", async (t) => {
       });
 
       const doc = createMockDocument();
-      const applicator = createDomApplicator({
+      const applicator = new DomApplicator({
         document: doc,
         runtimeClient: createMockRuntimeClient(),
         onEvent: () => {},

--- a/packages/html/test/worker-keying.test.ts
+++ b/packages/html/test/worker-keying.test.ts
@@ -3,11 +3,7 @@
  */
 
 import { assertEquals, assertNotEquals } from "@std/assert";
-import {
-  generateChildKeys,
-  generateKey,
-  keysMatch,
-} from "../src/worker/keying.ts";
+import { generateChildKeys, generateKey } from "../src/worker/keying.ts";
 
 Deno.test("keying - generateKey", async (t) => {
   await t.step("generates stable keys for strings", () => {
@@ -169,16 +165,5 @@ Deno.test("keying - generateChildKeys", async (t) => {
     const keys = generateChildKeys(["only"]);
     assertEquals(keys.length, 1);
     assertEquals(keys[0], `${generateKey("only")}-0`);
-  });
-});
-
-Deno.test("keying - keysMatch", async (t) => {
-  await t.step("returns true for matching keys", () => {
-    assertEquals(keysMatch("foo-0", "foo-0"), true);
-  });
-
-  await t.step("returns false for non-matching keys", () => {
-    assertEquals(keysMatch("foo-0", "foo-1"), false);
-    assertEquals(keysMatch("foo", "bar"), false);
   });
 });

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -995,31 +995,14 @@ export interface PendingWritesNotification {
 }
 
 /**
- * VDOM operation for IPC.
+ * The vocabulary of DOM mutations carried by a VDOM batch. The worker
+ * reconciler that produces them and the main-thread applicator that consumes
+ * them both live in `@commonfabric/html`, which defines the union; the protocol
+ * re-exports it so a message shape and the ops inside it cannot describe
+ * different things.
  */
-export type VDomOp =
-  | { op: "create-element"; nodeId: number; tagName: string }
-  | { op: "create-text"; nodeId: number; text: string }
-  | { op: "update-text"; nodeId: number; text: string }
-  | { op: "set-prop"; nodeId: number; key: string; value: JSONValue }
-  | { op: "remove-prop"; nodeId: number; key: string }
-  | { op: "set-event"; nodeId: number; eventType: string; handlerId: number }
-  | { op: "remove-event"; nodeId: number; eventType: string }
-  | { op: "set-binding"; nodeId: number; propName: string; cellRef: CellRef }
-  | {
-    op: "insert-child";
-    parentId: number;
-    childId: number;
-    beforeId: number | null;
-  }
-  | {
-    op: "move-child";
-    parentId: number;
-    childId: number;
-    beforeId: number | null;
-  }
-  | { op: "remove-node"; nodeId: number }
-  | { op: "set-attrs"; nodeId: number; attrs: Record<string, JSONValue> };
+import type { VDomOp } from "@commonfabric/html/vdom-ops";
+export type { VDomOp };
 
 /**
  * VDOM batch notification sent from worker to main thread.


### PR DESCRIPTION
…ound them

The worker-to-main VDOM protocol declared twelve operation types. Only ten of them ever reach the wire. The worker reconciler is the sole producer of these operations, and it never constructs a `move-child` or a `set-attrs`. The two implementations on the receiving side said as much: the applicator's `moveChild` was one line handing straight off to `insertChild`, and its `setAttrs` was a loop calling `setProp` once per entry. The only code that built either operation was the applicator's own unit tests.

The union was also written out three times: once in the html package, once in the applicator's switch, and once by hand in the runtime client's protocol types. The hand-written copy had already drifted. The html definition of `create-element` gained an optional `space` field, which the reconciler sets and the applicator reads, and which therefore crosses the wire on every cross-space render; the protocol copy never gained it. Nothing broke, because the two unions only ever meet where one is assigned to the other and the extra field is accepted, but the protocol's description of its own message had stopped being true.

So this change gives the union a single owner. The html package defines it, because that is where both the producer and the consumer live, and the protocol re-exports it. The runtime client already depends on the html package for the reconciler itself, so this adds no new dependency. It does close a type-only loop, since the html definition reaches back for `CellRef` and `JSONValue`; both directions erase at build time, and the type checker resolves it without complaint.

Removed along with the two operations:

- `isVDomOp` and `isVDomBatch`, type guards with no callers anywhere.
- `DomApplicator.mountInto`, marked deprecated in favour of `setContainer`, which nothing but its own test called.
- `createDomApplicator`, `createVDomRenderer`, and `renderVDom`, wrappers whose whole body was a constructor call. Production code builds the classes directly.
- `keysMatch`, a function whose body was `oldKey === newKey`.
- The `./utils` export entry, which pointed at a file that does not exist, and the `./main` entry, which nothing outside the package imported.

The tests keep the coverage that was real. The two event-provenance tests used `set-attrs` only as a convenient way to stamp several `data-` attributes on an element, so they now stamp them with the `set-prop` operations the reconciler actually emits. The reordering test moved a child with `move-child`, but the reconciler reorders children by re-emitting `insert-child` for each one, so that test now does the same and is named for what it checks. The test for replaying a deferred `move-child` is gone rather than converted, because the step immediately above it already replays a deferred `insert-child` through the identical path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trimmed unused VDOM operations and unified the VDOM op type to remove drift and simplify the protocol. This reduces code paths, clarifies the API, and keeps the runtime behavior unchanged.

- **Refactors**
  - Removed never-emitted ops: `move-child` and `set-attrs` (and their applicator code).
  - Made `VDomOp` a single source of truth in `@commonfabric/html/vdom-ops`; protocol now re-exports it (includes `create-element.space`).
  - Deleted dead APIs: `isVDomOp`, `isVDomBatch`, `DomApplicator.mountInto`, `createDomApplicator`, `createVDomRenderer`, `renderVDom`, and `keysMatch`.
  - Pruned unused exports: `./utils`, `./main`.
  - Updated tests to use `insert-child` for reorders and `set-prop` for attributes.

- **Migration**
  - Use `new DomApplicator(...)` instead of `createDomApplicator(...)`.
  - Use `new VDomRenderer(...)` and `renderer.render(...)` instead of `createVDomRenderer(...)` or `renderVDom(...)`.
  - Replace `mountInto(...)` with `setContainer(...)`.
  - Use `insert-child` to reorder and `set-prop` for attributes (no `move-child` / `set-attrs`).
  - If typing against the protocol, import `VDomOp` from `@commonfabric/html/vdom-ops`.

<sup>Written for commit f11c1fbdfb70ea072a3ae2d27ef859953e11b9b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

