### PR TITLE
fix(runner): separate a release's authority from a stop's

### DIFF
--- a/docs/specs/runner-child-run-ownership.md
+++ b/docs/specs/runner-child-run-ownership.md
@@ -105,5 +105,8 @@ A start gated on a commit has no registration until its callback installs one.
 Ownership of it begins when the start is scheduled, so stopping the result
 before that commit tombstones the pending start and the callback does not
 install it. Without this a piece the user stopped starts anyway, moments
-later. Releasing the result's registration cancels the pending starts held
-for that result too, at the width the exception above describes.
+later. Releasing the child cancels the pending starts held for that result
+too, at the width the exception above describes. A launch whose child is
+still gated holds that child through the pending start and nothing else, so a
+release that passed it over would let the child start after the pattern that
+launched it is gone.

--- a/docs/specs/runner-child-run-ownership.md
+++ b/docs/specs/runner-child-run-ownership.md
@@ -14,7 +14,29 @@ The registration is not part of any transaction. The writes a setup stages
 roll back when its transaction fails; the registration does not. A result is
 also reachable from more than one place: a nested pattern inside its parent, a
 list element inside its coordinator, and a page the user navigated to can all
-name the same result. These two facts decide the four rules below.
+name the same result. These two facts decide the rules below.
+
+## Two ways a registration ends
+
+Two operations end a registration, and they carry different authority.
+
+An explicit *stop* is authoritative over the result. It ends whatever
+registration it finds, discards any lifetime the result holds, and reaches
+starts that hold no registration yet: a start still resolving a link to this
+result terminates when it resolves.
+
+A *release* is authoritative over the registration its own launch installed,
+and over nothing else. A pattern releases a child it launched when that
+pattern is torn down, and a launch releases its own registration when the
+transaction staging its setup does not become durable. A release leaves a
+replacement registration alone, leaves a result that holds a lifetime of its
+own running, and leaves a start it cannot see to settle on its own terms.
+Pending commit-gated starts are the exception: a release cancels every one
+held for the result, including one another launch scheduled, because a start
+that has installed no registration yet offers nothing to tell launches apart
+by.
+
+Each rule below is one of these two authorities applied to a case.
 
 ## Releasing a child
 
@@ -26,6 +48,14 @@ only when both of these hold:
   replaced it owns itself, so a release that no longer recognises what it
   finds does nothing.
 - Nothing holds an independent lifetime for the result (below).
+
+The second condition reaches only the starts a release can see. A start that
+has not yet resolved its link to this result is indexed under no key the
+release consults, so a release cannot tell that one is in flight. That
+release proceeds: it ends the registration its own launch installed, and
+leaves the start running. The start may go on to install a registration of
+its own and claim a lifetime for it, by the rule below. A stop of the same
+result instead terminates that start when it resolves.
 
 ## Independent lifetimes
 
@@ -40,13 +70,28 @@ cannot say so yet, so a release declines while one is in flight. A start that
 then fails leaves the result registered until the runtime stops it, the same
 bound the scheduler accepts for a start that exhausts its retries.
 
+The lifetime is claimed when the start settles, and only when its target is
+still current at that moment: no stop has tombstoned the target for this
+start or replaced the target's registration since this start discovered it.
+A start whose target a stop superseded while it was resolving claims nothing:
+any registration under the result's key belongs to whatever installed it
+after the stop, not to this start. Such a start reports that it did not leave
+the piece running. The judgment is about the target alone — a stop of an
+intermediate link doc the start resolved through does not touch the target's
+registration, so it voids neither the claim nor the report.
+
 ## Rolling back with the transaction
 
 A run stages its setup in a transaction and installs its registration outside
-one. When that transaction does not become durable, the registration is
-stopped: the piece would otherwise run against writes that never landed, and
-the memo that decides whether to materialize it again would describe a child
-that exists nowhere.
+one. When that transaction does not become durable, the launch releases its
+registration: the piece would otherwise run against writes that never landed,
+and the memo that decides whether to materialize it again would describe a
+child that exists nowhere.
+
+The rollback is a release rather than a stop, so it compensates the
+registration this launch installed and reaches no further. A result someone
+opened in its own right stays running, and a start still resolving is left to
+settle against whatever state became durable.
 
 A stale basis is the exception. A conflict or a local inconsistency is
 resolved by re-running the same work against fresher state, and that re-run
