### PR TITLE
repro(piece): CFC aborts swap-setup default-merge into owner-protected paths — design ruling needed (home-heal layer 6)

### DIFF
--- a/packages/piece/test/check-update-default-pattern.test.ts
+++ b/packages/piece/test/check-update-default-pattern.test.ts
@@ -123,6 +123,38 @@ const SOURCE_HOME_TWO_EXPORT = [
   "",
 ].join("\n");
 
+// A roll target whose ARGUMENT gains an owner-protected field with its default
+// outside the Cfc wrapper — home.tsx's own `profiles: Default<TrustedProfileList,
+// []>` shape. A stored doc predating the field forces swap-setup to merge the
+// default INTO an owner-protected path of the EXISTING argument doc, a write
+// no runtime-held policy input authorizes.
+const SOURCE_HOME_GUARDED_DEFAULT = [
+  "import { Cfc, Default, Writable, WriteAuthorizedBy, handler, pattern } from 'commonfabric';",
+  "const bump = handler<void, { count: Writable<number> }>((_, { count }) => {",
+  "  count.set((count.get() ?? 0) + 1);",
+  "});",
+  "type GuardedRow = { label: string };",
+  "const addGuardedRow = handler<",
+  "  { label?: string },",
+  "  { guarded: Writable<GuardedRow[]> }",
+  ">((event, { guarded }) => {",
+  "  guarded.push({ label: event.label ?? '' });",
+  "});",
+  "type CurrentPrincipal = { readonly __ctCurrentPrincipal: true };",
+  "type GuardedList = Cfc<",
+  "  WriteAuthorizedBy<GuardedRow[], typeof addGuardedRow>,",
+  "  { ownerPrincipal: CurrentPrincipal }",
+  ">;",
+  "export default pattern<{",
+  "  items?: string[];",
+  "  guarded: Default<GuardedList, []>;",
+  "}>(({ items }) => {",
+  "  const count = new Writable<number>(0).for('count');",
+  "  return { items, count, bump: bump({ count }) };",
+  "});",
+  "",
+].join("\n");
+
 const IMPORTED_MODULE_URL = "/api/patterns/system/update-marker.ts";
 
 // A same-host custom-app path, as home config would supply via
