### PR TITLE
feat(cli): `@` marks a position for its address in a field list

### DIFF
--- a/docs/common/verbs-over-the-cli.md
+++ b/docs/common/verbs-over-the-cli.md
@@ -325,9 +325,10 @@ that can go stale.
 ### Asking a read for an address
 
 A cell is a point in a graph, so a read that does not say where to stop follows
-links onward and hands back a copy of everything behind them. `--schema` says
-where to stop: a position marked `{"$link": true}` returns that position's
-address rather than its contents.
+links onward and hands back a copy of everything behind them. A projection says
+where to stop: a marked position returns that position's address rather than
+its contents. A field list marks with a trailing `@`, and a JSON Schema marks
+with `{"$link": true}`.
 
 ```bash
 cf piece get --piece <board> notes \
@@ -361,6 +362,19 @@ cf piece get --piece <board> notes --schema \
 ```json
 [{ "$link": { "id": "of:fid1:…", "…": "…" }, "title": "First note" }]
 ```
+
+A field list unions the same way, and its two paths meet at the one position:
+
+```bash
+cf piece get --piece <board> --select 'notes@,noteCount'
+```
+
+```json
+{ "notes": { "$link": { "id": "of:fid1:…", "…": "…" } }, "noteCount": 3 }
+```
+
+The suffix is special only at the end of a segment, and `\@` writes a literal
+one, so a field named `user@home` stays reachable.
 
 A marked position is not fetched — the address is stored in the document that
 contains it, so a marked collection of a hundred notes costs the one read that

--- a/docs/common/verbs-over-the-cli.md
+++ b/docs/common/verbs-over-the-cli.md
@@ -376,6 +376,11 @@ cf piece get --piece <board> --select 'notes@,noteCount'
 The suffix is special only at the end of a segment, and `\@` writes a literal
 one, so a field named `user@home` stays reachable.
 
+A path that is only `@` names the position the read is already at, which no
+field path reaches because it sits above every field. `--select '@'` returns
+the source's own address in place of its contents, and `--select '@,title'`
+returns the address beside the title.
+
 A marked position is not fetched — the address is stored in the document that
 contains it, so a marked collection of a hundred notes costs the one read that
 document already needed. Where the marker is the whole selection, nothing

--- a/docs/common/verbs-over-the-cli.md
+++ b/docs/common/verbs-over-the-cli.md
@@ -370,16 +370,23 @@ cf piece get --piece <board> --select 'notes@,noteCount'
 ```
 
 ```json
-{ "notes": { "$link": { "id": "of:fid1:…", "…": "…" } }, "noteCount": 3 }
+{ "notes": [{ "$link": { "id": "of:fid1:…", "…": "…" } }], "noteCount": 3 }
 ```
+
+A field list applies to each element wherever it crosses an array, and an
+address is one of the things it applies: `notes@` answers with the address of
+each note rather than of the slot it sits in, which makes it the concise
+spelling of the `items` marker above. Where the marked position holds anything
+else, the address is that position's own.
 
 The suffix is special only at the end of a segment, and `\@` writes a literal
 one, so a field named `user@home` stays reachable.
 
 A path that is only `@` names the position the read is already at, which no
 field path reaches because it sits above every field. `--select '@'` returns
-the source's own address in place of its contents, and `--select '@,title'`
-returns the address beside the title.
+the source's own address in place of its contents — one per element where the
+source is an array — and `--select '@,title'` returns the address beside the
+title.
 
 A marked position is not fetched — the address is stored in the document that
 contains it, so a marked collection of a hundred notes costs the one read that

--- a/docs/common/verbs-over-the-cli.md
+++ b/docs/common/verbs-over-the-cli.md
@@ -363,10 +363,11 @@ cf piece get --piece <board> notes --schema \
 [{ "$link": { "id": "of:fid1:…", "…": "…" }, "title": "First note" }]
 ```
 
-A field list unions the same way, and its two paths meet at the one position:
+A field list unions the same way, and its two paths meet at the one position.
+`noteCount` is computed, so the read steps the piece to bring it up to date:
 
 ```bash
-cf piece get --piece <board> --select 'notes@,noteCount'
+cf piece get --piece <board> --step --select 'notes@,noteCount'
 ```
 
 ```json

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -175,7 +175,8 @@ missing value and is also falsey. Filtering happens before schema projection.
 
 Two flags project, one per input language:
 
-- `--select` takes a comma-separated field list such as `id,title,author.name`;
+- `--select` takes a comma-separated field list such as `id,title,author.name`,
+  in which a segment ending in `@` asks for an address rather than contents;
 - `--schema` takes an inline JSON Schema object or `@path/to/schema.json`, and
   also accepts the same field list `--select` takes.
 
@@ -229,8 +230,8 @@ override `ifc`, `asCell`, `scope`, or `default` through `--schema`.
 
 #### Asking for an address instead of contents
 
-A JSON `--schema` marks a position with `"$link": true` to get that position's
-address rather than what is behind it:
+A projection marks a position to get that position's address rather than what is
+behind it. A JSON `--schema` marks with `"$link": true`:
 
 ```bash
 cf piece get --piece ID notes --schema '{"type":"array","items":{"$link":true}}'
@@ -271,13 +272,33 @@ and the title — and replaces the contents when it is alone. It is accepted
 anywhere `properties` is, except under `additionalProperties`, whose membership
 the stored value rather than the selection decides.
 
+A field list marks with a trailing `@`, which is that same marker at the
+position the segment names:
+
+```bash
+cf piece get --piece ID --select 'topic@,topic.title'
+```
+
+```json
+{ "topic": { "$link": { "id": "of:fid1:…", "…": "…" }, "title": "First note" } }
+```
+
+The two paths union into the one position, and `topic@.title` says the same
+thing in one path. `@` is special only as the final character of a segment:
+`user@home` names a field, and `\@` writes a literal `@` where a trailing one
+would otherwise mark, so `a\@` names the field `a@`. A path stops where it
+stops, so `notes@` returns the address of the `notes` position itself, while
+marking a field below an array — `notes.title@` — returns an address per
+element, because that is where the field list puts a field path. Naming a
+position both ways, `topic,topic@`, returns the address beside the whole
+contents.
+
 A marked position is never fetched: it contributes a rejecting selector to the
 same path union the projection builds, and the address is composed from links
 already stored in the documents the read visited rather than by following one. A
 marked collection therefore costs one document read rather than one per element.
-The marker is a JSON-schema spelling only, and it cannot be combined with
-`--filter`: the elements a predicate keeps no longer say which positions they
-came from, and an address names a position.
+Neither spelling can be combined with `--filter`: the elements a predicate keeps
+no longer say which positions they came from, and an address names a position.
 
 #### What a selection means for a call
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -286,12 +286,28 @@ cf piece get --piece ID --select 'topic@,topic.title'
 The two paths union into the one position, and `topic@.title` says the same
 thing in one path. `@` is special only as the final character of a segment:
 `user@home` names a field, and `\@` writes a literal `@` where a trailing one
-would otherwise mark, so `a\@` names the field `a@`. A path stops where it
-stops, so `notes@` returns the address of the `notes` position itself, while
-marking a field below an array — `notes.title@` — returns an address per
-element, because that is where the field list puts a field path. Naming a
-position both ways, `topic,topic@`, returns the address beside the whole
-contents.
+would otherwise mark, so `a\@` names the field `a@`. Naming a position both
+ways, `topic,topic@`, returns the address beside the whole contents.
+
+A field list applies to each element wherever it crosses an array, and an
+address is one of the things it applies. Where the marked position holds an
+array the answer is one address per element, so `notes@` is the concise spelling
+of `{"type":"array","items":{"$link":true}}`:
+
+```bash
+cf piece get --piece ID --select 'notes@'
+```
+
+```json
+{ "notes": [{ "$link": { "id": "of:fid1:…", "…": "…" } }] }
+```
+
+Those element documents are what a caller cannot work out for themselves; the
+array position's own address is only the source address plus the path they just
+typed. Where the marked position holds anything else, `topic@` among them, the
+address is that position's own. Marking below an array — `notes.title@` — is
+element-wise for the same reason, and answers with each note's own `id` and
+`path` `["title"]`.
 
 A path that is only `@` names the position the read is already at, which no
 field path reaches because it sits above every field:
@@ -305,10 +321,10 @@ cf piece get --piece ID topic --select '@,title'
 ```
 
 It composes exactly as a suffix one level down does: `@` alone replaces the
