### PR TITLE
test(cli): deflake continuous UI environment check

### DIFF
--- a/packages/cli/test/test-runner-render-step.test.ts
+++ b/packages/cli/test/test-runner-render-step.test.ts
@@ -185,13 +185,17 @@ describe(
       const coverageDir = await Deno.makeTempDir();
       try {
         await withEnv("CF_TEST_CONTINUOUS_UI", "1", async () => {
-          const { code, stderr } = await cf(
-            `test "${
-              fixture("continuous-ui.test.tsx")
-            }" --root "${FIXTURES}" --pattern-coverage-dir "${coverageDir}"`,
-          );
-          expect(code).toBe(0);
-          checkStderr(stderr);
+          // Wall-clock performance diagnostics can fire under CI contention;
+          // keep this environment-contract test strict about errors instead.
+          await withEnv("CF_LOG_LEVEL", "error", async () => {
+            const { code, stderr } = await cf(
+              `test "${
+                fixture("continuous-ui.test.tsx")
+              }" --root "${FIXTURES}" --pattern-coverage-dir "${coverageDir}"`,
+            );
+            expect(code).toBe(0);
+            checkStderr(stderr);
+          });
         });
 
         const files: string[] = [];


### PR DESCRIPTION
## Summary

- run the `CF_TEST_CONTINUOUS_UI` CLI subprocess with `CF_LOG_LEVEL=error`
- keep the shared stderr assertion strict while excluding wall-clock performance noise from this environment-contract test

## Root cause

The failed main run captured a `Cell.get()` timing diagnostic (`get() took 61ms`) as 21 stderr lines. The diagnostic is load-sensitive, and the same SHA passed on retry. `cf test` already classifies this logger key as a performance-only warning, but the outer CLI test asserted the raw child stderr.

Failed job: https://github.com/commontoolsinc/labs/actions/runs/31037773827/job/92414213878

## Validation

- Deno 2.9.4: format, lint, and type-check the affected file
- Deno 2.9.4: affected test file — 13 steps, 0 failures
- Deno 2.9.4: CLI shard 1/3 — 604 parallel tests and 108 serial tests, 0 failures
- rebased onto current `main` and reran the affected test file — 13 steps, 0 failures

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

