### PR TITLE
lint + skill: an on-demand audit for the prototype-name hazard, and the judgement to use it

### DIFF
--- a/.agents/skills/prototype-name-hazard
+++ b/.agents/skills/prototype-name-hazard
@@ -1,0 +1,1 @@
+../../skills/prototype-name-hazard

--- a/.claude/skills/prototype-name-hazard
+++ b/.claude/skills/prototype-name-hazard
@@ -1,0 +1,1 @@
+../../skills/prototype-name-hazard

--- a/packages/utils/lint-plugins/audit-in-usage.jsonc
+++ b/packages/utils/lint-plugins/audit-in-usage.jsonc
@@ -1,0 +1,28 @@
+// Config for the ON-DEMAND `in`-usage audit. Deliberately separate from the
+// workspace lint config: the rule reports ~56 sites in the runner/data-model
+// core alone, and roughly four in five of those are CORRECT — array
+// sparse-hole probes (`i in value`), where `in` is the right operator because
+// arrays do not inherit index properties, plus the query-result proxy's `has`
+// trap, where prototype-chain semantics are the point.
+//
+// A CI rule at that signal-to-noise would train people to silence it. So this
+// is a tool you point at a subsystem when you are asking the question, not a
+// gate. Run it as:
+//
+//     deno lint -c packages/utils/lint-plugins/audit-in-usage.jsonc <paths>
+//
+// Then read every hit and decide. What you are looking for is a key that comes
+// from DATA or a SCHEMA meeting a record — not a loop index, and not a name the
+// code chose itself.
+//
+// Regression protection for the paths where this actually bit lives in
+// packages/runner/test/prototype-named-properties.test.ts, which asserts
+// behaviour instead of syntax and so has no false positives.
+{
+  "lint": {
+    "plugins": ["./no-prototype-aware-in.ts"],
+    "rules": {
+      "tags": []
+    }
+  }
+}

