### PR TITLE
DO NOT LAND experiment: measure the lunch-poll card-wedge flake on both fix sides

### DIFF
--- a/.github/workflows/lunch-poll-flake-ab.yml
+++ b/.github/workflows/lunch-poll-flake-ab.yml
@@ -1,0 +1,109 @@
+# Measures the lunch-poll card-wedge flake rate on CI runners, on both sides
+# of the list-coordinator setup-debt fix: one side builds and tests a main
+# snapshot from before the fix, the other this pull request's merge ref. Each
+# soak shard runs the lunch-poll browser test repeatedly against its side's
+# toolshed and classifies every failure by signature, so the pre-fix side is
+# the positive control (it should produce card wedges) and the current side
+# the measurement (it should produce none). Experiment only — this workflow
+# leaves with its pull request and must not land.
+
+name: Lunch Poll Flake A/B (experiment)
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: "Build toolshed (${{ matrix.side }})"
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        side: [pre-fix, current]
+    steps:
+      - name: 📥 Checkout side ref
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ matrix.side == 'pre-fix' && '8b7a2a067af27b6751f3be7bc8740d4d33ce6e2b' || github.sha }}
+
+      - name: 🦕 Setup Deno
+        uses: ./.github/actions/deno-setup
+
+      - name: 🔍 Verify lock file & install dependencies
+        uses: ./.github/actions/deno-install
+
+      - name: 🏗️ Build toolshed binary
+        run: deno task build-binaries toolshed
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+
+      - name: 📤 Upload toolshed binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: toolshed-${{ matrix.side }}
+          path: ./dist/toolshed
+          if-no-files-found: error
+
+  soak:
+    name: "Soak (${{ matrix.side }} ${{ matrix.shard }}/4)"
+    needs: build
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        side: [pre-fix, current]
+        shard: [1, 2, 3, 4]
+    steps:
+      - name: 📥 Checkout side ref
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ matrix.side == 'pre-fix' && '8b7a2a067af27b6751f3be7bc8740d4d33ce6e2b' || github.sha }}
+
+      - name: 📥 Checkout experiment driver
+        uses: actions/checkout@v7
+        with:
+          path: _experiment
+
+      - name: 🦕 Setup Deno
+        uses: ./.github/actions/deno-setup
+
+      - name: 🔍 Verify lock file & install dependencies
+        uses: ./.github/actions/deno-install
+
+      - name: 📥 Download toolshed binary
+        uses: actions/download-artifact@v8
+        with:
+          name: toolshed-${{ matrix.side }}
+          path: common-binaries
+
+      # For Astral
+      # https://github.com/lino-levan/astral/blob/f5ef833b2c5bde3783564a6b925073d5d46bb4b8/README.md#no-usable-sandbox-with-user-namespace-cloning-enabled
+      - name: 🛡️ Disable AppArmor restriction for browser tests
+        shell: bash
+        run: |
+          sysctl_path=/proc/sys/kernel/apparmor_restrict_unprivileged_userns
+          if [[ -e "$sysctl_path" ]]; then
+            printf '0\n' | sudo tee "$sysctl_path" >/dev/null
+          else
+            echo "AppArmor unprivileged-userns sysctl is unavailable; no change required."
+          fi
+
+      - name: 🔁 Run the soak
+        env:
+          SIDE: ${{ matrix.side }}
+          SHARD: ${{ matrix.shard }}
+          RUNS: "6"
+          TOOLSHED_BINARY: ${{ github.workspace }}/common-binaries/toolshed
+          RESULT_DIR: flake-ab-results
+        run: bash _experiment/tasks/lunch-poll-flake-ab.sh
+
+      - name: 📤 Upload failure logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: flake-ab-${{ matrix.side }}-${{ matrix.shard }}
+          path: flake-ab-results/
+          if-no-files-found: ignore

--- a/.github/workflows/lunch-poll-flake-ab.yml
+++ b/.github/workflows/lunch-poll-flake-ab.yml
@@ -12,6 +12,11 @@ name: Lunch Poll Flake A/B (experiment)
 on:
   pull_request:
   workflow_dispatch:
+    inputs:
+      runs:
+        description: "Soak iterations per shard"
+        required: false
+        default: "6"
 
 jobs:
   build:
@@ -55,7 +60,7 @@ jobs:
       fail-fast: false
       matrix:
         side: [pre-fix, current]
-        shard: [1, 2, 3, 4]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
     steps:
       - name: 📥 Checkout side ref
         uses: actions/checkout@v7
