### PR TITLE
dashboard: separate the wall's statuses without relying on hue

### DIFF
--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -31,6 +31,7 @@ deno task test
 dashboard/
   types.ts      the interface: Tile, TileView, Status, Ctx, Route
   config.ts     port, repo, tunable status thresholds
+  palette.ts    THE ONE PLACE status colors, washes and dot shapes are chosen
   lib.ts        shared helpers (github, memo, escapeHtml, sparkline, strip, …)
   blacksmith.ts authenticated read client for Blacksmith billing data
   ctx.ts        shared, memoized data sources handed to every tile (ctx.runs)
@@ -192,13 +193,54 @@ tiles sit red or amber most of the time, people stop seeing them, and a board
 everyone has learned to ignore is worse than no board. A tile earns a color
 change; it never reaches for one to get attention.
 
-Each signal carries a texture behind the tile as well as a color, so a state is
-legible without depending on color alone. A gray tile is covered in a grid of
-tiny dots, an amber tile in wavy lines, and a red tile in zig-zags. Green tiles
+A signal is carried by four things at once, so that no one of them has to be
+read on its own. Losing any single cue still leaves a state legible, which is
+what a person who cannot separate red from green is doing all day.
+
+The first is color, chosen so the four stay apart for that person too. Green
+sits at a teal and amber at an orange rather than at a yellow, which puts the
+two on the blue/yellow axis; red/green color blindness leaves that axis
+working, and good against warn is otherwise the hardest pair on the wall. Every
+pair of statuses is measured in `palette.test.ts`, which simulates the two
+common forms of red/green color blindness and fails if any pair comes within
+reach of reading as one color.
+
+The second is the shape of the header dot: a circle for good, a triangle for
+warn, a diamond for bad, and a hollow ring for unknown. A shape survives any
+kind of color vision, and any distance at which the dot is still visible at all.
+
+The third is weight. A tile's background wash and its border both get stronger
+as its status gets more serious, so a good tile is the quietest thing on the
+wall and a red one the loudest. That ordering holds with the color taken away
+altogether.
+
+The fourth is texture, behind the tile. A gray tile is covered in a grid of
+tiny dots, an amber tile in broad wavy lines, and a red tile in zig-zags. The
+lines are wide and faint rather than fine and dark, which puts enough of the
+pattern on the tile to catch the eye without any one line drawing it. The
+zig-zag covers a little under half of a red tile, and the longer, gentler wave
+about a third of an amber one. Green tiles
 are left plain, which is the calm the rest of the wall is measured against.
-Every texture fades out down the tile: it is whole for the tile's top fifth,
-thins from there, and is gone four fifths of the way down, which leaves the
+Every texture fades out down the tile: it is whole for the tile's top seventh,
+thins from there, and is gone seven tenths of the way down, which leaves the
 sub line and the foot of a chart on plain color.
+
+Everything the wall draws over a texture has to stay legible against it, and
+the faintest marks are the ones that decide how strong a texture can be: a
+tile's title, its drill-down hint, its running badge, and the times, dividers
+and pop-out arrows down the recent-runs list. Those are set against the lightest the background
+reaches under a texture band rather than against the tile's flat color. The
+dividers and the arrows are fractions of white rather than fixed grays,
+because the surface they sit on is tinted by the status and a gray that reads
+on one wash washes out on another.
+
+`palette.ts` holds all of this, and it is the only place any of it is chosen.
+A status color that appears anywhere — a tile, a dot, a headline, a run cell,
+a sparkline's fade, a drill-down row, the favicon — comes from there. A shade
+that follows from another, like the one a sparkline fades up out of, is worked
+out there too rather than written down beside it, so a change to a color or to
+a tile's wash carries to it without a second edit. The shape a dot takes is
+geometry rather than color, and lives with the rest of the tile's CSS.
 
 Think about how a tile makes someone feel before you think about what it
 measures. Prefer an honest gray "unknown" over a false green — a tile that

--- a/packages/dashboard/favicon-artwork.ts
+++ b/packages/dashboard/favicon-artwork.ts
@@ -1,12 +1,13 @@
 // Source artwork for raster generation and parity tests. Runtime modules serve
 // only the generated PNGs and do not import this file.
 import type { FaviconFace } from "./favicon-types.ts";
+import { STATUS_COLOR } from "./palette.ts";
 
 const FAVICON_COLORS: Record<FaviconFace, string> = {
-  good: "#43c574",
-  warn: "#e0a852",
-  bad: "#e2504a",
-  "bad-crying": "#e2504a",
+  good: STATUS_COLOR.good,
+  warn: STATUS_COLOR.warn,
+  bad: STATUS_COLOR.bad,
+  "bad-crying": STATUS_COLOR.bad,
 };
 
 const OCTAGON = `<path d="M10 2h12l8 8v12l-8 8H10l-8-8V10Z"/>`;

--- a/packages/dashboard/favicon-png.generated.ts
+++ b/packages/dashboard/favicon-png.generated.ts
@@ -6,41 +6,41 @@ function decodePng(encoded: string): Uint8Array {
 }
 
 export const FAVICON_VERSION =
