### PR TITLE
feat(dashboard): report benchmark outages and hand reruns to GitHub

### DIFF
--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -576,7 +576,21 @@ Notes:
   benchmarks the latest run measured and the highlighted window when applicable.
   **Red** marks the **most recent run failing outright, or finishing green on CI
   with no readable benchmark data**. A successful run with no usable output is
-  treated as failed. This
+  treated as failed. Either failure takes over that second line, in place of the
+  count and the window. A run that failed outright dates the outage and counts
+  it: **last good 2 days ago · 12 runs failed**. The count reads back through
+  the newest-first run list. It stops at the first completed run that did not
+  fail, so a cancelled run ends it. The date comes from the newest run that
+  passed, including one that passed on a later attempt, and it is read from the
+  run list the collection paged rather than from the trend's 45-day window. That
+  list runs to the end of the first page past 45 days, so an older outage is
+  dated whenever the run that ended it is still on the last page fetched. With
+  no passing run anywhere on the list there is nothing to date the outage from,
+  and the line is the count alone: **last 12 runs failed**. A run that finished green
+  with nothing readable reads **no benchmark data**. A **running** badge sits in
+  the header while a run is under way, wherever in the list it sits — a rerun
+  keeps its original place instead of moving to the head. The badge says the
+  colour may be about to move; the runs that have finished still set it. The red
   state reads the workflow-run list and the latest run's cached result. It
   therefore fires when the artifacts cannot be read. **Orange** means at least
   one CPU index is **trending up** past 5%. Each CPU trend uses the runs in the
@@ -620,6 +634,12 @@ Notes:
   days in the window the trend is marked new: there is too little data to claim one.
   The window is capped by the 90-day artifact retention, so it shows at most ~45
   days and only as far back as the job has run.
+  - The tile collects every minute, which is what the run state needs: a
+    benchmark run lasts about an hour, so a slower collection could miss one from
+    start to finish and never show its **running** badge. Each collection pages
+    the run list. The artifact history behind it is left alone while the last
+    refresh is recent and already covers the runs that list names — nothing new
+    has been sampled, so there is nothing to download.
   - The tile drills through to the per-benchmark history behind `/bench`, which the
     tile's collection keeps warm in the background. The collection lists
     benchmark runs on main. It samples one run per shortest-view bucket,
@@ -662,7 +682,13 @@ Notes:
     Idle between
     collections. During collection it shows cached, queued, requested,
     responded, outstanding, and failed artifact checks. Changing the range
-    leaves the server collection running and joins it from the new page.
+    leaves the server collection running and joins it from the new page. The
+    page closes with a **rerun hand-off**: a link to GitHub, where the run is
+    started. It targets the newest completed run when that run failed, whose
+    **Re-run all jobs** repeats it, and the workflow otherwise, whose **Run
+    workflow** starts a fresh run. The dashboard's GitHub token is read-only, so
+    the board cannot start a run itself, and GitHub decides whether the viewer
+    may start one.
   - The **CI duration history** view at `/bench?view=ci` selects either labs
     `deno.yml` or loom `test-fast.yml`. It charts every job's start-to-finish
     duration on one calendar-time axis. An overall row measures the workflow