@@ -1828,6 +1860,54 @@ describe("checkAndUpdateDefaultPattern", () => {
     await (after as unknown as { pull: () => Promise<unknown> }).pull();
     const afterEvent = (await manager.getDefaultPattern(false))!;
     expect(afterEvent.key("count").get()).toBe(1);
+  });
+
+  it("swaps in a pattern whose argument adds an owner-protected defaulted field", async () => {
+    // The swap target's argument schema carries a Cfc-wrapped
+    // (writeAuthorizedBy) field with its default outside the wrapper —
+    // home.tsx's `profiles: Default<TrustedProfileList, []>` shape. The
+    // stored doc predates the field, so setup must merge the default into an
+    // owner-protected path of the EXISTING argument doc. Enforcement is on
+    // (the default here): that runtime-context write needs an authorizing
+    // write-policy input, and without one the whole swap transaction aborts
+    // with `cfc-relevant-transaction-not-prepared` (here the ownerPrincipal
+    // arm: "requires matching represents-principal integrity at /guarded";
+    // sibling arms of the same class report writeAuthorizedBy binding
+    // identity, or "missing schema write-policy input" per target doc) —
+    // fail-closed, with no recovery: the roll-forward backstop matches only
+    // the schema-migration token, not this reason, so the root stays pinned
+    // to an unloadable identity.
+    await setupHome({ systemPatternAutoUpdate: true });
+    expect(runtime.cfcEnforcementMode).not.toBe("disabled");
+    await controller.recreateDefaultPattern({
+      customProgram: {
+        main: "/custom-home.tsx",
+        files: [{ name: "/custom-home.tsx", contents: SOURCE_V1 }],
+      },
+    });
+    const root = (await manager.getDefaultPattern(false))!;
+    const staleRef = getPatternIdentityRef(root)!;
+    await manager.stopPiece(root);
+
+    stub.setSource(SOURCE_HOME_GUARDED_DEFAULT);
+    const restore = shadowLoadProbe(staleRef.identity, "undefined");
+    try {
+      expect(await controller.checkAndUpdateDefaultPattern()).toBe("updated");
+    } finally {
+      restore();
+    }
+    await runtime.idle();
+
+    const after = (await manager.getDefaultPattern(true))!;
+    await runtime.idle();
+    expect(getPatternIdentityRef(after)?.identity).toBe(
+      await identityForSource(
+        SOURCE_HOME_GUARDED_DEFAULT,
+        {},
+        HOME_PATTERN_PATH,
+      ),
+    );
+    expect(after.key("count").get()).toBe(0);
   });
 
   it("heals a root whose pinned pattern fails CFC migration by rolling forward to official", async () => {


### PR DESCRIPTION
**DRAFT — deliberately red.** This PR carries a repro test, not a fix: the fix's shape depends on a CFC design ruling. @seefeldb — the question below is yours; everything after it is context.

## The CFC question (blocking everything else)

**When pattern-update setup materializes schema defaults into an EXISTING doc, how should CFC authorize the write?**

Today the runtime's only self-authorization for materialization is the structural-provenance seed claim, which `prepare.ts` accepts **only together with doc-creation** (the `data-updating.ts` chokepoint records it exactly there, by design). Swap-setup's default-merge writes absent-key defaults into existing docs — on paths carrying `writeAuthorizedBy` / `ownerPrincipal` / ifc — with no authorizing input at all, so the entire swap transaction aborts fail-closed (`cfc-relevant-transaction-not-prepared`). Options as we see them — pick, refine, or replace:

1. **Extend the seed-materialization claim past doc-creation**, scoped hard: recorded only by the runtime chokepoint, only for absent-key→schema-default fills, only in pattern-update setup context.
2. **A distinct claim kind** ("pattern-update materialization") with its own prepare arm, leaving the seed claim's creation-only semantics untouched.
3. **Stop writing these defaults at setup**: leave absent keys absent on existing docs and rely on validation-time `Default<>` fill at the consumer boundary. (Interacts with the validator-gate board topic's fill semantics; makes setup's writes on aged docs near-empty.)
4. Something narrower you'd prefer.

Until one of these is chosen, the heal chain cannot finish for any CFC-rich home.

## Why this is the fleet blocker (layer 6 of the home heal)

The July chain (#4873 → #4883/#4899 → #4900 → #4926, plus #4967's roll-forward backstop) heals CFC-thin spaces — the throwaway repro testbed loads clean today. But a **rich** aged home dies one layer later, live on estuary right now (2026-08-07 console, space `did:key:z6MkowWh…g84dT`):

1. Stored root is a `cf-cell-context`-vintage home.tsx — the current toolchain rejects the intrinsic, so the source no longer compiles → unloadable → swap-eligible.
2. The pattern-updater engages and runs setup inside the swap transaction (correct, #4900/#4926 semantics).
3. Setup merges current-schema defaults into the existing docs. `home.tsx`'s own argument carries `profiles: Default<TrustedProfileList, []>` / `mru: Default<TrustedProfileMru, []>` — owner-protected fields with defaults outside the Cfc wrapper — and aged docs predate some of these keys, so the fill writes into owner-protected paths with no acting handler identity.
4. CFC rejects the commit; `swap-failed pattern update setup failed … StorageTransactionAborted … cfc-relevant-transaction-not-prepared`; fail-closed leaves the root pinned to the unloadable identity.
5. **No recovery path exists**: the #4967 roll-forward backstop triggers on the machine-tagged `CFC_SCHEMA_MIGRATION_INCOMPATIBLE_REASON` token only — this reason class never matches it.

Every long-lived home with owner-protected state is in this class. Enforcement is doing its job against a writer nobody anticipated; no data is at risk — the docs sit intact underneath.

## The repro (this PR)

One test in `check-update-default-pattern.test.ts`, following the file's stale-sourceless recipe: a V1 custom root is created and stopped, its identity made unloadable via the probe seam, and the official source replaced by `SOURCE_HOME_GUARDED_DEFAULT` — whose argument adds `guarded: Default<GuardedList, []>` where `GuardedList` is `Cfc<WriteAuthorizedBy<…>, { ownerPrincipal }>`, i.e. profile-home's `OwnerProtectedProfileWrite` wrapper in home.tsx's defaulted-argument placement. The test asserts the heal contract — `checkAndUpdateDefaultPattern()` returns `"updated"`, the identity rolls, setup ran, and the pattern instantiates — and fails today at the first assertion with:

```
swap-failed pattern update setup failed …
StorageTransactionAborted: CFC enforcement rejected commit: relevant transaction
was not prepared: ownerPrincipal requires matching represents-principal
integrity at /guarded
reason: cfc-relevant-transaction-not-prepared
```

It goes green with whichever fix the ruling produces. The file's other 69 steps stay green.

## Arm inventory (one class, three spellings)

The same setup write trips a per-annotation-kind arm of the same prepare-time rejection:

| Where | Message arm |
| --- | --- |
| Live estuary console (aged home) | `missing schema write-policy input for of:fid1:g6guyiUU…` (per-target-doc; the doc carries stored claims) |
| This repro (`ownerPrincipal` wrapper — `OwnerProtectedProfileWrite`'s shape) | `ownerPrincipal requires matching represents-principal integrity at /guarded` |
| `addIntegrity` container spelling (`TrustedProfileList`'s shape), tried during fixture design | `writeAuthorizedBy requires a trusted verified binding identity at /guarded` |

All three: `StorageTransactionAborted` / `cfc-relevant-transaction-not-prepared` from the same swap-setup write. One fix territory. (Reproducing the live console's per-doc arm exactly appears to need a target doc already bearing stored claims — a two-pattern fixture; deliberately not built until the design ruling says which arm the fix must prove out.)

## Coordination

The heal line is @bfollington's (#4900/#4926 lineage — this test extends the same file). Once the ruling lands, the red test's green becomes the acceptance criterion for the fix, here or in a successor PR. Estuary deploy note: the fix is the last gate before rich aged homes (including the reporting user's) heal on next load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

