### PR TITLE
refactor(cli): extract the shared read step as a cell selection

### DIFF
--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -49,11 +49,9 @@ import ports from "@commonfabric/ports" with { type: "json" };
 import type { PiecePatternRef } from "@commonfabric/piece/ops";
 import { reservesStdoutForCommandOutput } from "../lib/json-output.ts";
 import {
-  parsePieceGetFilter,
-  parsePieceGetProjection,
-  type PieceGetTransform,
-  PieceGetTransformError,
-} from "../lib/piece-get-transform.ts";
+  CellSelectionError,
+  parseCellSelectionOptions,
+} from "../lib/cell-selection.ts";
 
 // Hint system: print helpful next-step suggestions after operations
 let quietMode = false;
@@ -78,21 +76,6 @@ export function normalizeApiUrl(apiUrl: string): string {
   normalized.hash = "";
   const href = normalized.toString();
   return basePath ? href : href.slice(0, -1);
-}
-
-export async function parsePieceGetTransformOptions(options: {
-  filter?: string;
-  schema?: string;
-}): Promise<PieceGetTransform | undefined> {
-  const filter = options.filter === undefined
-    ? undefined
-    : parsePieceGetFilter(options.filter);
-  const projection = options.schema === undefined
-    ? undefined
-    : await parsePieceGetProjection(options.schema);
-  return filter === undefined && projection === undefined
-    ? undefined
-    : { filter, projection };
 }
 
 function summarizeForDisplay(value: unknown): unknown {
@@ -184,7 +167,7 @@ export function localPatternEntry(
  * A `piece get` failure caused by a data condition rather than bad arguments:
  * a path that doesn't resolve, a result schema that can't project stored data
  * (PieceResultProjectionError), a filter/projection that doesn't fit the
- * selected value (PieceGetTransformError), or a path that lands on a verb
+ * selected value (CellSelectionError), or a path that lands on a verb
  * (PieceVerbReadError — the read-path guard's redirect at `cf piece call`).
  * Reported as a plain error on stderr with exit 1, never as a Cliffy
  * ValidationError (which would dump the usage screen and read as an arg-parse
@@ -192,7 +175,7 @@ export function localPatternEntry(
  */
 export function isPieceGetDataError(error: unknown): error is Error {
   return error instanceof PieceResultProjectionError ||
-    error instanceof PieceGetTransformError ||
+    error instanceof CellSelectionError ||
     error instanceof PieceVerbReadError ||
     (error instanceof Error &&
       error.message.startsWith("Cannot access path"));
@@ -202,7 +185,7 @@ export function isPieceGetDataError(error: unknown): error is Error {
  * Build the stderr report for a `piece get` failure. Returns null when the
  * error is not a data error (the caller should rethrow). `message` is the
  * one-line error; `hint` is an optional next-step tip. A projection error
- * already carries its own `--step` guidance, transform errors stand alone,
+ * already carries its own `--step` guidance, selection errors stand alone,
  * a verb refusal already carries its `cf piece call` redirect, and an
  * input-mode read has nothing more to suggest — only a result-mode
  * unresolved path gets the `--input` tip.
@@ -214,7 +197,7 @@ export function pieceGetDataErrorReport(
   if (!isPieceGetDataError(error)) return null;
   if (
     error instanceof PieceResultProjectionError ||
-    error instanceof PieceGetTransformError ||
+    error instanceof CellSelectionError ||
     error instanceof PieceVerbReadError ||
     opts.input
   ) {
@@ -1456,11 +1439,11 @@ PATH FORMAT: Use forward slashes and numeric indices for arrays.
     };
     const pathSegments = pathString ? parseCellPath(pathString) : [];
     try {
-      const transform = await parsePieceGetTransformOptions(options);
+      const selection = await parseCellSelectionOptions(options);
       const value = await getCellValue(pieceConfig, pathSegments, {
         input: options.input,
         step: options.step,
-        ...(transform === undefined ? {} : { transform }),
+        ...(selection === undefined ? {} : { selection }),
       });
       render(value, { json: true });
     } catch (error) {

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -1,3 +1,10 @@
+/**
+ * The selection a CLI read applies to a cell it has already arrived at: the
+ * `--filter` predicate and the `--schema` projection, their parsers, and the
+ * step that turns a cell plus a selection into a value. Resolving an address
+ * to a cell belongs to whoever holds the address, and stays there.
+ */
+
 import type { Cell } from "@commonfabric/api";
 import {
   ContextualFlowControl,
@@ -14,44 +21,65 @@ import { runtimeErrorLog } from "./callable.ts";
 
 type PredicateComparisonOperator = "==" | "!=" | "<" | "<=" | ">" | ">=";
 
-export type PieceGetPredicate =
+/** A parsed `--filter` expression, evaluated against one array element. */
+export type SelectionPredicate =
   | { kind: "literal"; value: string | number | boolean | null }
   | { kind: "path"; path: Array<string | number> }
-  | { kind: "not"; value: PieceGetPredicate }
+  | { kind: "not"; value: SelectionPredicate }
   | {
     kind: "boolean";
     operator: "and" | "or";
-    left: PieceGetPredicate;
-    right: PieceGetPredicate;
+    left: SelectionPredicate;
+    right: SelectionPredicate;
   }
   | {
     kind: "comparison";
     operator: PredicateComparisonOperator;
-    left: PieceGetPredicate;
-    right: PieceGetPredicate;
+    left: SelectionPredicate;
+    right: SelectionPredicate;
   };
 
-export interface ParsedPieceGetFilter {
+/**
+ * A `--filter` argument, parsed. `source` is the text as written, kept for
+ * error messages and for the result cell's cause. `paths` collects every path
+ * the predicate reads, which narrows the schema the source is read through.
+ */
+export interface ParsedSelectionFilter {
   source: string;
-  predicate: PieceGetPredicate;
+  predicate: SelectionPredicate;
   paths: Array<Array<string | number>>;
 }
 
-export interface PieceGetProjection {
+/**
+ * A `--schema` argument, parsed. `source` is the text as written; `kind`
+ * records which of the two spellings it used, since a concise field list
+ * traverses arrays implicitly and a JSON Schema does not.
+ */
+export interface SelectionProjection {
   source: string;
   schema: JSONSchema;
   kind: "concise" | "json";
 }
 
-export interface PieceGetTransform {
-  filter?: ParsedPieceGetFilter;
-  projection?: PieceGetProjection;
+/**
+ * What a caller asked to be returned from the cell it selected. Both parts are
+ * optional; a selection with neither returns the whole value.
+ */
+export interface CellSelection {
+  filter?: ParsedSelectionFilter;
+  projection?: SelectionProjection;
 }
 
-export class PieceGetTransformError extends Error {
+/**
+ * A selection that cannot be parsed, or that does not fit the value it was
+ * pointed at — a `--filter` on a non-array, a `--schema` whose root shape
+ * disagrees with the source. Reported to the user as a data error, not as an
+ * argument-parsing failure.
+ */
+export class CellSelectionError extends Error {
   constructor(message: string, options?: ErrorOptions) {
     super(message, options);
-    this.name = "PieceGetTransformError";
+    this.name = "CellSelectionError";
   }
 }
 
@@ -74,7 +102,7 @@ interface Token {
 }
 
 function expressionError(source: string, position: number, message: string) {
-  return new PieceGetTransformError(
+  return new CellSelectionError(
     `Invalid --filter predicate at column ${position + 1}: ${message}\n` +
       `  ${source}`,
   );
@@ -175,7 +203,7 @@ class PredicateParser {
     private readonly tokens: Token[],
   ) {}
 
-  parse(): PieceGetPredicate {
+  parse(): SelectionPredicate {
     const result = this.#parseOr();
     const trailing = this.#peek();
     if (trailing.kind !== "eof") {
@@ -213,7 +241,7 @@ class PredicateParser {
     return false;
   }
 
-  #parseOr(): PieceGetPredicate {
+  #parseOr(): SelectionPredicate {
     let left = this.#parseAnd();
     while (this.#takeKeyword("or")) {
       left = {
@@ -226,7 +254,7 @@ class PredicateParser {
     return left;
   }
 
-  #parseAnd(): PieceGetPredicate {
+  #parseAnd(): SelectionPredicate {
     let left = this.#parseComparison();
     while (this.#takeKeyword("and")) {
       left = {
@@ -239,7 +267,7 @@ class PredicateParser {
     return left;
   }
 
-  #parseComparison(): PieceGetPredicate {
+  #parseComparison(): SelectionPredicate {
     const left = this.#parseUnary();
     const token = this.#peek();
     if (token.kind !== "operator") return left;
@@ -252,14 +280,14 @@ class PredicateParser {
     };
   }
 
-  #parseUnary(): PieceGetPredicate {
+  #parseUnary(): SelectionPredicate {
     if (this.#takeKeyword("not")) {
       return { kind: "not", value: this.#parseUnary() };
     }
     return this.#parsePrimary();
   }
 
-  #parsePrimary(): PieceGetPredicate {
+  #parsePrimary(): SelectionPredicate {
     const token = this.#peek();
     if (token.kind === "left-paren") {
       this.#take();
@@ -295,7 +323,7 @@ class PredicateParser {
     );
   }
 
-  #parsePath(): PieceGetPredicate {
+  #parsePath(): SelectionPredicate {
     this.#take();
     const path: Array<string | number> = [];
     const first = this.#peek();
@@ -339,7 +367,7 @@ class PredicateParser {
 }
 
 function collectPredicatePaths(
-  predicate: PieceGetPredicate,
+  predicate: SelectionPredicate,
   result: Array<Array<string | number>>,
 ): void {
   switch (predicate.kind) {
@@ -359,9 +387,9 @@ function collectPredicatePaths(
   }
 }
 
-export function parsePieceGetFilter(source: string): ParsedPieceGetFilter {
+export function parseSelectionFilter(source: string): ParsedSelectionFilter {
   if (source.trim().length === 0) {
-    throw new PieceGetTransformError("--filter predicate must not be empty");
+    throw new CellSelectionError("--filter predicate must not be empty");
   }
   const predicate = new PredicateParser(
     source,
@@ -413,7 +441,7 @@ function comparePredicateValues(
     (typeof left !== "number" || typeof right !== "number") &&
     (typeof left !== "string" || typeof right !== "string")
   ) {
-    throw new PieceGetTransformError(
+    throw new CellSelectionError(
       `--filter ${operator} requires two numbers or two strings`,
     );
   }
@@ -429,11 +457,11 @@ function comparePredicateValues(
   }
 }
 
-export function evaluatePieceGetPredicate(
-  predicate: PieceGetPredicate,
+export function evaluateSelectionPredicate(
+  predicate: SelectionPredicate,
   value: unknown,
 ): boolean {
-  const evaluate = (node: PieceGetPredicate): unknown => {
+  const evaluate = (node: SelectionPredicate): unknown => {
     switch (node.kind) {
       case "literal":
         return node.value;
@@ -490,24 +518,24 @@ function normalizeProjectionSchema(
 ): JSONSchema {
   if (schema === true) return true;
   if (schema === false) {
-    throw new PieceGetTransformError(
+    throw new CellSelectionError(
       `Invalid --schema at ${path}: false cannot project a value`,
     );
   }
   if (!isRecord(schema) || Array.isArray(schema)) {
-    throw new PieceGetTransformError(
+    throw new CellSelectionError(
       `Invalid --schema at ${path}: expected a JSON Schema object`,
     );
   }
   for (const key of Object.keys(schema)) {
     if (FORBIDDEN_PROJECTION_KEYS.has(key)) {
-      throw new PieceGetTransformError(
+      throw new CellSelectionError(
         `Invalid --schema at ${path}: "${key}" is controlled by the source ` +
           "schema and cannot be supplied by a projection",
       );
     }
     if (UNSUPPORTED_PROJECTION_KEYS.has(key)) {
-      throw new PieceGetTransformError(
+      throw new CellSelectionError(
         `Invalid --schema at ${path}: "${key}" is not supported by projection schemas`,
       );
     }
@@ -516,7 +544,7 @@ function normalizeProjectionSchema(
   const result: Record<string, unknown> = { ...schema };
   if (schema.properties !== undefined) {
     if (!isRecord(schema.properties) || Array.isArray(schema.properties)) {
-      throw new PieceGetTransformError(
+      throw new CellSelectionError(
         `Invalid --schema at ${path}: "properties" must be an object`,
       );
     }
@@ -553,7 +581,7 @@ function normalizeProjectionSchema(
 function conciseProjectionSchema(source: string): JSONSchema {
   const paths = source.split(",").map((part) => part.trim());
   if (paths.some((path) => path.length === 0)) {
-    throw new PieceGetTransformError(
+    throw new CellSelectionError(
       "Invalid --schema concise projection: expected comma-separated field paths",
     );
   }
@@ -563,7 +591,7 @@ function conciseProjectionSchema(source: string): JSONSchema {
     if (
       segments.some((segment) => !/^[A-Za-z_$][A-Za-z0-9_$-]*$/.test(segment))
     ) {
-      throw new PieceGetTransformError(
+      throw new CellSelectionError(
         `Invalid --schema field path ${JSON.stringify(path)}`,
       );
     }
@@ -600,19 +628,19 @@ export interface ProjectionParseDependencies {
   readTextFile?: (path: string) => Promise<string>;
 }
 
-export async function parsePieceGetProjection(
+export async function parseSelectionProjection(
   source: string,
   deps: ProjectionParseDependencies = {},
-): Promise<PieceGetProjection> {
+): Promise<SelectionProjection> {
   const trimmed = source.trim();
   if (trimmed.length === 0) {
-    throw new PieceGetTransformError("--schema must not be empty");
+    throw new CellSelectionError("--schema must not be empty");
   }
 
   if (trimmed.startsWith("@")) {
     const path = trimmed.slice(1);
     if (path.length === 0) {
-      throw new PieceGetTransformError(
+      throw new CellSelectionError(
         "--schema @file requires a file path",
       );
     }
@@ -620,7 +648,7 @@ export async function parsePieceGetProjection(
     try {
       contents = await (deps.readTextFile ?? Deno.readTextFile)(path);
     } catch (error) {
-      throw new PieceGetTransformError(
+      throw new CellSelectionError(
         `Could not read --schema file "${path}": ${
           error instanceof Error ? error.message : String(error)
         }`,
@@ -631,7 +659,7 @@ export async function parsePieceGetProjection(
     try {
       parsed = JSON.parse(contents);
     } catch (error) {
-      throw new PieceGetTransformError(
+      throw new CellSelectionError(
         `Invalid JSON in --schema file "${path}": ${
           error instanceof Error ? error.message : String(error)
         }`,
@@ -650,7 +678,7 @@ export async function parsePieceGetProjection(
     try {
       parsed = JSON.parse(trimmed);
     } catch (error) {
-      throw new PieceGetTransformError(
+      throw new CellSelectionError(
         `Invalid JSON passed to --schema: ${
           error instanceof Error ? error.message : String(error)
         }`,
@@ -669,6 +697,26 @@ export async function parsePieceGetProjection(
     schema: conciseProjectionSchema(trimmed),
     kind: "concise",
   };
+}
+
+/**
+ * Parses a command's `--filter` and `--schema` arguments into the selection
+ * they describe, or `undefined` when neither was given and the caller wants
+ * the whole value.
+ */
+export async function parseCellSelectionOptions(options: {
+  filter?: string;
+  schema?: string;
+}): Promise<CellSelection | undefined> {
+  const filter = options.filter === undefined
+    ? undefined
+    : parseSelectionFilter(options.filter);
+  const projection = options.schema === undefined
+    ? undefined
+    : await parseSelectionProjection(options.schema);
+  return filter === undefined && projection === undefined
+    ? undefined
+    : { filter, projection };
 }
 
 function schemaTypes(schema: JSONSchema | undefined): string[] {
@@ -917,7 +965,7 @@ export function schemaMayBeArray(
       // Unlike root classification, concise-path alignment cannot safely
       // continue without resolving the schema that determines array traversal.
       unresolvedRef: (error) => {
-        throw new PieceGetTransformError(
+        throw new CellSelectionError(
           `Could not resolve source schema reference for --schema: ${
             error instanceof Error ? error.message : String(error)
           }`,
@@ -1181,7 +1229,7 @@ interface ResolvedProjection {
 }
 
 function resolveProjection(
-  projection: PieceGetProjection | undefined,
+  projection: SelectionProjection | undefined,
   sourceSchema: JSONSchema | undefined,
   sourceIsArray: boolean,
 ): ResolvedProjection | undefined {
@@ -1231,7 +1279,7 @@ function resolveProjection(
     projection.schema !== true &&
     sourceIsArray !== projectsArrayItems
   ) {
-    throw new PieceGetTransformError(
+    throw new CellSelectionError(
       sourceIsArray
         ? "A JSON --schema for an array value must describe the returned " +
           'array (for example {"type":"array","items":{...}}).'
@@ -1258,12 +1306,19 @@ function resolveProjection(
   };
 }
 
-export interface DerivePieceGetDependencies {
+/** Optional hooks into {@link deriveSelectedValue}'s internals. */
+export interface DeriveSelectedValueDependencies {
+  /** Called with the cell the returned value was read from. */
   onOutputCell?: (cell: Cell<unknown>) => void;
 }
 
 /**
- * Apply a piece-get filter/projection through an actual runtime pattern graph.
+ * Applies `selection` to `sourceCell` through an actual runtime pattern graph,
+ * returning the value the caller asked for.
+ *
+ * `runtime` and `space` say where that pattern runs, and are the caller's to
+ * decide rather than the cell's: a path that crosses a link can land
+ * `sourceCell` in a space other than the one its reader is working in.
  *
  * The filter uses the runner's list builtin, so predicate observations taint
  * collection membership exactly as they do in authored patterns. Array
@@ -1274,12 +1329,12 @@ export interface DerivePieceGetDependencies {
  * shape only; source schemas remain authoritative for CFC and other Fabric
  * metadata.
  */
-export async function derivePieceGetValue(
+export async function deriveSelectedValue(
   runtime: Runtime,
   space: MemorySpace,
   sourceCell: Cell<unknown>,
-  transform: PieceGetTransform,
-  deps: DerivePieceGetDependencies = {},
+  selection: CellSelection,
+  deps: DeriveSelectedValueDependencies = {},
 ): Promise<unknown> {
   const declaredSourceSchema = sourceCell.schema;
   const sourceSchema = isRecord(declaredSourceSchema) &&
@@ -1289,7 +1344,7 @@ export async function derivePieceGetValue(
   const sourceValueCell = sourceSchema === declaredSourceSchema
     ? sourceCell
     : sourceCell.asSchema(sourceSchema);
-  if (transform.filter === undefined && transform.projection === undefined) {
+  if (selection.filter === undefined && selection.projection === undefined) {
     return await sourceValueCell.pull();
   }
 
@@ -1297,30 +1352,30 @@ export async function derivePieceGetValue(
   const sourceIsArray = rootKind === "unknown"
     ? Array.isArray(await sourceValueCell.pull())
     : rootKind === "array";
-  if (transform.filter !== undefined && !sourceIsArray) {
-    throw new PieceGetTransformError(
+  if (selection.filter !== undefined && !sourceIsArray) {
+    throw new CellSelectionError(
       "--filter can only be applied to an array",
     );
   }
   const projection = resolveProjection(
-    transform.projection,
+    selection.projection,
     sourceSchema,
     sourceIsArray,
   );
   const sourceItemSchema = schemaAtArrayItem(sourceSchema);
-  const predicateItemMask = transform.filter === undefined
+  const predicateItemMask = selection.filter === undefined
     ? undefined
-    : maskFromPaths(transform.filter.paths);
+    : maskFromPaths(selection.filter.paths);
   const projectionMaskSchema = projection?.mask;
   const projectionItemMask = projection?.itemMask;
 
   let sourceMask: ProjectionMask = true;
-  if (transform.filter !== undefined && projection === undefined) {
+  if (selection.filter !== undefined && projection === undefined) {
     // Filtering returns original elements. Keep their complete source schema
     // on the links that survive, while the predicate pattern below narrows the
     // actual predicate reads.
     sourceMask = true;
-  } else if (transform.filter !== undefined) {
+  } else if (selection.filter !== undefined) {
     sourceMask = {
       type: "array",
       items: mergeMasks(
@@ -1345,7 +1400,7 @@ export async function derivePieceGetValue(
   };
 
   let predicatePattern: ReturnType<typeof pattern> | undefined;
-  if (transform.filter !== undefined) {
+  if (selection.filter !== undefined) {
     const elementSchema = selectSourceSchema(
       sourceItemSchema,
       predicateItemMask!,
@@ -1365,8 +1420,8 @@ export async function derivePieceGetValue(
     const predicateModule = lift(
       ({ element, params }: {
         element: unknown;
-        params: { predicate: PieceGetPredicate };
-      }) => evaluatePieceGetPredicate(params.predicate, element),
+        params: { predicate: SelectionPredicate };
+      }) => evaluateSelectionPredicate(params.predicate, element),
       argumentSchema,
       { type: "boolean" },
     );
@@ -1457,7 +1512,7 @@ export async function derivePieceGetValue(
       let result: any = value;
       if (predicatePattern !== undefined) {
         result = result.filterWithPattern(predicatePattern as any, {
-          predicate: transform.filter!.predicate,
+          predicate: selection.filter!.predicate,
         });
       }
       if (itemProjectionPattern !== undefined) {
@@ -1477,8 +1532,8 @@ export async function derivePieceGetValue(
     {
       pieceGetTransform: {
         source: sourceValueCell.getAsNormalizedFullLink(),
-        filter: transform.filter?.source,
-        schema: transform.projection?.source,
+        filter: selection.filter?.source,
+        schema: selection.projection?.source,
       },
     },
     mainResultSchema,
@@ -1506,7 +1561,7 @@ export async function derivePieceGetValue(
     runtime.prepareTxForCommit(tx);
     const committed = await tx.commit();
     if (committed.error !== undefined) {
-      throw new PieceGetTransformError(
+      throw new CellSelectionError(
         `Could not apply piece get transform: ${committed.error}`,
       );
     }
@@ -1524,12 +1579,12 @@ export async function derivePieceGetValue(
       // test in piece-get-transform.test.ts guards this package-boundary
       // coupling.
       if (
-        transform.filter !== undefined &&
+        selection.filter !== undefined &&
         recorded.some((error) =>
           error.message === "filter currently only supports arrays"
         )
       ) {
-        throw new PieceGetTransformError(
+        throw new CellSelectionError(
           "--filter can only be applied to an array",
         );
       }
@@ -1539,12 +1594,12 @@ export async function derivePieceGetValue(
           error.message === "map currently only supports arrays"
         )
       ) {
-        throw new PieceGetTransformError(
+        throw new CellSelectionError(
           "--schema can only project array items from an array value",
         );
       }
       const lastError = recorded.at(-1)!;
-      throw new PieceGetTransformError(
+      throw new CellSelectionError(
         `Could not apply piece get transform: ${lastError.message}`,
       );
     }

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -76,10 +76,10 @@ import { deriveDiskHandleId } from "./sqlite-source.ts";
 import { startVersionCheck } from "./version-check.ts";
 import { stderrConsoleHandler } from "./json-output.ts";
 import {
-  derivePieceGetValue,
-  type PieceGetTransform,
-  PieceGetTransformError,
-} from "./piece-get-transform.ts";
+  type CellSelection,
+  CellSelectionError,
+  deriveSelectedValue,
+} from "./cell-selection.ts";
 
 export interface EntryConfig {
   mainPath: string;
@@ -115,7 +115,7 @@ export interface SetPiecePatternOptions {
 export interface GetCellValueOptions {
   input?: boolean;
   step?: boolean;
-  transform?: PieceGetTransform;
+  selection?: CellSelection;
 }
 
 /** A `cf piece get` path that lands ON a verb. Reading a verb returns the
@@ -225,7 +225,7 @@ interface PieceOperationDependencies extends PieceResolutionDeps {
     source: "input data" | "result data" | "metadata",
     error: unknown,
   ) => void;
-  derivePieceGetValue?: typeof derivePieceGetValue;
+  deriveSelectedValue?: typeof deriveSelectedValue;
 }
 
 const CLI_TRACE_TIMINGS = Deno.env.get("CF_CLI_TRACE_TIMINGS") === "1";
@@ -2361,16 +2361,16 @@ export async function getCellValue(
     }
 
     const prop = options.input ? "input" : "result";
-    if (options.transform !== undefined) {
+    if (options.selection !== undefined) {
       const rootCell = await piece[prop].getCell();
       const targetCell = rootCell.key(...path);
-      let transformed: unknown;
+      let selected: unknown;
       try {
-        transformed = await (deps.derivePieceGetValue ?? derivePieceGetValue)(
+        selected = await (deps.deriveSelectedValue ?? deriveSelectedValue)(
           manager.runtime,
           manager.getSpace(),
           targetCell,
-          options.transform,
+          options.selection,
         );
       } catch (error) {
         if (
@@ -2387,21 +2387,21 @@ export async function getCellValue(
         }
         throw error;
       }
-      // Read-path guard (verb contract WS-F): the transform path returns
+      // Read-path guard (verb contract WS-F): the selection path returns
       // early, so it needs the same verb refusal the plain read applies
-      // below — a verb read through a transform is the same mistake.
-      const transformPathVerb = await classifyReadPathVerb(piece, prop, path);
-      if (transformPathVerb) {
+      // below — a verb read through a selection is the same mistake.
+      const selectionPathVerb = await classifyReadPathVerb(piece, prop, path);
+      if (selectionPathVerb) {
         throw new PieceVerbReadError(
-          transformPathVerb.verb,
+          selectionPathVerb.verb,
           resolvedConfig.piece,
-          transformPathVerb.callable,
+          selectionPathVerb.callable,
         );
       }
       const sourceWasAbsent = typeof targetCell.getRaw === "function" &&
         targetCell.getRaw() === undefined;
       if (
-        !options.input && transformed === undefined &&
+        !options.input && selected === undefined &&
         await resultProjectionFailedAtPath(piece, path)
       ) {
         throw await verbReadRefusalOrNull(
@@ -2411,15 +2411,15 @@ export async function getCellValue(
           resolvedConfig.piece,
         ) ?? new PieceResultProjectionError(path, shouldStep);
       }
-      if (transformed === undefined && !sourceWasAbsent) {
-        throw new PieceGetTransformError(
+      if (selected === undefined && !sourceWasAbsent) {
+        throw new CellSelectionError(
           "Cannot read transformed value: the filter/schema expression did " +
             "not materialize a JSON-renderable value. This is not JSON " +
             "null. Retry with --step for a computed result, or inspect the " +
             "selected source data and schema.",
         );
       }
-      return transformed;
+      return selected;
     }
 
     let value: unknown;

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -39,7 +39,7 @@ import {
   WaitBoundExpired,
 } from "../commands/piece.ts";
 import { LinkValidationError } from "../lib/piece.ts";
-import { PieceGetTransformError } from "../lib/piece-get-transform.ts";
+import { CellSelectionError } from "../lib/cell-selection.ts";
 
 describe("executePieceCallable", () => {
   it("reports not-found when the piece cell has no schema-cast surface", async () => {
@@ -3030,12 +3030,12 @@ describe("piece get data errors", () => {
     expect(report?.hint).toBeUndefined();
   });
 
-  it("reports transform failures without an unrelated --input hint", () => {
-    const transformError = new PieceGetTransformError(
+  it("reports selection failures without an unrelated --input hint", () => {
+    const selectionError = new CellSelectionError(
       "--filter can only be applied to an array",
     );
-    expect(isPieceGetDataError(transformError)).toBe(true);
-    const report = pieceGetDataErrorReport(transformError, {
+    expect(isPieceGetDataError(selectionError)).toBe(true);
+    const report = pieceGetDataErrorReport(selectionError, {
       input: false,
       piece: "fid1:piece-123",
     });

--- a/packages/cli/test/piece-get-transform.test.ts
+++ b/packages/cli/test/piece-get-transform.test.ts
@@ -5,16 +5,16 @@ import { Identity } from "@commonfabric/identity";
 import { type Cell, type JSONSchema, Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import {
-  derivePieceGetValue,
-  evaluatePieceGetPredicate,
+  CellSelectionError,
+  deriveSelectedValue,
+  evaluateSelectionPredicate,
   mergeMasks,
-  parsePieceGetFilter,
-  parsePieceGetProjection,
-  PieceGetTransformError,
+  parseSelectionFilter,
+  parseSelectionProjection,
   schemaMayBeArray,
   schemaRootKind,
   selectSourceSchema,
-} from "../lib/piece-get-transform.ts";
+} from "../lib/cell-selection.ts";
 
 const signer = await Identity.fromPassphrase("cf-piece-get-transform");
 const space = signer.did();
@@ -44,7 +44,7 @@ describe("cf piece get transforms", () => {
   });
 
   it("parses and evaluates jq-inspired predicates", () => {
-    const parsed = parsePieceGetFilter(
+    const parsed = parseSelectionFilter(
       '.status == "open" and (.score >= 10 or .priority == true)',
     );
     expect(parsed.paths).toEqual([
@@ -52,12 +52,12 @@ describe("cf piece get transforms", () => {
       ["score"],
       ["priority"],
     ]);
-    expect(evaluatePieceGetPredicate(parsed.predicate, {
+    expect(evaluateSelectionPredicate(parsed.predicate, {
       status: "open",
       score: 12,
       priority: false,
     })).toBe(true);
-    expect(evaluatePieceGetPredicate(parsed.predicate, {
+    expect(evaluateSelectionPredicate(parsed.predicate, {
       status: "closed",
       score: 12,
       priority: true,
@@ -65,10 +65,10 @@ describe("cf piece get transforms", () => {
   });
 
   it("supports bracket paths, negative indices, and not", () => {
-    const parsed = parsePieceGetFilter(
+    const parsed = parseSelectionFilter(
       'not .disabled and .["tags"][-1] == "current"',
     );
-    expect(evaluatePieceGetPredicate(parsed.predicate, {
+    expect(evaluateSelectionPredicate(parsed.predicate, {
       disabled: false,
       tags: ["old", "current"],
     })).toBe(true);
@@ -93,14 +93,14 @@ describe("cf piece get transforms", () => {
         ".disabled == false",
       ]
     ) {
-      expect(evaluatePieceGetPredicate(
-        parsePieceGetFilter(source).predicate,
+      expect(evaluateSelectionPredicate(
+        parseSelectionFilter(source).predicate,
         value,
       )).toBe(true);
     }
     for (const source of [".disabled", ".nil", ".unset", ".missing"]) {
-      expect(evaluatePieceGetPredicate(
-        parsePieceGetFilter(source).predicate,
+      expect(evaluateSelectionPredicate(
+        parseSelectionFilter(source).predicate,
         value,
       )).toBe(false);
     }
@@ -121,13 +121,13 @@ describe("cf piece get transforms", () => {
         ".tags[-3]",
       ]
     ) {
-      expect(evaluatePieceGetPredicate(
-        parsePieceGetFilter(source).predicate,
+      expect(evaluateSelectionPredicate(
+        parseSelectionFilter(source).predicate,
         value,
       )).toBe(false);
     }
-    expect(evaluatePieceGetPredicate(
-      parsePieceGetFilter(".tags[0]").predicate,
+    expect(evaluateSelectionPredicate(
+      parseSelectionFilter(".tags[0]").predicate,
       value,
     )).toBe(true);
   });
@@ -149,14 +149,14 @@ describe("cf piece get transforms", () => {
         ".tags != null",
       ]
     ) {
-      expect(evaluatePieceGetPredicate(
-        parsePieceGetFilter(source).predicate,
+      expect(evaluateSelectionPredicate(
+        parseSelectionFilter(source).predicate,
         value,
       )).toBe(true);
     }
     expect(() =>
-      evaluatePieceGetPredicate(
-        parsePieceGetFilter(".score > true").predicate,
+      evaluateSelectionPredicate(
+        parseSelectionFilter(".score > true").predicate,
         value,
       )
     ).toThrow("--filter > requires two numbers or two strings");
@@ -177,14 +177,14 @@ describe("cf piece get transforms", () => {
         "unknown",
       ]
     ) {
-      expect(() => parsePieceGetFilter(source)).toThrow(
-        PieceGetTransformError,
+      expect(() => parseSelectionFilter(source)).toThrow(
+        CellSelectionError,
       );
     }
   });
 
   it("parses concise, inline, and file projection schemas", async () => {
-    const concise = await parsePieceGetProjection("id,author.name");
+    const concise = await parseSelectionProjection("id,author.name");
     expect(concise.kind).toBe("concise");
     expect(concise.schema).toEqual({
       type: "object",
@@ -199,7 +199,7 @@ describe("cf piece get transforms", () => {
       additionalProperties: false,
     });
 
-    const inline = await parsePieceGetProjection(
+    const inline = await parseSelectionProjection(
       '{"type":"object","properties":{"title":{"type":"string"}}}',
     );
     expect(inline.schema).toEqual({
@@ -208,7 +208,7 @@ describe("cf piece get transforms", () => {
       additionalProperties: false,
     });
 
-    const fromFile = await parsePieceGetProjection("@projection.json", {
+    const fromFile = await parseSelectionProjection("@projection.json", {
       readTextFile: () =>
         Promise.resolve(
           '{"type":"array","items":{"type":"object","properties":{"id":true}}}',
@@ -227,7 +227,7 @@ describe("cf piece get transforms", () => {
     const path = await Deno.makeTempFile({ suffix: ".json" });
     try {
       await Deno.writeTextFile(path, '{"type":"object"}');
-      expect((await parsePieceGetProjection(`@${path}`)).schema).toEqual({
+      expect((await parseSelectionProjection(`@${path}`)).schema).toEqual({
         type: "object",
         additionalProperties: true,
       });
@@ -389,7 +389,7 @@ describe("cf piece get transforms", () => {
 
   it("collapses overlapping concise paths without exposing siblings", async () => {
     for (const source of ["author,author.name", "author.name,author"]) {
-      expect((await parsePieceGetProjection(source)).schema).toEqual({
+      expect((await parseSelectionProjection(source)).schema).toEqual({
         type: "object",
         properties: { author: true },
         additionalProperties: false,
@@ -398,63 +398,63 @@ describe("cf piece get transforms", () => {
   });
 
   it("validates projection schema roots and nested schema objects", async () => {
-    await expect(parsePieceGetProjection("")).rejects.toThrow(
+    await expect(parseSelectionProjection("")).rejects.toThrow(
       "--schema must not be empty",
     );
-    await expect(parsePieceGetProjection("@")).rejects.toThrow(
+    await expect(parseSelectionProjection("@")).rejects.toThrow(
       "--schema @file requires a file path",
     );
-    await expect(parsePieceGetProjection("@missing.json", {
+    await expect(parseSelectionProjection("@missing.json", {
       readTextFile: () => Promise.reject(new Error("gone")),
     })).rejects.toThrow('Could not read --schema file "missing.json": gone');
-    await expect(parsePieceGetProjection("@bad.json", {
+    await expect(parseSelectionProjection("@bad.json", {
       readTextFile: () => Promise.resolve("{"),
     })).rejects.toThrow('Invalid JSON in --schema file "bad.json"');
-    await expect(parsePieceGetProjection("@array.json", {
+    await expect(parseSelectionProjection("@array.json", {
       readTextFile: () => Promise.resolve("[]"),
     })).rejects.toThrow("expected a JSON Schema object");
-    await expect(parsePieceGetProjection("{")).rejects.toThrow(
+    await expect(parseSelectionProjection("{")).rejects.toThrow(
       "Invalid JSON passed to --schema",
     );
-    await expect(parsePieceGetProjection("false")).rejects.toThrow(
+    await expect(parseSelectionProjection("false")).rejects.toThrow(
       "false cannot project a value",
     );
-    await expect(parsePieceGetProjection(
+    await expect(parseSelectionProjection(
       '{"type":"object","properties":[]}',
     )).rejects.toThrow('"properties" must be an object');
-    await expect(parsePieceGetProjection("a,,b")).rejects.toThrow(
+    await expect(parseSelectionProjection("a,,b")).rejects.toThrow(
       "expected comma-separated field paths",
     );
-    await expect(parsePieceGetProjection("a.0")).rejects.toThrow(
+    await expect(parseSelectionProjection("a.0")).rejects.toThrow(
       "Invalid --schema field path",
     );
   });
 
   it("normalizes identity and additional-property projection schemas", async () => {
-    expect((await parsePieceGetProjection('{"type":"object"}')).schema)
+    expect((await parseSelectionProjection('{"type":"object"}')).schema)
       .toEqual({
         type: "object",
         additionalProperties: true,
       });
     expect(
-      (await parsePieceGetProjection(
+      (await parseSelectionProjection(
         '{"type":"object","additionalProperties":{"type":"string"}}',
       )).schema,
     ).toEqual({
       type: "object",
       additionalProperties: { type: "string" },
     });
-    expect((await parsePieceGetProjection("true")).schema).toBe(true);
+    expect((await parseSelectionProjection("true")).schema).toBe(true);
   });
 
   it("does not let caller projection schemas forge CFC metadata", async () => {
     for (const key of ["asCell", "default", "ifc", "scope"]) {
-      await expect(parsePieceGetProjection(JSON.stringify({
+      await expect(parseSelectionProjection(JSON.stringify({
         type: "object",
         properties: {
           secret: { type: "string", [key]: key === "asCell" ? ["cell"] : {} },
         },
-      }))).rejects.toThrow(PieceGetTransformError);
+      }))).rejects.toThrow(CellSelectionError);
     }
   });
 
@@ -479,7 +479,7 @@ describe("cf piece get transforms", () => {
         "contentSchema",
       ]
     ) {
-      await expect(parsePieceGetProjection(JSON.stringify({
+      await expect(parseSelectionProjection(JSON.stringify({
         type: "object",
         [key]: {},
       }))).rejects.toThrow(`"${key}" is not supported`);
@@ -511,9 +511,9 @@ describe("cf piece get transforms", () => {
     ]);
     expect((await tx.commit()).ok).toBeDefined();
 
-    const result = await derivePieceGetValue(runtime, space, source, {
-      filter: parsePieceGetFilter('.status == "open"'),
-      projection: await parsePieceGetProjection("id,title"),
+    const result = await deriveSelectedValue(runtime, space, source, {
+      filter: parseSelectionFilter('.status == "open"'),
+      projection: await parseSelectionProjection("id,title"),
     });
 
     expect(result).toEqual([
@@ -521,8 +521,8 @@ describe("cf piece get transforms", () => {
       { id: 3, title: "Third" },
     ]);
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        projection: await parsePieceGetProjection(
+      await deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection(
           '{"type":"array","items":{"type":"object","properties":{"id":{"type":"string"},"title":true}}}',
         ),
       }),
@@ -595,9 +595,9 @@ describe("cf piece get transforms", () => {
     }) as typeof provider.sync;
 
     expect(
-      await derivePieceGetValue(runtime, space, sourceRead, {
-        filter: parsePieceGetFilter('.status == "open"'),
-        projection: await parsePieceGetProjection("id,title"),
+      await deriveSelectedValue(runtime, space, sourceRead, {
+        filter: parseSelectionFilter('.status == "open"'),
+        projection: await parseSelectionProjection("id,title"),
       }),
     ).toEqual([{ id: 1, title: "First" }]);
     const initialSelector = sourceSelectors.at(0) as {
@@ -673,9 +673,9 @@ describe("cf piece get transforms", () => {
     expect((await tx.commit()).ok).toBeDefined();
 
     expect(
-      await derivePieceGetValue(runtime, space, container.key("items"), {
-        filter: parsePieceGetFilter(".id == 2"),
-        projection: await parsePieceGetProjection("title"),
+      await deriveSelectedValue(runtime, space, container.key("items"), {
+        filter: parseSelectionFilter(".id == 2"),
+        projection: await parseSelectionProjection("title"),
       }),
     ).toEqual([{ title: "Second" }]);
   });
@@ -732,19 +732,19 @@ describe("cf piece get transforms", () => {
     expect((await tx.commit()).ok).toBeDefined();
 
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        projection: await parsePieceGetProjection("title,createdBy.name"),
+      await deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection("title,createdBy.name"),
       }),
     ).toEqual([{ title: "T1", createdBy: { name: "Sol" } }]);
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        filter: parsePieceGetFilter('.createdBy.name == "Sol"'),
-        projection: await parsePieceGetProjection("title"),
+      await deriveSelectedValue(runtime, space, source, {
+        filter: parseSelectionFilter('.createdBy.name == "Sol"'),
+        projection: await parseSelectionProjection("title"),
       }),
     ).toEqual([{ title: "T1" }]);
     expect(
-      await derivePieceGetValue(runtime, space, direct, {
-        projection: await parsePieceGetProjection("title,createdBy.name"),
+      await deriveSelectedValue(runtime, space, direct, {
+        projection: await parseSelectionProjection("title,createdBy.name"),
       }),
     ).toEqual({ title: "T1", createdBy: { name: "Sol" } });
   });
@@ -780,8 +780,8 @@ describe("cf piece get transforms", () => {
     expect((await tx.commit()).ok).toBeDefined();
 
     expect(
-      await derivePieceGetValue(runtime, space, container.key("topic"), {
-        projection: await parsePieceGetProjection("title"),
+      await deriveSelectedValue(runtime, space, container.key("topic"), {
+        projection: await parseSelectionProjection("title"),
       }),
     ).toEqual({ title: "Visible" });
   });
@@ -805,8 +805,8 @@ describe("cf piece get transforms", () => {
 
     let outputCell: Cell<unknown> | undefined;
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        projection: await parsePieceGetProjection("title"),
+      await deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection("title"),
       }, {
         onOutputCell: (cell) => outputCell = cell,
       }),
@@ -869,9 +869,9 @@ describe("cf piece get transforms", () => {
     expect((await tx.commit()).ok).toBeDefined();
 
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        filter: parsePieceGetFilter(".id == 2"),
-        projection: await parsePieceGetProjection("title"),
+      await deriveSelectedValue(runtime, space, source, {
+        filter: parseSelectionFilter(".id == 2"),
+        projection: await parseSelectionProjection("title"),
       }),
     ).toEqual([{ title: "Second" }]);
   });
@@ -905,8 +905,8 @@ describe("cf piece get transforms", () => {
     }]);
     expect((await tx.commit()).ok).toBeDefined();
 
-    const result = await derivePieceGetValue(runtime, space, source, {
-      projection: await parsePieceGetProjection(
+    const result = await deriveSelectedValue(runtime, space, source, {
+      projection: await parseSelectionProjection(
         "author.name,author.name.first",
       ),
     });
@@ -934,18 +934,18 @@ describe("cf piece get transforms", () => {
     expect((await tx.commit()).ok).toBeDefined();
 
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        projection: await parsePieceGetProjection("id"),
+      await deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection("id"),
       }),
     ).toEqual({ id: 1 });
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        projection: await parsePieceGetProjection("missing"),
+      await deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection("missing"),
       }),
     ).toEqual({});
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        projection: await parsePieceGetProjection(JSON.stringify({
+      await deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection(JSON.stringify({
           type: "object",
           properties: {
             subtitle: { type: ["string", "null"] },
@@ -955,11 +955,11 @@ describe("cf piece get transforms", () => {
       }),
     ).toEqual({ subtitle: null });
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        projection: await parsePieceGetProjection('{"type":"object"}'),
+      await deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection('{"type":"object"}'),
       }),
     ).toEqual({ id: 1, title: "Visible", subtitle: null });
-    expect(await derivePieceGetValue(runtime, space, source, {})).toEqual({
+    expect(await deriveSelectedValue(runtime, space, source, {})).toEqual({
       id: 1,
       title: "Visible",
       subtitle: null,
@@ -1010,8 +1010,8 @@ describe("cf piece get transforms", () => {
       additionalProperties: false,
     };
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        projection: await parsePieceGetProjection(JSON.stringify(projection)),
+      await deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection(JSON.stringify(projection)),
       }),
     ).toEqual({ comments: [{ body: "Hello" }] });
   });
@@ -1036,23 +1036,23 @@ describe("cf piece get transforms", () => {
     source.set([{ name: "a", secret: "hidden" }, null]);
     expect((await tx.commit()).ok).toBeDefined();
 
-    expect(await derivePieceGetValue(runtime, space, source, {})).toEqual([
+    expect(await deriveSelectedValue(runtime, space, source, {})).toEqual([
       { name: "a", secret: "hidden" },
       null,
     ]);
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        filter: parsePieceGetFilter('.name == "a"'),
+      await deriveSelectedValue(runtime, space, source, {
+        filter: parseSelectionFilter('.name == "a"'),
       }),
     ).toEqual([{ name: "a", secret: "hidden" }]);
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        projection: await parsePieceGetProjection("name"),
+      await deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection("name"),
       }),
     ).toEqual([{ name: "a" }, null]);
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        projection: await parsePieceGetProjection(JSON.stringify({
+      await deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection(JSON.stringify({
           type: "array",
           items: {
             type: ["object", "null"],
@@ -1106,8 +1106,8 @@ describe("cf piece get transforms", () => {
     expect((await tx.commit()).ok).toBeDefined();
 
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        projection: await parsePieceGetProjection(
+      await deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection(
           "comments.body,comments.replies.body",
         ),
       }),
@@ -1157,8 +1157,8 @@ describe("cf piece get transforms", () => {
       expect((await tx.commit()).ok).toBeDefined();
 
       expect(
-        await derivePieceGetValue(runtime, space, source, {
-          projection: await parsePieceGetProjection("profiles.profile.name"),
+        await deriveSelectedValue(runtime, space, source, {
+          projection: await parseSelectionProjection("profiles.profile.name"),
         }),
       ).toEqual({
         profiles: [{ profile: { name: "Ada" } }, { profile: null }],
@@ -1192,8 +1192,8 @@ describe("cf piece get transforms", () => {
     expect((await tx.commit()).ok).toBeDefined();
 
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        projection: await parsePieceGetProjection("name"),
+      await deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection("name"),
       }),
     ).toEqual([{ name: "Ada" }, null]);
   });
@@ -1224,8 +1224,8 @@ describe("cf piece get transforms", () => {
     expect((await tx.commit()).ok).toBeDefined();
 
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        projection: await parsePieceGetProjection("name"),
+      await deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection("name"),
       }),
     ).toEqual([{ name: "Ada" }]);
   });
@@ -1273,8 +1273,8 @@ describe("cf piece get transforms", () => {
     expect((await tx.commit()).ok).toBeDefined();
 
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        projection: await parsePieceGetProjection("comments.body"),
+      await deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection("comments.body"),
       }),
     ).toEqual({ comments: [{ body: "Visible" }] });
   });
@@ -1319,8 +1319,8 @@ describe("cf piece get transforms", () => {
     expect((await tx.commit()).ok).toBeDefined();
 
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        projection: await parsePieceGetProjection("comments.body"),
+      await deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection("comments.body"),
       }),
     ).toEqual({ comments: [{ body: "Visible" }] });
   });
@@ -1342,8 +1342,8 @@ describe("cf piece get transforms", () => {
     expect((await tx.commit()).ok).toBeDefined();
 
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        projection: await parsePieceGetProjection("comments.body"),
+      await deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection("comments.body"),
       }),
     ).toEqual({ comments: [{ body: "Visible" }] });
   });
@@ -1404,8 +1404,8 @@ describe("cf piece get transforms", () => {
       expect((await tx.commit()).ok).toBeDefined();
 
       expect(
-        await derivePieceGetValue(runtime, space, source, {
-          projection: await parsePieceGetProjection("entry.body"),
+        await deriveSelectedValue(runtime, space, source, {
+          projection: await parseSelectionProjection("entry.body"),
         }),
       ).toEqual({ entry: { body: "Visible" } });
     }
@@ -1482,58 +1482,58 @@ describe("cf piece get transforms", () => {
     expect((await tx.commit()).ok).toBeDefined();
 
     expect(
-      await derivePieceGetValue(runtime, space, schemaLess, {
-        filter: parsePieceGetFilter("true"),
+      await deriveSelectedValue(runtime, space, schemaLess, {
+        filter: parseSelectionFilter("true"),
       }),
     ).toEqual([1, 2]);
     expect(
-      await derivePieceGetValue(runtime, space, schemaLess, {
-        filter: parsePieceGetFilter("."),
+      await deriveSelectedValue(runtime, space, schemaLess, {
+        filter: parseSelectionFilter("."),
       }),
     ).toEqual([1, 2]);
     expect(
-      await derivePieceGetValue(runtime, space, nestedArrays, {
-        filter: parsePieceGetFilter(".[0]"),
+      await deriveSelectedValue(runtime, space, nestedArrays, {
+        filter: parseSelectionFilter(".[0]"),
       }),
     ).toEqual([[1]]);
     expect(
-      await derivePieceGetValue(runtime, space, nestedArrays, {
-        filter: parsePieceGetFilter(".length"),
-        projection: await parsePieceGetProjection(
+      await deriveSelectedValue(runtime, space, nestedArrays, {
+        filter: parseSelectionFilter(".length"),
+        projection: await parseSelectionProjection(
           '{"type":"array","items":{"type":"array","items":true}}',
         ),
       }),
     ).toEqual([]);
     expect(
-      await derivePieceGetValue(runtime, space, schemaLess, {
-        projection: await parsePieceGetProjection("true"),
+      await deriveSelectedValue(runtime, space, schemaLess, {
+        projection: await parseSelectionProjection("true"),
       }),
     ).toEqual([1, 2]);
     expect(
-      await derivePieceGetValue(runtime, space, schemaLess, {
-        projection: await parsePieceGetProjection('{"type":"array"}'),
+      await deriveSelectedValue(runtime, space, schemaLess, {
+        projection: await parseSelectionProjection('{"type":"array"}'),
       }),
     ).toEqual([1, 2]);
     expect(
-      await derivePieceGetValue(runtime, space, schemaLess, {
-        projection: await parsePieceGetProjection(
+      await deriveSelectedValue(runtime, space, schemaLess, {
+        projection: await parseSelectionProjection(
           '{"type":["array","null"],"items":true}',
         ),
       }),
     ).toEqual([1, 2]);
     expect(
-      await derivePieceGetValue(runtime, space, scalar, {
-        projection: await parsePieceGetProjection('{"type":"string"}'),
+      await deriveSelectedValue(runtime, space, scalar, {
+        projection: await parseSelectionProjection('{"type":"string"}'),
       }),
     ).toBe("visible");
     expect(
-      await derivePieceGetValue(runtime, space, permissiveArray, {
-        projection: await parsePieceGetProjection("id"),
+      await deriveSelectedValue(runtime, space, permissiveArray, {
+        projection: await parseSelectionProjection("id"),
       }),
     ).toEqual([{ id: 1 }]);
     expect(
-      await derivePieceGetValue(runtime, space, composedObject, {
-        projection: await parsePieceGetProjection("id"),
+      await deriveSelectedValue(runtime, space, composedObject, {
+        projection: await parseSelectionProjection("id"),
       }),
     ).toEqual({ id: 2 });
   });
@@ -1553,8 +1553,8 @@ describe("cf piece get transforms", () => {
     expect((await tx.commit()).ok).toBeDefined();
 
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        projection: await parsePieceGetProjection(
+      await deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection(
           '{"type":"object","additionalProperties":false}',
         ),
       }),
@@ -1579,11 +1579,11 @@ describe("cf piece get transforms", () => {
     objectSource.set({ id: 1 });
     expect((await tx.commit()).ok).toBeDefined();
 
-    await expect(derivePieceGetValue(runtime, space, arraySource, {
-      projection: await parsePieceGetProjection('{"type":"object"}'),
+    await expect(deriveSelectedValue(runtime, space, arraySource, {
+      projection: await parseSelectionProjection('{"type":"object"}'),
     })).rejects.toThrow("must describe the returned array");
-    await expect(derivePieceGetValue(runtime, space, objectSource, {
-      projection: await parsePieceGetProjection(
+    await expect(deriveSelectedValue(runtime, space, objectSource, {
+      projection: await parseSelectionProjection(
         '{"type":"array","items":true}',
       ),
     })).rejects.toThrow(
@@ -1609,8 +1609,8 @@ describe("cf piece get transforms", () => {
     expect((await tx.commit()).ok).toBeDefined();
 
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        filter: parsePieceGetFilter(".missing"),
+      await deriveSelectedValue(runtime, space, source, {
+        filter: parseSelectionFilter(".missing"),
       }),
     ).toEqual([]);
   });
@@ -1626,8 +1626,8 @@ describe("cf piece get transforms", () => {
     source.set({ id: 1 });
     expect((await tx.commit()).ok).toBeDefined();
 
-    await expect(derivePieceGetValue(runtime, space, source, {
-      filter: parsePieceGetFilter(".id == 1"),
+    await expect(deriveSelectedValue(runtime, space, source, {
+      filter: parseSelectionFilter(".id == 1"),
     })).rejects.toThrow("--filter can only be applied to an array");
   });
 
@@ -1642,8 +1642,8 @@ describe("cf piece get transforms", () => {
     expect((await tx.commit()).ok).toBeDefined();
 
     expect(
-      await derivePieceGetValue(runtime, space, unsetSource, {
-        filter: parsePieceGetFilter("true"),
+      await deriveSelectedValue(runtime, space, unsetSource, {
+        filter: parseSelectionFilter("true"),
       }),
     ).toEqual([]);
   });
@@ -1666,15 +1666,15 @@ describe("cf piece get transforms", () => {
     objectSource.set({ id: 1 } as never);
     expect((await tx.commit()).ok).toBeDefined();
 
-    await expect(derivePieceGetValue(runtime, space, nullSource, {
-      filter: parsePieceGetFilter("true"),
+    await expect(deriveSelectedValue(runtime, space, nullSource, {
+      filter: parseSelectionFilter("true"),
     })).rejects.toThrow(/^--filter can only be applied to an array$/);
-    await expect(derivePieceGetValue(runtime, space, nullSource, {
-      filter: parsePieceGetFilter("true"),
-      projection: await parsePieceGetProjection("id"),
+    await expect(deriveSelectedValue(runtime, space, nullSource, {
+      filter: parseSelectionFilter("true"),
+      projection: await parseSelectionProjection("id"),
     })).rejects.toThrow(/^--filter can only be applied to an array$/);
-    await expect(derivePieceGetValue(runtime, space, objectSource, {
-      projection: await parsePieceGetProjection("id"),
+    await expect(deriveSelectedValue(runtime, space, objectSource, {
+      projection: await parseSelectionProjection("id"),
     })).rejects.toThrow(
       /^--schema can only project array items from an array value$/,
     );
@@ -1697,8 +1697,8 @@ describe("cf piece get transforms", () => {
     source.set([{ score: true }]);
     expect((await tx.commit()).ok).toBeDefined();
 
-    await expect(derivePieceGetValue(runtime, space, source, {
-      filter: parsePieceGetFilter(".score > 1"),
+    await expect(deriveSelectedValue(runtime, space, source, {
+      filter: parseSelectionFilter(".score > 1"),
     })).rejects.toThrow("Could not apply piece get transform");
   });
 
@@ -1724,8 +1724,8 @@ describe("cf piece get transforms", () => {
       return tx;
     };
     try {
-      await expect(derivePieceGetValue(runtime, space, source, {
-        projection: await parsePieceGetProjection("id"),
+      await expect(deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection("id"),
       })).rejects.toThrow(
         "Could not apply piece get transform: forced commit failure",
       );
@@ -1772,8 +1772,8 @@ describe("cf piece get transforms", () => {
     );
 
     let outputCell: Cell<unknown> | undefined;
-    const result = await derivePieceGetValue(runtime, space, sourceRead, {
-      filter: parsePieceGetFilter('.status == "open"'),
+    const result = await deriveSelectedValue(runtime, space, sourceRead, {
+      filter: parseSelectionFilter('.status == "open"'),
     }, {
       onOutputCell: (cell) => outputCell = cell,
     });
@@ -1822,8 +1822,8 @@ describe("cf piece get transforms", () => {
     expect((await setup.commit()).ok).toBeDefined();
 
     let outputCell: Cell<unknown> | undefined;
-    const result = await derivePieceGetValue(runtime, space, source, {
-      projection: await parsePieceGetProjection("id"),
+    const result = await deriveSelectedValue(runtime, space, source, {
+      projection: await parseSelectionProjection("id"),
     }, {
       onOutputCell: (cell) => outputCell = cell,
     });

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -45,7 +45,6 @@ import {
   localPatternEntry,
   normalizeApiUrl,
   parseLink,
-  parsePieceGetTransformOptions,
   parsePieceOptions,
   parseSpaceOptions,
   piece,
@@ -53,10 +52,11 @@ import {
 } from "../commands/piece.ts";
 import { safeStringify } from "../lib/render.ts";
 import {
-  parsePieceGetFilter,
-  parsePieceGetProjection,
-  PieceGetTransformError,
-} from "../lib/piece-get-transform.ts";
+  CellSelectionError,
+  parseCellSelectionOptions,
+  parseSelectionFilter,
+  parseSelectionProjection,
+} from "../lib/cell-selection.ts";
 
 const API_URL = "https://cf.dev";
 const SPACE = "common-knowledge";
@@ -563,22 +563,22 @@ describe("cli piece parsing", () => {
     expect(getFlags).toContain("--schema");
   });
 
-  it("parses piece get transform options", async () => {
-    expect(await parsePieceGetTransformOptions({})).toBeUndefined();
+  it("parses the --filter and --schema options into a selection", async () => {
+    expect(await parseCellSelectionOptions({})).toBeUndefined();
 
-    const filterOnly = await parsePieceGetTransformOptions({
+    const filterOnly = await parseCellSelectionOptions({
       filter: ".active",
     });
     expect(filterOnly?.filter?.source).toBe(".active");
     expect(filterOnly?.projection).toBeUndefined();
 
-    const schemaOnly = await parsePieceGetTransformOptions({
+    const schemaOnly = await parseCellSelectionOptions({
       schema: "id,name",
     });
     expect(schemaOnly?.filter).toBeUndefined();
     expect(schemaOnly?.projection?.source).toBe("id,name");
 
-    const both = await parsePieceGetTransformOptions({
+    const both = await parseCellSelectionOptions({
       filter: ".active",
       schema: "id",
     });
@@ -586,7 +586,7 @@ describe("cli piece parsing", () => {
     expect(both?.projection?.source).toBe("id");
   });
 
-  it("passes parsed transforms through the piece get command action", async () => {
+  it("passes a parsed selection through the piece get command action", async () => {
     const { code, stderr } = await cf(
       "piece get " +
         "--identity ./definitely-missing-piece-get-review.key " +
@@ -599,7 +599,7 @@ describe("cli piece parsing", () => {
     );
   });
 
-  it("applies get transforms to the selected path cell", async () => {
+  it("applies a selection to the cell at the read path", async () => {
     const targetCell = { marker: "selected-path-cell" };
     const rootCell = {
       key: (...path: Array<string | number>) => {
@@ -613,7 +613,7 @@ describe("cli piece parsing", () => {
           input: { get: () => Promise.resolve(undefined) },
           result: {
             get: () => {
-              throw new Error("transform reads must not materialize result");
+              throw new Error("selection reads must not materialize result");
             },
             getCell: () => Promise.resolve(rootCell),
           },
@@ -623,21 +623,21 @@ describe("cli piece parsing", () => {
       runtime: { marker: "runtime" },
       getSpace: () => "did:key:test-space",
     };
-    const filter = parsePieceGetFilter(".id == 2");
+    const filter = parseSelectionFilter(".id == 2");
 
     const value = await getCellValue(
       { apiUrl: API_URL, space: SPACE, identity: ID, piece: PIECE },
       ["items"],
-      { transform: { filter } },
+      { selection: { filter } },
       {
         loadManager: () => Promise.resolve(manager as any),
         resolvePieceAddress: (_manager, id) => Promise.resolve(id),
         createController: () => controller as any,
-        derivePieceGetValue: (runtime, space, source, transform) => {
+        deriveSelectedValue: (runtime, space, source, selection) => {
           expect(runtime).toBe(manager.runtime as any);
           expect(space).toBe("did:key:test-space");
           expect(source).toBe(targetCell as any);
-          expect(transform.filter).toBe(filter);
+          expect(selection.filter).toBe(filter);
           return Promise.resolve([{ id: 2 }]);
         },
       },
@@ -646,8 +646,8 @@ describe("cli piece parsing", () => {
     expect(value).toEqual([{ id: 2 }]);
   });
 
-  it("preserves transform errors that are not result projection failures", async () => {
-    const transformError = new PieceGetTransformError("invalid transform");
+  it("preserves selection errors that are not result projection failures", async () => {
+    const selectionError = new CellSelectionError("invalid selection");
     const targetCell = {};
     const rootCell = { key: () => targetCell };
     const controller = {
@@ -660,7 +660,7 @@ describe("cli piece parsing", () => {
     await expect(getCellValue(
       { apiUrl: API_URL, space: SPACE, identity: ID, piece: PIECE },
       [],
-      { transform: { filter: parsePieceGetFilter(".active") } },
+      { selection: { filter: parseSelectionFilter(".active") } },
       {
         loadManager: () =>
           Promise.resolve({
@@ -669,12 +669,12 @@ describe("cli piece parsing", () => {
           } as any),
         resolvePieceAddress: (_manager, id) => Promise.resolve(id),
         createController: () => controller as any,
-        derivePieceGetValue: () => Promise.reject(transformError),
+        deriveSelectedValue: () => Promise.reject(selectionError),
       },
-    )).rejects.toBe(transformError);
+    )).rejects.toBe(selectionError);
   });
 
-  it("reports projection failures encountered during transformed reads", async () => {
+  it("reports projection failures encountered during a selection read", async () => {
     const targetCell = {
       schema: { type: "number" },
       getRaw: () => ({ "/": "missing-session-count" }),
@@ -703,7 +703,7 @@ describe("cli piece parsing", () => {
       createController: () => controller as any,
     };
     const options = {
-      transform: { filter: parsePieceGetFilter(".active") },
+      selection: { filter: parseSelectionFilter(".active") },
     };
 
     await expect(getCellValue(
@@ -712,7 +712,7 @@ describe("cli piece parsing", () => {
       options,
       {
         ...deps,
-        derivePieceGetValue: () =>
+        deriveSelectedValue: () =>
           Promise.reject(
             new Error('Cannot access path "count" - property not found'),
           ),
@@ -725,12 +725,12 @@ describe("cli piece parsing", () => {
       options,
       {
         ...deps,
-        derivePieceGetValue: () => Promise.resolve(undefined),
+        deriveSelectedValue: () => Promise.resolve(undefined),
       },
     )).rejects.toThrow(PieceResultProjectionError);
   });
 
-  it("distinguishes failed transforms, JSON null, and absent sources", async () => {
+  it("distinguishes failed selections, JSON null, and absent sources", async () => {
     let sourceRaw: unknown;
     const targetCell = {
       schema: { type: ["object", "null"] },
@@ -746,7 +746,7 @@ describe("cli piece parsing", () => {
 
     const options = {
       input: true,
-      transform: { projection: await parsePieceGetProjection("id") },
+      selection: { projection: await parseSelectionProjection("id") },
     };
     const deps = {
       loadManager: () =>
@@ -764,7 +764,7 @@ describe("cli piece parsing", () => {
       options,
       {
         ...deps,
-        derivePieceGetValue: () => {
+        deriveSelectedValue: () => {
           sourceRaw = { id: "loaded-during-transform" };
           return Promise.resolve(undefined);
         },
@@ -778,7 +778,7 @@ describe("cli piece parsing", () => {
       options,
       {
         ...deps,
-        derivePieceGetValue: () => Promise.resolve(null),
+        deriveSelectedValue: () => Promise.resolve(null),
       },
     )).resolves.toBeNull();
 
@@ -789,7 +789,7 @@ describe("cli piece parsing", () => {
       options,
       {
         ...deps,
-        derivePieceGetValue: () => Promise.resolve(undefined),
+        deriveSelectedValue: () => Promise.resolve(undefined),
       },
     )).resolves.toBeUndefined();
   });
@@ -1275,8 +1275,8 @@ describe("cli piece parsing", () => {
       expect((error as Error).message).not.toContain("--step");
     });
 
-    it("refuses a verb read through a transform, not a projection error", async () => {
-      // The transform path has its own projection-failure exits, so a verb
+    it("refuses a verb read through a selection, not a projection error", async () => {
+      // The selection path has its own projection-failure exits, so a verb
       // read through --filter/--schema must reach the same refusal: asking a
       // stream to project is the same mistake whichever route it takes.
       const verbCell = {
@@ -1306,13 +1306,15 @@ describe("cli piece parsing", () => {
             { runtime: {}, getSpace: () => "did:key:test-space" } as never,
           ),
       };
-      const options = { transform: { filter: parsePieceGetFilter(".active") } };
+      const options = {
+        selection: { filter: parseSelectionFilter(".active") },
+      };
 
-      // The transform throws the "Cannot access path" shape a real projection
+      // The selection throws the "Cannot access path" shape a real projection
       // failure raises.
       const thrown = await getCellValue(config, ["addTopic"], options, {
         ...deps,
-        derivePieceGetValue: () =>
+        deriveSelectedValue: () =>
           Promise.reject(
             new Error('Cannot access path "addTopic" - property not found'),
           ),
@@ -1320,10 +1322,10 @@ describe("cli piece parsing", () => {
       expect(thrown).toBeInstanceOf(PieceVerbReadError);
       expect((thrown as Error).message).toContain("cf piece call");
 
-      // And the same when the transform simply yields nothing.
+      // And the same when the selection simply yields nothing.
       const empty = await getCellValue(config, ["addTopic"], options, {
         ...deps,
-        derivePieceGetValue: () => Promise.resolve(undefined),
+        deriveSelectedValue: () => Promise.resolve(undefined),
       }).catch((error) => error);
       expect(empty).toBeInstanceOf(PieceVerbReadError);
     });


### PR DESCRIPTION
## Why

`cf piece get`, `cf piece call`, `cf wish` and `cf exec` are different ways of
*arriving* at a cell, but they all finish the same way: turn a cell plus a
caller-supplied selection into structured output. Today only `piece get` can
reach that step, because the path from address to value has piece-specific
machinery welded through the middle — config resolution, `--step`,
input-vs-result, the path walk, the verb-read refusal.

Three more callers arrive in later work, so this factors the shared step out
first. Sequenced as F1 in `docs/plans/shaped-reads-implementation.md`.

## What Changed

`packages/cli/lib/piece-get-transform.ts` → `lib/cell-selection.ts` (git tracks
it as an 88%-similarity rename), exporting:

```ts
deriveSelectedValue(runtime, space, sourceCell, selection, deps)
```

Selection vocabulary throughout: `CellSelection`, `SelectionProjection`,
`parseSelectionFilter`, `parseCellSelectionOptions`, and so on. The old name
asserted a piece where none is required.

`runtime` and `space` stay **explicit parameters** rather than being derived
from the cell. `runtime` is not on the public `Cell` interface, and the caller's
space is not always the cell's — `getCellValue` passes `manager.getSpace()`
while a path crossing a link can land the cell elsewhere, so deriving would
silently relocate where the transform pattern runs.

What stayed with `piece get`: config resolution, `PiecesController`, `--step`,
input-vs-result, the path walk, `classifyReadPathVerb` / `PieceVerbReadError`,
and the `--step`-naming error text.

## Test plan

**No test expectation moved**, which is the exit criterion for a refactor.
Verified mechanically: reversing the renames over the new test file reproduces
the original exactly, bar one import changing position under `deno fmt`.

`deno task test` in `packages/cli` (the only package touched) — pass.
`check-docs`, `check-conflict-markers`, `check-skill-facts`, `deno fmt --check`,
`deno lint` — all clean.

## Note for the next change

The unsafe-host-trust reason still reads `"cf piece get filter/schema computed
projection"`. Accurate while `piece get` is the only caller; it wants to become
caller-supplied when a second one lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

