### PR TITLE
fix(ci): ratchet coverage against an ancestor of the commit under test

### DIFF
--- a/docs/development/COVERAGE.md
+++ b/docs/development/COVERAGE.md
@@ -226,9 +226,11 @@ condition's own count. See
 ## Ratchet baselines and accepting debt
 
 The ratchet applies per source group and only to the groups a PR changes: for
-each such group the uncovered-line count must not rise above the latest non-cold
-`main` run's count. Debt in unchanged groups is still reported, but does not
-block the PR.
+each such group the uncovered-line count must not rise above the count from the
+`main` run for the base-branch commit the PR is merged with, or the nearest
+ancestor of it that has one (see "Which `main` run the ratchet compares
+against"). Debt in unchanged groups is still reported, but does not block the
+PR.
 
 Accept one metric's increase with the narrow per-metric marker in the PR
 description:
@@ -301,6 +303,39 @@ its cache-state artifact is missing. Fingerprint inference cannot see
 non-fingerprint cold causes (cache eviction, cache-service outages): a run cold
 for those reasons and lacking a recorded state stays unknown, so it is treated
 as not-cold and may still be used as a baseline.
+
+## Which `main` run the ratchet compares against
+
+A `pull_request` run checks out `refs/pull/<number>/merge`, whose first parent
+is the base-branch commit and whose second parent is the pull request head.
+GitHub rebuilds that merge ref whenever the base branch moves, so the run
+measures the pull request merged with `main` as it stood when the run started.
+
+The baseline is the `main` run for that commit, or for the nearest ancestor of
+it that has one. Comparing against the commit itself is exact: both numbers
+count the same base-branch code, so the only difference between them is the
+pull request. Runs that are not ancestors are never used, in either direction —
+one that landed after the run started measured code the run does not contain.
+
+The base commit's own run is usually available, but not always: it may still be
+going, or it may have failed. Rather than skip the gate, the ratchet steps back
+to the nearest ancestor that has a usable run. Whatever the base branch changed
+in between is then present in this run and absent from the baseline, so the
+groups it touched have totals that count different code on the two sides. Those
+groups are reported and not gated; every other group still is, which is the
+point of stepping back rather than giving up. A gap of one or two commits
+usually touches one or two groups.
+
+One case this does not reach: a base-branch commit that changes a test in one
+package can move the coverage of source in another, and no diff of that source
+names it. It ends when a `main` run measures the base commit.
+
+Two details of reading the base commit are load-bearing. It comes from the
+checked-out merge commit rather than the triggering event, because GitHub does
+not rewrite `pull_request.base.sha` when it rebuilds the merge ref. And it is
+read with `git cat-file commit HEAD` rather than `git log --format=%P`, because
+`actions/checkout` clones to depth one and git reports a shallow boundary commit
+as having no parents.
 
 ## A combined report for IDEs
 

--- a/docs/development/COVERAGE.md
+++ b/docs/development/COVERAGE.md
@@ -110,7 +110,7 @@ file's first record both covers real lines and drops the never-named lines out o
 the count.
 
 The gate absorbs that safely, because it is a ratchet: it fails a pull request
-only when a group's uncovered count *rises* above the latest `main` baseline.
+only when a group's uncovered count *rises* above its `main` baseline.
 Gaining a record can only *lower* a file's count, since the record names a subset
 of the file's lines and the rest stop being counted, so it settles at a lower —
 and therefore stricter — bar rather than failing anything. The instrumented
@@ -257,9 +257,10 @@ Each run writes a per-run baseline artifact recording its coverage-debt metrics
 and its compile cache states. It is named `perf-metrics` for historical reasons
 — it once also carried CI timing metrics for the removed performance gate — and
 keeps that name so the ratchet needs no migration; a run from before the gate
-was removed reads as a valid baseline unchanged. A later PR run reads the most
-recent `main` run's `perf-metrics` artifact as its ratchet baseline; there is no
-separate history store. The workflow downloads the current run's
+was removed reads as a valid baseline unchanged. A later PR run reads its ratchet
+baseline from the `perf-metrics` artifact of the `main` run for the base-branch
+commit it merged, or of the nearest ancestor of that commit which has one; there
+is no separate history store. The workflow downloads the current run's
 `coverage-profile-*` artifacts before starting `tasks/coverage-check.ts`.
 `COVERAGE_ARTIFACTS_DIR` points the script at one subdirectory per artifact. The
 download step checks the artifact digests. The script separately checks the
@@ -290,8 +291,9 @@ any of its shards had a full cache miss, detected as the cache file being absent
 after the restore step (the combined `actions/cache` action does not expose the
 matched key). A partial hit through a restore key counts as warm: both key forms
 start with the fingerprint hash, so any restore means the compiled bytes are
-current. The ratchet then uses the latest non-cold `main` sample, so a cold
-`main` run cannot lower the baseline that warm PRs are held to.
+current. The ratchet skips a cold sample when choosing among the
+base-branch commit and its ancestors, so a cold `main` run cannot lower the
+baseline that warm PRs are held to.
 
 A run without a recorded cache state — an artifact carrying no stamp, or a run
 whose cache-state artifact failed to upload — is retro-classified from the

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -124,6 +124,10 @@ One line per archived document; each document's header carries the fuller
 - [2026-07-28-completed-transaction-retention.md](packages/runner/2026-07-28-completed-transaction-retention.md)
   — a completed transaction kept the activity of everything it read, and the
   unbounded document cache that still exhausts a browser tab, July 2026.
+- [2026-08-04-coverage-gate-base-branch-drift.md](development/2026-08-04-coverage-gate-base-branch-drift.md)
+  — why Coverage Check failed `packages/runner` at random: the ratchet graded a
+  pull request merged with a newer `main` against an older `main` baseline,
+  August 2026.
 - [pattern-update-open-argument-investigation.md](plans/pattern-update-open-argument-investigation.md)
   — why the open-argument update class went unvalidated on the repair path, and
   the correction of an earlier measurement that named the wrong mechanism,

--- a/docs/history/development/2026-08-04-coverage-gate-base-branch-drift.md
+++ b/docs/history/development/2026-08-04-coverage-gate-base-branch-drift.md
@@ -1,0 +1,108 @@
+---
+status: historical
+created: 2026-08-04
+archived: 2026-08-04
+reason: "Investigation finding: why Coverage Check failed packages/runner at random, and what the measurement actually depends on."
+---
+
+# Why Coverage Check failed `packages/runner` at random
+
+Coverage Check failed pull request #5198 on `packages/runner` with 5747
+uncovered lines against a baseline of 5746. A run seventeen minutes earlier, on
+a head that differed only in three `packages/content-hash` files, reported 5746
+and passed. The failure looked like measurement noise. It was not.
+
+## What the two runs actually measured
+
+The two runs checked out different trees:
+
+```text
+run 30514963895 (04:50)  HEAD is now at cdd97f5 Merge 66ef4bf2 into f69af094c
+run 30515725503 (05:07)  HEAD is now at 90a4c9e Merge 5d89521c into c8afb078b
+```
+
+A `pull_request` run checks out `refs/pull/<number>/merge`, and GitHub rebuilds
+that merge ref whenever the base branch moves. Between the two runs,
+`c8afb078b` — "feat(runner): map every instantiated pattern back to its source
+file" (#5196) — landed on `main` at 05:04:32Z. It touched eight files under
+`packages/runner/src`. So the runner source was not identical between the two
+runs at all; only the two pull request heads were.
+
+Both runs took their baseline from the same `main` run, 30504402912 at
+`a5dde681`, which predates `c8afb078b`. The failing run therefore measured
+`main`'s newer code against a baseline that did not contain it.
+
+The gate had already noticed and said so, one line before failing the run:
+
+```text
+Warning: Newest successful baseline run 30504402912 (2026-07-30T01:00:42Z) is
+for a5dde681..., but current main is c8afb078b...
+```
+
+## Confirming it, and finding the one line
+
+Scoring the two trees with the gate's own code (`collectSourceFiles`,
+`parseLcov`, `countUncoveredProfileLines` from `tasks/coverage-metrics.ts`) and
+the combined `main` LCOV reports published to
+`gs://commontools-build-artifacts/workspace-artifacts/labs-<sha>.lcov`:
+
+| tree | LCOV | `packages/runner` |
+| --- | --- | --- |
+| `f69af094c` | `f69af094c` | 5746 |
+| `f69af094c` | `c8afb078b` | 5746 |
+| `c8afb078b` | `f69af094c` | 5747 |
+| `c8afb078b` | `c8afb078b` | 5747 |
+
+The number tracks the tree and ignores the coverage data entirely. That falls
+out of how the metric is computed: for a file that *has* an LCOV record, the
+score counts the zero-hit lines that record names and never reads the file, so
+the tree can only change the number through files that have *no* record.
+
+The per-file difference between the two trees was a single file:
+
+```text
+packages/runner/src/harness/types.ts   114 -> 115
+```
+
+`types.ts` declares interfaces and nothing else. It compiles to no executable
+statements, so Deno's coverage never emitted a record for it, and at the time
+the gate charged every one of its tracked lines as uncovered — debt no test
+could pay. `c8afb078b` added a nine-line block to it, one line of which is code
+and eight of which are a doc comment. Debt went 114 → 115, `packages/runner`
+went 5746 → 5747, and because the ratchet parks every group at exactly its
+baseline, that was enough.
+
+That charge is gone: the gate now compiles a file it finds no record for and
+charges it nothing when nothing comes out, so this particular line can no longer
+move a group's total. What made the failure possible in general — a baseline
+measured at a different commit from the run — is what the fix below addresses.
+
+The `packages/toolshed` movement noted alongside this (−25 in one run, −23 in
+the other, with unchanged toolshed source) has the same origin by a different
+route: `c8afb078b` also rewrote `packages/cli/lib/test-runner.ts` and the piece
+state-continuity harness, which changes what the tests execute.
+
+## The fix
+
+The ratchet now uses the `main` run for the base-branch commit the run merged,
+so the baseline and the measurement cover the same base-branch code and the only
+difference left between them is the pull request. Runs that are not ancestors of
+that commit are never used, which closes the mirror-image case: a `main` run
+that finished after the base commit measured code the run does not contain. When
+no `main` run has measured the base commit, the nearest ancestor with one stands
+in, and the groups the base branch changed in between are reported and not
+gated.
+
+Two things had to be read carefully to make it correct:
+
+- The base-branch commit cannot come from the triggering event. This run's
+  payload carried `pull_request.base.sha: f69af094c` and
+  `merge_commit_sha: cdd97f5` — both describing the *previous* run — while the
+  checkout merged `c8afb078b`. GitHub does not rewrite the event when it
+  rebuilds the merge ref.
+- It cannot be read with `git log --format=%P` either. `actions/checkout`
+  clones to depth one, and git reports a shallow boundary commit as having no
+  parents. `git cat-file commit HEAD` prints the stored object, which keeps
+  them.
+
+The live description is in [`COVERAGE.md`](../../development/COVERAGE.md).

