### PR TITLE
fix(integration): settle and aim a trusted click in one page turn

### DIFF
--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -156,17 +156,36 @@ declines it. A test that needs a control enabled before clicking says so with
 `waitForDisabled(page, selector, false)`.
 
 A control has to be rendered when the predicate tags it, but that alone does
-not make the click that follows safe. The trusted click measures the control's
-box a few protocol round trips after the tag, and in that window the surface the
-control sits in can still be settling: a join card's profile surface toggles
-display through its entrance, or a re-render relays out the region. The box can
-therefore move or vanish, and `DOM.getBoxModel` returns nothing for an element
-with no box, which the click reports as "Unable to get stable box model to click
-on". So after tagging, `clickMarked` holds until the tagged control's bounding
-box is unchanged across two consecutive animation frames before it dispatches.
-That wait is frame-driven and drops its baseline whenever the box disappears, so
-a control hidden partway through is picked up once it returns rather than clicked
-mid-shift; the stuck-condition net bounds a box that never settles.
+not make the click that follows safe. The page keeps running between the tag and
+the click, and the surface the control sits in can still be settling: a join
+card's profile surface toggles display through its entrance, a re-render relays
+out the region, or a piece re-render replaces the control with an equivalent one.
+So `clickMarked` settles the control and works out where to click it in a single
+page turn, and dispatches immediately afterwards. That one turn holds until the
+tagged control's bounding box is unchanged across two consecutive animation
+frames, then scrolls it into view and measures the point, all without handing
+control back to the test process in between. The hold is frame-driven and drops
+its baseline whenever the box disappears, so a control hidden partway through is
+picked up once it returns rather than clicked mid-shift; the stuck-condition net
+bounds a box that never settles.
+
+Deciding and measuring in one turn is the point of the design, not an
+optimization. Split across protocol round trips, the measurement describes a
+different moment from the decision, and a control the page dropped in between
+measures as nothing at all — which is what "Unable to get stable box model to
+click on" means. A helper that tags a control by name also passes its tagging
+predicate to `clickMarked`, so a control the page rebuilt is tagged again on
+whatever took its place, under that helper's own readiness rules, rather than
+reported as gone.
+
+That error message covers more than a missing layout box: the underlying
+`DOM.getBoxModel` reports a node the browser's DOM agent no longer knows about
+the same way it reports a node with no box, and the agent forgets every
+outstanding node the moment anything queries the document afresh. Any diagnosis
+that reads the message as "the element had no layout box" is therefore reading
+in more than it says. `Page`'s own click measures through the element rather
+than through a node handle, and names the condition it found — detached from
+the document, no layout box, or a handle that no longer resolves.
 
 Waiting for a click's effect carries the same requirement, for the same reason.
 Nothing in an integration test holds a UI subscription, so between one check and

