### PR TITLE
docs(specs): state the unified JSON encoding as the settled direction

### DIFF
--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -3041,19 +3041,68 @@ boundary-only serialization and the three-layer architecture:
 
 ### 7.2 Unifying JSON Encoding
 
-Three legacy conventions in the current codebase must be migrated to the unified
-`/<Type>@<Version>` format:
+**The JSON layering defined by `codec-json` is to be the only JSON layering the
+system defines. This is settled.** It is the direction the system is committed
+to, not one option among several: a value's JSON form is the
+`/<Type>@<Version>` tagged-object convention of `3-json-encoding.md`, and no
+other layer defines a competing one.
 
-| Legacy Convention | Where Used | Example | New Form |
-|-------------------|------------|---------|----------|
-| IPLD sigil | Links (`sigil-types.ts`) | `{ "/": { "link@1": { id, path, space } } }` | `{ "/Link@1": { id, path, space } }` |
-| `@` prefix | Errors (`fabric-value.ts`) | `{ "@Error": { name, message, ... } }` | `{ "/Error@1": { name, message, ... } }` |
-| `$` prefix (stream) | Streams (`builder/types.ts`) | `{ "$stream": true }` | `{ "/Stream@1": null }` |
+**It is not yet the whole truth of the system, and this section says so
+deliberately.** Conventions predating that decision still appear on the wire,
+and they are being retired rather than accommodated. The distinction matters for
+anyone reading this to decide something: treat the unified encoding as the
+target to build toward and to write new code against, and treat what follows as
+the remaining distance, not as a menu.
 
-> **Note on `$stream`:** In the current codebase, `$stream` is a stateless
-> marker — it signals that a cell path is a stream endpoint rather than carrying
-> reconstructible state. Under the new encoding it becomes `{ "/Stream@1": null }`
-> (a stateless tagged type per Section 5 of `3-json-encoding.md`), preserving its marker semantics.
+`codec-json` already holds up its end. It attaches no meaning to any of the
+conventions below — a record carrying one round-trips as the record it is, with
+the marker as an ordinary key. So the work is not to teach the JSON layer about
+alternative encodings; it is to retire the conventions where they are produced
+and recognized, in the layers above it.
+
+**What remains:**
+
+| Convention | Where Produced and Recognized | Example | Unified Form |
+|------------|-------------------------------|---------|--------------|
+| Link-ref envelope | Links (`runner/src/sigil-types.ts`, chokepointed on `data-model/cell-rep`) | `{ "/": { "link@1": { id, path, space } } }` | `{ "/Link@1": { id, path, space } }` |
+| `$stream` marker | Streams (`runner/src/builder/types.ts`) | `{ "$stream": true }` | `{ "/Stream@1": null }` |
+
+> **Note on `$stream`:** `$stream` is a stateless marker — it signals that a
+> cell path is a stream endpoint rather than carrying reconstructible state.
+> Under the unified encoding it becomes `{ "/Stream@1": null }` (a stateless
+> tagged type per Section 5 of `3-json-encoding.md`), preserving its marker
+> semantics.
+
+> **The link-ref envelope has a named owner.** `sigil-types.ts` states that the
+> envelope and its tag belong to `data-model/cell-rep`, the chokepoint that
+> dispatches the form — and the envelope's occurrences are concentrated there
+> rather than scattered across the tree. The unification therefore has a place
+> to happen rather than a search to perform first, which is a large part of why
+> the direction is settled and not merely intended.
+
+> **"IPLD" here names a shape, not a codec.** No IPLD codec is used: `dag-cbor`
+> and `multihash` appear nowhere, and `dag-json` only as a link to the IPLD spec
+> in prose. (`multiformats` is a real dependency, but `identity` uses it for
+> multibase and varint handling in DIDs, which is unrelated to this section.) So
+> retiring IPLD here means retiring the `{ "/": … }` envelope above and nothing
+> else; reading it as a codec to rip out overstates the work considerably.
+
+> **`$alias` is not on this list, and must not be added to it.** It is a
+> Pattern-binding form rather than a link, and it is kept: link recognition is
+> sigil-only, and `$alias` survives as binding vocabulary. Its open work is
+> unrelated to this section — making alias objects unambiguously distinguishable
+> from plain objects, so that the full plain-object space stays available to
+> callers.
+
+> **On counting what remains.** A bare search for `$`-prefixed tokens badly
+> overstates the residue: JSON Schema keywords (`$ref`, `$defs`, `$schema`),
+> CFC datalog variables (`{ var: "$s" }` and kin), and Pattern authoring
+> vocabulary (`$UI`, `$NAME`, `$TYPE`) all match and none are on this arc — the
+> datalog variables alone outnumber `$stream` several times over. Any figure
+> quoted for this work should come from a classified count, and a count of
+> occurrences measures distance from the end state rather than the effort to
+> close it, since it does not distinguish a live wire path from a debugging or
+> inspection one.
 
 ### 7.3 Replacing CID-Based Hashing
 


### PR DESCRIPTION
Follow-on to #5434, covering item (2) of the three items scoped at that merge
gate. Docs-only, one file. `check-docs` (533 blocks) and
`check-conflict-markers` pass.

**Items (1) and (3) turn out to need no change, and the reporting on that is the
second half of this PR — see below.** Nothing was written for them, because
writing something would have meant inventing work.

