### PR TITLE
docs(common): document what bounds a derivation's read

### DIFF
--- a/docs/common/README.md
+++ b/docs/common/README.md
@@ -40,6 +40,7 @@ on the Common Fabric runtime.
 - [concepts/pattern.md](concepts/pattern.md) — what a pattern is; inputs, outputs, `[UI]`, `[NAME]`
 - [concepts/reactivity.md](concepts/reactivity.md) — the cell system, read/write access, reactive mental model
 - [concepts/computed/computed.md](concepts/computed/computed.md) — `computed()`, `lift()`, derived values
+- [concepts/computed/read-bounds.md](concepts/computed/read-bounds.md) — what a derivation actually reads: the generated input schema, what narrows it, what widens it to the whole space
 - [concepts/action.md](concepts/action.md) — handling events with `action()`
 - [concepts/handler.md](concepts/handler.md) — reusable parameterized handlers with `handler()`
 - [concepts/identity.md](concepts/identity.md) — object identity, `equals()`, why `===` fails across cells

--- a/docs/common/ai/pattern-critique-guide.md
+++ b/docs/common/ai/pattern-critique-guide.md
@@ -255,13 +255,15 @@ Applies only to patterns with multiple people or a "current user" concept. **N/A
 | identity comparison | dedup or "is this me?" by display-name equality | compare a cell reference with `equals()`, never the mutable name |
 | ownership / authorship | "who created / wrote this" stored as a bare name | snapshot the actor's profile, or attest with CFC `AuthoredByCurrentUser` / `RepresentsCurrentUser` |
 
-On the viewer wish: `initialNameApplied` is the display name — the same field
-`#profileName` resolves, with the bootstrap initial name applied. The raw
-`name` is the owner-protected field and reads `""` for a tick longer on a
-freshly created profile, so a gate on `name` flickers where one on
-`initialNameApplied` does not. Separate `#profileName` / `#profileAvatar`
-wishes remain correct; they just cost a resolution each for fields one
-`#profile` wish already carries.
+On the viewer wish: `initialNameApplied` and `name` are not two spellings of
+one field. `name` is the profile's owner-protected `Writable` — asking for it
+hands out a write-capable cell, not a display string. `initialNameApplied` is
+the derived read-only string, and it is what `#profileName` resolves. A
+display surface wants the derived one; declare it optional, as
+`packages/patterns/shared-profile-demo` does.
+
+Separate `#profileName` / `#profileAvatar` wishes remain correct; they just
+cost a resolution each for fields one `#profile` wish already carries.
 
 See `docs/common/patterns/multi-user-patterns.md#presenting-identity` and `docs/common/components/COMPONENTS.md#identity-components`. Severity: a forgeable / dead-string **current-viewer** identity is MAJOR (wrong behavior across users); rendering others as name strings is MINOR–MAJOR per case; rendering a co-participant with `cf-avatar` when their live profile cell is available is MINOR (misses the trusted seal and live data).
 

--- a/docs/common/ai/pattern-critique-guide.md
+++ b/docs/common/ai/pattern-critique-guide.md
@@ -249,11 +249,19 @@ Applies only to patterns with multiple people or a "current user" concept. **N/A
 |-------|----------------|-----|
 | people rendered as data | a person shown as `{name}` text or a raw `<img>` | render **every** participant with `cf-profile-badge` bound to their profile cell; `cf-avatar` + snapshot only as an explicit offline fallback |
 | others rendered as `cf-avatar` when a live cell exists | `cf-avatar` used for co-participants even though their `#profile` cell is (or could be) stored on join | store each joiner's profile cell in the shared roster and badge it — cross-space reads resolve (CT-1667/1687). `cf-avatar` is only for snapshot-only cases |
-| current viewer | a "type your name" / "who am I" text field used as the viewer's identity | resolve via `wish({ query: "#profile" })` (+ `#profileName` / `#profileAvatar`) |
+| current viewer | a "type your name" / "who am I" text field used as the viewer's identity | resolve via one `wish<{ initialNameApplied?: string; avatar?: string }>({ query: "#profile" })` — both display fields off a single resolution |
 | per-user isolation | stored DIDs / user-ids / name strings used to fake isolation | use `PerUser` / `PerSpace` scope; let the scope select the instance |
 | roster construction | a participant list built from typed names | join by profile cell: each viewer pushes their own live `#profile` cell (plus a `{ displayName, avatar }` snapshot fallback) into the shared roster |
 | identity comparison | dedup or "is this me?" by display-name equality | compare a cell reference with `equals()`, never the mutable name |
 | ownership / authorship | "who created / wrote this" stored as a bare name | snapshot the actor's profile, or attest with CFC `AuthoredByCurrentUser` / `RepresentsCurrentUser` |
