### PR TITLE
refactor(cf-harness): replace the trivial run-state setters with a pa…

### DIFF
--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -9,30 +9,15 @@ import {
   type HarnessArtifactStore,
 } from "./artifacts.ts";
 import {
-  appendHarnessCfcInvocationContext,
   appendHarnessCfcModelContextObservations,
   appendHarnessFailureRecord,
-  appendHarnessPolicyDecision,
-  appendHarnessPolicyEvent,
-  appendHarnessToolOutput,
+  appendToHarnessRunState,
   createHarnessRunState,
   type HarnessRunState,
   type HarnessRunTerminalReason,
-  setHarnessCapabilitySnapshot,
-  setHarnessCfcPolicySnapshot,
-  setHarnessPolicyTrace,
-  setHarnessPromptSlotBinding,
-  setHarnessRunCurrentDir,
-  setHarnessRunManifestPath,
-  setHarnessRunModel,
-  setHarnessRunReportPath,
+  patchHarnessRunState,
   setHarnessRunStatus,
-  setHarnessSkillActivations,
-  setHarnessSkillRegistry,
-  setHarnessSkillResourceReads,
-  setHarnessSkillScriptExecutions,
   setHarnessSubagentRun,
-  setHarnessTranscriptPath,
 } from "./run-state.ts";
 import type { HarnessCfcModelContextObservationInput } from "./contracts/cfc-model-context.ts";
 import {
@@ -488,7 +473,11 @@ export class CfHarnessEngine {
       );
     }
     if (recordedModel !== model) {
-      this.#runState = setHarnessRunModel(this.#runState, model, this.#now());
+      this.#runState = patchHarnessRunState(
+        this.#runState,
+        { model },
+        this.#now(),
+      );
     }
     this.#runModelBound = true;
     return this.getRunState();
@@ -531,9 +520,9 @@ export class CfHarnessEngine {
   setPromptSlotBinding(
     promptSlotBinding: PromptSlotBinding,
   ): HarnessRunState {
-    this.#runState = setHarnessPromptSlotBinding(
+    this.#runState = patchHarnessRunState(
       this.#runState,
-      promptSlotBinding,
+      { promptSlotBinding },
       this.#now(),
     );
     return this.getRunState();
@@ -544,8 +533,9 @@ export class CfHarnessEngine {
   ): Promise<HarnessRunState> {
     const now = this.#now();
     const policyEvent = createHarnessPolicyEvent({ ...event, at: now });
-    this.#runState = appendHarnessPolicyEvent(
+    this.#runState = appendToHarnessRunState(
       this.#runState,
+      "policyEvents",
       policyEvent,
       now,
     );
@@ -570,8 +560,9 @@ export class CfHarnessEngine {
       sequence: (this.#runState.policyDecisions ?? []).length + 1,
       at: now,
     });
-    this.#runState = appendHarnessPolicyDecision(
+    this.#runState = appendToHarnessRunState(
       this.#runState,
+      "policyDecisions",
       policyDecision,
       now,
     );
@@ -603,9 +594,9 @@ export class CfHarnessEngine {
       this.#runState.runManifest,
     );
     if (manifestPath !== undefined) {
-      this.#runState = setHarnessRunManifestPath(
+      this.#runState = patchHarnessRunState(
         this.#runState,
-        manifestPath,
+        { runManifestPath: manifestPath },
         this.#now(),
       );
       await this.persistRunState();
@@ -618,10 +609,9 @@ export class CfHarnessEngine {
   ): Promise<string | undefined> {
     const skillRegistryPath = await this.artifactStore
       ?.persistSkillRegistry?.(registry);
-    this.#runState = setHarnessSkillRegistry(
+    this.#runState = patchHarnessRunState(
       this.#runState,
-      registry,
-      skillRegistryPath,
+      { skillRegistry: registry, skillRegistryPath },
       this.#now(),
     );
     await this.persistRunState();
@@ -633,10 +623,9 @@ export class CfHarnessEngine {
   ): Promise<string | undefined> {
     const skillActivationsPath = await this.artifactStore
       ?.persistSkillActivations?.(activations);
-    this.#runState = setHarnessSkillActivations(
+    this.#runState = patchHarnessRunState(
       this.#runState,
-      activations,
-      skillActivationsPath,
+      { skillActivations: activations, skillActivationsPath },
       this.#now(),
     );
     await this.persistRunState();
