### PR TITLE
refactor(data-model): fold the `codec-json` module scope into `JsonCodec`

### DIFF
--- a/packages/data-model/src/codec-json/JsonCodec.ts
+++ b/packages/data-model/src/codec-json/JsonCodec.ts
@@ -12,72 +12,9 @@ import { EmptyReconstructionContext } from "@/codec-common/EmptyReconstructionCo
 import { UnknownValue } from "@/fabric-instances/UnknownValue.ts";
 import { ProblematicValue } from "@/fabric-instances/ProblematicValue.ts";
 import { createDefaultRegistry } from "@/codec-common/createDefaultRegistry.ts";
-import type { JsonCodecValue } from "./interface.ts";
+import { ENCODING_PREFIX_TAG, type JsonCodecValue } from "./interface.ts";
 import { type CodecRegistry, SELF_REP } from "@/codec-common/CodecRegistry.ts";
 import { CODEC_META_TAGS } from "@/codec-common/codec-meta-tags.ts";
-
-/**
- * Tag prefix for the encoded form used by this module. We use this explicit
- * prefix so as to make it unambiguous when a given JSON-ish text string is
- * the result of encoding via this module vs. being JSON from some other source.
- * The tag stands for "Fabric Value Json, version 1."
- */
-const ENCODING_PREFIX_TAG = "fvj1:";
-
-/** Shared text encoder, created once. */
-const textEncoder = new TextEncoder();
-
-/** Shared text decoder, created once. */
-const textDecoder = new TextDecoder();
-
-/** Shared default handler registry, created once. */
-const defaultRegistry: CodecRegistry = createDefaultRegistry();
-
-/** Returns true if `v` is a single-key object whose key starts with `/` —
- * the wire form of an encoded instance (tag-wrapped value). */
-function isEncodedInstance(v: JsonCodecValue): boolean {
-  if (v === null || typeof v !== "object" || Array.isArray(v)) return false;
-  const keys = Object.keys(v);
-  return keys.length === 1 && keys[0]!.startsWith("/");
-}
-
-/**
- * Returns true if the already-encoded codec value `v` can be embedded
- * inside a /quote wrap without inner deserialization: primitives, plain
- * objects/arrays free of non-/quote encoded instances, and /quote-wrapped
- * values (which `unquote()` can collapse).
- */
-function isQuoteSafe(v: JsonCodecValue): boolean {
-  if (v === null || typeof v !== "object") return true;
-  if (Array.isArray(v)) return v.every((item) => isQuoteSafe(item));
-  if (!isEncodedInstance(v)) {
-    return Object.values(v).every((item) =>
-      isQuoteSafe(item as JsonCodecValue)
-    );
-  }
-  return Object.keys(v)[0] === "/quote";
-}
-
-/**
- * Unwraps /quote forms one level so their literal content can be embedded
- * directly inside a parent /quote. The inner content of a /quote is already
- * literal and must not be recursed into.
- */
-function unquote(v: JsonCodecValue): JsonCodecValue {
-  if (v === null || typeof v !== "object") {
-    return v;
-  } else if (Array.isArray(v)) {
-    const result = v.map(unquote) as JsonCodecValue;
-    return Object.freeze(result);
-  } else if (isEncodedInstance(v) && Object.keys(v)[0] === "/quote") {
-    return (v as Record<string, JsonCodecValue>)["/quote"]!;
-  } else {
-    const result = Object.fromEntries(
-      Object.entries(v).map(([k, val]) => [k, unquote(val as JsonCodecValue)]),
-    ) as JsonCodecValue;
-    return Object.freeze(result);
-  }
-}
 
 /**
  * Whole-value JSON codec implementing the `/<Type>@<Version>` wire format from
@@ -175,11 +112,11 @@ export class JsonCodec implements SerializationContext<string> {
       return null;
     }
 
-    if (!isEncodedInstance(data)) {
+    if (!JsonCodec.#isEncodedInstance(data)) {
       return null;
     }
 
-    // `isEncodedInstance()` guaranteed a single-property object, so this
+    // `#isEncodedInstance()` guaranteed a single-property object, so this
     // destructures that one entry.
     const [key, value] = Object.entries(data)[0]!;
     return { tag: key.slice(1), state: value };
@@ -187,12 +124,12 @@ export class JsonCodec implements SerializationContext<string> {
 
   /** Converts a codec-value tree to UTF-8-encoded JSON bytes. */
   private toBytes(data: JsonCodecValue): Uint8Array {
-    return textEncoder.encode(JSON.stringify(data));
+    return JsonCodec.#textEncoder.encode(JSON.stringify(data));
   }
 
   /** Parses UTF-8-encoded JSON bytes back into a codec-value tree. */
   private fromBytes(bytes: Uint8Array): JsonCodecValue {
-    const json = textDecoder.decode(bytes);
+    const json = JsonCodec.#textDecoder.decode(bytes);
     return JsonCodec.#parseWireText(json);
   }
 
