### PR TITLE
fix(ts-transformers): lower a pattern-scope cell read at any lowerable site

### DIFF
--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -453,9 +453,8 @@ Diagnostics emitted in all modes:
     optionality-orthogonality resolution. Each lift's input schema shrinks to
     what its body reads (`test/validation.test.ts:3179`; goldens
     `cell-get-binding-autowrap`, `cell-get-terminal-binding-autowrap`,
-    `with-reactive`). This is an unratified delta from the target-language
-    matrix's unconditional "Unsupported" and from the lowering contract's §3.9
-    eager-read bullet — see the design-deltas 2026-07-10 record
+    `with-reactive`). This is the ratified has-a-lowerable-site rule —
+    target-language spec §5.7 and its matrix rows are normative for it
 - **Error** `pattern-context:function-creation`
   - function creation in pattern context unless inside compute
     wrappers/JSX/allowed callbacks

--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -434,7 +434,10 @@ Diagnostics emitted in all modes:
   - a `.get()` read in restricted reactive context with no lowerable
     expression site to carry it: a statement-position read (`count.get();`),
     a read inside a reactive array-method callback
-    (`rows.map((row) => row.cell.get())`), or a read whose receiver is not a
+    (`rows.map((row) => row.cell.get())`), a read inside a plain
+    (non-reactive) array-method callback
+    (`["-", "+"].map((sep) => rows.get().join(sep))`, which is not an eligible
+    pattern-owned wrapper site), or a read whose receiver is not a
     `Cell`/`Writable`/`Stream` (`items.get()` on a plain pattern input, which
     also draws `opaque-get:invalid-call`)
   - a cell read that DOES sit at a lowerable site is not rejected: the site is
@@ -443,12 +446,16 @@ Diagnostics emitted in all modes:
     `input.key("count").get()` at a return site), a computation over it
     (`{ value: count.get() * 2 }`), and a call whose receiver chain reaches it
     (`rows.get().join(",")`, `rows.get().filter(...)`, which lowers through
-    `filterWithPattern`). Each lift's input schema shrinks to what its body
-    reads (`test/validation.test.ts:3179`; goldens
+    `filterWithPattern`). Parentheses around the site and the computed-key
+    spelling of the read (`layout["get"]()`) do not change the decision, and
+    neither does optionality — `layout?.get()` and `layout?.get?.()` on a cell
+    lower like their non-optional spellings, per the 2026-07-23
+    optionality-orthogonality resolution. Each lift's input schema shrinks to
+    what its body reads (`test/validation.test.ts:3179`; goldens
     `cell-get-binding-autowrap`, `cell-get-terminal-binding-autowrap`,
     `with-reactive`). This is an unratified delta from the target-language
-    matrix's unconditional "Unsupported" — see the design-deltas 2026-07-10
-    record
+    matrix's unconditional "Unsupported" and from the lowering contract's §3.9
+    eager-read bullet — see the design-deltas 2026-07-10 record
 - **Error** `pattern-context:function-creation`
   - function creation in pattern context unless inside compute
     wrappers/JSX/allowed callbacks

--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -431,13 +431,21 @@ Compute wrappers override restrictions:
 Diagnostics emitted in all modes:
 
 - **Error** `pattern-context:get-call`
