### PR TITLE
dashboard: keep the wall live across a server outage

### DIFF
--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -89,6 +89,49 @@ serving, and the version in the page source says which start served it.
 An unattended display reloads when it reconnects to a server reporting a
 different version.
 
+An unattended display also survives the server going away. Every serving tick
+sends a heartbeat down each open event connection, so a browser can tell a
+server with nothing new to report from a stream that has stopped delivering.
+The page watches its own stream from the same one-second tick that paints the
+freshness indicator, and reopens the stream once the server has been silent for
+the length of time it takes that indicator to turn red. That covers each way a
+stream dies. The browser reconnects one that ended in a network error by
+itself. It gives up for good on one whose reconnect was answered by an error
+page, which is what the Tailscale proxy in front of the pod returns while the
+server restarts. And a connection that outlives a sleeping laptop stays open
+with nothing ever coming down it, which the browser never reports at all.
+
+A stream that was delivering and then closed is reopened immediately. One that
+has never delivered is reopened once per silence interval, so a server that
+refuses or fails connections costs one request an interval however long it is
+away, while one that accepts a connection and then drops it is followed as fast
+as it flaps. The silence interval is the fastest tile's collection interval
+plus a serving tick plus ten seconds. That keeps it clear of the heartbeat
+period, which is one serving tick, by the whole of the fastest tile's interval.
+A heartbeat slower than the silence interval would replace a healthy stream on
+every page tick.
+
+The indicator and the reconnect run off different clocks and mean different
+things. The indicator counts from the last tile update, so red means the data
+is old. The reconnect counts from the last event of any kind, heartbeats
+included, so reaching the interval means the server cannot be heard at all. A
+page can be red on a perfectly good stream, when every collector has been slow
+at once. The header badge is what tells the two apart, reading OFFLINE instead
+of LIVE whenever the page has no stream it is hearing the server on.
+
+Reopening the stream and saying whether the server can be heard are separate
+questions and get separate answers. Reopening is paced, because each attempt
+costs a request. Saying so is not. The browser reports a connection dropping as
+it drops, whether it means to retry or has given up, and the badge turns over on
+the next tick — a second, not an interval. Stopping the server therefore stands
+the page down almost at once, and the badge comes back the moment any event
+arrives on a stream again, including a heartbeat. The elapsed interval is only
+the last resort, for a connection that stays open with nothing coming down it,
+which is the one case the browser reports nothing about at all. A background
+tab's timers are throttled to about one a minute and a sleeping machine's stop
+altogether, so the page checks its stream on becoming visible and on the browser
+regaining the network as well as on its own tick.
+
 The tab favicon follows the most urgent visible tile. It is red when any tile is
 red, orange when there are no red tiles but at least one orange tile, and green
 otherwise. Gray tiles do not turn the favicon gray. The page uses one URL-backed

--- a/packages/dashboard/render.test.ts
+++ b/packages/dashboard/render.test.ts
@@ -10,6 +10,7 @@ import {
 } from "./render.ts";
 import { humanSpan } from "./lib.ts";
 import { FAVICON_VERSION } from "./favicon.ts";
+import { liveUpdateStream } from "./stream-client.ts";
 
 const TEST_VERSION = "1".repeat(40);
 
@@ -202,18 +203,24 @@ Deno.test("shell: the freshness age and the refresh interval reach both the text
   );
   assertStringIncludes(html, "let base = 7;");
   assertStringIncludes(html, `new EventSource('/events')`);
+  assertStringIncludes(html, `es.addEventListener('update'`);
+  assertStringIncludes(html, `es.addEventListener('ping', alive)`);
+  assertStringIncludes(html, `es.addEventListener('open', alive)`);
   assertStringIncludes(
     html,
-    `es.onmessage = (e) => { if (e.data === 'reload') location.reload(); };`,
+    `es.addEventListener('error', () => { updates.lost(); paint(); });`,
   );
-  assertStringIncludes(html, `es.addEventListener('update'`);
   assertStringIncludes(html, `reconcileTiles(grid, update.gridHtml)`);
   assertStringIncludes(html, `reconcileTiles(wide, update.wideHtml)`);
   assertStringIncludes(
     html,
     `if (update.shellVersion !== SHELL_VERSION) { location.reload(); return; }`,
   );
