### PR TITLE
perf(runner): resolve the default storage route when it is read

### DIFF
--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -886,8 +886,15 @@ export class StorageManager implements IStorageManager {
   #seedHosts: Record<string, string>;
   /** Late-bound host hints; see registerSpaceHost. */
   #dynamicHosts = new Map<string, string>();
-  /** WebSocket storage endpoint used by an unseeded, unhinted space. */
+  /** Base URL the default storage route is resolved from, held as text so a
+   *  caller mutating their URL object cannot move the route. */
+  #memoryHost: string;
+  /** WebSocket storage endpoint used by an unseeded, unhinted space; read it
+   *  through #resolveDefaultStorageRoute(). */
   #defaultStorageRoute?: string;
+  /** Whether #defaultStorageRoute holds the result of a resolution attempt.
+   *  Separate from the value, which is undefined when resolution failed. */
+  #defaultStorageRouteResolved = false;
   /** Late-bound marker sink (the Runtime's telemetry bus); see setTelemetry. */
   #telemetry?: TelemetrySink;
 
@@ -934,14 +941,31 @@ export class StorageManager implements IStorageManager {
     // open(), so refusal logic must see the same fixed facts — a
     // caller mutating their map object must not desynchronize them.
     this.#seedHosts = Object.freeze({ ...(options.spaceHostMap ?? {}) });
-    try {
-      const resolveDefault = createStorageAddressResolver(options.memoryHost);
-      this.#defaultStorageRoute = toWebSocketAddress(
-        resolveDefault("did:key:route-comparison" as MemorySpace),
-      ).toString();
-    } catch {
-      // A custom session factory may use a non-network memoryHost placeholder.
+    this.#memoryHost = String(options.memoryHost);
+  }
+
+  /**
+   * The WebSocket storage endpoint an unseeded, unhinted space opens against,
+   * resolved from the memory host on the first read and kept from then on.
+   * registerSpaceHost() is its only reader. A failed resolution is kept as
+   * well: a custom session factory may use a non-network memoryHost
+   * placeholder, and such a manager has no default route.
+   */
+  #resolveDefaultStorageRoute(): string | undefined {
+    if (!this.#defaultStorageRouteResolved) {
+      this.#defaultStorageRouteResolved = true;
+      try {
+        const resolveDefault = createStorageAddressResolver(
+          new URL(this.#memoryHost),
+        );
+        this.#defaultStorageRoute = toWebSocketAddress(
+          resolveDefault("did:key:route-comparison" as MemorySpace),
+        ).toString();
+      } catch {
+        // The route stays undefined; the flag above stops the retry.
+      }
     }
+    return this.#defaultStorageRoute;
   }
 
   /**
@@ -981,7 +1005,7 @@ export class StorageManager implements IStorageManager {
     }
     const provider = this.#providers.get(space);
     const replacesDefaultRoute = provider !== undefined &&
-      this.#defaultStorageRoute !==
+      this.#resolveDefaultStorageRoute() !==
         toWebSocketAddress(storageAddressForHost(normalized)).toString();
     if (replacesDefaultRoute && !provider.canReplaceProvisionalReplica()) {
       return false;

--- a/packages/runner/test/space-host-late-hint.test.ts
+++ b/packages/runner/test/space-host-late-hint.test.ts
@@ -53,10 +53,11 @@ class TestStorageManager extends StorageManager {
   static create(
     signer: Signer,
     sessionFactory: SessionFactory,
+    memoryHost = new URL("https://default-toolshed.test"),
   ): TestStorageManager {
     return new TestStorageManager({
       as: signer,
-      memoryHost: new URL("https://default-toolshed.test"),
+      memoryHost,
     }, sessionFactory);
   }
 
@@ -138,6 +139,53 @@ describe("late space host hints", () => {
           "https://different-toolshed.test",
         ),
       ).toBe(false);
+    } finally {
+      await manager.close();
+      await defaultServer.close();
+    }
+  });
+
+  it("confirms the default host after the caller mutates the host URL", async () => {
+    const signer = await Identity.fromPassphrase("mutated-default-host-hint");
+    const targetSpace = (await Identity.fromPassphrase(
+      "mutated-default-host-target",
+    )).did();
+    const targetId = "of:mutated-default-host-target" as URI;
+    const defaultServer = makeServer("mutated-default-host");
+    const memoryHost = new URL("https://default-toolshed.test");
+    let targetSessions = 0;
+    const manager = TestStorageManager.create(
+      signer,
+      new LoopbackSessionFactory(() => {
+        targetSessions++;
+        return defaultServer;
+      }),
+      memoryHost,
+    );
+
+    try {
+      const provider = manager.open(targetSpace);
+      const provisionalReplica = provider.replica;
+      const firstRead = await provider.sync(targetId, {
+        path: [],
+        schema: true,
+      });
+      expect(firstRead.error).toBeUndefined();
+      expect(targetSessions).toBe(1);
+
+      memoryHost.href = "https://moved-toolshed.test/";
+
+      expect(
+        manager.registerSpaceHost(
+          targetSpace,
+          "https://default-toolshed.test",
+        ),
+      ).toBe(true);
+      await manager.crossSpaceSettled();
+
+      expect(manager.open(targetSpace)).toBe(provider);
+      expect(provider.replica).toBe(provisionalReplica);
+      expect(targetSessions).toBe(1);
     } finally {
       await manager.close();
       await defaultServer.close();


### PR DESCRIPTION
Constructing a StorageManager resolved the memory host into the WebSocket storage endpoint that an unseeded, unhinted space would open against, and stringified the resulting URL. That work happened on every construction, and its result had exactly one reader: the comparison in registerSpaceHost() that decides whether a late host hint replaces the default route. Most managers never call registerSpaceHost at all, so for them the address was resolved and thrown away.

The resolution costs roughly four and a half microseconds, which dominated manager construction. The benchmark "Immutable cell - storage manager setup and cleanup only", which times nothing but constructing a StorageManager and closing it, went from about 0.7us to about 5.2us when the eager resolution landed, on every processor type the benchmarks run on.

Move the resolution into a private method that runs on the first read and keeps its answer. The failure case is kept too, tracked by a separate "already attempted" flag, because a resolution that failed legitimately yields undefined: a custom session factory may pass a non-network memoryHost placeholder, and such a manager has no default route. Without the flag every read would retry the throwing path.

Reading the host later than construction means the host that is read has to be the one the manager was constructed with, rather than whatever the caller's URL object says at the time of the read. So the memory host is now held as text, which matches how the seed host map is already snapshotted, and a test covers that through the public surface: open a provider against the default route, mutate the URL object the manager was constructed with, and then hint the space at the original default host. The hint has to read as a confirmation of the route already in use, leaving the provider's replica in place. A manager that followed the mutated object would instead see a different route, treat the hint as a replacement, and rebuild the replica. The test manager gains an optional memory host argument, defaulting to the URL every other case in the file already uses.

Nothing else observable changes. The eager resolution was already wrapped in a catch that discarded the error, so no validation failure was reported at construction time, and deferring it therefore cannot hide one.

Measured on that benchmark, three runs of each, compared by median: 5.23us before, 0.77us after.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

