### PR TITLE
feat(ts-transformers,runner): carry a verb's declared result to its module

### DIFF
--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -886,6 +886,10 @@ Transforms `action(...)` to handler factory invocation:
 - event schema:
   - no event param -> `never`
   - event param present -> inferred/explicit type
+- `action<Event, Result>(cb)` adds `Result` as a third type argument on the
+  emitted `handler`, which is where the declared result would otherwise be
+  lost: the rewritten call carries schemas rather than the authored type
+  arguments. SchemaInjection lowers that slot (§10.3).
 - callback extraction currently supports arrow callbacks only
 
 ### 9.4 Array-method strategy
@@ -1082,6 +1086,18 @@ structurally representable top-level result:
 - with single function arg:
   - infers event/state schemas from parameters
   - event absent -> `never`; untyped params -> `unknown`
+- with a third type arg `<Event, State, Result>`: appends a trailing options
+  object carrying `{ resultSchema: toSchema<Result>() }`. `action<Event,
+  Result>` reaches the same emission — its lowering to `handler` carries the
+  declared result into this third type-argument slot (§7). An absent third
+  argument, and an explicit `void`, emit no options object at all: a declared
+  result is opt-in and never inferred, so a concise body whose completion
+  value happens to be a cell declares nothing. A call that already passes
+  options (the `{ proxy: true }` form) keeps them, spread into the same object.
+  The runtime reads `resultSchema` off that slot onto the node's
+  `Module.resultSchema` (`packages/runner/src/builder/module.ts`); it does NOT
+  reach the pattern's own `resultSchema`, which is what the piece update gate
+  compares across versions.
 
 ### 10.4 `lift(...)`
 

--- a/packages/runner/src/builder/module.ts
+++ b/packages/runner/src/builder/module.ts
@@ -396,6 +396,22 @@ export function byRef<T, R>(ref: string): ModuleFactory<T, R> {
   });
 }
 