@@ -60,4 +105,5 @@ A start gated on a commit has no registration until its callback installs one.
 Ownership of it begins when the start is scheduled, so stopping the result
 before that commit tombstones the pending start and the callback does not
 install it. Without this a piece the user stopped starts anyway, moments
-later.
+later. Releasing the result's registration cancels the pending starts held
+for that result too, at the width the exception above describes.

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -2220,9 +2220,10 @@ export class Runner {
     installedCancel: Cancel | undefined,
   ): void {
     const key = this.getDocKey(resultCell);
-    if (installedCancel !== undefined) {
-      if (this.cancels.get(key) !== installedCancel) return;
-    } else if (!this.cancels.has(key)) return;
+    const registration = this.cancels.get(key);
+    if (installedCancel !== undefined && registration !== installedCancel) {
+      return;
+    }
     if (this.independentlyStartedResults.has(key)) return;
     // A start still resolving may be about to give this result a lifetime of
     // its own, and it cannot say so until it finishes. Declining here keeps a
@@ -2231,6 +2232,16 @@ export class Runner {
     // which is the same bound the scheduler already accepts for a start that
     // exhausts its retries.
     if ((this.activeStartAttemptsByDoc.get(key)?.size ?? 0) > 0) return;
+    if (registration === undefined) {
+      // A commit-gated start installs nothing until its transaction commits,
+      // so a launch whose child is still gated holds that child through the
+      // pending start alone. Cancelling it is what keeps the child from
+      // starting after the pattern that launched it is gone. The width is the
+      // one the TODO in stopResult() describes: every pending start for the
+      // result goes, not only the one this launch scheduled.
+      this.cancelPendingDeferredStarts(key);
+      return;
+    }
     // A link start that has not yet followed its link is not indexed under
     // `key`, so the check above cannot see it. An explicit stop is
     // authoritative over such a start and tombstones it; a release is not, and

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -3125,9 +3125,15 @@ export class Runner {
     const resultLink = resultCell.getAsNormalizedFullLink();
     const ownership = this.createDeferredStartOwnership(resultCell);
     tx.addCommitCallback((_committedTx, result) => {
-      if (result.error || ownership.isCancelled()) {
+      if (result.error) {
+        // The callback that would install this start is the one running now,
+        // so a failed transaction leaves nothing to reach the pending entry
+        // later. Settle it here, which also drops it from the index of starts
+        // pending under this result's key.
+        ownership.cancel();
         return;
       }
+      if (ownership.isCancelled()) return;
 
       const startTx = this.runtime.edit();
       const committedResultCell = this.runtime.getCellFromLink<T>(

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -3198,7 +3198,14 @@ export class Runner {
     const resultLink = resultCell.getAsNormalizedFullLink();
     const ownership = this.createDeferredStartOwnership(resultCell);
     tx.addCommitCallback((_committedTx, result) => {
-      if (result.error || ownership.isCancelled()) return;
+      if (result.error) {
+        // Settled here for the same reason as the start above: this callback
+        // is the only thing that reaches the pending entry, so a failed
+        // transaction would otherwise strand it under the result's key.
+        ownership.cancel();
+        return;
+      }
+      if (ownership.isCancelled()) return;
 
       const startTx = this.runtime.edit();
       const committedResultCell = this.runtime.getCellFromLink<T>(

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -4201,7 +4201,7 @@ export class Runner {
   private stopResult<T>(resultCell: Cell<T>): void {
     const key = this.getDocKey(resultCell);
     this.independentlyStartedResults.delete(key);
-    // TODO: This reaches every pending commit-gated start for the result,
+    // TODO(hixie): This reaches every pending commit-gated start for the result,
     // which is wider than a release's authority: one that another launch
     // scheduled goes too. Narrowing it needs the release to name the pending
     // start its own launch created, the way it already names the registration

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -2162,7 +2162,9 @@ export class Runner {
    * Start scheduling nodes for a previously set up piece.
    * If already started, this is a no-op.
    *
-   * Returns a Promise that resolves to true on success, or rejects with an error.
+   * Returns a Promise that resolves to true when this start left the piece
+   * running with a lifetime of its own, false when it was superseded or the
+   * piece was stopped while the start resolved, or rejects with an error.
    * Runs synchronously when data is available (important for tests).
    */
   start<T = any>(
@@ -2182,12 +2184,22 @@ export class Runner {
       return this.doStart(resultCell, new Set(), attempt)
         .then((started) => {
           // This start gives the result a lifetime of its own, so an enclosing
-          // pattern releasing it later leaves it running.
+          // pattern releasing it later leaves it running. An attempt whose
+          // target a stop superseded claims nothing: the registration under
+          // the key belongs to whatever replaced it, and a stop that won the
+          // race leaves no registration at all. Both cases report that this
+          // start is not running. The check is scoped to the target: a stop of
+          // an intermediate link doc after the target's registration installed
+          // does not touch that registration, so it neither voids the claim
+          // nor the report.
           const target = attempt.targetKey;
-          if (started && target !== undefined && this.cancels.has(target)) {
+          const stillRunning = started && target !== undefined &&
+            this.isStartAttemptCurrentFor(attempt, target) &&
+            this.cancels.has(target);
+          if (stillRunning) {
             this.independentlyStartedResults.add(target);
           }
-          return started;
+          return stillRunning;
         })
         .finally(() => {
           this.finishStartAttempt(attempt);
@@ -2219,7 +2231,11 @@ export class Runner {
     // which is the same bound the scheduler already accepts for a start that
     // exhausts its retries.
     if ((this.activeStartAttemptsByDoc.get(key)?.size ?? 0) > 0) return;
-    this.stop(resultCell);
+    // A link start that has not yet followed its link is not indexed under
+    // `key`, so the check above cannot see it. An explicit stop is
+    // authoritative over such a start and tombstones it; a release is not, and
+    // leaves it to resolve into a result of its own.
+    this.stopResult(resultCell);
   }
 
   /**
@@ -4165,8 +4181,31 @@ export class Runner {
    * @param resultCell - The result doc or cell to stop.
    */
   stop<T>(resultCell: Cell<T>): void {
+    // An unresolved link start does not know its target yet, so it cannot be
+    // indexed under the target's key. An explicit stop records the target on
+    // every active attempt that has not discovered it; an attempt that later
+    // resolves to the target observes the tombstone and terminates. The
+    // tombstone lives only on the active token and is released when that start
+    // settles. This step is what makes a stop authoritative over a start still
+    // resolving; releaseChild() calls stopResult() directly and leaves such a
+    // start to resolve into a result of its own.
+    const key = this.getDocKey(resultCell);
+    for (const attempt of this.activeStartAttempts) {
+      if (!attempt.generationsByDoc.has(key)) {
+        attempt.preResolutionStopKeys.add(key);
+      }
+    }
+    this.stopResult(resultCell);
+  }
+
+  private stopResult<T>(resultCell: Cell<T>): void {
     const key = this.getDocKey(resultCell);
     this.independentlyStartedResults.delete(key);
+    // TODO: This reaches every pending commit-gated start for the result,
+    // which is wider than a release's authority: one that another launch
+    // scheduled goes too. Narrowing it needs the release to name the pending
+    // start its own launch created, the way it already names the registration
+    // it installed.
     this.cancelPendingDeferredStarts(key);
     if ((this.activeStartAttemptsByDoc.get(key)?.size ?? 0) > 0) {
       this.startGenerationByDoc.set(
@@ -4177,16 +4216,6 @@ export class Runner {
       // No asynchronous continuation can observe this generation. Avoid
       // retaining one entry per stopped piece for the runtime's lifetime.
       this.startGenerationByDoc.delete(key);
-    }
-    // An unresolved link start does not know its target yet, so it cannot be
-    // indexed under `key`. Snapshot this stop onto every currently active
-    // attempt that has not discovered the doc. If one later resolves to `key`,
-    // it observes the tombstone and terminates. The tombstone lives only on the
-    // active token and is released when that start settles.
-    for (const attempt of this.activeStartAttempts) {
-      if (!attempt.generationsByDoc.has(key)) {
-        attempt.preResolutionStopKeys.add(key);
-      }
     }
     const cancel = this.cancels.get(key);
     try {
@@ -4250,6 +4279,26 @@ export class Runner {
       }
     }
     return true;
+  }
+
+  /**
+   * True when the attempt's view of one doc is still current: the doc was
+   * discovered, and no stop has tombstoned it or moved its generation since.
+   * The whole-attempt check above ranges over every doc a link chain visited,
+   * which is the right guard while the cascade is still resolving; claiming
+   * the target's lifetime at settle time asks about the target alone, because
+   * a stop of an intermediate link doc does not touch the target's
+   * registration.
+   */
+  private isStartAttemptCurrentFor(
+    attempt: StartAttempt,
+    key: `${MemorySpace}/${CellScope}/${URI}`,
+  ): boolean {
+    if (attempt.lifecycleEpoch !== this.lifecycleEpoch) return false;
+    if (attempt.preResolutionStopKeys.has(key)) return false;
+    const generation = attempt.generationsByDoc.get(key);
+    return generation !== undefined &&
+      (this.startGenerationByDoc.get(key) ?? 0) === generation;
   }
 
   /**
@@ -5506,18 +5555,21 @@ export class Runner {
 
       tx.addCommitCallback((_committedTx, result) => {
         if (!result.error) return;
-        // Stopping the child is only half of the rollback: this memo of what
+        // Releasing the child is only half of the rollback: this memo of what
         // the result cell holds decides whether the next run materializes the
         // child again. A rejected commit rolls the child's links back and the
         // notification for that rollback clears the memo, but an abort settles
         // without reaching storage, so clear it here. Left set, the memo makes
         // the next run treat the pattern as unchanged and skip a child that
-        // now exists nowhere. Cleared ahead of the stop, so a materialization
-        // that stopping re-enters keeps the memo it writes.
+        // now exists nowhere. Cleared ahead of the release, so a
+        // materialization that releasing re-enters keeps the memo it writes.
+        // A rollback carries a release's authority, not a stop's: it lets go
+        // of the registration this materialization installed and is not
+        // authoritative over a lifetime or a start it does not own.
         if (this.resultPatternCache.get(cacheKey) === resultPatternKey) {
           this.resultPatternCache.delete(cacheKey);
         }
-        this.stop(resultCell);
+        this.releaseChild(resultCell, undefined);
       });
       this.pullCellOnceAfterSuccessfulCommit(tx, resultCell);
     }

--- a/packages/runner/test/child-run-ownership.test.ts
+++ b/packages/runner/test/child-run-ownership.test.ts
@@ -188,6 +188,34 @@ describe("child run ownership", () => {
     expect(runtime.runner.cancels.has(key(result))).toBe(false);
   });
 
+  it("cancels a pending commit-gated start on release", async () => {
+    const { lift, pattern } = createTrustedBuilder(runtime).commonfabric;
+    const Piece = pattern<{ value: number }>(({ value }) => ({
+      doubled: lift((input: number) => input * 2)(value),
+    }));
+    const tx = runtime.edit();
+    tx.tx.immediate = true;
+    (tx.tx as { deferRunnerStartUntilCommit?: boolean })
+      .deferRunnerStartUntilCommit = true;
+    const result = runtime.getCell<Record<string, unknown>>(
+      space,
+      "released before its deferred start",
+      undefined,
+      tx,
+    );
+    runtime.run(tx, Piece, { value: 3 }, result.withTx(tx));
+
+    // The launch holds this result through the pending start alone: nothing is
+    // registered under its key until that start installs.
+    expect(runtime.runner.cancels.has(key(result))).toBe(false);
+
+    runtime.runner.releaseChild(result, undefined);
+    expect((await tx.commit()).error).toBeUndefined();
+    await runtime.idle();
+
+    expect(runtime.runner.cancels.has(key(result))).toBe(false);
+  });
+
   it("tombstones a pending commit-gated start when the runtime stops", async () => {
     const { lift, pattern } = createTrustedBuilder(runtime).commonfabric;
     const Piece = pattern<{ value: number }>(({ value }) => ({

--- a/packages/runner/test/child-run-ownership.test.ts
+++ b/packages/runner/test/child-run-ownership.test.ts
@@ -337,6 +337,37 @@ describe("child run ownership", () => {
     runtime.runner.stop(result);
   });
 
+  it("stops tracking a commit-gated start when its transaction fails", async () => {
+    const { lift, pattern } = createTrustedBuilder(runtime).commonfabric;
+    const Piece = pattern<{ value: number }>(({ value }) => ({
+      doubled: lift((input: number) => input * 2)(value),
+    }));
+    const tx = runtime.edit();
+    tx.tx.immediate = true;
+    (tx.tx as { deferRunnerStartUntilCommit?: boolean })
+      .deferRunnerStartUntilCommit = true;
+    const result = runtime.getCell<Record<string, unknown>>(
+      space,
+      "deferred start whose transaction fails",
+      undefined,
+      tx,
+    );
+    runtime.run(tx, Piece, { value: 3 }, result.withTx(tx));
+
+    const pending = (runtime.runner as unknown as {
+      pendingDeferredStarts: Map<string, Set<unknown>>;
+    }).pendingDeferredStarts;
+    expect(pending.size).toBe(1);
+
+    expect(tx.abort("setup rejected").error).toBeUndefined();
+    await runtime.idle();
+
+    // The start will never install, so it settles as cancelled and leaves
+    // nothing behind for the result's key.
+    expect(runtime.runner.cancels.has(key(result))).toBe(false);
+    expect(pending.size).toBe(0);
+  });
+
   it("declines to release a result that has no registration", () => {
     const result = runtime.getCell<Record<string, unknown>>(
       space,

--- a/packages/runner/test/child-run-ownership.test.ts
+++ b/packages/runner/test/child-run-ownership.test.ts
@@ -5,7 +5,10 @@ import type { OpaqueCell } from "@commonfabric/api";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import type { Cell } from "../src/cell.ts";
-import { createTrustedBuilder } from "./support/trusted-builder.ts";
+import {
+  createTrustedBuilder,
+  trustExecutable,
+} from "./support/trusted-builder.ts";
 import { Runtime } from "../src/runtime.ts";
 
 // The four guarantees a child run carries beyond "whoever created it stops it".
@@ -366,6 +369,50 @@ describe("child run ownership", () => {
     // nothing behind for the result's key.
     expect(runtime.runner.cancels.has(key(result))).toBe(false);
     expect(pending.size).toBe(0);
+  });
+
+  it("stops tracking a commit-gated pattern run when its transaction fails", async () => {
+    const { lift, pattern } = createTrustedBuilder(runtime).commonfabric;
+    const Piece = pattern<{ value: number }>(({ value }) => ({
+      doubled: lift((input: number) => input * 2)(value),
+    }));
+    // The commit-gated run a navigateTo handler schedules goes through its own
+    // entry point, reached here directly: driving it through a handler would
+    // mean failing whichever storage transaction the dispatch happened to
+    // land on.
+    const harness = runtime.runner as unknown as {
+      runPatternAfterSuccessfulCommit(
+        tx: unknown,
+        resultCell: unknown,
+        pattern: unknown,
+        inputs: unknown,
+        pullOnceAfterStart?: boolean,
+        markCreateOnlyResult?: boolean,
+      ): () => void;
+      pendingDeferredStarts: Map<string, Set<unknown>>;
+    };
+    const tx = runtime.edit();
+    const receipt = runtime.getCell<Record<string, unknown>>(
+      space,
+      "deferred pattern run whose transaction fails",
+      undefined,
+      tx,
+    );
+    harness.runPatternAfterSuccessfulCommit(
+      tx,
+      receipt,
+      trustExecutable(runtime, Piece),
+      { value: 3 },
+      true,
+      true,
+    );
+    expect(harness.pendingDeferredStarts.size).toBe(1);
+
+    expect(tx.abort("handler rejected").error).toBeUndefined();
+    await runtime.idle();
+
+    expect(harness.pendingDeferredStarts.size).toBe(0);
+    expect(runtime.runner.cancels.has(key(receipt))).toBe(false);
   });
 
   it("declines to release a result that has no registration", () => {

--- a/packages/runner/test/reload-rehydration-safety.test.ts
+++ b/packages/runner/test/reload-rehydration-safety.test.ts
@@ -470,6 +470,151 @@ Deno.test("stopping a target before link resolution invalidates the held start",
   }
 });
 
+Deno.test("releasing a target before link resolution preserves the held start", async () => {
+  const env = createSchedulerTestRuntime(import.meta.url, {});
+  try {
+    const { runtime, tx } = env;
+    const compiled = await runtime.patternManager.compilePattern(PROGRAM, {
+      space,
+      tx,
+    });
+    const input = runtime.getCell<number>(
+      space,
+      "pre-resolution-release-input",
+      undefined,
+      tx,
+    );
+    input.withTx(tx).set(5);
+    const target = runtime.getCell<{ doubled: number }>(
+      space,
+      "pre-resolution-release-target",
+      undefined,
+      tx,
+    );
+    // run() gives the target a plain child registration: live in `cancels`,
+    // with no independent lifetime recorded for it, so the release below
+    // reaches the registration instead of declining.
+    runtime.run(tx, compiled, { value: input }, target);
+    runtime.prepareTxForCommit(tx);
+    expect((await tx.commit()).error).toBeUndefined();
+    await runtime.idle();
+    expect(runtime.runner.cancels.size).toBe(1);
+
+    const link = runtime.getCell<unknown>(
+      space,
+      "pre-resolution-release-alias",
+    );
+    const syncStarted = Promise.withResolvers<void>();
+    const releaseSync = Promise.withResolvers<void>();
+    const targetLink = target.getAsLink();
+    let resolved = false;
+    link.getRaw = (() =>
+      resolved ? targetLink : undefined) as typeof link.getRaw;
+    link.sync = (() => {
+      syncStarted.resolve();
+      return releaseSync.promise.then(() => {
+        resolved = true;
+        return link;
+      });
+    }) as typeof link.sync;
+
+    const lifecycleState = runtime.runner as unknown as {
+      activeStartAttempts: Set<{ preResolutionStopKeys: Set<string> }>;
+    };
+    const start = runtime.start(link);
+    await syncStarted.promise;
+    // The release stops the child registration it owns, and leaves the start
+    // still resolving toward the same target without a tombstone.
+    runtime.runner.releaseChild(target, undefined);
+    expect(runtime.runner.cancels.size).toBe(0);
+    expect(
+      [...lifecycleState.activeStartAttempts][0]?.preResolutionStopKeys.size,
+    ).toBe(0);
+    releaseSync.resolve();
+
+    expect(await start).toBe(true);
+    expect(runtime.runner.cancels.size).toBe(1);
+    expect(await target.pull()).toEqual({ doubled: 10 });
+    runtime.runner.stop(target);
+  } finally {
+    await disposeSchedulerTestRuntime(env);
+  }
+});
+
+Deno.test("stopping the link doc after resolution leaves the started target owned", async () => {
+  const env = createSchedulerTestRuntime(import.meta.url, {});
+  try {
+    const { runtime, tx } = env;
+    const compiled = await runtime.patternManager.compilePattern(PROGRAM, {
+      space,
+      tx,
+    });
+    const input = runtime.getCell<number>(
+      space,
+      "link-doc-stop-input",
+      undefined,
+      tx,
+    );
+    input.withTx(tx).set(5);
+    const target = runtime.getCell<{ doubled: number }>(
+      space,
+      "link-doc-stop-target",
+      undefined,
+      tx,
+    );
+    await runtime.setup(tx, compiled, { value: input }, target);
+    runtime.prepareTxForCommit(tx);
+    expect((await tx.commit()).error).toBeUndefined();
+    expect(runtime.runner.cancels.size).toBe(0);
+
+    const link = runtime.getCell<unknown>(space, "link-doc-stop-alias");
+    const syncStarted = Promise.withResolvers<void>();
+    const releaseSync = Promise.withResolvers<void>();
+    const targetLink = target.getAsLink();
+    let resolved = false;
+    link.getRaw = (() =>
+      resolved ? targetLink : undefined) as typeof link.getRaw;
+    link.sync = (() => {
+      syncStarted.resolve();
+      return releaseSync.promise.then(() => {
+        resolved = true;
+        return link;
+      });
+    }) as typeof link.sync;
+
+    const runnerHarness = runtime.runner as unknown as {
+      startCore(resultCell: Cell<unknown>, options?: unknown): void;
+    };
+    const originalStartCore = runnerHarness.startCore.bind(runtime.runner);
+    const installed = Promise.withResolvers<void>();
+    runnerHarness.startCore = (resultCell, options) => {
+      originalStartCore(resultCell, options);
+      installed.resolve();
+    };
+
+    const start = runtime.start(link);
+    await syncStarted.promise;
+    releaseSync.resolve();
+    // The continuation below is queued when startCore installs the target's
+    // registration, ahead of the start's own settle bookkeeping, so the stop
+    // of the link doc lands in between: after the install, before the claim.
+    await installed.promise;
+    runtime.runner.stop(link);
+
+    // The stop of the link doc touched neither the target nor its
+    // registration, so the start claims the target's lifetime and reports it
+    // running; a release then declines against that lifetime.
+    expect(await start).toBe(true);
+    expect(runtime.runner.cancels.size).toBe(1);
+    runtime.runner.releaseChild(target, undefined);
+    expect(runtime.runner.cancels.size).toBe(1);
+    expect(await target.pull()).toEqual({ doubled: 10 });
+    runtime.runner.stop(target);
+  } finally {
+    await disposeSchedulerTestRuntime(env);
+  }
+});
+
 Deno.test("stopping a link target invalidates its held start", async () => {
   const seeded = await seedReloadablePiece("snapshot-link-target-stop-race");
   const reloaded = await reloadRuntime(seeded.env.storageManager);

--- a/packages/runner/test/runner.test.ts
+++ b/packages/runner/test/runner.test.ts
@@ -1847,6 +1847,50 @@ describe("setup/start", () => {
     expect(cellValue).toEqual({ output: 9 });
   });
 
+  it("does not retain direct ownership after stop wins a start race", async () => {
+    const pattern: Pattern = {
+      argumentSchema: {
+        type: "object",
+        properties: { input: { type: "number" } },
+      },
+      resultSchema: {},
+      result: { output: { $alias: { partialCause: "output", path: [] } } },
+      nodes: [
+        {
+          module: {
+            type: "javascript",
+            implementation: (v: { input: number }) => v.input,
+          },
+          inputs: { $alias: { cell: "argument", path: [] } },
+          outputs: { $alias: { partialCause: "output", path: [] } },
+        },
+      ],
+    };
+
+    const resultCell = runtime.getCell(space, "stopped direct start");
+    setupTrusted(runtime, undefined, pattern, { input: 1 }, resultCell);
+    await runtime.start(resultCell);
+
+    // The redundant start resolves on the already-running fast path, so its
+    // claim to a direct lifetime is decided by the bookkeeping that runs when
+    // its promise settles — after the stop and the replacement run below.
+    const redundantStart = runtime.start(resultCell);
+    runtime.runner.stop(resultCell);
+    runTrusted(runtime, undefined, pattern, { input: 2 }, resultCell);
+
+    // The stop superseded the redundant start: it reports that it left
+    // nothing running and claims no lifetime for the replacement's
+    // registration.
+    await expect(redundantStart).resolves.toBe(false);
+
+    await resultCell.pull();
+    const link = resultCell.getAsNormalizedFullLink();
+    const resultKey = `${link.space}/${link.scope}/${link.id}` as const;
+    expect(runtime.runner.cancels.has(resultKey)).toBe(true);
+    runtime.runner.releaseChild(resultCell, undefined);
+    expect(runtime.runner.cancels.has(resultKey)).toBe(false);
+  });
+
   it("stop and restart works with setup/start", async () => {
     const pattern: Pattern = {
       argumentSchema: {


### PR DESCRIPTION
The runner keeps one registration per running result: the scheduler actions for that piece, indexed by the result's key. A pattern that launches a child registers a *release* for it, which runs when the launching pattern is torn down. An explicit *stop* ends a piece on its owner's behalf.

docs/specs/runner-child-run-ownership.md already governs the difference, and "Independent lifetimes" already states the rule this change implements: "A start that is still resolving may be about to acquire that lifetime and cannot say so yet, so a release declines while one is in flight." The runner honored that only for a start it could see. A start that has not yet followed its link to the result is indexed under no key the release consults, and the shared release-and-stop path recorded a stop tombstone on every such attempt, which then terminated when it resolved. A result being opened directly — navigated to as a page — while its parent released it was silently never started. A start still resolving a link is a start in flight; the spec draws no distinction between the ones a release happens to see and the ones it does not.

Fixing that exposed a second defect of the same family. A start that lost a race with a stop still reported success and recorded an independent lifetime for the result. The registration under the key at that point belonged to whatever replaced it, or to nothing. The stale lifetime record then made every later release of that result decline, so a list element or nested child outlived its parent until an explicit stop.

Split the shared path. stop() records the pre-resolution tombstones itself and then calls stopResult(), which carries the rest of the teardown; releaseChild() calls stopResult() directly, so a release ends the registration it recognizes and leaves unresolved starts to settle on their own. start() claims the independent lifetime — and reports true — only when its target is still current as the attempt settles: no stop tombstoned the target or moved its registration's generation since this attempt discovered it. That judgment is scoped to the target doc alone, because a stop of an intermediate link doc the start resolved through does not touch the target's registration.

The specification had a hole, which is why one defect could sit under a rule and the other had no rule at all. It stated the release-side constraints case by case — release the exact registration, decline against an independent lifetime — without ever naming what those cases have in common. So it had nothing to say when the same question arose somewhere it had not enumerated.

Fill it by naming the distinction the cases come from, in a new section, "Two ways a registration ends": a stop is authoritative over the result, while a release is authoritative over the registration its own launch installed and over nothing else. The existing sections then read as that distinction applied to a case rather than as separate rules that happen to agree, and two questions the document could not previously answer follow from it. A start whose target a stop superseded claims nothing, because the registration it would claim is not the one it installed. A transaction rollback carries a release's authority, not a stop's, for the same reason — so the nested action-result child rollback, which used a full stop and therefore also tombstoned unresolved starts, now releases like the run() launch rollback beside it always did.

Tests cover each rule. Releasing a live child registration while a link start resolves toward the same target leaves no tombstone and the start completes. A stop that wins against a redundant start leaves that start claiming nothing for the replacement that follows. A stop of the link doc between the target's installation and the start's settlement leaves the target's lifetime claimed. Each test was run against the previous behavior and fails at the assertion naming its bug.

One case stays wider than the distinction demands, marked with a TODO where it happens. A release cancels every pending commit-gated start held for the result, including one another launch scheduled, because a start that has installed no registration yet offers nothing to tell launches apart by. Narrowing it needs the release to name the pending start its own launch created, the way it already names the registration it installed. The specification states the width as it stands.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Separates a release’s authority from a stop’s: a release ends only what it launched (its registration or a pending commit‑gated start); a stop remains authoritative over the result. Fixes lost starts, stale lifetimes, and leaked commit‑gated operations; aligns code and spec.

- **Bug Fixes**
  - `releaseChild()` no longer tombstones unresolved link starts; it ends only the registration it installed. When no registration exists, it cancels all pending commit‑gated starts for the result so a released child doesn’t start after commit.
  - `start()` returns true only if it claims a lifetime at settle and the target is still current; returns false when superseded by a stop or a generation change. Scoped to the target; stops of intermediate link docs don’t void the claim.
  - Transaction rollback now releases the child registration instead of stopping it, preserving unrelated lifetimes and in‑flight starts.
  - On failed transactions, pending commit‑gated starts and commit‑gated pattern runs settle as cancelled and are removed from the pending index.
  - Spec adds “Two ways a registration ends.” Tests cover release‑vs‑pre‑resolution starts, stop‑vs‑redundant start, link‑doc stops after target install, release of a commit‑gated child, and commit‑gated failures; tagged the pending‑start TODO to satisfy linting.

<sup>Written for commit 43bee987b4940496418bf244bf54eb06a75c7581. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

