### PR TITLE
refactor(memory): take the principal contract from identity

### DIFF
--- a/packages/memory/interface.ts
+++ b/packages/memory/interface.ts
@@ -1,42 +1,29 @@
 import type { FabricValue, SchemaPathSelector } from "@commonfabric/api";
 import type { FabricHash } from "@commonfabric/data-model/fabric-primitives";
+import type { Signer as IdentitySigner } from "@commonfabric/identity";
 import type { ClientCommit } from "./v2.ts";
 
+export type {
+  AsBytes,
+  AuthorizationError,
+  Principal,
+  Signature,
+  Verifier,
+} from "@commonfabric/identity";
+
 /**
- * Some principal identified via DID identifier.
+ * The signing half of the principal contract as the memory protocol uses it:
+ * an {@link IdentitySigner} without the `serialize()` method that hands back
+ * raw key material.
  */
-export type Principal<ID extends DID = DID> = {
-  did(): ID;
-};
-
-export interface Verifier<ID extends DID = DID> extends Principal<ID> {
-  verify(authorization: {
-    payload: Uint8Array;
-    signature: Uint8Array;
-  }): AwaitResult<Unit, AuthorizationError>;
-}
-
-export interface Signer<ID extends DID = DID> extends Principal<ID> {
-  sign<T>(payload: AsBytes<T>): AwaitResult<Signature<T>, Error>;
-
-  verifier: Verifier<ID>;
-}
-
-export interface AsBytes<T> extends Uint8Array {
-  valueOf(): this & AsBytes<T>;
-}
+export type Signer<ID extends DID = DID> = Omit<
+  IdentitySigner<ID>,
+  "serialize"
+>;
 
 export type AsString<T> = string & {
   valueOf(): AsString<T>;
 };
-
-export interface Signature<Payload> extends Uint8Array {
-  valueOf(): this & Signature<Payload>;
-}
-
-export interface AuthorizationError extends Error {
-  name: "AuthorizationError";
-}
 
 /**
  * Unique identifier for the memory space.


### PR DESCRIPTION
The cryptographic principal contract -- a principal that can name its own DID, a verifier that checks a signature, a signer that produces one, and the two phantom-typed byte wrappers `AsBytes` and `Signature` that carry the payload type through the byte array -- was written down twice. `packages/identity/src/interface.ts` holds the copy that every implementation is written against, and `packages/memory/interface.ts` held a second, independent copy of the same six declarations.

Two authorities for one contract is a problem in its own right for a security-relevant type, and grep for `interface Signer` returned two answers with no indication of which one a reader wanted. It had already started to cost something concrete: the runner package types against both authorities at once, with `toolshed-http-auth.ts` importing `AsBytes` from identity while `storage/interface.ts` imports `Signer` from memory. The copies had also drifted, because identity's `Signer` requires a `serialize()` method returning the raw key pair and memory's does not, so a value satisfying memory's `Signer` is not an identity `Signer`.

This change deletes memory's declarations and re-exports the identity ones instead, so there is a single place the contract is written down. Memory already depended on identity -- `memory/util.ts` imports `VerifierIdentity` -- so no new dependency edge appears, and the re-export is type-only, so nothing changes at runtime.

The drift is preserved deliberately rather than erased. Memory's consumers pass in signing callbacks that hold no key material and therefore cannot implement `serialize()`; the mock signers in the runner's remote-session tests are object literals with `did`, `verifier`, and `sign` and nothing else. So memory re-exports a narrowed alias, `Omit<IdentitySigner<ID>, "serialize">`, rather than identity's full `Signer`. That alias is structurally the same type memory declared before, so every existing consumer type-checks unchanged.

`AsString`, which memory declares and identity does not, stays where it was.

Verified with `deno task test` in packages/memory, packages/identity, and packages/runner, plus `deno check` in packages/fuse and packages/piece, which are the other two consumers of memory's `Signer`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

