### PR TITLE
feat(runner): give a receipt a durable schema describing what it holds

### DIFF
--- a/docs/specs/scheduler-v2/README.md
+++ b/docs/specs/scheduler-v2/README.md
@@ -797,6 +797,20 @@ persists as-is, a live cell handle converts to a link, so a one-line setter
 verb's receipt links to the cell it mutated. The create-only witness
 semantics are unchanged either way.
 
+A receipt-only handling also describes what it wrote, in the same transaction,
+on the cell's durable `schema` metadata — so a receipt says what it holds the
+way any other cell does, which is what lets a reader's selection narrow the
+fetch instead of filtering an already-loaded value. The description is
+structural and nothing more: the root container kind, plus the property names
+when that kind is a record. Every property is left admissible, which is what
+keeps a link position honest, since the spelling that would name one is
+`asCell` and `["cell"]` asserts a writable handle on a document nothing can be
+written through. A value with no container kind of its own — a scalar, or a
+link, whose kind is its target's — goes undeclared. None of this constrains a
+later write: the create-only mark means the value the schema describes is the
+only value that document ever holds. A verb's *declared* result type is a
+separate question, settled at the type layer and never reaching the runtime.
+
 For an inline, non-navigation handler result, an `inSpace` child does not move
 that canonical handler-result wrapper into the child space. The result/receipt
 stays in the handler's originating space, while each child node materializes its

--- a/docs/specs/scheduler-v2/README.md
+++ b/docs/specs/scheduler-v2/README.md
@@ -806,7 +806,10 @@ when that kind is a record. Every property is left admissible, which is what
 keeps a link position honest, since the spelling that would name one is
 `asCell` and `["cell"]` asserts a writable handle on a document nothing can be
 written through. A value with no container kind of its own — a scalar, or a
-link, whose kind is its target's — goes undeclared. None of this constrains a
+link, whose kind is its target's — goes undeclared. A `data:` link is the one
+link that is described: it carries its value inside its own identifier and the
+write inlines it, so the receipt holds that value rather than a link to it, and
+the description is taken after the same inlining. None of this constrains a
 later write: the create-only mark means the value the schema describes is the
 only value that document ever holds. A verb's *declared* result type is a
 separate question, settled at the type layer and never reaching the runtime.

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -41,6 +41,7 @@ import {
   pushFrameFromCause,
 } from "./builder/pattern.ts";
 import { type Cell, createCell, isCell } from "./cell.ts";
