### PR TITLE
test(runtime-client): cover FabricBytes VDOM props across worker IPC

### DIFF
--- a/packages/runtime-client/test/backends/post-to-client.test.ts
+++ b/packages/runtime-client/test/backends/post-to-client.test.ts
@@ -1,9 +1,11 @@
 /**
- * What the worker's outbound side does with a message the encoding refuses.
+ * What the worker's outbound side carries, and what it does with a message the
+ * encoding refuses.
  *
- * `postToClient()` is the whole of that side, so it is also the only place a
- * failure to encode can be answered. What it answers with differs by whether
- * anyone is awaiting a reply, and it must not throw either way.
+ * `postToClient()` is the whole of that side. A successful message crosses as
+ * one realm encoding; a failure to encode is answered here. What a failure
+ * becomes differs by whether anyone is awaiting a reply, and it must not throw
+ * either way.
  */
 
 import { describe, it } from "@std/testing/bdd";
@@ -11,9 +13,14 @@ import { expect } from "@std/expect";
 
 import { fabricFromRealmValue } from "@commonfabric/data-model/codecs";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
+import type { SetPropOp } from "@commonfabric/html/vdom-ops";
+import { WorkerReconciler } from "@commonfabric/html/worker";
 
 import { postToClient } from "@/backends/post-to-client.ts";
-import { NotificationType } from "@/protocol/mod.ts";
+import {
+  NotificationType,
+  type VDomBatchNotification,
+} from "@/protocol/mod.ts";
 
 /**
  * A value that passes every `FabricValue` check and has no encoding: an object
@@ -25,7 +32,10 @@ function forged(): unknown {
   return Object.create(FabricBytes.prototype);
 }
 
-/** Captures what the worker posts, decoding it as the client's transport does. */
+/**
+ * Captures what the worker posts after the clone-and-decode the client's
+ * transport performs.
+ */
 function capturing(): {
   posted: Record<string, unknown>[];
   restore: () => void;
@@ -34,7 +44,10 @@ function capturing(): {
   const original = (globalThis as { postMessage?: unknown }).postMessage;
   (globalThis as { postMessage: (m: unknown) => void }).postMessage = (m) => {
     posted.push(
-      fabricFromRealmValue(m as never) as Record<string, unknown>,
+      fabricFromRealmValue(structuredClone(m) as never) as Record<
+        string,
+        unknown
+      >,
     );
   };
   return {
@@ -46,6 +59,49 @@ function capturing(): {
 }
 
 describe("post-to-client", () => {
+  describe("a VDOM batch", () => {
+    it("carries a FabricBytes prop emitted by the reconciler", () => {
+      const content = new Uint8Array([0xff, 0xd8, 0xff, 0xe0]);
+      const { posted, restore } = capturing();
+      let sent = false;
+
+      const reconciler = new WorkerReconciler({
+        onOps: (ops) => {
+          sent = postToClient({
+            type: NotificationType.VDomBatch,
+            batchId: 7,
+            ops,
+          });
+          return 7;
+        },
+      });
+      const cancel = reconciler.mount({
+        type: "vnode",
+        name: "cf-image",
+        props: { bytes: new FabricBytes(content) } as never,
+        children: [],
+      });
+
+      try {
+        // Mount queues operations onto a microtask. Flush them at the explicit
+        // boundary so the assertion observes exactly one complete batch.
+        reconciler.flush();
+
+        expect(sent).toBe(true);
+        expect(posted).toHaveLength(1);
+        const batch = posted[0] as unknown as VDomBatchNotification;
+        const prop = batch.ops.find((op): op is SetPropOp =>
+          op.op === "set-prop" && op.key === "bytes"
+        );
+        expect(prop?.value).toBeInstanceOf(FabricBytes);
+        expect((prop?.value as FabricBytes).slice()).toEqual(content);
+      } finally {
+        cancel();
+        restore();
+      }
+    });
+  });
+
   describe("a message the encoding refuses", () => {
     it("answers a reply as a failure, so the request settles", () => {
       // The client is awaiting this `msgId`. Dropping the message would leave


### PR DESCRIPTION
## Summary

Adds a focused green regression for the worker → main-thread VDOM prop seam closed by #5823 and #6323.

A pattern can render a `FabricBytes` as an element prop. The reconciler must emit it whole, and the runtime-client transport must carry the containing `VDomBatch` through the realm boundary without structured clone reducing the primitive to `{}`.

## What the test exercises

The test follows the production composition rather than mirroring its individual helpers:

1. A real `WorkerReconciler` renders a `<cf-image>` VNode with a `FabricBytes` `bytes` prop.
2. The reconciler emits the real `set-prop` operation inside a VDOM batch.
3. Production `postToClient()` realm-encodes the complete notification.
4. `structuredClone()` reproduces the `postMessage()` crossing.
5. `fabricFromRealmValue()` reproduces the client transport's decode.
6. The delivered prop is asserted to still be a `FabricBytes` with the original contents.

The existing outbound capture helper now includes the structured-clone step as well, so its other tests model encode → clone → decode rather than encode → decode.

## Why this adds coverage

The underlying pieces already have strong independent coverage:

- `codec-realm` preserves `FabricBytes` (#5823).
- The complete runtime-worker IPC envelope uses the realm codec (#6323).
- `convertCellsToLinks()` treats fabric primitives as leaves.
- `cf-image` accepts byte-like values.

What was not pinned was their composition for the exact VDOM prop path that exposed the original failure. A future reconciler transformation or VDOM-specific transport change could flatten the value while the codec and generic worker tests continued to pass.

This PR deliberately does not duplicate `cf-image` coercion or maintain a local copy of component behavior.

## Verification

- `deno test packages/runtime-client/test/backends/post-to-client.test.ts`
- `cd packages/runtime-client && deno task test` — 371 steps passed
- `deno task check`
- `deno fmt --check`
- `deno lint`

<sub>Originally opened as a deliberately-red probe of the raw structured-clone gap. Dan's realm-codec work resolved the production path; the PR is now the green composition regression for that resolution.</sub>