### PR TITLE
fix(cf-harness): harden compaction budget discovery

### DIFF
--- a/packages/cf-harness/src/model/openai-compatible-gateway.ts
+++ b/packages/cf-harness/src/model/openai-compatible-gateway.ts
@@ -287,26 +287,75 @@ const toModelAttempt = (
 });
 
 /**
- * Conservative serialized-input size at which model-budget discovery starts.
+ * Conservative text-byte footprint at which model-budget discovery starts.
  *
  * This is deliberately measured after Responses conversion rather than from
  * transcript text. The wire input also carries tool-call arguments, images,
  * encrypted continuation items, and tool schemas, any of which can dominate
- * the token count. UTF-8 bytes avoid pretending to know the model tokenizer;
+ * the token count. UTF-8 bytes also vary less by script than characters do;
  * the floor only decides when one cached registry request becomes worthwhile.
  */
 const BUDGET_DISCOVERY_FLOOR_BYTES = 200_000;
 
-const renderedResponsesInputByteLength = (
+/**
+ * Counts at most `limit` UTF-8 bytes without allocating an encoded copy.
+ *
+ * Unpaired surrogates follow `TextEncoder`: each becomes the three-byte
+ * replacement character. Every UTF-16 code unit contributes at least one
+ * byte, so a string already as long as the remaining limit can stop at once.
+ */
+const utf8ByteLengthUpTo = (text: string, limit: number): number => {
+  if (limit <= 0 || text.length === 0) return 0;
+  if (text.length >= limit) return limit;
+  let bytes = 0;
+  for (let index = 0; index < text.length; index += 1) {
+    const codePoint = text.codePointAt(index)!;
+    if (codePoint <= 0x7f) {
+      bytes += 1;
+    } else if (codePoint <= 0x7ff) {
+      bytes += 2;
+    } else if (codePoint <= 0xffff) {
+      bytes += 3;
+    } else {
+      bytes += 4;
+      index += 1;
+    }
+    if (bytes >= limit) return limit;
+  }
+  return bytes;
+};
+
+/**
+ * Walks the converted value graph rather than serializing it solely to
+ * measure it. String values carry messages, tool arguments, image data, and
+ * continuations; property names are included because schema keys are model
+ * input too. The walk stops as soon as discovery becomes worthwhile.
+ */
+const responsesInputReachesDiscoveryFloor = (
   instructions: string | undefined,
   input: readonly ResponsesInputItem[],
   tools: readonly ResponsesInputItem[],
-): number =>
-  new TextEncoder().encode(JSON.stringify({
-    ...(instructions !== undefined ? { instructions } : {}),
-    input,
-    ...(tools.length > 0 ? { tools } : {}),
-  })).byteLength;
+): boolean => {
+  let remaining = BUDGET_DISCOVERY_FLOOR_BYTES;
+  const pending: unknown[] = [input, tools];
+  if (instructions !== undefined) pending.push(instructions);
+  while (pending.length > 0) {
+    const value = pending.pop();
+    if (typeof value === "string") {
+      remaining -= utf8ByteLengthUpTo(value, remaining);
+    } else if (Array.isArray(value)) {
+      for (const item of value) pending.push(item);
+    } else if (typeof value === "object" && value !== null) {
+      for (const [key, child] of Object.entries(value)) {
+        remaining -= utf8ByteLengthUpTo(key, remaining);
+        if (remaining <= 0) return true;
+        pending.push(child);
+      }
+    }
+    if (remaining <= 0) return true;
+  }
+  return false;
+};
 
 export class OpenAICompatibleGatewayModelClient implements HarnessModelClient {
   readonly providerId = OPENAI_COMPATIBLE_GATEWAY_PROVIDER_ID;
@@ -352,8 +401,7 @@ export class OpenAICompatibleGatewayModelClient implements HarnessModelClient {
     }
     if (
       !this.#compactThresholds.has(request.model) &&
-      renderedResponsesInputByteLength(instructions, input, tools) >=
-        BUDGET_DISCOVERY_FLOOR_BYTES
+      responsesInputReachesDiscoveryFloor(instructions, input, tools)
     ) {
       await this.#ensureBudgets(request.signal);
     }

--- a/packages/cf-harness/src/model/openai-compatible-gateway.ts
+++ b/packages/cf-harness/src/model/openai-compatible-gateway.ts
@@ -24,6 +24,7 @@ import {
   assertPromptCacheModeSupported,
   normalizeTerminalResponse,
   providerRunAffinityKey,
+  type ResponsesInputItem,
   toResponsesInput,
   toResponsesTools,
 } from "./responses-protocol.ts";
@@ -286,25 +287,32 @@ const toModelAttempt = (
 });
 
 /**
- * Transcript size below which registry discovery is not worth a round trip.
+ * Conservative serialized-input size at which model-budget discovery starts.
  *
- * The smallest input budget the registry advertises is 272,000 tokens, so the
- * smallest 75% guard sits at 204,000 — roughly 800,000 characters. A turn
- * under this floor cannot approach any derived threshold, so ordinary runs
- * pay no extra request and only genuinely large contexts trigger discovery.
+ * This is deliberately measured after Responses conversion rather than from
+ * transcript text. The wire input also carries tool-call arguments, images,
+ * encrypted continuation items, and tool schemas, any of which can dominate
+ * the token count. UTF-8 bytes avoid pretending to know the model tokenizer;
+ * the floor only decides when one cached registry request becomes worthwhile.
  */
