### PR TITLE
fix(runtime-client): refuse what the connection cannot carry

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -843,24 +843,52 @@ otherwise hand it back whole, leaving a binding nested inside it silently
 unresolved.
 
 These throws are **discovery instruments**. Each one that fires names a site
-that owes work before the relevant flag can graduate, which is more useful than
-a quiet wrong answer that surfaces later as corrupted data.
+that owes work — for a flag-gated site, work the flag needs before it can
+graduate — which is more useful than a quiet wrong answer that surfaces later
+as corrupted data.
 
-**The invariant that makes this safe rather than merely lucky:** anything
-introduced that would reach one of these throws is itself gated on an experiment
-flag. A default configuration therefore never arrives at one, and any arrival is
-something a flag was deliberately turned on to reach.
+**The invariant that makes this safe rather than merely lucky:** nothing that
+reaches one of these throws is believed to be in production use. That is what a
+tripwire asserts, and it is what makes refusing the right answer — refusing
+costs nothing if nobody is doing the thing, and says so immediately if somebody
+is.
 
-Two obligations follow, and they are the reason this is recorded here rather
+The invariant holds in two strengths, and it is worth knowing which one a given
+site has:
+
+- **By construction**, where an experiment flag gates the only path that
+  arrives. A default configuration never reaches the throw, and any arrival is
+  something a flag was deliberately turned on to reach.
+- **De facto**, where the value is shipped and ungated and simply has no
+  production caller yet. A `FabricError` is exposed to pattern authors
+  (`builder/factory.ts`) and reaches these throws with every flag off; a
+  `FabricBytes` written from the client reaches `CellHandle.serialize()`'s
+  refusal the same way. Nothing stops such a call being written tomorrow. What
+  makes the tripwire safe today is that none exists.
+
+The second is the weaker claim, but it does not fail quietly, and that is the
+point. Add a production use of one of these values and the throw fires — at the
+moment the use is added, in the change that added it — leaving exactly two
+honest ways forward: implement the handling the throw names, or back the use
+out. So the tripwire is its own enforcement, which is why an ungated site is
+legitimate. What it is not is a flag, so do not cite this section as though one
+stood behind every throw.
+
+Three obligations follow, and they are the reason this is recorded here rather
 than at any one of the sites:
 
 - **Adding a feature.** If your change would let a value reach one of these