@@ -655,10 +644,9 @@ export class CfHarnessEngine {
     };
     const skillResourceReadsPath = await this.artifactStore
       ?.persistSkillResourceReads?.(skillResourceReads);
-    this.#runState = setHarnessSkillResourceReads(
+    this.#runState = patchHarnessRunState(
       this.#runState,
-      skillResourceReads,
-      skillResourceReadsPath,
+      { skillResourceReads, skillResourceReadsPath },
       generatedAt,
     );
     await this.persistRunState();
@@ -680,10 +668,9 @@ export class CfHarnessEngine {
     };
     const skillScriptExecutionsPath = await this.artifactStore
       ?.persistSkillScriptExecutions?.(skillScriptExecutions);
-    this.#runState = setHarnessSkillScriptExecutions(
+    this.#runState = patchHarnessRunState(
       this.#runState,
-      skillScriptExecutions,
-      skillScriptExecutionsPath,
+      { skillScriptExecutions, skillScriptExecutionsPath },
       generatedAt,
     );
     await this.persistRunState();
@@ -746,9 +733,9 @@ export class CfHarnessEngine {
       transcript,
     );
     if (transcriptPath !== undefined) {
-      this.#runState = setHarnessTranscriptPath(
+      this.#runState = patchHarnessRunState(
         this.#runState,
-        transcriptPath,
+        { transcriptPath },
         this.#now(),
       );
       await this.persistRunState();
@@ -761,9 +748,9 @@ export class CfHarnessEngine {
   ): Promise<string | undefined> {
     const runReportPath = await this.artifactStore?.persistRunReport(report);
     if (runReportPath !== undefined) {
-      this.#runState = setHarnessRunReportPath(
+      this.#runState = patchHarnessRunState(
         this.#runState,
-        runReportPath,
+        { runReportPath },
         this.#now(),
       );
       await this.persistRunState();
@@ -791,10 +778,9 @@ export class CfHarnessEngine {
         now,
       );
     }
-    this.#runState = setHarnessCfcPolicySnapshot(
+    this.#runState = patchHarnessRunState(
       this.#runState,
-      snapshot,
-      cfcPolicySnapshotPath,
+      { cfcPolicySnapshot: snapshot, cfcPolicySnapshotPath },
       this.#now(),
     );
     await this.persistRunState();
@@ -818,10 +804,9 @@ export class CfHarnessEngine {
         now,
       );
     }
-    this.#runState = setHarnessPolicyTrace(
+    this.#runState = patchHarnessRunState(
       this.#runState,
-      trace,
-      policyTracePath,
+      { policyTrace: trace, policyTracePath },
       this.#now(),
     );
     await this.persistRunState();
@@ -885,10 +870,9 @@ export class CfHarnessEngine {
           this.#now(),
         );
       }
-      this.#runState = setHarnessCapabilitySnapshot(
+      this.#runState = patchHarnessRunState(
         this.#runState,
-        capabilitySnapshot,
-        capabilitiesPath,
+        { capabilitySnapshot, capabilitiesPath },
         this.#now(),
       );
     } catch (error) {
@@ -967,13 +951,14 @@ export class CfHarnessEngine {
       artifactPath,
     );
     const completionTime = this.#now();
-    this.#runState = appendHarnessToolOutput(
+    this.#runState = appendToHarnessRunState(
       setHarnessRunStatus(
         this.#runState,
         "completed",
         completionTime,
         "tool_completed",
       ),
+      "toolOutputs",
       resultRef,
       completionTime,
     );
@@ -1253,8 +1238,9 @@ export class CfHarnessEngine {
         ? { cfcModelContext: this.#runState.cfcModelContext }
         : {}),
     });
-    this.#runState = appendHarnessCfcInvocationContext(
+    this.#runState = appendToHarnessRunState(
       this.#runState,
+      "cfcInvocationContexts",
       invocation,
       now,
     );
