### PR TITLE
refactor(runtime-client): name the two domains `CellHandle` converts between

### DIFF
--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -3188,17 +3188,6 @@ function maybeConvertArrayPathToDataURILink(
 }
 
 /**
- * Validates that a value contains only static data (no cells or cell-like objects)
- * and has no circular references. Used by Cell.of() to ensure only serializable
- * static data is passed.
- *
- * Note: Shared references (same object at multiple paths) are allowed.
- * Only true cycles (object referencing an ancestor) are rejected.
- *
- * @param value - The value to validate
- * @throws Error if value contains cells or has circular references
- */
-/**
  * Whether `value` contains a reference cycle through plain containers.
  * Cells, links, and other non-plain objects are treated as leaves -- a cycle
  * through those resolves at read time and is not a structural cycle of the
@@ -3231,6 +3220,17 @@ function containsCycle(value: unknown): boolean {
   return walk(value);
 }
 
+/**
+ * Validates that a value contains only static data (no cells or cell-like objects)
+ * and has no circular references. Used by Cell.of() to ensure only serializable
+ * static data is passed.
+ *
+ * Note: Shared references (same object at multiple paths) are allowed.
+ * Only true cycles (object referencing an ancestor) are rejected.
+ *
+ * @param value - The value to validate
+ * @throws Error if value contains cells or has circular references
+ */
 function validateStaticData(value: unknown): void {
   // Track ancestors in current path (for cycle detection)
   // Shared references are fine - only cycles back to ancestors are errors
@@ -3322,6 +3322,14 @@ export function frameAnchorIds(
  * @param value - The value to convert.
  * @returns The converted value.
  */
+// TODO(danfuzz): name the two domains this converts between, the way
+// `ClientCellValue` and `WireCellValue` do for the connection. What arrives is
+// what a pattern produced -- a fabric value, or a native convertible to one,
+// plus the `Cell`s this exists to replace -- and what leaves is a `FabricValue`
+// carrying links in their place. The signature says `any` at both ends and for
+// `ancestors`, so nothing here can be checked, and a walk whose domain is
+// unwritten is one that cannot be told what it must do about a member of it:
+// the `FabricInstance` gap marked below is exactly that.
 export function convertCellsToLinks(
   value: readonly any[] | Record<string, any> | any,
   options: {

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -3322,14 +3322,6 @@ export function frameAnchorIds(
  * @param value - The value to convert.
  * @returns The converted value.
  */
-// TODO(danfuzz): name the two domains this converts between, the way
-// `ClientCellValue` and `WireCellValue` do for the connection. What arrives is
-// what a pattern produced -- a fabric value, or a native convertible to one,
-// plus the `Cell`s this exists to replace -- and what leaves is a `FabricValue`
-// carrying links in their place. The signature says `any` at both ends and for
-// `ancestors`, so nothing here can be checked, and a walk whose domain is
-// unwritten is one that cannot be told what it must do about a member of it:
-// the `FabricInstance` gap marked below is exactly that.
 export function convertCellsToLinks(
   value: readonly any[] | Record<string, any> | any,
   options: {
@@ -3341,6 +3333,15 @@ export function convertCellsToLinks(
   path: string[] = [],
   ancestors: Map<any, string[]> = new Map(),
 ): any {
+  // TODO(danfuzz): name the two domains this converts between, the way
+  // `ClientCellValue` and `WireCellValue` do for the connection. What arrives
+  // is what a pattern produced -- a fabric value, or a native convertible to
+  // one, plus the `Cell`s this exists to replace -- and what leaves is a
+  // `FabricValue` carrying links in their place. The signature says `any` at
+  // both ends and for `ancestors`, so nothing here can be checked, and a walk
+  // whose domain is unwritten is one that cannot be told what it must do about
+  // a member of it: the `FabricInstance` gap marked below is exactly that.
+
   if (ancestors.has(value)) {
     return linkRefFrom({ path: ancestors.get(value) });
   }

--- a/packages/runtime-client/cell-handle.ts
+++ b/packages/runtime-client/cell-handle.ts
@@ -37,9 +37,6 @@ const logger = getLogger("cell-handle", { enabled: false });
 export const $onCellUpdate = Symbol("$onCellUpdate");
 
 /**
- * CellHandle provides a cell interface for cells living in a web worker.
- */
-/**
  * A cell's value as the CLIENT holds it: what a cell holds, with a
  * `CellHandle` wherever a cell sits. That is the substitution
  * `vnode-types.ts` already makes for the render types -- `Cell` replaced by
@@ -60,6 +57,9 @@ export type ClientCellValue =
   | { readonly [key: string]: ClientCellValue }
   | CellHandle<unknown>;
 
+/**
+ * CellHandle provides a cell interface for cells living in a web worker.
+ */
 export class CellHandle<T = unknown> {
   #rt: RuntimeClient;
   #conn: InitializedRuntimeConnection;

--- a/packages/runtime-client/cell-handle.ts
+++ b/packages/runtime-client/cell-handle.ts
@@ -25,6 +25,7 @@ import {
   type WireCellValue,
 } from "./protocol/mod.ts";
 import { DID } from "@commonfabric/identity";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { isRecord } from "@commonfabric/utils/types";
 import { InitializedRuntimeConnection } from "./client/connection.ts";
 import { getLogger } from "@commonfabric/utils/logger";
@@ -39,23 +40,22 @@ export const $onCellUpdate = Symbol("$onCellUpdate");
  * CellHandle provides a cell interface for cells living in a web worker.
  */
 /**
- * A cell's value as the CLIENT holds it: the data a cell carries, with a
- * `CellHandle` wherever a cell sits. This is the same substitution
- * `vnode-types.ts` makes for the render types -- `Cell` replaced by
+ * A cell's value as the CLIENT holds it: what a cell holds, with a
+ * `CellHandle` wherever a cell sits. That is the substitution
+ * `vnode-types.ts` already makes for the render types -- `Cell` replaced by
  * `CellHandle` -- applied to a cell's own value.
  *
- * What it does NOT admit is as much of the point as what it does. There is no
- * `FabricSpecialObject` here: a `FabricBytes` or a `FabricError` has no
- * representation on this connection (see `IPCCellValue` in `protocol/types.ts`),
- * and nothing on this side produces one, so a walk over this domain never has
- * to have an opinion about one.
+ * What a cell holds is a `FabricValue`, so that is an arm of this rather than
+ * something restated: a `FabricBytes` in a cell is a value the client holds
+ * like any other, and this stays true of whatever `FabricValue` comes to admit.
+ * The container arms are here too, since theirs hold `FabricValue` where these
+ * hold handles as well.
+ *
+ * That the connection cannot presently CARRY all of it is a fact about
+ * `WireCellValue`, not about this: see the note there.
  */
 export type ClientCellValue =
-  | null
-  | undefined
-  | boolean
-  | number
-  | string
+  | FabricValue
   | readonly ClientCellValue[]
   | { readonly [key: string]: ClientCellValue }
   | CellHandle<unknown>;
@@ -516,6 +516,12 @@ export class CellHandle<T = unknown> {
    *
    * `CellHandle.deserialize()` is the inverse.
    */
+  // TODO(danfuzz): this does not handle the whole of its stated input. A
+  // `FabricSpecialObject` is a `ClientCellValue`, and `isRecord()` reports one,
+  // so it reaches the record branch below and is rebuilt from its (empty)
+  // enumerable members -- `{}` in place of a `FabricBytes`. `WireCellValue`
+  // cannot represent one either, so the fix is a refusal here rather than a
+  // conversion, and belongs with the wire gap marked on that type.
   static serialize(value: ClientCellValue): WireCellValue {
     if (isCellHandle(value)) return value.ref();
 

--- a/packages/runtime-client/cell-handle.ts
+++ b/packages/runtime-client/cell-handle.ts
@@ -516,13 +516,15 @@ export class CellHandle<T = unknown> {
    *
    * `CellHandle.deserialize()` is the inverse.
    */
-  // TODO(danfuzz): this does not handle the whole of its stated input. A
-  // `FabricSpecialObject` is a `ClientCellValue`, and `isRecord()` reports one,
-  // so it reaches the record branch below and is rebuilt from its (empty)
-  // enumerable members -- `{}` in place of a `FabricBytes`. `WireCellValue`
-  // cannot represent one either, so the fix is a refusal here rather than a
-  // conversion, and belongs with the wire gap marked on that type.
   static serialize(value: ClientCellValue): WireCellValue {
+    // TODO(danfuzz): this does not handle the whole of its stated input. A
+    // `FabricSpecialObject` is a `ClientCellValue`, and `isRecord()` reports
+    // one, so it reaches the record branch below and is rebuilt from its
+    // (empty) enumerable members -- `{}` in place of a `FabricBytes`.
+    // `WireCellValue` cannot represent one either, so the fix is a refusal
+    // here rather than a conversion, and belongs with the wire gap marked on
+    // that type.
+
     if (isCellHandle(value)) return value.ref();
 
     if (Array.isArray(value)) {

--- a/packages/runtime-client/cell-handle.ts
+++ b/packages/runtime-client/cell-handle.ts
@@ -22,6 +22,7 @@ import {
   type CfcLabelView,
   JSONValue,
   RequestType,
+  type WireCellValue,
 } from "./protocol/mod.ts";
 import { DID } from "@commonfabric/identity";
 import { isRecord } from "@commonfabric/utils/types";
@@ -37,6 +38,28 @@ export const $onCellUpdate = Symbol("$onCellUpdate");
 /**
  * CellHandle provides a cell interface for cells living in a web worker.
  */
+/**
+ * A cell's value as the CLIENT holds it: the data a cell carries, with a
+ * `CellHandle` wherever a cell sits. This is the same substitution
+ * `vnode-types.ts` makes for the render types -- `Cell` replaced by
+ * `CellHandle` -- applied to a cell's own value.
+ *
+ * What it does NOT admit is as much of the point as what it does. There is no
+ * `FabricSpecialObject` here: a `FabricBytes` or a `FabricError` has no
+ * representation on this connection (see `IPCCellValue` in `protocol/types.ts`),
+ * and nothing on this side produces one, so a walk over this domain never has
+ * to have an opinion about one.
+ */
+export type ClientCellValue =
+  | null
+  | undefined
+  | boolean
+  | number
+  | string
+  | readonly ClientCellValue[]
+  | { readonly [key: string]: ClientCellValue }
+  | CellHandle<unknown>;
+
 export class CellHandle<T = unknown> {
   #rt: RuntimeClient;
   #conn: InitializedRuntimeConnection;
@@ -142,7 +165,15 @@ export class CellHandle<T = unknown> {
     }
 
     const cell = this.ref();
-    const serialized = CellHandle.serialize(value);
+    // `T` is unconstrained, so this says what the write path requires rather
+    // than what the class guarantees. Constraining `T` to `ClientCellValue` is
+    // the honest fix and is not a small one: the schema-derived types
+    // (`ObjectFromProperties<...>`) and the looser `Props` of `vnode-types.ts`
+    // do not satisfy it, an interface having no implicit index signature where
+    // an identical type alias does.
+    //
+    // TODO(danfuzz): constrain `T`, once those types are assignable.
+    const serialized = CellHandle.serialize(value as ClientCellValue);
     const request = type === RequestType.CellPush
       ? this.#conn.request<RequestType.CellPush>({
         type: RequestType.CellPush,
@@ -165,7 +196,7 @@ export class CellHandle<T = unknown> {
     await this.#conn.request<RequestType.CellSend>({
       type: RequestType.CellSend,
       cell: this.ref(),
-      event: CellHandle.serialize(event),
+      event: CellHandle.serialize(event as ClientCellValue),
     }).catch((error) => {
       if (!this.#conn.signal.aborted) {
         console.error("[CellHandle] Send failed:", error);
@@ -480,33 +511,39 @@ export class CellHandle<T = unknown> {
   }
 
   /**
-   * Recursively converts any CellHandle references in the object into CellRefs.
-   * This is a CellHandle compatible form of `convertCellsToLinks`.
+   * Converts a value the client holds into the one the connection carries,
+   * which is the same data with a `CellRef` wherever a `CellHandle` sat.
+   *
+   * `CellHandle.deserialize()` is the inverse.
    */
-  static serialize(
-    value: readonly any[] | Record<string, any> | any,
-  ): any {
-    if (isCellHandle(value)) {
-      value = value.ref();
-    } else if (isRecord(value)) {
-      if (Array.isArray(value)) {
-        value = value.map((value) => CellHandle.serialize(value));
-      } else {
-        value = Object.fromEntries(
-          Object.entries(value).map(([key, value]) => [
-            key,
-            CellHandle.serialize(value),
-          ]),
-        );
-      }
-    } else if (
-      !(typeof value === "string" || typeof value === "number" ||
-        typeof value === "boolean" || value === undefined || value === null)
-    ) {
-      throw new Error(`Unknown type: ${value}`);
+  static serialize(value: ClientCellValue): WireCellValue {
+    if (isCellHandle(value)) return value.ref();
+
+    if (Array.isArray(value)) {
+      return value.map((element) => CellHandle.serialize(element));
     }
 
-    return value;
+    if (isRecord(value)) {
+      return Object.fromEntries(
+        Object.entries(value).map((
+          [key, member],
+        ) => [key, CellHandle.serialize(member)]),
+      );
+    }
+
+    if (
+      typeof value === "string" || typeof value === "number" ||
+      typeof value === "boolean" || value === undefined || value === null
+    ) {
+      return value;
+    }
+
+    // Unreachable by the type, and kept for callers that reach this untyped:
+    // `CellHandle<T>` does not constrain `T`, so `set()` and `send()` cast on
+    // the way in. `String()` rather than interpolation, a symbol throwing on
+    // implicit conversion and replacing this refusal with a `TypeError` naming
+    // nothing.
+    throw new Error(`Unknown type: ${String(value)}`);
   }
 }
 

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -246,10 +246,35 @@ export interface CellGetRequest extends BaseRequest {
   includeRef?: boolean;
 }
 
+/**
+ * A cell's value as this connection carries it: the data a cell holds, with a
+ * `CellRef` wherever a cell sits.
+ *
+ * Distinct from `JSONValue` in the two ways the traffic actually differs: a
+ * present `undefined` is a value a cell can hold, and the containers are
+ * readonly.
+ *
+ * TODO(danfuzz): this still cannot carry the whole `FabricValue` domain -- a
+ * `FabricSpecialObject` has no representation here, though the transport is
+ * `postMessage` rather than JSON, so that is a gap rather than a limit.
+ * `JsonEncodingContext` (`@commonfabric/data-model/codec-json`) is the
+ * mechanism, already used for blob-upload bodies in
+ * `backends/runtime-processor.ts`.
+ */
+export type WireCellValue =
+  | null
+  | undefined
+  | boolean
+  | number
+  | string
+  | readonly WireCellValue[]
+  | { readonly [key: string]: WireCellValue }
+  | CellRef;
+
 export interface CellSetRequest extends BaseRequest {
   type: RequestType.CellSet;
   cell: CellRef;
-  value: JSONValue;
+  value: WireCellValue;
 }
 
 // A read-modify-write append (`CellHandle.push`). Same wire shape as CellSet —
@@ -259,13 +284,13 @@ export interface CellSetRequest extends BaseRequest {
 export interface CellPushRequest extends BaseRequest {
   type: RequestType.CellPush;
   cell: CellRef;
-  value: JSONValue;
+  value: WireCellValue;
 }
 
 export interface CellSendRequest extends BaseRequest {
   type: RequestType.CellSend;
   cell: CellRef;
-  event: JSONValue;
+  event: WireCellValue;
 }
 
 export interface CellSubscribeRequest extends BaseRequest {

--- a/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.ts
+++ b/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.ts
@@ -944,7 +944,9 @@ export class CFPieceMenu extends BaseElement {
     const cell = this.cell;
     if (!cell || this.#dispatching) return;
     this.dispatchNote = undefined;
-    let payload: unknown = {};
+    // What `JSON.parse()` yields, which is what a cell's value may be minus
+    // the handles this menu never puts in one.
+    let payload: JSONValue = {};
     const text = this.payloadText.trim();
     if (text.length > 0) {
       try {
@@ -965,7 +967,7 @@ export class CFPieceMenu extends BaseElement {
       await cell.runtime()[$conn]().request<RequestType.CellSend>({
         type: RequestType.CellSend,
         cell: action.handle.ref(),
-        event: CellHandle.serialize(payload) as JSONValue,
+        event: CellHandle.serialize(payload),
       });
       if (generation !== this.#dataGeneration) return;
       this.dispatchNote = {


### PR DESCRIPTION
`CellHandle.serialize()` took `any` and `deserialize()` took `unknown`, so
neither said what it converts. They are inverses over two domains, and naming
them is enough to say so:

```ts
ClientCellValue  // what a cell holds, with a `CellHandle` where a cell sits
WireCellValue    // the same, with a `CellRef` where the handle sat
```

That is the substitution `vnode-types.ts` already documents for the render types
— *"our render types from `api` … replacing instances of `Cell` with
`CellHandle`"* — applied to a cell's own value.

`ClientCellValue` mirrors `FabricValue` arm for arm, `FabricSpecialObject`
included, because that is what a cell holds. That the connection cannot
presently *carry* all of it is a fact about `WireCellValue`, recorded there
rather than folded into the client's domain.

## `JSONValue` was the wrong wire type, concretely

`WireCellValue` replaces `JSONValue` on the three request fields that carry one.
Not aspirationally: the traffic already differs from `JSONValue` in two ways —
a cell can hold a **present `undefined`**, and the containers are **readonly**.
Widening those three fields cost nothing else in the tree.

## Types only

No behavior changes here. Where the types now admit something the code does not
handle, that is marked rather than fixed:

- **`serialize()` does not cover its stated input.** A `FabricSpecialObject` is
  a `ClientCellValue`, and `isRecord()` reports one, so it reaches the record
  branch and is rebuilt from its (empty) enumerable members — `{}` in place of a
  `FabricBytes`. `WireCellValue` cannot represent one either, so the fix is a
  refusal rather than a conversion, and belongs with the wire gap.
- **The wire cannot carry the full `FabricValue` domain**, though its transport
  is `postMessage` rather than JSON, so that is a gap rather than a limit.
  `JsonEncodingContext` is the mechanism, already used for blob-upload bodies in
  `backends/runtime-processor.ts`.
- **`CellHandle<T>` cannot yet be constrained** to `ClientCellValue`. Trying it
  produces 43 errors: the schema-derived types (`ObjectFromProperties<…>`) and
  the looser `Props` of `vnode-types.ts` do not satisfy it, an interface having
  no implicit index signature where an identical type alias does. `T` stays
  unconstrained, and the two casts in `set()` / `send()` are the ones that TODO
  covers.
- **`convertCellsToLinks()` has the same problem on the runtime side.** Its
  signature says `any` for its input, its result, and its `ancestors` map, so
  nothing in it can be checked. Marked rather than narrowed: the two sides are
  separable, and a walk whose domain is unwritten is one that cannot be told
  what it must do about a member of it — the `FabricInstance` gap already
  marked inside it is exactly that.

## Two things the types found

- **`serialize()` reassigned its parameter**, so no type could follow a handle
  becoming a ref. It returns instead, which reads better regardless.
- **A `packages/ui` caller passed `unknown`** — `JSON.parse()` output, then cast
  on the way out. It now says `JSONValue`, and the cast is gone.

## Two stranded doc comments, repaired

Both are the same defect, from a declaration being inserted above an existing
one: the comment stays put and ends up describing its new neighbor.
`CellHandle`'s own comment was left above `ClientCellValue` by this change, and
`validateStaticData()`'s was left above `containsCycle()` by an earlier one.
Each is back on the thing it describes. No gate sees this.

## Verification

`deno task check` 0 · `deno lint` 0 · `deno fmt --check` 0 ·
`runtime-client` 52/0 · `ui` 52/0 · full workspace suite passing. The `cell.ts`
change is comment-only, verified by filtering the diff to non-comment lines.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Named the two value domains `CellHandle` converts between: `ClientCellValue` (values with `CellHandle`s) and `WireCellValue` (same values with `CellRef`s). Switched protocol requests to `WireCellValue` to clarify data flow and allow present `undefined`.

- **Refactors**
  - Added `ClientCellValue` and `WireCellValue`; `ClientCellValue` includes `FabricValue`. The wire still cannot carry `FabricSpecialObject`.
  - Switched `CellSet`/`CellPush`/`CellSend` from `JSONValue` to `WireCellValue` (readonly containers; allows present `undefined`).
  - Made `serialize()` return a converted value and map `CellHandle` → `CellRef` without mutating input; rejects unknown types.
  - Typed UI payload as `JSONValue` and removed an unsafe cast; `CellHandle.serialize(payload)` is used directly.
  - Left `CellHandle<T>` unconstrained with a TODO to narrow to `ClientCellValue`; temporary casts in `set()`/`send()`.
  - Restored the `CellHandle` class doc and kept docs attached for `convertCellsToLinks()` and `serialize()` by moving the marker into each function body.

<sup>Written for commit fb1bd1f7722155efd8ef6030b661936d3250b71f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

