### PR TITLE
feat(toolshed): apply per-model provider options, and register gpt-5.6

### DIFF
--- a/packages/llm/src/types.ts
+++ b/packages/llm/src/types.ts
@@ -14,7 +14,7 @@ export const DEFAULT_MODEL_NAME: ModelName = "default";
 
 // NOTE(ja): This should be an array of models, the first model will be tried, if it
 // fails, the second model will be tried, etc.
-export const DEFAULT_GENERATE_OBJECT_MODELS: ModelName = "openai:gpt-5-mini";
+export const DEFAULT_GENERATE_OBJECT_MODELS: ModelName = "openai:gpt-5.6-terra";
 
 export type LLMResponse = BuiltInLLMMessage & {
   // The trace span ID

--- a/packages/toolshed/routes/ai/llm/generateObject.ts
+++ b/packages/toolshed/routes/ai/llm/generateObject.ts
@@ -96,6 +96,10 @@ export async function generateObject(
       // Registering a telemetry integration turns span collection on for every
       // AI SDK call. This route has never emitted AI SDK spans, so it opts out.
       telemetry: { isEnabled: false },
+      // Registry-level options for the model (reasoning effort, ZDR settings).
+      ...(modelConfig.providerOptions !== undefined
+        ? { providerOptions: modelConfig.providerOptions }
+        : {}),
       ...(params.system && { system: params.system }),
     });
 

