### PR TITLE
feat(cli): `--select` takes the concise path list, `--schema` takes schemas

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -129,7 +129,7 @@ to a smaller shape:
 cf piece get --piece ID items --filter '.status == "open"'
 cf piece get --piece ID items \
   --filter '.status == "open" and .score >= 10' \
-  --schema id,title,author.name
+  --select id,title,author.name
 ```
 
 `--filter` is jq-inspired rather than a full jq interpreter. It applies only to
@@ -139,13 +139,16 @@ arrays and accepts value paths (`.status`, `.author.name`, `.["display-name"]`,
 missing path simply does not match. A stored `undefined` is treated like a
 missing value and is also falsey. Filtering happens before schema projection.
 
-`--schema` accepts one of three forms:
+Two flags project, one per input language:
 
-- a comma-separated field projection such as `id,title,author.name`;
-- an inline JSON Schema object;
-- `@path/to/schema.json`.
+- `--select` takes a comma-separated field list such as `id,title,author.name`;
+- `--schema` takes an inline JSON Schema object or `@path/to/schema.json`, and
+  also accepts the same field list `--select` takes.
 
-For an array result, the concise form describes each item. An inline/file JSON
+A command that names both has not said which shape it wants, and is refused
+before the read.
+
+For an array result, the field list describes each item. An inline/file JSON
 Schema describes the complete returned value, so a schema combined with
 `--filter` must have an array root. Object `properties` are an allowlist by
 default; use `"additionalProperties": true` to retain unspecified properties.

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -1409,7 +1409,7 @@ PATH FORMAT: Use forward slashes and numeric indices for arrays.
   )
   .example(
     cliText(
-      `cf piece get ${EX_ID} ${EX_COMP_PIECE} items --schema id,title`,
+      `cf piece get ${EX_ID} ${EX_COMP_PIECE} items --select id,title`,
     ),
     "Project each returned item to selected fields.",
   )
@@ -1435,8 +1435,15 @@ PATH FORMAT: Use forward slashes and numeric indices for arrays.
     "Filter an array with a jq-inspired predicate",
   )
   .option(
+    "--select <fields:string>",
+    "Project output to comma-separated field paths",
+  )
+  .option(
     "--schema <schema:string>",
-    "Project output with comma-separated fields, inline JSON Schema, or @file",
+    "Project output with an inline JSON Schema or @file",
+    // Both flags carry the one projection, so a command naming both has not
+    // said which shape it wants. Refuse before the read rather than pick.
+    { conflicts: ["select"] },
   )
   .arguments("[path:string]")
   .action(async (options, pathString) => {

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -1440,7 +1440,8 @@ PATH FORMAT: Use forward slashes and numeric indices for arrays.
   )
   .option(
     "--schema <schema:string>",
-    "Project output with an inline JSON Schema or @file",
+    "Project output with an inline JSON Schema, @file, or the --select " +
+      "field list",
     // Both flags carry the one projection, so a command naming both has not
     // said which shape it wants. Refuse before the read rather than pick.
     { conflicts: ["select"] },

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -1,8 +1,8 @@
 /**
  * The selection a CLI read applies to a cell it has already arrived at: the
- * `--filter` predicate and the `--schema` projection, their parsers, and the
- * step that turns a cell plus a selection into a value. Resolving an address
- * to a cell belongs to whoever holds the address, and stays there.
+ * `--filter` predicate and the `--select`/`--schema` projection, their parsers,
+ * and the step that turns a cell plus a selection into a value. Resolving an
+ * address to a cell belongs to whoever holds the address, and stays there.
  */
 
 import type { Cell } from "@commonfabric/api";
@@ -89,7 +89,15 @@ export interface LinkMarkers {
 }
 
 /**
- * A `--schema` argument, parsed. `source` is the text as written; `kind`
+ * The flag a projection was written on. `--select` takes the concise field
+ * list; `--schema` takes a JSON Schema, an `@file`, and the concise list too.
+ * Which one was written decides nothing about what the projection means — only
+ * which flag its error messages name.
+ */
+export type ProjectionFlag = "--select" | "--schema";
+
+/**
+ * A projection argument, parsed. `source` is the text as written; `kind`
  * records which of the two spellings it used, since a concise field list
  * traverses arrays implicitly and a JSON Schema does not. `schema` carries no
  * `$link` marker: markers move to `markers`, and a position that asked for
@@ -99,6 +107,7 @@ export interface SelectionProjection {
   source: string;
   schema: JSONSchema;
   kind: "concise" | "json";
+  flag: ProjectionFlag;
   markers?: LinkMarkers;
 }
 
@@ -113,7 +122,7 @@ export interface CellSelection {
 
 /**
  * A selection that cannot be parsed, or that does not fit the value it was
- * pointed at — a `--filter` on a non-array, a `--schema` whose root shape
+ * pointed at — a `--filter` on a non-array, a projection whose root shape
  * disagrees with the source. Reported to the user as a data error, not as an
  * argument-parsing failure.
  */
@@ -710,11 +719,14 @@ function normalizeProjectionSchema(
   };
 }
 
-function conciseProjectionSchema(source: string): JSONSchema {
+function conciseProjectionSchema(
+  source: string,
+  flag: ProjectionFlag,
+): JSONSchema {
   const paths = source.split(",").map((part) => part.trim());
   if (paths.some((path) => path.length === 0)) {
     throw new CellSelectionError(
-      "Invalid --schema concise projection: expected comma-separated field paths",
+      `Invalid ${flag} concise projection: expected comma-separated field paths`,
     );
   }
   const root: Record<string, unknown> = {};
@@ -724,7 +736,7 @@ function conciseProjectionSchema(source: string): JSONSchema {
       segments.some((segment) => !/^[A-Za-z_$][A-Za-z0-9_$-]*$/.test(segment))
     ) {
       throw new CellSelectionError(
-        `Invalid --schema field path ${JSON.stringify(path)}`,
+        `Invalid ${flag} field path ${JSON.stringify(path)}`,
       );
     }
     let node = root;
@@ -760,6 +772,38 @@ export interface ProjectionParseDependencies {
   readTextFile?: (path: string) => Promise<string>;
 }
 
+/**
+ * Parses a `--select` argument: the comma-separated field paths, which is the
+ * whole of what this flag accepts. `--schema` reads the same spelling and more,
+ * so an argument written in the JSON Schema language is pointed at the flag
+ * that reads it rather than reported as a malformed field path.
+ */
+export function parseSelectProjection(source: string): SelectionProjection {
+  const trimmed = source.trim();
+  if (trimmed.length === 0) {
+    throw new CellSelectionError("--select must not be empty");
+  }
+  if (
+    trimmed.startsWith("{") || trimmed.startsWith("@") ||
+    trimmed === "true" || trimmed === "false"
+  ) {
+    throw new CellSelectionError(
+      "--select takes comma-separated field paths. Pass a JSON Schema or an " +
+        "@file to --schema instead.",
+    );
+  }
+  return {
+    source,
+    schema: conciseProjectionSchema(trimmed, "--select"),
+    kind: "concise",
+    flag: "--select",
+  };
+}
+
+/**
+ * Parses a `--schema` argument, which is written as a JSON Schema, as `@file`
+ * naming one, or as the same comma-separated field paths `--select` takes.
+ */
 export async function parseSelectionProjection(
   source: string,
   deps: ProjectionParseDependencies = {},
@@ -798,7 +842,12 @@ export async function parseSelectionProjection(
         { cause: error },
       );
     }
-    return { source, ...normalizeProjectionSchema(parsed), kind: "json" };
+    return {
+      source,
+      ...normalizeProjectionSchema(parsed),
+      kind: "json",
+      flag: "--schema",
+    };
   }
 
   if (trimmed.startsWith("{") || trimmed === "true" || trimmed === "false") {
@@ -813,29 +862,40 @@ export async function parseSelectionProjection(
         { cause: error },
       );
     }
-    return { source, ...normalizeProjectionSchema(parsed), kind: "json" };
+    return {
+      source,
+      ...normalizeProjectionSchema(parsed),
+      kind: "json",
+      flag: "--schema",
+    };
   }
 
   return {
     source,
-    schema: conciseProjectionSchema(trimmed),
+    schema: conciseProjectionSchema(trimmed, "--schema"),
     kind: "concise",
+    flag: "--schema",
   };
 }
 
 /**
- * Parses a command's `--filter` and `--schema` arguments into the selection
+ * Parses a command's `--filter` and projection arguments into the selection
  * they describe, or `undefined` when neither was given and the caller wants
- * the whole value.
+ * the whole value. `select` and `schema` are two spellings of one projection,
+ * and the commands that offer them declare the two flags conflicting, so at
+ * most one arrives here; `select` is the one read when both do.
  */
 export async function parseCellSelectionOptions(options: {
   filter?: string;
   schema?: string;
+  select?: string;
 }): Promise<CellSelection | undefined> {
   const filter = options.filter === undefined
     ? undefined
     : parseSelectionFilter(options.filter);
-  const projection = options.schema === undefined
+  const projection = options.select !== undefined
+    ? parseSelectProjection(options.select)
+    : options.schema === undefined
     ? undefined
     : await parseSelectionProjection(options.schema);
   return filter === undefined && projection === undefined
@@ -1091,6 +1151,7 @@ function schemaFromProjectionMask(mask: ProjectionMask): JSONSchema {
 /** @internal Exported for focused schema-shape tests. */
 export function schemaMayBeArray(
   schema: JSONSchema | undefined,
+  flag: ProjectionFlag = "--schema",
   root: JSONSchema = schema ?? true,
   ancestors = new Set<object>(),
 ): boolean {
@@ -1105,7 +1166,7 @@ export function schemaMayBeArray(
       // continue without resolving the schema that determines array traversal.
       unresolvedRef: (error) => {
         throw new CellSelectionError(
-          `Could not resolve source schema reference for --schema: ${
+          `Could not resolve source schema reference for ${flag}: ${
             error instanceof Error ? error.message : String(error)
           }`,
           { cause: error },
@@ -1120,16 +1181,17 @@ export function schemaMayBeArray(
 function alignConciseProjectionMask(
   source: JSONSchema | undefined,
   mask: ProjectionMask,
+  flag: ProjectionFlag,
 ): ProjectionMask {
   if (
     typeof mask === "boolean" || source === undefined || source === true
   ) return mask;
 
-  if (schemaMayBeArray(source)) {
+  if (schemaMayBeArray(source, flag)) {
     const sourceItem = schemaAtArrayItem(source);
     return {
       type: "array",
-      items: alignConciseProjectionMask(sourceItem, mask),
+      items: alignConciseProjectionMask(sourceItem, mask, flag),
     };
   }
 
@@ -1144,6 +1206,7 @@ function alignConciseProjectionMask(
           alignConciseProjectionMask(
             child === false ? undefined : child,
             childMask,
+            flag,
           ),
         ];
       }),
@@ -1389,6 +1452,7 @@ function resolveProjection(
     const mask = alignConciseProjectionMask(
       source,
       projectionMask(projection.schema),
+      projection.flag,
     );
     const projectionSchema = schemaFromProjectionMask(mask);
     const outputSchema = sanitizeSchemaForLinks(
@@ -1921,7 +1985,8 @@ export async function deriveSelectedValue(
         )
       ) {
         throw new CellSelectionError(
-          "--schema can only project array items from an array value",
+          `${selection.projection!.flag} can only project array items from ` +
+            "an array value",
         );
       }
       const lastError = recorded.at(-1)!;

--- a/packages/cli/test/piece-get-transform.test.ts
+++ b/packages/cli/test/piece-get-transform.test.ts
@@ -11,6 +11,7 @@ import {
   mergeMasks,
   parseSelectionFilter,
   parseSelectionProjection,
+  parseSelectProjection,
   schemaMayBeArray,
   schemaRootKind,
   selectSourceSchema,
@@ -2473,6 +2474,102 @@ describe("cf piece get transforms", () => {
     it("still refuses `asCell` in a projection", async () => {
       await expect(parseSelectionProjection('{"asCell":["cell"]}')).rejects
         .toThrow('"asCell" is controlled by the source schema');
+    });
+  });
+
+  describe("--select", () => {
+    it("parses the concise spelling into the projection --schema parses", async () => {
+      const selected = parseSelectProjection("id,author.name");
+      const schema = await parseSelectionProjection("id,author.name");
+
+      expect(selected.kind).toBe("concise");
+      expect(selected.flag).toBe("--select");
+      expect(schema.flag).toBe("--schema");
+      expect(selected.schema).toEqual(schema.schema);
+      expect(selected.source).toBe(schema.source);
+    });
+
+    it("projects an array through the same step --schema projects through", async () => {
+      const tx = runtime.edit();
+      const source = runtime.getCell(
+        space,
+        "select-flag-source",
+        {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              id: { type: "number" },
+              title: { type: "string" },
+              status: { type: "string" },
+            },
+          },
+        },
+        tx,
+      );
+      source.set([
+        { id: 1, title: "First", status: "open" },
+        { id: 2, title: "Second", status: "closed" },
+      ]);
+      expect((await tx.commit()).ok).toBeDefined();
+
+      expect(
+        await deriveSelectedValue(runtime, space, source, {
+          filter: parseSelectionFilter('.status == "open"'),
+          projection: parseSelectProjection("id,title"),
+        }),
+      ).toEqual([{ id: 1, title: "First" }]);
+    });
+
+    it("points a JSON Schema or @file argument at --schema", () => {
+      for (
+        const source of [
+          '{"type":"object","properties":{"id":true}}',
+          "@projection.json",
+          "true",
+          "false",
+        ]
+      ) {
+        expect(() => parseSelectProjection(source)).toThrow(
+          "--select takes comma-separated field paths",
+        );
+      }
+    });
+
+    it("names itself in the errors its own argument causes", async () => {
+      expect(() => parseSelectProjection("")).toThrow(
+        "--select must not be empty",
+      );
+      expect(() => parseSelectProjection("a,,b")).toThrow(
+        "Invalid --select concise projection",
+      );
+      expect(() => parseSelectProjection("a.0")).toThrow(
+        'Invalid --select field path "a.0"',
+      );
+
+      const tx = runtime.edit();
+      const objectSource = runtime.getCell(
+        space,
+        "select-flag-root-mismatch-source",
+        { type: "array", items: { type: "object" } },
+        tx,
+      );
+      objectSource.set({ id: 1 } as never);
+      expect((await tx.commit()).ok).toBeDefined();
+
+      await expect(deriveSelectedValue(runtime, space, objectSource, {
+        projection: parseSelectProjection("id"),
+      })).rejects.toThrow(
+        /^--select can only project array items from an array value$/,
+      );
+    });
+
+    it("names itself when a source reference cannot resolve", () => {
+      expect(() => schemaMayBeArray({ $ref: "#/$defs/Missing", $defs: {} }))
+        .toThrow("Could not resolve source schema reference for --schema");
+      expect(() =>
+        schemaMayBeArray({ $ref: "#/$defs/Missing", $defs: {} }, "--select")
+      ).toThrow("Could not resolve source schema reference for --select");
     });
   });
 

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -558,6 +558,17 @@ describe("cli piece parsing", () => {
     expect(getFlags).toContain("--schema");
   });
 
+  it("describes `--schema` as taking the field list `--select` takes", () => {
+    // `--schema` reads that field list as well as a JSON Schema, and its
+    // description is the only place a caller reading `--help` learns so. A
+    // description naming one of the two languages sends a caller who wants
+    // both a field list and a schema shape to the wrong flag.
+    const schemaOption = piece.getCommand("get")!.getOptions().find((option) =>
+      option.flags.includes("--schema")
+    )!;
+    expect(schemaOption.description).toContain("--select field list");
+  });
+
   it("parses the --filter, --select, and --schema options into a selection", async () => {
     expect(await parseCellSelectionOptions({})).toBeUndefined();
 

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -554,10 +554,11 @@ describe("cli piece parsing", () => {
     );
     expect(getFlags).toContain("--step");
     expect(getFlags).toContain("--filter");
+    expect(getFlags).toContain("--select");
     expect(getFlags).toContain("--schema");
   });
 
-  it("parses the --filter and --schema options into a selection", async () => {
+  it("parses the --filter, --select, and --schema options into a selection", async () => {
     expect(await parseCellSelectionOptions({})).toBeUndefined();
 
     const filterOnly = await parseCellSelectionOptions({
@@ -571,6 +572,17 @@ describe("cli piece parsing", () => {
     });
     expect(schemaOnly?.filter).toBeUndefined();
     expect(schemaOnly?.projection?.source).toBe("id,name");
+    expect(schemaOnly?.projection?.flag).toBe("--schema");
+
+    const selectOnly = await parseCellSelectionOptions({
+      select: "id,name",
+    });
+    expect(selectOnly?.filter).toBeUndefined();
+    expect(selectOnly?.projection?.flag).toBe("--select");
+    expect(selectOnly?.projection?.schema).toEqual(
+      schemaOnly?.projection
+        ?.schema,
+    );
 
     const both = await parseCellSelectionOptions({
       filter: ".active",
@@ -578,6 +590,32 @@ describe("cli piece parsing", () => {
     });
     expect(both?.filter?.source).toBe(".active");
     expect(both?.projection?.source).toBe("id");
+  });
+
+  it("refuses a piece get command that names both projection flags", async () => {
+    const { code, stderr } = await cf(
+      "piece get " +
+        "--identity ./definitely-missing-piece-get-review.key " +
+        "--api-url https://cf.dev --space common-knowledge " +
+        `--piece ${PIECE} --select id --schema id`,
+    );
+    expect(code).not.toBe(0);
+    expect(stripAnsi(stderr.join("\n"))).toContain(
+      'Option "--schema" conflicts with option "--select".',
+    );
+  });
+
+  it("passes a --select projection through the piece get command action", async () => {
+    const { code, stderr } = await cf(
+      "piece get " +
+        "--identity ./definitely-missing-piece-get-review.key " +
+        "--api-url https://cf.dev --space common-knowledge " +
+        `--piece ${PIECE} --select id,title`,
+    );
+    expect(code).toBe(1);
+    expect(stderr.join("\n")).toContain(
+      "definitely-missing-piece-get-review.key",
+    );
   });
 
   it("passes a parsed selection through the piece get command action", async () => {

--- a/packages/patterns/topics/README.md
+++ b/packages/patterns/topics/README.md
@@ -87,7 +87,7 @@ cf piece call --piece <board> addTopic \
   '{"title":"...","body":"the initial living document","agentName":"Sol"}'
 # -> { "result": { "topic": … } }: the topic this call created
 cf piece get --piece <board> topics --input \
-  --schema title,createdAt,lastActivityAt,commentCount
+  --select title,createdAt,lastActivityAt,commentCount
 cf piece call --piece <topic> addComment \
   '{"body":"point-in-time progress update","agentName":"Sol"}'
 cf piece call --piece <topic> setBody \
@@ -108,24 +108,24 @@ cf piece get --piece <board> index --step
 
 The board input links to complete Topic objects, including bodies, threads,
 handlers, and cross-reference data. Targeted headless discovery beyond the index
-should therefore combine an exact/range `--filter` with a concise `--schema`
+should therefore combine an exact/range `--filter` with a concise `--select`
 instead of materializing the whole corpus:
 
 ```bash
 cf piece get --piece <board> topics --input \
   --filter '.title == "<exact title>"' \
-  --schema title,lastActivityAt,commentCount
+  --select title,lastActivityAt,commentCount
 cf piece get --piece <board> topics --input \
   --filter '.lastActivityAt >= <epoch-milliseconds>' \
-  --schema title,lastActivityAt,commentCount,createdBy.kind,createdBy.name
+  --select title,lastActivityAt,commentCount,createdBy.kind,createdBy.name
 cf piece get --piece <board> crossrefs --step \
   --filter '.topic.title == "<exact title>"' \
-  --schema fid,topic.title,topic.lastActivityAt,topic.commentCount
+  --select fid,topic.title,topic.lastActivityAt,topic.commentCount
 cf piece get --piece <topic> comments --input \
   --filter '.author.name == "Sol" or .authorName == "Sol"' \
-  --schema sentAt,author.kind,author.name,authorName,body
+  --select sentAt,author.kind,author.name,authorName,body
 cf piece get --piece <topic> links --input \
-  --filter '.kind == "pr"' --schema kind,url,label,addedAt
+  --filter '.kind == "pr"' --select kind,url,label,addedAt
 ```
 
 Filtering happens before projection and preserves list order. The jq-inspired

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -138,7 +138,7 @@ See `docs/development/EXPERIMENTAL_OPTIONS.md` for available flags.
 | Inspect state      | `deno task cf piece inspect --piece ID ...`                                                          |
 | Get field          | `deno task cf piece get --piece ID fieldPath ...`                                                    |
 | Filter array       | `deno task cf piece get --piece ID items --filter '.active == true' ...`                             |
-| Project fields     | `deno task cf piece get --piece ID items --schema id,title ...`                                      |
+| Project fields     | `deno task cf piece get --piece ID items --select id,title ...`                                      |
 | Read addresses     | `deno task cf piece get --piece ID items --schema '{"type":"array","items":{"$link":true}}' ...`     |
 | Step + get         | `deno task cf piece get --piece ID fieldPath --step ...`                                             |
 | Set field          | `echo '{"data":...}' \| deno task cf piece set --piece ID path ...`                                  |
@@ -236,41 +236,42 @@ callers can request the format explicitly.
 `piece get --filter` accepts a jq-inspired predicate over array items: paths,
 JSON literals, comparisons, `and`/`or`/`not`, and parentheses. Only `false` and
 `null` are falsey; stored `undefined` is treated like a missing value and is
-also falsey. Non-array inputs are rejected. `--schema` projects output from a
-comma-separated field list, an inline JSON Schema, or `@schema.json`; concise
-fields apply per item for arrays, while JSON Schema describes the whole output.
-In a JSON Schema, `properties` projects an object and `items` projects an array
-at every level of nesting, with or without a matching `type`. In an array-item
-projection, a typed scalar leaf that does not match stored data is omitted
-rather than reported as an error; prefer `true` leaves unless type filtering is
-intentional. Concise dotted paths follow declared source schemas through nested
-arrays: `comments.body` selects `body` from every comment and drops its
-siblings. Source-declared nullable items and properties remain null. If a
-present source cannot materialize the transform, the command exits nonzero with
-an explicit "not JSON null" error; an absent optional source retains the
-ordinary successful `null` response. If the source schema does not identify a
-nested container, concise projection still applies its field mask across
-encountered arrays to prevent sibling disclosure; use an explicit schema for a
-fixed output contract. The two flags compose as filter-then-project. Both run
-through runtime filter/map/lift nodes, which construct projected values from
-source-schema-selected reads. A declared root shape and structurally selectable
-properties make the initial read the union of predicate and projection paths, so
-omitted linked subgraphs are not hydrated; ambiguous compositions can retain a
-wider selector, and schema-less or root-union sources need a value-shape read
-first. CFC behavior is the same as a computed pattern expression. Source schema
-metadata is authoritative; projection schemas cannot supply `ifc`, `asCell`,
-`scope`, or `default`. A JSON `--schema` marks a position `"$link": true` to get
-that position's address — `{"id","space","scope","path"}`, all four always
-present, no schema inlined — instead of what is behind it, or beside a
-projection to get both. That address is the deepest stored link crossed on the
-way to the marked position plus the segments below it, so marking a field under
-a linked element names that element's own document rather than a slot in the
-collection above it; a position with no link above it keeps the source
-document's own address. A marked position is never fetched, so a marked
-collection costs one document read rather than one per element; the rendered
-`id` minus its `of:` prefix is what `--piece` accepts. Markers do not compose
-with `--filter`. See `packages/cli/README.md` for the exact syntax and supported
-schema subset.
+also falsey. Non-array inputs are rejected. Two flags project the output:
+`--select` takes a comma-separated field list, and `--schema` takes an inline
+JSON Schema or `@schema.json` — and still accepts the same field list. Naming
+both on one command is refused. A field list applies per item for arrays, while
+a JSON Schema describes the whole output. In a JSON Schema, `properties`
+projects an object and `items` projects an array at every level of nesting, with
+or without a matching `type`. In an array-item projection, a typed scalar leaf
+that does not match stored data is omitted rather than reported as an error;
+prefer `true` leaves unless type filtering is intentional. Concise dotted paths
+follow declared source schemas through nested arrays: `comments.body` selects
+`body` from every comment and drops its siblings. Source-declared nullable items
+and properties remain null. If a present source cannot materialize the
+transform, the command exits nonzero with an explicit "not JSON null" error; an
+absent optional source retains the ordinary successful `null` response. If the
+source schema does not identify a nested container, concise projection still
+applies its field mask across encountered arrays to prevent sibling disclosure;
+use an explicit schema for a fixed output contract. A filter and a projection
+compose as filter-then-project. Both run through runtime filter/map/lift nodes,
+which construct projected values from source-schema-selected reads. A declared
+root shape and structurally selectable properties make the initial read the
+union of predicate and projection paths, so omitted linked subgraphs are not
+hydrated; ambiguous compositions can retain a wider selector, and schema-less or
+root-union sources need a value-shape read first. CFC behavior is the same as a
+computed pattern expression. Source schema metadata is authoritative; projection
+schemas cannot supply `ifc`, `asCell`, `scope`, or `default`. A JSON `--schema`
+marks a position `"$link": true` to get that position's address —
+`{"id","space","scope","path"}`, all four always present, no schema inlined —
+instead of what is behind it, or beside a projection to get both. That address
+is the deepest stored link crossed on the way to the marked position plus the
+segments below it, so marking a field under a linked element names that
+element's own document rather than a slot in the collection above it; a position
+with no link above it keeps the source document's own address. A marked position
+is never fetched, so a marked collection costs one document read rather than one
+per element; the rendered `id` minus its `of:` prefix is what `--piece` accepts.
+Markers do not compose with `--filter`. See `packages/cli/README.md` for the
+exact syntax and supported schema subset.
 
 For `piece call`, options before the callable name configure `piece call`.
 Arguments after the callable name configure the invoked handler or tool. The

--- a/skills/topics/SKILL.md
+++ b/skills/topics/SKILL.md
@@ -64,7 +64,7 @@ linked Topic and can include its body, comments, handlers, and reference graph.
 ```bash
 deno task cf piece get --url "$TOPICS_BOARD_URL" topics --input \
   --filter '.title != null' \
-  --schema title,createdAt,lastActivityAt,commentCount,createdBy.kind,createdBy.name
+  --select title,createdAt,lastActivityAt,commentCount,createdBy.kind,createdBy.name
 ```
 
 The title predicate keeps discovery output uniformly object-shaped by omitting
@@ -72,30 +72,30 @@ valid null rows. Concise projection itself preserves nullable rows and follows
 declared nested arrays without exposing sibling fields.
 
 `--filter` is useful for exact field and range searches. It runs before
-`--schema`, so a predicate can inspect a field that the result omits:
+`--select`, so a predicate can inspect a field that the result omits:
 
 ```bash
 # Find one Topic by exact title.
 deno task cf piece get --url "$TOPICS_BOARD_URL" topics --input \
   --filter '.title == "<exact title>"' \
-  --schema title,lastActivityAt,commentCount
+  --select title,lastActivityAt,commentCount
 
 # Find Topics active at or after an epoch-millisecond threshold.
 deno task cf piece get --url "$TOPICS_BOARD_URL" topics --input \
   --filter '.lastActivityAt >= 1785074400000' \
-  --schema title,lastActivityAt,commentCount,createdBy.kind,createdBy.name
+  --select title,lastActivityAt,commentCount,createdBy.kind,createdBy.name
 
 # Combine predicates for a narrower field search.
 deno task cf piece get --url "$TOPICS_BOARD_URL" topics --input \
   --filter '.createdBy.name == "<name>" and .commentCount > 0' \
-  --schema title,lastActivityAt,commentCount
+  --select title,lastActivityAt,commentCount
 ```
 
 Filtering preserves board order; it does not sort by activity. The predicate
 language supports paths, JSON literals, comparisons, boolean operators, and
 parentheses, but not substring, regex, sorting, or arbitrary jq programs. Use
 exact known fields or numeric ranges to shrink the corpus, then inspect the
-small result. Always combine a Topic-list filter with `--schema`; filter alone
+small result. Always combine a Topic-list filter with `--select`; filter alone
 returns every property of each match.
 
 Address a selected Topic by the canonical fid published in the board's
@@ -104,21 +104,21 @@ Address a selected Topic by the canonical fid published in the board's
 ```bash
 deno task cf piece get --url "$TOPICS_BOARD_URL" crossrefs --step \
   --filter '.topic.title == "<exact title>"' \
-  --schema fid,topic.title,topic.lastActivityAt,topic.commentCount
+  --select fid,topic.title,topic.lastActivityAt,topic.commentCount
 export TOPIC_URL='https://estuary.saga-castor.ts.net/topics-dev-476ea34f/<topic-fid>'
 deno task cf piece get --url "$TOPIC_URL" title --input
 deno task cf piece get --url "$TOPIC_URL" body --input
 deno task cf piece get --url "$TOPIC_URL" comments --input \
-  --schema sentAt,author.kind,author.name,authorName,body
+  --select sentAt,author.kind,author.name,authorName,body
 deno task cf piece get --url "$TOPIC_URL" links --input \
-  --schema kind,url,label,addedAt,addedBy.kind,addedBy.name
+  --select kind,url,label,addedAt,addedBy.kind,addedBy.name
 
 # Search within a selected Topic's arrays.
 deno task cf piece get --url "$TOPIC_URL" comments --input \
   --filter '.author.name == "<agent>" or .authorName == "<legacy name>"' \
-  --schema sentAt,author.kind,author.name,authorName,body
+  --select sentAt,author.kind,author.name,authorName,body
 deno task cf piece get --url "$TOPIC_URL" links --input \
-  --filter '.kind == "pr"' --schema kind,url,label,addedAt
+  --filter '.kind == "pr"' --select kind,url,label,addedAt
 ```
 
 Each crossref row's `fid` is the canonical address for its `topic`. Prefer it to
@@ -140,7 +140,7 @@ directly:
 deno task cf piece call --url "$TOPICS_BOARD_URL" addTopic \
   '{"title":"<title>","agentName":"<agent name>"}'
 deno task cf piece get --url "$TOPICS_BOARD_URL" crossrefs --step \
-  --filter '.topic.title == "<exact title>"' --schema fid,topic.title
+  --filter '.topic.title == "<exact title>"' --select fid,topic.title
 ```
 
 `addTopic` returns the topic it created, so a board running this source hands


### PR DESCRIPTION
## Why

`cf piece get --schema` accepted two different input languages through one
flag: a concise dotted path list (`--schema id,title,comments.body`) and a full
JSON Schema (`--schema '{"type":"object",…}'`, including `@file`). One flag
taking two languages means every error message has to hedge about which one you
meant, and a caller cannot tell from the flag name what it takes.

Splitting them is also what lets `@` land later: the suffix in `topic@,title`
only makes sense in the concise language, and it needs a flag that means only
that.

Stage F2 of the shaped-reads plan (#5435). Stacked on #5497.

## What Changed

- **`--select`** takes the concise path list.
- **`--schema`** keeps full JSON Schemas and `@file`.
- Concise input on `--schema` keeps working, with **no deprecation warning** —
  there is no removal date, and warning on every invocation would be noise in
  the skills that teach the current spelling.

Both flags converge on the existing internal representation; there is no second
path. A `ProjectionFlag` rides along so every message names the flag the caller
actually wrote.

## Supplying both is refused

At the argument surface (`conflicts: ["select"]`), not in the selection layer,
exiting 2 with the usage screen. The conflict is a property of which flags were
written, not of the data — and `CellSelectionError` is documented as "a data
condition rather than bad arguments", so routing an argument conflict through
it would blur a distinction the code draws deliberately. It also keeps
`packages/cli/lib/` free of any Cliffy import, which it is today.

## Exit criterion

The plan's exit criterion was that `piece-get-transform.test.ts` pass
**unchanged** — a moved expectation would mean the surface change altered
behavior. The diff on that file is **97 insertions, 0 deletions**: it contains
no `-` lines at all. `--schema`'s messages are byte-identical, because
`--schema` is the default everywhere the flag is threaded.

## Test plan

`deno task test` in packages/cli (1672 + 123 passed) and packages/runner (1156
passed); `check`, `fmt`, `lint`, `check-docs`, `check-skill-facts`,
`check-no-waitfor`, `check-conflict-markers` — all pass.

Both flags driven through the real `cf` binary for the failure paths (they fail
before the network): a bad `--select` path, a JSON Schema or `@file` passed to
`--select`, a bad `--schema` path, and the both-flags conflict.

**Not exercised:** a networked `cf piece get --select` returning projected data
— that path needs a live toolshed and self-skips locally; CI's `cli-integration`
job covers it. No `--select` case was added to `verbs-over-the-cli.sh`, whose
subject is `$link` JSON schemas.

## Noted, not fixed

`--select` is only on `cf piece get`. `cf piece call`, `cf wish` and `cf exec`
are meant to reach the same read step later; when they do they should take both
flags and the same `conflicts` declaration.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

