### PR TITLE
feat(api): type-enforce a pattern's reserved output keys

### DIFF
--- a/docs/common/components/COMPONENTS.md
+++ b/docs/common/components/COMPONENTS.md
@@ -433,6 +433,11 @@ export default pattern(({ title }) => ({
 }));
 ```
 
+`pattern()` types these variant keys at its return position: each is a `VNode`
+or a `JSXElement` (a renderable sub-piece), or a reactive value of one, so a
+value of the wrong shape under `[UI]`, `[CHIP_UI]` or `[TILE_UI]` is a compile
+error at the pattern.
+
 See `packages/patterns/examples/ui-variants-demo.tsx` for a full example.
 
 > Note: `sidebarUI`/`fabUI`/`settingsUI` are shell composition **slots**, a

--- a/docs/common/concepts/pattern.md
+++ b/docs/common/concepts/pattern.md
@@ -92,6 +92,8 @@ interface ColumnOutput {
 }
 ```
 
+The runtime reads a set of reserved keys off the returned object, and `pattern()` types each one at its return position. `[NAME]` (a string) names the piece; `[UI]` and its `[TILE_UI]`/`[CHIP_UI]` variants are a `VNode` or a `JSXElement` (which admits a renderable sub-piece); `[FS]` is an `FsProjection`. Each also accepts a reactive value in place of a plain one. A value of the wrong shape under one — a non-string `[NAME]`, a `[UI]` that is not renderable — is a compile error at the pattern, whether or not the Output type lists that key.
+
 ## See Also
 
 - [Pattern Composition](../patterns/composition.md) - How sub-pattern rendering works

--- a/docs/specs/fuse-filesystem/8-fs-projections.md
+++ b/docs/specs/fuse-filesystem/8-fs-projections.md
@@ -53,6 +53,10 @@ type FsProjection =
   | Record<string, unknown>; // plain object → default JSON projection
 ```
 
+`pattern()` types `[FS]` at its return position as a `FactoryInput<FsProjection>`,
+so a projection that matches none of these shapes is a compile error at the
+pattern rather than a surprise at mount time.
+
 ## Projection Variants
 
 ### `text/markdown` — Markdown with YAML Frontmatter

--- a/docs/specs/fuse-filesystem/8-fs-projections.md
+++ b/docs/specs/fuse-filesystem/8-fs-projections.md
@@ -50,7 +50,7 @@ type FsProjection =
       type: "application/json";
       content: Record<string, unknown>;
     }
-  | Record<string, unknown>; // plain object → default JSON projection
+  | { type?: undefined; [key: string]: unknown }; // plain object → default JSON projection
 ```
 
 `pattern()` types `[FS]` at its return position as a `FactoryInput<FsProjection>`,

