### PR TITLE
refactor(cf-harness): record each model attempt once

### DIFF
--- a/docs/plans/cf-harness-codex-subscription-auth.md
+++ b/docs/plans/cf-harness-codex-subscription-auth.md
@@ -269,13 +269,14 @@ Tests to extend first:
 - `packages/cf-harness/test/openai-client.test.ts`
 - `packages/cf-harness/test/interactive-chat-service.test.ts`
 
-### WP1.3 — Generalize attempt provenance compatibly
+### WP1.3 — Generalize attempt provenance
 
 - [x] Add provider-neutral model-attempt records to run reports with provider,
   operation, endpoint origin, timing, request summary, status, selected request
   id, and bounded error metadata.
-- [x] Preserve reading and producing the current `gatewayAttempts` field for the
-  existing gateway until an explicit artifact-version migration removes it.
+- [x] Record each attempt exactly once, in the provider-neutral `modelAttempts`
+  field. A gateway turn carries the same kind of record as any other turn, with
+  `operation` naming the API that served it.
 - [x] Never record authorization, cookies, account ids, refresh responses, or
   arbitrary response headers.
 

--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -73,8 +73,8 @@ What works today:
 - persisted run state, transcript, run reports, Loom run manifests, capability
   snapshots, and tool outputs, plus explicit skill registry and activation
   artifacts
-- provider-neutral run-report model-attempt diagnostics; the compatibility
-  gateway retains its existing gateway-attempt records
+- provider-neutral run-report model-attempt diagnostics, one record per attempt,
+  naming the provider and the API operation that served it
 - provider-reported per-turn token usage in run reports, with aggregate input,
   cached-input, cache-write, output, reasoning, and total tokens surfaced in
   operator and batch results

--- a/packages/cf-harness/src/contracts/run-report.ts
+++ b/packages/cf-harness/src/contracts/run-report.ts
@@ -13,7 +13,6 @@ import type { HarnessSubagentRunRef } from "./subagent.ts";
 import type { HarnessToolEffectClass } from "./tool-descriptor.ts";
 import type { HarnessTranscriptMessage } from "./transcript.ts";
 import type { ToolResultRef } from "./tool-result.ts";
