### PR TITLE
docs(specs): align the fabric-value type declarations to `interface.ts`

### DIFF
--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -61,17 +61,25 @@ layer (Section 8) and represented in `FabricValue` trees as `FabricInstance`
 wrapper classes (Section 1.4).
 
 > **Package note:** The data model implementation lives in
-> `packages/data-model/`. The fabric-value types, base classes
-> (`FabricSpecialObject`, `FabricInstance`, `FabricPrimitive`), and the
-> in-process lifecycle symbols (`DEEP_FREEZE`, `IS_DEEP_FROZEN`) are
-> defined in `packages/data-model/interface.ts`; the serialization
-> vocabulary (the `CODEC` symbol, `FabricCodec`, `ReconstructionContext`,
-> `SerializationContext`) lives in `packages/data-model/codec-common/`
-> (Section 2). The dispatch and conversion
-> functions are in `packages/data-model/fabric-value.ts`. Type declarations visible to
-> patterns are in `packages/api/index.ts` (inline `interface` + `declare
-> const` pattern). The `packages/runner/` wires concrete implementations
-> into builder exports.
+> `packages/data-model/`. The fabric-value types and the base classes
+> (`FabricSpecialObject`, `FabricInstance`, `FabricPrimitive`) are declared in
+> `interface.ts`, and the in-process lifecycle symbols (`DEEP_FREEZE`,
+> `IS_DEEP_FROZEN`) on `BaseFabricInstance` alongside the abstract base that
+> carries them (Section 8.6). The serialization vocabulary (the `CODEC`
+> symbol, `FabricCodec`, `ReconstructionContext`, `SerializationContext`)
+> lives in `codec-common/` (Section 2), and the conversion functions in
+> `native-conversion.ts` (Section 8).
+>
+> **Where a thing is declared is not where it is imported from.** The package
+> exports one surface for all of the above, `fabric-value`, which re-exports
+> them; the modules named here are internal and not reachable as subpaths.
+> Cite them to say where something is defined, and import from
+> `@commonfabric/data-model/fabric-value`.
+>
+> Type declarations visible to patterns are in `packages/api/index.ts`
+> (inline `interface` + `declare const` pattern), and must agree with the
+> `data-model` declarations — nothing checks that mechanically.
+> `packages/runner/` wires concrete implementations into builder exports.
 
 ```typescript
 // Shown at module scope.
@@ -108,10 +116,38 @@ type FabricValue =
   //       - System types: `UnknownValue`, `ProblematicValue`
   | FabricInstance
 
-  // (d) Recursive containers
-  | FabricValue[]
-  | { [key: string]: FabricValue };
+  // (d) Recursive containers -- read-only; see the immutability callout below
+  | readonly FabricValue[]
+  | { readonly [key: string]: FabricValue };
 ```
+
+> **Fabric values are deeply read-only, with one intentional hole.** The
+> container arms are read-only, and because their element and property types
+> are themselves `FabricValue`, that read-only-ness is inherited all the way
+> down: a `FabricValue` tree cannot be written through at any depth. The
+> implementation names the two container arms `FabricArray`
+> (`ReadonlyArray<FabricValue>`) and `FabricPlainObject`
+> (`Readonly<Record<string, FabricValue>>`); this is the type-level
+> counterpart of the runtime deep-freeze contract in Section 8.6, and the two
+> are meant to agree.
+>
+> The hole is the `FabricInstance` arm. An instance exposes arbitrary members,
+> and a member can change instance state — including which values the instance
+> refers to — so the read-only-ness stops at an instance boundary and does not
+> reach what lies beyond it. This is deliberate rather than an oversight: the
+> intended semantics *are* expressible in TypeScript, but not concisely enough
+> to be worth the cost at every use site. Treat the type-level guarantee as
+> covering the containers and the primitives, and Section 8.6 as the statement
+> that actually binds instances.
+>
+> **Construction is the exception that proves the rule.** Building a container
+> requires writing to it, so the implementation provides
+> `MutableFabricValueLayer` — a value whose *root* container is mutable
+> (`MutableFabricArrayLayer` is `FabricValue[]`,
+> `MutableFabricPlainObjectLayer` is `Record<string, FabricValue>`) while
+> everything nested within it remains an ordinary read-only `FabricValue`. It
+> is a single construction layer, not a deep thaw, and it is a builder's type:
+> a value that has finished being built is a `FabricValue`.
 
 > **Restricted and excluded JS types.**
 >
