### PR TITLE
feat(cli): show whole-diff change totals in the pager's corner

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -21,6 +21,10 @@ line. Recognized shebangs and transformed compiler headers remain explicit
 selectors. JSON-, YAML-, Markdown-, Python-, and other language-shaped source is
 not guessed from its syntax.
 
+A diff shows its whole-diff change totals at the top right corner of its first
+line: the added line count and the removed line count, coloured like additions
+and removals.
+
 Markdown files can switch between the source and a rendered terminal view with
 `V`. The rendered view formats headings, emphasis, links, quotes, lists, task
 markers, tables, rules, and code. The same view is available for Markdown files

--- a/packages/cli/lib/view/fold.ts
+++ b/packages/cli/lib/view/fold.ts
@@ -22,6 +22,9 @@ export interface DiffFileRange {
   readonly path: string;
   readonly isTest: boolean;
   readonly isMarkdown: boolean;
+  /** Added and removed line counts within the file's range. */
+  readonly adds: number;
+  readonly dels: number;
   /** The one-line summary shown when the file is collapsed. */
   readonly summary: Line;
 }
@@ -48,6 +51,8 @@ export function diffFiles(text: string): DiffFileRange[] {
       path,
       isTest: isTestPath(path),
       isMarkdown: isMarkdownPath(path),
+      adds,
+      dels,
       summary: summaryLine({
         oldPath: file.oldPath,
         newPath: file.newPath,

--- a/packages/cli/lib/view/render.ts
+++ b/packages/cli/lib/view/render.ts
@@ -20,7 +20,7 @@ import {
   glyphFor,
 } from "./display.ts";
 import { overlaySpanStyle, spanStyle } from "./highlight.ts";
-import { lineBg, ui } from "./theme.ts";
+import { lineBg, styleFor, ui } from "./theme.ts";
 import {
   buildWrapPlan,
   fitViewLayout,
@@ -86,12 +86,71 @@ export function diffAnnotationDecoration(
   };
 }
 
+/** Whole-diff added and removed line totals. */
+export interface DiffTotals {
+  readonly adds: number;
+  readonly dels: number;
+}
+
+/** One right-edge annotation cell: its glyph, and its style when it differs
+ * from the wrap-marker style. */
+interface SuffixCell {
+  readonly ch: string;
+  readonly style?: Style;
+}
+
+function plainSuffix(text: string): SuffixCell[] {
+  return [...text].map((ch) => ({ ch }));
+}
+
+/** The two segments of the corner label for the whole-diff totals, e.g.
+ * `+345 ` and `−12`: the added count and the removed count. */
+function diffTotalsSegments(totals: DiffTotals): [string, string] {
+  return [`+${totals.adds} `, `−${totals.dels}`];
+}
+
+/** The corner label's cells: the added count in the addition colour, the
+ * removed count in the removal colour. */
+function diffTotalsCells(totals: DiffTotals): SuffixCell[] {
+  const [add, del] = diffTotalsSegments(totals);
+  return [
+    ...[...add].map((ch) => ({ ch, style: styleFor("diffAdd") })),
+    ...[...del].map((ch) => ({ ch, style: styleFor("diffDel") })),
+  ];
+}
+
+/** Columns the whole-diff totals label occupies. */
+export function diffTotalsWidth(totals: DiffTotals): number {
+  const [add, del] = diffTotalsSegments(totals);
+  return cpLen(add) + cpLen(del);
+}
+
+/** Wrapped source widths reserved by the totals label on the first line,
+ * layered over any annotation decoration that line already carries. */
+export function diffTotalsDecoration(
+  labelWidth: number,
+  width: number,
+  annotation?: WrapDecoration,
+): WrapDecoration {
+  const available = Math.max(0, width - 1);
+  return {
+    firstWidth: Math.min(
+      (annotation?.firstWidth ?? 0) + labelWidth,
+      available,
+    ),
+    firstContinuationWidth: annotation?.firstContinuationWidth ??
+      annotation?.continuationWidth ?? 0,
+    continuationWidth: annotation?.continuationWidth ?? 0,
+  };
+}
+
 /** The metadata line that carries the Ctrl-L label in this wrapped layout. */
 export function labeledDiffMetadataLine(
   lines: readonly Line[],
   mode: DisplayMode,
   width: number,
   annotations: readonly DiffAnnotation[],
+  totalsWidth = 0,
 ): number | null {
   const metadata = annotations.find((annotation) =>
     annotation.kind === "diffMetadata"
@@ -103,7 +162,10 @@ export function labeledDiffMetadataLine(
   if (!downward || metadata.line !== downward.line + 1) return metadata.line;
   const line = lines[downward.line];
   if (!line) return metadata.line;
-  const firstWidth = diffAnnotationDecoration("expandDown", width).firstWidth;
+  const decoration = diffAnnotationDecoration("expandDown", width);
+  const firstWidth = downward.line === 0 && totalsWidth > 0
+    ? diffTotalsDecoration(totalsWidth, width, decoration).firstWidth
+    : decoration.firstWidth;
   return displayWidth(line, mode) > Math.max(1, width) - firstWidth
     ? null
     : metadata.line;
@@ -164,6 +226,9 @@ export interface ViewState {
   expandMargin?: boolean;
   /** Per-line annotations drawn against the right edge. */
   diffAnnotations?: readonly DiffAnnotation[];
+  /** Whole-diff added/removed totals, drawn at the top right corner of the
+   * first line. */
+  diffTotals?: DiffTotals | null;
   /** Absolute display row of the diff edge the next Ctrl-L will expand. */
   expandRow?: number | null;
   /** Whether the marked edge expands upward. False means downward. */
@@ -341,6 +406,15 @@ function clipConnectorAnnotation(text: string, width: number): string {
   return capacity === 0 ? "" : [...text].slice(-capacity).join("");
 }
 
+/** Keep at least one source cell when a styled suffix meets a narrow view. */
+function clipSuffixCells(
+  cells: readonly SuffixCell[],
+  width: number,
+): SuffixCell[] {
+  const capacity = Math.max(0, width - 1);
+  return capacity === 0 ? [] : cells.slice(-capacity);
+}
+
 const MATCH_BLOCK_SIZE = 64;
 
 /** The contiguous slice of document-ordered matches on one visible line. */
@@ -387,12 +461,14 @@ export function renderFrame(doc: Document, view: ViewState): string[] {
       annotation.kind,
     ]),
   );
+  const totalsCells = view.diffTotals ? diffTotalsCells(view.diffTotals) : [];
   const metadataLabelLine = view.wrapMode !== "off"
     ? labeledDiffMetadataLine(
       doc.lines,
       view.displayMode,
       contentWidth,
       view.diffAnnotations ?? [],
+      totalsCells.length,
     )
     : view.diffAnnotations?.find((annotation) =>
       annotation.kind === "diffMetadata"
@@ -405,6 +481,16 @@ export function renderFrame(doc: Document, view: ViewState): string[] {
         kind,
         contentWidth,
         kind !== "diffMetadata" || line === metadataLabelLine,
+      ),
+    );
+  }
+  if (totalsCells.length > 0) {
+    decorations.set(
+      0,
+      diffTotalsDecoration(
+        totalsCells.length,
+        contentWidth,
+        decorations.get(0),
       ),
     );
   }
@@ -456,9 +542,11 @@ export function renderFrame(doc: Document, view: ViewState): string[] {
     const rowIdx = view.top + r;
     const endMark = endRows[rowIdx - endMarkStart] ?? null;
     if (endMark !== null) {
-      const suffix = hasDiffEndConnector && rowIdx === diffEndRow
-        ? diffEndSuffix(view.width)
-        : "";
+      const suffix = plainSuffix(
+        hasDiffEndConnector && rowIdx === diffEndRow
+          ? diffEndSuffix(view.width)
+          : "",
+      );
       rows.push(
         composeContent(
           undefined,
@@ -500,14 +588,17 @@ export function renderFrame(doc: Document, view: ViewState): string[] {
       wrapPlan !== null &&
       wrappedRow !== undefined &&
       rowIdx === wrapPlan.firstRow[lineIdx] + 1;
+    // Row 0 reserves the leading cells of its suffix for the totals label, so
+    // the plain block marker only marks a width reserved beyond the label.
+    const reservedTotals = rowIdx === 0 ? totalsCells.length : 0;
     const marginMarker: MarginMarker = firstOfLine && annotation
       ? annotation
-      : wrappedRow && wrappedRow.suffixWidth > 0
+      : wrappedRow && wrappedRow.suffixWidth > reservedTotals
       ? "diffMetadata"
       : hasDiffEndConnector && rowIdx === diffEndRow
       ? "diffEnd"
       : null;
-    const suffix = firstOfLine && annotation === "diffMetadata" &&
+    const annotationSuffix = firstOfLine && annotation === "diffMetadata" &&
         lineIdx === metadataLabelLine
       ? clipAnnotation("^L█", contentWidth)
       : labelsWrappedExpansion
@@ -515,6 +606,12 @@ export function renderFrame(doc: Document, view: ViewState): string[] {
       : hasDiffEndConnector && rowIdx === diffEndRow
       ? diffEndSuffix(contentWidth)
       : marginAnnotation(marginMarker, contentWidth);
+    const suffix = reservedTotals > 0
+      ? clipSuffixCells(
+        [...totalsCells, ...plainSuffix(annotationSuffix)],
+        contentWidth,
+      )
+      : plainSuffix(annotationSuffix);
     const sourceWidth = wrappedRow?.sourceWidth ??
       Math.max(1, contentWidth - suffix.length);
     rows.push(
@@ -574,7 +671,7 @@ function renderContentRow(
   guideWidth: number,
   contentWidth: number,
   wrapPlan: WrapPlan | null,
-  suffix: string,
+  suffix: readonly SuffixCell[],
 ): string {
   const line: Line | undefined = doc.lines[lineIdx];
   const inSelRange = !!view.selected &&
@@ -765,7 +862,7 @@ function composeContent(
   display: readonly DisplayCell[] | undefined,
   lineMatches: LineMatches | null,
   endMark: string | null,
-  suffix: string,
+  suffix: readonly SuffixCell[],
 ): string {
   const { color } = view;
   // Every content cell sits on the blue editor background; a diff line carries a
@@ -815,11 +912,10 @@ function composeContent(
       style: color ? mergeBg(ui.wrapMarker, rowBg) : EMPTY_STYLE,
     };
   }
-  const suffixCells = [...suffix];
   if (endMark !== null) {
     const ornament = [...endMark];
     const centeredStart = Math.floor((width - ornament.length) / 2);
-    const suffixStart = cells.length - suffixCells.length;
+    const suffixStart = cells.length - suffix.length;
     const start = centeredStart + ornament.length <= suffixStart
       ? centeredStart
       : Math.floor((suffixStart - ornament.length) / 2);
@@ -832,12 +928,14 @@ function composeContent(
       }
     }
   }
-  if (suffixCells.length > 0) {
-    const start = cells.length - suffixCells.length;
-    for (let i = 0; i < suffixCells.length; i++) {
+  if (suffix.length > 0) {
+    const start = cells.length - suffix.length;
+    for (let i = 0; i < suffix.length; i++) {
       cells[start + i] = {
-        ch: suffixCells[i],
-        style: color ? mergeBg(ui.wrapMarker, rowBg) : EMPTY_STYLE,
+        ch: suffix[i].ch,
+        style: color
+          ? mergeBg(suffix[i].style ?? ui.wrapMarker, rowBg)
+          : EMPTY_STYLE,
       };
     }
   }

--- a/packages/cli/lib/view/session.ts
+++ b/packages/cli/lib/view/session.ts
@@ -21,6 +21,9 @@ import {
   DIFF_MARGIN_WIDTH,
   type DiffAnnotation,
   diffAnnotationDecoration,
+  type DiffTotals,
+  diffTotalsDecoration,
+  diffTotalsWidth,
   type KeyHint,
   labeledDiffMetadataLine,
   type Match,
@@ -433,6 +436,29 @@ export class Session {
       };
     }
     return this.foldFileCache.files;
+  }
+
+  /** Whole-diff totals for the corner label on the first line, summed over the
+   * diff's files. Null when the source is not a diff, when the text parses to
+   * no diff files, or while the text cursor is active (edit mode reflows the
+   * content the label would cover). */
+  private activeDiffTotals(): DiffTotals | null {
+    if (this.cursorOn || this.source?.isDiff !== true) return null;
+    const files = this.foldFiles();
+    if (files.length === 0) return null;
+    let adds = 0;
+    let dels = 0;
+    for (const file of files) {
+      adds += file.adds;
+      dels += file.dels;
+    }
+    return { adds, dels };
+  }
+
+  /** Columns the whole-diff totals label occupies, 0 when hidden. */
+  private cornerTotalsWidth(): number {
+    const totals = this.activeDiffTotals();
+    return totals ? diffTotalsWidth(totals) : 0;
   }
 
   /** Whether the document holds any non-printable character, so cycling the
@@ -906,6 +932,7 @@ export class Session {
       canExpand: offeredExpand !== null,
       expandMargin: diffMargin,
       diffAnnotations,
+      diffTotals: this.activeDiffTotals(),
       expandRow,
       expandUp: offeredExpand?.up ?? null,
       diffMetadataRows: diffMargin
@@ -2811,19 +2838,23 @@ export class Session {
     return this.maxDisplayWidthCache.width;
   }
 
-  /** Source cells available on one folded line after its annotation. */
+  /** Source cells available on one folded line after its annotation and, on
+   * the first line, the whole-diff totals label. */
   private lineContentWidth(
     foldedLine: number,
     annotations = this.activeDiffAnnotations(),
     contentWidth = this.contentWidth(),
   ): number {
     const annotation = annotations.find((item) => item.line === foldedLine);
-    if (!annotation) return contentWidth;
-    const decoration = diffAnnotationDecoration(annotation.kind, contentWidth);
-    return Math.max(1, contentWidth - decoration.firstWidth);
+    const annotationWidth = annotation
+      ? diffAnnotationDecoration(annotation.kind, contentWidth).firstWidth
+      : 0;
+    const totalsWidth = foldedLine === 0 ? this.cornerTotalsWidth() : 0;
+    return Math.max(1, contentWidth - annotationWidth - totalsWidth);
   }
 
-  /** Furthest horizontal offset needed by any line under its own annotation. */
+  /** Furthest horizontal offset needed by any line under its own annotation
+   * or, on the first line, the whole-diff totals label. */
   private maxLeft(
     annotations: readonly DiffAnnotation[] = this.activeDiffAnnotations(),
   ): number {
@@ -2831,17 +2862,17 @@ export class Session {
     const contentWidth = this.contentWidth();
     let width = this.maxDisplayWidth() - contentWidth;
     const lines = this.foldPlan().displayLines;
-    for (const annotation of annotations) {
-      const line = lines[annotation.line];
+    const constrained = new Set(
+      annotations.map((annotation) => annotation.line),
+    );
+    if (this.cornerTotalsWidth() > 0) constrained.add(0);
+    for (const lineIdx of constrained) {
+      const line = lines[lineIdx];
       if (!line) continue;
       width = Math.max(
         width,
         displayWidth(line, this.displayMode) -
-          this.lineContentWidth(
-            annotation.line,
-            annotations,
-            contentWidth,
-          ),
+          this.lineContentWidth(lineIdx, annotations, contentWidth),
       );
     }
     return Math.max(0, width);
@@ -2851,7 +2882,7 @@ export class Session {
   private horizontalStep(): number {
     if (!this.hasDiffMargin()) return HORIZONTAL_STEP;
     const annotations = this.activeDiffAnnotations();
-    let width = this.contentWidth();
+    let width = this.lineContentWidth(0, annotations);
     for (const annotation of annotations) {
       width = Math.min(
         width,
@@ -3675,12 +3706,14 @@ export class Session {
   ): { decorations: Map<number, WrapDecoration>; key: string } {
     const decorations = new Map<number, WrapDecoration>();
     const contentWidth = this.contentWidth();
+    const totalsWidth = this.wrapLines ? this.cornerTotalsWidth() : 0;
     const metadataLabelLine = this.wrapLines
       ? labeledDiffMetadataLine(
         this.foldPlan().displayLines,
         this.displayMode,
         contentWidth,
         annotations,
+        totalsWidth,
       )
       : null;
     if (this.wrapLines) {
@@ -3695,9 +3728,17 @@ export class Session {
           ),
         );
       }
+      if (totalsWidth > 0) {
+        decorations.set(
+          0,
+          diffTotalsDecoration(totalsWidth, contentWidth, decorations.get(0)),
+        );
+      }
     }
     const key = this.wrapLines
-      ? `${contentWidth}|${this.displayMode}|${metadataLabelLine ?? "-"}|${
+      ? `${contentWidth}|${this.displayMode}|${
+        metadataLabelLine ?? "-"
+      }|${totalsWidth}|${
         annotations.map((annotation) => `${annotation.line}:${annotation.kind}`)
           .join(",")
       }`

--- a/packages/cli/test/view-diffedit.test.ts
+++ b/packages/cli/test/view-diffedit.test.ts
@@ -1290,7 +1290,11 @@ Deno.test("diffedit: Ctrl-L expands context in pager mode (no text cursor)", () 
       { line: 4, kind: "diffMetadata" },
     ]);
     const rows = renderFrame(s.displayDoc(), view).map(stripAnsi);
-    for (let row = 0; row < 4; row++) {
+    assert(
+      rows[0].endsWith("+1 −1"),
+      "the first line carries the whole-diff totals, not a marker",
+    );
+    for (let row = 1; row < 4; row++) {
       assertEquals(rows[row].at(-1), " ", "earlier metadata is not marked");
     }
     assert(

--- a/packages/cli/test/view-fold.test.ts
+++ b/packages/cli/test/view-fold.test.ts
@@ -291,7 +291,14 @@ Deno.test("fold: a summary omits markers for a hidden expansion edge", () => {
   assertEquals(view.expandUp, false);
   assertEquals(view.diffAnnotations, [{ line: 7, kind: "expandDown" }]);
   const rendered = renderFrame(s.displayDoc(), view);
-  assertEquals(rendered[0].trimEnd(), "▸ src/app.ts  +1 −1");
+  assert(
+    rendered[0].startsWith("▸ src/app.ts  +1 −1 "),
+    "the summary line is shown",
+  );
+  assert(
+    rendered[0].endsWith("+2 −1"),
+    "the corner carries the whole-diff totals",
+  );
   assertEquals(rendered[7].at(-1), "◢");
 
   const internals = s as unknown as {

--- a/packages/cli/test/view-render.test.ts
+++ b/packages/cli/test/view-render.test.ts
@@ -9,7 +9,7 @@ import {
 import { _internal } from "../lib/view/render.ts";
 import { stripAnsi, visibleWidth } from "../lib/view/ansi.ts";
 import { renderLineColored } from "../lib/view/highlight.ts";
-import { lineBg, ui } from "../lib/view/theme.ts";
+import { lineBg, styleFor, ui } from "../lib/view/theme.ts";
 
 function baseView(over: Partial<ViewState> = {}): ViewState {
   return {
@@ -555,6 +555,144 @@ Deno.test("renderFrame: wrapped metadata keeps its label beside the backslash", 
     "ij    █",
     " ☙ ❦ ❧ ",
   ]);
+});
+
+Deno.test("renderFrame: draws the whole-diff totals in the first line's corner", () => {
+  const doc = parseDocument("meta\nbody");
+  const view = diffView({
+    width: 16,
+    height: 4,
+    color: false,
+    diffTotals: { adds: 456, dels: 123 },
+  });
+  const rows = renderFrame(doc, view);
+  assertEquals(rows[0], "meta   +456 −123");
+  assertEquals(rows[1], "body            ");
+  // The label belongs to the first line: scrolling down takes it off screen.
+  const scrolled = renderFrame(doc, { ...view, top: 1 });
+  assertEquals(scrolled[0], "body            ");
+  assert(!scrolled.some((row) => row.includes("+456")));
+});
+
+Deno.test("renderFrame: colours the totals as removals and additions", () => {
+  const doc = parseDocument("meta");
+  const rows = renderFrame(
+    doc,
+    diffView({ width: 12, height: 3, diffTotals: { adds: 2, dels: 1 } }),
+  );
+  assertEquals(stripAnsi(rows[0]), "meta   +2 −1");
+  const del = styleFor("diffDel").fg!.join(",");
+  const add = styleFor("diffAdd").fg!.join(",");
+  assertEquals(fgAtColumn(rows[0], 7), add, "the + sign");
+  assertEquals(fgAtColumn(rows[0], 8), add, "the added count");
+  assertEquals(fgAtColumn(rows[0], 10), del, "the − sign");
+  assertEquals(fgAtColumn(rows[0], 11), del, "the removed count");
+  assertEquals(bgAtColumn(rows[0], 8), ui.editorBg.join(","));
+});
+
+Deno.test("renderFrame: the totals reserve wrapped width on the first line", () => {
+  const doc = parseDocument("abcdefghijklmnop");
+  const rows = renderFrame(
+    doc,
+    diffView({
+      width: 12,
+      height: 4,
+      color: false,
+      wrapMode: "hard",
+      diffTotals: { adds: 2, dels: 1 },
+    }),
+  );
+  assertEquals(rows[0], "abcdef\\+2 −1");
+  assertEquals(rows[1], "ghijklmnop  ");
+});
+
+Deno.test("renderFrame: the totals sit before a first-line Ctrl-L label", () => {
+  const doc = parseDocument("meta\nbody");
+  const rows = renderFrame(
+    doc,
+    diffView({
+      width: 16,
+      height: 4,
+      color: false,
+      expandMargin: true,
+      diffAnnotations: [
+        { line: 1, kind: "expandUp" },
+        { line: 0, kind: "diffMetadata" },
+      ],
+      diffTotals: { adds: 2, dels: 1 },
+    }),
+  );
+  assertEquals(rows[0], "meta    +2 −1^L█");
+  assertEquals(rows[1], "body           ◥");
+});
+
+Deno.test("renderFrame: wrapped totals layer over a first-line annotation", () => {
+  const doc = parseDocument("metadatax\nabc");
+  const rows = renderFrame(
+    doc,
+    diffView({
+      width: 12,
+      height: 4,
+      color: false,
+      expandMargin: true,
+      wrapMode: "hard",
+      diffAnnotations: [
+        { line: 1, kind: "expandUp" },
+        { line: 0, kind: "diffMetadata" },
+      ],
+      diffTotals: { adds: 2, dels: 1 },
+    }),
+  );
+  assertEquals(rows[0], "met\\+2 −1^L█");
+  assertEquals(rows[1], "adatax     █");
+  assertEquals(rows[2], "abc        ◥");
+});
+
+Deno.test("renderFrame: totals reflow moves the Ctrl-L label, not copies it", () => {
+  // Without the totals, the 16-column first line fits beside its expansion
+  // triangle, so the metadata line below would carry the ^L label. The totals
+  // reservation wraps the first line, and the label must follow it onto the
+  // wrapped row rather than appear in both places.
+  const doc = parseDocument("abcdefghijklmnop\nmeta");
+  const rows = renderFrame(
+    doc,
+    diffView({
+      width: 20,
+      height: 5,
+      color: false,
+      expandMargin: true,
+      wrapMode: "hard",
+      diffAnnotations: [
+        { line: 0, kind: "expandDown" },
+        { line: 1, kind: "diffMetadata" },
+      ],
+      diffTotals: { adds: 2, dels: 1 },
+    }),
+  );
+  assertEquals(rows.slice(0, 3), [
+    "abcdefghijklm\\+2 −1◢",
+    "nop              ^L█",
+    "meta               █",
+  ]);
+  assertEquals(
+    rows.filter((row) => row.includes("^L")).length,
+    1,
+    "exactly one Ctrl-L label",
+  );
+});
+
+Deno.test("renderFrame: narrow totals keep at least one source cell", () => {
+  const doc = parseDocument("abcdef");
+  const rows = renderFrame(
+    doc,
+    diffView({
+      width: 4,
+      height: 3,
+      color: false,
+      diffTotals: { adds: 345, dels: 12 },
+    }),
+  );
+  assertEquals(rows[0], "a−12");
 });
 
 Deno.test("renderFrame: a diff without a final triangle omits the end connector", () => {

--- a/packages/cli/test/view-session.test.ts
+++ b/packages/cli/test/view-session.test.ts
@@ -233,6 +233,122 @@ Deno.test("session: clearing a selection clamps expansion-margin panning", () =>
   assertEquals(s.view().left, atRightEdge, "right does not move left");
 });
 
+const TOTALS_DIFF = [
+  "diff --git a/a.ts b/a.ts",
+  "index 1111111..2222222 100644",
+  "--- a/a.ts",
+  "+++ b/a.ts",
+  "@@ -1,3 +1,3 @@",
+  " keep",
+  "-old",
+  "+new",
+  "diff --git a/b.ts b/b.ts",
+  "index 3333333..4444444 100644",
+  "--- a/b.ts",
+  "+++ b/b.ts",
+  "@@ -1 +1,2 @@",
+  " x",
+  "+added",
+  "",
+].join("\n");
+
+function totalsSource(editable = false): EditableSource {
+  return {
+    label: null,
+    isDiff: true,
+    editable,
+    parse: (next) => parseDocument(next),
+    save: () => "",
+  };
+}
+
+Deno.test("session: a diff source carries whole-diff totals to the view", () => {
+  const s = new Session(
+    parseDocument(TOTALS_DIFF),
+    { color: false, showLineNumbers: false },
+    { width: 40, height: 6 },
+    undefined,
+    totalsSource(),
+  );
+  assertEquals(s.view().diffTotals, { adds: 2, dels: 1 });
+  const rows = renderFrame(s.displayDoc(), s.view());
+  assert(rows[0].endsWith("+2 −1"), "the first line's corner sums both files");
+
+  const plain = new Session(
+    parseDocument(TOTALS_DIFF),
+    { color: false, showLineNumbers: false },
+    { width: 40, height: 6 },
+  );
+  assertEquals(
+    plain.view().diffTotals,
+    null,
+    "no totals without a diff source",
+  );
+
+  const noFiles = new Session(
+    parseDocument(SAMPLE),
+    { color: false, showLineNumbers: false },
+    { width: 40, height: 6 },
+    undefined,
+    totalsSource(),
+  );
+  assertEquals(noFiles.view().diffTotals, null, "no totals without diff files");
+});
+
+Deno.test("session: edit mode hides the whole-diff totals", () => {
+  const s = new Session(
+    parseDocument(TOTALS_DIFF),
+    { color: false, showLineNumbers: false },
+    { width: 40, height: 8 },
+    undefined,
+    totalsSource(true),
+  );
+  press(s, "e");
+  assert(s.view().cursor, "the text cursor is active");
+  assertEquals(s.view().diffTotals, null);
+  assert(!renderFrame(s.displayDoc(), s.view())[0].includes("+2 −1"));
+  press(s, "escape");
+  assertEquals(s.view().diffTotals, { adds: 2, dels: 1 });
+});
+
+Deno.test("session: a wrapped first line flows around the totals label", () => {
+  const s = new Session(
+    parseDocument(TOTALS_DIFF),
+    { color: false, showLineNumbers: false },
+    { width: 20, height: 6 },
+    undefined,
+    totalsSource(),
+  );
+  press(s, "\\");
+  const rows = renderFrame(s.displayDoc(), s.view());
+  assertEquals(rows[0], "diff --git a/a\\+2 −1");
+  assertEquals(rows[1], ".ts b/a.ts          ");
+});
+
+Deno.test("session: panning reaches content hidden under the totals label", () => {
+  const PAN_DIFF = [
+    "diff --git a/src/app.ts b/src/app.ts",
+    "index 1111111..2222222 100644",
+    "--- a/src/app.ts",
+    "+++ b/src/app.ts",
+    "@@ -1,2 +1,2 @@",
+    " keep",
+    "-old",
+    "+new",
+    "",
+  ].join("\n");
+  const s = expandableSession(PAN_DIFF, 20);
+  press(s, ...Array(4).fill("l"));
+  // The first line is 36 columns; the clamp leaves room to pan its tail out
+  // from under the five-column label: 36 − (20 − 5).
+  assertEquals(s.view().left, 21);
+  assertEquals(
+    renderFrame(s.displayDoc(), s.view())[0],
+    "ts b/src/app.ts+1 −1",
+    "the end of the first line is visible beside the label",
+  );
+});
+
 Deno.test("session: removing the gutter clamps expansion-margin panning", () => {
   const s = expandableSession("abcdefghijklmnopqrst", 10);
   press(s, "#");


### PR DESCRIPTION
When cf view shows a diff, the total number of added and removed lines is not visible anywhere: the collapsed file summaries carry per-file counts, but nothing sums the whole diff.

The pager now draws a totals label at the top right corner of the first line, in the form "+456 −123" — additions first, the order the collapsed file summaries and git's own diffstat output use. The added count is coloured like an addition and the removed count like a removal, so the label reads as chrome rather than as part of the line's text. The label belongs to the first line: it scrolls away with it, and it is hidden while the text cursor is active, matching the expansion margin.

The label uses the same right-edge suffix machinery as the Ctrl-L expansion label, generalised to carry a style per cell. On the first line the label reserves cells in the wrap plan, so a wrapped first line flows around it; when both the label and a first-line annotation are present they compose, totals first. The prediction that decides whether the expansion triangle's line wraps, and with it where the Ctrl-L label sits, measures the first line against the composed reservation, so the prediction and the plan agree on every line. In unwrapped mode the horizontal scroll clamp gains the room needed to pan the first line's tail out from under the label.

The totals are summed from the diff's parsed files, which now expose their added and removed line counts on DiffFileRange. A source that is not a diff, or diff text with no parsed files (for example plain commit output with no file hunks), shows no label.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

