### PR TITLE
 test(cli): make a multi-user test marker a data barrier

### DIFF
--- a/docs/common/ai/pattern-testing-guide.md
+++ b/docs/common/ai/pattern-testing-guide.md
@@ -293,17 +293,22 @@ Key points:
 - Each participant gets its own identity. Use
   `{ pattern: aliceTab2, user: "alice" }` for a second session of an
   existing user (PerUser state shared, PerSession state isolated).
-- Assertions retry (with settling) until the step timeout, since asserted
-  state may still be propagating from another runtime — don't assert
-  "other user does NOT see X yet" right after the other user acted; assert
-  stable invariants instead.
+- A marker is a durable write in the shared space, so crossing
+  `{ await: "name" }` means everything the announcing participant committed
+  before `{ label: "name" }` has reached this runtime. An assertion is read
+  once, there: a false value is a failure rather than a cue to wait longer.
+  Put every assertion about another participant's state after the marker
+  that carries it. A marker says what HAS arrived and nothing about what has
+  not, so "other user does NOT see X yet" is still not something to assert —
+  assert stable invariants instead.
 - Pattern outputs a participant asserts on must be computed snapshots that
   always yield a REAL, STABLE value. In a runtime that didn't write the
   underlying scoped cell, the cell reads as `undefined` — and a computed that
   returns `undefined` (or a fresh `[]` per recompute) is indistinguishable
   from "not yet computed" for cross-runtime readers, so the assertion never
-  settles. Normalize inside the computed (`trimmedName(name.get())`,
-  `cell.get() ?? EMPTY_LIST` with a module-level constant).
+  sees the value the writing runtime holds. Normalize inside the computed
+  (`trimmedName(name.get())`, `cell.get() ?? EMPTY_LIST` with a module-level
+  constant).
 - Read another runtime's arrays with INLINE literal indexing in the assertion
   computed (`users?.[0]?.name === "Alice"`). `.map()`, loop-variable
   indexing, and module-level helper calls over the array resolve in the

--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -259,6 +259,35 @@ probe is such a client. It disposes its controller once the wait returns, which
 also keeps a finished wait from holding the loop open for the rest of the
 suite.
 
+### Naming the arrival, across runtimes
+
+A wait for state a *different* runtime wrote takes the same `defer()`-from-a-sink
+shape, once the arrival it waits on is named. `cf test`'s multi-user mode
+(`packages/cli/lib/multi-user-test-runner.ts`) runs each participant in its own
+worker realm against one shared space, and its `{ label }` / `{ await }` markers
+are writes to a marker document in that space — one per participant, so no
+document has two writers. Announcing a marker commits it after everything the
+announcing participant has already committed, and the orchestrator announces
+only once that commit is confirmed. Crossing a marker resolves a `defer()` from
+that document's sink in the awaiting worker.
+
+By the time the marker arrives, the server holds what the announcing participant
+wrote before it, so the reads that follow resolve against a server that has it.
+Two mechanisms deliver it and both are ordered behind the marker. A document
+already in the awaiting replica's watch set arrives in a fan-out frame the
+server computes by diffing current storage, so a frame carrying the marker
+cannot omit an earlier write it has not yet sent. A document outside that set is
+fetched on demand by the assertion's own `pull()`, and the response reflects
+current server state. The assertion is therefore read once, at quiescence, with
+no convergence loop around it: a false value is a failure.
+
+Reach for this rather than a settle-and-retry loop whenever the write is
+something the test can name — name the arrival, wait on it, then read. What the
+awaiting side gets in place of the Deno fail-fast above is the orchestrator's
+worker RPC deadline, which is the ambient limit the previous paragraph
+describes: a marker that never arrives is reported against the participant,
+marker, and announcer rather than fast.
+
 ### Browser-hosted unit tests have a harness backstop
 
 That fail-fast is Deno's, and the browser-hosted unit tests that
@@ -758,7 +787,13 @@ control, and there is no single "it converged" promise to await.
 `packages/patterns/integration/multi-runtime-harness.ts`), a different method
 that settles several in-process Deno-worker runtimes and reads durable cells
 across them. It is not the `@commonfabric/integration` `waitFor`, has no page,