+import { findAndInlineDataUriLinks } from "./data-uri.ts";
 import { type Action } from "./scheduler.ts";
 import {
   isSchedulerActionObservation,
@@ -278,6 +279,11 @@ function patternDefaultScope(pattern: Pattern): CellScope | undefined {
  * or a link, whose kind belongs to whatever it resolves to rather than to the
  * receipt.
  *
+ * A `data:` link is the exception among links: it carries its value inside
+ * its own identifier, and the write inlines it, so the receipt holds that
+ * value rather than a link to it. The description comes from the same
+ * inlining, so it describes what is stored.
+ *
  * This is DESCRIPTIVE — what this one receipt holds — and never a contract
  * bearing on anything written later. Description and authority cannot diverge
  * here, because the receipt's create-only mark means the value it describes is
@@ -291,11 +297,12 @@ function patternDefaultScope(pattern: Pattern): CellScope | undefined {
  * asserts a writable handle on a document nothing can be written through.
  */
 function receiptShapeSchema(value: unknown): JSONSchema | undefined {
-  if (isCellLink(value)) return undefined;
-  if (Array.isArray(value)) return { type: "array" };
-  if (!isPlainObject(value)) return undefined;
+  const stored = isCellLink(value) ? findAndInlineDataUriLinks(value) : value;
+  if (isCellLink(stored)) return undefined;
+  if (Array.isArray(stored)) return { type: "array" };
+  if (!isPlainObject(stored)) return undefined;
   const properties: Record<string, JSONSchema> = {};
-  for (const key of Object.keys(value)) properties[key] = true;
+  for (const key of Object.keys(stored)) properties[key] = true;
   return { type: "object", properties };
 }
 

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -14,7 +14,7 @@ import { ContextualFlowControl } from "./cfc.ts";
 import { hashOf } from "@commonfabric/data-model/value-hash";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { getLogger } from "@commonfabric/utils/logger";
-import { isRecord } from "@commonfabric/utils/types";
+import { isPlainObject, isRecord } from "@commonfabric/utils/types";
 import { BoundedKeyMap } from "@commonfabric/utils/cache";
 import { PatternManager } from "./pattern-manager.ts";
 import { rendererVDOMSchema } from "./schemas.ts";
@@ -268,6 +268,35 @@ function schemaCellScope(
 
 function patternDefaultScope(pattern: Pattern): CellScope | undefined {
   return schemaCellScope(pattern.resultSchema) ?? pattern.defaultScope;
+}
+
+/**
+ * Structural description of `value` for the durable `schema` metadata of the
+ * receipt cell it is about to be written into: the root container kind, plus
+ * the property names when that kind is a record. Returns `undefined` for a
+ * value with no container kind of its own — a scalar, a `FabricSpecialObject`,
+ * or a link, whose kind belongs to whatever it resolves to rather than to the
+ * receipt.
+ *
+ * This is DESCRIPTIVE — what this one receipt holds — and never a contract
+ * bearing on anything written later. Description and authority cannot diverge
+ * here, because the receipt's create-only mark means the value it describes is
+ * the only value the document ever holds.
+ *
+ * The root kind is what lets a reader's selection become a fetch selector
+ * instead of a filter applied after loading, since the same selection means
+ * different things over a record and over an array. The property schemas are
+ * left as `true` — everything is admissible at every position — which is what
+ * keeps a link position honest: spelling one out means `asCell`, and `["cell"]`
+ * asserts a writable handle on a document nothing can be written through.
+ */
+function receiptShapeSchema(value: unknown): JSONSchema | undefined {
+  if (isCellLink(value)) return undefined;
+  if (Array.isArray(value)) return { type: "array" };
+  if (!isPlainObject(value)) return undefined;
+  const properties: Record<string, JSONSchema> = {};
+  for (const key of Object.keys(value)) properties[key] = true;
+  return { type: "object", properties };
 }
 
 const recordOutputSchemaPolicyInputs = (
@@ -5273,7 +5302,15 @@ export class Runner {
             result !== undefined
             ? result
             : {};
-        receiptCell.withTx(tx).set(receiptValue);
+        const receipt = receiptCell.withTx(tx);
+        receipt.set(receiptValue);
+        // The receipt says what it holds, the way any other cell does. The
+        // shape is only knowable here: the cell is minted at the top of the
+        // dispatch, before the handler runs. Both writes ride this one
+        // transaction, which the create-only mark below gates, so the schema
+        // and the value it describes commit together or not at all.
+        const shape = receiptShapeSchema(receiptValue);
+        if (shape !== undefined) receipt.setMetaRaw("schema", shape);
         tx.markCreateOnly?.(receiptCell.getAsNormalizedFullLink());
       }
       return result;

--- a/packages/runner/test/receipt-schema.test.ts
+++ b/packages/runner/test/receipt-schema.test.ts
@@ -1,0 +1,293 @@
+// The durable `schema` metadata a settled handler dispatch records on its
+// receipt cell alongside the value (`handleJavaScriptHandlerResult`,
+// `src/runner.ts`). It is descriptive — the root container kind, plus the
+// property names when that kind is a record — so what these cases pin is that
+// the declared kind is the one that was stored, that a value with no container
+// kind of its own goes undeclared, and that reading a receipt back THROUGH its
+// own declaration is lossless.
+import {
+  afterEach,
+  beforeEach,
+  createSchedulerTestRuntime,
+  describe,
+  disposeSchedulerTestRuntime,
+  expect,
+  it,
+  Runtime,
+  space,
+} from "./scheduler-test-utils.ts";
+import type {
+  Cell,
+  IExtendedStorageTransaction,
+  JSONSchema,
+  SchedulerTestStorageManager,
+} from "./scheduler-test-utils.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+import { defer } from "@commonfabric/utils/defer";
+import { parseLink } from "../src/link-utils.ts";
+import { resolveLink } from "../src/link-resolution.ts";
+
+/** Outcome of one dispatch, as its commit callback reported it. */
+type Outcome = {
+  status: string;
+  precondition?: string;
+  receiptLink?: NonNullable<
+    IExtendedStorageTransaction["handlingReceiptLink"]
+  >;
+};
+
+describe("receipt schema", () => {
+  let storageManager: SchedulerTestStorageManager;
+  let runtime: Runtime;
+  let tx: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    ({ storageManager, runtime, tx } = createSchedulerTestRuntime(
+      import.meta.url,
+    ));
+  });
+
+  afterEach(async () => {
+    await disposeSchedulerTestRuntime({ storageManager, runtime, tx });
+  });
+
+  /**
+   * Instantiates a one-verb board whose handler returns `returns()`, and hands
+   * back the verb's stream.
+   */
+  async function boardReturning(
+    rootName: string,
+    returns: () => unknown,
+  ): Promise<Cell<unknown>> {
+    const { commonfabric } = createTrustedBuilder(runtime);
+    const { handler, pattern } = commonfabric;
+    const verb = handler<unknown, Record<string, never>>(
+      () => returns(),
+      { proxy: true },
+    );
+    const rootPattern = pattern(() => ({ verb: verb({}) }));
+    const rootCell = runtime.getCell<{ verb: unknown }>(
+      space,
+      rootName,
+      undefined,
+      tx,
+    );
+    const root = runtime.run(tx, rootPattern, {}, rootCell);
+    expect((await tx.commit()).error).toBeUndefined();
+    tx = runtime.edit();
+    await root.pull();
+    return root.key("verb") as Cell<unknown>;
+  }
+
+  /**
+   * Dispatches `payload` at `stream` under `eventId` and resolves once the
+   * handling's transaction has settled, waking on the commit callback `send`
+   * already registers.
+   */
+  async function dispatch(
+    stream: Cell<unknown>,
+    payload: unknown,
+    eventId: string,
+  ): Promise<Outcome> {
+    const settled = defer<Outcome>();
+    stream.send(payload, (t: IExtendedStorageTransaction) => {
+      const status = t.status();
+      settled.resolve({
+        status: status.status,
+        precondition: (status as { error?: { precondition?: string } }).error
+          ?.precondition,
+        receiptLink: t.handlingReceiptLink,
+      });
+    }, { eventId });
+    const outcome = await settled.promise;
+    await runtime.scheduler.idleWithPendingCommits();
+    return outcome;
+  }
+
+  /** The receipt at the address `send` reported, loaded and ready to read. */
+  async function receiptOf(outcome: Outcome): Promise<Cell<unknown>> {
+    expect(outcome.status).toBe("done");
+    const receipt = runtime.getCellFromLink<unknown>(outcome.receiptLink!);
+    await receipt.pull();
+    return receipt;
+  }
+
+  it("declares the root kind and property names of a record return", async () => {
+    const stored = { topic: { fid: "fid-1" }, count: 3 };
+    const stream = await boardReturning(
+      "receipt schema record root",
+      () => stored,
+    );
+    const receipt = await receiptOf(
+      await dispatch(stream, {}, "evt:receipt-schema:record"),
+    );
+
+    const declared = receipt.getMetaRaw("schema") as JSONSchema;
+    expect(declared).toEqual({
+      type: "object",
+      properties: { topic: true, count: true },
+    });
+    // Every property is admissible, so narrowing a read to the declaration
+    // keeps levels below the names it lists rather than trimming to them.
+    expect(receipt.asSchema(declared).get()).toEqual(stored);
+  });
+
+  it("declares an empty record for a value-less verb", async () => {
+    const stream = await boardReturning(
+      "receipt schema value-less root",
+      () => undefined,
+    );
+    const receipt = await receiptOf(
+      await dispatch(stream, {}, "evt:receipt-schema:value-less"),
+    );
+
+    // `{}` is what a value-less verb's receipt holds — the existence-only
+    // witness — and a record carrying no properties is what describes it.
+    expect(receipt.get()).toEqual({});
+    expect(receipt.getMetaRaw("schema")).toEqual({
+      type: "object",
+      properties: {},
+    });
+  });
+
+  it("declares an array root for an array return", async () => {
+    const stream = await boardReturning(
+      "receipt schema array root",
+      () => ["a", "b"],
+    );
+    const receipt = await receiptOf(
+      await dispatch(stream, {}, "evt:receipt-schema:array"),
+    );
+
+    // The root kind is the half a selection needs before it can become a
+    // fetch selector, since the same selection means different things over a
+    // record and over an array.
+    const declared = receipt.getMetaRaw("schema") as JSONSchema;
+    expect(declared).toEqual({ type: "array" });
+    expect(receipt.asSchema(declared).get()).toEqual(["a", "b"]);
+  });
+
+  it("names a property holding a reference without constraining it", async () => {
+    const referenced = runtime.getCell<number>(
+      space,
+      "receipt schema referenced",
+      undefined,
+      tx,
+    );
+    referenced.set(7);
+    const stream = await boardReturning(
+      "receipt schema reference root",
+      () => ({ note: referenced, tag: "x" }),
+    );
+    const receipt = await receiptOf(
+      await dispatch(stream, {}, "evt:receipt-schema:reference"),
+    );
+
+    // The declaration names both properties and says nothing about which of
+    // them is a link: the spelling for that is `asCell`, and `["cell"]` would
+    // assert a writable handle on a document nothing can be written through.
+    // An unconstrained position reads through to the referenced value the
+    // same way an undeclared one does.
+    const declared = receipt.getMetaRaw("schema") as JSONSchema;
+    expect(declared).toEqual({
+      type: "object",
+      properties: { note: true, tag: true },
+    });
+    expect(receipt.asSchema(declared).get()).toEqual({ note: 7, tag: "x" });
+  });
+
+  it("declares nothing for a scalar return", async () => {
+    const stream = await boardReturning(
+      "receipt schema scalar root",
+      () => 42,
+    );
+    const receipt = await receiptOf(
+      await dispatch(stream, {}, "evt:receipt-schema:scalar"),
+    );
+
+    // A scalar has no container kind, and no selection has anything to narrow
+    // against it.
+    expect(receipt.get()).toBe(42);
+    expect(receipt.getMetaRaw("schema")).toBeUndefined();
+  });
+
+  it("declares nothing for an incidental cell return", async () => {
+    // `set()` returns its cell for chaining, so an expression-body verb
+    // returns a live Cell, which the receipt write converts to a link. The
+    // root kind then belongs to the link's target rather than to the receipt,
+    // and calling the stored envelope a record with a `/` property would make
+    // a schema-narrowed read resolve the link and then fail the target's
+    // value against `type: "object"`.
+    const counter = runtime.getCell<number>(
+      space,
+      "receipt schema counter",
+      undefined,
+      tx,
+    );
+    counter.set(1);
+    const stream = await boardReturning(
+      "receipt schema cell return root",
+      () => counter,
+    );
+    const receipt = await receiptOf(
+      await dispatch(stream, {}, "evt:receipt-schema:cell"),
+    );
+
+    expect(receipt.getMetaRaw("schema")).toBeUndefined();
+    expect(receipt.get()).toBe(1);
+
+    // The stored link still addresses the returned cell.
+    const written = parseLink(receipt.getRaw(), receipt);
+    expect(written).toBeDefined();
+    const writtenResolved = resolveLink(runtime, runtime.readTx(), written!);
+    const target = resolveLink(
+      runtime,
+      runtime.readTx(),
+      counter.getAsNormalizedFullLink(),
+    );
+    expect(writtenResolved.id).toBe(target.id);
+    expect(writtenResolved.path).toEqual(target.path);
+  });
+
+  it("keeps the winner's schema when a same-id replay collides", async () => {
+    let invocations = 0;
+    const { commonfabric } = createTrustedBuilder(runtime);
+    const { handler, pattern } = commonfabric;
+    // The second delivery returns a DIFFERENT shape, so a loser whose metadata
+    // write landed would show up in the schema as well as in the value.
+    const verb = handler<unknown, Record<string, never>>(
+      () => (++invocations === 1 ? { first: true } : { second: true, n: 2 }),
+      { proxy: true },
+    );
+    const rootPattern = pattern(() => ({ verb: verb({}) }));
+    const rootCell = runtime.getCell<{ verb: unknown }>(
+      space,
+      "receipt schema replay root",
+      undefined,
+      tx,
+    );
+    const root = runtime.run(tx, rootPattern, {}, rootCell);
+    expect((await tx.commit()).error).toBeUndefined();
+    tx = runtime.edit();
+    await root.pull();
+    const stream = root.key("verb") as Cell<unknown>;
+
+    const eventId = "evt:receipt-schema:replay";
+    const winner = await dispatch(stream, {}, eventId);
+    const loser = await dispatch(stream, {}, eventId);
+
+    // The body re-runs — exactly-once is per commit, not per execution — and
+    // the create-only mark refuses the whole transaction, metadata included.
+    expect(invocations).toBe(2);
+    expect(loser.status).toBe("error");
+    expect(loser.precondition).toBe("receipt-exists");
+    expect(loser.receiptLink?.id).toBe(winner.receiptLink?.id);
+
+    const receipt = await receiptOf(winner);
+    expect(receipt.get()).toEqual({ first: true });
+    expect(receipt.getMetaRaw("schema")).toEqual({
+      type: "object",
+      properties: { first: true },
+    });
+  });
+});

--- a/packages/runner/test/receipt-schema.test.ts
+++ b/packages/runner/test/receipt-schema.test.ts
@@ -167,6 +167,44 @@ describe("receipt schema", () => {
     expect(receipt.asSchema(declared).get()).toEqual(["a", "b"]);
   });
 
+  it("declares the record a returned `data:` cell inlines to", async () => {
+    // A `data:` cell carries its value in its own identifier, and the write
+    // dissolves the link into that value, so the receipt holds a record and
+    // is described as one. Left as a link it would go undeclared, and a
+    // shaped read would have nothing to narrow against.
+    const inline = runtime.getImmutableCell(space, { topic: "x", count: 3 });
+    const stream = await boardReturning(
+      "receipt schema data uri root",
+      () => inline,
+    );
+    const receipt = await receiptOf(
+      await dispatch(stream, {}, "evt:receipt-schema:data-uri"),
+    );
+
+    const declared = receipt.getMetaRaw("schema") as JSONSchema;
+    expect(declared).toEqual({
+      type: "object",
+      properties: { topic: true, count: true },
+    });
+    expect(receipt.getRaw()).toEqual({ topic: "x", count: 3 });
+    expect(receipt.asSchema(declared).get()).toEqual({ topic: "x", count: 3 });
+  });
+
+  it("declares an array root for a returned `data:` cell holding one", async () => {
+    const inline = runtime.getImmutableCell(space, ["a", "b"]);
+    const stream = await boardReturning(
+      "receipt schema data uri array root",
+      () => inline,
+    );
+    const receipt = await receiptOf(
+      await dispatch(stream, {}, "evt:receipt-schema:data-uri-array"),
+    );
+
+    const declared = receipt.getMetaRaw("schema") as JSONSchema;
+    expect(declared).toEqual({ type: "array" });
+    expect(receipt.asSchema(declared).get()).toEqual(["a", "b"]);
+  });
+
   it("names a property holding a reference without constraining it", async () => {
     const referenced = runtime.getCell<number>(
       space,


### PR DESCRIPTION
## Why

A receipt is read through a schema like any other cell, but receipts carry none.
Two things follow: a projection can't be pushed into the fetch, because
narrowing needs the root container kind before it can build a selector; and a
reader's schema matches a runtime value rather than a declaration. Giving a
receipt a durable schema removes both.

This is per-invocation metadata describing what one receipt holds. It is *not*
the `Pattern.resultSchema` emission withdrawn in July: the compatibility gate
(`assertPatternSchemasBackwardCompatible`) only ever compares `argumentSchema`
and `resultSchema` between two versions of a pattern, so it never reaches a
receipt and no permanence obligation attaches.

Part of the shaped-reads plan (#5435), which builds on the read model in #5316.

## What Changed

`receiptShapeSchema` derives a one-level shape from the settled value and writes
it via `setMetaRaw("schema", …)` in the same create-only transaction as the
result. Container kind only — `{"type": "object", "properties": {k: true}}` —
since that is all the narrowing needs. Cell links yield no schema.

## Known limitation

The write sits on the receipt-only branch (`runner.ts`, guarded by
`!resultHasReactives && frame.reactives.size === 0`). A verb returning anything
reactive — including a child piece — takes the branch where
`updateResultSchemaMeta` is called with the synthesized pattern's
`resultSchema`, which is `undefined` because `Stream<E, R>` drops `R`. Those
receipts still get no schema. Closing that needs a declared result schema at the
source; tracked in the plan's backlog.

## Test plan

`deno task test` in packages/runner.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

