### PR TITLE
fix(cli): hand a spawned CLI its environment, don't inherit one

### DIFF
--- a/docs/development/CI_PERFORMANCE.md
+++ b/docs/development/CI_PERFORMANCE.md
@@ -235,12 +235,25 @@ slow package may also be running many independent test modules serially.
 Deno's `--parallel` mode can reduce that package's wall time, but only after
 checking for tests that share process-wide state.
 
+Deno runs each parallel test file on its own thread of a single process, so
+"process-wide state" means state every file shares: environment variables,
+replaced globals, and the current directory. A test that only configures a CLI
+it spawns shares nothing — `cf` in `packages/cli/test/utils.ts` takes the
+command's environment as an argument and gives it nothing else, so those tests
+stay in the parallel group.
+
 Known serial CLI tests:
 
-- `test/fuse.test.ts`, `test/inspect-remote.test.ts`,
+- `test/completion-output.test.ts`, `test/completion-providers.test.ts`,
+  `test/fuse.test.ts`, `test/inspect-remote.test.ts`,
   `test/log-level.test.ts`, `test/main-command.test.ts`,
-  `test/test-runner-compile-byte-cache.test.ts`, and
-  `test/test-runner-pattern-coverage.test.ts` mutate shared process state.
+  `test/test-runner-compile-byte-cache.test.ts`,
+  `test/test-runner-pattern-coverage.test.ts`, `test/view-commitmsg.test.ts`
+  and `test/wish-command.test.ts` set an environment variable that the test
+  process itself then reads, so another file setting the same name would
+  decide what they read.
+- `test/json-command.test.ts` and `test/runtime-creation.test.ts` replace
+  globals — the console methods and runtime prototype methods.
 - `test/view-mod-gate.test.ts` changes into a removed directory to test the
   missing-current-directory fallback.
 - `test/view-pager-pty.test.ts` drives a real pseudo-terminal, spawning a full

