### PR TITLE
feat(cli): `piece call` takes the same selection flags as `piece get`

### DIFF
--- a/docs/common/verbs-over-the-cli.md
+++ b/docs/common/verbs-over-the-cli.md
@@ -104,6 +104,36 @@ Anything the *pattern* resolved comes back too. A verb that stamps a write time
 or derives structured authorship from the event returns those in its record;
 the caller could not have computed them.
 
+### Asking for a smaller result
+
+A verb decides what it returns; the caller decides how much of it to look at.
+`--filter`, `--select`, and `--schema` — the same three flags `cf piece get`
+takes, with the same grammar — shape the `result` before it reaches stdout, and
+go before the callable name:
+
+```bash
+cf piece call --piece <topic> --select comment.writtenAt addComment \
+  '{"body":"first","agentName":"Sol"}'
+```
+
+```json
+{
+  "invocation": "0f4c…",
+  "status": "settled",
+  "result": { "comment": { "writtenAt": "2026-08-07T09:15:27Z" } }
+}
+```
+
+This shapes a result that already exists rather than deciding what travels: the
+readback has the whole receipt in hand before the selection runs. So a
+value-less verb keeps reporting no `result` at all — there is nothing for a
+selection to be about — and `--no-wait`, which never reads the receipt back,
+refuses all three flags. `--show-links` composes with a projection, because a
+projection leaves every surviving path where it was; it does not compose with
+`--filter`, which moves the positions a link names.
+
+`packages/cli/README.md` has the grammar and the supported schema subset.
+
 ### Retries are safe, and cheap to reason about
 
 `--invocation <id>` makes a call idempotent. Replaying a settled id returns the
@@ -254,6 +284,12 @@ one, so a chain of references annotates each hop exactly once. The walk stops at
 any non-plain object: a live runtime object reached through a result gets its
 own entry and nothing below it, because its properties belong to the runtime
 rather than to the result.
+
+The links describe whatever result you were handed, so a projection composes
+with them: a path `--select` or `--schema` dropped simply gets no entry.
+`--filter` is refused alongside `--show-links` — a predicate leaves the elements
+it keeps at positions that are no longer the ones they came from, and every
+address below a filtered array would name the wrong element.
 
 A pattern should not mint identifier fields to make any of this easier —
 rendering identity is the client's job, and a pattern-authored fid is a copy

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -120,7 +120,7 @@ standard error and continues searching that piece and the rest of the space.
 - The launcher spawns the child CLI with `deno run --quiet` so Deno's own
   warnings (npm "Ignored build scripts" banner) never reach users.
 
-### Transforming `piece get` output
+### Transforming `piece get` and `piece call` output
 
 `piece get` can filter an array before it reaches stdout and project the result
 to a smaller shape:
