### PR TITLE
fix(cf-harness): scope child provider controls to inherited models

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -652,7 +652,9 @@ child on the configured Gemini search model, requests the gateway's
 browser, or fetch tools. The intended use is the same CFC boundary as browser
 and web_fetch subagents: the parent delegates a focused search task, raw search
 observations stay in child artifacts, and the parent receives only the sanitized
-subagent return channel.
+subagent return channel. Because this profile overrides the parent model, parent
+`--reasoning-effort` and `--prompt-cache-mode` settings remain on
+model-inheriting loops and do not apply to the search child.
 
 Programmatic `delegate_task` calls may include `returnSchema`, a JSON Schema
 object or boolean. In that mode the child is required to return a single JSON

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -2710,6 +2710,7 @@ export class CfHarnessPromptLoop {
       delegateInput.profile,
     );
     const childModel = resolveSubagentModel(options.model, profileConfig);
+    const inheritsParentModel = childModel.source === "parent";
     const maxModelTurns = delegateInput.maxModelTurns ??
       profileConfig.maxModelTurns;
     const parentRunState = this.engine.getRunState();
@@ -2825,19 +2826,19 @@ export class CfHarnessPromptLoop {
       engine: childEngine,
       modelClient: this.modelClient,
       cacheAffinityKey: childRunId,
-      // A positive threshold is calibrated to the parent model's input
-      // budget, so it follows only a child that inherits that model; a
-      // profile-overridden child keeps its own model's derived default (and a
-      // chat-routed override like web_search could not honour it at all).
-      // `0` is model-independent — the off-switch stays run-wide.
+      // Provider controls follow only a child that inherits the parent model.
+      // A profile-overridden child keeps its model's own reasoning/cache
+      // defaults, and a chat-routed override like web_search cannot honour the
+      // parent model's controls at all. `compactThreshold: 0` is the exception:
+      // the model-independent off-switch stays run-wide.
       ...(this.#compactThreshold !== undefined &&
-          (this.#compactThreshold === 0 || childModel.source === "parent")
+          (this.#compactThreshold === 0 || inheritsParentModel)
         ? { compactThreshold: this.#compactThreshold }
         : {}),
-      ...(this.#promptCacheMode !== undefined
+      ...(this.#promptCacheMode !== undefined && inheritsParentModel
         ? { promptCacheMode: this.#promptCacheMode }
         : {}),
-      ...(this.#reasoningEffort !== undefined
+      ...(this.#reasoningEffort !== undefined && inheritsParentModel
         ? { reasoningEffort: this.#reasoningEffort }
         : {}),
       maxModelTurns,

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -48,7 +48,6 @@ import type { HarnessModelClient } from "../src/model/client.ts";
 import { InMemoryHarnessCredentialStore } from "../src/auth/credential-store.ts";
 import { OpenAICodexCredentialResolver } from "../src/auth/openai-codex.ts";
 import { OpenAICodexResponsesClient } from "../src/model/openai-codex-responses.ts";
-import { assertPromptCacheModeSupported } from "../src/model/responses-protocol.ts";
 
 const directPromptSlotBinding: PromptSlotBinding = {
   type: CFC_PROMPT_SLOT_BOUND_ATOM_TYPE,
@@ -645,20 +644,23 @@ Deno.test("Codex profile model overrides fail the child without aborting the par
   );
 });
 
-Deno.test("CfHarnessPromptLoop preserves cache-mode validation for child model overrides", async () => {
+Deno.test("CfHarnessPromptLoop keeps provider controls off profile-overridden child models", async () => {
   let parentTurns = 0;
   let childTurns = 0;
   const modelClient: HarnessModelClient = {
     providerId: "test-provider",
     complete: (request) => {
-      assertPromptCacheModeSupported(request.model, request.promptCacheMode);
       if (request.model !== "gpt-5.6-terra") {
         childTurns += 1;
+        assertEquals(request.promptCacheMode, undefined);
+        assertEquals(request.reasoningEffort, undefined);
         return Promise.resolve({
-          assistant: { role: "assistant", content: "unexpected child success" },
+          assistant: { role: "assistant", content: "child search complete" },
         });
       }
       parentTurns += 1;
+      assertEquals(request.promptCacheMode, "explicit");
+      assertEquals(request.reasoningEffort, "low");
       return Promise.resolve({
         assistant: parentTurns === 1
           ? {
@@ -678,7 +680,7 @@ Deno.test("CfHarnessPromptLoop preserves cache-mode validation for child model o
           }
           : {
             role: "assistant" as const,
-            content: "Parent handled the unsupported child configuration.",
+            content: "Parent used the child result.",
           },
       });
     },
@@ -686,6 +688,7 @@ Deno.test("CfHarnessPromptLoop preserves cache-mode validation for child model o
   const loop = new CfHarnessPromptLoop({
     modelClient,
     promptCacheMode: "explicit",
+    reasoningEffort: "low",
     allowedToolIds: ["delegate_task"],
     allowedSubagentProfiles: ["web_search"],
     engine: new CfHarnessEngine({
@@ -707,15 +710,71 @@ Deno.test("CfHarnessPromptLoop preserves cache-mode validation for child model o
 
   assertEquals(
     result.finalAssistantText,
-    "Parent handled the unsupported child configuration.",
+    "Parent used the child result.",
   );
   assertEquals(parentTurns, 2);
-  assertEquals(childTurns, 0);
-  assertEquals(output.subagent.status, "failed");
+  assertEquals(childTurns, 1);
+  assertEquals(output.subagent.status, "completed");
   assertStringIncludes(
     output.subagent.summary,
-    "prompt cache mode explicit requires a GPT-5.6 model",
+    "child search complete",
   );
+});
+
+Deno.test("CfHarnessPromptLoop propagates provider controls to model-inheriting children", async () => {
+  let turns = 0;
+  const modelClient: HarnessModelClient = {
+    providerId: "test-provider",
+    complete: (request) => {
+      turns += 1;
+      assertEquals(request.model, "gpt-5.6-terra");
+      assertEquals(request.promptCacheMode, "explicit");
+      assertEquals(request.reasoningEffort, "low");
+      if (turns === 1) {
+        return Promise.resolve({
+          assistant: {
+            role: "assistant" as const,
+            content: "",
+            toolCalls: [{
+              id: "call-default-provider-controls",
+              type: "function" as const,
+              function: {
+                name: "delegate_task",
+                arguments: JSON.stringify({
+                  goal: "Inspect the inherited-model path.",
+                  profile: "default",
+                }),
+              },
+            }],
+          },
+        });
+      }
+      return Promise.resolve({
+        assistant: {
+          role: "assistant",
+          content: turns === 2 ? "child done" : "parent done",
+        },
+      });
+    },
+  };
+  const loop = new CfHarnessPromptLoop({
+    modelClient,
+    promptCacheMode: "explicit",
+    reasoningEffort: "low",
+    allowedToolIds: ["delegate_task"],
+    allowedSubagentProfiles: ["default"],
+    engine: new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime(),
+      runId: "run-inherited-provider-controls",
+      model: "gpt-5.6-terra",
+      cfcEnforcementMode: "disabled",
+    }),
+  });
+
+  const result = await loop.runPrompt({ prompt: "Delegate and continue." });
+
+  assertEquals(result.finalAssistantText, "parent done");
+  assertEquals(turns, 3);
 });
 
 class FailingArtifactStore implements HarnessArtifactStore {


### PR DESCRIPTION
## Summary

- pass `reasoningEffort` and `promptCacheMode` only to delegated loops that inherit the parent model
- leave profile-overridden children on their own model's provider defaults
- preserve the existing run-wide `compactThreshold: 0` behavior
- document the behavior for the Gemini-backed `web_search` profile

## Why

The `web_search` profile overrides a GPT parent with the chat-routed Gemini search model. Parent-level reasoning-effort and GPT-5.6 cache-mode controls were copied into that child unconditionally, so the gateway's model-capability validation rejected the child before its first request. Wilk identified this as follow-up material while addressing the compaction review on #5327.

With this change, inherited-model children still receive both controls, while a model-overridden child uses the defaults appropriate to its own provider path.

## Validation

- regression test mutation-checked against the previous behavior: the profile-overridden child test fails before the source fix
- `deno task test` in `packages/cf-harness`: 601 passed, 0 failed
- `deno task check`
- targeted `deno lint`, `deno fmt --check`, and `deno check packages/cf-harness/src/prompt-loop.ts`
- focused regressions rerun after rebasing onto current `main`: 2 passed, 0 failed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

