### PR TITLE
test(patterns): wait for lunch poll root readiness

### DIFF
--- a/packages/patterns/integration/lunch-poll-vote.test.ts
+++ b/packages/patterns/integration/lunch-poll-vote.test.ts
@@ -37,6 +37,7 @@ import {
   logBrowserLoadSummary,
   logStepTimings,
   StepTimer,
+  waitForActiveSpaceRoot,
   waitForRuntimeIdle,
   waitForSettledText,
 } from "./cfc-browser-helpers.ts";
@@ -140,6 +141,7 @@ describe("lunch poll: two users vote on a shared option", () => {
     const view = { spaceName: SPACE_NAME, pieceId };
     const hostPage = hostShell.page();
     const guestPage = guestShell.page();
+    const spaceDid = cc.manager().getSpace();
 
     try {
       await timer.run(
@@ -156,6 +158,20 @@ describe("lunch poll: two users vote on a shared option", () => {
               view,
               identity: guestIdentity,
             }),
+          ]),
+      );
+      // ShellIntegration.goto() waits for URL/login state, while RootView
+      // resolves the named space and AppView loads its active pattern
+      // independently. A runtime can report idle during that handoff, with the
+      // previous or provisional root still rendered. Wait for the PageHandle
+      // on each browser to belong to this poll's space before interacting with
+      // either surface.
+      await timer.run(
+        "both active space roots ready",
+        () =>
+          Promise.all([
+            waitForActiveSpaceRoot(hostPage, spaceDid),
+            waitForActiveSpaceRoot(guestPage, spaceDid),
           ]),
       );
       await timer.run(


### PR DESCRIPTION
## Summary

- wait for both lunch-poll browser pages to expose the expected active space root before the first interaction
- keep the existing single-dispatch settle-and-click path unchanged
- record the readiness barrier separately in the test's step timings

## Root cause

`ShellIntegration.goto()` waits for URL and login state, but RootView resolves the named space and AppView loads its active pattern independently. The existing `runtimeIdle()` check could therefore return while `pattern:getSpaceRoot` was still in flight.

In the flaky runs, the test began its first click against that provisional surface and the root handoff removed its layout box before `DOM.getBoxModel` measured it. Waiting for the active PageHandle to belong to the poll's exact space uses the existing readiness primitive and removes that startup race without click retries or extra timeouts.

Observed in https://github.com/commontoolsinc/labs/actions/runs/31050326759/job/92455860779.

## Validation

- `deno task integration patterns lunch-poll-vote` — six completed cold-start runs passed, including one after rebasing onto latest `main`
- `deno fmt --check packages/patterns/integration/lunch-poll-vote.test.ts`
- `deno lint`
- `deno task check-no-waitfor`

Repo-wide `deno fmt --check` currently reports 23 pre-existing unformatted files on `main`; the changed file passes its focused formatting check.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