@@ -203,7 +140,7 @@ export class JsonCodec implements SerializationContext<string> {
   #encodeValue(
     value: FabricValue,
     _seen?: Set<object>,
-    registry: CodecRegistry = defaultRegistry,
+    registry: CodecRegistry = JsonCodec.#defaultRegistry,
   ): JsonCodecValue {
     const codec = registry.codecFromValue(value);
 
@@ -317,10 +254,10 @@ export class JsonCodec implements SerializationContext<string> {
     // Otherwise wrap with /object so the decoder deserializes entries.
     const keys = Object.keys(result);
     if (keys.some((k) => k.startsWith("/"))) {
-      if (Object.values(result).every((v) => isQuoteSafe(v))) {
+      if (Object.values(result).every((v) => JsonCodec.#isQuoteSafe(v))) {
         const unquoted = Object.freeze(
           Object.fromEntries(
-            Object.entries(result).map(([k, v]) => [k, unquote(v)]),
+            Object.entries(result).map(([k, v]) => [k, JsonCodec.#unquote(v)]),
           ),
         );
         return this.wrapTag(CODEC_META_TAGS.quote, unquoted) as JsonCodecValue;
@@ -343,7 +280,7 @@ export class JsonCodec implements SerializationContext<string> {
   #decodeValue(
     data: JsonCodecValue,
     context: ReconstructionContext,
-    registry: CodecRegistry = defaultRegistry,
+    registry: CodecRegistry = JsonCodec.#defaultRegistry,
   ): FabricValue {
     const decoded = this.unwrapTag(data);
     if (decoded !== null) {
@@ -492,6 +429,15 @@ export class JsonCodec implements SerializationContext<string> {
   // Static members
   //
 
+  /** Shared text encoder, created once. */
+  static readonly #textEncoder = new TextEncoder();
+
+  /** Shared text decoder, created once. */
+  static readonly #textDecoder = new TextDecoder();
+
+  /** Shared default codec registry, created once. */
+  static readonly #defaultRegistry: CodecRegistry = createDefaultRegistry();
+
   /**
    * Reconstruction context for the throwaway checks in the testing helpers
    * below. Deep-freezes, as the ordinary decode path does. Paired with a
@@ -504,6 +450,60 @@ export class JsonCodec implements SerializationContext<string> {
       "no runtime context (validity check in a test-only helper).",
     ),
   );
+
+  /**
+   * Returns true if `v` is a single-key object whose key starts with `/` --
+   * the wire form of an encoded instance (tag-wrapped value).
+   */
+  static #isEncodedInstance(v: JsonCodecValue): boolean {
+    if (v === null || typeof v !== "object" || Array.isArray(v)) return false;
+    const keys = Object.keys(v);
+    return keys.length === 1 && keys[0]!.startsWith("/");
+  }
+
+  /**
+   * Returns true if the already-encoded codec value `v` can be embedded
+   * inside a /quote wrap without inner deserialization: primitives, plain
+   * objects/arrays free of non-/quote encoded instances, and /quote-wrapped
+   * values (which `#unquote()` can collapse).
+   */
+  static #isQuoteSafe(v: JsonCodecValue): boolean {
+    if (v === null || typeof v !== "object") return true;
+    if (Array.isArray(v)) {
+      return v.every((item) => JsonCodec.#isQuoteSafe(item));
+    }
+    if (!JsonCodec.#isEncodedInstance(v)) {
+      return Object.values(v).every((item) =>
+        JsonCodec.#isQuoteSafe(item as JsonCodecValue)
+      );
+    }
+    return Object.keys(v)[0] === "/quote";
+  }
+
+  /**
+   * Unwraps /quote forms one level so their literal content can be embedded
+   * directly inside a parent /quote. The inner content of a /quote is already
+   * literal and must not be recursed into.
+   */
+  static #unquote(v: JsonCodecValue): JsonCodecValue {
+    if (v === null || typeof v !== "object") {
+      return v;
+    } else if (Array.isArray(v)) {
+      const result = v.map(JsonCodec.#unquote) as JsonCodecValue;
+      return Object.freeze(result);
+    } else if (
+      JsonCodec.#isEncodedInstance(v) && Object.keys(v)[0] === "/quote"
+    ) {
+      return (v as Record<string, JsonCodecValue>)["/quote"]!;
+    } else {
+      const result = Object.fromEntries(
+        Object.entries(v).map(
+          ([k, val]) => [k, JsonCodec.#unquote(val as JsonCodecValue)],
+        ),
+      ) as JsonCodecValue;
+      return Object.freeze(result);
+    }
+  }
 
   /**
    * Indicates if the given text has a "first-blush" appearance as valid JSON

--- a/packages/data-model/src/codec-json/index.ts
+++ b/packages/data-model/src/codec-json/index.ts
@@ -12,6 +12,3 @@ export {
 
 // Whole-value codec for the wire format.
 export { JsonCodec } from "./JsonCodec.ts";
-
-// Shared codec-value vocabulary.
-export type { JsonCodecValue } from "./interface.ts";

--- a/packages/data-model/src/codec-json/interface.ts
+++ b/packages/data-model/src/codec-json/interface.ts
@@ -1,4 +1,12 @@
 /**
+ * Tag prefix on the encoded form of a fabric value. The prefix is explicit so
+ * as to make it unambiguous whether a given JSON-ish text string is the result
+ * of encoding by `JsonCodec` vs. being JSON from some other source. The tag
+ * stands for "Fabric Value Json, version 1."
+ */
+export const ENCODING_PREFIX_TAG = "fvj1:";
+
+/**
  * JSON-compatible codec value. This is the intermediate tree representation
  * used during serialization tree walking -- NOT the final serialized form
  * (which is `string`). Internal to the JSON implementation.
@@ -11,7 +19,7 @@
  * trees built on the *serialize* side are not covered by this invariant: they
  * are `JSON.stringify`-ed and discarded by `encode()` / `encodeToBytes()` and
  * never reach a caller. (The serialize-side `/quote` form happens to be
- * deep-frozen as a side effect of `unquote()`'s recursive rebuild, but no
+ * deep-frozen as a side effect of `#unquote()`'s recursive rebuild, but no
  * other serialize output is, and none needs to be.)
  */
 export type JsonCodecValue =

--- a/packages/data-model/src/codec-json/interface.ts
+++ b/packages/data-model/src/codec-json/interface.ts
@@ -4,7 +4,7 @@
  * of encoding by `JsonCodec` vs. being JSON from some other source. The tag
  * stands for "Fabric Value Json, version 1."
  */
-export const ENCODING_PREFIX_TAG = "fvj1:";
+export const ENCODING_PREFIX_TAG = "fvj1:" as const;
 
 /**
  * JSON-compatible codec value. This is the intermediate tree representation

--- a/packages/data-model/test/codec-json/JsonCodec.test.ts
+++ b/packages/data-model/test/codec-json/JsonCodec.test.ts
@@ -702,6 +702,21 @@ describe("JsonCodec", () => {
         >;
         expect(result["/x"]!["a"]).toBe(1);
       });
+
+      it("collapses a `/quote` nested inside an array value into the outer one", () => {
+        // The array element is itself a literal `/`-keyed object, so it encodes
+        // as its own `/quote`. Wrapping the whole structure has to unquote
+        // *through* the array; otherwise the inner wrapper survives into the
+        // output, and decoding -- which strips exactly one `/quote` layer --
+        // hands back the wrapper instead of the object the caller wrote.
+        const obj = { "/outer": [{ "/inner": "val" }] };
+        expect(toWireFormat(obj)).toEqual({
+          "/quote": { "/outer": [{ "/inner": "val" }] },
+        });
+
+        const result = roundTrip(obj) as Record<string, FabricValue[]>;
+        expect(result["/outer"]![0]).toEqual({ "/inner": "val" });
+      });
     });
 
     describe("/object: any value requires encoding", () => {


### PR DESCRIPTION
Two commits. The first empties `JsonCodec.ts`'s module scope; the second closes
a coverage gap that emptying it exposed.

## Folding the module scope into the class

`JsonCodec.ts` had a module scope holding one constant, three shared objects,
and three helper functions.

- `ENCODING_PREFIX_TAG` moves to `interface.ts`, alongside `JsonCodecValue` as
  the area's shared vocabulary, and is declared `as const`.
- The shared `TextEncoder` / `TextDecoder`, the default registry, and the
  `isEncodedInstance` / `isQuoteSafe` / `unquote` helpers become
  `static #private`s on the class, joining the statics already in its
  `Static members` section (data fields first, then methods, matching
  `FabricBytes` and its neighbors).
- `JsonCodecValue` drops out of the barrel: it names the codec's internal
  intermediate tree, nothing outside `codec-json` refers to it, and the one
  test that does reaches it through `@/codec-json/interface.ts` rather than the
  package export. Every external importer of
  `@commonfabric/data-model/codec-json` takes only `JsonCodec` and the four
  entry-point functions, so no consumer changes.

`ENCODING_PREFIX_TAG` is deliberately *not* added to the barrel -- the public
surface of the subpackage is unchanged in both directions.

Notes on the move:

- `interface.ts` was type-only and now carries a runtime value, so importers
  take a value import rather than `import type`. Only `JsonCodec.ts` is
  affected.
- The constant's doc comment said "this module" twice, which stopped being
  true once it moved; it now names `JsonCodec` instead.
- `v.map(unquote)` became `v.map(JsonCodec.#unquote)`. Reading a private static
  method off the class and calling it detached is fine -- the brand check is at
  the access site, and the body reaches its siblings through `JsonCodec.`
  rather than `this`.
- `as const` is type-inert here: a `const` bound to a string literal already
  has the literal type `"fvj1:"`. It carries intent rather than changing what
  is checked.

## Pinning `/quote` collapsing through an array

Because the first commit is a pure move, "the tests pass" is only worth as much
as the tests' grip on the moved code. Each moved member was ablated to confirm
the suite notices:

| ablation | result |
| --- | --- |
| `#isQuoteSafe` always returns false | red |
| `#isEncodedInstance` always returns false | red |
| `#defaultRegistry` swapped for an empty registry | red |
| `#unquote`'s array arm reduced to a pass-through | green -- a real gap |

That last one was a pre-existing hole, not one this PR opened: the equivalent
ablation against `main` is also green. A throw probe in that arm fires 12 times
and reddens three test files, so the arm *is* reached -- but no assertion
distinguished "recursively unquoted" from "passed through" for an array,
because no test case put a `/quote` form inside one, and a structural `toEqual`
cannot tell those two apart.

The second commit closes it. Encoding `{ "/outer": [{ "/inner": "val" }] }` has
to unquote *through* the array: the element has already become its own
`/quote`, and the outer wrap must absorb it. Otherwise the inner wrapper
survives into the output, and decoding -- which strips exactly one `/quote`
layer -- hands back the wrapper instead of the object the caller wrote. The new
test pins both the wire form and the round trip, and the same ablation now goes
red naming that test.

## Verification

Green on the final tree: `deno fmt --check`, `deno lint`, `deno task check`,
`deno task check-docs`, `deno task check-skill-facts`,
`deno task check-no-waitfor`, and the full workspace `deno task test` (all
packages ok, tree clean at `b78cd8bb4`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QxM2ZBpzGbYiGjsjTbn8wU


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->