-const BUDGET_DISCOVERY_FLOOR_CHARS = 200_000;
+const BUDGET_DISCOVERY_FLOOR_BYTES = 200_000;
 
-const transcriptSize = (
-  transcript: readonly HarnessTranscriptMessage[],
+const renderedResponsesInputByteLength = (
+  instructions: string | undefined,
+  input: readonly ResponsesInputItem[],
+  tools: readonly ResponsesInputItem[],
 ): number =>
-  transcript.reduce((total, message) => total + message.content.length, 0);
+  new TextEncoder().encode(JSON.stringify({
+    ...(instructions !== undefined ? { instructions } : {}),
+    input,
+    ...(tools.length > 0 ? { tools } : {}),
+  })).byteLength;
 
 export class OpenAICompatibleGatewayModelClient implements HarnessModelClient {
   readonly providerId = OPENAI_COMPATIBLE_GATEWAY_PROVIDER_ID;
   /** Input budgets by model id, keyed from the gateway registry. */
   readonly #compactThresholds = new Map<string, number>();
-  /** Registry discovery is attempted once per client, successful or not. */
+  /** Successful registry discovery is shared and cached per client. */
   #budgetDiscovery?: Promise<void>;
 
   constructor(readonly gatewayClient: OpenAICompatibleGatewayClient) {}
@@ -314,19 +322,28 @@ export class OpenAICompatibleGatewayModelClient implements HarnessModelClient {
    * caller having to call `listModels()` first — nothing on the normal run
    * path does.
    *
-   * Runs at most once per client and never fails a turn: compaction is a
-   * guard, so an unreachable registry means running without it rather than
-   * aborting the run.
+   * A successful request runs at most once per client. A failed request never
+   * fails the model turn, but is cleared so a later turn can try discovery
+   * again instead of losing the compaction guard for the rest of the run.
    */
   #ensureBudgets(signal?: AbortSignal): Promise<void> {
-    this.#budgetDiscovery ??= this.listModels(signal)
+    if (this.#budgetDiscovery !== undefined) return this.#budgetDiscovery;
+    const discovery = this.listModels(signal)
       .then(() => {})
-      .catch(() => {});
-    return this.#budgetDiscovery;
+      .catch(() => {
+        if (this.#budgetDiscovery === discovery) {
+          this.#budgetDiscovery = undefined;
+        }
+      });
+    this.#budgetDiscovery = discovery;
+    return discovery;
   }
 
   async #resolveCompactThreshold(
     request: HarnessModelTurnRequest,
+    instructions: string | undefined,
+    input: readonly ResponsesInputItem[],
+    tools: readonly ResponsesInputItem[],
   ): Promise<number | undefined> {
     if (request.compactThreshold !== undefined) {
       return request.compactThreshold > 0
@@ -335,7 +352,8 @@ export class OpenAICompatibleGatewayModelClient implements HarnessModelClient {
     }
     if (
       !this.#compactThresholds.has(request.model) &&
-      transcriptSize(request.transcript) >= BUDGET_DISCOVERY_FLOOR_CHARS
+      renderedResponsesInputByteLength(instructions, input, tools) >=
+        BUDGET_DISCOVERY_FLOOR_BYTES
     ) {
       await this.#ensureBudgets(request.signal);
     }
@@ -416,19 +434,25 @@ export class OpenAICompatibleGatewayModelClient implements HarnessModelClient {
       "drop",
     );
     const tools = toResponsesTools(request.tools);
-    const compactThreshold = await this.#resolveCompactThreshold(request);
+    const input = request.promptCacheMode === "explicit"
+      ? addFirstUserPromptCacheBreakpoint(
+        converted.input,
+        GATEWAY_RESPONSES_LABEL,
+      )
+      : converted.input;
+    const compactThreshold = await this.#resolveCompactThreshold(
+      request,
+      converted.instructions,
+      input,
+      tools,
+    );
     const payload: OpenAIResponsesRequest = {
       model: request.model,
       store: false,
       ...(converted.instructions !== undefined
         ? { instructions: converted.instructions }
         : {}),
-      input: request.promptCacheMode === "explicit"
-        ? addFirstUserPromptCacheBreakpoint(
-          converted.input,
-          GATEWAY_RESPONSES_LABEL,
-        )
-        : converted.input,
+      input,
       ...(tools.length > 0 ? { tools } : {}),
       tool_choice: "auto",
       parallel_tool_calls: true,

--- a/packages/cf-harness/test/openai-compaction.test.ts
+++ b/packages/cf-harness/test/openai-compaction.test.ts
@@ -351,6 +351,30 @@ Deno.test("the default accounts for the rendered Responses input", async () => {
   }]);
 });
 
+Deno.test("multibyte input uses the UTF-8 byte discovery floor", async () => {
+  const captured: Captured[] = [];
+  const client = clientWith(captured, [
+    registry([{
+      id: MODEL,
+      capabilities: { contextWindow: 1_050_000, maxOutputTokens: 128_000 },
+    }]),
+    completed([]),
+  ]);
+
+  // This is far below 200,000 JavaScript characters but above 200,000 UTF-8
+  // bytes. Token-dense scripts need discovery before a character floor would
+  // fire or the smallest model's 204,000-token guard could already be late.
+  await client.complete(turn({
+    transcript: [{ role: "user", content: "界".repeat(70_000) }],
+  }));
+
+  assertEquals(captured[0].url, `${GATEWAY}/v1/models`);
+  assertEquals(captured[1].body.context_management, [{
+    type: "compaction",
+    compact_threshold: 691_500,
+  }]);
+});
+
 Deno.test("successful discovery is attempted once, then reused", async () => {
   const captured: Captured[] = [];
   const client = clientWith(captured, [
@@ -366,6 +390,26 @@ Deno.test("successful discovery is attempted once, then reused", async () => {
 
   const listCalls = captured.filter((c) => c.url.endsWith("/v1/models")).length;
   assertEquals(listCalls, 1, "discovery must not repeat per turn");
+});
+
+Deno.test("successful discovery is cached for an unlisted model", async () => {
+  const captured: Captured[] = [];
+  const client = clientWith(captured, [
+    registry([{
+      id: "gpt-another-model",
+      capabilities: { contextWindow: 400_000, maxOutputTokens: 128_000 },
+    }]),
+    completed([]),
+    completed([]),
+  ]);
+
+  await client.complete(turn({ transcript: toolHeavyTranscript() }));
+  await client.complete(turn({ transcript: toolHeavyTranscript() }));
+
+  const listCalls = captured.filter((c) => c.url.endsWith("/v1/models")).length;
+  assertEquals(listCalls, 1, "successful discovery must stay cached");
+  assertEquals(captured[1].body.context_management, undefined);
+  assertEquals(captured[2].body.context_management, undefined);
 });
 
 Deno.test("small turns pay no discovery round trip", async () => {

--- a/packages/cf-harness/test/openai-compaction.test.ts
+++ b/packages/cf-harness/test/openai-compaction.test.ts
@@ -90,11 +90,9 @@ Deno.test("an unknown budget yields no threshold rather than a guess", () => {
   assertEquals(compactThresholdForBudget(1_000, 2_000), undefined);
 });
 
-Deno.test("compaction is sent once the registry budget is known", async () => {
+Deno.test("listModels primes the compaction budget", async () => {
   const captured: Captured[] = [];
-  // Order matches the call sequence below: completion, registry, completion.
   const client = clientWith(captured, [
-    completed([]),
     registry([{
       id: MODEL,
       capabilities: { contextWindow: 1_050_000, maxOutputTokens: 128_000 },
@@ -102,16 +100,12 @@ Deno.test("compaction is sent once the registry budget is known", async () => {
     completed([]),
   ]);
 
-  // Before discovery there is no budget, so no threshold is asserted.
-  await client.complete(turn());
-  assertEquals(captured[0].body.context_management, undefined);
-
   const models = await client.listModels();
   assertEquals(models[0].contextWindow, 1_050_000);
   assertEquals(models[0].maxOutputTokens, 128_000);
 
   await client.complete(turn());
-  assertEquals(captured[2].body.context_management, [{
+  assertEquals(captured[1].body.context_management, [{
     type: "compaction",
     compact_threshold: 691_500,
   }]);
@@ -313,13 +307,33 @@ Deno.test("a compaction from another model is not replayed", async () => {
 // The default must work on the normal run path, with no primed catalog.
 // ---------------------------------------------------------------------------
 
-const bigTranscript = (): HarnessTranscriptMessage[] => [
-  { role: "user", content: "x".repeat(250_000) },
+const toolHeavyTranscript = (): HarnessTranscriptMessage[] => [
+  { role: "user", content: "Go." },
+  {
+    role: "assistant",
+    content: "",
+    toolCalls: [{
+      id: "call-large",
+      type: "function",
+      function: {
+        name: "write_file",
+        arguments: JSON.stringify({ content: "x".repeat(210_000) }),
+      },
+    }],
+  },
+  {
+    role: "tool",
+    toolCallId: "call-large",
+    toolName: "write_file",
+    content: "done",
+  },
 ];
 
-Deno.test("the default threshold applies without any listModels() call", async () => {
+Deno.test("the default accounts for the rendered Responses input", async () => {
   const captured: Captured[] = [];
-  // Nothing primes the catalog here: this is what a real run does.
+  // Nothing primes the catalog here: this is what a normal run does. Budget
+  // discovery cannot be gated on transcript text because the rendered input
+  // also contains tools, images, and encrypted continuation items.
   const client = clientWith(captured, [
     registry([{
       id: MODEL,
@@ -328,7 +342,7 @@ Deno.test("the default threshold applies without any listModels() call", async (
     completed([]),
   ]);
 
-  await client.complete(turn({ transcript: bigTranscript() }));
+  await client.complete(turn({ transcript: toolHeavyTranscript() }));
 
   assertEquals(captured[0].url, `${GATEWAY}/v1/models`);
   assertEquals(captured[1].body.context_management, [{
@@ -337,7 +351,7 @@ Deno.test("the default threshold applies without any listModels() call", async (
   }]);
 });
 
-Deno.test("discovery is attempted once, then reused", async () => {
+Deno.test("successful discovery is attempted once, then reused", async () => {
   const captured: Captured[] = [];
   const client = clientWith(captured, [
     registry([{
@@ -347,8 +361,8 @@ Deno.test("discovery is attempted once, then reused", async () => {
     completed([]),
   ]);
 
-  await client.complete(turn({ transcript: bigTranscript() }));
-  await client.complete(turn({ transcript: bigTranscript() }));
+  await client.complete(turn({ transcript: toolHeavyTranscript() }));
+  await client.complete(turn());
 
   const listCalls = captured.filter((c) => c.url.endsWith("/v1/models")).length;
   assertEquals(listCalls, 1, "discovery must not repeat per turn");
@@ -358,7 +372,6 @@ Deno.test("small turns pay no discovery round trip", async () => {
   const captured: Captured[] = [];
   const client = clientWith(captured, [completed([])]);
 
-  // Nothing this small can approach any registry-derived threshold.
   await client.complete(turn());
 
   assertEquals(captured.length, 1);
@@ -366,9 +379,23 @@ Deno.test("small turns pay no discovery round trip", async () => {
   assertEquals(captured[0].body.context_management, undefined);
 });
 
-Deno.test("an unreachable registry degrades instead of failing the run", async () => {
+Deno.test("an explicit threshold avoids registry discovery", async () => {
   const captured: Captured[] = [];
-  let call = 0;
+  const client = clientWith(captured, [completed([])]);
+
+  await client.complete(turn({ compactThreshold: 12_000 }));
+
+  assertEquals(captured.length, 1);
+  assertEquals(captured[0].url, `${GATEWAY}/v1/responses`);
+  assertEquals(captured[0].body.context_management, [{
+    type: "compaction",
+    compact_threshold: 12_000,
+  }]);
+});
+
+Deno.test("a later turn retries after an unreachable registry", async () => {
+  const captured: Captured[] = [];
+  let registryCalls = 0;
   const client = new OpenAICompatibleGatewayModelClient(
     new OpenAICompatibleGatewayClient({
       baseUrl: GATEWAY,
@@ -380,10 +407,24 @@ Deno.test("an unreachable registry degrades instead of failing the run", async (
             ? JSON.parse(String(init.body)) as Record<string, unknown>
             : {},
         });
-        call += 1;
-        // Discovery fails; the completion that follows must still succeed.
         if (String(input).endsWith("/v1/models")) {
-          return Promise.resolve(new Response("nope", { status: 503 }));
+          registryCalls += 1;
+          // The current turn degrades gracefully. The next turn must retry
+          // rather than treating this transient failure as a populated cache.
+          return Promise.resolve(
+            registryCalls === 1
+              ? new Response("nope", { status: 503 })
+              : new Response(
+                JSON.stringify(registry([{
+                  id: MODEL,
+                  capabilities: {
+                    contextWindow: 1_050_000,
+                    maxOutputTokens: 128_000,
+                  },
+                }])),
+                { status: 200 },
+              ),
+          );
         }
         return Promise.resolve(
           new Response(JSON.stringify(completed([])), { status: 200 }),
@@ -392,12 +433,28 @@ Deno.test("an unreachable registry degrades instead of failing the run", async (
     }),
   );
 
-  const result = await client.complete(turn({ transcript: bigTranscript() }));
-  assertEquals(result.assistant.content, "");
+  const first = await client.complete(turn({
+    transcript: toolHeavyTranscript(),
+  }));
+  assertEquals(first.assistant.content, "");
   // Compaction is a guard, so losing it is not worth failing a run over.
-  const last = captured[captured.length - 1];
-  assertEquals(last.body.context_management, undefined);
-  assert(call >= 2);
+  assertEquals(captured[1].body.context_management, undefined);
+
+  const second = await client.complete(turn({
+    transcript: toolHeavyTranscript(),
+  }));
+  assertEquals(second.assistant.content, "");
+  assertEquals(registryCalls, 2);
+  assertEquals(captured.map((call) => call.url), [
+    `${GATEWAY}/v1/models`,
+    `${GATEWAY}/v1/responses`,
+    `${GATEWAY}/v1/models`,
+    `${GATEWAY}/v1/responses`,
+  ]);
+  assertEquals(captured[3].body.context_management, [{
+    type: "compaction",
+    compact_threshold: 691_500,
+  }]);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What changed

- Gate lazy model-budget discovery on the text-bearing parts of the converted Responses input, including tool-call arguments, image data, encrypted continuation items, instructions, tool descriptions, and schema/property names.
- Keep the conservative 200,000-byte floor, but measure it with a bounded value-graph walk that stops at the floor instead of constructing an extra JSON string and encoded request copy.
- Clear failed or aborted discovery promises so a later eligible turn can recover, while still sharing in-flight discovery and caching every successful lookup—even when the requested model is absent from the registry response.
- Preserve the no-registry-request path for small turns and requests with an explicit threshold.
- Add regression coverage for tool-heavy input, token-dense multibyte input, transient registry failures, and successful discovery of an unlisted model.

## Why

Follow-up to #5327. The default-threshold gate counted only transcript message text, so a run whose size lived primarily in tool arguments, images, tool schemas, or encrypted continuation state could cross the real model-input budget without discovering a compaction threshold. Retained encrypted reasoning is especially important because it grows on every turn of the long runs this guard exists to protect.

A failed discovery was also cached for the client lifetime. Because the cached promise captured the first eligible turn's abort signal, cancelling that turn could permanently disable automatic compaction for the client just as a transient registry failure could.

UTF-8 bytes remain the discovery unit deliberately: character-to-token density varies sharply by script, and discovering at 200,000 characters can be too late for token-dense input near the smallest 204,000-token guard. The byte floor pays at most one successful registry request per client while reducing that false-negative risk.

## Impact

Default compaction remains lazy. Large text-bearing inputs activate discovery regardless of where their size lives, multilingual input receives a consistent safety margin, successful discovery stays cached, and later turns can recover after failed or cancelled discovery. Measurement no longer serializes the request solely to size it.

## Verification

- `deno task check`
- `cd packages/cf-harness && deno task test` — 600 passed
- `deno fmt --check packages/cf-harness/src/model/openai-compatible-gateway.ts packages/cf-harness/test/openai-compaction.test.ts`
- `deno lint packages/cf-harness/src/model/openai-compatible-gateway.ts packages/cf-harness/test/openai-compaction.test.ts`