### PR TITLE
fix(dashboard): end each spend line at its source's known days

### DIFF
--- a/packages/dashboard/spend.ts
+++ b/packages/dashboard/spend.ts
@@ -1,6 +1,9 @@
 // Shared daily-spend projection and charting for the dashboard's spend tiles.
 // A monthly estimate uses every settled day in the current month. Until that
 // supplies two weeks, it fills the rate window from the end of the prior month.
+// A chart line ends on the day its source is known through — its last
+// reported day, or the newest day its reporting lag has settled — even when
+// another source's line runs further.
 import type { Status } from "./types.ts";
 import { multiSparkline, SPARK_FADE } from "./lib.ts";
 
@@ -34,6 +37,7 @@ export interface SpendChartSource {
   spend: ChartSpend | null;
   color: string;
   label?: string;
+  lagDays: number;
 }
 
 export function settled(
@@ -182,7 +186,25 @@ export function spendChart(
   if (allDays.size < 2) return { chart: "", duration: 0 };
   const sorted = [...allDays].sort();
   const timeOf = (day: string) => Date.parse(`${day}T00:00:00Z`);
-  const end = timeOf(sorted[sorted.length - 1]);
+  // A source is known through its last reported day or through the newest day
+  // its reporting lag has settled, whichever is later. A settled day with no
+  // report is a real $0; a day past that horizon has no figure yet, and the
+  // source's line stops there rather than drawing the missing days as zero.
+  const today = Date.UTC(
+    now.getUTCFullYear(),
+    now.getUTCMonth(),
+    now.getUTCDate(),
+  );
+  const knownThrough = new Map<SpendChartSource, number>();
+  for (const source of sources) {
+    if (!source.spend) continue;
+    let known = today - source.lagDays * DAY_MS;
+    for (const day of source.spend.byDay.keys()) {
+      known = Math.max(known, timeOf(day));
+    }
+    knownThrough.set(source, known);
+  }
+  const end = Math.max(...knownThrough.values());
   const start = Math.max(
     timeOf(sorted[0]),
     end - (SPEND_HISTORY_DAYS - 1) * DAY_MS,
@@ -191,15 +213,6 @@ export function spendChart(
   for (let time = start; time <= end; time += DAY_MS) {
     grid.push(new Date(time).toISOString().slice(0, 10));
   }
-  const lines = sources.flatMap((source) =>
-    source.spend
-      ? [{
-        vals: grid.map((day) => source.spend!.byDay.get(day) ?? 0),
-        color: source.color,
-        label: source.label,
-      }]
-      : []
-  );
   const monthStart = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}-01`;
   const currentDays = grid.filter((day) => day >= monthStart).length;
   const highlightDays = Math.min(
@@ -207,6 +220,28 @@ export function spendChart(
     estimateDays ??
       Math.max(currentDays, MIN_SPEND_WINDOW_DAYS),
   );
+  const lines = sources.flatMap((source) => {
+    const known = knownThrough.get(source);
+    if (known === undefined) return [];
+    const covered = Math.min(
+      grid.length,
+      Math.max(0, Math.round((known - start) / DAY_MS) + 1),
+    );
+    if (covered === 0) return [];
+    const days = grid.slice(0, covered);
+    return [{
+      vals: days.map((day) => source.spend!.byDay.get(day) ?? 0),
+      // A line the grid outlives keeps its points on the shared day axis and
+      // its highlight aligned to the shared trailing window.
+      xs: covered === grid.length
+        ? undefined
+        : days.map((_, index) => index / (grid.length - 1)),
+      color: source.color,
+      label: source.label,
+      highlightCount: Math.max(0, covered - (grid.length - highlightDays)),
+      showSinglePoint: true,
+    }];
+  });
   return {
     chart: multiSparkline(lines, {
       fadeFrom: SPARK_FADE[status],

--- a/packages/dashboard/test/spend.test.ts
+++ b/packages/dashboard/test/spend.test.ts
@@ -1,0 +1,98 @@
+// spendChart: the shared multi-source daily-spend chart. Each source's line
+// covers only the days that source is known for — reported days plus settled
+// quiet days — so one source's freshness never pads another with zeros.
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { spendChart } from "../spend.ts";
+
+const DAY = 86_400_000;
+
+// `days` equal daily figures starting at `from`, as byDay entries.
+const run = (
+  from: string,
+  days: number,
+  amount: number,
+): Array<[string, number]> => {
+  const start = Date.parse(`${from}T00:00:00Z`);
+  return Array.from({ length: days }, (_, index): [string, number] => [
+    new Date(start + index * DAY).toISOString().slice(0, 10),
+    amount,
+  ]);
+};
+
+const source = (
+  entries: Array<[string, number]>,
+  lagDays: number,
+  color: string,
+) => ({
+  spend: { byDay: new Map(entries) },
+  color,
+  lagDays,
+});
+
+// Every polyline in the chart, as [x, y] point lists in drawing order.
+const polylines = (chart: string): number[][][] =>
+  [...chart.matchAll(/<polyline points="([^"]+)"/g)].map((match) =>
+    match[1].split(" ").map((pair) => pair.split(",").map(Number))
+  );
+
+const NOW = new Date("2026-01-20T09:00:00Z");
+
+describe("spend", () => {
+  it("ends a lagging source at its own known day instead of padding it with zeros", () => {
+    const github = source(run("2026-01-01", 20, 1), 2, "#58a6ff");
+    const blacksmith = source(run("2026-01-01", 19, 2), 1, "#f59e0b");
+    const { chart, duration } = spendChart([github, blacksmith], NOW, "good");
+    expect(duration).toBe(20 * DAY);
+    const lines = polylines(chart);
+    expect(lines.length).toBe(2);
+    const [first, second] = lines;
+    expect(first.length).toBe(20);
+    expect(first[first.length - 1][0]).toBe(220);
+    // The shorter line stops one day column short of the chart's right edge,
+    // and holds its $2 height there instead of plunging to a padded zero.
+    expect(second.length).toBe(19);
+    expect(second[second.length - 1][0]).toBeCloseTo((18 / 19) * 220, 1);
+    expect(new Set(second.map(([, y]) => y)).size).toBe(1);
+  });
+
+  it("charts a settled quiet stretch as zeros and stops at the settled horizon", () => {
+    const github = source(run("2026-01-01", 10, 18), 2, "#58a6ff");
+    const { chart, duration } = spendChart([github], NOW, "good");
+    expect(duration).toBe(18 * DAY);
+    const lines = polylines(chart);
+    expect(lines.length).toBe(1);
+    const heights = lines[0].map(([, y]) => y);
+    // The 2-day lag settles the quiet 11th-18th into real charted zeros; the
+    // unsettled 19th-20th are not drawn at all.
+    expect(lines[0].length).toBe(18);
+    expect(lines[0][17][0]).toBe(220);
+    expect(new Set(heights.slice(10)).size).toBe(1);
+    expect(heights[10]).toBeGreaterThan(heights[9]);
+  });
+
+  it("leaves a source alone whose newest day is already its settled horizon", () => {
+    const gcp = source(run("2026-01-01", 19, 3), 1, "#4285f4");
+    const { chart, duration } = spendChart([gcp], NOW, "good");
+    expect(duration).toBe(19 * DAY);
+    const lines = polylines(chart);
+    expect(lines.length).toBe(1);
+    expect(lines[0].length).toBe(19);
+    expect(lines[0][18][0]).toBe(220);
+  });
+
+  it("aligns each line's highlight to the shared trailing window", () => {
+    const github = source(run("2026-01-01", 20, 1), 2, "#58a6ff");
+    const blacksmith = source(run("2026-01-01", 19, 2), 1, "#f59e0b");
+    const { chart } = spendChart([github, blacksmith], NOW, "good", 5);
+    const lines = polylines(chart);
+    // Two bases, then the two bright trailing slices.
+    expect(lines.length).toBe(4);
+    const [, , firstTint, secondTint] = lines;
+    // The window is the last five day columns; the shorter line has four of
+    // them, and both slices start at the same column.
+    expect(firstTint.length).toBe(5);
+    expect(secondTint.length).toBe(4);
+    expect(secondTint[0][0]).toBe(firstTint[0][0]);
+  });
+});

--- a/packages/dashboard/tiles/gcp-spend.ts
+++ b/packages/dashboard/tiles/gcp-spend.ts
@@ -303,8 +303,14 @@ export const gcpSpend: Tile = {
     const dailyBudget = readBudget(ctx.env("GCP_DAILY_BUDGET"));
     const monthlyBudget = dailyBudget * daysInMonth;
     const status = budgetStatus(summary.projected, monthlyBudget);
+    // The history holds finished days only, so its newest day is exactly the
+    // lag behind today and the line already ends on it.
     const chart = spendChart(
-      [{ spend: { byDay: history.paid }, color: GCP_COLOR }],
+      [{
+        spend: { byDay: history.paid },
+        color: GCP_COLOR,
+        lagDays: history.lagDays,
+      }],
       now,
       status,
       summary.estimateDays,

--- a/packages/dashboard/tiles/github-ci-spend.test.ts
+++ b/packages/dashboard/tiles/github-ci-spend.test.ts
@@ -202,10 +202,11 @@ Deno.test("ci spend: projects the month from the settled daily rate, against the
   );
   assertEquals(v.hint, "billing ↗");
   assertStringIncludes(v.extra ?? "", "<polyline");
-  // The line ends on the last day with a figure (the 10th), not on today: billing
-  // runs a day or two behind, and drawing to today would show a fake dip to zero.
-  // December 1st to January 10th inclusive is 41 days.
-  assertEquals(v.duration, 41 * D);
+  // The line runs to the newest settled day, the 18th: the quiet 11th-18th are
+  // real zeros and chart as such, while the unsettled 19th-20th have no figure
+  // yet and are left off rather than drawn as a dip to zero. The 45-day window
+  // then reaches back to December 5th.
+  assertEquals(v.duration, 45 * D);
 });
 
 Deno.test("ci spend: a 200 without a usageItems array grays out rather than reading as $0", async () => {
@@ -293,7 +294,7 @@ Deno.test("ci spend: a prior month we can't read shortens the chart, it doesn't 
   });
   assertEquals(v.status, "good");
   assertEquals(v.value, "~$310/mo");
-  assertEquals(v.duration, 10 * D); // January 1st to 10th only
+  assertEquals(v.duration, 18 * D); // January 1st to the settled 18th only
 });
 
 Deno.test("ci spend: an unavailable prior month is not zero-spend history", async () => {
@@ -424,7 +425,9 @@ Deno.test("ci spend: Blacksmith invoice, runner history, and threshold form one 
   assertStringIncludes(v.extra ?? "", "$150");
   assertStringIncludes(v.extra ?? "", "Budget $230");
   assertStringIncludes(v.extra ?? "", "<polyline");
-  assertEquals(v.duration, 10 * D);
+  // Blacksmith settles a day behind, so the line runs to the 19th, charting
+  // the quiet 11th-19th as the zeros they are.
+  assertEquals(v.duration, 19 * D);
   const blacksmithRequests = requests.filter((path) =>
     path.startsWith("api/user/github/orgs/")
   );

--- a/packages/dashboard/tiles/github-ci-spend.ts
+++ b/packages/dashboard/tiles/github-ci-spend.ts
@@ -512,11 +512,13 @@ export const githubCiSpend: Tile = {
           spend: githubDollars,
           color: GITHUB_COLOR,
           label: githubDollars ? usd(githubDollars.mtd) : undefined,
+          lagDays: GITHUB_LAG_DAYS,
         },
         {
           spend: blacksmithValue,
           color: BLACKSMITH_COLOR,
           label: blacksmithValue ? usd(blacksmithValue.mtd) : undefined,
+          lagDays: BLACKSMITH_LAG_DAYS,
         },
       ],
       now,

--- a/packages/dashboard/tiles/model-spend.ts
+++ b/packages/dashboard/tiles/model-spend.ts
@@ -166,11 +166,13 @@ export const modelSpend: Tile = {
           spend: oaMap ? { byDay: oaMap } : null,
           color: OPENAI_COLOR,
           label: oa ? usd(oa.mtd) : undefined,
+          lagDays: PROVIDER_LAG_DAYS,
         },
         {
           spend: anMap ? { byDay: anMap } : null,
           color: ANTHROPIC_COLOR,
           label: an ? usd(an.mtd) : undefined,
+          lagDays: PROVIDER_LAG_DAYS,
         },
       ],
       now,


### PR DESCRIPTION
spendChart builds one shared day grid for every source, ends it on the newest day any source reported, and charts each source's missing days as $0. The sources report on different schedules: the GitHub usage report carries a partial figure for today, while Blacksmith's daily costs are requested only through yesterday, and each settles a day or two later still. Zero-filling the shared grid therefore draws a drop to zero at the right edge of every line whose source has not reported the newest charted day. On the deployed board the Blacksmith line fell to zero on today's column every day, which reads as CI spend having stopped rather than as a day with no figure yet.

Give each chart source the reporting lag its tile already uses for its projection, and end its line on the day it is known through: its last reported day, or the newest day the lag has settled, whichever is later. A settled day with no report is a real $0 and still charts as one, so a source that goes quiet declines to zero and keeps advancing. Days past the horizon are not drawn at all. The grid runs to the latest known day across sources, each line's trailing highlight counts only the day columns that line covers, and a line the grid outlives places its points with explicit positions on the shared axis so its day columns stay aligned with the other lines.

The rule guarantees only where a line ends. Interior grid days a source never reported — a prior month whose usage report could not be fetched, for example — still chart as zeros without being known, and the spend.ts comment claims no more than the line-end rule.

The GCP tile already trims its history to finished days and measures its lag as the distance to the newest one, so its chart is unchanged; it now states that lag explicitly. The GitHub and model-spend tiles pass the lag constants they already apply to their projections.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

