### PR TITLE
docs(specs): separate the two ways a convention reaches `codec-json`

### DIFF
--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -3054,11 +3054,24 @@ anyone reading this to decide something: treat the unified encoding as the
 target to build toward and to write new code against, and treat what follows as
 the remaining distance, not as a menu.
 
-`codec-json` already holds up its end. It attaches no meaning to any of the
-conventions below — a record carrying one round-trips as the record it is, with
-the marker as an ordinary key. So the work is not to teach the JSON layer about
-alternative encodings; it is to retire the conventions where they are produced
-and recognized, in the layers above it.
+`codec-json` already holds up its end: **neither convention below is an encoding
+it defines**, so the work is not to teach the JSON layer about alternative
+encodings, but to retire the conventions where they are produced and recognized,
+in the layers above it. The two get there by different routes, and the
+difference matters to anyone tracing a value through the wire format.
+
+- **`$stream` is an ordinary key.** The JSON layer attaches no meaning to it: a
+  record carrying it round-trips as the record it is.
+- **The link-ref envelope is not.** `/` is reserved — the prefix is wholly owned
+  by the encoding system in the wire format (Section 9 of `3-json-encoding.md`),
+  so a `/`-keyed record reaching the wire is a tagged value, a built-in escape,
+  or an encoding error, never a literal user key. A literal one survives only by
+  being wrapped in the `/object` escape first.
+
+That the envelope needs escaping is the stronger statement of the two. It is not
+a rival encoding the JSON layer tolerates alongside its own; it is user data the
+layer has to work around, and it can only reach the wire intact by being hidden
+from the very rule that gives `/` its meaning.
 
 **What remains:**
 

--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -3065,8 +3065,10 @@ difference matters to anyone tracing a value through the wire format.
 - **The link-ref envelope is not.** `/` is reserved — the prefix is wholly owned
   by the encoding system in the wire format (Section 9 of `3-json-encoding.md`),
   so a `/`-keyed record reaching the wire is a tagged value, a built-in escape,
-  or an encoding error, never a literal user key. A literal one survives only by
-  being wrapped in the `/object` escape first.
+  or an encoding error, never a literal user key. A literal one reaches the wire
+  only by being wrapped in an escape first — `/object` where its values should
+  still be interpreted, `/quote` where the whole subtree is to be taken
+  literally (Section 6 of the same document).
 
 That the envelope needs escaping is the stronger statement of the two. It is not
 a rival encoding the JSON layer tolerates alongside its own; it is user data the


### PR DESCRIPTION
A correction to §7.2 of `1-fabric-values.md`, introduced by #5449. Docs-only,
one file, 18 insertions / 5 deletions. `check-docs` (533 blocks) and
`check-conflict-markers` pass at this base.

## The defect: a claim that is false for half its population

§7.2 currently reads:

> `codec-json` already holds up its end. It attaches no meaning to any of the
> conventions below — a record carrying one round-trips as the record it is,
> **with the marker as an ordinary key.**

The table beneath that sentence has **two rows** — the link-ref envelope
`{ "/": … }` and `$stream`. The claim is true of `$stream` and **false of the
link-ref envelope**, which is the *first row of its own table*. So this is not
an over-broad claim with an edge case at its margin; it is wrong for half of
what it quantifies over, and wrong about the row a reader meets first.

It also contradicts the corpus. `3-json-encoding.md` §9 states that the `/`
prefix is **wholly owned by the encoding system** in the wire format, and the
same rule is asserted again in `space-model/1-data-model.md`. So the corpus said
twice that `/` is reserved while §7.2 assumed it was ordinary.

**The evidence is in the tests**, which distinguish the two cases precisely
(`packages/data-model/test/codec-json/json-encoding.test.ts`):

```
:122  it('`{ "/": value }` round-trips via `/object` escaping')
:143  it('`{ "/": "string" }` round-trips via `/object` escaping')
:150  it("`$stream` marker passes through unchanged")
```

The envelope does not pass through. It survives *because it is escaped*.

## The fix is a split, not a hedge

Because the two conventions differ in kind rather than degree, softening the
sentence would have been the wrong repair. §7.2 now names both routes:

- **`$stream` is an ordinary key** — the JSON layer attaches no meaning to it,
  and a record carrying it round-trips as the record it is.
- **The link-ref envelope is reserved** — a `/`-keyed record reaching the wire
  is a tagged value, a built-in escape, or an encoding error, never a literal
  user key; a literal one survives only by being wrapped in `/object` first.
  §9 is cross-referenced by name, since the point is that the corpus currently
  disagrees with itself.

## The section's conclusion is unchanged and now rests on firmer ground

Needing the escape is the *stronger* of the two statements, not a weakening. The
envelope is not a rival encoding the JSON layer tolerates alongside its own; it
is user data the layer has to work around, **able to reach the wire intact only
by being hidden from the very rule that gives `/` its meaning.** That supports
the settled-direction framing in §7.2 better than the original sentence did.

## How the defect arose

Worth recording, because the mechanism is not "careless wording."

The sentence was written while the table had **three** rows. It was defensible
over that population. The `@Error` row was then removed in the same commit —
correctly, since `"@Error"` appears in no source file and the tagged form is
registered in `codec-common/codec-type-tags.ts` — and removing it left the
sentence false over the two rows that remained.

**A quantified claim can be broken by editing what it quantifies over, without
touching the claim.** Nothing about care at writing time prevents that; the
discipline is to re-read every sentence that quantifies over a list after
changing the list.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



## Folded after review: cubic's P3, verified

cubic flagged that the link-ref bullet said a literal `/`-keyed record survives
only via `/object`. Verified at-source before acting: **§9 of
`3-json-encoding.md` — the rule the bullet cites — says a conforming encoder
wraps such a record via `/object` *or* `/quote`**, and §6 defines both and
treats the choice between them as a recommendation rather than an exclusivity.
So the sentence narrowed the rule it was citing, in the act of citing it. Both
escapes are now named with what distinguishes them: `/object` where the values
should still be interpreted, `/quote` where the whole subtree is literal.

The rest of the diff was re-read whole for the same over-narrow phrasing, on the
theory that an imprecision written once may have been written twice in the same
sitting. **It was not** — the closing paragraph speaks of "escaping" without
naming a mechanism, so it is unaffected. A checked negative rather than an
assumption.

A good catch, and a pointed one: the deliverable of this PR is precision about
exactly these routes.