--- a/packages/cli/test/acl-command.test.ts
+++ b/packages/cli/test/acl-command.test.ts
@@ -11,20 +11,32 @@ describe("cf acl", () => {
     // `--api-url` and `--identity` reach the option parser through the
     // command's `CF_API_URL` and `CF_IDENTITY` declarations, so the only
     // option left unset is the one with no environment fallback.
-    await withEnv("CF_API_URL", "https://toolshed.test", async () => {
-      await withEnv("CF_IDENTITY", "/nonexistent/identity.key", async () => {
-        const { code, stderr } = await cf("acl ls");
-        expect(code).toBe(1);
-        expect(errorText(stderr)).toContain(
-          'Missing required option: "--space".',
-        );
-      });
+    const { code, stderr } = await cf("acl ls", {
+      env: {
+        CF_API_URL: "https://toolshed.test",
+        CF_IDENTITY: "/nonexistent/identity.key",
+      },
     });
+    expect(code).toBe(1);
+    expect(errorText(stderr)).toContain('Missing required option: "--space".');
   });
 
   it("reports a missing identity on stderr and exits non-zero", async () => {
-    await withEnv("CF_API_URL", undefined, async () => {
-      await withEnv("CF_IDENTITY", undefined, async () => {
+    const { code, stderr } = await cf("acl ls");
+    expect(code).toBe(1);
+    expect(errorText(stderr)).toContain(
+      'Missing required option: "--identity", or "CF_IDENTITY".',
+    );
+  });
+
+  it("reports a missing identity that only the test process declared", async () => {
+    // Every test file in a `deno test --parallel` run shares one process
+    // environment, so another file's identity and api-url can be set while
+    // this one spawns the CLI. The spawned CLI takes its fabric configuration
+    // from the test, so the surrounding process leaves no trace in it: the
+    // missing identity is still the first thing the command reports.
+    await withEnv("CF_API_URL", "https://ambient.test", async () => {
+      await withEnv("CF_IDENTITY", "/ambient/identity.key", async () => {
         const { code, stderr } = await cf("acl ls");
         expect(code).toBe(1);
         expect(errorText(stderr)).toContain(

--- a/packages/cli/test/command-env.test.ts
+++ b/packages/cli/test/command-env.test.ts
@@ -1,0 +1,40 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { commandEnv } from "./utils.ts";
+
+// What a test would inherit from the process running it.
+const INHERITED = {
+  PATH: "/usr/bin",
+  CF_IDENTITY: "/inherited/identity.key",
+  EXPERIMENTAL_COMPUTED_CELL_IDS: "false",
+  MEMORY_DIR: "file:///inherited/memory/",
+};
+
+describe("commandEnv", () => {
+  it("keeps an inherited name that is not the CLI's configuration", () => {
+    expect(commandEnv(INHERITED, {}).PATH).toBe("/usr/bin");
+  });
+
+  it("drops inherited configuration the call says nothing about", () => {
+    const env = commandEnv(INHERITED, {});
+    expect("CF_IDENTITY" in env).toBe(false);
+    expect("EXPERIMENTAL_COMPUTED_CELL_IDS" in env).toBe(false);
+    expect("MEMORY_DIR" in env).toBe(false);
+  });
+
+  it("carries the configuration the call declares", () => {
+    const env = commandEnv(INHERITED, {
+      CF_IDENTITY: "/declared/identity.key",
+    });
+    expect(env.CF_IDENTITY).toBe("/declared/identity.key");
+  });
+
+  it("drops a name the call maps to `undefined`", () => {
+    const env = commandEnv(INHERITED, { PATH: undefined });
+    expect("PATH" in env).toBe(false);
+  });
+
+  it("overrides an inherited name that is not configuration", () => {
+    expect(commandEnv(INHERITED, { PATH: "/opt/bin" }).PATH).toBe("/opt/bin");
+  });
+});

--- a/packages/cli/test/id.test.ts
+++ b/packages/cli/test/id.test.ts
@@ -76,7 +76,9 @@ describe("cli id", () => {
   it("Derives a passphrase key from stdin via '-'", async () => {
     // Trailing newline (as `echo`/files produce) must be stripped so the
     // result matches the equivalent argv invocation.
-    const { code, stdout, stderr } = await cf("id derive -", "common user\n");
+    const { code, stdout, stderr } = await cf("id derive -", {
+      stdin: "common user\n",
+    });
     const keyBuffer = encode(stdout.join("\n"));
     const identity = await Identity.fromPkcs8(keyBuffer);
     expect(identity.did()).toBe(COMMON_USER_DID);
@@ -85,7 +87,9 @@ describe("cli id", () => {
   });
 
   it("Derives a passphrase key from stdin when the argument is omitted", async () => {
-    const { code, stdout, stderr } = await cf("id derive", "common user");
+    const { code, stdout, stderr } = await cf("id derive", {
+      stdin: "common user",
+    });
     const keyBuffer = encode(stdout.join("\n"));
     const identity = await Identity.fromPkcs8(keyBuffer);
     expect(identity.did()).toBe(COMMON_USER_DID);
@@ -96,7 +100,7 @@ describe("cli id", () => {
   it("Derives a mnemonic key from stdin via '-'", async () => {
     const { code, stdout, stderr } = await cf(
       "id from-mnemonic -",
-      `${TEST_MNEMONIC}\n`,
+      { stdin: `${TEST_MNEMONIC}\n` },
     );
     const keyBuffer = encode(stdout.join("\n"));
     const identity = await Identity.fromPkcs8(keyBuffer);
@@ -106,7 +110,7 @@ describe("cli id", () => {
   });
 
   it("Errors when no secret is provided on stdin", async () => {
-    const { code, stdout } = await cf("id from-mnemonic -", "");
+    const { code, stdout } = await cf("id from-mnemonic -", { stdin: "" });
     expect(code).not.toBe(0);
     expect(stdout.length).toBe(0);
   });

--- a/packages/cli/test/json-command.test.ts
+++ b/packages/cli/test/json-command.test.ts
@@ -5,7 +5,7 @@ import {
   pieceCallRawArgs,
   writePieceRenderStatus,
 } from "../commands/piece.ts";
-import { cf, stripAnsi, withEnv } from "./utils.ts";
+import { cf, stripAnsi } from "./utils.ts";
 import { ConsoleMethod } from "@commonfabric/runner";
 import {
   hasJsonArgument,
@@ -82,22 +82,23 @@ describe("JSON command contracts", () => {
   });
 
   it("keeps the profiling marker off pattern JSON stdout", async () => {
-    await withEnv("CF_PROFILE_DONE_MARKER", "profile finished", async () => {
-      const { code, stdout, stderr } = await cf(
-        "check fixtures/check-json-no-evaluate.ts --pattern-json",
-      );
+    const env = { CF_PROFILE_DONE_MARKER: "profile finished" };
+    const { code, stdout, stderr } = await cf(
+      "check fixtures/check-json-no-evaluate.ts --pattern-json",
+      { env },
+    );
 
-      expect(code).toBe(0);
-      expect(stdout).toEqual(["1"]);
-      expect(stderr.join("\n")).toContain("profile finished");
+    expect(code).toBe(0);
+    expect(stdout).toEqual(["1"]);
+    expect(stderr.join("\n")).toContain("profile finished");
 
-      const transformed = await cf(
-        "check fixtures/check-json-no-evaluate.ts --show-transformed",
-      );
-      expect(transformed.code).toBe(0);
-      expect(transformed.stdout.join("\n")).not.toContain("profile finished");
-      expect(transformed.stderr.join("\n")).toContain("profile finished");
-    });
+    const transformed = await cf(
+      "check fixtures/check-json-no-evaluate.ts --show-transformed",
+      { env },
+    );
+    expect(transformed.code).toBe(0);
+    expect(transformed.stdout.join("\n")).not.toContain("profile finished");
+    expect(transformed.stderr.join("\n")).toContain("profile finished");
   });
 
   it("keeps parser help off reserved stdout modes", async () => {

--- a/packages/cli/test/run-tests.ts
+++ b/packages/cli/test/run-tests.ts
@@ -36,7 +36,16 @@ function parseCliTestShard(): { index: number; count: number } {
   return { index, count };
 }
 
+// Test files that cannot run beside another file. `deno test --parallel` runs
+// each file on its own thread of one process, so a file belongs here when it
+// changes state the whole process shares: a test that reads an environment
+// variable in the test process itself is the common case, since another file
+// setting the same name decides what it reads. A test that only configures a
+// CLI it spawns does not belong here; `cf` in test/utils.ts gives the spawned
+// command its environment directly.
 const SERIAL_TESTS = [
+  "test/completion-output.test.ts",
+  "test/completion-providers.test.ts",
   "test/fuse.test.ts",
   "test/inspect-remote.test.ts",
   "test/json-command.test.ts",
@@ -48,6 +57,7 @@ const SERIAL_TESTS = [
   "test/view-commitmsg.test.ts",
   "test/view-mod-gate.test.ts",
   "test/view-pager-pty.test.ts",
+  "test/wish-command.test.ts",
 ];
 
 // Tests that need a live toolshed named by API_URL. This runner excludes

--- a/packages/cli/test/space.test.ts
+++ b/packages/cli/test/space.test.ts
@@ -10,7 +10,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Database } from "@db/sqlite";
 import { clonePaths } from "@commonfabric/state-inspector";
-import { cf, withEnv } from "./utils.ts";
+import { cf } from "./utils.ts";
 
 /** `CliResult` streams are line arrays; join before substring assertions. */
 const text = (lines: string[]): string => lines.join("\n");
@@ -171,18 +171,16 @@ describe("cf space", () => {
     await withFixture(async ({ snapshot, root }) => {
       const live = `${root}/live-memory`;
       await Deno.mkdir(live);
-      // The CLI subprocess inherits this env, which is how it learns what the
-      // local server is serving.
-      await withEnv("MEMORY_DIR", `file://${live}/`, async () => {
-        const result = await cf(
-          `space clone ${SPACE} --from ${snapshot} --to ${live}/clone`,
-        );
-        expect(result.code).not.toBe(0);
-        expect(text(result.stderr)).toContain(
-          "overlaps the live store directory",
-        );
-        expect(await exists(`${live}/clone`)).toBe(false);
-      });
+      // MEMORY_DIR is how the CLI learns what the local server is serving.
+      const result = await cf(
+        `space clone ${SPACE} --from ${snapshot} --to ${live}/clone`,
+        { env: { MEMORY_DIR: `file://${live}/` } },
+      );
+      expect(result.code).not.toBe(0);
+      expect(text(result.stderr)).toContain(
+        "overlaps the live store directory",
+      );
+      expect(await exists(`${live}/clone`)).toBe(false);
     });
   });
 
@@ -572,15 +570,14 @@ describe("cf space", () => {
     await withFixture(async ({ snapshot, root }) => {
       const live = `${root}/single-file`;
       await Deno.mkdir(live);
-      await withEnv("DB_PATH", `${live}/store.sqlite`, async () => {
-        const result = await cf(
-          `space clone ${SPACE} --from ${snapshot} --to ${live}/clone`,
-        );
-        expect(result.code).not.toBe(0);
-        expect(text(result.stderr)).toContain(
-          "overlaps the live store directory",
-        );
-      });
+      const result = await cf(
+        `space clone ${SPACE} --from ${snapshot} --to ${live}/clone`,
+        { env: { DB_PATH: `${live}/store.sqlite` } },
+      );
+      expect(result.code).not.toBe(0);
+      expect(text(result.stderr)).toContain(
+        "overlaps the live store directory",
+      );
     });
   });
 
@@ -588,12 +585,11 @@ describe("cf space", () => {
     // MEMORY_DIR comes from the environment and may be junk; that must not
     // stop an operator from making a clone somewhere harmless.
     await withFixture(async ({ snapshot, clone }) => {
-      await withEnv("MEMORY_DIR", "file://[not-a-url", async () => {
-        const result = await cf(
-          `space clone ${SPACE} --from ${snapshot} --to ${clone}`,
-        );
-        expect(result.code).toBe(0);
-      });
+      const result = await cf(
+        `space clone ${SPACE} --from ${snapshot} --to ${clone}`,
+        { env: { MEMORY_DIR: "file://[not-a-url" } },
+      );
+      expect(result.code).toBe(0);
     });
   });
 

--- a/packages/cli/test/test-runner-compile-byte-cache.test.ts
+++ b/packages/cli/test/test-runner-compile-byte-cache.test.ts
@@ -184,28 +184,25 @@ describe(
       const command = `test "${TEST_FILE}" --root "${FIXTURES}"`;
 
       try {
-        await withEnv("CF_COMPILE_CACHE_FILE", cacheFile, async () => {
-          await withEnv("CF_LOG_LEVEL", "info", async () => {
-            const first = await cf(command);
-            expect(first.code).toBe(0);
-            checkStderr(first.stderr);
-            const entries = JSON.parse(await Deno.readTextFile(cacheFile));
-            expect(Array.isArray(entries)).toBe(true);
-            expect(entries.length).toBeGreaterThan(0);
+        const env = { CF_COMPILE_CACHE_FILE: cacheFile, CF_LOG_LEVEL: "info" };
+        const first = await cf(command, { env });
+        expect(first.code).toBe(0);
+        checkStderr(first.stderr);
+        const entries = JSON.parse(await Deno.readTextFile(cacheFile));
+        expect(Array.isArray(entries)).toBe(true);
+        expect(entries.length).toBeGreaterThan(0);
 
-            const second = await cf(command);
-            expect(second.code).toBe(0);
-            checkStderr(second.stderr);
-            expect(
-              second.stdout.some((line) =>
-                line.includes("[compile-byte-cache] restored")
-              ),
-            ).toBe(true);
-            expect(
-              second.stdout.some((line) => line.includes("compile-cache-hit")),
-            ).toBe(true);
-          });
-        });
+        const second = await cf(command, { env });
+        expect(second.code).toBe(0);
+        checkStderr(second.stderr);
+        expect(
+          second.stdout.some((line) =>
+            line.includes("[compile-byte-cache] restored")
+          ),
+        ).toBe(true);
+        expect(
+          second.stdout.some((line) => line.includes("compile-cache-hit")),
+        ).toBe(true);
       } finally {
         await Deno.remove(dir, { recursive: true });
       }
@@ -220,47 +217,44 @@ describe(
       const command = `test "${TEST_FILE}" --root "${FIXTURES}"`;
 
       try {
-        await withEnv("CF_COMPILE_CACHE_FILE", cacheFile, async () => {
-          await withEnv("CF_PATTERN_COVERAGE_DIR", coverageDir, async () => {
-            await withEnv("CF_LOG_LEVEL", "info", async () => {
-              const first = await cf(command);
-              expect(first.code).toBe(0);
-              checkStderr(first.stderr);
+        const env = {
+          CF_COMPILE_CACHE_FILE: cacheFile,
+          CF_PATTERN_COVERAGE_DIR: coverageDir,
+          CF_LOG_LEVEL: "info",
+        };
+        const first = await cf(command, { env });
+        expect(first.code).toBe(0);
+        checkStderr(first.stderr);
 
-              const entries = JSON.parse(await Deno.readTextFile(cacheFile));
-              expect(Array.isArray(entries)).toBe(true);
-              expect(
-                entries.some((entry: { key?: unknown }) =>
-                  typeof entry.key === "string" &&
-                  entry.key.includes("/pattern-coverage\0")
-                ),
-              ).toBe(true);
-              expect(
-                entries.some((
-                  entry: { patternCoverageSpans?: unknown },
-                ) => Array.isArray(entry.patternCoverageSpans)),
-              ).toBe(true);
+        const entries = JSON.parse(await Deno.readTextFile(cacheFile));
+        expect(Array.isArray(entries)).toBe(true);
+        expect(
+          entries.some((entry: { key?: unknown }) =>
+            typeof entry.key === "string" &&
+            entry.key.includes("/pattern-coverage\0")
+          ),
+        ).toBe(true);
+        expect(
+          entries.some((
+            entry: { patternCoverageSpans?: unknown },
+          ) => Array.isArray(entry.patternCoverageSpans)),
+        ).toBe(true);
 
-              const second = await cf(command);
-              expect(second.code).toBe(0);
-              checkStderr(second.stderr);
-              expect(
-                second.stdout.some((line) =>
-                  line.includes("[compile-byte-cache] restored")
-                ),
-              ).toBe(true);
-              expect(
-                second.stdout.some((line) =>
-                  line.includes("compile-cache-hit")
-                ),
-              ).toBe(true);
+        const second = await cf(command, { env });
+        expect(second.code).toBe(0);
+        checkStderr(second.stderr);
+        expect(
+          second.stdout.some((line) =>
+            line.includes("[compile-byte-cache] restored")
+          ),
+        ).toBe(true);
+        expect(
+          second.stdout.some((line) => line.includes("compile-cache-hit")),
+        ).toBe(true);
 
-              const coverage = await readCoverageText(coverageDir);
-              expect(coverage).toContain("SF:");
-              expect(coverage).toMatch(/LH:[1-9]/);
-            });
-          });
-        });
+        const coverage = await readCoverageText(coverageDir);
+        expect(coverage).toContain("SF:");
+        expect(coverage).toMatch(/LH:[1-9]/);
       } finally {
         await Deno.remove(dir, { recursive: true });
       }

--- a/packages/cli/test/test-runner-pattern-coverage.test.ts
+++ b/packages/cli/test/test-runner-pattern-coverage.test.ts
@@ -268,16 +268,18 @@ describe(
 
     it("passes the coverage directory from CF_PATTERN_COVERAGE_DIR", async () => {
       await withTempDir(async (coverageDir) => {
-        await withEnv("CF_PATTERN_COVERAGE_DIR", coverageDir, async () => {
-          await withEnv("CF_LOG_LEVEL", "error", async () => {
-            const { code, stderr } = await cf(
-              `test "${fixture("single.test.tsx")}" --root "${FIXTURES}"`,
-            );
+        const { code, stderr } = await cf(
+          `test "${fixture("single.test.tsx")}" --root "${FIXTURES}"`,
+          {
+            env: {
+              CF_PATTERN_COVERAGE_DIR: coverageDir,
+              CF_LOG_LEVEL: "error",
+            },
+          },
+        );
 
-            expect(code).toBe(0);
-            checkStderr(stderr);
-          });
-        });
+        expect(code).toBe(0);
+        checkStderr(stderr);
 
         const coverageFiles = await readCoverageFiles(coverageDir);
         expect(coverageFiles.length).toBe(1);

--- a/packages/cli/test/test-runner-render-step.test.ts
+++ b/packages/cli/test/test-runner-render-step.test.ts
@@ -5,7 +5,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { join, resolve } from "@std/path";
 import { runTests } from "../lib/test-runner.ts";
-import { cf, checkStderr, withEnv } from "./utils.ts";
+import { cf, checkStderr } from "./utils.ts";
 
 const FIXTURES = resolve(import.meta.dirname!, "fixtures/render-step");
 const SUBJECT = join(FIXTURES, "subject.tsx").replaceAll("\\", "/");
@@ -184,19 +184,22 @@ describe(
     it("enables continuous $UI demand through CF_TEST_CONTINUOUS_UI", async () => {
       const coverageDir = await Deno.makeTempDir();
       try {
-        await withEnv("CF_TEST_CONTINUOUS_UI", "1", async () => {
-          // Wall-clock performance diagnostics can fire under CI contention;
-          // keep this environment-contract test strict about errors instead.
-          await withEnv("CF_LOG_LEVEL", "error", async () => {
-            const { code, stderr } = await cf(
-              `test "${
-                fixture("continuous-ui.test.tsx")
-              }" --root "${FIXTURES}" --pattern-coverage-dir "${coverageDir}"`,
-            );
-            expect(code).toBe(0);
-            checkStderr(stderr);
-          });
-        });
+        const { code, stderr } = await cf(
+          `test "${
+            fixture("continuous-ui.test.tsx")
+          }" --root "${FIXTURES}" --pattern-coverage-dir "${coverageDir}"`,
+          {
+            env: {
+              CF_TEST_CONTINUOUS_UI: "1",
+              // Wall-clock performance diagnostics can fire under CI
+              // contention; keep this environment-contract test strict about
+              // errors instead.
+              CF_LOG_LEVEL: "error",
+            },
+          },
+        );
+        expect(code).toBe(0);
+        checkStderr(stderr);
 
         const files: string[] = [];
         for await (const entry of Deno.readDir(coverageDir)) {

--- a/packages/cli/test/utils.ts
+++ b/packages/cli/test/utils.ts
@@ -46,6 +46,49 @@ export interface CliResult {
   stderr: string[];
 }
 
+export interface CliOptions {
+  // Text written to the command's standard input.
+  stdin?: string;
+  // Names the command's environment holds. A name mapped to `undefined` is
+  // absent from it. The CLI's own configuration comes from here and from
+  // nowhere else, so a configuration name this map leaves out is absent too;
+  // every other name the command takes from this process.
+  env?: Record<string, string | undefined>;
+}
+
+// The names the CLI reads as its own configuration: the `CF_` variables, the
+// experimental flags, and the two that point at a local memory store.
+const CONFIG_ENV_PREFIXES = ["CF_", "EXPERIMENTAL_"];
+const CONFIG_ENV_NAMES = ["DB_PATH", "MEMORY_DIR"];
+
+function isConfigEnvName(name: string): boolean {
+  return CONFIG_ENV_PREFIXES.some((prefix) => name.startsWith(prefix)) ||
+    CONFIG_ENV_NAMES.includes(name);
+}
+
+// The environment a spawned command runs with: `inherited` without the CLI's
+// own configuration, and then `declared` applied over that, where a value of
+// `undefined` leaves the name absent.
+//
+// `deno test --parallel` runs each test file on its own thread of a single
+// process, and those threads share one environment. Configuration a command
+// inherited would therefore be whatever the file running beside this one had
+// set, so the call decides it instead.
+export function commandEnv(
+  inherited: Record<string, string>,
+  declared: Record<string, string | undefined>,
+): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [name, value] of Object.entries(inherited)) {
+    if (!isConfigEnvName(name)) env[name] = value;
+  }
+  for (const [name, value] of Object.entries(declared)) {
+    if (value === undefined) delete env[name];
+    else env[name] = value;
+  }
+  return env;
+}
+
 // Splits a command string into arguments on spaces outside of double quotes,
 // then strips the quotes.
 function parseCliCommand(command: string): string[] {
@@ -59,11 +102,14 @@ function parseCliCommand(command: string): string[] {
 async function spawnCli(
   executable: string,
   args: string[],
-  stdin?: string,
+  options: CliOptions,
 ): Promise<CliResult> {
+  const { stdin } = options;
   const child = new Deno.Command(executable, {
     cwd: join(import.meta.dirname!, ".."),
     args,
+    clearEnv: true,
+    env: commandEnv(Deno.env.toObject(), options.env ?? {}),
     // `.output()` requires stdout/stderr to be piped; `.spawn()` would
     // otherwise default them to "inherit".
     stdout: "piped",
@@ -88,7 +134,7 @@ async function spawnCli(
 async function runCliTask(
   task: "cli-no-pwd-override",
   command: string,
-  stdin?: string,
+  options: CliOptions,
 ): Promise<CliResult> {
   return await spawnCli(
     Deno.execPath(),
@@ -102,18 +148,19 @@ async function runCliTask(
       task,
       ...parseCliCommand(command),
     ],
-    stdin,
+    options,
   );
 }
 
 // Executes the `cf` command via CLI
 // `const { stdout, stderr, code } = cf("check --no-run ./pattern.tsx")`
-// Pass `stdin` to feed the command's standard input.
+// Pass `stdin` to feed the command's standard input, and `env` to give it
+// fabric configuration; it starts with none.
 export async function cf(
   command: string,
-  stdin?: string,
+  options: CliOptions = {},
 ): Promise<CliResult> {
-  return await runCliTask("cli-no-pwd-override", command, stdin);
+  return await runCliTask("cli-no-pwd-override", command, options);
 }
 
 let cfBinaryProbe: Promise<boolean> | undefined;
@@ -148,14 +195,19 @@ function cfBinaryAvailable(): Promise<boolean> {
 // CF_CLI_INTEGRATION_USE_LOCAL=1 to force the source-tree CLI.
 export async function integrationCf(
   command: string,
-  stdin?: string,
+  options: CliOptions = {},
 ): Promise<CliResult> {
   if (await cfBinaryAvailable()) {
-    return await spawnCli("cf", parseCliCommand(command), stdin);
+    return await spawnCli("cf", parseCliCommand(command), options);
   }
-  return await cf(command, stdin);
+  return await cf(command, options);
 }
 
+// Runs `fn` with `name` set on this process. Every test file in a
+// `deno test --parallel` run shares one environment, so a file that calls
+// this cannot run beside one that reads the same name: list it in
+// SERIAL_TESTS in test/run-tests.ts. Configuring a spawned CLI needs none of
+// this — pass `env` to `cf` instead.
 export async function withEnv(
   name: string,
   value: string | undefined,

--- a/packages/cli/test/view-cli.test.ts
+++ b/packages/cli/test/view-cli.test.ts
@@ -20,32 +20,36 @@ index 0000000..1111111 100644
 `;
 
 Deno.test("cf view --plain prints colourised source and exits 0", async () => {
-  const { code, stdout } = await cf("view --plain", SRC);
+  const { code, stdout } = await cf("view --plain", { stdin: SRC });
   assertEquals(code, 0);
   assert(stdout.join("\n").includes("pattern"), stdout.join("\n"));
 });
 
 Deno.test("cf view --plain --color never prints without escapes", async () => {
-  const { code, stdout } = await cf("view --plain --color never", SRC);
+  const { code, stdout } = await cf("view --plain --color never", {
+    stdin: SRC,
+  });
   assertEquals(code, 0);
   assert(!stdout.join("\n").includes("\x1b["), "no ANSI escapes");
 });
 
 Deno.test("cf view --plain --color always emits escapes", async () => {
-  const { code, stdout } = await cf("view --plain --color always", SRC);
+  const { code, stdout } = await cf("view --plain --color always", {
+    stdin: SRC,
+  });
   assertEquals(code, 0);
   assert(stdout.join("\n").includes("\x1b["), "has ANSI escapes");
 });
 
 Deno.test("cf view --plain --line-numbers exits 0", async () => {
-  const { code } = await cf("view --plain --line-numbers", SRC);
+  const { code } = await cf("view --plain --line-numbers", { stdin: SRC });
   assertEquals(code, 0);
 });
 
 Deno.test("cf view --plain --line-numbers prefixes lines with numbers", async () => {
   const { code, stdout } = await cf(
     "view --plain --line-numbers --color never",
-    SRC,
+    { stdin: SRC },
   );
   assertEquals(code, 0);
   // The two source lines are printed with a right-aligned line-number gutter.
@@ -60,7 +64,9 @@ Deno.test("cf view --plain --line-numbers prefixes lines with numbers", async ()
 });
 
 Deno.test("cf view --plain without --line-numbers has no number gutter", async () => {
-  const { code, stdout } = await cf("view --plain --color never", SRC);
+  const { code, stdout } = await cf("view --plain --color never", {
+    stdin: SRC,
+  });
   assertEquals(code, 0);
   assert(
     stdout.some((line) => /^export const x = pattern/.test(line)),
@@ -69,19 +75,19 @@ Deno.test("cf view --plain without --line-numbers has no number gutter", async (
 });
 
 Deno.test("cf view --plain --diff renders a forced diff", async () => {
-  const { code, stdout } = await cf("view --plain --diff", DIFF);
+  const { code, stdout } = await cf("view --plain --diff", { stdin: DIFF });
   assertEquals(code, 0);
   assert(stdout.join("\n").includes("next"), stdout.join("\n"));
 });
 
 Deno.test("cf view --plain auto-detects a diff", async () => {
-  const { code, stdout } = await cf("view --plain", DIFF);
+  const { code, stdout } = await cf("view --plain", { stdin: DIFF });
   assertEquals(code, 0);
   assert(stdout.join("\n").includes("next"));
 });
 
 Deno.test("cf view --plain --no-diff is accepted and views a diff as source", async () => {
-  const { code } = await cf("view --plain --no-diff", DIFF);
+  const { code } = await cf("view --plain --no-diff", { stdin: DIFF });
   assertEquals(code, 0);
 });
 
@@ -89,7 +95,7 @@ Deno.test("cf view --filename selects piped source by its virtual name", async (
   const source = "# Title with **weight**\n";
   const { code, stdout } = await cf(
     "view --plain --rendered --color never --filename notes.md",
-    source,
+    { stdin: source },
   );
   assertEquals(code, 0);
   assertEquals(stdout, ["Title with weight"]);
@@ -99,14 +105,16 @@ Deno.test("cf view --language aliases override a piped virtual filename", async 
   const source = "# Title with **weight**\n";
   const { code, stdout } = await cf(
     "view --plain --rendered --color never --language md --filename notes.txt",
-    source,
+    { stdin: source },
   );
   assertEquals(code, 0);
   assertEquals(stdout, ["Title with weight"]);
 });
 
 Deno.test("cf view rejects an unknown --language", async () => {
-  const { code, stderr } = await cf("view --plain --language ruby", SRC);
+  const { code, stderr } = await cf("view --plain --language ruby", {
+    stdin: SRC,
+  });
   assertEquals(code, 1);
   assert(
     stderr.join("\n").includes('unknown language "ruby"'),
@@ -124,7 +132,7 @@ Deno.test("cf view rejects source selection combined with forced diff mode", asy
   ) {
     const { code, stderr } = await cf(
       `view --plain --diff ${selector}`,
-      DIFF,
+      { stdin: DIFF },
     );
     assertEquals(code, 1);
     assert(
@@ -137,13 +145,15 @@ Deno.test("cf view rejects source selection combined with forced diff mode", asy
 });
 
 Deno.test("cf view rejects an invalid --color", async () => {
-  const { code, stderr } = await cf("view --plain --color bogus", SRC);
+  const { code, stderr } = await cf("view --plain --color bogus", {
+    stdin: SRC,
+  });
   assertEquals(code, 1);
   assert(stderr.join("\n").toLowerCase().includes("color"), stderr.join("\n"));
 });
 
 Deno.test("cf view reports empty piped input", async () => {
-  const { code, stderr } = await cf("view --plain", "");
+  const { code, stderr } = await cf("view --plain", { stdin: "" });
   assertEquals(code, 1);
   assert(
     stderr.join("\n").toLowerCase().includes("no input"),


### PR DESCRIPTION
A CLI test that needs the command under test to see `CF_IDENTITY`, or to see no `CF_IDENTITY`, used to set that variable on the test process and let the spawned command inherit it. The CLI suite runs its files with `deno test --parallel`, which puts each file on its own thread of one process, and all those threads share one environment. So the variable a command inherited was whichever value the file running alongside it had set a moment earlier, and the file that thought it was in charge of that variable had no say.

That is how this failed in CI. The completion tests set an identity and an api-url for their own in-process reads. The acl test, running beside them, spawned `cf acl ls` with both deleted and got a command that could see both. `cf acl ls` reports the first piece of configuration it is missing, checking identity, then api-url, then space, so the leaked values satisfied the first two checks and it reported the missing space. The test asserting on the missing identity failed.

Give the spawned command its environment instead. `cf` and `integrationCf` now take the configuration as an argument next to `stdin`, and start the command with none of it: the names the CLI reads as its own configuration are dropped from what it would otherwise inherit, and only the ones the call declares are put back. That covers the `CF_` variables, the experimental flags, and `DB_PATH` and `MEMORY_DIR`. A test now states the configuration it means to exercise in the call that spawns the command, and nothing running beside it can change that.

A new acl test pins the behaviour without waiting for the race to line up: it leaves an identity and an api-url set on the test process, spawns the CLI, and expects the missing identity to be reported anyway. Before this change it fails with the message CI produced.

Three files stay on process-wide state because what reads the variable is the test process itself rather than a command it spawns: the two completion suites and the wish command suite all read an identity and an api-url in-process. They were racing each other over those two names for the same reason, so they join the serial group, and the group now says what puts a file in it. The list of serial CLI tests in the CI performance guide had drifted from the runner and is brought back into line.

deflaked by Hixie's agent (Claude Opus 5)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

