### PR TITLE
feat(cli): mint a call session and carry it to the send boundary

### DIFF
--- a/packages/cli/commands/main.ts
+++ b/packages/cli/commands/main.ts
@@ -9,6 +9,7 @@ import { fuse } from "./fuse.ts";
 import { init } from "./init.ts";
 import { inspect } from "./inspect.ts";
 import { piece } from "./piece.ts";
+import { session } from "./session.ts";
 import { space } from "./space.ts";
 import { identity } from "./identity.ts";
 import { test } from "./test-command.ts";
@@ -167,5 +168,6 @@ export const main = new Command()
   .command("completion", completion)
   .command("id", identity)
   .command("init", init)
+  .command("session", session)
   .command("test", test)
   .command("wish", wish);

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -454,6 +454,33 @@ export function resolveInvocationId(
 }
 
 /**
+ * Resolve the session a handler call's invocation id was chosen within: the
+ * caller's own session (`--session`, or `CF_SESSION`), or none.
+ *
+ * Nothing is minted for a caller that named no session. A session only means
+ * something if the SAME one accompanies every call of a run, and a per-call
+ * mint would be a fresh one each time — a value that looks like a session and
+ * relates no two calls. So an absent session stays absent, and travels as
+ * `undefined`.
+ *
+ * A blank session is rejected for the reason a blank invocation id is: it
+ * would read as "the caller named one" while naming nobody.
+ *
+ * The resolved session is carried beside the invocation id (see
+ * `newSessionId`, packages/cli/lib/session.ts); the event address the id
+ * derives is not scoped by it.
+ */
+export function resolveInvocationSession(
+  raw: string | undefined,
+): string | undefined {
+  if (raw === undefined) return undefined;
+  if (!raw.trim()) {
+    throw new ValidationError("--session requires a non-blank id");
+  }
+  return raw;
+}
+
+/**
  * Build the phase observer for a handler invocation. Its whole job is to put
  * the invocation id on stderr at the moment the event is about to dispatch —
  * BEFORE any network work — so a caller whose process dies past that line
@@ -1586,6 +1613,17 @@ after --. Handlers interpret piped input when no input argument is present.`,
       "outcome — but the handler body does re-run, so effects outside the " +
       "transaction repeat. Minted automatically when omitted.",
   )
+  .env("CF_SESSION=<id:string>", "Session that invocation ids belong to.", {
+    prefix: "CF_",
+  })
+  .option(
+    "--session <id:string>",
+    "Session this call's invocation id was chosen within (before the " +
+      "callable name): the caller that chose it, since an invocation id is " +
+      "the caller's own word and another caller can pick the same one. Mint " +
+      "a session per agent run with `cf session new`, and pass that one " +
+      "session with every call of the run.",
+  )
   .option(
     "--verbose",
     "Print per-phase wall-clock timings to stderr (before the callable " +
@@ -1628,6 +1666,7 @@ after --. Handlers interpret piped input when no input argument is present.`,
   .arguments("<callable:string> [tail...:string]")
   .action(async function (options, callableName, ...tail) {
     const invocationId = resolveInvocationId(options.invocation);
+    const session = resolveInvocationSession(options.session);
     const waitControl = resolveWaitControl(options);
     let phase: InvocationPhase = "initial_sync";
     const observer = pieceCallPhaseObserver(
@@ -1651,6 +1690,7 @@ after --. Handlers interpret piped input when no input argument is present.`,
           invocation.rawArgs,
           {
             invocationId,
+            session,
             skipReadback: waitControl.mode === "commit",
             showLinks: !!options.showLinks,
             onPhase: invocationPhaseReporter(

--- a/packages/cli/commands/session.ts
+++ b/packages/cli/commands/session.ts
@@ -1,0 +1,31 @@
+import { Command } from "@cliffy/command";
+import { cliText } from "../lib/cli-name.ts";
+import { render } from "../lib/render.ts";
+import { newSessionId } from "../lib/session.ts";
+
+/**
+ * Emit a freshly minted session id. Nothing else goes to stdout: the id is the
+ * whole output, so `$(cf session new)` captures exactly it.
+ *
+ * The `write` seam is the unit-test hold on the command's output — a command
+ * action body only ever runs under Cliffy, and is therefore unreachable from
+ * the unit suite. Runtime callers use the default.
+ */
+export function renderNewSession(write: (text: string) => void = render): void {
+  write(newSessionId());
+}
+
+export const session = new Command()
+  .name("session")
+  .description(
+    "Mint the session `cf piece call --session` names: the caller an " +
+      "invocation id was chosen within. One per agent run.",
+  )
+  .default("help")
+  /* session new */
+  .command("new", "Output a new session id to stdout.")
+  .example(
+    cliText("export CF_SESSION=$(cf session new)"),
+    "Mint a session for this shell, so every call made from it shares one.",
+  )
+  .action(() => renderNewSession());

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -58,6 +58,12 @@ export interface CallableExecutionDeps {
    * outside its transaction (an LLM call, a fetch) repeats those effects on
    * retry even though nothing commits twice. */
   invocationId?: string;
+  /** The caller's session: who chose `invocationId` (`newSessionId`,
+   * ./session.ts). The id is the caller's own word, so the id alone does not
+   * say whose invocation it is. Rides the send options beside the id; the
+   * event address the id derives is not scoped by it. A caller that named no
+   * session travels without one. */
+  session?: string;
   /** Phase observer for early-exit reporting. */
   onPhase?: (phase: InvocationPhase) => void;
   /** `--no-wait`: await this handling's transaction-local commit
@@ -585,6 +591,10 @@ export async function executeResolvedCallable(
           if (invocationId !== undefined) {
             resolved.callableCell.send(dispatchInput, resolve, {
               eventId: invocationId,
+              // The id and the session that chose it travel together: an id
+              // is the caller's own word, and only the pair names one
+              // invocation. A caller that named no session sends none.
+              session: deps.session,
             });
           } else {
             resolved.callableCell.send(dispatchInput, resolve);

--- a/packages/cli/lib/session.ts
+++ b/packages/cli/lib/session.ts
@@ -1,0 +1,24 @@
+/**
+ * Mint a session id: the caller identity that an invocation id is chosen
+ * within.
+ *
+ * `cf piece call --invocation <id>` lets a caller name a dispatch so that a
+ * retry settles on the original outcome instead of executing the verb again.
+ * The id is the caller's own word — `add-comment-1` — and nothing stops a
+ * second caller from picking that same word for its own call on the same verb.
+ * The id alone therefore does not say whose invocation it is. A session is
+ * what tells the two callers apart.
+ *
+ * The id is a bare unguessable string. There is no format to parse and no key
+ * material to store — a session signs nothing and authenticates nobody, so
+ * giving it a keyfile shape would only invite storing and handling it as if it
+ * did. Mint one per agent run, carry it in `CF_SESSION` (or `--session`), and
+ * let every call of that run share it: one run is exactly the span over which
+ * repeating an id should mean repeating a call.
+ *
+ * The session travels with the call today; the address a handling's receipt
+ * lands at is derived from the invocation id alone and does not join it yet.
+ */
+export function newSessionId(): string {
+  return crypto.randomUUID();
+}

--- a/packages/cli/test/main-command.test.ts
+++ b/packages/cli/test/main-command.test.ts
@@ -134,6 +134,31 @@ describe("main command", () => {
     ]);
   });
 
