### PR TITLE
fix(piece): use current home pattern path in test

### DIFF
--- a/packages/piece/test/check-update-default-pattern.test.ts
+++ b/packages/piece/test/check-update-default-pattern.test.ts
@@ -1797,8 +1797,8 @@ describe("checkAndUpdateDefaultPattern", () => {
     // an unloadable identity — a different failure than the one under test.
     const targetPattern = await runtime.patternManager.compilePattern(
       {
-        main: HOME_PATTERN_URL,
-        files: [{ name: HOME_PATTERN_URL, contents: SOURCE_V3_HANDLER }],
+        main: HOME_PATTERN_PATH,
+        files: [{ name: HOME_PATTERN_PATH, contents: SOURCE_V3_HANDLER }],
       },
       { space: manager.getSpace() },
     );
@@ -1808,7 +1808,7 @@ describe("checkAndUpdateDefaultPattern", () => {
     const targetId = await identityForSource(
       SOURCE_V3_HANDLER,
       {},
-      HOME_PATTERN_URL,
+      HOME_PATTERN_PATH,
     );
     expect(targetRef.identity).toBe(targetId);
     const { error } = await runtime.editWithRetry((tx) => {


### PR DESCRIPTION
## What changed

Replaces three stale `HOME_PATTERN_URL` references in `check-update-default-pattern.test.ts` with the current route-path constant, `HOME_PATTERN_PATH`.

## Why

PR #5065 was authored before PR #5255 split system-pattern provenance from its served route and renamed `HOME_PATTERN_URL` to `HOME_PATTERN_SOURCE` / `HOME_PATTERN_PATH`. Because #5065 added new lines, its stale references merged cleanly without a conflict and made `main` fail both type-checking and the affected piece test.

This preserves the intended test behavior: the replacement pattern is compiled and identity-resolved using the served module path.

## Impact

Test-only fix. No runtime behavior changes.

## Validation

- `deno fmt --check packages/piece/test/check-update-default-pattern.test.ts`
- `deno check packages/piece/test/check-update-default-pattern.test.ts`
- Full `check-update-default-pattern.test.ts` suite: 69 steps, 0 failures
- `deno task check`: 433 paths passed


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the test to use the current home pattern route path constant. Replaces stale `HOME_PATTERN_URL` with `HOME_PATTERN_PATH` to restore type-checking and the test suite; no runtime impact.

- **Bug Fixes**
  - In packages/piece/test/check-update-default-pattern.test.ts, replace three `HOME_PATTERN_URL` references with `HOME_PATTERN_PATH` to keep compilation and identity resolution aligned with the served module path.

<sup>Written for commit ba193a551a94552eb8285a728ccb8b7355360a21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

