### PR TITLE
fix(coverage): score type-only modules as zero tracked lines

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -2210,6 +2210,11 @@
           "npm:htmlparser2@12",
           "npm:marked@^18.0.6"
         ]
+      },
+      "tasks": {
+        "dependencies": [
+          "npm:typescript@6.0.3"
+        ]
       }
     }
   }

--- a/docs/development/COVERAGE.md
+++ b/docs/development/COVERAGE.md
@@ -102,7 +102,9 @@ covered a line.
 
 One detail of the gate's accounting is worth knowing when reasoning about
 pattern coverage. A file with no LCOV record has every tracked line counted as
-uncovered. A file with a record is scored against the lines that record names.
+uncovered — unless the file produces no executable code, as described in the
+next section. A file with a record is scored against the lines that record
+names.
 For a file measured by Deno's V8 coverage that is every executable line; pattern
 instrumentation names only the statements it could instrument, so a pattern
 file's first record both covers real lines and drops the never-named lines out of
@@ -115,6 +117,30 @@ of the file's lines and the rest stop being counted, so it settles at a lower �
 and therefore stricter — bar rather than failing anything. The instrumented
 statements are also the only lines this mechanism can speak to: a line the
 instrumentation cannot reach is not a line a pattern test could cover.
+
+## Type-only modules are scored as zero tracked lines
+
+A module whose every top-level statement is erased by type stripping —
+interfaces, type aliases, wholly type-only imports and exports, and ambient
+(`declare`) declarations — transpiles to an empty module. V8 never emits a
+coverage record for it, even when tests import it, so treating its missing
+record as "never loaded" would charge every line as permanently uncoverable
+debt, and any PR adding type-level lines to such a file would fail the ratchet
+with an "add tests" suggestion that is impossible to follow.
+
+So `tasks/coverage-metrics.ts` parses each tracked file and scores a file that
+produces no executable code as zero tracked lines
+(`producesNoExecutableCode()`). The `.d.ts` suffix exclusion is the
+declared-by-name case of the same rule. The detection is conservative: any
+statement it does not recognize as erased — a value import, a bare
+side-effect import, an enum, a `const` — keeps the file tracked, so a mistake
+leaves debt standing rather than hiding real uncovered code.
+
+Two related exclusions sit next to it. Files whose paths end in `.bench.ts` or
+`.bench.tsx` are benchmarks, and `packages/api/perf/` is the type-profiling
+harness, whose scenario files exist to be type-checked rather than run — some
+of them contain value statements precisely to stress the checker, so the
+type-only rule alone would not release them.
 
 ## Coverage must not depend on the execution environment
 

--- a/docs/development/DEPENDENCIES.md
+++ b/docs/development/DEPENDENCIES.md
@@ -167,8 +167,9 @@ disagrees with the pin.
 The runtime compiles patterns itself, using the TypeScript compiler API at
 runtime. Seven runtime and build packages (`js-compiler`, `ts-transformers`,
 `schema-generator`, `runner`, `cli`, `static`, `deno-web-test`) import
-`npm:typescript`. The `api` package imports it for the type-profiling harness.
-All eight workspace members pin the same version in their `deno.jsonc` import
+`npm:typescript`. The `api` package imports it for the type-profiling harness,
+and `tasks` imports it to detect type-only modules in the coverage accounting.
+All nine workspace members pin the same version in their `deno.jsonc` import
 maps. This npm dependency is separate from the TypeScript that `deno check`
 uses: Deno bundles its own copy of the compiler. Keeping the npm pin on the
 same minor version as the Deno-bundled compiler (`deno --version` prints it)

--- a/tasks/coverage-metrics.test.ts
+++ b/tasks/coverage-metrics.test.ts
@@ -8,6 +8,7 @@ import {
   countUncoveredProfileLines,
   metricGroupFor,
   parseLcov,
+  producesNoExecutableCode,
   shouldTrackSourceFile,
   trackedSourceLineNumbers,
 } from "./coverage-metrics.ts";
@@ -94,6 +95,57 @@ Deno.test("trackedSourceLineNumbers reports the executable line numbers", () => 
   );
 });
 