+  it("takes piece call's session from the flag ahead of CF_SESSION", async () => {
+    const { piece } = await import(
+      "../commands/piece.ts?piece-call-session-test"
+    );
+    const call = piece.getCommand("call")!;
+    const sessions: Array<string | undefined> = [];
+    call.action((options) => {
+      sessions.push(options.session);
+    });
+
+    await withEnv("CF_SESSION", "from-env", async () => {
+      await piece.parse(["call", "--session", "from-flag", "increment"]);
+      await piece.parse(["call", "increment"]);
+    });
+    await withEnv("CF_SESSION", undefined, async () => {
+      await piece.parse(["call", "increment"]);
+    });
+
+    // The environment is the standing default for a shell or an agent run,
+    // and the flag is the one call that departs from it — so the flag wins.
+    // With neither, no session: nothing is invented for a caller that named
+    // none.
+    expect(sessions).toEqual(["from-flag", "from-env", undefined]);
+  });
+
   it("rejects multiple inline inputs to piece call", async () => {
     const { main } = await import(
       "../commands/main.ts?piece-call-inline-validation-test"

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -34,6 +34,7 @@ import {
   renderPieceCallOutcome,
   reportVerbInputErrorOrRethrow,
   resolveInvocationId,
+  resolveInvocationSession,
   resolveWaitControl,
   verbInputErrorReport,
   WaitBoundExpired,
@@ -951,6 +952,87 @@ describe("executePieceCallable", () => {
     expect(harness.tracker.syncedCalls).toBe(0);
   });
 
+  it("carries the caller's session beside the invocation id to send", async () => {
+    const harness = createPieceCallableHarness({
+      callableKind: "handler",
+      cellKey: "addComment",
+      inputSchema: {
+        type: "object",
+        properties: {
+          message: { type: "string" },
+        },
+        required: ["message"],
+      },
+      receiptValue: { commentId: "c-1" },
+    });
+
+    const result = await executePieceCallable(
+      {
+        apiUrl: "http://localhost:8000",
+        identity: "/tmp/test-identity.pem",
+        piece: "fid1:piece-123",
+        space: "home",
+      },
+      "addComment",
+      ["--message", "milk"],
+      {
+        loadManager: () => Promise.resolve(harness.manager),
+        loadPiece: () => Promise.resolve(harness.piece),
+        invocationId: "inv-123",
+        session: "ses-abc",
+      },
+    );
+
+    // An invocation id is the caller's own word, so the session that chose it
+    // travels with it: they reach the send together or the id says nothing
+    // about whose invocation it is.
+    expect(harness.tracker.sendOptions).toEqual([
+      { eventId: "inv-123", session: "ses-abc" },
+    ]);
+    // Session or no session, the outcome a caller reads is the same one.
+    expect(result.invocation).toEqual({
+      id: "inv-123",
+      status: "settled",
+      result: { commentId: "c-1" },
+    });
+  });
+
+  it("sends an undefined session for a caller that named none", async () => {
+    const harness = createPieceCallableHarness({
+      callableKind: "handler",
+      cellKey: "addComment",
+      inputSchema: {
+        type: "object",
+        properties: {
+          message: { type: "string" },
+        },
+        required: ["message"],
+      },
+      receiptValue: { commentId: "c-1" },
+    });
+
+    await executePieceCallable(
+      {
+        apiUrl: "http://localhost:8000",
+        identity: "/tmp/test-identity.pem",
+        piece: "fid1:piece-123",
+        space: "home",
+      },
+      "addComment",
+      ["--message", "milk"],
+      {
+        loadManager: () => Promise.resolve(harness.manager),
+        loadPiece: () => Promise.resolve(harness.piece),
+        invocationId: "inv-123",
+      },
+    );
+
+    // Absent, not substituted: nothing downstream is handed a stand-in
+    // session it would have to tell apart from a real one.
+    expect(harness.tracker.sendOptions.length).toBe(1);
+    expect(harness.tracker.sendOptions[0]?.session).toBeUndefined();
+  });
+
   it("reclassifies a receipt-exists collision as the original settled outcome", async () => {
     const harness = createPieceCallableHarness({
       callableKind: "handler",
@@ -1082,7 +1164,9 @@ function createPieceCallableHarness(options: {
       path: (string | number)[] | undefined;
       value: unknown;
     }>,
-    sendOptions: [] as Array<{ eventId?: string } | undefined>,
+    sendOptions: [] as Array<
+      { eventId?: string; session?: string } | undefined
+    >,
     receiptLinkRequested: undefined as { id?: string } | undefined,
     idleCalls: 0,
     syncedCalls: 0,
@@ -1128,7 +1212,7 @@ function createPieceCallableHarness(options: {
                 handlingReceiptLink?: NormalizedFullLink;
               },
             ) => void,
-            sendOptions?: { eventId?: string },
+            sendOptions?: { eventId?: string; session?: string },
           ) => {
             tracker.handlerWrites.push({
               cellProp: "result",
@@ -1532,6 +1616,18 @@ describe("piece call stdin payloads", () => {
     // not be safe.
     expect(() => resolveInvocationId("")).toThrow(/non-blank id/);
     expect(() => resolveInvocationId("   ")).toThrow(/non-blank id/);
+  });
+
+  it("carries a named session and mints nothing for a caller without one", () => {
+    expect(resolveInvocationSession("ses-7")).toBe("ses-7");
+    // Deliberately not minted: a per-call mint would hand back a fresh
+    // session every call, relating no two of them — a value shaped like a
+    // session that is none. An absent session travels as absent.
+    expect(resolveInvocationSession(undefined)).toBeUndefined();
+    // Blank is refused for the reason a blank invocation id is: it reads as
+    // "the caller named one" while naming nobody.
+    expect(() => resolveInvocationSession("")).toThrow(/non-blank id/);
+    expect(() => resolveInvocationSession("   ")).toThrow(/non-blank id/);
   });
 
   it("announces the invocation id once, at dispatch", () => {

--- a/packages/cli/test/session.test.ts
+++ b/packages/cli/test/session.test.ts
@@ -1,0 +1,52 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { renderNewSession, session } from "../commands/session.ts";
+import { newSessionId } from "../lib/session.ts";
+
+// A random (version 4) UUID: the version nibble is 4 and the variant nibble is
+// one of 8/9/a/b, with every other nibble drawn from the CSPRNG.
+const RANDOM_UUID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+describe("session", () => {
+  describe("newSessionId()", () => {
+    it("returns a distinct id on every call", () => {
+      const minted = new Set(
+        Array.from({ length: 1000 }, () => newSessionId()),
+      );
+      expect(minted.size).toBe(1000);
+    });
+
+    it("returns a random id rather than a countable or timed one", () => {
+      // The shape is the evidence of where the bits came from: a counter, a
+      // timestamp, or a time-ordered UUID (v1, v7) all carry a version other
+      // than 4, and all let a caller who has seen one session id name the
+      // next one. Reusing another caller's session id is reusing its
+      // invocation ids.
+      expect(newSessionId()).toMatch(RANDOM_UUID);
+    });
+  });
+
+  describe("renderNewSession()", () => {
+    it("writes one freshly minted id, and nothing besides", () => {
+      const written: string[] = [];
+      renderNewSession((text) => written.push(text));
+      renderNewSession((text) => written.push(text));
+
+      // Exactly one bare token per call: no prose to strip and no envelope to
+      // parse (`cf id new`'s PEM has one because it carries key material; a
+      // session carries none), so `$(cf session new)` captures the id itself.
+      expect(written.length).toBe(2);
+      expect(written[0]).toMatch(RANDOM_UUID);
+      expect(written[1]).toMatch(RANDOM_UUID);
+      // Two runs of the command are two sessions.
+      expect(written[0]).not.toBe(written[1]);
+    });
+  });
+
+  describe("session", () => {
+    it("registers `new` as a subcommand", () => {
+      expect(session.getCommand("new")?.getName()).toBe("new");
+    });
+  });
+});

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -283,6 +283,15 @@ export const recordRelevantSchemaWritePolicyInput = (
  * `eventId` is a caller-supplied durable event id (verb contract WS-D): a
  * same-id retry collides on the handling's create-only receipt.
  *
+ * `session` names the caller that chose that `eventId`. An ingress caller's id
+ * is its own word — an agent picks `add-comment-1` — and two agents can pick
+ * the same word for two different calls on one verb, so the id alone does not
+ * say whose invocation it is; the session does. It is accepted here so an
+ * ingress caller can carry the session it is acting within all the way to the
+ * point the durable id is derived. The derived id is
+ * {@link scopeCallerEventId}'s, over the caller's id and the stream, and does
+ * not take the session as an input.
+ *
  * `runtimeInjectedEventKeys` names payload keys the RUNTIME itself merged
  * into this send's event value (the LLM tool-call path injects a `result`
  * cell: `builtins/llm-dialog.ts` sends `{ ...input, result }`). The
@@ -303,6 +312,7 @@ export const recordRelevantSchemaWritePolicyInput = (
  */
 export type StreamSendOptions = {
   eventId?: string;
+  session?: string;
   runtimeInjectedEventKeys?: readonly string[];
 };
 
@@ -347,18 +357,15 @@ declare module "@commonfabric/api" {
     set(
       value: AnyCellWrapping<T> | T,
       onCommit?: (tx: IExtendedStorageTransaction) => void,
-      sendOptions?: {
-        eventId?: string;
-        runtimeInjectedEventKeys?: readonly string[];
-      },
+      sendOptions?: StreamSendOptions,
     ): C;
   }
 
   /**
    * Augment Streamable to add onCommit callback and internal send-options
-   * support (see `StreamSendOptions` — `eventId` and the runtime-injected
-   * key marker). Event is optional only when T is void (matching public
-   * API).
+   * support ({@link StreamSendOptions} — the caller's event id and session,
+   * and the runtime-injected key marker). Event is optional only when T is
+   * void (matching public API).
    */
   interface IStreamable<T> {
     send(
@@ -368,7 +375,7 @@ declare module "@commonfabric/api" {
         ] | [
           AnyCellWrapping<T> | T,
           ((tx: IExtendedStorageTransaction) => void) | undefined,
-          { eventId?: string; runtimeInjectedEventKeys?: readonly string[] },
+          StreamSendOptions,
         ]
         : [AnyCellWrapping<T> | T] | [
           AnyCellWrapping<T> | T,
@@ -376,7 +383,7 @@ declare module "@commonfabric/api" {
         ] | [
           AnyCellWrapping<T> | T,
           ((tx: IExtendedStorageTransaction) => void) | undefined,
-          { eventId?: string; runtimeInjectedEventKeys?: readonly string[] },
+          StreamSendOptions,
         ]
     ): void;
   }


### PR DESCRIPTION
## Why

`cf piece call --invocation <id>` lets a caller name a dispatch so a retry
returns the original outcome instead of executing again. That id decides where
the receipt lands: `scopeCallerEventId` hashes `{caller, id, path, space}` where
`caller` is the id *string*, not a principal. So no identity enters the address —
two callers picking the same id against the same verb compute one address and
read one receipt, and a guessed id reads someone else's outcome.

The fix is to scope ids to a caller-supplied **session**, not a principal: agents
are directed to work under their human user's key rather than mint their own, so
the collision that actually happens is two agents under one key. A session
distinguishes them; a DID does not. And because a session is *minted* rather than
derived, it is unguessable, which closes the second half — a DID is public.

This PR builds the mechanism and **deliberately does not use it**. Sequenced as
S1 in `docs/plans/shaped-reads-implementation.md`; S2 joins it to the hash.

## What Changed

**`cf session new`** emits a bare random id on stdout. No file format — unlike
`cf id new` there is no key material, and a keyfile shape would only be
cargo-culted.

**`--session` / `CF_SESSION`** on `cf piece call`, following the existing
`--identity`/`CF_IDENTITY` shape exactly. Flag wins over env; blank is refused,
mirroring `--invocation`.

**Threaded** from `resolveInvocationSession` through `CallableExecutionDeps` to
the `Cell.send` options beside `eventId`, and into `StreamSendOptions`.

## Where it stops — the point of this PR

`session` is carried to the send boundary and **never read**. It reaches neither
`scopeCallerEventId`, nor the queue options, nor the event value, nor storage.
Every address derived today is byte-identical. That lets the mechanism be
exercised before the change that makes it matter, and keeps the one
address-changing commit small and alone.

One adjacent edit: the `declare module "@commonfabric/api"` augmentation in
`cell.ts` carried two inline copies of the send-options shape, which is what the
CLI type-checks against. They were replaced with `StreamSendOptions` rather than
adding a third and fourth copy of the field.

## Test plan

New: `packages/cli/test/session.test.ts` (distinct over 1000 mints; random-UUID
shape, which a counter, a timestamp or a v1/v7 id fails; bare single-token
output), plus flag-beats-env resolution through the real command, and the session
arriving in send options beside the id.

No test pins "the address is unchanged when a session is passed" — that fact is
exactly what S2 inverts, so such a test would be written to be deleted. The
invariant is visible instead as the absent read in `cell.ts`.

`deno task test`: cli 123, runner 1156. `deno task check` repo-wide,
`check-docs`, `check-conflict-markers`, `check-skill-facts`, `fmt`, `lint` — clean.

## Follow-up owed

`docs/common/verbs-over-the-cli.md` documents `--invocation` and wants its
`--session` paragraph when S2 lands and the pairing becomes required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

