### PR TITLE
docs(shell): name the seams the shell guide leaves out

### DIFF
--- a/packages/shell/AGENTS.md
+++ b/packages/shell/AGENTS.md
@@ -26,6 +26,25 @@ runtime and gives a user a way to move around their spaces. Entry point is
   outside the element sees as `ShellApp`: the shell's `Navigation` takes one,
   and `src/index.ts` publishes the root element on `globalThis.app` under that
   type, which is how integration tests drive the page.
+- Navigation is the other way in, and it does not come from a shell view. Anyone
+  holding `@commonfabric/shell/shared` calls `navigate(...)`, which dispatches a
+  `cf-navigate` event on `globalThis`; the `Navigation` class in
+  `shared/navigate.ts` listens, writes browser history, and calls `setView` on
+  the `ShellApp` it holds. `cf-cell-link`, `cf-space-link`, `cf-render`, and
+  `cf-profile-badge` navigate this way, so a piece being rendered can move the
+  whole shell. The events an embedding host may bind to instead are listed in
+  [`host-embedding.md`](../../docs/features/host-embedding.md).
+- `XRootView` is where a `cf-` component gets its runtime. It holds the only
+  `@provide` of `runtimeContext` and `spaceContext`, the two Lit contexts
+  defined in the `ui` package, and five components there `@consume` them:
+  `cf-cell-link`, `cf-code-editor`, `cf-file-input`, `cf-profile-badge`, and
+  `cf-prompt-input`. One of those mounted outside this tree sees `undefined` for
+  both and renders as though nothing is connected.
+- `src/lib/runtime.ts` and `src/lib/credentials.ts` are one-line re-exports of
+  `@commonfabric/lib-shell`, which is where `RuntimeInternals` and the key
+  handling actually live. The pattern integration tests import that package
+  directly, so editing it changes something outside this package too. Look there
+  first when a runtime question is not answered by the files under `src/`.
 - Embed mode is a property of the route, not of a component. The `.embed` path
   prefix (`shared/app/view.ts`) strips shell-owned chrome, and every navigation
   has to preserve it — including one issued by a rendered pattern. A navigation
@@ -44,6 +63,8 @@ runtime and gives a user a way to move around their spaces. Entry point is
 | The state shape                | `shared/app/state.ts`                                                                                        |
 | What commands exist            | `Command` in `src/views/BaseView.ts`                                                                         |
 | How a command is applied       | `onCommand` and the state setters in `src/views/RootView.ts`                                                 |
-| How the runtime is mounted     | `src/lib/runtime.ts`                                                                                         |
+| How a navigation becomes one   | `Navigation` in `shared/navigate.ts`                                                                         |
+| What a URL means, embed mode   | `shared/app/view.ts`                                                                                         |
+| How the runtime is mounted     | `RuntimeInternals` in `packages/lib-shell/src/runtime.ts`                                                    |
 | Coding style and test commands | [`DEVELOPMENT.md`](../../docs/development/DEVELOPMENT.md), [`TESTING.md`](../../docs/development/TESTING.md) |
 | Writing a `cf-` component      | the `lit-component` skill                                                                                    |


### PR DESCRIPTION
The shell's agent guide lists the facts that will bite someone working in this package. Three things that bite are missing from it, and one entry sends the reader to a file that answers nothing.

Navigation is a second way into application state, and it does not start at a shell view. The guide says a component never writes state and instead calls `this.command(...)`, which is true of the views under `src/views/`, but anything holding `@commonfabric/shell/shared` can call `navigate(...)` instead. That dispatches a `cf-navigate` event on the global object, and `Navigation` in `shared/navigate.ts` listens for it, writes browser history, and calls `setView` on the `ShellApp` it holds. Four components in the `ui` package navigate that way, which is how a piece being rendered inside the shell can move the whole shell. The guide already warned that a navigation issued by a rendered pattern has to preserve the embed prefix without saying where such a navigation comes from; it now says, and points at the host-embedding document for the events an embedder binds to instead.

A `cf-` component gets its runtime from a Lit context, and `XRootView` holds the only provider of it. Five components in the `ui` package consume `runtimeContext` and `spaceContext`; mounted anywhere outside that tree they see `undefined` for both and render as though nothing is connected. Nothing in this package said so, and the failure looks like a broken component rather than a missing provider. The entry names the class rather than `RootView`, which is the file the class lives in, so it matches how the surrounding entries refer to the root element.

`src/lib/runtime.ts` and `src/lib/credentials.ts` are each a single line re-exporting `@commonfabric/lib-shell`. The guide's table pointed at the first of those as the answer to how the runtime is mounted, so following it landed on an export statement. `RuntimeInternals` and the key handling live in the other package, the pattern integration tests import it directly, and a change there is a change outside this package — the same trap the guide already names for `shared/`. The table now points at the class, and a new entry says why the files under `src/lib/` look local but are not.

Two more table rows name where a navigation becomes a state write, and where a URL is parsed and embed mode decided.

Every path, class, event name, and component tag added here was checked against the tree. The component counts are exact rather than approximate, since an approximate count in a guide like this is what stops being true first.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