-  "ff2c588d7e036104b8bc81803f6737b08ee1fa7c2ab7e03570e1f0f9757559bd";
+  "224994fd19ccb8f2b172c34e41235e68619bb9408f8bc17e7913a1abcbd14b9a";
 
 export const FAVICON_PNG = {
   "good": decodePng(
-    "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAADJklEQVR4nNWXMUwTYRTH39emBFOjJYGD" +
-      "UlqLMZpAjcfCZCJODpIomshG1M3o4uQmZXQwcdDopIYNE0UTXAUTJxZqLCQy2EqB0pOkQGwgkvb8v2uv" +
-      "HPbaa67Uhl/S6/u+S/P+99777r0KajAVBbR3+q+oOSELUgdUIWRSVQ+2rRFiQ6hqRCUxIxxqJLWa+IBd" +
-      "U0wF+HxBeTeXewWHMpa1I0TE5XDcWlmJR7DaR4kAqSMwSqSGCRwJeuhYfxe5e9uoubuFnG4Xdq3JZnZp" +
-      "J5amzPwv2ppdpu34BnYZEVbWlsZgFBH4FIHzMJxDAFHr5dPkvd0HqzZYjDIRpfWPi1jBoRD3U8mlJzA1" +
-      "igK0sGezczDpxIPzeHIfrINja3aFfj76AovI5XT26ekoCpC8gTnO+UE9uRnJl3P5SKAmlOSS5kQTIHUG" +
-      "r1IuO8k5P/X4EnbqA6cj9vATaTXhcA4pq/H3eQGF3LffCJE03Ev1RJmYp9SbKCwxhoIMawLaO/wzKtGF" +
-      "k2MXyR2SsFM/MlGFfoxOExx/Tq0lBvCNCHgDaeTf0zN+reqjZhdOw8LIOwRAbKAOWvICOvwIANHZt8O4" +
-      "1p9v1ydwRTrWEqJqARy65WezsIi67vaXpMrqvhFbAr7fmaI/SgYWUZPkpjPPB2HtYXXfiC0BnDfOH9PU" +
-      "Bgcv9juwum/ElgAtxE8LIb5XGmKr+0ZsCThIDqeAhZFJXPPhLdeouOHoaegZH8LVHJsC9oqMZ4SjIcwI" +
-      "wRasiHbiafodzfd+hl9m/FIrhy0B7NzY18vB3VQaDmkiymEiIID2pB5n1ZV+yHC1c6i5o2XmFewQJiap" +
-      "MD35KlY/ww/C0cS7eBPNyKMJaHwzanQ7lvSBBINnN6JglQa7cPhjePrtWHr/QMJIXn+EVDrHRVT/kYy+" +
-      "KsmEjC2YBRo+lDJ6LRBoHcRxQk3Umg4Ou4Kcr08tYgWH5cZyHaMIrgmOBB+zZhyzasWw053CMU1Px4pt" +
-      "+l/nTIkARktHLvuaUBNY1g5y7nI4b+phN2IqQEfSTkdO1v6ckpAJLytsV4HYxG+0P6fkcES42rFpSkUB" +
-      "/4O/Cam/MHcVf0MAAAAASUVORK5CYII=",
+    "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAADHklEQVR4nNWXTUwTURDH57VUmiBSRJcW" +
+      "0qbcMJpYLqIn8WiiEU5q4gHiwXggkZseCCUc9GRIOHEwcDBRT2A08aZ4UrywJhi50dBAPwxSRCJf3fU/" +
+      "u2xZ7cfWbWvDL2l33tts3v/NzM68FVRlCgpobvFfUxUREqR2qUKESFU9mLZGiJRQVVklMSMcqpxYib7E" +
+      "bE5yCmhtDYZ2FWUCC4YwLB0hZJfD0be8HJEx+oMsAZI3MESkhgm42rzkPtdOR860abaoc2PWGnVzi3YX" +
+      "47Qzv0hbnxY0W0eEk/GlYRgZBH4ZsHgYj0MAUd2V83Ts9mVYpcFiNp6/o83XHzHCgkIMJGJLozA1MgI0" +
+      "t6fTczDp+P2bVNvZDqt8bM8u0PdHz2DBs05nhxGOjADJF5jjmJdr57n48eSN7gnkRDK21IEpXYDUEuwm" +
+      "JT3FcT7x+C5mKgOHY3VwQs8Jh7MnuRKZ1gXsx77+ehcdvXGJKslP5MPGixnC3oeRkGEBi5q9/hmV6GLT" +
+      "SB8yPkiVZGc+onkBC79PxKNduMIDvsAa4u/xPn1Q9KtmFw5D/NZDOECkkAeNugCvHw4g8k0N47/yxHqG" +
+      "8E+UjEeFwLUoAey69bFpWEQN/d1ZobK6b8aWgG93RmkvuQaLqEZqpJPj92AdYHXfjC0BCcRNQfwYp+Qh" +
+      "aXwA1gFW983YEsAuTo1NwSLy9PdkudjqvhlbAsrJ4RTAMWbYvfkaFTccIwzNqCn5sC3ASDJ35yktxtw7" +
+      "GK7tnANbs18xQplHMSu7AK5g5r6eD+6m9egnhSpqDgGBFJZoKKYUGzvdw663v0SIqT0dpBp4w/BMIXgj" +
+      "WikmsY5m5NEEVL8ZVbsdHxxIfNQ00msZBruw+1cHJ5G0MWSq6UDCSD6/TCqd5SSq/JGMPidj0RCmYO5T" +
+      "9UMpY+QCgbqrF4hzotRwsNs55puvPmBEOIfkOZYbmEVwTrjhCX4zXMF//DCJ6MXp11s506b/XpzJEsBo" +
+      "4VDSk5wTGJYOYu5yOHsNt5vJKcBAfzuUkPZxSvg4RbHCdBGIdTyjfZySwyFztmMyJwUF/A9+A94RvzDx" +
+      "GkU1AAAAAElFTkSuQmCC",
   ),
   "warn": decodePng(
-    "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAC3klEQVR4nMWWXUhTYRzGn3dGpmSIxHY2" +
-      "2TgDqSDIVOg27UoocN1VNxkkJHhRgUE38+OmywgEA5MMoi5VKPAq9TbIsm76EDYmujMJkwzFaDs97+yY" +
-      "mztn5xw/9oM/57//NvY8z3nPu1egxOxKgNcfes8LlpKJBl5c4VqAogTbM8BTtvAANzRtfgQucC3Ap4Ri" +
-      "OnQVREDEU1oizNYxguUYw72/ppyvgOTyhusUHAtQVbV6bSMTg65XD3adwup6GveGv0GmUHHE0xCPx1f4" +
-      "Mds4FuBVQr2A3tNYV4XHFCC5NfAZM3Or7ETfkpbohQMcCVDz3DdRhOQdf7yTIiDESmW5J+wkBUcCCrk3" +
-      "cJuCbQGqiXsDtynYFmDl3sBNCrYEqEXcG7hJwZYAuh+h++sXzx1Hz7UwrOgensP0px/UIB6lkonbHFki" +
-      "WJYoiqpmkI6xxVi0HoGaw+zMWVz+jUj/LDu5RZeFNS0ehwVFBThxb9D3IobXb7+zE8+4FtphgWCZku/+" +
-      "1/ofPJlY5CvgZmsAJ2or2QFfF9Zy5kcrDtlOwVJAvvtI/0dGvAFJgP8DY9Ez7FBwbjcFwSpIvnt57y/c" +
-      "n2EKaU5Al2V486CRHQrO7a4FUwE+f3BU1xG5ct6Hu5dDnAAvp1N4OJpgB9zh7Crfk5jN7aQgWDug+2a6" +
-      "n5Ruxum+ilcD+e8n2T6TFJrLWRtTkOkwhRamMIU8CgrwKcFJHWjuaK1FBxfVbhji4hyaWJA/NJXS5ls4" +
-      "ykGwcrBy74ZiKewQYOa+c+ALt9qf7IrTVHcMg10n2W1ilYJgbWHlfvtKL4b8vnwSDKxSyBFg5l4iHyt5" +
-      "9rODPCvKx3Y7ZikIVhZvQI0gkx6VX37efTrH/V5glsKWAOOYHeWOd4k7337wintCP/cGeYA1jvGCxXv/" +
-      "/5g9Ht3cXveLNm7b8lZ6/h3jswIM9zhAjBSyArz+4AfoqGd7cAjMLiXnz2YFlJKSC/gL42ypMOYMleAA" +
-      "AAAASUVORK5CYII=",
+    "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAC60lEQVR4nMWWTUwTQRzF3xQM9QOoJrRb" +
+      "SOty82KUxJ7UBBIOkhjlLCbycREuEg960YjRkwcTL+AFxUQ8mBiiMcGDCSTqCRM1XowXagl0W4xS8ING" +
+      "2vVNzWJbutvdVegvmex//+m2772ZnY5AhfknAf5g+A0vSMZjLby4wrUARQl1Z4G7LOEBejRtbgwucC0g" +
+      "oIRndegqiICIJrRYM0vHCA7HGO4b66t5Byyk1lyn4FiAqqq+H+nsLHTdN9rlx8pqFoOPPkOmsN3raYlG" +
+      "o0v8mG0cC/Ar4SFAv3Io7MWdrgZIescX8Tq2ykpcTWqxITjAkQC1yH0kXMMuMBNLo288yW8TSztqPM1O" +
+      "UnAkoJR7A7cp2Bagmrg3cJuCbQFW7g3cpGBLgFrGvYGbFGwJoPsxuj9zYv9OXD++B1ac4ys59fEnNYhb" +
+      "iXhskC1LygpQFFXNIjPLEpMDjWiqr2Jlznwqg47hBVZyi65q1rRoFBaUFeDEvcGlp1/w5P13VuIe10I3" +
+      "LBAcphS7l7ve7Zcp3gFnj9RjX2AbK+BD4ldBv9brsZ2CpYBi9x0jccwvrUHS5KvGZH+QFUr27aYgOEpS" +
+      "7F7O/eGb81hJ82+I1NZ48Op8EyuU7NtdC6YCAsHQhK6jsytSi4vtPnaA+zPfcOP5V1bAhfbdOB3Zxcq8" +
+      "bycFwbEBum+l+ynpZnIgiDrOqcEy14Ekvycp1Ze9juF4Lh2m0MYUplFESQEBJTSlA639XFD9R+vYcc/I" +
+      "i2WMcIHyh6YT2lwbWwUIjgKs3LuhXAobBJi573uwiJlPcp8vT2SvF6OnGlj9wSoFwbGOlfv8lV4O+bx8" +
+      "EwysUigQYOZeIl8refazgzwrytc2H7MUBEcOf6PaiWxmQj78sDdQ4P5/YJbCugDjmH2NO95J7nybwWPu" +
+      "CZe5N8gDrHGMFxyc+7/H7Gec+83kGFOQU8l8e+QxPifAcI8txEghJ8AfDL2FjgMstw6Bd8n43MGcgEpS" +
+      "cQG/AU7oqTD2PJ50AAAAAElFTkSuQmCC",
   ),
   "bad": decodePng(
     "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAACIUlEQVR4nNWV30obQRTGvzSlsUmVthRp" +

--- a/packages/dashboard/favicon.test.ts
+++ b/packages/dashboard/favicon.test.ts
@@ -9,6 +9,7 @@ import {
 } from "./favicon.ts";
 import { faviconSvg } from "./favicon-artwork.ts";
 import { FAVICON_FACES } from "./favicon-types.ts";
+import { STATUS_COLOR } from "./palette.ts";
 
 Deno.test("faviconStatus: red wins, then orange, and gray never replaces green", () => {
   assertEquals(faviconStatus([]), "good");
@@ -32,26 +33,26 @@ Deno.test("favicon artwork: each face has one matching URL-backed raster icon", 
     }
   > = {
     good: {
-      color: "#43c574",
+      color: STATUS_COLOR.good,
       shape: `<rect x="2" y="2" width="28" height="28" rx="9"/>`,
       eyes: [12, 20],
       mouth: `d="M11 19c2.8 2.6 7.2 2.6 10 0"`,
     },
     warn: {
-      color: "#e0a852",
+      color: STATUS_COLOR.warn,
       shape: `<path d="M16 2 30 29H2Z"/>`,
       eyes: [13, 19],
       mouth: `d="M11 20h10"`,
       drop: 3.2,
     },
     bad: {
-      color: "#e2504a",
+      color: STATUS_COLOR.bad,
       shape: `<path d="M10 2h12l8 8v12l-8 8H10l-8-8V10Z"/>`,
       eyes: [12, 20],
       mouth: `d="M11 21c2.8-2.6 7.2-2.6 10 0"`,
     },
     "bad-crying": {
-      color: "#e2504a",
+      color: STATUS_COLOR.bad,
       shape: `<path d="M10 2h12l8 8v12l-8 8H10l-8-8V10Z"/>`,
       eyes: [12, 20],
       mouth: `d="M10.5 22c3-4 8-4 11 0"`,

--- a/packages/dashboard/lib.ts
+++ b/packages/dashboard/lib.ts
@@ -1,6 +1,7 @@
 // Shared helpers used across tiles and the core.
 import type { Status } from "./types.ts";
 import { PROD_SERVICE } from "./config.ts";
+import { RUNNING_COLOR, STATUS_COLOR } from "./palette.ts";
 import {
   type GitHubPrimaryRateLimit,
   performanceGitHubRateLimit,
@@ -150,14 +151,7 @@ export const STATUS_DOT: Record<Status, string> = { good: "green", warn: "amber"
 export const escapeHtml = (s: string) =>
   s.replace(/[<>&"]/g, (c) => ({ "<": "&lt;", ">": "&gt;", "&": "&amp;", '"': "&quot;" }[c]!));
 
-// Per-status left edge for a sparkline's fade gradient — a shade just below the
-// tile's own (status-tinted) background, so the line fades up out of the tile.
-export const SPARK_FADE: Record<Status, string> = {
-  good: "#0e1915",
-  warn: "#1a1713",
-  bad: "#1e1113",
-  unknown: "#121317",
-};
+export { SPARK_FADE } from "./palette.ts";
 
 // How a sparkline caption spells a day span, consistently across tiles:
 // "5 days", "1 day", "<1 day".
@@ -553,7 +547,13 @@ export function thin<T>(arr: T[], max: number): T[] {
 export function strip(cells: { outcome: string; href: string }[], cols: number): string {
   if (!cells.length) return "";
   const col = (d: string) =>
-    d === "green" ? "#43c574" : d === "red" ? "#e2504a" : d === "run" ? "#6ea8fe" : "#7c828c";
+    d === "green"
+      ? STATUS_COLOR.good
+      : d === "red"
+      ? STATUS_COLOR.bad
+      : d === "run"
+      ? RUNNING_COLOR
+      : STATUS_COLOR.unknown;
   const html = cells.map((c) =>
     `<a class="cell" href="${escapeHtml(c.href)}" target="_blank" rel="noopener" style="background:${col(c.outcome)}"></a>`
   ).join("");

--- a/packages/dashboard/palette.test.ts
+++ b/packages/dashboard/palette.test.ts
@@ -1,0 +1,199 @@
+// The palette's job is to keep four statuses apart, including for a viewer who
+// cannot separate red from green. That is a measurable property rather than a
+// matter of taste, so it is measured here: each color is put through a
+// simulation of dichromatic vision and the pairs are compared in a space where
+// distance matches what a person sees.
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import type { Status } from "./types.ts";
+import {
+  rgba,
+  STATUS_COLOR,
+  STATUS_EDGE,
+  STATUS_TEXT,
+  STATUS_WASH,
+} from "./palette.ts";
+
+type Triple = [number, number, number];
+
+function channels(hex: string): Triple {
+  const n = parseInt(hex.slice(1), 16);
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255].map((c) => c / 255) as
+    Triple;
+}
+
+// sRGB stores a color with a curve applied, so light has to be taken back out
+// of that curve before any of it can be added up or mixed.
+const toLinear = (c: number) =>
+  c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+
+function apply(m: readonly Triple[], rgb: Triple): Triple {
+  const linear = rgb.map(toLinear) as Triple;
+  return m.map((row) =>
+    row.reduce((sum, weight, i) => sum + weight * linear[i], 0)
+  ) as Triple;
+}
+
+// Viénot, Brettel and Mollon (1999): what a dichromat sees, as a matrix over
+// linear light. Missing the long-wavelength cone is protanopia and missing the
+// medium-wavelength one is deuteranopia; between them they cover almost every
+// case of red/green color blindness.
+const DEUTERANOPIA: readonly Triple[] = [
+  [0.29275, 0.70725, 0],
+  [0.29275, 0.70725, 0],
+  [-0.02234, 0.02234, 1],
+];
+const PROTANOPIA: readonly Triple[] = [
+  [0.11238, 0.88762, 0],
+  [0.11238, 0.88762, 0],
+  [0.00401, -0.00401, 1],
+];
+const TRICHROMAT: readonly Triple[] = [[1, 0, 0], [0, 1, 0], [0, 0, 1]];
+
+const VISION = {
+  "normal color vision": TRICHROMAT,
+  deuteranopia: DEUTERANOPIA,
+  protanopia: PROTANOPIA,
+} as const;
+
+const TO_XYZ: readonly Triple[] = [
+  [0.4124564, 0.3575761, 0.1804375],
+  [0.2126729, 0.7151522, 0.0721750],
+  [0.0193339, 0.1191920, 0.9503041],
+];
+const D65: Triple = [0.95047, 1, 1.08883];
+
+/** CIE Lab, the space distances are measured in below. */
+function lab(linear: Triple): Triple {
+  const xyz = TO_XYZ.map((row) =>
+    row.reduce((sum, weight, i) => sum + weight * linear[i], 0)
+  ).map((v, i) => v / D65[i]);
+  const f = xyz.map((v) =>
+    v > 216 / 24389 ? Math.cbrt(v) : (24389 / 27 * v + 16) / 116
+  );
+  return [116 * f[1] - 16, 500 * (f[0] - f[1]), 200 * (f[1] - f[2])];
+}
+
+const rad = (deg: number) => deg * Math.PI / 180;
+const deg = (r: number) => r * 180 / Math.PI;
+
+/**
+ * CIEDE2000: how different two colors look, on a scale where about 1 is the
+ * smallest difference a person can find with the two side by side, and where
+ * two colors a glance can tell apart from across a room are far above that.
+ */
+function difference(first: Triple, second: Triple): number {
+  const [l1, a1, b1] = lab(first);
+  const [l2, a2, b2] = lab(second);
+  const c1 = Math.hypot(a1, b1), c2 = Math.hypot(a2, b2);
+  const cMean = (c1 + c2) / 2;
+  const g = 0.5 *
+    (1 - Math.sqrt(cMean ** 7 / (cMean ** 7 + 25 ** 7))); // 25 ** 7 keeps grays out of it
+  const ap1 = (1 + g) * a1, ap2 = (1 + g) * a2;
+  const cp1 = Math.hypot(ap1, b1), cp2 = Math.hypot(ap2, b2);
+  const hp1 = (deg(Math.atan2(b1, ap1)) + 360) % 360;
+  const hp2 = (deg(Math.atan2(b2, ap2)) + 360) % 360;
+  const dL = l2 - l1, dC = cp2 - cp1;
+  let dh = 0;
+  if (cp1 * cp2 !== 0) {
+    dh = hp2 - hp1;
+    if (Math.abs(dh) > 180) dh -= 360 * Math.sign(dh);
+  }
+  const dH = 2 * Math.sqrt(cp1 * cp2) * Math.sin(rad(dh) / 2);
+  const lMean = (l1 + l2) / 2, cpMean = (cp1 + cp2) / 2;
+  let hMean = hp1 + hp2;
+  if (cp1 * cp2 !== 0) {
+    if (Math.abs(hp1 - hp2) <= 180) hMean = (hp1 + hp2) / 2;
+    else hMean = (hp1 + hp2 + (hp1 + hp2 < 360 ? 360 : -360)) / 2;
+  }
+  const t = 1 - 0.17 * Math.cos(rad(hMean - 30)) +
+    0.24 * Math.cos(rad(2 * hMean)) + 0.32 * Math.cos(rad(3 * hMean + 6)) -
+    0.20 * Math.cos(rad(4 * hMean - 63));
+  const sL = 1 + (0.015 * (lMean - 50) ** 2) / Math.sqrt(20 + (lMean - 50) ** 2);
+  const sC = 1 + 0.045 * cpMean;
+  const sH = 1 + 0.015 * cpMean * t;
+  const rT = -2 * Math.sqrt(cpMean ** 7 / (cpMean ** 7 + 25 ** 7)) *
+    Math.sin(rad(60 * Math.exp(-(((hMean - 275) / 25) ** 2))));
+  return Math.sqrt(
+    (dL / sL) ** 2 + (dC / sC) ** 2 + (dH / sH) ** 2 +
+      rT * (dC / sC) * (dH / sH),
+  );
+}
+
+/** How far apart two of the wall's colors look to the named kind of viewer. */
+function apart(
+  first: string,
+  second: string,
+  vision: readonly Triple[],
+): number {
+  return difference(
+    apply(vision, channels(first)),
+    apply(vision, channels(second)),
+  );
+}
+
+// Below about this, two colors read as the same one at a glance. Every pair of
+// statuses has to clear it under every kind of vision, so a later change to a
+// color cannot quietly collapse a distinction the wall depends on.
+const LEGIBLE = 10;
+
+const STATUSES: readonly Status[] = ["good", "warn", "bad", "unknown"];
+const PAIRS = STATUSES.flatMap((first, i) =>
+  STATUSES.slice(i + 1).map((second) => [first, second] as const)
+);
+
+describe("palette", () => {
+  describe("STATUS_COLOR", () => {
+    for (const [name, vision] of Object.entries(VISION)) {
+      for (const [first, second] of PAIRS) {
+        it(`tells ${first} from ${second} under ${name}`, () => {
+          expect(
+            apart(STATUS_COLOR[first], STATUS_COLOR[second], vision),
+          ).toBeGreaterThan(LEGIBLE);
+        });
+      }
+    }
+  });
+
+  describe("STATUS_TEXT", () => {
+    // The headline is the largest thing a status colors, so its four shades
+    // answer to the same rule the dots do.
+    for (const [name, vision] of Object.entries(VISION)) {
+      for (const [first, second] of PAIRS) {
+        it(`tells ${first} from ${second} under ${name}`, () => {
+          expect(apart(STATUS_TEXT[first], STATUS_TEXT[second], vision))
+            .toBeGreaterThan(LEGIBLE);
+        });
+      }
+    }
+
+    it("is lighter than the color it lifts, for text on a dark tile", () => {
+      for (const status of STATUSES) {
+        const [text] = lab(apply(TRICHROMAT, channels(STATUS_TEXT[status])));
+        const [base] = lab(apply(TRICHROMAT, channels(STATUS_COLOR[status])));
+        expect(text).toBeGreaterThan(base);
+      }
+    });
+  });
+
+  describe("STATUS_WASH and STATUS_EDGE", () => {
+    it("gets stronger as the status gets more serious", () => {
+      expect(STATUS_WASH.good).toBeLessThan(STATUS_WASH.warn);
+      expect(STATUS_WASH.warn).toBeLessThan(STATUS_WASH.bad);
+      expect(STATUS_EDGE.good).toBeLessThan(STATUS_EDGE.warn);
+      expect(STATUS_EDGE.warn).toBeLessThan(STATUS_EDGE.bad);
+    });
+
+    it("leaves an unknown tile with no color of its own", () => {
+      expect(STATUS_WASH.unknown).toBe(0);
+      expect(STATUS_EDGE.unknown).toBe(0);
+    });
+  });
+
+  describe("rgba()", () => {
+    it("writes a hex color as CSS with the alpha applied", () => {
+      expect(rgba("#2fc79e", 0.15)).toBe("rgba(47,199,158,0.15)");
+      expect(rgba("#000000", 1)).toBe("rgba(0,0,0,1)");
+    });
+  });
+});

--- a/packages/dashboard/palette.ts
+++ b/packages/dashboard/palette.ts
@@ -1,0 +1,106 @@
+// The one place the wall's status colors are chosen, and the one place a shade
+// derived from them is worked out. Everything that paints a status in color
+// reads from here: the tile, the header dot, the headline, a sparkline's fade,
+// a run cell, the drill-down rows, and the favicon. The shape a header dot
+// takes is CSS geometry rather than a color, and lives with the rest of the
+// tile's CSS in render.ts.
+//
+// Green sits at teal and amber at orange rather than at a yellow. The two then
+// differ along the blue/yellow axis, which red/green color blindness leaves
+// working, so good and warn stay apart for a viewer who cannot separate them by
+// the red/green axis alone. Color is one of four cues the wall carries: the
+// header dot also takes a per-status shape, the tile's wash and border get
+// stronger as the status gets more serious, and warn and bad carry a texture.
+import type { Status } from "./types.ts";
+
+export const STATUS_COLOR: Record<Status, string> = {
+  good: "#2fc79e",
+  warn: "#e8913a",
+  bad: "#e2504a",
+  unknown: "#7c828c",
+};
+
+// The headline number, lifted off the status color so it reads as text on the
+// dark tile.
+export const STATUS_TEXT: Record<Status, string> = {
+  good: "#4ed3ae",
+  warn: "#f5a34d",
+  bad: "#f0726c",
+  unknown: "#9aa0ab",
+};
+
+// How much of its color a tile's background carries, and how much its border
+// does. The three rise together with the seriousness of the status, so the
+// tiles separate by weight as well as by hue. An unknown tile takes no color
+// at all and keeps the neutral border every tile starts from.
+export const STATUS_WASH: Record<Status, number> = {
+  good: 0.06,
+  warn: 0.12,
+  bad: 0.15,
+  unknown: 0,
+};
+
+export const STATUS_EDGE: Record<Status, number> = {
+  good: 0.28,
+  warn: 0.5,
+  bad: 0.58,
+  unknown: 0,
+};
+
+// The stroke a status texture is drawn in. The line is broad and faint rather
+// than fine and dark, which puts enough of it on the tile to be seen at a
+// glance without any one line drawing the eye. At this width the zig-zag covers
+// a little under half of its tile, and the wave, which runs flatter and so
+// leaves more room between its lines, about a third. It is also the bound on
+// the stroke: a mitered corner keeps its point inside the pattern tile up to
+// this width, and the pattern repeats without a clipped corner.
+export const TEXTURE_ALPHA = 0.13;
+export const TEXTURE_WIDTH = 8;
+
+// A run that is still going, which is a state rather than a verdict: the same
+// blue wherever it appears.
+export const RUNNING_COLOR = "#6ea8fe";
+
+// The flat surface a status tints: the tile itself, and the rows of the
+// drill-down pages that wear a status the same way.
+export const TILE_BASE = "#16181d";
+
+function channels(hex: string): [number, number, number] {
+  const n = parseInt(hex.slice(1), 16);
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+}
+
+function hex(channels: readonly number[]): string {
+  return `#${
+    channels.map((c) => Math.round(c).toString(16).padStart(2, "0")).join("")
+  }`;
+}
+
+// How much darker than its tile a sparkline's fade sits.
+const FADE_DEPTH = 0.6;
+
+/** The shade a sparkline fades up out of, on a tile of the given status. */
+function fadeUnder(status: Status): string {
+  const base = channels(TILE_BASE);
+  const tint = channels(STATUS_COLOR[status]);
+  return hex(
+    base.map((b, i) => (b + (tint[i] - b) * STATUS_WASH[status]) * FADE_DEPTH),
+  );
+}
+
+// The left edge of a sparkline's fade gradient, a shade below the tile's own
+// background so the line fades up out of it. Worked out from the status color
+// and the tile's wash rather than written down beside them, so a change to
+// either carries here on its own.
+export const SPARK_FADE: Record<Status, string> = {
+  good: fadeUnder("good"),
+  warn: fadeUnder("warn"),
+  bad: fadeUnder("bad"),
+  unknown: fadeUnder("unknown"),
+};
+
+/** A `#rrggbb` color as a CSS `rgba()` at the given alpha. */
+export function rgba(hex: string, alpha: number): string {
+  const n = parseInt(hex.slice(1), 16);
+  return `rgba(${(n >> 16) & 255},${(n >> 8) & 255},${n & 255},${alpha})`;
+}

--- a/packages/dashboard/performance-views.ts
+++ b/packages/dashboard/performance-views.ts
@@ -1,6 +1,24 @@
 import { escapeHtml } from "./lib.ts";
+import {
+  rgba,
+  STATUS_COLOR,
+  STATUS_EDGE,
+  STATUS_WASH,
+  TILE_BASE,
+} from "./palette.ts";
 
 export type PerformanceView = "runtime" | "ci" | "gantt";
+
+// A benchmark or CI row wears its status the way a tile does, at three quarters
+// of the tile's wash: a row is a thin band in a long list, and the full wash
+// stacked down a page of them is more color than the page needs.
+const ROW_WASH = 0.75;
+
+const ROW_RULES = (["good", "warn", "bad"] as const).map((s) =>
+  `  .brow.${s},.crow.${s}{border-color:${
+    rgba(STATUS_COLOR[s], STATUS_EDGE[s])
+  };background:${rgba(STATUS_COLOR[s], STATUS_WASH[s] * ROW_WASH)}}`
+).join("\n");
 
 export interface PerformanceViewState {
   repo: "labs" | "loom";
@@ -15,7 +33,7 @@ export const PERFORMANCE_HISTORY_SCALE_TRIM = 2;
 
 export const PERFORMANCE_PROGRESS_STYLES = `
   .fetch-progress{background:#16181d;border:1px solid #2f333c;border-radius:10px;padding:10px 12px;margin:0 0 12px}
-  .fetch-progress.error,.fetch-progress.warning{border-color:rgba(224,168,82,.42)}
+  .fetch-progress.error,.fetch-progress.warning{border-color:${rgba(STATUS_COLOR.warn, STATUS_EDGE.warn)}}
   .fetch-head{display:flex;justify-content:space-between;gap:12px;align-items:baseline;font-size:12px;color:#c7ccd4}
   .fetch-head strong{font-weight:600}.fetch-head span,#fetch-detail{font-variant-numeric:tabular-nums;color:#878d97}
   .fetch-progress progress{display:block;width:100%;height:7px;margin:7px 0 6px;accent-color:#6ea8fe}
@@ -43,17 +61,15 @@ export const PERFORMANCE_VIEW_STYLES = `
   .axisrow{display:flex;gap:18px;margin:0 14px 4px}.timeaxis{flex:0 0 42%;display:flex;justify-content:space-between;color:#666c76;font-size:10px}
   h2{font-size:12px;letter-spacing:.04em;color:#878d97;font-weight:600;margin:20px 0 8px;font-family:ui-monospace,Menlo,monospace}
   .blist,.clist{display:flex;flex-direction:column;gap:7px}
-  .brow,.crow{display:flex;align-items:center;gap:18px;background:#16181d;border:1px solid #23262d;border-radius:10px;padding:8px 14px}
-  .brow.good,.crow.good{border-color:rgba(67,197,116,.34);background:rgba(67,197,116,.06)}
-  .brow.warn,.crow.warn{border-color:rgba(224,168,82,.42);background:rgba(224,168,82,.07)}
-  .brow.bad,.crow.bad{border-color:rgba(226,80,74,.5);background:rgba(226,80,74,.09)}
+  .brow,.crow{display:flex;align-items:center;gap:18px;background:${TILE_BASE};border:1px solid #23262d;border-radius:10px;padding:8px 14px}
+${ROW_RULES}
   .bspark,.cspark{flex:0 0 42%;min-width:0;position:relative}
   .bspark>div,.bspark>svg,.cspark>div,.cspark>svg{margin-top:0!important}
   .bmeta,.cmeta{flex:1 1 auto;min-width:0;display:flex;flex-direction:column;gap:2px}
   .bname,.cname{font-size:13px;color:#c7ccd4;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
   .bval,.cval{color:#e7e9ee;font-size:18px;font-weight:600;font-variant-numeric:tabular-nums}
   .btrend,.ctrend{font-size:11px;font-weight:400;color:#9aa0ab}
-  .empty,.refresh-error{color:#9aa0ab;font-size:14px}.refresh-error{color:#e0a852}
+  .empty,.refresh-error{color:#9aa0ab;font-size:14px}.refresh-error{color:${STATUS_COLOR.warn}}
   .note{font-size:11px;color:#666c76;margin-top:22px}.note a{color:#6ea8fe;text-decoration:none}
   @media(max-width:640px){.timeaxis{flex:1}.brow,.crow{align-items:stretch;gap:7px;flex-wrap:wrap}.bspark,.cspark{flex:1 0 100%}.controls .field,.controls .choice-group{flex:1 1 100%}.controls input[type=range]{flex:1;width:auto;min-width:0}.controls label.trailing{margin-left:0}}`;
 

--- a/packages/dashboard/render.test.ts
+++ b/packages/dashboard/render.test.ts
@@ -8,7 +8,8 @@ import {
   renderTile,
   shell,
 } from "./render.ts";
-import { humanSpan } from "./lib.ts";
+import { humanSpan, STATUS_DOT } from "./lib.ts";
+import { TEXTURE_WIDTH } from "./palette.ts";
 import { FAVICON_VERSION } from "./favicon.ts";
 import { liveUpdateStream } from "./stream-client.ts";
 
@@ -358,19 +359,97 @@ Deno.test("shell: the browser runs the viewer-time formatter", () => {
 Deno.test("shell: the texture fades out towards the bottom of its own tile", () => {
   const html = shell(renderTile(view({ status: "bad" }), "labs-ci"), "", 0, 30_000, TEST_VERSION, "bad");
   assertStringIncludes(html, `<div class="texture"></div>`);
-  // Measured against the tile: whole for its top fifth, gone four fifths down.
+  // Measured against the tile: whole for its top seventh, gone seven tenths
+  // of the way down.
   assertStringIncludes(
     html,
-    ".texture{position:absolute;inset:0;z-index:-1;overflow:hidden;mask-image:linear-gradient(to bottom,#000 20%,transparent 80%)}",
+    ".texture{position:absolute;inset:0;z-index:-1;overflow:hidden;mask-image:linear-gradient(to bottom,#000 15%,transparent 70%)}",
   );
   // Measured against the turned frame the texture is drawn in.
   assertStringIncludes(
     html,
-    ".texture::before{content:\"\";position:absolute;inset:-100%;transform:rotate(30deg)}",
+    ".texture::before{content:\"\";position:absolute;top:50%;left:50%;",
   );
   for (const status of ["unknown", "warn", "bad"]) {
     assertStringIncludes(html, `.tile.${status} .texture::before{`);
   }
+  // The stroked textures are drawn at the width the palette sets, inside the
+  // data URI that carries them.
+  const strokes = [...html.matchAll(/stroke-width%3D%22([\d.]+)%22/g)];
+  assertEquals(strokes.length, 2, "one stroked texture each for warn and bad");
+  for (const stroke of strokes) assertEquals(Number(stroke[1]), TEXTURE_WIDTH);
+  // A pattern repeats at the size of the artwork that draws it. The two are
+  // written separately into the CSS, and a pattern drawn at one size and tiled
+  // at another is stretched.
+  const tiles = [
+    ...html.matchAll(
+      /width%3D%22(\d+)%22%20height%3D%22(\d+)%22[^;]*;background-size:(\d+)px (\d+)px/g,
+    ),
+  ];
+  assertEquals(tiles.length, 2, "both stroked textures set their own size");
+  for (const [, width, height, sizeX, sizeY] of tiles) {
+    assertEquals(sizeX, width, "the pattern tiles at the width it is drawn at");
+    assertEquals(sizeY, height, "and at the height it is drawn at");
+  }
+});
+
+Deno.test("shell: the turned texture layer still covers a tile far wider than it is tall", () => {
+  const html = shell("", "", 0, 30_000, TEST_VERSION, "bad");
+  const layer = /\.texture::before\{[^}]*width:(\d+)%[^}]*\}/.exec(html);
+  assert(layer, "the texture layer sets its own size");
+  assertStringIncludes(layer[0], "aspect-ratio:1");
+  assertStringIncludes(layer[0], "top:50%;left:50%");
+  assertStringIncludes(layer[0], "translate(-50%,-50%)");
+  // Turning a square about its centre sweeps its corners inward, so the layer
+  // covers the tile only while half its side still reaches the tile's corner.
+  // That reach is the tile's half-diagonal. The layer is measured off the
+  // tile's width alone, so the shape that strains it is a tall narrow tile:
+  // the tightest the wall's grid gets is a tile 0.94 as tall as it is wide,
+  // and this asks for room well past that.
+  const tallest = 1.5;
+  const halfSide = Number(layer[1]) / 100 / 2;
+  assert(
+    halfSide >= Math.hypot(1, tallest) / 2,
+    `a layer of ${layer[1]}% of the tile width leaves the corners of a tile ${
+      tallest
+    } times as tall as it is wide outside it once turned`,
+  );
+});
+
+Deno.test("shell: the header dot takes a shape per status, not just a color", () => {
+  const html = shell(renderTile(view(), "labs-ci"), "", 0, 30_000, TEST_VERSION, "good");
+  // The dot is empty and its shape is drawn by a layer inside it.
+  assertStringIncludes(html, `.dot::before{content:"";position:absolute;inset:0}`);
+  const shapes = (["good", "warn", "bad", "unknown"] as Status[]).map((status) => {
+    const rule = new RegExp(`\\.dot\\.${STATUS_DOT[status]}::before\\{([^}]*)\\}`).exec(html);
+    assert(rule, `${status} has a rule for its dot`);
+    return rule[1];
+  });
+  assertEquals(
+    new Set(shapes).size,
+    shapes.length,
+    "no two statuses draw the same dot, so the shape alone says which is which",
+  );
+  // A ring rather than a disc, for the one status that is an absence of news.
+  assertStringIncludes(shapes[3], "border:2px solid");
+  for (const shape of shapes.slice(0, 3)) assert(!shape.includes("border:"));
+});
+
+Deno.test("shell: a tile's wash and border grow with the seriousness of its status", () => {
+  const html = shell("", "", 0, 30_000, TEST_VERSION, "good");
+  const alphas = (["good", "warn", "bad"] as Status[]).map((status) => {
+    const rule = new RegExp(
+      `\\.tile\\.${status},\\.tile\\.wide\\.${status}\\{border-color:rgba\\([\\d,]+,([\\d.]+)\\);background:rgba\\([\\d,]+,([\\d.]+)\\)\\}`,
+    ).exec(html);
+    assert(rule, `${status} has a tile rule`);
+    return { edge: Number(rule[1]), wash: Number(rule[2]) };
+  });
+  for (let i = 1; i < alphas.length; i++) {
+    assert(alphas[i].edge > alphas[i - 1].edge, "each border is stronger than the last");
+    assert(alphas[i].wash > alphas[i - 1].wash, "each wash is stronger than the last");
+  }
+  // A tile that cannot tell takes no color at all.
+  assertStringIncludes(html, ".tile.unknown,.tile.wide.unknown{border-color:#2f333c}");
 });
 
 Deno.test("shell: server-measured red age changes the favicon after one hour", () => {

--- a/packages/dashboard/render.ts
+++ b/packages/dashboard/render.ts
@@ -1,7 +1,18 @@
 // Uniform rendering: every tile becomes the same markup from its TileView, and
 // the shell wraps the grid + wide tiles in the dark page with the SSE client.
-import type { TileView } from "./types.ts";
+import type { Status, TileView } from "./types.ts";
 import { durationTag, escapeHtml, STATUS_DOT } from "./lib.ts";
+import {
+  rgba,
+  RUNNING_COLOR,
+  STATUS_COLOR,
+  STATUS_EDGE,
+  STATUS_TEXT,
+  STATUS_WASH,
+  TEXTURE_ALPHA,
+  TEXTURE_WIDTH,
+  TILE_BASE,
+} from "./palette.ts";
 import { faviconHref, faviconLink, type FaviconStatus } from "./favicon.ts";
 import { paintStatusFavicon } from "./favicon-client.ts";
 import { liveUpdateStream } from "./stream-client.ts";
@@ -22,25 +33,50 @@ const STALE_GRACE_MS = 10_000;
 
 export const FAVICON_CRY_AFTER_MS = 60 * 60 * 1000;
 
+// A texture tile is this tall, and one line's worth of it repeats down the
+// layer at that spacing. The width is the pattern's own period, so the tile
+// holds a whole number of them and repeats across without a seam.
+const TEXTURE_HEIGHT = 24;
+
 /**
- * A tiling background image of one stroked path, for the texture that sits
- * behind a tile's flat colour wash. The tile is 48 by 24 CSS pixels and the
- * path is drawn in that coordinate space.
+ * A tiling background of one stroked path, for the texture that sits behind a
+ * tile's flat colour wash. Returns the whole background declaration, because
+ * the size the tile repeats at is part of the pattern rather than a separate
+ * choice. The path is drawn in a `period` by `TEXTURE_HEIGHT` space, and its
+ * corners come to a point.
+ *
+ * A path has to begin and end on the left and right edges of that space,
+ * heading the same way at both, so the two ends butt together where the
+ * pattern repeats. The round cap is what makes that joint clean: it fills the
+ * stroke out to the edge, and the part that reaches past is clipped away.
  */
-function strokeTexture(path: string, stroke: string): string {
+function strokeTexture(path: string, stroke: string, period: number): string {
   const svg = `<svg xmlns="http://www.w3.org/2000/svg" ` +
-    `width="48" height="24" viewBox="0 0 48 24">` +
-    `<path d="${path}" fill="none" stroke="${stroke}" stroke-width="1"/></svg>`;
-  return `url("data:image/svg+xml,${encodeURIComponent(svg)}")`;
+    `width="${period}" height="${TEXTURE_HEIGHT}" ` +
+    `viewBox="0 0 ${period} ${TEXTURE_HEIGHT}">` +
+    `<path d="${path}" fill="none" stroke="${stroke}" ` +
+    `stroke-width="${TEXTURE_WIDTH}" stroke-linecap="round"/></svg>`;
+  return `background-image:url("data:image/svg+xml,${
+    encodeURIComponent(svg)
+  }");background-size:${period}px ${TEXTURE_HEIGHT}px`;
 }
 
+// The wave rises and falls once across its period, which is long enough for a
+// stroke this wide to follow without a crest reaching the trough below it. It
+// starts and ends halfway up a rise, which is where the pattern repeats.
+const WAVE_PERIOD = 60;
 const WAVE_TEXTURE = strokeTexture(
-  "M0 12q6-8 12 0t12 0t12 0t12 0",
-  "rgba(224,168,82,.13)",
+  `M0 12q${WAVE_PERIOD / 4} -8 ${WAVE_PERIOD / 2} 0t${WAVE_PERIOD / 2} 0`,
+  rgba(STATUS_COLOR.warn, TEXTURE_ALPHA),
+  WAVE_PERIOD,
 );
+// Two turns of the zig-zag, which puts its period at half the tile. It starts
+// and ends halfway along a run rather than on a corner, which keeps every
+// corner inside a tile, where the join between its two runs draws the point.
 const ZIGZAG_TEXTURE = strokeTexture(
-  "M0 18l12-12 12 12 12-12 12 12",
-  "rgba(226,80,74,.13)",
+  "M0 12l6-6 12 12 12-12 12 12 6-6",
+  rgba(STATUS_COLOR.bad, TEXTURE_ALPHA),
+  48,
 );
 // Two copies of the same dot grid make a triangular lattice, where each dot has
 // six neighbours at one distance rather than a square lattice's four near ones
@@ -51,14 +87,64 @@ const ZIGZAG_TEXTURE = strokeTexture(
 // again from the two below.
 const DOT_SPACING_PX = 16;
 const DOT_ROW_PX = DOT_SPACING_PX * Math.sqrt(3);
+const DOT_STIPPLE = `radial-gradient(${
+  rgba(STATUS_COLOR.unknown, 0.15)
+} 1px,transparent 1px)`;
 const DOT_TEXTURE = [
-  `background-image:radial-gradient(rgba(124,130,140,.15) 1px,transparent 1px),`,
-  `radial-gradient(rgba(124,130,140,.15) 1px,transparent 1px);`,
+  `background-image:${DOT_STIPPLE},${DOT_STIPPLE};`,
   `background-position:0 0,${DOT_SPACING_PX / 2}px ${
     (DOT_ROW_PX / 2).toFixed(2)
   }px;`,
   `background-size:${DOT_SPACING_PX}px ${DOT_ROW_PX.toFixed(2)}px`,
 ].join("");
+
+// The tallest a tile is taken to be against its own width. The grid gives a
+// tile at least 220 pixels across and lets its height follow its content, and
+// the tightest the two come is a little under square, on the narrowest layout
+// the grid produces. The margin above that carries a label or a sub line that
+// wraps onto another line or two.
+const MAX_TILE_ASPECT = 1.5;
+
+// The side of the square texture layer, as a percentage of the tile's width.
+// Turning the layer sweeps its corners inward, so half its side has to reach
+// the tile's corner from the tile's centre — the tile's half-diagonal — at
+// whatever angle the texture is turned to.
+const TEXTURE_LAYER_PCT = Math.ceil(Math.hypot(1, MAX_TILE_ASPECT) * 100);
+
+const STATUSES: readonly Status[] = ["good", "warn", "bad", "unknown"];
+
+// A tile's own color: the wash behind it and the border around it, both
+// stronger the more serious the status is. An unknown tile takes neither and
+// keeps the neutral border below.
+const TILE_RULES = STATUSES.filter((s) => s !== "unknown").map((s) =>
+  `  .tile.${s},.tile.wide.${s}{border-color:${
+    rgba(STATUS_COLOR[s], STATUS_EDGE[s])
+  };background:${rgba(STATUS_COLOR[s], STATUS_WASH[s])}}`
+).join("\n");
+
+const BIG_RULES = STATUSES.map((s) => `.big.${s}{color:${STATUS_TEXT[s]}}`)
+  .join("");
+
+// The header dot's shape, which says the same thing its color does without
+// using color: a circle when all is well, a triangle to warn, a diamond when
+// something needs a person, and a hollow ring when the tile cannot tell. The
+// diamond is drawn a pixel over each edge so it carries the weight the circle
+// does at the same nominal size.
+const DOT_SHAPE: Record<Status, string> = {
+  good: "border-radius:50%",
+  warn: "clip-path:polygon(50% 0,100% 100%,0 100%)",
+  bad: "inset:-1px;clip-path:polygon(50% 0,100% 50%,50% 100%,0 50%)",
+  unknown: "border-radius:50%",
+};
+
+const DOT_RULES = STATUSES.map((s) =>
+  `.dot.${STATUS_DOT[s]}::before{${DOT_SHAPE[s]};${
+    s === "unknown"
+      ? `border:2px solid ${STATUS_COLOR[s]}`
+      : `background:${STATUS_COLOR[s]}`
+  }}`
+).join("") +
+  `.dot.run::before{border-radius:50%;background:${RUNNING_COLOR}}`;
 
 type ViewerTimeElement = Pick<HTMLTimeElement, "dateTime" | "textContent">;
 
@@ -135,61 +221,69 @@ ${faviconLink(status)}
   body{margin:0;background:#0d0e11;color:#e7e9ee;font-family:-apple-system,Segoe UI,Roboto,sans-serif;padding:18px 20px 26px;max-width:1100px;margin:0 auto}
   .top{display:flex;justify-content:space-between;align-items:center;margin-bottom:14px}
   .brand b{font-size:16px;font-weight:600}.brand span{font-size:12px;color:#6f757f;margin-left:8px}
-  .badge{font-size:11px;color:#62d18d;border:1px solid rgba(67,197,116,.4);border-radius:6px;padding:2px 8px;margin-left:8px}
+  .badge{font-size:11px;color:${STATUS_TEXT.good};border:1px solid ${
+    rgba(STATUS_COLOR.good, 0.4)
+  };border-radius:6px;padding:2px 8px;margin-left:8px}
   .live{font-size:12px;color:#9aa0ab}
   .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:12px;margin-bottom:12px}
-  .tile{background:#16181d;border:1px solid #23262d;border-radius:12px;padding:14px 16px;position:relative;isolation:isolate;overflow:hidden}
+  .tile{background:${TILE_BASE};border:1px solid #23262d;border-radius:12px;padding:14px 16px;position:relative;isolation:isolate;overflow:hidden}
   .tile.wide{margin-bottom:12px}
-  .tile.good,.tile.wide.good{border-color:rgba(67,197,116,.34);background:rgba(67,197,116,.08)}
-  .tile.warn,.tile.wide.warn{border-color:rgba(224,168,82,.42);background:rgba(224,168,82,.09)}
-  .tile.bad,.tile.wide.bad{border-color:rgba(226,80,74,.5);background:rgba(226,80,74,.11)}
+${TILE_RULES}
   .tile.unknown,.tile.wide.unknown{border-color:#2f333c}
   /* Each status carries a texture as well as a colour, so the wall reads at a
      glance and without relying on colour alone: dots for gray, waves for
      amber, zig-zags for red. The waves run across the zig-zags, a quarter turn
      from the angle the others take. The texture layer covers the tile and sits
      above the colour wash and below the content. It carries the fade: whole
-     for the top fifth of the tile, thinning from there, and gone four fifths
-     of the way down. Inside it the texture is turned on an angle and drawn
-     past all four edges, so the turned corners still reach the tile's. The
-     fade is measured against the tile and the texture is drawn in the turned
-     frame, which is why they are two boxes rather than one. */
-  .texture{position:absolute;inset:0;z-index:-1;overflow:hidden;mask-image:linear-gradient(to bottom,#000 20%,transparent 80%)}
-  .texture::before{content:"";position:absolute;inset:-100%;transform:rotate(30deg)}
+     for the top seventh of the tile, thinning from there, and gone seven
+     tenths of the way down. Inside it the texture is turned on an angle, on a
+     square layer centred on the tile and measured from the tile's width.
+     Turning a box sweeps its corners inward, so the layer only still covers
+     the tile if half its side reaches the tile's corner from the centre. That
+     distance is the tile's half-diagonal, which ${TEXTURE_LAYER_PCT}% of the
+     width clears for a tile up to ${MAX_TILE_ASPECT} times as tall as it is
+     wide. The fade is measured against the tile and the texture is drawn in
+     the turned frame, which is why they are two boxes rather than one. */
+  .texture{position:absolute;inset:0;z-index:-1;overflow:hidden;mask-image:linear-gradient(to bottom,#000 15%,transparent 70%)}
+  .texture::before{content:"";position:absolute;top:50%;left:50%;width:${TEXTURE_LAYER_PCT}%;aspect-ratio:1;transform:translate(-50%,-50%) rotate(var(--turn,30deg))}
   .tile.unknown .texture::before{${DOT_TEXTURE}}
-  .tile.warn .texture::before{background-image:${WAVE_TEXTURE};background-size:48px 24px;transform:rotate(120deg)}
-  .tile.bad .texture::before{background-image:${ZIGZAG_TEXTURE};background-size:48px 24px}
-  .lbl{font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:#878d97;margin:0 0 7px;display:flex;align-items:center;gap:7px}
+  .tile.warn .texture::before{${WAVE_TEXTURE};--turn:120deg}
+  .tile.bad .texture::before{${ZIGZAG_TEXTURE}}
+  .lbl{font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:#a5adb9;margin:0 0 7px;display:flex;align-items:center;gap:7px}
   .lbl .spacer{flex:1}
-  .drill{font-size:10px;color:#6f757f;letter-spacing:0;text-transform:none}
+  .drill{font-size:10px;color:#9ba3b0;letter-spacing:0;text-transform:none}
   .hmtd{font-size:11px;color:#9aa0ab;letter-spacing:0;text-transform:none;font-variant-numeric:tabular-nums;margin-right:8px}
   /* Fixed line-height so the headline's line box is the same height regardless of
      which font the glyph comes from: the ▲/▼ trend arrows fall back to a taller
      symbol font, and under line-height:normal that stretched the tile. */
   .big{font-size:30px;font-weight:600;margin:0;line-height:1.2}
-  .big.good{color:#62d18d}.big.warn{color:#f0b968}.big.bad{color:#f0726c}.big.unknown{color:#9aa0ab}
+  ${BIG_RULES}
   .sub{font-size:13px;color:#9aa0ab;margin:5px 0 0}
-  .running{display:inline-flex;align-items:center;gap:5px;font-size:10px;color:#8a93a5;letter-spacing:.02em;text-transform:none;margin-top:10px}
+  .running{display:inline-flex;align-items:center;gap:5px;font-size:10px;color:#9ba3b0;letter-spacing:.02em;text-transform:none;margin-top:10px}
   /* In the header the badge is a facet of a single line, not a block under the
      chart, so it takes the line's own vertical rhythm. */
   .lbl .running{margin-top:0;margin-right:8px}
-  .rdot{width:7px;height:7px;border-radius:50%;background:#6ea8fe;flex:none}
+  .rdot{width:7px;height:7px;border-radius:50%;background:${RUNNING_COLOR};flex:none}
   .cells{display:grid;gap:1px;margin-top:10px}
   .cell{aspect-ratio:1;border-radius:1px}
   a.cell{display:block}
   a.cell:hover{outline:1px solid #6ea8fe;outline-offset:-1px}
-  .dot{width:9px;height:9px;border-radius:50%;display:inline-block;flex:none}
-  .dot.green{background:#43c574}.dot.red{background:#e2504a}.dot.grey{background:#7c828c}.dot.amber{background:#e0a852}.dot.run{background:#6ea8fe}
+  /* The dot is drawn by its own layer so each status can take a shape as well
+     as a color. The shape carries the same signal the color does, which is
+     what a viewer who cannot separate the hues reads instead. */
+  .dot{width:10px;height:10px;display:inline-block;flex:none;position:relative}
+  .dot::before{content:"";position:absolute;inset:0}
+  ${DOT_RULES}
   a.tile.link{display:block;text-decoration:none;color:inherit;cursor:pointer;transition:border-color .12s}
   a.tile.link:hover{border-color:#3a4150}
   .evscroll{max-height:340px;overflow:auto}
-  .ev{display:flex;align-items:center;gap:11px;padding:6px 0;font-size:13px;border-top:1px solid #1c2026}.ev:first-child{border-top:0}
-  .ev .t{color:#7d838e;min-width:54px;flex:none}
+  .ev{display:flex;align-items:center;gap:11px;padding:6px 0;font-size:13px;border-top:1px solid rgba(255,255,255,.09)}.ev:first-child{border-top:0}
+  .ev .t{color:#9ba3b0;min-width:54px;flex:none}
   .evtxt{color:inherit;text-decoration:none;flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;transition:color .1s}
   .evtxt:hover{color:#fff}
-  .evdur{color:#9aa0ab;text-decoration:none;text-align:right;min-width:64px;flex:none;font-variant-numeric:tabular-nums}
+  .evdur{color:#a1a9b6;text-decoration:none;text-align:right;min-width:64px;flex:none;font-variant-numeric:tabular-nums}
   a.evdur:hover{color:#6ea8fe}
-  .evarrow{color:#33373f;text-decoration:none;flex:none;font-size:11px;transition:color .1s}
+  .evarrow{color:rgba(255,255,255,.40);text-decoration:none;flex:none;font-size:11px;transition:color .1s}
   .evarrow:hover{color:#8a93a5}
   .swatch{display:inline-block;width:8px;height:8px;border-radius:2px;vertical-align:middle}
   .note{font-size:11px;color:#666c76;margin-top:14px}
@@ -205,7 +299,13 @@ ${faviconLink(status)}
   const REFRESH = ${refreshMs};
   const RED_AFTER = REFRESH + ${STALE_GRACE_MS};
   const SHELL_VERSION = ${JSON.stringify(shellVersion)};
-  const COL = { green: '#43c574', amber: '#e0a852', red: '#e2504a' };
+  const COL = ${
+    JSON.stringify({
+      green: STATUS_COLOR.good,
+      amber: STATUS_COLOR.warn,
+      red: STATUS_COLOR.bad,
+    })
+  };
   const FAVICONS = ${FAVICON_PNG_HREFS};
   const FAVICON_CRY_AFTER_MS = ${FAVICON_CRY_AFTER_MS};
   const paintStatusFavicon = ${PAINT_STATUS_FAVICON};
@@ -236,9 +336,9 @@ ${faviconLink(status)}
     // LIVE badge: green only when fresh AND no tile is gray; gray if a tile is gray;
     // when stale, the border takes the orange/red and the contents go gray.
     const anyGray = document.querySelector('.tile.unknown') !== null;
-    if (state !== 'green') { badge.style.borderColor = COL[state]; badge.style.color = '#7c828c'; }
-    else if (anyGray) { badge.style.borderColor = '#7c828c'; badge.style.color = '#7c828c'; }
-    else { badge.style.borderColor = '#62d18d'; badge.style.color = '#62d18d'; }
+    if (state !== 'green') { badge.style.borderColor = COL[state]; badge.style.color = '${STATUS_COLOR.unknown}'; }
+    else if (anyGray) { badge.style.borderColor = '${STATUS_COLOR.unknown}'; badge.style.color = '${STATUS_COLOR.unknown}'; }
+    else { badge.style.borderColor = '${STATUS_TEXT.good}'; badge.style.color = '${STATUS_TEXT.good}'; }
     paintStatusFavicon(
       FAVICONS,
       FAVICON_CRY_AFTER_MS,

--- a/packages/dashboard/tiles.test.ts
+++ b/packages/dashboard/tiles.test.ts
@@ -18,6 +18,7 @@ import {
   githubCiSpend,
 } from "./tiles/github-ci-spend.ts";
 import { projectMonthly, settled } from "./spend.ts";
+import { RUNNING_COLOR, STATUS_COLOR } from "./palette.ts";
 import { modelSpend } from "./tiles/model-spend.ts";
 import {
   benchmark,
@@ -112,7 +113,7 @@ Deno.test(
       "first-try green · 199 of last 200 runs",
     );
     assert(
-      !(view.extra ?? "").includes("#e2504a"),
+      !(view.extra ?? "").includes(STATUS_COLOR.bad),
       "the 201st run must be outside the grid and percentage window",
     );
   },
@@ -133,10 +134,13 @@ Deno.test("labs ci trust grid: cell colors match trust scoring", async () => {
     ...(view.extra ?? "").matchAll(/background:(#[0-9a-f]+)/g),
   ].map((match) => match[1]);
   assertEquals(view.value, "25.0%");
-  assertEquals(colors.filter((color) => color === "#43c574").length, 1);
-  assertEquals(colors.filter((color) => color === "#e2504a").length, 3);
-  assertEquals(colors.filter((color) => color === "#6ea8fe").length, 1);
-  assertEquals(colors.filter((color) => color === "#7c828c").length, 2);
+  assertEquals(colors.filter((color) => color === STATUS_COLOR.good).length, 1);
+  assertEquals(colors.filter((color) => color === STATUS_COLOR.bad).length, 3);
+  assertEquals(colors.filter((color) => color === RUNNING_COLOR).length, 1);
+  assertEquals(
+    colors.filter((color) => color === STATUS_COLOR.unknown).length,
+    2,
+  );
 });
 
 Deno.test("ci-duration window: the 6h window when it has >= 20 runs, else the most recent 20", async () => {


### PR DESCRIPTION
The wall's green and its amber differ from each other almost entirely along the red/green axis of color vision. For a viewer who cannot use that axis — roughly one man in twelve — the two states a tile spends almost all of its time in read as the same color. Measured as CIEDE2000 after simulating dichromatic vision, the two sat 5.1 apart for a protanope on the header dot and 2.0 apart on the tile itself, where about 1 is the smallest difference anyone can find with two colors side by side. The texture behind a tile was meant to carry the distinction on its own, but green tiles are deliberately plain, so the whole signal rested on noticing a hairline wave at 13% opacity across the top fifth of a tile. That is too little to lean on.

Rather than pick a louder single cue, carry the signal four ways, so that losing any one of them still leaves a state legible.

Move the two hues apart on the axis that stays intact. Green goes to a teal and amber to an orange, which separates them along blue and yellow rather than red and green. On the dots that takes the closest pair from 5.1 to 16.8 for a protanope and from 10.2 to 22.3 for a deuteranope, and it lifts every other pair too: the run-history strip's green and red cells, which are small and carry no texture at all, go from 10.6 to 20.0 for a deuteranope.

Give the header dot a shape per status — a circle, a triangle, a diamond and a hollow ring. The dot is already in every tile header and in every row of the recent-runs list, so this adds nothing to the wall while giving it a cue that survives any kind of color vision. The favicon already worked this way.

Ramp the tile's wash and border with the seriousness of the status, so a good tile is the quietest thing on the wall and a red one the loudest. The three then separate by weight with the color taken away altogether, which is what fixes the tile body: the wash is a few percent of the status color over a near-black tile, so there was very little color there to tell apart. Green against amber on the body goes from 2.0 to 7.5 for a protanope. This ordering is what the wall already meant to say.

Draw the texture as broad soft bands rather than hairlines, and pull its fade in to whole for the top seventh and gone seven tenths down. A pattern at 13% opacity is easy to miss when it is drawn in fine lines, and the way to make a faint pattern legible is to put more of it on the tile rather than to darken it: a broad soft band reads at a glance, while a fine dark line is what pulls the eye off the number the tile exists to show. Eight units is the widest a mitered right angle can be and still keep its point inside a tile 24 units tall with its corners 6 units from the edge; at nine the point reaches a third of a unit past, and every corner would be clipped flat. That leaves the zig-zag covering a little under half its tile and the wave, which runs flatter and so leaves more room between its lines, about a third.

Both patterns needed their geometry reworked to carry a stroke that wide. The wave repeated every 24 units while its crest sat only 8 units above its trough, so crests ran into troughs and the line came out as a lumpy tube; its period is now 60, and a constant the path is built from rather than four numbers written into the path data. The zig-zag began and ended on a corner, which put that corner across the point where the pattern repeats, where it is two stroke ends butted together with the point between them never drawn — so one corner in every two came out blunt. Both now begin and end partway along a run, and a texture carries the size it repeats at instead of having that written separately into the CSS beside it, because a pattern drawn at one size and tiled at another is stretched.

A texture this visible decides how much contrast everything drawn over it needs, and the faintest marks the wall draws were relying on a plain surface. Against the lightest the background reaches under a band, as a ratio where small text wants 4.5 and a mark wants 3, a tile's title goes from 3.51 to 5.18, its drill-down hint from 2.53 to 4.61, a run's time from 3.07 to 4.61, its duration from 4.46 to 4.95, the pop-out arrow beside it from 1.02 to 3.27, and the rule between runs from 1.01 to 1.29.

The arrow and the rule become fractions of white rather than fixed grays. Both are marks on a surface whose tint follows the status, and a gray that reads on one wash washes out on another.

Also, carry the texture into the corners of a wide tile. The layer it is drawn on was sized by insetting it a tile's width on each side and a tile's height above and below, then turning it thirty degrees. Turning a box sweeps its corners inward, so the layer covers the tile only while half its side still reaches the tile's corner from the centre. Three times a tile's height does not reach that far when the tile is several times wider than it is tall, so the wide recent-runs tile lost a corner at each end, along a clean diagonal partway across. The layer is now a square measured from the tile's width and centred on it: the reach needed is the tile's half-diagonal, and a tile at least as wide as it is tall has a half-diagonal of at most its half-width times the square root of two. It is also less to paint than the box it replaces. The angle moves to a custom property, so the wave's rule sets the angle alone rather than restating the whole transform and dropping the centring with it.

Collect the colors in palette.ts, which is now the only place one is chosen. The four had been written out by hand in the tile CSS, the dot CSS, the headline CSS, the live-badge script, the run-history strip, the drill-down rows and the favicon artwork, so a change to one of them had seven places to reach. The sparkline fade shades move with the washes they sit under, and the favicon PNGs are regenerated from the new artwork.

palette.test.ts states the accessibility requirement as a test rather than as a comment: it simulates protanopia and deuteranopia with the Viénot, Brettel and Mollon transform and fails if any pair of statuses comes within reach of reading as one color, for the dots and for the headline text. Run against the previous palette it fails on green against amber under protanopia, which is the report this change started from. Two more tests hold the texture together: one that a pattern tiles at the size it is drawn at, and one that half the texture layer's side clears the half-diagonal of the squarest tile the wall can produce.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