--- a/tasks/coverage-check.test.ts
+++ b/tasks/coverage-check.test.ts
@@ -21,9 +21,11 @@ import {
   collectCurrentCacheStates,
   copyCoverageArtifactFiles,
   currentWorkflowRunFromEvent,
+  fetchAncestorRanks,
   fetchArtifactsForRunBestEffort,
   fetchBaselineRunsForCheck,
   fetchCommitsBehindMain,
+  fetchGroupsChangedOnBase,
   fetchLatestBaselineRunSha,
   fetchMainHeadSha,
   fetchPRForCommitWithError,
@@ -36,14 +38,17 @@ import {
   formatRelativeAge,
   formatRelativeDuration,
   githubApiOrSkip,
+  isComparableBaseline,
   logBaselineSourceRuns,
   main,
   metricDisplayParts,
   metricTableRows,
+  nearestUsableBaseline,
   newestArtifactNamed,
   parseCoverageBaselineFromArtifacts,
   parseMergedBaselineOverrides,
   printMetricTable,
+  readBaseBranchSha,
   reportBaselineContextResults,
   reportBaselineRunAvailability,
   reportPRLookupResults,
@@ -1494,4 +1499,183 @@ Deno.test("baseline PR lookup summary counts found, missing, and failed lookups"
     ]),
     { found: 1, noPR: 1, failed: 1 },
   );
+});
+
+Deno.test("readBaseBranchSha reads the first parent of a merge checkout", async () => {
+  const commit = [
+    "tree 1111111111111111111111111111111111111111",
+    `parent ${SHA_A}`,
+    `parent ${SHA_B}`,
+    "author CI <ci@example.com> 1780000000 +0000",
+    "",
+    `parent ${SHA_C} looks like a header but is message text`,
+  ].join("\n");
+
+  assertEquals(await readBaseBranchSha(() => Promise.resolve(commit)), SHA_A);
+});
+
+Deno.test("readBaseBranchSha reports no base for a non-merge checkout", async () => {
+  const commit = [
+    "tree 1111111111111111111111111111111111111111",
+    `parent ${SHA_A}`,
+    "",
+    "a push run checks out the commit itself",
+  ].join("\n");
+
+  assertEquals(await readBaseBranchSha(() => Promise.resolve(commit)), null);
+  assertEquals(await readBaseBranchSha(() => Promise.resolve(null)), null);
+});
+
+function makeBaselineSample(
+  runId: number,
+  sha: string,
+  createdAt: string,
+  uncoveredLines: number,
+): TimingSample {
+  return {
+    runId,
+    runUrl: `https://github.com/commontoolsinc/labs/actions/runs/${runId}`,
+    sha,
+    createdAt,
+    durationSeconds: uncoveredLines,
+  };
+}
+
+const NEVER_COLD = () => false;
+
+/** Ancestry of base-branch commit `SHA_C`, newest first. */
+const RANKS = new Map([[SHA_C, 0], [SHA_B, 1], [SHA_A, 2]]);
+
+Deno.test("nearestUsableBaseline prefers the base-branch commit's own run", () => {
+  const samples = [
+    makeBaselineSample(1, SHA_A, "2026-08-04T10:00:00Z", 5740),
+    makeBaselineSample(2, SHA_B, "2026-08-04T10:20:00Z", 5746),
+    makeBaselineSample(3, SHA_C, "2026-08-04T10:40:00Z", 5760),
+  ];
+
+  assertEquals(
+    nearestUsableBaseline(samples, NEVER_COLD, RANKS)?.durationSeconds,
+    5760,
+  );
+});
+
+Deno.test("nearestUsableBaseline falls back to the nearest ancestor with a run", () => {
+  // Nothing has measured SHA_C, the base-branch commit, so its parent stands
+  // in rather than the gate giving up.
+  const samples = [
+    makeBaselineSample(1, SHA_A, "2026-08-04T10:00:00Z", 5740),
+    makeBaselineSample(2, SHA_B, "2026-08-04T10:20:00Z", 5746),
+  ];
+
+  assertEquals(
+    nearestUsableBaseline(samples, NEVER_COLD, RANKS)?.durationSeconds,
+    5746,
+  );
+});
+
+Deno.test("nearestUsableBaseline ignores a run that is not an ancestor", () => {
+  const sibling = "dddddddddddddddddddddddddddddddddddddddd";
+  const samples = [
+    makeBaselineSample(1, SHA_B, "2026-08-04T10:20:00Z", 5746),
+    // Landed after this run started, so it measured code the run lacks.
+    makeBaselineSample(2, sibling, "2026-08-04T10:50:00Z", 5700),
+  ];
+
+  assertEquals(
+    nearestUsableBaseline(samples, NEVER_COLD, RANKS)?.durationSeconds,
+    5746,
+  );
+});
+
+Deno.test("nearestUsableBaseline skips a cold ancestor for a warm one", () => {
+  const samples = [
+    makeBaselineSample(1, SHA_A, "2026-08-04T10:00:00Z", 5740),
+    makeBaselineSample(2, SHA_B, "2026-08-04T10:20:00Z", 5600),
+  ];
+
+  assertEquals(
+    nearestUsableBaseline(samples, (runId) => runId === 2, RANKS)
+      ?.durationSeconds,
+    5740,
+  );
+});
+
+Deno.test("nearestUsableBaseline takes a cold ancestor when every ancestor is cold", () => {
+  const samples = [makeBaselineSample(2, SHA_B, "2026-08-04T10:20:00Z", 5600)];
+
+  assertEquals(
+    nearestUsableBaseline(samples, () => true, RANKS)?.durationSeconds,
+    5600,
+  );
+});
+
+Deno.test("nearestUsableBaseline falls back to the latest run without ancestry", () => {
+  const samples = [
+    makeBaselineSample(1, SHA_A, "2026-08-04T10:00:00Z", 5740),
+    makeBaselineSample(2, SHA_B, "2026-08-04T10:20:00Z", 5746),
+  ];
+
+  assertEquals(
+    nearestUsableBaseline(samples, NEVER_COLD, null)?.durationSeconds,
+    5746,
+  );
+  assertEquals(nearestUsableBaseline([], NEVER_COLD, RANKS), undefined);
+});
+
+Deno.test("fetchAncestorRanks ranks commits by distance from the base", async () => {
+  const ranks = await withMockFetch(
+    (input) => {
+      assertStringIncludes(String(input), `/commits?sha=${SHA_C}`);
+      return new Response(
+        JSON.stringify([{ sha: SHA_C }, { sha: SHA_B }, { sha: SHA_A }]),
+      );
+    },
+    () => fetchAncestorRanks(SHA_C),
+  );
+
+  assertEquals([...ranks], [[SHA_C, 0], [SHA_B, 1], [SHA_A, 2]]);
+});
+
+Deno.test("fetchGroupsChangedOnBase reports the groups the base branch moved", async () => {
+  const groups = await withMockFetch(
+    (input) => {
+      assertStringIncludes(String(input), `/compare/${SHA_A}...${SHA_C}`);
+      return new Response(JSON.stringify({
+        files: [
+          { filename: "packages/runner/src/runner.ts" },
+          { filename: "packages/runner/test/runner.test.ts" },
+          { filename: "docs/development/COVERAGE.md" },
+        ],
+      }));
+    },
+    () => fetchGroupsChangedOnBase(SHA_A, SHA_C),
+  );
+
+  assertEquals([...groups], ["packages/runner"]);
+});
+
+Deno.test("fetchGroupsChangedOnBase compares nothing against the base itself", async () => {
+  const groups = await withMockFetch(
+    () => {
+      throw new Error("must not compare a commit against itself");
+    },
+    () => fetchGroupsChangedOnBase(SHA_C, SHA_C),
+  );
+
+  assertEquals(groups.size, 0);
+});
+
+Deno.test("isComparableBaseline withholds only the groups the base branch moved", () => {
+  const sample = makeBaselineSample(1, SHA_A, "2026-08-04T10:00:00Z", 5740);
+  const runner = "coverage-debt: packages/runner uncovered lines";
+  const memory = "coverage-debt: packages/memory uncovered lines";
+  const moved = new Set(["packages/runner"]);
+
+  assertEquals(isComparableBaseline(sample, runner, moved, true), false);
+  assertEquals(isComparableBaseline(sample, memory, moved, true), true);
+  assertEquals(isComparableBaseline(sample, runner, new Set(), true), true);
+  assertEquals(isComparableBaseline(undefined, memory, new Set(), true), false);
+
+  // A main push run has no base-branch commit and only reports.
+  assertEquals(isComparableBaseline(sample, runner, moved, false), true);
 });

