### PR TITLE
Apply the same own-property fix where it is reachable but unproven

### DIFF
--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -344,7 +344,7 @@ function cloneWithoutBoundToolKeys(
 
   const required = Array.isArray(schema.required)
     ? (schema.required as string[]).filter((key) =>
-      key !== "result" && !(key in extraParams)
+      key !== "result" && !Object.hasOwn(extraParams, key)
     )
     : undefined;
 

--- a/packages/cli/lib/exec-schema.ts
+++ b/packages/cli/lib/exec-schema.ts
@@ -355,7 +355,9 @@ function parseObjectInput(
   // JSON input validation is deferred to the runner.
   if (!usedJson) {
     for (const key of requiredFlags(schema)) {
-      if (!(key in input)) {
+      // `Object.hasOwn`: a required flag named for a prototype member would
+      // otherwise read as supplied on every input.
+      if (!Object.hasOwn(input, key)) {
         throw new Error(`Missing required flag --${flagNameForKey(key)}`);
       }
     }

--- a/packages/cli/lib/piece-get-transform.ts
+++ b/packages/cli/lib/piece-get-transform.ts
@@ -996,7 +996,8 @@ function projectValue(
     return projected;
   }
   for (const [key, childSchema] of Object.entries(properties)) {
-    if (key in value) {
+    // `Object.hasOwn`: schema-declared `key` against data.
+    if (Object.hasOwn(value, key)) {
       projected[key] = projectValue(
         value[key],
         childSchema,
@@ -1160,7 +1161,9 @@ export function selectSourceSchema(
       purpose,
     );
   }
-  const selectedRequired = required?.filter((key) => key in properties);
+  const selectedRequired = required?.filter((key) =>
+    Object.hasOwn(properties, key)
+  );
   return {
     ...metadata,
     properties,

--- a/packages/memory/v2/sqlite/row-label.ts
+++ b/packages/memory/v2/sqlite/row-label.ts
@@ -598,7 +598,9 @@ function evalMatch(
   row: Record<string, unknown>,
 ): string[] {
   const field = node.field as string;
-  if (!(field in row)) {
+  // `Object.hasOwn`: `field` names row data, so a field named for a prototype
+  // member must not read as present on every row.
+  if (!Object.hasOwn(row, field)) {
     return fail(`rule input field "${field}" is absent from the row`);
   }
   const value = row[field];
@@ -647,7 +649,7 @@ function evalTest(
     return fail("malformed when gate (use whenMatches())");
   }
   const { field, source, flags } = test.match as Record<string, unknown>;
-  if (typeof field !== "string" || !(field in row)) {
+  if (typeof field !== "string" || !Object.hasOwn(row, field)) {
     return fail(`rule input field "${String(field)}" is absent from the row`);
   }
   const value = row[field];

--- a/packages/runner/src/builder/pattern.ts
+++ b/packages/runner/src/builder/pattern.ts
@@ -924,9 +924,13 @@ function assignComputedCellKinds(
           ? schema.properties
           : undefined;
       for (const [key, child] of Object.entries(target)) {
-        const childSchema = properties !== undefined && key in properties
-          ? properties[key]
-          : schema.additionalProperties;
+        // `Object.hasOwn`: `key` is a DATA key and `properties` is the
+        // schema. `in` matched a data key named `toString` against every
+        // schema and then read `Object.prototype`'s function as its subschema.
+        const childSchema =
+          properties !== undefined && Object.hasOwn(properties, key)
+            ? properties[key]
+            : schema.additionalProperties;
         if (childSchema !== undefined) {
           collectWritablyBoundRoots(child, childSchema, out, seen);
         }

--- a/packages/runner/src/builtins/sqlite-builtins.ts
+++ b/packages/runner/src/builtins/sqlite-builtins.ts
@@ -207,7 +207,10 @@ function decodeRowLinkColumns(
     // reactive read path.
     let out: Record<string, unknown> | undefined;
     for (const c of cols) {
-      if (!(c in r)) continue;
+      // `Object.hasOwn`: `c` is a column name and `r` is a row record. `in`
+      // matched a column named e.g. `toString` against every row and then
+      // handed the inherited function to the decoder below.
+      if (!Object.hasOwn(r, c)) continue;
       let decoded: unknown;
       try {
         decoded = parseCfLinkToSigil(r[c]);

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -2810,7 +2810,9 @@ const valuesAtPatternPath = (
   if (value === null || value === undefined || typeof value !== "object") {
     return [];
   }
-  if (!(head in value)) {
+  // `Object.hasOwn`: `head` is a pattern-path segment naming data, so an
+  // absent segment named for a prototype member must not read as present.
+  if (!Object.hasOwn(value as object, head)) {
     return [];
   }
   return valuesAtPatternPath((value as Record<string, unknown>)[head], rest);
@@ -2841,12 +2843,16 @@ const changedValuesAtPatternPath = (
   if (value === null || value === undefined || typeof value !== "object") {
     return [];
   }
+  // Own-property reads on both sides: `head` names data, so an absent segment
+  // named for a prototype member must read as absent rather than yielding
+  // `Object.prototype`'s member as the previous/current child.
   const previousChild = previousValue !== null &&
       previousValue !== undefined &&
-      typeof previousValue === "object"
+      typeof previousValue === "object" &&
+      Object.hasOwn(previousValue as object, head)
     ? (previousValue as Record<string, unknown>)[head]
     : undefined;
-  if (!(head in value)) {
+  if (!Object.hasOwn(value as object, head)) {
     return [];
   }
   return changedValuesAtPatternPath(

--- a/packages/runner/src/cfc/structured-result.ts
+++ b/packages/runner/src/cfc/structured-result.ts
@@ -210,7 +210,9 @@ const childSchemaForKey = (
     }
   }
   if (
-    !(isRecord(resolved.properties) && key in resolved.properties) &&
+    // `Object.hasOwn`: data-derived `key` against schema properties.
+    !(isRecord(resolved.properties) &&
+      Object.hasOwn(resolved.properties, key)) &&
     (typeof resolved.additionalProperties === "boolean" ||
       isRecord(resolved.additionalProperties))
   ) {

--- a/packages/runner/src/pattern-binding.ts
+++ b/packages/runner/src/pattern-binding.ts
@@ -359,7 +359,11 @@ function sendValueToBindingInner<T>(
     // slots rather than codec contents). Mark ahead of that.
   } else if (isRecord(binding) && isRecord(value)) {
     for (const key of Object.keys(binding)) {
-      if (key in value) {
+      // `Object.hasOwn`, not `in`: `key` comes from the binding shape and
+      // `value` is data. `in` walks the prototype chain, so a binding key
+      // called `toString` matched every object and forwarded
+      // `Object.prototype.toString` — a function — as the bound value.
+      if (Object.hasOwn(value, key)) {
         sendValueToBindingInner(
           tx,
           cell,


### PR DESCRIPTION
> **Stacked on #5373.** Split out of it deliberately — see below. Mergeable or droppable on its own merits; #5373 does not depend on it.

## Why this is separate

#5373 now carries only the sites with a **demonstrated** failure — each has a test that fails when the fix is backed out. These nine are the same predicate shape and reachable in principle, but **nothing here reproduces a bug.**

That makes them a judgement call rather than a fix, and the call should be made on its own instead of riding in on the proven set's coattails. Two of them are also in `cli` and `memory` — packages a runner reviewer shouldn't have to take on trust to approve a one-word change.

## The argument, per site

In every case the key can come from data or a schema, which is what makes a prototype-member name possible in the first place:

| site | key comes from |
|---|---|
| `builder/pattern.ts`, `cfc/structured-result.ts` | a **data** key from `Object.entries(target)`, tested against schema `properties` and then used to read the child schema — a field named `toString` would take `Object.prototype.toString` as its subschema |
| `cfc/prepare.ts` | pattern-path segments walked over data; both the presence test and the previous-value read |
| `builtins/sqlite-builtins.ts`, `memory/v2/sqlite/row-label.ts` | column and rule-field names against row records, then indexed — column names are legal SQL identifiers, so `toString` is available to anyone writing a query |
| `pattern-binding.ts` | binding-shape keys against the bound value |
| `cli/{callable,exec-schema,piece-get-transform}.ts` | schema-declared names (`required`, `properties`) against data or a built map |

## The argument against

None is demonstrated. If you'd rather not carry nine speculative changes across three packages, dropping this loses nothing that's currently broken.

For: `Object.hasOwn` is never a worse answer to an own-property question, and every change is mechanical.

## Test plan

No tests added, because no behaviour change is expected — which is itself part of what makes these weaker than the proven set, and worth saying plainly rather than dressing up with tests that would pass either way.

Suites unchanged: runner **1149 / 0**, memory **478 / 0**, cli **123 / 0**.

Refs [CT-1951](https://linear.app/common-tools/issue/CT-1951).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

