### PR TITLE
refactor(data-model): move the codec registry to `codec-common`

### DIFF
--- a/docs/plans/first-class-serializable-factories.md
+++ b/docs/plans/first-class-serializable-factories.md
@@ -195,10 +195,10 @@ Expected implementation files:
 - [ ] Decode to a frozen branded callable shell whose body throws
   `factory requires runner materialization` and whose state can be re-encoded.
 - [ ] Add a dedicated callable-factory codec slot to
-  `packages/data-model/src/codec-json/CodecRegistry.ts`; do not classify all
+  `packages/data-model/src/codec-common/CodecRegistry.ts`; do not classify all
   functions as primitives or match `Function` by constructor.
 - [ ] Register the codec in
-  `packages/data-model/src/codec-json/createDefaultRegistry.ts`.
+  `packages/data-model/src/codec-common/createDefaultRegistry.ts`.
 - [ ] Route callable factories through codec lookup before the generic function
   rejection.
 - [ ] Include callable factories in JSON encoder cycle tracking.
@@ -208,12 +208,12 @@ Expected implementation files:
 Expected implementation and test files:
 
 - `packages/data-model/src/codec-common/` for the codec/state validator
-- `packages/data-model/src/codec-json/CodecRegistry.ts`
+- `packages/data-model/src/codec-common/CodecRegistry.ts`
 - `packages/data-model/src/codec-json/JsonEncodingContext.ts`
-- `packages/data-model/src/codec-json/createDefaultRegistry.ts`
+- `packages/data-model/src/codec-common/createDefaultRegistry.ts`
 - `packages/data-model/src/codec-json/json-encoding.ts`
 - `packages/data-model/test/codec-common/FactoryCodec.test.ts`
-- `packages/data-model/test/codec-json/CodecRegistry.test.ts`
+- `packages/data-model/test/codec-common/CodecRegistry.test.ts`
 - `packages/data-model/test/codec-json/JsonEncodingContext.test.ts`
 - `packages/data-model/test/codec-json/json-encoding.test.ts`
 - a focused `packages/data-model/test/fabric-factory.test.ts`

--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -2361,14 +2361,14 @@ recursive descent and codec dispatch are entirely internal to the context.
 
 The serialization and deserialization logic is implemented as private
 methods on `JsonEncodingContext`. The context dispatches per-type logic to