@@ -131,6 +131,21 @@ cf piece get --piece ID items \
   --filter '.status == "open" and .score >= 10' \
   --select id,title,author.name
 ```
+
+`piece call` takes the same three flags, with the same grammar, the same
+conflict rule, and the same error messages, written before the callable name:
+
+```bash
+cf piece call --piece ID --select topic.title addTopic '{"title":"Ship it"}'
+cf piece call --piece ID --filter '.status == "open"' listTopics
+```
+
+Everything below describes both commands. The one difference is what the
+selection is about: `piece get` shapes a cell's value, and `piece call` shapes
+the **result of the call** — a handler's `result` inside the Invocation JSON, or
+a tool's JSON on stdout. See
+[what a selection means for a call](#what-a-selection-means-for-a-call) for the
+three cases where that difference shows.
 
 `--filter` is jq-inspired rather than a full jq interpreter. It applies only to
 arrays and accepts value paths (`.status`, `.author.name`, `.["display-name"]`,
@@ -146,7 +161,7 @@ Two flags project, one per input language:
   also accepts the same field list `--select` takes.
 
 A command that names both has not said which shape it wants, and is refused
-before the read.
+before the read or the call.
 
 For an array result, the field list describes each item. An inline/file JSON
 Schema describes the complete returned value, so a schema combined with
@@ -244,6 +259,35 @@ marked collection therefore costs one document read rather than one per element.
 The marker is a JSON-schema spelling only, and it cannot be combined with
 `--filter`: the elements a predicate keeps no longer say which positions they
 came from, and an address names a position.
+
+#### What a selection means for a call
+
+A selection shapes a result that already exists. It does not narrow what the
+call fetches: the readback materializes the whole receipt before the selection
+runs, and a handling's receipt declares no schema for a selector to narrow
+against. The same holds for a tool, whose result is read off the cell the tool
+wrote. Use a selection to control what reaches stdout, not to control what
+travels.
+
+Three cases follow from that:
+
+- **A value-less verb still reports nothing.** Its receipt is the empty witness,
+  and the Invocation JSON omits `result` to say so. A selection is about a
+  value, so with none there the step never runs and `result` stays absent — it
+  does not become `{}`, and it is not an error. A selection that keeps nothing
+  from a result that _does_ exist is a different fact, and it is refused rather
+  than reported as an absent result.
+- **`--no-wait` refuses all three flags.** That mode exits once the commit is
+  acknowledged and skips the receipt readback, so there is no result to shape.
+  The refusal names the flags that need the readback, alongside `--show-links`
+  for the same reason.
+- **`--show-links` composes with a projection, not with `--filter`.** Links are
+  collected after the selection, over exactly the value the caller is holding: a
+  projection leaves every surviving path where it was, so each address still
+  names the position it annotates, and a path the projection dropped simply gets
+  no entry. A predicate does not — the elements it keeps land at positions that
+  are no longer the ones they came from — so `--filter --show-links` is refused,
+  the same refusal a `$link` marker meets for the same reason.
 
 ## Built Binary
 

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -50,6 +50,7 @@ import ports from "@commonfabric/ports" with { type: "json" };
 import type { PiecePatternRef } from "@commonfabric/piece/ops";
 import { reservesStdoutForCommandOutput } from "../lib/json-output.ts";
 import {
+  type CellSelection,
   CellSelectionError,
   parseCellSelectionOptions,
 } from "../lib/cell-selection.ts";
@@ -631,19 +632,45 @@ export interface PieceCallWaitControl {
   boundSeconds?: number;
 }
 
+/** The `cf piece call` flags whose answer needs the receipt readback. */
+export interface PieceCallReadbackFlags {
+  showLinks?: boolean;
+  filter?: string;
+  select?: string;
+  schema?: string;
+}
+
+/**
+ * Those flags paired with the spelling a refusal names them by, in the order a
+ * caller writes them.
+ */
+const READBACK_FLAGS: ReadonlyArray<
+  [keyof PieceCallReadbackFlags, string]
+> = [
+  ["showLinks", "--show-links"],
+  ["filter", "--filter"],
+  ["select", "--select"],
+  ["schema", "--schema"],
+];
+
 /**
  * Resolve the wait flags into one control. `--await` is the explicit spelling
  * of the default (flag parity, so a script can state its intent), which makes
  * `--await --no-wait` a contradiction rather than a precedence puzzle — it is
  * refused. `--await --wait <s>` is fine: both mean "wait", the bound just
  * names the patience. A non-positive bound is refused: it would spell
- * "don't wait" while claiming to be a wait. `--show-links --no-wait` is
- * refused too: the links ride the receipt readback a detached exit skips,
- * so honoring both is impossible — refusing beats silently dropping the
+ * "don't wait" while claiming to be a wait.
+ *
+ * `--no-wait` also refuses every flag that shapes or annotates the outcome —
+ * `--show-links` and the selection flags. All of them are answered from the
+ * receipt a detached exit never reads, so honoring both is impossible;
+ * refusing beats silently handing back an unshaped result or dropping the
  * links.
  */
 export function resolveWaitControl(
-  options: { await?: boolean; wait?: number | boolean; showLinks?: boolean },
+  options:
+    & { await?: boolean; wait?: number | boolean }
+    & PieceCallReadbackFlags,
 ): PieceCallWaitControl {
   if (options.wait === false) {
     if (options.await) {
@@ -651,10 +678,13 @@ export function resolveWaitControl(
         "--await and --no-wait contradict each other; pass one.",
       );
     }
-    if (options.showLinks) {
+    const named = READBACK_FLAGS
+      .filter(([key]) => options[key] !== undefined && options[key] !== false)
+      .map(([, flag]) => flag);
+    if (named.length > 0) {
       throw new ValidationError(
-        "--show-links needs the receipt readback that --no-wait skips; " +
-          "pass one.",
+        `${listFlags(named)} need${named.length === 1 ? "s" : ""} the ` +
+          "receipt readback that --no-wait skips; pass one.",
       );
     }
     return { mode: "commit" };
@@ -668,6 +698,38 @@ export function resolveWaitControl(
     return { mode: "settle", boundSeconds: options.wait };
   }
   return { mode: "settle" };
+}
+
+/** Flag names as prose: "--a", "--a and --b", "--a, --b and --c". */
+function listFlags(flags: readonly string[]): string {
+  if (flags.length <= 1) return flags.join("");
+  return `${flags.slice(0, -1).join(", ")} and ${flags.at(-1)}`;
+}
+
+/**
+ * Parse `cf piece call`'s selection flags into the shape the result should
+ * arrive in, through the same parser `cf piece get` uses — one grammar, one
+ * set of error messages, whichever command a caller reaches for.
+ *
+ * The one combination refused here is `--filter` with `--show-links`. A link
+ * names a position in the result, and a predicate that drops elements leaves
+ * the survivors at positions that are no longer the ones they came from, so
+ * every address below a filtered array would name the wrong element. It is
+ * the same refusal a `$link` marker meets inside the selection step, on the
+ * same grounds.
+ */
+export async function parsePieceCallSelection(
+  options: PieceCallReadbackFlags,
+): Promise<CellSelection | undefined> {
+  const selection = await parseCellSelectionOptions(options);
+  if (options.showLinks && selection?.filter !== undefined) {
+    throw new ValidationError(
+      "--show-links cannot be combined with --filter: a filtered array's " +
+        "elements no longer say which positions they came from, and a link " +
+        "names a position.",
+    );
+  }
+  return selection;
 }
 
 /**
@@ -1577,6 +1639,21 @@ after --. Handlers interpret piped input when no input argument is present.`,
     cliText(`cf piece call ${EX_ID} ${EX_COMP_PIECE} search -- --query milk`),
     `Run the "search" tool using schema-derived flags after "--".`,
   )