@@ -173,17 +209,44 @@ native JS object types that the conversion layer can handle:
  */
 type FabricNativeObject =
   | Error
-  | Map<FabricValue | FabricNativeObject, FabricValue | FabricNativeObject>
-  | Set<FabricValue | FabricNativeObject>
+  | Map<unknown, unknown>
+  | Set<unknown>
   | Date
   | RegExp
   | Uint8Array;
+
+/**
+ * A `FabricValue`, a `FabricNativeObject`, or a deep tree of either — the
+ * values that convert to and from fabric form. This is the precondition of
+ * `fabricFromNativeValue()`, the result of `nativeFromFabricValue()`, and
+ * what `isFabricCompatible()` tests for (Section 8).
+ */
+type FabricOrConvertibleNativeValue =
+  | FabricValue
+  | FabricNativeObject
+  | readonly FabricOrConvertibleNativeValue[]
+  | { readonly [key: string]: FabricOrConvertibleNativeValue };
 ```
 
-The `FabricNativeObject` type exists solely at function parameter/return
-boundaries — for example, `shallowFabricFromNativeValue()` accepts
-`FabricValue | FabricNativeObject` as input (Section 8). It is never a
-member of `FabricValue`.
+`Map` and `Set` are named with unconstrained type arguments: their contents are
+checked when they are converted, not by the type. The constraint has nowhere to
+bind in any case while `FabricMap` and `FabricSet` remain stubbed
+(Sections 1.4.3 and 1.4.4).
+
+Neither type is ever a member of `FabricValue`; both exist solely at the
+conversion boundary (Section 8). Of the two, **`FabricOrConvertibleNativeValue`
+is the one the boundary actually speaks**, and it exists because
+`FabricValue | FabricNativeObject` cannot say "or a tree of these." A container
+arm of `FabricValue` holds `FabricValue`s, so it cannot hold an `Error`; and a
+`FabricNativeObject` is a single native object, not a container of them.
+Converting a `FabricError` yields an `Error`, so an array of `FabricError`s
+converts to an array of `Error`s — a value that is neither a `FabricValue` nor a
+`FabricNativeObject`, and which only the recursive type names. It is what
+`fabricFromNativeValue()` succeeds on, what `nativeFromFabricValue()` returns,
+and what `isFabricCompatible()` tests (Sections 8.3 and 8.4). It is a
+precondition rather than a parameter type: the conversion functions that accept
+arbitrary input declare `unknown` and reject what they cannot convert
+(Section 8.2).
 
 Every arm names a specific native class. There is no duck-typed arm: a value
 becomes fabric-representable by being one of these, by implementing the fabric
@@ -3221,9 +3284,9 @@ returned value is always a valid `FabricValue` regardless of its frozen state.
 /**
  * Type predicate: returns `true` if `fabricFromNativeValue()` would succeed
  * on the given value — i.e., the value is a `FabricValue`, a
- * `FabricNativeObject`, or a tree of these types. The return type is a
- * type predicate (`value is FabricValue | FabricNativeObject`), so
- * callers can use `isFabricCompatible(x)` as a type guard in conditionals.
+ * `FabricNativeObject`, or a tree of these types. That is exactly what
+ * `FabricOrConvertibleNativeValue` names (Section 1.2), so callers can use
+ * `isFabricCompatible(x)` as a type guard in conditionals.
  *
  * This is a check-without-conversion function for system boundaries where
  * code receives `unknown` and needs to determine convertibility without
@@ -3231,10 +3294,9 @@ returned value is always a valid `FabricValue` regardless of its frozen state.
  * and allocation).
  *
  * Relationship to other functions and checks:
- * - The narrower conceptual check -- "is `x` already a `FabricValue`?",
- *   which would NOT accept raw native types like `Error` or `Map` -- has
- *   no standalone predicate; a dedicated `isFabricValue()` is a noted
- *   TODO in `deep-freeze.ts`.
+ * - `isFabricValue(x)` (in `type-check.ts`): the narrower check — "is `x`
+ *   already a `FabricValue`?" — which does NOT accept raw native types like
+ *   `Error` or `Map`.
  * - `isFabricCompatible(x)`: "Could `x` be converted to a `FabricValue` via
  *   `fabricFromNativeValue()`?" Returns `true` for both `FabricValue`
  *   values AND `FabricNativeObject` values (and deep trees thereof).
@@ -3243,7 +3305,7 @@ returned value is always a valid `FabricValue` regardless of its frozen state.
  */
 export function isFabricCompatible(
   value: unknown,
-): value is FabricValue | FabricNativeObject;
+): value is FabricOrConvertibleNativeValue;
 ```
 
 The function recursively checks the value tree. It returns `true` if and only