## What this changes

The request was to *"state as settled: the project arc is to have the
JSON-layering defined by `codec-json` be the only JSON-layering defined by the
system,"* while noting that this *"is still aspirational,"* the trend being to
retire IPLD stuff and the ad-hoc sigil forms.

The distinction that drove the wording: **the arc is settled; the end state is
aspirational.** Both at once. So §7.2 was never stale — it was correct and
*under-committed*, describing the destination while leaving its standing
implicit. This edit strengthens it rather than hedging it toward current
behavior.

The reframing that made the rest fall out: **`codec-json` attaches no meaning to
any of the listed conventions.** A record carrying one round-trips as the record
it is, marker as an ordinary key — `codec-json/json-encoding.test.ts` pins
exactly this for `@Error`, `$stream`, and `{"/": …}` alike. So these were never
alternative encodings the JSON layer honors; they are conventions produced and
recognized in layers *above* it. That is a stronger argument for the settled
framing than "these should be migrated," because it means `codec-json` already
holds up its end.

Four things the table could not say on its own, now said explicitly:

- **The link-ref envelope has a named owner.** `sigil-types.ts` states the
  envelope and its tag belong to `data-model/cell-rep`, and occurrences
  concentrate there rather than scattering. The unification has a *place to
  happen* rather than a search to perform first — much of why this reads as
  settled rather than merely intended.
- **"IPLD" names a shape, not a codec.** `dag-cbor` and `multihash` appear
  nowhere; `dag-json` only as a prose link to the IPLD spec. `multiformats` is a
  real dependency but serves DID multibase handling in `identity`. Retiring IPLD
  means retiring the `{ "/": … }` envelope and nothing else.
- **`$alias` is not on the list, and the section says it must not be added.**
  It is a Pattern-binding form, not a link, and it is kept, per the 093 ruling.
  "All the ad-hoc sigil forms" read literally would re-open a closed migration,
  so the section writes the negative in to prevent that.
- **Counting the residue by searching `$`-prefixed tokens overstates it badly.**
  JSON Schema keywords, CFC datalog variables, and Pattern authoring vocabulary
  all match; the datalog variables alone outnumber `$stream` several times over.

**The errors row is dropped:** `"@Error"` appears in no source file, and the
tagged form is registered in `codec-common/codec-type-tags.ts`. That migration
is done. Remaining rows' citations are corrected to their real paths.

## Item (1) — already complete, both halves

**The spec half was done by #5434.** Swept rather than assumed: the only
`isFabricValue` mention in the formal spec is the corrected line, and
`sparse-array-preservation.md` already describes the predicate as existing.

**The code half was done by #4940.** The comment named in the request is:

```
TODO(@danfuzz): A function `isFabricValue()` should ultimately get
extracted from this function, which does just the recursive type check.
```

It sat on `isDeepFrozenFabricValue()` in `deep-freeze.ts` — exactly what the
stale spec text pointed at — and **`7df0babe8` (#4940) removed it, the same
commit that extracted `isFabricValue()`.** Pinned: `grep -c` at `7df0babe8^`
→ 1, at `7df0babe8` → 0; absent at `b1a5333ce` with a positive control. Only
the spec carried the denial forward, and #5434 has already fixed that.

**One live candidate, offered rather than taken.** `isFabricCompatible()`'s doc
comment in `native-conversion.ts` draws its distinction only against the
*shallow* `isFabricValueLayer()` and never mentions `isFabricValue()` — so a
reader asking "is x already a `FabricValue`, deeply?" is pointed at the wrong
predicate. It is very plausibly where the spec's framing came from. But it
**omits** rather than denies, so it is not obviously the comment intended by the
request. **It is a small change and can land as a sibling commit here on
request.**

(Two people reached this independently — once by opening the barrel for an
unrelated reason, once via a census — which is the main thing supporting it as
the right candidate.)

## Item (3) — the comment does not exist, and the cause is an error in #5434

The request was to drop the `interface.ts` comment about possible
prototype-detection of plain objects, "because we actually did that already."
**It was indeed done already — which is exactly why the comment is gone.**
`git log -S` pins its removal to `9035197cf` (#5264), the same commit that added
the reserved-name refusal.

**The reason it appeared to still exist is an error in #5434's body**, authored
by this agent. That PR's out-of-scope section claimed the comment was still
present. It was not: the sentence had been read as **diff context** out of
`git show <sha> -- <path>`, which renders lines as they stood at that commit and
is indistinguishable from current source. A teammate caught it and it was
retracted in the team channel — **but the PR body was not corrected, and the PR
body is what a reader scopes from.** #5434's body is now corrected in place,
with a follow-up comment carrying the full trace.

The generalizable lesson, since it caused a scoping decision to be made on a
false premise: **a retraction has to reach every surface the claim landed on,
and the durable artifact outranks the conversation.**

## A scoping decision worth flagging

Items (1) and (3) needed no change, so there was no separate small PR for them
to ride in; they are reported here instead. And the settled-arc statement does
**not** depend on the residue census — the arc is settled regardless of how many
forms remain — so this ships now rather than waiting. Putting the counts
themselves in the spec would be a follow-up; the section deliberately explains
*how to count* rather than quoting a number, since a raw figure would be wrong
in both directions and would be read as scope by anyone without the caveat.