--- a/packages/integration/astral-adapter.ts
+++ b/packages/integration/astral-adapter.ts
@@ -34,12 +34,15 @@ export type ElementHandle = AstralElementHandle & {
 };
 
 export interface InteractionObserver {
+  // `element` is absent when the click was aimed at a point rather than
+  // resolved to a handle, which is how the CFC helpers dispatch: the wait that
+  // settles the control answers with coordinates, and no handle is taken.
   beforeClick?(
-    element: ElementHandle,
+    element: ElementHandle | undefined,
     point: { x: number; y: number },
   ): Promise<void> | void;
   afterClick?(
-    element: ElementHandle,
+    element: ElementHandle | undefined,
     point: { x: number; y: number },
     error?: unknown,
   ): Promise<void> | void;

--- a/packages/integration/page.ts
+++ b/packages/integration/page.ts
@@ -437,6 +437,19 @@ export class Page extends EventTarget {
     return elements.map((element) => this.decorateElement(element));
   }
 
+  // Extended method: Dispatch one trusted click at a viewport point.
+  //
+  // For a caller that has already worked out where to click — a wait that
+  // measured its target at the instant the target was ready, say — this is the
+  // dispatch on its own, with no measurement of its own to go stale.
+  // The interaction observer sees this dispatch as it sees an element's, with
+  // no element to name, so a presentation recording still moves and pulses its
+  // cursor over a click aimed by coordinates.
+  async clickPoint(point: { x: number; y: number }): Promise<void> {
+    this.checkIsOk();
+    await this.dispatchObservedClick(undefined, point);
+  }
+
   // Passthru of `@astral/astral`'s `Page#close`
   async close() {
     this.checkIsOk();
@@ -531,35 +544,26 @@ export class Page extends EventTarget {
     element: AstralElementHandle,
     options?: Parameters<AstralElementHandle["click"]>[0],
   ): Promise<void> {
-    await element.scrollIntoView();
-    const model = await element.boxModel();
-    if (!model) throw new Error("Unable to get stable box model to click on");
-
-    const origin = model.content[0];
-    let point: { x: number; y: number };
-    if (options?.offset) {
-      point = {
-        x: origin.x + options.offset.x,
-        y: origin.y + options.offset.y,
-      };
-    } else {
-      const total = model.content.reduce(
-        (result, vertex) => ({
-          x: result.x + vertex.x,
-          y: result.y + vertex.y,
-        }),
-        { x: 0, y: 0 },
-      );
-      point = {
-        x: total.x / model.content.length,
-        y: total.y / model.content.length,
-      };
+    const aim = await aimAtElement(element, options?.offset);
+    if ("unclickable" in aim) {
+      throw new Error(`Cannot click ${describeAimTarget(aim)}`);
     }
-
-    await this.interactionObserver?.beforeClick?.(
+    await this.dispatchObservedClick(
       element as ElementHandle,
-      point,
+      { x: aim.x, y: aim.y },
+      options,
     );
+  }
+
+  // Dispatch one trusted click at `point`, with the interaction observer told
+  // before and after. The observer's failure is reported only when the click
+  // itself succeeded, so a recording problem never masks a click problem.
+  private async dispatchObservedClick(
+    element: ElementHandle | undefined,
+    point: { x: number; y: number },
+    options?: Parameters<AstralElementHandle["click"]>[0],
+  ): Promise<void> {
+    await this.interactionObserver?.beforeClick?.(element, point);
     let actionError: unknown;
     try {
       await this.page!.mouse.click(point.x, point.y, options);
@@ -567,11 +571,7 @@ export class Page extends EventTarget {
       actionError = error;
     }
     try {
-      await this.interactionObserver?.afterClick?.(
-        element as ElementHandle,
-        point,
-        actionError,
-      );
+      await this.interactionObserver?.afterClick?.(element, point, actionError);
     } catch (observerError) {
       if (actionError === undefined) throw observerError;
     }
@@ -604,5 +604,112 @@ export class Page extends EventTarget {
       if (actionError === undefined) throw observerError;
     }
     if (actionError !== undefined) throw actionError;
+  }
+}
+
+/**
+ * Where a trusted click should land, or why it cannot land at all.
+ *
+ * The point is in viewport coordinates, which is what `Input.dispatchMouseEvent`
+ * takes, and is measured after the element has been scrolled into view.
+ */
+export type AimResult =
+  | { x: number; y: number }
+  | {
+    unclickable: "detached" | "not-rendered" | "unresolvable";
+    tag?: string;
+    id?: string;
+    rootHost?: string;
+    display?: string;
+    visibility?: string;
+    width?: number;
+    height?: number;
+    detail?: string;
+  };
+
+/**
+ * Scroll `element` into view and measure the point to click, both inside a
+ * single page turn.
+ *
+ * Aiming is one turn on purpose. Scrolling and measuring as two protocol
+ * commands leaves the page free to relayout or rebuild between them, and the
+ * second command then measures something other than what the first scrolled to.
+ * Doing both in the page means the coordinates describe the element as it was
+ * at one instant, and the only remaining gap is the one dispatch that follows.
+ *
+ * An element with no layout box yields `unclickable` naming what is wrong with
+ * it, rather than an empty measurement the caller has to guess at.
+ */
+async function aimAtElement(
+  element: AstralElementHandle,
+  offset?: { x: number; y: number },
+): Promise<AimResult> {
+  try {
+    return await element.evaluate(
+      (
+        el: Element,
+        offsetX: number | null,
+        offsetY: number | null,
+      ): AimResult => {
+        const describe = () => ({
+          tag: el.tagName.toLowerCase(),
+          id: el.id,
+          rootHost: (el.getRootNode() as ShadowRoot).host?.tagName
+            ?.toLowerCase(),
+        });
+        if (!el.isConnected) {
+          return { unclickable: "detached", ...describe() };
+        }
+        // Instant, because a page-level `scroll-behavior: smooth` would leave
+        // the element still moving when the rect below is read.
+        el.scrollIntoView({
+          block: "nearest",
+          inline: "nearest",
+          behavior: "instant",
+        });
+        const style = globalThis.getComputedStyle(el);
+        const rect = el.getBoundingClientRect();
+        if (
+          style.display === "none" || style.visibility === "hidden" ||
+          rect.width === 0 || rect.height === 0
+        ) {
+          return {
+            unclickable: "not-rendered",
+            ...describe(),
+            display: style.display,
+            visibility: style.visibility,
+            width: rect.width,
+            height: rect.height,
+          };
+        }
+        return offsetX === null || offsetY === null
+          ? { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 }
+          : { x: rect.x + offsetX, y: rect.y + offsetY };
+      },
+      { args: [offset?.x ?? null, offset?.y ?? null] },
+    );
+  } catch (error) {
+    // A handle whose node the DOM agent no longer knows about cannot be
+    // resolved to a page object at all. That happens to every outstanding
+    // handle the moment anything else queries the document, so it is a
+    // separate condition from an element that is present but unclickable.
+    return { unclickable: "unresolvable", detail: String(error) };
+  }
+}
+
+/** The human-readable half of an {@link AimResult} that cannot be clicked. */
+function describeAimTarget(aim: Extract<AimResult, { unclickable: string }>) {
+  const named = aim.id ? `${aim.tag}#${aim.id}` : aim.tag ?? "the element";
+  const inside = aim.rootHost ? ` inside <${aim.rootHost}>` : "";
+  switch (aim.unclickable) {
+    case "detached":
+      return `${named}${inside}: it is no longer in the document`;
+    case "not-rendered":
+      return `${named}${inside}: it has no layout box ` +
+        `(display: ${aim.display}, visibility: ${aim.visibility}, ` +
+        `${aim.width}x${aim.height})`;
+    default:
+      return `the element: its handle no longer resolves to a node ` +
+        `(${aim.detail})`;
   }
 }

--- a/packages/integration/test/astral-adapter.test.ts
+++ b/packages/integration/test/astral-adapter.test.ts
@@ -1364,8 +1364,16 @@ Deno.test("Page preserves Common Tools behavior on published Astral", async () =
       const button = document.createElement("button");
       button.id = "click-target";
       button.textContent = "click";
-      button.style.width = "100px";
-      button.style.height = "30px";
+      // Pinned so the click point is arithmetic on a known rect rather than
+      // on wherever the default layout put the control.
+      Object.assign(button.style, {
+        position: "fixed",
+        left: "60px",
+        top: "60px",
+        width: "100px",
+        height: "30px",
+        margin: "0",
+      });
       button.addEventListener("click", () => {
         document.body.dataset.clicked = "yes";
       });
@@ -1383,30 +1391,9 @@ Deno.test("Page preserves Common Tools behavior on published Astral", async () =
       "yes",
     );
 
-    const content = [
-      { x: 160, y: 60 },
-      { x: 200, y: 100 },
-      { x: 130, y: 160 },
-      { x: 70, y: 100 },
-    ];
-    const boxModel = {
-      border: content,
-      content,
-      height: 40,
-      margin: content,
-      padding: content,
-      width: 80,
-    };
-    Object.defineProperties(clickTarget, {
-      boxModel: {
-        configurable: true,
-        value: () => Promise.resolve(boxModel),
-      },
-      scrollIntoView: {
-        configurable: true,
-        value: () => Promise.resolve(),
-      },
-    });
+    // The click aims at the centre of the control's own rect, and an offset
+    // aims from the rect's top-left corner. Both are measured in the page, so
+    // the numbers come from the pinned control above.
     let mousePoint: { x: number; y: number } | undefined;
     Object.defineProperty(astralPage.mouse, "click", {
       configurable: true,
@@ -1416,12 +1403,12 @@ Deno.test("Page preserves Common Tools behavior on published Astral", async () =
       },
     });
     await clickTarget.click();
-    assertEquals(mousePoint, { x: 140, y: 105 });
-    assertEquals(clickPoints[1], { x: 140, y: 105 });
+    assertEquals(mousePoint, { x: 110, y: 75 });
+    assertEquals(clickPoints[1], { x: 110, y: 75 });
 
-    await clickTarget.click({ offset: { x: 0, y: 0 } });
-    assertEquals(mousePoint, { x: 160, y: 60 });
-    assertEquals(clickPoints[2], { x: 160, y: 60 });
+    await clickTarget.click({ offset: { x: 4, y: 6 } });
+    assertEquals(mousePoint, { x: 64, y: 66 });
+    assertEquals(clickPoints[2], { x: 64, y: 66 });
 
     const typeTarget = await page.waitForSelector("#type-target");
     await typeTarget.type("text");

--- a/packages/integration/utils.ts
+++ b/packages/integration/utils.ts
@@ -113,11 +113,18 @@ export interface ProbeApi {
  * A predicate evaluated in the page. It receives a {@link ProbeApi} plus the
  * `args` passed to {@link waitForCondition}, and returns whether the awaited
  * condition holds. It may be async (for example to await `rt.idle()`).
+ *
+ * A predicate may answer with a value instead of `true`. Any truthy result
+ * satisfies the condition, and a result other than `true` is carried back to
+ * the test process as {@link waitForCondition}'s resolution. That is how a
+ * wait hands over a measurement taken at the instant the condition held —
+ * the coordinates a trusted click is about to be aimed at, say — without a
+ * second round trip in which the page could move on.
  */
-export type PageCondition<A extends readonly unknown[]> = (
+export type PageCondition<A extends readonly unknown[], R = unknown> = (
   probe: ProbeApi,
   ...args: A
-) => boolean | Promise<boolean>;
+) => boolean | R | Promise<boolean | R>;
 
 /**
  * Installed in the page by {@link waitForCondition}. Re-evaluates `predicate`
@@ -290,11 +297,29 @@ function installWaiter(
   let running = false;
   let rerun = false;
 
+  // The value the predicate answered with, carried to the test process in the
+  // binding payload so a measurement taken at the instant the condition held
+  // reaches the caller without a second round trip.
+  let answer: unknown = true;
+
   const fire = (): boolean => {
     const notify = (globalThis as Record<string, unknown>)[bindingName];
     if (typeof notify !== "function") return false;
     signalled = true;
-    (notify as (payload: string) => void)("ok");
+    let payload: string;
+    try {
+      payload = JSON.stringify({ value: answer === true ? undefined : answer });
+    } catch (error) {
+      // An answer that cannot cross the boundary is reported as one. Sending
+      // "no value" instead would read to the caller as a condition that held
+      // and simply had nothing to say, which is a different thing.
+      payload = JSON.stringify({
+        unserializable: String(
+          error instanceof Error ? error.message : error,
+        ),
+      });
+    }
+    (notify as (payload: string) => void)(payload);
     return true;
   };
 
@@ -344,8 +369,10 @@ function installWaiter(
       .then((ok) => {
         running = false;
         if (stopped) return;
-        if (ok) onConditionMet();
-        else if (rerun) {
+        if (ok) {
+          answer = ok;
+          onConditionMet();
+        } else if (rerun) {
           rerun = false;
           evaluate();
         }
@@ -387,19 +414,37 @@ function installWaiter(
  * safety net elapses; callers add the context and rich probe for the failure
  * message. There is no caller-supplied timeout: the wait resolves on the
  * condition, and the safety net is not the common-case latency.
+ *
+ * Resolves with whatever the predicate answered, when that answer is a value
+ * rather than `true`. The answer travels in the same notification that ends
+ * the wait, so a caller acting on it acts on the page as it was when the
+ * condition held, with no round trip in between for the page to change in.
  */
-export const waitForCondition = async <A extends readonly unknown[]>(
+export const waitForCondition = async <A extends readonly unknown[], R>(
   page: Page,
-  predicate: PageCondition<A>,
+  predicate: PageCondition<A, R>,
   { args }: { args?: A } = {},
-): Promise<void> => {
+): Promise<R | undefined> => {
   const bindingName = `__cfcWait_${crypto.randomUUID().replace(/-/g, "")}`;
+  let answer: R | undefined;
+  let answerError: string | undefined;
   let resolveSignal!: () => void;
   const signalled = new Promise<void>((resolve) => {
     resolveSignal = resolve;
   });
-  const unsubscribe = page.onBindingCalled((name) => {
-    if (name === bindingName) resolveSignal();
+  const unsubscribe = page.onBindingCalled((name, payload) => {
+    if (name !== bindingName) return;
+    try {
+      const parsed = JSON.parse(payload) as {
+        value?: R;
+        unserializable?: string;
+      };
+      answerError = parsed.unserializable;
+      answer = parsed.value;
+    } catch (error) {
+      answerError = `the wait's notification did not parse: ${String(error)}`;
+    }
+    resolveSignal();
   });
   await page.addBinding(bindingName);
 
@@ -420,6 +465,13 @@ export const waitForCondition = async <A extends readonly unknown[]>(
       );
     });
     await Promise.race([signalled, timedOut]);
+    if (answerError !== undefined) {
+      throw new Error(
+        `The condition held, but its answer did not reach the test: ` +
+          answerError,
+      );
+    }
+    return answer;
   } finally {
     if (timer !== undefined) clearTimeout(timer);
     unsubscribe();

--- a/packages/patterns/integration/cfc-browser-helpers.test.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.test.ts
@@ -886,4 +886,215 @@ describe("CFC browser helpers", () => {
       "the click never reached the target after its hidden surface returned",
     );
   });
+
+  it("clicks a control its surface keeps rebuilding under the aim", async () => {
+    await page.evaluate((clickTargetAttr: string) => {
+      const host = document.createElement("div");
+      const root = host.attachShadow({ mode: "open" });
+      const surface = document.createElement("div");
+      root.append(surface);
+      document.body.append(host);
+
+      let clicked = 0;
+      // Listen on the surface, not the control: each rebuild is a different
+      // element, and a listener on the control would only ever see the one
+      // instance it was attached to.
+      surface.addEventListener("click", (event) => {
+        const target = event.target as HTMLElement | null;
+        if (target?.id === "rebuilt-guest-button") clicked++;
+      });
+
+      const makeButton = () => {
+        const button = document.createElement("button");
+        button.id = "rebuilt-guest-button";
+        button.textContent = "Continue as guest";
+        Object.assign(button.style, {
+          display: "block",
+          width: "200px",
+          height: "32px",
+        });
+        return button;
+      };
+      surface.append(makeButton());
+
+      // Once the helper marks the control, the surface rebuilds it on every
+      // animation frame, the way a piece re-render replaces the DOM it drew
+      // while a test is already interacting with it. Each replacement is
+      // geometrically identical, so what changes is which element is there,
+      // not where a click has to land. The mark travels to the replacement,
+      // which is what a helper addressing the control by name would find.
+      //
+      // A click that resolves the control to a handle up front and measures
+      // that handle's box some protocol round trips later measures an element
+      // the surface has since dropped, and reports "Unable to get stable box
+      // model to click on". A click that decides and measures inside one page
+      // turn measures whichever element is there at that instant, and lands.
+      const observer = new MutationObserver(() => {
+        if (!surface.querySelector(`[${clickTargetAttr}]`)) return;
+        observer.disconnect();
+        let framesLeft = 20;
+        const rebuild = () => {
+          const current = surface.querySelector("#rebuilt-guest-button");
+          if (!current || framesLeft-- <= 0) return;
+          const replacement = makeButton();
+          for (const name of current.getAttributeNames()) {
+            replacement.setAttribute(name, current.getAttribute(name)!);
+          }
+          current.replaceWith(replacement);
+          requestAnimationFrame(rebuild);
+        };
+        requestAnimationFrame(rebuild);
+      });
+      observer.observe(surface, {
+        attributes: true,
+        subtree: true,
+        attributeFilter: [clickTargetAttr],
+      });
+
+      (globalThis as typeof globalThis & {
+        commonfabric: { viewSettled: () => Promise<void> };
+      }).commonfabric = { viewSettled: () => Promise.resolve() };
+      (globalThis as typeof globalThis & {
+        __rebuiltClicks: () => number;
+      }).__rebuiltClicks = () => clicked;
+    }, { args: [CLICK_TARGET_ATTR] });
+
+    await clickCfButton(page, "#rebuilt-guest-button");
+
+    const clicks = await page.evaluate(() =>
+      (globalThis as typeof globalThis & {
+        __rebuiltClicks: () => number;
+      }).__rebuiltClicks()
+    );
+    assertEquals(
+      clicks,
+      1,
+      "the click never reached the control the surface rebuilt under it",
+    );
+  });
+
+  it("tells the interaction observer where a marked click landed", async () => {
+    // A presentation recording animates its cursor from these callbacks. The
+    // click is aimed at a point rather than resolved to a handle, so the
+    // observer is told about a point with no element to name.
+    const observed: { phase: string; x: number; y: number }[] = [];
+    page.setInteractionObserver({
+      beforeClick: (_element, point) =>
+        void observed.push({ phase: "before", x: point.x, y: point.y }),
+      afterClick: (_element, point) =>
+        void observed.push({ phase: "after", x: point.x, y: point.y }),
+    });
+    try {
+      await page.evaluate(() => {
+        const host = document.createElement("div");
+        const root = host.attachShadow({ mode: "open" });
+        const button = document.createElement("button");
+        button.id = "observed-guest-button";
+        button.textContent = "Continue as guest";
+        Object.assign(button.style, {
+          position: "fixed",
+          left: "40px",
+          top: "40px",
+          width: "120px",
+          height: "40px",
+          margin: "0",
+        });
+        root.append(button);
+        document.body.append(host);
+        (globalThis as typeof globalThis & {
+          commonfabric: { viewSettled: () => Promise<void> };
+        }).commonfabric = { viewSettled: () => Promise.resolve() };
+      });
+
+      await clickCfButton(page, "#observed-guest-button");
+
+      assertEquals(
+        observed.map((entry) => entry.phase),
+        ["before", "after"],
+        "the observer should bracket the click",
+      );
+      // The control sits at 40,40 and is 120x40, so its centre is 100,60.
+      assertEquals({ x: observed[0].x, y: observed[0].y }, { x: 100, y: 60 });
+      assertEquals({ x: observed[1].x, y: observed[1].y }, { x: 100, y: 60 });
+    } finally {
+      page.setInteractionObserver(undefined);
+    }
+  });
+
+  it("clicks a control on a page that is not being rendered", async () => {
+    // A page sharing a browser with a fronted page is hidden, and a hidden page
+    // produces no animation frames. A settle that waits for a frame there waits
+    // for one that never arrives, and a settle that yields only to the
+    // microtask queue starves the timers and tasks that would bring a
+    // momentarily hidden control back — so it spins against a control it is
+    // itself preventing from returning. Both leave the click unable to land.
+    const background = await browser.newPage();
+    const fronted = await browser.newPage();
+    try {
+      assertEquals(
+        await background.evaluate(() => document.visibilityState),
+        "hidden",
+        "the background page should not be rendering",
+      );
+
+      await background.evaluate((clickTargetAttr: string) => {
+        const host = document.createElement("div");
+        const root = host.attachShadow({ mode: "open" });
+        const button = document.createElement("button");
+        button.id = "background-guest-button";
+        button.textContent = "Continue as guest";
+        Object.assign(button.style, {
+          display: "block",
+          width: "200px",
+          height: "32px",
+        });
+        root.append(button);
+        document.body.append(host);
+
+        let clicked = 0;
+        button.addEventListener("click", () => {
+          clicked++;
+        });
+
+        // The control goes away for a spell once marked and comes back on a
+        // task. Only a settle that lets the event loop turn will ever see it
+        // return.
+        const observer = new MutationObserver(() => {
+          if (!button.hasAttribute(clickTargetAttr)) return;
+          observer.disconnect();
+          button.style.display = "none";
+          setTimeout(() => {
+            button.style.display = "block";
+          }, 250);
+        });
+        observer.observe(button, {
+          attributes: true,
+          attributeFilter: [clickTargetAttr],
+        });
+
+        (globalThis as typeof globalThis & {
+          commonfabric: { viewSettled: () => Promise<void> };
+        }).commonfabric = { viewSettled: () => Promise.resolve() };
+        (globalThis as typeof globalThis & {
+          __backgroundClicks: () => number;
+        }).__backgroundClicks = () => clicked;
+      }, { args: [CLICK_TARGET_ATTR] });
+
+      await clickCfButton(background, "#background-guest-button");
+
+      const clicks = await background.evaluate(() =>
+        (globalThis as typeof globalThis & {
+          __backgroundClicks: () => number;
+        }).__backgroundClicks()
+      );
+      assertEquals(
+        clicks,
+        1,
+        "the click never landed on the unrendered page's control",
+      );
+    } finally {
+      await fronted.close();
+      await background.close();
+    }
+  });
 });

--- a/packages/patterns/integration/cfc-browser-helpers.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.ts
@@ -478,7 +478,13 @@ export async function clickTrustedAction(
     await waitForCondition(page, markTrustedAction, {
       args: [action, token, CLICK_TARGET_ATTR],
     });
-    await clickMarked(page, token);
+    await clickMarked(page, {
+      token,
+      remark: {
+        predicate: markTrustedAction,
+        args: [action, token, CLICK_TARGET_ATTR],
+      },
+    });
   } catch (cause) {
     probe ??= await readTrustedActionProbe(page, action).catch(() => undefined);
     // Indented for readable test-log output
@@ -792,7 +798,13 @@ export async function clickCfButton(
   if (token === undefined) {
     throw new Error(`Unable to mark ${selector} for click.`);
   }
-  await clickMarked(page, token);
+  await clickMarked(page, {
+    token,
+    remark: {
+      predicate: settleAndMarkClickTargets,
+      args: [[selector], [token], CLICK_TARGET_ATTR],
+    },
+  });
   await settleView(page);
 }
 
@@ -889,96 +901,241 @@ export async function clickNthCfButton(
       { cause },
     );
   }
-  await clickMarked(page, token);
+  await clickMarked(page, {
+    token,
+    remark: {
+      predicate: markNthForClick,
+      args: [selector, index, token, CLICK_TARGET_ATTR],
+    },
+  });
 }
 
-// Hold until the element carrying the click mark `selector` has a settled
-// layout box: rendered — laid out, not display:none or visibility:hidden — with
-// an unchanged bounding rect across two consecutive animation frames. Between
-// marking a control and dispatching its trusted click, the surface it sits in
-// can still be settling: a join card's profile surface toggles display through
-// its entrance, and a re-render can relayout the region. The box the click
-// measures a few round trips after the mark may therefore have moved or gone,
-// and `DOM.getBoxModel` returns nothing for an element with no box — which the
-// click reports as "Unable to get stable box model to click on". Waiting here
-// for the box to stop shifting means the click measures a box that is present
-// and where it was. The wait drives itself off the frame signal and drops its
+// Where a trusted click is about to be aimed, or why the marked control could
+// not be aimed at.
+type ClickAim =
+  | { x: number; y: number }
+  | { missing: true; sawTarget: boolean };
+
+// Resolve the marked control, hold until it has a settled layout box, scroll it
+// into view, and answer with the point to click — all inside one page turn.
+//
+// The control is settled when it is rendered (laid out, not display:none or
+// visibility:hidden) with an unchanged bounding rect across two consecutive
+// animation frames. A surface that is still settling — a join card's profile
+// surface toggling display through its entrance, a re-render relaying out the
+// region — shifts or drops the box, and the wait keeps holding; it drops its
 // baseline whenever the box disappears, so a control hidden partway through is
-// picked up once it returns rather than clicked mid-shift; the stuck-condition
-// net in `waitForCondition` bounds a box that never settles.
-const clickTargetBoxStable = async (
+// picked up once it returns rather than aimed at mid-shift.
+//
+// The point is measured here rather than by the test process because the two
+// used to be separated by several protocol round trips, and the page is free to
+// rebuild in that gap. What it rebuilt away was the very control the wait had
+// just declared settled, so the measurement found no box and the click reported
+// "Unable to get stable box model to click on". Deciding and measuring in the
+// same turn leaves nothing between them.
+//
+// A mark that is absent from the start is reported rather than waited on: the
+// caller placed it a moment ago, so its absence means the control it names was
+// replaced, which no amount of further waiting resolves. `remarkSource`, when
+// the caller supplies it, is the mark predicate's own source; running it again
+// re-establishes the mark on whatever control took the old one's place, so a
+// rebuilt surface is clicked rather than reported.
+const aimAtMarkedTarget = async (
   probe: ProbeApi,
   selector: string,
-): Promise<boolean> => {
+  remarkSource: string | null,
+  remarkArgs: readonly unknown[],
+): Promise<ClickAim | false> => {
+  type AimDiag = { phase: string; frames: number; lastBox: string };
+  const registry = ((globalThis as typeof globalThis & {
+    __cfAimDiag?: Record<string, AimDiag>;
+  }).__cfAimDiag ??= {});
+  const diag: AimDiag = { phase: "resolving", frames: 0, lastBox: "none" };
+  registry[selector] = diag;
+
+  const find = (): HTMLElement | undefined =>
+    probe.collect(selector)[0] as HTMLElement | undefined;
+  const remark = remarkSource === null ? null : new Function(
+    "return (" + remarkSource + ")",
+  )() as (
+    probe: ProbeApi,
+    ...args: readonly unknown[]
+  ) => boolean | Promise<boolean>;
+
+  // One step of page progress, after which the settle looks again.
+  //
+  // While the document is being rendered that step is a frame, which is what
+  // moves a box. A document that is not being rendered produces no frames, so
+  // waiting for one waits for something that will not arrive; the step there is
+  // one turn of the event loop, delivered through a message channel. It has to
+  // be a real turn rather than a resolved promise: a hidden control comes back
+  // when a timer or a task puts it back, and a loop that only yields to the
+  // microtask queue never lets either run, so it would spin against a control
+  // it is itself preventing from returning.
+  const nextFrame = (): Promise<void> => {
+    diag.frames++;
+    return new Promise((resolve) => {
+      if (document.visibilityState !== "hidden") {
+        requestAnimationFrame(() => resolve());
+        return;
+      }
+      const channel = new MessageChannel();
+      channel.port1.onmessage = () => resolve();
+      channel.port2.postMessage(0);
+    });
+  };
+
+  // Absent and hidden are different answers. A hidden control is coming back,
+  // so the settle keeps holding for it. A control that has left the document
+  // is not coming back — the page rebuilt the surface it was on — so the mark
+  // has to be placed again on whatever took its place.
   const measure = ():
     | { x: number; y: number; width: number; height: number }
+    | "gone"
     | null => {
-    const target = probe.collect(selector)[0] as HTMLElement | undefined;
-    if (!target || !probe.isRendered(target)) return null;
+    const target = find();
+    if (!target) return "gone";
+    if (!probe.isRendered(target)) return null;
     const { x, y, width, height } = target.getBoundingClientRect();
     return { x, y, width, height };
   };
-  const nextFrame = (): Promise<void> =>
-    new Promise((resolve) => requestAnimationFrame(() => resolve()));
 
-  let previous = measure();
-  await nextFrame();
-  let current = measure();
-  while (
-    previous === null || current === null ||
-    previous.x !== current.x || previous.y !== current.y ||
-    previous.width !== current.width || previous.height !== current.height
-  ) {
-    previous = current;
+  for (;;) {
+    if (find() === undefined) {
+      if (remark === null) {
+        diag.phase = "mark-gone";
+        return { missing: true, sawTarget: false };
+      }
+      diag.phase = "re-marking";
+      if (!await remark(probe, ...remarkArgs)) {
+        diag.phase = "no-target-to-mark";
+        return false;
+      }
+      if (find() === undefined) {
+        diag.phase = "mark-not-placed";
+        return false;
+      }
+    }
+
+    diag.phase = "settling";
+    let previous = measure();
     await nextFrame();
-    current = measure();
+    let current = measure();
+    while (
+      previous === null || current === null ||
+      previous === "gone" || current === "gone" ||
+      previous.x !== current.x || previous.y !== current.y ||
+      previous.width !== current.width || previous.height !== current.height
+    ) {
+      if (previous === "gone" || current === "gone") break;
+      diag.lastBox = JSON.stringify(current);
+      previous = current;
+      await nextFrame();
+      current = measure();
+    }
+    if (previous === "gone" || current === "gone") {
+      // Rebuilt under the settle. Take a frame so a surface rebuilding on
+      // every frame cannot spin this, then mark whatever is there now.
+      diag.phase = "rebuilt-under-settle";
+      await nextFrame();
+      continue;
+    }
+    diag.lastBox = JSON.stringify(current);
+
+    diag.phase = "aiming";
+    const target = find();
+    if (target === undefined) {
+      diag.phase = "rebuilt-before-aim";
+      await nextFrame();
+      continue;
+    }
+    // Instant, because the shell sets `scroll-behavior: smooth` and an animated
+    // scroll would still be moving the control when the point below is read.
+    target.scrollIntoView({
+      block: "nearest",
+      inline: "nearest",
+      behavior: "instant",
+    });
+    const rect = target.getBoundingClientRect();
+    diag.phase = "aimed";
+    return { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 };
   }
-  return true;
 };
 
-// Hold until the marked control at `selector` has a settled layout box — see
-// `clickTargetBoxStable` — so the trusted click that follows measures a box
-// that is present and unmoving. Shared by every helper whose click routes
-// through `clickMarked`.
-async function waitForStableClickTarget(
-  page: Page,
-  selector: string,
-): Promise<void> {
-  try {
-    await waitForCondition(page, clickTargetBoxStable, { args: [selector] });
-  } catch (cause) {
-    const probe = await readTextProbe(page, selector).catch(() => undefined);
-    throw new Error(
-      `Marked click target ${selector} never presented a stable box. ` +
-        `Last probe: ${toIndentedDebugString(probe)}`,
-      { cause },
-    );
-  }
+/**
+ * The mark a click aims at, and how to place it again.
+ *
+ * A caller passes the predicate it used to mark its target, so a control that
+ * the page rebuilds between the mark and the click can be marked again and
+ * clicked, rather than reported as vanished. The predicate is the same one the
+ * caller ran to place the mark, so re-marking applies the caller's own
+ * readiness rules — including its settle — to whatever control took over.
+ */
+export interface ClickMark {
+  token: string;
+  remark?: {
+    predicate: (
+      probe: ProbeApi,
+      // deno-lint-ignore no-explicit-any
+      ...args: any[]
+    ) => boolean | Promise<boolean>;
+    args: readonly unknown[];
+  };
 }
 
 /**
- * Resolve the element whose click marks contain `token` and click it, then
- * clear that mark.
+ * Click the element whose click marks contain the token, then clear that mark.
  * Shared by `clickCfButton`, `clickNthCfButton`, `clickTrustedAction`, and the
  * text-matching click helpers in `note-button-helpers.ts`: each one marks its
- * target through its own predicate, and the resolve/click/untag tail is the
- * same for all of them.
+ * target through its own predicate, and the aim/click/untag tail is the same
+ * for all of them.
+ *
+ * One wait settles the control and measures where to click it; one dispatch
+ * follows. Nothing separates the measurement from the decision that produced
+ * it, so the coordinates describe the control as the wait left it.
  */
 export async function clickMarked(
   page: Page,
-  token: string,
+  mark: string | ClickMark,
 ): Promise<void> {
+  const { token, remark } = typeof mark === "string" ? { token: mark } : mark;
   const markSelector = `[${CLICK_TARGET_ATTR}~="${token}"]`;
   try {
-    const clickTarget = await page.waitForSelector(markSelector, {
-      strategy: "pierce",
-    });
-    // The mark resolves the target the instant it is laid out, but the click
-    // measures its box a few round trips later. Hold until that box has stopped
-    // shifting, so the click does not race a surface that is still settling and
-    // fail to get a stable box model.
-    await waitForStableClickTarget(page, markSelector);
-    await clickTarget.click();
+    let aim: ClickAim | undefined;
+    try {
+      aim = await waitForCondition(page, aimAtMarkedTarget, {
+        args: [
+          markSelector,
+          remark ? remark.predicate.toString() : null,
+          remark ? remark.args : [],
+        ],
+      });
+    } catch (cause) {
+      const probe = await readTextProbe(page, markSelector).catch(() =>
+        undefined
+      );
+      const progress = await readAimProgress(page, markSelector).catch(() =>
+        undefined
+      );
+      throw new Error(
+        `Marked click target ${markSelector} never presented a stable box. ` +
+          `Aim reached: ${toIndentedDebugString(progress)}. ` +
+          `Last probe: ${toIndentedDebugString(probe)}`,
+        { cause },
+      );
+    }
+    if (aim === undefined || "missing" in aim) {
+      const probe = await readTextProbe(page, markSelector).catch(() =>
+        undefined
+      );
+      throw new Error(
+        `The control marked for click was replaced before the click could be ` +
+          `aimed at it${
+            aim?.sawTarget ? " while its box was settling" : ""
+          }. Last probe: ${toIndentedDebugString(probe)}`,
+      );
+    }
+    await page.clickPoint(aim);
   } finally {
     await clearClickMark(page, token).catch(() => {});
   }
@@ -2058,6 +2215,24 @@ async function readTrustedActionProbe(
       bodyText: (document.body?.innerText ?? "").slice(0, 1_000),
     };
   }, { args: [action] });
+}
+
+/**
+ * How far the aim for `selector` got, and what it last measured. `aimAtMarkedTarget`
+ * keeps this ledger in the page as it works, so a stalled aim names the step it
+ * died in — resolving the mark, settling the box, or reading the point — rather
+ * than reporting only that no point ever arrived.
+ */
+async function readAimProgress(
+  page: Page,
+  selector: string,
+): Promise<unknown> {
+  return await page.evaluate((targetSelector: string) => ({
+    aim: (globalThis as typeof globalThis & {
+      __cfAimDiag?: Record<string, unknown>;
+    }).__cfAimDiag?.[targetSelector],
+    documentVisibility: document.visibilityState,
+  }), { args: [selector] });
 }
 
 async function readTextProbe(

--- a/packages/patterns/integration/note-button-helpers.ts
+++ b/packages/patterns/integration/note-button-helpers.ts
@@ -73,7 +73,13 @@ async function settleAndClickNoteButton(
       { cause },
     );
   }
-  await clickMarked(page, token);
+  await clickMarked(page, {
+    token,
+    remark: {
+      predicate: markNoteButton,
+      args: [selector, match, needle, token, CLICK_TARGET_ATTR],
+    },
+  });
 }
 
 // The click helpers resolve `true` once the single click has landed (they throw


### PR DESCRIPTION
A CFC click used to resolve its marked control to a node handle, run a separate wait until that control's box stopped shifting, and only then ask the browser for the box to work out where to click. Four protocol round trips separated the decision from the measurement, and the page ran freely across all of them. When the surface rebuilt the control in that gap — a piece re-render replacing the DOM it drew, which the shell does on its own while a space is still starting up — the handle pointed at an element that was no longer in the document, the measurement came back empty, and the click failed with "Unable to get stable box model to click on". That is the intermittent failure the lunch-poll two-browser vote test hits at its first join-card click, and every CFC click shared the exposure.

Settling and aiming now happen in a single evaluation in the page. `clickMarked` runs one wait that resolves the marked control, holds until its bounding box is unchanged across two consecutive animation frames, scrolls it into view, and answers with the point to click. The point rides back on the same notification that ends the wait, so the test process gets the coordinates and the readiness verdict together and dispatches straight away. There is nothing left between the decision and the measurement for the page to change in.

To carry that answer, `waitForCondition` now resolves with whatever its predicate returned when the value is not simply `true`, passing it through the binding payload it already sends.

A control the page rebuilds is now clicked rather than reported as gone. Each helper hands `clickMarked` the predicate it used to place the mark, so a mark that has vanished is placed again on whatever control took over, under that helper's own readiness rules — its settle, its text match, its index — rather than under a rule invented at the click site. The grouped dispatch keeps its existing shape: it marks every target before clicking any of them, so it passes no re-mark predicate and no settle can slip between a group's marks and its clicks.

Two smaller corrections come with it. The scroll asks for instant behaviour, because the shell sets `scroll-behavior: smooth` and an animated scroll would still be moving the control when its point was read. And the frame wait treats a document that is not being rendered as already settled, since such a document produces no animation frames and its layout cannot move; waiting for a frame there waits for something that will not arrive.

`Page`'s own click, which non-CFC callers reach through an element handle, gets the same one-turn treatment: it scrolls and measures through the element rather than through the DOM agent's node handle. That also fixes a trap the old path hid. The underlying `DOM.getBoxModel` reports a node the DOM agent no longer knows about exactly as it reports a node with no layout box, and the agent forgets every outstanding node the moment anything queries the document afresh — so a handle could rot with no involvement from layout at all, and say so in the language of layout. The click now names what it found: detached from the document, no layout box, or a handle that no longer resolves.

A stalled aim also reports where it stalled. It keeps a ledger in the page of the step it reached, the frames it waited, and the last box it measured, and the failure prints that alongside the existing probe.

The regression test that comes with this removes the timing coincidence the failure needs in the wild. Its fixture marks a control and then rebuilds it on every animation frame for a bounded stretch, each replacement geometrically identical and carrying the mark over, so the control is always present and always in the same place while its identity keeps changing. Any click that decides and measures in one page turn lands on whichever element is there; a click that measures a handle it resolved earlier measures an element the surface has dropped. Against the previous click path it fails with the same error and the same clickCfButton -> clickMarked -> Page.clickElement stack seen in CI.

The astral adapter test that pinned the old click arithmetic against a stubbed box model now pins it against a control at a known position, since the point is measured from the element itself. waiting-in-tests.md gains the one-turn rule and drops its claim that the error means a missing layout box.

Absent and hidden are separate answers during that settle. A hidden control is coming back, so the settle keeps holding for it; a control that has left the document is not, because the page rebuilt the surface it was on, so the settle ends and the mark is placed again on whatever took its place, under the caller's own mark predicate, with the settle starting over on that element. A frame is taken before re-marking, so a surface rebuilding on every frame cannot spin the wait. Without that distinction the settle holds for a box that never returns and the wait runs to its stuck-condition net — the failure stops being a bad measurement and becomes a wait that never finishes, which is worse.

Measured against the lunch poll's first join-card click, driving the shell's own cf-render teardown at a delay drawn from the window between marking a control and aiming at it, four browsers at a time on one machine:

  before        334 loads   144 failed   43%
  after         400 loads   0 failed    0%

Every "Unable to get stable box model to click on" is gone, and so is the wait that would otherwise have replaced it.

Deflaked by Hixie's agent (Claude Opus 5).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