@@ -1298,9 +1284,9 @@ export class CfHarnessEngine {
           path,
           this.#runState.currentDir,
         );
-        this.#runState = setHarnessRunCurrentDir(
+        this.#runState = patchHarnessRunState(
           this.#runState,
-          resolved,
+          { currentDir: resolved },
           this.#now(),
         );
       },

--- a/packages/cf-harness/src/run-state.ts
+++ b/packages/cf-harness/src/run-state.ts
@@ -240,80 +240,61 @@ export const createHarnessRunState = (
   };
 };
 
+// Applies an immutable update to a run state and stamps `updatedAt`. A key
+// whose value is undefined is left out of the result instead of being written
+// as an explicit undefined, so a caller can pass an optional artifact path
+// through without testing it first.
+export const patchHarnessRunState = (
+  state: HarnessRunState,
+  patch: Partial<HarnessRunState>,
+  now = new Date().toISOString(),
+): HarnessRunState => {
+  const defined = Object.fromEntries(
+    Object.entries(patch).filter(([, value]) => value !== undefined),
+  );
+  return Object.assign({ ...state }, defined, { updatedAt: now });
+};
+
+type HarnessRunStateListField = {
+  [K in keyof HarnessRunState]-?: NonNullable<HarnessRunState[K]> extends
+    readonly unknown[] ? K : never;
+}[keyof HarnessRunState];
+
+type HarnessRunStateListEntry<K extends HarnessRunStateListField> =
+  NonNullable<HarnessRunState[K]> extends readonly (infer TEntry)[] ? TEntry
+    : never;
+
+// Appends one entry to a list-valued run state field, treating an absent list
+// as empty.
+export const appendToHarnessRunState = <K extends HarnessRunStateListField>(
+  state: HarnessRunState,
+  field: K,
+  entry: HarnessRunStateListEntry<K>,
+  now = new Date().toISOString(),
+): HarnessRunState =>
+  patchHarnessRunState(
+    state,
+    { [field]: [...(state[field] ?? []), entry] } as Partial<HarnessRunState>,
+    now,
+  );
+
 export const setHarnessRunStatus = (
   state: HarnessRunState,
   status: HarnessRunStatus,
   now = new Date().toISOString(),
   terminalReason?: HarnessRunTerminalReason,
 ): HarnessRunState => {
-  const base = {
-    ...state,
-    status,
-    updatedAt: now,
-  };
   if (status === "completed" || status === "failed") {
-    return {
-      ...base,
-      endedAt: now,
-      ...(terminalReason !== undefined ? { terminalReason } : {}),
-    };
+    return patchHarnessRunState(
+      state,
+      { status, endedAt: now, terminalReason },
+      now,
+    );
   }
   const { endedAt: _endedAt, terminalReason: _terminalReason, ...nonTerminal } =
-    base;
-  return {
-    ...nonTerminal,
-  };
+    state;
+  return patchHarnessRunState(nonTerminal, { status }, now);
 };