-  assertEquals(html.match(/location\.reload\(\)/g)?.length, 2);
+  assertEquals(
+    html.match(/location\.reload\(\)/g)?.length,
+    1,
+    "a version mismatch is the one thing that navigates the page",
+  );
   assertStringIncludes(
     html,
     `if (current.outerHTML === next.outerHTML) return current;`,
@@ -221,6 +228,62 @@ Deno.test("shell: the freshness age and the refresh interval reach both the text
   assertStringIncludes(html, `nextScroller.scrollTop = scrollTop`);
   assertStringIncludes(html, `active.dataset.focusKey ?? null`);
   assertStringIncludes(html, `link.dataset.focusKey === focusedKey`);
+});
+
+Deno.test("shell: the page watches its own stream and reopens one that stops delivering", () => {
+  const html = shell("", "", 0, 45_000, TEST_VERSION, "good");
+  // The silence the page reconnects on is the silence that turns the dot red.
+  assertStringIncludes(html, "const RED_AFTER = REFRESH + 10000;");
+  assertStringIncludes(html, `ago * 1000 <= RED_AFTER ? 'amber' : 'red'`);
+  assertStringIncludes(html, `const updates = liveUpdateStream(RED_AFTER, () => {`);
+  assertStringIncludes(
+    html,
+    `badge.textContent = updates.check(now) ? '● LIVE' : '● OFFLINE';`,
+  );
+  assertStringIncludes(html, `document.addEventListener('visibilitychange', paint);`);
+  assertStringIncludes(html, `addEventListener('online', paint);`);
+});
+
+// The functions the page runs are authored as TypeScript here and reach the
+// browser as the text of `Function.prototype.toString()`. That text has to be
+// JavaScript the browser accepts, and it has to stand alone: a reference to
+// anything outside the function is a name the page does not have. Neither
+// property is visible to a test that only looks for substrings.
+Deno.test("shell: the injected script is JavaScript, and each injected function stands alone", () => {
+  const script = shell("", "", 0, 45_000, TEST_VERSION, "good")
+    .match(/<script>([\s\S]*)<\/script>/)![1];
+  // Parses the whole body without running it, which is where a leftover type
+  // annotation or generic parameter would show up.
+  new Function(script);
+
+  // Evaluated on its own, outside its module, so a reference to anything at
+  // module scope throws instead of quietly resolving.
+  const source = script.match(
+    /const liveUpdateStream = ([\s\S]*?);\n {2}const badge =/,
+  )![1];
+  const injected = new Function(`return (${source});`)() as typeof liveUpdateStream;
+
+  const opened: { readyState: number; closed: boolean; close(): void }[] = [];
+  const live = injected(55_000, () => {
+    const stream = {
+      readyState: 0,
+      closed: false,
+      close() {
+        this.closed = true;
+      },
+    };
+    opened.push(stream);
+    return stream;
+  });
+  assert(live.check(0), "the page starts out hearing the server that served it");
+  assertEquals(opened.length, 1);
+  opened[0].readyState = 1;
+  live.heard(0);
+  assert(live.check(54_999));
+  assertEquals(opened.length, 1, "a stream that is delivering is left alone");
+  assertEquals(live.check(55_000), false, "and one that goes quiet is replaced");
+  assertEquals(opened.length, 2);
+  assert(opened[0].closed);
 });
 
 Deno.test("shell: live data and runtime settings keep the compatibility version", () => {

--- a/packages/dashboard/render.ts
+++ b/packages/dashboard/render.ts
@@ -283,8 +283,8 @@ ${faviconLink(status)}
   }
   const updates = liveUpdateStream(RED_AFTER, () => {
     const es = new EventSource('/events');
-    // Repainting from the connection's own events puts the badge right as the
-    // connection changes, rather than up to a tick later.
+    // The connection's own events repaint, so the badge follows the connection
+    // as it changes.
     const alive = () => { updates.heard(Date.now()); paint(); };
     es.addEventListener('open', alive);
     es.addEventListener('ping', alive);
@@ -307,8 +307,8 @@ ${faviconLink(status)}
   paint();
   setInterval(paint, 1000);
   // A background tab's timers are throttled to about one a minute, and a
-  // sleeping machine's stop altogether. Both events land before the next tick
-  // would, so a page someone turns back to is checked as they look at it.
+  // sleeping machine's stop altogether. These two events fire as the page comes
+  // back into use, which is when someone is there to read it.
   document.addEventListener('visibilitychange', paint);
   addEventListener('online', paint);
 </script></body></html>`;

--- a/packages/dashboard/render.ts
+++ b/packages/dashboard/render.ts
@@ -4,6 +4,7 @@ import type { TileView } from "./types.ts";
 import { durationTag, escapeHtml, STATUS_DOT } from "./lib.ts";
 import { faviconHref, faviconLink, type FaviconStatus } from "./favicon.ts";
 import { paintStatusFavicon } from "./favicon-client.ts";
+import { liveUpdateStream } from "./stream-client.ts";
 
 const FAVICON_PNG_HREFS = JSON.stringify({
   good: faviconHref("good"),
@@ -12,6 +13,12 @@ const FAVICON_PNG_HREFS = JSON.stringify({
   "bad-crying": faviconHref("bad-crying"),
 });
 const PAINT_STATUS_FAVICON = paintStatusFavicon.toString();
+const LIVE_UPDATE_STREAM = liveUpdateStream.toString();
+
+// How long past the refresh interval the freshness indicator stays orange before
+// it turns red. The page treats the same span of silence from the server as a
+// stream that has stopped delivering, and reconnects.
+const STALE_GRACE_MS = 10_000;
 
 export const FAVICON_CRY_AFTER_MS = 60 * 60 * 1000;
 
@@ -193,11 +200,13 @@ ${faviconLink(status)}
   <div id="dashboard-wide">${wideHtml}</div>
 <script>
   const REFRESH = ${refreshMs};
+  const RED_AFTER = REFRESH + ${STALE_GRACE_MS};
   const SHELL_VERSION = ${JSON.stringify(shellVersion)};
   const COL = { green: '#43c574', amber: '#e0a852', red: '#e2504a' };
   const FAVICONS = ${FAVICON_PNG_HREFS};
   const FAVICON_CRY_AFTER_MS = ${FAVICON_CRY_AFTER_MS};
   const paintStatusFavicon = ${PAINT_STATUS_FAVICON};
+  const liveUpdateStream = ${LIVE_UPDATE_STREAM};
   const badge = document.getElementById('livebadge');
   const dot = document.getElementById('freshdot');
   const agotext = document.getElementById('agotext');
@@ -211,12 +220,16 @@ ${faviconLink(status)}
   let faviconServerRedAgeMs = ${serverRedAgeMs};
   let faviconStartedAt = performance.now();
   function paint() {
-    const ago = base + Math.floor((Date.now() - t0) / 1000);
+    const now = Date.now();
+    const ago = base + Math.floor((now - t0) / 1000);
     agotext.textContent = 'updated ' + ago + 's ago';
     // Fresh up to the refresh interval, then orange for 10s, then red.
-    const state = ago * 1000 <= REFRESH ? 'green' : ago * 1000 <= REFRESH + 10000 ? 'amber' : 'red';
+    const state = ago * 1000 <= REFRESH ? 'green' : ago * 1000 <= RED_AFTER ? 'amber' : 'red';
     dot.className = 'dot ' + state;
     agotext.style.color = COL[state];
+    // The badge says which of the two the stale data means: the server is there
+    // and has nothing new, or the page cannot hear it.
+    badge.textContent = updates.check(now) ? '● LIVE' : '● OFFLINE';
     // LIVE badge: green only when fresh AND no tile is gray; gray if a tile is gray;
     // when stale, the border takes the orange/red and the contents go gray.
     const anyGray = document.querySelector('.tile.unknown') !== null;
@@ -268,22 +281,36 @@ ${faviconLink(status)}
       if (atIndex !== tile) container.insertBefore(tile, atIndex ?? null);
     });
   }
-  const es = new EventSource('/events');
-  es.onmessage = (e) => { if (e.data === 'reload') location.reload(); };
-  es.addEventListener('update', (e) => {
-    const update = JSON.parse(e.data);
-    if (update.shellVersion !== SHELL_VERSION) { location.reload(); return; }
-    reconcileTiles(grid, update.gridHtml);
-    reconcileTiles(wide, update.wideHtml);
-    base = update.ageSeconds;
-    t0 = Date.now();
-    faviconServerRedSince = update.faviconRedSince;
-    faviconServerRedAgeMs = update.faviconRedAgeMs;
-    faviconStartedAt = performance.now();
-    paint();
+  const updates = liveUpdateStream(RED_AFTER, () => {
+    const es = new EventSource('/events');
+    // Repainting from the connection's own events puts the badge right as the
+    // connection changes, rather than up to a tick later.
+    const alive = () => { updates.heard(Date.now()); paint(); };
+    es.addEventListener('open', alive);
+    es.addEventListener('ping', alive);
+    es.addEventListener('error', () => { updates.lost(); paint(); });
+    es.addEventListener('update', (e) => {
+      updates.heard(Date.now());
+      const update = JSON.parse(e.data);
+      if (update.shellVersion !== SHELL_VERSION) { location.reload(); return; }
+      reconcileTiles(grid, update.gridHtml);
+      reconcileTiles(wide, update.wideHtml);
+      base = update.ageSeconds;
+      t0 = Date.now();
+      faviconServerRedSince = update.faviconRedSince;
+      faviconServerRedAgeMs = update.faviconRedAgeMs;
+      faviconStartedAt = performance.now();
+      paint();
+    });
+    return es;
   });
   paint();
   setInterval(paint, 1000);
+  // A background tab's timers are throttled to about one a minute, and a
+  // sleeping machine's stop altogether. Both events land before the next tick
+  // would, so a page someone turns back to is checked as they look at it.
+  document.addEventListener('visibilitychange', paint);
+  addEventListener('online', paint);
 </script></body></html>`;
 }
 

--- a/packages/dashboard/server.test.ts
+++ b/packages/dashboard/server.test.ts
@@ -6,6 +6,7 @@
 import {
   assert,
   assertEquals,
+  assertMatch,
   assertRejects,
   assertStringIncludes,
 } from "@std/assert";
@@ -13,8 +14,10 @@ import {
   broadcast,
   clients,
   handle,
+  heartbeat,
   nextFaviconRedSince,
   page,
+  serveTick,
   start,
   tick,
 } from "./server.ts";
@@ -1114,6 +1117,44 @@ Deno.test("sse: /events opens a stream, tick pushes new tile markup, disconnect 
   assertEquals(clients.size, 0, "a disconnected browser is not kept as a client");
 });
 
+Deno.test("sse: every serving tick sends a heartbeat, so silence means a broken stream", async () => {
+  const res = await handle(req("/events"));
+  const reader = res.body!.getReader();
+  await chunk(reader); // ": connected"
+  await chunk(reader); // the snapshot every connection opens with
+
+  let collections = 0;
+  await serveTick(() => {
+    collections++;
+  });
+  assertEquals(collections, 1, "the tick still collects what is due");
+  const beat = await chunk(reader);
+  assertStringIncludes(beat, "event: ping\n");
+  // An event with no data is never delivered to the page, so the heartbeat
+  // carries its count.
+  assertMatch(beat, /^data: \d+$/m);
+
+  await serveTick(() => {});
+  const next = await chunk(reader);
+  assertStringIncludes(next, "event: ping\n");
+  assert(
+    Number(next.match(/^data: (\d+)$/m)![1]) >
+      Number(beat.match(/^data: (\d+)$/m)![1]),
+    "each heartbeat differs from the last",
+  );
+
+  await reader.cancel();
+});
+
+Deno.test("heartbeat: a client whose stream is gone is dropped rather than throwing", async () => {
+  const res = await handle(req("/events"));
+  const dead = [...clients].at(-1)!;
+  await res.body!.cancel();
+  clients.add(dead);
+  heartbeat();
+  assertEquals(clients.size, 0);
+});
+
 Deno.test("broadcast: a client whose stream is gone is dropped rather than throwing", async () => {
   const res = await handle(req("/events"));
   const dead = [...clients].at(-1)!;
@@ -1182,4 +1223,40 @@ Deno.test("start: serves the handler on the configured port and keeps collecting
   assertStringIncludes(logged[0], `http://localhost:${PORT}`);
   assertStringIncludes(logged[0], `${TILES.length} tiles registered`);
   assertEquals(collections, 1, "startup collects immediately");
+});
+
+Deno.test("start: the work it schedules on its clock both heartbeats and collects", async () => {
+  const res = await handle(req("/events"));
+  const reader = res.body!.getReader();
+  await chunk(reader); // ": connected"
+  await chunk(reader); // the snapshot every connection opens with
+
+  const log = console.log;
+  console.log = () => {};
+  let collections = 0;
+  let timer = 0;
+  let onTick = () => Promise.resolve();
+  try {
+    ({ timer, onTick } = start(
+      ((opts: Deno.ServeTcpOptions) => {
+        opts.onListen?.({ transport: "tcp", hostname: "localhost", port: PORT });
+        return undefined;
+      }) as unknown as typeof Deno.serve,
+      () => {
+        collections++;
+      },
+    ));
+  } finally {
+    clearInterval(timer);
+    console.log = log;
+  }
+  assertEquals(collections, 1, "the startup collection does not go through the clock");
+
+  // Without this, a browser hears nothing between tile changes and replaces a
+  // healthy stream once a minute forever.
+  await onTick();
+  assertStringIncludes(await chunk(reader), "event: ping\n");
+  assertEquals(collections, 2);
+
+  await reader.cancel();
 });

--- a/packages/dashboard/server.ts
+++ b/packages/dashboard/server.ts
@@ -112,8 +112,7 @@ export const clients = new Set<ReadableStreamDefaultController<Uint8Array>>();
 const enc = new TextEncoder();
 const encodeUpdate = (update: DashboardUpdate) =>
   enc.encode(`event: update\ndata: ${JSON.stringify(update)}\n\n`);
-export const broadcast = (update: DashboardUpdate) => {
-  const event = encodeUpdate(update);
+const send = (event: Uint8Array) => {
   for (const c of clients) {
     try {
       c.enqueue(event);
@@ -122,6 +121,14 @@ export const broadcast = (update: DashboardUpdate) => {
     }
   }
 };
+export const broadcast = (update: DashboardUpdate) => send(encodeUpdate(update));
+// A tick that collects nothing publishes nothing, so a browser cannot read
+// silence as a fault unless the server speaks on its own schedule. The
+// heartbeat is that schedule: a browser that stops hearing it replaces its
+// stream. The SSE data field carries the tick count because an event with no
+// data is not delivered to the page.
+let beats = 0;
+export const heartbeat = () => send(enc.encode(`event: ping\ndata: ${++beats}\n\n`));
 
 const runSourceKey = (source: RunSource): string => `${source.repo} ${source.workflow}`;
 const runSourceTileKey = (source: RunSource, tile: Tile): string => `${runSourceKey(source)} ${tile.id}`;
@@ -447,6 +454,15 @@ export async function handle(req: Request): Promise<Response> {
   return new Response(page(), { headers: { "content-type": "text/html; charset=utf-8" } });
 }
 
+// One turn of the server's clock: tell every connected browser the server is
+// still there, then collect whatever tiles are due.
+export async function serveTick(
+  collect: () => void | Promise<void> = tick,
+): Promise<void> {
+  heartbeat();
+  await collect();
+}
+
 // The side effects: collect once, keep collecting, and serve. Running the file
 // starts them; importing it does not.
 export function start(
@@ -454,12 +470,15 @@ export function start(
   collect: () => void | Promise<void> = tick,
 ) {
   collect();
-  const timer = setInterval(collect, TICK_MS);
+  // Returned so a test can run the scheduled work itself rather than wait out
+  // the interval.
+  const onTick = () => serveTick(collect);
+  const timer = setInterval(onTick, TICK_MS);
   const server = serve({
     port: PORT,
     onListen: () => console.log(`\n  Fabric wall LIVE:  http://localhost:${PORT}\n  ${TILES.length} tiles registered.\n`),
   }, handle);
-  return { timer, server };
+  return { timer, server, onTick };
 }
 
 // Running the file boots; importing it (the tests do) boots nothing.

--- a/packages/dashboard/server.ts
+++ b/packages/dashboard/server.ts
@@ -470,8 +470,7 @@ export function start(
   collect: () => void | Promise<void> = tick,
 ) {
   collect();
-  // Returned so a test can run the scheduled work itself rather than wait out
-  // the interval.
+  // Returned so a caller can run one turn of the clock on demand.
   const onTick = () => serveTick(collect);
   const timer = setInterval(onTick, TICK_MS);
   const server = serve({

--- a/packages/dashboard/stream-client.ts
+++ b/packages/dashboard/stream-client.ts
@@ -59,7 +59,14 @@ export function liveUpdateStream<S extends UpdateStream>(
   let dropped = false;
 
   const replace = (now: number): S => {
-    if (stream) stream.close();
+    if (stream) {
+      // Standing in a stream the page has heard nothing on leaves it with
+      // nothing it is hearing the server on, whatever the stream being
+      // replaced had managed. The page it was opened for is the exception:
+      // that one arrived over a working connection to the same server.
+      stream.close();
+      dropped = true;
+    }
     stream = open();
     openedAt = now;
     heardOnThisStream = false;

--- a/packages/dashboard/stream-client.ts
+++ b/packages/dashboard/stream-client.ts
@@ -1,0 +1,98 @@
+// Keeps the page's live-update stream connected. Runs in the browser: the shell
+// injects it into the page and drives it from the same one-second tick that
+// paints the freshness indicator.
+
+/** The parts of `EventSource` the reconnection logic reads. */
+export interface UpdateStream {
+  readonly readyState: number;
+  close(): void;
+}
+
+export interface LiveUpdateStream {
+  /** Records that the server was heard from. Called for every stream event. */
+  heard(now: number): void;
+  /** Records the browser reporting the connection failed or dropped. */
+  lost(): void;
+  /**
+   * Opens the stream, replaces one that has stopped delivering, and reports
+   * whether the page has a stream it is hearing the server on.
+   */
+  check(now: number): boolean;
+}
+
+/**
+ * Watches one update stream and replaces it when the server stops arriving.
+ *
+ * The browser reconnects a stream that ends in a network error and gives up on
+ * one whose reconnect is answered with an error page, which is what a proxy in
+ * front of a restarting server sends. A connection can also stay open while
+ * nothing comes down it, after the machine sleeps or the network moves. This
+ * covers all three: any stream the server has not been heard on for
+ * `silenceMs` is closed and reopened, and a stream that was working and then
+ * closed is reopened at once.
+ *
+ * A stream that has never been heard on is only ever reopened on the silence
+ * interval, so a server that refuses or fails connections costs one request an
+ * interval however long it is away. A server that accepts a connection and then
+ * drops it arms the prompt reopen again each time, so the page follows a
+ * flapping server as fast as it flaps.
+ *
+ * Reopening the stream and reporting whether the page can hear the server are
+ * separate questions with separate answers. Reopening is paced, because each
+ * attempt costs a request. Reporting is not: the browser says the moment a
+ * connection drops, and `check` passes that on the first time it is asked.
+ *
+ * `silenceMs` has to be longer than the server's heartbeat period, or a healthy
+ * stream is replaced on every tick.
+ */
+export function liveUpdateStream<S extends UpdateStream>(
+  silenceMs: number,
+  open: () => S,
+): LiveUpdateStream {
+  const CLOSED = 2; // EventSource.CLOSED
+  let stream: S | null = null;
+  let openedAt = 0;
+  let heardAt = 0;
+  let heardOnThisStream = false;
+  // The page arrived over a working connection to the same server, so it starts
+  // out as connected as the browser has told it anything.
+  let dropped = false;
+
+  const replace = (now: number): S => {
+    if (stream) stream.close();
+    stream = open();
+    openedAt = now;
+    heardOnThisStream = false;
+    return stream;
+  };
+
+  return {
+    heard(now: number): void {
+      heardAt = now;
+      heardOnThisStream = true;
+      dropped = false;
+    },
+    lost(): void {
+      dropped = true;
+    },
+    check(now: number): boolean {
+      let current = stream;
+      if (!current) {
+        heardAt = now; // the server served this page
+        current = replace(now);
+      } else if (heardOnThisStream && current.readyState === CLOSED) {
+        current = replace(now);
+      } else if (now - Math.max(heardAt, openedAt) >= silenceMs) {
+        current = replace(now);
+      }
+      // Every part of this is something the browser has said, not something
+      // inferred from how long ago it said it. A dropped connection is reported
+      // the moment it drops, and a stream is only heard on again when an event
+      // actually arrives. The elapsed interval is the last resort, for a
+      // connection that stays open with nothing coming down it, which is the
+      // one case the browser reports nothing about at all.
+      return !dropped && current.readyState !== CLOSED &&
+        now - heardAt < silenceMs;
+    },
+  };
+}

--- a/packages/dashboard/stream-client.ts
+++ b/packages/dashboard/stream-client.ts
@@ -55,15 +55,15 @@ export function liveUpdateStream<S extends UpdateStream>(
   let heardAt = 0;
   let heardOnThisStream = false;
   // The page arrived over a working connection to the same server, so it starts
-  // out as connected as the browser has told it anything.
+  // out with one it is hearing the server on.
   let dropped = false;
 
   const replace = (now: number): S => {
     if (stream) {
-      // Standing in a stream the page has heard nothing on leaves it with
-      // nothing it is hearing the server on, whatever the stream being
-      // replaced had managed. The page it was opened for is the exception:
-      // that one arrived over a working connection to the same server.
+      // A stream just opened is one nothing has arrived on, so the page has
+      // nothing it is hearing the server on until something does. The stream
+      // the page itself arrived over is the exception, and it has no stream to
+      // stand in.
       stream.close();
       dropped = true;
     }
@@ -92,12 +92,12 @@ export function liveUpdateStream<S extends UpdateStream>(
       } else if (now - Math.max(heardAt, openedAt) >= silenceMs) {
         current = replace(now);
       }
-      // Every part of this is something the browser has said, not something
-      // inferred from how long ago it said it. A dropped connection is reported
-      // the moment it drops, and a stream is only heard on again when an event
-      // actually arrives. The elapsed interval is the last resort, for a
-      // connection that stays open with nothing coming down it, which is the
-      // one case the browser reports nothing about at all.
+      // Three ways of having nothing to hear the server on, in the order the
+      // browser makes them known. It reports a connection dropping as it
+      // drops, and reports a stream it has given up on through `readyState`.
+      // It reports nothing at all about a connection that stays open with
+      // nothing coming down it, which is what the elapsed interval is left to
+      // catch.
       return !dropped && current.readyState !== CLOSED &&
         now - heardAt < silenceMs;
     },

--- a/packages/dashboard/test/stream-client.test.ts
+++ b/packages/dashboard/test/stream-client.test.ts
@@ -1,0 +1,210 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { liveUpdateStream, type UpdateStream } from "../stream-client.ts";
+
+const CONNECTING = 0, OPEN = 1, CLOSED = 2;
+const SILENCE = 55_000;
+
+interface FakeStream extends UpdateStream {
+  readyState: number;
+  closed: boolean;
+}
+
+interface Fixture {
+  /** Every stream the page has opened, oldest first. */
+  opened: FakeStream[];
+  current(): FakeStream;
+  heard(now: number): void;
+  lost(): void;
+  check(now: number): boolean;
+  /** The browser losing the connection and retrying it on its own. */
+  connectionDropped(): void;
+  /** The connection being made, and the first event arriving on it. */
+  connectionMade(now: number): void;
+}
+
+function fixture(): Fixture {
+  const opened: FakeStream[] = [];
+  const live = liveUpdateStream<FakeStream>(SILENCE, () => {
+    const stream: FakeStream = {
+      readyState: CONNECTING,
+      closed: false,
+      close() {
+        this.closed = true;
+        this.readyState = CLOSED;
+      },
+    };
+    opened.push(stream);
+    return stream;
+  });
+  const current = () => opened[opened.length - 1];
+  return {
+    opened,
+    current,
+    heard: (now) => live.heard(now),
+    lost: () => live.lost(),
+    check: (now) => live.check(now),
+    connectionDropped() {
+      current().readyState = CONNECTING;
+      live.lost();
+    },
+    connectionMade(now) {
+      current().readyState = OPEN;
+      live.heard(now);
+    },
+  };
+}
+
+describe("stream-client", () => {
+  describe("liveUpdateStream()", () => {
+    it("opens no stream until the page first checks", () => {
+      const page = fixture();
+      expect(page.opened.length).toBe(0);
+      expect(page.check(1_000)).toBe(true); // the server served this page
+      expect(page.opened.length).toBe(1);
+    });
+
+    it("leaves a stream that keeps delivering alone", () => {
+      const page = fixture();
+      page.check(1_000);
+      page.connectionMade(1_000);
+      for (let now = 2_000; now < 10 * SILENCE; now += 1_000) {
+        expect(page.check(now)).toBe(true);
+        page.heard(now); // the server keeps arriving
+      }
+      expect(page.opened.length).toBe(1);
+    });
+
+    it("returns false one tick after the server is stopped, rather than one interval after", () => {
+      const page = fixture();
+      page.check(0);
+      page.connectionMade(0);
+      expect(page.check(1_000)).toBe(true);
+
+      // Nothing answers the port, so the browser holds the stream at
+      // CONNECTING and retries on its own, reporting each failure as it
+      // happens. Waiting out the silence interval before believing it would
+      // leave the badge claiming LIVE for the best part of a minute.
+      page.connectionDropped();
+      expect(page.check(2_000)).toBe(false);
+      for (let now = 3_000; now < SILENCE; now += 1_000) {
+        page.connectionDropped(); // each of the browser's own retries fails too
+        expect(page.check(now)).toBe(false);
+      }
+
+      page.connectionMade(SILENCE); // the browser's own retry finds the server back
+      expect(page.check(SILENCE)).toBe(true);
+      expect(page.opened.length).toBe(1); // its stream was never replaced
+    });
+
+    it("replaces a stream the browser has given up on at once", () => {
+      const page = fixture();
+      page.check(1_000);
+      page.connectionMade(1_000);
+
+      // An error page answered the browser's own reconnect, which closes the
+      // stream for good and is reported as it happens.
+      const abandoned = page.current();
+      abandoned.readyState = CLOSED;
+      page.lost();
+
+      expect(page.check(2_000)).toBe(false);
+      expect(page.opened.length).toBe(2);
+      expect(abandoned.closed).toBe(true);
+      expect(page.current().readyState).toBe(CONNECTING);
+
+      page.connectionMade(2_100);
+      expect(page.check(3_000)).toBe(true); // without the interval elapsing
+    });
+
+    it("returns false for every tick of an outage that refuses each stream", () => {
+      const page = fixture();
+      page.check(0);
+      page.connectionMade(0);
+
+      // The server is behind a proxy answering every reconnect with an error
+      // page, so each stream closes without ever delivering.
+      page.current().readyState = CLOSED;
+      page.lost();
+      page.check(1_000);
+      page.current().readyState = CLOSED;
+      page.lost();
+
+      for (let now = 2_000; now < SILENCE; now += 1_000) {
+        expect(page.check(now)).toBe(false);
+        page.current().readyState = CLOSED;
+        page.lost();
+      }
+    });
+
+    it("opens one stream an interval while every stream is refused", () => {
+      const page = fixture();
+      page.check(0);
+      page.connectionMade(0);
+      page.current().readyState = CLOSED;
+      page.lost();
+      page.check(1_000); // the prompt replacement
+      expect(page.opened.length).toBe(2);
+
+      // Ticking every second must not open a stream every second.
+      page.current().readyState = CLOSED;
+      for (let now = 2_000; now < 1_000 + SILENCE; now += 1_000) {
+        page.check(now);
+        page.current().readyState = CLOSED;
+      }
+      expect(page.opened.length).toBe(2);
+
+      page.check(1_000 + SILENCE);
+      expect(page.opened.length).toBe(3);
+    });
+
+    it("replaces a stream that stays open with nothing arriving on it", () => {
+      const page = fixture();
+      page.check(0);
+      const zombie = page.current();
+      page.connectionMade(0);
+
+      // The connection survives a sleeping machine or a network that moved
+      // while nothing comes down it. The browser reports nothing wrong, so the
+      // elapsed interval is the only thing left to go on.
+      expect(page.check(SILENCE - 1)).toBe(true);
+      expect(page.opened.length).toBe(1);
+
+      expect(page.check(SILENCE)).toBe(false);
+      expect(page.opened.length).toBe(2);
+      expect(zombie.closed).toBe(true);
+
+      page.connectionMade(SILENCE + 500);
+      expect(page.check(SILENCE + 1_000)).toBe(true);
+      expect(page.opened.length).toBe(2);
+    });
+
+    it("gives a stream that is still connecting the whole interval before replacing it", () => {
+      const page = fixture();
+      page.check(0);
+      page.connectionMade(0);
+      page.current().readyState = CLOSED;
+      page.lost();
+      page.check(0); // prompt replacement, now at CONNECTING
+      expect(page.opened.length).toBe(2);
+
+      // The browser is retrying this one on its own schedule. Replacing it
+      // every tick would cancel that.
+      page.check(SILENCE - 1);
+      expect(page.opened.length).toBe(2);
+      page.check(SILENCE);
+      expect(page.opened.length).toBe(3);
+    });
+
+    it("returns true through a long lull in the data, which heartbeats carry", () => {
+      const page = fixture();
+      page.check(0);
+      page.connectionMade(0);
+      for (let now = 1_000; now < 10 * SILENCE; now += 1_000) {
+        page.heard(now); // a heartbeat, with no tile having changed
+        expect(page.check(now)).toBe(true);
+      }
+      expect(page.opened.length).toBe(1);
+    });
+  });
+});

--- a/packages/dashboard/test/stream-client.test.ts
+++ b/packages/dashboard/test/stream-client.test.ts
@@ -75,16 +75,15 @@ describe("stream-client", () => {
       expect(page.opened.length).toBe(1);
     });
 
-    it("returns false one tick after the server is stopped, rather than one interval after", () => {
+    it("returns `false` on the tick after the connection drops", () => {
       const page = fixture();
       page.check(0);
       page.connectionMade(0);
       expect(page.check(1_000)).toBe(true);
 
       // Nothing answers the port, so the browser holds the stream at
-      // CONNECTING and retries on its own, reporting each failure as it
-      // happens. Waiting out the silence interval before believing it would
-      // leave the badge claiming LIVE for the best part of a minute.
+      // `CONNECTING` and retries on its own, reporting each failure as it
+      // happens. The answer follows that report, on the tick after it.
       page.connectionDropped();
       expect(page.check(2_000)).toBe(false);
       for (let now = 3_000; now < SILENCE; now += 1_000) {
@@ -117,7 +116,7 @@ describe("stream-client", () => {
       expect(page.check(3_000)).toBe(true); // without the interval elapsing
     });
 
-    it("returns false for a stream it has just opened, with nothing reporting the loss", () => {
+    it("returns `false` for a stream it has just opened, with nothing reporting the loss", () => {
       const page = fixture();
       page.check(0);
       page.connectionMade(0);
@@ -134,7 +133,7 @@ describe("stream-client", () => {
       expect(page.check(2_000)).toBe(true);
     });
 
-    it("returns false for every tick of an outage that refuses each stream", () => {
+    it("returns `false` for every tick of an outage that refuses each stream", () => {
       const page = fixture();
       page.check(0);
       page.connectionMade(0);
@@ -202,7 +201,7 @@ describe("stream-client", () => {
       page.connectionMade(0);
       page.current().readyState = CLOSED;
       page.lost();
-      page.check(0); // prompt replacement, now at CONNECTING
+      page.check(0); // prompt replacement, now at `CONNECTING`
       expect(page.opened.length).toBe(2);
 
       // The browser is retrying this one on its own schedule. Replacing it
@@ -213,7 +212,7 @@ describe("stream-client", () => {
       expect(page.opened.length).toBe(3);
     });
 
-    it("returns true through a long lull in the data, which heartbeats carry", () => {
+    it("returns `true` through a long lull in the data, which heartbeats carry", () => {
       const page = fixture();
       page.check(0);
       page.connectionMade(0);

--- a/packages/dashboard/test/stream-client.test.ts
+++ b/packages/dashboard/test/stream-client.test.ts
@@ -117,6 +117,23 @@ describe("stream-client", () => {
       expect(page.check(3_000)).toBe(true); // without the interval elapsing
     });
 
+    it("returns false for a stream it has just opened, with nothing reporting the loss", () => {
+      const page = fixture();
+      page.check(0);
+      page.connectionMade(0);
+
+      // Only the closed state is set here, standing for a caller that reports
+      // nothing. The answer cannot rest on a report the module does not make
+      // itself: the stream it is now being asked about is one it has heard
+      // nothing on, whatever the stream it replaced had delivered.
+      page.current().readyState = CLOSED;
+      expect(page.check(1_000)).toBe(false);
+      expect(page.opened.length).toBe(2);
+
+      page.connectionMade(1_100);
+      expect(page.check(2_000)).toBe(true);
+    });
+
     it("returns false for every tick of an outage that refuses each stream", () => {
       const page = fixture();
       page.check(0);


### PR DESCRIPTION
An unattended display has one job when the server goes away, which is to come back on its own when the server returns. The wall did not. It froze on whatever it was last told, with the freshness indicator red and the header badge still reading LIVE, until a person reloaded the page by hand.

The page opened one EventSource and never looked at it again, relying entirely on the browser to reconnect. The browser does reconnect a stream that ended in a network error, but per the HTML specification it gives up permanently when a reconnect is answered by anything that is not a 200 with a content type of text/event-stream: it fires an error, sets readyState to CLOSED, and never tries again. The deployed dashboard sits behind a Tailscale serve sidecar proxying to the pod on loopback, with a Recreate rollout strategy, so while the pod is down that proxy answers with an HTML 502. Every browser watching the wall closes its stream for good within seconds of a restart beginning. Reproduced against a stand-in for that topology: killing the server put the page at readyState 2, and it stayed there after the server returned, with the age climbing forever. Killing a bare server with nothing in front of it, by contrast, leaves the browser retrying by itself and the page recovers unaided, which is why this never showed up in local use.

Two other ways a stream stops delivering end the same way. A reconnect can be answered by a captive portal, a 200 of the wrong type and equally fatal. And a connection can outlive a sleeping laptop or a network that moved, staying open with nothing ever coming down it, which the browser does not report as an error because from its side nothing went wrong.

The page now watches its own stream. The logic is a module of its own, authored as a TypeScript function and injected through toString the way the favicon painter already is, so it can be unit tested against a stand-in stream. It is driven from the one-second tick that already paints the freshness indicator and adds no timer. A stream nothing has arrived on for the silence interval is closed and reopened, which covers all three failures without having to tell them apart. A stream that was delivering and then closed is reopened at once, so a brief restart is picked up promptly, while a stream that has never delivered is only reopened on the interval, so a long outage costs one request an interval rather than one a tick.

Silence only means something if the server is expected to speak, and it was not: a collection cycle with nothing due publishes nothing, so a quiet server and a broken stream looked identical from the browser. Each serving tick now sends a heartbeat event down every open connection. Its data field carries a counter because an event with an empty data buffer is not dispatched to the page at all. The heartbeat also keeps the connection under the idle timeouts proxies tend to impose, and gives the server a regular write, so a dead socket errors out and is dropped from the client set sooner than a change-only broadcast managed.

Whether the page can hear the server is a separate question from when to try reopening, and it gets a separate answer. Reopening is paced, because each attempt costs a request. Reporting is not paced at all. The browser reports a connection dropping as it drops, whether it intends to retry or has given up, so the page listens for that, records it, clears it when an event next arrives, and turns the badge over on the following tick. Pacing this too would be the difference between a badge that is right in a second and one that is right in a minute: with nothing answering the port the browser holds the stream at CONNECTING and retries on its own schedule, so a page waiting out the interval would keep claiming LIVE for the best part of it. The elapsed interval remains the last resort for the connection that stays open with nothing coming down it, the one case the browser reports nothing about. Everything else the badge says is something the browser said, not something inferred from how long ago it said it.

The badge distinguishes two things the indicator alone cannot. They run off different clocks: the indicator counts from the last tile update, so red means the data is old, while the reconnect counts from the last event of any kind, heartbeats included, so reaching the interval means the server cannot be heard. A page can legitimately be red on a healthy stream, when every collector has been slow at once, and the badge is what says which.

Repainting from the connection's own events rather than only from the tick also keeps this working in a background tab, whose timers are throttled to about one a minute while its event handlers are not. For the same reason the page checks its stream when it becomes visible and when the browser regains the network, both events rather than polls, and both landing before a throttled tick would.

Verified in a browser against both topologies. Through the proxy stand-in, the page rode out an outage and picked the server back up on its own, arriving at the restarted server, reading the compatibility version it now reports, and reloading onto the code that restart is serving. That reload is what a server started from a checkout is meant to produce, and it can only happen because the page reconnects: a stream closed at a 502 never reaches the server again, so it never learns the version moved. A deployed image holds one version for its life, so there the same recovery lands in place with no navigation. Against a bare server, with a mutation observer on the badge so the transitions are timestamped rather than sampled: OFFLINE within about a second of the process being killed, while the freshness indicator was still green, and LIVE again as soon as it was restarted.

The watcher's own tests were confirmed against a deliberately wrong expectation rather than trusted for being green. Neutering the recording of a dropped connection fails the two cases that pin prompt reporting, and only those two: the case covering an outage where every stream is refused stays green under that mutation, because a closed stream is caught by a different term, which is the answer that case is there for.

The shell test for the injected watcher does not compare the page against the same toString it was built from, which could only fail if the injection were deleted outright. It extracts the function from the rendered page and evaluates it standalone, proving what a string comparison could not: that the injected text is valid browser JavaScript with its types stripped and closes over nothing from its module. The whole page script is checked for parseability the same way.

One tidy-up in the code this touched. The page's onmessage handler for a bare "reload" frame is gone, along with the test asserting its presence; nothing in the repository has ever sent a frame without an event name, and the page's one remaining reload, for a server reporting a different compatibility version, is in the update listener.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the dashboard wall live across server restarts and outages by adding a client-side SSE watcher and server heartbeats. The wall now reconnects on its own and flips the badge to OFFLINE within a second when the stream drops.

- **New Features**
  - Added `liveUpdateStream` (`packages/dashboard/stream-client.ts`) to watch the SSE, reopen on silence or CLOSED, and pace retries; drives the "● LIVE"/"● OFFLINE" badge.
  - Server heartbeats every tick (`event: ping` with a counter) via `heartbeat()` and `serveTick()` to distinguish silence from no updates and to keep connections alive.
  - Page repaints on stream `open`/`ping`/`update`/`error`, and also on `visibilitychange`/`online`; reconnect silence interval = refresh + 10s. README updated.

- **Bug Fixes**
  - Handles proxies returning non-SSE during rollouts (e.g., 502) where browsers permanently CLOSE the stream; the page now replaces dead/quiet streams and recovers automatically.
  - Stream watcher now reports OFFLINE immediately after it replaces a stream until an event arrives, avoiding a false LIVE state during reconnect.
  - Drops dead clients during heartbeat/broadcast without throwing; strengthened tests for server/client behavior and injected script validity.
  - Removed unused bare "reload" message handler.

<sup>Written for commit 30660ee9fc169c2f3948657178d0644c407aeeca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

