### PR TITLE
refactor(runner): the encodable form of a value without one is the value

### DIFF
--- a/packages/runner/src/builder/reactive.ts
+++ b/packages/runner/src/builder/reactive.ts
@@ -8,7 +8,7 @@ import {
   type Stream,
 } from "./types.ts";
 import { getTopFrame } from "./pattern.ts";
-import { encodableFormOf, hasEncodableForm } from "../encodable-form.ts";
+import { encodableFormOf } from "../encodable-form.ts";
 import { createCell } from "../cell.ts";
 import { ContextualFlowControl } from "../cfc.ts";
 
@@ -89,7 +89,5 @@ export function stream<T>(
 function defaultForValue(value: unknown): JSONValue {
   // A builder artifact stands in as its encodable form: that is what a
   // default written from it has to be.
-  return (hasEncodableForm(value)
-    ? encodableFormOf(value)
-    : value) as JSONValue;
+  return encodableFormOf(value) as JSONValue;
 }

--- a/packages/runner/src/builder/to-encodable-form.ts
+++ b/packages/runner/src/builder/to-encodable-form.ts
@@ -383,9 +383,11 @@ export function serializePatternGraph(
   const previous = internalGraphSerialization;
   internalGraphSerialization = true;
   try {
-    return (hasEncodableForm(pattern)
-      ? encodableFormOf(pattern)
-      : patternToEncodableForm(pattern)) as Record<string, unknown>;
+    // `undefined` as the no-form answer is what stands the fallback behind the
+    // `??`, and one read gets there. A pattern's form is a record by
+    // construction, so nothing nullish can arrive from the other side.
+    return (encodableFormOf(pattern, undefined) ??
+      patternToEncodableForm(pattern)) as Record<string, unknown>;
   } finally {
     internalGraphSerialization = previous;
   }

--- a/packages/runner/src/create-ref.ts
+++ b/packages/runner/src/create-ref.ts
@@ -145,8 +145,11 @@ export function createRef(
       return Object.fromEntries(
         Object.entries(obj).map(([key, value]) => [key, traverse(value)]),
       );
-    } else if (typeof obj === "function") return obj.toString();
-    else return obj;
+    }
+
+    // A function is all that is left: the walk answered every primitive at the
+    // top, and `isRecord()` admits every other non-null object.
+    return obj.toString();
   }
 
   // The entity kind deliberately does NOT enter the preimage: a computed

