### PR TITLE
fix(cli): a projection keyword names its container, so `type` is inferred

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -147,24 +147,29 @@ missing value and is also falsey. Filtering happens before schema projection.
 
 For an array result, the concise form describes each item. An inline/file JSON
 Schema describes the complete returned value, so a schema combined with
-`--filter` must have an array root. Object `properties` are a whitelist by
+`--filter` must have an array root. Object `properties` are an allowlist by
 default; use `"additionalProperties": true` to retain unspecified properties.
 Projection schemas support structural `properties`, `items`, and scalar leaf
-schemas. In an array-item projection, a scalar leaf whose declared type does not
-match the stored value is omitted by the runtime rather than reported as an
-error; prefer `true` leaves unless that type filtering is intentional. Schema
-combinators and references are rejected in caller-supplied projection schemas.
-Concise dotted paths follow the declared source schema through nested arrays, so
-`comments.body` selects `body` from every comment without retaining comment
-siblings. The projection preserves source-declared nullable items and
-properties, including `type` arrays and `anyOf` unions. When the source schema
-does not identify a nested container, the concise form applies the same field
-mask across arrays encountered in the value so siblings still cannot leak; use
-an explicit JSON Schema when the output schema itself must be fixed. If a
-present source value cannot materialize the transform, the command exits nonzero
-and states that the failure is not JSON `null`. An absent optional source
-remains the ordinary successful `null` CLI response, as does a valid projected
-null.
+schemas. A position that names an object keyword (`properties`,
+`additionalProperties`, `required`) projects an object and one that names
+`items` projects an array, at every level of nesting and whether or not it also
+states `type` — `{"properties":{"topic":{"properties":{"title":true}}}}` returns
+`topic.title`. Neither `true` nor `{}` names a container, and both keep
+everything at the position they sit at. In an array-item projection, a scalar
+leaf whose declared type does not match the stored value is omitted by the
+runtime rather than reported as an error; prefer `true` leaves unless that type
+filtering is intentional. Schema combinators and references are rejected in
+caller-supplied projection schemas. Concise dotted paths follow the declared
+source schema through nested arrays, so `comments.body` selects `body` from
+every comment without retaining comment siblings. The projection preserves
+source-declared nullable items and properties, including `type` arrays and
+`anyOf` unions. When the source schema does not identify a nested container, the
+concise form applies the same field mask across arrays encountered in the value
+so siblings still cannot leak; use an explicit JSON Schema when the output
+schema itself must be fixed. If a present source value cannot materialize the
+transform, the command exits nonzero and states that the failure is not JSON
+`null`. An absent optional source remains the ordinary successful `null` CLI
+response, as does a valid projected null.
 
 Both transforms run as a short-lived computed pattern in the caller's session.
 When the declared source schema fixes the root container shape, the pattern

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -553,6 +553,49 @@ const UNSUPPORTED_PROJECTION_KEYS = new Set([
   "contentSchema",
 ]);
 