@@ -3307,7 +3369,7 @@ symbols.
 export function nativeFromFabricValue(
   value: FabricValue,
   frozen?: boolean, // default: true
-): FabricValue;
+): FabricOrConvertibleNativeValue;
 ```
 
 #### Unwrapping Rules
@@ -3327,8 +3389,10 @@ export function nativeFromFabricValue(
 | Arrays | Recursively unwrapped; output frozen | Recursively unwrapped; output NOT frozen |
 | Plain objects | Recursively unwrapped; output frozen | Recursively unwrapped; output NOT frozen |
 
-The output type is `FabricValue | FabricNativeObject`, reflecting that the
-result may contain native JS types at any depth.
+The output type is `FabricOrConvertibleNativeValue` (Section 1.2), reflecting
+that the result may contain native JS types at any depth — a container of them
+is neither a `FabricValue` nor a `FabricNativeObject`, so the recursive type is
+what names it.
 
 > **Implementation: `FabricNativeWrapper` dispatch.** The unwrapping
 > functions use a single `instanceof FabricNativeWrapper` check to identify

--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -70,11 +70,17 @@ wrapper classes (Section 1.4).
 > lives in `codec-common/` (Section 2), and the conversion functions in
 > `native-conversion.ts` (Section 8).
 >
-> **Where a thing is declared is not where it is imported from.** The package
-> exports one surface for all of the above, `fabric-value`, which re-exports
-> them; the modules named here are internal and not reachable as subpaths.
-> Cite them to say where something is defined, and import from
-> `@commonfabric/data-model/fabric-value`.
+> **Where a thing is declared is not where it is imported from**, and the
+> modules named here divide on that point. `interface.ts` and
+> `native-conversion.ts` are internal: they are not exported subpaths, and
+> their contents are reached through `@commonfabric/data-model/fabric-value`,
+> which re-exports them. `codec-common/` and `fabric-instances/` are exported
+> subpaths in their own right and are imported directly under those names;
+> `fabric-value` does *not* re-export the codec vocabulary, so
+> `ReconstructionContext` and its siblings come from
+> `@commonfabric/data-model/codec-common`. Cite a module to say where
+> something is defined; consult the package's `exports` map to know where to
+> import it from.
 >
 > Type declarations visible to patterns are in `packages/api/index.ts`
 > (inline `interface` + `declare const` pattern), and must agree with the
@@ -120,6 +126,13 @@ type FabricValue =
   | readonly FabricValue[]
   | { readonly [key: string]: FabricValue };
 ```
+
+Arms (b) and (c) are a deliberate expansion, not a divergence. The
+implementation writes a single `FabricSpecialObject` arm; `FabricPrimitive` and
+`FabricInstance` are its only two subclasses, so naming them separately — and
+naming the `FabricPrimitive` subclasses individually — describes exactly the
+same set while saying more about it. Read the split as this document's
+elaboration of one implementation arm.
 
 > **Fabric values are deeply read-only, with one intentional hole.** The
 > container arms are read-only, and because their element and property types


### PR DESCRIPTION
A spec-alignment pass over `docs/specs/space-model-formal-spec/`, reconciling it
against the implementation across the last ~308 commits of upstream. Docs-only,
one file. `check-docs` (533 blocks) and `check-conflict-markers` pass.

## The finding behind the change