--- a/packages/runner/src/create-ref.ts
+++ b/packages/runner/src/create-ref.ts
@@ -66,16 +66,22 @@ export function createRef(
   // Unwrap query result proxies and replace docs with their ids; functions are
   // stringified, since our data model doesn't support them as values.
   function traverse(obj: any): any {
-    // Avoid cycles — only track objects/arrays/functions (not primitives).
-    // Primitives use value equality in Set, so repeated strings like
-    // "primary" would be incorrectly deduplicated, causing hash collisions
-    // for patterns that differ only in the position of repeated values.
+    // A primitive is its own preimage. Nothing below applies to one -- it
+    // carries no members to serialize, is no kind of reference, and holds
+    // nothing to descend into -- and `obj` is `any`, so `null`, `undefined` and
+    // every scalar arrive here.
     if (
-      obj !== null && (typeof obj === "object" || typeof obj === "function")
+      obj === null || (typeof obj !== "object" && typeof obj !== "function")
     ) {
-      if (seen.has(obj)) return null;
-      seen.add(obj);
+      return obj;
     }
+
+    // Avoid cycles. Primitives are not tracked, and are gone by here: they use
+    // value equality in a Set, so repeated strings like "primary" would be
+    // deduplicated and collide the hashes of patterns differing only in the
+    // position of a repeated value.
+    if (seen.has(obj)) return null;
+    seen.add(obj);
 
     // Don't traverse into atomic values or already-serialized references. A
     // `FabricPrimitive` (a `FabricHash` id, `FabricBytes`, a date, …) is an

--- a/packages/runner/src/create-ref.ts
+++ b/packages/runner/src/create-ref.ts
@@ -96,6 +96,13 @@ export function createRef(
     // A builder artifact is replaced by its encodable form, then descended
     // into: what the ref is derived from is the form that gets written.
     // Functions qualify because a pattern factory is one.
+    //
+    // A _nullish_ form leaves the value in place, which is what the `??` is
+    // for -- a value carrying no form at all needs no fallback, since that
+    // answer is the value already. A cell whose link is not materialized answers `null`
+    // here, and the branches below need the cell itself: one of them builds the
+    // link. Collapsing to the `null` instead would derive the id `null` derives
+    // and carry none of the value's own contents into it.
     obj = encodableFormOf(obj) ?? obj;
 
     if (isReactive(obj)) {

--- a/packages/runner/src/create-ref.ts
+++ b/packages/runner/src/create-ref.ts
@@ -145,11 +145,12 @@ export function createRef(
       return Object.fromEntries(
         Object.entries(obj).map(([key, value]) => [key, traverse(value)]),
       );
-    }
-
-    // A function is all that is left: the walk answered every primitive at the
-    // top, and `isRecord()` admits every other non-null object.
-    return obj.toString();
+    } else if (typeof obj === "function") return obj.toString();
+    // A primitive reaches here only as an encodable FORM, the reassignment above
+    // having replaced the value it came from -- a primitive INPUT is answered at
+    // the top of the walk. A form is its own preimage, and stringifying one
+    // would make the form `7` and the form `"7"` name a single document.
+    else return obj;
   }
 
   // The entity kind deliberately does NOT enter the preimage: a computed

--- a/packages/runner/src/create-ref.ts
+++ b/packages/runner/src/create-ref.ts
@@ -1,5 +1,5 @@
 import { hashOf } from "@commonfabric/data-model/value-hash";
-import { encodableFormOf, hasEncodableForm } from "./encodable-form.ts";
+import { encodableFormOf } from "./encodable-form.ts";
 import { hasEntityUriScheme } from "./entity-kind.ts";
 import {
   BaseFabricPrimitive,
@@ -96,9 +96,7 @@ export function createRef(
     // A builder artifact is replaced by its encodable form, then descended
     // into: what the ref is derived from is the form that gets written.
     // Functions qualify because a pattern factory is one.
-    if (hasEncodableForm(obj)) {
-      obj = encodableFormOf(obj) ?? obj;
-    }
+    obj = encodableFormOf(obj) ?? obj;
 
     if (isReactive(obj)) {
       const val = obj.export().value;

--- a/packages/runner/src/create-ref.ts
+++ b/packages/runner/src/create-ref.ts
@@ -99,10 +99,10 @@ export function createRef(
     //
     // A _nullish_ form leaves the value in place, which is what the `??` is
     // for -- a value carrying no form at all needs no fallback, since that
-    // answer is the value already. A cell whose link is not materialized answers `null`
-    // here, and the branches below need the cell itself: one of them builds the
-    // link. Collapsing to the `null` instead would derive the id `null` derives
-    // and carry none of the value's own contents into it.
+    // answer is the value already. `CellImpl` is the one implementation that
+    // answers nullish, doing so for a cell whose link is not built yet, and the
+    // branches below need that cell rather than the `null`: one of them builds
+    // the link.
     obj = encodableFormOf(obj) ?? obj;
 
     if (isReactive(obj)) {

--- a/packages/runner/src/encodable-form.ts
+++ b/packages/runner/src/encodable-form.ts
@@ -52,13 +52,24 @@ export function hasEncodableForm(value: unknown): boolean {
  * stands" asks once. Asking `hasEncodableForm()` first and then calling this
  * reads the member twice, and the member can be accessor-backed.
  *
+ * `ifNone` replaces the value as the answer for a value carrying no form, so a
+ * caller whose fallback is something else also asks once. Pass `undefined` to
+ * stand a computed fallback behind a `??`. Passing it explicitly is not the same
+ * as omitting it.
+ *
  * A caller that needs to tell a value with no form from one whose form is
  * nullish asks `hasEncodableForm()`, which is the question that distinguishes
  * them.
  */
-export function encodableFormOf<T>(value: T): unknown | T {
+export function encodableFormOf<T>(value: T): unknown | T;
+export function encodableFormOf<F>(value: unknown, ifNone: F): unknown | F;
+export function encodableFormOf(
+  value: unknown,
+  ...ifNone: [] | [unknown]
+): unknown {
   const method = encodableFormMethod(value);
-  return method === undefined ? value : encodableFormFrom(method, value);
+  if (method !== undefined) return encodableFormFrom(method, value);
+  return ifNone.length === 0 ? value : ifNone[0];
 }
 
 /**

--- a/packages/runner/src/encodable-form.ts
+++ b/packages/runner/src/encodable-form.ts
@@ -27,10 +27,11 @@ function encodableFormMethod(value: unknown): (() => unknown) | undefined {
     return undefined;
   }
 
-  const named = value as { toEncodableForm?: unknown };
-  return typeof named.toEncodableForm === "function"
-    ? named.toEncodableForm as () => unknown
-    : undefined;
+  // Read once and hand back what was read. The member may be accessor-backed,
+  // and a second read at the invoke would run that accessor again, so what got
+  // serialized would be whatever it produced the second time.
+  const method = (value as { toEncodableForm?: unknown }).toEncodableForm;
+  return typeof method === "function" ? method as () => unknown : undefined;
 }
 
 /**
@@ -46,13 +47,18 @@ export function hasEncodableForm(value: unknown): boolean {
 }
 
 /**
- * Produces the encodable form of a value that has one, or `undefined` for a
- * value that does not. Ask `hasEncodableForm()` to tell those apart from a
- * value whose encodable form is itself `undefined`.
+ * Produces the encodable form of a value that has one, and the value itself for
+ * a value that does not -- so a caller that wants "the form, or this as it
+ * stands" asks once. Asking `hasEncodableForm()` first and then calling this
+ * reads the member twice, and the member can be accessor-backed.
+ *
+ * A caller that needs to tell a value with no form from one whose form is
+ * nullish asks `hasEncodableForm()`, which is the question that distinguishes
+ * them.
  */
-export function encodableFormOf(value: unknown): unknown {
+export function encodableFormOf<T>(value: T): unknown | T {
   const method = encodableFormMethod(value);
-  return method === undefined ? undefined : encodableFormFrom(method, value);
+  return method === undefined ? value : encodableFormFrom(method, value);
 }
 
 /**

--- a/packages/runner/test/create-ref-fail-closed.test.ts
+++ b/packages/runner/test/create-ref-fail-closed.test.ts
@@ -26,6 +26,18 @@ describe("createRef fail-closed", () => {
     expect(a.taggedHashString).toEqual(b.taggedHashString);
   });
 
+  it('derives distinct ids for the encodable forms `7` and `"7"`', () => {
+    // An encodable form reaches the walk in place of the value it came from, so
+    // a primitive form arrives past the point where a primitive INPUT is
+    // answered. Stringifying one would make these two name one document.
+    const asNumber = createRef({ held: { toEncodableForm: () => 7 } }, "cause");
+    const asString = createRef(
+      { held: { toEncodableForm: () => "7" } },
+      "cause",
+    );
+    expect(asNumber.toString()).not.toBe(asString.toString());
+  });
+
   it("still mints a fresh id when no cause is given (documented behavior)", () => {
     const a = createRef({ x: 1 });
     const b = createRef({ x: 1 });

--- a/packages/runner/test/encodable-form.test.ts
+++ b/packages/runner/test/encodable-form.test.ts
@@ -501,8 +501,34 @@ describe("encodable-form", () => {
         .toEqual({ invoked: true });
     });
 
-    it("returns `undefined` for a value carrying no such member", () => {
-      expect(encodableFormOf({ a: 1 })).toBe(undefined);
+    it("returns the value itself when it carries no such member", () => {
+      const value = { a: 1 };
+      expect(encodableFormOf(value)).toBe(value);
+    });
+
+    it("returns the form, not the value, when the member is there", () => {
+      // Including when the form is itself nullish, which the value-fallback
+      // must not swallow: a caller telling those apart asks
+      // `hasEncodableForm()`.
+      expect(encodableFormOf({ toEncodableForm: () => null })).toBe(null);
+      expect(encodableFormOf({ toEncodableForm: () => undefined }))
+        .toBe(undefined);
+    });
+
+    it("reads the member once", () => {
+      // One question instead of two. Asking `hasEncodableForm()` first and then
+      // calling this reads an accessor-backed member twice, and the second read
+      // is what would get serialized.
+      let reads = 0;
+      const value = {
+        get toEncodableForm() {
+          reads++;
+          const nth = reads;
+          return () => ({ fromRead: nth });
+        },
+      };
+      expect(encodableFormOf(value)).toEqual({ fromRead: 1 });
+      expect(reads).toBe(1);
     });
   });
 

--- a/packages/runner/test/encodable-form.test.ts
+++ b/packages/runner/test/encodable-form.test.ts
@@ -515,6 +515,38 @@ describe("encodable-form", () => {
         .toBe(undefined);
     });
 
+    it("returns `ifNone` instead of the value when given one", () => {
+      const value = { a: 1 };
+      expect(encodableFormOf(value, "none")).toBe("none");
+    });
+
+    it("tells an explicit `undefined` `ifNone` from an omitted one", () => {
+      // The distinction is what lets a caller stand a computed fallback behind
+      // a `??`: omitting it answers the value, which is never nullish for an
+      // object, so a `??` would never reach the fallback.
+      const value = { a: 1 };
+      expect(encodableFormOf(value)).toBe(value);
+      expect(encodableFormOf(value, undefined)).toBe(undefined);
+    });
+
+    it("returns the form, not `ifNone`, when the member is there", () => {
+      expect(encodableFormOf({ toEncodableForm: () => ({ a: 1 }) }, "none"))
+        .toEqual({ a: 1 });
+    });
+
+    it("reads the member once when given an `ifNone`", () => {
+      let reads = 0;
+      const value = {
+        get toEncodableForm() {
+          reads++;
+          const nth = reads;
+          return () => ({ fromRead: nth });
+        },
+      };
+      expect(encodableFormOf(value, undefined)).toEqual({ fromRead: 1 });
+      expect(reads).toBe(1);
+    });
+
     it("reads the member once", () => {
       // One question instead of two. Asking `hasEncodableForm()` first and then
       // calling this reads an accessor-backed member twice, and the second read


### PR DESCRIPTION
Prep for #5409, and inert on its own.

`encodableFormOf()` returned `undefined` for a value carrying no
`toEncodableForm`, so a caller wanting *"the form, or this as it stands"* had to
ask twice:

```ts
if (hasEncodableForm(obj)) obj = encodableFormOf(obj) ?? obj;   // two reads
obj = encodableFormOf(obj) ?? obj;                              // one
```

The member can be accessor-backed, and the second read runs that accessor again —
so what gets serialized is whatever it produced the *second* time. Same defect
class as #5389, which fixed it inside the walk's private reader; this is the
public one.

## Every get-site now reads once

| site | fallback it wants | after |
| --- | --- | --- |
| `create-ref.ts:99` | the value | `encodableFormOf(obj) ?? obj` |
| `builder/reactive.ts:92` | the value | `encodableFormOf(value)` |
| `to-encodable-form.ts:386` | a **computation** | `encodableFormOf(pattern, undefined) ?? patternToEncodableForm(pattern)` |
| `to-encodable-form.ts:200` | — predicate only | unchanged |
| `sandbox/result-normalization.ts:45` | — predicate only | unchanged |

The value is the default because that is what most sites want. `ifNone` replaces
it for the one whose fallback is a computation — and `undefined` is the sentinel
that makes the `??` shape work: `false` would be *returned* by `??` rather than
falling through, and `||` in its place would swallow a falsy form. A pattern's
form is a record by construction, so nothing nullish arrives from the other side.

Omitting the argument and passing `undefined` are different answers, which is
what the rest parameter is for. Omitted gives the value, which is never nullish
for an object, so a `??` after it would never reach a fallback.

`hasEncodableForm()` stays for the two sites that only ask the question, and for
a caller needing to tell "no form" from "the form is nullish" — that is the
question which distinguishes them.

## A second double-read, found by the test

Writing the read-count case turned up one inside `encodableFormMethod()` itself:

```ts
return typeof named.toEncodableForm === "function"
  ? named.toEncodableForm as () => unknown      // second read
  : undefined;
```

It now reads once and hands back what it read — the shape
`ownEncodableFormMethod()` already had.

## Provably inert

Member reads on the `createRef` path, and the ids they produce:

| form | reads before | reads after | id |
| --- | --- | --- | --- |
| a record | 4 | **1** | identical |
| `null` | 5 | **2** | identical |
| `undefined` | 5 | **2** | identical |
| a nested artifact | 4 | **1** | identical |
| no member at all | — | — | identical |

The residual pair for a nullish form is honest rather than a missed read: a
nullish form leaves the object in place, so the record walk afterwards reads the
member once *as data*.

## Verification

Runner 1149/0, full workspace passing, 120/120 pattern tests, `pattern-vintage`
(6 vintages, 95 recorded instantiations, 20 targets updated cleanly) and
`pattern-compat` (336 patterns) both clean, plus `fmt`, `lint`, `check`,
`check-docs`, `check-no-waitfor`, `check-conflict-markers`, `check-skill-facts`,
`check-baselines-append-only`.
