### PR TITLE
refactor(utils): delete the superseded naive LRU cache

### DIFF
--- a/packages/utils/src/cache.bench.ts
+++ b/packages/utils/src/cache.bench.ts
@@ -1,20 +1,13 @@
-import {
-  Cache,
-  LRUCache,
-  LRUCacheNaive,
-  WeightedCacheOptions,
-} from "./cache.ts";
+import { LRUCache } from "./cache.ts";
 
 const CACHE_SIZE = 1000;
 const OPERATIONS = 10000;
 
-function createCache<K, V>(
-  Ctor: new (options: WeightedCacheOptions<K, V>) => Cache<K, V>,
-): Cache<K, V> {
-  return new Ctor({ capacity: CACHE_SIZE });
+function createCache<K, V>(): LRUCache<K, V> {
+  return new LRUCache<K, V>({ capacity: CACHE_SIZE });
 }
 
-function fillCache(cache: Cache<number, number>, count: number): void {
+function fillCache(cache: LRUCache<number, number>, count: number): void {
   for (let i = 0; i < count; i++) {
     cache.put(i, i);
   }
@@ -23,17 +16,7 @@ function fillCache(cache: Cache<number, number>, count: number): void {
 Deno.bench({
   name: "LRUCache (linked list) - sequential put",
   fn() {
-    const cache = createCache<number, number>(LRUCache);
-    for (let i = 0; i < OPERATIONS; i++) {
-      cache.put(i, i);
-    }
-  },
-});
-
-Deno.bench({
-  name: "LRUCacheNaive (map) - sequential put",
-  fn() {
-    const cache = createCache<number, number>(LRUCacheNaive);
+    const cache = createCache<number, number>();
     for (let i = 0; i < OPERATIONS; i++) {
       cache.put(i, i);
     }
@@ -42,24 +25,8 @@ Deno.bench({
 
 Deno.bench({
   name: "LRUCache (linked list) - sequential get (hit)",
-  group: "get-hit",
-  baseline: true,
   fn(b) {
-    const cache = createCache<number, number>(LRUCache);
-    fillCache(cache, CACHE_SIZE);
-    b.start();
-    for (let i = 0; i < OPERATIONS; i++) {
-      cache.get(i % CACHE_SIZE);
-    }
-    b.end();
-  },
-});
-
-Deno.bench({
-  name: "LRUCacheNaive (map) - sequential get (hit)",
-  group: "get-hit",
-  fn(b) {
-    const cache = createCache<number, number>(LRUCacheNaive);
+    const cache = createCache<number, number>();
     fillCache(cache, CACHE_SIZE);
     b.start();
     for (let i = 0; i < OPERATIONS; i++) {
@@ -71,24 +38,8 @@ Deno.bench({
 
 Deno.bench({
   name: "LRUCache (linked list) - sequential get (miss)",
-  group: "get-miss",
-  baseline: true,
   fn(b) {
-    const cache = createCache<number, number>(LRUCache);
-    fillCache(cache, CACHE_SIZE);
-    b.start();
-    for (let i = 0; i < OPERATIONS; i++) {
-      cache.get(i + CACHE_SIZE);
-    }
-    b.end();
-  },
-});
-
-Deno.bench({
-  name: "LRUCacheNaive (map) - sequential get (miss)",
-  group: "get-miss",
-  fn(b) {
-    const cache = createCache<number, number>(LRUCacheNaive);
+    const cache = createCache<number, number>();
     fillCache(cache, CACHE_SIZE);
     b.start();
     for (let i = 0; i < OPERATIONS; i++) {
@@ -100,28 +51,8 @@ Deno.bench({
 
 Deno.bench({
   name: "LRUCache (linked list) - mixed put/get with eviction",
-  group: "mixed-eviction",
-  baseline: true,
   fn(b) {
-    const cache = createCache<number, number>(LRUCache);
-    fillCache(cache, CACHE_SIZE);
-    b.start();
-    for (let i = 0; i < OPERATIONS; i++) {
-      if (i % 2 === 0) {
-        cache.put(i + CACHE_SIZE, i);
-      } else {
-        cache.get(i % CACHE_SIZE);
-      }
-    }
-    b.end();
-  },
-});
-
-Deno.bench({
-  name: "LRUCacheNaive (map) - mixed put/get with eviction",
-  group: "mixed-eviction",
-  fn(b) {
-    const cache = createCache<number, number>(LRUCacheNaive);
+    const cache = createCache<number, number>();
     fillCache(cache, CACHE_SIZE);
     b.start();
     for (let i = 0; i < OPERATIONS; i++) {
@@ -137,24 +68,8 @@ Deno.bench({
 
 Deno.bench({
   name: "LRUCache (linked list) - update existing keys",
-  group: "update",
-  baseline: true,
   fn(b) {
-    const cache = createCache<number, number>(LRUCache);
-    fillCache(cache, CACHE_SIZE);
-    b.start();
-    for (let i = 0; i < OPERATIONS; i++) {
-      cache.put(i % CACHE_SIZE, i);
-    }
-    b.end();
-  },
-});
-
-Deno.bench({
-  name: "LRUCacheNaive (map) - update existing keys",
-  group: "update",
-  fn(b) {
-    const cache = createCache<number, number>(LRUCacheNaive);
+    const cache = createCache<number, number>();
     fillCache(cache, CACHE_SIZE);
     b.start();
     for (let i = 0; i < OPERATIONS; i++) {
@@ -166,24 +81,8 @@ Deno.bench({
 
 Deno.bench({
   name: "LRUCache (linked list) - delete",
-  group: "delete",
-  baseline: true,
   fn(b) {
-    const cache = createCache<number, number>(LRUCache);
-    fillCache(cache, CACHE_SIZE);
-    b.start();
-    for (let i = 0; i < CACHE_SIZE; i++) {
-      cache.delete(i);
-    }
-    b.end();
-  },
-});
-
-Deno.bench({
-  name: "LRUCacheNaive (map) - delete",
-  group: "delete",
-  fn(b) {
-    const cache = createCache<number, number>(LRUCacheNaive);
+    const cache = createCache<number, number>();
     fillCache(cache, CACHE_SIZE);
     b.start();
     for (let i = 0; i < CACHE_SIZE; i++) {
@@ -195,32 +94,8 @@ Deno.bench({
 
 Deno.bench({
   name: "LRUCache (linked list) - random access pattern",
-  group: "random",
-  baseline: true,
   fn(b) {
-    const cache = createCache<number, number>(LRUCache);
-    fillCache(cache, CACHE_SIZE);
-    const keys = Array.from(
-      { length: OPERATIONS },
-      () => Math.floor(Math.random() * CACHE_SIZE * 2),
-    );
-    b.start();
-    for (const key of keys) {
-      if (cache.has(key)) {
-        cache.get(key);
-      } else {
-        cache.put(key, key);
-      }
-    }
-    b.end();
-  },
-});
-
-Deno.bench({
-  name: "LRUCacheNaive (map) - random access pattern",
-  group: "random",
-  fn(b) {
-    const cache = createCache<number, number>(LRUCacheNaive);
+    const cache = createCache<number, number>();
     fillCache(cache, CACHE_SIZE);
     const keys = Array.from(
       { length: OPERATIONS },

--- a/packages/utils/src/cache.ts
+++ b/packages/utils/src/cache.ts
@@ -12,15 +12,6 @@ export interface WeightedCacheOptions<K, V> extends CacheOptions {
   maxWeight?: number;
 }
 
-export interface Cache<K, V> {
-  readonly size: number;
-  has(key: K): boolean;
-  get(key: K): V | undefined;
-  put(key: K, value: V): void;
-  delete(key: K): boolean;
-  clear(): void;
-}
-
 /**
  * A Map that drops its oldest key once it holds `limit` of them. Insertion
  * order is the eviction order, and re-setting a key refreshes its place, so
@@ -101,55 +92,6 @@ export class BoundedKeyMap<K, V> implements ReadonlyMap<K, V> {
   }
 }
 
-export class LRUCacheNaive<K, V> implements Cache<K, V> {
-  #map = new Map<K, V>();
-  #capacity: number;
-
-  constructor(options: CacheOptions = {}) {
-    this.#capacity = Math.max(options.capacity ?? 1000, 1);
-  }
-
-  get size(): number {
-    return this.#map.size;
-  }
-
-  has(key: K): boolean {
-    return this.#map.has(key);
-  }
-
-  get(key: K): V | undefined {
-    const value = this.#map.get(key);
-    if (value !== undefined) {
-      this.#map.delete(key);
-      this.#map.set(key, value);
-    }
-    return value;
-  }
-
-  put(key: K, value: V): void {
-    if (this.#map.has(key)) {
-      this.#map.delete(key);
-      this.#map.set(key, value);
-      return;
-    }
-    if (this.#map.size >= this.#capacity) {
-      const oldestKey = this.#map.keys().next().value;
-      if (oldestKey !== undefined) {
-        this.#map.delete(oldestKey);
-      }
-    }
-    this.#map.set(key, value);
-  }
-
-  delete(key: K): boolean {
-    return this.#map.delete(key);
-  }
-
-  clear(): void {
-    this.#map.clear();
-  }
-}
-
 interface LRUNode<K, V> {
   key: K;
   value: V;
@@ -158,7 +100,7 @@ interface LRUNode<K, V> {
   next: LRUNode<K, V> | null;
 }
 
-export class LRUCache<K, V> implements Cache<K, V> {
+export class LRUCache<K, V> {
   #map = new Map<K, LRUNode<K, V>>();
   #head: LRUNode<K, V> | null = null;
   #tail: LRUNode<K, V> | null = null;


### PR DESCRIPTION
`packages/utils/src/cache.ts` carried two complete least-recently-used cache implementations behind one shared `Cache<K, V>` interface. The first, `LRUCacheNaive`, tracked recency by deleting and re-inserting a key in a plain `Map` so that the Map's own insertion order became the eviction order. The second, `LRUCache`, threads the entries onto a doubly-linked list, which is what lets it also carry the weight accounting that the weighted-cache callers depend on. `LRUCache` replaced the naive one everywhere in the tree.

Nothing outside the utils package ever named `LRUCacheNaive`, and nothing anywhere typed a variable or a parameter as `Cache<K, V>`. Every production caller names a concrete class, either `LRUCache` or `BoundedKeyMap`. The naive class had no test coverage of its own: the cache test file exercises only `LRUCache` and `BoundedKeyMap`. The one thing keeping the naive class alive was the benchmark file, which ran every measurement twice, once per implementation, so that the two could be compared against each other. That comparison was settled when the linked-list version landed, so the second implementation was being maintained purely to lose a race nobody was still running.

This change deletes `LRUCacheNaive`, deletes the `Cache<K, V>` interface (`LRUCache` now stands on its own rather than declaring `implements Cache`), and deletes the seven duplicated "LRUCacheNaive (map)" benchmark tracks. The benchmark's two helpers took a constructor-of-`Cache` and a `Cache` so they could build either implementation; with one implementation left they are typed directly to `LRUCache`, and `createCache` no longer takes a constructor argument. The seven remaining "LRUCache (linked list)" tracks keep their names and now measure absolute cost. Their `group` and `baseline` markers are dropped along with the tracks they were comparing against, since a group holding a single benchmark has nothing to compare.

One downstream consequence worth stating: the benchmarks workflow runs this file on a four-hour schedule and the results feed trend charts on the ops dashboard's bench page, so the seven "LRUCacheNaive (map)" series stop receiving new data points from here on. Nothing breaks as a result. The dashboard keys its metrics generically by benchmark name rather than from a fixed list, and the workflow's own validation only requires that the results file contain a nonempty set of benchmarks.

The benchmark was run against the edited file to confirm all seven remaining tracks still execute, and the utils test suite passes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

