### PR TITLE
refactor(static): collapse the asset cache to one class

### DIFF
--- a/packages/cli/commands/init.ts
+++ b/packages/cli/commands/init.ts
@@ -2,7 +2,7 @@ import { Command } from "@cliffy/command";
 import { Engine } from "@commonfabric/runner";
 import { join } from "@std/path/join";
 import { getCompilerOptions } from "@commonfabric/js-compiler/typescript";
-import { StaticCacheFS } from "@commonfabric/static";
+import { StaticCache } from "@commonfabric/static";
 import { dirname } from "@std/path/dirname";
 
 export const init = new Command()
@@ -79,7 +79,7 @@ function createTsConfig() {
 //
 // Also copies pattern documentation from docs/common to .cf-docs for reference.
 async function initWorkspace(cwd: string) {
-  const cache = new StaticCacheFS();
+  const cache = StaticCache.fromFileSystem();
   const runtimeModuleTypes = await Engine.getRuntimeModuleTypes(
     cache,
   );

--- a/packages/js-compiler/test/source-map.test.ts
+++ b/packages/js-compiler/test/source-map.test.ts
@@ -9,10 +9,10 @@ import {
   SourceMapParser,
   TypeScriptCompiler,
 } from "../mod.ts";
-import { StaticCacheFS } from "@commonfabric/static";
+import { StaticCache } from "@commonfabric/static";
 import { SourceMapConsumer, SourceMapGenerator } from "source-map-js";
 
-const staticCache = new StaticCacheFS();
+const staticCache = StaticCache.fromFileSystem();
 const types = await getTypeScriptEnvironmentTypes(staticCache);
 types["commonfabric.d.ts"] = await staticCache.getText(
   "types/commonfabric.d.ts",

--- a/packages/js-compiler/test/typescript.compiler.test.ts
+++ b/packages/js-compiler/test/typescript.compiler.test.ts
@@ -8,7 +8,7 @@ import {
   TypeScriptCompiler,
   TypeScriptCompilerOptions,
 } from "../mod.ts";
-import { StaticCacheFS } from "@commonfabric/static";
+import { StaticCache } from "@commonfabric/static";
 
 type TestDef =
   & { name: string; source: string; expectedError?: string }
@@ -110,7 +110,7 @@ const TESTS: TestDef[] = [
   },
 ];
 
-const staticCache = new StaticCacheFS();
+const staticCache = StaticCache.fromFileSystem();
 const types = await getTypeScriptEnvironmentTypes(staticCache);
 types["commonfabric.d.ts"] = await staticCache.getText(
   "types/commonfabric.d.ts",

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -35,7 +35,7 @@ import {
 } from "./compile-interleave.ts";
 import { type MemorySpace, Runtime } from "../runtime.ts";
 import { hashOf } from "@commonfabric/data-model/value-hash";
-import { StaticCache } from "@commonfabric/static";
+import type { StaticCache } from "@commonfabric/static";
 import {
   pretransformProgramForModules,
   transformInjectHelperModule,

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -1,8 +1,4 @@
-import {
-  StaticCache,
-  StaticCacheFS,
-  StaticCacheHTTP,
-} from "@commonfabric/static";
+import { StaticCache } from "@commonfabric/static";
 import { RuntimeTelemetry } from "@commonfabric/runner";
 import { fabricFromNativeValue } from "@commonfabric/data-model/fabric-value";
 import { dataUriFromValue } from "@commonfabric/data-model/data-uri-codec";
@@ -1047,8 +1043,8 @@ export class Runtime {
     this.fetch = options.fetch ??
       ((input, init) => globalThis.fetch(input, init));
     this.staticCache = isDeno()
-      ? new StaticCacheFS()
-      : new StaticCacheHTTP(new URL("/static", this.apiUrl));
+      ? StaticCache.fromFileSystem()
+      : new StaticCache(new URL("/static", this.apiUrl));
 
     this.telemetry = options.telemetry ?? new RuntimeTelemetry();
 

--- a/packages/runner/src/sandbox/runtime-modules.ts
+++ b/packages/runner/src/sandbox/runtime-modules.ts
@@ -1,5 +1,5 @@
 import { createBuilder } from "../builder/factory.ts";
-import { StaticCache } from "@commonfabric/static";
+import type { StaticCache } from "@commonfabric/static";
 import turndown from "turndown";
 import { freezeSandboxValue } from "./hardening.ts";
 import * as cfcModule from "@commonfabric/api/cfc-authoring";

--- a/packages/runner/test/builder-fabric-classes.test.ts
+++ b/packages/runner/test/builder-fabric-classes.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { StaticCacheFS } from "@commonfabric/static";
+import { StaticCache } from "@commonfabric/static";
 import {
   FabricInstance,
   FabricPrimitive,
@@ -31,7 +31,7 @@ import { getRuntimeModuleExports } from "../src/sandbox/runtime-modules.ts";
 // artifact the sandbox hands a pattern as its view of `commonfabric`. Deriving
 // the expected names from it means this test tracks the real declarations
 // rather than a hand-copied list that someone has to remember to extend.
-const patternVisibleTypes = await new StaticCacheFS().getText(
+const patternVisibleTypes = await StaticCache.fromFileSystem().getText(
   "types/commonfabric.d.ts",
 );
 const declaredClasses = [

--- a/packages/runner/test/sandbox-global-contract.test.ts
+++ b/packages/runner/test/sandbox-global-contract.test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "@std/assert";
-import { assets, StaticCacheFS } from "@commonfabric/static";
+import { assets, StaticCache } from "@commonfabric/static";
 import { SANDBOX_WITHHELD_GLOBALS } from "@commonfabric/utils/sandbox-contract";
 import { createCallbackCompartmentGlobals } from "../src/sandbox/compartment-globals.ts";
 import { ensureSESLockdown } from "../src/sandbox/ses-runtime.ts";
@@ -73,7 +73,7 @@ function declaresValueMember(libText: string, start: number): boolean {
 }
 
 async function compilerDeclaredGlobals(): Promise<string[]> {
-  const cache = new StaticCacheFS();
+  const cache = StaticCache.fromFileSystem();
   const perFile = await Promise.all(
     TYPE_ASSETS.map(async (file) => declaredGlobals(await cache.getText(file))),
   );

--- a/packages/schema-generator/test/utils.ts
+++ b/packages/schema-generator/test/utils.ts
@@ -1,5 +1,5 @@
 import ts from "typescript";
-import { StaticCacheFS } from "@commonfabric/static";
+import { StaticCache } from "@commonfabric/static";
 import { isRecord } from "@commonfabric/utils/types";
 import { FabricPrimitive } from "@commonfabric/data-model/fabric-value";
 import type { JSONSchemaObj } from "@commonfabric/api";
@@ -51,7 +51,7 @@ async function getTypeScriptEnvironmentTypes(): Promise<
     return typeLibsCache;
   }
 
-  const cache = new StaticCacheFS();
+  const cache = StaticCache.fromFileSystem();
   const es2023 = await cache.getText("types/es2023.d.ts");
   const jsx = await cache.getText("types/jsx.d.ts");
   const dom = await cache.getText("types/dom.d.ts");

--- a/packages/static/cache.ts
+++ b/packages/static/cache.ts
@@ -9,7 +9,7 @@ import { toFileUrl } from "@std/path/posix/to-file-url";
 import { join } from "@std/path/posix/join";
 import { generateETag } from "./etag.ts";
 
-export const FS_URL = (import.meta.dirname && isDeno())
+const FS_URL = (import.meta.dirname && isDeno())
   ? toFileUrl(join(import.meta.dirname, "assets"))
   : undefined;
 
@@ -21,18 +21,24 @@ export interface CachedAsset {
   etag: string;
 }
 
-export interface StaticCache {
-  get(assetName: string): Promise<Uint8Array>;
-  getText(assetName: string): Promise<string>;
-  getUrl(assetName: string): URL;
-  getWithETag(assetName: string): Promise<CachedAsset>;
-}
-
-export class InnerCache {
+export class StaticCache {
   private cache: Map<string, Promise<CachedAsset>> = new Map();
   private baseUrl: URL;
   constructor(baseUrl: URL) {
     this.baseUrl = baseUrl;
+  }
+
+  /**
+   * Serve the assets bundled alongside this module from the file system.
+   * Only available in Deno.
+   */
+  static fromFileSystem(): StaticCache {
+    if (!FS_URL) {
+      throw new Error(
+        "The file system static cache is only available in Deno.",
+      );
+    }
+    return new StaticCache(new URL(FS_URL));
   }
 
   /**
@@ -67,13 +73,9 @@ export class InnerCache {
       throw new Error(`No static asset "${assetName}" found.`);
     }
 
-    const url = this.getBaseUrl();
+    const url = new URL(this.baseUrl);
     url.pathname = join(url.pathname, assetName);
     return url;
-  }
-
-  getBaseUrl(): URL {
-    return new URL(this.baseUrl);
   }
 
   /**
@@ -101,20 +103,5 @@ export class InnerCache {
 
     const etag = await generateETag(buffer);
     return { buffer, etag };
-  }
-}
-
-export class StaticCacheHTTP extends InnerCache implements StaticCache {
-  constructor(baseUrl: URL) {
-    super(baseUrl);
-  }
-}
-
-export class StaticCacheFS extends InnerCache implements StaticCache {
-  constructor() {
-    if (!FS_URL) {
-      throw new Error("FsCache only available in Deno.");
-    }
-    super(new URL(FS_URL));
   }
 }

--- a/packages/static/cache.ts
+++ b/packages/static/cache.ts
@@ -21,21 +21,31 @@ export interface CachedAsset {
   etag: string;
 }
 
+/**
+ * The cache of static assets served from one base location, holding each
+ * asset's content together with a strong ETag over that content. An asset is
+ * read at most once per instance: under Deno it is read off the file system,
+ * and elsewhere it is fetched over the network.
+ */
 export class StaticCache {
   private cache: Map<string, Promise<CachedAsset>> = new Map();
   private baseUrl: URL;
+
+  /**
+   * Constructs an instance which resolves asset names against `baseUrl`.
+   */
   constructor(baseUrl: URL) {
     this.baseUrl = baseUrl;
   }
 
   /**
-   * Serve the assets bundled alongside this module from the file system.
-   * Only available in Deno.
+   * Constructs an instance reading the assets bundled alongside this module,
+   * which requires the file system and so is available only under Deno.
    */
   static fromFileSystem(): StaticCache {
     if (!FS_URL) {
       throw new Error(
-        "The file system static cache is only available in Deno.",
+        "`StaticCache.fromFileSystem()` is only available in Deno.",
       );
     }
     return new StaticCache(new URL(FS_URL));

--- a/packages/static/cache.ts
+++ b/packages/static/cache.ts
@@ -52,8 +52,7 @@ export class StaticCache {
   }
 
   /**
-   * Get the content buffer of a static asset.
-   * Backward compatible method that returns only the buffer.
+   * Gets the content of a static asset, without its ETag.
    */
   async get(assetName: string): Promise<Uint8Array> {
     const cached = await this.getWithETag(assetName);
@@ -61,8 +60,8 @@ export class StaticCache {
   }
 
   /**
-   * Get a static asset with its ETag for cache validation.
-   * Returns both the content buffer and the generated ETag.
+   * Gets a static asset's content together with the ETag a caller validates
+   * it against.
    */
   getWithETag(assetName: string): Promise<CachedAsset> {
     const currentValue = this.cache.get(assetName);
@@ -74,10 +73,17 @@ export class StaticCache {
     return promise;
   }
 
+  /**
+   * Gets the content of a static asset, decoded as text.
+   */
   async getText(assetName: string): Promise<string> {
     return decode(await this.get(assetName));
   }
 
+  /**
+   * Gets the location of a static asset, and throws when `assetName` is not
+   * one this package ships.
+   */
   getUrl(assetName: string): URL {
     if (!assets.includes(assetName)) {
       throw new Error(`No static asset "${assetName}" found.`);
@@ -89,8 +95,8 @@ export class StaticCache {
   }
 
   /**
-   * Fetch an asset and generate its ETag.
-   * Handles both Deno (file system) and browser (HTTP) environments.
+   * Helper for `getWithETag()`, which reads an asset and generates its ETag,
+   * off the file system under Deno and over the network elsewhere.
    */
   private async requestWithETag(assetName: string): Promise<CachedAsset> {
     const url = this.getUrl(assetName);

--- a/packages/static/etag.ts
+++ b/packages/static/etag.ts
@@ -50,25 +50,9 @@ export function compareETags(
  * Create cache headers with ETag support.
  * Uses no-cache strategy to always validate with ETag.
  */
-export function createCacheHeaders(
-  etag: string,
-  options: {
-    noCache?: boolean;
-    public?: boolean;
-  } = {},
-): Record<string, string> {
-  const {
-    noCache = true,
-    public: isPublic = true,
-  } = options;
-
-  const headers: Record<string, string> = {
+export function createCacheHeaders(etag: string): Record<string, string> {
+  return {
     "ETag": etag,
+    "Cache-Control": "public, no-cache",
   };
-
-  if (noCache) {
-    headers["Cache-Control"] = isPublic ? "public, no-cache" : "no-cache";
-  }
-
-  return headers;
 }

--- a/packages/static/etag.ts
+++ b/packages/static/etag.ts
@@ -47,8 +47,9 @@ export function compareETags(
 }
 
 /**
- * Create cache headers with ETag support.
- * Uses no-cache strategy to always validate with ETag.
+ * Creates the response headers that carry `etag` and require a client to
+ * revalidate against it on every request rather than serving from its own
+ * cache.
  */
 export function createCacheHeaders(etag: string): Record<string, string> {
   return {

--- a/packages/static/index.ts
+++ b/packages/static/index.ts
@@ -1,2 +1,2 @@
-export { type StaticCache, StaticCacheFS, StaticCacheHTTP } from "./cache.ts";
+export { StaticCache } from "./cache.ts";
 export { assets } from "./assets.ts";

--- a/packages/static/test/assets.test.ts
+++ b/packages/static/test/assets.test.ts
@@ -1,6 +1,10 @@
 import { decode } from "@commonfabric/utils/encoding";
 import { assert } from "@std/assert";
-import { createTestStaticCache, TEST_ASSET, TEST_ASSET_CONTENT } from "../utils.ts";
+import {
+  createTestStaticCache,
+  TEST_ASSET,
+  TEST_ASSET_CONTENT,
+} from "../utils.ts";
 
 Deno.test("get() and getText() returns static data", async () => {
   const cache = createTestStaticCache();

--- a/packages/static/test/assets.test.ts
+++ b/packages/static/test/assets.test.ts
@@ -1,9 +1,9 @@
 import { decode } from "@commonfabric/utils/encoding";
 import { assert } from "@std/assert";
-import { TEST_ASSET, TEST_ASSET_CONTENT, TestStaticCache } from "../utils.ts";
+import { createTestStaticCache, TEST_ASSET, TEST_ASSET_CONTENT } from "../utils.ts";
 
 Deno.test("get() and getText() returns static data", async () => {
-  const cache = new TestStaticCache();
+  const cache = createTestStaticCache();
   const buffer = await cache.get(TEST_ASSET);
   const text = await cache.getText(TEST_ASSET);
   assert(decode(buffer) === text, "buffer and text match");
@@ -11,7 +11,7 @@ Deno.test("get() and getText() returns static data", async () => {
 });
 
 Deno.test("getUrl() returns asset URL", async () => {
-  const cache = new TestStaticCache();
+  const cache = createTestStaticCache();
   const url = await cache.getUrl(TEST_ASSET);
   assert(url.pathname.endsWith(`/${TEST_ASSET}`), "Expected URL path");
 });

--- a/packages/static/test/etag-cache.test.ts
+++ b/packages/static/test/etag-cache.test.ts
@@ -5,7 +5,7 @@ import {
   generateETag,
 } from "@commonfabric/static/etag";
 import { decode } from "@commonfabric/utils/encoding";
-import { TEST_ASSET, TEST_ASSET_CONTENT, TestStaticCache } from "../utils.ts";
+import { createTestStaticCache, TEST_ASSET, TEST_ASSET_CONTENT } from "../utils.ts";
 
 Deno.test("ETag Generation - generates same ETag for same content", async () => {
   const content = new TextEncoder().encode("Hello, World!");
@@ -97,7 +97,7 @@ Deno.test("ETag Comparison - handles both weak ETags", () => {
   assertEquals(compareETags(etag, ifNoneMatch), true);
 });
 
-Deno.test("Cache Headers - generates 'public, no-cache' by default", () => {
+Deno.test("Cache Headers - generates 'public, no-cache'", () => {
   const etag = '"abc123"';
   const headers = createCacheHeaders(etag);
   assertEquals(headers["Cache-Control"], "public, no-cache");
@@ -109,31 +109,8 @@ Deno.test("Cache Headers - includes ETag header", () => {
   assertEquals(headers["ETag"], etag);
 });
 
-Deno.test("Cache Headers - respects noCache: false option", () => {
-  const etag = '"abc123"';
-  const headers = createCacheHeaders(etag, { noCache: false });
-  assertEquals("Cache-Control" in headers, false);
-  assertEquals(headers["ETag"], etag);
-});
-
-Deno.test("Cache Headers - respects public: false option", () => {
-  const etag = '"abc123"';
-  const headers = createCacheHeaders(etag, { public: false });
-  assertEquals(headers["Cache-Control"], "no-cache");
-});
-
-Deno.test("Cache Headers - respects both options together", () => {
-  const etag = '"abc123"';
-  const headers = createCacheHeaders(etag, {
-    noCache: false,
-    public: false,
-  });
-  assertEquals("Cache-Control" in headers, false);
-  assertEquals(headers["ETag"], etag);
-});
-
 Deno.test("StaticCache ETag - getWithETag returns both buffer and ETag", async () => {
-  const cache = new TestStaticCache();
+  const cache = createTestStaticCache();
   const result = await cache.getWithETag(TEST_ASSET);
 
   assert(result.buffer instanceof Uint8Array);
@@ -142,7 +119,7 @@ Deno.test("StaticCache ETag - getWithETag returns both buffer and ETag", async (
 });
 
 Deno.test("StaticCache ETag - returns same ETag for same asset (caching works)", async () => {
-  const cache = new TestStaticCache();
+  const cache = createTestStaticCache();
   const result1 = await cache.getWithETag(TEST_ASSET);
   const result2 = await cache.getWithETag(TEST_ASSET);
 
@@ -152,7 +129,7 @@ Deno.test("StaticCache ETag - returns same ETag for same asset (caching works)",
 });
 
 Deno.test("StaticCache ETag - get() method still works (backward compatibility)", async () => {
-  const cache = new TestStaticCache();
+  const cache = createTestStaticCache();
   const buffer = await cache.get(TEST_ASSET);
 
   assert(buffer instanceof Uint8Array);
@@ -161,7 +138,7 @@ Deno.test("StaticCache ETag - get() method still works (backward compatibility)"
 });
 
 Deno.test("StaticCache ETag - ETag is consistent for same content", async () => {
-  const cache = new TestStaticCache();
+  const cache = createTestStaticCache();
   const result = await cache.getWithETag(TEST_ASSET);
 
   // Generate ETag directly from the buffer
@@ -170,7 +147,7 @@ Deno.test("StaticCache ETag - ETag is consistent for same content", async () => 
 });
 
 Deno.test("StaticCache ETag - different assets have different ETags", async () => {
-  const cache = new TestStaticCache();
+  const cache = createTestStaticCache();
   const result1 = await cache.getWithETag(TEST_ASSET);
   const result2 = await cache.getWithETag("types/es2023.d.ts");
 

--- a/packages/static/test/etag-cache.test.ts
+++ b/packages/static/test/etag-cache.test.ts
@@ -5,7 +5,11 @@ import {
   generateETag,
 } from "@commonfabric/static/etag";
 import { decode } from "@commonfabric/utils/encoding";
-import { createTestStaticCache, TEST_ASSET, TEST_ASSET_CONTENT } from "../utils.ts";
+import {
+  createTestStaticCache,
+  TEST_ASSET,
+  TEST_ASSET_CONTENT,
+} from "../utils.ts";
 
 Deno.test("ETag Generation - generates same ETag for same content", async () => {
   const content = new TextEncoder().encode("Hello, World!");

--- a/packages/static/utils.ts
+++ b/packages/static/utils.ts
@@ -12,9 +12,11 @@ export const TEST_ASSET = "types/dom.d.ts";
 // needing an update.
 export const TEST_ASSET_CONTENT = "interface AddEventListenerOptions";
 
-// Reads assets from the file system in Deno and from
-// `${window.location.origin}/static` in non-Deno, used for tests that run via
-// deno-web-test that target both environments.
+/**
+ * Creates a cache for a test that targets both Deno and the browser, as the
+ * tests run under deno-web-test do. It reads assets from the file system under
+ * Deno, and from `/static` on the page origin elsewhere.
+ */
 export function createTestStaticCache(): StaticCache {
   if (isDeno()) {
     return StaticCache.fromFileSystem();

--- a/packages/static/utils.ts
+++ b/packages/static/utils.ts
@@ -1,5 +1,5 @@
 import { isDeno } from "@commonfabric/utils/env";
-import { FS_URL, InnerCache, type StaticCache } from "./cache.ts";
+import { StaticCache } from "./cache.ts";
 
 // What a test fetches when it needs an asset and does not care which one. Any
 // entry in `assets` serves, under two constraints: `TEST_ASSET_CONTENT` has to
@@ -12,20 +12,14 @@ export const TEST_ASSET = "types/dom.d.ts";
 // needing an update.
 export const TEST_ASSET_CONTENT = "interface AddEventListenerOptions";
 
-// `TestStaticCache` uses StaticCacheFS in Deno and `${window.location.origin}/static`
-// in non-Deno, used for tests that run via deno-web-test that target both environments.
-export class TestStaticCache extends InnerCache implements StaticCache {
-  constructor() {
-    let url;
-    if (isDeno()) {
-      if (!FS_URL) {
-        throw new Error("Could not create static cache in Deno.");
-      }
-      url = new URL(FS_URL);
-    } else {
-      url = new URL(globalThis.location.origin);
-      url.pathname = "static";
-    }
-    super(url);
+// Reads assets from the file system in Deno and from
+// `${window.location.origin}/static` in non-Deno, used for tests that run via
+// deno-web-test that target both environments.
+export function createTestStaticCache(): StaticCache {
+  if (isDeno()) {
+    return StaticCache.fromFileSystem();
   }
+  const url = new URL(globalThis.location.origin);
+  url.pathname = "static";
+  return new StaticCache(url);
 }

--- a/packages/toolshed/routes/static/static.index.ts
+++ b/packages/toolshed/routes/static/static.index.ts
@@ -1,6 +1,6 @@
 import { createRouter } from "@/lib/create-app.ts";
 import { cors } from "@hono/hono/cors";
-import { StaticCacheFS } from "@commonfabric/static";
+import { StaticCache } from "@commonfabric/static";
 import { getMimeType } from "@/lib/mime-type.ts";
 import { compareETags, createCacheHeaders } from "@commonfabric/static/etag";
 
@@ -8,7 +8,7 @@ const router = createRouter();
 
 // Static cache instance - separate from runtime cache
 // for isolation and performance
-const cache = new StaticCacheFS();
+const cache = StaticCache.fromFileSystem();
 
 router.use(
   "*",

--- a/packages/ts-transformers/test/call-expression-flap-coverage.test.ts
+++ b/packages/ts-transformers/test/call-expression-flap-coverage.test.ts
@@ -1,6 +1,6 @@
 import { assert, assertEquals } from "@std/assert";
 import ts from "typescript";
-import { StaticCacheFS } from "@commonfabric/static";
+import { StaticCache } from "@commonfabric/static";
 
 import { TransformationContext } from "../src/core/context.ts";
 import { transformCfDirective } from "../src/mod.ts";
@@ -16,7 +16,7 @@ import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
 // tests drive the emitter directly with a real TransformationContext and assert
 // on the node it returns.
 
-const cache = new StaticCacheFS();
+const cache = StaticCache.fromFileSystem();
 const es2023 = await cache.getText("types/es2023.d.ts");
 const dom = await cache.getText("types/dom.d.ts");
 const jsx = await cache.getText("types/jsx.d.ts");

--- a/packages/ts-transformers/test/closures/module-scope-helper-hoisting.test.ts
+++ b/packages/ts-transformers/test/closures/module-scope-helper-hoisting.test.ts
@@ -1,8 +1,8 @@
 import { assert, assertMatch, assertNotMatch } from "@std/assert";
-import { StaticCacheFS } from "@commonfabric/static";
+import { StaticCache } from "@commonfabric/static";
 import { transformSource } from "../utils.ts";
 
-const staticCache = new StaticCacheFS();
+const staticCache = StaticCache.fromFileSystem();
 const commonfabric = await staticCache.getText("types/commonfabric.d.ts");
 const commonfabricSchema = await staticCache.getText(
   "types/commonfabric-schema.d.ts",

--- a/packages/ts-transformers/test/commonfabric-test-types.ts
+++ b/packages/ts-transformers/test/commonfabric-test-types.ts
@@ -2,11 +2,11 @@
  * Shared type definitions for commonfabric module used in tests.
  *
  * Loads types from the same source as production: types/commonfabric.d.ts
- * via StaticCacheFS (which is a symlink to packages/api/index.ts).
+ * via the static cache (which is a symlink to packages/api/index.ts).
  */
-import { StaticCacheFS } from "@commonfabric/static";
+import { StaticCache } from "@commonfabric/static";
 
-const staticCache = new StaticCacheFS();
+const staticCache = StaticCache.fromFileSystem();
 
 /**
  * The commonfabric type definitions, loaded from the same source as production.

--- a/packages/ts-transformers/test/fixture-based.test.ts
+++ b/packages/ts-transformers/test/fixture-based.test.ts
@@ -2,7 +2,7 @@ import {
   createUnifiedDiff,
   defineFixtureSuite,
 } from "@commonfabric/test-support/fixture-runner";
-import { StaticCacheFS } from "@commonfabric/static";
+import { StaticCache } from "@commonfabric/static";
 import { resolve } from "@std/path";
 import ts from "typescript";
 
@@ -99,7 +99,7 @@ const configs: FixtureConfig[] = [
   },
 ];
 
-const staticCache = new StaticCacheFS();
+const staticCache = StaticCache.fromFileSystem();
 const commonfabric = await staticCache.getText("types/commonfabric.d.ts");
 const commonfabricSchema = await staticCache.getText(
   "types/commonfabric-schema.d.ts",

--- a/packages/ts-transformers/test/misc-emitters-flap-coverage.test.ts
+++ b/packages/ts-transformers/test/misc-emitters-flap-coverage.test.ts
@@ -1,6 +1,6 @@
 import ts from "typescript";
 import { assert, assertEquals } from "@std/assert";
-import { StaticCacheFS } from "@commonfabric/static";
+import { StaticCache } from "@commonfabric/static";
 
 import { TransformationContext } from "../src/core/context.ts";
 import { transformCfDirective } from "../src/mod.ts";
@@ -21,7 +21,7 @@ import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
 // value the branch produces (a decision, a returned node/undefined, a resolved
 // type, or a diagnostic-free classification), not merely that the line ran.
 
-const cache = new StaticCacheFS();
+const cache = StaticCache.fromFileSystem();
 const es2023 = await cache.getText("types/es2023.d.ts");
 const dom = await cache.getText("types/dom.d.ts");
 const jsx = await cache.getText("types/jsx.d.ts");

--- a/packages/ts-transformers/test/synthetic-helper-wrapper-flap-coverage.test.ts
+++ b/packages/ts-transformers/test/synthetic-helper-wrapper-flap-coverage.test.ts
@@ -1,6 +1,6 @@
 import { assertEquals } from "@std/assert";
 import ts from "typescript";
-import { StaticCacheFS } from "@commonfabric/static";
+import { StaticCache } from "@commonfabric/static";
 
 import { TransformationContext } from "../src/core/context.ts";
 import { transformCfDirective } from "../src/mod.ts";
@@ -22,7 +22,7 @@ import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
 // upward walk finds no function and the classifier returns false — the wrapper
 // is not treated as living inside an array-method callback.
 
-const cache = new StaticCacheFS();
+const cache = StaticCache.fromFileSystem();
 const es2023 = await cache.getText("types/es2023.d.ts");
 const dom = await cache.getText("types/dom.d.ts");
 const jsx = await cache.getText("types/jsx.d.ts");

--- a/packages/ts-transformers/test/utils.ts
+++ b/packages/ts-transformers/test/utils.ts
@@ -1,6 +1,6 @@
 import ts from "typescript";
 import { dirname, join } from "@std/path";
-import { StaticCacheFS } from "@commonfabric/static";
+import { StaticCache } from "@commonfabric/static";
 import {
   CommonFabricTransformerPipeline,
   CrossStageState,
@@ -885,7 +885,7 @@ export async function compareFixtureTransformation(
 }
 
 async function loadEnvironmentTypes(): Promise<Record<EnvTypeKey, string>> {
-  const cache = new StaticCacheFS();
+  const cache = StaticCache.fromFileSystem();
   const entries = await Promise.all(
     ENV_TYPE_ENTRIES.map(async (key) =>
       [key, await cache.getText(`types/${key}.d.ts`)] as const


### PR DESCRIPTION
The static-asset cache has always been a single concrete implementation, but it was exposed through five names. `InnerCache` held all the behavior. A hand-written `StaticCache` interface restated four of that class's public methods. Three subclasses carried no behavior of their own: `StaticCacheHTTP` took a base URL and handed it straight to the base constructor, `StaticCacheFS` supplied the file URL of the assets directory, and `TestStaticCache` in the test utilities chose between that file URL and the page origin. Every one of them declared `implements StaticCache`, which verified nothing that extending the base class did not already guarantee. A caller wanting the one behavior that exists had to work out which of the five names to reach for.

`InnerCache` is now exported as `StaticCache`, and the interface and the three subclasses are gone. The distinction the subclass split was built to make visible — whether a given call site reads assets over HTTP or off the file system — is preserved at the call site: reading from the file system is now the static factory `StaticCache.fromFileSystem()`, and serving over HTTP is plain construction with a base URL. The runner picks between the two in the same expression it did before. `TestStaticCache` becomes the function `createTestStaticCache()`, which returns the file-system cache under Deno and one rooted at the page origin elsewhere; both paths are covered, since the static package runs its suite under Deno and again in a browser through deno-web-test.

Two smaller pieces of surface go with the subclasses. `FS_URL` was exported only so the test helper could reach it, and is now private to the module. `getBaseUrl()` had no caller outside the class, so its single use is inlined. The three call sites in the runner and js-compiler that name `StaticCache` only as a type now import it as a type, so pulling the class into scope does not add a runtime import to modules that never construct one.

Separately, `createCacheHeaders` accepted an options object with `noCache` and `public`. Every production caller — the toolshed's static, shell, and pattern routes — called it with the ETag alone and relied on the defaults. The only code that ever passed a non-default value was three tests written to exercise the options. The function now always returns the ETag together with `public, no-cache`, and those three tests are removed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapses the static asset cache to a single `StaticCache` class with a `fromFileSystem()` factory, removes redundant types/subclasses, and simplifies cache headers; adds doc comments aligned with the style guide and clearer errors. This streamlines usage across runtime, toolshed, and tests.

- **Refactors**
  - Export `StaticCache` (formerly `InnerCache`); remove `StaticCacheFS`, `StaticCacheHTTP`, and the `StaticCache` interface.
  - Add `StaticCache.fromFileSystem()`; HTTP usage is `new StaticCache(new URL(...))`.
  - Replace `TestStaticCache` with `createTestStaticCache()`.
  - Make `FS_URL` private; inline the only `getBaseUrl()` call.
  - Use type-only imports of `StaticCache` where only the type is needed.
  - `createCacheHeaders(etag)` now always returns `ETag` and `Cache-Control: public, no-cache`; options removed and related tests dropped.
  - Add doc comments to `StaticCache`, its constructor, `fromFileSystem()`, and the test helper; clarify the Deno-only error message.

- **Migration**
  - Import only `StaticCache` from `@commonfabric/static`.
  - Deno: `StaticCache.fromFileSystem()`. HTTP: `new StaticCache(new URL("/static", apiUrl))`.
  - Replace `TestStaticCache` with `createTestStaticCache()`.
  - Update calls to `createCacheHeaders(etag)`; remove `noCache`/`public` options.

<sup>Written for commit 55a7f0646da71c079b740e2321640259211b0998. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