+Deno.test("producesNoExecutableCode recognizes wholly type-level modules", () => {
+  assertEquals(
+    producesNoExecutableCode(
+      [
+        'import type { Cell } from "commonfabric";',
+        "export type Wrapped<T> = Cell<T>;",
+        "export interface Shape {",
+        "  value: number;",
+        "}",
+        "declare const ambient: Shape;",
+        'declare module "commonfabric" {',
+        "  interface Augmented {}",
+        "}",
+        "export type { Shape as Alias };",
+      ].join("\n"),
+      "packages/example/src/types.ts",
+    ),
+    true,
+  );
+});
+
+Deno.test("producesNoExecutableCode treats value statements as executable", () => {
+  // A value statement next to ambient declarations still transpiles to code.
+  assertEquals(
+    producesNoExecutableCode(
+      [
+        "declare const ambient: { key(name: string): unknown };",
+        'const result = ambient.key("id");',
+      ].join("\n"),
+      "packages/example/src/stress.ts",
+    ),
+    false,
+  );
+  // A bare import loads its module at runtime.
+  assertEquals(
+    producesNoExecutableCode(
+      'import "./side-effect.ts";\nexport type Marker = true;',
+      "packages/example/src/marker.ts",
+    ),
+    false,
+  );
+  // A value import stays executable even when only types follow it.
+  assertEquals(
+    producesNoExecutableCode(
+      'import { helper } from "./helper.ts";\nexport type Uses = typeof helper;',
+      "packages/example/src/uses.ts",
+    ),
+    false,
+  );
+});
+
 Deno.test("source inventory helpers group tracked files by package", () => {
   assertEquals(shouldTrackSourceFile("packages/runner/src/cell.ts"), true);
   assertEquals(
@@ -102,6 +154,8 @@ Deno.test("source inventory helpers group tracked files by package", () => {
   );
   assertEquals(shouldTrackSourceFile("scripts/start-local-dev.sh"), false);
   assertEquals(shouldTrackSourceFile("scripts/build.ts"), false);
+  // The type-profiling harness holds compile-only scenario files.
+  assertEquals(shouldTrackSourceFile("packages/api/perf/schema.ts"), false);
   assertEquals(
     metricGroupFor("packages/runner/src/cell.ts"),
     "packages/runner",
@@ -164,6 +218,42 @@ Deno.test("collectCoverageDebtMetricsFromLcov computes debt from compact reports
       )?.uncoveredLines,
       1,
     );
+    assertEquals(
+      metrics.find((metric) =>
+        metric.name === "coverage-debt: packages/example uncovered lines"
+      )?.uncoveredLines,
+      1,
+    );
+  } finally {
+    await Deno.remove(rootDir, { recursive: true });
+  }
+});
+
+Deno.test("collectCoverageDebtMetricsFromLcov scores a type-only module as zero debt", async () => {
+  const rootDir = await Deno.makeTempDir({ prefix: "coverage-typeonly-test-" });
+  try {
+    const typeOnlyPath = path.join(rootDir, "packages/example/src/types.ts");
+    const executablePath = path.join(rootDir, "packages/example/src/mod.ts");
+    await Deno.mkdir(path.dirname(typeOnlyPath), { recursive: true });
+    // Never gains an LCOV record: it transpiles to an empty module, so V8
+    // emits no script coverage for it even when tests import it.
+    await Deno.writeTextFile(
+      typeOnlyPath,
+      [
+        "export interface Shape {",
+        "  value: number;",
+        "}",
+        "export type Alias = Shape;",
+      ].join("\n"),
+    );
+    await Deno.writeTextFile(executablePath, "export const uncovered = 1;\n");
+
+    const metrics = await collectCoverageDebtMetricsFromLcov({
+      rootDir,
+      lcov: "",
+    });
+
+    // Only the executable file's line counts; the type-only file adds none.
     assertEquals(
       metrics.find((metric) =>
         metric.name === "coverage-debt: packages/example uncovered lines"
@@ -261,6 +351,28 @@ Deno.test("collectUncoveredLinesForFiles resolves lines only for requested files
     assertEquals(uncovered.has("scripts/build.ts"), false);
     assertEquals(uncovered.has("packages/example/src/covered.test.ts"), false);
     assertEquals(uncovered.has("packages/example/src/other.ts"), false);
+  } finally {
+    await Deno.remove(rootDir, { recursive: true });
+  }
+});
+
+Deno.test("collectUncoveredLinesForFiles reports no lines for a type-only module", async () => {
+  const rootDir = await Deno.makeTempDir({ prefix: "coverage-lines-test-" });
+  try {
+    const typeOnlyPath = path.join(rootDir, "packages/example/src/types.ts");
+    await Deno.mkdir(path.dirname(typeOnlyPath), { recursive: true });
+    await Deno.writeTextFile(
+      typeOnlyPath,
+      "export type Alias = { value: number };\n",
+    );
+
+    const uncovered = await collectUncoveredLinesForFiles({
+      rootDir,
+      lcov: "",
+      files: ["packages/example/src/types.ts"],
+    });
+
+    assertEquals(uncovered.size, 0);
   } finally {
     await Deno.remove(rootDir, { recursive: true });
   }

--- a/tasks/coverage-metrics.ts
+++ b/tasks/coverage-metrics.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env -S deno run --allow-read --allow-write --allow-run
 import * as path from "@std/path";
+import ts from "typescript";
 import { normalizeLcovInstancePaths } from "./write-coverage-lcov.ts";
 
 export const COVERAGE_PROFILE_ARTIFACT_PREFIX = "coverage-profile-";
@@ -20,6 +21,9 @@ const EXCLUDED_PATH_PARTS = new Set([
 ]);
 
 const EXCLUDED_RELATIVE_PREFIXES = [
+  // Type-profiling harness: its scenario files exist to be type-checked, not
+  // run, so no test can ever cover them (see packages/api/perf/README.md).
+  "packages/api/perf/",
   "packages/generated-patterns/integration/",
   "packages/patterns/factory-outputs/",
   "packages/patterns-saves-backup/",
@@ -85,7 +89,9 @@ export async function collectCoverageDebtMetricsFromLcov(
   for (const source of sourceFiles) {
     const coverage = lcovCoverage.get(source.absolutePath);
     // A file the tests never loaded has no coverage record; every tracked
-    // line counts as uncovered, matching how the debt metric scores it.
+    // line counts as uncovered, matching how the debt metric scores it. A
+    // module that produces no executable code also never gains a record, but
+    // it carries zero tracked lines, so it adds no debt.
     const uncovered = coverage
       ? countUncoveredProfileLines(coverage)
       : source.trackedLineCount;
@@ -142,7 +148,8 @@ export async function collectUncoveredLinesForFiles(
       uncoveredLines = uncoveredProfileLineNumbers(coverage);
     } else {
       // No coverage record: the file was never loaded by any test, so every
-      // tracked line is uncovered.
+      // tracked line is uncovered — unless it produces no executable code,
+      // in which case there is nothing a test could have covered.
       let content: string;
       try {
         content = await Deno.readTextFile(absolutePath);
@@ -153,7 +160,9 @@ export async function collectUncoveredLinesForFiles(
         if (error instanceof Deno.errors.NotFound) continue;
         throw error;
       }
-      uncoveredLines = trackedSourceLineNumbers(content);
+      uncoveredLines = producesNoExecutableCode(content, relativePath)
+        ? []
+        : trackedSourceLineNumbers(content);
     }
 
     if (uncoveredLines.length > 0) result.set(relativePath, uncoveredLines);
@@ -175,11 +184,15 @@ export async function collectSourceFiles(
       if (!shouldTrackSourceFile(relativePath)) continue;
 
       const content = await Deno.readTextFile(file);
+      const trackedLineCount = countTrackedSourceLines(content);
       files.push({
         absolutePath: path.normalize(file),
         relativePath,
         metricGroup: metricGroupFor(relativePath),
-        trackedLineCount: countTrackedSourceLines(content),
+        trackedLineCount: trackedLineCount > 0 &&
+            producesNoExecutableCode(content, relativePath)
+          ? 0
+          : trackedLineCount,
       });
     }
   }
@@ -216,6 +229,63 @@ export function metricGroupFor(relativePath: string): string {
     return `packages/${parts[1]}`;
   }
   return parts[0] ?? "workspace";
+}
+
+/**
+ * True when transpiling the module would leave no executable code: every
+ * top-level statement is erased by type stripping — an interface, a type
+ * alias, a wholly type-only import or export, or an ambient (`declare`)
+ * declaration. V8 never emits a coverage record for such a module even when
+ * tests import it, so the debt metric scores it as zero tracked lines rather
+ * than as permanently uncoverable. The `.d.ts` suffix exclusion is the
+ * declared-by-name case of the same rule.
+ *
+ * Conservative on purpose: a statement this does not recognize as erased
+ * counts as executable, so a mistake here keeps a file tracked rather than
+ * silently dropping real uncovered code.
+ */
+export function producesNoExecutableCode(
+  content: string,
+  fileName: string,
+): boolean {
+  const source = ts.createSourceFile(
+    fileName,
+    content,
+    ts.ScriptTarget.Latest,
+  );
+  return source.statements.every(isErasedStatement);
+}
+
+function isErasedStatement(statement: ts.Statement): boolean {
+  if (
+    ts.isInterfaceDeclaration(statement) ||
+    ts.isTypeAliasDeclaration(statement) ||
+    statement.kind === ts.SyntaxKind.EmptyStatement
+  ) {
+    return true;
+  }
+
+  // Ambient declarations (`declare const`, `declare module`, `declare
+  // global`, ...) describe values without creating them.
+  if (
+    ts.canHaveModifiers(statement) &&
+    ts.getModifiers(statement)?.some((modifier) =>
+      modifier.kind === ts.SyntaxKind.DeclareKeyword
+    )
+  ) {
+    return true;
+  }
+
+  // A bare `import "./mod"` or a value import loads its module at runtime;
+  // only a wholly type-only clause is erased. `import { type A } from ...`
+  // keeps its module load, so it stays executable.
+  if (ts.isImportDeclaration(statement)) {
+    return statement.importClause?.isTypeOnly ?? false;
+  }
+  if (ts.isExportDeclaration(statement)) return statement.isTypeOnly;
+  if (ts.isImportEqualsDeclaration(statement)) return statement.isTypeOnly;
+
+  return false;
 }
 
 export function countTrackedSourceLines(content: string): number {

--- a/tasks/deno.jsonc
+++ b/tasks/deno.jsonc
@@ -2,5 +2,8 @@
   // Dependency guide: ../docs/development/DEPENDENCIES.md
   "tasks": {
     "test": "deno test -A"
+  },
+  "imports": {
+    "typescript": "npm:typescript@6.0.3"
   }
 }


### PR DESCRIPTION
## Problem

A module whose every top-level statement is erased by type stripping transpiles to an empty module, so V8 never emits a coverage record for it — even when tests import it at runtime (verified for `packages/api/schema.ts`, which `packages/api/test/factory-input-types.test.ts` imports both statically and dynamically; no `SF` entry appears in any CI LCOV artifact). The debt metric read the missing record as "never loaded" and charged every tracked line as permanently uncoverable debt. Any PR adding type-level lines to such a file failed the ratchet with an "add tests" suggestion that is impossible to follow — see #5365, where +10 type-only lines in `api/schema.ts` tripped the gate and required an `ACCEPT_COVERAGE_DEBT` override.

## Change

- `tasks/coverage-metrics.ts` gains `producesNoExecutableCode()`: it parses each tracked file with the TypeScript compiler and scores a file whose statements are all erased by type stripping (interfaces, type aliases, wholly type-only imports/exports, ambient `declare` declarations) as **zero tracked lines**. `collectUncoveredLinesForFiles` likewise reports no lines for one, so the PR-comment suggestions stay consistent with the gate.
- Detection is conservative on purpose: any statement not recognized as erased (a value import, a bare side-effect import, an enum) keeps the file tracked, so a mistake leaves debt standing rather than hiding real uncovered code. The `.d.ts` suffix exclusion remains as the declared-by-name case of the same rule.
- `packages/api/perf/` is excluded outright via `EXCLUDED_RELATIVE_PREFIXES`. The type-only rule alone would not release it: `ikeyable_realistic.ts` deliberately holds value statements to stress the checker, and `run-tsc.ts`/`run-benchmarks.ts` are compile-harness tools — none exist to be run by tests.
- `tasks` now declares `npm:typescript@6.0.3`, the same pin as the other eight workspace members; `docs/development/DEPENDENCIES.md` updated to count it.
- `docs/development/COVERAGE.md` gains a "Type-only modules are scored as zero tracked lines" section.

Parsing all 1,838 tracked files costs ~1s in the coverage job (measured).

## Effect on ratchet baselines

This lowers the maximum possible debt in 14 groups, **2,706 tracked lines** total: `packages/api` −1,526 (schema.ts + the perf harness), `packages/cf-harness` −236, `packages/patterns` −220, `packages/runner` −200, `packages/ui` −151, `packages/memory` −145, and eight smaller groups (`html` −71, `toolshed` −68, `fuse` −32, `deno-web-test` −19, `fs-sync-example` −17, `ts-transformers` −8, `data-model` −7, `content-hash` −6). A repo-wide baseline **drop** is safe for a ratchet — it only fails on rises — and the first `main` run after merge seeds the lower baselines.

## Tests

New cases in `tasks/coverage-metrics.test.ts`: the recognizer both ways (type-level module → true; `declare` + value statement, bare import, value import → false), a record-less type-only file adding zero group debt, `collectUncoveredLinesForFiles` returning nothing for a type-only file, and the perf-path exclusion. Full `tasks` suite: 450 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