--- a/packages/utils/lint-plugins/no-prototype-aware-in.ts
+++ b/packages/utils/lint-plugins/no-prototype-aware-in.ts
@@ -1,0 +1,160 @@
+/// <reference lib="deno.unstable" />
+
+// Flags `key in obj` where `key` is not a safe literal.
+//
+// `in` walks the prototype chain, so it answers YES for every member of
+// `Object.prototype` — `toString`, `valueOf`, `hasOwnProperty`,
+// `isPrototypeOf`, `propertyIsEnumerable`, `toLocaleString`, `constructor`,
+// `__proto__` — on every object, whether or not the object carries them. Those
+// are ordinary, legal property names in data: unlike `__proto__`/`constructor`
+// (refused at the FabricValue boundary), the rest store and round-trip like any
+// other key. A pattern with a field named `valueOf` is not exotic.
+//
+// Asking `in` about a DATA key therefore gets the wrong answer, and the code
+// that follows usually indexes — yielding `Object.prototype`'s FUNCTION where
+// data was expected. That has cost this codebase real defects: schema defaults
+// silently skipped (caller receives a function), required properties satisfied
+// by nothing, keys that could not be deleted, a public path helper throwing
+// "Cannot compare a function value", and — the one that started this — a proxy
+// trap reporting inherited names as own, which took every Loom state-cell push
+// offline for three days. See CT-1949 / CT-1951, labs#5357 and labs#5373.
+//
+// WHAT IS ALLOWED, and why it is safe:
+//
+//   - A string literal that is not a prototype member name:
+//         if ("error" in result)
+//     The name is chosen by the code, not derived from data, and cannot
+//     collide. This is the ordinary discriminated-union narrowing TypeScript
+//     encourages, and it stays idiomatic.
+//
+//   - A numeric literal:
+//         if (0 in arr)
+//     An array-index probe. Arrays do not inherit index properties, so `in` is
+//     the CORRECT sparse-hole test there.
+//
+// WHAT IS FLAGGED:
+//
+//   - A non-literal key — a variable, member expression, or template. The
+//     linter cannot see types, so it cannot tell `index in array` (fine) from
+//     `key in record` (usually wrong). The former is rare and stable; annotate
+//     it once and the annotation documents that the author checked.
+//
+//   - A string literal that IS a prototype member name, e.g.
+//     `"toString" in value`. Even spelled out, this is almost always asking an
+//     own-property question with an operator that cannot answer it.
+//
+// TO FIX: use `Object.hasOwn(obj, key)`.
+//
+// TO OPT OUT, where `in` is genuinely what you mean — an array sparse-hole
+// probe, or a deliberate prototype-chain question — silence it AT THE LINE and
+// say which:
+//
+//     // deno-lint-ignore cf-utils/no-prototype-aware-in -- sparse-hole probe:
+//     // arrays do not inherit index properties.
+//     if (!(i in value)) continue;
+//
+// THIS IS NOT WIRED INTO THE WORKSPACE LINT CONFIG, on purpose. Measured on the
+// runner + data-model core — the subsystems where this defect has actually
+// bitten — it reports ~56 sites, and roughly four in five are CORRECT: array
+// sparse-hole probes and the query-result proxy's `has` trap. A rule cannot
+// tell those from the real thing without types, and directory-scoping does not
+// help, because the core is exactly where the legitimate probes live. Wired
+// into CI at that ratio it would teach people to silence it, which is worse
+// than not having it.
+//
+// So it is an AUDIT TOOL. Point it at a subsystem when you are asking the
+// question:
+//
+//     deno lint -c packages/utils/lint-plugins/audit-in-usage.jsonc <paths>
+//
+// Regression protection for the paths where this bit lives in
+// `packages/runner/test/prototype-named-properties.test.ts` — behaviour, not
+// syntax, so no false positives and nothing to silence.
+
+interface LintContext {
+  readonly filename: string;
+  report(report: { node: unknown; message: string }): void;
+}
+
+interface LintNode {
+  readonly type: string;
+  readonly operator?: string;
+  readonly left?: {
+    readonly type: string;
+    readonly value?: unknown;
+  };
+}
+
+/**
+ * Own properties of `Object.prototype`. A key with one of these names is
+ * ordinary data, but `in` cannot distinguish "the record carries it" from
+ * "every object inherits it".
+ */
+const PROTOTYPE_MEMBER_NAMES: ReadonlySet<string> = new Set([
+  "__proto__",
+  "constructor",
+  "hasOwnProperty",
+  "isPrototypeOf",
+  "propertyIsEnumerable",
+  "toLocaleString",
+  "toString",
+  "valueOf",
+  "__defineGetter__",
+  "__defineSetter__",
+  "__lookupGetter__",
+  "__lookupSetter__",
+]);
+
+const FIX =
+  "Use `Object.hasOwn(obj, key)`. If `in` is genuinely what you mean (an " +
+  "array sparse-hole probe, or a deliberate prototype-chain question), " +
+  "silence this at the line with `// deno-lint-ignore " +
+  "cf-utils/no-prototype-aware-in -- <why>`.";
+
+export default {
+  name: "cf-utils",
+  rules: {
+    "no-prototype-aware-in": {
+      create(context: unknown) {
+        const localContext = context as unknown as LintContext;
+        return {
+          BinaryExpression(node: unknown) {
+            const localNode = node as unknown as LintNode;
+            if (localNode.operator !== "in") return;
+            const left = localNode.left;
+            if (left === undefined) return;
+
+            // Deno's AST spells string/number literals a couple of ways
+            // depending on version; accept both rather than silently passing
+            // everything when the shape changes.
+            const isLiteral = left.type === "Literal" ||
+              left.type === "StringLiteral" || left.type === "NumericLiteral";
+
+            if (isLiteral && typeof left.value === "number") return;
+
+            if (isLiteral && typeof left.value === "string") {
+              if (!PROTOTYPE_MEMBER_NAMES.has(left.value)) return;
+              localContext.report({
+                node,
+                message:
+                  `\`"${left.value}" in obj\` is true for every object: ` +
+                  `\`${left.value}\` is inherited from Object.prototype. ` +
+                  FIX,
+              });
+              return;
+            }
+
+            localContext.report({
+              node,
+              message:
+                "`in` walks the prototype chain, so a key named after an " +
+                "Object.prototype member (`toString`, `valueOf`, " +
+                "`hasOwnProperty`, …) reads as present on every object. " +
+                FIX,
+            });
+          },
+        };
+      },
+    },
+  },
+};