--- a/tasks/coverage-check.test.ts
+++ b/tasks/coverage-check.test.ts
@@ -18,6 +18,7 @@ import {
   addCoverageBaselineFromArtifacts,
   type BaselineRunContext,
   buildBaselineRunContexts,
+  buildCoverageRows,
   collectCurrentCacheStates,
   copyCoverageArtifactFiles,
   currentWorkflowRunFromEvent,
@@ -49,10 +50,15 @@ import {
   parseMergedBaselineOverrides,
   printMetricTable,
   readBaseBranchSha,
+  readHeadCommitObject,
   reportBaselineContextResults,
+  reportBaselineDistance,
   reportBaselineRunAvailability,
   reportPRLookupResults,
+  reportUngatedGroups,
+  resolveMetricBaselines,
   type Row,
+  selectBaselines,
   selectMergedPRForCommit,
   summarizeBaselinePRLookups,
   validateBaselineRunsForMainHead,
@@ -1665,17 +1671,530 @@ Deno.test("fetchGroupsChangedOnBase compares nothing against the base itself", a
   assertEquals(groups.size, 0);
 });
 
+const RUNNER_METRIC = "coverage-debt: packages/runner uncovered lines";
+const MEMORY_METRIC = "coverage-debt: packages/memory uncovered lines";
+
 Deno.test("isComparableBaseline withholds only the groups the base branch moved", () => {
   const sample = makeBaselineSample(1, SHA_A, "2026-08-04T10:00:00Z", 5740);
-  const runner = "coverage-debt: packages/runner uncovered lines";
-  const memory = "coverage-debt: packages/memory uncovered lines";
-  const moved = new Set(["packages/runner"]);
+  const moved = new Map([[SHA_A, new Set(["packages/runner"])]]);
+  const at = (metric: string, sha: string | null = SHA_C) =>
+    isComparableBaseline({
+      sample,
+      metric,
+      baseSha: sha,
+      groupsChangedByBaseline: moved,
+      isPullRequest: true,
+    });
 
-  assertEquals(isComparableBaseline(sample, runner, moved, true), false);
-  assertEquals(isComparableBaseline(sample, memory, moved, true), true);
-  assertEquals(isComparableBaseline(sample, runner, new Set(), true), true);
-  assertEquals(isComparableBaseline(undefined, memory, new Set(), true), false);
+  assertEquals(at(RUNNER_METRIC), false);
+  assertEquals(at(MEMORY_METRIC), true);
+
+  // No base-branch commit means no ancestry, so the baseline is whatever ran
+  // last and nothing may be gated against it.
+  assertEquals(at(MEMORY_METRIC, null), false);
+
+  assertEquals(
+    isComparableBaseline({
+      sample: undefined,
+      metric: MEMORY_METRIC,
+      baseSha: SHA_C,
+      groupsChangedByBaseline: moved,
+      isPullRequest: true,
+    }),
+    false,
+  );
 
   // A main push run has no base-branch commit and only reports.
-  assertEquals(isComparableBaseline(sample, runner, moved, false), true);
+  assertEquals(
+    isComparableBaseline({
+      sample,
+      metric: RUNNER_METRIC,
+      baseSha: null,
+      groupsChangedByBaseline: moved,
+      isPullRequest: false,
+    }),
+    true,
+  );
+});
+
+Deno.test("isComparableBaseline reads the moved groups of its own baseline", () => {
+  const atBase = makeBaselineSample(2, SHA_C, "2026-08-04T10:40:00Z", 5746);
+  const older = makeBaselineSample(1, SHA_A, "2026-08-04T10:00:00Z", 5740);
+  // The base branch moved packages/runner since SHA_A but not since SHA_C, so
+  // a metric baselined at SHA_C stays gated.
+  const moved = new Map([
+    [SHA_A, new Set(["packages/runner"])],
+    [SHA_C, new Set<string>()],
+  ]);
+  const at = (sample: TimingSample) =>
+    isComparableBaseline({
+      sample,
+      metric: RUNNER_METRIC,
+      baseSha: SHA_C,
+      groupsChangedByBaseline: moved,
+      isPullRequest: true,
+    });
+
+  assertEquals(at(atBase), true);
+  assertEquals(at(older), false);
+});
+
+Deno.test("resolveMetricBaselines picks a baseline and its gating for each metric", () => {
+  const timelines = new Map([
+    [RUNNER_METRIC, {
+      name: RUNNER_METRIC,
+      samples: [
+        makeBaselineSample(1, SHA_A, "2026-08-04T10:00:00Z", 5740),
+        makeBaselineSample(3, SHA_C, "2026-08-04T10:40:00Z", 5746),
+      ],
+    }],
+    // Only an older run measured this metric, and the base branch moved its
+    // group since, so it is reported and not gated.
+    [MEMORY_METRIC, {
+      name: MEMORY_METRIC,
+      samples: [makeBaselineSample(1, SHA_A, "2026-08-04T10:00:00Z", 400)],
+    }],
+  ]);
+
+  const resolved = resolveMetricBaselines({
+    metrics: [
+      RUNNER_METRIC,
+      MEMORY_METRIC,
+      "coverage-debt: gone uncovered lines",
+    ],
+    timelines,
+    isRunCold: NEVER_COLD,
+    ancestorRank: RANKS,
+    groupsChangedByBaseline: new Map([
+      [SHA_A, new Set(["packages/memory"])],
+      [SHA_C, new Set<string>()],
+    ]),
+    baseSha: SHA_C,
+    isPullRequest: true,
+  });
+
+  assertEquals(resolved.get(RUNNER_METRIC)?.sample?.durationSeconds, 5746);
+  assertEquals(resolved.get(RUNNER_METRIC)?.comparable, true);
+  assertEquals(resolved.get(MEMORY_METRIC)?.sample?.durationSeconds, 400);
+  assertEquals(resolved.get(MEMORY_METRIC)?.comparable, false);
+
+  // A metric with no timeline at all has nothing to be gated against.
+  const missing = resolved.get("coverage-debt: gone uncovered lines");
+  assertEquals(missing?.sample, undefined);
+  assertEquals(missing?.comparable, false);
+});
+
+Deno.test("reportBaselineDistance names each baseline and its distance", () => {
+  const captured = captureConsole(() =>
+    reportBaselineDistance(
+      new Set([SHA_C, SHA_A]),
+      SHA_C,
+      RANKS,
+      (message) => console.log(message),
+    )
+  );
+
+  const logs = captured.logs.join("\n");
+  assertStringIncludes(
+    logs,
+    `measured at the base-branch commit: ${SHA_C.slice(0, 8)}`,
+  );
+  assertStringIncludes(
+    logs,
+    `measured 2 commits before the base-branch commit: ${SHA_A.slice(0, 8)}`,
+  );
+});
+
+Deno.test("reportBaselineDistance reports an ancestry it could not read", () => {
+  const unknown = captureConsole(() =>
+    reportBaselineDistance(new Set([SHA_A]), SHA_C, null, (m) => console.log(m))
+  );
+  assertStringIncludes(
+    unknown.logs.join("\n"),
+    "at an unknown distance from the base-branch commit",
+  );
+
+  const none = captureConsole(() =>
+    reportBaselineDistance(new Set(), SHA_C, RANKS, (m) => console.log(m))
+  );
+  assertStringIncludes(
+    none.logs.join("\n"),
+    `No \`main\` run has measured base-branch commit ${SHA_C.slice(0, 8)}`,
+  );
+});
+
+function timelineOf(metric: string, samples: TimingSample[]) {
+  return { name: metric, samples };
+}
+
+Deno.test("selectBaselines chooses each metric's baseline against the base commit", async () => {
+  const timelines = new Map([
+    [
+      RUNNER_METRIC,
+      timelineOf(RUNNER_METRIC, [
+        makeBaselineSample(1, SHA_A, "2026-08-04T10:00:00Z", 5740),
+        makeBaselineSample(3, SHA_C, "2026-08-04T10:40:00Z", 5746),
+      ]),
+    ],
+  ]);
+  const compared: string[] = [];
+
+  const captured = await captureConsoleAsync(() =>
+    selectBaselines({
+      metrics: [RUNNER_METRIC],
+      timelines,
+      isRunCold: NEVER_COLD,
+      isPullRequest: true,
+      readBaseSha: () => Promise.resolve(SHA_C),
+      fetchRanks: (baseSha) => {
+        assertEquals(baseSha, SHA_C);
+        return Promise.resolve(RANKS);
+      },
+      fetchChangedGroups: (baselineSha, baseSha) => {
+        compared.push(`${baselineSha}...${baseSha}`);
+        return Promise.resolve(new Set<string>());
+      },
+    })
+  );
+
+  assertEquals(
+    captured.result.get(RUNNER_METRIC)?.sample?.durationSeconds,
+    5746,
+  );
+  assertEquals(captured.result.get(RUNNER_METRIC)?.comparable, true);
+  // Only the baseline actually chosen is compared against the base commit.
+  assertEquals(compared, [`${SHA_C}...${SHA_C}`]);
+  assertStringIncludes(
+    captured.logs.join("\n"),
+    `merges the pull request into base-branch commit ${SHA_C.slice(0, 8)}`,
+  );
+});
+
+Deno.test("selectBaselines gates nothing when the base commit cannot be read", async () => {
+  const timelines = new Map([
+    [
+      RUNNER_METRIC,
+      timelineOf(RUNNER_METRIC, [
+        makeBaselineSample(1, SHA_A, "2026-08-04T10:00:00Z", 5740),
+      ]),
+    ],
+  ]);
+
+  const captured = await captureConsoleAsync(() =>
+    selectBaselines({
+      metrics: [RUNNER_METRIC],
+      timelines,
+      isRunCold: NEVER_COLD,
+      isPullRequest: true,
+      readBaseSha: () => Promise.resolve(null),
+      fetchRanks: () => {
+        throw new Error("must not rank an ancestry it has no base for");
+      },
+      fetchChangedGroups: () => {
+        throw new Error("must not compare without a base commit");
+      },
+    })
+  );
+
+  // The fallback still names a sample, but nothing may be failed against it.
+  assertEquals(
+    captured.result.get(RUNNER_METRIC)?.sample?.durationSeconds,
+    5740,
+  );
+  assertEquals(captured.result.get(RUNNER_METRIC)?.comparable, false);
+  assertStringIncludes(
+    captured.warnings.join("\n"),
+    "could not read the base-branch commit",
+  );
+});
+
+Deno.test("selectBaselines reports against whatever it has for a push run", async () => {
+  const timelines = new Map([
+    [
+      RUNNER_METRIC,
+      timelineOf(RUNNER_METRIC, [
+        makeBaselineSample(1, SHA_A, "2026-08-04T10:00:00Z", 5740),
+      ]),
+    ],
+  ]);
+
+  const resolved = await selectBaselines({
+    metrics: [RUNNER_METRIC],
+    timelines,
+    isRunCold: NEVER_COLD,
+    isPullRequest: false,
+    readBaseSha: () => {
+      throw new Error("a push run has no base-branch commit to read");
+    },
+    log: () => {},
+    warn: () => {},
+  });
+
+  assertEquals(resolved.get(RUNNER_METRIC)?.comparable, true);
+});
+
+Deno.test("reportUngatedGroups names the groups it withheld", () => {
+  const captured = captureConsole(() =>
+    reportUngatedGroups(
+      new Set(["packages/runner", "packages/memory"]),
+      (message) => console.log(message),
+    )
+  );
+  assertStringIncludes(
+    captured.logs.join("\n"),
+    "packages/memory, packages/runner",
+  );
+
+  const quiet = captureConsole(() =>
+    reportUngatedGroups(new Set(), (message) => console.log(message))
+  );
+  assertEquals(quiet.logs, []);
+});
+
+Deno.test("readHeadCommitObject returns the commit object of a checkout", async () => {
+  const commit = await readHeadCommitObject();
+  assert(commit !== null);
+  assertStringIncludes(commit, "tree ");
+});
+
+Deno.test("readHeadCommitObject returns null outside a checkout", async () => {
+  const outside = await Deno.makeTempDir({ prefix: "coverage-no-repo-" });
+  try {
+    const captured = await captureConsoleAsync(() =>
+      readHeadCommitObject(outside)
+    );
+    assertEquals(captured.result, null);
+    assertStringIncludes(
+      captured.warnings.join("\n"),
+      "could not read the `HEAD` commit object",
+    );
+  } finally {
+    await Deno.remove(outside, { recursive: true });
+  }
+});
+
+Deno.test("fetchGroupsChangedOnBase warns when the compare response is capped", async () => {
+  const files = Array.from({ length: 300 }, (_, index) => ({
+    filename: `packages/runner/src/file-${index}.ts`,
+  }));
+  const warnings: string[] = [];
+
+  const groups = await withMockFetch(
+    () => new Response(JSON.stringify({ files })),
+    () =>
+      fetchGroupsChangedOnBase(SHA_A, SHA_C, (message) => {
+        warnings.push(message);
+      }),
+  );
+
+  assertEquals([...groups], ["packages/runner"]);
+  assertStringIncludes(warnings.join("\n"), "300-file response cap");
+});
+
+Deno.test("isComparableBaseline gates a metric that names no coverage group", () => {
+  assertEquals(
+    isComparableBaseline({
+      sample: makeBaselineSample(1, SHA_A, "2026-08-04T10:00:00Z", 1),
+      metric: "some-other-metric",
+      baseSha: SHA_C,
+      groupsChangedByBaseline: new Map(),
+      isPullRequest: true,
+    }),
+    true,
+  );
+});
+
+Deno.test("readHeadCommitObject returns null when git cannot be run", async () => {
+  const captured = await captureConsoleAsync(() =>
+    readHeadCommitObject("/coverage-check-no-such-directory")
+  );
+
+  assertEquals(captured.result, null);
+  assertStringIncludes(
+    captured.warnings.join("\n"),
+    "could not run `git` to read the `HEAD` commit object",
+  );
+});
+
+Deno.test("selectBaselines routes its GitHub calls through the guard", async () => {
+  const guarded: string[] = [];
+
+  await selectBaselines({
+    metrics: [RUNNER_METRIC],
+    timelines: new Map([
+      [
+        RUNNER_METRIC,
+        timelineOf(RUNNER_METRIC, [
+          makeBaselineSample(1, SHA_C, "2026-08-04T10:40:00Z", 5746),
+        ]),
+      ],
+    ]),
+    isRunCold: NEVER_COLD,
+    isPullRequest: true,
+    readBaseSha: () => Promise.resolve(SHA_C),
+    fetchRanks: () => Promise.resolve(RANKS),
+    fetchChangedGroups: () => Promise.resolve(new Set<string>()),
+    guard: (description, operation) => {
+      guarded.push(description);
+      return operation();
+    },
+    log: () => {},
+  });
+
+  assertEquals(guarded, [
+    "listing the base-branch commit's ancestry",
+    "comparing the baseline commit against the base-branch commit",
+  ]);
+});
+
+const NO_OVERRIDES = { metrics: new Map(), coverageBaselineReset: false };
+
+function rowsFor(
+  metrics: Record<string, number>,
+  baselines: Record<string, { value?: number; comparable: boolean }>,
+  extra: Partial<Parameters<typeof buildCoverageRows>[0]> = {},
+) {
+  const currentMetrics = new Map(
+    Object.entries(metrics).map(([metric, value]) => [
+      metric,
+      makeBaselineSample(9, SHA_C, "2026-08-04T11:00:00Z", value),
+    ]),
+  );
+  const baselineByMetric = new Map(
+    Object.entries(baselines).map(([metric, spec]) => [metric, {
+      sample: spec.value === undefined
+        ? undefined
+        : makeBaselineSample(1, SHA_A, "2026-08-04T10:00:00Z", spec.value),
+      comparable: spec.comparable,
+    }]),
+  );
+  return buildCoverageRows({
+    currentMetrics,
+    timelines: new Map(),
+    baselineByMetric,
+    overrides: NO_OVERRIDES,
+    changedCoverageGroups: new Set(["packages/runner", "packages/memory"]),
+    ...extra,
+  });
+}
+
+Deno.test("buildCoverageRows fails a gated group above its baseline", () => {
+  const { rows, failures } = rowsFor(
+    { [RUNNER_METRIC]: 5747 },
+    { [RUNNER_METRIC]: { value: 5746, comparable: true } },
+  );
+
+  assertEquals(rows[0].status, "OVER");
+  assertEquals(rows[0].median, 5746);
+  assertEquals(rows[0].baselineSha, SHA_A);
+  assertEquals(failures.length, 1);
+});
+
+Deno.test("buildCoverageRows passes a gated group at its baseline", () => {
+  const { rows, failures } = rowsFor(
+    { [RUNNER_METRIC]: 5746 },
+    { [RUNNER_METRIC]: { value: 5746, comparable: true } },
+  );
+
+  assertEquals(rows[0].status, "OK");
+  assertEquals(failures, []);
+});
+
+Deno.test("buildCoverageRows reports an incomparable baseline without failing it", () => {
+  const { rows, failures, ungatedGroups } = rowsFor(
+    { [RUNNER_METRIC]: 9999 },
+    { [RUNNER_METRIC]: { value: 5746, comparable: false } },
+  );
+
+  assertEquals(rows[0].status, "excl");
+  assertEquals(rows[0].median, 5746);
+  assertEquals(failures, []);
+  assertEquals([...ungatedGroups], ["packages/runner"]);
+});
+
+Deno.test("buildCoverageRows leaves a group the PR did not change alone", () => {
+  const other = "coverage-debt: packages/toolshed uncovered lines";
+  const { rows, failures, ungatedGroups } = rowsFor(
+    { [other]: 9999 },
+    { [other]: { value: 10, comparable: true } },
+  );
+
+  assertEquals(rows[0].status, "excl");
+  assertEquals(failures, []);
+  // Comparable, so nothing is withheld for want of a baseline.
+  assertEquals([...ungatedGroups], []);
+});
+
+Deno.test("buildCoverageRows honors a per-metric acceptance and a reset", () => {
+  const accepted = rowsFor(
+    { [RUNNER_METRIC]: 5800 },
+    { [RUNNER_METRIC]: { value: 5746, comparable: true } },
+    {
+      overrides: {
+        metrics: new Map([[RUNNER_METRIC, 5800]]),
+        coverageBaselineReset: false,
+      },
+    },
+  );
+  assertEquals(accepted.rows[0].status, "ovrd");
+  assertEquals(accepted.failures, []);
+
+  const reset = rowsFor(
+    { [RUNNER_METRIC]: 5800 },
+    { [RUNNER_METRIC]: { value: 5746, comparable: true } },
+    {
+      overrides: { metrics: new Map(), coverageBaselineReset: true },
+    },
+  );
+  assertEquals(reset.rows[0].status, "ovrd");
+  assertEquals(reset.failures, []);
+});
+
+Deno.test("buildCoverageRows bootstraps a metric with no baseline", () => {
+  const fresh = rowsFor(
+    { [RUNNER_METRIC]: 12 },
+    { [RUNNER_METRIC]: { comparable: true } },
+  );
+  assertEquals(fresh.rows[0].status, "OVER");
+  assertEquals(fresh.rows[0].median, 0);
+  assertEquals(fresh.failures.length, 1);
+
+  const empty = rowsFor(
+    { [RUNNER_METRIC]: 0 },
+    { [RUNNER_METRIC]: { comparable: true } },
+  );
+  assertEquals(empty.rows[0].status, "n/a");
+  assertEquals(empty.failures, []);
+
+  // With no baseline and nothing gating it, the metric is only reported.
+  const ungated = rowsFor(
+    { [RUNNER_METRIC]: 12 },
+    { [RUNNER_METRIC]: { comparable: false } },
+  );
+  assertEquals(ungated.rows[0].status, "excl");
+  assertEquals(ungated.failures, []);
+
+  // A reset accepts a metric that has no baseline yet.
+  const reset = rowsFor(
+    { [RUNNER_METRIC]: 12 },
+    { [RUNNER_METRIC]: { comparable: true } },
+    { overrides: { metrics: new Map(), coverageBaselineReset: true } },
+  );
+  assertEquals(reset.rows[0].status, "ovrd");
+});
+
+Deno.test("buildCoverageRows reports a rise from a zero baseline as complete", () => {
+  const { rows } = rowsFor(
+    { [RUNNER_METRIC]: 4 },
+    { [RUNNER_METRIC]: { value: 0, comparable: true } },
+  );
+  assertEquals(rows[0].status, "OVER");
+  assertEquals(rows[0].pctIncrease, 100);
+
+  const held = rowsFor(
+    { [RUNNER_METRIC]: 0 },
+    { [RUNNER_METRIC]: { value: 0, comparable: true } },
+  );
+  assertEquals(held.rows[0].status, "OK");
+  assertEquals(held.rows[0].pctIncrease, 0);
 });

--- a/tasks/coverage-check.ts
+++ b/tasks/coverage-check.ts
@@ -278,10 +278,13 @@ interface GitHubCompareResponse {
   ahead_by?: unknown;
 }
 
-async function readHeadCommitObject(): Promise<string | null> {
+export async function readHeadCommitObject(
+  cwd?: string,
+): Promise<string | null> {
   try {
     const result = await new Deno.Command("git", {
       args: ["cat-file", "commit", "HEAD"],
+      cwd,
       stdout: "piped",
       stderr: "piped",
     }).output();
@@ -458,30 +461,195 @@ export async function fetchGroupsChangedOnBase(
  * Returns whether a metric's baseline can be held against this run.
  *
  * The two numbers must count the same base-branch code, or the difference
- * between them is not the pull request's. A group the base branch changed
- * between the baseline commit and the base-branch commit fails that, and so
- * does a metric with no baseline at all; both are reported and not gated.
+ * between them is not the pull request's. Three things break that, and each
+ * leaves the metric reported and not gated:
+ *
+ * - No base-branch commit. Without one there is no ancestry to select against,
+ *   so the baseline is whatever ran most recently and counts unrelated code.
+ * - No baseline at all for the metric.
+ * - A group the base branch changed between this metric's own baseline commit
+ *   and the base-branch commit. The lookup is keyed by that commit, so a metric
+ *   whose baseline is the base-branch commit itself stays gated even when
+ *   another metric fell back to an older one.
  *
  * A `main` push run has no base-branch commit and is informational, so it
  * reports against whatever baseline it has.
  */
 export function isComparableBaseline(
-  sample: TimingSample | undefined,
-  metric: string,
-  groupsChangedOnBase: Set<string>,
-  isPullRequest: boolean,
+  options: {
+    sample: TimingSample | undefined;
+    metric: string;
+    baseSha: string | null;
+    groupsChangedByBaseline: Map<string, Set<string>>;
+    isPullRequest: boolean;
+  },
 ): boolean {
-  if (!isPullRequest) return true;
-  if (sample === undefined) return false;
+  if (!options.isPullRequest) return true;
+  if (options.baseSha === null || options.sample === undefined) return false;
 
-  const group = coverageMetricGroupName(metric);
-  return group === null || !groupsChangedOnBase.has(group);
+  const group = coverageMetricGroupName(options.metric);
+  if (group === null) return true;
+
+  const moved = options.groupsChangedByBaseline.get(options.sample.sha);
+  return !moved?.has(group);
+}
+
+export interface MetricBaseline {
+  sample?: TimingSample;
+  /** Whether the ratchet may fail this metric against that sample. */
+  comparable: boolean;
+}
+
+export interface ResolveMetricBaselinesOptions {
+  metrics: Iterable<string>;
+  timelines: Map<string, MetricTimeline>;
+  isRunCold: (runId: number) => boolean;
+  ancestorRank: Map<string, number> | null;
+  groupsChangedByBaseline: Map<string, Set<string>>;
+  baseSha: string | null;
+  isPullRequest: boolean;
+}
+
+export interface SelectBaselinesOptions {
+  metrics: Iterable<string>;
+  timelines: Map<string, MetricTimeline>;
+  isRunCold: (runId: number) => boolean;
+  isPullRequest: boolean;
+  readBaseSha?: () => Promise<string | null>;
+  fetchRanks?: (baseSha: string) => Promise<Map<string, number>>;
+  fetchChangedGroups?: (
+    baselineSha: string,
+    baseSha: string,
+  ) => Promise<Set<string>>;
+  /** Wraps each GitHub call so a rate limit skips the check (see main). */
+  guard?: <T>(description: string, operation: () => Promise<T>) => Promise<T>;
+  log?: (message: string) => void;
+  warn?: (message: string) => void;
+}
+
+/**
+ * Chooses every metric's ratchet baseline against the base-branch commit this
+ * run merged, and reports what it chose.
+ *
+ * Reads the base-branch commit, ranks its ancestry, asks which coverage groups
+ * the base branch moved since each baseline the metrics would take, and hands
+ * the answers to `resolveMetricBaselines()`.
+ */
+export async function selectBaselines(
+  options: SelectBaselinesOptions,
+): Promise<Map<string, MetricBaseline>> {
+  const log = options.log ?? console.log;
+  const warn = options.warn ?? console.warn;
+  const readBaseSha = options.readBaseSha ?? readBaseBranchSha;
+  const fetchRanks = options.fetchRanks ?? fetchAncestorRanks;
+  const fetchChangedGroups = options.fetchChangedGroups ??
+    fetchGroupsChangedOnBase;
+  const guard = options.guard ?? ((_description, operation) => operation());
+
+  const baseSha = options.isPullRequest ? await readBaseSha() : null;
+  if (options.isPullRequest && baseSha === null) {
+    warn(
+      "  Warning: could not read the base-branch commit this run merges " +
+        "into; coverage debt metrics will be reported but not gated.",
+    );
+  } else if (baseSha !== null) {
+    log(
+      `This run merges the pull request into base-branch commit ${
+        baseSha.slice(0, 8)
+      }.`,
+    );
+  }
+
+  const ancestorRank = baseSha === null ? null : await guard(
+    "listing the base-branch commit's ancestry",
+    () => fetchRanks(baseSha),
+  );
+
+  // Which baseline each metric would take, before asking what moved since.
+  const candidateShas = new Set<string>();
+  for (const metric of options.metrics) {
+    const timeline = options.timelines.get(metric);
+    const sample = timeline
+      ? nearestUsableBaseline(timeline.samples, options.isRunCold, ancestorRank)
+      : undefined;
+    if (sample) candidateShas.add(sample.sha);
+  }
+
+  const groupsChangedByBaseline = new Map<string, Set<string>>();
+  if (baseSha !== null) {
+    for (const sha of candidateShas) {
+      groupsChangedByBaseline.set(
+        sha,
+        await guard(
+          "comparing the baseline commit against the base-branch commit",
+          () => fetchChangedGroups(sha, baseSha),
+        ),
+      );
+    }
+    reportBaselineDistance(candidateShas, baseSha, ancestorRank, log);
+  }
+
+  return resolveMetricBaselines({
+    metrics: options.metrics,
+    timelines: options.timelines,
+    isRunCold: options.isRunCold,
+    ancestorRank,
+    groupsChangedByBaseline,
+    baseSha,
+    isPullRequest: options.isPullRequest,
+  });
+}
+
+/** Picks each metric's baseline and says whether the ratchet may act on it. */
+export function resolveMetricBaselines(
+  options: ResolveMetricBaselinesOptions,
+): Map<string, MetricBaseline> {
+  const resolved = new Map<string, MetricBaseline>();
+
+  for (const metric of options.metrics) {
+    const timeline = options.timelines.get(metric);
+    const sample = timeline
+      ? nearestUsableBaseline(
+        timeline.samples,
+        options.isRunCold,
+        options.ancestorRank,
+      )
+      : undefined;
+
+    resolved.set(metric, {
+      sample,
+      comparable: isComparableBaseline({
+        sample,
+        metric,
+        baseSha: options.baseSha,
+        groupsChangedByBaseline: options.groupsChangedByBaseline,
+        isPullRequest: options.isPullRequest,
+      }),
+    });
+  }
+
+  return resolved;
 }
 
 /**
  * Reports which commit each baseline was measured at, and how far back from the
  * base-branch commit that sits.
  */
+/** Names the groups no baseline could speak to, and why they are not gated. */
+export function reportUngatedGroups(
+  groups: Set<string>,
+  log: (message: string) => void = console.log,
+): void {
+  if (groups.size === 0) return;
+
+  log(
+    "\nNot gated, because no baseline counts the same base-branch code as " +
+      `this run does: ${[...groups].sort().join(", ")}. A later run of this ` +
+      "pull request gates them, once a `main` run has measured the commit it " +
+      "merges.",
+  );
+}
+
 export function reportBaselineDistance(
   baselineShas: Set<string>,
   baseSha: string,
@@ -1106,6 +1274,114 @@ export function metricTableRows(
   });
 }
 
+export interface BuildCoverageRowsOptions {
+  currentMetrics: Map<string, TimingSample>;
+  timelines: Map<string, MetricTimeline>;
+  baselineByMetric: Map<string, MetricBaseline>;
+  overrides: BaselineOverrides;
+  /** Undefined when the PR's changed files could not be read. */
+  changedCoverageGroups: Set<string> | undefined;
+}
+
+export interface CoverageRows {
+  rows: Row[];
+  /** The subset of `rows` that fails the gate. */
+  failures: Row[];
+  /** Groups whose baseline could not be held against this run. */
+  ungatedGroups: Set<string>;
+}
+
+/**
+ * Scores every metric against its baseline and says which ones fail.
+ *
+ * A metric is failed only when it is gated and its count rose above the
+ * baseline. It is not gated when the pull request left its group alone, when
+ * the description accepts its level, or when no baseline counts the same
+ * base-branch code as this run.
+ */
+export function buildCoverageRows(
+  options: BuildCoverageRowsOptions,
+): CoverageRows {
+  const rows: Row[] = [];
+  const failures: Row[] = [];
+  const ungatedGroups = new Set<string>();
+
+  for (const [metric, currentSample] of options.currentMetrics) {
+    const current = currentSample.durationSeconds;
+    const n = options.timelines.get(metric)?.samples.length ?? 0;
+    const resolvedBaseline = options.baselineByMetric.get(metric);
+    const baselineSample = resolvedBaseline?.sample;
+    const latestBaseline = baselineSample?.durationSeconds;
+    const override = options.overrides.metrics.get(metric);
+    const coverageReset = options.overrides.coverageBaselineReset;
+    const comparable = resolvedBaseline?.comparable ?? false;
+    if (!comparable) {
+      const group = coverageMetricGroupName(metric);
+      if (group !== null) ungatedGroups.add(group);
+    }
+    const shouldGateCoverage = comparable &&
+      shouldGateCoverageDebtMetric(metric, options.changedCoverageGroups);
+
+    if (latestBaseline === undefined) {
+      if (
+        coverageReset || (override !== undefined && current <= override)
+      ) {
+        rows.push({ metric, status: "ovrd", current, n });
+      } else if (!shouldGateCoverage) {
+        rows.push({ metric, status: "excl", current, n });
+      } else if (current > 0) {
+        const row: Row = {
+          metric,
+          status: "OVER",
+          current,
+          median: 0,
+          n,
+          pctIncrease: 100,
+        };
+        rows.push(row);
+        failures.push(row);
+      } else {
+        rows.push({ metric, status: "n/a", current, n });
+      }
+      continue;
+    }
+
+    const pctIncrease = latestBaseline === 0
+      ? current > 0 ? 100 : 0
+      : ((current - latestBaseline) / latestBaseline) * 100;
+    const stats = {
+      median: latestBaseline,
+      baselineSha: baselineSample?.sha,
+      pctIncrease,
+    };
+
+    if (coverageReset) {
+      rows.push({ metric, status: "ovrd", current, n, ...stats });
+      continue;
+    }
+
+    if (override !== undefined && current <= override) {
+      rows.push({ metric, status: "ovrd", current, n, ...stats });
+      continue;
+    }
+
+    if (!shouldGateCoverage) {
+      rows.push({ metric, status: "excl", current, n, ...stats });
+      continue;
+    }
+
+    if (current > latestBaseline) {
+      const row: Row = { metric, status: "OVER", current, n, ...stats };
+      rows.push(row);
+      failures.push(row);
+    } else {
+      rows.push({ metric, status: "OK", current, n, ...stats });
+    }
+  }
+
+  return { rows, failures, ungatedGroups };
+}
+
 export function printMetricTable(rows: Row[], includeStatus = false): void {
   const headers = includeStatus
     ? ["Status", "Baseline", "Current", "Change", "Task", "Metric"]
@@ -1670,156 +1946,24 @@ export async function main() {
 
   // 5. Compare the current run's coverage debt against the ratchet baseline.
 
-  // The base-branch commit this run's tree merges the pull request into. Its
-  // ancestry decides which main run is the baseline, so that the baseline and
-  // this run count the same base-branch code.
-  const baseSha = prNumber ? await readBaseBranchSha() : null;
-  if (prNumber && baseSha === null) {
-    console.warn(
-      "  Warning: could not read the base-branch commit this run merges " +
-        "into; coverage debt metrics will be reported but not gated.",
-    );
-  } else if (baseSha !== null) {
-    console.log(
-      `This run merges the pull request into base-branch commit ${
-        baseSha.slice(0, 8)
-      }.`,
-    );
-  }
+  const baselineByMetric = await selectBaselines({
+    metrics: currentMetrics.keys(),
+    timelines,
+    isRunCold,
+    isPullRequest: prNumber !== null,
+    guard: (description, operation) =>
+      githubApiOrSkip(description, operation, currentMetrics),
+  });
 
-  let ancestorRank: Map<string, number> | null = null;
-  if (baseSha !== null) {
-    ancestorRank = await githubApiOrSkip(
-      "listing the base-branch commit's ancestry",
-      () => fetchAncestorRanks(baseSha),
-      currentMetrics,
-    );
-  }
+  const { rows, failures, ungatedGroups } = buildCoverageRows({
+    currentMetrics,
+    timelines,
+    baselineByMetric,
+    overrides: prOverrides,
+    changedCoverageGroups,
+  });
 
-  const baselineByMetric = new Map<string, TimingSample | undefined>();
-  for (const metric of currentMetrics.keys()) {
-    const timeline = timelines.get(metric);
-    baselineByMetric.set(
-      metric,
-      timeline
-        ? nearestUsableBaseline(timeline.samples, isRunCold, ancestorRank)
-        : undefined,
-    );
-  }
-
-  // Groups the base branch changed between a chosen baseline and the
-  // base-branch commit. Their totals count different code on the two sides, so
-  // they are reported and not gated; every other group still is.
-  const groupsChangedOnBase = new Set<string>();
-  if (baseSha !== null) {
-    const baselineShas = new Set(
-      [...baselineByMetric.values()].map((sample) => sample?.sha).filter((
-        sha,
-      ): sha is string => sha !== undefined),
-    );
-    for (const sha of baselineShas) {
-      for (
-        const group of await githubApiOrSkip(
-          "comparing the baseline commit against the base-branch commit",
-          () => fetchGroupsChangedOnBase(sha, baseSha),
-          currentMetrics,
-        )
-      ) {
-        groupsChangedOnBase.add(group);
-      }
-    }
-    reportBaselineDistance(baselineShas, baseSha, ancestorRank);
-  }
-
-  const rows: Row[] = [];
-  const failures: Row[] = [];
-  const ungatedGroups = new Set<string>();
-
-  for (const [metric, currentSample] of currentMetrics) {
-    const current = currentSample.durationSeconds;
-    const n = timelines.get(metric)?.samples.length ?? 0;
-    const baselineSample = baselineByMetric.get(metric);
-    const latestBaseline = baselineSample?.durationSeconds;
-    const override = prOverrides.metrics.get(metric);
-    const coverageReset = prOverrides.coverageBaselineReset;
-    const comparable = isComparableBaseline(
-      baselineSample,
-      metric,
-      groupsChangedOnBase,
-      prNumber !== null,
-    );
-    if (!comparable) {
-      const group = coverageMetricGroupName(metric);
-      if (group !== null) ungatedGroups.add(group);
-    }
-    const shouldGateCoverage = comparable &&
-      shouldGateCoverageDebtMetric(metric, changedCoverageGroups);
-
-    if (latestBaseline === undefined) {
-      if (
-        coverageReset || (override !== undefined && current <= override)
-      ) {
-        rows.push({ metric, status: "ovrd", current, n });
-      } else if (!shouldGateCoverage) {
-        rows.push({ metric, status: "excl", current, n });
-      } else if (current > 0) {
-        const row: Row = {
-          metric,
-          status: "OVER",
-          current,
-          median: 0,
-          n,
-          pctIncrease: 100,
-        };
-        rows.push(row);
-        failures.push(row);
-      } else {
-        rows.push({ metric, status: "n/a", current, n });
-      }
-      continue;
-    }
-
-    const pctIncrease = latestBaseline === 0
-      ? current > 0 ? 100 : 0
-      : ((current - latestBaseline) / latestBaseline) * 100;
-    const stats = {
-      median: latestBaseline,
-      baselineSha: baselineSample?.sha,
-      pctIncrease,
-    };
-
-    if (coverageReset) {
-      rows.push({ metric, status: "ovrd", current, n, ...stats });
-      continue;
-    }
-
-    if (override !== undefined && current <= override) {
-      rows.push({ metric, status: "ovrd", current, n, ...stats });
-      continue;
-    }
-
-    if (!shouldGateCoverage) {
-      rows.push({ metric, status: "excl", current, n, ...stats });
-      continue;
-    }
-
-    if (current > latestBaseline) {
-      const row: Row = { metric, status: "OVER", current, n, ...stats };
-      rows.push(row);
-      failures.push(row);
-    } else {
-      rows.push({ metric, status: "OK", current, n, ...stats });
-    }
-  }
-
-  if (ungatedGroups.size > 0) {
-    console.log(
-      `\nNot gated, because no baseline counts the same base-branch code as ` +
-        `this run does: ${[...ungatedGroups].sort().join(", ")}. A later run ` +
-        "of this pull request gates them, once a `main` run has measured the " +
-        "commit it merges.",
-    );
-  }
+  reportUngatedGroups(ungatedGroups);
 
   // 6. Report results
 
@@ -1834,7 +1978,7 @@ export async function main() {
 
   // 6b. Cold compile cache note. A cold run covers cold-compile-only branches,
   // so it is recorded cold and a later PR's coverage ratchet skips it as a
-  // baseline in favour of the latest warm main run.
+  // baseline in favour of the nearest warm ancestor of its base-branch commit.
   const coldFamilies = COMPILE_CACHE_FAMILIES.filter(
     (family) => currentCacheStates[family] === "cold",
   );
@@ -1847,7 +1991,7 @@ export async function main() {
       "This run is recorded cold. A cold run covers cold-compile-only branches,",
     );
     console.log(
-      "so a later PR's coverage ratchet skips it and uses the latest warm main run",
+      "so a later PR's coverage ratchet skips it for the nearest warm ancestor",
     );
     console.log(
       "instead — otherwise warm PRs would be held to a stricter, unreachable bar.",
@@ -1858,7 +2002,8 @@ export async function main() {
   console.log(
     "\n::group::All coverage debt metrics:\n" +
       "Ratchet: for a source group the PR changed, uncovered lines must not rise\n" +
-      "above the latest non-cold main run's count.\n" +
+      "above the count from the main run for the base-branch commit this run\n" +
+      "merged, or the nearest ancestor of it that has one.\n" +
       "Status key: OVER = above baseline (fails); OK = at or below baseline;\n" +
       "  ovrd = accepted by a PR override/reset; excl = not gated for this PR;\n" +
       "  n/a = no baseline yet and no new uncovered lines.",

--- a/tasks/coverage-check.ts
+++ b/tasks/coverage-check.ts
@@ -6,8 +6,9 @@
  * Runs as a PR CI job after all test jobs complete. Joins the coverage
  * profiles every test job uploaded and gates the PR on coverage debt: for each
  * source group the PR changed, the count of uncovered lines must not rise above
- * the latest non-cold `main` run's count, unless the PR description accepts the
- * increase. Fails (exit 1) when a changed group regresses.
+ * the count from the `main` run for the base-branch commit this run merged,
+ * unless the PR description accepts the increase. Fails (exit 1) when a changed
+ * group regresses.
  *
  * Environment:
  *   GITHUB_TOKEN        - Required.
@@ -275,6 +276,240 @@ export function formatBaselineSourceRunAge(
 
 interface GitHubCompareResponse {
   ahead_by?: unknown;
+}
+
+async function readHeadCommitObject(): Promise<string | null> {
+  try {
+    const result = await new Deno.Command("git", {
+      args: ["cat-file", "commit", "HEAD"],
+      stdout: "piped",
+      stderr: "piped",
+    }).output();
+    if (!result.success) {
+      console.warn(
+        `  Warning: could not read the \`HEAD\` commit object: ${
+          new TextDecoder().decode(result.stderr).trim()
+        }`,
+      );
+      return null;
+    }
+    return new TextDecoder().decode(result.stdout);
+  } catch (error) {
+    console.warn(
+      `  Warning: could not run \`git\` to read the \`HEAD\` commit object: ${
+        formatErrorForLog(error)
+      }`,
+    );
+    return null;
+  }
+}
+
+/**
+ * Reads the base-branch commit the checked-out tree merges this pull request
+ * into.
+ *
+ * A `pull_request` run checks out `refs/pull/<number>/merge`, a merge commit
+ * whose first parent is the base-branch commit and whose second parent is the
+ * pull request head. GitHub rebuilds that merge ref whenever the base branch
+ * moves and does not rewrite the base recorded in the triggering event, so the
+ * event can name an older commit than the one the checkout merged. The commit
+ * object names the commit whose code the test jobs ran.
+ *
+ * The parents come from the raw commit object, because `actions/checkout`
+ * clones to depth one and git treats a shallow boundary commit as having no
+ * parents. `git cat-file` prints the stored object, which still lists them.
+ *
+ * Returns null when `HEAD` has fewer than two parents, and when `git` cannot
+ * be run.
+ */
+export async function readBaseBranchSha(
+  readCommitObject: () => Promise<string | null> = readHeadCommitObject,
+): Promise<string | null> {
+  const commit = await readCommitObject();
+  if (commit === null) return null;
+
+  const parents: string[] = [];
+  for (const line of commit.split("\n")) {
+    // The header ends at the first blank line; the commit message that follows
+    // it can contain a line that reads like a parent.
+    if (line === "") break;
+    const match = /^parent ([0-9a-f]{40,64})$/.exec(line);
+    if (match) parents.push(match[1]);
+  }
+
+  return parents.length >= 2 ? parents[0] : null;
+}
+
+/** How far back from the base-branch commit a baseline may sit. */
+const BASELINE_ANCESTRY_DEPTH = 100;
+
+/** The compare endpoint returns at most this many files. */
+const COMPARE_FILE_LIMIT = 300;
+
+/**
+ * Reads how far back each recent commit sits from the base-branch commit this
+ * run merged, newest first, so that `0` is that commit itself.
+ *
+ * Listing commits from the base-branch commit walks its ancestry, so a commit
+ * absent from the result is not an ancestor. That is what keeps a `main` run
+ * that landed after this run started from becoming the baseline: it measured
+ * base-branch code this run does not contain.
+ */
+export async function fetchAncestorRanks(
+  baseSha: string,
+  depth = BASELINE_ANCESTRY_DEPTH,
+): Promise<Map<string, number>> {
+  const commits = await githubGet<{ sha: string }[]>(
+    `/repos/${REPO}/commits?sha=${
+      encodeURIComponent(baseSha)
+    }&per_page=${depth}`,
+  );
+  return new Map(commits.map((commit, index) => [commit.sha, index]));
+}
+
+/**
+ * Returns the ratchet baseline for one metric: the run for the nearest
+ * ancestor of the base-branch commit this run merged.
+ *
+ * The base-branch commit's own run is the ideal baseline, because it measured
+ * exactly the base-branch code this run merged, leaving the pull request as the
+ * only difference between the two numbers. It is often available, but a run
+ * still going or one that failed leaves the nearest ancestor with a usable run
+ * standing in for it. Whatever the base branch changed in between is then in
+ * this run and not in the baseline, so `isComparableBaseline()` withholds
+ * gating from the groups it touched.
+ *
+ * Prefers a non-cold run: a cold run covers cold-compile-only branches, and its
+ * lower debt would hold a warm pull request to an unreachable bar. Takes the
+ * nearest ancestor regardless when every ancestor is cold, which keeps the
+ * reset semantics of an override-truncated timeline.
+ *
+ * Falls back to the latest non-cold run when there is no ancestry to work from
+ * — a `main` push run, a checkout that is not a merge, or a commit listing that
+ * could not be fetched.
+ */
+export function nearestUsableBaseline(
+  samples: TimingSample[],
+  isRunCold: (runId: number) => boolean,
+  ancestorRank: Map<string, number> | null,
+): TimingSample | undefined {
+  if (ancestorRank === null) return latestNonColdSample(samples, isRunCold);
+
+  let nearest: TimingSample | undefined;
+  let nearestRank = Infinity;
+  let nearestCold: TimingSample | undefined;
+  let nearestColdRank = Infinity;
+
+  for (const sample of samples) {
+    const rank = ancestorRank.get(sample.sha);
+    if (rank === undefined) continue;
+
+    if (isRunCold(sample.runId)) {
+      if (rank < nearestColdRank) {
+        nearestCold = sample;
+        nearestColdRank = rank;
+      }
+      continue;
+    }
+    if (rank < nearestRank) {
+      nearest = sample;
+      nearestRank = rank;
+    }
+  }
+
+  return nearest ?? nearestCold;
+}
+
+/**
+ * Reads the coverage source groups the base branch changed between the baseline
+ * run's commit and the base-branch commit this run merged.
+ *
+ * A group's uncovered-line count is a total over its files, so a group the base
+ * branch touched in between has a baseline counting different code from this
+ * run. Those groups are the ones the ratchet cannot speak to. Every other
+ * group's total stays comparable, which is what lets a pull request still be
+ * gated when the base-branch commit has no run of its own.
+ */
+export async function fetchGroupsChangedOnBase(
+  baselineSha: string,
+  baseSha: string,
+  warn: (message: string) => void = console.warn,
+): Promise<Set<string>> {
+  if (baselineSha === baseSha) return new Set();
+
+  const comparison = await githubGet<{ files?: { filename: string }[] }>(
+    `/repos/${REPO}/compare/${encodeURIComponent(baselineSha)}...${
+      encodeURIComponent(baseSha)
+    }`,
+  );
+  const files = comparison.files ?? [];
+  if (files.length >= COMPARE_FILE_LIMIT) {
+    warn(
+      `  Warning: comparing ${baselineSha.slice(0, 8)} against ${
+        baseSha.slice(0, 8)
+      } hit the ${COMPARE_FILE_LIMIT}-file response cap, so a group the base ` +
+        "branch changed may still be gated.",
+    );
+  }
+  return coverageGroupsForChangedFiles(files.map((file) => file.filename));
+}
+
+/**
+ * Returns whether a metric's baseline can be held against this run.
+ *
+ * The two numbers must count the same base-branch code, or the difference
+ * between them is not the pull request's. A group the base branch changed
+ * between the baseline commit and the base-branch commit fails that, and so
+ * does a metric with no baseline at all; both are reported and not gated.
+ *
+ * A `main` push run has no base-branch commit and is informational, so it
+ * reports against whatever baseline it has.
+ */
+export function isComparableBaseline(
+  sample: TimingSample | undefined,
+  metric: string,
+  groupsChangedOnBase: Set<string>,
+  isPullRequest: boolean,
+): boolean {
+  if (!isPullRequest) return true;
+  if (sample === undefined) return false;
+
+  const group = coverageMetricGroupName(metric);
+  return group === null || !groupsChangedOnBase.has(group);
+}
+
+/**
+ * Reports which commit each baseline was measured at, and how far back from the
+ * base-branch commit that sits.
+ */
+export function reportBaselineDistance(
+  baselineShas: Set<string>,
+  baseSha: string,
+  ancestorRank: Map<string, number> | null,
+  log: (message: string) => void = console.log,
+): void {
+  if (baselineShas.size === 0) {
+    log(
+      `No \`main\` run has measured base-branch commit ${
+        baseSha.slice(0, 8)
+      } or any of its ancestors.`,
+    );
+    return;
+  }
+
+  for (const sha of [...baselineShas].sort()) {
+    const rank = ancestorRank?.get(sha);
+    const distance = rank === undefined
+      ? "at an unknown distance from"
+      : rank === 0
+      ? "at"
+      : `${pluralize(rank, "commit")} before`;
+    log(
+      `Ratchet baseline measured ${distance} the base-branch commit: ${
+        sha.slice(0, 8)
+      }.`,
+    );
+  }
 }
 
 export async function fetchCommitsBehindMain(
@@ -848,6 +1083,8 @@ export interface Row {
   current: number;
   /** Latest non-cold `main` ratchet baseline (uncovered lines). */
   median?: number;
+  /** Head SHA of the run that baseline came from. */
+  baselineSha?: string;
   n: number;
   pctIncrease?: number;
 }
@@ -1432,25 +1669,91 @@ export async function main() {
   }
 
   // 5. Compare the current run's coverage debt against the ratchet baseline.
+
+  // The base-branch commit this run's tree merges the pull request into. Its
+  // ancestry decides which main run is the baseline, so that the baseline and
+  // this run count the same base-branch code.
+  const baseSha = prNumber ? await readBaseBranchSha() : null;
+  if (prNumber && baseSha === null) {
+    console.warn(
+      "  Warning: could not read the base-branch commit this run merges " +
+        "into; coverage debt metrics will be reported but not gated.",
+    );
+  } else if (baseSha !== null) {
+    console.log(
+      `This run merges the pull request into base-branch commit ${
+        baseSha.slice(0, 8)
+      }.`,
+    );
+  }
+
+  let ancestorRank: Map<string, number> | null = null;
+  if (baseSha !== null) {
+    ancestorRank = await githubApiOrSkip(
+      "listing the base-branch commit's ancestry",
+      () => fetchAncestorRanks(baseSha),
+      currentMetrics,
+    );
+  }
+
+  const baselineByMetric = new Map<string, TimingSample | undefined>();
+  for (const metric of currentMetrics.keys()) {
+    const timeline = timelines.get(metric);
+    baselineByMetric.set(
+      metric,
+      timeline
+        ? nearestUsableBaseline(timeline.samples, isRunCold, ancestorRank)
+        : undefined,
+    );
+  }
+
+  // Groups the base branch changed between a chosen baseline and the
+  // base-branch commit. Their totals count different code on the two sides, so
+  // they are reported and not gated; every other group still is.
+  const groupsChangedOnBase = new Set<string>();
+  if (baseSha !== null) {
+    const baselineShas = new Set(
+      [...baselineByMetric.values()].map((sample) => sample?.sha).filter((
+        sha,
+      ): sha is string => sha !== undefined),
+    );
+    for (const sha of baselineShas) {
+      for (
+        const group of await githubApiOrSkip(
+          "comparing the baseline commit against the base-branch commit",
+          () => fetchGroupsChangedOnBase(sha, baseSha),
+          currentMetrics,
+        )
+      ) {
+        groupsChangedOnBase.add(group);
+      }
+    }
+    reportBaselineDistance(baselineShas, baseSha, ancestorRank);
+  }
+
   const rows: Row[] = [];
   const failures: Row[] = [];
+  const ungatedGroups = new Set<string>();
 
   for (const [metric, currentSample] of currentMetrics) {
     const current = currentSample.durationSeconds;
-    const timeline = timelines.get(metric);
-    const n = timeline?.samples.length ?? 0;
-    // Ratchet against the latest run that was not known-cold: a cold main
-    // run covers rare cold-compile-only branches, and ratcheting against
-    // its lower debt would fail later warm PRs with phantom regressions.
-    const latestBaseline = timeline
-      ? latestNonColdSample(timeline.samples, isRunCold)?.durationSeconds
-      : undefined;
+    const n = timelines.get(metric)?.samples.length ?? 0;
+    const baselineSample = baselineByMetric.get(metric);
+    const latestBaseline = baselineSample?.durationSeconds;
     const override = prOverrides.metrics.get(metric);
     const coverageReset = prOverrides.coverageBaselineReset;
-    const shouldGateCoverage = shouldGateCoverageDebtMetric(
+    const comparable = isComparableBaseline(
+      baselineSample,
       metric,
-      changedCoverageGroups,
+      groupsChangedOnBase,
+      prNumber !== null,
     );
+    if (!comparable) {
+      const group = coverageMetricGroupName(metric);
+      if (group !== null) ungatedGroups.add(group);
+    }
+    const shouldGateCoverage = comparable &&
+      shouldGateCoverageDebtMetric(metric, changedCoverageGroups);
 
     if (latestBaseline === undefined) {
       if (
@@ -1479,7 +1782,11 @@ export async function main() {
     const pctIncrease = latestBaseline === 0
       ? current > 0 ? 100 : 0
       : ((current - latestBaseline) / latestBaseline) * 100;
-    const stats = { median: latestBaseline, pctIncrease };
+    const stats = {
+      median: latestBaseline,
+      baselineSha: baselineSample?.sha,
+      pctIncrease,
+    };
 
     if (coverageReset) {
       rows.push({ metric, status: "ovrd", current, n, ...stats });
@@ -1503,6 +1810,15 @@ export async function main() {
     } else {
       rows.push({ metric, status: "OK", current, n, ...stats });
     }
+  }
+
+  if (ungatedGroups.size > 0) {
+    console.log(
+      `\nNot gated, because no baseline counts the same base-branch code as ` +
+        `this run does: ${[...ungatedGroups].sort().join(", ")}. A later run ` +
+        "of this pull request gates them, once a `main` run has measured the " +
+        "commit it merges.",
+    );
   }
 
   // 6. Report results


### PR DESCRIPTION
Coverage Check failed pull requests that touched `packages/runner` at what looked like random, and the cause was not in the measurement.

A `pull_request` run checks out `refs/pull/<number>/merge`, and GitHub rebuilds that merge ref whenever the base branch moves, so the run measures the pull request merged with `main` as it stood when the run started. The ratchet baseline was the newest successful `main` run, whichever commit that happened to be — not necessarily an ancestor of the tree being measured, and usually several commits behind it. The two numbers therefore routinely counted different base-branch code, and the difference between them was charged to the pull request.

The reported instance: two runs seventeen minutes apart on the same pull request scored 5746 and 5747 against a baseline of 5746. In between, "feat(runner): map every instantiated pattern back to its source file" landed on `main` and added one line of code to
`packages/runner/src/harness/types.ts`. Scoring both trees with the gate's own code confirms the number tracks the tree and ignores the coverage data — which follows from the metric, since a file with an LCOV record is scored from that record alone, so the tree can only move the number through files that have none. That file declares only interfaces and compiles to no executable statements, so it got no record and was charged its whole tracked-line count. That particular charge has since gone away, because the gate now compiles a file it finds no record for and charges nothing when nothing comes out. What made the failure possible in general is untouched by that, and is what this change fixes: a baseline measured at a different commit from the run.

The baseline is now the `main` run for the base-branch commit the run merged, read from the checked-out merge commit's first parent. That comparison is exact: both numbers count the same base-branch code, so the only difference between them is the pull request. Across eleven consecutive pull request runs sampled from the workflow history, that run had already completed for eight of them.

For the rest — a `main` run still going, or one that failed — the ratchet steps back to the nearest ancestor that has a usable run rather than skipping the gate. Whatever the base branch changed in between is then present in this run and absent from the baseline, so the groups it touched have totals counting different code on the two sides; those groups are reported and not gated, and every other group still is. Replaying the reported failure this way picks a baseline three commits back, withholds gating from the five groups the base branch moved (`packages/runner` among them, so the phantom regression is gone), and still gates `packages/content-hash`, which is the group that pull request actually changed.

Ancestry comes from listing commits reachable from the base-branch commit, which also settles the mirror-image mistake: a `main` run that landed after this run started is not in that list and can no longer become the bar, so a pull request is not failed for lacking coverage somebody else added after it began. Cold-run skipping is unchanged, so a cold ancestor yields to the nearest warm one.

Two details of reading the base commit are load-bearing. It comes from the checked-out merge commit rather than the triggering event, because GitHub does not rewrite `pull_request.base.sha` when it rebuilds the merge ref; on the reported run that field named the previous run's base. And it is read with `git cat-file commit HEAD` rather than `git log --format=%P`, because `actions/checkout` clones to depth one and git reports a shallow boundary commit as having no parents.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

