### PR TITLE
refactor(data-model): delist `./interface`, leaving `fabric-value` the one surface

### DIFF
--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -1768,7 +1768,7 @@ serialization system can round-trip it back to a real `Temperature` instance.
 
 import {
   type FabricValue,
-} from '@commonfabric/data-model/interface';
+} from '@commonfabric/data-model/fabric-value';
 import {
   CODEC,
   BaseFabricCodec,

--- a/packages/cli/test/piece-get-transform.test.ts
+++ b/packages/cli/test/piece-get-transform.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import type { FabricValue } from "@commonfabric/data-model/interface";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { Identity } from "@commonfabric/identity";
 import { type Cell, type JSONSchema, Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";

--- a/packages/data-model/deno.jsonc
+++ b/packages/data-model/deno.jsonc
@@ -38,7 +38,6 @@
     "./fabric-value": "./src/fabric-value.ts",
     "./value-clone": "./src/value-clone.ts",
     "./frozen-builtins": "./src/frozen-builtins.ts",
-    "./interface": "./src/interface.ts",
     "./codec-json": "./src/codec-json/index.ts",
     "./data-uri-codec": "./src/data-uri-codec.ts",
     "./native-type-tags": "./src/native-type-tags.ts",

--- a/packages/memory/test/v2-patch-test.ts
+++ b/packages/memory/test/v2-patch-test.ts
@@ -1,7 +1,7 @@
 import { assert, assertEquals, assertStrictEquals } from "@std/assert";
 import { applyPatch } from "../v2/patch.ts";
 import { FabricError } from "@commonfabric/data-model/fabric-instances";
-import { FabricInstance } from "@commonfabric/data-model/interface";
+import { FabricInstance } from "@commonfabric/data-model/fabric-value";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { FabricEpochNsec } from "@commonfabric/data-model/fabric-primitives";
 

--- a/packages/piece/test/pull-materialization.test.ts
+++ b/packages/piece/test/pull-materialization.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import type { FabricValue } from "@commonfabric/data-model/interface";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { createSession, Identity } from "@commonfabric/identity";
 import {
   type Cell,

--- a/packages/piece/test/state-continuity-harness.ts
+++ b/packages/piece/test/state-continuity-harness.ts
@@ -66,7 +66,7 @@ import type { RuntimeProgram } from "@commonfabric/runner";
 // `asCell`/`asStream` position it holds a live cell, and a durable doc may hold
 // a fabric special object (bytes, an epoch). Neither survives a structural
 // comparison unaided — see `comparableState`.
-import { FabricSpecialObject } from "@commonfabric/data-model/interface";
+import { FabricSpecialObject } from "@commonfabric/data-model/fabric-value";
 import { taggedHashStringOf } from "@commonfabric/data-model/value-hash";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 // Relative into the runner's internals for the same reason as the test

--- a/packages/runner/src/pattern-binding.ts
+++ b/packages/runner/src/pattern-binding.ts
@@ -1,10 +1,10 @@
 import { isRecord } from "@commonfabric/utils/types";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
-import { valueEqual } from "@commonfabric/data-model/fabric-value";
 import {
   FabricInstance,
   FabricPrimitive,
-} from "@commonfabric/data-model/interface";
+  valueEqual,
+} from "@commonfabric/data-model/fabric-value";
 import {
   type FabricExecValue,
   isPattern,

--- a/packages/runner/test/cfc-array-shrink-slot-labels.test.ts
+++ b/packages/runner/test/cfc-array-shrink-slot-labels.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import type { FabricValue } from "@commonfabric/data-model/interface";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";

--- a/packages/runner/test/cfc-creation-membership-anchor.test.ts
+++ b/packages/runner/test/cfc-creation-membership-anchor.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import type { FabricValue } from "@commonfabric/data-model/interface";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";

--- a/packages/runner/test/cfc-cross-space-integrity.test.ts
+++ b/packages/runner/test/cfc-cross-space-integrity.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from "@std/testing/bdd";
 import type { IFCLabel } from "../src/cfc/mod.ts";
 import { type CfcConfClause } from "../src/cfc/clause.ts";
 import { expect } from "@std/expect";
-import type { FabricValue } from "@commonfabric/data-model/interface";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";

--- a/packages/runner/test/cfc-existence-channel.test.ts
+++ b/packages/runner/test/cfc-existence-channel.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, it } from "@std/testing/bdd";
 import type { FabricPlainObject } from "@commonfabric/api";
 import type { IFCLabel } from "../src/cfc/mod.ts";
 import { expect } from "@std/expect";
-import type { FabricValue } from "@commonfabric/data-model/interface";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { Identity } from "@commonfabric/identity";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { StorageManager } from "../src/storage/cache.deno.ts";

--- a/packages/runner/test/cfc-flow-pointwise.test.ts
+++ b/packages/runner/test/cfc-flow-pointwise.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import type { FabricValue } from "@commonfabric/data-model/interface";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";

--- a/packages/runner/test/cfc-observation-classes.test.ts
+++ b/packages/runner/test/cfc-observation-classes.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import type { FabricValue } from "@commonfabric/data-model/interface";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { Identity } from "@commonfabric/identity";
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
 import { internSchema } from "@commonfabric/data-model/schema-hash";

--- a/packages/runner/test/cfc-persist-split.test.ts
+++ b/packages/runner/test/cfc-persist-split.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import type { FabricValue } from "@commonfabric/data-model/interface";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { Identity } from "@commonfabric/identity";
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
 import { StorageManager } from "../src/storage/cache.deno.ts";

--- a/packages/runner/test/cfc-prefix-provenance-stats.test.ts
+++ b/packages/runner/test/cfc-prefix-provenance-stats.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "@std/testing/bdd";
 import type { IFCLabel } from "../src/cfc/mod.ts";
 import { expect } from "@std/expect";
-import type { FabricValue } from "@commonfabric/data-model/interface";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";

--- a/packages/runner/test/cfc-required-integrity-provenance.test.ts
+++ b/packages/runner/test/cfc-required-integrity-provenance.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "@std/testing/bdd";
 import type { IFCLabel } from "../src/cfc/mod.ts";
 import { expect } from "@std/expect";
-import type { FabricValue } from "@commonfabric/data-model/interface";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";

--- a/packages/runner/test/cfc-template-metadata-population.test.ts
+++ b/packages/runner/test/cfc-template-metadata-population.test.ts
@@ -3,7 +3,7 @@ import type { IFCLabel } from "../src/cfc/mod.ts";
 import type { CfcConfClause } from "../src/cfc/clause.ts";
 import type { CfcAtom } from "@commonfabric/api/cfc";
 import { expect } from "@std/expect";
-import type { FabricValue } from "@commonfabric/data-model/interface";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { Identity } from "@commonfabric/identity";
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
 import { internSchema } from "@commonfabric/data-model/schema-hash";

--- a/packages/runner/test/cfc-template-population.test.ts
+++ b/packages/runner/test/cfc-template-population.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, it } from "@std/testing/bdd";
 import type { IFCLabel } from "../src/cfc/mod.ts";
 import { expect } from "@std/expect";
-import type { FabricValue } from "@commonfabric/data-model/interface";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { Identity } from "@commonfabric/identity";
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
 import { internSchema } from "@commonfabric/data-model/schema-hash";

--- a/packages/runner/test/cfc-write-floor.test.ts
+++ b/packages/runner/test/cfc-write-floor.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "@std/testing/bdd";
 import type { IFCLabel } from "../src/cfc/mod.ts";
 import { expect } from "@std/expect";
-import type { FabricValue } from "@commonfabric/data-model/interface";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";

--- a/packages/runner/test/cfc-write-prefix-provenance.test.ts
+++ b/packages/runner/test/cfc-write-prefix-provenance.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "@std/testing/bdd";
 import type { IFCLabel } from "../src/cfc/mod.ts";
 import { expect } from "@std/expect";
-import type { FabricValue } from "@commonfabric/data-model/interface";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";

--- a/packages/runner/test/frozen-reads-cache.bench.ts
+++ b/packages/runner/test/frozen-reads-cache.bench.ts
@@ -23,7 +23,7 @@
  *     --allow-write=/tmp,/var/folders test/frozen-reads-cache.bench.ts
  */
 
-import type { MutableFabricPlainObjectLayer } from "@commonfabric/data-model/interface";
+import type { MutableFabricPlainObjectLayer } from "@commonfabric/data-model/fabric-value";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 


### PR DESCRIPTION
`interface.ts` is where the fabric types are *declared*; `fabric-value` is where
they are meant to be *imported from* — its own header says so. With both
subpaths exported, which one a caller reached for was a matter of taste rather
than something the export map settled. Now only the barrel is exported.

## Nothing became unreachable

`interface.ts` declares **13** exports and `fabric-value` already re-exported
**all 13**, so delisting removes a route rather than a capability. Checked
before making the change, not after.

## The 19 sites

| what they imported | count |
| --- | --- |
| `type FabricValue` | 15 |
| `FabricInstance` | 2 |
| `FabricSpecialObject` | 1 |
| `FabricPrimitive` | 1 |
| `type MutableFabricPlainObjectLayer` | 1 |

All but two are tests or a bench. The exceptions are
`packages/runner/src/pattern-binding.ts`, which had one import from each subpath
and now has a single merged one, and a TypeScript block in
`docs/specs/space-model-formal-spec/1-fabric-values.md`.

Internal `data-model` imports are unaffected: they use relative or `@/` file
paths rather than the package subpath.

## Verification

Confirmed the delisting actually bites, rather than trusting a green build: an
import from `@commonfabric/data-model/interface` now fails to resolve (Deno
lists the valid exports back), while the same import from `fabric-value`
checks clean.

`deno task check` · `check-docs` · `check-unused-deps` ·
`check-single-copy-deps` · `check-deno-pins` · `check-skill-facts` ·
`check-conflict-markers` · `check-no-waitfor` · `deno fmt --check` ·
`deno lint` — all clean.

Suites for every package touched: `runner` 1155/0, `data-model` 49/0,
`memory` 478/0, `cli` 123/0, `piece` 34/0.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