+/**
+ * The keywords that apply to exactly one container. Naming one says which
+ * container the position describes, so the traversal that reads the projection
+ * back needs no separate `type` from the caller.
+ */
+const OBJECT_PROJECTION_KEYS = [
+  "properties",
+  "additionalProperties",
+  "required",
+  "minProperties",
+  "maxProperties",
+];
+const ARRAY_PROJECTION_KEYS = [
+  "items",
+  "minItems",
+  "maxItems",
+  "uniqueItems",
+];
+
+/**
+ * The container a projection position describes but did not state. Schema
+ * traversal descends `properties` only under `type: "object"` and `items` only
+ * under `type: "array"`, so an omitted `type` silently empties the position —
+ * and a nested position is where a caller omits it. Filling it in here keeps
+ * that requirement out of what a caller has to know, and keeps traversal's
+ * meaning of a stated type intact for every other reader.
+ *
+ * Arrays are tested first, matching {@link projectionMask}, so a position that
+ * names both vocabularies reads as the array it named rather than disagreeing
+ * with the selector built from it.
+ */
+function impliedProjectionType(
+  declared: Record<string, unknown>,
+): "object" | "array" | undefined {
+  if (declared.type !== undefined) return undefined;
+  if (ARRAY_PROJECTION_KEYS.some((key) => declared[key] !== undefined)) {
+    return "array";
+  }
+  return OBJECT_PROJECTION_KEYS.some((key) => declared[key] !== undefined)
+    ? "object"
+    : undefined;
+}
+
 /** A projection schema with its `$link` markers lifted out of it. */
 interface NormalizedProjectionSchema {
   schema: JSONSchema;
@@ -597,7 +640,14 @@ function normalizeProjectionSchema(
 
   const { [LINK_MARKER_KEY]: _marker, ...declared } = schema;
   const markers: LinkMarkers = marker === true ? { marked: true } : {};
-  const result: Record<string, unknown> = { ...declared };
+  const implied = impliedProjectionType(declared);
+  // An implied `type` leads the result, so a normalized schema reads the way a
+  // caller would have written it out in full. A position that declared nothing
+  // gains nothing: `{}` stays the wildcard it already is, and a bare marker
+  // still reduces to `false` below.
+  const result: Record<string, unknown> = implied === undefined
+    ? { ...declared }
+    : { type: implied, ...declared };
   if (declared.properties !== undefined) {
     if (!isRecord(declared.properties) || Array.isArray(declared.properties)) {
       throw new CellSelectionError(
@@ -619,7 +669,7 @@ function normalizeProjectionSchema(
       result.additionalProperties = false;
     }
   } else if (
-    schemaTypes(declared as JSONSchema).includes("object") &&
+    schemaTypes(result as JSONSchema).includes("object") &&
     declared.additionalProperties === undefined
   ) {
     result.additionalProperties = true;

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -1028,12 +1028,6 @@ function projectionMask(schema: JSONSchema): ProjectionMask {
   if (schema === true) return true;
   if (schema === false) return false;
   const objectSchema = schema as Exclude<JSONSchema, boolean>;
-  if (
-    objectSchema.additionalProperties === true ||
-    isRecord(objectSchema.additionalProperties)
-  ) {
-    return true;
-  }
   if (objectSchema.type === "array" || objectSchema.items !== undefined) {
     const items = objectSchema.items === undefined
       ? true
@@ -1044,6 +1038,18 @@ function projectionMask(schema: JSONSchema): ProjectionMask {
     // schema, so a rejection one level down arrives after the load it was
     // meant to prevent.
     return items === false ? false : { type: "array", items };
+  }
+  // An object that admits keys it does not name cannot be narrowed: the
+  // selector has to read whatever is there. The array branch above takes a
+  // position that names both vocabularies, the same way
+  // `impliedProjectionType()` types one: `additionalProperties` describes no
+  // part of an array, and deciding an array position by it reads the whole
+  // source over a keyword that says nothing about that position.
+  if (
+    objectSchema.additionalProperties === true ||
+    isRecord(objectSchema.additionalProperties)
+  ) {
+    return true;
   }
   if (
     objectSchema.type === "object" || objectSchema.properties !== undefined

--- a/packages/cli/test/piece-get-transform.test.ts
+++ b/packages/cli/test/piece-get-transform.test.ts
@@ -1748,6 +1748,71 @@ describe("cf piece get transforms", () => {
     ).toEqual([{ title: "First" }]);
   });
 
+  it("masks the read of an array projection that also names `additionalProperties`", async () => {
+    const listSchema = {
+      type: "object",
+      properties: {
+        notes: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              title: { type: "string" },
+              body: { type: "string" },
+            },
+          },
+        },
+      },
+    } as const satisfies JSONSchema;
+
+    const tx = runtime.edit();
+    // The bodies are left unwritten: reading one has to reach storage, which
+    // is what makes a read of a field nobody asked for observable.
+    const bodies = ["a", "b"].map((suffix) =>
+      runtime.getCell(space, `array-extra-props-body-${suffix}`, {
+        type: "string",
+      }, tx)
+    );
+    const source = runtime.getCell(
+      space,
+      "array-extra-props-source",
+      listSchema,
+      tx,
+    );
+    source.setRaw({
+      notes: bodies.map((body, index) => ({
+        title: ["a", "b"][index],
+        body: body.getAsLink(),
+      })),
+    } as never);
+    expect((await tx.commit()).ok).toBeDefined();
+
+    const provider = storageManager.open(space);
+    const originalSync = provider.sync.bind(provider);
+    const syncedUris: string[] = [];
+    provider.sync = ((uri, selector, scope) => {
+      syncedUris.push(uri);
+      return originalSync(uri, selector, scope);
+    }) as typeof provider.sync;
+    const bodyUris: string[] = bodies.map((body) =>
+      body.getAsNormalizedFullLink().id
+    );
+
+    const read = runtime.getCell(space, "array-extra-props-source", listSchema);
+    expect(
+      await deriveSelectedValue(runtime, space, read, {
+        projection: await parseSelectionProjection(
+          '{"properties":{"notes":{"items":{"properties":{"title":true}},' +
+            '"additionalProperties":{"type":"string"}}}}',
+        ),
+      }),
+    ).toEqual({ notes: [{ title: "a" }, { title: "b" }] });
+    // `additionalProperties` describes an object, and `items` says this
+    // position is an array. Reading it as an object that admits anything
+    // loads every document behind a field the caller did not name.
+    expect(syncedUris.filter((uri) => bodyUris.includes(uri))).toEqual([]);
+  });
+
   it("rejects an untyped `items` root against a non-array value", async () => {
     const tx = runtime.edit();
     const source = runtime.getCell(

--- a/packages/cli/test/piece-get-transform.test.ts
+++ b/packages/cli/test/piece-get-transform.test.ts
@@ -466,6 +466,46 @@ describe("cf piece get transforms", () => {
     expect((await parseSelectionProjection("true")).schema).toBe(true);
   });
 
+  it("normalizes an untyped projection to the container its keywords name", async () => {
+    expect(
+      (await parseSelectionProjection('{"properties":{"label":true}}')).schema,
+    ).toEqual({
+      type: "object",
+      properties: { label: true },
+      additionalProperties: false,
+    });
+    expect(
+      (await parseSelectionProjection(
+        '{"additionalProperties":{"type":"string"}}',
+      )).schema,
+    ).toEqual({ type: "object", additionalProperties: { type: "string" } });
+    expect(
+      (await parseSelectionProjection('{"required":["id"]}')).schema,
+    ).toEqual({ type: "object", required: ["id"], additionalProperties: true });
+    expect(
+      (await parseSelectionProjection('{"items":{"properties":{"id":true}}}'))
+        .schema,
+    ).toEqual({
+      type: "array",
+      items: {
+        type: "object",
+        properties: { id: true },
+        additionalProperties: false,
+      },
+    });
+  });
+
+  it("keeps `true`, `{}`, `false`, and a bare marker distinct from an inferred object", async () => {
+    expect((await parseSelectionProjection("true")).schema).toBe(true);
+    expect((await parseSelectionProjection("{}")).schema).toEqual({});
+    expect((await parseSelectionProjection('{"$link":true}')).schema).toBe(
+      false,
+    );
+    await expect(parseSelectionProjection("false")).rejects.toThrow(
+      "false cannot project a value",
+    );
+  });
+
   it("does not let caller projection schemas forge CFC metadata", async () => {
     for (const key of ["asCell", "default", "ifc", "scope"]) {
       await expect(parseSelectionProjection(JSON.stringify({
@@ -983,6 +1023,75 @@ describe("cf piece get transforms", () => {
       title: "Visible",
       subtitle: null,
     });
+  });
+
+  it("projects an untyped `properties` at every level of nesting", async () => {
+    const tx = runtime.edit();
+    const source = runtime.getCell(
+      space,
+      "inferred-object-projection-source",
+      {
+        type: "object",
+        properties: {
+          label: { type: "string" },
+          hidden: { type: "string" },
+          topic: {
+            type: "object",
+            properties: {
+              title: { type: "string" },
+              body: { type: "string" },
+            },
+          },
+          notes: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                title: { type: "string" },
+                body: { type: "string" },
+              },
+            },
+          },
+        },
+      },
+      tx,
+    );
+    source.set({
+      label: "Visible",
+      hidden: "not returned",
+      topic: { title: "First", body: "not returned" },
+      notes: [{ title: "Note", body: "not returned" }],
+    });
+    expect((await tx.commit()).ok).toBeDefined();
+
+    expect(
+      await deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection(
+          '{"properties":{"label":true}}',
+        ),
+      }),
+    ).toEqual({ label: "Visible" });
+    expect(
+      await deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection(
+          '{"type":"object","properties":{"topic":{"properties":{"title":true}}}}',
+        ),
+      }),
+    ).toEqual({ topic: { title: "First" } });
+    expect(
+      await deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection(
+          '{"properties":{"topic":{"properties":{"title":true}}}}',
+        ),
+      }),
+    ).toEqual({ topic: { title: "First" } });
+    expect(
+      await deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection(
+          '{"properties":{"notes":{"items":{"properties":{"title":true}}}}}',
+        ),
+      }),
+    ).toEqual({ notes: [{ title: "Note" }] });
   });
 
   it("projects nested arrays with explicit item schemas", async () => {
@@ -1610,6 +1719,66 @@ describe("cf piece get transforms", () => {
     );
   });
 
+  it("projects an untyped `items` root through an array value", async () => {
+    const tx = runtime.edit();
+    const source = runtime.getCell(
+      space,
+      "untyped-items-root-array-source",
+      {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            title: { type: "string" },
+            body: { type: "string" },
+          },
+        },
+      },
+      tx,
+    );
+    source.set([{ title: "First", body: "not returned" }]);
+    expect((await tx.commit()).ok).toBeDefined();
+
+    expect(
+      await deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection(
+          '{"items":{"properties":{"title":true}}}',
+        ),
+      }),
+    ).toEqual([{ title: "First" }]);
+  });
+
+  it("rejects an untyped `items` root against a non-array value", async () => {
+    const tx = runtime.edit();
+    const source = runtime.getCell(
+      space,
+      "untyped-items-root-object-source",
+      {
+        type: "object",
+        properties: {
+          title: { type: "string" },
+          body: { type: "string" },
+        },
+      },
+      tx,
+    );
+    source.set({ title: "First", body: "not returned" });
+    expect((await tx.commit()).ok).toBeDefined();
+
+    // A root naming `items` is an array projection, so it meets the same
+    // root-shape refusal a stated `{"type":"array"}` does. The refusal is what
+    // keeps the read selector and the output schema agreeing on the container:
+    // where they disagree, the transform computes a value that neither of them
+    // describes and hands back an empty answer that looks like a real one.
+    await expect(deriveSelectedValue(runtime, space, source, {
+      projection: await parseSelectionProjection(
+        '{"items":{"properties":{"title":true}}}',
+      ),
+    })).rejects.toThrow(
+      "An array-rooted JSON --schema can only be applied to an array value.",
+    );
+  });
+
   it("treats a missing filter path as a non-match", async () => {
     const tx = runtime.edit();
     const source = runtime.getCell(
@@ -1973,6 +2142,17 @@ describe("cf piece get transforms", () => {
           projection: await parseSelectionProjection(
             '{"type":"object","properties":{"topic":' +
               '{"$link":true,"type":"object","properties":{"title":true}}}}',
+          ),
+        }),
+      ).toEqual({ topic: { $link: addressOf(notes[0]), title: "a" } });
+    });
+
+    it("returns both when the marked position's projection states no type", async () => {
+      const { board, notes } = await seedBoard("link-marker-untyped", true);
+      expect(
+        await deriveSelectedValue(runtime, space, board, {
+          projection: await parseSelectionProjection(
+            '{"properties":{"topic":{"$link":true,"properties":{"title":true}}}}',
           ),
         }),
       ).toEqual({ topic: { $link: addressOf(notes[0]), title: "a" } });

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -239,13 +239,15 @@ JSON literals, comparisons, `and`/`or`/`not`, and parentheses. Only `false` and
 also falsey. Non-array inputs are rejected. `--schema` projects output from a
 comma-separated field list, an inline JSON Schema, or `@schema.json`; concise
 fields apply per item for arrays, while JSON Schema describes the whole output.
-In an array-item projection, a typed scalar leaf that does not match stored data
-is omitted rather than reported as an error; prefer `true` leaves unless type
-filtering is intentional. Concise dotted paths follow declared source schemas
-through nested arrays: `comments.body` selects `body` from every comment and
-drops its siblings. Source-declared nullable items and properties remain null.
-If a present source cannot materialize the transform, the command exits nonzero
-with an explicit "not JSON null" error; an absent optional source retains the
+In a JSON Schema, `properties` projects an object and `items` projects an array
+at every level of nesting, with or without a matching `type`. In an array-item
+projection, a typed scalar leaf that does not match stored data is omitted
+rather than reported as an error; prefer `true` leaves unless type filtering is
+intentional. Concise dotted paths follow declared source schemas through nested
+arrays: `comments.body` selects `body` from every comment and drops its
+siblings. Source-declared nullable items and properties remain null. If a
+present source cannot materialize the transform, the command exits nonzero with
+an explicit "not JSON null" error; an absent optional source retains the
 ordinary successful `null` response. If the source schema does not identify a
 nested container, concise projection still applies its field mask across
 encountered arrays to prevent sibling disclosure; use an explicit schema for a


### PR DESCRIPTION
## Why

`cf piece get --schema` silently returned nothing unless the caller wrote
`"type": "object"` at *every* object level. `--schema '{"properties":{"label":true}}'`
returned `{}`. Nested was worse, because that is where a caller forgets:
`{"type":"object","properties":{"topic":{"properties":{"title":true}}}}` returned
`{"topic":{}}`.

In JSON Schema `properties` applies to objects whether or not `type` is stated,
so this was a trap with no upside — and a silent-empty one, which is the kind a
caller cannot diagnose from the output.

Stacked on #5470.

## What Changed

`normalizeProjectionSchema` fills in the container a position's own keywords
already name, at every level. `properties`/`additionalProperties`/`required`/
`minProperties`/`maxProperties` imply an object; `items`/`minItems`/`maxItems`/
`uniqueItems` imply an array. A stated `type` always wins. Arrays are tested
first, matching `projectionMask`, so the mask and the output schema cannot
disagree about the container.

## Why here and not in traversal

The root cause is `ContextualFlowControl.schemaAtPathInternal`, which descends
`properties` only under `type: "object"` and `items` only under `type: "array"`.
The projected value was computed correctly and then discarded on read-back
through the untyped output schema.

Loosening that would change what an untyped schema means for every reader in
the system — the read selector, the `ifc` walk, `getSchemaAtPath`'s callers, the
write path — to fix one flag's ergonomics. The projection schema is the one
schema the CLI already owns and already rewrites, and `projectionMask` was
*already* inferring the container this way, so the two were out of step. Now
they agree.

## Blast radius

One production caller: `cf piece get --schema`. `true`, `{}`, `false`, and a
bare `$link` marker all normalize byte-identically, so the four spellings stay
distinct. Concise `--schema id,title` already emitted `type` explicitly.

Behavior changes, all in the direction of the projection the caller asked for:
untyped object keywords now project instead of returning `{}`; untyped `items`
likewise; `{"required":[…]}` alone now keeps everything, matching
`{"type":"object"}`.

An untyped `items` at the **root** against a non-array value now refuses with
"An array-rooted JSON --schema can only be applied to an array value." It
previously returned `{}` to the caller *after* computing and committing the
unprojected object — including fields the projection excluded — into the
session result cell, because the mask and the output schema disagreed.
Materializing more than was selected and then hiding it behind an empty answer
is worse than either half; both halves are now covered by tests.

## Test plan

`deno task test` in packages/cli (123 passed) and packages/runner (1156
passed); `deno task check`, `fmt`, `lint`, `check-docs`, `check-skill-facts`.
Six tests added, none deleted, test file is additions-only. Five of the six were
confirmed to fail on the base commit, with the observed failure recorded for
each; the sixth is a deliberate guard that `true`/`{}`/`false`/bare-marker stay
distinct and passes on both sides by design.

The full-form example in `docs/plans/shaped-reads-and-verb-results.md` now works
as literally written, asserted verbatim.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

