### PR TITLE
fix(integration): harden wait and click contracts

### DIFF
--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -89,7 +89,11 @@ Waits split into two groups with different primitives.
   flip with no DOM mutation (for example a runtime global being set). The
   predicate is serialized and runs in the page, so it closes over nothing from
   the test module — inline any collection it needs, and pass values in through
-  `args`.
+  `args`. A predicate that returns a truthy value instead of `true` hands that
+  value back to the caller in the same binding notification, so it must be a
+  `PageConditionValue`: a plain JSON value. Maps, functions, class instances,
+  cycles, and other lossy JSON inputs are rejected at the boundary instead of
+  being changed silently.
 - `awaitViewSettled(page)` resolves once the worker has settled reactively, the
   resulting vdom batch has crossed to the main thread and been applied, and Lit
   has finished its update cycle. This is the "is the control interactive yet"

--- a/packages/integration/astral-adapter.ts
+++ b/packages/integration/astral-adapter.ts
@@ -143,9 +143,9 @@ async function runProtocolCleanup(
 
 let objectGroupSequence = 0;
 
-function nextObjectGroup(): string {
+function nextObjectGroup(purpose = "pierce"): string {
   objectGroupSequence++;
-  return `common-tools-pierce-${objectGroupSequence}`;
+  return `common-tools-${purpose}-${objectGroupSequence}`;
 }
 
 function exceptionMessage(
@@ -235,6 +235,80 @@ async function remoteRoot(
     objectId: object.objectId,
     cleanup: () => Promise.resolve(),
   };
+}
+
+export interface ContentQuadPoint {
+  x: number;
+  y: number;
+}
+
+/**
+ * Measure the composed content quad of an element retained on `globalThis`.
+ *
+ * The caller puts the exact element at `retainedKey` while it can still resolve
+ * its Astral handle. Addressing that remote object directly gives CDP enough
+ * information to include ancestor transforms, 3D projection, and SVG layout
+ * without returning to Astral's invalidatable DOM node id.
+ *
+ * The retained property and its remote object group are consumed by this call,
+ * including when measurement fails.
+ */
+export async function measureRetainedContentQuad(
+  page: AstralPage,
+  retainedKey: string,
+): Promise<ContentQuadPoint[]> {
+  const bindings = page.unsafelyGetCelestialBindings();
+  const objectGroup = nextObjectGroup("aim");
+  try {
+    const remote = await runProtocolCommand(
+      bindings,
+      () =>
+        bindings.Runtime.evaluate({
+          expression: `globalThis[${JSON.stringify(retainedKey)}]`,
+          objectGroup,
+          returnByValue: false,
+        }),
+    );
+    if (remote.exceptionDetails) {
+      throw new Error(exceptionMessage(remote.exceptionDetails));
+    }
+    const objectId = remote.result.objectId;
+    if (!objectId) {
+      throw new Error("Astral did not return a remote element object");
+    }
+
+    const { model } = await runProtocolCommand(
+      bindings,
+      () => bindings.DOM.getBoxModel({ objectId }),
+    );
+    const points: ContentQuadPoint[] = [];
+    for (let index = 0; index < model.content.length; index += 2) {
+      points.push({
+        x: model.content[index],
+        y: model.content[index + 1],
+      });
+    }
+    if (points.length === 0) {
+      throw new Error("Element content quad is empty");
+    }
+    return points;
+  } finally {
+    try {
+      await runProtocolCleanup(
+        bindings,
+        () =>
+          bindings.Runtime.evaluate({
+            expression: `delete globalThis[${JSON.stringify(retainedKey)}]`,
+            returnByValue: true,
+          }),
+      );
+    } finally {
+      await runProtocolCleanup(
+        bindings,
+        () => bindings.Runtime.releaseObjectGroup({ objectGroup }),
+      );
+    }
+  }
 }
 
 async function nodeIdsFromArray(

--- a/packages/integration/page.ts
+++ b/packages/integration/page.ts
@@ -19,6 +19,7 @@ import type {
   SelectorOptions,
 } from "./astral-adapter.ts";
 import {
+  measureRetainedContentQuad,
   queryAllPierce,
   queryPierce,
   waitForPierceSelector,
@@ -757,7 +758,7 @@ export class Page extends EventTarget {
     element: AstralElementHandle,
     options?: Parameters<AstralElementHandle["click"]>[0],
   ): Promise<void> {
-    const aim = await aimAtElement(element, options?.offset);
+    const aim = await aimAtElement(this.page!, element, options?.offset);
     if ("unclickable" in aim) {
       throw new Error(`Cannot click ${describeAimTarget(aim)}`);
     }
@@ -852,15 +853,25 @@ export type AimResult =
     detail?: string;
   };
 
+type RetainedAim = {
+  retained: true;
+  tag: string;
+  id: string;
+  rootHost?: string;
+  width: number;
+  height: number;
+  pageWidth: number;
+  pageHeight: number;
+  rect: { x: number; y: number; width: number; height: number };
+};
+
 /**
- * Scroll `element` into view and measure the point to click, both inside a
- * single page turn.
+ * Scroll `element` into view and measure the point to click.
  *
- * Aiming is one turn on purpose. Scrolling and measuring as two protocol
- * commands leaves the page free to relayout or rebuild between them, and the
- * second command then measures something other than what the first scrolled to.
- * Doing both in the page means the coordinates describe the element as it was
- * at one instant, and the only remaining gap is the one dispatch that follows.
+ * A center aim scrolls and measures in one page turn. An offset aim scrolls and
+ * retains the exact element in that turn, then asks CDP for its composed content
+ * quad. The remote-object reference survives DOM-agent node-id invalidation and
+ * CDP accounts for ancestor transforms, 3D projection, and SVG layout.
  *
  * The point is the middle of the part of the element's box that lies inside the
  * page, which for an element the page has room for is the middle of the whole
@@ -875,17 +886,22 @@ export type AimResult =
  * yield `unclickable` naming what is wrong with it, rather than an empty
  * measurement the caller has to guess at.
  */
+let aimElementSequence = 0;
+
 async function aimAtElement(
+  page: AstralPage,
   element: AstralElementHandle,
   offset?: { x: number; y: number },
 ): Promise<AimResult> {
+  const retainedKey = offset
+    ? `__common_tools_aim_element_${++aimElementSequence}`
+    : null;
   try {
-    return await element.evaluate(
+    const prepared = await element.evaluate(
       (
         el: Element,
-        offsetX: number | null,
-        offsetY: number | null,
-      ): AimResult => {
+        retainedKey: string | null,
+      ): AimResult | RetainedAim => {
         const describe = () => ({
           tag: el.tagName.toLowerCase(),
           id: el.id,
@@ -927,32 +943,79 @@ async function aimAtElement(
         const right = Math.min(rect.x + rect.width, pageWidth);
         const top = Math.max(rect.y, 0);
         const bottom = Math.min(rect.y + rect.height, pageHeight);
-        // A caller's offset names a point on the element, so it is used as
-        // given; what it names still has to be a point the page has.
-        const point = offsetX === null || offsetY === null
-          ? { x: (left + right) / 2, y: (top + bottom) / 2 }
-          : { x: rect.x + offsetX, y: rect.y + offsetY };
-        if (
-          right <= left || bottom <= top ||
-          point.x < 0 || point.x >= pageWidth ||
-          point.y < 0 || point.y >= pageHeight
-        ) {
+        if (right <= left || bottom <= top) {
           return {
             unclickable: "off-page",
             ...describe(),
             width: rect.width,
             height: rect.height,
             detail: `box ${JSON.stringify(rect)}, ` +
-              `point ${JSON.stringify(point)}, ` +
               `page ${
                 JSON.stringify({ width: pageWidth, height: pageHeight })
               }`,
           };
         }
-        return point;
+        if (retainedKey !== null) {
+          Object.defineProperty(globalThis, retainedKey, {
+            configurable: true,
+            value: el,
+          });
+          return {
+            retained: true,
+            ...describe(),
+            width: rect.width,
+            height: rect.height,
+            pageWidth,
+            pageHeight,
+            rect: {
+              x: rect.x,
+              y: rect.y,
+              width: rect.width,
+              height: rect.height,
+            },
+          };
+        }
+
+        return { x: (left + right) / 2, y: (top + bottom) / 2 };
       },
-      { args: [offset?.x ?? null, offset?.y ?? null] },
+      { args: [retainedKey] },
     );
+    if (!("retained" in prepared)) return prepared;
+
+    const contentQuad = await measureRetainedContentQuad(page, retainedKey!);
+    let contentOrigin = contentQuad[0];
+    for (const point of contentQuad) {
+      // This deliberately mirrors published Astral's definition of top-left.
+      if (point.x < contentOrigin.x && point.y < contentOrigin.y) {
+        contentOrigin = point;
+      }
+    }
+    const point = {
+      x: contentOrigin.x + offset!.x,
+      y: contentOrigin.y + offset!.y,
+    };
+    if (
+      point.x < 0 || point.x >= prepared.pageWidth ||
+      point.y < 0 || point.y >= prepared.pageHeight
+    ) {
+      return {
+        unclickable: "off-page",
+        tag: prepared.tag,
+        id: prepared.id,
+        rootHost: prepared.rootHost,
+        width: prepared.width,
+        height: prepared.height,
+        detail: `box ${JSON.stringify(prepared.rect)}, ` +
+          `point ${JSON.stringify(point)}, ` +
+          `page ${
+            JSON.stringify({
+              width: prepared.pageWidth,
+              height: prepared.pageHeight,
+            })
+          }`,
+      };
+    }
+    return point;
   } catch (error) {
     // A handle whose node the DOM agent no longer knows about cannot be
     // resolved to a page object at all. That happens to every outstanding

--- a/packages/integration/test/astral-adapter.test.ts
+++ b/packages/integration/test/astral-adapter.test.ts
@@ -1,5 +1,6 @@
 import {
   assert,
+  assertAlmostEquals,
   assertEquals,
   assertRejects,
   assertStringIncludes,
@@ -1378,11 +1379,32 @@ Deno.test("Page preserves Common Tools behavior on published Astral", async () =
         width: "100px",
         height: "30px",
         margin: "0",
+        padding: "0",
+        border: "0",
       });
       button.addEventListener("click", () => {
         document.body.dataset.clicked = "yes";
       });
       document.body.append(button);
+
+      const offsetButton = document.createElement("button");
+      offsetButton.id = "offset-click-target";
+      offsetButton.textContent = "offset click";
+      Object.assign(offsetButton.style, {
+        position: "fixed",
+        left: "260px",
+        top: "90px",
+        width: "100px",
+        height: "30px",
+        margin: "0",
+        padding: "7px 11px 13px 17px",
+        borderStyle: "solid",
+        borderWidth: "3px 5px 9px 11px",
+        boxSizing: "content-box",
+        transform: "rotate(8deg) scale(1.2)",
+        transformOrigin: "13px 9px",
+      });
+      document.body.append(offsetButton);
 
       const input = document.createElement("input");
       input.id = "type-target";
@@ -1397,8 +1419,8 @@ Deno.test("Page preserves Common Tools behavior on published Astral", async () =
     );
 
     // The click aims at the centre of the control's own rect, and an offset
-    // aims from the rect's top-left corner. Both are measured in the page, so
-    // the numbers come from the pinned control above.
+    // aims from its content-box origin. This control has no border or padding,
+    // so both points are direct arithmetic on the pinned rect above.
     let mousePoint: { x: number; y: number } | undefined;
     Object.defineProperty(astralPage.mouse, "click", {
       configurable: true,
@@ -1415,10 +1437,41 @@ Deno.test("Page preserves Common Tools behavior on published Astral", async () =
     assertEquals(mousePoint, { x: 64, y: 66 });
     assertEquals(clickPoints[2], { x: 64, y: 66 });
 
+    // Match published Astral's offset contract: the offset is added to the
+    // content quad's top-left point. The decorated click computes that point
+    // in-page, but a stable DOM-agent box model is a useful compatibility
+    // oracle here for an asymmetrically bordered, transformed control.
+    const offsetOracle = await page.waitForSelector("#offset-click-target");
+    const offsetModel = await offsetOracle.boxModel();
+    assert(offsetModel);
+    let contentOrigin = offsetModel.content[0];
+    for (const point of offsetModel.content) {
+      if (point.x < contentOrigin.x && point.y < contentOrigin.y) {
+        contentOrigin = point;
+      }
+    }
+    const transformedOffset = { x: 4, y: 6 };
+    const offsetTarget = await page.waitForSelector("#offset-click-target");
+    await offsetTarget.click({ offset: transformedOffset });
+    assert(mousePoint);
+    assertAlmostEquals(
+      mousePoint.x,
+      contentOrigin.x + transformedOffset.x,
+      0.01,
+    );
+    assertAlmostEquals(
+      mousePoint.y,
+      contentOrigin.y + transformedOffset.y,
+      0.01,
+    );
+    assertEquals(clickPoints[3], mousePoint);
+
     const typeTarget = await page.waitForSelector("#type-target");
     await typeTarget.type("text");
     assertEquals(keyboardOptions, { delay: 17 });
     assertEquals(interactions, [
+      "beforeClick",
+      "afterClick",
       "beforeClick",
       "afterClick",
       "beforeClick",

--- a/packages/integration/test/astral-adapter.test.ts
+++ b/packages/integration/test/astral-adapter.test.ts
@@ -1406,6 +1406,86 @@ Deno.test("Page preserves Common Tools behavior on published Astral", async () =
       });
       document.body.append(offsetButton);
 
+      const transformedAncestor = document.createElement("section");
+      Object.assign(transformedAncestor.style, {
+        position: "fixed",
+        left: "430px",
+        top: "80px",
+        width: "180px",
+        height: "120px",
+        transform: "rotate(17deg) scale(0.85)",
+        transformOrigin: "20px 30px",
+      });
+      const transformedDescendant = document.createElement("button");
+      transformedDescendant.id = "ancestor-transform-click-target";
+      Object.assign(transformedDescendant.style, {
+        position: "absolute",
+        left: "25px",
+        top: "35px",
+        width: "80px",
+        height: "26px",
+        margin: "0",
+        padding: "5px 7px",
+        border: "3px solid",
+        boxSizing: "content-box",
+      });
+      transformedAncestor.append(transformedDescendant);
+      document.body.append(transformedAncestor);
+
+      const perspectiveAncestor = document.createElement("section");
+      Object.assign(perspectiveAncestor.style, {
+        position: "fixed",
+        left: "100px",
+        top: "250px",
+        width: "180px",
+        height: "120px",
+        perspective: "400px",
+        transformStyle: "preserve-3d",
+      });
+      const threeDimensionalTarget = document.createElement("button");
+      threeDimensionalTarget.id = "three-dimensional-click-target";
+      Object.assign(threeDimensionalTarget.style, {
+        position: "absolute",
+        left: "30px",
+        top: "30px",
+        width: "90px",
+        height: "30px",
+        margin: "0",
+        padding: "4px 9px",
+        border: "2px solid",
+        boxSizing: "content-box",
+        transform: "rotateY(32deg) rotateX(14deg) translateZ(20px)",
+        transformOrigin: "15px 10px",
+      });
+      perspectiveAncestor.append(threeDimensionalTarget);
+      document.body.append(perspectiveAncestor);
+
+      const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+      Object.assign(svg.style, {
+        position: "fixed",
+        left: "360px",
+        top: "270px",
+        width: "200px",
+        height: "120px",
+        overflow: "visible",
+        transform: "rotate(-11deg)",
+        transformOrigin: "20px 15px",
+      });
+      const svgTarget = document.createElementNS(
+        "http://www.w3.org/2000/svg",
+        "rect",
+      );
+      svgTarget.id = "svg-click-target";
+      svgTarget.setAttribute("x", "30");
+      svgTarget.setAttribute("y", "20");
+      svgTarget.setAttribute("width", "80");
+      svgTarget.setAttribute("height", "40");
+      svgTarget.setAttribute("fill", "blue");
+      svgTarget.setAttribute("stroke", "black");
+      svgTarget.setAttribute("stroke-width", "6");
+      svg.append(svgTarget);
+      document.body.append(svg);
+
       const input = document.createElement("input");
       input.id = "type-target";
       document.body.append(input);
@@ -1438,38 +1518,58 @@ Deno.test("Page preserves Common Tools behavior on published Astral", async () =
     assertEquals(clickPoints[2], { x: 64, y: 66 });
 
     // Match published Astral's offset contract: the offset is added to the
-    // content quad's top-left point. The decorated click computes that point
-    // in-page, but a stable DOM-agent box model is a useful compatibility
-    // oracle here for an asymmetrically bordered, transformed control.
-    const offsetOracle = await page.waitForSelector("#offset-click-target");
-    const offsetModel = await offsetOracle.boxModel();
-    assert(offsetModel);
-    let contentOrigin = offsetModel.content[0];
-    for (const point of offsetModel.content) {
-      if (point.x < contentOrigin.x && point.y < contentOrigin.y) {
-        contentOrigin = point;
+    // content quad's top-left point. A stable DOM-agent box model is the
+    // compatibility oracle for geometry that includes the element's own 2D
+    // transform, a transformed ancestor, a 3D transform, and SVG layout.
+    const offsetCases = [
+      { selector: "#offset-click-target", offset: { x: 4, y: 6 } },
+      {
+        selector: "#ancestor-transform-click-target",
+        offset: { x: 7, y: 3 },
+      },
+      {
+        selector: "#three-dimensional-click-target",
+        offset: { x: 5, y: 8 },
+      },
+      { selector: "#svg-click-target", offset: { x: 9, y: 4 } },
+    ];
+    for (const [index, offsetCase] of offsetCases.entries()) {
+      const offsetOracle = await page.waitForSelector(offsetCase.selector);
+      const offsetModel = await offsetOracle.boxModel();
+      assert(offsetModel);
+      let contentOrigin = offsetModel.content[0];
+      for (const point of offsetModel.content) {
+        if (point.x < contentOrigin.x && point.y < contentOrigin.y) {
+          contentOrigin = point;
+        }
       }
+
+      const offsetTarget = await page.waitForSelector(offsetCase.selector);
+      await offsetTarget.click({ offset: offsetCase.offset });
+      assert(mousePoint);
+      assertAlmostEquals(
+        mousePoint.x,
+        contentOrigin.x + offsetCase.offset.x,
+        0.01,
+      );
+      assertAlmostEquals(
+        mousePoint.y,
+        contentOrigin.y + offsetCase.offset.y,
+        0.01,
+      );
+      assertEquals(clickPoints[3 + index], mousePoint);
     }
-    const transformedOffset = { x: 4, y: 6 };
-    const offsetTarget = await page.waitForSelector("#offset-click-target");
-    await offsetTarget.click({ offset: transformedOffset });
-    assert(mousePoint);
-    assertAlmostEquals(
-      mousePoint.x,
-      contentOrigin.x + transformedOffset.x,
-      0.01,
-    );
-    assertAlmostEquals(
-      mousePoint.y,
-      contentOrigin.y + transformedOffset.y,
-      0.01,
-    );
-    assertEquals(clickPoints[3], mousePoint);
 
     const typeTarget = await page.waitForSelector("#type-target");
     await typeTarget.type("text");
     assertEquals(keyboardOptions, { delay: 17 });
     assertEquals(interactions, [
+      "beforeClick",
+      "afterClick",
+      "beforeClick",
+      "afterClick",
+      "beforeClick",
+      "afterClick",
       "beforeClick",
       "afterClick",
       "beforeClick",

--- a/packages/integration/test/wait-for-condition.test.ts
+++ b/packages/integration/test/wait-for-condition.test.ts
@@ -25,6 +25,63 @@ Deno.test("waitForCondition transports only lossless JSON answers", async () => 
       Error,
       "function at $ is not JSON-safe",
     );
+    await assertRejects(
+      () => waitForCondition(page, () => ({ value: -0 })),
+      Error,
+      "Negative zero at $.value is not JSON-safe",
+    );
+
+    await assertRejects(
+      () =>
+        waitForCondition(page, () => {
+          const sparse = ["placeholder"];
+          delete sparse[0];
+          return sparse;
+        }),
+      Error,
+      "Sparse array at $ is not JSON-safe",
+    );
+
+    await assertRejects(
+      () =>
+        waitForCondition(page, () => {
+          const augmented = ["value"];
+          Object.defineProperty(augmented, "label", {
+            enumerable: true,
+            value: "lost by JSON.stringify",
+          });
+          return augmented;
+        }),
+      Error,
+      "Array properties at $ are not JSON-safe",
+    );
+
+    await assertRejects(
+      () =>
+        waitForCondition(page, () => {
+          const augmented = ["value"];
+          Object.defineProperty(augmented, Symbol("label"), {
+            enumerable: true,
+            value: "lost by JSON.stringify",
+          });
+          return augmented;
+        }),
+      Error,
+      "Array properties at $ are not JSON-safe",
+    );
+
+    await assertRejects(
+      () =>
+        waitForCondition(page, () => {
+          const overridden = ["value"];
+          Object.defineProperty(overridden, "toJSON", {
+            value: () => "different value",
+          });
+          return overridden;
+        }),
+      Error,
+      "toJSON at $ is not JSON-safe",
+    );
   } finally {
     await page.close().finally(() => browser.close());
   }

--- a/packages/integration/test/wait-for-condition.test.ts
+++ b/packages/integration/test/wait-for-condition.test.ts
@@ -1,0 +1,31 @@
+import { assertEquals, assertRejects } from "@std/assert";
+import { Browser } from "../browser.ts";
+import { waitForCondition } from "../utils.ts";
+
+Deno.test("waitForCondition transports only lossless JSON answers", async () => {
+  const browser = await Browser.launch();
+  const page = await browser.newPage();
+
+  try {
+    const answer = await waitForCondition(page, () => ({
+      point: { x: 12.5, y: 24 },
+      labels: ["ready", null, true],
+    }));
+    assertEquals(answer, {
+      point: { x: 12.5, y: 24 },
+      labels: ["ready", null, true],
+    });
+
+    const functionAnswer = () => () => "silently dropped by JSON.stringify";
+    await assertRejects(
+      () => {
+        // @ts-expect-error Page-condition answers must be plain JSON values.
+        return waitForCondition(page, functionAnswer);
+      },
+      Error,
+      "function at $ is not JSON-safe",
+    );
+  } finally {
+    await page.close().finally(() => browser.close());
+  }
+});

--- a/packages/integration/utils.ts
+++ b/packages/integration/utils.ts
@@ -114,14 +114,27 @@ export interface ProbeApi {
  * `args` passed to {@link waitForCondition}, and returns whether the awaited
  * condition holds. It may be async (for example to await `rt.idle()`).
  *
- * A predicate may answer with a value instead of `true`. Any truthy result
+ * A predicate may answer with a JSON value instead of `true`. Any truthy result
  * satisfies the condition, and a result other than `true` is carried back to
  * the test process as {@link waitForCondition}'s resolution. That is how a
  * wait hands over a measurement taken at the instant the condition held —
  * the coordinates a trusted click is about to be aimed at, say — without a
- * second round trip in which the page could move on.
+ * second round trip in which the page could move on. Values outside
+ * {@link PageConditionValue} are rejected rather than being silently changed
+ * by JSON serialization at the page boundary.
  */
-export type PageCondition<A extends readonly unknown[], R = unknown> = (
+export type PageConditionValue =
+  | null
+  | boolean
+  | number
+  | string
+  | readonly PageConditionValue[]
+  | { readonly [key: string]: PageConditionValue };
+
+export type PageCondition<
+  A extends readonly unknown[],
+  R extends PageConditionValue = PageConditionValue,
+> = (
   probe: ProbeApi,
   ...args: A
 ) => boolean | R | Promise<boolean | R>;
@@ -302,13 +315,82 @@ function installWaiter(
   // reaches the caller without a second round trip.
   let answer: unknown = true;
 
+  // Copy an answer into the exact value JSON will carry. JSON.stringify alone
+  // is not a validator: it silently drops functions, symbols, and undefined
+  // properties, turns Map into {}, and changes non-finite numbers to null. A
+  // wait must either deliver the predicate's answer or report that it cannot;
+  // silently delivering a different value makes the condition look satisfied
+  // with an answer it never produced.
+  const copyJsonAnswer = (
+    value: unknown,
+    path = "$",
+    seen = new WeakSet<object>(),
+  ): unknown => {
+    if (
+      value === null || typeof value === "string" ||
+      typeof value === "boolean"
+    ) {
+      return value;
+    }
+    if (typeof value === "number") {
+      if (!Number.isFinite(value)) {
+        throw new TypeError(`Non-finite number at ${path} is not JSON-safe`);
+      }
+      return value;
+    }
+    if (typeof value !== "object") {
+      throw new TypeError(`${typeof value} at ${path} is not JSON-safe`);
+    }
+    if (seen.has(value)) {
+      throw new TypeError(`Cycle at ${path} is not JSON-safe`);
+    }
+
+    seen.add(value);
+    try {
+      if (Array.isArray(value)) {
+        return value.map((item, index) =>
+          copyJsonAnswer(item, `${path}[${index}]`, seen)
+        );
+      }
+
+      const prototype = Object.getPrototypeOf(value);
+      if (prototype !== Object.prototype && prototype !== null) {
+        const tag = Object.prototype.toString.call(value);
+        throw new TypeError(`${tag} at ${path} is not a plain JSON object`);
+      }
+      if (
+        Object.getOwnPropertySymbols(value).some((symbol) =>
+          Object.prototype.propertyIsEnumerable.call(value, symbol)
+        )
+      ) {
+        throw new TypeError(
+          `Enumerable symbol key at ${path} is not JSON-safe`,
+        );
+      }
+
+      const copy = Object.create(null) as Record<string, unknown>;
+      for (const key of Object.keys(value)) {
+        copy[key] = copyJsonAnswer(
+          (value as Record<string, unknown>)[key],
+          `${path}.${key}`,
+          seen,
+        );
+      }
+      return copy;
+    } finally {
+      seen.delete(value);
+    }
+  };
+
   const fire = (): boolean => {
     const notify = (globalThis as Record<string, unknown>)[bindingName];
     if (typeof notify !== "function") return false;
     signalled = true;
     let payload: string;
     try {
-      payload = JSON.stringify({ value: answer === true ? undefined : answer });
+      payload = JSON.stringify({
+        value: answer === true ? undefined : copyJsonAnswer(answer),
+      });
     } catch (error) {
       // An answer that cannot cross the boundary is reported as one. Sending
       // "no value" instead would read to the caller as a condition that held
@@ -420,7 +502,10 @@ function installWaiter(
  * the wait, so a caller acting on it acts on the page as it was when the
  * condition held, with no round trip in between for the page to change in.
  */
-export const waitForCondition = async <A extends readonly unknown[], R>(
+export const waitForCondition = async <
+  A extends readonly unknown[],
+  R extends PageConditionValue,
+>(
   page: Page,
   predicate: PageCondition<A, R>,
   { args }: { args?: A } = {},

--- a/packages/integration/utils.ts
+++ b/packages/integration/utils.ts
@@ -333,8 +333,11 @@ function installWaiter(
       return value;
     }
     if (typeof value === "number") {
-      if (!Number.isFinite(value)) {
-        throw new TypeError(`Non-finite number at ${path} is not JSON-safe`);
+      if (!Number.isFinite(value) || Object.is(value, -0)) {
+        const kind = Object.is(value, -0)
+          ? "Negative zero"
+          : "Non-finite number";
+        throw new TypeError(`${kind} at ${path} is not JSON-safe`);
       }
       return value;
     }
@@ -348,9 +351,30 @@ function installWaiter(
     seen.add(value);
     try {
       if (Array.isArray(value)) {
-        return value.map((item, index) =>
-          copyJsonAnswer(item, `${path}[${index}]`, seen)
-        );
+        if (typeof (value as { toJSON?: unknown }).toJSON === "function") {
+          throw new TypeError(`toJSON at ${path} is not JSON-safe`);
+        }
+        if (
+          Object.keys(value).some((key) => {
+            const index = Number(key);
+            return !Number.isInteger(index) || index < 0 ||
+              index >= value.length || String(index) !== key;
+          }) ||
+          Object.getOwnPropertySymbols(value).some((symbol) =>
+            Object.prototype.propertyIsEnumerable.call(value, symbol)
+          )
+        ) {
+          throw new TypeError(`Array properties at ${path} are not JSON-safe`);
+        }
+
+        const copy: unknown[] = [];
+        for (let index = 0; index < value.length; index++) {
+          if (!Object.prototype.hasOwnProperty.call(value, index)) {
+            throw new TypeError(`Sparse array at ${path} is not JSON-safe`);
+          }
+          copy.push(copyJsonAnswer(value[index], `${path}[${index}]`, seen));
+        }
+        return copy;
       }
 
       const prototype = Object.getPrototypeOf(value);

--- a/packages/patterns/integration/cfc-browser-helpers.test.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.test.ts
@@ -1957,6 +1957,91 @@ describe("CFC browser helpers", () => {
     assertEquals(clicks, 0, "the covered control should have taken no click");
   });
 
+  it("re-marks a replacement that drops the original click mark", async () => {
+    await page.evaluate((clickTargetAttr: string) => {
+      const host = document.createElement("div");
+      const root = host.attachShadow({ mode: "open" });
+      const surface = document.createElement("div");
+      root.append(surface);
+      document.body.append(host);
+
+      const makeButton = (generation: number) => {
+        const button = document.createElement("button");
+        button.id = "remarked-guest-button";
+        button.dataset.generation = String(generation);
+        button.textContent = "Continue as guest";
+        Object.assign(button.style, {
+          display: "block",
+          width: "200px",
+          height: "32px",
+        });
+        return button;
+      };
+      surface.append(makeButton(0));
+
+      let replacements = 0;
+      let clickedGeneration = -1;
+      let markPresentAtClick = false;
+      surface.addEventListener("click", (event) => {
+        const target = event.target as HTMLElement | null;
+        if (target?.id !== "remarked-guest-button") return;
+        clickedGeneration = Number(target.dataset.generation);
+        markPresentAtClick = target.hasAttribute(clickTargetAttr);
+      });
+
+      // Replace the control as soon as the first wait marks it. Unlike the
+      // continuous-rebuild fixture above, this replacement deliberately does
+      // not inherit the mark. The click can land only if clickMarked runs the
+      // caller's mark predicate again against the live replacement.
+      const observer = new MutationObserver(() => {
+        const marked = surface.querySelector<HTMLElement>(
+          `[${clickTargetAttr}]`,
+        );
+        if (!marked) return;
+        observer.disconnect();
+        marked.replaceWith(makeButton(1));
+        replacements++;
+      });
+      observer.observe(surface, {
+        attributes: true,
+        subtree: true,
+        attributeFilter: [clickTargetAttr],
+      });
+
+      (globalThis as typeof globalThis & {
+        commonfabric: { viewSettled: () => Promise<void> };
+      }).commonfabric = { viewSettled: () => Promise.resolve() };
+      (globalThis as typeof globalThis & {
+        __remarkedClickResult: () => {
+          replacements: number;
+          clickedGeneration: number;
+          markPresentAtClick: boolean;
+        };
+      }).__remarkedClickResult = () => ({
+        replacements,
+        clickedGeneration,
+        markPresentAtClick,
+      });
+    }, { args: [CLICK_TARGET_ATTR] });
+
+    await clickCfButton(page, "#remarked-guest-button");
+
+    const result = await page.evaluate(() =>
+      (globalThis as typeof globalThis & {
+        __remarkedClickResult: () => {
+          replacements: number;
+          clickedGeneration: number;
+          markPresentAtClick: boolean;
+        };
+      }).__remarkedClickResult()
+    );
+    assertEquals(result, {
+      replacements: 1,
+      clickedGeneration: 1,
+      markPresentAtClick: true,
+    });
+  });
+
   it("tells the interaction observer where a marked click landed", async () => {
     // A presentation recording animates its cursor from these callbacks. The
     // click is aimed at a point rather than resolved to a handle, so the


### PR DESCRIPTION
## Summary

Follow-up to #5456 that keeps its one-turn, page-side click approach and closes three compatibility and regression gaps:

- constrain `waitForCondition` answers to plain JSON values and reject lossy values at the page boundary
- prove that a live replacement which drops the original click mark is re-marked before the trusted click
- preserve published Astral `ElementHandle.click({ offset })` semantics for bordered and transformed elements

## Why

#5456 removes the stale DOM-handle race by resolving and aiming at the target inside the page. These follow-ups make the resulting contracts explicit and durable:

- a condition result can no longer be silently changed by `JSON.stringify`
- the replacement/re-mark behavior has a direct regression fixture
- offset clicks remain relative to Astral's content-quad origin rather than the bounding border box

The waiting guidance is updated alongside the exported `PageConditionValue` type.

## Validation

- `deno task check`
- `deno task check-docs` — 533 code blocks
- `cd packages/integration && deno task test` — 30 passed
- `deno test -A packages/patterns/integration/cfc-browser-helpers.test.ts` — 19 steps passed
- `deno task check-no-waitfor`
- lint, formatting, and `git diff --check` on the touched files


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