+  .example(
+    cliText(
+      `cf piece call ${EX_ID} ${EX_COMP_PIECE} --select topic.title addTopic ` +
+        `'{"title":"Ship it"}'`,
+    ),
+    "Return only the selected fields of the verb's result.",
+  )
+  .example(
+    cliText(
+      `cf piece call ${EX_ID} ${EX_COMP_PIECE} ` +
+        `--schema '{"properties":{"topic":{"$link":true}}}' addTopic ` +
+        `'{"title":"Ship it"}'`,
+    ),
+    "Return the address of what the verb returned instead of its contents.",
+  )
   .option("-c,--piece <piece:string>", "The target piece ID.")
   .option(
     "--invocation <id:string>",
@@ -1623,6 +1700,21 @@ after --. Handlers interpret piped input when no input argument is present.`,
       "appear only where a path is backed by a different document. Handler " +
       "invocations only — a tool already reports its result cell on stderr.",
   )
+  .option(
+    "--filter <predicate:string>",
+    "Filter an array with a jq-inspired predicate",
+  )
+  .option(
+    "--select <fields:string>",
+    "Project output to comma-separated field paths",
+  )
+  .option(
+    "--schema <schema:string>",
+    "Project output with an inline JSON Schema or @file",
+    // Both flags carry the one projection, so a command naming both has not
+    // said which shape it wants. Refuse before the call rather than pick.
+    { conflicts: ["select"] },
+  )
   .stopEarly()
   .arguments("<callable:string> [tail...:string]")
   .action(async function (options, callableName, ...tail) {
@@ -1635,6 +1727,7 @@ after --. Handlers interpret piped input when no input argument is present.`,
     );
     try {
       setQuietMode(!!options.quiet);
+      const selection = await parsePieceCallSelection(options);
       const invocation = pieceCallInvocation(
         tail,
         this.getLiteralArgs(),
@@ -1652,6 +1745,7 @@ after --. Handlers interpret piped input when no input argument is present.`,
             invocationId,
             skipReadback: waitControl.mode === "commit",
             showLinks: !!options.showLinks,
+            ...(selection === undefined ? {} : { selection }),
             onPhase: invocationPhaseReporter(
               invocationId,
               observer.onPhase,

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -1725,9 +1725,26 @@ after --. Handlers interpret piped input when no input argument is present.`,
       !!options.verbose,
       (next) => phase = next,
     );
+    setQuietMode(!!options.quiet);
+    // Read outside the invocation's failure wrapper below. Nothing is
+    // dispatched here — no callable resolved, no id spent — so a malformed
+    // selection is a data error about the flags, the same one `cf piece get`
+    // reports. Inside the wrapper it would name an id and a phase to retry
+    // from for a call that was never made; a selection that fails against a
+    // RESULT does sit inside it, and does name one.
+    let selection: CellSelection | undefined;
     try {
-      setQuietMode(!!options.quiet);
-      const selection = await parsePieceCallSelection(options);
+      selection = await parsePieceCallSelection(options);
+    } catch (error) {
+      // Both exits below leave without reaching the action's catch, so the
+      // verbose in-flight span is closed here.
+      observer.finish("failed");
+      if (error instanceof CellSelectionError) {
+        exitWithDataError({ message: error.message });
+      }
+      throw error;
+    }
+    try {
       const invocation = pieceCallInvocation(
         tail,
         this.getLiteralArgs(),

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -1710,7 +1710,8 @@ after --. Handlers interpret piped input when no input argument is present.`,
   )
   .option(
     "--schema <schema:string>",
-    "Project output with an inline JSON Schema or @file",
+    "Project output with an inline JSON Schema, @file, or the --select " +
+      "field list",
     // Both flags carry the one projection, so a command naming both has not
     // said which shape it wants. Refuse before the call rather than pick.
     { conflicts: ["select"] },

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -17,6 +17,11 @@ import {
   type CallableKind,
   classifyCallableEntry,
 } from "../../fuse/callables.ts";
+import {
+  type CellSelection,
+  CellSelectionError,
+  deriveSelectedValue,
+} from "./cell-selection.ts";
 import type { ExecCommandSpec } from "./exec-schema.ts";
 
 export const CF_RUNTIME_ERROR_LOG = Symbol.for("cf.cli.runtimeErrorLog");
@@ -81,6 +86,18 @@ export interface CallableExecutionDeps {
    * document, so plain JSON inside one doc adds nothing. Rides the receipt
    * readback, which is why it cannot combine with `--no-wait`. */
   showLinks?: boolean;
+  /** `--filter`/`--select`/`--schema`: the shape the caller asked the result
+   * to arrive in. Answered by the same selection step `cf piece get` reads
+   * through, so one grammar covers reads and calls.
+   *
+   * It shapes a result that exists rather than deciding what is fetched: the
+   * readback has already materialized the whole receipt by the time this
+   * applies, and a receipt declares no schema for a selector to narrow
+   * against. A verb that returns nothing keeps returning nothing — there is
+   * no value for a selection to be about. */
+  selection?: CellSelection;
+  /** @internal Seam for tests, mirroring `getCellValue`'s. */
+  deriveSelectedValue?: typeof deriveSelectedValue;
 }
 
 /** A backing-cell address in an Invocation's `links` dictionary: the same
@@ -555,6 +572,44 @@ export function collectInvocationResultLinks(
   return links;
 }
 
+/**
+ * Shape a call's result the way the caller asked for it, through the same step
+ * `cf piece get` reads through — the one place a `--filter`/`--select`/
+ * `--schema` grammar is interpreted, so a caller learns it once.
+ *
+ * `resultCell` is the cell the value was produced from: a handling's receipt,
+ * or a tool's result cell. The step reads through it and therefore reports the
+ * source's own links and Fabric metadata, which is what makes an address a
+ * caller can act on come back rather than a copy.
+ *
+ * A selection that materializes nothing over a result that exists is refused
+ * rather than reported as an absent result: an omitted `result` key means the
+ * verb returned nothing, and a projection that kept nothing is a different
+ * fact. `cf piece get` refuses the same condition on the same grounds.
+ */
+async function selectCallResult(
+  resolved: CallableResolution,
+  resultCell: Cell<any>,
+  selection: CellSelection,
+  deps: CallableExecutionDeps,
+): Promise<unknown> {
+  const selected = await (deps.deriveSelectedValue ?? deriveSelectedValue)(
+    resolved.pieces.runtime,
+    resolved.space,
+    resultCell,
+    selection,
+  );
+  if (selected === undefined) {
+    throw new CellSelectionError(
+      `Cannot shape the result of "${resolved.cellKey}": the filter/schema ` +
+        "expression did not materialize a JSON-renderable value. This is " +
+        "not JSON null, and it is not the empty receipt a value-less verb " +
+        "settles with — inspect the result and the selection.",
+    );
+  }
+  return selected;
+}
+
 export async function executeResolvedCallable(
   resolved: CallableResolution,
   input: unknown,
@@ -649,9 +704,24 @@ export async function executeResolvedCallable(
       ) {
         result = value;
       }
+      if (deps.selection !== undefined && result !== undefined) {
+        // Only where a result exists. Shaping the empty witness would report
+        // `{}` for a verb whose whole answer is that it returned nothing, and
+        // that omission is the distinction the empty receipt exists to draw.
+        result = await selectCallResult(
+          resolved,
+          receipt,
+          deps.selection,
+          deps,
+        );
+      }
       if (deps.showLinks) {
-        // After readback, off the same receipt the result came from: the
-        // links annotate exactly the value the caller is holding.
+        // After readback and after the selection, off the same receipt the
+        // result came from: the links annotate exactly the value the caller
+        // is holding. A projection keeps every surviving path where it was,
+        // so each address still names the position it annotates; a `--filter`
+        // does not, which is why the command refuses that pair rather than
+        // handing back addresses for elements the predicate moved.
         links = collectInvocationResultLinks(link, receipt, result);
       }
     }
@@ -750,6 +820,18 @@ export async function executeResolvedCallable(
     }
   } finally {
     cancelSink();
+  }
+
+  if (deps.selection !== undefined) {
+    // A tool's result reaches stdout through the same selection a handler's
+    // does. It is read off the cell the tool wrote, which is where the value
+    // above came from, so the shaped answer describes the same result.
+    outputValue = await selectCallResult(
+      resolved,
+      resultCell,
+      deps.selection,
+      deps,
+    );
   }
 
   // The result cell's durable address rides along: today the cell is

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -1,11 +1,19 @@
-import { describe, it } from "@std/testing/bdd";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import { expect } from "@std/expect";
 import type { JSONSchema } from "@commonfabric/api";
-import type { Cell, NormalizedFullLink } from "@commonfabric/runner";
+import { Identity } from "@commonfabric/identity";
 import {
+  type Cell,
+  type NormalizedFullLink,
+  Runtime,
+} from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import {
+  type CallableResolution,
   CF_RUNTIME_ERROR_LOG,
   collectInvocationResultLinks,
+  executeResolvedCallable,
   normalizeAbsentVerbPayload,
   runtimeErrorLog,
   schemaIsObjectShaped,
@@ -26,6 +34,7 @@ import {
   invocationJson,
   invocationPhaseReporter,
   isPieceGetDataError,
+  parsePieceCallSelection,
   pieceCallInvocation,
   pieceCallPhaseObserver,
   pieceCallRawArgs,
@@ -39,7 +48,12 @@ import {
   WaitBoundExpired,
 } from "../commands/piece.ts";
 import { LinkValidationError } from "../lib/piece.ts";
-import { CellSelectionError } from "../lib/cell-selection.ts";
+import {
+  type CellSelection,
+  CellSelectionError,
+  type deriveSelectedValue,
+  parseCellSelectionOptions,
+} from "../lib/cell-selection.ts";
 
 describe("executePieceCallable", () => {
   it("reports not-found when the piece cell has no schema-cast surface", async () => {
@@ -2971,6 +2985,491 @@ describe("piece call --show-links", () => {
       mode: "settle",
       boundSeconds: 5,
     });
+  });
+});
+
+/** What the shared selection step was handed, and the answer it gives back.
+ * Standing in for `deriveSelectedValue` is what makes "which cell did the
+ * call point the step at" observable — the answer itself is the step's own
+ * business, and `piece-get-transform.test.ts` is where it is pinned. */
+function recordingSelector(answer: unknown) {
+  const calls: Array<{
+    space: unknown;
+    cell: unknown;
+    selection: CellSelection;
+  }> = [];
+  const derive = ((
+    _runtime: unknown,
+    space: unknown,
+    cell: unknown,
+    selection: CellSelection,
+  ) => {
+    calls.push({ space, cell, selection });
+    return Promise.resolve(answer);
+  }) as unknown as typeof deriveSelectedValue;
+  return { calls, derive };
+}
+
+describe("piece call selection", () => {
+  const config = {
+    apiUrl: "http://localhost:8000",
+    identity: "/tmp/test-identity.pem",
+    piece: "fid1:piece-123",
+    space: "home",
+  };
+  const addTopic = {
+    callableKind: "handler" as const,
+    cellKey: "addTopic",
+    inputSchema: {
+      type: "object",
+      properties: { title: { type: "string" } },
+      required: ["title"],
+    } as JSONSchema,
+  };
+  const topicResult = {
+    topic: { title: "Ship it", body: "the initial document" },
+  };
+
+  it("points the shared selection step at the receipt the result came from", async () => {
+    // The whole of C2: a call reaches the same step `cf piece get` reads
+    // through, pointed at the cell the value was read from — so the shaped
+    // answer carries the source's own links rather than a copy of a copy.
+    const receiptCell = {
+      get: () => topicResult,
+      pull: () => Promise.resolve(topicResult),
+      key: () => receiptCell,
+    } as unknown as Cell<any>;
+    const harness = createPieceCallableHarness({ ...addTopic, receiptCell });
+    const selector = recordingSelector({ topic: { title: "Ship it" } });
+    const selection = await parseCellSelectionOptions({
+      select: "topic.title",
+    });
+
+    const result = await executePieceCallable(
+      config,
+      "addTopic",
+      ["--title", "Ship it"],
+      {
+        loadPieces: () => Promise.resolve(harness.pieces),
+        loadPiece: () => Promise.resolve(harness.piece),
+        invocationId: "inv-select",
+        selection,
+        deriveSelectedValue: selector.derive,
+      },
+    );
+
+    expect(result.invocation).toEqual({
+      id: "inv-select",
+      status: "settled",
+      result: { topic: { title: "Ship it" } },
+    });
+    expect(selector.calls).toHaveLength(1);
+    expect(selector.calls[0].cell).toBe(receiptCell);
+    expect(selector.calls[0].selection).toBe(selection);
+    expect(selector.calls[0].space).toBe("home");
+  });
+
+  it("leaves the Invocation JSON unshaped when no selection was asked for", async () => {
+    const harness = createPieceCallableHarness({
+      ...addTopic,
+      receiptValue: topicResult,
+    });
+    const selector = recordingSelector("never");
+
+    const result = await executePieceCallable(
+      config,
+      "addTopic",
+      ["--title", "Ship it"],
+      {
+        loadPieces: () => Promise.resolve(harness.pieces),
+        loadPiece: () => Promise.resolve(harness.piece),
+        invocationId: "inv-plain",
+        deriveSelectedValue: selector.derive,
+      },
+    );
+
+    expect(result.invocation).toEqual({
+      id: "inv-plain",
+      status: "settled",
+      result: topicResult,
+    });
+    expect(selector.calls).toEqual([]);
+  });
+
+  it("keeps a value-less verb reporting no result at all", async () => {
+    // The empty witness means "this verb returns nothing". A selection is
+    // about a value, and there is none, so the step never runs — reporting
+    // `{}` here would erase the distinction the empty receipt draws.
+    const harness = createPieceCallableHarness({
+      callableKind: "handler",
+      cellKey: "refresh",
+      inputSchema: { type: "object", properties: {} },
+      receiptValue: {},
+    });
+    const selector = recordingSelector({ never: true });
+
+    const result = await executePieceCallable(config, "refresh", [], {
+      loadPieces: () => Promise.resolve(harness.pieces),
+      loadPiece: () => Promise.resolve(harness.piece),
+      isStdinTerminal: () => true,
+      invocationId: "inv-void-select",
+      selection: await parseCellSelectionOptions({ select: "anything" }),
+      deriveSelectedValue: selector.derive,
+    });
+
+    expect(result.invocation).toEqual({
+      id: "inv-void-select",
+      status: "settled",
+    });
+    expect(invocationJson(result.invocation!)).not.toHaveProperty("result");
+    expect(selector.calls).toEqual([]);
+  });
+
+  it("refuses a selection that materializes nothing over a result that exists", async () => {
+    // Reporting no result here would say "the verb returned nothing", which
+    // is a different fact from "your projection kept nothing".
+    const harness = createPieceCallableHarness({
+      ...addTopic,
+      receiptValue: topicResult,
+    });
+    const selector = recordingSelector(undefined);
+
+    await expect(
+      executePieceCallable(config, "addTopic", ["--title", "Ship it"], {
+        loadPieces: () => Promise.resolve(harness.pieces),
+        loadPiece: () => Promise.resolve(harness.piece),
+        invocationId: "inv-empty-select",
+        selection: await parseCellSelectionOptions({
+          schema: '{"type":"string"}',
+        }),
+        deriveSelectedValue: selector.derive,
+      }),
+    ).rejects.toThrow(CellSelectionError);
+    expect(selector.calls).toHaveLength(1);
+  });
+
+  it("shapes a tool's stdout through the same step", async () => {
+    const harness = createPieceCallableHarness({
+      callableKind: "tool",
+      cellKey: "search",
+      inputSchema: {
+        type: "object",
+        properties: { query: { type: "string" } },
+        required: ["query"],
+      },
+      pattern: {
+        argumentSchema: {
+          type: "object",
+          properties: { query: { type: "string" } },
+          required: ["query"],
+        },
+        resultSchema: { type: "object" },
+      },
+      toolResult: { hits: [{ id: 1, title: "Tea" }], cursor: "abc" },
+    });
+    const selector = recordingSelector({ hits: [{ title: "Tea" }] });
+
+    const result = await executePieceCallable(
+      config,
+      "search",
+      ["--query", "tea"],
+      {
+        loadPieces: () => Promise.resolve(harness.pieces),
+        loadPiece: () => Promise.resolve(harness.piece),
+        uuid: () => "tool-result-id",
+        selection: await parseCellSelectionOptions({ select: "hits.title" }),
+        deriveSelectedValue: selector.derive,
+      },
+    );
+
+    // One grammar covers both callable kinds; the tool's own address surface
+    // is untouched by the shaping.
+    expect(JSON.parse(result.outputText!)).toEqual({
+      hits: [{ title: "Tea" }],
+    });
+    expect(result.resultRef).toEqual({
+      id: "of:tool-result-cell",
+      space: "did:key:test-home",
+      scope: "space",
+    });
+    expect(selector.calls).toHaveLength(1);
+  });
+
+  it("collects --show-links against the shaped result, not the whole receipt", async () => {
+    // Links annotate the value the caller is holding. With a projection that
+    // drops `comment`, an entry for `/comment` would name provenance for
+    // something the caller was not given.
+    const receiptDoc = { id: "of:receipt-1", space: "did:key:test-home" };
+    const stored = { comment: { body: "hi" }, count: 1 };
+    const harness = createPieceCallableHarness({
+      ...addTopic,
+      receiptCell: linkedReceiptCell(receiptDoc, stored, {
+        children: {
+          comment: { doc: { id: "of:comment-1", space: "did:key:test-home" } },
+        },
+      }),
+    });
+    const selector = recordingSelector({ count: 1 });
+
+    const result = await executePieceCallable(
+      config,
+      "addTopic",
+      ["--title", "Ship it"],
+      {
+        loadPieces: () => Promise.resolve(harness.pieces),
+        loadPiece: () => Promise.resolve(harness.piece),
+        invocationId: "inv-select-links",
+        showLinks: true,
+        selection: await parseCellSelectionOptions({ select: "count" }),
+        deriveSelectedValue: selector.derive,
+      },
+    );
+
+    expect(result.invocation).toEqual({
+      id: "inv-select-links",
+      status: "settled",
+      result: { count: 1 },
+      links: {
+        "/": { space: "did:key:test-home", id: "of:receipt-1", scope: "space" },
+      },
+    });
+  });
+
+  describe("flag combinations", () => {
+    it("refuses each selection flag with --no-wait, naming the ones passed", () => {
+      expect(() => resolveWaitControl({ wait: false, filter: ".a" })).toThrow(
+        /^--filter needs the receipt readback that --no-wait skips/,
+      );
+      expect(() => resolveWaitControl({ wait: false, select: "a" })).toThrow(
+        /^--select needs the receipt readback/,
+      );
+      expect(() => resolveWaitControl({ wait: false, schema: "{}" })).toThrow(
+        /^--schema needs the receipt readback/,
+      );
+      expect(() =>
+        resolveWaitControl({
+          wait: false,
+          showLinks: true,
+          filter: ".a",
+          select: "a",
+        })
+      ).toThrow(
+        /^--show-links, --filter and --select need the receipt readback/,
+      );
+    });
+
+    it("allows every selection flag with the default and bounded waits", () => {
+      expect(resolveWaitControl({ filter: ".a", select: "a" })).toEqual({
+        mode: "settle",
+      });
+      expect(resolveWaitControl({ wait: 5, schema: "{}" })).toEqual({
+        mode: "settle",
+        boundSeconds: 5,
+      });
+    });
+
+    it("refuses --filter with --show-links: a predicate moves the positions a link names", async () => {
+      await expect(
+        parsePieceCallSelection({
+          filter: '.status == "open"',
+          showLinks: true,
+        }),
+      ).rejects.toThrow(ValidationError);
+      await expect(
+        parsePieceCallSelection({
+          filter: '.status == "open"',
+          showLinks: true,
+        }),
+      ).rejects.toThrow(/--show-links cannot be combined with --filter/);
+      // A projection keeps every surviving path where it was, so it composes.
+      expect(
+        await parsePieceCallSelection({ select: "title", showLinks: true }),
+      ).toBeDefined();
+    });
+
+    it("parses through the same grammar `cf piece get` reads", async () => {
+      expect(await parsePieceCallSelection({})).toBeUndefined();
+      const selection = await parsePieceCallSelection({
+        filter: ".done == false",
+        select: "id,title",
+      });
+      expect(selection?.filter?.source).toBe(".done == false");
+      expect(selection?.projection?.flag).toBe("--select");
+      // The parser's own refusals arrive unchanged, so a caller reads one
+      // set of messages whichever command produced them.
+      await expect(parsePieceCallSelection({ filter: ".a ==" })).rejects
+        .toThrow(CellSelectionError);
+    });
+  });
+});
+
+const selectionSigner = await Identity.fromPassphrase(
+  "cf-piece-call-selection",
+);
+
+describe("piece call selection over a live runtime", () => {
+  const signer = selectionSigner;
+  const space = signer.did();
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    const runtimeErrors: Array<{ message: string }> = [];
+    runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "observe",
+      cfcFlowLabels: "persist",
+      errorHandlers: [
+        (error) => runtimeErrors.push({ message: error.message }),
+      ],
+    });
+    (runtime as unknown as Record<symbol, unknown>)[CF_RUNTIME_ERROR_LOG] =
+      runtimeErrors;
+  });
+
+  afterEach(async () => {
+    await runtime.dispose();
+    await storageManager.close();
+  });
+
+  /**
+   * A verb whose handling commits a receipt holding `value`, dispatched
+   * against the real runtime the selection then runs in. The receipt is
+   * written with NO declared schema, which is what a handling's receipt
+   * carries today — so this also pins that a schema-less source still
+   * projects.
+   */
+  async function settleWith(value: unknown): Promise<CallableResolution> {
+    const tx = runtime.edit();
+    const receipt = runtime.getCell(space, "handling-receipt", undefined, tx);
+    receipt.set(value);
+    expect((await tx.commit()).ok).toBeDefined();
+    const handlingReceiptLink = runtime
+      .getCell(space, "handling-receipt")
+      .getAsNormalizedFullLink();
+    return {
+      callableCell: {
+        schema: {
+          type: "object",
+          properties: { title: { type: "string" } },
+          required: ["title"],
+        },
+        send: (
+          _payload: unknown,
+          onCommit?: (tx: unknown) => void,
+        ) =>
+          onCommit?.({
+            status: () => ({ status: "done" }),
+            handlingReceiptLink,
+          }),
+      } as unknown as Cell<any>,
+      callableKind: "handler",
+      cellKey: "addTopic",
+      pieces: { runtime, getSpace: () => space } as never,
+      space,
+    };
+  }
+
+  it("projects a settled result through the real selection step", async () => {
+    const resolved = await settleWith({
+      topics: [
+        { id: 1, title: "First", status: "open" },
+        { id: 2, title: "Second", status: "closed" },
+      ],
+    });
+
+    const executed = await executeResolvedCallable(
+      resolved,
+      { title: "Ship it" },
+      {
+        invocationId: "inv-live",
+        selection: await parseCellSelectionOptions({ select: "topics.title" }),
+      },
+    );
+
+    expect(executed.invocation).toEqual({
+      id: "inv-live",
+      status: "settled",
+      result: { topics: [{ title: "First" }, { title: "Second" }] },
+    });
+  });
+
+  it("filters a settled array result", async () => {
+    const resolved = await settleWith([
+      { id: 1, title: "First", status: "open" },
+      { id: 2, title: "Second", status: "closed" },
+      { id: 3, title: "Third", status: "open" },
+    ]);
+
+    const executed = await executeResolvedCallable(
+      resolved,
+      { title: "Ship it" },
+      {
+        invocationId: "inv-live-filter",
+        selection: await parseCellSelectionOptions({
+          filter: '.status == "open"',
+          select: "id,title",
+        }),
+      },
+    );
+
+    expect(executed.invocation?.result).toEqual([
+      { id: 1, title: "First" },
+      { id: 3, title: "Third" },
+    ]);
+  });
+
+  it("returns the address of what a verb returned, in place of its contents", async () => {
+    // The `$link` marker reaches a call through the same step, which is what
+    // makes `cf piece call --schema '{"properties":{"topic":{"$link":true}}}'`
+    // — the command's own example — an address a later call can use.
+    const tx = runtime.edit();
+    const topic = runtime.getCell(space, "created-topic", undefined, tx);
+    topic.set({ title: "Ship it", body: "the initial document" });
+    expect((await tx.commit()).ok).toBeDefined();
+    const resolved = await settleWith({
+      topic: runtime.getCell(space, "created-topic"),
+    });
+
+    const executed = await executeResolvedCallable(
+      resolved,
+      { title: "Ship it" },
+      {
+        invocationId: "inv-live-link",
+        selection: await parseCellSelectionOptions({
+          schema: '{"properties":{"topic":{"$link":true}}}',
+        }),
+      },
+    );
+
+    expect(executed.invocation?.result).toEqual({
+      topic: {
+        $link: {
+          id: runtime.getCell(space, "created-topic")
+            .getAsNormalizedFullLink().id,
+          space,
+          scope: "space",
+          path: [],
+        },
+      },
+    });
+  });
+
+  it("refuses a selection that materializes nothing over a real result", async () => {
+    const resolved = await settleWith({ topic: { title: "Ship it" } });
+
+    await expect(
+      executeResolvedCallable(resolved, { title: "Ship it" }, {
+        invocationId: "inv-live-nothing",
+        selection: await parseCellSelectionOptions({
+          schema: '{"type":"string"}',
+        }),
+      }),
+    ).rejects.toThrow(
+      /Cannot shape the result of "addTopic".*did not materialize/s,
+    );
   });
 });
 

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -54,6 +54,7 @@ import {
   type deriveSelectedValue,
   parseCellSelectionOptions,
 } from "../lib/cell-selection.ts";
+import { cf, stripAnsi } from "./utils.ts";
 
 describe("executePieceCallable", () => {
   it("reports not-found when the piece cell has no schema-cast surface", async () => {
@@ -3299,6 +3300,24 @@ describe("piece call selection", () => {
       // set of messages whichever command produced them.
       await expect(parsePieceCallSelection({ filter: ".a ==" })).rejects
         .toThrow(CellSelectionError);
+    });
+
+    it("reports a malformed selection without naming an invocation to retry", async () => {
+      const { code, stderr } = await cf(
+        "piece call " +
+          "--identity ./definitely-missing-piece-call-review.key " +
+          "--api-url https://cf.dev --space common-knowledge " +
+          "--piece fid1:piece-123 --select a..b addTopic",
+      );
+      const errors = stripAnsi(stderr.join("\n"));
+      expect(code).toBe(1);
+      expect(errors).toContain('Invalid --select field path "a..b"');
+      // The selection is read before a callable is resolved and before
+      // anything is sent, so no id has been spent and no phase has been
+      // reached. An `invocation: <id> phase: <phase>` line here would send
+      // the caller to recover a call that was never made.
+      expect(errors).not.toContain("invocation:");
+      expect(errors).not.toContain("phase:");
     });
   });
 });

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -848,6 +848,17 @@ describe("cli piece parsing", () => {
     expect(callFlags).toContain("--show-links");
   });
 
+  it("describes piece call's `--schema` as taking a field list as well", () => {
+    // The call reads its selection through the read's grammar, so the flag
+    // takes every form the read's does. Its own `--help` line is where a
+    // caller learns which, and one naming fewer forms than the parser takes
+    // reads as a narrowing that is not there.
+    const schemaOption = piece.getCommand("call")!.getOptions().find((option) =>
+      option.flags.includes("--schema")
+    )!;
+    expect(schemaOption.description).toContain("--select field list");
+  });
+
   it("steps, reads, syncs, and stops in one get operation", async () => {
     const order: string[] = [];
     const controller = {

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -143,6 +143,7 @@ See `docs/development/EXPERIMENTAL_OPTIONS.md` for available flags.
 | Step + get         | `deno task cf piece get --piece ID fieldPath --step ...`                                             |
 | Set field          | `echo '{"data":...}' \| deno task cf piece set --piece ID path ...`                                  |
 | Call handler       | `deno task cf piece call --piece ID handlerName ...`                                                 |
+| Shape a result     | `deno task cf piece call --piece ID --select topic.title addTopic ...`                               |
 | List verbs         | `deno task cf piece verbs --piece ID --json ...`                                                     |
 | Trigger recompute  | `deno task cf piece step --piece ID ...`                                                             |
 | List pieces        | `deno task cf piece ls -i key -a url -s space`                                                       |
@@ -272,6 +273,25 @@ is never fetched, so a marked collection costs one document read rather than one
 per element; the rendered `id` minus its `of:` prefix is what `--piece` accepts.
 Markers do not compose with `--filter`. See `packages/cli/README.md` for the
 exact syntax and supported schema subset.
+
+`piece call` takes the same three flags, before the callable name, with the same
+grammar, the same `--select`/`--schema` conflict, and the same error messages.
+They shape the result of the call — a handler's `result` inside the Invocation
+JSON, or a tool's JSON on stdout:
+
+```bash
+deno task cf piece call --piece ID --select topic.title addTopic '{"title":"Ship it"}'
+```
+
+A selection shapes a result that already exists; it does not narrow what the
+call fetches, because the readback materializes the whole receipt first and a
+receipt declares no schema to narrow against. A value-less verb therefore still
+reports no `result` at all rather than `{}` — but a selection that keeps nothing
+from a result that does exist is refused, so the two stay distinguishable.
+`--no-wait` refuses all three flags, since it skips the receipt readback they
+are answered from. `--show-links` composes with a projection — links are
+collected after the selection, so each address names a position in the value you
+were handed — but not with `--filter`, which moves the positions a link names.
 
 For `piece call`, options before the callable name configure `piece call`.
 Arguments after the callable name configure the invoked handler or tool. The


### PR DESCRIPTION
## Why

`cf piece get` can shape what it returns; `cf piece call` could not. A verb's
result and a direct read are the same operation on different cells, so a caller
who learned `--select` on one had to abandon it on the other.

Stage C2 of the shaped-reads plan (#5435). Stacked on #5500.

## What Changed

`piece call` gains `--select`, `--schema` and `--filter`, routed through the same
`deriveSelectedValue` step `piece get` uses. No second output path, and
`piece get`'s behavior is untouched.

Wired for **tools** as well as handlers, since `piece call` runs both and leaving
a tool to silently ignore `--select` is worse than either supporting or refusing
it. Same step, same helper.

## What a selection over a call actually does

**It filters after materialization. It does not narrow the fetch, and this PR
claims no narrowing.** `callable.ts` pulls the whole receipt first because it
must — the empty-record test that identifies a value-less verb needs the value in
hand. And even reordered it would not narrow: a receipt carries no declared
schema, so `selectSourceSchema(undefined, mask)` returns the permissive read and
no selector is pushed. The live-runtime tests deliberately write the receipt with
`undefined` schema so that case is the one pinned.

What the shared step *does* buy is that the read goes *through the source cell*,
so its links and Fabric metadata survive — a `$link`-marked `--schema` over a
call returns a usable address, and that is tested.

## Three decisions the plan left open

**Value-less verbs.** The selection is skipped entirely and `result` stays
absent — not `{}`, not an error. Separately, a selection that materializes
nothing over a result that *does* exist is refused, because otherwise "the verb
returned nothing" and "your projection kept nothing" would be one wire shape, and
`invocationJson`'s contract says the omission means the former.

**`--no-wait`.** Refused. A detached exit skips the readback the selection is
answered from. The existing `--show-links --no-wait` refusal generalized into a
list, so the single-flag message is byte-identical and the existing test's regex
still holds.

**`--show-links`.** Collected *after* the selection, so links annotate the value
the caller is actually holding. A projection keeps every surviving path at its
original position, so each address still names what it annotates and a dropped
path simply gets no entry — tested. A predicate does not: survivors land at
indices that are no longer theirs, so `--filter --show-links` is refused, on the
same grounds `--filter` + a `$link` marker already is.

## Found, not fixed

**`deriveSelectedValue`'s failure messages say "piece get" to a `piece call`
user** — `Could not apply piece get transform: …`, plus a `pieceGetTransform`
cause key and a host-trust reason naming `piece get`. Fixing the message moves
two pre-existing expectations; renaming the cause key changes the derived id of
`piece get`'s transform result cell. Both out of scope here, but worth a
follow-up now that two commands share the step.

**A new import cycle** `callable.ts` → `cell-selection.ts` → `callable.ts`, the
latter only for `runtimeErrorLog`. Safe — both bindings are hoisted declarations
used at call time — and the package already has 17 cycles. The clean fix is
relocating `runtimeErrorLog` out of `callable.ts`, which touches five files
including two the branches beneath wrote. Say if you'd rather have the churn.

**`main-command.test.ts` fails whenever `FORCE_COLOR` is set** — pre-existing,
verified identical on a stashed unmodified tree. It asserts uncolored Cliffy help
while the CLI honors `FORCE_COLOR` exactly as the README documents, so the test
looks wrong rather than the CLI. All counts below are from runs with it unset.

## Test plan

`deno task test` in packages/cli (1674 + 123 passed) and packages/runner (1156
passed); `check`, `fmt`, `lint`, `check-docs`, `check-skill-facts`,
`check-no-waitfor`, `check-conflict-markers`, and the dependency gates — all
pass.

14 tests added, none deleted. `piece-get-transform.test.ts` is untouched — not in
the diff at all.

**Not exercised:** no live server, so the walkthrough script and the real `cf`
binary against a toolshed were never run, and no step was added to that script —
an integration step I could not execute is worse than none. What was exercised
end to end: `executeResolvedCallable` against a real `Runtime` with emulated
storage and a real committed receipt document, covering `--select`, `--filter` +
`--select`, a `$link`-marked `--schema`, and the materializes-nothing refusal.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

