### PR TITLE
fix(dashboard): stop the sparkline charts reserving descender space

### DIFF
--- a/packages/dashboard/lib.ts
+++ b/packages/dashboard/lib.ts
@@ -329,9 +329,9 @@ export function sparkline(
     const tail = pts.slice(vals.length - highlight.count);
     lines.push(`<polyline points="${tail.join(" ")}" fill="none" stroke="${highlight.color}" stroke-width="2"/>`);
   }
-  // display:block keeps the chart's box the height it draws. An inline svg sits on
-  // a text baseline, so its line box reserves descender space below it, and a tile
-  // whose tallest content is a chart ends up taller than the chart by that much.
+  // The svg is a block, so the chart's box is the height it draws: an inline svg
+  // sits on a text baseline, and the line box around it reserves descender space
+  // underneath.
   return `<svg viewBox="0 0 ${w} ${h}" width="100%" height="24" preserveAspectRatio="none" style="display:block;margin-top:9px">${defs}${lines.join("")}</svg>`;
 }
 

--- a/packages/dashboard/lib.ts
+++ b/packages/dashboard/lib.ts
@@ -329,7 +329,10 @@ export function sparkline(
     const tail = pts.slice(vals.length - highlight.count);
     lines.push(`<polyline points="${tail.join(" ")}" fill="none" stroke="${highlight.color}" stroke-width="2"/>`);
   }
-  return `<svg viewBox="0 0 ${w} ${h}" width="100%" height="24" preserveAspectRatio="none" style="margin-top:9px">${defs}${lines.join("")}</svg>`;
+  // display:block keeps the chart's box the height it draws. An inline svg sits on
+  // a text baseline, so its line box reserves descender space below it, and a tile
+  // whose tallest content is a chart ends up taller than the chart by that much.
+  return `<svg viewBox="0 0 ${w} ${h}" width="100%" height="24" preserveAspectRatio="none" style="display:block;margin-top:9px">${defs}${lines.join("")}</svg>`;
 }
 
 // Overlaid trend lines (each oldest -> newest) sharing one vertical scale, each
@@ -512,7 +515,7 @@ export function multiSparkline(
 
   const labeled = drawable.filter((s) => s.label !== undefined);
   if (labeled.length === 0) {
-    return `<svg viewBox="0 0 ${w} ${h}" width="100%" height="32" preserveAspectRatio="none" style="margin-top:9px">${defsBlock}${lines}</svg>`;
+    return `<svg viewBox="0 0 ${w} ${h}" width="100%" height="32" preserveAspectRatio="none" style="display:block;margin-top:9px">${defsBlock}${lines}</svg>`;
   }
   const RH = 32; // rendered svg height, px
   // Each label sits at its line's end height; when a chart is drawn its value


### PR DESCRIPTION
A tile on the fabric wall is as tall as its content, and the CSS grid sizes each row to its tallest tile and stretches the rest to match. So whatever makes one tile a few pixels taller than it should be moves a whole row of the wall.

The chart helpers had two different ways of emitting their SVG. The one that draws end-of-line value labels puts the SVG inside a wrapper whose height is fixed to the rendered height, and marks the SVG as a block, so the chart's box is exactly the pixels it draws. The plain single-line chart and the unlabelled multi-line chart returned the SVG on its own, where it is an inline element: it sits on a text baseline, and the line box around it reserves room for descenders underneath. That made those charts' boxes 3.5 pixels taller than the chart, and any tile whose tallest content is such a chart 3.5 pixels taller than its neighbours.

On the wall as it stands, the benchmarks tile draws an unlabelled multi-line chart and the CI spend tile draws a labelled one. The two tiles are otherwise built the same way, and they sit in the same column one row apart, so the top row of tiles rendered 3.5 pixels taller than the row below it for no reason a reader could see.

Both plain emitters now mark the SVG as a block, which drops the descender space and leaves the chart's box the height of the chart.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make plain sparkline SVGs block-level to stop reserving descender space, fixing ~3.5px extra height and uneven fabric wall rows. Aligns the Benchmarks and CI Spend tiles by matching chart box height to the pixels drawn.

- **Bug Fixes**
  - Set `display:block` on SVGs in `sparkline()` and unlabeled `multiSparkline()` paths.
  - Removes baseline descender space so rows no longer stretch due to these charts.

- **Refactors**
  - Tightened the inline comment to state the rule and local hazard per the comment style guide.

<sup>Written for commit 0a9d8c024c4c152eb415c99bb6c816beb0ea38fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

