### PR TITLE
fix(cli): honor cell JSON forms in renderer

### DIFF
--- a/packages/cli/lib/render.ts
+++ b/packages/cli/lib/render.ts
@@ -46,15 +46,22 @@ export function render(value: unknown, { json }: { json?: boolean } = {}) {
 
 // Helper function to safely stringify objects with circular references
 export function safeStringify(obj: unknown, maxDepth = 8): string {
-  const seen = new WeakSet();
+  const ancestors: object[] = [];
+  const seen = new WeakSet<object>();
 
   // TODO(danfuzz): Latent — schemas don't admit `Fabric*` values on this
-  // `.get()`-path today, but will in the not-too-distant future; at that point
-  // this `Object.entries` pre-walk plus `JSON.stringify` silently loses any
-  // `FabricPrimitive`/`FabricInstance` (class instances don't survive JSON).
-  // Mark ahead of that.
-  const stringify = (value: unknown, depth = 0): unknown => {
-    if (depth > maxDepth) {
+  // `.get()`-path today, but will in the not-too-distant future. Neither type
+  // has a JSON representation yet, so `JSON.stringify` renders its private
+  // state as an empty object. Add an explicit representation when schemas
+  // begin admitting them here.
+  const replacer = function (this: unknown, _key: string, value: unknown) {
+    while (
+      ancestors.length > 0 && ancestors[ancestors.length - 1] !== this
+    ) {
+      ancestors.pop();
+    }
+
+    if (ancestors.length > maxDepth) {
       return "<max depth reached>";
     }
 
@@ -62,30 +69,19 @@ export function safeStringify(obj: unknown, maxDepth = 8): string {
       return { $bigint: value.toString() };
     }
 
-    if (value === null || typeof value !== "object") {
-      return value;
+    if (value !== null && typeof value === "object") {
+      if (seen.has(value)) {
+        return "<circular reference>";
+      }
+      seen.add(value);
+      ancestors.push(value);
     }
 
-    if (seen.has(value)) {
-      return "<circular reference>";
-    }
-
-    seen.add(value);
-
-    if (Array.isArray(value)) {
-      return value.map((item) => stringify(item, depth + 1));
-    }
-
-    const result: Record<string, unknown> = {};
-    for (const [key, val] of Object.entries(value)) {
-      result[key] = stringify(val, depth + 1);
-    }
-
-    return result;
+    return value;
   };
 
   try {
-    return JSON.stringify(stringify(obj), null, 2) ?? "null";
+    return JSON.stringify(obj, replacer, 2) ?? "null";
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(`Could not serialize JSON output: ${message}`);

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -51,6 +51,7 @@ import {
   piece,
   setPieceSourceFromCommand,
 } from "../commands/piece.ts";
+import { safeStringify } from "../lib/render.ts";
 import {
   parsePieceGetFilter,
   parsePieceGetProjection,
@@ -1374,6 +1375,58 @@ describe("cli piece parsing", () => {
       await expect(getCellValue(config, [], {}, deps)).resolves.toEqual(
         RESULT_VALUE,
       );
+    });
+
+    it("renders an unshaped parent read without stream runtime internals", async () => {
+      const signer = await Identity.fromPassphrase("piece-get-live-stream");
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = new Runtime({
+        apiUrl: new URL("https://example.com"),
+        storageManager,
+      });
+
+      try {
+        const tx = runtime.edit();
+        const cell = runtime.getCell<{
+          name: string;
+          submit: { $stream: boolean };
+        }>(signer.did(), "piece-get-live-stream", undefined, tx);
+        cell.set({ name: "Ada", submit: { $stream: true } });
+        const schema = {
+          type: "object",
+          properties: {
+            name: { type: "string" },
+            submit: { type: "object", asCell: ["stream"] },
+          },
+        } as const satisfies JSONSchema;
+        await tx.commit();
+        await runtime.idle();
+        const value = cell.asSchema(schema).get();
+        const submit = value.submit;
+        expect(isCell(submit)).toBe(true);
+        const expectedLink = (submit as unknown as { toJSON(): unknown })
+          .toJSON();
+
+        const read = await getCellValue(
+          config,
+          [],
+          {},
+          guardDeps({ result: { get: () => Promise.resolve(value) } }),
+        );
+        const json = safeStringify(read);
+
+        expect(json.length).toBeLessThan(2000);
+        expect(json).not.toContain("scheduler");
+        expect(json).not.toContain("circular reference");
+        expect(json).not.toContain('"runtime"');
+        expect(JSON.parse(json)).toEqual({
+          name: "Ada",
+          submit: expectedLink,
+        });
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
     });
   });
 

--- a/packages/cli/test/wish.test.ts
+++ b/packages/cli/test/wish.test.ts
@@ -261,6 +261,13 @@ describe("cf wish headless read (resolveWish)", () => {
     expect(projected.right.setName).toBe("[stream:setName]");
 
     const json = safeStringify(projected);
+    expect(json).toBe(`{
+  "left": {
+    "label": "shared",
+    "setName": "[stream:setName]"
+  },
+  "right": "<circular reference>"
+}`);
     expect(json).not.toContain("scheduler");
     expect(json).not.toContain("runtime");
   });


### PR DESCRIPTION
## Why

Fixes #5391.

An unshaped `cf piece get` can return a live stream cell inside an otherwise ordinary result object. The shared CLI JSON renderer rebuilt every object with `Object.entries()` before calling `JSON.stringify()`, so `CellImpl.toJSON()` never had a chance to replace the handle with its stable sigil link. The renderer instead traversed enumerable runtime fields and emitted scheduler queues, handler tables, and circular runtime references. The two-field reproduction was 14,576 bytes.

The fix is renderer-wide rather than `piece get`-local because any CLI command sending a live cell through `render(..., { json: true })` had the same failure. Sigil links are used instead of wish-style markers so cell identity stays in-band and agrees with the canonical representation already returned by `CellImpl.toJSON()`.

`@commonfabric/data-model/value-debug` is not reused because its debug notation is intentionally not always valid JSON: bigints, functions, symbols, and Fabric values can be emitted as bare diagnostic tokens, and failures become a fallback string. CLI JSON must remain parseable and must surface serialization failures.

## What Changed

- Let `JSON.stringify()` perform the traversal with a replacer, so native `toJSON()` methods are honored while the existing bigint, maximum-depth, and repeated-reference protections remain.
- Add an unshaped `piece get` regression using a real emulated-runtime stream handle. The result is now a 300-byte object containing a `link@1` sigil and no `scheduler`, `runtime`, or circular-reference internals.
- Pin the existing `cf wish` shared-DAG serialization byte-for-byte. Its shipped marker output does not change.

Because this is the shared renderer, JSON output changes for CLI values that define `toJSON()`: those values now render their declared JSON form. Plain JSON data, bigint encoding, maximum-depth markers, repeated-reference markers, and `cf wish` output remain unchanged. Fuse has its own replacer-based renderer and is unaffected.

`FabricPrimitive` and `FabricInstance` are not folded into this fix: they do not yet define a JSON representation, and the data-model debug notation cannot satisfy the parseable-JSON contract. The adjacent TODO remains and now states that boundary accurately.

## Test plan

- `deno test --allow-ffi --allow-read --allow-write --allow-run --allow-env --allow-net=127.0.0.1 packages/cli/test/piece.test.ts packages/cli/test/json-command.test.ts packages/cli/test/wish.test.ts packages/fuse/tree-builder.test.ts`
- `deno task check`
- `deno fmt --check`
- `deno lint`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