-
-export const setHarnessRunModel = (
-  state: HarnessRunState,
-  model: string,
-  now = new Date().toISOString(),
-): HarnessRunState => ({
-  ...state,
-  model,
-  updatedAt: now,
-});
-
-export const appendHarnessToolOutput = (
-  state: HarnessRunState,
-  output: ToolResultRef,
-  now = new Date().toISOString(),
-): HarnessRunState => ({
-  ...state,
-  updatedAt: now,
-  toolOutputs: [...state.toolOutputs, output],
-});
-
-export const appendHarnessPolicyEvent = (
-  state: HarnessRunState,
-  event: HarnessPolicyEvent,
-  now = new Date().toISOString(),
-): HarnessRunState => ({
-  ...state,
-  updatedAt: now,
-  policyEvents: [...state.policyEvents, event],
-});
-
-export const appendHarnessPolicyDecision = (
-  state: HarnessRunState,
-  decision: HarnessPolicyDecisionRecord,
-  now = new Date().toISOString(),
-): HarnessRunState => ({
-  ...state,
-  updatedAt: now,
-  policyDecisions: [...(state.policyDecisions ?? []), decision],
-});
-
-export const appendHarnessCfcInvocationContext = (
-  state: HarnessRunState,
-  context: HarnessCfcInvocationContext,
-  now = new Date().toISOString(),
-): HarnessRunState => ({
-  ...state,
-  updatedAt: now,
-  cfcInvocationContexts: [...(state.cfcInvocationContexts ?? []), context],
-});
 
 export const appendHarnessCfcModelContextObservations = (
   state: HarnessRunState,
@@ -328,11 +309,7 @@ export const appendHarnessCfcModelContextObservations = (
   if (cfcModelContext === state.cfcModelContext) {
     return state;
   }
-  return {
-    ...state,
-    updatedAt: now,
-    ...(cfcModelContext !== undefined ? { cfcModelContext } : {}),
-  };
+  return patchHarnessRunState(state, { cfcModelContext }, now);
 };
 
 export const setHarnessSubagentRun = (
@@ -350,22 +327,8 @@ export const setHarnessSubagentRun = (
   } else {
     subagentRuns.push(subagentRun);
   }
-  return {
-    ...state,
-    updatedAt: now,
-    subagentRuns,
-  };
+  return patchHarnessRunState(state, { subagentRuns }, now);
 };
-
-export const setHarnessPromptSlotBinding = (
-  state: HarnessRunState,
-  promptSlotBinding: PromptSlotBinding,
-  now = new Date().toISOString(),
-): HarnessRunState => ({
-  ...state,
-  promptSlotBinding,
-  updatedAt: now,
-});
 
 export const appendHarnessFailureRecord = (
   state: HarnessRunState,
@@ -373,137 +336,12 @@ export const appendHarnessFailureRecord = (
   now = new Date().toISOString(),
 ): HarnessRunState => {
   const failureRecords = [...(state.failureRecords ?? []), failure];
-  const primaryFailure = selectPrimaryHarnessFailure(failureRecords);
-  return {
-    ...state,
-    updatedAt: now,
-    failureRecords,
-    ...(primaryFailure !== undefined ? { primaryFailure } : {}),
-  };
+  return patchHarnessRunState(
+    state,
+    {
+      failureRecords,
+      primaryFailure: selectPrimaryHarnessFailure(failureRecords),
+    },
+    now,
+  );
 };
-
-export const setHarnessRunCurrentDir = (
-  state: HarnessRunState,
-  currentDir: string,
-  now = new Date().toISOString(),
-): HarnessRunState => ({
-  ...state,
-  currentDir,
-  updatedAt: now,
-});
-
-export const setHarnessTranscriptPath = (
-  state: HarnessRunState,
-  transcriptPath: string,
-  now = new Date().toISOString(),
-): HarnessRunState => ({
-  ...state,
-  transcriptPath,
-  updatedAt: now,
-});
-
-export const setHarnessRunReportPath = (
-  state: HarnessRunState,
-  runReportPath: string,
-  now = new Date().toISOString(),
-): HarnessRunState => ({
-  ...state,
-  runReportPath,
-  updatedAt: now,
-});
-
-export const setHarnessRunManifestPath = (
-  state: HarnessRunState,
-  runManifestPath: string,
-  now = new Date().toISOString(),
-): HarnessRunState => ({
-  ...state,
-  runManifestPath,
-  updatedAt: now,
-});
-
-export const setHarnessSkillRegistry = (
-  state: HarnessRunState,
-  skillRegistry: HarnessSkillRegistry,
-  skillRegistryPath?: string,
-  now = new Date().toISOString(),
-): HarnessRunState => ({
-  ...state,
-  skillRegistry,
-  ...(skillRegistryPath !== undefined ? { skillRegistryPath } : {}),
-  updatedAt: now,
-});
-
-export const setHarnessSkillActivations = (
-  state: HarnessRunState,
-  skillActivations: HarnessSkillActivations,
-  skillActivationsPath?: string,
-  now = new Date().toISOString(),
-): HarnessRunState => ({
-  ...state,
-  skillActivations,
-  ...(skillActivationsPath !== undefined ? { skillActivationsPath } : {}),
-  updatedAt: now,
-});
-
-export const setHarnessSkillResourceReads = (
-  state: HarnessRunState,
-  skillResourceReads: HarnessSkillResourceReads,
-  skillResourceReadsPath?: string,
-  now = new Date().toISOString(),
-): HarnessRunState => ({
-  ...state,
-  skillResourceReads,
-  ...(skillResourceReadsPath !== undefined ? { skillResourceReadsPath } : {}),
-  updatedAt: now,
-});
-
-export const setHarnessSkillScriptExecutions = (
-  state: HarnessRunState,
-  skillScriptExecutions: HarnessSkillScriptExecutions,
-  skillScriptExecutionsPath?: string,
-  now = new Date().toISOString(),
-): HarnessRunState => ({
-  ...state,
-  skillScriptExecutions,
-  ...(skillScriptExecutionsPath !== undefined
-    ? { skillScriptExecutionsPath }
-    : {}),
-  updatedAt: now,
-});
-
-export const setHarnessCapabilitySnapshot = (
-  state: HarnessRunState,
-  capabilitySnapshot: HarnessCapabilitySnapshot,
-  capabilitiesPath?: string,
-  now = new Date().toISOString(),
-): HarnessRunState => ({
-  ...state,
-  capabilitySnapshot,
-  ...(capabilitiesPath !== undefined ? { capabilitiesPath } : {}),
-  updatedAt: now,
-});
-
-export const setHarnessCfcPolicySnapshot = (
-  state: HarnessRunState,
-  cfcPolicySnapshot: HarnessCfcPolicySnapshot,
-  cfcPolicySnapshotPath?: string,
-  now = new Date().toISOString(),
-): HarnessRunState => ({
-  ...state,
-  cfcPolicySnapshot,
-  ...(cfcPolicySnapshotPath !== undefined ? { cfcPolicySnapshotPath } : {}),
-  updatedAt: now,
-});
-
-export const setHarnessPolicyTrace = (
-  state: HarnessRunState,
-  policyTrace: HarnessPolicyTrace,
-  policyTracePath?: string,
-  now = new Date().toISOString(),
-): HarnessRunState => ({
-  ...state,
-  policyTrace,
-  ...(policyTracePath !== undefined ? { policyTracePath } : {}),
-  updatedAt: now,
-});


### PR DESCRIPTION
…tch helper

The run state of a harness run is an immutable record: every update copies the old state, changes a field or two, and stamps a new `updatedAt`. To express that, run-state.ts exported twenty-one named update functions, and seventeen of them were the same three-line body with a different field name substituted in. Each one existed only so that the engine could avoid writing an object spread. Every one of those seventeen had exactly one caller, all of them in the engine, and none had a caller in the tests. Because the package entry point re-exports run-state.ts wholesale, all seventeen were also part of the package's public surface, which nothing outside the package used — the harness is driven over its command line and its line-delimited JSON stdio interface, not by importing its TypeScript.

This replaces those seventeen with two general helpers:

`patchHarnessRunState(state, patch, now)` copies the state, applies the fields named in the patch, and stamps `updatedAt`. A patch entry whose value is undefined is left out rather than written as an explicit undefined property. That reproduces what the old setters did by hand for their optional second argument, so a caller can pass an artifact path that the artifact store may not have produced straight through without testing it first.

`appendToHarnessRunState(state, field, entry, now)` adds one entry to a list-valued field, treating an absent list as empty. The field name is constrained by a mapped type to the run state's list-valued properties, and the entry is constrained to that list's element type, so naming a non-list field or passing the wrong kind of entry is a compile error.

The four update functions that carry real logic stay, and now build their result through the patch helper rather than spreading by hand: `setHarnessRunStatus` (which adds an end timestamp and terminal reason on a terminal status and strips both on a non-terminal one), `setHarnessSubagentRun` (which replaces a matching child run rather than appending a duplicate), `appendHarnessCfcModelContextObservations` (which merges observations and returns the original state unchanged when nothing moved), and `appendHarnessFailureRecord` (which recomputes the primary failure over the whole list on every append).

Field order in the resulting object, and therefore in the persisted run-state.json, is unchanged: an assignment to a property the state already has keeps that property's original position, and a property the state lacks is appended, which is what the spreads did before.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

