### PR TITLE
fix(data-model): `FabricError` holds its fixed-schema slots privately

### DIFF
--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -441,19 +441,18 @@ export type FabricErrorState = {
  * by `toNativeValue()`.
  *
  * Like all `FabricInstance`s, a `FabricError` is wholeheartedly mutable
- * until frozen and immutable thereafter. The fixed-schema slots are plain
- * writable own properties: assigning to one throws once the instance is
- * `Object.freeze`'d. The extras bag mirrors this by gating `setExtra` /
- * `deleteExtra` on the frozen state. The serialization layer handles
- * `FabricError` via its static `[CODEC]`, which is the source of truth
- * for the encoded form.
+ * until frozen and immutable thereafter. Every mutator -- the slot setters
+ * along with `setExtra` / `deleteExtra` -- throws once the instance is
+ * `Object.freeze`'d. The serialization layer handles `FabricError` via its
+ * static `[CODEC]`, which is the source of truth for the encoded form.
  */
 export class FabricError extends FabricNativeWrapper<Error> {
-  type: string;
-  name: string;       // always a concrete string on instances
-  message: string;
-  stack: string | undefined;
-  cause: FabricValue | undefined;
+  // Fixed-schema slots, each a getter/setter pair over a private field.
+  get type(): string;                      // and `set type(value: string)`
+  get name(): string;                      // always a concrete string
+  get message(): string;
+  get stack(): string | undefined;
+  get cause(): FabricValue | undefined;
 
   /** Hidden bag of custom enumerable properties. */
   readonly #extras: Map<string, FabricValue>;
@@ -1407,6 +1406,14 @@ class-side `[CODEC]` (Section 2.4).
  * extend `BaseFabricInstance` (a subclass of this one) rather than this
  * class directly; `BaseFabricInstance` is where shared template-method
  * scaffolding (such as `shallowClone()`) lives.
+ *
+ * An instance holds all of its state privately and makes it reachable only
+ * through members, so it has no own properties at all. A structural view
+ * of one — a spread, `Object.keys()`, a naive walk — therefore sees
+ * nothing. Mutable state is exposed as an accessor pair over a private
+ * field, whose setter is responsible for honoring the instance's frozen
+ * state: `Object.freeze()` bears only on own properties and so cannot
+ * enforce that on its own.
  *
  * Subclasses must implement:
  * - `[DEEP_FREEZE](subFreeze)` -- deeply freezes this instance in place.

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -61,6 +61,10 @@ export declare const FabricSpecialObject:
 
 /**
  * Abstract base class for values that participate in the fabric protocol.
+ *
+ * An instance holds all of its state privately and makes it reachable only
+ * through members, so it has no own properties at all. A structural view of
+ * one -- a spread, `Object.keys()`, a naive walk -- therefore sees nothing.
  */
 export interface FabricInstance extends FabricSpecialObject {
   shallowClone(frozen: boolean): FabricInstance;
@@ -231,9 +235,9 @@ export type FabricErrorState = {
  * `cause` may be an arbitrary `FabricValue`, so it is a small object graph
  * rather than a leaf.
  *
- * Like every `FabricInstance` it is mutable until frozen: the slots are plain
- * writable properties, and `setExtra()` / `deleteExtra()` are gated on the
- * frozen state.
+ * Like every `FabricInstance` it is mutable until frozen, and every mutator --
+ * the slot setters along with `setExtra()` and `deleteExtra()` -- throws once
+ * the instance is frozen.
  */
 export interface FabricError extends FabricInstance {
   type: string;

--- a/packages/data-model/src/fabric-instances/FabricError.ts
+++ b/packages/data-model/src/fabric-instances/FabricError.ts
@@ -82,26 +82,28 @@ export type FabricErrorState = {
  * `toNativeValue()`.
  *
  * Like all `FabricInstance`s, a `FabricError` is wholeheartedly mutable
- * until frozen and immutable thereafter. The fixed-schema slots are plain
- * writable own properties: assigning to one throws once the instance is
- * `Object.freeze`'d (strict-mode non-writable-property semantics). The
- * extras bag mirrors this by gating `setExtra` / `deleteExtra` on the
- * frozen state. The serialization layer handles `FabricError` via its static
- * `[CODEC]`, which is the source of truth for the encoded form.
+ * until frozen and immutable thereafter. Every mutator -- the slot setters
+ * along with `setExtra` / `deleteExtra` -- throws once the instance is
+ * `Object.freeze`'d. The serialization layer handles `FabricError` via its
+ * static `[CODEC]`, which is the source of truth for the encoded form.
  * See Section 1.4.1 of the formal spec.
  */
 export class FabricError extends FabricNativeWrapper<Error>
   implements ApiFabricError {
   /** Constructor name of the originating native `Error` (e.g. `"TypeError"`). */
-  type: string;
+  #type: string;
+
   /** The `.name` property (always a concrete string). */
-  name: string;
+  #name: string;
+
   /** The `.message` property. */
-  message: string;
+  #message: string;
+
   /** The `.stack` property, or `undefined`. */
-  stack: string | undefined;
+  #stack: string | undefined;
+
   /** The `.cause` value, in `FabricValue` form, or `undefined`. */
-  cause: FabricValue | undefined;
+  #cause: FabricValue | undefined;
 
   /** Hidden bag of custom enumerable properties, in `FabricValue` form. */
   readonly #extras: Map<string, FabricValue>;
@@ -123,11 +125,11 @@ export class FabricError extends FabricNativeWrapper<Error>
    */
   constructor(state: FabricErrorState) {
     super();
-    this.type = state.type;
-    this.name = state.name ?? state.type;
-    this.message = state.message;
-    this.stack = state.stack;
-    this.cause = state.cause;
+    this.#type = state.type;
+    this.#name = state.name ?? state.type;
+    this.#message = state.message;
+    this.#stack = state.stack;
+    this.#cause = state.cause;
     this.#extras = new Map();
     const extras = state.extras;
     if (extras !== undefined) {
@@ -142,6 +144,81 @@ export class FabricError extends FabricNativeWrapper<Error>
         this.#extras.set(key, value);
       }
     }
+  }
+
+  /** Constructor name of the originating native `Error` (e.g. `"TypeError"`). */
+  get type(): string {
+    return this.#type;
+  }
+
+  /**
+   * Sets {@link type}.
+   *
+   * @throws If this instance is frozen.
+   */
+  set type(value: string) {
+    this.#assertNotFrozen();
+    this.#type = value;
+  }
+
+  /** The `.name` property (always a concrete string). */
+  get name(): string {
+    return this.#name;
+  }
+
+  /**
+   * Sets {@link name}.
+   *
+   * @throws If this instance is frozen.
+   */
+  set name(value: string) {
+    this.#assertNotFrozen();
+    this.#name = value;
+  }
+
+  /** The `.message` property. */
+  get message(): string {
+    return this.#message;
+  }
+
+  /**
+   * Sets {@link message}.
+   *
+   * @throws If this instance is frozen.
+   */
+  set message(value: string) {
+    this.#assertNotFrozen();
+    this.#message = value;
+  }
+
+  /** The `.stack` property, or `undefined`. */
+  get stack(): string | undefined {
+    return this.#stack;
+  }
+
+  /**
+   * Sets {@link stack}.
+   *
+   * @throws If this instance is frozen.
+   */
+  set stack(value: string | undefined) {
+    this.#assertNotFrozen();
+    this.#stack = value;
+  }
+
+  /** The `.cause` value, in `FabricValue` form, or `undefined`. */
+  get cause(): FabricValue | undefined {
+    return this.#cause;
+  }
+
+  /**
+   * Sets {@link cause}.
+   *
+   * @throws If this instance is frozen.
+   */
+  set cause(value: FabricValue | undefined) {
+    this.#assertNotFrozen();
+    this.#cause = value;
   }
 
   /**
@@ -189,9 +266,7 @@ export class FabricError extends FabricNativeWrapper<Error>
    * prototype-sensitive key (`__proto__`, `constructor`).
    */
   setExtra(key: string, value: FabricValue): void {
-    if (Object.isFrozen(this)) {
-      throw new Error("Cannot modify frozen FabricError");
-    }
+    this.#assertNotFrozen();
     if (isUnsafeObjectKey(key)) {
       throw new Error(`Cannot use unsafe key in FabricError extras: ${key}`);
     }
@@ -208,9 +283,7 @@ export class FabricError extends FabricNativeWrapper<Error>
    * Throws if this instance is frozen.
    */
   deleteExtra(key: string): boolean {
-    if (Object.isFrozen(this)) {
-      throw new Error("Cannot modify frozen FabricError");
-    }
+    this.#assertNotFrozen();
     return this.#extras.delete(key);
   }
 
@@ -241,8 +314,8 @@ export class FabricError extends FabricNativeWrapper<Error>
   [DEEP_FREEZE](
     subFreeze: (value: FabricValue) => FabricValue,
   ): FabricValue {
-    if (this.cause !== undefined) {
-      subFreeze(this.cause);
+    if (this.#cause !== undefined) {
+      subFreeze(this.#cause);
     }
     for (const value of this.#extras.values()) {
       subFreeze(value);
@@ -259,7 +332,7 @@ export class FabricError extends FabricNativeWrapper<Error>
     subIsDeepFrozen: (value: FabricValue) => boolean,
   ): boolean {
     if (!Object.isFrozen(this)) return false;
-    if (this.cause !== undefined && !subIsDeepFrozen(this.cause)) {
+    if (this.#cause !== undefined && !subIsDeepFrozen(this.#cause)) {
       return false;
     }
     for (const value of this.#extras.values()) {
@@ -271,11 +344,11 @@ export class FabricError extends FabricNativeWrapper<Error>
   /** @inheritDoc */
   protected [SHALLOW_UNFROZEN_CLONE](): FabricError {
     return new FabricError({
-      type: this.type,
-      name: this.name,
-      message: this.message,
-      stack: this.stack,
-      cause: this.cause,
+      type: this.#type,
+      name: this.#name,
+      message: this.#message,
+      stack: this.#stack,
+      cause: this.#cause,
       extras: this.#extras,
     });
   }
@@ -313,15 +386,26 @@ export class FabricError extends FabricNativeWrapper<Error>
    * need recursive unwrap should use `nativeFromFabricValue()`.
    */
   #buildNativeError(frozen: boolean): Error {
-    const ErrorClass = errorClassFromType(this.type);
-    const error = new ErrorClass(this.message);
-    if (error.name !== this.name) error.name = this.name;
-    if (this.stack !== undefined) error.stack = this.stack;
-    if (this.cause !== undefined) error.cause = this.cause;
+    const ErrorClass = errorClassFromType(this.#type);
+    const error = new ErrorClass(this.#message);
+    if (error.name !== this.#name) error.name = this.#name;
+    if (this.#stack !== undefined) error.stack = this.#stack;
+    if (this.#cause !== undefined) error.cause = this.#cause;
     for (const [key, value] of this.#extras) {
       (error as unknown as Record<string, unknown>)[key] = value;
     }
     return frozen ? Object.freeze(error) : error;
+  }
+
+  /**
+   * Guards a mutator against a frozen instance.
+   *
+   * @throws If this instance is frozen.
+   */
+  #assertNotFrozen(): void {
+    if (Object.isFrozen(this)) {
+      throw new Error("Cannot modify frozen FabricError");
+    }
   }
 
   /**

--- a/packages/data-model/src/interface.ts
+++ b/packages/data-model/src/interface.ts
@@ -53,6 +53,14 @@ export abstract class FabricSpecialObject {
  * than this class directly; `BaseFabricInstance` is where shared
  * template-method scaffolding (such as `shallowClone()`) lives.
  *
+ * An instance holds all of its state privately and makes it reachable only
+ * through members, so it has no own properties at all. A structural view of
+ * one -- a spread, `Object.keys()`, a naive walk -- therefore sees nothing.
+ * Mutable state is exposed as an accessor pair over a private field, whose
+ * setter is responsible for honoring the instance's frozen state:
+ * `Object.freeze()` bears only on own properties and so cannot enforce that
+ * on its own.
+ *
  * Subclasses must implement `deepClone()` and `shallowClone()`; both are
  * normally inherited from `BaseFabricInstance` as template methods, with the
  * subclass supplying the symbol-keyed clone core each one calls. The

--- a/packages/data-model/test/fabric-instances/FabricError.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricError.test.ts
@@ -32,6 +32,17 @@ describe("FabricError", () => {
     expect(se instanceof FabricNativeWrapper).toBe(true);
   });
 
+  it("has no own properties", () => {
+    // The `FabricInstance` contract, checked on the state-heaviest of the
+    // concrete classes: an own property here would leak into any structural
+    // view of the instance (spread, `Object.keys()`, a debug rendering).
+    const se = FabricError.fromNativeError(new Error("test"));
+    se.setExtra("extra", 1);
+    expect(Object.getOwnPropertyNames(se)).toEqual([]);
+    expect(Object.getOwnPropertySymbols(se)).toEqual([]);
+    expect({ ...se }).toEqual({});
+  });
+
   describe("constructor()", () => {
     it("wraps the `Error`'s `FabricValue`-shaped state", () => {
       const err = new TypeError("bad");
@@ -40,33 +51,51 @@ describe("FabricError", () => {
       expect(se.name).toBe("TypeError");
       expect(se.message).toBe("bad");
     });
-
-    it("has mutable fixed-schema slots while unfrozen", () => {
-      const se = FabricError.fromNativeError(new Error("orig"));
-      se.message = "changed";
-      se.name = "Renamed";
-      se.cause = { detail: 1 };
-      expect(se.message).toBe("changed");
-      expect(se.name).toBe("Renamed");
-      expect(se.cause).toEqual({ detail: 1 });
-      // The native projection reflects the mutated state (no stale cache).
-      expect(se.toNativeValue(true).message).toBe("changed");
-    });
-
-    it("throws on fixed-schema slot assignment once frozen", () => {
-      const se = FabricError.fromNativeError(new Error("orig"));
-      Object.freeze(se);
-      expect(() => {
-        se.message = "nope";
-      }).toThrow();
-      expect(() => {
-        (se as { name: string }).name = "nope";
-      }).toThrow();
-      expect(se.message).toBe("orig");
-    });
   });
 
   describe("instance members", () => {
+    describe("fixed-schema slots", () => {
+      it("reads back each value assigned while unfrozen", () => {
+        const se = FabricError.fromNativeError(new Error("orig"));
+        se.type = "RangeError";
+        se.name = "Renamed";
+        se.message = "changed";
+        se.stack = "at nowhere";
+        se.cause = { detail: 1 };
+        expect(se.type).toBe("RangeError");
+        expect(se.name).toBe("Renamed");
+        expect(se.message).toBe("changed");
+        expect(se.stack).toBe("at nowhere");
+        expect(se.cause).toEqual({ detail: 1 });
+        // The native projection reflects the mutated state (no stale cache).
+        expect(se.toNativeValue(true).message).toBe("changed");
+      });
+
+      it("throws on assignment to any slot once frozen", () => {
+        const se = FabricError.fromNativeError(new Error("orig"));
+        se.stack = "at nowhere";
+        se.cause = { detail: 1 };
+        Object.freeze(se);
+
+        const assignments: Array<() => void> = [
+          () => se.type = "nope",
+          () => se.name = "nope",
+          () => se.message = "nope",
+          () => se.stack = "nope",
+          () => se.cause = "nope",
+        ];
+        for (const assign of assignments) {
+          expect(assign).toThrow("Cannot modify frozen FabricError");
+        }
+
+        expect(se.type).toBe("Error");
+        expect(se.name).toBe("Error");
+        expect(se.message).toBe("orig");
+        expect(se.stack).toBe("at nowhere");
+        expect(se.cause).toEqual({ detail: 1 });
+      });
+    });
+
     describe("`[CODEC]` `encode()` state", () => {
       it("returns `type`, `name=null` (common case), `message`, `stack`", () => {
         const se = FabricError.fromNativeError(new Error("hello"));

--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -511,8 +511,18 @@ export function createQueryResultProxy<T>(
       // `toString`. Storage traversal deliberately considers own properties
       // only; keeping the same boundary here also avoids recording spurious
       // reactive dependencies for prototype members.
+      //
+      // The receiver is the container, not this proxy: a prototype accessor
+      // has to run against the object that actually holds the state. Every
+      // `FabricInstance` keeps its state in private fields behind accessors,
+      // and a private field is unreachable from a proxy that does not declare
+      // it. (The receiver is immaterial for a data property, which is what
+      // every prototype member of a plain object or array is, so this costs
+      // those nothing.) A `FabricInstance` leafs through storage traversal
+      // whole, so the read of the container already covers what an accessor
+      // returns.
       if (!Object.hasOwn(value, prop) && prop in value) {
-        return Reflect.get(value, prop, receiver);
+        return Reflect.get(value, prop);
       }
 
       return createQueryResultProxy(

--- a/packages/runner/test/query-result-proxy-fabric-instance.test.ts
+++ b/packages/runner/test/query-result-proxy-fabric-instance.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+
+const signer = await Identity.fromPassphrase("test proxy fabric instance");
+const space = signer.did();
+
+// A `FabricInstance` holds all of its state in private fields and exposes it
+// through accessors on its prototype. Reading one through the query-result
+// proxy has to evaluate the accessor against the instance itself: a private
+// field is unreachable from the proxy, which does not declare it, so an
+// accessor run with the proxy as receiver throws outright rather than
+// returning a wrong answer.
+//
+// `FabricError` stands in for the whole tree here because it is the instance a
+// cell write actually produces -- `Cell.set()` of a native `Error` wraps one --
+// and it is the state-heaviest of the concrete classes.
+describe("query-result proxy: FabricInstance accessors read through to the instance", () => {
+  let runtime: Runtime;
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let tx: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    tx = runtime.edit();
+  });
+
+  afterEach(async () => {
+    await tx.commit();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("returns each fixed-schema slot of a stored `FabricError`", () => {
+    const cell = runtime.getCell<unknown>(space, "errorCell", undefined, tx);
+    cell.set(new TypeError("something went wrong"));
+
+    const result = cell.get() as {
+      type: string;
+      name: string;
+      message: string;
+      stack: string;
+    };
+    expect(result.type).toBe("TypeError");
+    expect(result.name).toBe("TypeError");
+    expect(result.message).toBe("something went wrong");
+    expect(typeof result.stack).toBe("string");
+  });
+
+  it("returns a slot of a nested `FabricError` reached through `cause`", () => {
+    const cell = runtime.getCell<unknown>(space, "causeCell", undefined, tx);
+    cell.set(new Error("outer", { cause: new RangeError("inner") }));
+
+    const result = cell.get() as {
+      message: string;
+      cause: { type: string; message: string };
+    };
+    expect(result.message).toBe("outer");
+    expect(result.cause.type).toBe("RangeError");
+    expect(result.cause.message).toBe("inner");
+  });
+});


### PR DESCRIPTION
## The bug

A `FabricError` exposed `type`, `name`, `message`, `stack`, and `cause` as plain
public fields, so it had five own enumerable properties. That violates the
`FabricInstance` contract: an instance holds all of its state privately and has
no own properties at all. Anything taking a structural view of one — a spread,
`Object.keys()`, a debug rendering, a walk that descends by property name — saw
interior state that is supposed to be reachable only through members.

## The fix

The five slots become `#private` fields behind getter/setter pairs on the
prototype.

Frozen-state enforcement has to move into the code as a result. `Object.freeze()`
bears only on own properties, so a prototype setter runs happily on a frozen
instance and the language is no longer doing the work. A new `#assertNotFrozen()`
guards every setter, and `setExtra` / `deleteExtra` — which had the same check
inlined — now share it.

**One behavior shift:** assignment to a slot on a frozen instance threw a
strict-mode `TypeError` and now throws `Error("Cannot modify frozen
FabricError")`, matching the extras bag. The existing test asserted only
`.toThrow()`, so nothing was pinned to the old type.

## Where the design statement lives

On `FabricInstance`, not on this one subclass — `data-model/src/interface.ts`,
`packages/api/index.ts`, and §2.3 of the formal spec — so it flows to every
subclass without being restated. §1.4.2 and the two `FabricError` doc comments
lose the claim that the slots are plain writable own properties, which is what
they said.

The `api` copy stops after the "no own properties" sentence; `data-model` and the
spec continue with the accessor-pair and frozen-state guidance. That guidance is
about how an implementation satisfies the contract, and `api` carries no
implementations.

All other `FabricInstance` subclasses already honor the contract: a grep for
public instance fields across `data-model/src/fabric-instances/` returns only
`FabricErrorState` (a type) and a constructor parameter.

## The latent proxy bug this uncovers

Four runner tests broke with `Cannot read private member #message from an object
whose class did not declare it`. `query-result-proxy.ts` reflected an inherited
property with `Reflect.get(value, prop, receiver)`, the receiver being the proxy
— whose target, for a frozen value, is a bare `{}`. A prototype accessor reading
a private field cannot survive that.

This is not introduced here. Every `FabricInstance` accessor would throw at that
line; `FabricLink.payload` is the same shape and would hit it identically the
moment a link surfaced through a query result. The slots are simply the first
accessors to reach it.

Dropping the receiver runs the accessor against the object that actually holds
the state. The receiver is immaterial for a data property — which is every
prototype member of a plain object or array — so nothing else changes.

**Worth a reviewer's attention:** read granularity shifts for a `FabricInstance`.
`result.message` now returns the raw slot rather than a proxy over a storage read
at `path + "message"`. That reads as the honest granularity given that
`traverse.ts` already leafs a `FabricInstance` through whole — its own `TODO`
says it should descend by codec contents, which does not exist yet — so the read
of the container already covers what an accessor returns. But it is a change at
the read boundary.

## Tests

`FabricError.test.ts` gains a `has no own properties` test asserting empty
`getOwnPropertyNames` / `getOwnPropertySymbols` and an empty spread. The two slot
tests move out of `describe("constructor()")`, where they did not belong, into
their own group under instance members, now covering all five slots in both
directions rather than two of them.

`query-result-proxy-fabric-instance.test.ts` is new, and pins the proxy-side
contract directly. The `Reflect.get` change otherwise had only incidental
coverage: reverting it turns three `cell-core.test.ts` tests red, but that is a
file about `Cell` catching this through the `Error`-into-a-cell path, and both
existing `query-result-proxy-*` files pass against the reverted code. The new
file states the rule instead — a `FabricInstance`'s prototype accessor, read
through a query-result proxy, evaluates against the instance rather than the
proxy — with `FabricError` standing in for the tree.

## Verification

`deno fmt`, `deno lint`, `deno task check`, `deno task check-docs`,
`deno task check-no-waitfor`, and the full workspace suite all pass on the final
tree. Both new proxy cases were confirmed by ablation: they fail against the
`receiver`-passing version and pass with it.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


