### PR TITLE
docs: say "returns" for what a function returns

### DIFF
--- a/packages/data-model/src/native-conversion.ts
+++ b/packages/data-model/src/native-conversion.ts
@@ -150,7 +150,7 @@ export function shallowCleanPlainObject(
  * or `FabricInstance` types by the conversion layer.
  *
  * Arrays, plain objects, and system-defined special primitives are recognized
- * by `tagFromNativeValue()` but are NOT convertible native instances -- they
+ * by `tagFromNativeValue()` but are _not_ convertible native instances -- they
  * have their own handling paths in the conversion layer.
  */
 export function isConvertibleNativeInstance(value: object): boolean {
@@ -250,7 +250,7 @@ export function shallowFabricFromNativeValue(
     }
 
     case NATIVE_TAGS.Array: {
-      // An array in this system is INERT: a direct `Array` instance, which
+      // An array in this system is _inert_: a direct `Array` instance, which
       // may only carry numeric index properties, each a data property. A named
       // or symbol-keyed property has no fabric representation, and an
       // accessor-backed index is live code rather than inert data -- as is the
@@ -275,13 +275,12 @@ export function shallowFabricFromNativeValue(
     }
 
     case NATIVE_TAGS.Object: {
-      // A plain object in this system is INERT: `FabricPlainObject` is keyed
-      // by `string`, so a symbol key has no fabric representation, and
-      // neither does a non-enumerable string key; an accessor-backed
-      // property is live code rather than inert data. Reject any of them
-      // outright rather than dropping or flattening it on the way through
-      // ("death before confusion"), matching how an array's non-index
-      // properties are treated.
+      // A plain object in this system is _inert_: `FabricPlainObject` is keyed
+      // by `string`, so a symbol key has no fabric representation, and neither
+      // does a non-enumerable string key; an accessor-backed property is live
+      // code rather than inert data. Reject any of them outright rather than
+      // dropping or flattening it on the way through ("death before
+      // confusion"), matching how an array's non-index properties are treated.
       if (!isInertPlainObject(value)) {
         throw new Error(
           "Not representable as a `FabricValue`: object that is not an " +
@@ -289,8 +288,8 @@ export function shallowFabricFromNativeValue(
         );
       }
       // A restriction of this implementation rather than of the model, so it
-      // says so rather than blaming inertness: such an object IS inert, and a
-      // runtime that does not route property assignment through a prototype
+      // says so rather than blaming inertness: such an object _is_ inert, and
+      // a runtime that does not route property assignment through a prototype
       // chain reserves no names at all.
       const unsafeKey = unsafeObjectKeyIn(value as object);
       if (unsafeKey !== undefined) {
@@ -381,7 +380,7 @@ const PROCESSING = Symbol("PROCESSING");
  * optimization).
  *
  * @param value - The value to convert. Declared `unknown` for caller
- *   convenience, but the call THROWS unless it is in fact a
+ *   convenience, but the call _throws_ unless it is in fact a
  *   `FabricOrConvertibleNativeValue`; `isFabricCompatible()` reports in
  *   advance whether it is.
  * @param freeze - When `true` (default), deep-freezes the result tree.

--- a/packages/data-model/src/native-conversion.ts
+++ b/packages/data-model/src/native-conversion.ts
@@ -55,7 +55,7 @@ function rejectExtraProperties(value: object, typeName: string): void {
  *
  * The given array's index properties must all be enumerable data properties:
  * the copy reads elements through enumeration, which would execute an
- * accessor-backed index (silently flattening it to its momentary answer)
+ * accessor-backed index (silently flattening it to its momentary value)
  * and would turn a non-enumerable data index into a hole.
  *
  * @param value The array to clean.
@@ -255,7 +255,7 @@ export function shallowFabricFromNativeValue(
       // or symbol-keyed property has no fabric representation, and an
       // accessor-backed index is live code rather than inert data -- as is the
       // prototype of an `Array` subclass instance, which can make iteration
-      // answer differently than the indices say. Reject any of them outright
+      // yield differently than the indices say. Reject any of them outright
       // rather than silently dropping or flattening ("death before
       // confusion").
       if (!isInertArray(value)) {
@@ -448,8 +448,8 @@ function fabricFromNativeValueInternal(
   // already a `FabricValue`.
   //
   // Nothing is recorded in `converted` here. Reaching this means `original`
-  // was not a record: every record the shallow conversion accepts answers with
-  // an object, so a record cannot arrive at this branch, and a non-record is
+  // was not a record: every record the shallow conversion accepts returns an
+  // object, so a record cannot arrive at this branch, and a non-record is
   // not a key the map holds.
   if (typeof value !== "object" || value === null) {
     return value;

--- a/packages/data-model/src/native-type-tags.ts
+++ b/packages/data-model/src/native-type-tags.ts
@@ -122,9 +122,9 @@ export function tagFromNativeClass(
  * value is a recognized convertible native instance, or `null` otherwise.
  * Non-object types (`null`, `undefined`, primitives) return `Primitive`.
  *
- * An array answers `Array` before anything else is consulted.
+ * An array is tagged `Array` before anything else is consulted.
  * `Array.isArray()` is realm-agnostic and sees through both a subclass and a
- * severed prototype, so every array reaches array handling and is answered by
+ * severed prototype, so every array reaches array handling and is decided by
  * the array rule, which alone decides what an array may be.
  *
  * Otherwise dispatches via the value's constructor (O(1) switch in
@@ -148,7 +148,7 @@ export function tagFromNativeValue(value: unknown): NativeTag | null {
   // about its prototype; an own `constructor` property is ordinary data that
   // happens to share the name, and must not decide the value's type. Reading
   // it off the value would let `{constructor: Error}` -- a plain record --
-  // answer `Error` and be silently rebuilt as one.
+  // be tagged `Error` and silently rebuilt as one.
   //
   // Guard: a null-prototype object has no constructor to find, and an exotic
   // one may not have a callable one.
@@ -172,8 +172,8 @@ export function tagFromNativeValue(value: unknown): NativeTag | null {
   if (value instanceof FabricInstance) return NATIVE_TAGS.FabricInstance;
 
   // Null-prototype objects (`Object.create(null)`), which have no constructor
-  // to have been recognized. Answered `Object` so the object rule decides them
-  // by name, the same way an indirect array is answered `Array`.
+  // to have been recognized. Tagged `Object` so the object rule decides them
+  // by name, the same way an indirect array is tagged `Array`.
   if (proto === null) return NATIVE_TAGS.Object;
 
   return null;

--- a/packages/data-model/src/native-type-tags.ts
+++ b/packages/data-model/src/native-type-tags.ts
@@ -143,12 +143,12 @@ export function tagFromNativeValue(value: unknown): NativeTag | null {
     return NATIVE_TAGS.Array;
   }
 
-  // The constructor is read from the PROTOTYPE, not from the value. What is
+  // The constructor is read from the _prototype_, not from the value. What is
   // being asked is which class the value is an instance of, and that is a fact
   // about its prototype; an own `constructor` property is ordinary data that
   // happens to share the name, and must not decide the value's type. Reading
-  // it off the value would let `{constructor: Error}` -- a plain record --
-  // be tagged `Error` and silently rebuilt as one.
+  // it off the value would let `{constructor: Error}` -- a plain record -- be
+  // tagged `Error` and silently rebuilt as one.
   //
   // Guard: a null-prototype object has no constructor to find, and an exotic
   // one may not have a callable one.

--- a/packages/html/src/worker/keying.ts
+++ b/packages/html/src/worker/keying.ts
@@ -22,13 +22,14 @@ const OPAQUE: FabricValue = { "@@vdom-key": "opaque" };
  * stand-in.
  *
  * Everything else a render node may carry is a `JSONValue` (see `WorkerProps`),
- * and every one of those is a `FabricValue` already, so it is answered by
+ * and every one of those is a `FabricValue` already, so it is returned by
  * identity -- which also leaves a subtree carrying neither of the two shared
  * rather than rebuilt.
  *
  * A function is an event handler, and one render's is not the next render's
- * though they mean the same thing, so all of them stand alike. A cell answers
- * with its link, which is what stays put while the payload behind it moves.
+ * though they mean the same thing, so all of them stand alike. A cell is
+ * replaced by its link, which is what stays put while the payload behind it
+ * moves.
  *
  * @param node The render node to project.
  * @param seen Ancestors of `node`, so a cycle ends the walk rather than
@@ -76,8 +77,8 @@ function keyProjection(node: unknown, seen: Set<object>): unknown {
  * `undefined` element, `NaN` from `null`, `-0` from `0` -- keys them apart too.
  *
  * A node holding something no render node may hold can have no such key, and
- * answers a coarse one instead. Keying is on the render path, where an answer
- * is needed more than a precise one is.
+ * returns a coarse one instead. Keying is on the render path, where a key is
+ * needed more than a precise one is.
  *
  * @param node - The render node to generate a key for
  * @returns A stable string key
@@ -91,7 +92,7 @@ export function generateKey(node: unknown): string {
 }
 
 /**
- * Helper for `generateKey()`, which keys a node the hash has no answer for.
+ * Helper for `generateKey()`, which keys a node the hash refuses.
  * Nodes sharing a fallback key are told apart only by their position among
  * their siblings, so what it costs is the reuse of a DOM node that moved.
  */


### PR DESCRIPTION
House style is that a function _returns_ a value. "Answers" is left for a subject
that actually answers something — a proxy answering a property read, a hash
having no answer for a node — and those uses stay.

Comments only, in three files. After this, none of the three carries the word
at all.

Where "answers" was doing more work than "returns" would, the sentence says
what it meant rather than being flattened:

- a value being *tagged* (`native-type-tags.ts`: an array is tagged `Array`, a
  null-prototype object is tagged `Object`);
- a rule *deciding* a value (`tagFromNativeValue()`'s array rule);
- a cell being *replaced* by its link (`keying.ts`).

`encodable-form.ts` is not here: #5396 covers that file.

## Emphasis markup, same files

`docs/development/code-comment-style.md` § Markup calls for `_underscores_`
rather than caps for emphasis. Since this change is already reworking the
comments in these files, the caps go too: `NOT`, `INERT` twice, `IS`, `THROWS`
in `native-conversion.ts`, and `PROTOTYPE` in `native-type-tags.ts`. Acronyms
(`JS`) are not emphasis and stand.

`_x_` costs two columns over `X`, so each paragraph is reflowed as a unit
rather than patched in place — the failure mode being a substitution that goes
over 80 and gets resolved by dropping a word. Verified by comparing comment
word-bags before and after: nothing gained, nothing lost.

## Testing

Comment-only, so no behavior to test. `deno task test` passes in both packages
touched (`data-model`, `html`), and `deno fmt --check` and `deno lint` are
clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use "returns" for function results in comments across `data-model` and `html`, keeping "answers" only for true answering cases (e.g., proxy reads, hash refusals). Clarifies phrasing to say "tagged," "decided," or "replaced" in `native-type-tags.ts`, `native-conversion.ts`, and `keying.ts`; no behavior changes.

<sup>Written for commit 075b5722943af29ab5a9ab0050cffd6a9ab3d136. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