-the **codecs** (Section 2.4) held in a **`CodecRegistry`** — the JSON
-context's index of which codec handles which class (for encoding) and
-which tag (for decoding). Codecs are shallow: the context owns recursion
-and tag-wrapping, and each codec translates exactly one layer.
+the **codecs** (Section 2.4) held in a **`CodecRegistry`** — an index of
+which codec handles which class (for encoding) and which tag (for
+decoding). Codecs are shallow: the context owns recursion and
+tag-wrapping, and each codec translates exactly one layer.
 
 ```typescript
 // Shown for illustration only.
-// file: packages/data-model/codec-json/CodecRegistry.ts
+// file: packages/data-model/codec-common/CodecRegistry.ts
 
 /**
  * Sentinel returned by `CodecRegistry.codecFromValue()` for a
@@ -2431,7 +2431,7 @@ registered codecs:
 
 #### The default registry
 
-`createDefaultRegistry()` (`codec-json/createDefaultRegistry.ts`) builds
+`createDefaultRegistry()` (`codec-common/createDefaultRegistry.ts`) builds
 the registry the shared JSON context uses. The wire-format surface is
 **explicit and curated**: fabric classes whose instances have a fixed wire
 tag supply their codec via the static `[CODEC]`, and the curated

--- a/packages/data-model/src/codec-common/CodecRegistry.ts
+++ b/packages/data-model/src/codec-common/CodecRegistry.ts
@@ -1,5 +1,5 @@
 import type { FabricValue } from "@/interface.ts";
-import type { FabricCodec } from "@/codec-common/interface.ts";
+import type { FabricCodec } from "./interface.ts";
 import type { Constructor } from "@commonfabric/utils/types";
 
 /**

--- a/packages/data-model/src/codec-common/createDefaultRegistry.ts
+++ b/packages/data-model/src/codec-common/createDefaultRegistry.ts
@@ -1,11 +1,11 @@
-import { CODEC } from "@/codec-common/interface.ts";
-import { BigIntCodec } from "@/codec-common/BigIntCodec.ts";
-import { SpecialNumberCodec } from "@/codec-common/SpecialNumberCodec.ts";
-import { SymbolCodec } from "@/codec-common/SymbolCodec.ts";
-import { UndefinedCodec } from "@/codec-common/UndefinedCodec.ts";
 import { codecClasses as primitiveCodecClasses } from "@/fabric-primitives/index.ts";
 import { codecClasses as instanceCodecClasses } from "@/fabric-instances/index.ts";
 
+import { CODEC } from "./interface.ts";
+import { BigIntCodec } from "./BigIntCodec.ts";
+import { SpecialNumberCodec } from "./SpecialNumberCodec.ts";
+import { SymbolCodec } from "./SymbolCodec.ts";
+import { UndefinedCodec } from "./UndefinedCodec.ts";
 import { CodecRegistry } from "./CodecRegistry.ts";
 
 /**

--- a/packages/data-model/src/codec-common/index.ts
+++ b/packages/data-model/src/codec-common/index.ts
@@ -21,3 +21,7 @@ export { UndefinedCodec } from "./UndefinedCodec.ts";
 export { BigIntCodec } from "./BigIntCodec.ts";
 export { SpecialNumberCodec } from "./SpecialNumberCodec.ts";
 export { SymbolCodec } from "./SymbolCodec.ts";
+
+// Codec registry and factory.
+export { CodecRegistry } from "./CodecRegistry.ts";
+export { createDefaultRegistry } from "./createDefaultRegistry.ts";

--- a/packages/data-model/src/codec-json/JsonEncodingContext.ts
+++ b/packages/data-model/src/codec-json/JsonEncodingContext.ts
@@ -11,9 +11,9 @@ import { deepFreeze } from "@/deep-freeze.ts";
 import { EmptyReconstructionContext } from "@/codec-common/EmptyReconstructionContext.ts";
 import { UnknownValue } from "@/fabric-instances/UnknownValue.ts";
 import { ProblematicValue } from "@/fabric-instances/ProblematicValue.ts";
-import { createDefaultRegistry } from "./createDefaultRegistry.ts";
+import { createDefaultRegistry } from "@/codec-common/createDefaultRegistry.ts";
 import type { JsonWireValue } from "./interface.ts";
-import { type CodecRegistry, SELF_REP } from "./CodecRegistry.ts";
+import { type CodecRegistry, SELF_REP } from "@/codec-common/CodecRegistry.ts";
 import { CODEC_META_TAGS } from "@/codec-common/codec-meta-tags.ts";
 
 /**

--- a/packages/data-model/src/codec-json/index.ts
+++ b/packages/data-model/src/codec-json/index.ts
@@ -15,7 +15,3 @@ export { JsonEncodingContext } from "./JsonEncodingContext.ts";
 
 // Shared wire-format vocabulary.
 export type { JsonWireValue } from "./interface.ts";
-
-// Codec registry and factory.
-export { CodecRegistry } from "./CodecRegistry.ts";
-export { createDefaultRegistry } from "./createDefaultRegistry.ts";

--- a/packages/data-model/test/codec-common/CodecRegistry.test.ts
+++ b/packages/data-model/test/codec-common/CodecRegistry.test.ts
@@ -4,7 +4,7 @@ import { expect } from "@std/expect";
 import type { Constructor } from "@commonfabric/utils/types";
 
 import { toCompactDebugString } from "@/value-debug.ts";
-import { CodecRegistry, SELF_REP } from "@/codec-json/CodecRegistry.ts";
+import { CodecRegistry, SELF_REP } from "@/codec-common/CodecRegistry.ts";
 import { BaseFabricCodec } from "@/codec-common/BaseFabricCodec.ts";
 import type { ReconstructionContext } from "@/codec-common/interface.ts";
 import { UnknownValue } from "@/fabric-instances/UnknownValue.ts";


### PR DESCRIPTION
`CodecRegistry` and `createDefaultRegistry()` index and build the set of
`FabricCodec`s. That is wire-format-agnostic machinery -- nothing in either file
knows about JSON -- so this moves them from `codec-json` to `codec-common`,
alongside the codecs they hold.

Moved (`git mv`, contents otherwise unchanged apart from import paths):

- `src/codec-json/CodecRegistry.ts` -> `src/codec-common/CodecRegistry.ts`
- `src/codec-json/createDefaultRegistry.ts` ->
  `src/codec-common/createDefaultRegistry.ts`
- `test/codec-json/CodecRegistry.test.ts` ->
  `test/codec-common/CodecRegistry.test.ts`

No forwarding pointers: the `codec-json` barrel drops both exports, the
`codec-common` barrel picks them up with the same surface, and
`JsonEncodingContext` -- the sole in-tree consumer -- imports them from the new
location. Nothing outside `data-model` referenced either name, so no package's
public surface changes.

`docs/specs/space-model-formal-spec/1-fabric-values.md` and
`docs/plans/first-class-serializable-factories.md` are repointed at the new
paths; the spec's one-line description of the registry no longer calls it "the
JSON context's index", since it is no longer JSON's to own.

## Verification

Green locally: `deno fmt --check`, `deno lint`, `deno task check`,
`deno task check-docs`, `deno task check-skill-facts`, and the full workspace
`deno task test` (all packages ok).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QxM2ZBpzGbYiGjsjTbn8wU


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

