### PR TITLE
refactor(schema-generator): drop the unused generator interface

### DIFF
--- a/docs/specs/schema-generator/ts_to_json_schema_mapping.md
+++ b/docs/specs/schema-generator/ts_to_json_schema_mapping.md
@@ -26,10 +26,11 @@ Authoritative implementation sources:
 If this document conflicts with code or passing tests, code/tests win.
 
 Package exports (`deno.jsonc`): `.` → `src/index.ts` (no `mod.ts`), plus
-six subpaths — `./interface`, `./cell-brand`, `./wrapper-names`,
-`./type-traversal`, `./property-optionality`, `./property-name`.
-`src/index.ts` exports the `SchemaGenerator` class, the `ISchemaGenerator`
-type, and re-exports `MutableJSONSchemaObj`.
+five subpaths — `./cell-brand`, `./wrapper-names`, `./property-optionality`,
+`./property-name`, `./numeric-expression`.
+`src/index.ts` exports the `SchemaGenerator` class, the
+`SchemaGenerationOptions` and `WriterSourceIdentity` types, and re-exports
+`MutableJSONSchemaObj`.
 
 Consumers, as of this writing (verified by import grep): the only external
 consumer package is `@commonfabric/ts-transformers`, along two axes:

--- a/packages/schema-generator/AGENTS.md
+++ b/packages/schema-generator/AGENTS.md
@@ -4,8 +4,8 @@ Converts TypeScript types to Common Fabric JSON Schemas (2020-12 dialect + repo
 extensions). Consumed at compile time by `packages/ts-transformers`
 (SchemaGeneratorTransformer constructs a `SchemaGenerator`); also the repo's
 wrapper-type vocabulary oracle — ts-transformers imports `cell-brand`,
-`wrapper-names`, `type-traversal`, `property-name`, `property-optionality` via
-subpath exports. Entry point is `src/index.ts` (not `mod.ts`).
+`wrapper-names`, `property-name`, `property-optionality`, `numeric-expression`
+via subpath exports. Entry point is `src/index.ts` (not `mod.ts`).
 
 ## Where answers live
 

--- a/packages/schema-generator/deno.jsonc
+++ b/packages/schema-generator/deno.jsonc
@@ -3,10 +3,8 @@
   "version": "0.1.0",
   "exports": {
     ".": "./src/index.ts",
-    "./interface": "./src/interface.ts",
     "./cell-brand": "./src/typescript/cell-brand.ts",
     "./wrapper-names": "./src/typescript/wrapper-names.ts",
-    "./type-traversal": "./src/typescript/type-traversal.ts",
     "./property-optionality": "./src/typescript/property-optionality.ts",
     "./property-name": "./src/typescript/property-name.ts",
     "./numeric-expression": "./src/typescript/numeric-expression.ts"

--- a/packages/schema-generator/src/index.ts
+++ b/packages/schema-generator/src/index.ts
@@ -4,7 +4,6 @@ export { SchemaGenerator } from "./schema-generator.ts";
 // Public types for API consumers
 export type {
   SchemaGenerationOptions,
-  SchemaGenerator as ISchemaGenerator,
   WriterSourceIdentity,
 } from "./interface.ts";
 export type { MutableJSONSchemaObj } from "@commonfabric/api";

--- a/packages/schema-generator/src/interface.ts
+++ b/packages/schema-generator/src/interface.ts
@@ -111,38 +111,3 @@ export interface TypeFormatter {
     context: GenerationContext,
   ): SchemaDefinition;
 }
-
-/**
- * Main schema generator class
- */
-export interface SchemaGenerator {
-  /**
-   * Generate JSON Schema for a TypeScript type
-   */
-  generateSchema(
-    type: ts.Type,
-    checker: ts.TypeChecker,
-    typeNode?: ts.TypeNode,
-    options?: SchemaGenerationOptions,
-    schemaHints?: SchemaHints,
-    sourceFile?: ts.SourceFile,
-  ): SchemaDefinition;
-
-  /**
-   * Generate schema from a synthetic TypeNode that doesn't resolve to a proper Type.
-   * Used by transformers that create synthetic type structures programmatically.
-   *
-   * @param typeNode - Synthetic TypeNode to analyze
-   * @param checker - TypeScript type checker
-   * @param typeRegistry - Optional WeakMap of Node → Type for registered synthetic nodes
-   * @param schemaHints - Optional WeakMap of Node → hints for overriding default behavior
-   */
-  generateSchemaFromSyntheticTypeNode(
-    typeNode: ts.TypeNode,
-    checker: ts.TypeChecker,
-    typeRegistry?: WeakMap<ts.Node, ts.Type>,
-    schemaHints?: SchemaHints,
-    sourceFile?: ts.SourceFile,
-    options?: SchemaGenerationOptions,
-  ): SchemaDefinition;
-}

--- a/packages/schema-generator/src/schema-generator.ts
+++ b/packages/schema-generator/src/schema-generator.ts
@@ -8,7 +8,6 @@ import type {
 import type {
   GenerationContext,
   SchemaGenerationOptions,
-  SchemaGenerator as ISchemaGenerator,
   SchemaHints,
   TypeFormatter,
 } from "./interface.ts";
@@ -34,7 +33,7 @@ import { attachDocTags, extractDocFromType } from "./doc-utils.ts";
 /**
  * Main schema generator that uses a chain of formatters
  */
-export class SchemaGenerator implements ISchemaGenerator {
+export class SchemaGenerator {
   private formatters: TypeFormatter[] = [
     new CommonFabricFormatter(this),
     new NativeTypeFormatter(),


### PR DESCRIPTION
The schema-generator package declared an interface named SchemaGenerator alongside the concrete class of the same name. The class declared that it implemented that interface, and the package's entry point re-exported the interface under the alias ISchemaGenerator so that callers could depend on the abstraction rather than on the class.

Nothing ever took that option. The one external consumer of the package, the schema-generator transformer in ts-transformers, imports the concrete class and constructs it directly; no file outside this package mentions ISchemaGenerator at all. What remained was a second copy of two method signatures that had to be kept in step with the class by hand, with no caller benefiting from the indirection. The interface is deleted, along with the implements clause, the type import that supported it, and the alias export. The class's public methods are untouched, so no caller moves.

Two subpath entries in the package's export map are removed for the same reason. Nothing imports the package's './interface' subpath, and nothing outside the package imports './type-traversal' either — the module behind it is used only by its sibling cell-brand.ts, over a relative path. The five remaining subpaths (cell-brand, wrapper-names, property-name, property-optionality, numeric-expression) all have real importers in ts-transformers and stay. The type-traversal module itself is untouched; only its listing as a package entry point goes.

Two documents described the old shape and are corrected in the same change. The mapping spec enumerated the package's exports; its list was already stale, calling the set "six subpaths" while the export map held seven, because it omitted numeric-expression. It now lists the five that remain, and describes the entry point as exporting the class plus the SchemaGenerationOptions and WriterSourceIdentity types rather than the deleted alias. The package's agent guide claimed ts-transformers reaches for type-traversal through a subpath, which was not true even before this change; it now names numeric-expression, which that sentence had left out.

The type WriterSourceIdentity stays in interface.ts and stays exported: SchemaGenerationOptions refers to it in the signature of its writerIdentityForSourceFile member, so it is part of the surface that ts-transformers already uses.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

