### PR TITLE
refactor(utils): delete the logger's timing-output bridge

### DIFF
--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -374,19 +374,6 @@ class TimingDataStore {
 }
 
 /**
- * Build all hierarchical key paths from an array of key segments.
- * @example _buildKeyPaths(["cell", "get", "user"]) => ["cell", "cell/get", "cell/get/user"]
- * Currently unused but kept for potential future hierarchical rollup.
- */
-function _buildKeyPaths(keys: string[]): string[] {
-  const paths: string[] = [];
-  for (let i = 1; i <= keys.length; i++) {
-    paths.push(keys.slice(0, i).join("/"));
-  }
-  return paths;
-}
-
-/**
  * Numeric values for log levels to enable comparison
  */
 const LOG_LEVELS: Record<LogLevel, number> = {
@@ -507,24 +494,6 @@ export interface GetLoggerOptions {
 }
 
 /**
- * Optional timing-output bridge for exporting selected logger timings to
- * Performance entries and/or console output.
- *
- * Matching is prefix-based against:
- * - the timing key path, e.g. "scheduler/execute"
- * - the logger module name, e.g. "scheduler"
- * - the combined form "<module>:<keyPath>", e.g. "scheduler:scheduler/execute"
- *
- * Use ["*"] to match every timed span.
- */
-export interface TimingOutputConfig {
-  include: string[];
-  measure?: boolean;
-  console?: boolean;
-  minMs?: number;
-}
-
-/**
  * Call counts for each log level
  */
 export interface LogCounts {
@@ -533,88 +502,6 @@ export interface LogCounts {
   warn: number;
   error: number;
   readonly total: number;
-}
-
-let _globalTimingOutputConfig: TimingOutputConfig | undefined =
-  getEnvTimingOutputConfig();
-
-function parseBooleanEnv(value: string | undefined): boolean | undefined {
-  if (value === undefined) return undefined;
-  const normalized = value.trim().toLowerCase();
-  if (["1", "true", "yes", "on"].includes(normalized)) return true;
-  if (["0", "false", "no", "off"].includes(normalized)) return false;
-  return undefined;
-}
-
-function parseTimingInclude(source: string | undefined): string[] {
-  if (!source) return [];
-  return source
-    .split(",")
-    .map((part) => part.trim())
-    .filter((part) => part.length > 0);
-}
-
-function getEnvTimingOutputConfig(): TimingOutputConfig | undefined {
-  if (!isDeno()) return undefined;
-
-  try {
-    const include = parseTimingInclude(Deno.env.get("CF_LOG_TIMING"));
-    if (include.length === 0) return undefined;
-
-    const consoleEnabled = parseBooleanEnv(
-      Deno.env.get("CF_LOG_TIMING_CONSOLE"),
-    ) ?? false;
-    const measureEnabled = parseBooleanEnv(
-      Deno.env.get("CF_LOG_TIMING_MEASURE"),
-    ) ?? true;
-    const minMsRaw = Deno.env.get("CF_LOG_TIMING_MIN_MS");
-    const minMs = minMsRaw !== undefined ? Number(minMsRaw) : undefined;
-
-    const config: TimingOutputConfig = {
-      include,
-      console: consoleEnabled,
-      measure: measureEnabled,
-    };
-    if (typeof minMs === "number" && Number.isFinite(minMs)) {
-      config.minMs = minMs;
-    }
-    return config;
-  } catch {
-    return undefined;
-  }
-}
-
-export function setGlobalTimingOutputConfig(
-  config: TimingOutputConfig | undefined,
-): void {
-  _globalTimingOutputConfig = config ?? getEnvTimingOutputConfig();
-}
-
-export function getGlobalTimingOutputConfig():
-  | TimingOutputConfig
-  | undefined {
-  return _globalTimingOutputConfig
-    ? {
-      ..._globalTimingOutputConfig,
-      include: [..._globalTimingOutputConfig.include],
-    }
-    : undefined;
-}
-
-function matchesTimingOutputConfig(
-  config: TimingOutputConfig,
-  moduleName: string | undefined,
-  keyPath: string,
-): boolean {
-  if (config.include.length === 0) return false;
-  if (config.include.includes("*")) return true;
-
-  const combined = moduleName ? `${moduleName}:${keyPath}` : keyPath;
-  return config.include.some((pattern) =>
-    combined.startsWith(pattern) ||
-    keyPath.startsWith(pattern) ||
-    (moduleName?.startsWith(pattern) ?? false)
-  );
 }
 
 /**
@@ -747,50 +634,6 @@ export class Logger {
       this._countsByKey[key] = { debug: 0, info: 0, warn: 0, error: 0 };
     }
     this._countsByKey[key][level]++;
-  }
-
-  private emitTimingOutputs(
-    keyPath: string,
-    startTime: number,
-    endTime: number,
-    elapsed: number,
-  ): void {
-    const config = _globalTimingOutputConfig;
-    if (
-      !config || !matchesTimingOutputConfig(config, this.moduleName, keyPath)
-    ) {
-      return;
-    }
-    if (config.minMs !== undefined && elapsed < config.minMs) {
-      return;
-    }
-
-    const measureName = this.moduleName
-      ? `logger:${this.moduleName}:${keyPath}`
-      : `logger:${keyPath}`;
-
-    if (config.measure !== false) {
-      try {
-        performance.measure(measureName, {
-          start: startTime,
-          end: endTime,
-        });
-      } catch {
-        // Ignore measure failures in runtimes with partial support.
-      }
-    }
-
-    if (config.console) {
-      const prefix = this.moduleName
-        ? `%c[TIMING][${this.moduleName}::${getTimeStamp()}]`
-        : `%c[TIMING][${getTimeStamp()}]`;
-      const duration = `${elapsed.toFixed(3)}ms`;
-      if (shouldLogToStderr()) {
-        logToStderr(prefix.replace("%c", ""), keyPath, duration);
-      } else {
-        console.log(prefix, LOG_COLORS.debug, keyPath, duration);
-      }
-    }
   }
 
   /**
@@ -975,7 +818,6 @@ export class Logger {
     const endTime = performance.now();
     const elapsed = endTime - startTime;
     this._recordTime(elapsed, keys);
-    this.emitTimingOutputs(keyPath, startTime, endTime, elapsed);
     return elapsed;
   }
 
@@ -1011,9 +853,7 @@ export class Logger {
 
     const elapsed = endTime - startTime;
     if (keys.length > 0) {
-      const keyPath = keys.join("/");
       this._recordTime(elapsed, keys);
-      this.emitTimingOutputs(keyPath, startTime, endTime, elapsed);
     }
     return elapsed;
   }
@@ -1480,8 +1320,6 @@ if (typeof globalThis !== "undefined") {
       resetAllTimingBaselines?: typeof resetAllTimingBaselines;
       setGlobalLogFloor?: typeof setGlobalLogFloor;
       getGlobalLogFloor?: typeof getGlobalLogFloor;
-      setGlobalTimingOutputConfig?: typeof setGlobalTimingOutputConfig;
-      getGlobalTimingOutputConfig?: typeof getGlobalTimingOutputConfig;
     };
   };
   if (!global.commonfabric) {
@@ -1497,6 +1335,4 @@ if (typeof globalThis !== "undefined") {
   global.commonfabric.resetAllTimingBaselines = resetAllTimingBaselines;
   global.commonfabric.setGlobalLogFloor = setGlobalLogFloor;
   global.commonfabric.getGlobalLogFloor = getGlobalLogFloor;
-  global.commonfabric.setGlobalTimingOutputConfig = setGlobalTimingOutputConfig;
-  global.commonfabric.getGlobalTimingOutputConfig = getGlobalTimingOutputConfig;
 }

--- a/packages/utils/test/logger.test.ts
+++ b/packages/utils/test/logger.test.ts
@@ -2,7 +2,6 @@ import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {
   getGlobalLogFloor,
-  getGlobalTimingOutputConfig,
   getLogger,
   getLoggerCountsBreakdown,
   getTimingStatsBreakdown,
@@ -12,7 +11,6 @@ import {
   resetAllLoggerCounts,
   resetAllTimingStats,
   setGlobalLogFloor,
-  setGlobalTimingOutputConfig,
 } from "../src/logger.ts";
 
 describe("logger", () => {
@@ -21,8 +19,6 @@ describe("logger", () => {
     log.level = "info";
     // Clear global floor so it doesn't interfere with tests
     setGlobalLogFloor(undefined);
-    setGlobalTimingOutputConfig(undefined);
-    performance.clearMeasures();
   });
 
   afterEach(() => {
@@ -33,8 +29,6 @@ describe("logger", () => {
     if (global.commonfabric?.logger) {
       global.commonfabric.logger = {};
     }
-    setGlobalTimingOutputConfig(undefined);
-    performance.clearMeasures();
   });
 
   // Helper to check styled timestamp format
@@ -1457,80 +1451,6 @@ describe("logger", () => {
         expect(stats1?.count).toBe(1);
         expect(stats2?.count).toBe(1);
       });
-
-      it("should emit performance measures for matching timings when enabled", () => {
-        const logger = getLogger("timing-measure");
-        setGlobalTimingOutputConfig({
-          include: ["timing-measure:operation"],
-          measure: true,
-        });
-
-        logger.time(10, 25, "operation");
-
-        const measures = performance.getEntriesByType("measure").filter((
-          entry,
-        ) => entry.name === "logger:timing-measure:operation");
-
-        expect(measures).toHaveLength(1);
-        expect(measures[0]!.duration).toBe(15);
-      });
-
-      it("should not emit performance measures when timing config does not match", () => {
-        const logger = getLogger("timing-measure-filter");
-        setGlobalTimingOutputConfig({
-          include: ["other-prefix"],
-          measure: true,
-        });
-
-        logger.time(10, 25, "operation");
-
-        const measures = performance.getEntriesByType("measure").filter((
-          entry,
-        ) => entry.name.includes("timing-measure-filter"));
-
-        expect(measures).toHaveLength(0);
-      });
-
-      it("should emit console timing output for matching timings when enabled", () => {
-        const logger = getLogger("timing-console");
-        setGlobalTimingOutputConfig({
-          include: ["timing-console"],
-          console: true,
-          measure: false,
-        });
-
-        const { calls } = captureConsole("log", () => {
-          logger.time(0, 12.5, "operation");
-        });
-
-        expect(calls).toHaveLength(1);
-        expect(calls[0]![0]).toMatch(
-          /^\%c\[TIMING\]\[timing-console::\d{2}:\d{2}:\d{2}\.\d{3}\]$/,
-        );
-        expect(calls[0]![1]).toBe(LOG_COLORS.debug);
-        expect(calls[0]![2]).toBe("operation");
-        expect(calls[0]![3]).toBe("12.500ms");
-      });
-
-      it("should respect minimum duration threshold for timing output", () => {
-        const logger = getLogger("timing-min-threshold");
-        setGlobalTimingOutputConfig({
-          include: ["timing-min-threshold"],
-          console: true,
-          measure: true,
-          minMs: 10,
-        });
-
-        const { calls } = captureConsole("log", () => {
-          logger.time(0, 5, "operation");
-        });
-
-        expect(calls).toHaveLength(0);
-        const measures = performance.getEntriesByType("measure").filter((
-          entry,
-        ) => entry.name.includes("timing-min-threshold"));
-        expect(measures).toHaveLength(0);
-      });
     });
 
     describe("time() direct recording", () => {
@@ -2013,26 +1933,6 @@ describe("logger", () => {
       expect(logger.counts.info).toBe(1);
       expect(logger.counts.warn).toBe(1);
       expect(logger.counts.error).toBe(1);
-    });
-  });
-
-  describe("global timing output config", () => {
-    it("should expose timing output config getters and setters", () => {
-      expect(getGlobalTimingOutputConfig()).toBeUndefined();
-
-      setGlobalTimingOutputConfig({
-        include: ["scheduler/execute"],
-        measure: true,
-        console: true,
-        minMs: 5,
-      });
-
-      expect(getGlobalTimingOutputConfig()).toEqual({
-        include: ["scheduler/execute"],
-        measure: true,
-        console: true,
-        minMs: 5,
-      });
     });
   });
 });


### PR DESCRIPTION
The logger carried an optional side channel that exported selected timing spans to `performance.measure()` entries and to console output. It was switched on either by four environment variables — `CF_LOG_TIMING`, `CF_LOG_TIMING_CONSOLE`, `CF_LOG_TIMING_MEASURE` and `CF_LOG_TIMING_MIN_MS` — or by calling `setGlobalTimingOutputConfig()`, and it decided which spans to export by matching a list of prefixes against the timing key path, the logger's module name, and the two joined together.

Nothing in the repository turns it on. Neither the environment variables nor the setter appears anywhere outside `logger.ts` and its own test file. The environment variables are absent from the configuration documentation, and absent from the experimental-options registry that every flag is supposed to be listed in, so the flag has no supported status for anyone to depend on. The only code that ever read the performance measures it emitted was the test that checked they were emitted.

This deletes the configuration type, the four environment-variable readers, the getter and setter, the prefix matcher, the emit method, the two calls to it in `timeEnd()` and `time()`, the two lines registering the getter and setter on `globalThis.commonfabric`, and the tests covering all of that. It also deletes `_buildKeyPaths`, a helper that sat next to this machinery and that a comment already described as unused.

The timing machinery that the debugger interface actually uses is untouched: `timeStart()`, `timeEnd()` and `getTimingStatsBreakdown()` keep working exactly as before, and anyone profiling can still read `getTimingStatsBreakdown()` from the browser console.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