-contents with the address, and `@` beside a field path returns both in the one
-result. A leading `@` followed by anything else is an `@file`, which `--schema`
-reads and `--select` does not, so `--select '@fields.json'` is refused and
-pointed there.
+contents with the address, `@` beside a field path returns both in the one
+result, and a source that holds an array answers with one address per element. A
+leading `@` followed by anything else is an `@file`, which `--schema` reads and
+`--select` does not, so `--select '@fields.json'` is refused and pointed there.
 
 A marked position is never fetched: it contributes a rejecting selector to the
 same path union the projection builds, and the address is composed from links

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -293,6 +293,23 @@ element, because that is where the field list puts a field path. Naming a
 position both ways, `topic,topic@`, returns the address beside the whole
 contents.
 
+A path that is only `@` names the position the read is already at, which no
+field path reaches because it sits above every field:
+
+```bash
+cf piece get --piece ID topic --select '@,title'
+```
+
+```json
+{ "$link": { "id": "of:fid1:…", "…": "…" }, "title": "First note" }
+```
+
+It composes exactly as a suffix one level down does: `@` alone replaces the
+contents with the address, and `@` beside a field path returns both in the one
+result. A leading `@` followed by anything else is an `@file`, which `--schema`
+reads and `--select` does not, so `--select '@fields.json'` is refused and
+pointed there.
+
 A marked position is never fetched: it contributes a rejecting selector to the
 same path union the projection builds, and the address is composed from links
 already stored in the documents the read visited rather than by following one. A

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -1570,7 +1570,7 @@ PATH FORMAT: Use forward slashes and numeric indices for arrays.
   .option(
     "--select <fields:string>",
     "Project output to comma-separated field paths; a trailing @ asks for a " +
-      "position's address",
+      "position's address, and @ alone for the source's own",
   )
   .option(
     "--schema <schema:string>",

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -1542,6 +1542,12 @@ PATH FORMAT: Use forward slashes and numeric indices for arrays.
   )
   .example(
     cliText(
+      `cf piece get ${EX_ID} ${EX_COMP_PIECE} --select 'topic@,topic.title'`,
+    ),
+    "Return a field's address, and the fields asked for beside it.",
+  )
+  .example(
+    cliText(
       `cf piece get ${EX_ID} ${EX_COMP_PIECE} items ` +
         `--schema '{"type":"array","items":{"$link":true}}'`,
     ),
@@ -1563,7 +1569,8 @@ PATH FORMAT: Use forward slashes and numeric indices for arrays.
   )
   .option(
     "--select <fields:string>",
-    "Project output to comma-separated field paths",
+    "Project output to comma-separated field paths; a trailing @ asks for a " +
+      "position's address",
   )
   .option(
     "--schema <schema:string>",

--- a/packages/cli/integration/verbs-over-the-cli.sh
+++ b/packages/cli/integration/verbs-over-the-cli.sh
@@ -144,6 +144,14 @@ B=$($CF piece call --quiet --piece "$FIRST" $ARGS --invocation append-read \
 check "written at create
 appended through the read" "$(echo "$B" | jq -r '.result.body // empty')" \
   "the address a read returned is one a caller can call"
+# A field list spells the same marker with a trailing @, so one read asks for
+# an address at one position and projects at another.
+AT=$($CF piece get --quiet --piece "$BOARD" $ARGS \
+  --select 'notes@,noteCount' 2>/dev/null)
+check "true" "$(echo "$AT" | jq -c '.notes | has("$link")')" \
+  "a trailing @ returns the marked position's address"
+check "true" "$(echo "$AT" | jq -c '.noteCount >= 1')" \
+  "and a sibling path projects beside it in the one result"
 
 step "7. A replayed invocation id returns the ORIGINAL result — in its session"
 # Captured rather than hard-coded: the property is that the replay changes

--- a/packages/cli/integration/verbs-over-the-cli.sh
+++ b/packages/cli/integration/verbs-over-the-cli.sh
@@ -147,7 +147,8 @@ appended through the read" "$(echo "$B" | jq -r '.result.body // empty')" \
 # A field list spells the same marker with a trailing @, so one read asks for
 # an address at one position and projects at another. The list is element-wise
 # across an array, so the marked collection answers with one address per note.
-AT=$($CF piece get --quiet --piece "$BOARD" $ARGS \
+# noteCount is computed, so --step brings it up to date the way step 7 does.
+AT=$($CF piece get --quiet --piece "$BOARD" $ARGS --step \
   --select 'notes@,noteCount' 2>/dev/null)
 check "true" "$(echo "$AT" | jq -c \
   '(.notes | length > 0) and ([.notes[] | has("$link")] | all)')" \

--- a/packages/cli/integration/verbs-over-the-cli.sh
+++ b/packages/cli/integration/verbs-over-the-cli.sh
@@ -145,13 +145,19 @@ check "written at create
 appended through the read" "$(echo "$B" | jq -r '.result.body // empty')" \
   "the address a read returned is one a caller can call"
 # A field list spells the same marker with a trailing @, so one read asks for
-# an address at one position and projects at another.
+# an address at one position and projects at another. The list is element-wise
+# across an array, so the marked collection answers with one address per note.
 AT=$($CF piece get --quiet --piece "$BOARD" $ARGS \
   --select 'notes@,noteCount' 2>/dev/null)
-check "true" "$(echo "$AT" | jq -c '.notes | has("$link")')" \
-  "a trailing @ returns the marked position's address"
+check "true" "$(echo "$AT" | jq -c \
+  '(.notes | length > 0) and ([.notes[] | has("$link")] | all)')" \
+  "a trailing @ on an array returns an address per element"
 check "true" "$(echo "$AT" | jq -c '.noteCount >= 1')" \
   "and a sibling path projects beside it in the one result"
+# The bare suffix names the position the read is already at.
+ROOT=$($CF piece get --quiet --piece "$BOARD" $ARGS --select '@' 2>/dev/null)
+check "true" "$(echo "$ROOT" | jq -c 'has("$link")')" \
+  "a bare @ returns the read source's own address"
 
 step "7. A replayed invocation id returns the ORIGINAL result — in its session"
 # Captured rather than hard-coded: the property is that the replay changes

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -828,6 +828,10 @@ function conciseSelectionSchema(node: ConciseSelection): unknown {
  * list names positions rather than shapes, so it is collected as a tree first:
  * the same position can be reached by several paths, and `topic@` beside
  * `topic.title` is one position asked two questions rather than two answers.
+ *
+ * A path that is nothing but {@link CONCISE_ADDRESS_SUFFIX} names the position
+ * the read is already at, which no field path reaches because it is above
+ * every field.
  */
 function conciseProjectionSchema(
   source: string,
@@ -841,6 +845,10 @@ function conciseProjectionSchema(
   }
   const root = emptyConciseSelection();
   for (const path of paths) {
+    if (path === CONCISE_ADDRESS_SUFFIX) {
+      root.marked = true;
+      continue;
+    }
     const segments = path.split(".").map((segment) =>
       parseConciseSegment(segment, path, flag)
     );
@@ -867,18 +875,25 @@ export interface ProjectionParseDependencies {
  * Parses a `--select` argument: the comma-separated field paths, which is the
  * whole of what this flag accepts. A path segment ending in
  * {@link CONCISE_ADDRESS_SUFFIX} asks for the address of the position it
- * names. `--schema` reads the same spelling and more, so an argument written
- * in the JSON Schema language is pointed at the flag that reads it rather than
- * reported as a malformed field path.
+ * names, and a path that is only the suffix asks the read's own source for
+ * its address. `--schema` reads the same spelling and more, so an argument
+ * written in the JSON Schema language is pointed at the flag that reads it
+ * rather than reported as a malformed field path.
+ *
+ * `@file` names a schema file, which only `--schema` accepts, and a field name
+ * cannot begin with `@`. A leading one is therefore an argument for the other
+ * flag wherever it is not the bare suffix.
  */
 export function parseSelectProjection(source: string): SelectionProjection {
   const trimmed = source.trim();
   if (trimmed.length === 0) {
     throw new CellSelectionError("--select must not be empty");
   }
+  const leading = trimmed.split(",", 1)[0].trim();
   if (
-    trimmed.startsWith("{") || trimmed.startsWith("@") ||
-    trimmed === "true" || trimmed === "false"
+    trimmed.startsWith("{") || trimmed === "true" || trimmed === "false" ||
+    (leading.startsWith(CONCISE_ADDRESS_SUFFIX) &&
+      leading !== CONCISE_ADDRESS_SUFFIX)
   ) {
     throw new CellSelectionError(
       "--select takes comma-separated field paths. Pass a JSON Schema or an " +

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -1712,10 +1712,10 @@ function sourcePosition(cell: Cell<unknown>): WalkedPosition {
 
 /**
  * Helper for {@link composeLinkAddresses}, which reads the container stored at
- * `position` so a marked collection can be walked element by element. Reaches
- * for the container's own document when the walk cannot see the container:
- * behind a link, or where the selection's read stopped above it, which is what
- * a marked collection's rejecting selector does.
+ * `position` so a JSON `items` marker can be walked element by element.
+ * Reaches for the container's own document when the walk cannot see the
+ * container: behind a link, or where the selection's read stopped above it,
+ * which is what a marked collection's rejecting selector does.
  */
 async function storedContainer(position: WalkedPosition): Promise<unknown> {
   if (position.stored?.value !== undefined) return position.stored.value;
@@ -1723,6 +1723,34 @@ async function storedContainer(position: WalkedPosition): Promise<unknown> {
   if (stored !== undefined) return stored;
   await position.cell.asSchema(false).pull();
   return position.cell.getRaw({ lastNode: "value" });
+}
+
+/**
+ * Helper for {@link composeLinkAddresses}: `markers` asked of every element of
+ * `stored`, the array a position holds. Each element is addressed from the
+ * link its own slot stores, so the answers survive a reordering of the
+ * collection.
+ */
+async function composeElementAddresses(
+  position: WalkedPosition,
+  stored: readonly unknown[],
+  markers: LinkMarkers,
+  projected: unknown,
+  implicitArrayTraversal: boolean,
+): Promise<unknown[]> {
+  const projectedItems = Array.isArray(projected) ? projected : [];
+  const items: unknown[] = [];
+  for (let index = 0; index < stored.length; index++) {
+    items.push(
+      await composeLinkAddresses(
+        positionBelow(position, index, stored),
+        markers,
+        projectedItems[index],
+        implicitArrayTraversal,
+      ),
+    );
+  }
+  return items;
 }
 
 /**
@@ -1736,9 +1764,11 @@ async function storedContainer(position: WalkedPosition): Promise<unknown> {
  *
  * `implicitArrayTraversal` states that the markers came from a concise field
  * list, which names a field wherever the value holds one rather than at a
- * fixed depth. The positions below an array then belong to its elements, the
- * same way {@link projectValue} applies one field mask across them, while an
- * address asked for at the array names the array itself.
+ * fixed depth. A position holding an array is therefore asked of each of its
+ * elements — the same way {@link projectValue} applies one field mask across
+ * them, and the address included, so `notes@` answers with the note documents
+ * rather than with the slots they sit in. A JSON Schema states its own depth,
+ * and marks elements with `items`.
  */
 async function composeLinkAddresses(
   position: WalkedPosition,
@@ -1746,29 +1776,35 @@ async function composeLinkAddresses(
   projected: unknown,
   implicitArrayTraversal = false,
 ): Promise<unknown> {
+  // The container is the one the walk already holds. A marked position is
+  // never fetched, so below a crossed link there is nothing to look inside,
+  // and that link is the address.
+  const elements = implicitArrayTraversal && markers.items === undefined
+    ? position.stored?.value
+    : undefined;
+  if (Array.isArray(elements)) {
+    return await composeElementAddresses(
+      position,
+      elements,
+      markers,
+      projected,
+      implicitArrayTraversal,
+    );
+  }
+
   let composed = projected;
-  const elementMarkers = markers.items ??
-    (implicitArrayTraversal && markers.properties !== undefined
-      ? { properties: markers.properties }
-      : undefined);
-  const stored = elementMarkers === undefined
-    ? undefined
-    : await storedContainer(position);
-  if (elementMarkers !== undefined && Array.isArray(stored)) {
-    const projectedItems = Array.isArray(projected) ? projected : [];
-    const items: unknown[] = [];
-    for (let index = 0; index < stored.length; index++) {
-      items.push(
-        await composeLinkAddresses(
-          positionBelow(position, index, stored),
-          elementMarkers,
-          projectedItems[index],
-          implicitArrayTraversal,
-        ),
+  if (markers.items !== undefined) {
+    const stored = await storedContainer(position);
+    if (Array.isArray(stored)) {
+      composed = await composeElementAddresses(
+        position,
+        stored,
+        markers.items,
+        projected,
+        implicitArrayTraversal,
       );
     }
-    composed = items;
-  } else if (markers.items === undefined && markers.properties !== undefined) {
+  } else if (markers.properties !== undefined) {
     const projectedRecord = isRecord(projected) && !Array.isArray(projected)
       ? projected
       : {};

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -1322,6 +1322,45 @@ function alignConciseProjectionMask(
   };
 }
 
+/**
+ * Aligns the markers a concise field list wrote against the shape the source
+ * declares, the way {@link alignConciseProjectionMask} aligns the mask beside
+ * them. A field list names a field wherever the value holds one rather than at
+ * a fixed depth, so a name that crosses an array marks each of its elements:
+ * the aligned markers say that with `items`, which is what a JSON Schema
+ * states for itself. Where the source declares nothing the markers stay as
+ * written, and the value the walk holds decides.
+ */
+function alignConciseMarkers(
+  source: JSONSchema | undefined,
+  markers: LinkMarkers,
+  flag: ProjectionFlag,
+): LinkMarkers {
+  if (source === undefined || source === true) return markers;
+  if (schemaMayBeArray(source, flag)) {
+    return {
+      items: alignConciseMarkers(schemaAtArrayItem(source), markers, flag),
+    };
+  }
+  if (markers.properties === undefined) return markers;
+  return {
+    ...markers,
+    properties: Object.fromEntries(
+      Object.entries(markers.properties).map(([key, child]) => {
+        const childSchema = ContextualFlowControl.schemaAtPath(source, [key]);
+        return [
+          key,
+          alignConciseMarkers(
+            childSchema === false ? undefined : childSchema,
+            child,
+            flag,
+          ),
+        ];
+      }),
+    ),
+  };
+}
+
 function projectValue(
   value: unknown,
   schema: JSONSchema,
@@ -1549,6 +1588,8 @@ interface ResolvedProjection {
   itemProjectionSchema?: JSONSchema;
   itemMask?: ProjectionMask;
   implicitArrayTraversal: boolean;
+  /** The projection's markers, at the depth the source puts them. */
+  markers?: LinkMarkers;
 }
 
 function resolveProjection(
@@ -1576,6 +1617,9 @@ function resolveProjection(
       ),
       KeepAsCell.OnlyStream,
     );
+    const markers = projection.markers === undefined
+      ? undefined
+      : alignConciseMarkers(source, projection.markers, projection.flag);
     return projectsArrayItems
       ? {
         outputSchema: filteredOutputSchema(sourceSchema, outputSchema),
@@ -1589,6 +1633,9 @@ function resolveProjection(
         itemProjectionSchema: projectionSchema,
         itemMask: mask,
         implicitArrayTraversal: true,
+        // An array source is read element-wise, and a field list marks what it
+        // reads, so every marker below the root belongs to an element.
+        ...(markers === undefined ? {} : { markers: { items: markers } }),
       }
       : {
         outputSchema,
@@ -1596,6 +1643,7 @@ function resolveProjection(
         mask,
         projectsArrayItems: false,
         implicitArrayTraversal: true,
+        markers,
       };
   }
   const projectsArrayItems = schemaIsArray(projection.schema);
@@ -1620,6 +1668,8 @@ function resolveProjection(
     mask,
     projectsArrayItems,
     implicitArrayTraversal: false,
+    // A JSON Schema states its own depth, so its markers sit where it put them.
+    markers: projection.markers,
     ...(projectsArrayItems
       ? {
         itemOutputSchema: itemSchema,
@@ -1764,11 +1814,14 @@ async function composeElementAddresses(
  *
  * `implicitArrayTraversal` states that the markers came from a concise field
  * list, which names a field wherever the value holds one rather than at a
- * fixed depth. A position holding an array is therefore asked of each of its
- * elements — the same way {@link projectValue} applies one field mask across
- * them, and the address included, so `notes@` answers with the note documents
- * rather than with the slots they sit in. A JSON Schema states its own depth,
- * and marks elements with `items`.
+ * fixed depth. Where the source declares that depth,
+ * {@link alignConciseMarkers} has already written it out as `items`, so
+ * `notes@` answers with the note documents rather than with the slots they sit
+ * in. Where the source declares nothing, the value decides instead: a position
+ * the walk holds an array at is asked of each of its elements, the same way
+ * {@link projectValue} applies one field mask across them, and the address
+ * included. A JSON Schema states its own depth, and marks elements with
+ * `items`.
  */
 async function composeLinkAddresses(
   position: WalkedPosition,
@@ -1869,9 +1922,11 @@ export async function deriveSelectedValue(
   selection: CellSelection,
   deps: DeriveSelectedValueDependencies = {},
 ): Promise<unknown> {
-  const markers = selection.projection?.markers;
   const implicitArrayTraversal = selection.projection?.kind === "concise";
-  if (selection.filter !== undefined && markers !== undefined) {
+  if (
+    selection.filter !== undefined &&
+    selection.projection?.markers !== undefined
+  ) {
     const asked = implicitArrayTraversal
       ? `an \`${CONCISE_ADDRESS_SUFFIX}\` suffix in ` +
         selection.projection!.flag
@@ -1908,6 +1963,9 @@ export async function deriveSelectedValue(
     sourceSchema,
     sourceIsArray,
   );
+  // The markers at the depth the source puts them, which is where the walk
+  // below meets the positions they name.
+  const markers = projection?.markers;
   if (markers !== undefined && projection?.mask === false) {
     // The whole selection was addresses. There is no value to compute, so the
     // pattern graph would run over the rejecting selector and produce nothing

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -56,6 +56,14 @@ export interface ParsedSelectionFilter {
 const LINK_MARKER_KEY = "$link";
 
 /**
+ * The character a concise field path ends a segment with to ask for the
+ * address of the position that segment names. A backslash before it writes a
+ * literal `@`, which a name needs only at the end of its segment: anywhere
+ * else in a segment `@` is an ordinary character.
+ */
+const CONCISE_ADDRESS_SUFFIX = "@";
+
+/**
  * The address a marked position renders, and the key it renders under. Every
  * field is present so a caller indexes it without branching: `id` keeps its
  * scheme, because the scheme is the kind and dropping it retargets the
@@ -78,8 +86,9 @@ export interface RenderedLinkAddress {
 }
 
 /**
- * The positions a `--schema` marked with `$link`, mirroring the projection's
- * own shape. A node exists only where it, or something below it, is marked.
+ * The positions a projection marked for their address, mirroring the
+ * projection's own shape. A node exists only where it, or something below it,
+ * is marked.
  */
 export interface LinkMarkers {
   /** The address at this position was asked for. */
@@ -719,53 +728,135 @@ function normalizeProjectionSchema(
   };
 }
 
+/** A field name one concise path segment names, and what it asks for there. */
+interface ConciseSegment {
+  name: string;
+  /** The segment ended in an unescaped {@link CONCISE_ADDRESS_SUFFIX}. */
+  marked: boolean;
+}
+
+/**
+ * The positions a concise field list names, as a tree. `whole` and `marked`
+ * are separate questions about one position: `topic` asks for what is stored
+ * there, `topic@` asks for its address, and a list naming both asks for both.
+ */
+interface ConciseSelection {
+  whole: boolean;
+  marked: boolean;
+  properties: Map<string, ConciseSelection>;
+}
+
+/**
+ * Helper for {@link conciseProjectionSchema}, which reads one dot-separated
+ * segment of `path`. A trailing {@link CONCISE_ADDRESS_SUFFIX} asks for the
+ * named position's address unless a backslash escapes it, and the character is
+ * part of the name anywhere else: `user@home` names a field, and `a\@` names
+ * the field `a@`.
+ */
+function parseConciseSegment(
+  segment: string,
+  path: string,
+  flag: ProjectionFlag,
+): ConciseSegment {
+  const escaped = `\\${CONCISE_ADDRESS_SUFFIX}`;
+  const marked = segment.endsWith(CONCISE_ADDRESS_SUFFIX) &&
+    !segment.endsWith(escaped);
+  const name = (marked ? segment.slice(0, -1) : segment)
+    .replaceAll(escaped, CONCISE_ADDRESS_SUFFIX);
+  if (!/^[A-Za-z_$][A-Za-z0-9_$@-]*$/.test(name)) {
+    throw new CellSelectionError(
+      `Invalid ${flag} field path ${JSON.stringify(path)}`,
+    );
+  }
+  return { name, marked };
+}
+
+/**
+ * Helper for {@link conciseProjectionSchema}, which constructs a position that
+ * has named nothing yet.
+ */
+function emptyConciseSelection(): ConciseSelection {
+  return { whole: false, marked: false, properties: new Map() };
+}
+
+/**
+ * Helper for {@link conciseProjectionSchema}, which says whether `node` or
+ * anything below it asked for an address.
+ */
+function conciseSelectionMarks(node: ConciseSelection): boolean {
+  return node.marked ||
+    [...node.properties.values()].some(conciseSelectionMarks);
+}
+
+/**
+ * Helper for {@link conciseProjectionSchema}, which writes `node` out as the
+ * projection schema it describes, `$link` markers included. Normalization
+ * reads those markers back out, so a concise address suffix reaches the read
+ * selector and the address composition the same way a written one does.
+ */
+function conciseSelectionSchema(node: ConciseSelection): unknown {
+  const properties: Record<string, unknown> = {};
+  for (const [name, child] of node.properties) {
+    // A position asked for whole already answers every path through it, so a
+    // deeper path adds something only where it asked for an address.
+    if (node.whole && !conciseSelectionMarks(child)) continue;
+    properties[name] = conciseSelectionSchema(child);
+  }
+  const named = Object.keys(properties).length > 0;
+  const marker = node.marked ? { [LINK_MARKER_KEY]: true } : {};
+  if (!node.whole) {
+    // A position whose whole request was its address says exactly that, and
+    // normalization reduces it to the rejecting schema.
+    return named
+      ? { ...marker, type: "object", properties, additionalProperties: false }
+      : marker;
+  }
+  if (!named && !node.marked) return true;
+  // `additionalProperties` keeps what a projection did not name, which is what
+  // a bare path asks for at the position it ends on. `properties` is written
+  // out beside it only to carry the markers below.
+  return {
+    ...marker,
+    type: "object",
+    ...(named ? { properties } : {}),
+    additionalProperties: true,
+  };
+}
+
+/**
+ * Reads a comma-separated field list into the projection it describes. The
+ * list names positions rather than shapes, so it is collected as a tree first:
+ * the same position can be reached by several paths, and `topic@` beside
+ * `topic.title` is one position asked two questions rather than two answers.
+ */
 function conciseProjectionSchema(
   source: string,
   flag: ProjectionFlag,
-): JSONSchema {
+): NormalizedProjectionSchema {
   const paths = source.split(",").map((part) => part.trim());
   if (paths.some((path) => path.length === 0)) {
     throw new CellSelectionError(
       `Invalid ${flag} concise projection: expected comma-separated field paths`,
     );
   }
-  const root: Record<string, unknown> = {};
+  const root = emptyConciseSelection();
   for (const path of paths) {
-    const segments = path.split(".");
-    if (
-      segments.some((segment) => !/^[A-Za-z_$][A-Za-z0-9_$-]*$/.test(segment))
-    ) {
-      throw new CellSelectionError(
-        `Invalid ${flag} field path ${JSON.stringify(path)}`,
-      );
-    }
+    const segments = path.split(".").map((segment) =>
+      parseConciseSegment(segment, path, flag)
+    );
     let node = root;
-    for (let index = 0; index < segments.length; index++) {
-      const segment = segments[index];
-      if (index === segments.length - 1) {
-        node[segment] = true;
-        continue;
+    for (const [index, segment] of segments.entries()) {
+      let child = node.properties.get(segment.name);
+      if (child === undefined) {
+        child = emptyConciseSelection();
+        node.properties.set(segment.name, child);
       }
-      const existing = node[segment];
-      if (existing === true) break;
-      if (!isRecord(existing)) {
-        node[segment] = {};
-      }
-      node = node[segment] as Record<string, unknown>;
+      if (segment.marked) child.marked = true;
+      if (index === segments.length - 1 && !segment.marked) child.whole = true;
+      node = child;
     }
   }
-
-  const toSchema = (node: Record<string, unknown>): JSONSchema => ({
-    type: "object",
-    properties: Object.fromEntries(
-      Object.entries(node).map(([key, value]) => [
-        key,
-        value === true ? true : toSchema(value as Record<string, unknown>),
-      ]),
-    ),
-    additionalProperties: false,
-  });
-  return toSchema(root);
+  return normalizeProjectionSchema(conciseSelectionSchema(root));
 }
 
 export interface ProjectionParseDependencies {
@@ -774,9 +865,11 @@ export interface ProjectionParseDependencies {
 
 /**
  * Parses a `--select` argument: the comma-separated field paths, which is the
- * whole of what this flag accepts. `--schema` reads the same spelling and more,
- * so an argument written in the JSON Schema language is pointed at the flag
- * that reads it rather than reported as a malformed field path.
+ * whole of what this flag accepts. A path segment ending in
+ * {@link CONCISE_ADDRESS_SUFFIX} asks for the address of the position it
+ * names. `--schema` reads the same spelling and more, so an argument written
+ * in the JSON Schema language is pointed at the flag that reads it rather than
+ * reported as a malformed field path.
  */
 export function parseSelectProjection(source: string): SelectionProjection {
   const trimmed = source.trim();
@@ -794,7 +887,7 @@ export function parseSelectProjection(source: string): SelectionProjection {
   }
   return {
     source,
-    schema: conciseProjectionSchema(trimmed, "--select"),
+    ...conciseProjectionSchema(trimmed, "--select"),
     kind: "concise",
     flag: "--select",
   };
@@ -872,7 +965,7 @@ export async function parseSelectionProjection(
 
   return {
     source,
-    schema: conciseProjectionSchema(trimmed, "--schema"),
+    ...conciseProjectionSchema(trimmed, "--schema"),
     kind: "concise",
     flag: "--schema",
   };
@@ -1618,37 +1711,49 @@ async function storedContainer(position: WalkedPosition): Promise<unknown> {
 }
 
 /**
- * Composes the addresses a selection's `$link` markers asked for into
- * `projected`, the value its projection produced.
+ * Composes the addresses a selection's markers asked for into `projected`, the
+ * value its projection produced.
  *
  * A marked position renders `{"$link": <address>}`. Where the same position
  * also projected contents, the address joins them in one object, because both
  * were asked for. Where those contents are not an object there is nothing to
  * join them to, and the address is the whole answer.
+ *
+ * `implicitArrayTraversal` states that the markers came from a concise field
+ * list, which names a field wherever the value holds one rather than at a
+ * fixed depth. The positions below an array then belong to its elements, the
+ * same way {@link projectValue} applies one field mask across them, while an
+ * address asked for at the array names the array itself.
  */
 async function composeLinkAddresses(
   position: WalkedPosition,
   markers: LinkMarkers,
   projected: unknown,
+  implicitArrayTraversal = false,
 ): Promise<unknown> {
   let composed = projected;
-  if (markers.items !== undefined) {
-    const stored = await storedContainer(position);
-    if (Array.isArray(stored)) {
-      const projectedItems = Array.isArray(projected) ? projected : [];
-      const items: unknown[] = [];
-      for (let index = 0; index < stored.length; index++) {
-        items.push(
-          await composeLinkAddresses(
-            positionBelow(position, index, stored),
-            markers.items,
-            projectedItems[index],
-          ),
-        );
-      }
-      composed = items;
+  const elementMarkers = markers.items ??
+    (implicitArrayTraversal && markers.properties !== undefined
+      ? { properties: markers.properties }
+      : undefined);
+  const stored = elementMarkers === undefined
+    ? undefined
+    : await storedContainer(position);
+  if (elementMarkers !== undefined && Array.isArray(stored)) {
+    const projectedItems = Array.isArray(projected) ? projected : [];
+    const items: unknown[] = [];
+    for (let index = 0; index < stored.length; index++) {
+      items.push(
+        await composeLinkAddresses(
+          positionBelow(position, index, stored),
+          elementMarkers,
+          projectedItems[index],
+          implicitArrayTraversal,
+        ),
+      );
     }
-  } else if (markers.properties !== undefined) {
+    composed = items;
+  } else if (markers.items === undefined && markers.properties !== undefined) {
     const projectedRecord = isRecord(projected) && !Array.isArray(projected)
       ? projected
       : {};
@@ -1658,6 +1763,7 @@ async function composeLinkAddresses(
         positionBelow(position, key, position.stored?.value),
         child,
         projectedRecord[key],
+        implicitArrayTraversal,
       );
     }
     composed = record;
@@ -1697,13 +1803,13 @@ export interface DeriveSelectedValueDependencies {
  * shape only; source schemas remain authoritative for CFC and other Fabric
  * metadata.
  *
- * A `$link` marker is answered beside that graph rather than through it: the
- * marked position contributes the rejecting selector to the read, so nothing
- * behind it is loaded, and its address is composed in from the deepest link
- * the walk down to it crosses, plus the segments below that link. That
- * composition walks the source, which a `--filter` makes unavailable — the
- * elements a predicate keeps cannot be traced back to the positions they came
- * from — so the two are refused together.
+ * A marker is answered beside that graph rather than through it: the marked
+ * position contributes the rejecting selector to the read, so nothing behind
+ * it is loaded, and its address is composed in from the deepest link the walk
+ * down to it crosses, plus the segments below that link. That composition
+ * walks the source, which a `--filter` makes unavailable — the elements a
+ * predicate keeps cannot be traced back to the positions they came from — so
+ * the two are refused together.
  */
 export async function deriveSelectedValue(
   runtime: Runtime,
@@ -1713,11 +1819,16 @@ export async function deriveSelectedValue(
   deps: DeriveSelectedValueDependencies = {},
 ): Promise<unknown> {
   const markers = selection.projection?.markers;
+  const implicitArrayTraversal = selection.projection?.kind === "concise";
   if (selection.filter !== undefined && markers !== undefined) {
+    const asked = implicitArrayTraversal
+      ? `an \`${CONCISE_ADDRESS_SUFFIX}\` suffix in ` +
+        selection.projection!.flag
+      : `a "${LINK_MARKER_KEY}" projection`;
     throw new CellSelectionError(
-      `--filter cannot be combined with a "${LINK_MARKER_KEY}" projection: a ` +
-        "filtered array's elements no longer say which positions they came " +
-        "from, and an address names a position",
+      `--filter cannot be combined with ${asked}: a filtered array's ` +
+        "elements no longer say which positions they came from, and an " +
+        "address names a position",
     );
   }
   const declaredSourceSchema = sourceCell.schema;
@@ -1755,6 +1866,7 @@ export async function deriveSelectedValue(
       sourcePosition(sourceValueCell),
       markers,
       undefined,
+      implicitArrayTraversal,
     );
   }
   const sourceItemSchema = schemaAtArrayItem(sourceSchema);
@@ -2004,6 +2116,7 @@ export async function deriveSelectedValue(
       sourcePosition(sourceValueCell),
       markers,
       outputValue,
+      implicitArrayTraversal,
     );
   } finally {
     runtime.runner.stop(resultCell);

--- a/packages/cli/test/piece-get-transform.test.ts
+++ b/packages/cli/test/piece-get-transform.test.ts
@@ -2586,6 +2586,46 @@ describe("cf piece get transforms", () => {
         });
       });
 
+      it("desugars a bare `@` to the marker at the projection's root", async () => {
+        const written = await parseSelectionProjection('{"$link":true}');
+        const parsed = parseSelectProjection("@");
+        expect(parsed.schema).toEqual(written.schema);
+        expect(parsed.markers).toEqual(written.markers);
+      });
+
+      it("returns the read source's own address for a bare `@`", async () => {
+        const { board, notes } = await seedBoard("at-suffix-root", true);
+        expect(
+          await deriveSelectedValue(runtime, space, board, {
+            projection: parseSelectProjection("@"),
+          }),
+        ).toEqual({ $link: addressOf(board) });
+        expect(
+          await deriveSelectedValue(runtime, space, board.key("topic"), {
+            projection: parseSelectProjection("@"),
+          }),
+        ).toEqual({ $link: addressOf(notes[0]) });
+      });
+
+      it("returns the read source's address beside a sibling projection", async () => {
+        const { board } = await seedBoard("at-suffix-root-union", true);
+        for (const source of ["@,label", "label,@"]) {
+          expect(
+            await deriveSelectedValue(runtime, space, board, {
+              projection: parseSelectProjection(source),
+            }),
+          ).toEqual({ $link: addressOf(board), label: "Field notes" });
+        }
+      });
+
+      it("points a leading `@` that names a file at --schema", () => {
+        for (const source of ["@projection.json", "@label", "@label,label"]) {
+          expect(() => parseSelectProjection(source)).toThrow(
+            "--select takes comma-separated field paths",
+          );
+        }
+      });
+
       it("marks a position below an array for each of its elements", async () => {
         const { board, notes } = await seedBoard("at-suffix-elements", true);
         const titleAddresses = notes.map((note) => ({

--- a/packages/cli/test/piece-get-transform.test.ts
+++ b/packages/cli/test/piece-get-transform.test.ts
@@ -2505,6 +2505,230 @@ describe("cf piece get transforms", () => {
       await expect(parseSelectionProjection('{"asCell":["cell"]}')).rejects
         .toThrow('"asCell" is controlled by the source schema');
     });
+
+    describe("the `@` suffix a concise field path writes", () => {
+      it("desugars to the marker the JSON spelling writes", async () => {
+        const written = await parseSelectionProjection(
+          '{"properties":{"topic":{"$link":true}}}',
+        );
+        for (
+          const parsed of [
+            parseSelectProjection("topic@"),
+            await parseSelectionProjection("topic@"),
+          ]
+        ) {
+          expect(parsed.schema).toEqual(written.schema);
+          expect(parsed.markers).toEqual(written.markers);
+        }
+      });
+
+      it("unions a marked path with a sibling projection into one position", () => {
+        const union = {
+          type: "object",
+          properties: {
+            topic: {
+              type: "object",
+              properties: { title: true },
+              additionalProperties: false,
+            },
+          },
+          additionalProperties: false,
+        };
+        for (
+          const source of [
+            "topic@,topic.title",
+            "topic.title,topic@",
+            "topic@.title",
+          ]
+        ) {
+          const parsed = parseSelectProjection(source);
+          expect(parsed.schema).toEqual(union);
+          expect(parsed.markers).toEqual({
+            properties: { topic: { marked: true } },
+          });
+        }
+      });
+
+      it("returns a marked position's address instead of its contents", async () => {
+        const { board, notes } = await seedBoard("at-suffix-instead", true);
+        expect(
+          await deriveSelectedValue(runtime, space, board, {
+            projection: parseSelectProjection("topic@"),
+          }),
+        ).toEqual({ topic: { $link: addressOf(notes[0]) } });
+      });
+
+      it("returns one result carrying the address and the projection", async () => {
+        const { board, notes } = await seedBoard("at-suffix-union", true);
+        for (
+          const source of [
+            "topic@,topic.title",
+            "topic.title,topic@",
+            "topic@.title",
+          ]
+        ) {
+          expect(
+            await deriveSelectedValue(runtime, space, board, {
+              projection: parseSelectProjection(source),
+            }),
+          ).toEqual({ topic: { $link: addressOf(notes[0]), title: "a" } });
+        }
+      });
+
+      it("returns the address beside the contents a bare sibling path asked for", async () => {
+        const { board, notes } = await seedBoard("at-suffix-whole", true);
+        expect(
+          await deriveSelectedValue(runtime, space, board, {
+            projection: parseSelectProjection("topic,topic@"),
+          }),
+        ).toEqual({
+          topic: { $link: addressOf(notes[0]), title: "a", body: "body a" },
+        });
+      });
+
+      it("marks a position below an array for each of its elements", async () => {
+        const { board, notes } = await seedBoard("at-suffix-elements", true);
+        const titleAddresses = notes.map((note) => ({
+          title: { $link: { ...addressOf(note), path: ["title"] } },
+        }));
+
+        expect(
+          await deriveSelectedValue(runtime, space, board, {
+            projection: parseSelectProjection("notes.title@"),
+          }),
+        ).toEqual({ notes: titleAddresses });
+        expect(
+          await deriveSelectedValue(runtime, space, board.key("notes"), {
+            projection: parseSelectProjection("title@"),
+          }),
+        ).toEqual(titleAddresses);
+        expect(
+          await deriveSelectedValue(runtime, space, board, {
+            projection: await parseSelectionProjection(
+              '{"properties":{"notes":{"items":' +
+                '{"properties":{"title":{"$link":true}}}}}}',
+            ),
+          }),
+        ).toEqual({ notes: titleAddresses });
+      });
+
+      it("marks a position below an array the source schema leaves open", async () => {
+        const openSchema = {
+          type: "object",
+          properties: { comments: true },
+        } as const satisfies JSONSchema;
+        const tx = runtime.edit();
+        const source = runtime.getCell(
+          space,
+          "at-suffix-ambiguous",
+          openSchema,
+          tx,
+        );
+        source.set({
+          comments: [{ body: "Visible", privateNote: "hidden" }],
+        });
+        expect((await tx.commit()).ok).toBeDefined();
+
+        // Writing an object into an array gives it a document of its own, and
+        // the slot stores a link to it. That link is the deepest one the walk
+        // crosses, so `body` is addressed inside the element's own document.
+        const comment = source.key("comments").key(0).resolveAsCell();
+        expect(
+          await deriveSelectedValue(
+            runtime,
+            space,
+            runtime.getCell(space, "at-suffix-ambiguous", openSchema),
+            { projection: parseSelectProjection("comments.body@") },
+          ),
+        ).toEqual({
+          comments: [{
+            body: { $link: { ...addressOf(comment), path: ["body"] } },
+          }],
+        });
+      });
+
+      it("reads one document for a marked collection, not one per element", async () => {
+        const { board, notes } = await seedBoard("at-suffix-reads", false);
+        const provider = storageManager.open(space);
+        const originalSync = provider.sync.bind(provider);
+        let syncedUris: string[] = [];
+        provider.sync = ((uri, selector, scope) => {
+          syncedUris.push(uri);
+          return originalSync(uri, selector, scope);
+        }) as typeof provider.sync;
+        const boardUri = board.getAsNormalizedFullLink().id;
+        const noteUris: string[] = notes.map((note) =>
+          note.getAsNormalizedFullLink().id
+        );
+        const boardDocuments = (uris: string[]) =>
+          uris.filter((uri) => uri === boardUri || noteUris.includes(uri));
+
+        syncedUris = [];
+        await deriveSelectedValue(runtime, space, board, {
+          projection: parseSelectProjection("notes@"),
+        });
+        const marked = boardDocuments(syncedUris);
+
+        syncedUris = [];
+        await deriveSelectedValue(
+          runtime,
+          space,
+          runtime.getCell(space, "at-suffix-reads-board", boardSchema),
+          { projection: parseSelectProjection("notes.title") },
+        );
+
+        expect(marked).toEqual([boardUri]);
+        expect(boardDocuments(syncedUris)).toEqual(noteUris);
+      });
+
+      it("reaches a field whose name holds an `@` of its own", async () => {
+        const oddNameSchema = {
+          type: "object",
+          properties: {
+            "user@home": { type: "string" },
+            "a@": { type: "string" },
+          },
+        } as const satisfies JSONSchema;
+        const tx = runtime.edit();
+        const source = runtime.getCell(
+          space,
+          "at-suffix-escapes",
+          oddNameSchema,
+          tx,
+        );
+        source.set({ "user@home": "here", "a@": "there" });
+        expect((await tx.commit()).ok).toBeDefined();
+
+        expect(
+          await deriveSelectedValue(
+            runtime,
+            space,
+            runtime.getCell(space, "at-suffix-escapes", oddNameSchema),
+            { projection: parseSelectProjection("user@home,a\\@") },
+          ),
+        ).toEqual({ "user@home": "here", "a@": "there" });
+      });
+
+      it("refuses a marked path combined with a filter, naming the flag", async () => {
+        const { board } = await seedBoard("at-suffix-filter", true);
+        await expect(
+          deriveSelectedValue(runtime, space, board.key("notes"), {
+            filter: parseSelectionFilter('.title == "a"'),
+            projection: parseSelectProjection("title@"),
+          }),
+        ).rejects.toThrow(
+          "--filter cannot be combined with an `@` suffix in --select",
+        );
+        await expect(
+          deriveSelectedValue(runtime, space, board.key("notes"), {
+            filter: parseSelectionFilter('.title == "a"'),
+            projection: await parseSelectionProjection("title@"),
+          }),
+        ).rejects.toThrow(
+          "--filter cannot be combined with an `@` suffix in --schema",
+        );
+      });
+    });
   });
 
   describe("--select", () => {

--- a/packages/cli/test/piece-get-transform.test.ts
+++ b/packages/cli/test/piece-get-transform.test.ts
@@ -2626,6 +2626,67 @@ describe("cf piece get transforms", () => {
         }
       });
 
+      it("returns an address per element for a marked array", async () => {
+        const { board, notes } = await seedBoard("at-suffix-array", true);
+        const elementAddresses = notes.map((note) => ({
+          $link: addressOf(note),
+        }));
+        const concise = await deriveSelectedValue(runtime, space, board, {
+          projection: parseSelectProjection("notes@"),
+        });
+        expect(concise).toEqual({ notes: elementAddresses });
+        // The concise spelling of the JSON items marker, so it answers with
+        // what the JSON items marker answers.
+        expect(concise).toEqual(
+          await deriveSelectedValue(runtime, space, board, {
+            projection: await parseSelectionProjection(
+              '{"properties":{"notes":{"type":"array","items":{"$link":true}}}}',
+            ),
+          }),
+        );
+        expect(
+          await deriveSelectedValue(runtime, space, board, {
+            projection: parseSelectProjection("notes@,label"),
+          }),
+        ).toEqual({ notes: elementAddresses, label: "Field notes" });
+      });
+
+      it("leaves a JSON marker on an array naming that array's own position", async () => {
+        const { board } = await seedBoard("at-suffix-json-array", true);
+        expect(
+          await deriveSelectedValue(runtime, space, board, {
+            projection: await parseSelectionProjection(
+              '{"properties":{"notes":{"$link":true}}}',
+            ),
+          }),
+        ).toEqual({
+          notes: { $link: { ...addressOf(board), path: ["notes"] } },
+        });
+      });
+
+      it("returns an address per element for a bare `@` at an array", async () => {
+        const { board, notes } = await seedBoard("at-suffix-array-root", true);
+        expect(
+          await deriveSelectedValue(runtime, space, board.key("notes"), {
+            projection: parseSelectProjection("@"),
+          }),
+        ).toEqual(notes.map((note) => ({ $link: addressOf(note) })));
+      });
+
+      it("returns each element's address beside the addresses marked below it", async () => {
+        const { board, notes } = await seedBoard("at-suffix-array-deep", true);
+        expect(
+          await deriveSelectedValue(runtime, space, board, {
+            projection: parseSelectProjection("notes@,notes.title@"),
+          }),
+        ).toEqual({
+          notes: notes.map((note) => ({
+            $link: addressOf(note),
+            title: { $link: { ...addressOf(note), path: ["title"] } },
+          })),
+        });
+      });
+
       it("marks a position below an array for each of its elements", async () => {
         const { board, notes } = await seedBoard("at-suffix-elements", true);
         const titleAddresses = notes.map((note) => ({

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -597,6 +597,11 @@ describe("cli piece parsing", () => {
         ?.schema,
     );
 
+    const marked = await parseCellSelectionOptions({ select: "topic@" });
+    expect(marked?.projection?.markers).toEqual({
+      properties: { topic: { marked: true } },
+    });
+
     const both = await parseCellSelectionOptions({
       filter: ".active",
       schema: "id",

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -139,6 +139,7 @@ See `docs/development/EXPERIMENTAL_OPTIONS.md` for available flags.
 | Get field          | `deno task cf piece get --piece ID fieldPath ...`                                                    |
 | Filter array       | `deno task cf piece get --piece ID items --filter '.active == true' ...`                             |
 | Project fields     | `deno task cf piece get --piece ID items --select id,title ...`                                      |
+| Read an address    | `deno task cf piece get --piece ID --select 'topic@,topic.title' ...`                                |
 | Read addresses     | `deno task cf piece get --piece ID items --schema '{"type":"array","items":{"$link":true}}' ...`     |
 | Step + get         | `deno task cf piece get --piece ID fieldPath --step ...`                                             |
 | Set field          | `echo '{"data":...}' \| deno task cf piece set --piece ID path ...`                                  |
@@ -261,18 +262,21 @@ union of predicate and projection paths, so omitted linked subgraphs are not
 hydrated; ambiguous compositions can retain a wider selector, and schema-less or
 root-union sources need a value-shape read first. CFC behavior is the same as a
 computed pattern expression. Source schema metadata is authoritative; projection
-schemas cannot supply `ifc`, `asCell`, `scope`, or `default`. A JSON `--schema`
-marks a position `"$link": true` to get that position's address —
-`{"id","space","scope","path"}`, all four always present, no schema inlined —
-instead of what is behind it, or beside a projection to get both. That address
-is the deepest stored link crossed on the way to the marked position plus the
-segments below it, so marking a field under a linked element names that
-element's own document rather than a slot in the collection above it; a position
-with no link above it keeps the source document's own address. A marked position
-is never fetched, so a marked collection costs one document read rather than one
-per element; the rendered `id` minus its `of:` prefix is what `--piece` accepts.
-Markers do not compose with `--filter`. See `packages/cli/README.md` for the
-exact syntax and supported schema subset.
+schemas cannot supply `ifc`, `asCell`, `scope`, or `default`. A projection marks
+a position to get that position's address — `{"id","space","scope","path"}`, all
+four always present, no schema inlined — instead of what is behind it, or beside
+a projection to get both. A JSON `--schema` marks with `"$link": true`; a field
+list marks with a trailing `@`, so `--select 'topic@,topic.title'` returns one
+`topic` carrying its address and its title. `@` is special only at the end of a
+segment and `\@` writes a literal one, which keeps a field named `user@home`
+reachable. That address is the deepest stored link crossed on the way to the
+marked position plus the segments below it, so marking a field under a linked
+element names that element's own document rather than a slot in the collection
+above it; a position with no link above it keeps the source document's own
+address. A marked position is never fetched, so a marked collection costs one
+document read rather than one per element; the rendered `id` minus its `of:`
+prefix is what `--piece` accepts. Neither spelling composes with `--filter`. See
+`packages/cli/README.md` for the exact syntax and supported schema subset.
 
 `piece call` takes the same three flags, before the callable name, with the same
 grammar, the same `--select`/`--schema` conflict, and the same error messages.

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -272,7 +272,11 @@ position the read is already at, so `--select '@'` returns the source's own
 address and `--select '@,title'` returns it beside the title. `@` is otherwise
 special only at the end of a segment and `\@` writes a literal one, which keeps
 a field named `user@home` reachable; a leading `@` followed by anything else is
-the `@file` only `--schema` reads. That address is the deepest stored link
+the `@file` only `--schema` reads. A field list applies to each element wherever
+it crosses an array, an address included, so `--select 'notes@'` returns one
+address per note and is the concise spelling of
+`--schema '{"type":"array","items":{"$link":true}}'`; a marked position holding
+anything else returns its own address. That address is the deepest stored link
 crossed on the way to the marked position plus the segments below it, so marking
 a field under a linked element names that element's own document rather than a
 slot in the collection above it; a position with no link above it keeps the

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -267,16 +267,20 @@ a position to get that position's address — `{"id","space","scope","path"}`, a
 four always present, no schema inlined — instead of what is behind it, or beside
 a projection to get both. A JSON `--schema` marks with `"$link": true`; a field
 list marks with a trailing `@`, so `--select 'topic@,topic.title'` returns one
-`topic` carrying its address and its title. `@` is special only at the end of a
-segment and `\@` writes a literal one, which keeps a field named `user@home`
-reachable. That address is the deepest stored link crossed on the way to the
-marked position plus the segments below it, so marking a field under a linked
-element names that element's own document rather than a slot in the collection
-above it; a position with no link above it keeps the source document's own
-address. A marked position is never fetched, so a marked collection costs one
-document read rather than one per element; the rendered `id` minus its `of:`
-prefix is what `--piece` accepts. Neither spelling composes with `--filter`. See
-`packages/cli/README.md` for the exact syntax and supported schema subset.
+`topic` carrying its address and its title. A path that is only `@` marks the
+position the read is already at, so `--select '@'` returns the source's own
+address and `--select '@,title'` returns it beside the title. `@` is otherwise
+special only at the end of a segment and `\@` writes a literal one, which keeps
+a field named `user@home` reachable; a leading `@` followed by anything else is
+the `@file` only `--schema` reads. That address is the deepest stored link
+crossed on the way to the marked position plus the segments below it, so marking
+a field under a linked element names that element's own document rather than a
+slot in the collection above it; a position with no link above it keeps the
+source document's own address. A marked position is never fetched, so a marked
+collection costs one document read rather than one per element; the rendered
+`id` minus its `of:` prefix is what `--piece` accepts. Neither spelling composes
+with `--filter`. See `packages/cli/README.md` for the exact syntax and supported
+schema subset.
 
 `piece call` takes the same three flags, before the callable name, with the same
 grammar, the same `--select`/`--schema` conflict, and the same error messages.

--- a/skills/topics/SKILL.md
+++ b/skills/topics/SKILL.md
@@ -121,6 +121,16 @@ deno task cf piece get --url "$TOPIC_URL" links --input \
   --filter '.kind == "pr"' --select kind,url,label,addedAt
 ```
 
+A `--select` segment ending in `@` returns that position's address instead of a
+copy of what is behind it, which is what a following `piece call` needs. It does
+not compose with `--filter` — a filtered array's survivors no longer say which
+positions they came from — so ask for an address in its own unfiltered read:
+
+```bash
+deno task cf piece get --url "$TOPICS_BOARD_URL" crossrefs --step \
+  --select fid,topic@
+```
+
 Each crossref row's `fid` is the canonical address for its `topic`. Prefer it to
 the intermediate wrapper link stored in the board's topics array. Read the
 existing topic's input before changing it, especially its full body, comments,


### PR DESCRIPTION
## Why

`--select topic@` gets you the topic's address instead of its contents, in the
concise language, without writing a JSON Schema for it. A caller reaching for a
field list should not have to switch languages to ask where something lives.

Three commits: the suffix, a bare `@` for the read's own source, and a trailing
`@` on an array asking each element.

Stage A3 of the shaped-reads plan (#5435). Stacked on #5500.

## What `@` means

A trailing `@` on a path segment marks that position for its address. It
desugars in `conciseProjectionSchema` — the one place a field list becomes a
schema — and lands on the marker machinery that already exists, so the rejecting
selector, the address rendering and the `--filter` refusal are all reached
through code that was already there.

- `topic@` — the topic's address instead of its contents
- `topic@,topic.title` — one position asked two questions; returns both
- `notes@` — **one address per element**, not the array position's own address
- `@` — the read's own source
- `user@home` — an ordinary field name; `@` is only special as the final
  character of a segment, and `\@` escapes it

## Why `notes@` is per-element

The array position's own address is the source address plus the path the caller
just typed — no information they did not have. The element addresses are the
element documents, which is the point of asking.

It is also the rule rather than the exception: a field list is already
element-wise wherever it crosses an array (`notes.title` selects title from
every note), and `notes.title@` already yielded one address per element. This
makes `notes@` the concise spelling of the JSON items marker, asserted directly
against it — and against a concrete expected value first, so the comparison
cannot pass vacuously.

The JSON `{"type":"array","items":…}` spelling still names the array's own
position when the marker sits there, and a guard test pins that boundary.

## One consequence worth knowing

By the same rule, `--select '@'` against a source that *is* an array yields one
address per element rather than the array's own address. Both behaviors are
tested and documented.

## No second path — asserted, not claimed

`parseSelectProjection("topic@")` produces byte-identical `schema` **and**
`markers` to the JSON marker form; `parseSelectProjection("@")` likewise matches
`--schema '{"$link":true}'`. If the spellings ever diverge, those fail.

Fetch suppression holds across all three commits: `--select 'notes@'` observes
exactly one document (the board), zero note syncs — measured, not assumed.

## Flagged, not fixed

Calling `deriveSelectedValue` twice with an identical source *and* identical
projection string in one runtime throws `updated arguments do not match the
candidate schema` — the transform result cell is keyed by
`{source, filter, schema}`, so the second call collides with the first. Not
reachable from `cf piece get`, which runs once per process, but it would be
reachable from any long-lived host that serves two identical reads.

Also: `--select '@'` composes as a suffix does one level down, order-independent
(`@,label` and `label,@` agree).

## Test plan

`deno task test` in packages/cli (1672 + 123 passed) and packages/runner (1156
passed); `check`, `fmt`, `lint`, `check-docs`, `check-skill-facts`,
`check-no-waitfor`, `check-conflict-markers` — all pass.

Test files are additions-only. Every new behavior test was confirmed failing
before its change; the two guard tests are noted as passing on both sides by
design.

**Not exercised:** two lines in `verbs-over-the-cli.sh` need a live toolshed.