+/**
+ * The options a `handler(...)` call carries in its trailing slot.
+ *
+ * `resultSchema` is the verb's declared result — `action<E, R>` /
+ * `handler<E, T, R>` — lowered here by the CTS schema-injection stage. It is
+ * absent for a value-less verb, and the module then carries no result schema
+ * at all, which is what keeps a declared result opt-in.
+ *
+ * The schema-injected call spreads any options the author wrote into this same
+ * object, so a member here may be one this builder does not read: the writable
+ * proxy is asked for in the state-schema slot above.
+ */
+export interface HandlerOptions {
+  resultSchema?: JSONSchema;
+}
+
 function handlerInternal<E, T>(
   eventSchema:
     | JSONSchema
@@ -403,6 +419,7 @@ function handlerInternal<E, T>(
     | undefined,
   stateSchema?: JSONSchema | { proxy: true },
   handler?: (event: E, props: T) => any,
+  options?: HandlerOptions,
 ): HandlerFactory<E, T> {
   let writableProxy = false;
   if (typeof eventSchema === "function") {
@@ -434,6 +451,14 @@ function handlerInternal<E, T>(
     stateSchema as JSONSchema | undefined,
   );
 
+  // Carry the argument schema's ifc confidentiality through to the declared
+  // result, as `createNodeFactory` does for a lift. Only a declared result is
+  // joined: absence stays absence, so a verb that declares nothing keeps a
+  // module with no result schema rather than acquiring the join's `true`.
+  const resultSchema = options?.resultSchema === undefined
+    ? undefined
+    : applyArgumentIfcToResult(schema, options.resultSchema);
+
   const module: Handler<E, T> & toEncodableForm & toJSON & {
     bind: (inputs: FactoryInput<StripCell<T>>) => Stream<E>;
   } = {
@@ -447,6 +472,7 @@ function handlerInternal<E, T>(
     toJSON: toJSONMethod,
     toEncodableForm: () => moduleToEncodableForm(module),
     ...(schema !== undefined && { argumentSchema: schema }),
+    ...(resultSchema !== undefined && { resultSchema }),
     ...(writableProxy && { writableProxy: true }),
   };
 
@@ -525,6 +551,9 @@ export function handler<E, T, R>(
 export function handler<E, T, R>(
   handler: (event: E, props: T) => R,
 ): HandlerFactory<E, T, R>;
+// The trailing options slot is not part of the authored surface: a pattern
+// declares its result with the type argument above, and the schema-injection
+// stage lowers that declaration into `options.resultSchema` here.
 export function handler<E, T, R = void>(
   eventSchema:
     | JSONSchema
@@ -532,12 +561,14 @@ export function handler<E, T, R = void>(
     | undefined,
   stateSchema?: JSONSchema | { proxy: true },
   handler?: (event: E, props: T) => any,
+  options?: HandlerOptions,
 ): HandlerFactory<E, T, R> {
-  return handlerInternal(eventSchema, stateSchema, handler) as HandlerFactory<
-    E,
-    T,
-    R
-  >;
+  return handlerInternal(
+    eventSchema,
+    stateSchema,
+    handler,
+    options,
+  ) as HandlerFactory<E, T, R>;
 }
 
 // unsafe closures: doesn't need any arguments.

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -5324,6 +5324,7 @@ export class Runner {
 
   private handleJavaScriptHandlerResult(
     tx: IExtendedStorageTransaction,
+    resultSchema: JSONSchema | undefined,
     result: any,
     resultHasReactives: boolean,
     frame: Frame,
@@ -5409,7 +5410,18 @@ export class Runner {
       return result;
     }
 
-    const resultPattern = patternFromFrame(() => result);
+    // The verb's DECLARED result type (`module.resultSchema`, lowered from
+    // `action<E, R>` / `handler<E, T, R>`) becomes this synthesized pattern's
+    // result schema, which `setupInternal` records as the receipt cell's
+    // durable `schema` meta. A launched result is a link, so its settled value
+    // describes nothing; the declaration is the only description there is. An
+    // undeclared verb passes `undefined` and keeps the unconstrained schema a
+    // frame-synthesized pattern has always carried.
+    const resultPattern = patternFromFrame(
+      () => result,
+      undefined,
+      resultSchema,
+    );
     // navigateTo result patterns must start after the handler's transaction
     // commits so the navigation target is durable. Every other handler result
     // pattern runs into the canonical result/receipt cell in the handler's
@@ -5903,6 +5915,7 @@ export class Runner {
             const normalized = normalizeSandboxResult(result, name);
             return this.handleJavaScriptHandlerResult(
               tx,
+              module.resultSchema,
               normalized.value,
               normalized.hasReactive,
               frame,

--- a/packages/runner/test/declared-result-e2e.test.ts
+++ b/packages/runner/test/declared-result-e2e.test.ts
@@ -84,6 +84,68 @@ const DECLARED_RESULT_PROGRAM: RuntimeProgram = {
   }],
 };
 
+// A verb whose declared result CONTAINS a reactive value: `Note(...)`
+// instantiates a child pattern, so the returned record carries a builder
+// artifact and the receipt takes the launch branch of
+// `handleJavaScriptHandlerResult` rather than the settled-value one. The
+// declared `R` is the only description of that receipt's shape, since a
+// launched result is a link whose target the receipt cell cannot infer.
+const REACTIVE_RESULT_PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: [
+      'import { action, cell, pattern, Stream } from "commonfabric";',
+      "",
+      "interface NoteInput {",
+      "  title: string;",
+      "}",
+      "",
+      "interface NoteView {",
+      "  title: string;",
+      "}",
+      "",
+      "const Note = pattern<NoteInput, NoteView>((input) => ({",
+      "  title: input.title,",
+      "}));",
+      "",
+      "interface CreateNote {",
+      "  title: string;",
+      "}",
+      "",
+      "interface CreateNoteResult {",
+      "  note: NoteView;",
+      "}",
+      "",
+      "interface Verbs {",
+      "  createNote: Stream<CreateNote, CreateNoteResult>;",
+      "  createUndeclared: Stream<CreateNote>;",
+      "  count: number;",
+      "}",
+      "",
+      "export default pattern<Record<string, never>, Verbs>(() => {",
+      "  const count = cell(0);",
+      "",
+      "  const createNote = action<CreateNote, CreateNoteResult>((event) => {",
+      "    count.set(count.get() + 1);",
+      "    return { note: Note({ title: event.title }) };",
+      "  });",
+      "",
+      "  // The same launch with no declared result. It returns the child",
+      "  // bare rather than in a record because an object literal returned by",
+      "  // an undeclared verb is a compile error (verb-return validation) —",
+      "  // returning a freshly created piece is the exempt idiom.",
+      "  const createUndeclared = action((event: CreateNote) => {",
+      "    count.set(count.get() + 1);",
+      "    return Note({ title: event.title });",
+      "  });",
+      "",
+      "  return { createNote, createUndeclared, count };",
+      "});",
+    ].join("\n"),
+  }],
+};
+
 // Same shape as scheduler-event-receipts.test.ts's file-local helper.
 async function waitForSchedulerCondition(
   runtime: Runtime,
@@ -136,17 +198,15 @@ describe("compiled CTS action<E, R> results in receipts", () => {
     await disposeSchedulerTestRuntime({ storageManager, runtime, tx });
   });
 
-  async function instantiate(rootName: string) {
+  async function instantiate(
+    rootName: string,
+    program: RuntimeProgram = DECLARED_RESULT_PROGRAM,
+  ) {
     const compiled = await runtime.patternManager.compilePattern(
-      DECLARED_RESULT_PROGRAM,
+      program,
       { space, tx },
     );
-    const rootCell = runtime.getCell<{
-      addTopic: unknown;
-      touch: unknown;
-      bump: unknown;
-      count: number;
-    }>(
+    const rootCell = runtime.getCell<Record<string, unknown>>(
       space,
       rootName,
       undefined,
@@ -308,5 +368,92 @@ describe("compiled CTS action<E, R> results in receipts", () => {
       outcomes[0].receiptLink!,
     );
     expect(await receipt.pull()).toEqual({});
+  });
+
+  it("writes the declared result as the receipt's durable schema when the result launches a child piece", async () => {
+    const root = await instantiate(
+      "reactive declared result root",
+      REACTIVE_RESULT_PROGRAM,
+    );
+    const outcomes: Outcome[] = [];
+
+    dispatch(
+      root.key("createNote") as Cell<unknown>,
+      { title: "schema-proof" },
+      "evt:declared-result:4:create-note",
+      outcomes,
+    );
+    await waitForSchedulerCondition(
+      runtime,
+      () => outcomes.length === 1,
+      "reactive declared-result verb event did not settle",
+    );
+    await runtime.scheduler.idleWithPendingCommits();
+
+    expect(outcomes[0].status).toBe("done");
+    expect(await root.key("count").pull()).toBe(1);
+
+    // The receipt carries the verb's declared `R` as its durable `schema`
+    // meta — the description of a launched result, which the settled value
+    // (a link to the child) cannot supply. `CreateNoteResult` reaches the
+    // runtime whole, named definitions included.
+    const receipt = runtime.getCellFromLink<Record<string, unknown>>(
+      outcomes[0].receiptLink!,
+    );
+    await receipt.pull();
+    expect(receipt.getMetaRaw("schema")).toEqual({
+      type: "object",
+      properties: { note: { $ref: "#/$defs/NoteView" } },
+      required: ["note"],
+      $defs: {
+        NoteView: {
+          type: "object",
+          properties: { title: { type: "string" } },
+          required: ["title"],
+        },
+      },
+    });
+
+    // The schema describes what the receipt actually holds: the launched
+    // child, reachable through the receipt address.
+    expect(await receipt.pull()).toEqual({ note: { title: "schema-proof" } });
+  });
+
+  it("leaves the receipt schema unconstrained for a verb that declares no result", async () => {
+    const root = await instantiate(
+      "undeclared reactive result root",
+      REACTIVE_RESULT_PROGRAM,
+    );
+    const outcomes: Outcome[] = [];
+
+    dispatch(
+      root.key("createUndeclared") as Cell<unknown>,
+      { title: "no-declaration" },
+      "evt:declared-result:5:create-undeclared",
+      outcomes,
+    );
+    await waitForSchedulerCondition(
+      runtime,
+      () => outcomes.length === 1,
+      "undeclared reactive-result verb event did not settle",
+    );
+    await runtime.scheduler.idleWithPendingCommits();
+
+    expect(outcomes[0].status).toBe("done");
+    expect(await root.key("count").pull()).toBe(1);
+
+    // Same launch, no declaration: the receipt keeps the empty schema every
+    // frame-synthesized pattern carries, which constrains nothing. A declared
+    // result is opt-in, so its absence must not become an error or a guess.
+    const receipt = runtime.getCellFromLink<Record<string, unknown>>(
+      outcomes[0].receiptLink!,
+    );
+    await receipt.pull();
+    expect(receipt.getMetaRaw("schema")).toEqual({});
+
+    // The value still reads back. Receipt readback is schema-free
+    // (`packages/cli/lib/callable.ts` pulls the link with no schema), so what
+    // the declaration buys is the durable description above, not the value.
+    expect(await receipt.pull()).toEqual({ title: "no-declaration" });
   });
 });

--- a/packages/ts-transformers/src/ast/call-kind.ts
+++ b/packages/ts-transformers/src/ast/call-kind.ts
@@ -403,6 +403,35 @@ export function getPatternToolHoistablePatternCall(
   return patternCall;
 }
 
+/** The verb builders, and the type-argument slot each names its result in. */
+const VERB_RESULT_TYPE_ARG_SLOT = {
+  action: 1,
+  handler: 2,
+} as const;
+
+/** A builder whose call may declare a verb result. */
+export type VerbBuilderName = keyof typeof VERB_RESULT_TYPE_ARG_SLOT;
+
+/**
+ * The type node naming a verb's declared result, or undefined when the verb
+ * declares none.
+ *
+ * A result is opt-in by explicit type argument — `action<Event, Result>` /
+ * `handler<Event, State, Result>` (api `ActionFunction` / `HandlerFunction`) —
+ * and never inferred: the `=> any` overloads absorb every callback first, so a
+ * concise arrow body whose completion value happens to be a cell declares
+ * nothing. An absent type-argument list, a short one, and an explicit `void`
+ * all name the value-less verb.
+ */
+export function declaredVerbResultTypeNode(
+  call: ts.CallExpression,
+  builderName: VerbBuilderName,
+): ts.TypeNode | undefined {
+  const typeArg = call.typeArguments?.[VERB_RESULT_TYPE_ARG_SLOT[builderName]];
+  if (!typeArg) return undefined;
+  return typeArg.kind === ts.SyntaxKind.VoidKeyword ? undefined : typeArg;
+}
+
 export function getCapabilitySummaryCallbackArgument(
   call: ts.CallExpression,
   checker: ts.TypeChecker,

--- a/packages/ts-transformers/src/ast/mod.ts
+++ b/packages/ts-transformers/src/ast/mod.ts
@@ -14,6 +14,7 @@ export {
   classifyArrayMethodResultSinkCall,
   classifyArrayMethodResultSinkReceiverChainCall,
   classifyWildcardTraversalCall,
+  declaredVerbResultTypeNode,
   detectCallKind,
   detectDirectBuilderCall,
   detectNewExpressionKind,
@@ -33,6 +34,7 @@ export {
   isReactiveValueSymbol,
   isSimpleReactiveAccessExpression,
   isWildcardTraversalCall,
+  type VerbBuilderName,
 } from "./call-kind.ts";
 export * from "./dataflow.ts";
 export {

--- a/packages/ts-transformers/src/closures/strategies/action-strategy.ts
+++ b/packages/ts-transformers/src/closures/strategies/action-strategy.ts
@@ -1,6 +1,10 @@
 import ts from "typescript";
 import type { TransformationContext } from "../../core/mod.ts";
-import { detectCallKind, registerSyntheticCallType } from "../../ast/mod.ts";
+import {
+  declaredVerbResultTypeNode,
+  detectCallKind,
+  registerSyntheticCallType,
+} from "../../ast/mod.ts";
 import { CaptureCollector } from "../capture-collector.ts";
 import {
   createActionEventSchema,
@@ -124,6 +128,13 @@ export function transformActionCall(
     context,
   );
 
+  // `action<Event, Result>`'s second type argument is the verb's declared
+  // result. Lowering to `handler` is where it would otherwise be lost — the
+  // rewritten call carries schemas, not the authored type arguments — so it
+  // rides into `handler`'s third type-argument slot, which SchemaInjection
+  // lowers to the module's result schema.
+  const resultTypeNode = declaredVerbResultTypeNode(actionCall, "action");
+
   const finalCall = buildCapturedHandlerClosureCall(
     actionCall,
     callback,
@@ -135,6 +146,7 @@ export function transformActionCall(
     {
       eventParamName,
       paramsParamName: "__cf_action_params",
+      ...(resultTypeNode ? { resultTypeNode } : {}),
     },
   );
 

--- a/packages/ts-transformers/src/closures/utils/capture-scaffold.ts
+++ b/packages/ts-transformers/src/closures/utils/capture-scaffold.ts
@@ -29,6 +29,12 @@ export function buildCapturedHandlerClosureCall(
   options?: {
     readonly eventParamName?: string;
     readonly paramsParamName?: string;
+    /**
+     * The verb's declared result type, carried into `handler`'s third
+     * type-argument slot so SchemaInjection can lower it to the module's
+     * result schema. Omitted for a value-less verb.
+     */
+    readonly resultTypeNode?: ts.TypeNode;
   },
 ): ts.CallExpression {
   const builder = new PatternBuilder(context);
@@ -48,7 +54,9 @@ export function buildCapturedHandlerClosureCall(
   const handlerCall = context.cfHelpers.createHelperCall(
     "handler",
     originalNode,
-    [eventTypeNode, stateTypeNode],
+    options?.resultTypeNode
+      ? [eventTypeNode, stateTypeNode, options.resultTypeNode]
+      : [eventTypeNode, stateTypeNode],
     [handlerCallback],
   );
 

--- a/packages/ts-transformers/src/transformers/schema-injection.ts
+++ b/packages/ts-transformers/src/transformers/schema-injection.ts
@@ -10,6 +10,7 @@ import { FUNCTION_HARDENING_HELPER_NAME } from "@commonfabric/utils/sandbox-cont
 
 import {
   classifyArrayMethodCall,
+  declaredVerbResultTypeNode,
   detectCallKind,
   detectNewExpressionKind,
   ensureTypeNodeRegistered,
@@ -3037,6 +3038,70 @@ function handlePatternSchemaInjection(
   return visited;
 }
 
+/**
+ * Add the handler options object carrying the verb's declared result schema.
+ *
+ * `handler`'s trailing argument is its options object, and `resultSchema` is
+ * the member the builder reads from it (`builder/module.ts`) to put the
+ * declared result on the node's module — where the runner reads it when a
+ * handling's result launches a pattern and the receipt needs a schema. The
+ * result type reaches here in the third type-argument slot: authored directly
+ * on `handler<Event, State, Result>`, or carried there by the `action<Event,
+ * Result>` lowering (`closures/strategies/action-strategy.ts`).
+ *
+ * A call that already passes options — the `{ proxy: true }` form — keeps
+ * them, spread into the same object, so one slot holds every option. A verb
+ * that declares no result gets its arguments back untouched.
+ */
+function withDeclaredResultSchema(
+  args: readonly ts.Expression[],
+  node: ts.CallExpression,
+  context: TransformationContext,
+  checker: ts.TypeChecker,
+  typeRegistry: TypeRegistry | undefined,
+): ts.Expression[] {
+  const next = [...args];
+  const resultTypeNode = declaredVerbResultTypeNode(node, "handler");
+  if (!resultTypeNode) return next;
+
+  const { factory, sourceFile } = context;
+  const resultSchemaCall = createSchemaCallWithRegistryTransfer(
+    context,
+    resultTypeNode,
+    checker,
+    typeRegistry,
+  );
+  const resultType = getTypeFromTypeNodeWithFallback(
+    resultTypeNode,
+    checker,
+    typeRegistry,
+  );
+  if (resultType && typeRegistry) {
+    typeRegistry.set(resultSchemaCall, resultType);
+  }
+
+  // Only an argument the author wrote AFTER the callback is an options object;
+  // the callback itself, and the schemas prepended above, never are.
+  const authoredTail = node.arguments.length >= 2
+    ? node.arguments[node.arguments.length - 1]
+    : undefined;
+  const authoredOptions = authoredTail !== undefined &&
+      !resolveFunctionLikeExpression(authoredTail, checker, sourceFile)
+    ? authoredTail
+    : undefined;
+
+  const options = factory.createObjectLiteralExpression([
+    ...(authoredOptions
+      ? [factory.createSpreadAssignment(authoredOptions)]
+      : []),
+    factory.createPropertyAssignment("resultSchema", resultSchemaCall),
+  ]);
+
+  if (authoredOptions) next[next.length - 1] = options;
+  else next.push(options);
+  return next;
+}
+
 export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
   transform(context: TransformationContext): ts.SourceFile {
     const { sourceFile, tsContext: transformation, checker } = context;
@@ -3244,7 +3309,13 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
             factory.createCallExpression(
               node.expression,
               undefined,
-              [toSchemaEvent, toSchemaState, ...node.arguments],
+              withDeclaredResultSchema(
+                [toSchemaEvent, toSchemaState, ...node.arguments],
+                node,
+                context,
+                checker,
+                typeRegistry,
+              ),
             ),
             node,
           );

--- a/packages/ts-transformers/src/transformers/verb-return-validation.ts
+++ b/packages/ts-transformers/src/transformers/verb-return-validation.ts
@@ -35,16 +35,12 @@
  */
 import ts from "typescript";
 import { HelpersOnlyTransformer, TransformationContext } from "../core/mod.ts";
-import { detectCallKind } from "../ast/call-kind.ts";
+import {
+  declaredVerbResultTypeNode,
+  detectCallKind,
+  type VerbBuilderName,
+} from "../ast/call-kind.ts";
 import { visitEachChildWithJsx } from "../ast/utils.ts";
-
-type VerbBuilderName = "action" | "handler";
-
-/** Result slot: `action`'s 2nd type argument, `handler`'s 3rd. */
-const RESULT_TYPE_ARG_SLOT: Record<VerbBuilderName, number> = {
-  action: 1,
-  handler: 2,
-};
 
 const DECLARE_HINT: Record<VerbBuilderName, string> = {
   action: "action<Event, Result>(...)",
@@ -79,7 +75,7 @@ export class VerbReturnValidationTransformer extends HelpersOnlyTransformer {
     builderName: VerbBuilderName,
     context: TransformationContext,
   ): void {
-    if (declaresResult(call, builderName)) return;
+    if (declaredVerbResultTypeNode(call, builderName)) return;
 
     const callback = verbCallback(call);
     // Concise (expression) bodies never error: absorbing their completion
@@ -102,19 +98,6 @@ export class VerbReturnValidationTransformer extends HelpersOnlyTransformer {
       });
     }
   }
-}
-
-/**
- * Whether the call names a non-void result type argument. An absent argument
- * list, a short one, and an explicit `void` all mean the value-less shape.
- */
-function declaresResult(
-  call: ts.CallExpression,
-  builderName: VerbBuilderName,
-): boolean {
-  const typeArg = call.typeArguments?.[RESULT_TYPE_ARG_SLOT[builderName]];
-  if (!typeArg) return false;
-  return typeArg.kind !== ts.SyntaxKind.VoidKeyword;
 }
 
 /**

--- a/packages/ts-transformers/test/fixtures/handler-schema/stream-declared-result.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/stream-declared-result.expected.jsx
@@ -7,7 +7,7 @@ function __cfHardenFn(fn: Function) {
     return fn;
 }
 import { __cfHelpers } from "commonfabric";
-import { action, cell, pattern, Stream } from "commonfabric";
+import { action, cell, handler, pattern, Stream } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
@@ -21,8 +21,44 @@ interface AddTopicResult {
 }
 interface Verbs {
     addTopic: Stream<AddTopic, AddTopicResult>;
+    renameTopic: Stream<AddTopic, AddTopicResult>;
     touch: Stream<AddTopic>;
 }
+// The other result-authoring surface: `handler`'s THIRD type argument, bound
+// to its state at the call site rather than by closure capture.
+const renameTopic = handler({
+    type: "object",
+    properties: {
+        title: {
+            type: "string"
+        }
+    },
+    required: ["title"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        count: {
+            type: "number"
+        }
+    },
+    required: ["count"]
+} as const satisfies __cfHelpers.JSONSchema, (event, _state) => {
+    return { topic: { fid: event.title } };
+}, { resultSchema: {
+        type: "object",
+        properties: {
+            topic: {
+                type: "object",
+                properties: {
+                    fid: {
+                        type: "string"
+                    }
+                },
+                required: ["fid"]
+            }
+        },
+        required: ["topic"]
+    } as const satisfies __cfHelpers.JSONSchema });
 const __cfHandler_1 = __cfHelpers.handler({
     type: "object",
     properties: {
@@ -43,7 +79,21 @@ const __cfHandler_1 = __cfHelpers.handler({
 } as const satisfies __cfHelpers.JSONSchema, (event, { count }) => {
     count.set(count.get() + 1);
     return { topic: { fid: event.title } };
-});
+}, { resultSchema: {
+        type: "object",
+        properties: {
+            topic: {
+                type: "object",
+                properties: {
+                    fid: {
+                        type: "string"
+                    }
+                },
+                required: ["fid"]
+            }
+        },
+        required: ["topic"]
+    } as const satisfies __cfHelpers.JSONSchema });
 const __cfHandler_2 = __cfHelpers.handler({
     type: "object",
     properties: {
@@ -84,7 +134,7 @@ export default pattern(() => {
     // task), so if a returning verb ever stops satisfying `Stream<E, R>` this
     // file fails to compile. An earlier revision declared `Verbs` and never
     // returned against it, which asserted nothing.
-    return { addTopic: addTopic.for({ stream: ["__patternResult", "addTopic"] }, true), touch: touch.for({ stream: ["__patternResult", "touch"] }, true) };
+    return { addTopic: addTopic.for({ stream: ["__patternResult", "addTopic"] }, true), renameTopic: renameTopic({ count }).for({ stream: ["__patternResult", "renameTopic"] }, true), touch: touch.for({ stream: ["__patternResult", "touch"] }, true) };
 }, {
     type: "object",
     properties: {},
@@ -96,12 +146,16 @@ export default pattern(() => {
             $ref: "#/$defs/AddTopic",
             asCell: ["stream"]
         },
+        renameTopic: {
+            $ref: "#/$defs/AddTopic",
+            asCell: ["stream"]
+        },
         touch: {
             $ref: "#/$defs/AddTopic",
             asCell: ["stream"]
         }
     },
-    required: ["addTopic", "touch"],
+    required: ["addTopic", "renameTopic", "touch"],
     $defs: {
         AddTopic: {
             type: "object",
@@ -115,13 +169,22 @@ export default pattern(() => {
     }
 } as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: stream-declared-result
-// Verifies: a declared result on Stream's second parameter survives the
-//   transformer and still satisfies the pattern's own Output annotation.
-//   `action` is the sole result-authoring surface — `handler()` produces
-//   HandlerFactory<E, T, void>, so the same shape written with `handler` does
-//   not compile. C2 lowers the returned value; C3 emits the result schema.
-//   Until both land, a returning verb transforms exactly like a value-less
-//   one, and this golden is the baseline they move.
+// Verifies: a declared result on Stream's second parameter reaches the
+//   emitted module, and still satisfies the pattern's own Output annotation.
+//   Both authoring surfaces are covered: `action<Event, Result>`, whose
+//   lowering to `handler` carries the result into handler's third
+//   type-argument slot, and `handler<Event, State, Result>` written
+//   directly. Either way the schema lands in the trailing handler options as
+//   `{ resultSchema: … }`, which is where the runtime reads it
+//   (`builder/module.ts`) to describe a receipt whose result launched a
+//   pattern. The value-less `touch` beside them emits no options object at
+//   all — the declaration is opt-in, and its absence stays absent.
+//
+// The result does NOT reach the pattern's own `resultSchema`: the verbs there
+// keep the bare `asCell: ["stream"]` marker. That boundary is deliberate.
+// `Pattern.resultSchema` is what `assertPatternSchemasBackwardCompatible`
+// compares across versions, so a result landing there would make every
+// declared verb result permanently binding on the next deploy.
 //
 // The explicit type-argument form does NOT cost the input schema: `addTopic`
 // emits `{title: string}` from `action<AddTopic, …>` with an unannotated
@@ -134,6 +197,7 @@ export default pattern(() => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
+    renameTopic,
     __cfHandler_1,
     __cfHandler_2
 });

--- a/packages/ts-transformers/test/fixtures/handler-schema/stream-declared-result.input.tsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/stream-declared-result.input.tsx
@@ -1,4 +1,4 @@
-import { action, cell, pattern, Stream } from "commonfabric";
+import { action, cell, handler, pattern, Stream } from "commonfabric";
 
 interface AddTopic {
   title: string;
@@ -10,8 +10,17 @@ interface AddTopicResult {
 
 interface Verbs {
   addTopic: Stream<AddTopic, AddTopicResult>;
+  renameTopic: Stream<AddTopic, AddTopicResult>;
   touch: Stream<AddTopic>;
 }
+
+// The other result-authoring surface: `handler`'s THIRD type argument, bound
+// to its state at the call site rather than by closure capture.
+const renameTopic = handler<AddTopic, { count: number }, AddTopicResult>(
+  (event, _state) => {
+    return { topic: { fid: event.title } };
+  },
+);
 
 export default pattern<Record<string, never>, Verbs>(() => {
   const count = cell(0);
@@ -35,17 +44,26 @@ export default pattern<Record<string, never>, Verbs>(() => {
   // task), so if a returning verb ever stops satisfying `Stream<E, R>` this
   // file fails to compile. An earlier revision declared `Verbs` and never
   // returned against it, which asserted nothing.
-  return { addTopic, touch };
+  return { addTopic, renameTopic: renameTopic({ count }), touch };
 });
 
 // FIXTURE: stream-declared-result
-// Verifies: a declared result on Stream's second parameter survives the
-//   transformer and still satisfies the pattern's own Output annotation.
-//   `action` is the sole result-authoring surface — `handler()` produces
-//   HandlerFactory<E, T, void>, so the same shape written with `handler` does
-//   not compile. C2 lowers the returned value; C3 emits the result schema.
-//   Until both land, a returning verb transforms exactly like a value-less
-//   one, and this golden is the baseline they move.
+// Verifies: a declared result on Stream's second parameter reaches the
+//   emitted module, and still satisfies the pattern's own Output annotation.
+//   Both authoring surfaces are covered: `action<Event, Result>`, whose
+//   lowering to `handler` carries the result into handler's third
+//   type-argument slot, and `handler<Event, State, Result>` written
+//   directly. Either way the schema lands in the trailing handler options as
+//   `{ resultSchema: … }`, which is where the runtime reads it
+//   (`builder/module.ts`) to describe a receipt whose result launched a
+//   pattern. The value-less `touch` beside them emits no options object at
+//   all — the declaration is opt-in, and its absence stays absent.
+//
+// The result does NOT reach the pattern's own `resultSchema`: the verbs there
+// keep the bare `asCell: ["stream"]` marker. That boundary is deliberate.
+// `Pattern.resultSchema` is what `assertPatternSchemasBackwardCompatible`
+// compares across versions, so a result landing there would make every
+// declared verb result permanently binding on the next deploy.
 //
 // The explicit type-argument form does NOT cost the input schema: `addTopic`
 // emits `{title: string}` from `action<AddTopic, …>` with an unannotated


### PR DESCRIPTION
## Why

A verb's handler is typed `Stream<E, R>`. `R` was dropped at compile time, so a
receipt for a verb whose result contains anything reactive — including every
verb that returns a child piece, which is the motivating case — carried no
description of what it holds. A reader had nothing to push into the fetch and
nothing to match against but a runtime value.

The consumer already exists and is already correct: the reactive branch calls
`updateResultSchemaMeta(tx, resultCell, pattern.resultSchema)`, whose first line
is `if (resultSchema === undefined) return;`. It was never missing plumbing. It
was missing the one input.

## Relationship to the withdrawn verb-contract C3 — read this first

`docs/plans/pattern-verb-contract-implementation.md` records that result-schema
emission was built, proven, and then **deliberately withdrawn** before merge
(review, 2026-07-31), with instructions to revisit it as part of the
Fabric-types stream design and not before. This PR is deliberately not that
thing, and each of the three recorded objections is addressed rather than
re-argued:

| | withdrawn C3 | this |
|---|---|---|
| mechanism | new `result` **dialect keyword**, sibling to `asCell` | existing `Module.resultSchema` field, an ordinary JSON Schema |
| destination | the pattern's own `resultSchema`, on the stream property | the handler **node's** module, inside `pattern.nodes[]` |
| compat gate | new recursion + result-name permanence rules | none added |
| schema-generator | changed | **untouched** |

1. **"A keyword in durable schemas and append-only baselines hard-commits a
   shape."** Not tripped. A baseline record is exactly
   `{pattern, argumentSchema, resultSchema}` — the pattern's top-level schemas,
   with no slot for a node's module. `check-baselines-append-only` and
   `pattern-compat` (336 patterns) pass.
2. **"The compat rules would refuse its later removal."** Not tripped.
   `assertPatternSchemasBackwardCompatible` reads only
   `previous/candidate.{argumentSchema, resultSchema}` and never walks
   `pattern.nodes[].module`. Removing this later is an ordinary graph edit.
3. **"The value path never needed it."** Still true, and this PR does not
   contradict it — see the honest limitation below.

## Honest limitation

**Nothing consumes the receipt's schema today.** The receipt readback in
`packages/cli/lib/callable.ts` pulls schema-free. This lands a durable
description ahead of its reader; the reader is the receipt-envelope step of the
shaped-reads plan (#5435). Judged on its own it buys nothing yet — it is
groundwork, and worth taking on that basis or not at all.

## What Changed

A single predicate, `declaredVerbResultTypeNode`, decides "this verb declares a
result"; `verb-return-validation.ts` now shares it instead of keeping a private
copy. `action<E,R>`'s result is carried into the emitted `handler`'s third type
argument, schema injection appends `{resultSchema: toSchema<R>()}`, and
`handler`/`handlerInternal` thread it onto `module.resultSchema`, ifc-joined the
way `createNodeFactory` does for `lift`.

A verb with no declared result, or `R = void`, is unchanged and gets no schema —
pinned by a test, so this cannot become mandatory.

## Test plan

`stream-declared-result` — the golden fixture whose own comment named this as
the step that would move it — is the only fixture in the ts-transformers suite
that moved. A `handler<E,T,R>` verb was added beside the `action<E,R>` one so
both authoring surfaces are pinned.

`packages/runner/test/declared-result-e2e.test.ts` compiles a `createNote`-style
verb through the real pipeline, dispatches it, and reads `getMetaRaw("schema")`
off the receipt: it gets the declared result whole, `$defs` included.
Confirmed failing without the change.

runner 1156 · ts-transformers 1130 · cli 123 · piece 34 · api 25 · patterns 66 —
0 failed. `check`, `fmt`, `lint`, `check-docs`, `check-skill-facts`,
`check-no-waitfor`, `check-conflict-markers`, `check-baselines-append-only`,
`pattern-compat`, `check-single-copy-deps`, `check-unused-deps`,
`check-deno-pins` all green.

## Found wrong, not fixed

1. **`{proxy: true}` is silently dropped for every CTS-transformed pattern.**
   Schema injection emits it in the 4th slot; `handlerInternal` only recognizes
   the marker in the 2nd, so `module.writableProxy` is never set.
   `packages/patterns/system/default-app.tsx` relies on it. Pre-existing; this
   change routes around it rather than into it.
2. `handler<E,T>(eventSchema, stateSchema, cb)` with explicit type arguments
   emits a broken 5-argument call. No occurrence in the repo, so latent.

*Naming: C1–C5 above are the **verb contract** arc, not the identically
numbered steps of the shaped-reads plan.*


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

