### PR TITLE
fix(ci): stop charging coverage debt to files that compile to nothing

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -2210,6 +2210,11 @@
           "npm:htmlparser2@12",
           "npm:marked@^18.0.6"
         ]
+      },
+      "tasks": {
+        "dependencies": [
+          "npm:typescript@6.0.3"
+        ]
       }
     }
   }

--- a/docs/development/COVERAGE.md
+++ b/docs/development/COVERAGE.md
@@ -102,7 +102,8 @@ covered a line.
 
 One detail of the gate's accounting is worth knowing when reasoning about
 pattern coverage. A file with no LCOV record has every tracked line counted as
-uncovered. A file with a record is scored against the lines that record names.
+uncovered, unless it compiles to no code at all — see the next subsection. A
+file with a record is scored against the lines that record names.
 For a file measured by Deno's V8 coverage that is every executable line; pattern
 instrumentation names only the statements it could instrument, so a pattern
 file's first record both covers real lines and drops the never-named lines out of
@@ -115,6 +116,36 @@ of the file's lines and the rest stop being counted, so it settles at a lower �
 and therefore stricter — bar rather than failing anything. The instrumented
 statements are also the only lines this mechanism can speak to: a line the
 instrumentation cannot reach is not a line a pattern test could cover.
+
+### A file that compiles to nothing is charged nothing
+
+Charging every tracked line of a file with no coverage record is how the gate
+catches source that no test ever loaded. A second kind of file also has no
+record: one holding only declarations — interfaces, type aliases, ambient
+declarations — which compiles to an empty module. Such a file has no statement
+to run, so a test that loads it executes nothing and Deno's coverage has nothing
+to report. No test can cover a line of it, so the gate charges it nothing.
+
+The gate tells the two apart by compiling each file it finds no record for, and
+charges it only when something comes out. `tasks/executable-source.ts` runs the
+file through the TypeScript compiler and reads the emitted JavaScript: a file
+that emits no statement, an `export {}` module marker aside, is charged nothing,
+and every other file is charged its full tracked-line count. Which constructs
+reach the output is the compiler's rule. An enum, a namespace holding a value,
+and an import kept for its side effects all emit code. A type-only import, a
+namespace holding only types, and a comment do not. The compile happens at gate
+time, once per file the report leaves out. A file with a record never pays for
+it, because its record already says which of its lines ran.
+
+Such a file occasionally does get a record. A comment that survives into the
+emitted output leaves Deno one line to report, and that line is hit the moment
+the module loads, so the file contributes nothing either way.
+
+The charge is all or nothing. The first line of runnable code added to such a
+file charges the whole file, which is the bill a new module of that size runs
+up. A file that gains code usually gains a coverage record with it, and that
+brings the charge down to the lines no test reached. The full charge stands
+only while nothing loads the file.
 
 ## Coverage must not depend on the execution environment
 

--- a/docs/development/DEPENDENCIES.md
+++ b/docs/development/DEPENDENCIES.md
@@ -167,9 +167,10 @@ disagrees with the pin.
 The runtime compiles patterns itself, using the TypeScript compiler API at
 runtime. Seven runtime and build packages (`js-compiler`, `ts-transformers`,
 `schema-generator`, `runner`, `cli`, `static`, `deno-web-test`) import
-`npm:typescript`. The `api` package imports it for the type-profiling harness.
-All eight workspace members pin the same version in their `deno.jsonc` import
-maps. This npm dependency is separate from the TypeScript that `deno check`
+`npm:typescript`. The `api` package imports it for the type-profiling harness,
+and `tasks` imports it for the coverage gate, which compiles a source file to
+find out whether it holds any executable code. All nine workspace members pin
+the same version in their `deno.jsonc` import maps. This npm dependency is separate from the TypeScript that `deno check`
 uses: Deno bundles its own copy of the compiler. Keeping the npm pin on the
 same minor version as the Deno-bundled compiler (`deno --version` prints it)
 avoids the two disagreeing about what type-checks.

--- a/tasks/ci-check-lib.ts
+++ b/tasks/ci-check-lib.ts
@@ -88,7 +88,8 @@ export interface CoverageCommentPayload {
 export const COVERAGE_LOCAL_CHECK_COMMAND = [
   "rm -rf coverage/raw/local",
   'DENO_COVERAGE_DIR="$(pwd)/coverage/raw/local" deno task test',
-  "deno run --allow-read --allow-write --allow-run tasks/coverage-metrics.ts \\",
+  "deno run --allow-read --allow-write --allow-run --allow-env \\",
+  "  tasks/coverage-metrics.ts \\",
   '  --profile-dir="$(pwd)/coverage/raw/local" --root="$(pwd)"',
 ].join("\n");
 

--- a/tasks/coverage-metrics.test.ts
+++ b/tasks/coverage-metrics.test.ts
@@ -175,6 +175,48 @@ Deno.test("collectCoverageDebtMetricsFromLcov computes debt from compact reports
   }
 });
 