-import type { OpenAIChatCompletionAttemptDiagnostic } from "../gateway/openai-client.ts";
 import type {
   HarnessModelAttemptDiagnostic,
   HarnessModelUsage,
@@ -51,13 +50,6 @@ export interface HarnessToolActivity {
   policyEventIndexes?: number[];
   resultRef?: ToolResultRef;
   errorDetail?: string;
-}
-
-export interface HarnessGatewayAttempt
-  extends OpenAIChatCompletionAttemptDiagnostic {
-  runId: string;
-  sequence: number;
-  modelTurn: number;
 }
 
 export interface HarnessModelAttempt extends HarnessModelAttemptDiagnostic {
@@ -144,7 +136,6 @@ export interface HarnessRunReport {
   policyDecisions: HarnessPolicyDecisionRecord[];
   timeline: HarnessRunTimelineEntry[];
   toolActivity: HarnessToolActivity[];
-  gatewayAttempts?: HarnessGatewayAttempt[];
   modelAttempts?: HarnessModelAttempt[];
   toolOutputs: ToolResultRef[];
   subagentRuns?: HarnessSubagentRunRef[];
@@ -182,7 +173,6 @@ export interface CreateHarnessRunReportOptions {
   finalAssistantText?: string;
   timeline?: readonly HarnessRunTimelineEntryInput[];
   toolActivity: readonly HarnessToolActivity[];
-  gatewayAttempts?: readonly HarnessGatewayAttempt[];
   modelAttempts?: readonly HarnessModelAttempt[];
   usage?: HarnessModelUsage;
   totalUsage?: HarnessModelUsage;
@@ -380,9 +370,6 @@ export const createHarnessRunReport = (
       toolActivity: options.toolActivity,
     }),
     toolActivity: [...options.toolActivity],
-    ...((options.gatewayAttempts?.length ?? 0) > 0
-      ? { gatewayAttempts: [...(options.gatewayAttempts ?? [])] }
-      : {}),
     ...((options.modelAttempts?.length ?? 0) > 0
       ? { modelAttempts: [...(options.modelAttempts ?? [])] }
       : {}),

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -46,7 +46,6 @@ import {
 } from "./contracts/policy-trace.ts";
 import {
   createHarnessRunReport,
-  type HarnessGatewayAttempt,
   type HarnessModelAttempt,
   type HarnessModelTurnUsage,
   type HarnessRunTimelineEntryInput,
@@ -1851,7 +1850,6 @@ export class CfHarnessPromptLoop {
     const transcript: HarnessTranscriptMessage[] = [...options.transcript];
     const maxModelTurns = options.maxModelTurns ?? this.#maxModelTurns;
     const toolActivity: HarnessToolActivity[] = [];
-    const gatewayAttempts: HarnessGatewayAttempt[] = [];
     const modelAttempts: HarnessModelAttempt[] = [];
     const modelUsage: HarnessModelTurnUsage[] = [];
     const descendantUsage: HarnessModelUsage[] = [];
@@ -1899,7 +1897,6 @@ export class CfHarnessPromptLoop {
           ...(finalAssistantText !== undefined ? { finalAssistantText } : {}),
           timeline: reportTimeline,
           toolActivity,
-          gatewayAttempts,
           modelAttempts,
           ...(modelUsage.length > 0
             ? {
@@ -1929,29 +1926,6 @@ export class CfHarnessPromptLoop {
         ...attempt,
         runId: this.engine.getRunState().runId,
         sequence: modelAttempts.length + 1,
-        modelTurn: modelTurns,
-      });
-      if (
-        attempt.providerId !== "openai-compatible-gateway" ||
-        (attempt.operation !== "chat.completions" &&
-          attempt.operation !== "responses")
-      ) {
-        return;
-      }
-      const {
-        providerId: _providerId,
-        type: _type,
-        operation,
-        ...rest
-      } = attempt;
-      gatewayAttempts.push({
-        ...rest,
-        type: "cf-harness.gateway.chat-completion-attempt",
-        // Preserve which API served the turn: gpt-* goes to the Responses API,
-        // provider-native tools and non-OpenAI models stay on chat completions.
-        operation,
-        runId: this.engine.getRunState().runId,
-        sequence: gatewayAttempts.length + 1,
         modelTurn: modelTurns,
       });
     };

--- a/packages/cf-harness/test/artifacts.test.ts
+++ b/packages/cf-harness/test/artifacts.test.ts
@@ -646,35 +646,38 @@ Deno.test({
         },
         resultRef: result.runState.toolOutputs[0],
       });
-      assertEquals(persistedReport.gatewayAttempts?.length, 2);
       assertEquals(persistedReport.modelAttempts?.length, 2);
       assertEquals(
         persistedReport.modelAttempts?.map((attempt) => attempt.providerId),
         ["openai-compatible-gateway", "openai-compatible-gateway"],
       );
       assertEquals(
-        persistedReport.gatewayAttempts?.map((attempt) => attempt.sequence),
+        persistedReport.modelAttempts?.map((attempt) => attempt.operation),
+        ["responses", "responses"],
+      );
+      assertEquals(
+        persistedReport.modelAttempts?.map((attempt) => attempt.sequence),
         [1, 2],
       );
       assertEquals(
-        persistedReport.gatewayAttempts?.map((attempt) => attempt.modelTurn),
+        persistedReport.modelAttempts?.map((attempt) => attempt.modelTurn),
         [1, 2],
       );
       assertEquals(
-        persistedReport.gatewayAttempts?.map((attempt) => attempt.runId),
+        persistedReport.modelAttempts?.map((attempt) => attempt.runId),
         ["run-loop-persisted", "run-loop-persisted"],
       );
       assertEquals(
-        persistedReport.gatewayAttempts?.[0].outcome,
+        persistedReport.modelAttempts?.[0].outcome,
         "http_response",
       );
-      assertEquals(persistedReport.gatewayAttempts?.[0].httpStatus, 200);
+      assertEquals(persistedReport.modelAttempts?.[0].httpStatus, 200);
       assertEquals(
         {
-          model: persistedReport.gatewayAttempts?.[0].request.model,
-          messageCount: persistedReport.gatewayAttempts?.[0].request
+          model: persistedReport.modelAttempts?.[0].request.model,
+          messageCount: persistedReport.modelAttempts?.[0].request
             .messageCount,
-          toolCount: persistedReport.gatewayAttempts?.[0].request.toolCount,
+          toolCount: persistedReport.modelAttempts?.[0].request.toolCount,
         },
         {
           model: "gpt-5.4",
@@ -683,15 +686,15 @@ Deno.test({
         },
       );
       assert(
-        (persistedReport.gatewayAttempts?.[0].request.serializedBytes ?? 0) >
+        (persistedReport.modelAttempts?.[0].request.serializedBytes ?? 0) >
           0,
       );
       assertEquals(
-        persistedReport.gatewayAttempts?.[1].request.messageCount,
+        persistedReport.modelAttempts?.[1].request.messageCount,
         3,
       );
       assertEquals(
-        JSON.stringify(persistedReport.gatewayAttempts).includes(
+        JSON.stringify(persistedReport.modelAttempts).includes(
           "Summarize the todo file.",
         ),
         false,


### PR DESCRIPTION
When cf-harness gained a provider-neutral model client, run reports gained a matching provider-neutral record of each attempt at a model call, called `modelAttempts`. The older, gateway-specific `gatewayAttempts` record was kept alongside it so that anything reading the old field would keep working during the transition.

Nothing ever read the old field. Inside the package, `gatewayAttempts` appeared only in the contract that declares it and in the prompt loop that writes it: the CLI, the diagnostics module, the artifact readers, and the interactive chat service all ignore it, and no consumer outside the package reads it either. What the transition left behind was a round trip that produced no information: the gateway adapter converted the transport client's diagnostic into the neutral shape by adding a type tag and a provider id, and the prompt loop then converted that neutral record straight back into the old shape by stripping the provider id and restoring the old type tag, so every model call was written to `run-report.json` twice in two spellings of the same fields.

This deletes the legacy record. `HarnessGatewayAttempt` and the `gatewayAttempts` field are gone from the run-report contract, along with the option that fed them and the branch in `createHarnessRunReport` that persisted them. The prompt loop no longer keeps a second array or performs the reverse conversion, so recording an attempt is now just stamping the run id, the sequence number, and the model turn onto the diagnostic the model client handed over.

The transport-level diagnostic in `gateway/openai-client.ts` stays, as does the seven-line adapter in the gateway model client that lifts it into the neutral shape. The two types are not redundant: the transport diagnostic constrains `operation` to the two endpoints that client speaks, while the neutral one leaves it a free string that the Codex client fills with `responses.stream`. The provider id the adapter stamps is also a model-layer fact, defined next to the model client, so having the HTTP client stamp it would push knowledge of model providers down into transport code for no gain.

Which API served a gateway turn was the one thing the old record carried that nothing asserted; it now lives in the `operation` field of a model attempt, and the artifacts test asserts it there along with the rest of the assertions moved over from `gatewayAttempts`.

Two live documents described the double record, and both now describe what the code does instead: the package README, and the work package in the subscription-auth plan that had called for keeping the gateway field until an artifact-version migration removed it. That work package also loses the word in its heading naming the compatibility it no longer keeps.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