--- a/packages/utils/test/no-prototype-aware-in-lint-plugin.test.ts
+++ b/packages/utils/test/no-prototype-aware-in-lint-plugin.test.ts
@@ -1,0 +1,128 @@
+import { assert, assertEquals } from "@std/assert";
+
+import plugin from "../lint-plugins/no-prototype-aware-in.ts";
+
+interface Report {
+  node: unknown;
+  message: string;
+}
+
+function createRule(reports: Report[], filename = "/src/thing.ts") {
+  return plugin.rules["no-prototype-aware-in"].create({
+    filename,
+    report(report: Report) {
+      reports.push(report);
+    },
+  } as never);
+}
+
+/** `<left> in <right>`, with `left` spelled as the given AST node. */
+function inExpression(left: Record<string, unknown>) {
+  return { type: "BinaryExpression", operator: "in", left, right: {} };
+}
+
+const identifier = { type: "Identifier", name: "key" };
+const stringLiteral = (value: string) => ({ type: "Literal", value });
+const numberLiteral = (value: number) => ({ type: "Literal", value });
+
+function reportsFor(left: Record<string, unknown>): Report[] {
+  const reports: Report[] = [];
+  const rule = createRule(reports);
+  const visit = rule.BinaryExpression;
+  assert(visit);
+  visit(inExpression(left) as never);
+  return reports;
+}
+
+Deno.test("flags a non-literal key, which is the dangerous shape", () => {
+  assertEquals(reportsFor(identifier).length, 1);
+});
+
+Deno.test("flags a member-expression key", () => {
+  assertEquals(
+    reportsFor({
+      type: "MemberExpression",
+      object: { type: "Identifier", name: "node" },
+      property: { type: "Identifier", name: "field" },
+    }).length,
+    1,
+  );
+});
+
+// The overwhelmingly common safe use: discriminated-union narrowing on a name
+// the code chose. Flagging these would make the rule unusable.
+Deno.test("allows an ordinary string literal", () => {
+  assertEquals(reportsFor(stringLiteral("error")).length, 0);
+  assertEquals(reportsFor(stringLiteral("scope")).length, 0);
+  assertEquals(reportsFor(stringLiteral("$value")).length, 0);
+});
+
+Deno.test("flags a string literal that names an Object.prototype member", () => {
+  for (
+    const name of [
+      "toString",
+      "valueOf",
+      "hasOwnProperty",
+      "isPrototypeOf",
+      "propertyIsEnumerable",
+      "toLocaleString",
+      "constructor",
+      "__proto__",
+    ]
+  ) {
+    const reports = reportsFor(stringLiteral(name));
+    assertEquals(reports.length, 1, `expected \`"${name}" in x\` to report`);
+    assert(reports[0]!.message.includes(name));
+  }
+});
+
+// `0 in arr` is a sparse-hole probe. Arrays do not inherit index properties,
+// so `in` is the correct operator there and must stay quiet.
+Deno.test("allows a numeric literal index probe", () => {
+  assertEquals(reportsFor(numberLiteral(0)).length, 0);
+  assertEquals(reportsFor(numberLiteral(42)).length, 0);
+});
+
+Deno.test("ignores binary expressions that are not `in`", () => {
+  const reports: Report[] = [];
+  const rule = createRule(reports);
+  const visit = rule.BinaryExpression;
+  assert(visit);
+  visit(
+    {
+      type: "BinaryExpression",
+      operator: "instanceof",
+      left: identifier,
+      right: {},
+    } as never,
+  );
+  visit(
+    {
+      type: "BinaryExpression",
+      operator: "===",
+      left: identifier,
+      right: {},
+    } as never,
+  );
+  assertEquals(reports.length, 0);
+});
+
+// Deno has spelled literals more than one way across versions. If the AST shape
+// changes under us the rule must get LOUDER, not silently stop reporting —
+// an unknown left-hand shape is treated as non-literal and flagged.
+Deno.test("an unrecognised literal spelling still reports rather than passing", () => {
+  assertEquals(reportsFor({ type: "StringLiteral", value: "error" }).length, 0);
+  assertEquals(reportsFor({ type: "NumericLiteral", value: 0 }).length, 0);
+  assertEquals(
+    reportsFor({ type: "SomeFutureLiteralNode", value: "error" }).length,
+    1,
+  );
+});
+
+Deno.test("the message names the fix", () => {
+  const reports = reportsFor(identifier);
+  assertEquals(reports.length, 1);
+  const message = reports[0]!.message;
+  assert(message.includes("Object.hasOwn"));
+  assert(message.includes("deno-lint-ignore"));
+});

--- a/packages/utils/test/no-prototype-aware-in-lint-plugin.test.ts
+++ b/packages/utils/test/no-prototype-aware-in-lint-plugin.test.ts
@@ -119,6 +119,18 @@ Deno.test("an unrecognised literal spelling still reports rather than passing", 
   );
 });
 
