### PR TITLE
feat(cli): `$link` marks a selection position for its address

### DIFF
--- a/docs/common/verbs-over-the-cli.md
+++ b/docs/common/verbs-over-the-cli.md
@@ -280,6 +280,11 @@ branching. `id` keeps its scheme, because the scheme is the kind and dropping
 it retargets the address silently. No schema is inlined: a stored link can
 carry an entire one, and what was asked for is where the value lives.
 
+Marking a position deeper than a link names the linked document and the path
+below it — `notes[0].title`, where `notes` holds links, renders the note's own
+`id` with `path` `["title"]`. A link is a durable identity; the slot that holds
+it stops naming the same value the moment the collection is reordered.
+
 The marker sits beside a projection when both are wanted, and the answer
 carries both:
 

--- a/docs/common/verbs-over-the-cli.md
+++ b/docs/common/verbs-over-the-cli.md
@@ -200,8 +200,8 @@ Run it against any host:
 API_URL=http://localhost:8000 packages/cli/integration/verbs-over-the-cli.sh
 ```
 
-CI runs it in the `piece-call` shard. It takes about ten seconds and eleven `cf`
-invocations against a warm local toolshed.
+CI runs it in the `piece-call` shard. It takes under half a minute and around
+twenty `cf` invocations against a warm local toolshed.
 
 Each step demonstrates one use case:
 
@@ -210,12 +210,14 @@ Each step demonstrates one use case:
 | 1–2 | Deploy a pattern, then ask what it can do |
 | 3 | A create hands back the piece it created |
 | 4 | A verb returns what it wrote, including what only it could compute |
-| 5 | A replayed id returns the original result; nothing runs twice |
-| 6 | A piece result needs no option; a plain record does — and the write lands either way |
-| 7 | A value-less verb settles with the empty witness |
-| 8 | A refused call does not spend its invocation id |
-| 9 | Reading a verb redirects to `cf piece call` |
-| 10 | Timings on stderr, Invocation JSON still clean on stdout |
+| 5 | A call's result names the document behind each path, and that address calls |
+| 6 | A read returns an address in place of what is behind it |
+| 7 | A replayed id returns the original result; nothing runs twice |
+| 8 | A piece result needs no option; a plain record does — and the write lands either way |
+| 9 | A value-less verb settles with the empty witness |
+| 10 | A refused call does not spend its invocation id |
+| 11 | Reading a verb redirects to `cf piece call` |
+| 12 | Timings on stderr, Invocation JSON still clean on stdout |
 
 ## Addressing a piece you were handed
 
@@ -254,3 +256,46 @@ rather than to the result.
 A pattern should not mint identifier fields to make any of this easier —
 rendering identity is the client's job, and a pattern-authored fid is a copy
 that can go stale.
+
+### Asking a read for an address
+
+A cell is a point in a graph, so a read that does not say where to stop follows
+links onward and hands back a copy of everything behind them. `--schema` says
+where to stop: a position marked `{"$link": true}` returns that position's
+address rather than its contents.
+
+```bash
+cf piece get --piece <board> notes \
+  --schema '{"type":"array","items":{"$link":true}}'
+```
+
+```json
+[
+  { "$link": { "id": "of:fid1:…", "space": "did:key:…", "scope": "space", "path": [] } }
+]
+```
+
+Those four fields are always present, so a caller indexes them without
+branching. `id` keeps its scheme, because the scheme is the kind and dropping
+it retargets the address silently. No schema is inlined: a stored link can
+carry an entire one, and what was asked for is where the value lives.
+
+The marker sits beside a projection when both are wanted, and the answer
+carries both:
+
+```bash
+cf piece get --piece <board> notes --schema \
+  '{"type":"array","items":{"$link":true,"type":"object","properties":{"title":true}}}'
+```
+
+```json
+[{ "$link": { "id": "of:fid1:…", "…": "…" }, "title": "First note" }]
+```
+
+A marked position is not fetched — the address is stored in the document that
+contains it, so a marked collection of a hundred notes costs the one read that
+document already needed. Where the marker is the whole selection, nothing
+behind it is read at all.
+
+The address a marked read returns is one `cf piece call` accepts, minus the
+`of:` prefix, which is the reason to ask for it.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -185,6 +185,45 @@ JavaScript runs; stream handles remain capabilities. The source cell's schema
 remains authoritative for Common Fabric metadata. A caller cannot introduce or
 override `ifc`, `asCell`, `scope`, or `default` through `--schema`.
 
+#### Asking for an address instead of contents
+
+A JSON `--schema` marks a position with `"$link": true` to get that position's
+address rather than what is behind it:
+
+```bash
+cf piece get --piece ID notes --schema '{"type":"array","items":{"$link":true}}'
+```
+
+```json
+[{
+  "$link": {
+    "id": "of:fid1:…",
+    "space": "did:key:…",
+    "scope": "space",
+    "path": []
+  }
+}]
+```
+
+All four fields are always present, so a caller indexes them without branching:
+`id` keeps its scheme, `space` and `scope` are filled in even when they match
+the reader's own, and `path` is `[]` at a document's root. No schema is inlined
+and no write-redirect flag rides along. The rendered `id`, minus its `of:`
+prefix, is what `cf piece call --piece` and `cf piece get --piece` accept.
+
+The marker sits beside a projection when both are wanted —
+`{"$link":true,"type":"object","properties":{"title":true}}` returns the address
+and the title — and replaces the contents when it is alone. It is accepted
+anywhere `properties` is, except under `additionalProperties`, whose membership
+the stored value rather than the selection decides.
+
+A marked position is never fetched: it contributes a rejecting selector to the
+same path union the projection builds, and the address comes from the link
+stored in the containing document. A marked collection therefore costs one
+document read rather than one per element. The marker is a JSON-schema spelling
+only, and it cannot be combined with `--filter`: the elements a predicate keeps
+no longer say which positions they came from, and an address names a position.
+
 ## Built Binary
 
 `deno task build-binaries cf` compiles the CLI to `dist/cf` — fully

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -211,6 +211,18 @@ the reader's own, and `path` is `[]` at a document's root. No schema is inlined
 and no write-redirect flag rides along. The rendered `id`, minus its `of:`
 prefix, is what `cf piece call --piece` and `cf piece get --piece` accept.
 
+The address names the deepest stored link crossed on the way to the marked
+position, plus the segments that remain below that link. Marking `title` under
+each element of a `notes` array whose entries are links returns the note's own
+`id` with `path` `["title"]`, not the board's `id` with `path`
+`["notes","0","title"]`: a link is a durable identity, while a position in a
+containing document is a slot, and reordering the collection above it leaves the
+same path naming a different value. Where the stored link carries a path of its
+own, that path comes first and the segments below it follow — a link to
+`{"path":["content"]}` marked at `title` renders `["content","title"]`. Where
+nothing is linked on the way, the value lives in the source document itself and
+the address is its position there.
+
 The marker sits beside a projection when both are wanted —
 `{"$link":true,"type":"object","properties":{"title":true}}` returns the address
 and the title — and replaces the contents when it is alone. It is accepted
@@ -218,11 +230,12 @@ anywhere `properties` is, except under `additionalProperties`, whose membership
 the stored value rather than the selection decides.
 
 A marked position is never fetched: it contributes a rejecting selector to the
-same path union the projection builds, and the address comes from the link
-stored in the containing document. A marked collection therefore costs one
-document read rather than one per element. The marker is a JSON-schema spelling
-only, and it cannot be combined with `--filter`: the elements a predicate keeps
-no longer say which positions they came from, and an address names a position.
+same path union the projection builds, and the address is composed from links
+already stored in the documents the read visited rather than by following one. A
+marked collection therefore costs one document read rather than one per element.
+The marker is a JSON-schema spelling only, and it cannot be combined with
+`--filter`: the elements a predicate keeps no longer say which positions they
+came from, and an address names a position.
 
 ## Built Binary
 

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -49,11 +49,9 @@ import ports from "@commonfabric/ports" with { type: "json" };
 import type { PiecePatternRef } from "@commonfabric/piece/ops";
 import { reservesStdoutForCommandOutput } from "../lib/json-output.ts";
 import {
-  parsePieceGetFilter,
-  parsePieceGetProjection,
-  type PieceGetTransform,
-  PieceGetTransformError,
-} from "../lib/piece-get-transform.ts";
+  CellSelectionError,
+  parseCellSelectionOptions,
+} from "../lib/cell-selection.ts";
 
 // Hint system: print helpful next-step suggestions after operations
 let quietMode = false;
@@ -78,21 +76,6 @@ export function normalizeApiUrl(apiUrl: string): string {
   normalized.hash = "";
   const href = normalized.toString();
   return basePath ? href : href.slice(0, -1);
-}
-
-export async function parsePieceGetTransformOptions(options: {
-  filter?: string;
-  schema?: string;
-}): Promise<PieceGetTransform | undefined> {
-  const filter = options.filter === undefined
-    ? undefined
-    : parsePieceGetFilter(options.filter);
-  const projection = options.schema === undefined
-    ? undefined
-    : await parsePieceGetProjection(options.schema);
-  return filter === undefined && projection === undefined
-    ? undefined
-    : { filter, projection };
 }
 
 function summarizeForDisplay(value: unknown): unknown {
@@ -184,7 +167,7 @@ export function localPatternEntry(
  * A `piece get` failure caused by a data condition rather than bad arguments:
  * a path that doesn't resolve, a result schema that can't project stored data
  * (PieceResultProjectionError), a filter/projection that doesn't fit the
- * selected value (PieceGetTransformError), or a path that lands on a verb
+ * selected value (CellSelectionError), or a path that lands on a verb
  * (PieceVerbReadError — the read-path guard's redirect at `cf piece call`).
  * Reported as a plain error on stderr with exit 1, never as a Cliffy
  * ValidationError (which would dump the usage screen and read as an arg-parse
@@ -192,7 +175,7 @@ export function localPatternEntry(
  */
 export function isPieceGetDataError(error: unknown): error is Error {
   return error instanceof PieceResultProjectionError ||
-    error instanceof PieceGetTransformError ||
+    error instanceof CellSelectionError ||
     error instanceof PieceVerbReadError ||
     (error instanceof Error &&
       error.message.startsWith("Cannot access path"));
@@ -202,7 +185,7 @@ export function isPieceGetDataError(error: unknown): error is Error {
  * Build the stderr report for a `piece get` failure. Returns null when the
  * error is not a data error (the caller should rethrow). `message` is the
  * one-line error; `hint` is an optional next-step tip. A projection error
- * already carries its own `--step` guidance, transform errors stand alone,
+ * already carries its own `--step` guidance, selection errors stand alone,
  * a verb refusal already carries its `cf piece call` redirect, and an
  * input-mode read has nothing more to suggest — only a result-mode
  * unresolved path gets the `--input` tip.
@@ -214,7 +197,7 @@ export function pieceGetDataErrorReport(
   if (!isPieceGetDataError(error)) return null;
   if (
     error instanceof PieceResultProjectionError ||
-    error instanceof PieceGetTransformError ||
+    error instanceof CellSelectionError ||
     error instanceof PieceVerbReadError ||
     opts.input
   ) {
@@ -1456,11 +1439,11 @@ PATH FORMAT: Use forward slashes and numeric indices for arrays.
     };
     const pathSegments = pathString ? parseCellPath(pathString) : [];
     try {
-      const transform = await parsePieceGetTransformOptions(options);
+      const selection = await parseCellSelectionOptions(options);
       const value = await getCellValue(pieceConfig, pathSegments, {
         input: options.input,
         step: options.step,
-        ...(transform === undefined ? {} : { transform }),
+        ...(selection === undefined ? {} : { selection }),
       });
       render(value, { json: true });
     } catch (error) {

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -1412,6 +1412,13 @@ PATH FORMAT: Use forward slashes and numeric indices for arrays.
     ),
     "Project each returned item to selected fields.",
   )
+  .example(
+    cliText(
+      `cf piece get ${EX_ID} ${EX_COMP_PIECE} items ` +
+        `--schema '{"type":"array","items":{"$link":true}}'`,
+    ),
+    "Return each item's address instead of its contents.",
+  )
   .option("-c,--piece <piece:string>", "The target piece ID.")
   .option("--input", "Read from the piece's input cell instead of result cell")
   .option(

--- a/packages/cli/integration/verbs-over-the-cli.sh
+++ b/packages/cli/integration/verbs-over-the-cli.sh
@@ -107,7 +107,39 @@ check "first line
 second line" "$(echo "$A" | jq -r '.result.body // empty')" \
   "calling a verb ON the returned piece works, and returns what it wrote"
 
-step "6. A replayed invocation id returns the ORIGINAL result"
+step "6. Read an address instead of what is behind it"
+# A read follows a link onward unless the selection says where to stop, so a
+# created note arrives as a copy of its contents with no address in it. A
+# "$link" marker at a position asks for that position's address instead.
+ADDR=$($CF piece get --quiet --piece "$BOARD" $ARGS notes \
+  --schema '{"type":"array","items":{"$link":true}}' 2>/dev/null)
+check "true" "$(echo "$ADDR" | jq -c '[.[] | has("$link")] | all')" \
+  "every element carries an address"
+check "false" "$(echo "$ADDR" | jq -c '[.[] | has("title")] | any')" \
+  "and none of them carries the note's contents"
+check '["id","path","scope","space"]' \
+  "$(echo "$ADDR" | jq -c '[.[0]["$link"] | keys] | first')" \
+  "the address is id, space, scope, and path — no inlined schema"
+# A marker beside a projection asks for both, because both were asked for.
+BOTH=$($CF piece get --quiet --piece "$BOARD" $ARGS notes --schema \
+  '{"type":"array","items":{"$link":true,"type":"object","properties":{"title":true}}}' \
+  2>/dev/null)
+check "true" "$(echo "$BOTH" | jq -c \
+  '[.[] | has("$link") and (.title | length > 0)] | all')" \
+  "a marker beside a projection returns the address AND the fields"
+# The point of an address: act on the child, rather than read a copy of it.
+FIRST=$(echo "$BOTH" | jq -r \
+  '.[] | select(.title == "First note") | .["$link"].id' | sed 's/^of://')
+if [ -n "$FIRST" ]; then ok "the read names the first note: $FIRST"; else
+  bad "no address for the first note in the projected read"
+fi
+B=$($CF piece call --quiet --piece "$FIRST" $ARGS --invocation append-read \
+  append '{"text":"appended through the read"}' 2>/dev/null)
+check "written at create
+appended through the read" "$(echo "$B" | jq -r '.result.body // empty')" \
+  "the address a read returned is one a caller can call"
+
+step "7. A replayed invocation id returns the ORIGINAL result"
 # Captured rather than hard-coded: the property is that the replay changes
 # nothing, which stays true however many notes earlier steps created.
 BEFORE=$($CF piece get --quiet --piece "$BOARD" $ARGS noteCount --step 2>/dev/null)
@@ -120,7 +152,7 @@ check "true" "$(echo "$D" | jq -r '.deduplicated // false')" \
 check "$BEFORE" "$($CF piece get --quiet --piece "$BOARD" $ARGS noteCount --step 2>/dev/null)" \
   "the replay created no note (count unchanged at $BEFORE)"
 
-step "7. A piece result needs no option; a plain record does"
+step "8. A piece result needs no option; a plain record does"
 P=$(EXPERIMENTAL_PLAIN_RESULT_RECEIPTS=false $CF piece call --quiet \
   --piece "$BOARD" $ARGS --invocation create-flagoff \
   createNote '{"title":"Flag-off note"}' 2>/dev/null)
@@ -135,13 +167,13 @@ check "Written anyway" \
   "$($CF piece get --quiet --piece "$BOARD" $ARGS label --input 2>/dev/null | jq -r '.')" \
   "but the write landed regardless — an absent result is not a failed mutation"
 
-step "8. A value-less verb settles with no result"
+step "9. A value-less verb settles with no result"
 V=$($CF piece call --quiet --piece "$BOARD" $ARGS --invocation touch-1 \
   touch '{}' 2>/dev/null)
 check "settled" "$(echo "$V" | jq -r '.status')" "the value-less verb settled"
 check "{}" "$(echo "$V" | jq -c '.result // {}')" "its result is the empty witness"
 
-step "9. A refused call does not spend its invocation id"
+step "10. A refused call does not spend its invocation id"
 $CF piece call --quiet --piece "$BOARD" $ARGS --invocation reuse-1 \
   createNote '{"title":""}' >/dev/null 2>&1
 rc=$?
@@ -151,7 +183,7 @@ C=$($CF piece call --quiet --piece "$BOARD" $ARGS --invocation reuse-1 \
 check "Corrected" "$(echo "$C" | jq -r '.result.note["$NAME"] // empty')" \
   "the SAME id then executes, because the refusal never consumed it"
 
-step "10. Reading a verb redirects to cf piece call"
+step "11. Reading a verb redirects to cf piece call"
 OUT=$($CF piece get --piece "$BOARD" $ARGS createNote 2>&1)
 rc=$?
 check "1" "$([ "$rc" -ne 0 ] && echo 1 || echo 0)" "a verb read exits nonzero"
@@ -159,7 +191,7 @@ echo "$OUT" | grep -qi "piece call" &&
   ok "the refusal names cf piece call" ||
   bad "the refusal does not name the right command"
 
-step "11. --verbose times the phases on stderr; stdout stays JSON"
+step "12. --verbose times the phases on stderr; stdout stays JSON"
 ERR=$(mktemp)
 OUT=$($CF piece call --quiet --verbose --piece "$BOARD" $ARGS \
   --invocation timed-1 createNote '{"title":"Timed note"}' 2>"$ERR")

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -13,6 +13,8 @@ import {
   type JSONSchema,
   KeepAsCell,
   type MemorySpace,
+  type NormalizedFullLink,
+  parseLink,
   type Runtime,
   sanitizeSchemaForLinks,
 } from "@commonfabric/runner";
@@ -50,15 +52,49 @@ export interface ParsedSelectionFilter {
   paths: Array<Array<string | number>>;
 }
 
+/** The key a caller writes beside `properties` to ask for an address. */
+const LINK_MARKER_KEY = "$link";
+
+/**
+ * The address a marked position renders, and the key it renders under. Every
+ * field is present so a caller indexes it without branching: `id` keeps its
+ * scheme, because the scheme is the kind and dropping it retargets the
+ * address silently; `path` is `[]` at a document's root.
+ *
+ * `overwrite` is dropped and `schema` is never inlined. A stored link can
+ * carry an entire schema with its own `$defs`, and what was asked for is
+ * where the value lives, not what shape it declares.
+ */
+export interface RenderedLinkAddress {
+  id: NormalizedFullLink["id"];
+  space: NormalizedFullLink["space"];
+  scope: NormalizedFullLink["scope"];
+  path: string[];
+}
+
+/**
+ * The positions a `--schema` marked with `$link`, mirroring the projection's
+ * own shape. A node exists only where it, or something below it, is marked.
+ */
+export interface LinkMarkers {
+  /** The address at this position was asked for. */
+  marked?: true;
+  properties?: Record<string, LinkMarkers>;
+  items?: LinkMarkers;
+}
+
 /**
  * A `--schema` argument, parsed. `source` is the text as written; `kind`
  * records which of the two spellings it used, since a concise field list
- * traverses arrays implicitly and a JSON Schema does not.
+ * traverses arrays implicitly and a JSON Schema does not. `schema` carries no
+ * `$link` marker: markers move to `markers`, and a position that asked for
+ * nothing but an address becomes the `false` schema there.
  */
 export interface SelectionProjection {
   source: string;
   schema: JSONSchema;
   kind: "concise" | "json";
+  markers?: LinkMarkers;
 }
 
 /**
@@ -512,11 +548,17 @@ const UNSUPPORTED_PROJECTION_KEYS = new Set([
   "contentSchema",
 ]);
 
+/** A projection schema with its `$link` markers lifted out of it. */
+interface NormalizedProjectionSchema {
+  schema: JSONSchema;
+  markers?: LinkMarkers;
+}
+
 function normalizeProjectionSchema(
   schema: unknown,
   path = "<root>",
-): JSONSchema {
-  if (schema === true) return true;
+): NormalizedProjectionSchema {
+  if (schema === true) return { schema: true };
   if (schema === false) {
     throw new CellSelectionError(
       `Invalid --schema at ${path}: false cannot project a value`,
@@ -528,6 +570,7 @@ function normalizeProjectionSchema(
     );
   }
   for (const key of Object.keys(schema)) {
+    if (key === LINK_MARKER_KEY) continue;
     if (FORBIDDEN_PROJECTION_KEYS.has(key)) {
       throw new CellSelectionError(
         `Invalid --schema at ${path}: "${key}" is controlled by the source ` +
@@ -540,42 +583,76 @@ function normalizeProjectionSchema(
       );
     }
   }
+  const marker = schema[LINK_MARKER_KEY];
+  if (marker !== undefined && marker !== true) {
+    throw new CellSelectionError(
+      `Invalid --schema at ${path}: "${LINK_MARKER_KEY}" must be \`true\``,
+    );
+  }
 