@@ -91,11 +96,16 @@ jobs:
             echo "AppArmor unprivileged-userns sysctl is unavailable; no change required."
           fi
 
+      # Shards 1-4 run the test the way the regular job does, one instance
+      # at a time; the rest run two instances concurrently, contending for
+      # the runner's cores to widen the cross-browser commit-race window the
+      # card wedge needs.
       - name: 🔁 Run the soak
         env:
           SIDE: ${{ matrix.side }}
           SHARD: ${{ matrix.shard }}
-          RUNS: "6"
+          RUNS: ${{ github.event.inputs.runs || '6' }}
+          PAR: ${{ matrix.shard <= 4 && '1' || '2' }}
           TOOLSHED_BINARY: ${{ github.workspace }}/common-binaries/toolshed
           RESULT_DIR: flake-ab-results
         run: bash _experiment/tasks/lunch-poll-flake-ab.sh

--- a/tasks/lunch-poll-flake-ab.sh
+++ b/tasks/lunch-poll-flake-ab.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Drives repeated runs of the lunch-poll browser integration test against a
+# prebuilt toolshed binary and classifies every failure by its signature:
+# the option-card wedge (the second option's vote button never renders), the
+# guest join-input stall, or anything else. Part of the lunch-poll-flake-ab
+# experiment workflow; not part of regular CI, and it leaves with that
+# workflow's pull request.
+#
+# Inputs (environment):
+#   TOOLSHED_BINARY  path to the toolshed binary to serve the tests (required)
+#   RUNS             how many times to run the test (default 6)
+#   RESULT_DIR       where failure logs and the summary land (default
+#                    flake-ab-results)
+#   SIDE, SHARD      labels echoed into the summary
+#
+# Run from the repository root of the tree whose test should execute.
+set -euo pipefail
+
+RUNS="${RUNS:-6}"
+BINARY="${TOOLSHED_BINARY:?path to toolshed binary}"
+OUT="${RESULT_DIR:-flake-ab-results}"
+mkdir -p "$OUT"
+OUT_ABS="$(cd "$OUT" && pwd)"
+
+chmod +x "$BINARY"
+# --background returns once the server has bound its port, so the runs below
+# never race a not-yet-listening server (same invocation as the regular
+# pattern-integration job).
+CFTS_AI_GATEWAY_URL="" \
+CFTS_AI_LLM_ANTHROPIC_API_KEY=fake \
+  "$BINARY" --background --log-file="$OUT_ABS/toolshed.log"
+
+pass=0
+card=0
+join=0
+other=0
+cd packages/patterns
+for i in $(seq 1 "$RUNS"); do
+  log="$OUT_ABS/run-$i.log"
+  code=0
+  # 420s caps a run whose in-test wait would otherwise spend its full 300s
+  # plus teardown; a pass takes a fraction of that.
+  HEADLESS=1 \
+  API_URL=http://localhost:8000/ \
+  CF_COMPILE_CACHE_FILE="$OUT_ABS/compile-cache.json" \
+  timeout 420 deno test --no-check -A integration/lunch-poll-vote.test.ts \
+    > "$log" 2>&1 || code=$?
+  if [ "$code" -eq 0 ]; then
+    pass=$((pass + 1))
+    rm -f "$log"
+    echo "run $i: pass"
+  elif grep -q "data-option-title" "$log" &&
+    grep -q "Timed out waiting" "$log"; then
+    card=$((card + 1))
+    echo "run $i: CARD-WEDGE (exit $code)"
+  elif grep -q "lp-join-name" "$log"; then
+    join=$((join + 1))
+    echo "run $i: join-input stall (exit $code)"
+  else
+    other=$((other + 1))
+    echo "run $i: other failure (exit $code)"
+  fi
+done
+
+echo "FINAL side=${SIDE:-unlabeled} shard=${SHARD:-1}" \
+  "pass=$pass card-wedge=$card join-input=$join other=$other"
+{
+  echo "### ${SIDE:-unlabeled} shard ${SHARD:-1}"
+  echo ""
+  echo "| pass | card-wedge | join-input | other |"
+  echo "|---|---|---|---|"
+  echo "| $pass | $card | $join | $other |"
+  echo ""
+} >> "${GITHUB_STEP_SUMMARY:-/dev/null}"

--- a/tasks/lunch-poll-flake-ab.sh
+++ b/tasks/lunch-poll-flake-ab.sh
@@ -8,7 +8,11 @@
 #
 # Inputs (environment):
 #   TOOLSHED_BINARY  path to the toolshed binary to serve the tests (required)
