### PR TITLE
docs(runner): conform `encodable-form.ts` comments to the style guide

### DIFF
--- a/packages/runner/src/encodable-form.ts
+++ b/packages/runner/src/encodable-form.ts
@@ -13,11 +13,11 @@ import { isPlainObject } from "@commonfabric/utils/types";
  * has a representation for the cell itself. The storage boundary is elsewhere
  * and asks differently, recognizing a cell by class rather than by member.
  *
- * The name is the runtime's own, and asking by name is what keeps this module a
- * leaf: it sits below the runtime's core in the import graph, so it cannot name
- * `Cell` as a class. Being the runtime's own name is also what keeps the
- * question narrow, since no value acquires an encodable form by carrying a
- * member it defined for some other purpose.
+ * Asking by name is what keeps this module below the runtime's core in the
+ * import graph, where it cannot name `Cell` as a class. The name being the
+ * runtime's own is what keeps the question narrow: nothing outside the runtime
+ * has reason to define a member spelled this way, so a value does not acquire
+ * an encodable form by carrying one it meant for something else.
  */
 function encodableFormMethod(value: unknown): (() => unknown) | undefined {
   if (
@@ -36,12 +36,10 @@ function encodableFormMethod(value: unknown): (() => unknown) | undefined {
 /**
  * Checks whether a value can produce an encodable form of itself.
  *
- * Deliberately BROADER than the walk's own test (`ownEncodableFormMethod`):
- * this accepts an inherited member, because its callers ask about a specific
- * value they already hold -- a pattern, a cell -- rather than sifting an
- * arbitrary graph. A cell satisfies this through an inherited member, that
- * being where a class puts its methods. The walk cannot afford that latitude;
- * see there.
+ * BROADER than the walk's own test (`ownEncodableFormMethod()`), and
+ * intentionally: this accepts an INHERITED member, which is how a cell
+ * satisfies it, a class putting its methods on the prototype. The walk requires
+ * an own member; see there for what that buys it.
  */
 export function hasEncodableForm(value: unknown): boolean {
   return encodableFormMethod(value) !== undefined;
@@ -86,12 +84,12 @@ const IN_PROGRESS = Symbol("IN_PROGRESS");
 type OnCopy = (copy: unknown, original: unknown) => void;
 
 /**
- * Asked about each value the walk does not descend into, and returns what
- * should stand in its place -- the value itself to leave it alone. This is how
- * a caller says what ELSE has no fabric representation: a `Cell`, whose
- * encodable form is the link it stands for. Recognizing one takes `isCell()`,
- * which lives in the runtime's core, so the knowledge arrives as a function
- * rather than an import.
+ * Asked about each value the walk neither descends into nor replaces itself,
+ * and returns what should stand in its place -- the value itself to leave it
+ * alone. This is how a caller says what ELSE has no fabric representation: a
+ * `Cell`, whose encodable form is the link it stands for. Recognizing one takes
+ * `isCell()`, which lives in the runtime's core, so the knowledge arrives as a
+ * function rather than an import.
  */
 type ReplaceOther = (value: object | AnyFunction) => unknown;
 
@@ -110,9 +108,12 @@ type AnyFunction = (...args: never[]) => unknown;
  * pattern author put it -- under a tool's `handler` key, in a result, inside a
  * node's `inputs` -- so finding one takes a walk.
  *
- * The subject is BUILDER ARTIFACTS, and the `toEncodableForm` name is what
- * bounds it there. A plain object carrying the data model's duck-typed `toJSON`
- * is user data, and the conversion interprets it.
+ * The `toEncodableForm` name is what bounds the subject to BUILDER ARTIFACTS.
+ * An artifact carries `toJSON` as well, delegating to the same serializer (see
+ * `builder/json-member.ts`), but that name belongs to `JSON.stringify` and the
+ * conversion gives it no standing: a plain object carrying a `toJSON` of its
+ * own is user data, and the conversion rejects it for the function-valued
+ * member it is.
  *
  * An artifact is reached in two shapes and both are covered: a module is an
  * object, and a factory is a FUNCTION carrying its module's members (the
@@ -135,6 +136,15 @@ export function replaceArtifacts<T>(
   return replace(value, new Map(), onCopy, replaceOther) as T;
 }
 
+/**
+ * Helper for `replaceArtifacts()`, which carries the walk over one value and
+ * returns what should stand in its place -- the value itself when nothing under
+ * it moved.
+ *
+ * `seen` doubles as the cycle guard and the record of what each value was
+ * replaced by, so a value reachable twice is replaced once and comes back the
+ * same object both times.
+ */
 function replace(
   value: unknown,
   seen: Map<object, unknown>,
@@ -212,7 +222,7 @@ function replace(
  * to `replaceOther` and records whatever comes back.
  *
  * The replacement is NOT descended into: what the hook returns stands for the
- * value itself, a link say, and the walk has no further claim on it.
+ * value itself -- a link, say -- and only a container gets descended into.
  */
 function replaced(
   value: object | AnyFunction,
@@ -247,6 +257,12 @@ function copied(
   return replacement;
 }
 
+/**
+ * Helper for `replace()`, which walks an array's elements and returns the array
+ * itself when none of them moved.
+ *
+ * Holes stay holes: an absent element is not read, so nothing fills it in.
+ */
 function replaceInElements(
   value: readonly unknown[],
   seen: Map<object, unknown>,
@@ -279,6 +295,10 @@ function replaceInElements(
   return changed ? replaced : value;
 }
 
+/**
+ * Helper for `replace()`, which walks a record's members and returns the record
+ * itself when none of them moved.
+ */
 function replaceInEntries(
   value: Record<string, unknown>,
   seen: Map<object, unknown>,

--- a/packages/runner/src/encodable-form.ts
+++ b/packages/runner/src/encodable-form.ts
@@ -5,19 +5,19 @@ import { isPlainObject } from "@commonfabric/utils/types";
  * takes on the way to being encoded, which reaches storage without ever being
  * stringified.
  *
- * One name is asked for: `toEncodableForm`. Every builder artifact carries it -- a
- * module, a handler, a pattern, and the factory that carries a module's members
- * -- and so does a `Cell`, whose form is the link it names. A cell is what a
- * caller here is likeliest to hold that is not an artifact: a graph feeding a
- * content-derived id or a builder default can carry one, and neither has a
- * representation for the cell itself. The storage boundary is elsewhere and
- * asks differently, recognizing a cell by class rather than by member.
+ * One name is asked for: `toEncodableForm`. Every builder artifact carries it
+ * -- a module, a handler, a pattern, and the factory that carries a module's
+ * members -- and so does a `Cell`, whose form is the link it names. A cell is
+ * what a caller here is likeliest to hold that is not an artifact: a graph
+ * feeding a content-derived id or a builder default can carry one, and neither
+ * has a representation for the cell itself. The storage boundary is elsewhere
+ * and asks differently, recognizing a cell by class rather than by member.
  *
- * It is the runtime's OWN name, and that is the point. Asking by name rather
- * than by class is what lets this module stay a leaf -- naming `Cell` here
- * would mean importing the runtime's core, and the graph already runs the other
- * way. The name is not a public protocol, so no value acquires an encodable
- * form by carrying a member it defined for some other purpose.
+ * The name is the runtime's own, and asking by name is what keeps this module a
+ * leaf: it sits below the runtime's core in the import graph, so it cannot name
+ * `Cell` as a class. Being the runtime's own name is also what keeps the
+ * question narrow, since no value acquires an encodable form by carrying a
+ * member it defined for some other purpose.
  */
 function encodableFormMethod(value: unknown): (() => unknown) | undefined {
   if (
@@ -86,12 +86,12 @@ const IN_PROGRESS = Symbol("IN_PROGRESS");
 type OnCopy = (copy: unknown, original: unknown) => void;
 
 /**
- * Asked about each value the walk would otherwise pass through untouched,
- * and returns what should stand in its place -- the value itself to leave it
- * alone. This is how a caller says what ELSE has no fabric representation: a
- * `Cell`, whose encodable form is the link it stands for. Recognizing one takes
- * `isCell()`, and that lives in the runtime's core rather than here, so the
- * knowledge arrives as a function instead of as an import.
+ * Asked about each value the walk does not descend into, and returns what
+ * should stand in its place -- the value itself to leave it alone. This is how
+ * a caller says what ELSE has no fabric representation: a `Cell`, whose
+ * encodable form is the link it stands for. Recognizing one takes `isCell()`,
+ * which lives in the runtime's core, so the knowledge arrives as a function
+ * rather than an import.
  */
 type ReplaceOther = (value: object | AnyFunction) => unknown;
 
@@ -110,17 +110,9 @@ type AnyFunction = (...args: never[]) => unknown;
  * pattern author put it -- under a tool's `handler` key, in a result, inside a
  * node's `inputs` -- so finding one takes a walk.
  *
- * Keying on that name is what makes this walk's subject BUILDER ARTIFACTS
- * specifically, rather than everything the data model's duck-typed `toJSON`
- * protocol would honor. The narrower question is the intended one: a plain
- * object that answers `toJSON` and was not built here is the conversion's to
- * interpret, and is left to it.
- *
- * This looks for THE ARTIFACT rather than for the POSITIONS an artifact is
- * allowed to occupy. A traversal written the other way round has to be told
- * every shape a graph can take, and is wrong the moment a new one appears --
- * silently, since what it leaves behind is a live function in a value headed
- * for storage.
+ * The subject is BUILDER ARTIFACTS, and the `toEncodableForm` name is what
+ * bounds it there. A plain object carrying the data model's duck-typed `toJSON`
+ * is user data, and the conversion interprets it.
  *
  * An artifact is reached in two shapes and both are covered: a module is an
  * object, and a factory is a FUNCTION carrying its module's members (the
@@ -219,9 +211,8 @@ function replace(
  * Helper for `replace()`, which offers a value the walk does not descend into
  * to `replaceOther` and records whatever comes back.
  *
- * The replacement is NOT descended into. What the hook returns stands for the
- * value itself -- a link, say -- rather than being a container the walk has any
- * further claim on.
+ * The replacement is NOT descended into: what the hook returns stands for the
+ * value itself, a link say, and the walk has no further claim on it.
  */
 function replaced(
   value: object | AnyFunction,
@@ -238,12 +229,10 @@ function replaced(
  * Records a replacement: the single place a copy becomes the replacement for
  * its original.
  *
- * Every branch above returns through here, and that is deliberate. The
- * bookkeeping a copy needs -- telling the caller so identity-keyed facts can
- * follow, and remembering the replacement so a value reachable twice is replaced
- * once -- was previously written out at each branch, and was left off a new
- * branch three separate times. Routing every copy through one function is what
- * makes the fourth omission impossible rather than merely unlikely.
+ * Every branch that replaces a value returns through here, which is what makes
+ * a copy's bookkeeping unforgettable: the caller is told, so identity-keyed
+ * facts can follow the copy, and the replacement is remembered, so a value
+ * reachable twice is replaced once.
  *
  * A value that came back unchanged is not a copy and is not announced as one.
  */

--- a/packages/runner/src/encodable-form.ts
+++ b/packages/runner/src/encodable-form.ts
@@ -84,12 +84,12 @@ const IN_PROGRESS = Symbol("IN_PROGRESS");
 type OnCopy = (copy: unknown, original: unknown) => void;
 
 /**
- * Asked about each value the walk neither descends into nor replaces itself,
- * and returns what should stand in its place -- the value itself to leave it
- * alone. This is how a caller says what _else_ has no fabric representation: a
- * `Cell`, whose encodable form is the link it stands for. Recognizing one takes
- * `isCell()`, which lives in the runtime's core, so the knowledge arrives as a
- * function rather than an import.
+ * Asked about each object or function the walk neither descends into nor
+ * replaces itself, and returns what should stand in its place -- the value
+ * itself to leave it alone. This is how a caller says what _else_ has no fabric
+ * representation: a `Cell`, whose encodable form is the link it stands for.
+ * Recognizing one takes `isCell()`, which lives in the runtime's core, so the
+ * knowledge arrives as a function rather than an import.
  */
 type ReplaceOther = (value: object | AnyFunction) => unknown;
 
@@ -112,9 +112,9 @@ type AnyFunction = (...args: never[]) => unknown;
  * artifacts_.
  * An artifact carries `toJSON` as well, delegating to the same serializer (see
  * `builder/json-member.ts`), but that name belongs to `JSON.stringify` and the
- * conversion gives it no standing: a plain object carrying a `toJSON` of its
- * own is user data, and the conversion rejects it for the function-valued
- * member it is.
+ * conversion gives it no standing: a plain object carrying a `toJSON` it
+ * defined itself is user data, and the conversion rejects it, that `toJSON`
+ * being a function-valued member.
  *
  * An artifact is reached in two shapes and both are covered: a module is an
  * object, and a factory is a _function_ carrying its module's members (the
@@ -143,8 +143,9 @@ export function replaceArtifacts<T>(
  * it moved.
  *
  * `seen` doubles as the cycle guard and the record of what each value was
- * replaced by, so a value reachable twice is replaced once and comes back the
- * same object both times.
+ * replaced by, so a value reachable twice is replaced once. It comes back as
+ * the same object both times, except across a cycle edge: an ancestor still
+ * under way comes back as itself, which is what the guard is for.
  */
 function replace(
   value: unknown,

--- a/packages/runner/src/encodable-form.ts
+++ b/packages/runner/src/encodable-form.ts
@@ -108,8 +108,7 @@ type AnyFunction = (...args: never[]) => unknown;
  * pattern author put it -- under a tool's `handler` key, in a result, inside a
  * node's `inputs` -- so finding one takes a walk.
  *
- * The `toEncodableForm` name is what bounds the subject to _builder
- * artifacts_.
+ * The `toEncodableForm` name is what bounds the subject to _builder artifacts_.
  * An artifact carries `toJSON` as well, delegating to the same serializer (see
  * `builder/json-member.ts`), but that name belongs to `JSON.stringify` and the
  * conversion gives it no standing: a plain object carrying a `toJSON` it
@@ -125,7 +124,7 @@ type AnyFunction = (...args: never[]) => unknown;
  * deep-frozen `FabricValue` eligible for the conversion's identity fast path
  * and keeps a twice-reachable object shared.
  *
- * A cycle is left for the conversion to reject. What it rejects it BY may be
+ * A cycle is left for the conversion to reject. What it rejects it _by_ may be
  * the cycle or an artifact still raw inside the partial result: an ancestor is
  * returned as itself, so a copy's cycle edge points at the original.
  */
@@ -338,8 +337,8 @@ function ownEncodableFormMethod(
   value: object | ((...args: unknown[]) => unknown),
 ): (() => unknown) | undefined {
   // _Own_, not inherited: an inherited member is not the value's own
-  // and a single assignment to `Object.prototype.toEncodableForm` would
-  // otherwise route every plain object in the process through here.
+  // serializer, and a single assignment to `Object.prototype.toEncodableForm`
+  // would otherwise route every plain object in the process through here.
   if (!Object.hasOwn(value, "toEncodableForm")) return undefined;
 
   // Read once, and hand back what was read. `Object.hasOwn()` runs no accessor,

--- a/packages/runner/src/encodable-form.ts
+++ b/packages/runner/src/encodable-form.ts
@@ -36,8 +36,8 @@ function encodableFormMethod(value: unknown): (() => unknown) | undefined {
 /**
  * Checks whether a value can produce an encodable form of itself.
  *
- * BROADER than the walk's own test (`ownEncodableFormMethod()`), and
- * intentionally: this accepts an INHERITED member, which is how a cell
+ * _Broader_ than the walk's own test (`ownEncodableFormMethod()`), and
+ * intentionally: this accepts an _inherited_ member, which is how a cell
  * satisfies it, a class putting its methods on the prototype. The walk requires
  * an own member; see there for what that buys it.
  */
@@ -86,7 +86,7 @@ type OnCopy = (copy: unknown, original: unknown) => void;
 /**
  * Asked about each value the walk neither descends into nor replaces itself,
  * and returns what should stand in its place -- the value itself to leave it
- * alone. This is how a caller says what ELSE has no fabric representation: a
+ * alone. This is how a caller says what _else_ has no fabric representation: a
  * `Cell`, whose encodable form is the link it stands for. Recognizing one takes
  * `isCell()`, which lives in the runtime's core, so the knowledge arrives as a
  * function rather than an import.
@@ -108,7 +108,8 @@ type AnyFunction = (...args: never[]) => unknown;
  * pattern author put it -- under a tool's `handler` key, in a result, inside a
  * node's `inputs` -- so finding one takes a walk.
  *
- * The `toEncodableForm` name is what bounds the subject to BUILDER ARTIFACTS.
+ * The `toEncodableForm` name is what bounds the subject to _builder
+ * artifacts_.
  * An artifact carries `toJSON` as well, delegating to the same serializer (see
  * `builder/json-member.ts`), but that name belongs to `JSON.stringify` and the
  * conversion gives it no standing: a plain object carrying a `toJSON` of its
@@ -116,7 +117,7 @@ type AnyFunction = (...args: never[]) => unknown;
  * member it is.
  *
  * An artifact is reached in two shapes and both are covered: a module is an
- * object, and a factory is a FUNCTION carrying its module's members (the
+ * object, and a factory is a _function_ carrying its module's members (the
  * `Object.assign` in `builder/module.ts`). A function is replaced but never
  * descended into: its members are the builder's, not content.
  *
@@ -200,7 +201,7 @@ function replace(
   if (isArray) {
     flattened = replaceInElements(value, seen, onCopy, replaceOther);
   } else {
-    // The artifact's OWN method is what gets read and called, rather than the
+    // The artifact's _own_ method is what gets read and called, rather than the
     // serializer it delegates to: the method a copy carries is closed over the
     // artifact the copy was made from, and that original is what the
     // serialized form describes.
@@ -221,7 +222,7 @@ function replace(
  * Helper for `replace()`, which offers a value the walk does not descend into
  * to `replaceOther` and records whatever comes back.
  *
- * The replacement is NOT descended into: what the hook returns stands for the
+ * The replacement is _not_ descended into: what the hook returns stands for the
  * value itself -- a link, say -- and only a container gets descended into.
  */
 function replaced(
@@ -269,11 +270,11 @@ function replaceInElements(
   onCopy: OnCopy,
   replaceOther: ReplaceOther,
 ): readonly unknown[] {
-  // Read each element ONCE, and build any copy from what was read -- the
+  // Read each element _once_, and build any copy from what was read -- the
   // array counterpart of the entries `replaceInEntries` materializes, for the
   // same reason. Copying by re-reading (`slice()`, or an index-by-index pass
   // over the original) runs an accessor-backed element a second time and
-  // keeps THAT value, storing a value the array never held at any single
+  // keeps _that_ value, storing a value the array never held at any single
   // moment and which the walk never inspected.
   //
   // So the result is built as it goes rather than cloned at the first change:
@@ -305,7 +306,7 @@ function replaceInEntries(
   onCopy: OnCopy,
   replaceOther: ReplaceOther,
 ): Record<string, unknown> {
-  // Read each member ONCE, and build any copy from what was read: reading a
+  // Read each member _once_, and build any copy from what was read: reading a
   // second time to copy would run an accessor twice and keep the second
   // value, so a value whose members are accessor-backed would be recorded
   // as something it never was at any single moment.
@@ -335,7 +336,7 @@ function replaceInEntries(
 function ownEncodableFormMethod(
   value: object | ((...args: unknown[]) => unknown),
 ): (() => unknown) | undefined {
-  // OWN, not inherited: an inherited member is not the value's own serializer,
+  // _Own_, not inherited: an inherited member is not the value's own
   // and a single assignment to `Object.prototype.toEncodableForm` would
   // otherwise route every plain object in the process through here.
   if (!Object.hasOwn(value, "toEncodableForm")) return undefined;

--- a/packages/runner/test/encodable-form.test.ts
+++ b/packages/runner/test/encodable-form.test.ts
@@ -170,7 +170,7 @@ describe("encodable-form", () => {
         expect(reads).toBe(1);
       });
 
-      it("invokes a _function_ artifact's serializer once, on the artifact", () => {
+      it("invokes a _function_ artifact's serializer once, on it", () => {
         // The object branch has the shared-artifact case below to pin its
         // invoke count, and the pre-existing receiver case under
         // `encodableFormOf()` pins the shared invoke. Neither reaches the
@@ -327,14 +327,13 @@ describe("encodable-form", () => {
 
     describe("the `replaceOther` hook", () => {
       // The hook is how a caller names what _else_ has no fabric
-      // representation. Nothing else in this file passes a non-identity one, so
-      // this is the only place the hook's replacement is exercised at all.
+      // representation -- a `Cell`, in the runtime.
       const viaHook = (value: unknown, replace: (v: object) => unknown) => {
         const seen: { copy: unknown; original: unknown }[] = [];
         const result = replaceArtifacts(
           value,
           (copy, original) => seen.push({ copy, original }),
-          replace as (v: object | ((...args: never[]) => unknown)) => unknown,
+          replace,
         );
         return { result, seen };
       };

--- a/packages/runner/test/encodable-form.test.ts
+++ b/packages/runner/test/encodable-form.test.ts
@@ -170,22 +170,25 @@ describe("encodable-form", () => {
         expect(reads).toBe(1);
       });
 
-      it("invokes a _function_ artifact's serializer once, on it", () => {
-        // The object branch has the shared-artifact case below to pin its
-        // invoke count, and the pre-existing receiver case under
-        // `encodableFormOf()` pins the shared invoke. Neither reaches the
-        // function branch, which reads and invokes on its own.
-        let calls = 0;
-        const value = Object.assign(() => {}, {
-          marker: "factory",
-          toEncodableForm(this: { marker?: string }) {
-            calls++;
-            return { saw: this?.marker, nth: calls };
-          },
-        });
-        expect(flatten(value)).toEqual({ saw: "factory", nth: 1 });
-        expect(calls).toBe(1);
-      });
+      it(
+        "invokes a _function_ artifact's serializer once, on the artifact",
+        () => {
+          // The object branch has the shared-artifact case below to pin its
+          // invoke count, and the pre-existing receiver case under
+          // `encodableFormOf()` pins the shared invoke. Neither reaches the
+          // function branch, which reads and invokes on its own.
+          let calls = 0;
+          const value = Object.assign(() => {}, {
+            marker: "factory",
+            toEncodableForm(this: { marker?: string }) {
+              calls++;
+              return { saw: this?.marker, nth: calls };
+            },
+          });
+          expect(flatten(value)).toEqual({ saw: "factory", nth: 1 });
+          expect(calls).toBe(1);
+        },
+      );
 
       it("invokes an object artifact's serializer on the artifact", () => {
         const value = {
@@ -471,7 +474,7 @@ describe("encodable-form", () => {
         .toEqual({ a: 1 });
     });
 
-    it("calls the member ON the value, so `this` is the receiver", () => {
+    it("calls the member _on_ the value, so `this` is the receiver", () => {
       const value = {
         marker: "self",
         toEncodableForm(this: { marker: string }) {
@@ -547,7 +550,7 @@ describe("encodable-form", () => {
       // An id is derived from a value's encodable form, so the reference is the
       // link itself written out as data -- a value that reaches `createRef`
       // through none of the cell or proxy machinery. Comparing the two subjects
-      // only to each other would hold just as well if BOTH moved; comparing
+      // only to each other would hold just as well if _both_ moved; comparing
       // each to the link pins where they land, without naming a hash that a
       // later change to link shape would have to come back and edit.
       const { cell, reactive } = subjects();

--- a/packages/runner/test/encodable-form.test.ts
+++ b/packages/runner/test/encodable-form.test.ts
@@ -325,6 +325,49 @@ describe("encodable-form", () => {
       });
     });
 
+    describe("the `replaceOther` hook", () => {
+      // The hook is how a caller names what ELSE has no fabric representation.
+      // Nothing else in this file passes a non-identity one, so this is the only
+      // place the hook's replacement is exercised at all.
+      const viaHook = (value: unknown, replace: (v: object) => unknown) => {
+        const seen: { copy: unknown; original: unknown }[] = [];
+        const result = replaceArtifacts(
+          value,
+          (copy, original) => seen.push({ copy, original }),
+          replace as (v: object | ((...args: never[]) => unknown)) => unknown,
+        );
+        return { result, seen };
+      };
+
+      it("returns what the hook puts in a value's place", () => {
+        const stood = new Date(0);
+        const { result } = viaHook(
+          { held: stood },
+          (v) => v === stood ? "stand-in" : v,
+        );
+        expect(result).toEqual({ held: "stand-in" });
+      });
+
+      it("tells the copy callback about a hook's replacement", () => {
+        // The hook's replacement is a copy like any other, and identity-keyed
+        // facts have to be able to follow it.
+        const stood = new Date(0);
+        const { seen } = viaHook(
+          { held: stood },
+          (v) => v === stood ? "stand-in" : v,
+        );
+        expect(seen).toContainEqual({ copy: "stand-in", original: stood });
+      });
+
+      it("returns a value the hook left alone by identity", () => {
+        const untouched = new Date(0);
+        const value = { held: untouched };
+        const { result, seen } = viaHook(value, (v) => v);
+        expect(result).toBe(value);
+        expect(seen).toEqual([]);
+      });
+    });
+
     describe("the copy callback", () => {
       // Identity-keyed facts -- trust, the content-addressed entry ref -- do not
       // travel with the bytes, so a caller is told about each copy in order to

--- a/packages/runner/test/encodable-form.test.ts
+++ b/packages/runner/test/encodable-form.test.ts
@@ -83,7 +83,7 @@ describe("encodable-form", () => {
         });
       });
 
-      it("replaces a FUNCTION-shaped artifact", () => {
+      it("replaces a _function_-shaped artifact", () => {
         // A factory is a function carrying its module's members, so an artifact
         // is reached in two shapes and both have to be covered. This is the
         // shape the live idiom produces: `tools: { x: { pattern: SomePattern } }`.
@@ -98,7 +98,7 @@ describe("encodable-form", () => {
         // time and keeps that second answer, storing a value the array never
         // held at any single moment and which the walk never inspected.
         //
-        // Order matters. The accessor sits BEFORE the artifact, so it has
+        // Order matters. The accessor sits _before_ the artifact, so it has
         // already been read by the time the artifact forces a copy -- which is
         // exactly the window a copy-by-re-reading reads it in again.
         let reads = 0;
@@ -154,7 +154,7 @@ describe("encodable-form", () => {
         expect(reads).toBe(1);
       });
 
-      it("reads an accessor-backed serializer on a FUNCTION once", () => {
+      it("reads an accessor-backed serializer on a _function_ once", () => {
         // The function branch classifies and invokes separately too, and a
         // factory is a function carrying its module's members.
         let reads = 0;
@@ -170,7 +170,7 @@ describe("encodable-form", () => {
         expect(reads).toBe(1);
       });
 
-      it("invokes a FUNCTION artifact's serializer once, on the artifact", () => {
+      it("invokes a _function_ artifact's serializer once, on the artifact", () => {
         // The object branch has the shared-artifact case below to pin its
         // invoke count, and the pre-existing receiver case under
         // `encodableFormOf()` pins the shared invoke. Neither reaches the
@@ -326,9 +326,9 @@ describe("encodable-form", () => {
     });
 
     describe("the `replaceOther` hook", () => {
-      // The hook is how a caller names what ELSE has no fabric representation.
-      // Nothing else in this file passes a non-identity one, so this is the only
-      // place the hook's replacement is exercised at all.
+      // The hook is how a caller names what _else_ has no fabric
+      // representation. Nothing else in this file passes a non-identity one, so
+      // this is the only place the hook's replacement is exercised at all.
       const viaHook = (value: unknown, replace: (v: object) => unknown) => {
         const seen: { copy: unknown; original: unknown }[] = [];
         const result = replaceArtifacts(
@@ -400,7 +400,7 @@ describe("encodable-form", () => {
         expect(announced!.copy).toBe(result);
       });
 
-      it("is NOT told about a value that came back unchanged", () => {
+      it("is _not_ told about a value that came back unchanged", () => {
         // Answered by identity, so there is no copy and nothing to carry.
         const { seen } = copies({ a: 1, b: { c: [1, 2, 3] } });
         expect(seen).toEqual([]);
@@ -433,7 +433,7 @@ describe("encodable-form", () => {
       expect(hasEncodableForm({ toJSON: () => ({}) })).toBe(false);
     });
 
-    it("returns true for an INHERITED member", () => {
+    it("returns true for an _inherited_ member", () => {
       // Deliberately broader than the walk's own test: callers here ask about
       // a specific value they hold, not about every object in a graph.
       class Serializable {
@@ -444,7 +444,7 @@ describe("encodable-form", () => {
       expect(hasEncodableForm(new Serializable())).toBe(true);
     });
 
-    it("returns true for a FUNCTION carrying the member", () => {
+    it("returns true for a _function_ carrying the member", () => {
       expect(hasEncodableForm(Object.assign(() => {}, {
         toEncodableForm: () => ({}),
       }))).toBe(true);
@@ -483,7 +483,7 @@ describe("encodable-form", () => {
     });
 
     it("returns the result of a member only `Reflect.apply` can call", () => {
-      // A method can arrive wrapped in a proxy that answers EVERY property
+      // A method can arrive wrapped in a proxy that answers _every_ property
       // read with something of its own, so nothing read off the method --
       // `.call` included -- is callable, while the method itself still is. So
       // the invoke has to reach a function's call behavior rather than read a
@@ -491,7 +491,7 @@ describe("encodable-form", () => {
       //
       // The live producer of that shape is the reactive proxy in `cell.ts`: a
       // `cellMethods` name comes back as a proxy over the bound method, and
-      // every read off THAT is data navigation.
+      // every read off _that_ is data navigation.
       const method = new Proxy(function () {
         return { invoked: true };
       }, { get: () => ({ notAFunction: true }) });


### PR DESCRIPTION
`docs/development/code-comment-style.md` names the shapes this file's prose was
full of. **Comments only — no line of code changed**, verified by filtering the
diff for non-comment lines.

## What the guide's own check found

Its history grep — `before|used to|previously|no longer|formerly|the
alternative|rather than the old` — had one real hit. `copied()`'s doc recounted
that the bookkeeping *"was previously written out at each branch, and was left
off a new branch three separate times"*: history, plus a count of past mistakes,
plus an implied fourth. It now states the invariant instead — every replacing
branch returns through here, so a copy's bookkeeping cannot be forgotten.

## Three roads not taken, replaced by the requirement each argued for

- `replaceArtifacts` argued that a positional traversal *"has to be told every
  shape a graph can take, and is wrong the moment a new one appears"*. The
  requirement is stated a line above it already: an artifact sits wherever a
  pattern author put it, so finding one takes a walk. The argument was redundant
  with the fact.
- The same doc argued the narrow question *against* everything the data model's
  duck-typed `toJSON` would honor. It now says what the subject **is** — builder
  artifacts, bounded there by the name — and what a `toJSON`-carrying plain
  object is instead: user data, for the conversion to interpret.
- `encodableFormMethod` said naming `Cell` here *"would mean importing the
  runtime's core, and the graph already runs the other way"*. The constraint,
  stated directly: this module sits below the core in the import graph, so it
  cannot name `Cell` as a class.

## Two counterfactuals the grep does not reach

Stated positively instead: a hook asked about *"each value the walk does not
descend into"* rather than what it *"would otherwise pass through untouched"*,
and a replacement *"the walk has no further claim on"* rather than one it is not
*"a container"* for.

## Deliberately kept

- `hasEncodableForm`'s contrast with the walk's narrower test. That is a
  present-tense difference **within this file**, which § "Describe the system as
  it is" explicitly allows, and a reader who does not know it is intentional
  might reconcile the two.
- Both remaining uses of "before" — one temporal ("before the value crosses into
  the data model"), one positional in a test ("the accessor sits BEFORE the
  artifact"). The guide's own note anticipates these: *"not every hit is wrong."*
- `copied()`'s "every branch that replaces a value returns through here". A
  survey, but of a non-exported symbol whose callers this file bounds, which
  § "Not a survey of the rest of the system" permits at `:130-131`.

## Verification

Eleven lines shorter, and every line now within 80 columns — the file had two
overs before. Runner 1148/0, full workspace passing, `fmt`, `lint`, `check`,
`check-docs` green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Conformed comments in `packages/runner/src/encodable-form.ts` to `docs/development/code-comment-style.md` (including underscore emphasis), and added tests to guard the `copied()` invariant and `replaceOther`. No runtime behavior changes; lines wrap at 80 columns.

- **Refactors**
  - Clarified `toJSON`: plain objects with a `toJSON` they defined themselves are user data and the conversion rejects them; artifacts remain bounded by `toEncodableForm`.
  - Tightened docs: `ReplaceOther` applies to an object or function; bounded the cycle exception in `replace()`’s “reachable twice” claim; added concise docs for `replace()`, `replaceInElements()`, and `replaceInEntries()`; switched emphasis to underscores in comments and tests.
  - Added tests in `packages/runner/test/encodable-form.test.ts` to exercise `replaceOther` and ensure all replacements route through `copied()`.

<sup>Written for commit ca261957ab41d9c75b0c47a0533144d9e858149b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

