### PR TITLE
refactor(cf-harness): drop the two config fields nothing reads

### DIFF
--- a/packages/cf-harness/src/config.ts
+++ b/packages/cf-harness/src/config.ts
@@ -1,7 +1,6 @@
 import {
   type CfcEnforcementMode,
   isCfcEnforcementMode,
-  type TrustSnapshot,
 } from "@commonfabric/runner/cfc";
 import type { HarnessCfcEnforcementModeSource } from "./contracts/cfc-policy-snapshot.ts";
 import type { HarnessRunManifest } from "./contracts/run-manifest.ts";
@@ -24,7 +23,6 @@ export type HarnessModelAuthSource = "api-key" | "none" | "owner-bound-oauth";
 interface HarnessCommonConfig {
   cwd?: string;
   model?: string;
-  vmTarget?: string;
   skillsRoot?: string;
   allowedSkillScripts?: readonly HarnessAllowedSkillScript[];
   skillScriptExecutionTarget: HarnessSkillScriptExecutionTarget;
@@ -32,7 +30,6 @@ interface HarnessCommonConfig {
   artifactRoot?: string;
   cfcEnforcementMode: CfcEnforcementMode;
   cfcEnforcementModeSource: HarnessCfcEnforcementModeSource;
-  trustSnapshot?: TrustSnapshot;
   sandbox?: DockerRunscSandboxConfig;
   runManifest?: HarnessRunManifest;
   runManifestPath?: string;
@@ -73,7 +70,6 @@ export interface ResolveHarnessConfigOptions {
   gatewayAuthModeOverride?: string | HarnessGatewayAuthMode;
   cwd?: string;
   model?: string;
-  vmTarget?: string;
   skillsRoot?: string;
   allowedSkillScripts?: readonly HarnessAllowedSkillScript[];
   skillScriptExecutionTarget?: HarnessSkillScriptExecutionTarget;
@@ -82,7 +78,6 @@ export interface ResolveHarnessConfigOptions {
   cfcEnforcementMode?: CfcEnforcementMode;
   inheritedCfcEnforcementMode?: CfcEnforcementMode;
   cfcEnforcementModeOverride?: string | CfcEnforcementMode;
-  trustSnapshot?: TrustSnapshot;
   sandbox?: DockerRunscSandboxConfig;
   runManifest?: HarnessRunManifest;
   runManifestPath?: string;
@@ -197,7 +192,6 @@ export const resolveHarnessConfig = (
   const common: HarnessCommonConfig = {
     ...(options.cwd !== undefined ? { cwd: options.cwd } : {}),
     ...(options.model !== undefined ? { model: options.model } : {}),
-    ...(options.vmTarget !== undefined ? { vmTarget: options.vmTarget } : {}),
     ...(options.skillsRoot !== undefined
       ? { skillsRoot: options.skillsRoot }
       : {}),
@@ -210,9 +204,6 @@ export const resolveHarnessConfig = (
       : {}),
     ...(options.artifactRoot !== undefined
       ? { artifactRoot: options.artifactRoot }
-      : {}),
-    ...(options.trustSnapshot !== undefined
-      ? { trustSnapshot: options.trustSnapshot }
       : {}),
     ...(options.sandbox !== undefined ? { sandbox: options.sandbox } : {}),
     ...(options.runManifest !== undefined


### PR DESCRIPTION
`HarnessConfig` and `ResolveHarnessConfigOptions` both declared `vmTarget` and `trustSnapshot`, and `resolveHarnessConfig` faithfully copied each of them into the resolved configuration it hands back. Nothing then read either one. Not the engine, not the prompt loop, not the command-line interface, not the tools, not the tests. Both fields are exported as part of the package's public configuration surface, so an integrator can set either and get a silent no-op, which is worse than the field not existing: the type signature promises the harness will act on a value it discards.

Both arrived with the package's first pass in April and were never wired to anything in the months since, so this is unfinished scaffolding rather than a feature that regressed.

Delete both fields from the two interfaces and delete the two copy lines in `resolveHarnessConfig`. That leaves the `TrustSnapshot` import unused, so it goes as well. No other package is affected: the many `trustSnapshot` references elsewhere in the tree belong to the runner's content-flow control plumbing, which is unrelated to this configuration record and is untouched here.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

