### PR TITLE
refactor(runtime-client): remove the dead legacy-meta home fast path

### DIFF
--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -13,7 +13,6 @@ import {
   renderMembershipProviderFor,
   RuntimeProcessor,
   sanitizeForPostMessage,
-  shouldReconcileHomeRoot,
 } from "./runtime-processor.ts";
 import { atomsOutsideCeiling } from "@commonfabric/runner/cfc";
 import { cfcAtom } from "@commonfabric/api/cfc";
@@ -1412,17 +1411,13 @@ describe("RuntimeProcessor blob upload IPC", () => {
 });
 
 describe("RuntimeProcessor home pattern IPC", () => {
-  it("reconciles the home root when the update flag is enabled", () => {
-    expect(shouldReconcileHomeRoot({ experimental: {} })).toBe(false);
-    expect(shouldReconcileHomeRoot({
-      experimental: { systemPatternAutoUpdate: false },
-    })).toBe(false);
-    expect(shouldReconcileHomeRoot({
-      experimental: { systemPatternAutoUpdate: true },
-    })).toBe(true);
-  });
-
-  it("uses the default-pattern metadata fast path when the home pattern is already instantiated", async () => {
+  it("routes the home root through ensureDefaultPattern even when the legacy pattern meta is present", async () => {
+    // The sharpest pin of the always-controller contract: even with a legacy
+    // `pattern` meta present and the update flag unset, the handler reaches
+    // ensureDefaultPattern — the leg carrying the cold-start setup repair —
+    // and never starts the pattern directly. A metadata shortcut in front of
+    // the controller would skip that repair, and with the flag unset (every
+    // default deployment) nothing else heals an aged home root.
     const defaultPatternRef: CellRef = {
       id: "of:default-pattern-result" as CellRef["id"],
       space: "did:key:test-home" as CellRef["space"],
@@ -1435,73 +1430,10 @@ describe("RuntimeProcessor home pattern IPC", () => {
       scope: "space",
       path: [],
     };
-    let startedCell: unknown;
-    let idleCalled = false;
-    let defaultPatternSynced = false;
-
     const defaultPatternCell = {
       ...defaultPatternRef,
       getAsLink: () => cellRefToSigilLink(defaultPatternRef),
       getAsNormalizedFullLink: () => defaultPatternRef,
-      getMetaRaw: (metaField: string) =>
-        defaultPatternSynced && metaField === "pattern"
-          ? cellRefToSigilLink(patternRef)
-          : undefined,
-      sync: () => {
-        defaultPatternSynced = true;
-        return Promise.resolve();
-      },
-    };
-    const processor = {
-      runtime: {
-        getHomeSpaceCell: () => ({
-          sync: () => Promise.resolve(),
-          key: (key: string) => {
-            expect(key).toBe("defaultPattern");
-            return {
-              get: () => ({
-                resolveAsCell: () => defaultPatternCell,
-              }),
-            };
-          },
-        }),
-        start: (cell: unknown) => {
-          startedCell = cell;
-          return Promise.resolve();
-        },
-        idle: () => {
-          idleCalled = true;
-          return Promise.resolve();
-        },
-      },
-    } as unknown as RuntimeProcessor;
-
-    await expect(
-      RuntimeProcessor.prototype.handleEnsureHomePatternRunning.call(
-        processor,
-        { type: RequestType.EnsureHomePatternRunning },
-      ),
-    ).resolves.toEqual({ cell: defaultPatternRef });
-    expect(startedCell).toBe(defaultPatternCell);
-    expect(idleCalled).toBe(true);
-  });
-
-  it("routes an update-enabled home root through ensure before start", async () => {
-    const defaultPatternRef: CellRef = {
-      id: "of:update-enabled-home-root" as CellRef["id"],
-      space: "did:key:test-home" as CellRef["space"],
-      scope: "space",
-      path: [],
-    };
-    const patternRef: CellRef = {
-      id: "of:update-enabled-home-pattern" as CellRef["id"],
-      space: "did:key:test-home" as CellRef["space"],
-      scope: "space",
-      path: [],
-    };
-    const defaultPatternCell = {
-      ...defaultPatternRef,
-      getAsLink: () => cellRefToSigilLink(defaultPatternRef),
       getMetaRaw: (metaField: string) =>
         metaField === "pattern" ? cellRefToSigilLink(patternRef) : undefined,
       sync: () => Promise.resolve(),
@@ -1509,7 +1441,7 @@ describe("RuntimeProcessor home pattern IPC", () => {
     let startedDirectly = false;
     const runtime = {
       userIdentityDID: "did:key:test-home",
-      experimental: { systemPatternAutoUpdate: true },
+      experimental: {},
       getHomeSpaceCell: () => ({
         sync: () => Promise.resolve(),
         key: () => ({

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -202,13 +202,6 @@ function resolveBlobUrl(url: string, apiUrl: URL, space: DID): string {
   return new URL(url, spaceBaseUrl).href;
 }
 
-/** Whether the home root must take the reconcile-before-start path. */
-export function shouldReconcileHomeRoot(
-  runtime: Pick<Runtime, "experimental">,
-): boolean {
-  return runtime.experimental?.systemPatternAutoUpdate === true;
-}
-
 /**
  * Map host-decided `InitializationData` onto `runtimePresets.browserWorker`
  * params (CT-1814): the shared first-party posture (CFC pins,
@@ -1156,28 +1149,12 @@ export class RuntimeProcessor {
     const homeSpaceCell = this.runtime.getHomeSpaceCell();
     await homeSpaceCell.sync();
 
-    const defaultPatternCell = homeSpaceCell.key("defaultPattern").get()
-      .resolveAsCell();
-    await defaultPatternCell.sync();
-
-    // Fast path: pattern already exists. When home auto-update is enabled,
-    // deliberately fall through to PiecesController.ensureDefaultPattern():
-    // it reconciles the persisted identity before starting the root. Starting
-    // here first would recreate the stale-root bootstrap dependency.
-    // (Value is a Cell itself, and pattern metadata means it's instantiated)
-    // We've followed all the links from "defaultPattern", so our cell should
-    // be the result cell for the default pattern.
-    const reconcileHome = shouldReconcileHomeRoot(this.runtime);
-    if (getMetaLink(defaultPatternCell, "pattern") && !reconcileHome) {
-      await this.runtime.start(defaultPatternCell);
-      await this.runtime.idle();
-      return {
-        cell: createCellRef(defaultPatternCell),
-      };
-    }
-
-    // Pattern is absent, or update-enabled and must be reconciled before start:
-    // use the home-space PiecesController for the complete ensure sequence.
+    // Always the PiecesController path: ensureDefaultPattern() reconciles the
+    // persisted identity and carries the cold-start setup repair that heals an
+    // aged home root. Starting the pattern directly here would skip that
+    // repair, and with systemPatternAutoUpdate unset (every default
+    // deployment) nothing else heals the root — so no fast path belongs in
+    // front of the controller.
     const homeSession: Session = {
       as: this.identity,
       space: this.runtime.userIdentityDID,


### PR DESCRIPTION
## Why

`handleEnsureHomePatternRunning`'s fast path was keyed on the legacy `pattern` meta, which no current doc carries — verified against a real aged home store, where every request fell through to `PiecesController.ensureDefaultPattern()` regardless of the flag. Dead in practice, but worse than dead: the controller path is what carries the un-gated cold-start setup repair, so "fixing" the predicate to current metadata would have **bypassed the heal** and re-bricked aged home roots wherever `systemPatternAutoUpdate` is unset (every default deployment). It also misled a real investigation into believing the flag selected the path taken.

## What Changed

- `handleEnsureHomePatternRunning` always takes the controller path; the dead `defaultPatternCell` dereference goes with the branch, and the comment records why the shortcut must not come back.
- `shouldReconcileHomeRoot` (only consumer: the deleted branch) removed.
- Tests: the three home-pattern-IPC tests collapse into one pin of the new contract, deliberately using the exact configuration the fast path used to claim (legacy meta present, flag unset) and asserting the controller is reached with no direct start.

## Test plan

- `packages/runtime-client`: **55 passed (195 steps), 0 failed**.
- `deno fmt` / `deno lint` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