**The spec is in much better shape than the size of that delta suggests**, and
that is worth saying before the list of corrections. The inert-object arc
(#5247, #5261, #5264, #5191) is already written up in §1.5 in full; `toJSON()`
is not a conversion route (#5343) is already in §1.2 and §7.1; storage →
representability (#5249), `FabricError`'s private slots (#5417), and
`FabricSpecialObject`'s branding (#5057) are all already there. `[ID]` /
`ID_FIELD` is a **zero-hit grep** across all of `docs/specs/` (positive control:
`FabricValue` hits 13 files). `docs/specs/space-model/` is likewise live and
current; I propose no changes to it.

What did drift is narrower and has a single shape: **the described behavior is
current, but the TypeScript declarations the spec shows are not.** That is a
coherent failure mode rather than a coincidence — prose gets revisited when
behavior changes, and a type declaration that was correct when written attracts
no attention, because nothing about the behavior it types has changed. Three of
the five items are the actively-wrong kind rather than the merely-silent kind: a
reader who trusts these blocks writes code that will not compile, or reasons
about mutability the implementation does not permit.

## The five items

1. **§1.2 declared the recursive containers mutable.** `FabricValue[]` and
   `{ [key: string]: FabricValue }`, where #5121 made them
   `ReadonlyArray<FabricValue>` and `Readonly<Record<string, FabricValue>>`.
   Corrected, plus a callout for the two things the corrected arms cannot say on
   their own: that the read-only-ness is inherited to any depth, and that the
   `FabricInstance` arm is an **intentional hole** — an instance member can
   change instance state, so the guarantee stops at that boundary. The callout
   also names `MutableFabricValueLayer` as the builder's type.

2. **§1.2's package note attributed `DEEP_FREEZE`/`IS_DEEP_FROZEN` to
   `interface.ts`.** They are on `BaseFabricInstance`. The note now also
   separates *declared in* from *imported from*, per #5429.

3. **`FabricNativeObject` over-constrained its `Map`/`Set` type arguments.**
   They are `Map<unknown, unknown>` / `Set<unknown>` at-source.

4. **`FabricOrConvertibleNativeValue` was absent from the spec entirely** —
   another zero-hit grep — though it is what `fabricFromNativeValue()` succeeds
   on, what `nativeFromFabricValue()` returns, and what `isFabricCompatible()`
   tests. It exists precisely because `FabricValue | FabricNativeObject` cannot
   express "or a tree of these": an array of `Error`s is neither. §8.3's
   predicate named the inexpressible union; **§8.4's declaration and its own
   prose two paragraphs later contradicted each other**, with both wrong.

5. **§8.3 denied that `isFabricValue()` exists**, calling it "a noted TODO in
   `deep-freeze.ts`." It is in `type-check.ts`, exported from the barrel, and
   `deep-freeze.ts` — the very file cited — imports and calls it.

Plus one self-contradiction: §1.2 said `shallowFabricFromNativeValue()` accepts
`FabricValue | FabricNativeObject`; it takes `unknown`, as §8.2 already showed.

## Open questions — please push back on any of these

These are the places decided rather than asked, and where a correction at the
merge gate would be most valuable.

- **Does `MutableFabricValueLayer` belong in a model spec at all?** It is
  arguably an implementation convenience for builders rather than a fact about
  the value model, and a purist reading would leave it out. I included it,
  in the callout rather than as a union arm, because a reader who has just been
  told fabric values are deeply read-only will immediately wonder how one is
  ever built, and leaving that unanswered invites the wrong inference. Cut it if
  that reading is preferred; the rest of the callout stands without it.

- **~~Item 3 may be pointing the wrong way.~~ RESOLVED — no longer an open
  question.** I had flagged this as the item I was genuinely unsure of: I made
  the spec match the code by *removing* a constraint, and the competing reading
  was that the code was the placeholder and the spec had the intent right.
  **`ombudsman-olive` settled it with evidence in neither file.** `git log -S`
  shows `Map<FabricValue | FabricNativeObject...` has **zero commits, ever** —
  the constrained form never existed in the implementation. So this was never a
  drift where the code loosened and the spec kept an older truth; the spec
  asserted a constraint that was never true, and **there is no earlier state to
  revert toward.** No revert, no follow-on code change.

  Her semantic reason is stronger than the one I gave and I'm adopting it:
  `FabricNativeObject` types **raw input at the conversion boundary**, where the
  functions declare `unknown` and reject what they cannot convert. A caller
  holding an ordinary `Map<unknown, unknown>` — the common untrusted-input case
  — would not be assignable to the constrained form, so the constraint would
  exclude precisely the values the boundary exists to screen. The constraint
  belongs on the wrappers, and `FabricSet extends
  FabricNativeWrapper<Set<FabricValue>>` already carries it.

- **The framing of the intentional hole is a synthesis, not a quotation.** The
  source comment on `FabricValue` in `packages/api/index.ts` says the hole exists
  because TypeScript has no pithy way to express the semantics. I extended that
  to "treat the type-level guarantee as covering the containers and primitives,
  and §8.6 as the statement that actually binds instances." I believe that is
  the useful thing to tell a reader, but it is my inference about how the two
  guarantees divide, not something the source comment states.

- **I did not touch `3-json-encoding.md`'s target-vs-current gap** (§7.2, §9),
  which describes a unified `/<Type>@<Version>` encoding that diverges from
  current IPLD-sigil reality. I have carried this in my notes across three
  sessions now. It is not a drift finding — it is a question about intent (is it
  deliberately aspirational?), and guessing wrong would do more damage than
  leaving it. **It wants a direct answer from the human lead**, and asking here is
  better than writing something confident and wrong.

- **One PR rather than five.** The items are one file, one section-cluster, one
  theme, and one verification method; splitting them would multiply review
  overhead without separating any decision. They can be split on request.

## A correction to this PR, made in `f2981aec7`

The package note added by the first commit claimed the modules it names "are
internal and not reachable as subpaths." **That was wrong**, caught by
`ombudsman-olive` and verified at-source: `./codec-common` is an exported
subpath (16th entry in `packages/data-model/deno.jsonc`) with five external
importers, and `fabric-value.ts` re-exports no codec vocabulary at all — so a
reader following the note would have looked for `ReconstructionContext` in
`fabric-value` and found nothing. `./fabric-instances`, which the note also
names, is an exported subpath too.

Worth stating plainly because it is the same failure this PR exists to correct,
committed by the PR: **I generalized from the two modules I had actually checked
(`interface.ts`, `native-conversion.ts`) to "the modules named here."** The
generalization is where the error entered, and the original claims in this file
very likely got wrong the same way. The note now divides the two cases.

Also folded, per the same review: a short paragraph noting that §1.2's arms (b)
and (c) *expand* a single `FabricSpecialObject` arm rather than diverging from
it — cheap insurance against a later pass "correcting" correct text.

## Out of scope, flagged rather than fixed

> **⚠️ CORRECTED AFTER MERGE — the claim below was false; do not scope work from
> it.** This section originally reported that `interface.ts`'s doc comment on
> `FabricPlainObject` still read *"If prototype pollution becomes a concern, add
> boundary validation where values enter the fabric system."* **It does not, and
> has not since #5264** — `git log -S` pins the removal to `9035197cf`, the same
> commit that added the reserved-name refusal, so the comment was closed by the
> very change that made it false. Verified at `b1a5333ce`: `git grep "prototype
> pollution" -- 'packages/**'` returns two hits, neither in `interface.ts`
> (positive control: `grep -c "prototype" interface.ts` → 1, the current
> affirmative comment). The error was mine — I read the sentence as **diff
> context** out of `git show <sha> -- <path>`, which renders lines as they stood
> at that commit. The reliable form is `git show <sha>:<path>`. **There is no
> deletion to make here.** See the follow-up comment on this PR for the full
> trace.

The neighbouring finding is unaffected and still live: `FabricNativeObject`'s
doc comment in `packages/data-model/src/interface.ts` states that
`shallowFabricFromNativeValue()` accepts `FabricValue | FabricNativeObject`; it
takes `unknown`. That one is verified present at `b1a5333ce`. It is a code
comment, so out of scope for a spec PR, but it sits in the file people read to
learn the type universe — and it is very likely where the spec's version of the
same wrong sentence came from.