+Deno.test("a file that compiles to nothing carries no debt", async () => {
+  const rootDir = await Deno.makeTempDir({ prefix: "coverage-types-test-" });
+  try {
+    const writeSourceFile = async (relativePath: string, content: string) => {
+      const fullPath = path.join(rootDir, ...relativePath.split("/"));
+      await Deno.mkdir(path.dirname(fullPath), { recursive: true });
+      await Deno.writeTextFile(fullPath, content);
+    };
+
+    // Declarations only: no statement to run, so no test could cover a line of
+    // it, and Deno's coverage reports no record for it either way.
+    await writeSourceFile(
+      "packages/example/src/types.ts",
+      [
+        "export interface Shape {",
+        "  sides: number;",
+        "}",
+        "export type Either = Shape | number;",
+      ].join("\n"),
+    );
+    // Real code no test loaded: charged in full.
+    await writeSourceFile(
+      "packages/example/src/untested.ts",
+      ["export function untested() {", "  return 1;", "}"].join("\n"),
+    );
+
+    const metrics = await collectCoverageDebtMetricsFromLcov({
+      rootDir,
+      lcov: "",
+    });
+
+    assertEquals(
+      metrics.find((metric) =>
+        metric.name === "coverage-debt: packages/example uncovered lines"
+      )?.uncoveredLines,
+      3,
+    );
+  } finally {
+    await Deno.remove(rootDir, { recursive: true });
+  }
+});
+
 Deno.test("integration pattern coverage feeds the debt metric", async () => {
   const rootDir = await Deno.makeTempDir({ prefix: "coverage-fold-test-" });
   try {
@@ -261,6 +303,28 @@ Deno.test("collectUncoveredLinesForFiles resolves lines only for requested files
     assertEquals(uncovered.has("scripts/build.ts"), false);
     assertEquals(uncovered.has("packages/example/src/covered.test.ts"), false);
     assertEquals(uncovered.has("packages/example/src/other.ts"), false);
+  } finally {
+    await Deno.remove(rootDir, { recursive: true });
+  }
+});
+
+Deno.test("collectUncoveredLinesForFiles reports no lines for a file that compiles to nothing", async () => {
+  const rootDir = await Deno.makeTempDir({ prefix: "coverage-lines-test-" });
+  try {
+    const typesPath = path.join(rootDir, "packages/example/src/types.ts");
+    await Deno.mkdir(path.dirname(typesPath), { recursive: true });
+    await Deno.writeTextFile(
+      typesPath,
+      ["export interface Shape {", "  sides: number;", "}"].join("\n"),
+    );
+
+    const uncovered = await collectUncoveredLinesForFiles({
+      rootDir,
+      lcov: "",
+      files: ["packages/example/src/types.ts"],
+    });
+
+    assertEquals(uncovered.size, 0);
   } finally {
     await Deno.remove(rootDir, { recursive: true });
   }

--- a/tasks/coverage-metrics.test.ts
+++ b/tasks/coverage-metrics.test.ts
@@ -1,4 +1,5 @@
 import { assertEquals, assertRejects } from "@std/assert";
+import { expect } from "@std/expect";
 import * as path from "@std/path";
 import {
   collectCoverageDebtMetricsFromLcov,
@@ -206,12 +207,11 @@ Deno.test("a file that compiles to nothing carries no debt", async () => {
       lcov: "",
     });
 
-    assertEquals(
+    expect(
       metrics.find((metric) =>
         metric.name === "coverage-debt: packages/example uncovered lines"
       )?.uncoveredLines,
-      3,
-    );
+    ).toBe(3);
   } finally {
     await Deno.remove(rootDir, { recursive: true });
   }
@@ -324,7 +324,7 @@ Deno.test("collectUncoveredLinesForFiles reports no lines for a file that compil
       files: ["packages/example/src/types.ts"],
     });
 
-    assertEquals(uncovered.size, 0);
+    expect(uncovered.size).toBe(0);
   } finally {
     await Deno.remove(rootDir, { recursive: true });
   }

--- a/tasks/coverage-metrics.ts
+++ b/tasks/coverage-metrics.ts
@@ -114,8 +114,9 @@ export async function collectCoverageDebtMetricsFromLcov(
 }
 
 /**
- * The debt charged to a file the report has no record for. Two different things
- * produce a missing record, and they owe different amounts.
+ * Helper for `collectCoverageDebtMetricsFromLcov()`, which returns the debt
+ * charged to a file the report has no record for. Two different things produce
+ * a missing record, and they owe different amounts.
  *
  * A file no test ever loaded owes every tracked line: that is the case this
  * rule exists to catch.

--- a/tasks/coverage-metrics.ts
+++ b/tasks/coverage-metrics.ts
@@ -1,5 +1,6 @@
-#!/usr/bin/env -S deno run --allow-read --allow-write --allow-run
+#!/usr/bin/env -S deno run --allow-read --allow-write --allow-run --allow-env
 import * as path from "@std/path";
+import { hasExecutableCode } from "./executable-source.ts";
 import { normalizeLcovInstancePaths } from "./write-coverage-lcov.ts";
 
 export const COVERAGE_PROFILE_ARTIFACT_PREFIX = "coverage-profile-";
@@ -84,11 +85,9 @@ export async function collectCoverageDebtMetricsFromLcov(
 
   for (const source of sourceFiles) {
     const coverage = lcovCoverage.get(source.absolutePath);
-    // A file the tests never loaded has no coverage record; every tracked
-    // line counts as uncovered, matching how the debt metric scores it.
     const uncovered = coverage
       ? countUncoveredProfileLines(coverage)
-      : source.trackedLineCount;
+      : await debtWithoutCoverageRecord(source);
 
     workspaceUncovered += uncovered;
     groupUncovered.set(
@@ -112,6 +111,27 @@ export async function collectCoverageDebtMetricsFromLcov(
   }
 
   return metrics;
+}
+
+/**
+ * The debt charged to a file the report has no record for. Two different things
+ * produce a missing record, and they owe different amounts.
+ *
+ * A file no test ever loaded owes every tracked line: that is the case this
+ * rule exists to catch.
+ *
+ * A file that compiles to no executable code — one holding only interfaces,
+ * type aliases, or other declarations — owes nothing. It has no statement a
+ * test could run, so loading it leaves the report exactly as not loading it
+ * does, and no test could ever pay the debt down.
+ *
+ * The compile happens here, so only files the report leaves out pay for it.
+ */
+async function debtWithoutCoverageRecord(source: SourceFile): Promise<number> {
+  const content = await Deno.readTextFile(source.absolutePath);
+  return hasExecutableCode(content, source.absolutePath)
+    ? source.trackedLineCount
+    : 0;
 }
 
 /**
@@ -141,8 +161,10 @@ export async function collectUncoveredLinesForFiles(
     if (coverage) {
       uncoveredLines = uncoveredProfileLineNumbers(coverage);
     } else {
-      // No coverage record: the file was never loaded by any test, so every
-      // tracked line is uncovered.
+      // No coverage record: either no test loaded the file, in which case every
+      // tracked line is uncovered, or it compiles to no executable code, in
+      // which case none of its lines can be covered (see
+      // debtWithoutCoverageRecord).
       let content: string;
       try {
         content = await Deno.readTextFile(absolutePath);
@@ -153,7 +175,9 @@ export async function collectUncoveredLinesForFiles(
         if (error instanceof Deno.errors.NotFound) continue;
         throw error;
       }
-      uncoveredLines = trackedSourceLineNumbers(content);
+      uncoveredLines = hasExecutableCode(content, absolutePath)
+        ? trackedSourceLineNumbers(content)
+        : [];
     }
 
     if (uncoveredLines.length > 0) result.set(relativePath, uncoveredLines);

--- a/tasks/deno.jsonc
+++ b/tasks/deno.jsonc
@@ -1,5 +1,8 @@
 {
   // Dependency guide: ../docs/development/DEPENDENCIES.md
+  "imports": {
+    "typescript": "npm:typescript@6.0.3"
+  },
   "tasks": {
     "test": "deno test -A"
   }

--- a/tasks/executable-source.test.ts
+++ b/tasks/executable-source.test.ts
@@ -1,282 +1,298 @@
-import { assert, assertEquals } from "@std/assert";
+import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
 import * as path from "@std/path";
 import { hasExecutableCode } from "./executable-source.ts";
 import { parseLcov } from "./coverage-metrics.ts";
 
-Deno.test("declarations alone compile to nothing", () => {
-  const declarationOnly: [string, string][] = [
-    [
-      "interfaces and type aliases",
+/** A fixture module, and whether its content compiles to code that can run. */
+interface Fixture {
+  name: string;
+  content: string;
+  executable: boolean;
+}
+
+/**
+ * Fixtures for the coverage pass. The augmentation holds an import whose
+ * binding is used only in a type position: both compilers drop the import, so
+ * nothing of that file survives to run.
+ */
+const COVERAGE_FIXTURES: Fixture[] = [
+  {
+    name: "declarations.ts",
+    content: [
+      "export interface Shape {",
+      "  sides: number;",
+      "}",
+      "export type Either = Shape | number;",
+    ].join("\n"),
+    executable: false,
+  },
+  {
+    name: "augmentation.ts",
+    content: [
+      'import { used } from "./values.ts";',
+      "declare global {",
+      "  interface Window {",
+      "    extra?: typeof used;",
+      "  }",
+      "}",
+      "export {};",
+    ].join("\n"),
+    executable: false,
+  },
+  {
+    name: "values.ts",
+    content: [
+      "export function used() {",
+      "  return 1;",
+      "}",
+      "export function skipped() {",
+      "  return 2;",
+      "}",
+    ].join("\n"),
+    executable: true,
+  },
+  {
+    name: "barrel.ts",
+    content: 'export * from "./values.ts";\n',
+    executable: true,
+  },
+];
+
+describe("executable-source", () => {
+  describe("hasExecutableCode()", () => {
+    const declarationOnly: [string, string][] = [
       [
-        "export interface Shape {",
-        "  sides: number;",
-        "}",
-        "export type Either = Shape | number;",
-      ].join("\n"),
-    ],
-    [
-      "ambient declarations",
-      [
-        "declare const external: number;",
-        "export declare function helper(x: number): number;",
-        "export type Reference = typeof external;",
-      ].join("\n"),
-    ],
-    [
-      "a global augmentation",
-      [
-        "declare global {",
-        "  interface Window {",
-        "    extra?: number;",
-        "  }",
-        "}",
-        "export {};",
-      ].join("\n"),
-    ],
-    [
-      "a namespace holding only types",
-      [
-        "export namespace Shapes {",
-        "  export interface Circle {",
-        "    radius: number;",
-        "  }",
-        "}",
-      ].join("\n"),
-    ],
-    [
-      "a type-only re-export",
-      'export type { Shape } from "./shapes.ts";',
-    ],
-    [
-      "an import used only in type positions",
-      [
-        'import { Widget } from "./widget.ts";',
-        "export type Rendered = (widget: Widget) => string;",
-      ].join("\n"),
-    ],
-    [
-      "comments and the module marker",
-      ["/** Everything here is commented out. */", "export {};"].join("\n"),
-    ],
-    [
-      "declarations in a file with no import or export",
-      ["interface Local {", "  a: number;", "}", "type Other = Local;"].join(
-        "\n",
-      ),
-    ],
-  ];
-
-  for (const [description, content] of declarationOnly) {
-    assertEquals(hasExecutableCode(content, "example.ts"), false, description);
-  }
-});
-
-Deno.test("constructs that reach the output count as executable", () => {
-  const executable: [string, string][] = [
-    ["a value", "export const answer = 42;"],
-    ["an enum", "export enum Color {\n  Red,\n  Green,\n}"],
-    ["a const enum", "export const enum Speed {\n  Slow = 1,\n}"],
-    [
-      "a namespace holding a value",
-      "export namespace Values {\n  export const one = 1;\n}",
-    ],
-    [
-      "an abstract class",
-      "export abstract class Base {\n  abstract run(): void;\n}",
-    ],
-    [
-      "an import kept for its side effects",
-      [
-        'import "./register.ts";',
-        "export interface Marker {",
-        "  m: true;",
-        "}",
-      ]
-        .join("\n"),
-    ],
-    ["a re-export", 'export * from "./values.ts";'],
-    // A file the compiler cannot parse stays charged. Error recovery emits
-    // what it managed to read, so a file the gate cannot make sense of carries
-    // its full charge.
-    ["a file that does not parse", "export const broken = {"],
-    ["text that is not code at all", "This file is prose, not TypeScript.\n"],
-  ];
-
-  for (const [description, content] of executable) {
-    assertEquals(hasExecutableCode(content, "example.ts"), true, description);
-  }
-});
-
-Deno.test("markup in a .tsx file is executable, its types are not", () => {
-  const markup = [
-    "export const Greeting = () => <div>hello</div>;",
-  ].join("\n");
-  const types = [
-    "export interface Props {",
-    "  title: string;",
-    "}",
-    "export type Renderer = (props: Props) => unknown;",
-  ].join("\n");
-
-  assertEquals(hasExecutableCode(markup, "component.tsx"), true);
-  assertEquals(hasExecutableCode(types, "component.tsx"), false);
-});
-
-Deno.test("JavaScript is read as written", () => {
-  assertEquals(hasExecutableCode("export const value = 1;\n", "mod.js"), true);
-  assertEquals(hasExecutableCode("// nothing here\n", "mod.js"), false);
-});
-
-// The gate rests on a claim about Deno: a file this module calls non-executable
-// has no line Deno's coverage can report as uncovered, so charging it nothing
-// loses nothing. Deno transpiles with swc, and this module asks the TypeScript
-// compiler, so a real coverage pass over fixture modules holds the two to the
-// same answer.
-Deno.test("Deno's coverage reports no uncovered line for a file that compiles to nothing", async () => {
-  // Resolved, because the report names the real path and the temporary
-  // directory can be reached through a symlink (macOS puts one in front of it).
-  const root = await Deno.realPath(
-    await Deno.makeTempDir({ prefix: "executable-source-" }),
-  );
-  try {
-    const fixtures: { name: string; content: string; executable: boolean }[] = [
-      {
-        name: "declarations.ts",
-        content: [
+        "interfaces and type aliases",
+        [
           "export interface Shape {",
           "  sides: number;",
           "}",
           "export type Either = Shape | number;",
         ].join("\n"),
-        executable: false,
-      },
-      {
-        // An import whose binding is used only in a type position, inside a
-        // global augmentation. Both compilers drop the import, so nothing of
-        // this file survives to run.
-        name: "augmentation.ts",
-        content: [
-          'import { used } from "./values.ts";',
+      ],
+      [
+        "ambient declarations",
+        [
+          "declare const external: number;",
+          "export declare function helper(x: number): number;",
+          "export type Reference = typeof external;",
+        ].join("\n"),
+      ],
+      [
+        "a global augmentation",
+        [
           "declare global {",
           "  interface Window {",
-          "    extra?: typeof used;",
+          "    extra?: number;",
           "  }",
           "}",
           "export {};",
         ].join("\n"),
-        executable: false,
-      },
-      {
-        name: "values.ts",
-        content: [
-          "export function used() {",
-          "  return 1;",
-          "}",
-          "export function skipped() {",
-          "  return 2;",
+      ],
+      [
+        "a namespace holding only types",
+        [
+          "export namespace Shapes {",
+          "  export interface Circle {",
+          "    radius: number;",
+          "  }",
           "}",
         ].join("\n"),
-        executable: true,
-      },
-      {
-        name: "barrel.ts",
-        content: 'export * from "./values.ts";\n',
-        executable: true,
-      },
+      ],
+      [
+        "a type-only re-export",
+        'export type { Shape } from "./shapes.ts";',
+      ],
+      [
+        "an import used only in type positions",
+        [
+          'import { Widget } from "./widget.ts";',
+          "export type Rendered = (widget: Widget) => string;",
+        ].join("\n"),
+      ],
+      [
+        "comments and the module marker",
+        ["/** Everything here is commented out. */", "export {};"].join("\n"),
+      ],
+      [
+        "declarations in a file with no import or export",
+        ["interface Local {", "  a: number;", "}", "type Other = Local;"].join(
+          "\n",
+        ),
+      ],
     ];
 
-    for (const fixture of fixtures) {
-      await Deno.writeTextFile(path.join(root, fixture.name), fixture.content);
+    for (const [subject, content] of declarationOnly) {
+      it(`returns \`false\` for ${subject}`, () => {
+        expect(hasExecutableCode(content, "example.ts")).toBe(false);
+      });
     }
-    await Deno.writeTextFile(
-      path.join(root, "fixture.test.ts"),
+
+    const executable: [string, string][] = [
+      ["a value", "export const answer = 42;"],
+      ["an enum", "export enum Color {\n  Red,\n  Green,\n}"],
+      ["a const enum", "export const enum Speed {\n  Slow = 1,\n}"],
       [
-        // Side-effect imports, so every fixture is loaded whether or not it
-        // binds anything.
-        'import "./declarations.ts";',
-        'import "./augmentation.ts";',
-        'import { used } from "./barrel.ts";',
-        'Deno.test("drive", () => {',
-        '  if (used() !== 1) throw new Error("wrong");',
-        "});",
-      ].join("\n"),
-    );
+        "a namespace holding a value",
+        "export namespace Values {\n  export const one = 1;\n}",
+      ],
+      [
+        "an abstract class",
+        "export abstract class Base {\n  abstract run(): void;\n}",
+      ],
+      [
+        "an import kept for its side effects",
+        [
+          'import "./register.ts";',
+          "export interface Marker {",
+          "  m: true;",
+          "}",
+        ].join("\n"),
+      ],
+      ["a re-export", 'export * from "./values.ts";'],
+      // Error recovery emits what the compiler managed to read, so a file it
+      // cannot parse carries its full charge.
+      ["a file that does not parse", "export const broken = {"],
+      ["text that is not code at all", "This file is prose, not TypeScript.\n"],
+    ];
 
-    const rawDir = path.join(root, "raw");
-    const runInFixture = (args: string[]) =>
-      new Deno.Command(Deno.execPath(), {
-        args,
-        // Both runs read the same emit cache, which Deno keys on the config it
-        // resolves; running them from the fixture directory keeps that the same
-        // for the profile and the report.
-        cwd: root,
-        env: { DENO_COVERAGE_DIR: rawDir },
-        stdout: "null",
-        stderr: "piped",
-      }).output();
-
-    const generated = await runInFixture([
-      "test",
-      "--no-check",
-      "--no-lock",
-      `--coverage=${rawDir}`,
-      "fixture.test.ts",
-    ]);
-    assert(
-      generated.success,
-      `generating the fixture coverage profile failed: ${
-        new TextDecoder().decode(generated.stderr)
-      }`,
-    );
-
-    const lcovPath = path.join(root, "fixture.lcov");
-    const reported = await runInFixture([
-      "coverage",
-      "--lcov",
-      `--output=${lcovPath}`,
-      rawDir,
-    ]);
-    assert(
-      reported.success,
-      `converting the fixture profile to LCOV failed: ${
-        new TextDecoder().decode(reported.stderr)
-      }`,
-    );
-
-    const coverage = parseLcov(await Deno.readTextFile(lcovPath));
-    const recordFor = (name: string) =>
-      coverage.get(path.normalize(path.join(root, name)));
-
-    // The run does mark lines uncovered, so the checks below mean something:
-    // `skipped` is never called.
-    const values = recordFor("values.ts");
-    assert(values, "values.ts has no coverage record");
-    assert(
-      [...values.lineHits.values()].some((hits) => hits === 0),
-      "values.ts reports no uncovered line",
-    );
-
-    for (const fixture of fixtures) {
-      assertEquals(
-        hasExecutableCode(fixture.content, path.join(root, fixture.name)),
-        fixture.executable,
-        fixture.name,
-      );
-
-      const record = recordFor(fixture.name);
-      if (fixture.executable) {
-        assert(record, `${fixture.name} has no coverage record`);
-        continue;
-      }
-      // Either no record at all, or one whose lines the module's own load hit.
-      // A comment surviving into the emitted output can leave Deno a line to
-      // report, and loading the module hits it.
-      const uncovered = [...record?.lineHits.values() ?? []].filter((hits) =>
-        hits === 0
-      );
-      assertEquals(uncovered.length, 0, `${fixture.name} reports uncovered`);
+    for (const [subject, content] of executable) {
+      it(`returns \`true\` for ${subject}`, () => {
+        expect(hasExecutableCode(content, "example.ts")).toBe(true);
+      });
     }
-  } finally {
-    await Deno.remove(root, { recursive: true });
-  }
+
+    it("returns `true` for markup in a `.tsx` file", () => {
+      const markup = "export const Greeting = () => <div>hello</div>;";
+      expect(hasExecutableCode(markup, "component.tsx")).toBe(true);
+    });
+
+    it("returns `false` for a `.tsx` file holding only types", () => {
+      const types = [
+        "export interface Props {",
+        "  title: string;",
+        "}",
+        "export type Renderer = (props: Props) => unknown;",
+      ].join("\n");
+      expect(hasExecutableCode(types, "component.tsx")).toBe(false);
+    });
+
+    it("returns `true` for JavaScript that declares a value", () => {
+      expect(hasExecutableCode("export const value = 1;\n", "mod.js"))
+        .toBe(true);
+    });
+
+    it("returns `false` for JavaScript that is all comment", () => {
+      expect(hasExecutableCode("// nothing here\n", "mod.js")).toBe(false);
+    });
+
+    // The coverage gate rests on a claim about Deno: a file this function calls
+    // non-executable has no line Deno's coverage can report as uncovered, so
+    // charging it nothing loses nothing. Deno transpiles with swc and this
+    // function asks the TypeScript compiler, so a real coverage pass over
+    // fixture modules holds the two to the same answer.
+    describe("against a real coverage run", () => {
+      // Resolved, because the report names the real path and a temporary
+      // directory can be reached through a symlink (macOS puts one in front of
+      // it).
+      let root: string;
+      let coverage: ReturnType<typeof parseLcov>;
+
+      const recordFor = (name: string) =>
+        coverage.get(path.normalize(path.join(root, name)));
+
+      const runInFixture = async (args: string[]) => {
+        const result = await new Deno.Command(Deno.execPath(), {
+          args,
+          // Both runs read the same emit cache, which Deno keys on the config
+          // it resolves; running them from the fixture directory keeps that the
+          // same for the profile and the report.
+          cwd: root,
+          env: { DENO_COVERAGE_DIR: path.join(root, "raw") },
+          stdout: "null",
+          stderr: "piped",
+        }).output();
+        if (!result.success) {
+          throw new Error(
+            `\`deno ${args[0]}\` failed in the fixture directory: ${
+              new TextDecoder().decode(result.stderr)
+            }`,
+          );
+        }
+      };
+
+      beforeAll(async () => {
+        root = await Deno.realPath(
+          await Deno.makeTempDir({ prefix: "executable-source-" }),
+        );
+        for (const fixture of COVERAGE_FIXTURES) {
+          await Deno.writeTextFile(
+            path.join(root, fixture.name),
+            fixture.content,
+          );
+        }
+        await Deno.writeTextFile(
+          path.join(root, "fixture.test.ts"),
+          [
+            // Side-effect imports, so every fixture is loaded whether or not it
+            // binds anything.
+            'import "./declarations.ts";',
+            'import "./augmentation.ts";',
+            'import { used } from "./barrel.ts";',
+            'Deno.test("drive", () => {',
+            '  if (used() !== 1) throw new Error("wrong");',
+            "});",
+          ].join("\n"),
+        );
+
+        const rawDir = path.join(root, "raw");
+        await runInFixture([
+          "test",
+          "--no-check",
+          "--no-lock",
+          `--coverage=${rawDir}`,
+          "fixture.test.ts",
+        ]);
+        const lcovPath = path.join(root, "fixture.lcov");
+        await runInFixture([
+          "coverage",
+          "--lcov",
+          `--output=${lcovPath}`,
+          rawDir,
+        ]);
+        coverage = parseLcov(await Deno.readTextFile(lcovPath));
+      });
+
+      afterAll(async () => {
+        await Deno.remove(root, { recursive: true });
+      });
+
+      it("reports uncovered lines for a fixture holding code no test ran", () => {
+        const values = recordFor("values.ts");
+        expect(values).toBeDefined();
+        expect([...values!.lineHits.values()].filter((hits) => hits === 0))
+          .not.toEqual([]);
+      });
+
+      for (const fixture of COVERAGE_FIXTURES) {
+        it(`classifies \`${fixture.name}\` as the report does`, () => {
+          expect(
+            hasExecutableCode(fixture.content, path.join(root, fixture.name)),
+          ).toBe(fixture.executable);
+
+          const record = recordFor(fixture.name);
+          if (fixture.executable) {
+            expect(record).toBeDefined();
+            return;
+          }
+          // Either no record at all, or one whose lines the module's own load
+          // hit. A comment surviving into the emitted output can leave Deno a
+          // line to report, and loading the module hits it.
+          const hits = [...record?.lineHits.values() ?? []];
+          expect(hits.filter((count) => count === 0)).toEqual([]);
+        });
+      }
+    });
+  });
 });

--- a/tasks/executable-source.test.ts
+++ b/tasks/executable-source.test.ts
@@ -1,0 +1,282 @@
+import { assert, assertEquals } from "@std/assert";
+import * as path from "@std/path";
+import { hasExecutableCode } from "./executable-source.ts";
+import { parseLcov } from "./coverage-metrics.ts";
+
+Deno.test("declarations alone compile to nothing", () => {
+  const declarationOnly: [string, string][] = [
+    [
+      "interfaces and type aliases",
+      [
+        "export interface Shape {",
+        "  sides: number;",
+        "}",
+        "export type Either = Shape | number;",
+      ].join("\n"),
+    ],
+    [
+      "ambient declarations",
+      [
+        "declare const external: number;",
+        "export declare function helper(x: number): number;",
+        "export type Reference = typeof external;",
+      ].join("\n"),
+    ],
+    [
+      "a global augmentation",
+      [
+        "declare global {",
+        "  interface Window {",
+        "    extra?: number;",
+        "  }",
+        "}",
+        "export {};",
+      ].join("\n"),
+    ],
+    [
+      "a namespace holding only types",
+      [
+        "export namespace Shapes {",
+        "  export interface Circle {",
+        "    radius: number;",
+        "  }",
+        "}",
+      ].join("\n"),
+    ],
+    [
+      "a type-only re-export",
+      'export type { Shape } from "./shapes.ts";',
+    ],
+    [
+      "an import used only in type positions",
+      [
+        'import { Widget } from "./widget.ts";',
+        "export type Rendered = (widget: Widget) => string;",
+      ].join("\n"),
+    ],
+    [
+      "comments and the module marker",
+      ["/** Everything here is commented out. */", "export {};"].join("\n"),
+    ],
+    [
+      "declarations in a file with no import or export",
+      ["interface Local {", "  a: number;", "}", "type Other = Local;"].join(
+        "\n",
+      ),
+    ],
+  ];
+
+  for (const [description, content] of declarationOnly) {
+    assertEquals(hasExecutableCode(content, "example.ts"), false, description);
+  }
+});
+
+Deno.test("constructs that reach the output count as executable", () => {
+  const executable: [string, string][] = [
+    ["a value", "export const answer = 42;"],
+    ["an enum", "export enum Color {\n  Red,\n  Green,\n}"],
+    ["a const enum", "export const enum Speed {\n  Slow = 1,\n}"],
+    [
+      "a namespace holding a value",
+      "export namespace Values {\n  export const one = 1;\n}",
+    ],
+    [
+      "an abstract class",
+      "export abstract class Base {\n  abstract run(): void;\n}",
+    ],
+    [
+      "an import kept for its side effects",
+      [
+        'import "./register.ts";',
+        "export interface Marker {",
+        "  m: true;",
+        "}",
+      ]
+        .join("\n"),
+    ],
+    ["a re-export", 'export * from "./values.ts";'],
+    // A file the compiler cannot parse stays charged. Error recovery emits
+    // what it managed to read, so a file the gate cannot make sense of carries
+    // its full charge.
+    ["a file that does not parse", "export const broken = {"],
+    ["text that is not code at all", "This file is prose, not TypeScript.\n"],
+  ];
+
+  for (const [description, content] of executable) {
+    assertEquals(hasExecutableCode(content, "example.ts"), true, description);
+  }
+});
+
+Deno.test("markup in a .tsx file is executable, its types are not", () => {
+  const markup = [
+    "export const Greeting = () => <div>hello</div>;",
+  ].join("\n");
+  const types = [
+    "export interface Props {",
+    "  title: string;",
+    "}",
+    "export type Renderer = (props: Props) => unknown;",
+  ].join("\n");
+
+  assertEquals(hasExecutableCode(markup, "component.tsx"), true);
+  assertEquals(hasExecutableCode(types, "component.tsx"), false);
+});
+
+Deno.test("JavaScript is read as written", () => {
+  assertEquals(hasExecutableCode("export const value = 1;\n", "mod.js"), true);
+  assertEquals(hasExecutableCode("// nothing here\n", "mod.js"), false);
+});
+
+// The gate rests on a claim about Deno: a file this module calls non-executable
+// has no line Deno's coverage can report as uncovered, so charging it nothing
+// loses nothing. Deno transpiles with swc, and this module asks the TypeScript
+// compiler, so a real coverage pass over fixture modules holds the two to the
+// same answer.
+Deno.test("Deno's coverage reports no uncovered line for a file that compiles to nothing", async () => {
+  // Resolved, because the report names the real path and the temporary
+  // directory can be reached through a symlink (macOS puts one in front of it).
+  const root = await Deno.realPath(
+    await Deno.makeTempDir({ prefix: "executable-source-" }),
+  );
+  try {
+    const fixtures: { name: string; content: string; executable: boolean }[] = [
+      {
+        name: "declarations.ts",
+        content: [
+          "export interface Shape {",
+          "  sides: number;",
+          "}",
+          "export type Either = Shape | number;",
+        ].join("\n"),
+        executable: false,
+      },
+      {
+        // An import whose binding is used only in a type position, inside a
+        // global augmentation. Both compilers drop the import, so nothing of
+        // this file survives to run.
+        name: "augmentation.ts",
+        content: [
+          'import { used } from "./values.ts";',
+          "declare global {",
+          "  interface Window {",
+          "    extra?: typeof used;",
+          "  }",
+          "}",
+          "export {};",
+        ].join("\n"),
+        executable: false,
+      },
+      {
+        name: "values.ts",
+        content: [
+          "export function used() {",
+          "  return 1;",
+          "}",
+          "export function skipped() {",
+          "  return 2;",
+          "}",
+        ].join("\n"),
+        executable: true,
+      },
+      {
+        name: "barrel.ts",
+        content: 'export * from "./values.ts";\n',
+        executable: true,
+      },
+    ];
+
+    for (const fixture of fixtures) {
+      await Deno.writeTextFile(path.join(root, fixture.name), fixture.content);
+    }
+    await Deno.writeTextFile(
+      path.join(root, "fixture.test.ts"),
+      [
+        // Side-effect imports, so every fixture is loaded whether or not it
+        // binds anything.
+        'import "./declarations.ts";',
+        'import "./augmentation.ts";',
+        'import { used } from "./barrel.ts";',
+        'Deno.test("drive", () => {',
+        '  if (used() !== 1) throw new Error("wrong");',
+        "});",
+      ].join("\n"),
+    );
+
+    const rawDir = path.join(root, "raw");
+    const runInFixture = (args: string[]) =>
+      new Deno.Command(Deno.execPath(), {
+        args,
+        // Both runs read the same emit cache, which Deno keys on the config it
+        // resolves; running them from the fixture directory keeps that the same
+        // for the profile and the report.
+        cwd: root,
+        env: { DENO_COVERAGE_DIR: rawDir },
+        stdout: "null",
+        stderr: "piped",
+      }).output();
+
+    const generated = await runInFixture([
+      "test",
+      "--no-check",
+      "--no-lock",
+      `--coverage=${rawDir}`,
+      "fixture.test.ts",
+    ]);
+    assert(
+      generated.success,
+      `generating the fixture coverage profile failed: ${
+        new TextDecoder().decode(generated.stderr)
+      }`,
+    );
+
+    const lcovPath = path.join(root, "fixture.lcov");
+    const reported = await runInFixture([
+      "coverage",
+      "--lcov",
+      `--output=${lcovPath}`,
+      rawDir,
+    ]);
+    assert(
+      reported.success,
+      `converting the fixture profile to LCOV failed: ${
+        new TextDecoder().decode(reported.stderr)
+      }`,
+    );
+
+    const coverage = parseLcov(await Deno.readTextFile(lcovPath));
+    const recordFor = (name: string) =>
+      coverage.get(path.normalize(path.join(root, name)));
+
+    // The run does mark lines uncovered, so the checks below mean something:
+    // `skipped` is never called.
+    const values = recordFor("values.ts");
+    assert(values, "values.ts has no coverage record");
+    assert(
+      [...values.lineHits.values()].some((hits) => hits === 0),
+      "values.ts reports no uncovered line",
+    );
+
+    for (const fixture of fixtures) {
+      assertEquals(
+        hasExecutableCode(fixture.content, path.join(root, fixture.name)),
+        fixture.executable,
+        fixture.name,
+      );
+
+      const record = recordFor(fixture.name);
+      if (fixture.executable) {
+        assert(record, `${fixture.name} has no coverage record`);
+        continue;
+      }
+      // Either no record at all, or one whose lines the module's own load hit.
+      // A comment surviving into the emitted output can leave Deno a line to
+      // report, and loading the module hits it.
+      const uncovered = [...record?.lineHits.values() ?? []].filter((hits) =>
+        hits === 0
+      );
+      assertEquals(uncovered.length, 0, `${fixture.name} reports uncovered`);
+    }
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});

--- a/tasks/executable-source.ts
+++ b/tasks/executable-source.ts
@@ -1,0 +1,59 @@
+import ts from "typescript";
+
+/**
+ * Compiler options for the emit test. ES modules and an ESNext target keep the
+ * output close to the source, and `jsx` matches the workspace setting so markup
+ * in a `.tsx` file compiles to calls. `alwaysStrict` is off to match Deno,
+ * which loads every file as an ES module and so emits no `"use strict"` line
+ * for a file that has no import or export.
+ */
+const TRANSPILE_OPTIONS: ts.CompilerOptions = {
+  module: ts.ModuleKind.ESNext,
+  target: ts.ScriptTarget.ESNext,
+  jsx: ts.JsxEmit.ReactJSX,
+  alwaysStrict: false,
+};
+
+/**
+ * Whether a source file compiles to code that can run.
+ *
+ * A file holding only interfaces, type aliases, and other declarations compiles
+ * to an empty module, so it has no statement any test could execute, and Deno's
+ * coverage reports no line for it that a test could leave uncovered.
+ *
+ * The answer comes from compiling the file and reading what comes out. Which
+ * constructs reach the output is the compiler's rule. An enum, a namespace
+ * holding a value, and an import kept for its side effects all emit code. A
+ * type-only import, a namespace holding only types, and a comment do not.
+ *
+ * The coverage gate is the caller; `docs/development/COVERAGE.md` describes what
+ * it does with the answer.
+ */
+export function hasExecutableCode(content: string, filePath: string): boolean {
+  const emitted = ts.transpileModule(content, {
+    fileName: filePath,
+    compilerOptions: TRANSPILE_OPTIONS,
+  }).outputText;
+
+  const parsed = ts.createSourceFile(
+    "emitted.js",
+    emitted,
+    ts.ScriptTarget.ESNext,
+    false,
+    ts.ScriptKind.JS,
+  );
+  return parsed.statements.some((statement) => !isEmptyExportMarker(statement));
+}
+
+/**
+ * An `export {}` with nothing in it. The compiler emits this to keep a file
+ * that emitted nothing else a module rather than a script. It declares no
+ * binding and runs no code.
+ */
+function isEmptyExportMarker(statement: ts.Statement): boolean {
+  return ts.isExportDeclaration(statement) &&
+    statement.moduleSpecifier === undefined &&
+    statement.exportClause !== undefined &&
+    ts.isNamedExports(statement.exportClause) &&
+    statement.exportClause.elements.length === 0;
+}

--- a/tasks/executable-source.ts
+++ b/tasks/executable-source.ts
@@ -15,19 +15,23 @@ const TRANSPILE_OPTIONS: ts.CompilerOptions = {
 };
 
 /**
- * Whether a source file compiles to code that can run.
- *
- * A file holding only interfaces, type aliases, and other declarations compiles
- * to an empty module, so it has no statement any test could execute, and Deno's
- * coverage reports no line for it that a test could leave uncovered.
+ * Returns whether `content`, taken as the source of `filePath`, compiles to
+ * code that can run. A file holding only interfaces, type aliases, and other
+ * declarations compiles to an empty module, so it has no statement any test
+ * could execute, and Deno's coverage reports no line for it that a test could
+ * leave uncovered.
  *
  * The answer comes from compiling the file and reading what comes out. Which
  * constructs reach the output is the compiler's rule. An enum, a namespace
  * holding a value, and an import kept for its side effects all emit code. A
  * type-only import, a namespace holding only types, and a comment do not.
  *
- * The coverage gate is the caller; `docs/development/COVERAGE.md` describes what
- * it does with the answer.
+ * The answer is what the TypeScript compiler emits. What runs is what Deno
+ * emits, which is swc's work, so the two agreeing is a property held by test
+ * rather than one this function can enforce.
+ *
+ * `docs/development/COVERAGE.md` describes what the coverage gate does with the
+ * answer.
  */
 export function hasExecutableCode(content: string, filePath: string): boolean {
   const emitted = ts.transpileModule(content, {
@@ -46,9 +50,10 @@ export function hasExecutableCode(content: string, filePath: string): boolean {
 }
 
 /**
- * An `export {}` with nothing in it. The compiler emits this to keep a file
- * that emitted nothing else a module rather than a script. It declares no
- * binding and runs no code.
+ * Helper for `hasExecutableCode()`, which returns whether `statement` is an
+ * `export {}` with nothing in it. The compiler emits one to keep a file that
+ * emitted nothing else a module rather than a script. It declares no binding
+ * and runs no code.
  */
 function isEmptyExportMarker(statement: ts.Statement): boolean {
   return ts.isExportDeclaration(statement) &&


### PR DESCRIPTION
The coverage gate walks every tracked source file and, when the joined LCOV report holds no record for one, charges its whole tracked-line count as uncovered. That rule exists to catch a source file no test ever loaded, and for that it is right. It also catches a second kind of file it should not: one holding only declarations — interfaces, type aliases, ambient declarations — which compiles to an empty module. Such a file has no statement to run, so a test that loads it executes nothing and Deno's coverage has nothing to report. The report looks the same whether or not a test ever touched the file, so it scores as entirely uncovered and no test anyone could write moves it.

packages/runner/src/harness/types.ts is the clearest case. It declares only interfaces and carries 115 lines of debt nobody can pay off. Because the charge tracks the file's line count, editing one of those interfaces moves the whole group's number, which is enough to fail a pull request whose group sits at its ratchet baseline — for code that cannot be tested and does not need to be.

The gate now compiles each file it finds no record for, and charges it only when something comes out. tasks/executable-source.ts runs the file through the TypeScript compiler and parses the emitted JavaScript: a file whose output holds no statement, an `export {}` module marker aside, is charged nothing, and every other file is charged in full as before. Asking the compiler is what separates the two cases, because which constructs reach the output is the compiler's rule rather than something the source text shows. An enum, a namespace holding a value, and an import kept for its side effects all emit code. A type-only import, a namespace holding only types, and a comment do not. A heuristic reading the source would have to reimplement that rule, and would get those cases wrong.

`alwaysStrict` is off in those options, which matters for a file that has no import or export: TypeScript would otherwise head such a file with a `"use strict"` line and make it look like it emitted a statement. Deno loads every file as an ES module and emits no such line, and a coverage run confirms the consequence — a file with no import or export that holds only declarations gets no coverage record, while one that holds code gets a record with uncovered lines.

The compile runs at gate time and only for files the report leaves out, so a file with a record never pays for it. Compiling every tracked source file in the workspace takes a few seconds altogether, which bounds the worst case; the gate job spends far longer downloading its artifacts.

Two properties are held by tests. The classification itself is pinned against the constructs that do and do not reach the output, including a file the compiler cannot parse, which stays charged because error recovery emits what it managed to read. And because the gate rests on a claim about Deno rather than about TypeScript — a file called non-executable has no line Deno's coverage can report as uncovered — a second test runs a real coverage pass over fixture modules and holds the two compilers to the same answer. Deno transpiles with swc, so nothing else would catch them diverging.

Thirty-seven files in the workspace hold only declarations, 2588 tracked lines between them, across seventeen groups. Every group's number falls or stays level and none rises, because a file either keeps its full charge or drops to zero. The ratchet fails a pull request only when a changed group's count rises above the baseline, so the lower numbers settle in as a stricter bar rather than failing anything. The one transient is a pull request whose last run predates this change: it reported the old, higher numbers, which the new, lower baseline would reject. GitHub rebuilds a pull request's merge ref when main moves, so that pull request's next run measures the change too.

The tasks workspace member gains the repository's typescript pin as a dependency. Running the metrics script directly now needs --allow-env, which the TypeScript package requires at load to read its TSC_* settings; the coverage check job already passes it, and the local reproduction command records it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop charging coverage debt to TypeScript files that compile to no executable code. This removes false debt from declaration‑only modules and keeps the gate strict for real code.

- **Bug Fixes**
  - For files missing from the LCOV report, compile with `typescript` and inspect the emitted JS; if it emits no statements (ignoring the `export {}` marker), charge 0 lines, otherwise charge the full tracked-line count. `collectUncoveredLinesForFiles` follows the same rule.
  - Shaped the new emit test to the repo’s BDD/expect style and clarified `hasExecutableCode()` docs; no behavior change.

- **Migration**
  - When running `tasks/coverage-metrics.ts` locally, pass --allow-env (the script now loads `npm:typescript@6.0.3`).

<sup>Written for commit 7cca4d926e423ea2c419114d59a8a078b3add8dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

NEW_COVERAGE_BASELINE