--- a/docs/specs/sqlite-builtin/07-examples.md
+++ b/docs/specs/sqlite-builtin/07-examples.md
@@ -64,15 +64,17 @@ export default pattern<{ me: Cell<User> }>(({ me }) => {
   );
 
   return {
-    [UI]: lift((rows: typeof recent.result) =>
-      (rows ?? []).map((m) => (
-        // m.author_cf_link is a live Cell<User>; reading it is independently reactive
-        <div>
-          <b>{lift((u: User | undefined) => u?.name)(m.author_cf_link)}</b>:{" "}
-          {m.body}
-        </div>
-      ))
-    )(recent.result),
+    [UI]: lift((rows: typeof recent.result) => (
+      <cf-vstack>
+        {(rows ?? []).map((m) => (
+          // m.author_cf_link is a live Cell<User>; reading it is independently reactive
+          <div>
+            <b>{lift((u: User | undefined) => u?.name)(m.author_cf_link)}</b>:{" "}
+            {m.body}
+          </div>
+        ))}
+      </cf-vstack>
+    ))(recent.result),
     send: send.with({ author: me }),
   };
 });

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -2380,35 +2380,76 @@ export interface BuiltInCompileAndRunState<T> {
 // derived from these types, so it would silently downgrade live cells to dead
 // values. (`SELF` and the consumer-facing factory result deliberately use the
 // same unstripped `R`.)
+/**
+ * The reserved output fields the runtime reads off a pattern's result, each
+ * typed so a value of the wrong shape under a reserved key is a compile error.
+ * `[NAME]` names the piece; `[UI]`, `[TILE_UI]` and `[CHIP_UI]` are its
+ * renderings; `[FS]` is its filesystem projection. Each is `FactoryInput`-
+ * wrapped so a reactive value (a `computed()`, a cell) is accepted alongside a
+ * plain one.
+ */
+type ReservedOutput = {
+  [NAME]?: FactoryInput<string>;
+  [TYPE]?: FactoryInput<string>;
+  [UI]?: FactoryInput<VNode> | JSXElement;
+  [TILE_UI]?: FactoryInput<VNode> | JSXElement;
+  [CHIP_UI]?: FactoryInput<VNode> | JSXElement;
+  [FS]?: FactoryInput<FsProjection>;
+};
+
+/**
+ * Attach the reserved fields to an object return, so a reserved key is typed
+ * in the return position without disturbing the author's own output shape: a
+ * pattern that omits them is unaffected. A pattern that returns a bare value
+ * or `undefined` (not an object) is passed through untouched — there is no
+ * reserved field to type there.
+ */
+type WithReservedOutput<R> = R extends object ? R & ReservedOutput : R;
+
+/**
+ * Values a pattern can return that are not objects, and so carry no reserved
+ * fields to check. Unioned into the explicit-`<T>` overloads' return so a
+ * pattern that returns a bare value (e.g. `string | undefined`) still type-
+ * checks there, where the output type is not a constrained parameter.
+ */
+type NonObjectOutput =
+  | string
+  | number
+  | bigint
+  | boolean
+  | symbol
+  | null
+  | undefined;
+
 export interface PatternFunction {
   // Function-only overload: T and R inferred from function
   <T, R>(
     fn: (
       input: Reactive<RequireDefaults<T>> & { [SELF]: Reactive<R> },
-    ) => FactoryInput<R>,
+    ) => WithReservedOutput<FactoryInput<R>>,
   ): PatternFactory<StripCell<T>, R>;
 
   // Function-only overload: T explicit, R inferred
   <T>(
     fn: (
       input: Reactive<RequireDefaults<T>> & { [SELF]: Reactive<any> },
-    ) => any,
-  ): PatternFactory<StripCell<T>, ReturnType<typeof fn>>;
+    ) => (object & ReservedOutput) | NonObjectOutput,
+  ): PatternFactory<StripCell<T>, any>;
 
   // Function + schema overload: T explicit, R inferred
   <T>(
     fn: (
       input: Reactive<RequireDefaults<T>> & { [SELF]: Reactive<any> },
-    ) => any,
+    ) => (object & ReservedOutput) | NonObjectOutput,
     argumentSchema: JSONSchema,
     resultSchema?: JSONSchema,
-  ): PatternFactory<StripCell<T>, ReturnType<typeof fn>>;
+  ): PatternFactory<StripCell<T>, any>;
 
   // Function + schema overload: T and R explicit
   <T, R>(
     fn: (
       input: Reactive<RequireDefaults<T>> & { [SELF]: Reactive<R> },
-    ) => FactoryInput<R>,
+    ) => WithReservedOutput<FactoryInput<R>>,
     argumentSchema: JSONSchema,
     resultSchema?: JSONSchema,
   ): PatternFactory<StripCell<T>, R>;

