### PR TITLE
toolshed: retire the model catalog's fake -thinking entries

### DIFF
--- a/packages/toolshed/routes/ai/llm/models.ts
+++ b/packages/toolshed/routes/ai/llm/models.ts
@@ -90,7 +90,6 @@ const addModel = ({
   name,
   aliases,
   capabilities,
-  providerOptions: _,
   nativeModelToolFactories,
 }: {
   provider:
@@ -101,7 +100,6 @@ const addModel = ({
   name: string;
   aliases: string[];
   capabilities: Capabilities;
-  providerOptions?: Record<string, unknown>;
   nativeModelToolFactories?: Partial<Record<LLMNativeModelToolId, () => any>>;
 }) => {
   let modelName = name.includes(":")
@@ -111,10 +109,6 @@ const addModel = ({
   // AWS includes colons in their model names, so we need to special case it.
   if (name.includes("us.amazon")) {
     modelName = name;
-  }
-
-  if (name.includes("-thinking") && !name.startsWith("gateway:")) {
-    modelName = modelName.split("-thinking")[0];
   }
 
   const model = provider(modelName);
@@ -161,30 +155,6 @@ if (env.CFTS_AI_LLM_ANTHROPIC_API_KEY) {
 
   addModel({
     provider: anthropicProvider,
-    name: "anthropic:claude-opus-4-1-thinking",
-    aliases: [
-      "anthropic:claude-opus-4-1-thinking-latest",
-      "claude-opus-4-1-thinking",
-    ],
-    capabilities: {
-      contextWindow: 200_000,
-      maxOutputTokens: 32000,
-      images: true,
-      prefill: true,
-      systemPrompt: true,
-      stopSequences: true,
-      streaming: true,
-      reasoning: true,
-    },
-    providerOptions: {
-      anthropic: {
-        thinking: { type: "enabled", budgetTokens: 32000 },
-      },
-    },
-  });
-
-  addModel({
-    provider: anthropicProvider,
     name: "anthropic:claude-sonnet-4-0",
     aliases: ["anthropic:claude-sonnet-4-0-latest", "claude-sonnet-4-0"],
     capabilities: {
@@ -196,30 +166,6 @@ if (env.CFTS_AI_LLM_ANTHROPIC_API_KEY) {
       stopSequences: true,
       streaming: true,
       reasoning: false,
-    },
-  });
-
-  addModel({
-    provider: anthropicProvider,
-    name: "anthropic:claude-sonnet-4-0-thinking",
-    aliases: [
-      "anthropic:claude-sonnet-4-0-thinking-latest",
-      "claude-sonnet-4-0-thinking",
-    ],
-    capabilities: {
-      contextWindow: 200_000,
-      maxOutputTokens: 64000,
-      images: true,
-      prefill: true,
-      systemPrompt: true,
-      stopSequences: true,
-      streaming: true,
-      reasoning: true,
-    },
-    providerOptions: {
-      anthropic: {
-        thinking: { type: "enabled", budgetTokens: 64000 },
-      },
     },
   });
 
@@ -241,27 +187,6 @@ if (env.CFTS_AI_LLM_ANTHROPIC_API_KEY) {
 
   addModel({
     provider: anthropicProvider,
-    name: "anthropic:claude-sonnet-4-5-thinking",
-    aliases: ["sonnet-4-5-thinking", "sonnet-4.5-thinking"],
-    capabilities: {
-      contextWindow: 200_000,
-      maxOutputTokens: 64000,
-      images: true,
-      prefill: true,
-      systemPrompt: true,
-      stopSequences: true,
-      streaming: true,
-      reasoning: true,
-    },
-    providerOptions: {
-      anthropic: {
-        thinking: { type: "enabled", budgetTokens: 64000 },
-      },
-    },
-  });
-
-  addModel({
-    provider: anthropicProvider,
     name: "anthropic:claude-sonnet-4-6",
     aliases: ["sonnet-4-6", "sonnet-4.6"],
     capabilities: {
@@ -273,27 +198,6 @@ if (env.CFTS_AI_LLM_ANTHROPIC_API_KEY) {
       stopSequences: true,
       streaming: true,
       reasoning: false,
-    },
-  });
-
-  addModel({
-    provider: anthropicProvider,
-    name: "anthropic:claude-sonnet-4-6-thinking",
-    aliases: ["sonnet-4-6-thinking", "sonnet-4.6-thinking"],
-    capabilities: {
-      contextWindow: 200_000,
-      maxOutputTokens: 64000,
-      images: true,
-      prefill: true,
-      systemPrompt: true,
-      stopSequences: true,
-      streaming: true,
-      reasoning: true,
-    },
-    providerOptions: {
-      anthropic: {
-        thinking: { type: "enabled", budgetTokens: 64000 },
-      },
     },
   });
 
@@ -376,25 +280,6 @@ if (env.CFTS_AI_LLM_OPENAI_API_KEY) {
 
   addModel({
     provider: openAIProvider,
-    name: "openai:gpt-5-thinking",
-    aliases: ["openai:gpt-5-thinking-latest", "gpt-5-thinking"],
-    capabilities: {
-      contextWindow: 400_000,
-      maxOutputTokens: 128_000,
-      images: true,
-      prefill: false,
-      systemPrompt: true,
-      stopSequences: false,
-      streaming: true,
-      reasoning: true,
-    },
-    providerOptions: {
-      reasoningEffort: "high",
-    },
-  });
-
-  addModel({
-    provider: openAIProvider,
     name: "openai:gpt-5-mini",
     aliases: ["openai:gpt-5-mini-latest", "gpt-5-mini"],
     capabilities: {
@@ -406,25 +291,6 @@ if (env.CFTS_AI_LLM_OPENAI_API_KEY) {
       stopSequences: true,
       streaming: true,
       reasoning: false,
-    },
-  });
-
-  addModel({
-    provider: openAIProvider,
-    name: "openai:gpt-5-mini-thinking",
-    aliases: ["openai:gpt-5-mini-thinking-latest", "gpt-5-mini-thinking"],
-    capabilities: {
-      contextWindow: 400_000,
-      maxOutputTokens: 128_000,
-      images: true,
-      prefill: false,
-      systemPrompt: false,
-      stopSequences: false,
-      streaming: true,
-      reasoning: true,
-    },
-    providerOptions: {
-      reasoningEffort: "high",
     },
   });
 }


### PR DESCRIPTION
The model catalog registered six entries whose names end in `-thinking`: four Anthropic ones carrying a thinking budget and two OpenAI ones carrying a reasoning effort. Each passed those settings to `addModel` as `providerOptions`, and `addModel` bound that parameter to `_` and threw it away. Nothing downstream ever read provider options off a model entry either. The registration also stripped the `-thinking` suffix to find the underlying model, so each entry reached exactly the same model as its plain twin with exactly the same settings. The only difference a caller could observe was the `reasoning: true` capability flag that `/api/ai/llm/models` advertises, which promised reasoning that never happened.

Nothing in this repository asks for one of these names. The task models and the default model candidates all name plain models, and no other code, test, or document mentions a `-thinking` name.

This removes the six registrations, the parameter whose value was discarded, and the suffix strip that existed only to serve those registrations. Two capability flags go with them: the entry for `gpt-5-thinking` declared no support for stop sequences and the one for `gpt-5-mini-thinking` declared no support for a system prompt. Both were accommodations for a reasoning mode that was never reached, so nothing that behaved differently because of them is lost.

The alternative was to carry the options through to the model call and make the entries real. That keeps a surface nobody here asks for, and the registered values could not have worked as written: the OpenAI blocks were flat rather than filed under the provider's name, so no provider would have read them, and each Anthropic budget equalled its model's output limit, which Anthropic turns down. Making the entries real therefore meant rewriting the settings they carry as well as the plumbing beneath them. Retiring the entries costs less and leaves the catalog describing only what it delivers.

These six names were reachable over HTTP, so a caller outside this repository that named one now gets an "Unsupported model" error where it used to get a plain, non-reasoning answer. That error is the honest report: the answer it replaces was never the one the name asked for.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