--- a/packages/dashboard/render.ts
+++ b/packages/dashboard/render.ts
@@ -170,6 +170,9 @@ ${faviconLink(status)}
   .big.good{color:#62d18d}.big.warn{color:#f0b968}.big.bad{color:#f0726c}.big.unknown{color:#9aa0ab}
   .sub{font-size:13px;color:#9aa0ab;margin:5px 0 0}
   .running{display:inline-flex;align-items:center;gap:5px;font-size:10px;color:#8a93a5;letter-spacing:.02em;text-transform:none;margin-top:10px}
+  /* In the header the badge is a facet of a single line, not a block under the
+     chart, so it takes the line's own vertical rhythm. */
+  .lbl .running{margin-top:0;margin-right:8px}
   .rdot{width:7px;height:7px;border-radius:50%;background:#6ea8fe;flex:none}
   .cells{display:grid;gap:1px;margin-top:10px}
   .cell{aspect-ratio:1;border-radius:1px}

--- a/packages/dashboard/tiles/benchmark.test.ts
+++ b/packages/dashboard/tiles/benchmark.test.ts
@@ -10,6 +10,7 @@
 import {
   assert,
   assertEquals,
+  assertMatch,
   assertStringIncludes,
   assertThrows,
 } from "@std/assert";
@@ -21,7 +22,9 @@ import {
   benchmark,
   type BenchmarkFetchProgress,
   benchmarkHistoryCheckResponse,
+  benchmarkFailureLabel,
   benchmarkHistoryProgressResponse,
+  benchmarkRerunHandoff,
   benchmarkTrend,
   benchPage,
   formatNs,
@@ -38,6 +41,18 @@ import {
   ciHistoryBucketMs,
 } from "../ci-job-history.ts";
 import { PERFORMANCE_VIEW_STYLES } from "../performance-views.ts";
+
+// The history store falls back to the system temporary directory when no cache
+// directory is named. The package's test runner names a fresh one for each run.
+// Running this file directly gets whatever the last run left behind, which then
+// answers these tests in place of their own fixtures. Name a directory here when
+// nothing else has.
+if (Deno.env.get("DASHBOARD_CACHE_DIR") === undefined) {
+  Deno.env.set(
+    "DASHBOARD_CACHE_DIR",
+    await Deno.makeTempDir({ prefix: "benchmark-test-cache-" }),
+  );
+}
 
 const DAY = 86_400_000;
 const HOUR = 3_600_000;
@@ -357,7 +372,7 @@ Deno.test("benchmark: no token -> gray, and nothing is fetched", async () => {
     assertEquals(v.value, "—");
     assertEquals(v.sub, "set GH_TOKEN");
     assertEquals(v.href, "/bench?view=runtime&repo=labs");
-    assertEquals(v.hint, "all metrics ↗");
+    assertEquals(v.hint, "metrics ↗");
     assertEquals(calls, []);
   });
 });
@@ -921,9 +936,12 @@ Deno.test("benchmark: paging stops at the 45-day cutoff; failures and out-of-win
     // is out of the window, so there is no duration to headline.
     assertEquals(v.status, "bad");
     assertEquals(v.value, "—");
-    assertEquals(v.sub, "last run failed");
+    // Every failure on the page, in a row. The one success is older than the
+    // trend's window, but it is still on the page fetched, so it still dates the
+    // outage the failures make.
+    assertMatch(v.sub ?? "", /^last good \d+ days ago · 99 runs failed$/);
     assertEquals(v.href, "/bench?view=runtime&repo=labs");
-    assertEquals(v.hint, "all metrics ↗");
+    assertEquals(v.hint, "metrics ↗");
     assertEquals(apiCalls(calls).length, 1); // page 2 was never asked for
     assertEquals(artifactCalls(calls), []); // and no artifact was downloaded
   });
@@ -936,7 +954,7 @@ Deno.test("benchmark: an empty page ends the paging", async () => {
   );
   await withApi({ pages: { 1: page1, 2: [] } }, async (calls) => {
     const v = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
-    assertEquals(v.sub, "last run failed"); // every run in the window failed
+    assertEquals(v.sub, "last 100 runs failed"); // every run in the window failed
     // A full page still inside the window is followed; the empty page 2 stops it.
     assertEquals(
       apiCalls(calls).map((c) => c.match(/[?&]page=(\d+)/)![1]),
@@ -1253,8 +1271,238 @@ Deno.test("benchmark: a failed most-recent run turns the tile red over its last 
   ], async () => {
     const v = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
     assertEquals(v.status, "bad"); // the newest run failed
-    assertEquals(v.sub, "last run failed");
+    assertMatch(v.sub ?? "", /^last good .+ ago · 1 run failed$/);
     assertStringIncludes(v.value ?? "", "flat"); // the trend of the runs before the failure
+    assert(!(v.extra ?? "").includes("benchmark")); // the failure took the count line
+  });
+});
+
+Deno.test("benchmark: consecutive failures are counted on the tile", async () => {
+  const at = (d: number) => SAMPLED_BASE - (7 - d) * DAY;
+  // Seven good days, then three failures in a row.
+  await withTotals([
+    ...Array.from({ length: 7 }, (_, d) => ({ id: 9_310 + d, at: at(d), total: 5e6 })),
+    ...Array.from({ length: 3 }, (_, f) => ({
+      id: 9_390 + f,
+      at: SAMPLED_BASE + (f + 1) * HOUR,
+      conclusion: "failure",
+    })),
+  ], async () => {
+    const v = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
+    assertEquals(v.status, "bad"); // red however flat the trend is
+    assertMatch(v.sub ?? "", /^last good .+ ago · 3 runs failed$/);
+    assertStringIncludes(v.value ?? "", "flat"); // the trend over the runs before the failures
+    assert(!(v.extra ?? "").includes("benchmark")); // no count line beside the failure line
+  });
+});
+
+Deno.test("benchmark: a failure outranks a rising trend", async () => {
+  // Eight days whose one benchmark climbs from 5 to 12 ms, which alone reads orange,
+  // and then a failed run.
+  const at = (d: number) => SAMPLED_BASE - (8 - d) * DAY;
+  await withTotals([
+    ...Array.from({ length: 8 }, (_, d) => ({ id: 9_330 + d, at: at(d), total: (5 + d) * 1e6 })),
+    { id: 9_398, at: SAMPLED_BASE + HOUR, conclusion: "failure" },
+  ], async () => {
+    const v = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
+    assertEquals(v.status, "bad"); // red, not the orange the rise would give
+    assertMatch(v.sub ?? "", /^last good .+ ago · 1 run failed$/);
+    assertStringIncludes(v.value ?? "", "▲"); // the rise is still the headline
+  });
+});
+
+Deno.test("benchmark: a cancelled run ends the count of consecutive failures", async () => {
+  const at = (d: number) => SAMPLED_BASE - (7 - d) * DAY;
+  // Two failures with a cancelled run between them: only the newest failure can be
+  // counted, because the cancelled run neither failed nor succeeded.
+  await withTotals([
+    ...Array.from({ length: 7 }, (_, d) => ({ id: 9_320 + d, at: at(d), total: 5e6 })),
+    { id: 9_395, at: SAMPLED_BASE + HOUR, conclusion: "failure" },
+    { id: 9_396, at: SAMPLED_BASE + 2 * HOUR, conclusion: "cancelled" },
+    { id: 9_397, at: SAMPLED_BASE + 3 * HOUR, conclusion: "failure" },
+  ], async () => {
+    const v = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
+    assertEquals(v.status, "bad");
+    assertMatch(v.sub ?? "", /^last good .+ ago · 1 run failed$/);
+  });
+});
+
+Deno.test("benchmark: the failure line dates the outage and counts the failures", () => {
+  const now = BASE + 3 * DAY;
+  const good = ghRun(1, BASE, "success");
+  const failures = [ghRun(3, BASE + 2 * DAY, "failure"), ghRun(2, BASE + DAY, "failure")];
+  assertEquals(
+    benchmarkFailureLabel([...failures, good], now),
+    "last good 3 days ago · 2 runs failed",
+  );
+  assertEquals(
+    benchmarkFailureLabel([ghRun(4, now - HOUR, "failure"), ghRun(5, now - 4 * HOUR, "success")], now),
+    "last good 4 hours ago · 1 run failed",
+  );
+  // Nothing has passed in the window, so there is no outage to date.
+  assertEquals(benchmarkFailureLabel(failures, now), "last 2 runs failed");
+  assertEquals(benchmarkFailureLabel([failures[0]], now), "last run failed");
+  // A cancelled run ends the count but is not a good run to date the outage from.
+  assertEquals(
+    benchmarkFailureLabel([failures[0], ghRun(6, BASE + DAY, "cancelled"), good], now),
+    "last good 3 days ago · 1 run failed",
+  );
+  // A run that passed on a later attempt is still a run that passed.
+  assertEquals(
+    benchmarkFailureLabel([failures[0], ghRun(7, BASE + DAY, "success", 2)], now),
+    "last good 2 days ago · 1 run failed",
+  );
+});
+
+Deno.test("benchmark: a collection reads the run list every time and the artifacts only when a run is new", async () => {
+  // The tile collects every minute to keep up with the run state. The artifact
+  // history behind it moves with the runs, so a collection that finds the same
+  // sampled runs downloads nothing.
+  const directory = await Deno.makeTempDir({ prefix: "benchmark-cadence-" });
+  const previousCacheDirectory = Deno.env.get("DASHBOARD_CACHE_DIR");
+  Deno.env.set("DASHBOARD_CACHE_DIR", directory);
+  const at = (d: number) => SAMPLED_BASE - (7 - d) * DAY;
+  const artifacts: Api["artifacts"] = {};
+  const zips: Api["zips"] = {};
+  const runs: GhRun[] = [];
+  for (let d = 0; d <= 7; d++) {
+    const id = 9_280 + d;
+    runs.push(ghRun(id, at(d)));
+    artifacts[id] = [{ id: id * 10, name: "bench-results", expired: false }];
+    zips[id * 10] = await totalZip(5e6);
+  }
+  const newestFirst = [...runs].reverse();
+  const inFlight = {
+    ...ghRun(9_289, SAMPLED_BASE + HOUR),
+    status: "queued",
+    conclusion: null,
+  };
+  try {
+    const isolated = await import(`./benchmark.ts?cadence=${crypto.randomUUID()}`);
+    await withApi({ pages: { 1: newestFirst }, artifacts, zips }, async (calls) => {
+      await isolated.benchmark.collect(ctx({ GH_TOKEN: "t" }));
+      const firstArtifactReads = artifactCalls(calls).length;
+      const firstListReads = apiCalls(calls).length - firstArtifactReads;
+      assert(firstArtifactReads > 0); // a cold cache reads them
+      assert(firstListReads > 0);
+
+      const second = await isolated.benchmark.collect(ctx({ GH_TOKEN: "t" }));
+      assertEquals(artifactCalls(calls).length, firstArtifactReads); // nothing new to read
+      assert(apiCalls(calls).length - artifactCalls(calls).length > firstListReads);
+      assertEquals(second.aside, undefined); // no run under way
+      assertEquals(second.status, "good");
+    });
+    // A run starts. The next collection sees it from the run list alone.
+    await withApi({ pages: { 1: [inFlight, ...newestFirst] }, artifacts, zips }, async (calls) => {
+      const view = await isolated.benchmark.collect(ctx({ GH_TOKEN: "t" }));
+      assertStringIncludes(view.aside ?? "", "running");
+      assertEquals(artifactCalls(calls), []); // an unfinished run has no artifact
+    });
+  } finally {
+    if (previousCacheDirectory === undefined) {
+      Deno.env.delete("DASHBOARD_CACHE_DIR");
+    } else Deno.env.set("DASHBOARD_CACHE_DIR", previousCacheDirectory);
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("benchmark: a run under way shows on the tile before there is any history", async () => {
+  // Nothing has been collected yet, so the tile has no chart and no verdict. The
+  // run list still says a run is going, and that is worth showing.
+  const directory = await Deno.makeTempDir({ prefix: "benchmark-cold-badge-" });
+  const previousCacheDirectory = Deno.env.get("DASHBOARD_CACHE_DIR");
+  Deno.env.set("DASHBOARD_CACHE_DIR", directory);
+  try {
+    const isolated = await import(`./benchmark.ts?cold-badge=${crypto.randomUUID()}`);
+    const inFlight = {
+      ...ghRun(9_270, BASE),
+      status: "in_progress",
+      conclusion: null,
+    };
+    await withApi({ pages: { 1: [inFlight] } }, async () => {
+      const view = await isolated.benchmark.collect(ctx({ GH_TOKEN: "t" }));
+      assertEquals(view.value, "—"); // no history to headline
+      assertEquals(view.sub, "benchmark data unavailable");
+      assertStringIncludes(view.aside ?? "", "running");
+    });
+  } finally {
+    if (previousCacheDirectory === undefined) {
+      Deno.env.delete("DASHBOARD_CACHE_DIR");
+    } else Deno.env.set("DASHBOARD_CACHE_DIR", previousCacheDirectory);
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("benchmark: the rerun hand-off picks its target from the newest completed run", () => {
+  const workflow = `https://github.com/${REPO}/actions/workflows/benchmarks.yml`;
+  const failed = ghRun(3, BASE, "failure");
+  const inFlight = { ...ghRun(4, BASE + HOUR), status: "in_progress", conclusion: null };
+  assertEquals(benchmarkRerunHandoff(undefined).href, workflow); // no run list yet
+  assertEquals(benchmarkRerunHandoff([]).href, workflow);
+  assertEquals(benchmarkRerunHandoff([ghRun(1, BASE)]).href, workflow);
+  assertEquals(benchmarkRerunHandoff([ghRun(2, BASE, "cancelled")]).href, workflow);
+  assertEquals(benchmarkRerunHandoff([ghRun(5, BASE, "success", 2)]).href, workflow);
+  const handoff = benchmarkRerunHandoff([failed]);
+  assertEquals(handoff.href, `https://github.com/${REPO}/actions/runs/3`);
+  assertStringIncludes(handoff.label, "rerun the failed benchmark run");
+  // A run under way at the head does not hide the failure it sits above.
+  assertEquals(
+    benchmarkRerunHandoff([inFlight, failed]).href,
+    `https://github.com/${REPO}/actions/runs/3`,
+  );
+});
+
+Deno.test("benchmark: the drill-down closes with a rerun hand-off to the failed run", async () => {
+  const at = (d: number) => SAMPLED_BASE - (7 - d) * DAY;
+  await withTotals([
+    ...Array.from({ length: 7 }, (_, d) => ({ id: 9_240 + d, at: at(d), total: 5e6 })),
+    { id: 9_249, at: SAMPLED_BASE + HOUR, conclusion: "failure" },
+  ], async () => {
+    await benchmark.collect(ctx({ GH_TOKEN: "t" }));
+    const html = benchPage("p99", "file", 45, BASE);
+    assertStringIncludes(html, `https://github.com/${REPO}/actions/runs/9249`);
+    assertStringIncludes(html, "rerun the failed benchmark run ↗");
+    assertStringIncludes(html, "does not start runs itself");
+    // The hand-off closes the page, below the charts and the source note.
+    assert(html.indexOf('<p class="handoff">') > html.indexOf('<p class="note">'));
+    assert(html.indexOf('<p class="handoff">') > html.indexOf('class="blist"'));
+    // A later collection that cannot reach GitHub leaves the hand-off naming the
+    // run it knows failed, rather than dropping back to the workflow.
+    await withApi({ status: 500 }, async () => {
+      await benchmark.collect(ctx({ GH_TOKEN: "t" }));
+    });
+    assertStringIncludes(
+      benchPage("p99", "file", 45, BASE),
+      `https://github.com/${REPO}/actions/runs/9249`,
+    );
+  });
+});
+
+Deno.test("benchmark: a run under way is a badge, not a verdict", async () => {
+  const at = (d: number) => SAMPLED_BASE - (7 - d) * DAY;
+  const artifacts: Api["artifacts"] = {};
+  const zips: Api["zips"] = {};
+  const runs: GhRun[] = [];
+  for (let d = 0; d <= 7; d++) {
+    const id = 9_260 + d;
+    runs.push(ghRun(id, at(d)));
+    artifacts[id] = [{ id: id * 10, name: "bench-results", expired: false }];
+    zips[id * 10] = await totalZip(5e6);
+  }
+  const newestFirst = [...runs].reverse();
+  const inFlight = {
+    ...ghRun(9_269, SAMPLED_BASE + HOUR),
+    status: "in_progress",
+    conclusion: null,
+  };
+  await withApi({ pages: { 1: [inFlight, ...newestFirst] }, artifacts, zips }, async () => {
+    const v = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
+    assertStringIncludes(v.aside ?? "", "running");
+    assertEquals(v.status, "good"); // the runs that finished still set the colour
+  });
+  await withApi({ pages: { 1: newestFirst }, artifacts, zips }, async () => {
+    const v = await benchmark.collect(ctx({ GH_TOKEN: "t" }));
+    assertEquals(v.aside, undefined); // nothing under way
   });
 });
 

--- a/packages/dashboard/tiles/benchmark.ts
+++ b/packages/dashboard/tiles/benchmark.ts
@@ -6,7 +6,11 @@
 // Each processor has its own coloured line. The headline shows the largest
 // established trend. Orange means at least one processor trends up. Green means
 // every established processor stays flat or falls. Red means the most recent
-// run failed, or finished successfully without readable benchmark data. Deno
+// run failed, or finished successfully without readable benchmark data. A tile
+// in the failed state drops its benchmark count and window span and names the
+// failure in their place: how long ago the benchmarks last worked, and how many
+// runs have failed since. A run under way puts a "running" badge in the header.
+// Deno
 // bench samples each benchmark to a fixed time budget. Performance changes the
 // per-operation times without materially changing the run's wall-clock time.
 //
@@ -21,9 +25,15 @@
 // unavailable" after an empty fetch. A failed fetch keeps the last-known
 // processor lines gray and names the reason.
 //
-// The /bench drill-down keeps the deeper picture. The benchmarks.yml job runs
-// `deno bench --json` and uploads the output as a `bench-results` artifact with
-// 90-day retention. There is no committed history. The drill-down lists recent
+// Every collection pages the run list, once a minute, which is the cadence the
+// run state needs. The artifact history behind the tile moves with the runs
+// instead: a collection whose sampled runs match the last refresh downloads
+// nothing.
+//
+// The /bench drill-down keeps the deeper picture, and closes with a link that
+// hands a rerun to GitHub: this token reads, so GitHub is where a run starts.
+// The benchmarks.yml job runs `deno bench --json` and uploads the output as a
+// `bench-results` artifact with 90-day retention. There is no committed history. The drill-down lists recent
 // main runs and keeps one artifact per shortest-view time bucket. It unzips
 // each artifact in the process and reads every benchmark's timings and
 // processor identity. Results for a run attempt are immutable and persisted.
@@ -171,27 +181,12 @@ interface BenchmarkSeries {
 }
 
 let snapshot: BenchmarkSeries[] = [];
-// The most recent benchmarks.yml run list fetched by a collection, reused to
-// render the tile's run-duration view. The drill-down's artifact refresh fills it
-// as a side effect of its own paging, so the tile costs no extra request in the
-// common case.
+// The last benchmarks.yml run list a collection paged, which the drill-down reads
+// to name the run its rerun hand-off points at. A collection replaces it only on
+// a fetch that worked, so the hand-off keeps naming the failed run while a later
+// fetch is in flight or has failed. The tile itself reads the list its own
+// collection fetched, never this one.
 let latestBenchmarkRuns: Run[] | undefined;
-
-// Notified with the run list the moment a collection has paged it — before the
-// slower per-run artifact backfill — so the tile can paint its headline early
-// instead of waiting on the drill-down's downloads.
-const benchmarkRunListListeners = new Set<(runs: Run[]) => void>();
-function notifyBenchmarkRunList(runs: Run[]): void {
-  const listeners = [...benchmarkRunListListeners];
-  benchmarkRunListListeners.clear();
-  for (const listener of listeners) {
-    try {
-      listener(runs);
-    } catch {
-      // A listener that throws is simply dropped; the tile still finalizes below.
-    }
-  }
-}
 
 export type BenchmarkFetchPhase =
   | "discovering"
@@ -239,7 +234,6 @@ let benchmarkProgressSequence = 0;
 let benchmarkRefreshedAt = 0;
 let benchmarkRefreshFailedAt = 0;
 let benchmarkRefreshError = "";
-let benchmarkInitialCollection = true;
 const benchmarkProgressById = new Map<string, BenchmarkProgressRecord>();
 
 function benchmarkVersion(value: BenchmarkSeries[]): string {
@@ -459,8 +453,9 @@ async function fetchZip(
 }
 
 // The benchmarks.yml runs on main, newest first, paging back until past the
-// window (or the 12-page ceiling). The job runs on both pushes and a schedule, so
-// this is not filtered by event.
+// window (or the 12-page ceiling). The workflow runs to a four-hourly schedule
+// and on manual dispatch. Both kinds of run land on main, and the list is
+// filtered by branch alone, so it holds either.
 async function pageBenchmarkRuns(
   github: BenchmarkGitHub,
   token: string,
@@ -675,12 +670,13 @@ export function sampleBenchmarkRuns<
 
 const benchmarkDrill = {
   href: "/bench?view=runtime&repo=labs",
-  hint: "all metrics ↗",
+  hint: "metrics ↗",
 };
 
-function benchmarkUnavailable(sub: string): TileView {
+function benchmarkUnavailable(sub: string, aside?: string): TileView {
   return {
     ...benchmarkDrill,
+    aside,
     label: "benchmarks",
     status: "unknown",
     value: "—",
@@ -850,14 +846,102 @@ function benchmarkCpuIndices(
     });
 }
 
+const runIsCompleted = (run: Run): boolean =>
+  run.status === "completed" && run.conclusion !== null;
+
+// Only a genuine failure counts (concDot's red set), so a cancelled or
+// superseded run is not read as one.
+const runFailed = (run: Run): boolean =>
+  concDot(run.conclusion, run.run_attempt ?? 1) === "red";
+
+// The newest completed run, reading the newest-first run list. A run still in
+// flight is passed over until it finishes.
+const latestCompletedRun = (runs: Run[]): Run | undefined =>
+  runs.find(runIsCompleted);
+
+// How many of the most recent runs failed in a row, reading the newest-first run
+// list. Counting stops at the first completed run that did not fail. A run still
+// in flight is passed over. The count covers the runs this collection fetched,
+// so a streak reaching past the window reads as the length of the window.
+function failedRunStreak(runs: Run[]): number {
+  let streak = 0;
+  for (const run of runs) {
+    if (!runIsCompleted(run)) continue;
+    if (!runFailed(run)) break;
+    streak++;
+  }
+  return streak;
+}
+
+// The newest run that passed. A run that passed on a later attempt counts: it
+// ran and it worked.
+const lastSuccessfulRun = (runs: Run[]): Run | undefined =>
+  runs.find((run) => run.conclusion === "success");
+
+// The failed tile's line: how long ago the benchmarks last worked, and how many
+// runs have failed since. The age comes first because it is the size of the
+// outage. Without a passing run to date the outage from — every run in the
+// window failed — the line is the count alone.
+export function benchmarkFailureLabel(runs: Run[], now: number): string {
+  const streak = failedRunStreak(runs);
+  const failures = `${streak} run${streak === 1 ? "" : "s"} failed`;
+  const good = lastSuccessfulRun(runs);
+  if (good === undefined) {
+    return streak > 1 ? `last ${streak} runs failed` : "last run failed";
+  }
+  return `last good ${
+    humanSpan(now - Date.parse(good.created_at))
+  } ago · ${failures}`;
+}
+
+export interface BenchmarkRerunHandoff {
+  href: string;
+  label: string;
+  hint: string;
+}
+
+// Where the drill-down's rerun control sends the viewer. The dashboard reads
+// GitHub with a read-only token, so starting a run is GitHub's own job: the
+// control is a link, and GitHub decides whether the viewer may press the button
+// it lands on. A failed newest run points at that run, whose "Re-run all jobs"
+// repeats it. Anything else points at the workflow, whose "Run workflow" starts
+// a fresh run. Without a run list the workflow is the target, which is one click
+// from the newest run either way.
+export function benchmarkRerunHandoff(
+  runs: Run[] | undefined,
+): BenchmarkRerunHandoff {
+  const latest = latestCompletedRun(runs ?? []);
+  return latest !== undefined && runFailed(latest)
+    ? {
+      href: `https://github.com/${REPO}/actions/runs/${latest.id}`,
+      label: "rerun the failed benchmark run ↗",
+      hint: "Re-run all jobs on GitHub repeats it.",
+    }
+    : {
+      href: `https://github.com/${REPO}/actions/workflows/${WORKFLOW}`,
+      label: "run benchmarks now ↗",
+      hint: "Run workflow on GitHub starts a fresh run.",
+    };
+}
+
+// A run that has not finished, anywhere in the list. A rerun of an older run
+// keeps that run's place in the list rather than moving to the head, so this
+// looks past the newest entries.
+const runInFlight = (runs: Run[]): boolean =>
+  runs.some((run) => run.status !== "completed");
+
+const RUNNING_BADGE =
+  `<span class="running"><span class="rdot"></span>running</span>`;
+
 // The grid tile trends a scale-invariant benchmark index over about 45 days.
 // Each processor has its own index and line. Every index starts at one and
 // changes only between runs on that processor. Hardware changes therefore
 // never become benchmark changes. The headline shows the largest established
 // trend. Orange means any processor trends up. Red means the most recent run
-// failed or produced no readable data. `offline` names a fetch failure. The
-// tile then keeps its last-known trends gray, or shows a gray dash when no
-// history is cached.
+// failed or produced no readable data. The line under the headline then dates
+// the outage instead of counting the benchmarks measured. `offline` names a
+// fetch failure. The tile then keeps its last-known trends gray, or shows a
+// gray dash when no history is cached.
 function benchmarkIndexView(
   runs: Run[],
   now: number,
@@ -865,16 +949,12 @@ function benchmarkIndexView(
   offline?: string,
 ): TileView {
   const cutoff = now - SPARK_DAYS * 86_400_000;
-  // The most recent completed run (the list is newest first) sets the failed
-  // state; an in-flight run at the head is skipped until it finishes. Only a
-  // genuine failure counts (concDot's red set), so a cancelled or superseded run
-  // does not raise a false alarm.
-  const latestCompleted = runs.find((run) =>
-    run.status === "completed" && run.conclusion !== null
-  );
-  const failedCi = latestCompleted !== undefined &&
-    concDot(latestCompleted.conclusion, latestCompleted.run_attempt ?? 1) ===
-      "red";
+  // The most recent completed run sets the failed state.
+  const latestCompleted = latestCompletedRun(runs);
+  const failedCi = latestCompleted !== undefined && runFailed(latestCompleted);
+  // A run under way is a header badge, and leaves the verdict to the runs that
+  // have finished. The badge is what says the tile's colour may be about to move.
+  const aside = runInFlight(runs) ? RUNNING_BADGE : undefined;
   // A run that finished green on CI but whose artifact resolved to no readable
   // benchmark data is as good as failed: it ran and produced nothing usable. Only
   // a cached run with an empty result counts — a run still unread (or read-failed)
@@ -884,7 +964,9 @@ function benchmarkIndexView(
     : undefined;
   const noData = latestResult !== undefined && latestResult.metrics.size === 0;
   const failed = failedCi || noData;
-  const failSub = failedCi ? "last run failed" : "no benchmark data";
+  const failSub = failedCi
+    ? benchmarkFailureLabel(runs, now)
+    : "no benchmark data";
   // The successful runs with processor identities and readable artifacts in the
   // window, oldest -> newest.
   const cached = (benchmarkStore.refreshedRuns() ?? benchmarkStore.list(cutoff))
@@ -895,7 +977,7 @@ function benchmarkIndexView(
   const indices = benchmarkCpuIndices(cached, now);
   if (!indices.length) {
     // A fetch failure with nothing cached to stand on: a gray dash and the reason.
-    if (offline) return benchmarkUnavailable(offline);
+    if (offline) return benchmarkUnavailable(offline, aside);
     if (failed) {
       return {
         ...benchmarkDrill,
@@ -903,14 +985,16 @@ function benchmarkIndexView(
         status: "bad",
         value: "—",
         sub: failSub,
+        aside,
       };
     }
     // No data yet: "collecting…" while a fetch is still in progress (the early paints,
     // including the one before the run list is fetched), "benchmark data unavailable"
     // once a fetch has finished empty, "no benchmark runs" when it found none at all.
-    if (collecting) return benchmarkUnavailable("collecting…");
+    if (collecting) return benchmarkUnavailable("collecting…", aside);
     return benchmarkUnavailable(
       runs.length ? "benchmark data unavailable" : "no benchmark runs",
+      aside,
     );
   }
   const established = indices.filter((series) => series.trend.label !== "new");
@@ -941,8 +1025,11 @@ function benchmarkIndexView(
   const windowLabel = headline.windowCount < headline.points.length
     ? ` · last ${humanSpan(spanMs(headline.windowPoints))}`
     : "";
-  const countLine =
-    `<div style="font-size:13px;color:#9aa0ab;margin:5px 0 0">${count} benchmark${
+  // A failed tile has no count line. Its sub line lands in the same place and in
+  // the same style, and names the failure there.
+  const countLine = failed
+    ? ""
+    : `<div style="font-size:13px;color:#9aa0ab;margin:5px 0 0">${count} benchmark${
       count === 1 ? "" : "s"
     }${windowLabel}</div>`;
   const allPoints = indices.flatMap((series) => series.points);
@@ -969,6 +1056,7 @@ function benchmarkIndexView(
     sub: offline ?? (failed ? failSub : undefined),
     extra: `${countLine}${chart}`,
     duration: chartSpan,
+    aside,
   };
 }
 
@@ -980,15 +1068,17 @@ async function collectBenchmark(
   token: string,
   progress: BenchmarkProgressRecord,
   github: BenchmarkGitHub,
+  // The run list the caller has already paged, when it has one. The tile pages it
+  // for its own headline moments earlier, and one list serves both.
+  knownRuns?: Run[],
 ): Promise<BenchmarkCollectionOutcome> {
   const now = Date.now();
   const cutoff = now - SPARK_DAYS * 86_400_000;
 
   try {
     await benchmarkStore.load();
-    const runs = await pageBenchmarkRuns(github, token, cutoff);
+    const runs = knownRuns ?? await pageBenchmarkRuns(github, token, cutoff);
     latestBenchmarkRuns = runs;
-    notifyBenchmarkRunList(runs);
 
     const chosen = sampleBenchmarkRuns(runs, cutoff);
     const priorRefresh = benchmarkStore.refresh;
@@ -1097,6 +1187,11 @@ function startBenchmarkRefresh(
   baseline?: string,
   snapshotIsFresh = false,
   scope: BenchmarkRefreshScope = "bench",
+  // The caller's own run list, still in flight. Passing it registers this refresh
+  // before the list arrives, so a drill-down request landing meanwhile queues
+  // behind this collection instead of starting a second one. The refresh then
+  // decides whether there is anything to fetch once the list is in.
+  knownRuns?: Promise<Run[] | undefined>,
 ): BenchmarkRefresh {
   const github = scope === "bench"
     ? performanceBenchmarkGitHub
@@ -1132,7 +1227,21 @@ function startBenchmarkRefresh(
     ) {
       return {};
     }
-    return await collectBenchmark(token, progress, github);
+    let known: Run[] | undefined;
+    if (knownRuns) {
+      known = await knownRuns;
+      // The caller's list is the only one this refresh reads. Its failure is the
+      // caller's to report, and there is nothing here to refresh against.
+      if (!known) return {};
+      // Nothing new has been sampled since the last refresh, and that refresh is
+      // recent, so the artifact history already covers this list.
+      if (
+        benchmarkSnapshotIsFresh() && benchmarkRefreshCovers(known, Date.now())
+      ) {
+        return {};
+      }
+    }
+    return await collectBenchmark(token, progress, github, known);
   };
   let refreshFinished = false;
   const finishRefresh = () => {
@@ -1177,6 +1286,19 @@ function startBenchmarkRefresh(
   return { progress: { ...progress.state }, result };
 }
 
+// Whether the drill-down's last refresh already covers the runs this list names.
+// The refresh records which runs it sampled, and only a successful run in a new
+// time bucket changes that set, so an unchanged set means there is no artifact to
+// fetch and no reason to redo the work.
+function benchmarkRefreshCovers(runs: Run[], now: number): boolean {
+  const refresh = benchmarkStore.refresh;
+  if (!refresh) return false;
+  const chosen = sampleBenchmarkRuns(runs, now - SPARK_DAYS * 86_400_000).map((
+    run,
+  ) => ({ runId: run.id, runAttempt: run.run_attempt ?? 1 }));
+  return JSON.stringify(refresh.runs) === JSON.stringify(chosen);
+}
+
 function benchmarkSnapshotIsFresh(now = Date.now()): boolean {
   const age = now - benchmarkRefreshedAt;
   return Boolean(
@@ -1208,7 +1330,10 @@ function benchmarkServerContext(): Ctx {
 
 export const benchmark: Tile = {
   id: "benchmark",
-  intervalMs: 3_600_000,
+  // The run state is what this cadence is for: a benchmark run lasts about an
+  // hour, so an hourly collection can miss one from start to finish. The
+  // artifact reads behind the tile keep their own, slower gate.
+  intervalMs: 60_000,
   routes: [
     {
       path: "/bench",
@@ -1252,71 +1377,61 @@ export const benchmark: Tile = {
     const token = ctx.env("GH_TOKEN") ?? ctx.env("GITHUB_TOKEN");
     if (!token) return benchmarkUnavailable("set GH_TOKEN");
     await loadCachedBenchmarkSnapshot();
-    const initialCollection = benchmarkInitialCollection;
-    benchmarkInitialCollection = false;
-    // Only trust the run list this collection fetches, never a prior one: a
-    // collection whose fetch fails must gray the tile rather than show stale runs.
-    latestBenchmarkRuns = undefined;
-    // Paint the headline as soon as the refresh has paged the run list, without
-    // waiting for it to backfill the drill-down's artifacts. This is a collection in
-    // progress, so with no cached data yet the tile reads "collecting…", not the
-    // finished-and-empty "benchmark data unavailable".
-    const paintEarly = (runs: Run[]) => {
-      // Registered only when publish exists, and the notifier fires each listener at
-      // most once, so this needs no re-entry guard.
-      if (publish) publish(benchmarkIndexView(runs, Date.now(), true));
+    // A painted frame is not what the collection returns, so one that throws is
+    // one bad frame rather than a failed collection.
+    const paint = (view: TileView) => {
+      if (!publish) return;
+      try {
+        publish(view);
+      } catch {
+        // The next paint, or the return value, carries the tile instead.
+      }
     };
-    if (publish) benchmarkRunListListeners.add(paintEarly);
     // Paint at once, before the run list is even fetched, so a freshly loaded
     // dashboard shows the cached headline immediately (warm) or "collecting…" (cold)
     // rather than a blank tile while the first collection gets under way. The empty
-    // run list carries no failed state yet; paintEarly and the final return supply it.
-    if (publish) publish(benchmarkIndexView([], Date.now(), true));
-    // Drive the drill-down's artifact history (green while fresh, so its expensive
-    // artifact reads are skipped). Its collection also pages the benchmarks.yml run
-    // list into latestBenchmarkRuns, which the tile reuses. A read that only failed
-    // on the artifacts still leaves the run list, so the tile stands.
-    const outcome = await startBenchmarkRefresh(
+    // run list carries no failed state yet; the paint below and the final return
+    // supply it.
+    paint(benchmarkIndexView([], Date.now(), true));
+    // The run list is the tile's own read, made by every collection. This is the
+    // part that keeps up with a run starting: the artifact history behind it moves
+    // far more slowly than the tile's cadence.
+    let listError: unknown;
+    const listing = pageBenchmarkRuns(
+      ordinaryBenchmarkGitHub,
+      token,
+      Date.now() - SPARK_DAYS * 86_400_000,
+    ).catch((error) => {
+      listError = error;
+      return undefined;
+    });
+    // Drive the drill-down's artifact history off the same list. It reads nothing
+    // while its snapshot is fresh and already covers these runs. A refresh that
+    // failed on the artifacts leaves the run list standing, so the tile keeps its
+    // trend rather than graying.
+    const refresh = startBenchmarkRefresh(
       ctx,
       undefined,
-      initialCollection && benchmarkSnapshotIsFresh(),
+      false,
       "dashboard",
+      listing,
     ).result;
-    benchmarkRunListListeners.delete(paintEarly);
-    const now = Date.now();
-    let runs: Run[] | undefined = latestBenchmarkRuns;
+    const runs = await listing;
     if (!runs) {
-      // No run list this collection: on a failed fetch keep the last-known trend
-      // grayed with the reason (benchmarkIndexView with an empty run list and an
-      // offline reason); otherwise it short-circuited on a fresh snapshot, so read
-      // the list directly for the tile.
-      if (outcome.error !== undefined) {
-        return benchmarkIndexView(
-          [],
-          now,
-          false,
-          friendlyError(errorMessage(outcome.error)),
-        );
-      }
-      let directError: unknown;
-      runs = await pageBenchmarkRuns(
-        ordinaryBenchmarkGitHub,
-        token,
-        now - SPARK_DAYS * 86_400_000,
-      ).catch((error) => {
-        directError = error;
-        return undefined;
-      });
-      if (!runs) {
-        return benchmarkIndexView(
-          [],
-          now,
-          false,
-          friendlyError(errorMessage(directError)),
-        );
-      }
+      await refresh;
+      return benchmarkIndexView(
+        [],
+        Date.now(),
+        false,
+        friendlyError(errorMessage(listError)),
+      );
     }
-    return benchmarkIndexView(runs, now);
+    latestBenchmarkRuns = runs;
+    // The headline stands on the run list alone, so paint it before waiting on the
+    // artifact work behind it.
+    paint(benchmarkIndexView(runs, Date.now(), true));
+    await refresh;
+    return benchmarkIndexView(runs, Date.now());
   },
 };
 
@@ -1539,6 +1654,7 @@ export function benchPage(
     stat: stat.label,
   });
   const version = benchmarkSnapshotVersion();
+  const handoff = benchmarkRerunHandoff(latestBenchmarkRuns);
   const progress = options.progress;
   const progressIdle = !progress || progress.phase === "complete" ||
     progress.phase === "error";
@@ -1798,6 +1914,13 @@ export function benchPage(
     ${body}
     ${cpuLegend}
     <p class="note">Successful main runs come from the <a href="https://github.com/${REPO}/actions/workflows/${WORKFLOW}" target="_blank" rel="noopener">${WORKFLOW} runs ↗</a> (deno bench artifacts). Collection keeps enough samples for the shortest window, and charts reduce longer windows to about ${CI_HISTORY_POINT_TARGET} evenly spaced points.</p>
+    <p class="handoff"><a href="${
+    escapeHtml(handoff.href)
+  }" target="_blank" rel="noopener">${
+    escapeHtml(handoff.label)
+  }</a><span>${
+    escapeHtml(handoff.hint)
+  } This board reads GitHub and does not start runs itself.</span></p>
   </div>`;
   if (options.fragment) return rangeContent;
 
@@ -1815,6 +1938,11 @@ export function benchPage(
   .swatch{display:inline-block;width:8px;height:8px;border-radius:2px;flex:none;box-shadow:0 0 0 1px rgba(255,255,255,.42)}
   .cpu-id{display:inline-flex;align-items:center;justify-content:center;border:1px solid var(--cpu-color,#454b56);border-radius:4px;padding:1px 4px;font-size:9px;line-height:1.2;font-weight:500;color:#c7ccd4;white-space:nowrap}
   .cpu-legend{margin-top:22px}.cpu-legend-title{margin:0 0 8px}
+  .handoff{display:flex;align-items:center;flex-wrap:wrap;gap:10px;margin-top:10px}
+  .handoff a{font-size:13px;color:#c7ccd4;text-decoration:none;border:1px solid #2f333c;border-radius:6px;padding:4px 10px}
+  .handoff a:hover{border-color:#6ea8fe;color:#fff}
+  .handoff a:focus-visible{outline:2px solid #6ea8fe;outline-offset:2px}
+  .handoff span{font-size:11px;color:#666c76}
   .cpu-keys{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:7px}
   .cpu-key{display:flex;align-items:flex-start;gap:8px;background:#16181d;border:1px solid #23262d;border-radius:8px;padding:8px 10px}
   .cpu-key:target{border-color:#6ea8fe;box-shadow:0 0 0 1px rgba(110,168,254,.24);scroll-margin-top:16px}


### PR DESCRIPTION
A red benchmarks tile said "last run failed" and left the reader with two questions it could not answer: how long has this been broken, and what do I do about it. It also kept its healthy count line underneath, so a failed tile carried two lines where a healthy one carries one, and the count described a run that was no longer the newest.

The failure now takes that second line rather than sitting above it, and answers the first question: "last good 2 days ago · 12 runs failed". The age leads because it is the size of the outage; the count reads back through the newest-first run list and stops at the first completed run that did not fail, so a cancelled or superseded run ends it rather than joining it. The date comes from the newest run whose conclusion is success, including one that passed on a later attempt: it ran and it worked. With nothing passing in the fetched window there is no outage to date, and the line falls back to the count alone. The separator and the humanSpan wording match the healthy line it replaces, and the whole line fits the tile: the grid is four 266px columns inside the 1100px page, leaving 232px of text, and the longest realistic line measures 223px against the real stylesheet.

The second question goes to GitHub. Starting a workflow run is a write, and this board reads: its token is fine-grained and read-only. Giving the pod a write credential would be a real escalation, because a dispatch names a ref and this workflow runs on a self-hosted runner group, so anyone who could reach the board could run code there. So the /bench runtime view closes with a link instead. It targets the newest completed run when that run failed, where "Re-run all jobs" repeats it, and the workflow itself otherwise, where "Run workflow" starts a fresh one. Authorization comes for free: GitHub shows the button only to someone who may press it, so the board models no permissions of its own.

For the hand-off to have an answer on the board, the tile grows a "running" badge while a run is under way. The badge reads the whole run list rather than its head, because re-running an older run leaves that run where it sits rather than moving it to the front. A run under way sets no verdict: the runs that have finished still decide the colour, and the badge says that colour may be about to move. The header hint reads "metrics" rather than "all metrics" so the label, the badge and the hint still share one line at the tile's width.

None of that is any use at the tile's old cadence. It collected once an hour, and a benchmark run takes about an hour, so the tile could miss one from start to finish and never show the badge at all. The hourly figure was pacing the artifact reads behind the drill-down, not the run state, and those are two different clocks. Every collection now pages the run list, once a minute. The artifact history is left alone while the last refresh is recent and already covers the runs that list names: only a successful run in a new time bucket changes the sampled set, so an unchanged set means there is nothing to download, and a new run reaches the drill-down when it lands rather than when a timer expires.

The collection is reordered around that. It pages the run list itself and paints the headline from it, then hands the same list to the refresh instead of letting the refresh page a second copy. The refresh is still started before the list arrives, so a drill-down request landing meanwhile queues behind this collection rather than starting its own, and it decides whether there is anything to fetch once the list is in. A list that failed to fetch stops there: the refresh has nothing to work from, and the tile already reports the failure. Paging the list directly replaces the callback the refresh used to fire when it had paged one, so that notifier and its listener set are gone; the paints are wrapped instead, keeping the property the notifier gave them, that a paint which throws is one bad frame rather than a failed collection.

Two corrections in passing. The comment over the run paging said the workflow runs on pushes as well as on a schedule, and gave that as the reason the query is not filtered by event; it has no push trigger, and runs to a four-hourly cron and on manual dispatch. And the benchmark tile tests fell back to the system temporary directory for their history cache, so running the file directly inherited whatever the previous run left there — a cache that had grown to 44 MB on one machine, which both slowed the file from a third of a second to nine seconds and let stale fixture runs answer tests that assert on an empty store. The file now names its own directory when nothing else has, which the package's test runner still overrides.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