+
+On the viewer wish: `initialNameApplied` is the display name — the same field
+`#profileName` resolves, with the bootstrap initial name applied. The raw
+`name` is the owner-protected field and reads `""` for a tick longer on a
+freshly created profile, so a gate on `name` flickers where one on
+`initialNameApplied` does not. Separate `#profileName` / `#profileAvatar`
+wishes remain correct; they just cost a resolution each for fields one
+`#profile` wish already carries.
 
 See `docs/common/patterns/multi-user-patterns.md#presenting-identity` and `docs/common/components/COMPONENTS.md#identity-components`. Severity: a forgeable / dead-string **current-viewer** identity is MAJOR (wrong behavior across users); rendering others as name strings is MINOR–MAJOR per case; rendering a co-participant with `cf-avatar` when their live profile cell is available is MINOR (misses the trusted seal and live data).
 

--- a/docs/common/concepts/computed/computed.md
+++ b/docs/common/concepts/computed/computed.md
@@ -20,6 +20,11 @@ const filteredItems = computed(() => {
 rendering or other simple conditional values in normal pattern code, use plain
 ternaries — see [Conditional Rendering](../../patterns/conditional.md).
 
+Every derivation also carries a generated input schema, and that schema is
+exactly what the runtime reads. Over a list of pieces the spelling of the body
+decides whether a derived value reads one field or every piece whole — see
+[What a Derivation Reads](./read-bounds.md).
+
 ## When NOT to Use computed()
 
 **Never inside JSX for interpolation or property access** — reactivity is
@@ -74,17 +79,22 @@ const goodValue = computed(() => 123 + doubled);
 
 ## Dynamic `[NAME]`
 
-Input props are reactive and can't be read at init time. Wrap derived names in
-`computed()` (static strings don't need it):
+A template literal that interpolates reactive values is a lowerable expression:
+the transformer auto-lifts it, so `[NAME]` tracks its inputs with no wrapper.
 
 ```tsx
-// Shown for illustration only.
-// ❌ Error: reactive reference outside context
-[NAME]: `Study: ${deck.name}`,
+// Shown at module scope.
+interface Deck { name: string }
 
-// ✅ computed() creates a reactive context
-[NAME]: computed(() => `Study: ${deck.name}`),
+export default pattern<{ deck: Deck }>(({ deck }) => ({
+  // Reactive with no wrapper — the transformer auto-lifts the literal.
+  [NAME]: `Study: ${deck.name}`,
+  [UI]: <div>{deck.name}</div>,
+}));
 ```
+
+Reach for `computed()` here when the name needs statements — a branch, a loop,
+a local — rather than a single expression.
 
 ## Side Effects in computed()
 
@@ -122,11 +132,10 @@ The scheduler re-runs computations when their dependencies change. If a computat
 
 Prefer using handlers for mutations instead of side effects in `computed()`.
 
-## Reusable Computations: lift()
+## lift(): a Declared Input Schema
 
-`lift()` defines a reusable reactive computation at module scope. `computed()`
-is almost always better — reach for `lift()` only when the same derivation is
-used in multiple patterns or called multiple times in one pattern:
+`lift()` defines a reactive computation at module scope, with an explicitly
+declared parameter type:
 
 ```typescript
 // Shown for illustration only.
@@ -141,6 +150,18 @@ const result = getByDate({ grouped, date });
 // For one-off use, prefer computed()
 const result = computed(() => grouped[date]);
 ```
+
+That declared parameter is the reason to reach for `lift()`. It is emitted
+verbatim as the derivation's input schema — the exact set of paths the runtime
+will read — and it holds even when the body calls a helper the transformer
+cannot see through. A `computed()` has no such declaration: its schema is
+inferred from the body, and an opaque call in that body widens it to everything
+the input's type describes. When a derivation reads a list of pieces, that
+difference is the difference between reading a field and reading the space.
+[What a Derivation Reads](./read-bounds.md) covers the rules and how to measure
+them.
+
+Reuse across patterns is the other reason, and the lesser one.
 
 Like `handler()`, `lift()` must be defined at module scope, never inside the
 pattern body — see [Module Scope Requirement](../handler.md#module-scope-requirement)

--- a/docs/common/concepts/computed/read-bounds.md
+++ b/docs/common/concepts/computed/read-bounds.md
@@ -1,0 +1,182 @@
+# What a Derivation Reads
+
+Every derivation — a `computed()`, an expression the transformer auto-lifts, an
+explicit `lift()` — carries a generated **input schema**. That schema is not
+documentation of the derivation: it *is* the read. The runtime materializes
+exactly the paths the schema declares and nothing else.
+
+So the schema decides how much of a space a single derived value pulls in. Over
+a plain array of strings that is a rounding error. Over a list of pieces it is
+not: an element schema that describes the piece fully pulls whatever that type
+declares — its fields, its streams, its rendered `[UI]` VDOM — and then
+whatever those link to in turn. One derived value can end up reading a whole
+space.
+
+This document is about which spellings bound that read and which spellings
+give it up.
+
+## Seeing the schema
+
+The transformer's output is the ground truth, and it is one command away:
+
+```bash
+deno task cf check ./donut-board.tsx --show-transformed
+```
+
+Each derivation appears as a `__cfLift_N` with its input schema inline. This is
+worth reading whenever a derived value feels expensive — the schema tells you
+what it costs before you deploy anything.
+
+## A plain reactive input narrows to the paths the body reaches
+
+When an input is declared without `Writable<>`, the transformer tracks the
+property paths the body reaches and emits only those:
+
+```tsx
+// Shown at module scope.
+interface Donut { glaze: string; sprinkles: string[] }
+
+export default pattern<{ donuts: Donut[] }>(({ donuts }) => {
+  const donutCount = computed(() => donuts.length);
+  const glazes = computed(() => donuts.map((donut) => donut.glaze));
+  return { [UI]: <div>{donutCount}{glazes}</div> };
+});
+```
+
+`donutCount` emits `donuts: { type: "object", properties: { length: … } }` — it
+does not even describe an array, because nothing but the length is read.
+`glazes` emits an array whose element schema is `{ glaze: string }`; the
+`sprinkles` of every donut are never fetched.
+
+Object inputs narrow the same way, per property. A body that reaches
+`baker.name` emits a `baker` schema with `name` and nothing else.
+
+## A `Writable<>` input is delivered whole
+
+A `Writable<>` (or `Cell<>`) input is handed to the derivation as a live cell,
+at its **full declared type**. Reading through `.get()` does not narrow it:
+
+```tsx
+// Shown at module scope.
+interface Donut { glaze: string; sprinkles: string[] }
+
+export default pattern<{ donuts: Writable<Donut[]> }>(({ donuts }) => {
+  const firstGlaze = computed(() => donuts.get()[0].glaze);
+  return { [UI]: <div>{firstGlaze}</div> };
+});
+```
+
+`firstGlaze` emits the complete `Donut` element schema — `sprinkles` included —
+even though the body reaches one field of one element.
+
+There is one narrowing that survives a cell capture. When the body reads an
+array for nothing but its length — no path reaches an element — the element
+type collapses:
+
+```tsx
+// Shown at module scope.
+interface Donut { glaze: string; sprinkles: string[] }
+
+export default pattern<{ donuts: Writable<Donut[]> }>(({ donuts }) => {
+  const donutCount = computed(() => donuts.get().length);
+  return { [UI]: <div>{donutCount}</div> };
+});
+```
+
+That emits `donuts: { type: "array", items: { type: "unknown" }, asCell: […] }`,
+and at runtime the elements come back as `null` — the links are resolved to
+count them, and no field behind any of them is fetched.
+
+**This is the practical reason to omit `Writable<>` when you do not write.**
+[Reactivity and Write Access](../reactivity.md) states the rule as a matter of
+intent; the schema is where it becomes a cost. An input you only display, typed
+`Writable<>` out of habit, is read whole by every derivation that touches it.
+
+## An opaque call widens the read back to everything
+
+The analysis narrows only what it can see. Hand a value to a function it
+cannot see through and it records a read of the whole value, and the full
+declared schema comes back:
+
+```tsx
+// Shown at module scope.
+interface Donut { glaze: string; sprinkles: string[] }
+
+// A small helper in another module — opaque to the analysis.
+declare function toList<T>(value: readonly T[]): T[];
+
+export default pattern<{ donuts: Donut[] }>(({ donuts }) => {
+  const donutCount = computed(() => toList(donuts).length);
+  return { [UI]: <div>{donutCount}</div> };
+});
+```
+
+That emits the full `Donut` element schema. The helper's body is irrelevant —
+even a one-line `(v) => v` has this effect, because opacity is about what the
+analysis can follow, not about what the function does.
+
+The same applies to **any method call on a `.get()` result**, built-ins
+included. On a plain input, `donuts.map((donut) => donut.glaze)` narrows to
+`{ glaze }`; on a `Writable<>` input, `donuts.get().map((donut) => donut.glaze)`
+emits the full element schema. A `.filter()`, a `.sort()`, a `.join()`, or a
+chain through any of them behaves the same way.
+
+On a plain input, then: property access and index access are followed, a call
+is not. On a `Writable<>` input the value already arrives whole, and a call
+only forfeits the length-only collapse above.
+
+## Two costs, not one
+
+**Bytes and subscriptions.** The obvious one: a wider schema fetches more, and
+subscribes to more, so the derivation also re-runs more often.
+
+**Scope.** The less obvious one, and the one that produces startup behavior
+nobody asked for. Every read ratchets the transaction's narrowest read scope
+(`recordReadScope` in
+`packages/runner/src/storage/extended-storage-transaction.ts`), and the runtime
+derives the derived value's output scope from where that ratchet lands. Reach
+into anything session-scoped — a `PerSession` UI fragment inside a piece you
+read whole, for instance — and the entire derived value becomes session-scoped,
+which means it is computed and written again for every session.
+
+A schema that stops above the session-scoped value keeps the derivation at
+space scope. A schema that describes the element fully does not, and no amount
+of the body "not really using" that field changes it: the schema is the read.
+
+The scope machinery is specified in
+[cell scopes](../../../specs/server-side-execution/scopes.md).
+
+## Bounding a read you cannot narrow
+
+When the body genuinely needs an opaque helper, move the derivation into a
+`lift()` and **declare the parameter type**. A declared parameter is emitted
+verbatim as the schema, and it is a ceiling the helper's opacity cannot raise:
+
+```tsx
+// Shown at module scope.
+declare function toList<T>(value: readonly T[]): T[];
+
+// toList() is opaque to the analysis; the declared parameter bounds it anyway.
+const countDonuts = lift((args: { donuts: { glaze: string }[] }) =>
+  toList(args.donuts).length
+);
+```
+
+That emits exactly `donuts: { type: "array", items: { type: "object",
+properties: { glaze: … } } }` — nothing else about a donut is read, however the
+body is written.
+
+This is what `lift()` is for. Reuse across patterns is a convenience;
+bounding the read of a body the analysis cannot follow is the capability
+`computed()` does not have.
+
+## When a derived value looks too expensive
+
+1. Run `deno task cf check <file> --show-transformed` and find the derivation's
+   `__cfLift_N`.
+2. If its input schema describes more than the body needs, look for the cause
+   in this order: a `Writable<>` on an input you never write, a call on a
+   `.get()` result, a helper the analysis cannot see through.
+3. Drop the `Writable<>`, or rewrite the body in property and index access, or
+   move it to a `lift()` with a declared parameter type.
+4. Re-run `--show-transformed` and confirm the schema shrank.

--- a/docs/common/concepts/reactivity.md
+++ b/docs/common/concepts/reactivity.md
@@ -11,6 +11,18 @@ reads are tracked as dependencies (in computed/lift). Derive data with
 [computed()](./computed/computed.md) and gate UI with plain ternaries
 ([Conditional Rendering](../patterns/conditional.md)).
 
+`.get()` is not confined to those bodies. At pattern scope the transformer
+auto-lifts any expression built on a `.get()` — `rows.get().length`,
+`rows.get()[0]`, `rows.get().length > 0`, `` `Rows: ${rows.get().length}` `` —
+into a derivation, so those spellings need no wrapper either. What it cannot
+lift is a bare `rows.get()` (there is no expression around it to derive) or a
+**method call** on the result: `rows.get().join(", ")`, `name.get().trim()`,
+`rows.get().filter(…)`. Those report *"Calling .get() on a cell is not allowed
+in reactive context"* and belong inside a `computed()`.
+
+Which spelling you pick also decides how much the derivation reads — see
+[What a Derivation Reads](./computed/read-bounds.md).
+
 ## Core Principle: Writable<> is About Write Access, Not Reactivity
 
 **The most important thing to understand:** Everything in Common Fabric is reactive by default. The `Writable<>` wrapper in type signatures doesn't enable reactivity—it indicates **write intent**.
@@ -19,6 +31,12 @@ reads are tracked as dependencies (in computed/lift). Derive data with
 
 - **Use `Writable<T>`** in signatures ONLY when you need write access (`.set()`, `.update()`, `.push()`, `.key()`)
 - **Omit `Writable<>`** for read-only access - the framework automatically provides reactive values
+
+Omitting it is not only a statement of intent. A `Writable<>` input is handed
+to every derivation that touches it at its full declared type, while a plain
+one is narrowed to the paths the body actually reaches — so on a list of pieces
+a stray `Writable<>` is the difference between reading a field and reading the
+space. See [What a Derivation Reads](./computed/read-bounds.md).
 
 ```tsx
 // Shown for illustration only.


### PR DESCRIPTION
## Why

Found while diagnosing a Topics board that read the entire space — including every piece's rendered UI — on a single derived value at startup. Nothing under `docs/common/` named the mechanism that caused it.

## What

### New: [`docs/common/concepts/computed/read-bounds.md`](docs/common/concepts/computed/read-bounds.md)

Every derivation carries a generated input schema, and that schema *is* the read. The rules, each verified with `cf check --show-transformed`:

| capture | body | emitted schema |
|---|---|---|
| `donuts: Donut[]` | `donuts.length` | `{ type: "object", properties: { length } }` — not even an array |
| `donuts: Donut[]` | `donuts.map((d) => d.glaze)` | element narrowed to `{ glaze }` |
| `donuts: Donut[]` | `toList(donuts).length` | **full element schema** |
| `donuts: Writable<Donut[]>` | `donuts.get().length` | `items: { type: "unknown" }` |
| `donuts: Writable<Donut[]>` | `donuts.get()[0].glaze` | **full element schema** |
| `donuts: Writable<Donut[]>` | `donuts.get().map((d) => d.glaze)` | **full element schema** |
| `lift((args: { donuts: { glaze: string }[] }) => toList(args.donuts).length)` | | exactly the declared type |

Two axes, both documented: a `Writable<>`/`Cell` input is delivered whole at its declared type, and an opaque call — a helper, *or any method call on a `.get()` result, built-ins included* — records a whole-value read.

Both costs are stated: bytes/subscriptions, and scope. Measured against the runner rather than argued:

```
items: {type:"unknown"}   childDocsTouched=4  child paths: [value ×8]                    → values come back null
items: {title} only       childDocsTouched=4  child paths: [… value/title ×4]            → body never fetched
items: full element       childDocsTouched=4  child paths: [… value/title, value/body ×4]
```

```
reads only `plain`             narrowestReadScope = space
reads `plain` + `perSession`   narrowestReadScope = session
```

### Fixed: `computed.md`

- **`lift()` framing.** It said "`computed()` is almost always better — reach for `lift()` only when the same derivation is used in multiple patterns". That omits the decisive reason: a `lift`'s declared parameter is the only way to bound the input schema of a body the analysis cannot see through. Reuse is now the lesser reason.
- **Stale "Dynamic `[NAME]`" example.** It showed bare `` [NAME]: `Study: ${deck.name}` `` as *"❌ Error: reactive reference outside context"*. It compiles and auto-lifts (`__cfLift_1`, narrowed to `{ deck: { name } }`); eight patterns in-tree already spell it that way. Corrected.

### Fixed: `reactivity.md`

- The opening read as though `.get()` were legal only inside `computed()`/`lift()`/`action()`/`handler()` bodies. The actual pattern-scope rule, probed form by form: expressions built on a `.get()` auto-lift (`rows.get().length`, `rows.get()[0]`, `rows.get().length > 0`, template interpolation, ternary, object literal); a **bare `.get()`** and a **method call on the result** (`.join()`, `.trim()`, `.toFixed()`, `.map()`, `.filter()`, spread) do not.
- The `Writable<>` section now names the read cost, not just write intent.

### Minor: `pattern-critique-guide.md`

`#profile` **plus** `#profileName`/`#profileAvatar` → one `wish<{ initialNameApplied?: string; avatar?: string }>({ query: "#profile" })`. Noted that `initialNameApplied` is the same field `#profileName` resolves (`wish.ts:909`), so there is no timing regression — and that gating on the raw `name` is what flickers on a freshly created profile.

## Note for review

The task flagged `.get()` behavior partly differently from what I measured — it listed `s.get().trim()` as compiling and `rows.get()[0]` as erroring. Both are the other way round; the documented rule is property/index access vs. call, probed individually.

A separate task covers the possibly over-broad diagnostic at `packages/ts-transformers/src/transformers/pattern-context-validation.ts:262`. This documents today's behavior — if that lands first, `reactivity.md`'s second paragraph is the thing to update.

## Gates

`deno fmt --check` · `deno task check-docs` (539 blocks) · `deno task check-skill-facts` · `deno task check-conflict-markers` · `deno task docs-links --orphan` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

