### PR TITLE
fix(runner): un-gate the nested-piece cold-start setup repair

### DIFF
--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -2739,13 +2739,9 @@ export class Runner {
     // repair the home ROOT got in startEnsuredDefaultPattern, reachable at last
     // for the nested pieces that never pass through it.
     //
-    // Not gated on systemPatternAutoUpdate: that flag governs the UPDATE
-    // family (heals that move the durable identity pointer), while this is a
-    // same-identity self-REPAIR — the same posture as the root's
-    // controller-side cold-start repair (pinned at flag-off by
-    // check-update-default-pattern.test.ts). Default deployments leave the
-    // flag unset, and an aged nested piece (e.g. a profile surface reached
-    // through a wish) has no other heal there. On EXACTLY that
+    // The repair is not gated by `systemPatternAutoUpdate`: that flag governs
+    // updates which move the durable identity pointer, while this setup replays
+    // the pattern the pointer already names. On exactly that
     // failure, re-run the pinned pattern's OWN setup state (samePattern=true:
     // materializes the missing internal cells but leaves the existing argument
     // — the piece's data — untouched; no roll-forward, no user-data rewrite),

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -2739,7 +2739,13 @@ export class Runner {
     // repair the home ROOT got in startEnsuredDefaultPattern, reachable at last
     // for the nested pieces that never pass through it.
     //
-    // Gated on the systemPatternAutoUpdate experimental flag. On EXACTLY that
+    // Not gated on systemPatternAutoUpdate: that flag governs the UPDATE
+    // family (heals that move the durable identity pointer), while this is a
+    // same-identity self-REPAIR — the same posture as the root's
+    // controller-side cold-start repair (pinned at flag-off by
+    // check-update-default-pattern.test.ts). Default deployments leave the
+    // flag unset, and an aged nested piece (e.g. a profile surface reached
+    // through a wish) has no other heal there. On EXACTLY that
     // failure, re-run the pinned pattern's OWN setup state (samePattern=true:
     // materializes the missing internal cells but leaves the existing argument
     // — the piece's data — untouched; no roll-forward, no user-data rewrite),
@@ -2759,7 +2765,6 @@ export class Runner {
         if (
           useTx !== undefined ||
           ref === undefined ||
-          !this.runtime.experimental.systemPatternAutoUpdate ||
           !isMissingStreamMarkerFailure(instantiateError) ||
           // The root/default pattern is the PieceController's to repair (it has
           // the richer roll-forward + clear-error path); defer to it there.

--- a/packages/runner/test/nested-piece-setup-repair.test.ts
+++ b/packages/runner/test/nested-piece-setup-repair.test.ts
@@ -17,13 +17,11 @@ import type { RuntimeProgram } from "../src/harness/types.ts";
 // instantiation re-runs the pinned pattern's OWN setup on that failure and
 // retries — the same repair the home ROOT gets in startEnsuredDefaultPattern,
 // here for the nested pieces that never pass through the PieceController.
-// Like the root repair (whose flag-off posture
-// check-update-default-pattern.test.ts pins), it is not gated on
-// systemPatternAutoUpdate: the flag governs the UPDATE family (identity
-// moves); a same-identity self-repair also runs in default deployments,
-// where the flag is unset and is a nested piece's only heal. The root itself
-// is EXCLUDED (the controller owns it); a nested piece is never a space's
-// defaultPattern, so it heals here.
+// The repair is not gated by `systemPatternAutoUpdate`: that flag governs
+// updates which move the durable identity pointer, while this setup replays
+// the pattern the pointer already names. The root itself is excluded because
+// its controller owns the repair; a nested piece is never a space's
+// `.defaultPattern`, so it heals here.
 
 const signer = await Identity.fromPassphrase("nested-piece-setup-repair");
 const space = signer.did();
@@ -165,9 +163,8 @@ describe("nested-piece cold-start setup repair", () => {
   };
 
   it("heals with systemPatternAutoUpdate off (repair is not update)", async () => {
-    // The flag-off posture is the one every default deployment runs
-    // (experimental defaults omit the flag). An aged nested piece heals there
-    // too, as the root does via the controller's cold-start repair.
+    // Disabling pattern auto-update proves the same-identity repair is
+    // independent of the host's update posture.
     const rt = newRuntime(false);
     try {
       const { cell, v3Ref } = await brickedNestedPiece(rt);

--- a/packages/runner/test/nested-piece-setup-repair.test.ts
+++ b/packages/runner/test/nested-piece-setup-repair.test.ts
@@ -14,11 +14,16 @@ import type { RuntimeProgram } from "../src/harness/types.ts";
 // setup (here: set up for V1, then re-pointed at the handler-bearing V3 whose
 // `bump` stream marker the V1 doc never materialized), instantiation throws
 // "Handler used as lift … marker was never written". Runner.startCore's initial
-// instantiation re-runs the pinned pattern's OWN setup on that failure (gated by
-// systemPatternAutoUpdate) and retries — the same repair the home ROOT gets in
-// startEnsuredDefaultPattern, reachable at last for the nested pieces that never
-// pass through the PieceController. The root itself is EXCLUDED (the controller
-// owns it); a nested piece is never a space's defaultPattern, so it heals here.
+// instantiation re-runs the pinned pattern's OWN setup on that failure and
+// retries — the same repair the home ROOT gets in startEnsuredDefaultPattern,
+// here for the nested pieces that never pass through the PieceController.
+// Like the root repair (whose flag-off posture
+// check-update-default-pattern.test.ts pins), it is not gated on
+// systemPatternAutoUpdate: the flag governs the UPDATE family (identity
+// moves); a same-identity self-repair also runs in default deployments,
+// where the flag is unset and is a nested piece's only heal. The root itself
+// is EXCLUDED (the controller owns it); a nested piece is never a space's
+// defaultPattern, so it heals here.
 
 const signer = await Identity.fromPassphrase("nested-piece-setup-repair");
 const space = signer.did();
@@ -159,11 +164,27 @@ describe("nested-piece cold-start setup repair", () => {
     return { cell, v3Ref };
   };
 
-  it("bricks on start when the repair flag is OFF (locks in the gap)", async () => {
+  it("heals with systemPatternAutoUpdate off (repair is not update)", async () => {
+    // The flag-off posture is the one every default deployment runs
+    // (experimental defaults omit the flag). An aged nested piece heals there
+    // too, as the root does via the controller's cold-start repair.
     const rt = newRuntime(false);
     try {
-      const { cell } = await brickedNestedPiece(rt);
-      await expect(rt.start(cell)).rejects.toThrow("marker was never written");
+      const { cell, v3Ref } = await brickedNestedPiece(rt);
+      const started = await rt.start(cell);
+      expect(started).toBe(true);
+      await cell.pull();
+      // Same-identity self-repair, not an update: the pin stays at V3…
+      const idRaw = (cell as unknown as {
+        getMetaRaw: (k: string) => unknown;
+      }).getMetaRaw("patternIdentity") as { identity?: string } | undefined;
+      expect(idRaw?.identity).toBe(v3Ref.identity);
+      // …and the once-missing handler stream fires end to end.
+      const before = (cell.getAsQueryResult() as { count: number }).count;
+      (cell.key("bump") as unknown as { send: (e: unknown) => void }).send({});
+      await cell.pull();
+      const after = (cell.getAsQueryResult() as { count: number }).count;
+      expect(after).toBe(before + 1);
     } finally {
       await rt.dispose();
     }

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -1160,9 +1160,8 @@ export class RuntimeProcessor {
     // Always the PiecesController path: ensureDefaultPattern() reconciles the
     // persisted identity and carries the cold-start setup repair that heals an
     // aged home root. Starting the pattern directly here would skip that
-    // repair, and with systemPatternAutoUpdate unset (every default
-    // deployment) nothing else heals the root — so no fast path belongs in
-    // front of the controller.
+    // repair, and with `systemPatternAutoUpdate` unset nothing else heals the
+    // root — so no fast path belongs in front of the controller.
     const homeSession: Session = {
       as: this.identity,
       space: this.runtime.userIdentityDID,


### PR DESCRIPTION
## Why

The #4977 repair—re-running a pinned pattern's own setup when instantiation hits `Handler used as lift … marker was never written`—was gated on the `systemPatternAutoUpdate` experimental flag. That flag governs the **update** family, which moves the durable identity pointer; this is a same-identity self-**repair**, matching the root controller's cold-start repair posture.

Hosts that do not explicitly enable the flag—including the raw Runtime and server-side defaults—otherwise leave an aged nested piece with no repair path. The motivating failure was observed in Loom's native PatternHost, whose `RuntimeInternals.create()` call supplied no experimental flags, so `systemPatternAutoUpdate` was off there. The shell is distinct and explicitly defaults the flag on.

The repair is safe independent of update posture: it fires only on exactly the missing-stream-marker failure, re-reads the pinned identity as a precondition inside the repair transaction, never touches the piece's argument/data, and rethrows the original error on any failure. The CT-1923 pointer rollback, which does move identity, keeps its flag gate.

cc @bfollington—this is a posture proposal on your #4977; happy to adjust if the gate was deliberate for a reason the comments do not record.

## What Changed

- `runner.ts`: drop the `systemPatternAutoUpdate` clause from `instantiateInitialPattern`'s repair condition; the comment records the repair-versus-update invariant without making host-default claims.
- `nested-piece-setup-repair.test.ts`: flip the flag-off case from a locked-in failure to a successful end-to-end repair, while proving the durable pattern identity remains unchanged.
- `runtime-processor.ts`: remove a matching overstatement about deployment defaults from an existing comment; no behavior changes there.

## Test plan

- The flipped test was validated as an instrument: it fails on unmodified `main` and passes with this change.
- Focused nested-piece setup-repair test: passed.
- Full `packages/runtime-client` suite: 60 tests / 208 steps passed.
- Repo-wide `deno fmt --check` and `deno lint`: passed.
- Full `packages/runner` suite on the behavioral commit: 1157 passed, 0 failed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5508?utm_source=github" target="_blank" rel="noopener noreferrer nofollow"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