--- a/packages/api/test/reserved-output-types.test.ts
+++ b/packages/api/test/reserved-output-types.test.ts
@@ -1,0 +1,115 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import type {
+  FactoryInput,
+  FsProjection,
+  PatternFunction,
+  VNode,
+} from "@commonfabric/api";
+
+// The assertions in this file are made when it is type-checked (tasks/check.sh
+// runs `deno check` over packages/api), not when it runs. `pattern` and the
+// reserved-key symbols are ambient declarations with no runtime value, so they
+// are given local compile-time bindings here — typed from the real exports —
+// and the calls below are never executed; they sit in a function that is only
+// ever type-checked. A valid reserved value must type-check, and each
+// `@ts-expect-error` marks a value the reserved-output types must reject — if
+// the enforcement regresses, the directive becomes unused and `deno check`
+// fails on it.
+declare const pattern: PatternFunction;
+declare const UI: typeof import("@commonfabric/api").UI;
+declare const NAME: typeof import("@commonfabric/api").NAME;
+declare const TILE_UI: typeof import("@commonfabric/api").TILE_UI;
+declare const CHIP_UI: typeof import("@commonfabric/api").CHIP_UI;
+declare const FS: typeof import("@commonfabric/api").FS;
+
+declare const reactiveUi: FactoryInput<VNode>;
+declare const reactiveName: FactoryInput<string>;
+declare const reactiveFs: FactoryInput<FsProjection>;
+const plainVNode: VNode = { type: "vnode", name: "div", props: undefined };
+
+function reservedOutputTypeChecks() {
+  // Every reserved key with a correct shape, beside the author's own field.
+  const valid = pattern(() => ({
+    [NAME]: "Counter",
+    [UI]: plainVNode,
+    [TILE_UI]: plainVNode,
+    [CHIP_UI]: plainVNode,
+    [FS]: { type: "application/json" as const, content: { rows: 3 } },
+    count: 3,
+  }));
+
+  // A reactive reserved value (a computed(), a cell) is accepted alongside a
+  // plain one, for each key shape.
+  const reactive = pattern(() => ({
+    [UI]: reactiveUi,
+    [NAME]: reactiveName,
+    [FS]: reactiveFs,
+    count: 3,
+  }));
+
+  // A pattern that omits the reserved keys is unaffected.
+  const omitted = pattern(() => ({ count: 3 }));
+
+  // A bare non-object return carries no reserved fields and still type-checks.
+  const bare = pattern(() => "just a title");
+
+  const badName = pattern(() => ({
+    // @ts-expect-error [NAME] must be a string, not a number
+    [NAME]: 5,
+    count: 3,
+  }));
+
+  const badUi = pattern(() => ({
+    // @ts-expect-error [UI] must be a VNode or JSXElement, not a number
+    [UI]: 5,
+    count: 3,
+  }));
+
+  // A string is not renderable: guards against [UI] being loosened to accept
+  // one, which a number-only rejection would not catch.
+  const badUiString = pattern(() => ({
+    // @ts-expect-error [UI] must be a VNode or JSXElement, not a string
+    [UI]: "not a vnode",
+    count: 3,
+  }));
+
+  const badTileUi = pattern(() => ({
+    // @ts-expect-error [TILE_UI] must be a VNode or JSXElement, not a number
+    [TILE_UI]: 5,
+    count: 3,
+  }));
+
+  const badChipUi = pattern(() => ({
+    // @ts-expect-error [CHIP_UI] must be a VNode or JSXElement, not a number
+    [CHIP_UI]: 5,
+    count: 3,
+  }));
+
+  const badFs = pattern(() => ({
+    // @ts-expect-error [FS] must be an FsProjection, not a number
+    [FS]: 5,
+    count: 3,
+  }));
+
+  return {
+    valid,
+    reactive,
+    omitted,
+    bare,
+    badName,
+    badUi,
+    badUiString,
+    badTileUi,
+    badChipUi,
+    badFs,
+  };
+}
+
+describe("reserved-output-types", () => {
+  it("type-checks a pattern's reserved output keys at the authoring site", () => {
+    // The reject/accept behavior is enforced by the type-checker above; at run
+    // time only the carrier holding those checks is observable.
+    expect(typeof reservedOutputTypeChecks).toBe("function");
+  });
+});

--- a/packages/cli/test/fixtures/render-step/invalid-continuous-ui.test.tsx
+++ b/packages/cli/test/fixtures/render-step/invalid-continuous-ui.test.tsx
@@ -1,6 +1,8 @@
-import { computed, pattern, UI } from "commonfabric";
+import { computed, pattern, UI, type VNode } from "commonfabric";
 
 export default pattern(() => ({
-  [UI]: {},
+  // Deliberately not a real VNode at run time: this fixture feeds the runner
+  // an invalid continuous-UI value to check how it reports one.
+  [UI]: {} as VNode,
   tests: [{ assertion: computed(() => true) }],
 }));