-and its cross-runtime convergence poll is the honest mechanism.
+and its cross-runtime convergence poll is the honest mechanism for a caller
+that names only the state it wants and not the write that produces it.
+
+A caller that can name the write does better, and the multi-user `cf test`
+markers are that shape: a marker committed after the writes it stands for turns
+"has it converged yet" into "has this arrived", which a sink answers. [Naming
+the arrival, across runtimes](#naming-the-arrival-across-runtimes) describes it.
 
 ### Cross-page joint condition
 

--- a/packages/cli/lib/assert-record.ts
+++ b/packages/cli/lib/assert-record.ts
@@ -1,0 +1,59 @@
+/**
+ * Reading and rendering the record an `assert(...)` test assertion carries.
+ *
+ * Both `cf test` runners evaluate an assertion step to a value and report a
+ * failure from it, so the recognition and the rendering live here rather than
+ * in either runner.
+ */
+
+import type { AssertPart, AssertRecord } from "@commonfabric/api";
+
+/**
+ * Recognizes the record an `assert(...)` assertion carries. A `computed(...)`
+ * assertion carries a bare boolean instead, so this is what tells the two
+ * apart at the point the harness reads the value.
+ */
+export function asAssertRecord(value: unknown): AssertRecord | undefined {
+  if (typeof value !== "object" || value === null) return undefined;
+  const candidate = value as Partial<AssertRecord>;
+  if (
+    typeof candidate.ok !== "boolean" ||
+    typeof candidate.source !== "string" ||
+    !Array.isArray(candidate.parts)
+  ) {
+    return undefined;
+  }
+  const parts = candidate.parts.filter((part): part is AssertPart =>
+    typeof part === "object" && part !== null &&
+    typeof (part as Partial<AssertPart>).src === "string" &&
+    typeof (part as Partial<AssertPart>).rendered === "string"
+  );
+  return { ok: candidate.ok, source: candidate.source, parts };
+}
+
+/**
+ * Renders a failed `assert(...)` as its authored text followed by the operands
+ * recorded while it ran, for example:
+ *
+ *     a + b <= c
+ *       a + b = 3
+ *       c     = 2
+ *
+ * The operands say the assertion was false, so saying it again adds nothing.
+ * An assertion that recorded none — a bare value, or one whose operands are
+ * all literals — has nothing to explain itself with, so that one still reports
+ * what happened rather than restating the source on its own.
+ */
+export function formatAssertRecord(record: AssertRecord): string {
+  if (record.parts.length === 0) {
+    return record.source.length > 0
+      ? `Expected true, got false: ${record.source}`
+      : "Expected true, got false";
+  }
+
+  const width = Math.max(...record.parts.map((part) => part.src.length));
+  const lines = record.parts.map((part) =>
+    `  ${part.src.padEnd(width)} = ${part.rendered}`
+  );
+  return [record.source, ...lines].join("\n");
+}

--- a/packages/cli/lib/multi-user-test-runner.ts
+++ b/packages/cli/lib/multi-user-test-runner.ts
@@ -35,9 +35,16 @@
  * `{ await: marker }` for a marker no other participant has announced via
  * `{ label: marker }` yet; the orchestrator then switches to the next
  * runnable participant. If every unfinished participant is parked, the test
- * fails with a deadlock report. Assertions retry (with settling) until the
- * step timeout, since asserted state may still be propagating from another
- * runtime.
+ * fails with a deadlock report.
+ *
+ * A marker is also a durable write in the shared space, which is what makes
+ * the handshake a data barrier rather than bookkeeping. Each participant
+ * announces into its own marker document, committing after everything it has
+ * already committed; crossing a marker waits for it to arrive in the awaiting
+ * participant's replica. By then the server holds what the announcing
+ * participant wrote first, so the reads that follow resolve against it. An
+ * assertion placed after a marker is therefore read once: a false value is a
+ * failure rather than a cue to try again.
  */
 
 import { Identity } from "@commonfabric/identity";
@@ -102,7 +109,6 @@ export function multiUserDescriptorMeta(
 }
 
 const RPC_TIMEOUT_MS = 120_000;
-const ASSERTION_RETRY_DELAY_MS = 100;
 
 class ParticipantWorker {
   readonly name: string;
@@ -231,6 +237,7 @@ export async function runMultiUserTestPattern(
           patternCoverageDir: options.patternCoverageDir,
           continuousUI: options.continuousUI,
           participant: spec.name,
+          participants: meta.participants.map((p) => p.name),
           seedDefaults: index === 0,
         }) as ParticipantInitResult;
         participants.push({
@@ -260,7 +267,7 @@ export async function runMultiUserTestPattern(
 
     // Marker scheduler: round-robin in declaration order; each turn runs a
     // participant's steps until it parks on an unannounced marker or ends.
-    const announced = new Set<string>();
+    const announced = new Map<string, string>();
     while (participants.some((p) => p.cursor < p.steps.length)) {
       let progressed = false;
       for (const participant of participants) {
@@ -268,7 +275,22 @@ export async function runMultiUserTestPattern(
           const index = participant.cursor;
           const step = participant.steps[index];
           if (step.kind === "await" && !step.skip) {
-            if (!announced.has(step.marker!)) break; // parked
+            const announcedBy = announced.get(step.marker!);
+            if (announcedBy === undefined) break; // parked
+            // The marker is announced, so the server holds it. Wait for it to
+            // reach this participant's replica; whatever the announcing
+            // participant committed first is already on the server, so the
+            // reads that follow resolve against it.
+            await participant.worker.call("awaitMarker", {
+              announcedBy,
+              marker: step.marker,
+            }).catch((error: Error) => {
+              throw new Error(
+                `[${participant.spec.name}] waiting for marker ` +
+                  `"${step.marker}" announced by ${announcedBy}: ` +
+                  error.message,
+              );
+            });
             participant.cursor++;
             progressed = true;
             if (options.verbose) {
@@ -283,7 +305,10 @@ export async function runMultiUserTestPattern(
             continue;
           }
           if (step.kind === "label") {
-            announced.add(step.marker!);
+            // Commit before announcing, so a participant released by the
+            // announcement always finds a marker the server already holds.
+            await participant.worker.call("label", { marker: step.marker });
+            announced.set(step.marker!, participant.spec.name);
             if (options.verbose) {
               console.log(`  [${participant.spec.name}] ⇡ ${step.marker}`);
             }
@@ -318,31 +343,25 @@ export async function runMultiUserTestPattern(
             }
             continue;
           }
-          // Assertion: retry with settling until the step timeout — the
-          // asserted state may still be propagating from another runtime.
+          // Assertion: read once. The step that preceded it settled this
+          // participant's own work, and a marker it crossed carried the other
+          // participants' work with it, so a false value here is a failure.
           participant.assertionCount++;
           const name =
             `${participant.spec.name}/assertion_${participant.assertionCount}`;
           const stepStart = performance.now();
           let passed = false;
           let error: string | undefined;
-          while (true) {
-            try {
-              const outcome = await participant.worker.call("assertion", {
-                index,
-              }) as { passed: boolean };
-              passed = outcome.passed;
-              error = undefined;
-            } catch (assertionError) {
-              passed = false;
-              error = String(
-                (assertionError as Error).message ?? assertionError,
-              );
-            }
-            if (passed || performance.now() - stepStart >= stepTimeout) break;
-            await participant.worker.call("settle");
-            await new Promise((resolve) =>
-              setTimeout(resolve, ASSERTION_RETRY_DELAY_MS)
+          try {
+            const outcome = await participant.worker.call("assertion", {
+              index,
+            }) as { passed: boolean; error?: string };
+            passed = outcome.passed;
+            error = outcome.error;
+          } catch (assertionError) {
+            passed = false;
+            error = String(
+              (assertionError as Error).message ?? assertionError,
             );
           }
           const durationMs = performance.now() - stepStart;

--- a/packages/cli/lib/multi-user-test-runner.ts
+++ b/packages/cli/lib/multi-user-test-runner.ts
@@ -284,11 +284,12 @@ export async function runMultiUserTestPattern(
             await participant.worker.call("awaitMarker", {
               announcedBy,
               marker: step.marker,
-            }).catch((error: Error) => {
+            }).catch((cause: Error) => {
               throw new Error(
                 `[${participant.spec.name}] waiting for marker ` +
                   `"${step.marker}" announced by ${announcedBy}: ` +
-                  error.message,
+                  cause.message,
+                { cause },
               );
             });
             participant.cursor++;

--- a/packages/cli/lib/multi-user-test-runner.ts
+++ b/packages/cli/lib/multi-user-test-runner.ts
@@ -38,13 +38,12 @@
  * fails with a deadlock report.
  *
  * A marker is also a durable write in the shared space, which is what makes
- * the handshake a data barrier rather than bookkeeping. Each participant
- * announces into its own marker document, committing after everything it has
- * already committed; crossing a marker waits for it to arrive in the awaiting
- * participant's replica. By then the server holds what the announcing
- * participant wrote first, so the reads that follow resolve against it. An
- * assertion placed after a marker is therefore read once: a false value is a
- * failure rather than a cue to try again.
+ * the handshake a data barrier. Each participant announces into its own
+ * marker document, committing after everything it has already committed;
+ * crossing a marker waits for it to arrive in the awaiting participant's
+ * replica. By then the server holds what the announcing participant wrote
+ * first, so the reads that follow resolve against it. An assertion placed
+ * after a marker is therefore read once, and a false value is a failure.
  */
 
 import { Identity } from "@commonfabric/identity";

--- a/packages/cli/lib/multi-user-test-worker.ts
+++ b/packages/cli/lib/multi-user-test-worker.ts
@@ -20,7 +20,7 @@
  * server computes by diffing current storage, which cannot carry the marker
  * while omitting an earlier write it has not yet sent, and a document
  * outside that set is fetched on demand by the assertion's own `pull()`.
- * That is what lets an assertion be read once instead of retried.
+ * That is what lets an assertion be read once.
  *
  * Realm isolation is required, not an optimization: two runtimes in one
  * realm cross-talk through module-level state (verified-load registries,
@@ -93,10 +93,9 @@ const SETTLE_FAST_MS = 2;
 
 /**
  * One marker document per participant, so the only writer of a document is
- * the participant it belongs to. A single shared document would take a
- * conflict whenever a participant announced while holding a replica that
- * predates another participant's announcement, and the marker it dropped
- * would never arrive.
+ * the participant it belongs to. Announcing is then conflict-free whatever
+ * order participants announce in, including from a replica that predates
+ * another participant's announcement.
  */
 function markersCause(participant: string): string {
   return `multi-user-test-markers:${participant}`;

--- a/packages/cli/lib/multi-user-test-worker.ts
+++ b/packages/cli/lib/multi-user-test-worker.ts
@@ -10,6 +10,18 @@
  * participant pattern, whose `tests` steps the orchestrator drives via a
  * small request/response protocol.
  *
+ * The `{ label }` / `{ await }` markers travel through that same shared
+ * space, each participant announcing into its own marker document.
+ * Announcing commits the marker; awaiting waits for it to arrive here. The
+ * announcing participant settles each step before the next, so the server
+ * holds everything it wrote before it holds the marker. A replica that has
+ * the marker therefore reads the rest from a server that already has it:
+ * documents inside this replica's watch set arrive in a fan-out frame the
+ * server computes by diffing current storage, which cannot carry the marker
+ * while omitting an earlier write it has not yet sent, and a document
+ * outside that set is fetched on demand by the assertion's own `pull()`.
+ * That is what lets an assertion be read once instead of retried.
+ *
  * Realm isolation is required, not an optimization: two runtimes in one
  * realm cross-talk through module-level state (verified-load registries,
  * frame stack).
@@ -44,6 +56,9 @@ import {
   Identity,
   type KeyPairRaw,
 } from "@commonfabric/identity";
+import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
+import { defer } from "@commonfabric/utils/defer";
+import { asAssertRecord, formatAssertRecord } from "./assert-record.ts";
 import { materializeTestVDOM, mountTestVDOM } from "./materialize-test-vdom.ts";
 
 export interface WorkerRequest {
@@ -76,11 +91,32 @@ export interface ParticipantInitResult {
 const SETUP_CAUSE = "multi-user-test-setup";
 const SETTLE_FAST_MS = 2;
 
+/**
+ * One marker document per participant, so the only writer of a document is
+ * the participant it belongs to. A single shared document would take a
+ * conflict whenever a participant announced while holding a replica that
+ * predates another participant's announcement, and the marker it dropped
+ * would never arrive.
+ */
+function markersCause(participant: string): string {
+  return `multi-user-test-markers:${participant}`;
+}
+
+/** Markers one participant has announced, one property per marker name. */
+const markersSchema = {
+  type: "object",
+  additionalProperties: { type: "boolean" },
+  default: {},
+} as const;
+
 let runtime: Runtime | undefined;
 let storageManager:
   | { synced(): Promise<void>; close(): Promise<void> }
   | undefined;
 let engine: Engine | undefined;
+/** Every participant's marker document, keyed by participant name. */
+const markersCells = new Map<string, Cell<Record<string, boolean>>>();
+let selfParticipant: string | undefined;
 let stepCells: Cell<unknown>[] = [];
 let patternCoverage: PatternCoverageCollector | undefined;
 let patternCoveragePath: string | undefined;
@@ -109,6 +145,49 @@ async function settle(maxIterations = 20): Promise<void> {
     await rt().idle();
     await storageManager!.synced();
     if (performance.now() - start < SETTLE_FAST_MS) return;
+  }
+}
+
+function markersCellFor(participant: string): Cell<Record<string, boolean>> {
+  const cell = markersCells.get(participant);
+  if (!cell) {
+    throw new Error(`No marker document for participant "${participant}"`);
+  }
+  return cell;
+}
+
+/**
+ * Resolve once `marker` is present in this replica's copy of the marker
+ * document `announcedBy` writes.
+ *
+ * The wait sleeps on the cell's sink, so it wakes on the commit that carries
+ * the marker rather than on a clock, and it reads the value once the
+ * scheduler is quiescent.
+ */
+async function waitForMarker(
+  announcedBy: string,
+  marker: string,
+): Promise<void> {
+  const cell = markersCellFor(announcedBy);
+  let changed = defer<void>();
+  const cancel = cell.sink(() => {
+    changed.resolve();
+    changed = defer<void>();
+  });
+  try {
+    while (true) {
+      await rt().idle();
+      // Captured before the read, so a change racing the check wakes the next
+      // attempt instead of being missed.
+      const next = changed.promise;
+      if (cell.get()?.[marker] === true) return;
+      await next;
+    }
+  } finally {
+    // Cancelling while the action that reported a value is still finalizing
+    // does not stick, because finalizing an action resubscribes it.
+    await rt().idle();
+    cancel();
   }
 }
 
@@ -263,6 +342,20 @@ const handlers: Record<
       );
     }
 
+    // Subscribe to every participant's marker document before any step runs,
+    // so an announcement is already in this replica's watch set when it is
+    // made rather than being fetched after the fact.
+    selfParticipant = args.participant as string;
+    for (const name of args.participants as string[]) {
+      const cell = rt().getCell<Record<string, boolean>>(
+        space,
+        markersCause(name),
+        markersSchema,
+      );
+      await cell.sync();
+      markersCells.set(name, cell);
+    }
+
     // Minimal wish("#default") environment, seeded once by the first worker.
     if (args.seedDefaults === true) {
       const setupTx = rt().edit();
@@ -377,12 +470,24 @@ const handlers: Record<
     return {};
   },
 
-  /** Pull an assertion step's value; the orchestrator handles retries. */
+  /** Evaluate an assertion step, reporting what a false value held. */
   async assertion({ index }) {
     const stepCell = stepCells[index as number];
     const value = await (stepCell.key("assertion" as never) as Cell<unknown>)
       .pull();
-    return { passed: value === true };
+    if (value === true) return { passed: true };
+    // An `assert(...)` assertion carries the operands recorded by the
+    // evaluation that produced this value, so report them.
+    const record = asAssertRecord(value);
+    if (record) {
+      return record.ok
+        ? { passed: true }
+        : { passed: false, error: formatAssertRecord(record) };
+    }
+    return {
+      passed: false,
+      error: `Expected true, got ${toCompactDebugString(value)}`,
+    };
   },
 
   /** Materialize one VDOM target, then remove its renderer demand. */
@@ -395,9 +500,30 @@ const handlers: Record<
     return {};
   },
 
-  /** Let in-flight work and incoming subscription pushes land. */
-  async settle() {
-    await settle(6);
+  /**
+   * Announce a coordination marker as a durable write, ordered after every
+   * commit this participant has already made.
+   */
+  async label({ marker }) {
+    const tx = rt().edit();
+    markersCellFor(selfParticipant!).withTx(tx).key(marker as string).set(true);
+    rt().prepareTxForCommit?.(tx);
+    // A dropped marker is a wait that never ends, so the commit's verdict is
+    // read rather than assumed.
+    const result = await tx.commit();
+    if (result.error) {
+      throw new Error(
+        `Announcing marker "${marker}" failed: ${result.error.message}`,
+      );
+    }
+    await settle();
+    return {};
+  },
+
+  /** Wait for another participant's marker to reach this replica. */
+  async awaitMarker({ announcedBy, marker }) {
+    await waitForMarker(announcedBy as string, marker as string);
+    await settle();
     return {};
   },
 
@@ -445,6 +571,8 @@ const handlers: Record<
 
   async dispose() {
     stepCells = [];
+    markersCells.clear();
+    selfParticipant = undefined;
     continuousUiCancel?.();
     continuousUiCancel = undefined;
     continuousUiErrors.length = 0;

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -49,7 +49,8 @@ import type {
 } from "@commonfabric/runner";
 import type { CfcEnforcementMode } from "@commonfabric/runner/cfc";
 import { getDefaultModuleByteCache } from "./compile-byte-cache.ts";
-import type { AssertPart, AssertRecord, Reactive } from "@commonfabric/api";
+import type { AssertRecord, Reactive } from "@commonfabric/api";
+import { asAssertRecord, formatAssertRecord } from "./assert-record.ts";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
@@ -130,56 +131,6 @@ function indentLines(text: string, indent: string): string {
     .split("\n")
     .map((line) => `${indent}${line}`)
     .join("\n");
-}
-
-/**
- * Recognizes the record an `assert(...)` assertion carries. A `computed(...)`
- * assertion carries a bare boolean instead, so this is what tells the two
- * apart at the point the harness reads the value.
- */
-function asAssertRecord(value: unknown): AssertRecord | undefined {
-  if (typeof value !== "object" || value === null) return undefined;
-  const candidate = value as Partial<AssertRecord>;
-  if (
-    typeof candidate.ok !== "boolean" ||
-    typeof candidate.source !== "string" ||
-    !Array.isArray(candidate.parts)
-  ) {
-    return undefined;
-  }
-  const parts = candidate.parts.filter((part): part is AssertPart =>
-    typeof part === "object" && part !== null &&
-    typeof (part as Partial<AssertPart>).src === "string" &&
-    typeof (part as Partial<AssertPart>).rendered === "string"
-  );
-  return { ok: candidate.ok, source: candidate.source, parts };
-}
-
-/**
- * Renders a failed `assert(...)` as its authored text followed by the operands
- * recorded while it ran, for example:
- *
- *     a + b <= c
- *       a + b = 3
- *       c     = 2
- *
- * The operands say the assertion was false, so saying it again adds nothing.
- * An assertion that recorded none — a bare value, or one whose operands are
- * all literals — has nothing to explain itself with, so that one still reports
- * what happened rather than restating the source on its own.
- */
-function formatAssertRecord(record: AssertRecord): string {
-  if (record.parts.length === 0) {
-    return record.source.length > 0
-      ? `Expected true, got false: ${record.source}`
-      : "Expected true, got false";
-  }
-
-  const width = Math.max(...record.parts.map((part) => part.src.length));
-  const lines = record.parts.map((part) =>
-    `  ${part.src.padEnd(width)} = ${part.rendered}`
-  );
-  return [record.source, ...lines].join("\n");
 }
 
 /**

--- a/packages/cli/test/fixtures/multi-user-markers/crosswise-markers.test.tsx
+++ b/packages/cli/test/fixtures/multi-user-markers/crosswise-markers.test.tsx
@@ -1,0 +1,35 @@
+/// <cts-enable />
+/**
+ * Both participants announce before either crosses the other's marker, so
+ * each announces from a replica that predates the other's announcement. A
+ * marker document with more than one writer takes a conflict here and drops
+ * the marker it was asked to record, which shows up as a wait that never
+ * ends.
+ */
+import { assert, multiUserTest, pattern, Writable } from "commonfabric";
+
+export interface MarkerSetup {
+  note: Writable<string>;
+}
+
+export const setup = pattern<Record<string, never>, MarkerSetup>(() => ({
+  note: Writable.of<string>(""),
+}));
+
+export const alice = pattern<{ setup: MarkerSetup }>(({ setup }) => ({
+  tests: [
+    { label: "alice-1" },
+    { await: "bob-1" },
+    { assertion: assert(() => setup.note.get() === "") },
+  ],
+}));
+
+export const bob = pattern<{ setup: MarkerSetup }>(({ setup }) => ({
+  tests: [
+    { label: "bob-1" },
+    { await: "alice-1" },
+    { assertion: assert(() => setup.note.get() === "") },
+  ],
+}));
+
+export default multiUserTest({ setup, participants: { alice, bob } });

--- a/packages/cli/test/fixtures/multi-user-markers/crosswise-markers.test.tsx
+++ b/packages/cli/test/fixtures/multi-user-markers/crosswise-markers.test.tsx
@@ -1,10 +1,9 @@
 /// <cts-enable />
 /**
  * Both participants announce before either crosses the other's marker, so
- * each announces from a replica that predates the other's announcement. A
- * marker document with more than one writer takes a conflict here and drops
- * the marker it was asked to record, which shows up as a wait that never
- * ends.
+ * each announces from a replica that predates the other's announcement. Each
+ * writes its own marker document, so announcing in that order is
+ * conflict-free and both markers arrive.
  */
 import { assert, multiUserTest, pattern, Writable } from "commonfabric";
 

--- a/packages/cli/test/fixtures/multi-user-markers/false-assertion.test.tsx
+++ b/packages/cli/test/fixtures/multi-user-markers/false-assertion.test.tsx
@@ -1,0 +1,31 @@
+/// <cts-enable />
+/**
+ * A false assertion after a marker. Bob reads a note Alice did write, and
+ * compares it against something she never wrote, so the value is settled and
+ * the comparison is the failure.
+ */
+import { action, assert, multiUserTest, pattern, Writable } from "commonfabric";
+
+export interface MarkerSetup {
+  note: Writable<string>;
+}
+
+export const setup = pattern<Record<string, never>, MarkerSetup>(() => ({
+  note: Writable.of<string>(""),
+}));
+
+export const alice = pattern<{ setup: MarkerSetup }>(({ setup }) => ({
+  tests: [
+    { action: action(() => setup.note.set("from alice")) },
+    { label: "alice-wrote" },
+  ],
+}));
+
+export const bob = pattern<{ setup: MarkerSetup }>(({ setup }) => ({
+  tests: [
+    { await: "alice-wrote" },
+    { assertion: assert(() => setup.note.get() === "from nobody") },
+  ],
+}));
+
+export default multiUserTest({ setup, participants: { alice, bob } });

--- a/packages/cli/test/fixtures/multi-user-markers/false-computed.test.tsx
+++ b/packages/cli/test/fixtures/multi-user-markers/false-computed.test.tsx
@@ -1,0 +1,37 @@
+/// <cts-enable />
+/**
+ * A false `computed(...)` assertion. It carries a bare boolean rather than
+ * the record an `assert(...)` carries, so the failure has no operands to
+ * render and reports the value that was read instead.
+ */
+import {
+  action,
+  computed,
+  multiUserTest,
+  pattern,
+  Writable,
+} from "commonfabric";
+
+export interface MarkerSetup {
+  note: Writable<string>;
+}
+
+export const setup = pattern<Record<string, never>, MarkerSetup>(() => ({
+  note: Writable.of<string>(""),
+}));
+
+export const alice = pattern<{ setup: MarkerSetup }>(({ setup }) => ({
+  tests: [
+    { action: action(() => setup.note.set("from alice")) },
+    { label: "alice-wrote" },
+  ],
+}));
+
+export const bob = pattern<{ setup: MarkerSetup }>(({ setup }) => ({
+  tests: [
+    { await: "alice-wrote" },
+    { assertion: computed(() => setup.note.get() === "from nobody") },
+  ],
+}));
+
+export default multiUserTest({ setup, participants: { alice, bob } });

--- a/packages/cli/test/fixtures/multi-user-markers/marker-barrier.test.tsx
+++ b/packages/cli/test/fixtures/multi-user-markers/marker-barrier.test.tsx
@@ -1,0 +1,31 @@
+/// <cts-enable />
+/**
+ * Crossing `{ await }` delivers what the announcing participant wrote before
+ * `{ label }`. Bob's assertion is read once, so it passes only when the
+ * marker brought Alice's write with it.
+ */
+import { action, assert, multiUserTest, pattern, Writable } from "commonfabric";
+
+export interface MarkerSetup {
+  note: Writable<string>;
+}
+
+export const setup = pattern<Record<string, never>, MarkerSetup>(() => ({
+  note: Writable.of<string>(""),
+}));
+
+export const alice = pattern<{ setup: MarkerSetup }>(({ setup }) => ({
+  tests: [
+    { action: action(() => setup.note.set("from alice")) },
+    { label: "alice-wrote" },
+  ],
+}));
+
+export const bob = pattern<{ setup: MarkerSetup }>(({ setup }) => ({
+  tests: [
+    { await: "alice-wrote" },
+    { assertion: assert(() => setup.note.get() === "from alice") },
+  ],
+}));
+
+export default multiUserTest({ setup, participants: { alice, bob } });

--- a/packages/cli/test/fixtures/multi-user-markers/unannounced-marker.test.tsx
+++ b/packages/cli/test/fixtures/multi-user-markers/unannounced-marker.test.tsx
@@ -1,0 +1,28 @@
+/// <cts-enable />
+/**
+ * Bob parks on a marker nobody announces. Alice finishes, leaving Bob the
+ * only unfinished participant and nothing left to release him, which the
+ * orchestrator reports as a deadlock.
+ */
+import { assert, multiUserTest, pattern, Writable } from "commonfabric";
+
+export interface MarkerSetup {
+  note: Writable<string>;
+}
+
+export const setup = pattern<Record<string, never>, MarkerSetup>(() => ({
+  note: Writable.of<string>(""),
+}));
+
+export const alice = pattern<{ setup: MarkerSetup }>(({ setup }) => ({
+  tests: [{ assertion: assert(() => setup.note.get() === "") }],
+}));
+
+export const bob = pattern<{ setup: MarkerSetup }>(({ setup }) => ({
+  tests: [
+    { await: "never-announced" },
+    { assertion: assert(() => setup.note.get() === "") },
+  ],
+}));
+
+export default multiUserTest({ setup, participants: { alice, bob } });

--- a/packages/cli/test/multi-user-test-runner.test.ts
+++ b/packages/cli/test/multi-user-test-runner.test.ts
@@ -40,9 +40,9 @@ describe(
     });
 
     it("carries markers announced crosswise", async () => {
-      // Each participant announces before crossing the other's marker. With
-      // one marker document per announcer nothing conflicts, so both markers
-      // arrive; sharing one document drops the second and hangs the wait.
+      // Each participant announces before crossing the other's marker, from
+      // a replica that predates the other's announcement. One marker document
+      // per announcer keeps that order conflict-free.
       const { passed, failed } = await runTests(
         fixture("crosswise-markers.test.tsx"),
         { root: FIXTURES },

--- a/packages/cli/test/multi-user-test-runner.test.ts
+++ b/packages/cli/test/multi-user-test-runner.test.ts
@@ -63,6 +63,16 @@ describe(
       expect(results[0].results[0].error).toContain(`"from alice"`);
     });
 
+    it("reports a false assertion that recorded no operands", async () => {
+      const { passed, failed, results } = await runTests(
+        fixture("false-computed.test.tsx"),
+        { root: FIXTURES },
+      );
+      expect(passed).toBe(0);
+      expect(failed).toBe(1);
+      expect(results[0].results[0].error).toContain("Expected true, got false");
+    });
+
     it("reports a marker nobody announces as a deadlock", async () => {
       const { failed, results } = await runTests(
         fixture("unannounced-marker.test.tsx"),

--- a/packages/cli/test/multi-user-test-runner.test.ts
+++ b/packages/cli/test/multi-user-test-runner.test.ts
@@ -1,0 +1,76 @@
+/**
+ * The multi-user orchestrator's `{ label }` / `{ await }` handshake.
+ *
+ * A marker is a durable write in the shared space, so crossing one means the
+ * announcing participant's earlier writes have reached this replica. That is
+ * what lets an assertion be read once.
+ *
+ * What these tests hold in place is that contract as an author meets it: a
+ * marker carries state across, a marker announced from a replica that predates
+ * another participant's announcement still arrives, a false assertion is
+ * reported for what it read rather than for running out of time, and a marker
+ * nobody announces is still a deadlock. The propagation gap itself is too
+ * small to observe in a fixture this size — the barrier's discriminating
+ * coverage is the pattern-test corpus, where removing it fails seven
+ * assertions across `topics`, `lobby`, and `cfc-group-chat-demo`.
+ */
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { resolve } from "@std/path";
+import { runTests } from "../lib/test-runner.ts";
+
+const FIXTURES = resolve(import.meta.dirname!, "fixtures/multi-user-markers");
+
+function fixture(name: string): string {
+  return resolve(FIXTURES, name);
+}
+
+describe(
+  "multi-user-test-runner",
+  { sanitizeOps: false, sanitizeResources: false },
+  () => {
+    it("delivers what was written before the marker", async () => {
+      const { passed, failed, results } = await runTests(
+        fixture("marker-barrier.test.tsx"),
+        { root: FIXTURES },
+      );
+      expect(failed).toBe(0);
+      expect(passed).toBe(1);
+      expect(results[0].results[0].name).toBe("bob/assertion_1");
+    });
+
+    it("carries markers announced crosswise", async () => {
+      // Each participant announces before crossing the other's marker. With
+      // one marker document per announcer nothing conflicts, so both markers
+      // arrive; sharing one document drops the second and hangs the wait.
+      const { passed, failed } = await runTests(
+        fixture("crosswise-markers.test.tsx"),
+        { root: FIXTURES },
+      );
+      expect(failed).toBe(0);
+      expect(passed).toBe(2);
+    });
+
+    it("reports a false assertion with the operands it read", async () => {
+      const { passed, failed, results } = await runTests(
+        fixture("false-assertion.test.tsx"),
+        { root: FIXTURES },
+      );
+      expect(passed).toBe(0);
+      expect(failed).toBe(1);
+      // The assertion is answered from settled state, so the failure names
+      // the value that was there rather than reporting elapsed time.
+      expect(results[0].results[0].error).toContain(`"from alice"`);
+    });
+
+    it("reports a marker nobody announces as a deadlock", async () => {
+      const { failed, results } = await runTests(
+        fixture("unannounced-marker.test.tsx"),
+        { root: FIXTURES },
+      );
+      expect(failed).toBeGreaterThan(0);
+      expect(results[0].error).toContain("Deadlock");
+      expect(results[0].error).toContain(`bob awaits "never-announced"`);
+    });
+  },
+);


### PR DESCRIPTION
The multi-user mode of `cf test` runs each participant in its own worker realm, against one shared space on an in-process storage server. A participant asserting on state another participant wrote therefore has to wait for that state to cross between the two runtimes. The orchestrator did that waiting by re-evaluating the assertion in a loop: read it, and on a false value ask the worker to settle, sleep 100 milliseconds, and read it again, giving up once the step timeout elapsed.

That combines the three shapes the repository rules out. The sleep puts a floor under what every cross-runtime assertion costs. The loop lets an assertion that should have been true on the first read pass anyway, so a pattern that only converges late looks the same as one that converges promptly. And the timeout puts a ceiling on success: on a loaded machine, or after any pause that advances the wall clock without advancing the work, an assertion that would have passed is reported as a failure instead.

The waiting was there because nothing else carried the propagation. A participant's steps run in order, and cross-participant ordering happens only at the `{ label: "name" }` and `{ await: "name" }` markers, but those markers were bookkeeping inside the orchestrator: announcing one added a name to a set, and crossing one checked that set. Neither touched the space the participants share, so a released participant had no reason to hold the state the marker stood for, and the retry loop was what made up the difference.

So make a marker a write. Each participant announces into a marker document of its own, which every worker subscribes to as it initializes. Announcing commits the marker, which the announcing participant does after every commit it has already made, and the orchestrator announces only once that commit is confirmed; crossing a marker waits for it to appear in the awaiting participant's replica. One writer per document means a marker cannot be lost to a conflict whatever order markers are announced in, and the announcing side reads the commit's verdict rather than assuming it, so a marker that does not reach storage is reported where it happened rather than as a wait that never ends.

By the time a marker arrives, the server holds what the announcing participant wrote before it, so the reads that follow resolve against a server that has it. Two mechanisms deliver it and both are ordered behind the marker. A document already in the awaiting replica's watch set arrives in a fan-out frame the server computes by diffing current storage, so a frame carrying the marker cannot omit an earlier write it has not yet sent. A document outside that set is fetched on demand by the assertion's own `pull()`, whose response reflects current server state.

The wait itself resolves a deferred from the marker document's sink, so it wakes on the commit that carries the marker rather than on a clock, and it reads the document once the scheduler is quiescent. There is no poll interval under it and no iteration cap over it. A wait that does run out reaches the orchestrator's existing worker RPC deadline, and reports the participant, the marker, and who announced it.

That leaves an assertion something it can be read once from: whatever the step before it settled locally, plus whatever a marker it crossed brought with it. A false value is now a failure rather than a cue to try again, reported at once instead of after the step timeout, and a pattern whose state arrives late fails instead of passing on a retry. Reading once also makes the failure message worth having, so the assertion evaluation reports what it read. That fixes a second problem on the way: `assert(...)` evaluates to a record rather than to `true`, so every `assert(...)` in a multi-user test used to fail whatever it asserted, after the full step timeout and with nothing to say. The runner now recognizes the record and renders its operands the way the single-runtime runner does. The two functions that do that rendering move out of test-runner.ts into their own module, so both runners share one copy.

Removing the barrier fails seven assertions across the topics, lobby and cfc-group-chat-demo pattern tests, which is where its discriminating coverage is; the new fixtures state the contract an author relies on, and the test file says which is which. One of them covers the marker topology: both participants announcing before either crosses.

Documentation: the multi-user section of the pattern testing guide now describes a marker as a barrier and says an assertion is read once, while keeping the existing warning that a marker says what has arrived and nothing about what has not. The test-waits note gains a section for the shape, since it is the alternative to the cross-runtime convergence poll that note otherwise presents as the honest mechanism.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