--- a/packages/toolshed/routes/ai/llm/generateText.ts
+++ b/packages/toolshed/routes/ai/llm/generateText.ts
@@ -64,6 +64,12 @@ export function configureJsonMode(
   // Default to using the generic JSON mode
   streamParams.mode = "json";
 
+  // Model-level options must survive JSON mode, so the provider namespace is
+  // merged rather than replaced.
+  const providerOptions = streamParams.providerOptions as
+    | Record<string, Record<string, unknown>>
+    | undefined;
+
   // Apply provider-specific configurations
   if (modelName?.startsWith("groq:")) {
     // Groq uses response_format parameter
@@ -71,8 +77,9 @@ export function configureJsonMode(
 
     // Ensure it's also passed through providerOptions for the Vercel AI SDK
     streamParams.providerOptions = {
-      ...(streamParams.providerOptions as object | undefined),
+      ...providerOptions,
       groq: {
+        ...providerOptions?.groq,
         response_format: { type: "json_object" },
       },
     };
@@ -95,8 +102,9 @@ export function configureJsonMode(
 
     // Ensure it's also passed through providerOptions for the Vercel AI SDK
     streamParams.providerOptions = {
-      ...(streamParams.providerOptions as object | undefined),
+      ...providerOptions,
       openai: {
+        ...providerOptions?.openai,
         response_format: { type: "json_object" },
       },
     };
@@ -323,6 +331,11 @@ export async function generateText(
     // the caller, who now has a status to make it on.
     maxRetries: 0,
     stopWhen: stepCountIs(8), // TODO(bf): low limit to prevent runaway process
+    // Registry-level options for the model (reasoning effort, ZDR settings);
+    // request-specific configuration below merges on top of these.
+    ...(modelConfig.providerOptions !== undefined
+      ? { providerOptions: modelConfig.providerOptions }
+      : {}),
   };
 
   // Convert client-side tools to AI SDK format (without execute functions for client-side execution)

--- a/packages/toolshed/routes/ai/llm/models.test.ts
+++ b/packages/toolshed/routes/ai/llm/models.test.ts
@@ -1,0 +1,173 @@
+import { assert, assertEquals } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+import { fromFileUrl } from "@std/path";
+import { runDenoCommandWithTemporaryLock } from "@commonfabric/test-support/isolated-deno";
+import { DEFAULT_GENERATE_OBJECT_MODELS } from "@commonfabric/llm";
+
+/**
+ * Provider registration in `models.ts` runs at import time and is gated on API
+ * keys, so it is inert under the normal test env — generateObject.test.ts
+ * asserts MODELS is empty there, and that is the intended contract.
+ *
+ * Setting a key and importing the module in-process would register providers
+ * into the shared module graph and break that assertion for whichever file
+ * imports second, so registration is exercised in a subprocess instead. The
+ * pollution is the cached module, not the environment variable, so restoring
+ * the env afterwards would not be enough.
+ *
+ * The invariant that matters is the last test: the shared LLM default must
+ * name a model that is actually registered. Nothing checked that before, so
+ * renaming a model and missing a default would surface only at runtime.
+ */
+const TOOLSHED_ROOT = fromFileUrl(new URL("../../..", import.meta.url));
+const REPO_ROOT = fromFileUrl(new URL("../../../../..", import.meta.url));
+
+let cached: Record<string, unknown> | undefined;
+
+const registeredModels = async (): Promise<{
+  names: string[];
+  providerOptions: Record<string, unknown>;
+}> => {
+  if (cached === undefined) {
+    const probe = await Deno.makeTempFile({ suffix: ".ts" });
+    await Deno.writeTextFile(
+      probe,
+      `const mod = await import(${
+        JSON.stringify(new URL("./models.ts", import.meta.url).href)
+      });\n` +
+        `const providerOptions = Object.fromEntries(\n` +
+        `  Object.entries(mod.MODELS).flatMap(([name, config]) =>\n` +
+        `    config.providerOptions !== undefined\n` +
+        `      ? [[name, config.providerOptions]]\n` +
+        `      : []\n` +
+        `  ),\n` +
+        `);\n` +
+        `console.log(JSON.stringify({\n` +
+        `  names: Object.keys(mod.MODELS),\n` +
+        `  providerOptions,\n` +
+        `}));\n`,
+    );
+    try {
+      // Goes through the shared helper so the probe runs against a copied
+      // lockfile and cannot mutate the workspace `deno.lock`.
+      const output = await runDenoCommandWithTemporaryLock({
+        root: REPO_ROOT,
+        args: (lockPath) => [
+          "run",
+          "--no-check",
+          "-A",
+          `--lock=${lockPath}`,
+          // Both flags need the `=` form: passed as separate argv entries,
+          // Deno reads the value as the script path instead.
+          `--config=${TOOLSHED_ROOT}deno.jsonc`,
+          `--env-file=${TOOLSHED_ROOT}.env.test`,
+          probe,
+        ],
+        env: {
+          PATH: Deno.env.get("PATH") ?? "",
+          HOME: Deno.env.get("HOME") ?? "",
+          ENV: "test",
+          // Any non-empty value registers the OpenAI provider; nothing here
+          // reaches the network, since createOpenAI only builds a client.
+          CFTS_AI_LLM_OPENAI_API_KEY: "test-key-not-used-for-network",
+          // Keep the gateway discovery fetch disabled, as .env.test does.
+          CFTS_AI_GATEWAY_URL: "",
+          // Let coverage follow into the subprocess when CI is collecting it.
+          ...(Deno.env.get("DENO_COVERAGE_DIR") !== undefined
+            ? { DENO_COVERAGE_DIR: Deno.env.get("DENO_COVERAGE_DIR")! }
+            : {}),
+        },
+      });
+      assertEquals(
+        output.code,
+        0,
+        `model registry probe should exit cleanly: ${
+          new TextDecoder().decode(output.stderr)
+        }`,
+      );
+      const lines = new TextDecoder().decode(output.stdout).trim().split("\n");
+      cached = JSON.parse(lines[lines.length - 1]) as Record<string, unknown>;
+    } finally {
+      await Deno.remove(probe).catch(() => {});
+    }
+  }
+  return cached as {
+    names: string[];
+    providerOptions: Record<string, unknown>;
+  };
+};
+
+describe("llm model registry", () => {
+  it("registers the codename-tiered gpt-5.6 family", async () => {
+    const { names } = await registeredModels();
+    for (
+      const name of [
+        "openai:gpt-5.6-sol",
+        "openai:gpt-5.6-terra",
+        "openai:gpt-5.6-luna",
+      ]
+    ) {
+      assert(names.includes(name), `${name} should be registered`);
+    }
+  });
+
+  it("exposes bare and -latest aliases for the gpt-5.6 family", async () => {
+    const { names } = await registeredModels();
+    for (
+      const alias of [
+        "gpt-5.6",
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
+        "openai:gpt-5.6-sol-latest",
+      ]
+    ) {
+      assert(names.includes(alias), `${alias} should resolve`);
+    }
+  });
+
+  it("no longer registers the retired gpt-5-mini names", async () => {
+    const { names } = await registeredModels();
+    for (
+      const name of [
+        "openai:gpt-5-mini",
+        "gpt-5-mini",
+        "openai:gpt-5-mini-thinking",
+      ]
+    ) {
+      assert(!names.includes(name), `${name} should be gone`);
+    }
+  });
+
+  it("resolves the shared generate-object default to a registered model", async () => {
+    const { names } = await registeredModels();
+    assert(
+      names.includes(DEFAULT_GENERATE_OBJECT_MODELS),
+      `${DEFAULT_GENERATE_OBJECT_MODELS} is used as a default but is not registered`,
+    );
+  });
+
+  it("stores namespaced provider options on the registered models", async () => {
+    const { providerOptions } = await registeredModels();
+    // The un-namespaced `{ reasoningEffort }` shape was silently ignored by
+    // the AI SDK; everything must live under a provider key.
+    for (const [name, options] of Object.entries(providerOptions)) {
+      for (const [key, value] of Object.entries(options as object)) {
+        assert(
+          typeof value === "object" && value !== null && !Array.isArray(value),
+          `${name} providerOptions.${key} should be a provider namespace object`,
+        );
+      }
+    }
+    const openai = (providerOptions["openai:gpt-5.6-terra"] as {
+      openai: Record<string, unknown>;
+    }).openai;
+    assertEquals(openai.store, false);
+    assertEquals(openai.include, ["reasoning.encrypted_content"]);
+    const thinking = (providerOptions["openai:gpt-5-thinking"] as {
+      openai: Record<string, unknown>;
+    }).openai;
+    assertEquals(thinking.reasoningEffort, "high");
+    assertEquals(thinking.store, false);
+  });
+});

--- a/packages/toolshed/routes/ai/llm/models.test.ts
+++ b/packages/toolshed/routes/ai/llm/models.test.ts
@@ -30,6 +30,10 @@ const registeredModels = async (): Promise<{
 }> => {
   if (cached === undefined) {
     const probe = await Deno.makeTempFile({ suffix: ".ts" });
+    // A dedicated result file rather than stdout: module registration logs
+    // provider banners, so parsing stdout would couple the test to whatever
+    // the providers happen to print.
+    const resultPath = await Deno.makeTempFile({ suffix: ".json" });
     await Deno.writeTextFile(
       probe,
       `const mod = await import(${
@@ -42,7 +46,9 @@ const registeredModels = async (): Promise<{
         `      : []\n` +
         `  ),\n` +
         `);\n` +
-        `console.log(JSON.stringify({\n` +
+        `await Deno.writeTextFile(${
+          JSON.stringify(resultPath)
+        }, JSON.stringify({\n` +
         `  names: Object.keys(mod.MODELS),\n` +
         `  providerOptions,\n` +
         `}));\n`,
@@ -85,10 +91,13 @@ const registeredModels = async (): Promise<{
           new TextDecoder().decode(output.stderr)
         }`,
       );
-      const lines = new TextDecoder().decode(output.stdout).trim().split("\n");
-      cached = JSON.parse(lines[lines.length - 1]) as Record<string, unknown>;
+      cached = JSON.parse(await Deno.readTextFile(resultPath)) as Record<
+        string,
+        unknown
+      >;
     } finally {
       await Deno.remove(probe).catch(() => {});
+      await Deno.remove(resultPath).catch(() => {});
     }
   }
   return cached as {

--- a/packages/toolshed/routes/ai/llm/models.ts
+++ b/packages/toolshed/routes/ai/llm/models.ts
@@ -3,7 +3,7 @@ import { createOpenAI } from "@ai-sdk/openai";
 import { createGroq, groq } from "@ai-sdk/groq";
 import { openai } from "@ai-sdk/openai";
 import { createVertex, vertex } from "@ai-sdk/google-vertex";
-import type { LanguageModel } from "ai";
+import type { JSONValue, LanguageModel } from "ai";
 import {
   GOOGLE_SEARCH_NATIVE_MODEL_TOOL,
   isLLMNativeModelToolId,
@@ -51,11 +51,18 @@ type GatewayModelsResponse = {
   data: GatewayModel[];
 };
 
+/**
+ * Per-provider request options applied to every call made with the model,
+ * in the AI SDK's namespaced shape, e.g. `{ openai: { store: false } }`.
+ */
+export type ModelProviderOptions = Record<string, Record<string, JSONValue>>;
+
 export type ModelConfig = {
   model: LanguageModel;
   name: string;
   capabilities: Capabilities;
   aliases: string[];
+  providerOptions?: ModelProviderOptions;
   nativeModelToolFactories?: Partial<Record<LLMNativeModelToolId, () => any>>;
 };
 
@@ -90,7 +97,7 @@ const addModel = ({
   name,
   aliases,
   capabilities,
-  providerOptions: _,
+  providerOptions,
   nativeModelToolFactories,
 }: {
   provider:
@@ -101,7 +108,7 @@ const addModel = ({
   name: string;
   aliases: string[];
   capabilities: Capabilities;
-  providerOptions?: Record<string, unknown>;
+  providerOptions?: ModelProviderOptions;
   nativeModelToolFactories?: Partial<Record<LLMNativeModelToolId, () => any>>;
 }) => {
   let modelName = name.includes(":")
@@ -124,6 +131,7 @@ const addModel = ({
     name,
     capabilities,
     aliases,
+    ...(providerOptions !== undefined ? { providerOptions } : {}),
     ...(nativeModelToolFactories !== undefined
       ? { nativeModelToolFactories }
       : {}),
@@ -353,6 +361,15 @@ if (env.CFTS_AI_LLM_GROQ_API_KEY) {
   });
 }
 
+// The org runs OpenAI under Zero Data Retention, so the Responses API cannot
+// persist state between turns. Reasoning must come back encrypted and travel
+// with the messages instead; without this, the second turn of a tool loop
+// fails with "Item with id 'rs_...' not found".
+const OPENAI_ZDR_OPTIONS = {
+  store: false,
+  include: ["reasoning.encrypted_content"],
+} satisfies Record<string, JSONValue>;
+
 if (env.CFTS_AI_LLM_OPENAI_API_KEY) {
   const openAIProvider = createOpenAI({
     apiKey: env.CFTS_AI_LLM_OPENAI_API_KEY,
@@ -372,6 +389,9 @@ if (env.CFTS_AI_LLM_OPENAI_API_KEY) {
       streaming: true,
       reasoning: false,
     },
+    providerOptions: {
+      openai: { ...OPENAI_ZDR_OPTIONS },
+    },
   });
 
   addModel({
@@ -389,42 +409,70 @@ if (env.CFTS_AI_LLM_OPENAI_API_KEY) {
       reasoning: true,
     },
     providerOptions: {
-      reasoningEffort: "high",
+      // Namespaced under `openai` — the AI SDK ignores un-namespaced keys,
+      // which is why the previous `{ reasoningEffort }` shape never worked.
+      openai: { ...OPENAI_ZDR_OPTIONS, reasoningEffort: "high" },
     },
   });
 
+  // GPT-5.6 is codename-tiered rather than mini/nano: sol (flagship), terra
+  // (balanced), luna (fast). All three reason by default, which is why
+  // function tools must go through the Responses API rather than Chat
+  // Completions. Context is 1,050,000 total (922,000 in + 128,000 out).
   addModel({
     provider: openAIProvider,
-    name: "openai:gpt-5-mini",
-    aliases: ["openai:gpt-5-mini-latest", "gpt-5-mini"],
+    name: "openai:gpt-5.6-sol",
+    aliases: ["openai:gpt-5.6-sol-latest", "gpt-5.6-sol", "gpt-5.6"],
     capabilities: {
-      contextWindow: 400_000,
+      contextWindow: 1_050_000,
       maxOutputTokens: 128_000,
       images: true,
       prefill: false,
       systemPrompt: true,
       stopSequences: true,
       streaming: true,
-      reasoning: false,
+      reasoning: true,
+    },
+    providerOptions: {
+      openai: { ...OPENAI_ZDR_OPTIONS },
     },
   });
 
   addModel({
     provider: openAIProvider,
-    name: "openai:gpt-5-mini-thinking",
-    aliases: ["openai:gpt-5-mini-thinking-latest", "gpt-5-mini-thinking"],
+    name: "openai:gpt-5.6-terra",
+    aliases: ["openai:gpt-5.6-terra-latest", "gpt-5.6-terra"],
     capabilities: {
-      contextWindow: 400_000,
+      contextWindow: 1_050_000,
       maxOutputTokens: 128_000,
       images: true,
       prefill: false,
-      systemPrompt: false,
-      stopSequences: false,
+      systemPrompt: true,
+      stopSequences: true,
       streaming: true,
       reasoning: true,
     },
     providerOptions: {
-      reasoningEffort: "high",
+      openai: { ...OPENAI_ZDR_OPTIONS },
+    },
+  });
+
+  addModel({
+    provider: openAIProvider,
+    name: "openai:gpt-5.6-luna",
+    aliases: ["openai:gpt-5.6-luna-latest", "gpt-5.6-luna"],
+    capabilities: {
+      contextWindow: 1_050_000,
+      maxOutputTokens: 128_000,
+      images: true,
+      prefill: false,
+      systemPrompt: true,
+      stopSequences: true,
+      streaming: true,
+      reasoning: true,
+    },
+    providerOptions: {
+      openai: { ...OPENAI_ZDR_OPTIONS },
     },
   });
 }


### PR DESCRIPTION
The model-registry half deliberately split out of #5071, plus the plumbing fix that made the split necessary. Recovered from the pre-split PR chain (`2d61fc808`, reachable via `refs/pull/5071/head`) and rebuilt on current main.

## The core defect: `providerOptions` never reached a request

`addModel` destructured the field as `providerOptions: _` and dropped it. Every option a registration declared was configuration in name only:

- `gpt-5-thinking`'s `reasoningEffort: "high"` — never sent (doubly so: it also used the un-namespaced shape the AI SDK ignores).
- All four Anthropic `*-thinking` entries (`opus-4-1`, `sonnet-4-0`, `sonnet-4-5`, `sonnet-4-6`) declared `thinking: { type: "enabled", budgetTokens: 32000–64000 }` — never sent. The `-thinking` names have been serving **non-thinking** responses since they were added.

The registry now stores `providerOptions` (typed as the AI SDK's namespaced shape) and `generateText`/`generateObject` pass it through. JSON mode previously *replaced* the `openai`/`groq` namespace when setting `response_format`; it now merges into it, so model-level options survive JSON-mode requests.

## ZDR: multi-turn tool loops on direct OpenAI

The org runs OpenAI under Zero Data Retention, so the Responses API cannot persist state between turns; a second tool turn fails with `Item with id 'rs_...' not found`. Every direct-OpenAI registration now carries:

```ts
openai: { store: false, include: ["reasoning.encrypted_content"] }
```

so reasoning comes back encrypted and travels with the messages instead of being looked up server-side. This is the same mechanism cf-harness uses for its Responses path.

## gpt-5.6 family, and the retirement of gpt-5-mini

Registers the codename-tiered family — `gpt-5.6-sol` (flagship, bare `gpt-5.6` alias), `gpt-5.6-terra` (balanced), `gpt-5.6-luna` (fast) — 1,050,000-token context (922k in + 128k out), reasoning on by default. `gpt-5-mini`/`gpt-5-mini-thinking` are removed. `DEFAULT_GENERATE_OBJECT_MODELS` moves to `openai:gpt-5.6-terra`. (`DEFAULT_IFRAME_MODELS` no longer exists on main — deleted with the prompt-workflow layer in #5426.)

## Tests

A subprocess-isolated `models.test.ts`: registration runs at import time gated on API keys, and importing `models.ts` in-process with a key set would pollute the shared module graph (generateObject.test.ts asserts `MODELS` is empty — order-dependent breakage). The probe runs in a subprocess via `runDenoCommandWithTemporaryLock` instead. It pins: the gpt-5.6 registrations and aliases, the retirement of the mini names, that the shared default resolves to a registered model (nothing checked this before), and that every stored `providerOptions` is provider-namespaced with the ZDR keys present. The plumbing test was mutation-checked — reverting `addModel` to discard the field fails it.

`deno task check` clean, repo-wide `deno lint` clean (4,312 files), llm route suites 26 passed.

## ⚠️ Live-behavior changes to sign off on

1. **This activates the four dormant Anthropic thinking configs.** Anyone calling a `*-thinking` Anthropic model starts getting real extended thinking (32k–64k budgets) — a cost and latency change that lands the moment this merges, not a refactor.
2. **The generate-object default gets ~5× more expensive per prompt token** (gpt-5-mini → gpt-5.6-terra, ~5× prompt / ~3.75× completion at list prices), with reasoning on by default. `gpt-5.6-luna` (~2×/1.5×) is the cheaper alternative if that's too rich for a default.
3. **Routing note:** `openai:gpt-5.6-*` resolves to the direct OpenAI provider only when `CFTS_AI_LLM_OPENAI_API_KEY` is set; without it, the gateway registration claims the same names via its owner alias and serves them over Chat Completions.
4. **ZDR settings are not yet live-verified** — the previous smoke-test key was destroyed after #5071. I'll run a real multi-turn tool-loop smoke test with a fresh key before this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

