### PR TITLE
fix(shell): import Command from the view base it moved to

### DIFF
--- a/packages/shell/test/global-shortcuts-controller.test.ts
+++ b/packages/shell/test/global-shortcuts-controller.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { GlobalShortcutsController } from "../src/lib/global-shortcuts-controller.ts";
-import type { Command } from "../shared/mod.ts";
+import type { Command } from "../src/views/BaseView.ts";
 
 // Exercises the shell's two global keyboard shortcuts: Cmd/Ctrl+Shift+O opens
 // the quick jump view, and Alt+W navigates to the space the current view


### PR DESCRIPTION
The shell's global-shortcuts test asks for the `Command` type from `shared/mod.ts`, and nothing there declares it any more. Type checking the codebase fails, which fails the Check job, which fails every commit that lands on top.

Two changes landed a few minutes apart and were each green against the base they were written on. One collapsed the app command pipeline into XRootView methods and moved `Command` out of the shared app state and into `src/views/BaseView.ts`, next to the `command()` method that dispatches it and the `SHELL_COMMAND` event name it rides on. The other replaced the shell's keyboard router with a direct keydown listener and brought a test for it that imports `Command` from where it used to be. Neither touched a line the other touched, so git merged them without complaint and the break only appeared once both were on main.

The test now names the declaration's new home. The controller under test already imports from there for its own use of the type, so the test and the code it exercises agree on one source again.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