-  const result: Record<string, unknown> = { ...schema };
-  if (schema.properties !== undefined) {
-    if (!isRecord(schema.properties) || Array.isArray(schema.properties)) {
+  const { [LINK_MARKER_KEY]: _marker, ...declared } = schema;
+  const markers: LinkMarkers = marker === true ? { marked: true } : {};
+  const result: Record<string, unknown> = { ...declared };
+  if (declared.properties !== undefined) {
+    if (!isRecord(declared.properties) || Array.isArray(declared.properties)) {
       throw new CellSelectionError(
         `Invalid --schema at ${path}: "properties" must be an object`,
       );
     }
-    result.properties = Object.fromEntries(
-      Object.entries(schema.properties).map(([key, child]) => [
-        key,
-        normalizeProjectionSchema(child, `${path}.${key}`),
-      ]),
-    );
-    if (schema.additionalProperties === undefined) {
+    const properties: Record<string, JSONSchema> = {};
+    const childMarkers: Record<string, LinkMarkers> = {};
+    for (const [key, child] of Object.entries(declared.properties)) {
+      const normalized = normalizeProjectionSchema(child, `${path}.${key}`);
+      properties[key] = normalized.schema;
+      if (normalized.markers !== undefined) {
+        childMarkers[key] = normalized.markers;
+      }
+    }
+    result.properties = properties;
+    if (Object.keys(childMarkers).length > 0) markers.properties = childMarkers;
+    if (declared.additionalProperties === undefined) {
       result.additionalProperties = false;
     }
   } else if (
-    schemaTypes(schema as JSONSchema).includes("object") &&
-    schema.additionalProperties === undefined
+    schemaTypes(declared as JSONSchema).includes("object") &&
+    declared.additionalProperties === undefined
   ) {
     result.additionalProperties = true;
   }
   if (
-    schema.additionalProperties !== undefined &&
-    typeof schema.additionalProperties !== "boolean"
+    declared.additionalProperties !== undefined &&
+    typeof declared.additionalProperties !== "boolean"
   ) {
-    result.additionalProperties = normalizeProjectionSchema(
-      schema.additionalProperties,
+    const normalized = normalizeProjectionSchema(
+      declared.additionalProperties,
       `${path}.*`,
     );
+    // A marker names one position, and `additionalProperties` names a set
+    // whose membership the stored value decides. Refuse rather than drop the
+    // marker: dropping it answers with contents where an address was asked
+    // for, which reads as a successful answer to a different question.
+    if (normalized.markers !== undefined) {
+      throw new CellSelectionError(
+        `Invalid --schema at ${path}.*: "${LINK_MARKER_KEY}" is not ` +
+          'supported under "additionalProperties"',
+      );
+    }
+    result.additionalProperties = normalized.schema;
   }
-  if (schema.items !== undefined) {
-    result.items = normalizeProjectionSchema(schema.items, `${path}[]`);
+  if (declared.items !== undefined) {
+    const normalized = normalizeProjectionSchema(declared.items, `${path}[]`);
+    result.items = normalized.schema;
+    if (normalized.markers !== undefined) markers.items = normalized.markers;
   }
-  return result as JSONSchema;
+  // A position whose whole selection was its address reads nothing, and says
+  // so with the rejecting schema. Everything downstream — the read selector,
+  // the projector, the declared output shape — already means "nothing here"
+  // by `false`, and the address is composed back in from the stored link.
+  const reduced = marker === true && Object.keys(result).length === 0;
+  return {
+    schema: reduced ? false : result as JSONSchema,
+    ...(Object.keys(markers).length > 0 ? { markers } : {}),
+  };
 }
 
 function conciseProjectionSchema(source: string): JSONSchema {
@@ -666,11 +743,7 @@ export async function parseSelectionProjection(
         { cause: error },
       );
     }
-    return {
-      source,
-      schema: normalizeProjectionSchema(parsed),
-      kind: "json",
-    };
+    return { source, ...normalizeProjectionSchema(parsed), kind: "json" };
   }
 
   if (trimmed.startsWith("{") || trimmed === "true" || trimmed === "false") {
@@ -685,11 +758,7 @@ export async function parseSelectionProjection(
         { cause: error },
       );
     }
-    return {
-      source,
-      schema: normalizeProjectionSchema(parsed),
-      kind: "json",
-    };
+    return { source, ...normalizeProjectionSchema(parsed), kind: "json" };
   }
 
   return {
@@ -887,8 +956,14 @@ interface ArrayProjectionMask {
   items: ProjectionMask;
 }
 interface ObjectProjectionMask extends ObjectMask<ProjectionMask> {}
+/**
+ * Which positions a selection reads. `false` is the rejecting one: the
+ * position contributes nothing to the read, and the runner never loads what
+ * is behind it.
+ */
 type ProjectionMask =
   | true
+  | false
   | ArrayProjectionMask
   | ObjectProjectionMask;
 interface ObjectPredicateMask extends ObjectMask<PredicateMask> {}
@@ -896,7 +971,7 @@ type PredicateMask = true | ObjectPredicateMask;
 
 function projectionMask(schema: JSONSchema): ProjectionMask {
   if (schema === true) return true;
-  // `normalizeProjectionSchema()` rejects false schemas before this point.
+  if (schema === false) return false;
   const objectSchema = schema as Exclude<JSONSchema, boolean>;
   if (
     objectSchema.additionalProperties === true ||
@@ -905,12 +980,15 @@ function projectionMask(schema: JSONSchema): ProjectionMask {
     return true;
   }
   if (objectSchema.type === "array" || objectSchema.items !== undefined) {
-    return {
-      type: "array",
-      items: objectSchema.items === undefined
-        ? true
-        : projectionMask(objectSchema.items),
-    };
+    const items = objectSchema.items === undefined
+      ? true
+      : projectionMask(objectSchema.items);
+    // An array whose elements are not read is not read. The rejecting
+    // selector has to sit at the array itself to suppress the fetch: array
+    // traversal follows each element's link before it consults the item
+    // schema, so a rejection one level down arrives after the load it was
+    // meant to prevent.
+    return items === false ? false : { type: "array", items };
   }
   if (
     objectSchema.type === "object" || objectSchema.properties !== undefined
@@ -930,7 +1008,7 @@ function projectionMask(schema: JSONSchema): ProjectionMask {
 }
 
 function schemaFromProjectionMask(mask: ProjectionMask): JSONSchema {
-  if (mask === true) return true;
+  if (typeof mask === "boolean") return mask;
   if (mask.type === "array") {
     return {
       type: "array",
@@ -982,7 +1060,9 @@ function alignConciseProjectionMask(
   source: JSONSchema | undefined,
   mask: ProjectionMask,
 ): ProjectionMask {
-  if (mask === true || source === undefined || source === true) return mask;
+  if (
+    typeof mask === "boolean" || source === undefined || source === true
+  ) return mask;
 
   if (schemaMayBeArray(source)) {
     const sourceItem = schemaAtArrayItem(source);
@@ -1089,6 +1169,9 @@ export function mergeMasks(
   right: ProjectionMask,
 ): ProjectionMask {
   if (left === true || right === true) return true;
+  // A union: a position the projection declines still has to be read when the
+  // predicate observes it.
+  if (right === false) return left;
   if (right.type === "array") {
     return {
       type: "array",
@@ -1119,6 +1202,9 @@ export function selectSourceSchema(
   mask: ProjectionMask,
   purpose: "source-read" | "projected-output" = "source-read",
 ): JSONSchema {
+  // A rejecting mask is the whole answer wherever it appears: nothing is read
+  // at this position, whatever the source declares there.
+  if (mask === false) return false;
   // An absent/wildcard source schema cannot prove that a structural mask has
   // the same container shape as the current value. Keep that read permissive;
   // the materializing projector still applies the mask and drops siblings.
@@ -1306,6 +1392,95 @@ function resolveProjection(
   };
 }
 
+/**
+ * Helper for {@link composeLinkAddresses}, which renders the address of the
+ * position `cell` names. The link a position holds is stored in the document
+ * that contains it, so this reads no further than a document the selection
+ * has already read: `lastNode: "top"` stops at the stored link rather than
+ * following it.
+ *
+ * A position holding an inline value rather than a link renders where that
+ * value lives, which is the position's own address. `space` and `scope` come
+ * from the containing document when the stored link leaves them implicit, so
+ * both are always filled in.
+ */
+function renderedLinkAddress(cell: Cell<unknown>): RenderedLinkAddress {
+  const position = cell.getAsNormalizedFullLink();
+  const stored = cell.getRaw({ lastNode: "top" });
+  const link = parseLink(stored, position) ?? position;
+  return {
+    id: link.id,
+    space: link.space,
+    scope: link.scope,
+    path: [...link.path],
+  };
+}
+
+/**
+ * Helper for {@link composeLinkAddresses}, which reads the container stored at
+ * `cell` so a marked collection can be walked element by element. Pulls the
+ * container's own document when the selection's read stopped above it, which
+ * is what a marked collection's rejecting selector does.
+ */
+async function storedContainer(cell: Cell<unknown>): Promise<unknown> {
+  const stored = cell.getRaw({ lastNode: "value" });
+  if (stored !== undefined) return stored;
+  await cell.asSchema(false).pull();
+  return cell.getRaw({ lastNode: "value" });
+}
+
+/**
+ * Composes the addresses a selection's `$link` markers asked for into
+ * `projected`, the value its projection produced.
+ *
+ * A marked position renders `{"$link": <address>}`. Where the same position
+ * also projected contents, the address joins them in one object, because both
+ * were asked for. Where those contents are not an object there is nothing to
+ * join them to, and the address is the whole answer.
+ */
+async function composeLinkAddresses(
+  cell: Cell<unknown>,
+  markers: LinkMarkers,
+  projected: unknown,
+): Promise<unknown> {
+  let composed = projected;
+  if (markers.items !== undefined) {
+    const stored = await storedContainer(cell);
+    if (Array.isArray(stored)) {
+      const projectedItems = Array.isArray(projected) ? projected : [];
+      const items: unknown[] = [];
+      for (let index = 0; index < stored.length; index++) {
+        items.push(
+          await composeLinkAddresses(
+            cell.key(index),
+            markers.items,
+            projectedItems[index],
+          ),
+        );
+      }
+      composed = items;
+    }
+  } else if (markers.properties !== undefined) {
+    const projectedRecord = isRecord(projected) && !Array.isArray(projected)
+      ? projected
+      : {};
+    const record: Record<string, unknown> = { ...projectedRecord };
+    for (const [key, child] of Object.entries(markers.properties)) {
+      record[key] = await composeLinkAddresses(
+        cell.key(key),
+        child,
+        projectedRecord[key],
+      );
+    }
+    composed = record;
+  }
+  if (markers.marked !== true) return composed;
+  const address = { [LINK_MARKER_KEY]: renderedLinkAddress(cell) };
+  return isRecord(composed) && !Array.isArray(composed)
+    ? { ...address, ...composed }
+    : address;
+}
+
 /** Optional hooks into {@link deriveSelectedValue}'s internals. */
 export interface DeriveSelectedValueDependencies {
   /** Called with the cell the returned value was read from. */
@@ -1328,6 +1503,13 @@ export interface DeriveSelectedValueDependencies {
  * widening back to a broader linked target. Caller schemas describe output
  * shape only; source schemas remain authoritative for CFC and other Fabric
  * metadata.
+ *
+ * A `$link` marker is answered beside that graph rather than through it: the
+ * marked position contributes the rejecting selector to the read, so nothing
+ * behind it is loaded, and its address is composed in from the link stored at
+ * that position. That composition walks the source, which a `--filter` makes
+ * unavailable — the elements a predicate keeps cannot be traced back to the
+ * positions they came from — so the two are refused together.
  */
 export async function deriveSelectedValue(
   runtime: Runtime,
@@ -1336,6 +1518,14 @@ export async function deriveSelectedValue(
   selection: CellSelection,
   deps: DeriveSelectedValueDependencies = {},
 ): Promise<unknown> {
+  const markers = selection.projection?.markers;
+  if (selection.filter !== undefined && markers !== undefined) {
+    throw new CellSelectionError(
+      `--filter cannot be combined with a "${LINK_MARKER_KEY}" projection: a ` +
+        "filtered array's elements no longer say which positions they came " +
+        "from, and an address names a position",
+    );
+  }
   const declaredSourceSchema = sourceCell.schema;
   const sourceSchema = isRecord(declaredSourceSchema) &&
       declaredSourceSchema.asCell !== undefined
@@ -1362,6 +1552,13 @@ export async function deriveSelectedValue(
     sourceSchema,
     sourceIsArray,
   );
+  if (markers !== undefined && projection?.mask === false) {
+    // The whole selection was addresses. There is no value to compute, so the
+    // pattern graph would run over the rejecting selector and produce nothing
+    // for the composition to join. Read the stored links and answer.
+    await sourceValueCell.asSchema(false).pull();
+    return await composeLinkAddresses(sourceValueCell, markers, undefined);
+  }
   const sourceItemSchema = schemaAtArrayItem(sourceSchema);
   const predicateItemMask = selection.filter === undefined
     ? undefined
@@ -1604,7 +1801,9 @@ export async function deriveSelectedValue(
       );
     }
     deps.onOutputCell?.(outputCell);
-    return outputValue;
+    return markers === undefined
+      ? outputValue
+      : await composeLinkAddresses(sourceValueCell, markers, outputValue);
   } finally {
     runtime.runner.stop(resultCell);
   }

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -61,6 +61,11 @@ const LINK_MARKER_KEY = "$link";
  * scheme, because the scheme is the kind and dropping it retargets the
  * address silently; `path` is `[]` at a document's root.
  *
+ * The address names the deepest stored link crossed on the way to the marked
+ * position, plus the segments below that link. A link is a durable identity
+ * and a position in a containing document is not: reorder the collection
+ * above it and the same position holds a different value.
+ *
  * `overwrite` is dropped and `schema` is never inlined. A stored link can
  * carry an entire schema with its own `$defs`, and what was asked for is
  * where the value lives, not what shape it declares.
@@ -1393,40 +1398,98 @@ function resolveProjection(
 }
 
 /**
- * Helper for {@link composeLinkAddresses}, which renders the address of the
- * position `cell` names. The link a position holds is stored in the document
- * that contains it, so this reads no further than a document the selection
- * has already read: `lastNode: "top"` stops at the stored link rather than
- * following it.
+ * A position the address walk has reached, and what a marker there renders.
  *
- * A position holding an inline value rather than a link renders where that
- * value lives, which is the position's own address. `space` and `scope` come
- * from the containing document when the stored link leaves them implicit, so
- * both are always filled in.
+ * `address` is the deepest stored link the walk has crossed, plus the segments
+ * below that link. `stored` is what the document containing this position
+ * holds at it, and is absent below a crossed link: that link's target is a
+ * document the walk does not read, so it can see no link stored inside it.
  */
-function renderedLinkAddress(cell: Cell<unknown>): RenderedLinkAddress {
-  const position = cell.getAsNormalizedFullLink();
-  const stored = cell.getRaw({ lastNode: "top" });
-  const link = parseLink(stored, position) ?? position;
+interface WalkedPosition {
+  cell: Cell<unknown>;
+  address: RenderedLinkAddress;
+  stored?: { value: unknown };
+}
+
+/** The address `link` names, in the shape a marked position renders. */
+function renderedLinkAddress(link: NormalizedFullLink): RenderedLinkAddress {
   return {
     id: link.id,
     space: link.space,
     scope: link.scope,
-    path: [...link.path],
+    path: link.path.map((segment) => segment.toString()),
   };
 }
 
 /**
- * Helper for {@link composeLinkAddresses}, which reads the container stored at
- * `cell` so a marked collection can be walked element by element. Pulls the
- * container's own document when the selection's read stopped above it, which
- * is what a marked collection's rejecting selector does.
+ * Helper for {@link composeLinkAddresses}: the position `cell` names, carrying
+ * `address` from the walk above it unless the containing document stores a
+ * link there. A stored link is a durable identity, so it becomes the address
+ * this position renders and the base everything below it is addressed from.
+ *
+ * `space` and `scope` come from the containing document when the stored link
+ * leaves them implicit, so both are always filled in.
  */
-async function storedContainer(cell: Cell<unknown>): Promise<unknown> {
-  const stored = cell.getRaw({ lastNode: "value" });
+function walkedPosition(
+  cell: Cell<unknown>,
+  address: RenderedLinkAddress,
+  stored: { value: unknown } | undefined,
+): WalkedPosition {
+  const link = stored === undefined
+    ? undefined
+    : parseLink(stored.value, address);
+  return link === undefined
+    ? { cell, address, stored }
+    : { cell, address: renderedLinkAddress(link), stored: undefined };
+}
+
+/**
+ * Helper for {@link composeLinkAddresses}: the position the walk reaches by
+ * one more segment. `container` is what the document stores at the position
+ * above, which is where the segment's own stored value comes from — so the
+ * link a segment holds is read out of a document the selection already read,
+ * rather than by following anything.
+ */
+function positionBelow(
+  position: WalkedPosition,
+  segment: string | number,
+  container: unknown,
+): WalkedPosition {
+  const key = segment.toString();
+  return walkedPosition(
+    position.cell.key(key),
+    { ...position.address, path: [...position.address.path, key] },
+    isRecord(container) ? { value: container[key] } : undefined,
+  );
+}
+
+/**
+ * Helper for {@link composeLinkAddresses}: the position a composition starts
+ * from, which is the cell the selection read. `lastNode: "top"` stops at a
+ * link stored at that cell rather than following it, so a source that holds
+ * one is addressed by it, exactly as any position below is.
+ */
+function sourcePosition(cell: Cell<unknown>): WalkedPosition {
+  return walkedPosition(
+    cell,
+    renderedLinkAddress(cell.getAsNormalizedFullLink()),
+    { value: cell.getRaw({ lastNode: "top" }) },
+  );
+}
+
+/**
+ * Helper for {@link composeLinkAddresses}, which reads the container stored at
+ * `position` so a marked collection can be walked element by element. Reaches
+ * for the container's own document when the walk cannot see the container:
+ * behind a link, or where the selection's read stopped above it, which is what
+ * a marked collection's rejecting selector does.
+ */
+async function storedContainer(position: WalkedPosition): Promise<unknown> {
+  if (position.stored?.value !== undefined) return position.stored.value;
+  const stored = position.cell.getRaw({ lastNode: "value" });
   if (stored !== undefined) return stored;
-  await cell.asSchema(false).pull();
-  return cell.getRaw({ lastNode: "value" });
+  await position.cell.asSchema(false).pull();
+  return position.cell.getRaw({ lastNode: "value" });
 }
 
 /**
@@ -1439,20 +1502,20 @@ async function storedContainer(cell: Cell<unknown>): Promise<unknown> {
  * join them to, and the address is the whole answer.
  */
 async function composeLinkAddresses(
-  cell: Cell<unknown>,
+  position: WalkedPosition,
   markers: LinkMarkers,
   projected: unknown,
 ): Promise<unknown> {
   let composed = projected;
   if (markers.items !== undefined) {
-    const stored = await storedContainer(cell);
+    const stored = await storedContainer(position);
     if (Array.isArray(stored)) {
       const projectedItems = Array.isArray(projected) ? projected : [];
       const items: unknown[] = [];
       for (let index = 0; index < stored.length; index++) {
         items.push(
           await composeLinkAddresses(
-            cell.key(index),
+            positionBelow(position, index, stored),
             markers.items,
             projectedItems[index],
           ),
@@ -1467,7 +1530,7 @@ async function composeLinkAddresses(
     const record: Record<string, unknown> = { ...projectedRecord };
     for (const [key, child] of Object.entries(markers.properties)) {
       record[key] = await composeLinkAddresses(
-        cell.key(key),
+        positionBelow(position, key, position.stored?.value),
         child,
         projectedRecord[key],
       );
@@ -1475,7 +1538,12 @@ async function composeLinkAddresses(
     composed = record;
   }
   if (markers.marked !== true) return composed;
-  const address = { [LINK_MARKER_KEY]: renderedLinkAddress(cell) };
+  const address = {
+    [LINK_MARKER_KEY]: {
+      ...position.address,
+      path: [...position.address.path],
+    },
+  };
   return isRecord(composed) && !Array.isArray(composed)
     ? { ...address, ...composed }
     : address;
@@ -1506,10 +1574,11 @@ export interface DeriveSelectedValueDependencies {
  *
  * A `$link` marker is answered beside that graph rather than through it: the
  * marked position contributes the rejecting selector to the read, so nothing
- * behind it is loaded, and its address is composed in from the link stored at
- * that position. That composition walks the source, which a `--filter` makes
- * unavailable — the elements a predicate keeps cannot be traced back to the
- * positions they came from — so the two are refused together.
+ * behind it is loaded, and its address is composed in from the deepest link
+ * the walk down to it crosses, plus the segments below that link. That
+ * composition walks the source, which a `--filter` makes unavailable — the
+ * elements a predicate keeps cannot be traced back to the positions they came
+ * from — so the two are refused together.
  */
 export async function deriveSelectedValue(
   runtime: Runtime,
@@ -1557,7 +1626,11 @@ export async function deriveSelectedValue(
     // pattern graph would run over the rejecting selector and produce nothing
     // for the composition to join. Read the stored links and answer.
     await sourceValueCell.asSchema(false).pull();
-    return await composeLinkAddresses(sourceValueCell, markers, undefined);
+    return await composeLinkAddresses(
+      sourcePosition(sourceValueCell),
+      markers,
+      undefined,
+    );
   }
   const sourceItemSchema = schemaAtArrayItem(sourceSchema);
   const predicateItemMask = selection.filter === undefined
@@ -1801,9 +1874,11 @@ export async function deriveSelectedValue(
       );
     }
     deps.onOutputCell?.(outputCell);
-    return markers === undefined
-      ? outputValue
-      : await composeLinkAddresses(sourceValueCell, markers, outputValue);
+    return markers === undefined ? outputValue : await composeLinkAddresses(
+      sourcePosition(sourceValueCell),
+      markers,
+      outputValue,
+    );
   } finally {
     runtime.runner.stop(resultCell);
   }

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -1,3 +1,10 @@
+/**
+ * The selection a CLI read applies to a cell it has already arrived at: the
+ * `--filter` predicate and the `--schema` projection, their parsers, and the
+ * step that turns a cell plus a selection into a value. Resolving an address
+ * to a cell belongs to whoever holds the address, and stays there.
+ */
+
 import type { Cell } from "@commonfabric/api";
 import {
   ContextualFlowControl,
@@ -14,44 +21,65 @@ import { runtimeErrorLog } from "./callable.ts";
 
 type PredicateComparisonOperator = "==" | "!=" | "<" | "<=" | ">" | ">=";
 
-export type PieceGetPredicate =
+/** A parsed `--filter` expression, evaluated against one array element. */
+export type SelectionPredicate =
   | { kind: "literal"; value: string | number | boolean | null }
   | { kind: "path"; path: Array<string | number> }
-  | { kind: "not"; value: PieceGetPredicate }
+  | { kind: "not"; value: SelectionPredicate }
   | {
     kind: "boolean";
     operator: "and" | "or";
-    left: PieceGetPredicate;
-    right: PieceGetPredicate;
+    left: SelectionPredicate;
+    right: SelectionPredicate;
   }
   | {
     kind: "comparison";
     operator: PredicateComparisonOperator;
-    left: PieceGetPredicate;
-    right: PieceGetPredicate;
+    left: SelectionPredicate;
+    right: SelectionPredicate;
   };
 
-export interface ParsedPieceGetFilter {
+/**
+ * A `--filter` argument, parsed. `source` is the text as written, kept for
+ * error messages and for the result cell's cause. `paths` collects every path
+ * the predicate reads, which narrows the schema the source is read through.
+ */
+export interface ParsedSelectionFilter {
   source: string;
-  predicate: PieceGetPredicate;
+  predicate: SelectionPredicate;
   paths: Array<Array<string | number>>;
 }
 
-export interface PieceGetProjection {
+/**
+ * A `--schema` argument, parsed. `source` is the text as written; `kind`
+ * records which of the two spellings it used, since a concise field list
+ * traverses arrays implicitly and a JSON Schema does not.
+ */
+export interface SelectionProjection {
   source: string;
   schema: JSONSchema;
   kind: "concise" | "json";
 }
 
-export interface PieceGetTransform {
-  filter?: ParsedPieceGetFilter;
-  projection?: PieceGetProjection;
+/**
+ * What a caller asked to be returned from the cell it selected. Both parts are
+ * optional; a selection with neither returns the whole value.
+ */
+export interface CellSelection {
+  filter?: ParsedSelectionFilter;
+  projection?: SelectionProjection;
 }
 
-export class PieceGetTransformError extends Error {
+/**
+ * A selection that cannot be parsed, or that does not fit the value it was
+ * pointed at — a `--filter` on a non-array, a `--schema` whose root shape
+ * disagrees with the source. Reported to the user as a data error, not as an
+ * argument-parsing failure.
+ */
+export class CellSelectionError extends Error {
   constructor(message: string, options?: ErrorOptions) {
     super(message, options);
-    this.name = "PieceGetTransformError";
+    this.name = "CellSelectionError";
   }
 }
 
@@ -74,7 +102,7 @@ interface Token {
 }
 
 function expressionError(source: string, position: number, message: string) {
-  return new PieceGetTransformError(
+  return new CellSelectionError(
     `Invalid --filter predicate at column ${position + 1}: ${message}\n` +
       `  ${source}`,
   );
@@ -175,7 +203,7 @@ class PredicateParser {
     private readonly tokens: Token[],
   ) {}
 
-  parse(): PieceGetPredicate {
+  parse(): SelectionPredicate {
     const result = this.#parseOr();
     const trailing = this.#peek();
     if (trailing.kind !== "eof") {
@@ -213,7 +241,7 @@ class PredicateParser {
     return false;
   }
 
-  #parseOr(): PieceGetPredicate {
+  #parseOr(): SelectionPredicate {
     let left = this.#parseAnd();
     while (this.#takeKeyword("or")) {
       left = {
@@ -226,7 +254,7 @@ class PredicateParser {
     return left;
   }
 
-  #parseAnd(): PieceGetPredicate {
+  #parseAnd(): SelectionPredicate {
     let left = this.#parseComparison();
     while (this.#takeKeyword("and")) {
       left = {
@@ -239,7 +267,7 @@ class PredicateParser {
     return left;
   }
 
-  #parseComparison(): PieceGetPredicate {
+  #parseComparison(): SelectionPredicate {
     const left = this.#parseUnary();
     const token = this.#peek();
     if (token.kind !== "operator") return left;
@@ -252,14 +280,14 @@ class PredicateParser {
     };
   }
 
-  #parseUnary(): PieceGetPredicate {
+  #parseUnary(): SelectionPredicate {
     if (this.#takeKeyword("not")) {
       return { kind: "not", value: this.#parseUnary() };
     }
     return this.#parsePrimary();
   }
 
-  #parsePrimary(): PieceGetPredicate {
+  #parsePrimary(): SelectionPredicate {
     const token = this.#peek();
     if (token.kind === "left-paren") {
       this.#take();
@@ -295,7 +323,7 @@ class PredicateParser {
     );
   }
 
-  #parsePath(): PieceGetPredicate {
+  #parsePath(): SelectionPredicate {
     this.#take();
     const path: Array<string | number> = [];
     const first = this.#peek();
@@ -339,7 +367,7 @@ class PredicateParser {
 }
 
 function collectPredicatePaths(
-  predicate: PieceGetPredicate,
+  predicate: SelectionPredicate,
   result: Array<Array<string | number>>,
 ): void {
   switch (predicate.kind) {
@@ -359,9 +387,9 @@ function collectPredicatePaths(
   }
 }
 
-export function parsePieceGetFilter(source: string): ParsedPieceGetFilter {
+export function parseSelectionFilter(source: string): ParsedSelectionFilter {
   if (source.trim().length === 0) {
-    throw new PieceGetTransformError("--filter predicate must not be empty");
+    throw new CellSelectionError("--filter predicate must not be empty");
   }
   const predicate = new PredicateParser(
     source,
@@ -413,7 +441,7 @@ function comparePredicateValues(
     (typeof left !== "number" || typeof right !== "number") &&
     (typeof left !== "string" || typeof right !== "string")
   ) {
-    throw new PieceGetTransformError(
+    throw new CellSelectionError(
       `--filter ${operator} requires two numbers or two strings`,
     );
   }
@@ -429,11 +457,11 @@ function comparePredicateValues(
   }
 }
 
-export function evaluatePieceGetPredicate(
-  predicate: PieceGetPredicate,
+export function evaluateSelectionPredicate(
+  predicate: SelectionPredicate,
   value: unknown,
 ): boolean {
-  const evaluate = (node: PieceGetPredicate): unknown => {
+  const evaluate = (node: SelectionPredicate): unknown => {
     switch (node.kind) {
       case "literal":
         return node.value;
@@ -490,24 +518,24 @@ function normalizeProjectionSchema(
 ): JSONSchema {
   if (schema === true) return true;
   if (schema === false) {
-    throw new PieceGetTransformError(
+    throw new CellSelectionError(
       `Invalid --schema at ${path}: false cannot project a value`,
     );
   }
   if (!isRecord(schema) || Array.isArray(schema)) {
-    throw new PieceGetTransformError(
+    throw new CellSelectionError(
       `Invalid --schema at ${path}: expected a JSON Schema object`,
     );
   }
   for (const key of Object.keys(schema)) {
     if (FORBIDDEN_PROJECTION_KEYS.has(key)) {
-      throw new PieceGetTransformError(
+      throw new CellSelectionError(
         `Invalid --schema at ${path}: "${key}" is controlled by the source ` +
           "schema and cannot be supplied by a projection",
       );
     }
     if (UNSUPPORTED_PROJECTION_KEYS.has(key)) {
-      throw new PieceGetTransformError(
+      throw new CellSelectionError(
         `Invalid --schema at ${path}: "${key}" is not supported by projection schemas`,
       );
     }
@@ -516,7 +544,7 @@ function normalizeProjectionSchema(
   const result: Record<string, unknown> = { ...schema };
   if (schema.properties !== undefined) {
     if (!isRecord(schema.properties) || Array.isArray(schema.properties)) {
-      throw new PieceGetTransformError(
+      throw new CellSelectionError(
         `Invalid --schema at ${path}: "properties" must be an object`,
       );
     }
@@ -553,7 +581,7 @@ function normalizeProjectionSchema(
 function conciseProjectionSchema(source: string): JSONSchema {
   const paths = source.split(",").map((part) => part.trim());
   if (paths.some((path) => path.length === 0)) {
-    throw new PieceGetTransformError(
+    throw new CellSelectionError(
       "Invalid --schema concise projection: expected comma-separated field paths",
     );
   }
@@ -563,7 +591,7 @@ function conciseProjectionSchema(source: string): JSONSchema {
     if (
       segments.some((segment) => !/^[A-Za-z_$][A-Za-z0-9_$-]*$/.test(segment))
     ) {
-      throw new PieceGetTransformError(
+      throw new CellSelectionError(
         `Invalid --schema field path ${JSON.stringify(path)}`,
       );
     }
@@ -600,19 +628,19 @@ export interface ProjectionParseDependencies {
   readTextFile?: (path: string) => Promise<string>;
 }
 
-export async function parsePieceGetProjection(
+export async function parseSelectionProjection(
   source: string,
   deps: ProjectionParseDependencies = {},
-): Promise<PieceGetProjection> {
+): Promise<SelectionProjection> {
   const trimmed = source.trim();
   if (trimmed.length === 0) {
-    throw new PieceGetTransformError("--schema must not be empty");
+    throw new CellSelectionError("--schema must not be empty");
   }
 
   if (trimmed.startsWith("@")) {
     const path = trimmed.slice(1);
     if (path.length === 0) {
-      throw new PieceGetTransformError(
+      throw new CellSelectionError(
         "--schema @file requires a file path",
       );
     }
@@ -620,7 +648,7 @@ export async function parsePieceGetProjection(
     try {
       contents = await (deps.readTextFile ?? Deno.readTextFile)(path);
     } catch (error) {
-      throw new PieceGetTransformError(
+      throw new CellSelectionError(
         `Could not read --schema file "${path}": ${
           error instanceof Error ? error.message : String(error)
         }`,
@@ -631,7 +659,7 @@ export async function parsePieceGetProjection(
     try {
       parsed = JSON.parse(contents);
     } catch (error) {
-      throw new PieceGetTransformError(
+      throw new CellSelectionError(
         `Invalid JSON in --schema file "${path}": ${
           error instanceof Error ? error.message : String(error)
         }`,
@@ -650,7 +678,7 @@ export async function parsePieceGetProjection(
     try {
       parsed = JSON.parse(trimmed);
     } catch (error) {
-      throw new PieceGetTransformError(
+      throw new CellSelectionError(
         `Invalid JSON passed to --schema: ${
           error instanceof Error ? error.message : String(error)
         }`,
@@ -669,6 +697,26 @@ export async function parsePieceGetProjection(
     schema: conciseProjectionSchema(trimmed),
     kind: "concise",
   };
+}
+
+/**
+ * Parses a command's `--filter` and `--schema` arguments into the selection
+ * they describe, or `undefined` when neither was given and the caller wants
+ * the whole value.
+ */
+export async function parseCellSelectionOptions(options: {
+  filter?: string;
+  schema?: string;
+}): Promise<CellSelection | undefined> {
+  const filter = options.filter === undefined
+    ? undefined
+    : parseSelectionFilter(options.filter);
+  const projection = options.schema === undefined
+    ? undefined
+    : await parseSelectionProjection(options.schema);
+  return filter === undefined && projection === undefined
+    ? undefined
+    : { filter, projection };
 }
 
 function schemaTypes(schema: JSONSchema | undefined): string[] {
@@ -917,7 +965,7 @@ export function schemaMayBeArray(
       // Unlike root classification, concise-path alignment cannot safely
       // continue without resolving the schema that determines array traversal.
       unresolvedRef: (error) => {
-        throw new PieceGetTransformError(
+        throw new CellSelectionError(
           `Could not resolve source schema reference for --schema: ${
             error instanceof Error ? error.message : String(error)
           }`,
@@ -1181,7 +1229,7 @@ interface ResolvedProjection {
 }
 
 function resolveProjection(
-  projection: PieceGetProjection | undefined,
+  projection: SelectionProjection | undefined,
   sourceSchema: JSONSchema | undefined,
   sourceIsArray: boolean,
 ): ResolvedProjection | undefined {
@@ -1231,7 +1279,7 @@ function resolveProjection(
     projection.schema !== true &&
     sourceIsArray !== projectsArrayItems
   ) {
-    throw new PieceGetTransformError(
+    throw new CellSelectionError(
       sourceIsArray
         ? "A JSON --schema for an array value must describe the returned " +
           'array (for example {"type":"array","items":{...}}).'
@@ -1258,12 +1306,19 @@ function resolveProjection(
   };
 }
 
-export interface DerivePieceGetDependencies {
+/** Optional hooks into {@link deriveSelectedValue}'s internals. */
+export interface DeriveSelectedValueDependencies {
+  /** Called with the cell the returned value was read from. */
   onOutputCell?: (cell: Cell<unknown>) => void;
 }
 
 /**
- * Apply a piece-get filter/projection through an actual runtime pattern graph.
+ * Applies `selection` to `sourceCell` through an actual runtime pattern graph,
+ * returning the value the caller asked for.
+ *
+ * `runtime` and `space` say where that pattern runs, and are the caller's to
+ * decide rather than the cell's: a path that crosses a link can land
+ * `sourceCell` in a space other than the one its reader is working in.
  *
  * The filter uses the runner's list builtin, so predicate observations taint
  * collection membership exactly as they do in authored patterns. Array
@@ -1274,12 +1329,12 @@ export interface DerivePieceGetDependencies {
  * shape only; source schemas remain authoritative for CFC and other Fabric
  * metadata.
  */
-export async function derivePieceGetValue(
+export async function deriveSelectedValue(
   runtime: Runtime,
   space: MemorySpace,
   sourceCell: Cell<unknown>,
-  transform: PieceGetTransform,
-  deps: DerivePieceGetDependencies = {},
+  selection: CellSelection,
+  deps: DeriveSelectedValueDependencies = {},
 ): Promise<unknown> {
   const declaredSourceSchema = sourceCell.schema;
   const sourceSchema = isRecord(declaredSourceSchema) &&
@@ -1289,7 +1344,7 @@ export async function derivePieceGetValue(
   const sourceValueCell = sourceSchema === declaredSourceSchema
     ? sourceCell
     : sourceCell.asSchema(sourceSchema);
-  if (transform.filter === undefined && transform.projection === undefined) {
+  if (selection.filter === undefined && selection.projection === undefined) {
     return await sourceValueCell.pull();
   }
 
@@ -1297,30 +1352,30 @@ export async function derivePieceGetValue(
   const sourceIsArray = rootKind === "unknown"
     ? Array.isArray(await sourceValueCell.pull())
     : rootKind === "array";
-  if (transform.filter !== undefined && !sourceIsArray) {
-    throw new PieceGetTransformError(
+  if (selection.filter !== undefined && !sourceIsArray) {
+    throw new CellSelectionError(
       "--filter can only be applied to an array",
     );
   }
   const projection = resolveProjection(
-    transform.projection,
+    selection.projection,
     sourceSchema,
     sourceIsArray,
   );
   const sourceItemSchema = schemaAtArrayItem(sourceSchema);
-  const predicateItemMask = transform.filter === undefined
+  const predicateItemMask = selection.filter === undefined
     ? undefined
-    : maskFromPaths(transform.filter.paths);
+    : maskFromPaths(selection.filter.paths);
   const projectionMaskSchema = projection?.mask;
   const projectionItemMask = projection?.itemMask;
 
   let sourceMask: ProjectionMask = true;
-  if (transform.filter !== undefined && projection === undefined) {
+  if (selection.filter !== undefined && projection === undefined) {
     // Filtering returns original elements. Keep their complete source schema
     // on the links that survive, while the predicate pattern below narrows the
     // actual predicate reads.
     sourceMask = true;
-  } else if (transform.filter !== undefined) {
+  } else if (selection.filter !== undefined) {
     sourceMask = {
       type: "array",
       items: mergeMasks(
@@ -1345,7 +1400,7 @@ export async function derivePieceGetValue(
   };
 
   let predicatePattern: ReturnType<typeof pattern> | undefined;
-  if (transform.filter !== undefined) {
+  if (selection.filter !== undefined) {
     const elementSchema = selectSourceSchema(
       sourceItemSchema,
       predicateItemMask!,
@@ -1365,8 +1420,8 @@ export async function derivePieceGetValue(
     const predicateModule = lift(
       ({ element, params }: {
         element: unknown;
-        params: { predicate: PieceGetPredicate };
-      }) => evaluatePieceGetPredicate(params.predicate, element),
+        params: { predicate: SelectionPredicate };
+      }) => evaluateSelectionPredicate(params.predicate, element),
       argumentSchema,
       { type: "boolean" },
     );
@@ -1457,7 +1512,7 @@ export async function derivePieceGetValue(
       let result: any = value;
       if (predicatePattern !== undefined) {
         result = result.filterWithPattern(predicatePattern as any, {
-          predicate: transform.filter!.predicate,
+          predicate: selection.filter!.predicate,
         });
       }
       if (itemProjectionPattern !== undefined) {
@@ -1477,8 +1532,8 @@ export async function derivePieceGetValue(
     {
       pieceGetTransform: {
         source: sourceValueCell.getAsNormalizedFullLink(),
-        filter: transform.filter?.source,
-        schema: transform.projection?.source,
+        filter: selection.filter?.source,
+        schema: selection.projection?.source,
       },
     },
     mainResultSchema,
@@ -1506,7 +1561,7 @@ export async function derivePieceGetValue(
     runtime.prepareTxForCommit(tx);
     const committed = await tx.commit();
     if (committed.error !== undefined) {
-      throw new PieceGetTransformError(
+      throw new CellSelectionError(
         `Could not apply piece get transform: ${committed.error}`,
       );
     }
@@ -1524,12 +1579,12 @@ export async function derivePieceGetValue(
       // test in piece-get-transform.test.ts guards this package-boundary
       // coupling.
       if (
-        transform.filter !== undefined &&
+        selection.filter !== undefined &&
         recorded.some((error) =>
           error.message === "filter currently only supports arrays"
         )
       ) {
-        throw new PieceGetTransformError(
+        throw new CellSelectionError(
           "--filter can only be applied to an array",
         );
       }
@@ -1539,12 +1594,12 @@ export async function derivePieceGetValue(
           error.message === "map currently only supports arrays"
         )
       ) {
-        throw new PieceGetTransformError(
+        throw new CellSelectionError(
           "--schema can only project array items from an array value",
         );
       }
       const lastError = recorded.at(-1)!;
-      throw new PieceGetTransformError(
+      throw new CellSelectionError(
         `Could not apply piece get transform: ${lastError.message}`,
       );
     }

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -75,10 +75,10 @@ import { deriveDiskHandleId } from "./sqlite-source.ts";
 import { startVersionCheck } from "./version-check.ts";
 import { stderrConsoleHandler } from "./json-output.ts";
 import {
-  derivePieceGetValue,
-  type PieceGetTransform,
-  PieceGetTransformError,
-} from "./piece-get-transform.ts";
+  type CellSelection,
+  CellSelectionError,
+  deriveSelectedValue,
+} from "./cell-selection.ts";
 
 export interface EntryConfig {
   mainPath: string;
@@ -114,7 +114,7 @@ export interface SetPiecePatternOptions {
 export interface GetCellValueOptions {
   input?: boolean;
   step?: boolean;
-  transform?: PieceGetTransform;
+  selection?: CellSelection;
 }
 
 /** A `cf piece get` path that lands ON a verb. Reading a verb returns the
@@ -223,7 +223,7 @@ interface PieceOperationDependencies extends PieceResolutionDeps {
     source: "input data" | "result data" | "metadata",
     error: unknown,
   ) => void;
-  derivePieceGetValue?: typeof derivePieceGetValue;
+  deriveSelectedValue?: typeof deriveSelectedValue;
 }
 
 const CLI_TRACE_TIMINGS = Deno.env.get("CF_CLI_TRACE_TIMINGS") === "1";
@@ -2343,16 +2343,16 @@ export async function getCellValue(
     }
 
     const prop = options.input ? "input" : "result";
-    if (options.transform !== undefined) {
+    if (options.selection !== undefined) {
       const rootCell = await piece[prop].getCell();
       const targetCell = rootCell.key(...path);
-      let transformed: unknown;
+      let selected: unknown;
       try {
-        transformed = await (deps.derivePieceGetValue ?? derivePieceGetValue)(
+        selected = await (deps.deriveSelectedValue ?? deriveSelectedValue)(
           pieces.runtime,
           pieces.getSpace(),
           targetCell,
-          options.transform,
+          options.selection,
         );
       } catch (error) {
         if (
@@ -2369,21 +2369,21 @@ export async function getCellValue(
         }
         throw error;
       }
-      // Read-path guard (verb contract WS-F): the transform path returns
+      // Read-path guard (verb contract WS-F): the selection path returns
       // early, so it needs the same verb refusal the plain read applies
-      // below — a verb read through a transform is the same mistake.
-      const transformPathVerb = await classifyReadPathVerb(piece, prop, path);
-      if (transformPathVerb) {
+      // below — a verb read through a selection is the same mistake.
+      const selectionPathVerb = await classifyReadPathVerb(piece, prop, path);
+      if (selectionPathVerb) {
         throw new PieceVerbReadError(
-          transformPathVerb.verb,
+          selectionPathVerb.verb,
           resolvedConfig.piece,
-          transformPathVerb.callable,
+          selectionPathVerb.callable,
         );
       }
       const sourceWasAbsent = typeof targetCell.getRaw === "function" &&
         targetCell.getRaw() === undefined;
       if (
-        !options.input && transformed === undefined &&
+        !options.input && selected === undefined &&
         await resultProjectionFailedAtPath(piece, path)
       ) {
         throw await verbReadRefusalOrNull(
@@ -2393,15 +2393,15 @@ export async function getCellValue(
           resolvedConfig.piece,
         ) ?? new PieceResultProjectionError(path, shouldStep);
       }
-      if (transformed === undefined && !sourceWasAbsent) {
-        throw new PieceGetTransformError(
+      if (selected === undefined && !sourceWasAbsent) {
+        throw new CellSelectionError(
           "Cannot read transformed value: the filter/schema expression did " +
             "not materialize a JSON-renderable value. This is not JSON " +
             "null. Retry with --step for a computed result, or inspect the " +
             "selected source data and schema.",
         );
       }
-      return transformed;
+      return selected;
     }
 
     let value: unknown;

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -2395,7 +2395,7 @@ export async function getCellValue(
       }
       if (selected === undefined && !sourceWasAbsent) {
         throw new CellSelectionError(
-          "Cannot read transformed value: the filter/schema expression did " +
+          "Cannot read selected value: the filter/schema expression did " +
             "not materialize a JSON-renderable value. This is not JSON " +
             "null. Retry with --step for a computed result, or inspect the " +
             "selected source data and schema.",

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -39,7 +39,7 @@ import {
   WaitBoundExpired,
 } from "../commands/piece.ts";
 import { LinkValidationError } from "../lib/piece.ts";
-import { PieceGetTransformError } from "../lib/piece-get-transform.ts";
+import { CellSelectionError } from "../lib/cell-selection.ts";
 
 describe("executePieceCallable", () => {
   it("reports not-found when the piece cell has no schema-cast surface", async () => {
@@ -3030,12 +3030,12 @@ describe("piece get data errors", () => {
     expect(report?.hint).toBeUndefined();
   });
 
-  it("reports transform failures without an unrelated --input hint", () => {
-    const transformError = new PieceGetTransformError(
+  it("reports selection failures without an unrelated --input hint", () => {
+    const selectionError = new CellSelectionError(
       "--filter can only be applied to an array",
     );
-    expect(isPieceGetDataError(transformError)).toBe(true);
-    const report = pieceGetDataErrorReport(transformError, {
+    expect(isPieceGetDataError(selectionError)).toBe(true);
+    const report = pieceGetDataErrorReport(selectionError, {
       input: false,
       piece: "fid1:piece-123",
     });

--- a/packages/cli/test/piece-get-transform.test.ts
+++ b/packages/cli/test/piece-get-transform.test.ts
@@ -2103,7 +2103,12 @@ describe("cf piece get transforms", () => {
       );
 
       expect(marked).toEqual([boardUri]);
-      expect(boardDocuments(syncedUris)).toEqual(noteUris);
+      // `syncedUris` is a push-order log of concurrent syncs, so which
+      // documents were reached is the fact here and the order they resolved
+      // in is not.
+      expect(boardDocuments(syncedUris).toSorted()).toEqual(
+        noteUris.toSorted(),
+      );
     });
 
     it("returns the address of the position it was read at for a marked root", async () => {

--- a/packages/cli/test/piece-get-transform.test.ts
+++ b/packages/cli/test/piece-get-transform.test.ts
@@ -5,16 +5,16 @@ import { Identity } from "@commonfabric/identity";
 import { type Cell, type JSONSchema, Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import {
-  derivePieceGetValue,
-  evaluatePieceGetPredicate,
+  CellSelectionError,
+  deriveSelectedValue,
+  evaluateSelectionPredicate,
   mergeMasks,
-  parsePieceGetFilter,
-  parsePieceGetProjection,
-  PieceGetTransformError,
+  parseSelectionFilter,
+  parseSelectionProjection,
   schemaMayBeArray,
   schemaRootKind,
   selectSourceSchema,
-} from "../lib/piece-get-transform.ts";
+} from "../lib/cell-selection.ts";
 
 const signer = await Identity.fromPassphrase("cf-piece-get-transform");
 const space = signer.did();
@@ -44,7 +44,7 @@ describe("cf piece get transforms", () => {
   });
 
   it("parses and evaluates jq-inspired predicates", () => {
-    const parsed = parsePieceGetFilter(
+    const parsed = parseSelectionFilter(
       '.status == "open" and (.score >= 10 or .priority == true)',
     );
     expect(parsed.paths).toEqual([
@@ -52,12 +52,12 @@ describe("cf piece get transforms", () => {
       ["score"],
       ["priority"],
     ]);
-    expect(evaluatePieceGetPredicate(parsed.predicate, {
+    expect(evaluateSelectionPredicate(parsed.predicate, {
       status: "open",
       score: 12,
       priority: false,
     })).toBe(true);
-    expect(evaluatePieceGetPredicate(parsed.predicate, {
+    expect(evaluateSelectionPredicate(parsed.predicate, {
       status: "closed",
       score: 12,
       priority: true,
@@ -65,10 +65,10 @@ describe("cf piece get transforms", () => {
   });
 
   it("supports bracket paths, negative indices, and not", () => {
-    const parsed = parsePieceGetFilter(
+    const parsed = parseSelectionFilter(
       'not .disabled and .["tags"][-1] == "current"',
     );
-    expect(evaluatePieceGetPredicate(parsed.predicate, {
+    expect(evaluateSelectionPredicate(parsed.predicate, {
       disabled: false,
       tags: ["old", "current"],
     })).toBe(true);
@@ -93,14 +93,14 @@ describe("cf piece get transforms", () => {
         ".disabled == false",
       ]
     ) {
-      expect(evaluatePieceGetPredicate(
-        parsePieceGetFilter(source).predicate,
+      expect(evaluateSelectionPredicate(
+        parseSelectionFilter(source).predicate,
         value,
       )).toBe(true);
     }
     for (const source of [".disabled", ".nil", ".unset", ".missing"]) {
-      expect(evaluatePieceGetPredicate(
-        parsePieceGetFilter(source).predicate,
+      expect(evaluateSelectionPredicate(
+        parseSelectionFilter(source).predicate,
         value,
       )).toBe(false);
     }
@@ -121,13 +121,13 @@ describe("cf piece get transforms", () => {
         ".tags[-3]",
       ]
     ) {
-      expect(evaluatePieceGetPredicate(
-        parsePieceGetFilter(source).predicate,
+      expect(evaluateSelectionPredicate(
+        parseSelectionFilter(source).predicate,
         value,
       )).toBe(false);
     }
-    expect(evaluatePieceGetPredicate(
-      parsePieceGetFilter(".tags[0]").predicate,
+    expect(evaluateSelectionPredicate(
+      parseSelectionFilter(".tags[0]").predicate,
       value,
     )).toBe(true);
   });
@@ -149,14 +149,14 @@ describe("cf piece get transforms", () => {
         ".tags != null",
       ]
     ) {
-      expect(evaluatePieceGetPredicate(
-        parsePieceGetFilter(source).predicate,
+      expect(evaluateSelectionPredicate(
+        parseSelectionFilter(source).predicate,
         value,
       )).toBe(true);
     }
     expect(() =>
-      evaluatePieceGetPredicate(
-        parsePieceGetFilter(".score > true").predicate,
+      evaluateSelectionPredicate(
+        parseSelectionFilter(".score > true").predicate,
         value,
       )
     ).toThrow("--filter > requires two numbers or two strings");
@@ -177,14 +177,14 @@ describe("cf piece get transforms", () => {
         "unknown",
       ]
     ) {
-      expect(() => parsePieceGetFilter(source)).toThrow(
-        PieceGetTransformError,
+      expect(() => parseSelectionFilter(source)).toThrow(
+        CellSelectionError,
       );
     }
   });
 
   it("parses concise, inline, and file projection schemas", async () => {
-    const concise = await parsePieceGetProjection("id,author.name");
+    const concise = await parseSelectionProjection("id,author.name");
     expect(concise.kind).toBe("concise");
     expect(concise.schema).toEqual({
       type: "object",
@@ -199,7 +199,7 @@ describe("cf piece get transforms", () => {
       additionalProperties: false,
     });
 
-    const inline = await parsePieceGetProjection(
+    const inline = await parseSelectionProjection(
       '{"type":"object","properties":{"title":{"type":"string"}}}',
     );
     expect(inline.schema).toEqual({
@@ -208,7 +208,7 @@ describe("cf piece get transforms", () => {
       additionalProperties: false,
     });
 
-    const fromFile = await parsePieceGetProjection("@projection.json", {
+    const fromFile = await parseSelectionProjection("@projection.json", {
       readTextFile: () =>
         Promise.resolve(
           '{"type":"array","items":{"type":"object","properties":{"id":true}}}',
@@ -227,7 +227,7 @@ describe("cf piece get transforms", () => {
     const path = await Deno.makeTempFile({ suffix: ".json" });
     try {
       await Deno.writeTextFile(path, '{"type":"object"}');
-      expect((await parsePieceGetProjection(`@${path}`)).schema).toEqual({
+      expect((await parseSelectionProjection(`@${path}`)).schema).toEqual({
         type: "object",
         additionalProperties: true,
       });
@@ -389,7 +389,7 @@ describe("cf piece get transforms", () => {
 
   it("collapses overlapping concise paths without exposing siblings", async () => {
     for (const source of ["author,author.name", "author.name,author"]) {
-      expect((await parsePieceGetProjection(source)).schema).toEqual({
+      expect((await parseSelectionProjection(source)).schema).toEqual({
         type: "object",
         properties: { author: true },
         additionalProperties: false,
@@ -398,63 +398,63 @@ describe("cf piece get transforms", () => {
   });
 
   it("validates projection schema roots and nested schema objects", async () => {
-    await expect(parsePieceGetProjection("")).rejects.toThrow(
+    await expect(parseSelectionProjection("")).rejects.toThrow(
       "--schema must not be empty",
     );
-    await expect(parsePieceGetProjection("@")).rejects.toThrow(
+    await expect(parseSelectionProjection("@")).rejects.toThrow(
       "--schema @file requires a file path",
     );
-    await expect(parsePieceGetProjection("@missing.json", {
+    await expect(parseSelectionProjection("@missing.json", {
       readTextFile: () => Promise.reject(new Error("gone")),
     })).rejects.toThrow('Could not read --schema file "missing.json": gone');
-    await expect(parsePieceGetProjection("@bad.json", {
+    await expect(parseSelectionProjection("@bad.json", {
       readTextFile: () => Promise.resolve("{"),
     })).rejects.toThrow('Invalid JSON in --schema file "bad.json"');
-    await expect(parsePieceGetProjection("@array.json", {
+    await expect(parseSelectionProjection("@array.json", {
       readTextFile: () => Promise.resolve("[]"),
     })).rejects.toThrow("expected a JSON Schema object");
-    await expect(parsePieceGetProjection("{")).rejects.toThrow(
+    await expect(parseSelectionProjection("{")).rejects.toThrow(
       "Invalid JSON passed to --schema",
     );
-    await expect(parsePieceGetProjection("false")).rejects.toThrow(
+    await expect(parseSelectionProjection("false")).rejects.toThrow(
       "false cannot project a value",
     );
-    await expect(parsePieceGetProjection(
+    await expect(parseSelectionProjection(
       '{"type":"object","properties":[]}',
     )).rejects.toThrow('"properties" must be an object');
-    await expect(parsePieceGetProjection("a,,b")).rejects.toThrow(
+    await expect(parseSelectionProjection("a,,b")).rejects.toThrow(
       "expected comma-separated field paths",
     );
-    await expect(parsePieceGetProjection("a.0")).rejects.toThrow(
+    await expect(parseSelectionProjection("a.0")).rejects.toThrow(
       "Invalid --schema field path",
     );
   });
 
   it("normalizes identity and additional-property projection schemas", async () => {
-    expect((await parsePieceGetProjection('{"type":"object"}')).schema)
+    expect((await parseSelectionProjection('{"type":"object"}')).schema)
       .toEqual({
         type: "object",
         additionalProperties: true,
       });
     expect(
-      (await parsePieceGetProjection(
+      (await parseSelectionProjection(
         '{"type":"object","additionalProperties":{"type":"string"}}',
       )).schema,
     ).toEqual({
       type: "object",
       additionalProperties: { type: "string" },
     });
-    expect((await parsePieceGetProjection("true")).schema).toBe(true);
+    expect((await parseSelectionProjection("true")).schema).toBe(true);
   });
 
   it("does not let caller projection schemas forge CFC metadata", async () => {
     for (const key of ["asCell", "default", "ifc", "scope"]) {
-      await expect(parsePieceGetProjection(JSON.stringify({
+      await expect(parseSelectionProjection(JSON.stringify({
         type: "object",
         properties: {
           secret: { type: "string", [key]: key === "asCell" ? ["cell"] : {} },
         },
-      }))).rejects.toThrow(PieceGetTransformError);
+      }))).rejects.toThrow(CellSelectionError);
     }
   });
 
@@ -479,7 +479,7 @@ describe("cf piece get transforms", () => {
         "contentSchema",
       ]
     ) {
-      await expect(parsePieceGetProjection(JSON.stringify({
+      await expect(parseSelectionProjection(JSON.stringify({
         type: "object",
         [key]: {},
       }))).rejects.toThrow(`"${key}" is not supported`);
@@ -511,9 +511,9 @@ describe("cf piece get transforms", () => {
     ]);
     expect((await tx.commit()).ok).toBeDefined();
 
-    const result = await derivePieceGetValue(runtime, space, source, {
-      filter: parsePieceGetFilter('.status == "open"'),
-      projection: await parsePieceGetProjection("id,title"),
+    const result = await deriveSelectedValue(runtime, space, source, {
+      filter: parseSelectionFilter('.status == "open"'),
+      projection: await parseSelectionProjection("id,title"),
     });
 
     expect(result).toEqual([
@@ -521,8 +521,8 @@ describe("cf piece get transforms", () => {
       { id: 3, title: "Third" },
     ]);
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        projection: await parsePieceGetProjection(
+      await deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection(
           '{"type":"array","items":{"type":"object","properties":{"id":{"type":"string"},"title":true}}}',
         ),
       }),
@@ -595,9 +595,9 @@ describe("cf piece get transforms", () => {
     }) as typeof provider.sync;
 
     expect(
-      await derivePieceGetValue(runtime, space, sourceRead, {
-        filter: parsePieceGetFilter('.status == "open"'),
-        projection: await parsePieceGetProjection("id,title"),
+      await deriveSelectedValue(runtime, space, sourceRead, {
+        filter: parseSelectionFilter('.status == "open"'),
+        projection: await parseSelectionProjection("id,title"),
       }),
     ).toEqual([{ id: 1, title: "First" }]);
     const initialSelector = sourceSelectors.at(0) as {
@@ -673,9 +673,9 @@ describe("cf piece get transforms", () => {
     expect((await tx.commit()).ok).toBeDefined();
 
     expect(
-      await derivePieceGetValue(runtime, space, container.key("items"), {
-        filter: parsePieceGetFilter(".id == 2"),
-        projection: await parsePieceGetProjection("title"),
+      await deriveSelectedValue(runtime, space, container.key("items"), {
+        filter: parseSelectionFilter(".id == 2"),
+        projection: await parseSelectionProjection("title"),
       }),
     ).toEqual([{ title: "Second" }]);
   });
@@ -732,19 +732,19 @@ describe("cf piece get transforms", () => {
     expect((await tx.commit()).ok).toBeDefined();
 
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        projection: await parsePieceGetProjection("title,createdBy.name"),
+      await deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection("title,createdBy.name"),
       }),
     ).toEqual([{ title: "T1", createdBy: { name: "Sol" } }]);
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        filter: parsePieceGetFilter('.createdBy.name == "Sol"'),
-        projection: await parsePieceGetProjection("title"),
+      await deriveSelectedValue(runtime, space, source, {
+        filter: parseSelectionFilter('.createdBy.name == "Sol"'),
+        projection: await parseSelectionProjection("title"),
       }),
     ).toEqual([{ title: "T1" }]);
     expect(
-      await derivePieceGetValue(runtime, space, direct, {
-        projection: await parsePieceGetProjection("title,createdBy.name"),
+      await deriveSelectedValue(runtime, space, direct, {
+        projection: await parseSelectionProjection("title,createdBy.name"),
       }),
     ).toEqual({ title: "T1", createdBy: { name: "Sol" } });
   });
@@ -780,8 +780,8 @@ describe("cf piece get transforms", () => {
     expect((await tx.commit()).ok).toBeDefined();
 
     expect(
-      await derivePieceGetValue(runtime, space, container.key("topic"), {
-        projection: await parsePieceGetProjection("title"),
+      await deriveSelectedValue(runtime, space, container.key("topic"), {
+        projection: await parseSelectionProjection("title"),
       }),
     ).toEqual({ title: "Visible" });
   });
@@ -805,8 +805,8 @@ describe("cf piece get transforms", () => {
 
     let outputCell: Cell<unknown> | undefined;
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        projection: await parsePieceGetProjection("title"),
+      await deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection("title"),
       }, {
         onOutputCell: (cell) => outputCell = cell,
       }),
@@ -869,9 +869,9 @@ describe("cf piece get transforms", () => {
     expect((await tx.commit()).ok).toBeDefined();
 
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        filter: parsePieceGetFilter(".id == 2"),
-        projection: await parsePieceGetProjection("title"),
+      await deriveSelectedValue(runtime, space, source, {
+        filter: parseSelectionFilter(".id == 2"),
+        projection: await parseSelectionProjection("title"),
       }),
     ).toEqual([{ title: "Second" }]);
   });
@@ -905,8 +905,8 @@ describe("cf piece get transforms", () => {
     }]);
     expect((await tx.commit()).ok).toBeDefined();
 
-    const result = await derivePieceGetValue(runtime, space, source, {
-      projection: await parsePieceGetProjection(
+    const result = await deriveSelectedValue(runtime, space, source, {
+      projection: await parseSelectionProjection(
         "author.name,author.name.first",
       ),
     });
@@ -934,18 +934,18 @@ describe("cf piece get transforms", () => {
     expect((await tx.commit()).ok).toBeDefined();
 
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        projection: await parsePieceGetProjection("id"),
+      await deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection("id"),
       }),
     ).toEqual({ id: 1 });
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        projection: await parsePieceGetProjection("missing"),
+      await deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection("missing"),
       }),
     ).toEqual({});
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        projection: await parsePieceGetProjection(JSON.stringify({
+      await deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection(JSON.stringify({
           type: "object",
           properties: {
             subtitle: { type: ["string", "null"] },
@@ -955,11 +955,11 @@ describe("cf piece get transforms", () => {
       }),
     ).toEqual({ subtitle: null });
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        projection: await parsePieceGetProjection('{"type":"object"}'),
+      await deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection('{"type":"object"}'),
       }),
     ).toEqual({ id: 1, title: "Visible", subtitle: null });
-    expect(await derivePieceGetValue(runtime, space, source, {})).toEqual({
+    expect(await deriveSelectedValue(runtime, space, source, {})).toEqual({
       id: 1,
       title: "Visible",
       subtitle: null,
@@ -1010,8 +1010,8 @@ describe("cf piece get transforms", () => {
       additionalProperties: false,
     };
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        projection: await parsePieceGetProjection(JSON.stringify(projection)),
+      await deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection(JSON.stringify(projection)),
       }),
     ).toEqual({ comments: [{ body: "Hello" }] });
   });
@@ -1036,23 +1036,23 @@ describe("cf piece get transforms", () => {
     source.set([{ name: "a", secret: "hidden" }, null]);
     expect((await tx.commit()).ok).toBeDefined();
 
-    expect(await derivePieceGetValue(runtime, space, source, {})).toEqual([
+    expect(await deriveSelectedValue(runtime, space, source, {})).toEqual([
       { name: "a", secret: "hidden" },
       null,
     ]);
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        filter: parsePieceGetFilter('.name == "a"'),
+      await deriveSelectedValue(runtime, space, source, {
+        filter: parseSelectionFilter('.name == "a"'),
       }),
     ).toEqual([{ name: "a", secret: "hidden" }]);
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        projection: await parsePieceGetProjection("name"),
+      await deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection("name"),
       }),
     ).toEqual([{ name: "a" }, null]);
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        projection: await parsePieceGetProjection(JSON.stringify({
+      await deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection(JSON.stringify({
           type: "array",
           items: {
             type: ["object", "null"],
@@ -1106,8 +1106,8 @@ describe("cf piece get transforms", () => {
     expect((await tx.commit()).ok).toBeDefined();
 
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        projection: await parsePieceGetProjection(
+      await deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection(
           "comments.body,comments.replies.body",
         ),
       }),
@@ -1157,8 +1157,8 @@ describe("cf piece get transforms", () => {
       expect((await tx.commit()).ok).toBeDefined();
 
       expect(
-        await derivePieceGetValue(runtime, space, source, {
-          projection: await parsePieceGetProjection("profiles.profile.name"),
+        await deriveSelectedValue(runtime, space, source, {
+          projection: await parseSelectionProjection("profiles.profile.name"),
         }),
       ).toEqual({
         profiles: [{ profile: { name: "Ada" } }, { profile: null }],
@@ -1192,8 +1192,8 @@ describe("cf piece get transforms", () => {
     expect((await tx.commit()).ok).toBeDefined();
 
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        projection: await parsePieceGetProjection("name"),
+      await deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection("name"),
       }),
     ).toEqual([{ name: "Ada" }, null]);
   });
@@ -1224,8 +1224,8 @@ describe("cf piece get transforms", () => {
     expect((await tx.commit()).ok).toBeDefined();
 
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        projection: await parsePieceGetProjection("name"),
+      await deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection("name"),
       }),
     ).toEqual([{ name: "Ada" }]);
   });
@@ -1273,8 +1273,8 @@ describe("cf piece get transforms", () => {
     expect((await tx.commit()).ok).toBeDefined();
 
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        projection: await parsePieceGetProjection("comments.body"),
+      await deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection("comments.body"),
       }),
     ).toEqual({ comments: [{ body: "Visible" }] });
   });
@@ -1319,8 +1319,8 @@ describe("cf piece get transforms", () => {
     expect((await tx.commit()).ok).toBeDefined();
 
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        projection: await parsePieceGetProjection("comments.body"),
+      await deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection("comments.body"),
       }),
     ).toEqual({ comments: [{ body: "Visible" }] });
   });
@@ -1342,8 +1342,8 @@ describe("cf piece get transforms", () => {
     expect((await tx.commit()).ok).toBeDefined();
 
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        projection: await parsePieceGetProjection("comments.body"),
+      await deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection("comments.body"),
       }),
     ).toEqual({ comments: [{ body: "Visible" }] });
   });
@@ -1404,8 +1404,8 @@ describe("cf piece get transforms", () => {
       expect((await tx.commit()).ok).toBeDefined();
 
       expect(
-        await derivePieceGetValue(runtime, space, source, {
-          projection: await parsePieceGetProjection("entry.body"),
+        await deriveSelectedValue(runtime, space, source, {
+          projection: await parseSelectionProjection("entry.body"),
         }),
       ).toEqual({ entry: { body: "Visible" } });
     }
@@ -1482,58 +1482,58 @@ describe("cf piece get transforms", () => {
     expect((await tx.commit()).ok).toBeDefined();
 
     expect(
-      await derivePieceGetValue(runtime, space, schemaLess, {
-        filter: parsePieceGetFilter("true"),
+      await deriveSelectedValue(runtime, space, schemaLess, {
+        filter: parseSelectionFilter("true"),
       }),
     ).toEqual([1, 2]);
     expect(
-      await derivePieceGetValue(runtime, space, schemaLess, {
-        filter: parsePieceGetFilter("."),
+      await deriveSelectedValue(runtime, space, schemaLess, {
+        filter: parseSelectionFilter("."),
       }),
     ).toEqual([1, 2]);
     expect(
-      await derivePieceGetValue(runtime, space, nestedArrays, {
-        filter: parsePieceGetFilter(".[0]"),
+      await deriveSelectedValue(runtime, space, nestedArrays, {
+        filter: parseSelectionFilter(".[0]"),
       }),
     ).toEqual([[1]]);
     expect(
-      await derivePieceGetValue(runtime, space, nestedArrays, {
-        filter: parsePieceGetFilter(".length"),
-        projection: await parsePieceGetProjection(
+      await deriveSelectedValue(runtime, space, nestedArrays, {
+        filter: parseSelectionFilter(".length"),
+        projection: await parseSelectionProjection(
           '{"type":"array","items":{"type":"array","items":true}}',
         ),
       }),
     ).toEqual([]);
     expect(
-      await derivePieceGetValue(runtime, space, schemaLess, {
-        projection: await parsePieceGetProjection("true"),
+      await deriveSelectedValue(runtime, space, schemaLess, {
+        projection: await parseSelectionProjection("true"),
       }),
     ).toEqual([1, 2]);
     expect(
-      await derivePieceGetValue(runtime, space, schemaLess, {
-        projection: await parsePieceGetProjection('{"type":"array"}'),
+      await deriveSelectedValue(runtime, space, schemaLess, {
+        projection: await parseSelectionProjection('{"type":"array"}'),
       }),
     ).toEqual([1, 2]);
     expect(
-      await derivePieceGetValue(runtime, space, schemaLess, {
-        projection: await parsePieceGetProjection(
+      await deriveSelectedValue(runtime, space, schemaLess, {
+        projection: await parseSelectionProjection(
           '{"type":["array","null"],"items":true}',
         ),
       }),
     ).toEqual([1, 2]);
     expect(
-      await derivePieceGetValue(runtime, space, scalar, {
-        projection: await parsePieceGetProjection('{"type":"string"}'),
+      await deriveSelectedValue(runtime, space, scalar, {
+        projection: await parseSelectionProjection('{"type":"string"}'),
       }),
     ).toBe("visible");
     expect(
-      await derivePieceGetValue(runtime, space, permissiveArray, {
-        projection: await parsePieceGetProjection("id"),
+      await deriveSelectedValue(runtime, space, permissiveArray, {
+        projection: await parseSelectionProjection("id"),
       }),
     ).toEqual([{ id: 1 }]);
     expect(
-      await derivePieceGetValue(runtime, space, composedObject, {
-        projection: await parsePieceGetProjection("id"),
+      await deriveSelectedValue(runtime, space, composedObject, {
+        projection: await parseSelectionProjection("id"),
       }),
     ).toEqual({ id: 2 });
   });
@@ -1553,8 +1553,8 @@ describe("cf piece get transforms", () => {
     expect((await tx.commit()).ok).toBeDefined();
 
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        projection: await parsePieceGetProjection(
+      await deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection(
           '{"type":"object","additionalProperties":false}',
         ),
       }),
@@ -1579,11 +1579,11 @@ describe("cf piece get transforms", () => {
     objectSource.set({ id: 1 });
     expect((await tx.commit()).ok).toBeDefined();
 
-    await expect(derivePieceGetValue(runtime, space, arraySource, {
-      projection: await parsePieceGetProjection('{"type":"object"}'),
+    await expect(deriveSelectedValue(runtime, space, arraySource, {
+      projection: await parseSelectionProjection('{"type":"object"}'),
     })).rejects.toThrow("must describe the returned array");
-    await expect(derivePieceGetValue(runtime, space, objectSource, {
-      projection: await parsePieceGetProjection(
+    await expect(deriveSelectedValue(runtime, space, objectSource, {
+      projection: await parseSelectionProjection(
         '{"type":"array","items":true}',
       ),
     })).rejects.toThrow(
@@ -1609,8 +1609,8 @@ describe("cf piece get transforms", () => {
     expect((await tx.commit()).ok).toBeDefined();
 
     expect(
-      await derivePieceGetValue(runtime, space, source, {
-        filter: parsePieceGetFilter(".missing"),
+      await deriveSelectedValue(runtime, space, source, {
+        filter: parseSelectionFilter(".missing"),
       }),
     ).toEqual([]);
   });
@@ -1626,8 +1626,8 @@ describe("cf piece get transforms", () => {
     source.set({ id: 1 });
     expect((await tx.commit()).ok).toBeDefined();
 
-    await expect(derivePieceGetValue(runtime, space, source, {
-      filter: parsePieceGetFilter(".id == 1"),
+    await expect(deriveSelectedValue(runtime, space, source, {
+      filter: parseSelectionFilter(".id == 1"),
     })).rejects.toThrow("--filter can only be applied to an array");
   });
 
@@ -1642,8 +1642,8 @@ describe("cf piece get transforms", () => {
     expect((await tx.commit()).ok).toBeDefined();
 
     expect(
-      await derivePieceGetValue(runtime, space, unsetSource, {
-        filter: parsePieceGetFilter("true"),
+      await deriveSelectedValue(runtime, space, unsetSource, {
+        filter: parseSelectionFilter("true"),
       }),
     ).toEqual([]);
   });
@@ -1666,15 +1666,15 @@ describe("cf piece get transforms", () => {
     objectSource.set({ id: 1 } as never);
     expect((await tx.commit()).ok).toBeDefined();
 
-    await expect(derivePieceGetValue(runtime, space, nullSource, {
-      filter: parsePieceGetFilter("true"),
+    await expect(deriveSelectedValue(runtime, space, nullSource, {
+      filter: parseSelectionFilter("true"),
     })).rejects.toThrow(/^--filter can only be applied to an array$/);
-    await expect(derivePieceGetValue(runtime, space, nullSource, {
-      filter: parsePieceGetFilter("true"),
-      projection: await parsePieceGetProjection("id"),
+    await expect(deriveSelectedValue(runtime, space, nullSource, {
+      filter: parseSelectionFilter("true"),
+      projection: await parseSelectionProjection("id"),
     })).rejects.toThrow(/^--filter can only be applied to an array$/);
-    await expect(derivePieceGetValue(runtime, space, objectSource, {
-      projection: await parsePieceGetProjection("id"),
+    await expect(deriveSelectedValue(runtime, space, objectSource, {
+      projection: await parseSelectionProjection("id"),
     })).rejects.toThrow(
       /^--schema can only project array items from an array value$/,
     );
@@ -1697,8 +1697,8 @@ describe("cf piece get transforms", () => {
     source.set([{ score: true }]);
     expect((await tx.commit()).ok).toBeDefined();
 
-    await expect(derivePieceGetValue(runtime, space, source, {
-      filter: parsePieceGetFilter(".score > 1"),
+    await expect(deriveSelectedValue(runtime, space, source, {
+      filter: parseSelectionFilter(".score > 1"),
     })).rejects.toThrow("Could not apply piece get transform");
   });
 
@@ -1724,8 +1724,8 @@ describe("cf piece get transforms", () => {
       return tx;
     };
     try {
-      await expect(derivePieceGetValue(runtime, space, source, {
-        projection: await parsePieceGetProjection("id"),
+      await expect(deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection("id"),
       })).rejects.toThrow(
         "Could not apply piece get transform: forced commit failure",
       );
@@ -1772,8 +1772,8 @@ describe("cf piece get transforms", () => {
     );
 
     let outputCell: Cell<unknown> | undefined;
-    const result = await derivePieceGetValue(runtime, space, sourceRead, {
-      filter: parsePieceGetFilter('.status == "open"'),
+    const result = await deriveSelectedValue(runtime, space, sourceRead, {
+      filter: parseSelectionFilter('.status == "open"'),
     }, {
       onOutputCell: (cell) => outputCell = cell,
     });
@@ -1822,8 +1822,8 @@ describe("cf piece get transforms", () => {
     expect((await setup.commit()).ok).toBeDefined();
 
     let outputCell: Cell<unknown> | undefined;
-    const result = await derivePieceGetValue(runtime, space, source, {
-      projection: await parsePieceGetProjection("id"),
+    const result = await deriveSelectedValue(runtime, space, source, {
+      projection: await parseSelectionProjection("id"),
     }, {
       onOutputCell: (cell) => outputCell = cell,
     });

--- a/packages/cli/test/piece-get-transform.test.ts
+++ b/packages/cli/test/piece-get-transform.test.ts
@@ -1989,6 +1989,80 @@ describe("cf piece get transforms", () => {
       ).toEqual({ notes: notes.map((note) => ({ $link: addressOf(note) })) });
     });
 
+    it("returns the link crossed above a marked position, plus the segments below it", async () => {
+      const { board, notes } = await seedBoard("link-marker-below", true);
+      expect(
+        await deriveSelectedValue(runtime, space, board, {
+          projection: await parseSelectionProjection(
+            '{"properties":{"notes":{"type":"array","items":' +
+              '{"properties":{"title":{"$link":true}}}}}}',
+          ),
+        }),
+      ).toEqual({
+        notes: notes.map((note) => ({
+          title: { $link: { ...addressOf(note), path: ["title"] } },
+        })),
+      });
+    });
+
+    it("returns the link stored at the read's own source for a marked position below it", async () => {
+      const { board, notes } = await seedBoard(
+        "link-marker-below-source",
+        true,
+      );
+      expect(
+        await deriveSelectedValue(runtime, space, board.key("topic"), {
+          projection: await parseSelectionProjection(
+            '{"properties":{"title":{"$link":true}}}',
+          ),
+        }),
+      ).toEqual({
+        title: { $link: { ...addressOf(notes[0]), path: ["title"] } },
+      });
+    });
+
+    it("returns a stored link's own path followed by the segments below it", async () => {
+      const tx = runtime.edit();
+      const note = runtime.getCell(
+        space,
+        "link-marker-nested-note",
+        { type: "object", properties: { content: noteSchema } } as const,
+        tx,
+      );
+      note.set({ content: { title: "a", body: "body a" } });
+      const board = runtime.getCell(
+        space,
+        "link-marker-nested-board",
+        boardSchema,
+        tx,
+      );
+      board.setRaw({
+        notes: [],
+        topic: note.key("content").getAsLink(),
+        label: "Field notes",
+      } as never);
+      expect((await tx.commit()).ok).toBeDefined();
+
+      expect(
+        await deriveSelectedValue(
+          runtime,
+          space,
+          runtime.getCell(space, "link-marker-nested-board", boardSchema),
+          {
+            projection: await parseSelectionProjection(
+              '{"properties":{"topic":{"properties":{"title":{"$link":true}}}}}',
+            ),
+          },
+        ),
+      ).toEqual({
+        topic: {
+          title: {
+            $link: { ...addressOf(note), path: ["content", "title"] },
+          },
+        },
+      });
+    });
+
     it("reads one document for a marked collection, not one per element", async () => {
       const { board, notes } = await seedBoard("link-marker-reads", false);
       const provider = storageManager.open(space);

--- a/packages/cli/test/piece-get-transform.test.ts
+++ b/packages/cli/test/piece-get-transform.test.ts
@@ -343,6 +343,25 @@ describe("cf piece get transforms", () => {
     });
   });
 
+  it("keeps predicate reads a rejecting projection declines", () => {
+    const predicate = {
+      type: "object",
+      properties: { status: true },
+      additionalProperties: false,
+    } as const;
+    expect(mergeMasks(predicate, false)).toEqual(predicate);
+    expect(mergeMasks(true, false)).toBe(true);
+    expect(mergeMasks(predicate, {
+      type: "object",
+      properties: { topic: false },
+      additionalProperties: false,
+    })).toEqual({
+      type: "object",
+      properties: { status: true, topic: false },
+      additionalProperties: false,
+    });
+  });
+
   it("narrows referenced source schemas without dropping Fabric metadata", () => {
     const source: JSONSchema = {
       $ref: "#/$defs/Item",
@@ -1878,6 +1897,260 @@ describe("cf piece get transforms", () => {
     });
     expect((await seed.commit()).ok).toBeDefined();
   }
+
+  describe("$link projection marker", () => {
+    const noteSchema = {
+      type: "object",
+      properties: { title: { type: "string" }, body: { type: "string" } },
+    } as const satisfies JSONSchema;
+    const boardSchema = {
+      type: "object",
+      properties: {
+        notes: { type: "array", items: noteSchema },
+        topic: noteSchema,
+        label: { type: "string" },
+      },
+    } as const satisfies JSONSchema;
+
+    /**
+     * A board whose `topic` and `notes` entries are stored as links, the shape
+     * a verb produces when it hands back the piece it created. `written` says
+     * whether the note documents exist: reading an unwritten one has to reach
+     * storage, which is what makes a read of it observable.
+     */
+    async function seedBoard(
+      cause: string,
+      written: boolean,
+    ): Promise<{ board: Cell<unknown>; notes: Cell<unknown>[] }> {
+      const tx = runtime.edit();
+      const notes = ["a", "b", "c"].map((suffix) => {
+        const note = runtime.getCell(
+          space,
+          `${cause}-note-${suffix}`,
+          noteSchema,
+          tx,
+        );
+        if (written) note.set({ title: suffix, body: `body ${suffix}` });
+        return note;
+      });
+      const board = runtime.getCell(space, `${cause}-board`, boardSchema, tx);
+      board.setRaw({
+        notes: notes.map((note) => note.getAsLink()),
+        topic: notes[0].getAsLink(),
+        label: "Field notes",
+      } as never);
+      expect((await tx.commit()).ok).toBeDefined();
+      return {
+        board: runtime.getCell(space, `${cause}-board`, boardSchema),
+        notes,
+      };
+    }
+
+    function addressOf(cell: Cell<unknown>) {
+      return {
+        id: cell.getAsNormalizedFullLink().id,
+        space,
+        scope: "space",
+        path: [],
+      };
+    }
+
+    it("returns a marked position's address instead of its contents", async () => {
+      const { board, notes } = await seedBoard("link-marker-instead", true);
+      expect(
+        await deriveSelectedValue(runtime, space, board, {
+          projection: await parseSelectionProjection(
+            '{"properties":{"topic":{"$link":true}}}',
+          ),
+        }),
+      ).toEqual({ topic: { $link: addressOf(notes[0]) } });
+    });
+
+    it("returns the address and the contents asked for beside it", async () => {
+      const { board, notes } = await seedBoard("link-marker-beside", true);
+      expect(
+        await deriveSelectedValue(runtime, space, board, {
+          projection: await parseSelectionProjection(
+            '{"type":"object","properties":{"topic":' +
+              '{"$link":true,"type":"object","properties":{"title":true}}}}',
+          ),
+        }),
+      ).toEqual({ topic: { $link: addressOf(notes[0]), title: "a" } });
+    });
+
+    it("returns an address per element for a marked collection", async () => {
+      const { board, notes } = await seedBoard("link-marker-collection", true);
+      expect(
+        await deriveSelectedValue(runtime, space, board, {
+          projection: await parseSelectionProjection(
+            '{"properties":{"notes":{"type":"array","items":{"$link":true}}}}',
+          ),
+        }),
+      ).toEqual({ notes: notes.map((note) => ({ $link: addressOf(note) })) });
+    });
+
+    it("reads one document for a marked collection, not one per element", async () => {
+      const { board, notes } = await seedBoard("link-marker-reads", false);
+      const provider = storageManager.open(space);
+      const originalSync = provider.sync.bind(provider);
+      let syncedUris: string[] = [];
+      provider.sync = ((uri, selector, scope) => {
+        syncedUris.push(uri);
+        return originalSync(uri, selector, scope);
+      }) as typeof provider.sync;
+      const boardUri = board.getAsNormalizedFullLink().id;
+      const noteUris: string[] = notes.map((note) =>
+        note.getAsNormalizedFullLink().id
+      );
+      // A read of the transform's own session documents says nothing about
+      // which of the board's data this selection reached.
+      const boardDocuments = (uris: string[]) =>
+        uris.filter((uri) => uri === boardUri || noteUris.includes(uri));
+
+      syncedUris = [];
+      await deriveSelectedValue(runtime, space, board, {
+        projection: await parseSelectionProjection(
+          '{"properties":{"notes":{"type":"array","items":{"$link":true}}}}',
+        ),
+      });
+      const marked = boardDocuments(syncedUris);
+
+      syncedUris = [];
+      await deriveSelectedValue(
+        runtime,
+        space,
+        runtime.getCell(space, "link-marker-reads-board", boardSchema),
+        {
+          projection: await parseSelectionProjection(
+            '{"properties":{"notes":{"type":"array","items":' +
+              '{"type":"object","properties":{"title":true}}}}}',
+          ),
+        },
+      );
+
+      expect(marked).toEqual([boardUri]);
+      expect(boardDocuments(syncedUris)).toEqual(noteUris);
+    });
+
+    it("returns the address of the position it was read at for a marked root", async () => {
+      const { board, notes } = await seedBoard("link-marker-root", true);
+      expect(
+        await deriveSelectedValue(runtime, space, board.key("topic"), {
+          projection: await parseSelectionProjection('{"$link":true}'),
+        }),
+      ).toEqual({ $link: addressOf(notes[0]) });
+    });
+
+    it("returns where an inline value lives when nothing is linked there", async () => {
+      const tx = runtime.edit();
+      const board = runtime.getCell(
+        space,
+        "link-marker-inline",
+        boardSchema,
+        tx,
+      );
+      board.set({
+        notes: [],
+        topic: { title: "a", body: "inline" },
+        label: "L",
+      });
+      expect((await tx.commit()).ok).toBeDefined();
+
+      const read = runtime.getCell(space, "link-marker-inline", boardSchema);
+      expect(
+        await deriveSelectedValue(runtime, space, read, {
+          projection: await parseSelectionProjection(
+            '{"properties":{"topic":{"$link":true}}}',
+          ),
+        }),
+      ).toEqual({
+        topic: {
+          $link: {
+            id: read.getAsNormalizedFullLink().id,
+            space,
+            scope: "space",
+            path: ["topic"],
+          },
+        },
+      });
+    });
+
+    it("returns the address alone where the contents are not an object", async () => {
+      const { board } = await seedBoard("link-marker-scalar", true);
+      expect(
+        await deriveSelectedValue(runtime, space, board, {
+          projection: await parseSelectionProjection(
+            '{"type":"object","properties":{"label":{"$link":true,"type":"string"}}}',
+          ),
+        }),
+      ).toEqual({
+        label: {
+          $link: {
+            id: board.getAsNormalizedFullLink().id,
+            space,
+            scope: "space",
+            path: ["label"],
+          },
+        },
+      });
+    });
+
+    it("leaves a marked collection alone when nothing is stored at it", async () => {
+      const tx = runtime.edit();
+      const board = runtime.getCell(
+        space,
+        "link-marker-unset",
+        boardSchema,
+        tx,
+      );
+      board.set({ topic: { title: "a", body: "b" }, label: "L" } as never);
+      expect((await tx.commit()).ok).toBeDefined();
+
+      expect(
+        await deriveSelectedValue(
+          runtime,
+          space,
+          runtime.getCell(space, "link-marker-unset", boardSchema),
+          {
+            projection: await parseSelectionProjection(
+              '{"type":"object","properties":{"label":true,"notes":' +
+                '{"type":"array","items":{"$link":true}}}}',
+            ),
+          },
+        ),
+      ).toEqual({ label: "L" });
+    });
+
+    it("refuses a marker combined with a filter", async () => {
+      const { board } = await seedBoard("link-marker-filter", true);
+      await expect(
+        deriveSelectedValue(runtime, space, board.key("notes"), {
+          filter: parseSelectionFilter('.title == "a"'),
+          projection: await parseSelectionProjection(
+            '{"type":"array","items":{"$link":true}}',
+          ),
+        }),
+      ).rejects.toThrow("--filter cannot be combined");
+    });
+
+    it("refuses a marker that is not `true`", async () => {
+      await expect(parseSelectionProjection('{"$link":"yes"}')).rejects
+        .toThrow('"$link" must be `true`');
+    });
+
+    it("refuses a marker under `additionalProperties`", async () => {
+      await expect(
+        parseSelectionProjection('{"additionalProperties":{"$link":true}}'),
+      ).rejects.toThrow(
+        '"$link" is not supported under "additionalProperties"',
+      );
+    });
+
+    it("still refuses `asCell` in a projection", async () => {
+      await expect(parseSelectionProjection('{"asCell":["cell"]}')).rejects
+        .toThrow('"asCell" is controlled by the source schema');
+    });
+  });
 
   function derivedConfidentiality(id: string): string[] {
     type StoredEntry = {

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -45,7 +45,6 @@ import {
   localPatternEntry,
   normalizeApiUrl,
   parseLink,
-  parsePieceGetTransformOptions,
   parsePieceOptions,
   parseSpaceOptions,
   piece,
@@ -53,10 +52,11 @@ import {
 } from "../commands/piece.ts";
 import { safeStringify } from "../lib/render.ts";
 import {
-  parsePieceGetFilter,
-  parsePieceGetProjection,
-  PieceGetTransformError,
-} from "../lib/piece-get-transform.ts";
+  CellSelectionError,
+  parseCellSelectionOptions,
+  parseSelectionFilter,
+  parseSelectionProjection,
+} from "../lib/cell-selection.ts";
 
 const API_URL = "https://cf.dev";
 const SPACE = "common-knowledge";
@@ -557,22 +557,22 @@ describe("cli piece parsing", () => {
     expect(getFlags).toContain("--schema");
   });
 
-  it("parses piece get transform options", async () => {
-    expect(await parsePieceGetTransformOptions({})).toBeUndefined();
+  it("parses the --filter and --schema options into a selection", async () => {
+    expect(await parseCellSelectionOptions({})).toBeUndefined();
 
-    const filterOnly = await parsePieceGetTransformOptions({
+    const filterOnly = await parseCellSelectionOptions({
       filter: ".active",
     });
     expect(filterOnly?.filter?.source).toBe(".active");
     expect(filterOnly?.projection).toBeUndefined();
 
-    const schemaOnly = await parsePieceGetTransformOptions({
+    const schemaOnly = await parseCellSelectionOptions({
       schema: "id,name",
     });
     expect(schemaOnly?.filter).toBeUndefined();
     expect(schemaOnly?.projection?.source).toBe("id,name");
 
-    const both = await parsePieceGetTransformOptions({
+    const both = await parseCellSelectionOptions({
       filter: ".active",
       schema: "id",
     });
@@ -580,7 +580,7 @@ describe("cli piece parsing", () => {
     expect(both?.projection?.source).toBe("id");
   });
 
-  it("passes parsed transforms through the piece get command action", async () => {
+  it("passes a parsed selection through the piece get command action", async () => {
     const { code, stderr } = await cf(
       "piece get " +
         "--identity ./definitely-missing-piece-get-review.key " +
@@ -593,7 +593,7 @@ describe("cli piece parsing", () => {
     );
   });
 
-  it("applies get transforms to the selected path cell", async () => {
+  it("applies a selection to the cell at the read path", async () => {
     const targetCell = { marker: "selected-path-cell" };
     const rootCell = {
       key: (...path: Array<string | number>) => {
@@ -607,7 +607,7 @@ describe("cli piece parsing", () => {
           input: { get: () => Promise.resolve(undefined) },
           result: {
             get: () => {
-              throw new Error("transform reads must not materialize result");
+              throw new Error("selection reads must not materialize result");
             },
             getCell: () => Promise.resolve(rootCell),
           },
@@ -615,20 +615,20 @@ describe("cli piece parsing", () => {
       runtime: { marker: "runtime" },
       getSpace: () => "did:key:test-space",
     };
-    const filter = parsePieceGetFilter(".id == 2");
+    const filter = parseSelectionFilter(".id == 2");
 
     const value = await getCellValue(
       { apiUrl: API_URL, space: SPACE, identity: ID, piece: PIECE },
       ["items"],
-      { transform: { filter } },
+      { selection: { filter } },
       {
         loadPieces: () => Promise.resolve(controller as any),
         resolvePieceAddress: (_pieces, id) => Promise.resolve(id),
-        derivePieceGetValue: (runtime, space, source, transform) => {
+        deriveSelectedValue: (runtime, space, source, selection) => {
           expect(runtime).toBe(controller.runtime as any);
           expect(space).toBe("did:key:test-space");
           expect(source).toBe(targetCell as any);
-          expect(transform.filter).toBe(filter);
+          expect(selection.filter).toBe(filter);
           return Promise.resolve([{ id: 2 }]);
         },
       },
@@ -637,8 +637,8 @@ describe("cli piece parsing", () => {
     expect(value).toEqual([{ id: 2 }]);
   });
 
-  it("preserves transform errors that are not result projection failures", async () => {
-    const transformError = new PieceGetTransformError("invalid transform");
+  it("preserves selection errors that are not result projection failures", async () => {
+    const selectionError = new CellSelectionError("invalid selection");
     const targetCell = {};
     const rootCell = { key: () => targetCell };
     const controller = {
@@ -653,16 +653,16 @@ describe("cli piece parsing", () => {
     await expect(getCellValue(
       { apiUrl: API_URL, space: SPACE, identity: ID, piece: PIECE },
       [],
-      { transform: { filter: parsePieceGetFilter(".active") } },
+      { selection: { filter: parseSelectionFilter(".active") } },
       {
         loadPieces: () => Promise.resolve(controller as any),
         resolvePieceAddress: (_pieces, id) => Promise.resolve(id),
-        derivePieceGetValue: () => Promise.reject(transformError),
+        deriveSelectedValue: () => Promise.reject(selectionError),
       },
-    )).rejects.toBe(transformError);
+    )).rejects.toBe(selectionError);
   });
 
-  it("reports projection failures encountered during transformed reads", async () => {
+  it("reports projection failures encountered during a selection read", async () => {
     const targetCell = {
       schema: { type: "number" },
       getRaw: () => ({ "/": "missing-session-count" }),
@@ -688,7 +688,7 @@ describe("cli piece parsing", () => {
       resolvePieceAddress: (_pieces: any, id: string) => Promise.resolve(id),
     };
     const options = {
-      transform: { filter: parsePieceGetFilter(".active") },
+      selection: { filter: parseSelectionFilter(".active") },
     };
 
     await expect(getCellValue(
@@ -697,7 +697,7 @@ describe("cli piece parsing", () => {
       options,
       {
         ...deps,
-        derivePieceGetValue: () =>
+        deriveSelectedValue: () =>
           Promise.reject(
             new Error('Cannot access path "count" - property not found'),
           ),
@@ -710,12 +710,12 @@ describe("cli piece parsing", () => {
       options,
       {
         ...deps,
-        derivePieceGetValue: () => Promise.resolve(undefined),
+        deriveSelectedValue: () => Promise.resolve(undefined),
       },
     )).rejects.toThrow(PieceResultProjectionError);
   });
 
-  it("distinguishes failed transforms, JSON null, and absent sources", async () => {
+  it("distinguishes failed selections, JSON null, and absent sources", async () => {
     let sourceRaw: unknown;
     const targetCell = {
       schema: { type: ["object", "null"] },
@@ -733,7 +733,7 @@ describe("cli piece parsing", () => {
 
     const options = {
       input: true,
-      transform: { projection: await parsePieceGetProjection("id") },
+      selection: { projection: await parseSelectionProjection("id") },
     };
     const deps = {
       loadPieces: () => Promise.resolve(controller as any),
@@ -746,7 +746,7 @@ describe("cli piece parsing", () => {
       options,
       {
         ...deps,
-        derivePieceGetValue: () => {
+        deriveSelectedValue: () => {
           sourceRaw = { id: "loaded-during-transform" };
           return Promise.resolve(undefined);
         },
@@ -760,7 +760,7 @@ describe("cli piece parsing", () => {
       options,
       {
         ...deps,
-        derivePieceGetValue: () => Promise.resolve(null),
+        deriveSelectedValue: () => Promise.resolve(null),
       },
     )).resolves.toBeNull();
 
@@ -771,7 +771,7 @@ describe("cli piece parsing", () => {
       options,
       {
         ...deps,
-        derivePieceGetValue: () => Promise.resolve(undefined),
+        deriveSelectedValue: () => Promise.resolve(undefined),
       },
     )).resolves.toBeUndefined();
   });
@@ -1255,8 +1255,8 @@ describe("cli piece parsing", () => {
       expect((error as Error).message).not.toContain("--step");
     });
 
-    it("refuses a verb read through a transform, not a projection error", async () => {
-      // The transform path has its own projection-failure exits, so a verb
+    it("refuses a verb read through a selection, not a projection error", async () => {
+      // The selection path has its own projection-failure exits, so a verb
       // read through --filter/--schema must reach the same refusal: asking a
       // stream to project is the same mistake whichever route it takes.
       const verbCell = {
@@ -1280,13 +1280,15 @@ describe("cli piece parsing", () => {
         },
       };
       const deps = guardDeps(piece);
-      const options = { transform: { filter: parsePieceGetFilter(".active") } };
+      const options = {
+        selection: { filter: parseSelectionFilter(".active") },
+      };
 
-      // The transform throws the "Cannot access path" shape a real projection
+      // The selection throws the "Cannot access path" shape a real projection
       // failure raises.
       const thrown = await getCellValue(config, ["addTopic"], options, {
         ...deps,
-        derivePieceGetValue: () =>
+        deriveSelectedValue: () =>
           Promise.reject(
             new Error('Cannot access path "addTopic" - property not found'),
           ),
@@ -1294,10 +1296,10 @@ describe("cli piece parsing", () => {
       expect(thrown).toBeInstanceOf(PieceVerbReadError);
       expect((thrown as Error).message).toContain("cf piece call");
 
-      // And the same when the transform simply yields nothing.
+      // And the same when the selection simply yields nothing.
       const empty = await getCellValue(config, ["addTopic"], options, {
         ...deps,
-        derivePieceGetValue: () => Promise.resolve(undefined),
+        deriveSelectedValue: () => Promise.resolve(undefined),
       }).catch((error) => error);
       expect(empty).toBeInstanceOf(PieceVerbReadError);
     });

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -139,6 +139,7 @@ See `docs/development/EXPERIMENTAL_OPTIONS.md` for available flags.
 | Get field          | `deno task cf piece get --piece ID fieldPath ...`                                                    |
 | Filter array       | `deno task cf piece get --piece ID items --filter '.active == true' ...`                             |
 | Project fields     | `deno task cf piece get --piece ID items --schema id,title ...`                                      |
+| Read addresses     | `deno task cf piece get --piece ID items --schema '{"type":"array","items":{"$link":true}}' ...`     |
 | Step + get         | `deno task cf piece get --piece ID fieldPath --step ...`                                             |
 | Set field          | `echo '{"data":...}' \| deno task cf piece set --piece ID path ...`                                  |
 | Call handler       | `deno task cf piece call --piece ID handlerName ...`                                                 |
@@ -256,8 +257,14 @@ omitted linked subgraphs are not hydrated; ambiguous compositions can retain a
 wider selector, and schema-less or root-union sources need a value-shape read
 first. CFC behavior is the same as a computed pattern expression. Source schema
 metadata is authoritative; projection schemas cannot supply `ifc`, `asCell`,
-`scope`, or `default`. See `packages/cli/README.md` for the exact syntax and
-supported schema subset.
+`scope`, or `default`. A JSON `--schema` marks a position `"$link": true` to get
+that position's address — `{"id","space","scope","path"}`, all four always
+present, no schema inlined — instead of what is behind it, or beside a
+projection to get both. A marked position is never fetched, so a marked
+collection costs one document read rather than one per element; the rendered
+`id` minus its `of:` prefix is what `--piece` accepts. Markers do not compose
+with `--filter`. See `packages/cli/README.md` for the exact syntax and supported
+schema subset.
 
 For `piece call`, options before the callable name configure `piece call`.
 Arguments after the callable name configure the invoked handler or tool. The

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -260,7 +260,11 @@ metadata is authoritative; projection schemas cannot supply `ifc`, `asCell`,
 `scope`, or `default`. A JSON `--schema` marks a position `"$link": true` to get
 that position's address — `{"id","space","scope","path"}`, all four always
 present, no schema inlined — instead of what is behind it, or beside a
-projection to get both. A marked position is never fetched, so a marked
+projection to get both. That address is the deepest stored link crossed on the
+way to the marked position plus the segments below it, so marking a field under
+a linked element names that element's own document rather than a slot in the
+collection above it; a position with no link above it keeps the source
+document's own address. A marked position is never fetched, so a marked
 collection costs one document read rather than one per element; the rendered
 `id` minus its `of:` prefix is what `--piece` accepts. Markers do not compose
 with `--filter`. See `packages/cli/README.md` for the exact syntax and supported


### PR DESCRIPTION
## Why

A read can return a value, but it could not return *where that value lives*. So
a caller who read a board and wanted to act on one of its topics had no address
to act with — they had to know how to reconstruct one, or fall back to
`--show-links` and parse it. Marking a position gives the caller an address that
is directly actionable in the next command.

The second half is what it costs to read. Selecting a collection previously
fetched every element document even when the caller only wanted addresses.
Marking a position now suppresses the fetch beneath it.

Part of the shaped-reads plan (#5435), which builds on the read model in #5316.

## What Changed

`$link` at a position renders the address stored there instead of its contents:

```json
{ "$link": { "id": "of:fid1:…", "space": "did:key:…", "scope": "space", "path": [] } }
```

All four fields always present, `id` keeps its scheme, `space`/`scope` filled in
from the containing document, `path` is `[]` at a root. `overwrite` dropped,
`schema` never inlined. A marker beside a projection merges.

`normalizeProjectionSchema` lifts markers into a separate tree and returns a
marker-free schema in which a link-only position becomes the `false` schema,
which flows through the existing path union as a new `ProjectionMask` variant.
Addresses are composed back in from the link stored in the containing document,
reading nothing the selection had not already read.

## One finding that changed the design

A rejecting selector at an array's `items` does **not** suppress the fetch.
`traverseArrayWithSchema` follows every element link before consulting the item
schema — deliberately, per the comment there: element traversal is what kicks
async loads for absent targets, and short-circuiting would serialize them until
`Cell.pull()`'s round budget exhausts. So this reduces an array whose items ask
for nothing to `false` at the array itself, which is what actually delivers the
saving. `{"property": false}` does suppress.

Measured, not assumed: a test wraps `storageManager.open(space).sync` and
asserts a marked read syncs one document where the equivalent projected read
syncs all three. Confirmed non-vacuous by swapping the projection.

## Flagged, not fixed

A JSON `--schema` needs an explicit `"type": "object"` at *every* object level;
without it `{"properties":{"label":true}}` returns `{}` today. Pre-existing and
unrelated to markers, but it means a marker's sibling contents need the type.
Fixing it changes `--schema` behavior for non-marker projections, so it wants
its own decision.

`--filter` combined with a marker is refused rather than silently wrong: a
filtered array's survivors cannot be traced back to source positions.

#5469 is stacked on this branch, with the walkthrough renumbering already
resolved there; merge this one first.

## Test plan

`deno task test` in packages/cli; walkthrough step 6 asserts the returned
address is one a caller can pass straight back to `piece call` and `piece get`,
verified against a live toolshed.
