### PR TITLE
feat(runner): teach entity-address intake the `of:` URI form

### DIFF
--- a/docs/specs/space-model/3-identity-and-references.md
+++ b/docs/specs/space-model/3-identity-and-references.md
@@ -107,6 +107,16 @@ which brands an existing content-hash string or `FabricHash`. A `FabricHash` has
 a tagged string form, `<tag>:<hash>` (e.g. `fid1:…`); construct one from that
 string via `FabricHash.fromString()`.
 
+`entityIdFrom()` is the entity-specific intake seam, so it also accepts the
+`of:`-schemed URI over a tagged hash (`of:fid1:…`) — the two spellings name the
+same entity, and both are in circulation wherever an id crosses a boundary a
+person can type into. A KINDED id (`computed:fid1:…`) is refused by name rather
+than stripped: the hash preimage carries no kind, so `computed:fid1:H` and
+`of:fid1:H` are different entities over the same hash bytes, and the bare hash
+is not a complete identity to fall back on (see
+[Computed Cell Identity](../computed-cell-identity.md)). The reduction itself
+lives in `hashStringForEntityAddress()`, which any other address intake shares.
+
 The underlying `hashOf()` function — see
 [Data Model](./1-data-model.md#hashing-and-content-addressing) for the hashing
 mechanism — is also used directly for:

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -36,6 +36,7 @@ import {
   setPatternSource,
   type SpaceCellContents,
 } from "@commonfabric/runner";
+import { hashStringForEntityAddress } from "@commonfabric/runner/entity-kind";
 import type { CellScope } from "@commonfabric/api";
 import { cfcAtom } from "@commonfabric/api/cfc";
 import { StorageManager } from "@commonfabric/runner/storage/cache";
@@ -2171,10 +2172,17 @@ async function getCellByIdOrPiece(
   options?: { start?: boolean; targetScope?: CellScope },
 ): Promise<{ cell: Cell<unknown>; isPiece: boolean }> {
   const start = options?.start ?? true;
+  // The registry check below compares id STRINGS, and a registered piece
+  // reports its own id as the bare tagged hash, so an `of:`-schemed address
+  // has to be reduced to that one spelling before it can match. Reducing it
+  // out here also keeps a kinded address's refusal out of the catch below,
+  // which would otherwise report it as a missing cell. Messages keep `cellId`,
+  // so they echo the address the caller actually gave.
+  const hashString = hashStringForEntityAddress(cellId);
   try {
     // Try to get as a piece first
     const piece = await pieces.getPieceCell(
-      cellId,
+      hashString,
       start,
       undefined,
       options?.targetScope,
@@ -2196,7 +2204,7 @@ async function getCellByIdOrPiece(
     // cell ID
     try {
       const cell = await pieces.getCellById(
-        entityIdFrom(cellId),
+        entityIdFrom(hashString),
         [],
         undefined,
         options?.targetScope,
@@ -2209,7 +2217,7 @@ async function getCellByIdOrPiece(
         const id = pieceId(piece);
         // An entry without a piece ID cannot establish registration.
         if (!id) return false;
-        return id === cellId;
+        return id === hashString;
       });
       return { cell, isPiece: isRegisteredPiece };
     } catch (_) {

--- a/packages/piece/test/piece-address-forms.test.ts
+++ b/packages/piece/test/piece-address-forms.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { createSession, Identity } from "@commonfabric/identity";
+import { Runtime } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { createBuilder } from "../../runner/src/builder/factory.ts";
+import { PiecesController } from "../src/ops/pieces-controller.ts";
+import { pieceId } from "../src/piece-id.ts";
+
+const signer = await Identity.fromPassphrase("piece address form tests");
+
+describe("piece address forms", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let pieces: PiecesController;
+
+  beforeEach(async () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    const session = await createSession({
+      identity: signer,
+      spaceName: "piece-address-forms-" + crypto.randomUUID(),
+    });
+    pieces = new PiecesController(session, runtime);
+    await pieces.synced();
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  async function createPiece(cause: string) {
+    const { commonfabric } = createBuilder();
+    const piecePattern = commonfabric.pattern<{ value: number }>((
+      { value },
+    ) => ({ value }));
+    return await pieces.runPersistent(piecePattern, { value: 1 }, cause);
+  }
+
+  it("resolves one piece through its bare hash and through its `of:` URI", async () => {
+    const piece = await createPiece("address-forms-target");
+    const id = pieceId(piece)!;
+
+    const viaHash = await pieces.getPieceCell(id);
+    const viaUri = await pieces.getPieceCell(`of:${id}`);
+
+    expect(pieceId(viaUri)).toBe(id);
+    expect(viaUri.equals(viaHash)).toBe(true);
+    expect(viaUri.get()).toEqual(viaHash.get());
+  });
+
+  it("throws for a `computed:` address, naming the address it was given", async () => {
+    // The `of:` id over the same hash is a DIFFERENT entity, so the scheme
+    // cannot be dropped to reach a piece — the address is refused instead.
+    const piece = await createPiece("address-forms-computed");
+    const id = pieceId(piece)!;
+
+    await expect(pieces.getPieceCell(`computed:${id}`)).rejects.toThrow(
+      `Kinded entity id \`computed:${id}\``,
+    );
+  });
+});

--- a/packages/piece/test/piece-address-forms.test.ts
+++ b/packages/piece/test/piece-address-forms.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { createSession, Identity } from "@commonfabric/identity";
-import { Runtime } from "@commonfabric/runner";
+import { type Cell, Runtime } from "@commonfabric/runner";
+import { taggedHashStringOf } from "@commonfabric/data-model/value-hash";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { createBuilder } from "../../runner/src/builder/factory.ts";
 import { PiecesController } from "../src/ops/pieces-controller.ts";
@@ -62,5 +63,121 @@ describe("piece address forms", () => {
     await expect(pieces.getPieceCell(`computed:${id}`)).rejects.toThrow(
       `Kinded entity id \`computed:${id}\``,
     );
+  });
+
+  describe("link()", () => {
+    function plainCell(cause: string) {
+      return runtime.getCellFromLink({
+        id: `of:${taggedHashStringOf(cause)}`,
+        path: [],
+        space: pieces.getSpace(),
+      });
+    }
+
+    it("links into a piece named by its `of:` URI", async () => {
+      const source = plainCell("address-forms-link-piece-source");
+      const target = await createPiece("address-forms-link-piece-target");
+      const targetId = pieceId(target)!;
+      await runtime.editWithRetry((tx) => {
+        source.withTx(tx).set({ value: 9 });
+      });
+      await runtime.idle();
+
+      await pieces.link(
+        source.getAsNormalizedFullLink().id,
+        ["value"],
+        `of:${targetId}`,
+        ["value"],
+      );
+      await runtime.idle();
+
+      // The link landed in the piece's argument, so the piece's own result
+      // reports the source's value.
+      expect(pieces.getResult(target).key("value").get()).toBe(9);
+    });
+
+    /** Stands the piece registry up over `entries` for one test. */
+    function registryOf(entries: Cell<unknown>[]) {
+      pieces.getPieceRegistry = () =>
+        Promise.resolve(
+          { get: () => entries } as unknown as Awaited<
+            ReturnType<typeof pieces.getPieceRegistry>
+          >,
+        );
+    }
+
+    it("links into a plain cell named by its `of:` URI", async () => {
+      // A plain cell has no pattern to start, so the target resolves through
+      // the arbitrary-cell path — the one that asks the piece registry
+      // whether the address names a piece. A registry entry is what makes
+      // that question reach a comparison: over an empty registry it is
+      // answered without looking at an id at all.
+      registryOf([await createPiece("address-forms-link-registered")]);
+      const source = plainCell("address-forms-link-cell-source");
+      const target = plainCell("address-forms-link-cell-target");
+      await runtime.editWithRetry((tx) => {
+        source.withTx(tx).set({ data: "linked value" });
+        target.withTx(tx).set({ linked: null });
+      });
+      await runtime.idle();
+
+      await pieces.link(
+        source.getAsNormalizedFullLink().id,
+        ["data"],
+        target.getAsNormalizedFullLink().id,
+        ["linked"],
+      );
+
+      expect(target.key("linked").get()).toBe("linked value");
+    });
+
+    it("takes an `of:` address registered as a piece for the piece it names", async () => {
+      // The registry reports each entry's id as the bare tagged hash, so an
+      // `of:` address reaches a match only against that one spelling. A
+      // matched target is written through a piece's argument cell, and the
+      // registered cell here has none — which is how the match, rather than
+      // the plain-cell write above, shows in what comes back.
+      const source = plainCell("address-forms-registered-uri-source");
+      const target = plainCell("address-forms-registered-uri-target");
+      await runtime.editWithRetry((tx) => {
+        source.withTx(tx).set({ data: "linked value" });
+        target.withTx(tx).set({ linked: null });
+      });
+      await runtime.idle();
+      registryOf([target]);
+
+      // The failure arrives as the transaction's own error value rather than
+      // as a thrown `Error`, so it is read from the rejection directly.
+      const failure = await pieces.link(
+        source.getAsNormalizedFullLink().id,
+        ["data"],
+        target.getAsNormalizedFullLink().id,
+        ["linked"],
+      ).then(() => undefined, (error: unknown) => error);
+
+      expect((failure as { message?: string } | undefined)?.message).toContain(
+        "Target piece has no argument cell",
+      );
+    });
+
+    it("refuses a `computed:` target, naming the address it was given", async () => {
+      const source = plainCell("address-forms-link-computed-source");
+      const targetId = taggedHashStringOf("address-forms-link-computed-target");
+      await runtime.editWithRetry((tx) => {
+        source.withTx(tx).set({ data: "linked value" });
+      });
+      await runtime.idle();
+
+      // The refusal reaches the caller: an address this seam cannot resolve
+      // is a different report from a target that was looked for and missing.
+      await expect(
+        pieces.link(
+          source.getAsNormalizedFullLink().id,
+          ["data"],
+          `computed:${targetId}`,
+          ["linked"],
+        ),
+      ).rejects.toThrow(`Kinded entity id \`computed:${targetId}\``);
+    });
   });
 });

--- a/packages/runner/src/create-ref.ts
+++ b/packages/runner/src/create-ref.ts
@@ -1,6 +1,9 @@
 import { hashOf } from "@commonfabric/data-model/value-hash";
 import { encodableFormOf } from "./encodable-form.ts";
-import { hasEntityUriScheme } from "./entity-kind.ts";
+import {
+  hasEntityUriScheme,
+  hashStringForEntityAddress,
+} from "./entity-kind.ts";
 import {
   BaseFabricPrimitive,
   FabricHash,
@@ -33,10 +36,22 @@ declare const ENTITY_ID_BRAND: unique symbol;
  */
 export type EntityId = FabricHash & { readonly [ENTITY_ID_BRAND]: true };
 
-/** Brands a content-hash string (or `FabricHash`) as an {@link EntityId}. */
+/**
+ * Brands a content-hash string (or `FabricHash`) as an {@link EntityId}.
+ *
+ * A string may arrive in either spelling of an unkinded entity: the bare
+ * tagged hash (`fid1:<hash>`) or the `of:`-schemed URI over it. This is the
+ * entity-specific intake seam, so it is where the URI scheme is understood —
+ * `FabricHash.fromString` below parses a tagged hash, in which `of:` is not a
+ * tag but a second colon, and would reject the schemed form.
+ *
+ * A kinded id (`computed:fid1:<hash>`) throws by name rather than being
+ * stripped to the different entity its bare hash names; see
+ * {@link hashStringForEntityAddress}.
+ */
 export function entityIdFrom(hash: string | FabricHash): EntityId {
   return (typeof hash === "string"
-    ? FabricHash.fromString(hash)
+    ? FabricHash.fromString(hashStringForEntityAddress(hash))
     : hash) as EntityId;
 }
 

--- a/packages/runner/src/entity-kind.ts
+++ b/packages/runner/src/entity-kind.ts
@@ -83,6 +83,39 @@ export function stripEntityUriScheme(id: string): string {
   return prefix === undefined ? id : id.slice(prefix.length);
 }
 
+/**
+ * The bare tagged hash (`fid1:<hash>`) naming the entity that `address`
+ * addresses, accepting either spelling of an unkinded entity: the bare hash
+ * itself, or the `of:`-schemed URI over it. This is the intake seam for an
+ * address that came from outside the runtime — a command-line flag, a routing
+ * request, a pasted id — where both spellings are in circulation and both
+ * name the same entity.
+ *
+ * A KINDED scheme is refused rather than stripped. `computed:fid1:<hash>` and
+ * `of:fid1:<hash>` share hash bytes and name different entities (the preimage
+ * is kind-free; see the module comment above and
+ * `docs/specs/computed-cell-identity.md`), so dropping the scheme would
+ * silently address the sibling instead of reporting that the caller named
+ * something this seam cannot resolve. Every scheme but `of:` is refused, so a
+ * kind added to {@link ENTITY_URI_SCHEMES} is refused here without a further
+ * edit.
+ *
+ * A string carrying no entity scheme is returned unchanged, including one with
+ * no colon at all: recognizing a scheme is this function's job, and judging
+ * what remains belongs to the parser the caller hands it to.
+ *
+ * @throws Error if `address` carries a kinded entity URI scheme.
+ */
+export function hashStringForEntityAddress(address: string): string {
+  const prefix = entityUriSchemePrefix(address);
+  if (prefix === undefined) return address;
+  if (prefix === "of:") return address.slice(prefix.length);
+  throw new Error(
+    `Kinded entity id \`${address}\` cannot be addressed by its hash: ` +
+      `the \`of:\` id over the same hash names a different entity.`,
+  );
+}
+
 const KNOWN_ENTITY_KINDS: ReadonlySet<string> = new Set(["computed"]);
 
 export function isEntityKind(value: unknown): value is EntityKind {

--- a/packages/runner/test/entity-kind.test.ts
+++ b/packages/runner/test/entity-kind.test.ts
@@ -7,6 +7,7 @@ import {
   entityKindOfIdString,
   entityUriSchemePrefix,
   hasEntityUriScheme,
+  hashStringForEntityAddress,
   isEntityKind,
   stripEntityUriScheme,
   uriSchemeForEntityKind,
@@ -89,5 +90,40 @@ describe("entity-kind", () => {
     expect(stripEntityUriScheme("future:fid1:abc")).toBe(
       "future:fid1:abc",
     );
+  });
+
+  describe("hashStringForEntityAddress()", () => {
+    it("returns the same hash string for a bare hash and its `of:` URI", () => {
+      expect(hashStringForEntityAddress("fid1:abc")).toBe("fid1:abc");
+      expect(hashStringForEntityAddress("of:fid1:abc")).toBe("fid1:abc");
+    });
+
+    it("throws for a `computed:` id, naming the address", () => {
+      expect(() => hashStringForEntityAddress("computed:fid1:abc")).toThrow(
+        "Kinded entity id `computed:fid1:abc`",
+      );
+    });
+
+    it("throws for every kinded entity URI scheme", () => {
+      // Driven by the scheme list so a kind added there is refused without a
+      // further edit here.
+      for (const scheme of ENTITY_URI_SCHEMES) {
+        if (scheme === "of") continue;
+        expect(() => hashStringForEntityAddress(`${scheme}:fid1:abc`)).toThrow(
+          `\`${scheme}:fid1:abc\``,
+        );
+      }
+    });
+
+    it("returns a string carrying no entity scheme unchanged", () => {
+      expect(hashStringForEntityAddress("my-board")).toBe("my-board");
+      expect(hashStringForEntityAddress("data:application/json,{}")).toBe(
+        "data:application/json,{}",
+      );
+      expect(hashStringForEntityAddress("future:fid1:abc")).toBe(
+        "future:fid1:abc",
+      );
+      expect(hashStringForEntityAddress("")).toBe("");
+    });
   });
 });

--- a/packages/runner/test/entityIdFrom.test.ts
+++ b/packages/runner/test/entityIdFrom.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { entityRefToString } from "@commonfabric/data-model/cell-rep";
+import { hashOf } from "@commonfabric/data-model/value-hash";
+import { entityIdFrom } from "../src/create-ref.ts";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+
+const signer = await Identity.fromPassphrase("runner entityIdFrom tests");
+const space = signer.did();
+
+describe("entityIdFrom", () => {
+  const bare = hashOf({ probe: "entityIdFrom" }).taggedHashString;
+
+  it("returns the bare tagged hash for a bare tagged hash", () => {
+    expect(entityIdFrom(bare).taggedHashString).toBe(bare);
+    expect(entityIdFrom(bare).tag).toBe("fid1");
+  });
+
+  it("returns the same entity id for a bare hash and its `of:` URI", () => {
+    const fromUri = entityIdFrom(`of:${bare}`);
+    expect(fromUri.taggedHashString).toBe(bare);
+    expect(fromUri.bytes).toEqual(entityIdFrom(bare).bytes);
+  });
+
+  it("returns the `FabricHash` it is handed", () => {
+    const hash = hashOf({ probe: "entityIdFrom passthrough" });
+    expect(entityIdFrom(hash)).toBe(hash);
+  });
+
+  it("throws for a `computed:` id, naming the address it was given", () => {
+    // Refused rather than stripped: `computed:fid1:H` and `of:fid1:H` share
+    // hash bytes and name different entities, so the bare hash is not a
+    // complete identity to fall back on.
+    expect(() => entityIdFrom(`computed:${bare}`)).toThrow(
+      `Kinded entity id \`computed:${bare}\``,
+    );
+  });
+
+  it("throws for a string that is no kind of tagged hash", () => {
+    expect(() => entityIdFrom("my-board")).toThrow();
+    expect(() => entityIdFrom("of:my board")).toThrow();
+  });
+
+  describe("addressing a cell", () => {
+    let storageManager: ReturnType<typeof StorageManager.emulate>;
+    let runtime: Runtime;
+
+    beforeEach(() => {
+      storageManager = StorageManager.emulate({ as: signer });
+      runtime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager,
+      });
+    });
+
+    afterEach(async () => {
+      await runtime?.dispose();
+      await storageManager?.close();
+    });
+
+    it("reaches one cell through a bare hash and through its `of:` URI", async () => {
+      const cell = runtime.getCell(
+        space,
+        { space, random: "entity-uri-intake" },
+      );
+      await runtime.editWithRetry((tx) => {
+        cell.withTx(tx).set({ value: 1 });
+      });
+      const id = entityRefToString(cell.entityId!);
+
+      const viaHash = runtime.getCellFromEntityId(space, entityIdFrom(id));
+      const viaUri = runtime.getCellFromEntityId(
+        space,
+        entityIdFrom(`of:${id}`),
+      );
+
+      await viaHash.sync();
+      await viaUri.sync();
+      expect(viaUri.equals(viaHash)).toBe(true);
+      expect(viaUri.get()).toEqual({ value: 1 });
+
+      // A write through one spelling is visible through the other, which is
+      // the claim a shared entity id actually has to support.
+      await runtime.editWithRetry((tx) => {
+        viaUri.withTx(tx).set({ value: 2 });
+      });
+      expect(viaHash.get()).toEqual({ value: 2 });
+    });
+  });
+});

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -664,7 +664,7 @@ describe("page slug metadata", () => {
     expect(received).toEqual([bare, bare]);
   });
 
-  it("rejects computed ids as page ids", async () => {
+  it("throws for a `computed:` page id, naming the address", async () => {
     const processor = {
       getSpaceCtx: homeSpaceCtx,
       runtime: {
@@ -677,12 +677,13 @@ describe("page slug metadata", () => {
       },
     };
 
+    const computed = `computed:${fid("not-a-page")}`;
     await expect(
       (RuntimeProcessor.prototype as any).handlePageGetSlug.call(processor, {
         type: RequestType.PageGetSlug,
-        pageId: `computed:${fid("not-a-page")}`,
+        pageId: computed,
       }),
-    ).rejects.toThrow("Computed ids are not valid page ids");
+    ).rejects.toThrow(`Kinded entity id \`${computed}\``);
   });
 });
 
@@ -732,7 +733,7 @@ describe("page slug redirects", () => {
     };
   }
 
-  it("normalizes an of:-schemed id before the piece-manager lookup", async () => {
+  it("carries either spelling of a pageId to the same entity", async () => {
     const bare = fid("ordinary-page");
     const requestedRef: CellRef = {
       id: `of:${bare}` as CellRef["id"],
@@ -749,6 +750,7 @@ describe("page slug redirects", () => {
     const requestedCell = mockCell(requestedRef);
     const resultCell = mockCell(resultRef);
     const managerCalls: unknown[][] = [];
+    const lookedUp: string[] = [];
     const processor = {
       getSpaceCtx: () => ({
         getSpace: () => space,
@@ -758,18 +760,29 @@ describe("page slug redirects", () => {
         },
       }),
       runtime: {
-        getCellFromEntityId: () => requestedCell,
+        getCellFromEntityId: (_space: unknown, entityId: unknown) => {
+          lookedUp.push(String(entityId));
+          return requestedCell;
+        },
       },
     };
 
-    await (RuntimeProcessor.prototype as any).handlePageGet.call(processor, {
-      type: RequestType.PageGet,
-      pageId: `of:${bare}`,
-      runIt: true,
-      space,
-    });
+    for (const pageId of [bare, `of:${bare}`]) {
+      await (RuntimeProcessor.prototype as any).handlePageGet.call(processor, {
+        type: RequestType.PageGet,
+        pageId,
+        runIt: true,
+        space,
+      });
+    }
 
-    expect(managerCalls).toEqual([[bare, true]]);
+    expect(lookedUp).toEqual([bare, bare]);
+    // The address handed on to the piece manager still names the requested
+    // entity, whichever spelling the request carried.
+    expect(
+      managerCalls.map(([id]) => entityIdFrom(id as string).taggedHashString),
+    ).toEqual([bare, bare]);
+    expect(managerCalls.map(([, runIt]) => runIt)).toEqual([true, true]);
   });
 
   it("renders slug redirects to output cells directly", async () => {

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -43,6 +43,7 @@ import {
   unmarkUiInputBlindWriteTx,
 } from "@commonfabric/runner";
 import { linkRefPayload } from "@commonfabric/runner/shared";
+import { hashStringForEntityAddress } from "@commonfabric/runner/entity-kind";
 import {
   cfcLabelViewForCell,
   createRenderConfidentialityResolver,
@@ -179,24 +180,6 @@ const cfcLabelLogger = getLogger("runtime-client.cfc-label", {
   enabled: true,
   level: "error",
 });
-
-/**
- * PageId intake: accepts both the bare tagged hash (`fid1:<hash>`, the
- * routing form `PageHandle.id()` emits) and the `of:`-schemed URI
- * (`CellHandle.id()` emits the full schemed id). Without the strip, a
- * schemed pageId would silently parse as a hash whose TAG is `of:fid1`
- * and address the nonexistent entity `of:of:fid1:<hash>` — no error,
- * just a page that never resolves. `computed:` ids are deliberately NOT
- * accepted: pages are pieces (result cells, always `of:`-schemed), and
- * the scheme is part of the identity, so stripping `computed:` would
- * silently alias a different entity.
- */
-function pageIdForRouting(pageId: string): string {
-  if (pageId.startsWith("computed:")) {
-    throw new Error("Computed ids are not valid page ids.");
-  }
-  return pageId.startsWith("of:") ? pageId.slice("of:".length) : pageId;
-}
 
 function resolveBlobUrl(url: string, apiUrl: URL, space: DID): string {
   const spaceBaseUrl = new URL(`/${space}/`, apiUrl);
@@ -1236,10 +1219,9 @@ export class RuntimeProcessor {
     request: PageGetRequest,
   ): Promise<PageResponse> {
     const cc = this.getSpaceCtx(request.space);
-    const pageId = pageIdForRouting(request.pageId);
     const requestedCell = this.runtime.getCellFromEntityId(
       cc.getSpace(),
-      entityIdFrom(pageId),
+      entityIdFrom(request.pageId),
     );
     await requestedCell.sync();
     const redirect = parseLink(
@@ -1276,7 +1258,7 @@ export class RuntimeProcessor {
     }
 
     const cell = await cc.getPieceCell(
-      pageId,
+      request.pageId,
       request.runIt ?? false,
     );
 
@@ -1291,7 +1273,7 @@ export class RuntimeProcessor {
     const pieces = this.getSpaceCtx(request.space);
     const cell = this.runtime.getCellFromEntityId(
       pieces.getSpace(),
-      entityIdFrom(pageIdForRouting(request.pageId)),
+      entityIdFrom(request.pageId),
     );
     await cell.sync();
     const slug = cell.getMetaRaw("slug");
@@ -1345,7 +1327,7 @@ export class RuntimeProcessor {
     // The reader syncs the piece itself, as its first step.
     const cell = this.runtime.getCellFromEntityId(
       pieces.getSpace(),
-      entityIdFrom(pageIdForRouting(request.pieceId)),
+      entityIdFrom(request.pieceId),
     );
     const state = await readPieceSourceState(this.runtime, cell);
     return { source: { ...state, space: state.space as DID } };
@@ -1362,8 +1344,11 @@ export class RuntimeProcessor {
       throw new Error("confirmationToken must be a non-empty string");
     }
     const pieces = this.getSpaceCtx(request.space);
+    // Keyed on the piece's bare hash rather than the request's spelling of it:
+    // a caller may prepare a change under one accepted address form and
+    // confirm it under the other, and both must reach the one pending entry.
     const confirmationKey = `${request.space}\u0000${
-      pageIdForRouting(request.pieceId)
+      hashStringForEntityAddress(request.pieceId)
     }`;
     let confirmedChange: PreparedPieceSourceChange | undefined;
     if (request.confirmationToken === undefined) {
@@ -1383,7 +1368,7 @@ export class RuntimeProcessor {
     }
     const cell = this.runtime.getCellFromEntityId(
       pieces.getSpace(),
-      entityIdFrom(pageIdForRouting(request.pieceId)),
+      entityIdFrom(request.pieceId),
     );
     const controller = new PieceController(pieces, cell);
     const result = await controller.changeSource(request.action, {


### PR DESCRIPTION
## Why

`cf piece get --piece of:fid1:<hash>` throws today. `--piece` reaches
`entityIdFrom`, thence `FabricHash.fromString`, which splits on the first colon
and base64-decodes the rest — so `of:fid1:<b64>` parses as tag `of` with hash
`fid1:<b64>`, and the colon is not valid base64url. It surfaces as a decode
error, which is why it has never been reported as a missing feature.

That matters because an address emitted by one command should compose into the
next. Everything downstream that renders an address for a caller to reuse waits
on this. Sequenced as A4 in `docs/plans/shaped-reads-implementation.md`.

## What Changed

| Form | Before | After |
| --- | --- | --- |
| `my-board` (slug) | accepted | unchanged |
| `fid1:…` (bare hash) | accepted | unchanged |
| `of:fid1:…` | **throws** | **accepted** |
| `computed:fid1:…` | throws | **refused, by name** |

**Refused, not stripped.** Coercing `computed:` to its `of:` sibling renames an
id to a different entity — the hash preimage is kind-free, so a bare hash is not
a complete identity (`docs/specs/computed-cell-identity.md`). The refusal is
driven off `ENTITY_URI_SCHEMES`, so a new kind is refused without a further edit.

The seam is `hashStringForEntityAddress()` in `packages/runner/src/entity-kind.ts`,
called from `entityIdFrom`. `FabricHash.fromString` is untouched — it has
non-entity users, and `of:` is a URI scheme rather than a hash tag.

`pageIdForRouting` in runtime-client is **deleted** rather than duplicated; its
call sites pass addresses straight to `entityIdFrom`.

## One real bug fixed

`getCellByIdOrPiece` (`packages/piece/src/manager.ts`) compared a raw address
against `pieceId(entry)`, which always reports the bare form — so an `of:`
address could never match a registered piece. It now reduces once up front and
compares reduced forms.

## Audit: string-keyed lookups

Once two spellings resolve, anything keying on the *raw* input has two keys per
entity. Every string→cell path was checked.

- **Safe:** every CLI-side id in a comparison is cell-derived, not raw input.
- **Fixed:** `getCellByIdOrPiece`, above — the only raw-input comparison found.
- **Reported, not fixed:** `setBGPiece` upserts on an *external* `pieceId` from
  OAuth state or an HTTP body. Previously an `of:` id stored fine then hard-failed
  in the worker; now it works end to end, so two spellings could produce two
  registry entries. Normalizing at intake is right but changes stored-key
  semantics in another service.

## Adjacent, pre-existing, not fixed here

`getEntityId` already accepted schemed strings and routes through `fromURI`,
which **silently strips `computed:`** and yields the `of:` sibling — the exact
failure this change refuses, one function away. Low severity today, worth its own
issue.

## Test plan

New: `packages/runner/test/entityIdFrom.test.ts` (both spellings brand to one id;
a live cell reached both ways, a write through one visible through the other;
`computed:` throws naming the address) and
`packages/piece/test/piece-address-forms.test.ts`.

Confirmed the key assertion is not vacuous: `FabricHash.fromString("of:fid1:…")`
still throws on its own, so the test exercises the new path.

`deno task test` in runner (1157), piece (35), runtime-client, state-inspector
(96), cli — all pass. `check-docs`, `check-conflict-markers`,
`check-skill-facts`, `deno fmt --check`, `deno lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

