### PR TITLE
cf-harness: collapse the one-kind sandbox strategy machinery

### DIFF
--- a/packages/cf-harness/integration/engine.integration.test.ts
+++ b/packages/cf-harness/integration/engine.integration.test.ts
@@ -883,7 +883,7 @@ Deno.test({
         "integration-read-file-cfc-prompt-loop",
         async (engine, hostPath) => {
           assertEquals(
-            engine.sandbox.describe?.().cfc?.invocationContextTransport,
+            engine.sandbox.describe().cfc?.invocationContextTransport,
             "sidecar",
           );
           await Deno.mkdir(`${hostPath}/notes`, { recursive: true });

--- a/packages/cf-harness/src/config.ts
+++ b/packages/cf-harness/src/config.ts
@@ -10,7 +10,7 @@ import type {
   HarnessSkillScriptExecutionTarget,
 } from "./contracts/skill.ts";
 import type { HarnessBrowserAccessLease } from "./contracts/browser-access.ts";
-import type { HarnessSandboxConfig } from "./sandbox/types.ts";
+import type { DockerRunscSandboxConfig } from "./sandbox/types.ts";
 
 export const DEFAULT_GATEWAY_BASE_URL = "https://llm.stage.commontools.dev/";
 export const DEFAULT_HARNESS_CFC_ENFORCEMENT_MODE =
@@ -33,7 +33,7 @@ interface HarnessCommonConfig {
   cfcEnforcementMode: CfcEnforcementMode;
   cfcEnforcementModeSource: HarnessCfcEnforcementModeSource;
   trustSnapshot?: TrustSnapshot;
-  sandbox?: HarnessSandboxConfig;
+  sandbox?: DockerRunscSandboxConfig;
   runManifest?: HarnessRunManifest;
   runManifestPath?: string;
 }
@@ -83,7 +83,7 @@ export interface ResolveHarnessConfigOptions {
   inheritedCfcEnforcementMode?: CfcEnforcementMode;
   cfcEnforcementModeOverride?: string | CfcEnforcementMode;
   trustSnapshot?: TrustSnapshot;
-  sandbox?: HarnessSandboxConfig;
+  sandbox?: DockerRunscSandboxConfig;
   runManifest?: HarnessRunManifest;
   runManifestPath?: string;
 }

--- a/packages/cf-harness/src/diagnostics.ts
+++ b/packages/cf-harness/src/diagnostics.ts
@@ -295,19 +295,6 @@ const cfcSubstrateStatusFor = (options: {
   return options.mode === "enforce-strict" ? "missing" : "not-attested";
 };
 
-const describeSandbox = (
-  sandbox: SandboxRuntime,
-  cwd: string,
-): SandboxRuntimeDescription =>
-  sandbox.describe?.() ?? {
-    kind: sandbox.kind,
-    defaultWorkingDirectory: sandbox.defaultWorkingDirectory(),
-    cfc: {
-      runtimeRequested: sandbox.kind === "docker-runsc-cfc",
-      workspaceMountPath: cwd,
-    },
-  };
-
 const findMountDescription = (
   mounts: readonly SandboxRuntimeMountDescription[] | undefined,
   kind: SandboxRuntimeMountKind,
@@ -459,11 +446,10 @@ const createFabricWriteGovernance = (options: {
 
 const createCfcCapabilitySnapshot = (
   sandbox: SandboxRuntime,
-  cwd: string,
   options: CollectHarnessCapabilitySnapshotOptions,
 ): HarnessCfcCapabilitySnapshot => {
   const mode = options.cfcEnforcementMode ?? "enforce-explicit";
-  const sandboxDescription = describeSandbox(sandbox, cwd);
+  const sandboxDescription = sandbox.describe();
   return {
     enforcementMode: mode,
     absenceBehavior: cfcAbsenceBehaviorForMode(mode),
@@ -503,7 +489,7 @@ export const collectHarnessCapabilitySnapshot = async (
   at = new Date().toISOString(),
   options: CollectHarnessCapabilitySnapshotOptions = {},
 ): Promise<HarnessCapabilitySnapshot> => {
-  const cfc = createCfcCapabilitySnapshot(sandbox, cwd, options);
+  const cfc = createCfcCapabilitySnapshot(sandbox, options);
   const result = await sandbox.runShell({
     command: CAPABILITY_PROBE_SCRIPT,
     cwd,

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -101,7 +101,6 @@ import {
 import type {
   DockerRunscAdditionalMountConfig,
   DockerRunscSandboxConfig,
-  HarnessSandboxConfig,
   SandboxRuntime,
 } from "./sandbox/types.ts";
 import { type BashToolInput, type BashToolOutput } from "./tools/bash.ts";
@@ -213,7 +212,7 @@ interface ResolveSandboxConfigOptions {
 const resolveSandboxConfig = (
   config: HarnessConfig,
   options: ResolveSandboxConfigOptions,
-): HarnessSandboxConfig => {
+): DockerRunscSandboxConfig => {
   if (config.sandbox !== undefined) {
     return config.sandbox;
   }
@@ -241,16 +240,6 @@ const resolveSandboxConfig = (
       ? { cfcInvocationContextDir: options.cfcInvocationContextDir }
       : {}),
   });
-};
-
-const createSandboxRuntime = (
-  config: HarnessSandboxConfig,
-  processRunner?: ProcessRunner,
-): SandboxRuntime => {
-  switch (config.kind) {
-    case "docker-runsc-cfc":
-      return new DockerRunscSandboxRuntime(config, processRunner);
-  }
 };
 
 const resolveInitialCurrentDir = (
@@ -409,13 +398,12 @@ export class CfHarnessEngine {
     // sandboxRuntime is the thing that actually executes and carries its own
     // enforcement guarantees, while `sandboxConfig` in that branch is the
     // unused resolved config and may describe a different sandbox entirely.
-    this.#ownedRunscConfig = options.sandboxRuntime === undefined &&
-        sandboxConfig?.kind === "docker-runsc-cfc"
+    this.#ownedRunscConfig = options.sandboxRuntime === undefined
       ? sandboxConfig
       : undefined;
     this.hostProcessRunner = options.processRunner ?? new DenoProcessRunner();
     this.sandbox = options.sandboxRuntime ??
-      createSandboxRuntime(sandboxConfig!, options.processRunner);
+      new DockerRunscSandboxRuntime(sandboxConfig!, options.processRunner);
     this.workspaceHostPath = sandboxConfig?.workspaceHostPath ??
       options.workspaceHostPath;
     this.workspaceMountPath = normalizeSandboxRoot(

--- a/packages/cf-harness/src/sandbox/docker-runsc.ts
+++ b/packages/cf-harness/src/sandbox/docker-runsc.ts
@@ -13,7 +13,6 @@ import type {
   DockerNetworkMode,
   DockerRunscAdditionalMount,
   DockerRunscAdditionalMountConfig,
-  DockerRunscCfcInvocationContextTransport,
   DockerRunscSandboxConfig,
   ResolveDockerRunscSandboxConfigOptions,
   SandboxCommandRequest,
@@ -225,26 +224,16 @@ const dockerMountArg = (mount: {
     mount.readOnly ? ",readonly" : ""
   }`;
 
-const resolveCfcInvocationContextTransport = (
+const resolveCfcInvocationContextDir = (
   options: ResolveDockerRunscSandboxConfigOptions,
-): DockerRunscCfcInvocationContextTransport | undefined => {
-  if (options.cfcInvocationContextTransport !== undefined) {
-    return {
-      kind: "sidecar",
-      dir: validateAbsoluteHostDir(
-        options.cfcInvocationContextTransport.dir,
-        "cfcInvocationContextTransport.dir",
-      ),
-    };
-  }
+): string | undefined => {
   const dir = optionalNonEmptyString(
     options.cfcInvocationContextDir ??
       readEnvVar(CFC_INVOCATION_CONTEXT_DIR_ENV),
   );
-  return dir === undefined ? undefined : {
-    kind: "sidecar",
-    dir: validateAbsoluteHostDir(dir, "cfcInvocationContextDir"),
-  };
+  return dir === undefined
+    ? undefined
+    : validateAbsoluteHostDir(dir, "cfcInvocationContextDir");
 };
 
 export const resolveDockerRunscSandboxConfig = (
@@ -265,11 +254,8 @@ export const resolveDockerRunscSandboxConfig = (
   const cfcResultDir = optionalNonEmptyString(
     options.cfcResultDir ?? readEnvVar(CFC_RESULT_DIR_ENV),
   );
-  const cfcInvocationContextTransport = resolveCfcInvocationContextTransport(
-    options,
-  );
+  const cfcInvocationContextDir = resolveCfcInvocationContextDir(options);
   return {
-    kind: "docker-runsc-cfc",
     dockerBinary: options.dockerBinary ?? DEFAULT_DOCKER_BINARY,
     runtimeName: options.runtimeName ?? DEFAULT_DOCKER_RUNTIME_NAME,
     image: options.image ?? DEFAULT_DOCKER_RUNSC_IMAGE,
@@ -283,8 +269,8 @@ export const resolveDockerRunscSandboxConfig = (
     additionalMounts,
     extraDockerArgs: options.extraDockerArgs ?? [],
     ...(cfcResultDir !== undefined ? { cfcResultDir } : {}),
-    ...(cfcInvocationContextTransport !== undefined
-      ? { cfcInvocationContextTransport }
+    ...(cfcInvocationContextDir !== undefined
+      ? { cfcInvocationContextDir }
       : {}),
   };
 };
@@ -292,7 +278,7 @@ export const resolveDockerRunscSandboxConfig = (
 /**
  * In `enforce-*` modes the runtime depends on two trusted sidecar transports:
  *
- *  - `cfcInvocationContextTransport` — the harness writes the initial-taint
+ *  - `cfcInvocationContextDir` — the harness writes the initial-taint
  *    invocation context the sandbox reads in. Without it the sandbox starts
  *    untainted, so input labels (prompt-slot influence, prior observed labels)
  *    are silently dropped.
@@ -311,7 +297,7 @@ export const assertDockerRunscCfcTransportForMode = (
   mode: CfcEnforcementMode,
   config: Pick<
     DockerRunscSandboxConfig,
-    "cfcResultDir" | "cfcInvocationContextTransport"
+    "cfcResultDir" | "cfcInvocationContextDir"
   >,
 ): void => {
   // `disabled` and `observe` do not mediate or deny tool output, so a missing
@@ -320,7 +306,7 @@ export const assertDockerRunscCfcTransportForMode = (
     return;
   }
   const missing: string[] = [];
-  if (config.cfcInvocationContextTransport === undefined) {
+  if (config.cfcInvocationContextDir === undefined) {
     missing.push(
       `CFC invocation-context transport (set --cfc-invocation-context-dir or ${CFC_INVOCATION_CONTEXT_DIR_ENV})`,
     );
@@ -554,8 +540,6 @@ const cfcResultFromRunscSidecar = (
 };
 
 export class DockerRunscSandboxRuntime implements SandboxRuntime {
-  readonly kind = "docker-runsc-cfc" as const;
-
   constructor(
     readonly config: DockerRunscSandboxConfig,
     private readonly runner: ProcessRunner = new DenoProcessRunner(),
@@ -598,7 +582,7 @@ export class DockerRunscSandboxRuntime implements SandboxRuntime {
 
   describe(): SandboxRuntimeDescription {
     return {
-      kind: this.kind,
+      kind: "docker-runsc-cfc",
       defaultWorkingDirectory: this.defaultWorkingDirectory(),
       cfc: {
         runtimeRequested: true,
@@ -608,11 +592,8 @@ export class DockerRunscSandboxRuntime implements SandboxRuntime {
         mounts: this.#mountDescriptions(),
         networkMode: this.config.dockerNetworkMode,
         extraDockerArgsCount: this.config.extraDockerArgs.length,
-        ...(this.config.cfcInvocationContextTransport !== undefined
-          ? {
-            invocationContextTransport:
-              this.config.cfcInvocationContextTransport.kind,
-          }
+        ...(this.config.cfcInvocationContextDir !== undefined
+          ? { invocationContextTransport: "sidecar" }
           : {}),
       },
     };
@@ -809,35 +790,28 @@ export class DockerRunscSandboxRuntime implements SandboxRuntime {
     request: SandboxCommandRequest,
     createResult: SandboxCommandResult,
   ): Promise<SandboxCommandResult | undefined> {
-    if (
-      this.config.cfcInvocationContextTransport === undefined ||
-      request.cfcInvocationContext === undefined
-    ) {
+    const dir = this.config.cfcInvocationContextDir;
+    if (dir === undefined || request.cfcInvocationContext === undefined) {
       return undefined;
     }
-    const transport = this.config.cfcInvocationContextTransport;
-    switch (transport.kind) {
-      case "sidecar": {
-        try {
-          await Deno.mkdir(transport.dir, { recursive: true });
-          await Deno.writeTextFile(
-            cfcSidecarPath(transport.dir, containerID),
-            `${JSON.stringify(request.cfcInvocationContext, null, 2)}\n`,
-          );
-          return undefined;
-        } catch (error) {
-          return {
-            stdout: createResult.stdout,
-            stderr: appendStderr(
-              createResult.stderr,
-              `failed to write CFC invocation context sidecar: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            ),
-            exitCode: 125,
-          };
-        }
-      }
+    try {
+      await Deno.mkdir(dir, { recursive: true });
+      await Deno.writeTextFile(
+        cfcSidecarPath(dir, containerID),
+        `${JSON.stringify(request.cfcInvocationContext, null, 2)}\n`,
+      );
+      return undefined;
+    } catch (error) {
+      return {
+        stdout: createResult.stdout,
+        stderr: appendStderr(
+          createResult.stderr,
+          `failed to write CFC invocation context sidecar: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        ),
+        exitCode: 125,
+      };
     }
   }
 }

--- a/packages/cf-harness/src/sandbox/types.ts
+++ b/packages/cf-harness/src/sandbox/types.ts
@@ -1,8 +1,6 @@
 import type { CfcSandboxResult } from "@commonfabric/runner/cfc";
 import type { HarnessCfcInvocationContext } from "../contracts/cfc-invocation-context.ts";
 
-export type HarnessSandboxKind = "docker-runsc-cfc";
-
 export type DockerNetworkMode = "none" | "bridge" | "host";
 
 export type SandboxRuntimeMountKind =
@@ -59,16 +57,7 @@ export type DockerRunscAdditionalMount =
   | DockerRunscFabricAdditionalMount
   | DockerRunscHostBindAdditionalMount;
 
-export interface DockerRunscCfcInvocationContextSidecarTransport {
-  kind: "sidecar";
-  dir: string;
-}
-
-export type DockerRunscCfcInvocationContextTransport =
-  DockerRunscCfcInvocationContextSidecarTransport;
-
 export interface DockerRunscSandboxConfig {
-  kind: "docker-runsc-cfc";
   dockerBinary: string;
   runtimeName: string;
   image: string;
@@ -80,10 +69,8 @@ export interface DockerRunscSandboxConfig {
   additionalMounts: readonly DockerRunscAdditionalMount[];
   extraDockerArgs: readonly string[];
   cfcResultDir?: string;
-  cfcInvocationContextTransport?: DockerRunscCfcInvocationContextTransport;
+  cfcInvocationContextDir?: string;
 }
-
-export type HarnessSandboxConfig = DockerRunscSandboxConfig;
 
 export interface ResolveDockerRunscSandboxConfigOptions {
   dockerBinary?: string;
@@ -98,7 +85,6 @@ export interface ResolveDockerRunscSandboxConfigOptions {
   extraDockerArgs?: readonly string[];
   cfcResultDir?: string;
   cfcInvocationContextDir?: string;
-  cfcInvocationContextTransport?: DockerRunscCfcInvocationContextTransport;
 }
 
 export interface SandboxCommandRequest {
@@ -128,7 +114,7 @@ export interface SandboxCommandResult {
 }
 
 export interface SandboxRuntimeDescription {
-  kind: HarnessSandboxKind;
+  kind: "docker-runsc-cfc";
   defaultWorkingDirectory: string;
   cfc?: {
     runtimeRequested: boolean;
@@ -143,11 +129,10 @@ export interface SandboxRuntimeDescription {
 }
 
 export interface SandboxRuntime {
-  readonly kind: HarnessSandboxKind;
-  describe?(): SandboxRuntimeDescription;
+  describe(): SandboxRuntimeDescription;
   resolvePath(path: string, cwd?: string): string;
   isPathWithinWorkspace(path: string): boolean;
-  isPathWithinAllowedRoots?(path: string): boolean;
+  isPathWithinAllowedRoots(path: string): boolean;
   defaultWorkingDirectory(): string;
   run(request: SandboxCommandRequest): Promise<SandboxCommandResult>;
   runShell(request: SandboxShellRequest): Promise<SandboxCommandResult>;

--- a/packages/cf-harness/src/tools/bash.ts
+++ b/packages/cf-harness/src/tools/bash.ts
@@ -197,8 +197,7 @@ export const bashTool: HarnessToolDefinition<BashToolInput, BashToolOutput> = {
       ? parsedCwd.stdout
       : result.stdout;
     const isAllowedCurrentDir = parsedCwd?.cwd !== undefined &&
-      (context.sandbox.isPathWithinAllowedRoots?.(parsedCwd.cwd) ??
-        context.sandbox.isPathWithinWorkspace(parsedCwd.cwd));
+      context.sandbox.isPathWithinAllowedRoots(parsedCwd.cwd);
     const nextCurrentDir = parsedCwd?.cwd !== undefined &&
         isAllowedCurrentDir
       ? parsedCwd.cwd

--- a/packages/cf-harness/test/artifacts.test.ts
+++ b/packages/cf-harness/test/artifacts.test.ts
@@ -23,16 +23,24 @@ import type {
   SandboxCommandRequest,
   SandboxCommandResult,
   SandboxRuntime,
+  SandboxRuntimeDescription,
   SandboxShellRequest,
 } from "../src/sandbox/types.ts";
 
 class FakeSandboxRuntime implements SandboxRuntime {
-  readonly kind = "docker-runsc-cfc" as const;
   readonly shellRequests: SandboxShellRequest[] = [];
 
   constructor(
     private readonly shellResults: SandboxCommandResult[] = [],
   ) {}
+
+  describe(): SandboxRuntimeDescription {
+    return {
+      kind: "docker-runsc-cfc",
+      defaultWorkingDirectory: this.defaultWorkingDirectory(),
+      cfc: { runtimeRequested: true, workspaceMountPath: "/workspace" },
+    };
+  }
 
   resolvePath(path: string, cwd = this.defaultWorkingDirectory()): string {
     return normalize(path.startsWith("/") ? path : `${cwd}/${path}`);
@@ -40,6 +48,10 @@ class FakeSandboxRuntime implements SandboxRuntime {
 
   isPathWithinWorkspace(path: string): boolean {
     return path === "/workspace" || path.startsWith("/workspace/");
+  }
+
+  isPathWithinAllowedRoots(path: string): boolean {
+    return this.isPathWithinWorkspace(path);
   }
 
   defaultWorkingDirectory(): string {

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -3725,7 +3725,7 @@ Deno.test("runCfHarnessCli threads fabric-mount into engine additionalMounts", a
   assertEquals(exitCode, 0);
   assertEquals(stderr, []);
   const engine = createdOptions?.engine as CfHarnessEngine | undefined;
-  const mounts = engine?.sandbox.describe?.()?.cfc?.mounts;
+  const mounts = engine?.sandbox.describe().cfc?.mounts;
   assertEquals(mounts?.length, 2);
   assertEquals(mounts?.[1]?.kind, "fabric-fuse");
   assertEquals(mounts?.[1]?.sandboxPath, "/fabric");
@@ -3794,7 +3794,7 @@ Deno.test("runCfHarnessCli threads host-mount into engine additionalMounts", asy
   assertEquals(exitCode, 0);
   assertEquals(stderr, []);
   const engine = createdOptions?.engine as CfHarnessEngine | undefined;
-  const mounts = engine?.sandbox.describe?.()?.cfc?.mounts;
+  const mounts = engine?.sandbox.describe().cfc?.mounts;
   assertEquals(mounts?.[1], {
     kind: "host-bind",
     name: "file-cabinet",
@@ -3864,7 +3864,7 @@ Deno.test("runCfHarnessCli threads sandbox-image into engine sandbox config", as
   assertEquals(stderr, []);
   const engine = createdOptions?.engine as CfHarnessEngine | undefined;
   assertEquals(
-    engine?.sandbox.describe?.()?.cfc?.image,
+    engine?.sandbox.describe().cfc?.image,
     "registry.example/cf:deno2",
   );
 });

--- a/packages/cf-harness/test/diagnostics.test.ts
+++ b/packages/cf-harness/test/diagnostics.test.ts
@@ -22,7 +22,13 @@ import type {
 } from "../src/sandbox/types.ts";
 
 class FakeSandboxRuntime implements SandboxRuntime {
-  readonly kind = "docker-runsc-cfc" as const;
+  describe(): SandboxRuntimeDescription {
+    return {
+      kind: "docker-runsc-cfc",
+      defaultWorkingDirectory: this.defaultWorkingDirectory(),
+      cfc: { runtimeRequested: true, workspaceMountPath: "/workspace" },
+    };
+  }
 
   resolvePath(path: string, cwd = this.defaultWorkingDirectory()): string {
     return path.startsWith("/") ? path : `${cwd}/${path}`;
@@ -30,6 +36,10 @@ class FakeSandboxRuntime implements SandboxRuntime {
 
   isPathWithinWorkspace(path: string): boolean {
     return path === "/workspace" || path.startsWith("/workspace/");
+  }
+
+  isPathWithinAllowedRoots(path: string): boolean {
+    return this.isPathWithinWorkspace(path);
   }
 
   defaultWorkingDirectory(): string {
@@ -82,7 +92,7 @@ class FakeFabricSandboxRuntime extends FakeSandboxRuntime {
     return super.runShell(request);
   }
 
-  describe(): SandboxRuntimeDescription {
+  override describe(): SandboxRuntimeDescription {
     return {
       kind: "docker-runsc-cfc",
       defaultWorkingDirectory: "/workspace",
@@ -208,7 +218,7 @@ Deno.test("collectHarnessCapabilitySnapshot reports configured Fabric mounts", a
 });
 
 class FakeHostBindSandboxRuntime extends FakeSandboxRuntime {
-  describe(): SandboxRuntimeDescription {
+  override describe(): SandboxRuntimeDescription {
     return {
       kind: "docker-runsc-cfc",
       defaultWorkingDirectory: "/workspace",

--- a/packages/cf-harness/test/docker-runsc-sandbox.test.ts
+++ b/packages/cf-harness/test/docker-runsc-sandbox.test.ts
@@ -64,7 +64,6 @@ Deno.test("resolveDockerRunscSandboxConfig fills the expected defaults", () => {
   const config = resolveDockerRunscSandboxConfig({
     workspaceHostPath: "/host/project",
   });
-  assertEquals(config.kind, "docker-runsc-cfc");
   assertEquals(config.dockerBinary, "docker");
   assertEquals(config.runtimeName, "runsc-cfc");
   assertEquals(
@@ -77,7 +76,7 @@ Deno.test("resolveDockerRunscSandboxConfig fills the expected defaults", () => {
   assertEquals(config.additionalMounts, []);
   assertEquals(config.extraDockerArgs, []);
   assertEquals(config.cfcResultDir, undefined);
-  assertEquals(config.cfcInvocationContextTransport, undefined);
+  assertEquals(config.cfcInvocationContextDir, undefined);
 });
 
 Deno.test("resolveDefaultContainerUser omits default --user on macOS", () => {
@@ -182,6 +181,31 @@ Deno.test("DockerRunscSandboxRuntime describe preserves custom CFC runtime alias
   assertEquals(description.cfc.image, "sandbox:deno2");
 });
 
+// The description is persisted into the CFC policy snapshot that the ops
+// dashboard reads, so the wording of these two tags is part of that output.
+Deno.test("DockerRunscSandboxRuntime describe names the sandbox kind and the sidecar transport", () => {
+  const description = new DockerRunscSandboxRuntime(
+    resolveDockerRunscSandboxConfig({
+      workspaceHostPath: "/host/project",
+      cfcInvocationContextDir: "/tmp/cfc-invocations",
+    }),
+  ).describe();
+
+  assertEquals(description.kind, "docker-runsc-cfc");
+  assertEquals(description.cfc?.invocationContextTransport, "sidecar");
+});
+
+Deno.test("DockerRunscSandboxRuntime describe omits the transport when no invocation context dir is configured", () => {
+  const description = new DockerRunscSandboxRuntime({
+    // Written out rather than resolved, so that a host with the invocation
+    // context environment variable set still exercises the absent case.
+    ...resolveDockerRunscSandboxConfig({ workspaceHostPath: "/host/project" }),
+    cfcInvocationContextDir: undefined,
+  }).describe();
+
+  assertEquals(description.cfc?.invocationContextTransport, undefined);
+});
+
 Deno.test("resolveDockerRunscSandboxConfig normalizes a Fabric FUSE mount", () => {
   const config = resolveDockerRunscSandboxConfig({
     workspaceHostPath: "/host/project",
@@ -258,10 +282,7 @@ Deno.test("resolveDockerRunscSandboxConfig resolves invocation context sidecar t
     cfcInvocationContextDir: "/tmp/cfc-invocations",
   });
 
-  assertEquals(config.cfcInvocationContextTransport, {
-    kind: "sidecar",
-    dir: "/tmp/cfc-invocations",
-  });
+  assertEquals(config.cfcInvocationContextDir, "/tmp/cfc-invocations");
 });
 
 Deno.test("resolveDockerRunscSandboxConfig rejects relative invocation context sidecar dirs", () => {
@@ -726,7 +747,7 @@ Deno.test("assertDockerRunscCfcTransportForMode rejects enforce modes without tr
     assertThrows(
       () =>
         assertDockerRunscCfcTransportForMode(mode, {
-          cfcInvocationContextTransport: { kind: "sidecar", dir: "/host/ctx" },
+          cfcInvocationContextDir: "/host/ctx",
         }),
       Error,
       "result transport",
@@ -746,7 +767,7 @@ Deno.test("assertDockerRunscCfcTransportForMode allows enforce modes with both t
   for (const mode of ["enforce-explicit", "enforce-strict"] as const) {
     assertDockerRunscCfcTransportForMode(mode, {
       cfcResultDir: "/host/results",
-      cfcInvocationContextTransport: { kind: "sidecar", dir: "/host/ctx" },
+      cfcInvocationContextDir: "/host/ctx",
     });
   }
 });

--- a/packages/cf-harness/test/engine.test.ts
+++ b/packages/cf-harness/test/engine.test.ts
@@ -21,11 +21,11 @@ import type {
   SandboxCommandRequest,
   SandboxCommandResult,
   SandboxRuntime,
+  SandboxRuntimeDescription,
   SandboxShellRequest,
 } from "../src/sandbox/types.ts";
 
 class FakeSandboxRuntime implements SandboxRuntime {
-  readonly kind = "docker-runsc-cfc" as const;
   readonly shellRequests: SandboxShellRequest[] = [];
 
   constructor(
@@ -33,12 +33,24 @@ class FakeSandboxRuntime implements SandboxRuntime {
     private readonly shellError?: Error,
   ) {}
 
+  describe(): SandboxRuntimeDescription {
+    return {
+      kind: "docker-runsc-cfc",
+      defaultWorkingDirectory: this.defaultWorkingDirectory(),
+      cfc: { runtimeRequested: true, workspaceMountPath: "/workspace" },
+    };
+  }
+
   resolvePath(path: string, cwd = this.defaultWorkingDirectory()): string {
     return normalize(path.startsWith("/") ? path : `${cwd}/${path}`);
   }
 
   isPathWithinWorkspace(path: string): boolean {
     return path === "/workspace" || path.startsWith("/workspace/");
+  }
+
+  isPathWithinAllowedRoots(path: string): boolean {
+    return this.isPathWithinWorkspace(path);
   }
 
   defaultWorkingDirectory(): string {
@@ -101,7 +113,7 @@ Deno.test("CfHarnessEngine builds a default docker-runsc sandbox when given a wo
   });
 
   assertEquals(engine.config.sandbox, undefined);
-  assertEquals(engine.sandbox.kind, "docker-runsc-cfc");
+  assertEquals(engine.sandbox.describe().kind, "docker-runsc-cfc");
   assertEquals(engine.getRunState(), {
     runId: engine.getRunState().runId,
     status: "pending",
@@ -124,7 +136,7 @@ Deno.test("CfHarnessEngine accepts a default sandbox image override", () => {
   });
 
   assertEquals(
-    engine.sandbox.describe?.()?.cfc?.image,
+    engine.sandbox.describe().cfc?.image,
     "registry.example/cf:deno2",
   );
 });

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -34,6 +34,7 @@ import type {
   SandboxCommandRequest,
   SandboxCommandResult,
   SandboxRuntime,
+  SandboxRuntimeDescription,
   SandboxShellRequest,
 } from "../src/sandbox/types.ts";
 import { createToolOutputId } from "../src/contracts/tool-result.ts";
@@ -74,7 +75,6 @@ const contextPromptSlotBinding: PromptSlotBinding = {
 };
 
 class FakeSandboxRuntime implements SandboxRuntime {
-  readonly kind = "docker-runsc-cfc" as const;
   readonly shellRequests: SandboxShellRequest[] = [];
 
   constructor(
@@ -82,12 +82,24 @@ class FakeSandboxRuntime implements SandboxRuntime {
     private readonly shellError?: Error,
   ) {}
 
+  describe(): SandboxRuntimeDescription {
+    return {
+      kind: "docker-runsc-cfc",
+      defaultWorkingDirectory: this.defaultWorkingDirectory(),
+      cfc: { runtimeRequested: true, workspaceMountPath: "/workspace" },
+    };
+  }
+
   resolvePath(path: string, cwd = this.defaultWorkingDirectory()): string {
     return normalize(path.startsWith("/") ? path : `${cwd}/${path}`);
   }
 
   isPathWithinWorkspace(path: string): boolean {
     return path === "/workspace" || path.startsWith("/workspace/");
+  }
+
+  isPathWithinAllowedRoots(path: string): boolean {
+    return this.isPathWithinWorkspace(path);
   }
 
   defaultWorkingDirectory(): string {

--- a/packages/cf-harness/test/tools-execution.test.ts
+++ b/packages/cf-harness/test/tools-execution.test.ts
@@ -45,6 +45,7 @@ import type {
   SandboxCommandRequest,
   SandboxCommandResult,
   SandboxRuntime,
+  SandboxRuntimeDescription,
   SandboxShellRequest,
 } from "../src/sandbox/types.ts";
 
@@ -115,7 +116,6 @@ const installMockDenoConnect = (
 };
 
 class FakeSandboxRuntime implements SandboxRuntime {
-  readonly kind = "docker-runsc-cfc" as const;
   readonly calls: Array<
     | { type: "run"; request: SandboxCommandRequest }
     | { type: "runShell"; request: SandboxShellRequest }
@@ -129,12 +129,24 @@ class FakeSandboxRuntime implements SandboxRuntime {
     }],
   ) {}
 
+  describe(): SandboxRuntimeDescription {
+    return {
+      kind: "docker-runsc-cfc",
+      defaultWorkingDirectory: this.defaultWorkingDirectory(),
+      cfc: { runtimeRequested: true, workspaceMountPath: "/workspace" },
+    };
+  }
+
   resolvePath(path: string, cwd = this.defaultWorkingDirectory()): string {
     return normalize(path.startsWith("/") ? path : `${cwd}/${path}`);
   }
 
   isPathWithinWorkspace(path: string): boolean {
     return path === "/workspace" || path.startsWith("/workspace/");
+  }
+
+  isPathWithinAllowedRoots(path: string): boolean {
+    return this.isPathWithinWorkspace(path);
   }
 
   defaultWorkingDirectory(): string {
@@ -167,7 +179,7 @@ class StrictFakeSandboxRuntime extends FakeSandboxRuntime {
 }
 
 class MultiRootFakeSandboxRuntime extends FakeSandboxRuntime {
-  isPathWithinAllowedRoots(path: string): boolean {
+  override isPathWithinAllowedRoots(path: string): boolean {
     return this.isPathWithinWorkspace(path) ||
       path === "/fabric" ||
       path.startsWith("/fabric/");


### PR DESCRIPTION
The sandbox layer in cf-harness was written as a strategy and factory dispatch over sandbox kinds. There was a kind union, a config union whose members were tagged by that kind, a transport union for the invocation context sidecar, and a factory function that switched on the kind to pick a runtime class. Every one of those unions had exactly one member, the switch had exactly one case, and that has been true since the package was first added. The `SandboxRuntime` interface additionally declared `describe` and `isPathWithinAllowedRoots` as optional, which forced two call sites to carry fallback branches that the only production implementation could never reach, because that implementation always defines both methods.

This removes the machinery and keeps the single shape it was dispatching to.

- `HarnessSandboxKind` is gone. The two places that need the string spell it out: the `kind` field of `SandboxRuntimeDescription`, which is persisted into the CFC policy snapshot the ops dashboard reads, and the value that `DockerRunscSandboxRuntime.describe` puts there.
- `HarnessSandboxConfig` is gone; callers name `DockerRunscSandboxConfig` directly. The config no longer carries a `kind` tag, since nothing discriminates on it any more.
- The invocation-context transport is now a plain optional host directory, `cfcInvocationContextDir`, matching the neighbouring `cfcResultDir`. The description still reports `invocationContextTransport: "sidecar"` whenever that directory is configured, so the persisted output is unchanged. The resolver option of the same name, which nothing ever passed, is gone.
- `createSandboxRuntime` is replaced by constructing `DockerRunscSandboxRuntime` where the engine needs it, and the engine's companion test for the config kind becomes a plain presence check.
- `describe` and `isPathWithinAllowedRoots` are required on `SandboxRuntime`. The dead fallbacks in `diagnostics.ts` and `tools/bash.ts` are deleted, and the per-file test fakes gain the two methods. The fakes' new `isPathWithinAllowedRoots` returns what the deleted fallback computed for them, so the tests exercise the same paths as before.

The interface itself stays, because the tests substitute five fakes for it.

Two new unit tests pin the two strings that leave the process: the sandbox kind and the sidecar transport tag in the runtime description. Until now the transport tag was asserted only by an integration test that is skipped without a Docker daemon running the gVisor runtime, so a rename could reach the persisted snapshot without any test noticing.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