-  - a **terminal** `.get()` read in restricted reactive context — one whose
-    value is used directly (`{ value: count.get() }`,
-    `const v = count.get()`, `input.key("count").get()` at a return site)
-  - since #3725 (2026-05-28), a **computation-feeding** read at a lowerable
-    site (`{ value: count.get() * 2 }`) is NOT rejected: the containing
-    expression is auto-wrapped into a lift-applied computation
-    (`test/validation.test.ts:3179`; goldens `cell-get-binding-autowrap`,
+  - a `.get()` read in restricted reactive context with no lowerable
+    expression site to carry it: a statement-position read (`count.get();`),
+    a read inside a reactive array-method callback
+    (`rows.map((row) => row.cell.get())`), or a read whose receiver is not a
+    `Cell`/`Writable`/`Stream` (`items.get()` on a plain pattern input, which
+    also draws `opaque-get:invalid-call`)
+  - a cell read that DOES sit at a lowerable site is not rejected: the site is
+    auto-wrapped into a lift-applied computation. That covers the read itself
+    (`const v = count.get()`, `{ value: count.get() }`,
+    `input.key("count").get()` at a return site), a computation over it
+    (`{ value: count.get() * 2 }`), and a call whose receiver chain reaches it
+    (`rows.get().join(",")`, `rows.get().filter(...)`, which lowers through
+    `filterWithPattern`). Each lift's input schema shrinks to what its body
+    reads (`test/validation.test.ts:3179`; goldens
+    `cell-get-binding-autowrap`, `cell-get-terminal-binding-autowrap`,
     `with-reactive`). This is an unratified delta from the target-language
     matrix's unconditional "Unsupported" — see the design-deltas 2026-07-10
     record

--- a/docs/specs/ts-transformer/ts_transformers_design_deltas.md
+++ b/docs/specs/ts-transformer/ts_transformers_design_deltas.md
@@ -108,13 +108,19 @@ Language deltas found by adversarial verification of the target-language
 matrix (implementation vs normative spec). Resolution status is recorded on
 each finding:
 
-- **Top-level eager-read carve-out (#3725, 2026-05-28).** Validation accepts
-  computation-feeding top-level `.get()` reads and auto-wraps the containing
-  expression lift-applied; terminal reads still reject. Golden-pinned
-  (`cell-get-binding-autowrap`, `with-reactive`;
+- **Top-level eager-read carve-out (#3725, 2026-05-28).** Validation accepts a
+  top-level `.get()` read on a `Cell`/`Writable`/`Stream` wherever the read has
+  a lowerable expression site to carry it, and auto-wraps that site
+  lift-applied. The line is the site, not the shape of the read: a binding, a
+  return, an object property, an array element, an argument, and a call whose
+  receiver chain reaches the read are all accepted, terminal or not; a read
+  with no such site — statement position, or inside a reactive array-method
+  callback — still rejects, as does a read on a value that is not a cell.
+  Golden-pinned (`cell-get-binding-autowrap`,
+  `cell-get-terminal-binding-autowrap`, `with-reactive`;
   `test/validation.test.ts:3179`). Matrix row still says Unsupported
-  unconditionally. Decision open: ratify a terminal-vs-computation-feeding
-  split in the matrix, or revert (breaks two goldens + one test).
+  unconditionally. Decision open: ratify a has-a-lowerable-site split in the
+  matrix, or revert (breaks three goldens + several tests).
 - **Optional-call accepted in JSX and compute callbacks — resolved 2026-07-23
   by making optionality orthogonal to call support.** The earlier location
   split was an implementation leak, and the proposed blanket rejection would

--- a/docs/specs/ts-transformer/ts_transformers_design_deltas.md
+++ b/docs/specs/ts-transformer/ts_transformers_design_deltas.md
@@ -108,22 +108,29 @@ Language deltas found by adversarial verification of the target-language
 matrix (implementation vs normative spec). Resolution status is recorded on
 each finding:
 
-- **Top-level eager-read carve-out (#3725, 2026-05-28).** Validation accepts a
-  top-level `.get()` read on a `Cell`/`Writable`/`Stream` wherever the read has
-  a lowerable expression site to carry it, and auto-wraps that site
-  lift-applied. The line is the site, not the shape of the read: a binding, a
-  return, an object property, an array element, an argument, and a call whose
-  receiver chain reaches the read are all accepted, terminal or not; a read
-  with no such site — statement position, inside a reactive array-method
-  callback, or inside a plain (non-reactive) array-method callback — still
-  rejects, as does a read on a value that is not a cell. Golden-pinned
-  (`cell-get-binding-autowrap`, `cell-get-terminal-binding-autowrap`,
-  `with-reactive`; `test/validation.test.ts:3179`). Two normative records still
-  say otherwise: the matrix row says Unsupported unconditionally, and the
-  lowering contract's §3.9 lists a direct top-level eager read among the
-  constructs that must fail clearly. Decision open: ratify a
-  has-a-lowerable-site split in the matrix (and retire lowering-contract §3.9's
-  eager-read bullet), or revert (breaks three goldens + several tests).
+- **Top-level eager-read carve-out (#3725, 2026-05-28) — resolved 2026-08-07 by
+  ratifying the has-a-lowerable-site rule.** A `.get()` read on a
+  `Cell`/`Writable`/`Stream` in pattern-owned context is part of the language
+  wherever a lowerable expression site can carry it; that site lowers into a
+  lift, which is what keeps the read live. The line is the site, not the shape
+  of the read: a binding, a return, an object property, an array element, an
+  argument, a computation over the read, and a call whose receiver chain
+  reaches it are all accepted, terminal or not, and parentheses, the
+  computed-key spelling, and the optional spellings do not change the
+  classification. A read with no such site — statement position, a reactive
+  array-method callback, or a plain (non-reactive) array-method callback —
+  remains outside the language, as does a read on a value that is not a cell.
+
+  What settled it: the matrix already blessed the JSX spelling, so the earlier
+  rule was really "no eager reads outside JSX" — which made extracting a JSX
+  expression into a named binding change a program's legality. The rejection's
+  main output was "wrap it in `computed()`" diagnostics that bred wrapper
+  cascades in author code, against a platform direction of needing explicit
+  `computed()` less often. Ratified in the target-language matrix and §5.7;
+  lowering-contract §3.9's eager-read bullet now names the site-less read
+  rather than the top-level read. Golden-pinned (`cell-get-binding-autowrap`,
+  `cell-get-terminal-binding-autowrap`, `with-reactive`;
+  `test/validation.test.ts:3179`).
 - **Optional-call accepted in JSX and compute callbacks — resolved 2026-07-23
   by making optionality orthogonal to call support.** The earlier location
   split was an implementation leak, and the proposed blanket rejection would

--- a/docs/specs/ts-transformer/ts_transformers_design_deltas.md
+++ b/docs/specs/ts-transformer/ts_transformers_design_deltas.md
@@ -114,13 +114,16 @@ each finding:
   lift-applied. The line is the site, not the shape of the read: a binding, a
   return, an object property, an array element, an argument, and a call whose
   receiver chain reaches the read are all accepted, terminal or not; a read
-  with no such site — statement position, or inside a reactive array-method
-  callback — still rejects, as does a read on a value that is not a cell.
-  Golden-pinned (`cell-get-binding-autowrap`,
-  `cell-get-terminal-binding-autowrap`, `with-reactive`;
-  `test/validation.test.ts:3179`). Matrix row still says Unsupported
-  unconditionally. Decision open: ratify a has-a-lowerable-site split in the
-  matrix, or revert (breaks three goldens + several tests).
+  with no such site — statement position, inside a reactive array-method
+  callback, or inside a plain (non-reactive) array-method callback — still
+  rejects, as does a read on a value that is not a cell. Golden-pinned
+  (`cell-get-binding-autowrap`, `cell-get-terminal-binding-autowrap`,
+  `with-reactive`; `test/validation.test.ts:3179`). Two normative records still
+  say otherwise: the matrix row says Unsupported unconditionally, and the
+  lowering contract's §3.9 lists a direct top-level eager read among the
+  constructs that must fail clearly. Decision open: ratify a
+  has-a-lowerable-site split in the matrix (and retire lowering-contract §3.9's
+  eager-read bullet), or revert (breaks three goldens + several tests).
 - **Optional-call accepted in JSX and compute callbacks — resolved 2026-07-23
   by making optionality orthogonal to call support.** The earlier location
   split was an implementation leak, and the proposed blanket rejection would

--- a/docs/specs/ts-transformer/ts_transformers_lowering_contract.md
+++ b/docs/specs/ts-transformer/ts_transformers_lowering_contract.md
@@ -191,7 +191,9 @@ This is especially important for:
 
 - wildcard traversal outside supported whole-call expression-root positions
 - foreign callback-container roots in pattern-facing contexts
-- direct top-level eager `.get()` reads on reactive or cell-like values
+- eager `.get()` reads with no lowerable expression site to carry them, and
+  eager reads on ordinary opaque values — a read on a true cell at a lowerable
+  site lowers into a lift instead (target-language spec §5.7)
 - imperative statement-boundary constructs in top-level pattern context
 
 ## 3.10 Phase Choice Is An Implementation Detail

--- a/docs/specs/ts-transformer/ts_transformers_target_pattern_language_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_target_pattern_language_spec.md
@@ -78,7 +78,8 @@ Each construct family is classified as one of:
 | Optional receiver navigation and optional invocation on otherwise-supported call roots | Supported | Optionality does not define a separate call family: `value?.method()`, `value.method?.()`, and combined chains lower wherever the corresponding non-optional call is supported, with receiver binding, evaluation order, nullish short-circuiting, and skipped argument evaluation preserved |
 | Direct non-JSX receiver-method calls on reactive values in top-level pattern-body expression sites | Supported | Value-like receiver-method roots at top-level object-property, call-argument, variable-initializer, array-element, or return-expression sites lower to derived local value expressions |
 | Direct receiver-method roots inside supported collection callbacks | Supported | Callback-local value-like receiver-method roots lower to callback-local lift-applied computations instead of remaining raw or requiring manual wrapper calls |
-| Direct top-level `.get()` reads in pattern-owned reactive context | Unsupported | Even on true cell-like values, eager `.get()` reads should move into JSX or an explicit computation callback such as `computed`, `action`, `lift`, or `handler` rather than living directly in the top-level declarative pattern body |
+| Direct top-level `.get()` reads on explicitly cell-like values at a lowerable expression site | Supported | On a true `Cell`/`Writable`/`Stream`, an eager read is part of the language wherever a lowerable expression site can carry it: a variable initializer, a return, an object property, an array element, a call argument, a computation over the read, or a call whose receiver chain reaches it. That site lowers into a lift, so the read stays live rather than freezing. Parentheses, the computed-key spelling `cell["get"]()`, and the optional spellings `cell?.get()` / `cell.get?.()` do not change the classification |
+| Direct top-level `.get()` reads with no lowerable expression site | Unsupported | A read with nothing to carry it stays outside the language, because there is no site to lower into a lift: statement position (`count.get();`), a reactive array-method callback (`rows.map((row) => row.cell.get())`), and a plain array-method callback (`["-", "+"].map((sep) => rows.get().join(sep))`). These move into an explicit computation callback such as `computed`, `action`, `lift`, or `handler` |
 | `.get()` on ordinary opaque/reactive values | Unsupported | Pattern inputs, `computed` results, `lift` results, and other ordinary reactive values should be read directly rather than through `.get()` |
 | Statement-boundary imperative constructs in top-level pattern-owned code (`let`, loops, function creation, early return) | Unsupported | Top-level pattern context is intentionally declarative; imperative statement structure belongs in explicit callback bodies such as `computed`, `action`, `lift`, or `handler` |
 
@@ -136,9 +137,10 @@ pattern(({ items, show }) => ({
 
 ```ts
 // Shown for illustration only.
-pattern(({ user, count }) => ({
-  value: count.get(),
-}));
+pattern(({ count }) => {
+  count.get();
+  return { value: 1 };
+});
 ```
 
 Why:
@@ -148,7 +150,9 @@ Why:
 - top-level helper control flow is part of the language
 - top-level receiver-method roots are supported at lowerable non-JSX
   expression sites
-- eager `.get()` reads still move into JSX, authored helper control flow, or an explicit
+- an eager `.get()` read on a true cell is supported wherever a lowerable
+  expression site carries it, so `{ value: count.get() }` belongs here; a read
+  in statement position has no such site and moves into an explicit
   computation callback
 
 ### JSX Expressions
@@ -258,14 +262,18 @@ Why:
 When an authored form is unsupported, the right answer is usually to move it
 into a context that already has a clear language meaning.
 
-### Top-Level Eager `.get()` -> Helper Control Flow Or Computation Callback
+### Site-Less Eager `.get()` -> Computation Callback
+
+An eager read on a true cell needs a lowerable expression site to become a
+lift. A read in statement position, or inside an array-method callback, has
+none, so it moves into a callback that supplies one.
 
 **Avoid**
 
 ```ts
 // Shown for illustration only.
-pattern(({ count }) => ({
-  value: count.get(),
+pattern(({ rows }) => ({
+  labels: ["-", "+"].map((sep) => rows.get().join(sep)),
 }));
 ```
 
@@ -273,19 +281,14 @@ pattern(({ count }) => ({
 
 ```ts
 // Shown for illustration only.
-pattern(({ count, show }) => ({
-  value: ifElse(show, count.get(), 0),
+pattern(({ rows }) => ({
+  labels: computed(() => ["-", "+"].map((sep) => rows.get().join(sep))),
 }));
 ```
 
-or:
-
-```ts
-// Shown for illustration only.
-pattern(({ count }) => ({
-  value: computed(() => count.get()),
-}));
-```
+A read that already has a site needs no relocation — `{ value: count.get() }`,
+`const total = rows.get().length`, and `{ifElse(show, count.get(), 0)}` are all
+part of the language as written.
 
 ### Bare Dynamic Key Access -> JSX, Callback, Or Structural Binding
 
@@ -529,23 +532,41 @@ The intended split is:
      values is part of the authored language
    - example:
      - `input.key("foo")` where `input` is a declared `Writable<{ ... }>`
-2. **true cell-style eager read inside JSX, authored helper control flow, or an explicit computation callback**
-   - `.get()` remains valid when the authored value truly has cell semantics
-     and the read occurs inside JSX, helper control flow, or an explicit
-     computation callback
+2. **true cell-style eager read inside an explicit computation callback**
+   - `.get()` is ordinary eager reading inside a `computed` / `lift` /
+     `handler` / `action` body, where the callback already supplies the
+     compute context
    - examples:
      - `computed(() => input.key("foo").get())`
-     - JSX expression sites like `{input.key("foo").get()}`
-     - `ifElse(show, count.get(), 0)`
      - `lift` / `handler` / `action` callbacks that preserve declared cell
        semantics
-3. **direct top-level eager read in pattern-owned reactive context**
-   - not part of the target language, even for true cells
-   - example:
-     - `{ value: input.key("foo").get() }` directly in a top-level pattern body
-   - the implementation accepts this example today; see the nuance at the end
-     of this section for the shape of that unratified carve-out
-4. **`.get()` on ordinary opaque/reactive values**
+3. **true cell-style eager read at a lowerable expression site**
+   - `.get()` is part of the authored language in pattern-owned context
+     wherever a lowerable expression site can carry it; that site lowers into
+     a lift, which is what keeps the read live instead of freezing it to a
+     construction-time snapshot
+   - the qualifying sites are the variable initializer, the return, the object
+     property, the array element, the call argument, a computation over the
+     read, a call whose receiver chain reaches the read, and the JSX
+     expression
+   - examples:
+     - `{ value: input.key("foo").get() }` in a top-level pattern body
+     - `const total = rows.get().length`
+     - `const sorted = rows.get().toSorted(byDate)`
+     - JSX expression sites like `{input.key("foo").get()}`
+     - `ifElse(show, count.get(), 0)`
+   - the spelling of the read does not change the classification: parentheses
+     around the site, the computed-key form `cell["get"]()`, and the optional
+     forms `cell?.get()` and `cell.get?.()` all follow the same rule (§5.6)
+4. **eager read with no lowerable expression site**
+   - not part of the target language, even for true cells — there is no site
+     to lower into a lift, so the read cannot be kept live
+   - examples:
+     - statement position: `count.get();`
+     - a reactive array-method callback: `rows.map((row) => row.cell.get())`
+     - a plain array-method callback:
+       `["-", "+"].map((sep) => rows.get().join(sep))`
+5. **`.get()` on ordinary opaque/reactive values**
    - not part of the target language
    - examples:
      - `input.get()` where `input` is an ordinary pattern value
@@ -555,24 +576,17 @@ So the language should not be read as “`.get()` / `.key()` are transitional.�
 The real rule is:
 
 - `.key(...)` is a real source-level API for true cell-like values
-- `.get()` is valid only when both the value semantics and the authored
-  expression context justify an eager read, including helper control flow
+- `.get()` is valid when the value truly has cell semantics **and** the read
+  either sits inside an explicit computation callback or has a lowerable
+  expression site to carry it
 - ordinary opaque/reactive values should still prefer direct property access
   and canonical lowered traversal rather than authored `.get()`
 
-One important nuance: the implementation has moved on this boundary since
-this spec's v1. Validation accepts a top-level eager read on a true cell
-wherever the read has a lowerable expression site to carry it — a binding, a
-return, an object property, an array element, an argument, a computation over
-the read, or a call whose receiver chain reaches it — and auto-wraps that site
-into a lift-applied computation. A read with no such site (statement position,
-inside a reactive array-method callback, or inside a plain array-method
-callback) still rejects, as does a read on an ordinary opaque value. That
-carve-out is an unratified delta recorded in
-`ts_transformers_design_deltas.md` (2026-07-10), which also tracks the parallel
-tension with the lowering contract's §3.9: either this matrix gains the
-carve-out or the implementation reverts; per §1, do not treat the accident of
-acceptance as language policy in the meantime.
+The site rule is deliberately about the site rather than the shape of the
+read. A terminal read and a read feeding a computation are the same construct
+at the same site, and an author who extracts a JSX expression into a named
+binding is refactoring, not changing what their program means — so both
+spellings resolve the same way.
 
 ## 5.8 Verb Results Are Declared, Never Inferred
 

--- a/docs/specs/ts-transformer/ts_transformers_target_pattern_language_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_target_pattern_language_spec.md
@@ -566,9 +566,11 @@ wherever the read has a lowerable expression site to carry it — a binding, a
 return, an object property, an array element, an argument, a computation over
 the read, or a call whose receiver chain reaches it — and auto-wraps that site
 into a lift-applied computation. A read with no such site (statement position,
-or inside a reactive array-method callback) still rejects, as does a read on an
-ordinary opaque value. That carve-out is an unratified delta recorded in
-`ts_transformers_design_deltas.md` (2026-07-10): either this matrix gains the
+inside a reactive array-method callback, or inside a plain array-method
+callback) still rejects, as does a read on an ordinary opaque value. That
+carve-out is an unratified delta recorded in
+`ts_transformers_design_deltas.md` (2026-07-10), which also tracks the parallel
+tension with the lowering contract's §3.9: either this matrix gains the
 carve-out or the implementation reverts; per §1, do not treat the accident of
 acceptance as language policy in the meantime.
 

--- a/docs/specs/ts-transformer/ts_transformers_target_pattern_language_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_target_pattern_language_spec.md
@@ -559,10 +559,13 @@ The real rule is:
   and canonical lowered traversal rather than authored `.get()`
 
 One important nuance: the implementation has moved on this boundary since
-this spec's v1 — since #3725, validation accepts **computation-feeding**
-top-level eager reads (`{ value: count.get() * 2 }`) and auto-wraps them into
-lift-applied computations, while terminal reads (`{ value: count.get() }`)
-still reject. That carve-out is an unratified delta recorded in
+this spec's v1. Validation accepts a top-level eager read on a true cell
+wherever the read has a lowerable expression site to carry it — a binding, a
+return, an object property, an array element, an argument, a computation over
+the read, or a call whose receiver chain reaches it — and auto-wraps that site
+into a lift-applied computation. A read with no such site (statement position,
+or inside a reactive array-method callback) still rejects, as does a read on an
+ordinary opaque value. That carve-out is an unratified delta recorded in
 `ts_transformers_design_deltas.md` (2026-07-10): either this matrix gains the
 carve-out or the implementation reverts; per §1, do not treat the accident of
 acceptance as language policy in the meantime.

--- a/docs/specs/ts-transformer/ts_transformers_target_pattern_language_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_target_pattern_language_spec.md
@@ -543,6 +543,8 @@ The intended split is:
    - not part of the target language, even for true cells
    - example:
      - `{ value: input.key("foo").get() }` directly in a top-level pattern body
+   - the implementation accepts this example today; see the nuance at the end
+     of this section for the shape of that unratified carve-out
 4. **`.get()` on ordinary opaque/reactive values**
    - not part of the target language
    - examples:

--- a/packages/ts-transformers/src/transformers/call-root-support.ts
+++ b/packages/ts-transformers/src/transformers/call-root-support.ts
@@ -57,6 +57,36 @@ function hasOpaquePathTerminalReceiverChain(
     !!classifyOpaquePathTerminalCall(callee.expression);
 }
 
+/**
+ * True when `expression` is `<receiver>.get()` on a real cell or stream — the
+ * receivers for which `.get()` is a value read. Every other receiver either
+ * exposes its value directly (`opaque-get:invalid-call` covers those) or has no
+ * `.get()` at all, so a read through one is never a site worth lowering.
+ */
+export function isCellReadTerminalCall(
+  expression: ts.CallExpression,
+  context: TransformationContext,
+): boolean {
+  if (classifyOpaquePathTerminalCall(expression) !== "get") {
+    return false;
+  }
+
+  const callee = expression.expression;
+  if (!ts.isPropertyAccessExpression(callee)) {
+    return false;
+  }
+
+  try {
+    const cellKind = getCellKind(
+      context.checker.getTypeAtLocation(callee.expression),
+      context.checker,
+    );
+    return cellKind === "cell" || cellKind === "stream";
+  } catch {
+    return false;
+  }
+}
+
 export function classifyCallRootPolicy(
   expression: ts.Expression,
   siteInfo: CallRootPolicySiteInfo,
@@ -67,24 +97,14 @@ export function classifyCallRootPolicy(
   }
 
   if (classifyOpaquePathTerminalCall(expression) === "get") {
-    if (siteInfo.helperBoundaryKind) {
-      const callee = expression.expression;
-      if (ts.isPropertyAccessExpression(callee)) {
-        try {
-          const receiverType = context.checker.getTypeAtLocation(
-            callee.expression,
-          );
-          const cellKind = getCellKind(receiverType, context.checker);
-          if (cellKind === "cell" || cellKind === "stream") {
-            return {
-              kind: "supported",
-              supportedKind: "helper-owned-explicit-read",
-            };
-          }
-        } catch {
-          // Fall through to the shared unsupported decision below.
-        }
-      }
+    if (
+      siteInfo.helperBoundaryKind &&
+      isCellReadTerminalCall(expression, context)
+    ) {
+      return {
+        kind: "supported",
+        supportedKind: "helper-owned-explicit-read",
+      };
     }
 
     if (siteInfo.reactiveContext.kind === "pattern") {

--- a/packages/ts-transformers/src/transformers/call-root-support.ts
+++ b/packages/ts-transformers/src/transformers/call-root-support.ts
@@ -62,6 +62,10 @@ function hasOpaquePathTerminalReceiverChain(
  * receivers for which `.get()` is a value read. Every other receiver either
  * exposes its value directly (`opaque-get:invalid-call` covers those) or has no
  * `.get()` at all, so a read through one is never a site worth lowering.
+ *
+ * The computed spelling `<receiver>["get"]()` is the same read, and
+ * {@link classifyOpaquePathTerminalCall} already reports it as one, so both
+ * callee forms are accepted.
  */
 export function isCellReadTerminalCall(
   expression: ts.CallExpression,
@@ -72,7 +76,10 @@ export function isCellReadTerminalCall(
   }
 
   const callee = expression.expression;
-  if (!ts.isPropertyAccessExpression(callee)) {
+  if (
+    !ts.isPropertyAccessExpression(callee) &&
+    !ts.isElementAccessExpression(callee)
+  ) {
     return false;
   }
 

--- a/packages/ts-transformers/src/transformers/expression-site-policy.ts
+++ b/packages/ts-transformers/src/transformers/expression-site-policy.ts
@@ -25,6 +25,7 @@ import {
   classifyCallRootPolicy,
   type ExpressionSiteCallRootKind,
   type ExpressionSiteHelperBoundaryKind,
+  isCellReadTerminalCall,
   type SupportedCallRootKind,
   type UnsupportedCallRootKind,
 } from "./call-root-support.ts";
@@ -323,6 +324,60 @@ function isSharedPostClosureCallRootKind(
   kind: ExpressionSiteCallRootKind | undefined,
 ): boolean {
   return kind === "ordinary-call" || kind === "parameterized-inline-call";
+}
+
+/**
+ * True when a call site reads a cell — `count.get()` itself, or a call whose
+ * receiver chain reaches one (`rows.get().toSorted(byDate)`,
+ * `rows.get().items.join(", ")`).
+ *
+ * A cell read yields a plain snapshot, so the site holding it has to become a
+ * lift for the value to stay reactive. `classifyCallRootPolicy` reports the read
+ * as `restricted-get-call` and declines to classify a call over one, leaving
+ * both shapes without a supported call root; the JSX router admits them anyway
+ * as owned `jsx-root` sites. This is the same admission for the other container
+ * kinds, so a binding, a return, an argument, or an object property holding a
+ * cell read lowers into the lift its JSX spelling already gets.
+ *
+ * Receivers that are not cells are excluded by {@link isCellReadTerminalCall}:
+ * a `.get()` on an opaque value is a mistake with its own diagnostic, not a
+ * computation to lower.
+ */
+function isCellReadCallRootExpression(
+  expression: ts.Expression,
+  context: TransformationContext,
+): boolean {
+  if (!ts.isCallExpression(expression)) {
+    return false;
+  }
+
+  let current: ts.Expression = expression;
+  while (true) {
+    if (ts.isCallExpression(current)) {
+      if (isCellReadTerminalCall(current, context)) {
+        return true;
+      }
+      const callee = unwrapExpression(current.expression);
+      if (
+        !ts.isPropertyAccessExpression(callee) &&
+        !ts.isElementAccessExpression(callee)
+      ) {
+        return false;
+      }
+      current = unwrapExpression(callee.expression);
+      continue;
+    }
+
+    if (
+      ts.isPropertyAccessExpression(current) ||
+      ts.isElementAccessExpression(current)
+    ) {
+      current = unwrapExpression(current.expression);
+      continue;
+    }
+
+    return false;
+  }
 }
 
 const STRUCTURAL_NESTED_CONTAINER_KINDS = new Set<ExpressionContainerKind>([
@@ -1189,7 +1244,11 @@ export function classifyExpressionSiteHandling(
     );
     const patternOwnedReceiverMethod = supportedCallRootKind ===
       "pattern-owned-receiver-method";
-    if (!sharedPostClosureCallRoot && !patternOwnedReceiverMethod) {
+    if (
+      !sharedPostClosureCallRoot &&
+      !patternOwnedReceiverMethod &&
+      !isCellReadCallRootExpression(expression, context)
+    ) {
       if (!isPostClosureWrapperRewriteExpression(expression, context)) {
         return { kind: "skip", reason: "not-lowerable" };
       }

--- a/packages/ts-transformers/src/transformers/expression-site-policy.ts
+++ b/packages/ts-transformers/src/transformers/expression-site-policy.ts
@@ -335,9 +335,10 @@ function isSharedPostClosureCallRootKind(
  * lift for the value to stay reactive. `classifyCallRootPolicy` reports the read
  * as `restricted-get-call` and declines to classify a call over one, leaving
  * both shapes without a supported call root; the JSX router admits them anyway
- * as owned `jsx-root` sites. This is the same admission for the other container
- * kinds, so a binding, a return, an argument, or an object property holding a
- * cell read lowers into the lift its JSX spelling already gets.
+ * (a bare read as an owned `jsx-root` site, a call over one as a shared
+ * post-closure site). This is the same admission for the other container kinds,
+ * so a binding, a return, an argument, or an object property holding a cell read
+ * lowers into the lift its JSX spelling already gets.
  *
  * Receivers that are not cells are excluded by {@link isCellReadTerminalCall}:
  * a `.get()` on an opaque value is a mistake with its own diagnostic, not a
@@ -347,11 +348,11 @@ function isCellReadCallRootExpression(
   expression: ts.Expression,
   context: TransformationContext,
 ): boolean {
-  if (!ts.isCallExpression(expression)) {
+  let current: ts.Expression = unwrapExpression(expression);
+  if (!ts.isCallExpression(current)) {
     return false;
   }
 
-  let current: ts.Expression = expression;
   while (true) {
     if (ts.isCallExpression(current)) {
       if (isCellReadTerminalCall(current, context)) {
@@ -1246,10 +1247,12 @@ export function classifyExpressionSiteHandling(
       "pattern-owned-receiver-method";
     if (
       !sharedPostClosureCallRoot &&
-      !patternOwnedReceiverMethod &&
-      !isCellReadCallRootExpression(expression, context)
+      !patternOwnedReceiverMethod
     ) {
-      if (!isPostClosureWrapperRewriteExpression(expression, context)) {
+      if (
+        !isPostClosureWrapperRewriteExpression(expression, context) &&
+        !isCellReadCallRootExpression(expression, context)
+      ) {
         return { kind: "skip", reason: "not-lowerable" };
       }
 

--- a/packages/ts-transformers/src/transformers/pattern-context-validation.ts
+++ b/packages/ts-transformers/src/transformers/pattern-context-validation.ts
@@ -28,7 +28,9 @@
  *   - optional property/element access is allowed in supported lowerable
  *     expression sites
  *   - non-lowerable optional access still errors
- * - Calling .get() on cells: ERROR (must wrap in computed())
+ * - Calling .get() on a cell with no lowerable expression site to carry the
+ *   read: ERROR (must wrap in computed()); a read at a lowerable site is
+ *   auto-wrapped into a lift instead
  * - Function creation in pattern context: ERROR (move to module scope)
  * - lift()/handler() inside pattern: ERROR (move to module scope)
  * - Local computed()/lift() aliases used as plain values in the same
@@ -260,17 +262,21 @@ export class PatternContextValidationTransformer
           unsupportedCallRoot === "restricted-get-call" &&
           !findLowerableExpressionSite(node, context, analyze)
         ) {
-          // A bare terminal `.get()` (no enclosing lowerable expression site)
-          // can't be auto-wrapped, so it stays an error. But a `.get()` that
-          // feeds a computation at a lowerable site (variable initializer, JSX,
-          // return, …) is auto-wrapped into a lift by the rewriter — so don't
-          // reject it here.
+          // A cell read needs a lowerable expression site to carry it: the
+          // rewriter turns that site into a lift, which is what keeps the read
+          // live. A read with no such site — statement position, or inside an
+          // array-method callback — has nothing to lower into, so it errors.
+          // A read that does have one (variable initializer, JSX, return, …)
+          // is auto-wrapped, so don't reject it here.
           context.reportDiagnostic({
             severity: "error",
             type: "pattern-context:get-call",
             message:
-              `Calling .get() on a cell is not allowed in reactive context. ` +
-              `Wrap the computation in computed(() => myCell.get()) instead.`,
+              `This .get() read has no expression site that can carry it, so ` +
+              `it cannot be lowered into a lift and would freeze to a ` +
+              `one-time snapshot. Move it into computed(() => myCell.get()), ` +
+              `or read it at a site that lowers — a binding, a return, an ` +
+              `object property, or a JSX expression.`,
             node,
           });
         }

--- a/packages/ts-transformers/test/fixtures/schema-transform/cell-get-binding-autowrap.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/cell-get-binding-autowrap.expected.jsx
@@ -26,14 +26,14 @@ const __cfLift_1 = __cfHelpers.lift<{
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: cell-get-binding-autowrap
-// Verifies: a bare `cell.get()` that feeds a computation at a variable-initializer
-//   binding is auto-wrapped into a lift, the same way it is in a JSX expression.
-//   Previously the validator rejected top-level cell .get() with
-//   `pattern-context:get-call`; that restriction was legacy (the rewriter already
-//   lowers the computation). A bare *terminal* `cell.get()` (no enclosing
-//   computation) is still rejected elsewhere, since it has no lowerable site.
-// Context: enabled migrating `cell.get()`-wrapped reads to drop the wrapper and
-//   write a plain expression even when the input is a Writable/Cell.
+// Verifies: a `cell.get()` that feeds a chained computation at a
+//   variable-initializer binding is auto-wrapped into a lift, the same way it is
+//   in a JSX expression. A read with no lowerable container site at all — a bare
+//   `cell.get();` statement — is still rejected with `pattern-context:get-call`.
+// Context: lets an author drop a `computed()` wrapper and write the plain
+//   expression even when the input is a Writable/Cell. The terminal-read
+//   spellings of the same binding are covered by
+//   `cell-get-terminal-binding-autowrap`.
 export default pattern((__cf_pattern_input) => {
     const layout = __cf_pattern_input.key("layout");
     const len = __cfLift_1({ layout: layout }).for("len", true);

--- a/packages/ts-transformers/test/fixtures/schema-transform/cell-get-binding-autowrap.input.tsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/cell-get-binding-autowrap.input.tsx
@@ -1,14 +1,14 @@
 import { pattern, Writable } from "commonfabric";
 
 // FIXTURE: cell-get-binding-autowrap
-// Verifies: a bare `cell.get()` that feeds a computation at a variable-initializer
-//   binding is auto-wrapped into a lift, the same way it is in a JSX expression.
-//   Previously the validator rejected top-level cell .get() with
-//   `pattern-context:get-call`; that restriction was legacy (the rewriter already
-//   lowers the computation). A bare *terminal* `cell.get()` (no enclosing
-//   computation) is still rejected elsewhere, since it has no lowerable site.
-// Context: enabled migrating `cell.get()`-wrapped reads to drop the wrapper and
-//   write a plain expression even when the input is a Writable/Cell.
+// Verifies: a `cell.get()` that feeds a chained computation at a
+//   variable-initializer binding is auto-wrapped into a lift, the same way it is
+//   in a JSX expression. A read with no lowerable container site at all — a bare
+//   `cell.get();` statement — is still rejected with `pattern-context:get-call`.
+// Context: lets an author drop a `computed()` wrapper and write the plain
+//   expression even when the input is a Writable/Cell. The terminal-read
+//   spellings of the same binding are covered by
+//   `cell-get-terminal-binding-autowrap`.
 export default pattern<{
   layout: Writable<string>;
 }>(({ layout }) => {

--- a/packages/ts-transformers/test/fixtures/schema-transform/cell-get-terminal-binding-autowrap.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/cell-get-terminal-binding-autowrap.expected.jsx
@@ -1,0 +1,363 @@
+function __cfHardenFn(fn: Function) {
+    Object.freeze(fn);
+    const prototype = fn.prototype;
+    if (prototype && typeof prototype === "object") {
+        Object.freeze(prototype);
+    }
+    return fn;
+}
+import { __cfHelpers } from "commonfabric";
+import { pattern, Writable } from "commonfabric";
+const define = undefined;
+const runtimeDeps = undefined;
+const __cfAmdHooks = undefined;
+interface Row {
+    sentAt: number;
+    body: string;
+}
+const __cfLift_1 = __cfHelpers.lift<{
+    rows: __cfHelpers.Writable<Row[]>;
+}, number>(({ rows }) => rows.get().length, {
+    type: "object",
+    properties: {
+        rows: {
+            type: "array",
+            items: {
+                type: "unknown"
+            },
+            asCell: ["readonly"]
+        }
+    },
+    required: ["rows"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "number"
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_2 = __cfHelpers.lift<{
+    rows: __cfHelpers.Writable<Row[]>;
+}, readonly Row[]>(({ rows }) => rows.get(), {
+    type: "object",
+    properties: {
+        rows: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/Row"
+            },
+            asCell: ["readonly"]
+        }
+    },
+    required: ["rows"],
+    $defs: {
+        Row: {
+            type: "object",
+            properties: {
+                sentAt: {
+                    type: "number"
+                },
+                body: {
+                    type: "string"
+                }
+            },
+            required: ["sentAt", "body"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "array",
+    items: {
+        $ref: "#/$defs/Row"
+    },
+    $defs: {
+        Row: {
+            type: "object",
+            properties: {
+                sentAt: {
+                    type: "number"
+                },
+                body: {
+                    type: "string"
+                }
+            },
+            required: ["sentAt", "body"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_3 = __cfHelpers.lift<{
+    rows: __cfHelpers.Writable<Row[]>;
+}, Row | undefined>(({ rows }) => rows.get()[0], {
+    type: "object",
+    properties: {
+        rows: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/Row"
+            },
+            asCell: ["readonly"]
+        }
+    },
+    required: ["rows"],
+    $defs: {
+        Row: {
+            type: "object",
+            properties: {
+                sentAt: {
+                    type: "number"
+                },
+                body: {
+                    type: "string"
+                }
+            },
+            required: ["sentAt", "body"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            type: "undefined"
+        }, {
+            $ref: "#/$defs/Row"
+        }],
+    $defs: {
+        Row: {
+            type: "object",
+            properties: {
+                sentAt: {
+                    type: "number"
+                },
+                body: {
+                    type: "string"
+                }
+            },
+            required: ["sentAt", "body"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_4 = __cfHelpers.lift<{
+    rows: __cfHelpers.Writable<Row[]>;
+}, string>(({ rows }) => rows.get().join(","), {
+    type: "object",
+    properties: {
+        rows: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/Row"
+            },
+            asCell: ["readonly"]
+        }
+    },
+    required: ["rows"],
+    $defs: {
+        Row: {
+            type: "object",
+            properties: {
+                sentAt: {
+                    type: "number"
+                },
+                body: {
+                    type: "string"
+                }
+            },
+            required: ["sentAt", "body"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "string"
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_5 = __cfHelpers.lift<{
+    rows: __cfHelpers.Writable<Row[]>;
+}, readonly Row[]>(({ rows }) => rows.get(), {
+    type: "object",
+    properties: {
+        rows: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/Row"
+            },
+            asCell: ["readonly"]
+        }
+    },
+    required: ["rows"],
+    $defs: {
+        Row: {
+            type: "object",
+            properties: {
+                sentAt: {
+                    type: "number"
+                },
+                body: {
+                    type: "string"
+                }
+            },
+            required: ["sentAt", "body"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "array",
+    items: {
+        $ref: "#/$defs/Row"
+    },
+    $defs: {
+        Row: {
+            type: "object",
+            properties: {
+                sentAt: {
+                    type: "number"
+                },
+                body: {
+                    type: "string"
+                }
+            },
+            required: ["sentAt", "body"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_6 = __cfHelpers.lift<{
+    row: {
+        sentAt: number;
+    };
+}, boolean>(({ row }) => row.sentAt > 0, {
+    type: "object",
+    properties: {
+        row: {
+            type: "object",
+            properties: {
+                sentAt: {
+                    type: "number"
+                }
+            },
+            required: ["sentAt"]
+        }
+    },
+    required: ["row"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const row = __cf_pattern_input.key("element");
+    return __cfLift_6({ row: {
+            sentAt: row.key("sentAt")
+        } }).for("__patternResult", true);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Row"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Row: {
+            type: "object",
+            properties: {
+                sentAt: {
+                    type: "number"
+                },
+                body: {
+                    type: "string"
+                }
+            },
+            required: ["sentAt", "body"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema);
+// FIXTURE: cell-get-terminal-binding-autowrap
+// Verifies: a cell read at a variable-initializer binding is auto-wrapped into a
+//   lift whether or not a computation sits on top of it — a bare `rows.get()`,
+//   an element access, a value-returning method call, and an array method taking
+//   a callback all lower the same way. Each lift's input schema shrinks to what
+//   its body actually reads: `.length` needs no element shape and gets
+//   `items: { type: "unknown" }`, while the reads that hand the elements onward
+//   carry the full `Row`.
+// Context: `.filter` over the read array lowers through `filterWithPattern`, so
+//   the element schema of its own lift shrinks to the `sentAt` the callback
+//   reads.
+export default pattern((__cf_pattern_input) => {
+    const rows = __cf_pattern_input.key("rows");
+    const count = __cfLift_1({ rows: rows }).for("count", true);
+    const all = __cfLift_2({ rows: rows }).for("all", true);
+    const first = __cfLift_3({ rows: rows }).for("first", true);
+    const joined = __cfLift_4({ rows: rows }).for("joined", true);
+    const recent = __cfLift_5({ rows: rows }).filterWithPattern(__cfPattern_1, {}).for("recent", true);
+    return { count, all, first, joined, recent };
+}, {
+    type: "object",
+    properties: {
+        rows: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/Row"
+            },
+            asCell: ["cell"]
+        }
+    },
+    required: ["rows"],
+    $defs: {
+        Row: {
+            type: "object",
+            properties: {
+                sentAt: {
+                    type: "number"
+                },
+                body: {
+                    type: "string"
+                }
+            },
+            required: ["sentAt", "body"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        count: {
+            type: "number"
+        },
+        all: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/Row"
+            }
+        },
+        first: {
+            anyOf: [{
+                    type: "undefined"
+                }, {
+                    $ref: "#/$defs/Row"
+                }]
+        },
+        joined: {
+            type: "string"
+        },
+        recent: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/Row"
+            }
+        }
+    },
+    required: ["count", "all", "first", "joined", "recent"],
+    $defs: {
+        Row: {
+            type: "object",
+            properties: {
+                sentAt: {
+                    type: "number"
+                },
+                body: {
+                    type: "string"
+                }
+            },
+            required: ["sentAt", "body"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+// @ts-ignore: Internals
+function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
+__cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3,
+    __cfLift_4,
+    __cfLift_5,
+    __cfLift_6,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/schema-transform/cell-get-terminal-binding-autowrap.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/cell-get-terminal-binding-autowrap.expected.jsx
@@ -259,6 +259,23 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_7 = __cfHelpers.lift<{
+    label?: __cfHelpers.Writable<string> | undefined;
+}, string | undefined>(({ label }) => label?.get(), {
+    type: "object",
+    properties: {
+        label: {
+            anyOf: [{
+                    type: "string"
+                }, {
+                    type: "undefined"
+                }],
+            asCell: ["readonly"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: ["string", "undefined"]
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: cell-get-terminal-binding-autowrap
 // Verifies: a cell read at a variable-initializer binding is auto-wrapped into a
 //   lift whether or not a computation sits on top of it — a bare `rows.get()`,
@@ -269,15 +286,19 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 //   carry the full `Row`.
 // Context: `.filter` over the read array lowers through `filterWithPattern`, so
 //   the element schema of its own lift shrinks to the `sentAt` the callback
-//   reads.
+//   reads. `label` pins the optional spelling: optionality rides through the
+//   lift rather than blocking the site, so the input schema carries `label` as
+//   an unrequired `anyOf` and the result widens to include `undefined`.
 export default pattern((__cf_pattern_input) => {
     const rows = __cf_pattern_input.key("rows");
+    const label = __cf_pattern_input.key("label");
     const count = __cfLift_1({ rows: rows }).for("count", true);
     const all = __cfLift_2({ rows: rows }).for("all", true);
     const first = __cfLift_3({ rows: rows }).for("first", true);
     const joined = __cfLift_4({ rows: rows }).for("joined", true);
     const recent = __cfLift_5({ rows: rows }).filterWithPattern(__cfPattern_1, {}).for("recent", true);
-    return { count, all, first, joined, recent };
+    const optional = __cfLift_7({ label: label }).for("optional", true);
+    return { count, all, first, joined, recent, optional };
 }, {
     type: "object",
     properties: {
@@ -286,6 +307,10 @@ export default pattern((__cf_pattern_input) => {
             items: {
                 $ref: "#/$defs/Row"
             },
+            asCell: ["cell"]
+        },
+        label: {
+            type: "string",
             asCell: ["cell"]
         }
     },
@@ -331,9 +356,12 @@ export default pattern((__cf_pattern_input) => {
             items: {
                 $ref: "#/$defs/Row"
             }
+        },
+        optional: {
+            type: ["string", "undefined"]
         }
     },
-    required: ["count", "all", "first", "joined", "recent"],
+    required: ["count", "all", "first", "joined", "recent", "optional"],
     $defs: {
         Row: {
             type: "object",
@@ -359,5 +387,6 @@ __cfReg({
     __cfLift_4,
     __cfLift_5,
     __cfLift_6,
-    __cfPattern_1
+    __cfPattern_1,
+    __cfLift_7
 });

--- a/packages/ts-transformers/test/fixtures/schema-transform/cell-get-terminal-binding-autowrap.input.tsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/cell-get-terminal-binding-autowrap.input.tsx
@@ -1,0 +1,26 @@
+import { pattern, Writable } from "commonfabric";
+
+interface Row {
+  sentAt: number;
+  body: string;
+}
+
+// FIXTURE: cell-get-terminal-binding-autowrap
+// Verifies: a cell read at a variable-initializer binding is auto-wrapped into a
+//   lift whether or not a computation sits on top of it — a bare `rows.get()`,
+//   an element access, a value-returning method call, and an array method taking
+//   a callback all lower the same way. Each lift's input schema shrinks to what
+//   its body actually reads: `.length` needs no element shape and gets
+//   `items: { type: "unknown" }`, while the reads that hand the elements onward
+//   carry the full `Row`.
+// Context: `.filter` over the read array lowers through `filterWithPattern`, so
+//   the element schema of its own lift shrinks to the `sentAt` the callback
+//   reads.
+export default pattern<{ rows: Writable<Row[]> }>(({ rows }) => {
+  const count = rows.get().length;
+  const all = rows.get();
+  const first = rows.get()[0];
+  const joined = rows.get().join(",");
+  const recent = rows.get().filter((row) => row.sentAt > 0);
+  return { count, all, first, joined, recent };
+});

--- a/packages/ts-transformers/test/fixtures/schema-transform/cell-get-terminal-binding-autowrap.input.tsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/cell-get-terminal-binding-autowrap.input.tsx
@@ -15,12 +15,17 @@ interface Row {
 //   carry the full `Row`.
 // Context: `.filter` over the read array lowers through `filterWithPattern`, so
 //   the element schema of its own lift shrinks to the `sentAt` the callback
-//   reads.
-export default pattern<{ rows: Writable<Row[]> }>(({ rows }) => {
+//   reads. `label` pins the optional spelling: optionality rides through the
+//   lift rather than blocking the site, so the input schema carries `label` as
+//   an unrequired `anyOf` and the result widens to include `undefined`.
+export default pattern<{ rows: Writable<Row[]>; label?: Writable<string> }>((
+  { rows, label },
+) => {
   const count = rows.get().length;
   const all = rows.get();
   const first = rows.get()[0];
   const joined = rows.get().join(",");
   const recent = rows.get().filter((row) => row.sentAt > 0);
-  return { count, all, first, joined, recent };
+  const optional = label?.get();
+  return { count, all, first, joined, recent, optional };
 });

--- a/packages/ts-transformers/test/validation.test.ts
+++ b/packages/ts-transformers/test/validation.test.ts
@@ -3264,6 +3264,115 @@ Deno.test("Reactive .get() Validation", async (t) => {
   );
 
   await t.step(
+    "allows the computed-key spelling inside an authored ifElse branch",
+    async () => {
+      const source =
+        `      import { ifElse, pattern, Writable } from "commonfabric";
+
+      export default pattern<{ layout: Writable<string>; show: boolean }>((
+        { layout, show },
+      ) => {
+        return { value: ifElse(show, layout["get"](), "fallback") };
+      });
+    `;
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const errors = getErrors(diagnostics);
+      assertEquals(
+        errors.length,
+        0,
+        "the helper boundary and the binding site share one cell-read predicate",
+      );
+    },
+  );
+
+  await t.step(
+    "allows the optional spellings of a .get() on a Writable (auto-wrapped)",
+    async () => {
+      const source = `      import { pattern, Writable } from "commonfabric";
+
+      export default pattern<{ layout?: Writable<string> }>(({ layout }) => {
+        const optionalReceiver = layout?.get();
+        const optionalInvocation = layout?.get?.();
+        return { optionalReceiver, optionalInvocation };
+      });
+    `;
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const errors = getErrors(diagnostics);
+      assertEquals(
+        errors.length,
+        0,
+        "optionality does not change whether the read has a lowerable site",
+      );
+    },
+  );
+
+  await t.step(
+    "errors on a .get() inside a reactive array-method callback",
+    async () => {
+      const source = `      import { pattern, Writable } from "commonfabric";
+
+      export default pattern<{ rows: { title: Writable<string> }[] }>((
+        { rows },
+      ) => {
+        const titles = rows.map((row) => row.title.get());
+        return { titles };
+      });
+    `;
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const errors = getErrors(diagnostics);
+      assertGreater(errors.length, 0, "Expected at least one error");
+      assertHasErrorType(errors, "pattern-context:get-call");
+    },
+  );
+
+  await t.step(
+    "errors on a .get() inside a plain array-method callback",
+    async () => {
+      const source = `      import { pattern, Writable } from "commonfabric";
+
+      export default pattern<{ rows: Writable<string[]> }>(({ rows }) => {
+        const joined = ["-", "+"].map((sep) => rows.get().join(sep));
+        return { joined };
+      });
+    `;
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const errors = getErrors(diagnostics);
+      assertGreater(errors.length, 0, "Expected at least one error");
+      assertHasErrorType(errors, "pattern-context:get-call");
+    },
+  );
+
+  await t.step(
+    "allows a parenthesized method call over a .get() binding",
+    async () => {
+      const source = `      import { pattern, Writable } from "commonfabric";
+
+      export default pattern<{ rows: Writable<string[]> }>(({ rows }) => {
+        const joined = (rows.get().join(","));
+        return { joined };
+      });
+    `;
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const errors = getErrors(diagnostics);
+      assertEquals(
+        errors.length,
+        0,
+        "parentheses do not change whether the read has a lowerable site",
+      );
+    },
+  );
+
+  await t.step(
     "still errors on an opaque .get() binding",
     async () => {
       const source = `      import { pattern } from "commonfabric";

--- a/packages/ts-transformers/test/validation.test.ts
+++ b/packages/ts-transformers/test/validation.test.ts
@@ -3242,6 +3242,28 @@ Deno.test("Reactive .get() Validation", async (t) => {
   );
 
   await t.step(
+    "allows the computed-key spelling of a .get() binding (auto-wrapped)",
+    async () => {
+      const source = `      import { pattern, Writable } from "commonfabric";
+
+      export default pattern<{ layout: Writable<string> }>(({ layout }) => {
+        const value = layout["get"]();
+        return { value };
+      });
+    `;
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const errors = getErrors(diagnostics);
+      assertEquals(
+        errors.length,
+        0,
+        "layout['get']() is the same read as layout.get()",
+      );
+    },
+  );
+
+  await t.step(
     "still errors on an opaque .get() binding",
     async () => {
       const source = `      import { pattern } from "commonfabric";

--- a/packages/ts-transformers/test/validation.test.ts
+++ b/packages/ts-transformers/test/validation.test.ts
@@ -3179,7 +3179,7 @@ Deno.test("Reactive .get() Validation", async (t) => {
   );
 
   await t.step(
-    "errors on top-level .get() on Writable path in pattern body",
+    "allows top-level .get() on Writable path in pattern body (auto-wrapped)",
     async () => {
       const source = `      import { pattern, Writable } from "commonfabric";
 
@@ -3191,8 +3191,96 @@ Deno.test("Reactive .get() Validation", async (t) => {
         types: COMMONFABRIC_TYPES,
       });
       const errors = getErrors(diagnostics);
+      assertEquals(
+        errors.length,
+        0,
+        "return-site .get() is auto-wrapped, not an error",
+      );
+    },
+  );
+
+  await t.step(
+    "errors on statement-position .get() on a Writable",
+    async () => {
+      const source = `      import { pattern, Writable } from "commonfabric";
+
+      export default pattern<{ count: Writable<number> }>(({ count }) => {
+        count.get();
+        return {};
+      });
+    `;
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const errors = getErrors(diagnostics);
       assertGreater(errors.length, 0, "Expected at least one error");
       assertHasErrorType(errors, "pattern-context:get-call");
+    },
+  );
+
+  await t.step(
+    "allows a bare .get() binding on a Writable (auto-wrapped)",
+    async () => {
+      const source = `      import { pattern, Writable } from "commonfabric";
+
+      export default pattern<{ rows: Writable<string[]> }>(({ rows }) => {
+        const all = rows.get();
+        const first = rows.get()[0];
+        return { all, first };
+      });
+    `;
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const errors = getErrors(diagnostics);
+      assertEquals(
+        errors.length,
+        0,
+        "binding-site .get() with no further computation is auto-wrapped",
+      );
+    },
+  );
+
+  await t.step(
+    "still errors on an opaque .get() binding",
+    async () => {
+      const source = `      import { pattern } from "commonfabric";
+
+      export default pattern<{ items: string[] }>(({ items }) => {
+        const all = items.get();
+        return { all };
+      });
+    `;
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const errors = getErrors(diagnostics);
+      assertGreater(errors.length, 0, "Expected at least one error");
+      assertHasErrorType(errors, "opaque-get:invalid-call");
+      assertHasErrorType(errors, "pattern-context:get-call");
+    },
+  );
+
+  await t.step(
+    "allows a method call over a .get() binding on a Writable (auto-wrapped)",
+    async () => {
+      const source = `      import { pattern, Writable } from "commonfabric";
+
+      export default pattern<{ rows: Writable<string[]> }>(({ rows }) => {
+        const joined = rows.get().join(",");
+        const kept = rows.get().filter((row) => row.length > 0);
+        return { joined, kept };
+      });
+    `;
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const errors = getErrors(diagnostics);
+      assertEquals(
+        errors.length,
+        0,
+        "a method call whose receiver chain reaches a .get() is auto-wrapped",
+      );
     },
   );
 


### PR DESCRIPTION
## Problem

`pattern-context:get-call` rejected several pattern-scope `.get()` forms that are plainly lowerable, forcing authors into needless `computed()` wrappers.

The split was not terminal-vs-computation-feeding, as the diagnostic's comment claimed — it was **the shape of the enclosing expression**. `classifyExpressionSiteHandling`'s non-JSX tail admits a site only for a supported call root or an `isPostClosureWrapperRewriteExpression` (property access, element access, template, unary `!`, binary). A *call* is neither: `classifyCallRootPolicy` reports `cell.get()` itself as `restricted-get-call`, and bails to `none` for a call over one (`hasOpaquePathTerminalReceiverChain`).

Meanwhile the JSX router has always admitted both shapes explicitly as owned `jsx-root` sites. So at a variable initializer:

```tsx
const a = input.rows.get().length;                        // lowered
const e = input.rows.get()[0];                            // lowered
const c = input.s.get();                                  // rejected
const g = input.rows.get().join(",");                     // rejected
const h = input.rows.get().filter((r) => r.sentAt > 0);   // rejected
const j = input.rows.get().toSorted(byDate);              // rejected
```

…while `{input.s.get()}` in JSX lowered fine.

## Fix

`isCellReadTerminalCall()` is extracted in `call-root-support.ts` — the "is this `.get()` on a real `Cell`/`Writable`/`Stream`" test the helper-owned branch already did inline. The non-JSX tail of `classifyExpressionSiteHandling` now also admits a call site whose receiver chain reaches one, giving the other container kinds the same admission JSX already had.

The diagnostic keeps its purpose. Still rejected:

- a read with no lowerable site at all — statement position (`count.get();`)
- a read inside a reactive array-method callback (`rows.map((r) => r.c.get())`)
- a read on a non-cell receiver (`items.get()` on a plain pattern input), which also draws `opaque-get:invalid-call`

## Schemas

Each lift's input schema still shrinks to what its body reads — `.length` takes `items: { type: "unknown" }`, the reads that hand elements onward carry the full element type, and `.filter` lowers through `filterWithPattern` with its own callback lift shrunk to the one field the predicate reads. No fallback `items: true` anywhere. Pinned by the new `cell-get-terminal-binding-autowrap` golden.

## Verification

- Full `packages/ts-transformers` suite green
- Goldens for previously-accepted code are **byte-identical** (diffed before/after), so this only adds acceptance
- All 423 pattern files still pass `deno task cfcheck`
- A scratch pattern test confirmed the emitted lifts evaluate correctly and reactively at runtime (bare `.get()`, `.map(cb).join(",")`, `.filter(cb)`)
- `deno fmt --check`, `deno lint`, `deno task check`, `check-docs`, `check-skill-facts`, `check-no-waitfor`, `check-conflict-markers`, `check-baselines-append-only`, `check-single-copy-deps`, `check-unused-deps`, `check-deno-pins` all pass

## Specs

Behavior change, so all three records are updated: current-behavior §6.5, design-deltas Addendum 2, and the target-language §5.7 nuance paragraph. The normative matrix rows are left alone — that row is already an open ratification decision recorded in design-deltas, and widening the delta is not the same as ratifying it.

## Note on the motivating case

Of the `packages/patterns/topics/topic.tsx` wrappers this came from, only `linksView` unwraps cleanly. `commentsView` still fails — not on `pattern-context:get-call` but on `pattern-context:optional-chaining`, for `a?.sentAt` / `b?.sentAt` in the `.toSorted` comparator. That comparator ends up as plain JS inside the lift body, so the rejection looks equally over-broad, but it is a different diagnostic with its own blast radius. Left for a follow-up; topics is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