-#   RUNS             how many times to run the test (default 6)
+#   RUNS             how many soak iterations to run (default 6)
+#   PAR              test instances run concurrently per iteration (default 1);
+#                    above 1 the instances contend for the runner's cores,
+#                    which widens the cross-browser commit-race window the
+#                    card wedge needs
 #   RESULT_DIR       where failure logs and the summary land (default
 #                    flake-ab-results)
 #   SIDE, SHARD      labels echoed into the summary
@@ -17,6 +21,7 @@
 set -euo pipefail
 
 RUNS="${RUNS:-6}"
+PAR="${PAR:-1}"
 BINARY="${TOOLSHED_BINARY:?path to toolshed binary}"
 OUT="${RESULT_DIR:-flake-ab-results}"
 mkdir -p "$OUT"
@@ -35,37 +40,51 @@ card=0
 join=0
 other=0
 cd packages/patterns
-for i in $(seq 1 "$RUNS"); do
-  log="$OUT_ABS/run-$i.log"
-  code=0
-  # 420s caps a run whose in-test wait would otherwise spend its full 300s
-  # plus teardown; a pass takes a fraction of that.
-  HEADLESS=1 \
-  API_URL=http://localhost:8000/ \
-  CF_COMPILE_CACHE_FILE="$OUT_ABS/compile-cache.json" \
-  timeout 420 deno test --no-check -A integration/lunch-poll-vote.test.ts \
-    > "$log" 2>&1 || code=$?
+
+classify() {
+  local label="$1" code="$2" log="$3"
   if [ "$code" -eq 0 ]; then
     pass=$((pass + 1))
     rm -f "$log"
-    echo "run $i: pass"
+    echo "$label: pass"
   elif grep -q "data-option-title" "$log" &&
     grep -q "Timed out waiting" "$log"; then
     card=$((card + 1))
-    echo "run $i: CARD-WEDGE (exit $code)"
+    echo "$label: CARD-WEDGE (exit $code)"
   elif grep -q "lp-join-name" "$log"; then
     join=$((join + 1))
-    echo "run $i: join-input stall (exit $code)"
+    echo "$label: join-input stall (exit $code)"
   else
     other=$((other + 1))
-    echo "run $i: other failure (exit $code)"
+    echo "$label: other failure (exit $code)"
   fi
+}
+
+for i in $(seq 1 "$RUNS"); do
+  pids=()
+  for j in $(seq 1 "$PAR"); do
+    log="$OUT_ABS/run-$i-$j.log"
+    # 420s caps a run whose in-test wait would otherwise spend its full 300s
+    # plus teardown; a pass takes a fraction of that.
+    HEADLESS=1 \
+    API_URL=http://localhost:8000/ \
+    CF_COMPILE_CACHE_FILE="$OUT_ABS/compile-cache-$j.json" \
+    timeout 420 deno test --no-check -A integration/lunch-poll-vote.test.ts \
+      > "$log" 2>&1 &
+    pids+=($!)
+  done
+  for k in "${!pids[@]}"; do
+    j=$((k + 1))
+    code=0
+    wait "${pids[$k]}" || code=$?
+    classify "run $i.$j" "$code" "$OUT_ABS/run-$i-$j.log"
+  done
 done
 
-echo "FINAL side=${SIDE:-unlabeled} shard=${SHARD:-1}" \
+echo "FINAL side=${SIDE:-unlabeled} shard=${SHARD:-1} par=$PAR" \
   "pass=$pass card-wedge=$card join-input=$join other=$other"
 {
-  echo "### ${SIDE:-unlabeled} shard ${SHARD:-1}"
+  echo "### ${SIDE:-unlabeled} shard ${SHARD:-1} (par $PAR)"
   echo ""
   echo "| pass | card-wedge | join-input | other |"
   echo "|---|---|---|---|"


### PR DESCRIPTION
The lunch-poll browser integration test's card-wedge failure — the second option's vote button never renders while the runtime sits idle — only ever manifested on CI runners, so no local environment can demonstrate either its presence before the list-coordinator setup-debt fix or its absence after. This workflow measures it where it lived: it builds toolshed at a pre-fix main snapshot and at this pull request's merge ref, then four soak shards per side each run the lunch-poll test six times against their side's server, classifying every failure as the card wedge, the (separate, still open) guest join-input stall, or other. The pre-fix side is the positive control and the current side the measurement; per-shard counts land in the step summaries and failure logs upload as artifacts.

Experiment only: this workflow and its driver leave with the pull request and must not land.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