+// A malformed node — no `left` at all — must be ignored rather than crash the
+// lint run. Deno's AST should never produce one, which is exactly why the guard
+// needs a test: nothing else will ever exercise it.
+Deno.test("a binary expression with no left operand is ignored", () => {
+  const reports: Report[] = [];
+  const rule = createRule(reports);
+  const visit = rule.BinaryExpression;
+  assert(visit);
+  visit({ type: "BinaryExpression", operator: "in", right: {} } as never);
+  assertEquals(reports.length, 0);
+});
+
 Deno.test("the message names the fix", () => {
   const reports = reportsFor(identifier);
   assertEquals(reports.length, 1);

--- a/skills/prototype-name-hazard/SKILL.md
+++ b/skills/prototype-name-hazard/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: prototype-name-hazard
+description: Audit code for property-name collisions with Object.prototype — `in`, `for...in`, and plain indexing that answer wrong when a data key is named `toString`, `valueOf`, `hasOwnProperty` and friends. Use when auditing membership checks, when a schema/data key meets a record, when a proxy trap answers about own properties, or when something reads back a function where data was expected.
+---
+
+# The prototype-name hazard
+
+## The principle
+
+A property name is **data**. `toString`, `valueOf`, `hasOwnProperty`,
+`isPrototypeOf`, `propertyIsEnumerable`, `toLocaleString` are legal keys a
+pattern author or an external document may use. Every one of them is also an own
+property of `Object.prototype`.
+
+So any operation that consults the prototype chain gives the wrong answer about
+such a key: `in` reports it present on every object, plain indexing returns the
+inherited **function**, and `for...in` enumerates beyond own keys. The hazard is
+not the operator — it is **a key whose name comes from data or a schema meeting
+a record**. Wherever those two meet, ask whether the question being asked is an
+own-property question. It usually is.
+
+## The local fact that makes this bite here
+
+`unsafeObjectKeyIn()` in `packages/utils/src/types.ts` reserves exactly two
+names — `__proto__` and `constructor` — at the FabricValue boundary. **Every
+other `Object.prototype` member is an ordinary key that stores, round-trips, and
+reads back like any other.** So "the data model guards against prototype
+pollution" is true and beside the point: the guarded pair is not the dangerous
+set here.
+
+The one place prototype-chain semantics are correct is where the question really
+is "does this object respond to this name": the `has` trap in
+`packages/runner/src/query-result-proxy.ts` keeps `in` deliberately, because
+`has` _is_ the `in` operator's own trap. Its `getOwnPropertyDescriptor`
+neighbour must not — that pair disagreeing is what took every Loom state-cell
+push offline for three days (CT-1949).
+
+## Finding candidates
+
+There is a lint rule, deliberately **not** wired into CI:
+
+```bash
+deno lint -c packages/utils/lint-plugins/audit-in-usage.jsonc <paths>
+```
+
+It flags `in` with a non-literal key, and `in` with a literal that names a
+prototype member. It allows other string literals (discriminated-union
+narrowing, which cannot collide) and numeric literals.
+
+**Expect roughly four in five hits to be correct code**, measured across
+`packages/runner/src` and `packages/data-model/src`. The dominant legitimate
+shape is the array sparse-hole probe — `i in value`, `slot in parent` — where
+`in` is the right operator precisely because arrays do not inherit index
+properties. That ratio is why the rule is a tool and not a gate: at that signal,
+a CI rule would train people to silence it.
+
+So the tool narrows the search; **it does not make the judgement.** For each hit
+ask where the key came from. A loop index or a name the code chose itself is
+fine. A key from parsed data, a schema's `properties`/`required`, a column name,
+or a path segment is the real thing.
+
+## What the tool cannot see
+
+It only knows about `in`. It is blind to the other half, which did the worse
+damage: **plain indexing that falls through**. `currentRecord[key]` for an
+absent `valueOf` yields `Object.prototype.valueOf`, and handing that to a
+comparator threw `Cannot compare a function value` from a public write path — a
+write refused because of a method the data never had.
+
+When a hit turns out to be real, look at what the surrounding code does with the
+key next. The membership test is usually the symptom; the read beside it is
+usually the injury.
+
+## What being wrong looks like
+
+Tells from the two sweeps that found these, offered as seed rather than boundary
+— the failure is quiet far more often than loud:
+
+- a schema default silently skipped, so the caller receives a **function** where
+  the schema promised a string
+- a `required` property satisfied by nothing, so an invalid value is accepted
+- a key that cannot be deleted, because the removal pass thinks the new value
+  still has it
+- a path helper reporting a segment present on an empty object
+- a proxy whose `hasOwn` and `ownKeys` disagree, so a read-back value cannot be
+  written back — which breaks read-modify-write generally, for every consumer
+
+## Fixing
+
+`Object.hasOwn(obj, key)` for membership; `Object.keys()` in place of `for...in`
+when own keys are meant; an own-guarded read where indexing fell through. Where
+`in` is genuinely wanted, silence the rule at the line and say which case it is
+— the annotation is the record that someone checked.
+
+## Regression protection
+
+`packages/runner/test/prototype-named-properties.test.ts` exercises the surfaces
+where this actually bit — defaults, required, removal, writes, path helpers —
+using prototype-named keys with ordinary-named controls beside them. It asserts
+behaviour rather than syntax, so it has no false positives and nothing to
+silence.
+
+When you fix a new instance, prefer extending that file over adding a lint
+annotation somewhere. A test that fails when the bug returns is worth more than
+a comment saying it was considered once.
+
+History: CT-1949 (the outage), CT-1951 (the class), labs#5357 and labs#5373 (the
+fixes).


### PR DESCRIPTION
> **Stacked on #5373** — base is `fix/own-property-membership-in-schema-paths`, because the skill cites the regression test that lands there. Review/merge that one first; GitHub will retarget this to `main` automatically.

## Why

We found this defect class twice by hand-grepping, and **the second sweep found four blocking sites the first had declared clean**. The audit needs to stop being a bespoke grep.

But a CI rule can't be the answer, and it's worth being precise about why rather than shipping one and finding out. Measured across `packages/runner/src` and `packages/data-model/src` — the subsystems where this has actually bitten, with #5373's fixes already applied — the rule reports **~56 sites, and roughly four in five are correct code**: array sparse-hole probes (`i in value`, `slot in parent`), where `in` is right precisely because arrays don't inherit index properties, plus the query-result proxy's `has` trap where prototype-chain semantics are the point.

Scoping by directory doesn't rescue it either — the core is exactly where the legitimate probes live. Wired into CI at that ratio, the rule would train people to silence it, which is worse than not having it.

So this ships **a tool plus the judgement to use it**, not a gate.

## What Changed

**`packages/utils/lint-plugins/no-prototype-aware-in.ts`** — flags `in` with a non-literal key, and `in` with a literal naming an `Object.prototype` member. Allows other string literals (discriminated-union narrowing, which can't collide) and numeric literals. Not in the workspace lint config; run on demand:

```bash
deno lint -c packages/utils/lint-plugins/audit-in-usage.jsonc <paths>
```

**`skills/prototype-name-hazard/SKILL.md`** — the part the rule can't encode. Written as a map per `docs/development/skill-authoring.md`: the non-derivable local facts, minimal procedure.

The load-bearing one: `unsafeObjectKeyIn()` reserves **only** `__proto__` and `constructor`, so every *other* prototype name is an ordinary storable key — which means "the data model guards against prototype pollution" is true and beside the point. Also records the measured signal-to-noise so nobody reads 56 hits as 56 bugs, that the proxy's `has` trap keeps `in` deliberately, and that the tool is blind to `record[key]` falling through — which did the worse damage (a public write path throwing `Cannot compare a function value`). Failure tells are given as seed, not a closed list.

## Test plan

- 8 unit tests for the rule, both directions — including that an **unrecognised literal spelling reports rather than silently passing**, so an AST shape change under us makes the rule louder rather than quietly inert.
- `deno task check-skill-facts` passes (46 documents). It caught a real error while writing this: the skill cited the regression test before that file existed on this branch, which is what forced the stacking.
- `deno fmt --check` clean.

## What actually protects the regression

`packages/runner/test/prototype-named-properties.test.ts` in #5373 — behaviour, not syntax, so no false positives and nothing to silence. The skill points at it and says to prefer extending it over adding a lint annotation. This PR is for *finding* new instances; that file is for *keeping* the fixed ones fixed.

Refs [CT-1951](https://linear.app/common-tools/issue/CT-1951).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an on-demand lint rule and a companion skill to audit “prototype-name” hazards where `in` or indexing can misread keys like `toString`/`valueOf`. Keeps noisy checks out of CI while providing a precise tool and guidance to find real issues. Refs CT-1951.

- New Features
  - Added `packages/utils/lint-plugins/no-prototype-aware-in.ts`: flags `key in obj` when the key is non-literal or a literal matching an `Object.prototype` name; allows safe string and numeric literals.
  - Run on demand: `deno lint -c packages/utils/lint-plugins/audit-in-usage.jsonc <paths>`; not wired into CI due to low signal in core code.
  - Added `skills/prototype-name-hazard/SKILL.md`: when to use the audit, safe/unsafe patterns, blind spots (e.g., `record[key]` fall-through), and intentional `in` usage (proxy `has` trap).
  - Tests: unit coverage for the rule, including unknown literal spellings reporting rather than silently passing.
  - Exposed the skill to agents via `.agents/skills/prototype-name-hazard` and `.claude/skills/prototype-name-hazard` pointers.

<sup>Written for commit e669873b5005f8f632885bba350eb72b4375e8d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