-  throws in a default configuration, gate the change on an experiment flag. That
-  is what keeps the default path clear and the tripwire honest.
-- **Meeting one.** A throw firing under a flag is the instrument working, not a
-  defect in it. The answer is to implement the missing handling at the site it
-  names — that work *is* the flag's graduation work — rather than to exempt the
-  value so the walk stays quiet.
+  throws in a default configuration, you have three options and they are all
+  fine: gate the change on an experiment flag, implement the handling the throw
+  names first, or do not add the use. What is not an option is shipping the use
+  and leaving the throw reachable in production.
+- **Adding a throw.** Say which strength it has. A de-facto one is legitimate —
+  several exist — but it is a claim about the callers that exist today, so it
+  should be made deliberately rather than assumed from this section.
+- **Meeting one.** A throw firing is the instrument working, not a defect in it.
+  Implement the missing handling at the site it names — for a flag-gated site
+  that work *is* the flag's graduation work — or back out the use that reached
+  it. What is not on the list is exempting the value so the walk stays quiet.
 
 Worked example: with [`modernCellRep`](#moderncellrep) on, a link is a
 `FabricLink` and therefore a `FabricInstance`, so ordinary links reach these

--- a/packages/runtime-client/cell-handle.test.ts
+++ b/packages/runtime-client/cell-handle.test.ts
@@ -768,10 +768,10 @@ describe("CellHandle push (read-modify-write)", () => {
 });
 
 describe("CellHandle special-object refusal", () => {
-  // A `FabricSpecialObject` is a `ClientCellValue` -- a cell holds one like any
-  // other value -- and `WireCellValue` has no representation for it. Serializing
-  // one used to rebuild it from its enumerable own properties, putting `{}` on
-  // the wire in place of the bytes.
+  // A `FabricSpecialObject` is a `ClientCellValue` -- a cell holds one like
+  // any other value -- and `WireCellValue` has no representation for it.
+  // Without the refusal, serializing one rebuilds it from its enumerable own
+  // properties, putting `{}` on the wire in place of the bytes.
 
   it("throws for a `FabricBytes` rather than sending an empty record", () => {
     expect(() =>
@@ -805,7 +805,7 @@ describe("CellHandle special-object refusal", () => {
     //
     // `toStrictEqual`, because `toEqual` ignores an `undefined`-valued key in
     // both directions -- so it would pass just as well if `c` were dropped
-    // entirely. Carrying a PRESENT `undefined` is one of the two properties
+    // entirely. Carrying a _present_ `undefined` is one of the two properties
     // `WireCellValue` exists to have over `JSONValue`, which makes it the half
     // of this fixture most worth actually asserting.
     expect(CellHandle.serialize({ a: 1, b: [true, null], c: undefined }))
@@ -834,10 +834,10 @@ describe("CellHandle refused writes", () => {
       }),
     }) as unknown as RuntimeClient;
 
-  // The local update is optimistic about the WRITE landing, not about whether
-  // the value can be sent at all. A value the connection refuses is one the
-  // runtime will never hold, so it must not become the cached value or reach a
-  // subscriber -- that would show state that does not exist anywhere.
+  // The local update is optimistic about the _write_ landing, not about
+  // whether the value can be sent at all. A value the connection refuses is
+  // one the runtime will never hold, so it must not become the cached value or
+  // reach a subscriber -- that would show state that does not exist anywhere.
 
   it("keeps the prior value after a refused set", async () => {
     const cell = new CellHandle<unknown>(runtimeCapturing([]), ref);

--- a/packages/runtime-client/cell-handle.test.ts
+++ b/packages/runtime-client/cell-handle.test.ts
@@ -802,12 +802,18 @@ describe("CellHandle special-object refusal", () => {
 
   it("serializes an ordinary record unchanged", () => {
     // The refusal must not claim a plain record on its way past.
+    //
+    // `toStrictEqual`, because `toEqual` ignores an `undefined`-valued key in
+    // both directions -- so it would pass just as well if `c` were dropped
+    // entirely. Carrying a PRESENT `undefined` is one of the two properties
+    // `WireCellValue` exists to have over `JSONValue`, which makes it the half
+    // of this fixture most worth actually asserting.
     expect(CellHandle.serialize({ a: 1, b: [true, null], c: undefined }))
-      .toEqual({ a: 1, b: [true, null], c: undefined });
+      .toStrictEqual({ a: 1, b: [true, null], c: undefined });
   });
 });
 
-describe("CellHandle refused write leaves no local trace", () => {
+describe("CellHandle refused writes", () => {
   const ref: CellRef = {
     id: "of:refused-cell" as CellRef["id"],
     space: "did:key:test" as CellRef["space"],
@@ -834,8 +840,7 @@ describe("CellHandle refused write leaves no local trace", () => {
   // subscriber -- that would show state that does not exist anywhere.
 
   it("keeps the prior value after a refused set", async () => {
-    const requests: unknown[] = [];
-    const cell = new CellHandle<unknown>(runtimeCapturing(requests), ref);
+    const cell = new CellHandle<unknown>(runtimeCapturing([]), ref);
     cell[$onCellUpdate]("before");
 
     await expect(cell.set(new FabricBytes(new Uint8Array([1])))).rejects
@@ -845,8 +850,7 @@ describe("CellHandle refused write leaves no local trace", () => {
   });
 
   it("notifies no subscriber of a refused set", async () => {
-    const requests: unknown[] = [];
-    const cell = new CellHandle<unknown>(runtimeCapturing(requests), ref);
+    const cell = new CellHandle<unknown>(runtimeCapturing([]), ref);
     cell[$onCellUpdate]("before");
     const seen: unknown[] = [];
     cell.subscribe((value) => {
@@ -868,5 +872,67 @@ describe("CellHandle refused write leaves no local trace", () => {
       .toThrow("Cannot yet handle `FabricBytes`");
 
     expect(requests).toEqual([]);
+  });
+});
+
+describe("CellHandle refusal reaches every write path", () => {
+  const ref: CellRef = {
+    id: "of:paths-cell" as CellRef["id"],
+    space: "did:key:test" as CellRef["space"],
+    scope: "space",
+    path: [],
+  };
+
+  const runtimeCapturing = (requests: unknown[]): RuntimeClient =>
+    ({
+      [$conn]: () => ({
+        request: (request: unknown) => {
+          requests.push(request);
+          return Promise.resolve({});
+        },
+        subscribe: () => Promise.resolve(),
+        unsubscribe: () => Promise.resolve(),
+        signal: { aborted: false },
+      }),
+    }) as unknown as RuntimeClient;
+
+  // Three methods serialize, and each refuses through a different caller
+  // contract: `set()` rejects, `send()` rejects, and `push()` throws
+  // synchronously out of a `void` return. Pinning all three is what keeps a
+  // later refactor from moving the check somewhere only `set()` reaches.
+
+  it("throws synchronously out of `push()`, which returns void", () => {
+    const requests: unknown[] = [];
+    const cell = new CellHandle<unknown[]>(runtimeCapturing(requests), ref);
+    cell[$onCellUpdate]([1, 2]);
+
+    expect(() => cell.push(new FabricBytes(new Uint8Array([1])))).toThrow(
+      "Cannot yet handle `FabricBytes`",
+    );
+    expect(requests).toEqual([]);
+    // The read-modify-write left the cached array alone.
+    expect(cell.get()).toEqual([1, 2]);
+  });
+
+  it("rejects from `send()` without reaching the connection", async () => {
+    const requests: unknown[] = [];
+    const cell = new CellHandle<unknown>(runtimeCapturing(requests), ref);
+
+    await expect(cell.send(new FabricBytes(new Uint8Array([1])))).rejects
+      .toThrow("Cannot yet handle `FabricBytes`");
+    expect(requests).toEqual([]);
+  });
+
+  it("rejects a `bigint`, which no arm of the wire type carries", async () => {
+    // Not an object, so the `FabricSpecialObject` check cannot catch it. It is
+    // a `FabricValue` arm all the same, so a cell holds one and
+    // `ClientCellValue` admits one -- the same gap, for an arm that is not an
+    // object. The message names the kind, since `1n` prints as `1` and would
+    // otherwise read as a number refused for no reason.
+    const cell = new CellHandle<unknown>(runtimeCapturing([]), ref);
+
+    await expect(cell.set(1n)).rejects.toThrow(
+      "Cannot send a `bigint` on this connection",
+    );
   });
 });

--- a/packages/runtime-client/cell-handle.test.ts
+++ b/packages/runtime-client/cell-handle.test.ts
@@ -11,6 +11,10 @@ import {
 } from "./mod.ts";
 import { cellRefToKey } from "./shared/utils.ts";
 import { linkRefPayloadFromString } from "@commonfabric/runner/shared";
+import {
+  FabricBytes,
+  FabricEpochNsec,
+} from "@commonfabric/data-model/fabric-primitives";
 
 describe("CellHandle CFC label IPC", () => {
   it("queries the runtime for the label view behind a cell", async () => {
@@ -760,5 +764,45 @@ describe("CellHandle push (read-modify-write)", () => {
     expect(() => cell.push(1)).toThrow(
       "push() can only be used on array cells",
     );
+  });
+});
+
+describe("CellHandle special-object refusal", () => {
+  // A `FabricSpecialObject` is a `ClientCellValue` -- a cell holds one like any
+  // other value -- and `WireCellValue` has no representation for it. Serializing
+  // one used to rebuild it from its enumerable own properties, putting `{}` on
+  // the wire in place of the bytes.
+
+  it("throws for a `FabricBytes` rather than sending an empty record", () => {
+    expect(() =>
+      CellHandle.serialize(new FabricBytes(new Uint8Array([1, 2, 3])))
+    ).toThrow(
+      "Cannot yet handle `FabricBytes` (a `FabricSpecialObject`) on this " +
+        "connection.",
+    );
+  });
+
+  it("throws for a `FabricSpecialObject` nested in a record", () => {
+    // The branch it has to precede is the record one, so the nested position
+    // is the case that pins the ordering rather than merely the check.
+    expect(() => CellHandle.serialize({ a: { b: new FabricEpochNsec(1n) } }))
+      .toThrow(
+        "Cannot yet handle `FabricEpochNsec` (a `FabricSpecialObject`) on this " +
+          "connection.",
+      );
+  });
+
+  it("throws for a `FabricSpecialObject` nested in an array", () => {
+    expect(() => CellHandle.serialize([new FabricBytes(new Uint8Array([7]))]))
+      .toThrow(
+        "Cannot yet handle `FabricBytes` (a `FabricSpecialObject`) on this " +
+          "connection.",
+      );
+  });
+
+  it("serializes an ordinary record unchanged", () => {
+    // The refusal must not claim a plain record on its way past.
+    expect(CellHandle.serialize({ a: 1, b: [true, null], c: undefined }))
+      .toEqual({ a: 1, b: [true, null], c: undefined });
   });
 });

--- a/packages/runtime-client/cell-handle.test.ts
+++ b/packages/runtime-client/cell-handle.test.ts
@@ -806,3 +806,67 @@ describe("CellHandle special-object refusal", () => {
       .toEqual({ a: 1, b: [true, null], c: undefined });
   });
 });
+
+describe("CellHandle refused write leaves no local trace", () => {
+  const ref: CellRef = {
+    id: "of:refused-cell" as CellRef["id"],
+    space: "did:key:test" as CellRef["space"],
+    scope: "space",
+    path: [],
+  };
+
+  const runtimeCapturing = (requests: unknown[]): RuntimeClient =>
+    ({
+      [$conn]: () => ({
+        request: (request: unknown) => {
+          requests.push(request);
+          return Promise.resolve({});
+        },
+        subscribe: () => Promise.resolve(),
+        unsubscribe: () => Promise.resolve(),
+        signal: { aborted: false },
+      }),
+    }) as unknown as RuntimeClient;
+
+  // The local update is optimistic about the WRITE landing, not about whether
+  // the value can be sent at all. A value the connection refuses is one the
+  // runtime will never hold, so it must not become the cached value or reach a
+  // subscriber -- that would show state that does not exist anywhere.
+
+  it("keeps the prior value after a refused set", async () => {
+    const requests: unknown[] = [];
+    const cell = new CellHandle<unknown>(runtimeCapturing(requests), ref);
+    cell[$onCellUpdate]("before");
+
+    await expect(cell.set(new FabricBytes(new Uint8Array([1])))).rejects
+      .toThrow("Cannot yet handle `FabricBytes`");
+
+    expect(cell.get()).toBe("before");
+  });
+
+  it("notifies no subscriber of a refused set", async () => {
+    const requests: unknown[] = [];
+    const cell = new CellHandle<unknown>(runtimeCapturing(requests), ref);
+    cell[$onCellUpdate]("before");
+    const seen: unknown[] = [];
+    cell.subscribe((value) => {
+      seen.push(value);
+    });
+    seen.length = 0; // Drop any initial delivery; what follows is the point.
+
+    await expect(cell.set(new FabricBytes(new Uint8Array([1])))).rejects
+      .toThrow("Cannot yet handle `FabricBytes`");
+
+    expect(seen).toEqual([]);
+  });
+
+  it("sends nothing over the connection for a refused set", async () => {
+    const requests: unknown[] = [];
+    const cell = new CellHandle<unknown>(runtimeCapturing(requests), ref);
+
+    await expect(cell.set(new FabricBytes(new Uint8Array([1])))).rejects
+      .toThrow("Cannot yet handle `FabricBytes`");
+
+    expect(requests).toEqual([]);
+  });
+});

--- a/packages/runtime-client/cell-handle.ts
+++ b/packages/runtime-client/cell-handle.ts
@@ -40,10 +40,10 @@ const logger = getLogger("cell-handle", { enabled: false });
 export const $onCellUpdate = Symbol("$onCellUpdate");
 
 /**
- * A cell's value as the CLIENT holds it: what a cell holds, with a
- * `CellHandle` wherever a cell sits. That is the substitution
- * `vnode-types.ts` already makes for the render types -- `Cell` replaced by
- * `CellHandle` -- applied to a cell's own value.
+ * A cell's value as the _client_ holds it: what a cell holds, with a
+ * `CellHandle` wherever a cell sits. That is the substitution `vnode-types.ts`
+ * already makes for the render types -- `Cell` replaced by `CellHandle` --
+ * applied to a cell's own value.
  *
  * What a cell holds is a `FabricValue`, so that is an arm of this rather than
  * something restated: a `FabricBytes` in a cell is a value the client holds
@@ -51,7 +51,7 @@ export const $onCellUpdate = Symbol("$onCellUpdate");
  * The container arms are here too, since theirs hold `FabricValue` where these
  * hold handles as well.
  *
- * That the connection cannot presently CARRY all of it is a fact about
+ * That the connection cannot presently _carry_ all of it is a fact about
  * `WireCellValue`, not about this: see the note there.
  */
 export type ClientCellValue =
@@ -150,18 +150,19 @@ export class CellHandle<T = unknown> {
   }
 
   // Optimistic local update (mirrors the old set()) plus the remote write. The
-  // request TYPE encodes the intent: CellSet is a blind overwrite, CellPush is a
-  // read-modify-write append that the runtime keeps as compare-and-set.
+  // request _type_ encodes the intent: CellSet is a blind overwrite, CellPush
+  // is a read-modify-write append that the runtime keeps as compare-and-set.
   #applyLocalAndSend(
     value: T,
     type: RequestType.CellSet | RequestType.CellPush,
   ): Promise<void> {
-    // Serialized FIRST, because it can refuse. The local update below is
-    // optimistic about the WRITE -- it assumes a value the connection accepts
-    // will land -- and not about whether the value can be sent at all. Were the
-    // refusal to come after, a value the runtime is never going to see would
-    // already be this handle's cached value and would already have reached
-    // every subscriber, leaving the display showing state that does not exist.
+    // Serialized _first_, because it can refuse. The local update below is
+    // optimistic about the _write_ -- it assumes a value the connection
+    // accepts will land -- and not about whether the value can be sent at all.
+    // Were the refusal to come after, a value the runtime is never going to
+    // see would already be this handle's cached value and would already have
+    // reached every subscriber, leaving the display showing state that does
+    // not exist.
     //
     // `T` is unconstrained, so this says what the write path requires rather
     // than what the class guarantees. Constraining `T` to `ClientCellValue` is
@@ -538,13 +539,13 @@ export class CellHandle<T = unknown> {
 
     // A `FabricSpecialObject` is a `ClientCellValue` -- a cell holds one like
     // any other value -- but `WireCellValue` has no representation for it, so
-    // this refuses rather than converting. It goes BEFORE the record test:
+    // this refuses rather than converting. It goes _before_ the record test:
     // such a value is also a record, and that branch would otherwise rebuild
     // it from enumerable own properties it is not supposed to have, putting
     // `{}` on the wire in place of a `FabricBytes` and losing the bytes with
     // nothing to show for it.
     //
-    // A DE-FACTO tripwire, in the sense of "Flag-gated tripwires" in
+    // A _de facto_ tripwire, in the sense of "Flag-gated tripwires" in
     // `docs/development/EXPERIMENTAL_OPTIONS.md`: no flag gates this, and a
     // `FabricBytes` is an ordinary shipped value, so what makes the refusal
     // safe is that nothing writes one from the client today. The first thing

--- a/packages/runtime-client/cell-handle.ts
+++ b/packages/runtime-client/cell-handle.ts
@@ -156,6 +156,23 @@ export class CellHandle<T = unknown> {
     value: T,
     type: RequestType.CellSet | RequestType.CellPush,
   ): Promise<void> {
+    // Serialized FIRST, because it can refuse. The local update below is
+    // optimistic about the WRITE -- it assumes a value the connection accepts
+    // will land -- and not about whether the value can be sent at all. Were the
+    // refusal to come after, a value the runtime is never going to see would
+    // already be this handle's cached value and would already have reached
+    // every subscriber, leaving the display showing state that does not exist.
+    //
+    // `T` is unconstrained, so this says what the write path requires rather
+    // than what the class guarantees. Constraining `T` to `ClientCellValue` is
+    // the honest fix and is not a small one: the schema-derived types
+    // (`ObjectFromProperties<...>`) and the looser `Props` of `vnode-types.ts`
+    // do not satisfy it, an interface having no implicit index signature where
+    // an identical type alias does.
+    //
+    // TODO(danfuzz): constrain `T`, once those types are assignable.
+    const serialized = CellHandle.serialize(value as ClientCellValue);
+
     this.#value = value;
 
     for (const callback of this.#callbacks.values()) {
@@ -168,15 +185,6 @@ export class CellHandle<T = unknown> {
     }
 
     const cell = this.ref();
-    // `T` is unconstrained, so this says what the write path requires rather
-    // than what the class guarantees. Constraining `T` to `ClientCellValue` is
-    // the honest fix and is not a small one: the schema-derived types
-    // (`ObjectFromProperties<...>`) and the looser `Props` of `vnode-types.ts`
-    // do not satisfy it, an interface having no implicit index signature where
-    // an identical type alias does.
-    //
-    // TODO(danfuzz): constrain `T`, once those types are assignable.
-    const serialized = CellHandle.serialize(value as ClientCellValue);
     const request = type === RequestType.CellPush
       ? this.#conn.request<RequestType.CellPush>({
         type: RequestType.CellPush,

--- a/packages/runtime-client/cell-handle.ts
+++ b/packages/runtime-client/cell-handle.ts
@@ -570,12 +570,21 @@ export class CellHandle<T = unknown> {
       return value;
     }
 
-    // Unreachable by the type, and kept for callers that reach this untyped:
-    // `CellHandle<T>` does not constrain `T`, so `set()` and `send()` cast on
-    // the way in. `String()` rather than interpolation, a symbol throwing on
-    // implicit conversion and replacing this refusal with a `TypeError` naming
-    // nothing.
-    throw new Error(`Unknown type: ${String(value)}`);
+    // Reachable two ways. A `bigint` and a `symbol` are `FabricValue` arms, so
+    // a cell holds either and `ClientCellValue` admits either, while
+    // `WireCellValue` has neither -- the same gap the refusal above covers,
+    // for the two arms that are not objects. And `CellHandle<T>` does not
+    // constrain `T`, so `set()` and `send()` cast on the way in and a caller
+    // can arrive here with anything at all.
+    //
+    // `typeof` names the kind, since the value's own text rarely explains the
+    // refusal: a `1n` prints as `1`, which reads like a number that was
+    // rejected for no reason. `String()` rather than interpolation, a symbol
+    // throwing on implicit conversion and replacing this refusal with a
+    // `TypeError` naming nothing.
+    throw new Error(
+      `Cannot send a \`${typeof value}\` on this connection: ${String(value)}`,
+    );
   }
 }
 

--- a/packages/runtime-client/cell-handle.ts
+++ b/packages/runtime-client/cell-handle.ts
@@ -544,6 +544,12 @@ export class CellHandle<T = unknown> {
     // `{}` on the wire in place of a `FabricBytes` and losing the bytes with
     // nothing to show for it.
     //
+    // A DE-FACTO tripwire, in the sense of "Flag-gated tripwires" in
+    // `docs/development/EXPERIMENTAL_OPTIONS.md`: no flag gates this, and a
+    // `FabricBytes` is an ordinary shipped value, so what makes the refusal
+    // safe is that nothing writes one from the client today. The first thing
+    // that does will throw here, in the change that adds it.
+    //
     // TODO(danfuzz): carry the whole `FabricValue` domain across this
     // connection, at which point this becomes a conversion rather than a
     // refusal. `JsonEncodingContext` is the mechanism, and the gap it closes

--- a/packages/runtime-client/cell-handle.ts
+++ b/packages/runtime-client/cell-handle.ts
@@ -25,7 +25,10 @@ import {
   type WireCellValue,
 } from "./protocol/mod.ts";
 import { DID } from "@commonfabric/identity";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import {
+  FabricSpecialObject,
+  type FabricValue,
+} from "@commonfabric/data-model/fabric-value";
 import { isRecord } from "@commonfabric/utils/types";
 import { InitializedRuntimeConnection } from "./client/connection.ts";
 import { getLogger } from "@commonfabric/utils/logger";
@@ -514,21 +517,34 @@ export class CellHandle<T = unknown> {
    * Converts a value the client holds into the one the connection carries,
    * which is the same data with a `CellRef` wherever a `CellHandle` sat.
    *
+   * Refuses a `FabricSpecialObject`, which the connection cannot carry.
+   *
    * `CellHandle.deserialize()` is the inverse.
    */
   static serialize(value: ClientCellValue): WireCellValue {
-    // TODO(danfuzz): this does not handle the whole of its stated input. A
-    // `FabricSpecialObject` is a `ClientCellValue`, and `isRecord()` reports
-    // one, so it reaches the record branch below and is rebuilt from its
-    // (empty) enumerable members -- `{}` in place of a `FabricBytes`.
-    // `WireCellValue` cannot represent one either, so the fix is a refusal
-    // here rather than a conversion, and belongs with the wire gap marked on
-    // that type.
-
     if (isCellHandle(value)) return value.ref();
 
     if (Array.isArray(value)) {
       return value.map((element) => CellHandle.serialize(element));
+    }
+
+    // A `FabricSpecialObject` is a `ClientCellValue` -- a cell holds one like
+    // any other value -- but `WireCellValue` has no representation for it, so
+    // this refuses rather than converting. It goes BEFORE the record test:
+    // such a value is also a record, and that branch would otherwise rebuild
+    // it from enumerable own properties it is not supposed to have, putting
+    // `{}` on the wire in place of a `FabricBytes` and losing the bytes with
+    // nothing to show for it.
+    //
+    // TODO(danfuzz): carry the whole `FabricValue` domain across this
+    // connection, at which point this becomes a conversion rather than a
+    // refusal. `JsonEncodingContext` is the mechanism, and the gap it closes
+    // is the one marked on `WireCellValue` in `protocol/types.ts`.
+    if (value instanceof FabricSpecialObject) {
+      throw new Error(
+        `Cannot yet handle \`${value.constructor.name}\` (a ` +
+          "`FabricSpecialObject`) on this connection.",
+      );
     }
 
     if (isRecord(value)) {

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -259,7 +259,8 @@ export interface CellGetRequest extends BaseRequest {
  * `postMessage` rather than JSON, so that is a gap rather than a limit.
  * `JsonEncodingContext` (`@commonfabric/data-model/codec-json`) is the
  * mechanism, already used for blob-upload bodies in
- * `backends/runtime-processor.ts`.
+ * `backends/runtime-processor.ts`. Until then `CellHandle.serialize()` refuses
+ * one, so what the gap costs is a throw rather than silent loss.
  */
 export type WireCellValue =
   | null

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -254,13 +254,16 @@ export interface CellGetRequest extends BaseRequest {
  * present `undefined` is a value a cell can hold, and the containers are
  * readonly.
  *
- * TODO(danfuzz): this still cannot carry the whole `FabricValue` domain -- a
- * `FabricSpecialObject` has no representation here, though the transport is
- * `postMessage` rather than JSON, so that is a gap rather than a limit.
- * `JsonEncodingContext` (`@commonfabric/data-model/codec-json`) is the
- * mechanism, already used for blob-upload bodies in
- * `backends/runtime-processor.ts`. Until then `CellHandle.serialize()` refuses
- * one, so what the gap costs is a throw rather than silent loss.
+ * TODO(danfuzz): this still cannot carry the whole `FabricValue` domain. A
+ * `FabricSpecialObject` has no representation here, and neither does a
+ * `bigint` or a `symbol`, both of which are `FabricValue` arms. The transport
+ * is `postMessage` rather than JSON, so that is a gap rather than a limit --
+ * though structured clone alone does not close it, a class instance arriving
+ * with its prototype and private fields gone. `JsonEncodingContext`
+ * (`@commonfabric/data-model/codec-json`) is the mechanism, already used for
+ * blob-upload bodies in `backends/runtime-processor.ts`. Until then
+ * `CellHandle.serialize()` refuses all three, so what the gap costs is a throw
+ * rather than silent loss.
  */
 export type WireCellValue =
   | null


### PR DESCRIPTION
The `TODO` #5394 left on `CellHandle.serialize()`, closed the way #5411 closed
its runtime-side counterpart: by refusing.

`serialize()` claims a `ClientCellValue`, which admits a `FabricSpecialObject`
— a cell holds one like any other value. `WireCellValue` has no representation
for it, and `isRecord()` reports one, so it reached the record branch and came
back rebuilt from its enumerable own properties.

Measured before the change:

| input | on the wire |
| --- | --- |
| `FabricBytes` | `{}` |
| `{ deep: FabricBytes }` | `{ deep: {} }` |

The bytes were gone, at any depth, with nothing to show for it.

## The refusal

It throws now, in the same shape the value walks already use
(`pattern-binding.ts`, `builder/to-encodable-form.ts`, and `convertCellsToLinks`
as of #5411):

```
Cannot yet handle `FabricBytes` (a `FabricSpecialObject`) on this connection.
```

It covers the whole of `FabricSpecialObject` rather than just one arm, because
unlike the runtime-side walk — where a `FabricPrimitive` is a legitimate leaf
and only a `FabricInstance` is refused — the wire can carry *neither*.

The check goes **before** the record test, which is the ordering the nested
tests pin: such a value is also a record, so that branch would otherwise claim
it first.

## The gap is unchanged, and now says what it costs

`WireCellValue` still cannot carry the whole `FabricValue` domain, and its
`TODO` still names `JsonEncodingContext` as the mechanism. It now adds that
`serialize()` refuses one in the meantime, so what the gap costs until it
closes is a throw rather than silent loss.

## A refused write leaves no local trace

`#applyLocalAndSend()` assigned `#value` and ran every subscriber callback
*before* serializing, so the refusal arrived after the value had already
reached the cache and the UI. Serialization goes first now.

The local update is optimistic about the **write landing**, not about whether
the value can be **sent at all**. The first is a reasonable bet; the second is
knowable on the spot, so nothing is published on the strength of it.

(The ordering was already wrong before this change, just less visibly: the
local cache held the `FabricBytes` while `{}` went over the wire.)

## Testing

Seven tests.

Four pin the refusal — bare, nested in a record, nested in an array — plus one
pinning that an ordinary record still serializes unchanged, so the check cannot
over-claim on its way past. Ablating the refusal turns the three red and leaves
the fourth green.

Three pin that a refused write leaves no local trace: the prior value survives,
no subscriber is notified, and nothing reaches the connection. Putting the local
update back ahead of serialization turns the first two red. The third stays
green under *that* ablation — the throw always preceded the request — so its
differential is against removing the refusal rather than against the ordering.

## Verification

`deno task check` · `check-docs` · `check-no-waitfor` · `check-conflict-markers`
· `check-skill-facts` · `deno fmt --check` · `deno lint` — all clean.
`runtime-client` 53/0, `ui` 52/0.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


