### PR TITLE
fix(runner): let a write skip the artifact walk over a query result

### DIFF
--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -304,6 +304,10 @@ One line per archived document; each document's header carries the fuller
   — why deriving demand refcounts from the roots on every change cost a growing
   list cubic work, and what incremental maintenance measured instead, August
   2026.
+- [2026-08-read-modify-write-artifact-walk.md](development/performance/2026-08-read-modify-write-artifact-walk.md)
+  — why reading a list, changing one element, and writing it back grew seven
+  times more expensive: the builder-artifact walk on the raw write path read
+  into the query results a read hands out, August 2026.
 - [coverage-ratchet-noise-2026-07-28.md](development/coverage-ratchet-noise-2026-07-28.md)
   — why a rename-only pull request owed coverage debt: a wall-clock-guarded
   diagnostic and a shard re-partition each moved the `packages/runner`

--- a/docs/history/development/performance/2026-08-read-modify-write-artifact-walk.md
+++ b/docs/history/development/performance/2026-08-read-modify-write-artifact-walk.md
@@ -1,0 +1,128 @@
+---
+status: historical
+created: 2026-08-06
+archived: 2026-08-06
+reason: "Investigation of the read-modify-write benchmark regression traced to the artifact walk."
+---
+
+# Read-modify-write regression from the artifact walk, August 2026
+
+## Result
+
+Between the benchmark runs for `e7ea3bc9c2` and `9d927b8af7`, every
+`flat list update - READ-MODIFY-WRITE` benchmark in
+`packages/runner/test/cell-set-flat-index-list.bench.ts` slowed by roughly
+seven times. The measurements below are from the Intel Xeon Platinum 8573C
+runner; the same step appeared on both AMD runners, one run later on each,
+which is when each next drew that processor.
+
+| Benchmark | Before | After |
+| --- | ---: | ---: |
+| READ-MODIFY-WRITE, 100 items | 261 ms | 1,850 ms |
+| READ-MODIFY-WRITE, 1000 items | 2,323 ms | 16,206 ms |
+| READ-MODIFY-WRITE, 3000 items | 7,103 ms | 49,562 ms |
+
+Each figure covers 20 update transactions, which is what the bench times.
+
+The step inverted the relationship the benchmark exists to show. Reading the
+list, replacing one element, and writing it back is meant to be far cheaper
+than regenerating the whole list from scratch, because the elements a read
+hands back carry their identity and only the changed one has to be written.
+After the step, the read-modify-write case was slower than the regenerate
+case: 16.2 seconds against 13.8 at 1000 items.
+
+`Cell.set() - multiple transactions, one set each` in
+`packages/runner/test/cell-set.bench.ts` moved on the same run boundary, from
+about 98 ms to about 144 ms, and has the same cause.
+
+## Cause
+
+Bisecting the 28 commits between the two runs, with the bench cut down to
+1000 items and 5 update transactions, identified
+[#5342](https://github.com/commontoolsinc/labs/pull/5342) — `refactor(runner):
+the runtime serializes its own cells and artifacts`. That change added a call
+to `flattenBuilderArtifacts()` in `diffAndUpdate()`, so the raw write path
+behind `Cell.set()` walks every value on its way in, looking for builder
+artifacts to replace.
+
+What a read hands back is a query-result proxy: a view whose members resolve
+through the transaction it is bound to, one at a time, as they are asked for.
+The walk descends into anything that reports itself as a plain object or an
+array, and a view reports itself as both. So walking a list of 1000 views read
+back a member of each, and each of their nested records in turn, and every one
+of those reads was recorded on the transaction as a dependency the commit then
+had to check.
+
+Two costs, measured at 1000 items, one update transaction:
+
+| Phase | Before | After |
+| --- | ---: | ---: |
+| `cell.set()` | 3 ms | 50 ms |
+| `tx.commit()` | 38 ms | 250 ms |
+
+The walk found nothing either time. Every element came back from it by
+identity, exactly as it went in. A view fronts stored data, and a builder
+artifact has no stored form, so on this path there was nothing under one for
+the walk to replace.
+
+The write path below the walk already treated a view as a leaf.
+`normalizeAndDiff()` recognizes one and replaces it with the sigil link it
+names, without reading a single member. That is why the read-modify-write case
+was cheap to begin with: 1000 unchanged elements each became a link naming the
+slot they already occupied, and only the one replaced element was written. The
+walk running ahead of it defeated that by forcing the view before the diff
+could decline to look at it.
+
+## Fix
+
+`replaceArtifacts()` in `packages/runner/src/encodable-form.ts` gained an
+`isLeaf` hook, by which a caller names a value the walk must not read into,
+and `diffAndUpdate()` answers it with the predicate `normalizeAndDiff()`
+already uses to recognize a query result. `Runner.updateArgument()` answers it
+too: the value it flattens goes only to writes, never to a serializer.
+
+The hook belongs to the caller rather than to the walk, and the first attempt
+at this fix, which made the walk skip a view unconditionally, is what shows
+why. Reading a member of a view that holds a stream marker yields a real
+`Cell`, because `createQueryResultProxy()` answers a `{ $stream: true }` value
+with one. A `Cell` has no fabric representation either, and
+`Runtime.getImmutableCell()` supplies the `replaceOther` hook that turns one
+into the link naming it. Skipping the view there left the `Cell` in place, and
+the conversion rejected it: "Not representable as a `FabricValue`: CellImpl".
+Nothing in the tree covered that, so the whole runner suite passed.
+
+The two boundaries want opposite answers, and what separates them is what each
+does with the result. `getImmutableCell()` derives an entity id from the bytes
+of the whole value, so it has to read every member either way, and descending
+costs nothing it was not already going to spend. `diffAndUpdate()` hands the
+value to a diff that replaces a query result with a link, so reading into one
+is effect with no reader.
+
+Measured on an Apple M5 Max, at 1000 items and 5 update transactions, three
+runs of each variant of one tree back to back:
+
+| Variant | Runs | Median |
+| --- | --- | ---: |
+| the walk absent from the raw write path | 216, 215, 213 ms | 215 ms |
+| the walk as it stands | 1397, 1407, 1418 ms | 1,407 ms |
+| the walk with the hook | 217, 210, 216 ms | 216 ms |
+
+The per-transaction split above accounts for the same totals: five
+transactions of 3 ms plus 38 ms is the first row, and of 50 ms plus 250 ms is
+the second.
+
+## Two things found along the way, not fixed here
+
+The write accounting in `cell-set-flat-index-list.bench.ts` reports zeros for
+every benchmark — `docs=0 storedBytes=0`, `avgBytes/tx=0 avgDocs/tx=0.0`. It
+reads `tx.journal.novelty(space)` after the transaction has committed, and a
+settled transaction no longer holds its journal. Stored bytes per item and
+documents written per transaction are the questions the bench file's header
+says it exists to answer, and it currently answers neither.
+
+Those same reports never reach continuous integration in any case. They are
+written with `console.error` from inside a benchmark body, which the JSON
+reporter captures rather than passing through to stderr.
+[`../../../development/BENCHMARKS.md`](../../../development/BENCHMARKS.md)
+states the rule and names the fix: a body diagnostic writes to `Deno.stderr`
+directly.

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -404,11 +404,19 @@ export function diffAndUpdate(
   // the raw write path, reached by `Cell.set()` and the collection operations;
   // the pattern-driven paths (a run's result, its argument) do the same at
   // their own boundaries.
+  //
+  // A query result is a leaf to that walk, because it is one to the diff
+  // below: `normalizeAndDiff()` replaces such a value with the sigil link it
+  // names without reading a member of it. Each member read on one resolves
+  // through this transaction and is recorded on it as a dependency the commit
+  // has to check.
   const changes = normalizeAndDiff(
     runtime,
     tx,
     link,
-    flattenBuilderArtifacts(newValue),
+    flattenBuilderArtifacts(newValue, {
+      isLeaf: isCellResultForDereferencing,
+    }),
     context,
     readOptions,
     { seen: new Map(), nextAnchorId: anchorIds },

--- a/packages/runner/src/encodable-form.ts
+++ b/packages/runner/src/encodable-form.ts
@@ -110,13 +110,40 @@ type OnCopy = (copy: unknown, original: unknown) => void;
  */
 type ReplaceOther = (value: object | AnyFunction) => unknown;
 
+/**
+ * Asked about each container the walk is about to descend into, and answers
+ * whether the caller holds it to be a leaf -- a value whose members the walk
+ * must not read.
+ *
+ * A live query-result view is what the hook is for: its members resolve
+ * through the transaction behind it as they are asked for, and each read is
+ * recorded there as a dependency. A caller supplies this when what receives
+ * the result does not read inside such a value either, so the reading would
+ * buy nothing. A caller that goes on to serialize the whole value does not,
+ * since those members have to be read either way.
+ */
+type IsLeaf = (value: object) => boolean;
+
+/**
+ * The two questions the walk puts to its caller, about values it cannot settle
+ * on its own. Each defaults to the answer that leaves the walk to its own
+ * judgment.
+ */
+export type WalkHooks = {
+  replaceOther?: ReplaceOther;
+  isLeaf?: IsLeaf;
+};
+
+/** The same pair with both answers in hand, which is what the walk carries. */
+type Hooks = Required<WalkHooks>;
+
 /** Shorthand for the callable shape the walk reaches. */
 type AnyFunction = (...args: never[]) => unknown;
 
 /**
  * Replaces every builder artifact reachable from `value` with its encodable
- * form, yielding a value the data model can represent. `replaceOther` extends
- * that to values the walk does not descend into (see `ReplaceOther`).
+ * form, yielding a value the data model can represent. The hooks are the two
+ * questions a caller answers for it (see `WalkHooks`).
  *
  * A builder artifact carries its serializer as a `toEncodableForm` method (see
  * `builder/module.ts` and `builder/pattern.ts`). A method is a function-valued
@@ -148,9 +175,12 @@ type AnyFunction = (...args: never[]) => unknown;
 export function replaceArtifacts<T>(
   value: T,
   onCopy: OnCopy,
-  replaceOther: ReplaceOther = (value) => value,
+  hooks: WalkHooks = {},
 ): T {
-  return replace(value, new Map(), onCopy, replaceOther) as T;
+  return replace(value, new Map(), onCopy, {
+    replaceOther: hooks.replaceOther ?? ((value) => value),
+    isLeaf: hooks.isLeaf ?? (() => false),
+  }) as T;
 }
 
 /**
@@ -167,7 +197,7 @@ function replace(
   value: unknown,
   seen: Map<object, unknown>,
   onCopy: OnCopy,
-  replaceOther: ReplaceOther,
+  hooks: Hooks,
 ): unknown {
   if (value === null) return value;
   const isFunction = typeof value === "function";
@@ -185,15 +215,22 @@ function replace(
   if (isFunction) {
     const method = ownEncodableFormMethod(value);
     if (method === undefined) {
-      return replaced(value, replaceOther, seen, onCopy);
+      return replaced(value, hooks, seen, onCopy);
     }
     seen.set(value, IN_PROGRESS);
     return copied(
-      replace(encodableFormFrom(method, value), seen, onCopy, replaceOther),
+      replace(encodableFormFrom(method, value), seen, onCopy, hooks),
       value,
       seen,
       onCopy,
     );
+  }
+
+  // A value the caller holds to be a leaf is settled ahead of the shape
+  // questions below, whatever shape it reports. It still goes to
+  // `replaceOther`, which is what stands something in its place.
+  if (hooks.isLeaf(value)) {
+    return replaced(value, hooks, seen, onCopy);
   }
 
   // The array rule applies whatever an array carries, so an array is only ever
@@ -210,13 +247,13 @@ function replace(
     // walk's to rewrite. That is not the same as the conversion refusing one:
     // `native-type-tags.ts` reports it as `Object`. Whether to accept it is the
     // conversion's question, asked of the value as it stands.
-    return replaced(value, replaceOther, seen, onCopy);
+    return replaced(value, hooks, seen, onCopy);
   }
 
   seen.set(value, IN_PROGRESS);
   let flattened: unknown;
   if (isArray) {
-    flattened = replaceInElements(value, seen, onCopy, replaceOther);
+    flattened = replaceInElements(value, seen, onCopy, hooks);
   } else {
     // The artifact's _own_ method is what gets read and called, rather than the
     // serializer it delegates to: the method a copy carries is closed over the
@@ -228,9 +265,9 @@ function replace(
         value as Record<string, unknown>,
         seen,
         onCopy,
-        replaceOther,
+        hooks,
       )
-      : replace(encodableFormFrom(method, value), seen, onCopy, replaceOther);
+      : replace(encodableFormFrom(method, value), seen, onCopy, hooks);
   }
   return copied(flattened, value, seen, onCopy);
 }
@@ -244,11 +281,11 @@ function replace(
  */
 function replaced(
   value: object | AnyFunction,
-  replaceOther: ReplaceOther,
+  hooks: Hooks,
   seen: Map<object, unknown>,
   onCopy: OnCopy,
 ): unknown {
-  const replacement = replaceOther(value);
+  const replacement = hooks.replaceOther(value);
   if (replacement === value) return value;
   return copied(replacement, value, seen, onCopy);
 }
@@ -285,7 +322,7 @@ function replaceInElements(
   value: readonly unknown[],
   seen: Map<object, unknown>,
   onCopy: OnCopy,
-  replaceOther: ReplaceOther,
+  hooks: Hooks,
 ): readonly unknown[] {
   // Read each element _once_, and build any copy from what was read -- the
   // array counterpart of the entries `replaceInEntries` materializes, for the
@@ -306,7 +343,7 @@ function replaceInElements(
     // a hole here too.
     if (!(i in value)) continue;
     const element = value[i];
-    const flattened = replace(element, seen, onCopy, replaceOther);
+    const flattened = replace(element, seen, onCopy, hooks);
     replaced[i] = flattened;
     if (flattened !== element) changed = true;
   }
@@ -321,7 +358,7 @@ function replaceInEntries(
   value: Record<string, unknown>,
   seen: Map<object, unknown>,
   onCopy: OnCopy,
-  replaceOther: ReplaceOther,
+  hooks: Hooks,
 ): Record<string, unknown> {
   // Read each member _once_, and build any copy from what was read: reading a
   // second time to copy would run an accessor twice and keep the second
@@ -331,7 +368,7 @@ function replaceInEntries(
   let result: Record<string, unknown> | undefined;
   for (let i = 0; i < entries.length; i++) {
     const [key, element] = entries[i];
-    const flattened = replace(element, seen, onCopy, replaceOther);
+    const flattened = replace(element, seen, onCopy, hooks);
     if (flattened === element) continue;
     result ??= Object.fromEntries(entries);
     result[key] = flattened;

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -76,6 +76,7 @@ import {
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { sendValueToBinding } from "./pattern-binding.ts";
 import { flattenBuilderArtifacts } from "./storage-preflight.ts";
+import { isCellResultForDereferencing } from "./query-result-proxy.ts";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import {
   type AddCancel,
@@ -1509,8 +1510,12 @@ export class Runner {
     // A sub-pattern's argument can carry a builder artifact -- a pattern
     // handed to another pattern as an input. This is a storage boundary like
     // any other, so the artifact is replaced on the way in, once, for every
-    // write below: they must agree on what was stored.
-    const storable = flattenBuilderArtifacts(argument);
+    // write below: they must agree on what was stored. A query result is a
+    // leaf here for the same reason it is one to the writes below, which each
+    // replace such a value with the sigil link it names.
+    const storable = flattenBuilderArtifacts(argument, {
+      isLeaf: isCellResultForDereferencing,
+    });
     argumentCell.set(storable);
     // The policy recorder sees the RAW argument, as its sibling in
     // `updateResultProjection` does. Handing it the flattened one would walk

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -2042,7 +2042,9 @@ export class Runtime {
     // artifact's encodable form is walked in turn, so a cell inside one is
     // reached as well.
     const asDataURI = dataUriFromValue(
-      fabricFromNativeValue(flattenBuilderArtifacts(data, cellAsLink)),
+      fabricFromNativeValue(
+        flattenBuilderArtifacts(data, { replaceOther: cellAsLink }),
+      ),
     );
     return createCell(
       this,

--- a/packages/runner/src/storage-preflight.ts
+++ b/packages/runner/src/storage-preflight.ts
@@ -1,10 +1,10 @@
 import { noteDerivedCopy } from "./builder/pattern-metadata.ts";
-import { replaceArtifacts } from "./encodable-form.ts";
+import { replaceArtifacts, type WalkHooks } from "./encodable-form.ts";
 
 /**
  * Replaces every builder artifact reachable from `value` with its encodable
- * form, on the way into the data model. `replaceOther` extends that to values
- * the walk does not descend into; see `ReplaceOther` in `encodable-form.ts`.
+ * form, on the way into the data model. The hooks are the walk's own; see
+ * `WalkHooks` in `encodable-form.ts`.
  *
  * The walk itself is `replaceArtifacts`; this names the one thing a storage
  * boundary adds to it -- carrying trust and the content-addressed entry ref
@@ -21,9 +21,6 @@ import { replaceArtifacts } from "./encodable-form.ts";
  * original. A copy of a trusted artifact being trusted is the property the
  * side tables exist to preserve; not carrying it was the bug.
  */
-export function flattenBuilderArtifacts<T>(
-  value: T,
-  replaceOther?: (value: object | ((...args: never[]) => unknown)) => unknown,
-): T {
-  return replaceArtifacts(value, noteDerivedCopy, replaceOther);
+export function flattenBuilderArtifacts<T>(value: T, hooks?: WalkHooks): T {
+  return replaceArtifacts(value, noteDerivedCopy, hooks);
 }

--- a/packages/runner/test/data-updating.test.ts
+++ b/packages/runner/test/data-updating.test.ts
@@ -1719,6 +1719,56 @@ describe("data-updating", () => {
       expect(cell.withTx(tx).get().value).toBe(42);
     });
   });
+
+  describe("writing back what a read handed out", () => {
+    /** The list shape a search index or an autocomplete list has. */
+    const list = (n: number) =>
+      Array.from({ length: n }, (_, i) => ({
+        label: `entry-${i}`,
+        nested: { id: `id-${i}` },
+      }));
+
+    /** Writes a list back with one element replaced, counting reads. */
+    const rewriteOneElement = (n: number) => {
+      const cell = runtime.getCell<ReturnType<typeof list>>(
+        space,
+        `write back ${n}`,
+        undefined,
+        tx,
+      );
+      cell.set(list(n));
+
+      const written = [...cell.get()];
+      written[7] = { label: "changed", nested: { id: "changed" } };
+      const before = tx.getReactivityLog!().reads.length;
+      cell.set(written);
+      const reads = tx.getReactivityLog!().reads.length - before;
+
+      return { reads, value: cell.get() };
+    };
+
+    it("records the same reads however long the list is", () => {
+      // Each element a read hands out is a query result, and the diff replaces
+      // one with the link it names rather than reading into it. Nothing ahead
+      // of the diff reads into one either, so what a write-back costs does not
+      // follow the length: a member read resolves through the transaction and
+      // is recorded on it as a dependency the commit has to check.
+      const short = rewriteOneElement(50);
+      const long = rewriteOneElement(500);
+
+      expect(long.reads).toBe(short.reads);
+      // And what it records is a handful, not a number that merely happens to
+      // match: fewer reads than the shorter list has elements.
+      expect(long.reads).toBeLessThan(50);
+    });
+
+    it("writes the changed element and leaves its neighbor", () => {
+      const { value } = rewriteOneElement(50);
+
+      expect(value[7].label).toBe("changed");
+      expect(value[8].label).toBe("entry-8");
+    });
+  });
 });
 
 /**

--- a/packages/runner/test/data-updating.test.ts
+++ b/packages/runner/test/data-updating.test.ts
@@ -1758,7 +1758,11 @@ describe("data-updating", () => {
 
       expect(long.reads).toBe(short.reads);
       // And what it records is a handful, not a number that merely happens to
-      // match: fewer reads than the shorter list has elements.
+      // match at both lengths: fewer reads than the shorter list has
+      // elements, and more than none. A write-back records the dependencies
+      // its commit is checked against, so a count of zero is a write that
+      // conflicts with nothing, which two equal counts alone would accept.
+      expect(long.reads).toBeGreaterThan(0);
       expect(long.reads).toBeLessThan(50);
     });
 

--- a/packages/runner/test/data-updating.test.ts
+++ b/packages/runner/test/data-updating.test.ts
@@ -1766,6 +1766,48 @@ describe("data-updating", () => {
       expect(long.reads).toBeLessThan(50);
     });
 
+    it("stores a value answering `toCell` as the link it names", () => {
+      // What the walk stops at, the diff replaces with a link -- which is
+      // what makes an unchanged element of a read-back list cost nothing to
+      // write, and is the property the walk stopping must not disturb. Both
+      // kinds of value answer `toCell` and both land the same way: the live
+      // view a schemaless read hands out, and the frozen result a read
+      // through a schema annotates.
+      const source = runtime.getCell<{ inner: { deep: number } }>(
+        space,
+        "toCell source",
+        undefined,
+        tx,
+      );
+      source.set({ inner: { deep: 1 } });
+      const innerLink = source.key("inner").getAsNormalizedFullLink();
+
+      const live = (source.get() as { inner: unknown }).inner;
+      const frozen = (runtime.getCell(
+        space,
+        "toCell source",
+        {
+          type: "object",
+          properties: { inner: { type: "object" } },
+        } as JSONSchema,
+        tx,
+      ).get() as { inner: unknown }).inner;
+
+      const storedFor = (name: string, held: unknown) => {
+        const holder = runtime.getCell(space, name, undefined, tx);
+        holder.set({ held });
+        return (holder.getRaw() as { held: unknown }).held;
+      };
+      const fromLive = storedFor("toCell holder live", live);
+      const fromFrozen = storedFor("toCell holder frozen", frozen);
+
+      expect(isSigilLink(fromLive)).toBe(true);
+      expect(areNormalizedLinksSame(parseLink(fromLive)!, innerLink)).toBe(
+        true,
+      );
+      expect(fromFrozen).toEqual(fromLive);
+    });
+
     it("writes the changed element and leaves its neighbor", () => {
       const { value } = rewriteOneElement(50);
 

--- a/packages/runner/test/encodable-form.test.ts
+++ b/packages/runner/test/encodable-form.test.ts
@@ -328,15 +328,67 @@ describe("encodable-form", () => {
       });
     });
 
+    describe("the `isLeaf` hook", () => {
+      // The hook is how a caller names a value the walk must not read into.
+      // In the runtime that is a live query-result view, whose members
+      // resolve through a transaction as they are asked for.
+      const viaLeaf = (value: unknown, isLeaf: (v: object) => boolean) =>
+        replaceArtifacts(value, () => {}, { isLeaf });
+
+      /** A value whose members cost something to read, counting each read. */
+      function watched(record: Record<string, unknown>) {
+        const reads: (string | symbol)[] = [];
+        const marker = Symbol("a leaf to its caller");
+        const value = new Proxy(record, {
+          get(target, prop, receiver) {
+            if (prop === marker) return true;
+            reads.push(prop);
+            return Reflect.get(target, prop, receiver);
+          },
+          ownKeys(target) {
+            reads.push("[[ownKeys]]");
+            return Reflect.ownKeys(target);
+          },
+        });
+        function isLeaf(v: object) {
+          return (v as Record<symbol, unknown>)[marker] === true;
+        }
+        return { value, reads, isLeaf };
+      }
+
+      it("reads no member of a value the hook claims", () => {
+        const { value, reads, isLeaf } = watched({ a: 1, b: { c: 2 } });
+        viaLeaf({ held: value }, isLeaf);
+        expect(reads).toEqual([]);
+      });
+
+      it("leaves an artifact inside a claimed value alone", () => {
+        const { value, isLeaf } = watched({ tool: artifact({ ok: true }) });
+        expect((viaLeaf({ held: value }, isLeaf) as { held: unknown }).held)
+          .toBe(value);
+      });
+
+      it("descends into the same value when no hook is given", () => {
+        const { value, reads } = watched({ tool: artifact({ ok: true }) });
+        const held = (flatten({ held: value }) as { held: { tool: unknown } })
+          .held;
+        expect(held.tool).toEqual({ ok: true });
+        expect(reads).toContain("[[ownKeys]]");
+      });
+    });
+
     describe("the `replaceOther` hook", () => {
       // The hook is how a caller names what _else_ has no fabric
       // representation -- a `Cell`, in the runtime.
-      const viaHook = (value: unknown, replace: (v: object) => unknown) => {
+      const viaHook = (
+        value: unknown,
+        replaceOther: (v: object) => unknown,
+      ) => {
         const seen: { copy: unknown; original: unknown }[] = [];
         const result = replaceArtifacts(
           value,
           (copy, original) => seen.push({ copy, original }),
-          replace,
+          { replaceOther },
         );
         return { result, seen };
       };
@@ -638,6 +690,58 @@ describe("encodable-form", () => {
       const { cell, reactive } = subjects();
       const held = { cell, reactive };
       expect(flatten(held)).toBe(held);
+    });
+  });
+
+  describe("a query result holding a stream marker", () => {
+    let runtime: Runtime;
+    let storageManager: ReturnType<typeof StorageManager.emulate>;
+    let tx: IExtendedStorageTransaction;
+
+    beforeEach(() => {
+      storageManager = StorageManager.emulate({ as: signer });
+      runtime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager,
+      });
+      tx = runtime.edit();
+    });
+
+    afterEach(async () => {
+      await tx.commit();
+      await runtime?.dispose();
+      await storageManager?.close();
+    });
+
+    it("encodes a stream member as the link naming the cell", () => {
+      // A query result is not uniformly a leaf to the walk. Reading a member
+      // that holds a stream marker yields a `Cell`, which has no fabric
+      // representation of its own and reaches the conversion only as the link
+      // naming it. So a caller that goes on to serialize what it gets back
+      // reads into a query result rather than claiming it with `isLeaf`.
+      //
+      // An immutable cell derives its id from the bytes of what it is given,
+      // so two ids agreeing is the two values encoding the same way.
+      const cell = runtime.getCell<{ handler: unknown; other: number }>(
+        space,
+        "encodable-form-stream-holder",
+        undefined,
+        tx,
+      );
+      cell.set({ handler: { $stream: true }, other: 1 });
+      const view = cell.get() as unknown as {
+        handler: { toSigilLinkOrNull(): unknown };
+      };
+
+      const idOf = (held: unknown) =>
+        runtime.getImmutableCell(space, { held }, undefined, tx)
+          .getAsNormalizedFullLink().id;
+      const link = view.handler.toSigilLinkOrNull();
+
+      expect(idOf(view)).toBe(idOf({ handler: link, other: 1 }));
+      // And the comparison discriminates: the link is what carries the
+      // difference, so a different member in its place is a different id.
+      expect(idOf({ handler: link, other: 2 })).not.toBe(idOf(view));
     });
   });
 });


### PR DESCRIPTION
`Cell.set()` and the collection operations reach the data model through `diffAndUpdate()`, which walks the value on its way in and replaces every builder artifact with its encodable form. That walk descends into anything reporting itself as a plain object or an array.

A query result reports itself as both and is neither. It is a view onto stored data whose members resolve through the transaction it is bound to, one at a time, as they are asked for, and each one of those reads is recorded on the transaction as a dependency the commit then has to check. So writing back a list of a thousand elements that a read had handed back cost a member read of every element, and of every record under each of them, and then a commit checking all of them.

The diff underneath already treats a query result as a leaf. `normalizeAndDiff()` recognizes one and replaces it with the sigil link it names, without reading a single member. That is what makes the read-modify-write shape cheap: an unchanged element becomes a link naming the slot it already occupies, and only the element that changed is written. Forcing the view before the diff could decline to look at it took that away.

`replaceArtifacts()` gains an `isLeaf` hook, by which a caller names a value the walk must not read into. Two callers answer it, and both hand what they get to a diff rather than to a serializer: `diffAndUpdate()`, and `Runner.updateArgument()`, whose flattened argument goes only to the two writes below it. Each answers with the same predicate `normalizeAndDiff()` uses to recognize a query result.

The hook is the caller's rather than the walk's, because the boundaries that walk a value want opposite answers, and what separates them is what each does with the result. `Runtime.getImmutableCell()` derives an entity id from the bytes of the whole value, so it reads every member either way; a query result there can also hand out a `Cell`, which its `replaceOther` hook turns into a link, since reading a member holding a stream marker yields one. A caller feeding a diff reads nothing it will use.

The `flat list update - READ-MODIFY-WRITE` benchmarks in `packages/runner/test/cell-set-flat-index-list.bench.ts` are where this showed up, on all three of the scheduled Benchmarks workflow's runner processors, at up to seven times slower. It inverted the comparison the benchmark exists to make: the read-modify-write case had become slower than regenerating the whole list from scratch, when it should be several times faster. `Cell.set() - multiple transactions, one set each` in `cell-set.bench.ts` moved on the same boundary and comes back with it.

Measured at 1000 items and 5 update transactions, three runs of each variant of one tree back to back, medians: 215 ms with the walk absent from the raw write path, 1,407 ms with it, 216 ms with the hook. What a write-back records no longer grows with the length of the list, which is what the new test in `data-updating.test.ts` pins.

The investigation is recorded in
`docs/history/development/performance/2026-08-read-modify-write-artifact-walk.md`, including two defects it turned up in the benchmark file's own write accounting, which are left for their own change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