--- a/packages/patterns/baselines/emoji-picker.tsx/20260807T000834Z-1e7fG7rotN9LvKTF.json
+++ b/packages/patterns/baselines/emoji-picker.tsx/20260807T000834Z-1e7fG7rotN9LvKTF.json
@@ -1,0 +1,31 @@
+{
+  "argumentSchema": {
+    "properties": {
+      "selectedEmoji": {
+        "default": "",
+        "type": "string"
+      }
+    },
+    "required": [
+      "selectedEmoji"
+    ],
+    "type": "object"
+  },
+  "pattern": "emoji-picker.tsx",
+  "resultSchema": {
+    "properties": {
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "selectedEmoji": {
+        "default": "",
+        "type": "string"
+      }
+    },
+    "required": [
+      "selectedEmoji",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/cfc-trusted-component-examples/disclaimer-examples.tsx
+++ b/packages/patterns/cfc-trusted-component-examples/disclaimer-examples.tsx
@@ -8,6 +8,7 @@ import {
   pattern,
   Stream,
   UI,
+  type VNode,
   Writable,
 } from "commonfabric";
 
@@ -87,7 +88,7 @@ type FactCheckHostInput = {
 
 export type DisclosureExampleOutput = {
   [NAME]: string;
-  [UI]: unknown;
+  [UI]: VNode;
   content: string;
   disclaimerText?: string;
   acknowledgedDisclaimer?: string;

--- a/packages/patterns/emoji-picker.tsx
+++ b/packages/patterns/emoji-picker.tsx
@@ -11,6 +11,7 @@ import {
   NAME,
   pattern,
   UI,
+  type UIRenderable,
   Writable,
 } from "commonfabric";
 import type { ModuleMetadata } from "./container-protocol.ts";
@@ -2684,7 +2685,10 @@ const clearSelection = handler<unknown, { selectedEmoji: Writable<string> }>(
 );
 
 // ===== The Pattern =====
-export const EmojiPicker = pattern<EmojiPickerInput, EmojiPickerInput>(
+export const EmojiPicker = pattern<
+  EmojiPickerInput,
+  EmojiPickerInput & UIRenderable
+>(
   ({ selectedEmoji }) => {
     const displayText = computed(() =>
       selectedEmoji ? `Selected: ${selectedEmoji}` : "None"

--- a/packages/ts-transformers/test/fixtures/closures/map-pattern-factory-result-key-access.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-pattern-factory-result-key-access.expected.jsx
@@ -7,7 +7,7 @@ function __cfHardenFn(fn: Function) {
     return fn;
 }
 import { __cfHelpers } from "commonfabric";
-import { NAME, pattern, UI } from "commonfabric";
+import { NAME, pattern, UI, type VNode } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
@@ -26,12 +26,12 @@ interface RowInput {
 }
 interface RowOutput {
     rendered: string;
-    [UI]: string;
+    [UI]: VNode;
     [NAME]: string;
 }
 const EntryRow = pattern((input) => ({
     rendered: input.key("piece"),
-    [UI]: input.key("piece"),
+    [UI]: <div />,
     [NAME]: input.key("name"),
 }), {
     type: "object",
@@ -57,7 +57,7 @@ const EntryRow = pattern((input) => ({
             type: "string"
         },
         $UI: {
-            type: "string"
+            $ref: "https://commonfabric.org/schemas/vnode.json"
         },
         $NAME: {
             type: "string"
@@ -108,7 +108,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     type: "object",
     properties: {
         ui: {
-            type: "string"
+            $ref: "https://commonfabric.org/schemas/vnode.json"
         },
         n: {
             type: "string"

--- a/packages/ts-transformers/test/fixtures/closures/map-pattern-factory-result-key-access.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-pattern-factory-result-key-access.input.tsx
@@ -1,4 +1,4 @@
-import { NAME, pattern, UI } from "commonfabric";
+import { NAME, pattern, UI, type VNode } from "commonfabric";
 
 interface Entry {
   piece: string;
@@ -18,13 +18,13 @@ interface RowInput {
 
 interface RowOutput {
   rendered: string;
-  [UI]: string;
+  [UI]: VNode;
   [NAME]: string;
 }
 
 const EntryRow = pattern<RowInput, RowOutput>((input) => ({
   rendered: input.piece,
-  [UI]: input.piece,
+  [UI]: <div />,
   [NAME]: input.name,
 }));
 


### PR DESCRIPTION
The runtime reads reserved keys off a pattern's result — `[NAME]`, `[UI]`, `[TILE_UI]`, `[CHIP_UI]`, `[FS]` — but nothing typed them, so a wrong-shaped value under one (a non-string `[NAME]`, a non-renderable `[UI]`) reached the runtime unchecked, to fail or misrender there.

This types each reserved key at `pattern()`'s return position (`WithReservedOutput<…>`), not as an `extends` bound, which sidesteps the weak-type detection and lenient-overload traps a bound hits. `[NAME]` is a string; `[UI]`/`[TILE_UI]`/`[CHIP_UI]` a `VNode` or `JSXElement`; `[FS]` an `FsProjection`; each also accepts a reactive value. A wrong-shaped value is now a compile error at the authoring site. Patterns that omit the keys, and bare non-object returns, are unaffected, and result-type inference for consumers is preserved.

The change flags three sites, each fixed honestly: emoji-picker's output becomes `EmojiPickerInput & UIRenderable` (it returns `[UI]`); a CLI fixture keeps its deliberately-invalid UI via `{} as VNode`; a doc example wraps its `[UI]` array in `cf-vstack`.

Adds a type-level test (`@ts-expect-error`, verified by `deno check`) covering every key, plus notes in three docs. `[TESTS]` is intentionally out of scope.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

