### PR TITLE
fix(cli): make profiler startup transactional

### DIFF
--- a/packages/cli/support/profiling/capture-deno-inspector-profile-lib.test.ts
+++ b/packages/cli/support/profiling/capture-deno-inspector-profile-lib.test.ts
@@ -33,6 +33,14 @@ function createState(): ProfileCaptureState {
   };
 }
 
+function createProfilerStarter(start: () => Promise<void>) {
+  return {
+    enable: () => Promise.resolve(),
+    setSamplingInterval: (_params: { interval: number }) => Promise.resolve(),
+    start,
+  };
+}
+
 class FakeWebSocket {
   readyState: number = WebSocket.CONNECTING;
   added: string[] = [];
@@ -120,10 +128,12 @@ class FakeCelestial {
       });
     },
     setSamplingInterval: (params: { interval: number }) => {
+      this.calls.push("Profiler.setSamplingInterval");
       this.samplingIntervals.push(params.interval);
       return Promise.resolve();
     },
     start: () => {
+      this.calls.push("Profiler.start");
       this.starts += 1;
       // What the inspector answers a `Profiler.start` it has not enabled yet.
       if (!this.profilerEnabled) {
@@ -133,6 +143,7 @@ class FakeCelestial {
       return this.startPromise ?? Promise.resolve();
     },
     stop: () => {
+      this.calls.push("Profiler.stop");
       this.stops += 1;
       return Promise.resolve({ profile: this.profile });
     },
@@ -525,19 +536,27 @@ describe("capture-deno-inspector-profile helpers", () => {
     assertEquals(stringifyRemoteObject({}), "[unknown]");
   });
 
-  it("starts the profiler when the websocket is open", async () => {
+  it("enables, configures, and starts the profiler when the websocket is open", async () => {
     const state = createState();
     const ws = new FakeWebSocket();
     ws.readyState = WebSocket.OPEN;
     const logs: string[] = [];
-    let starts = 0;
+    const calls: string[] = [];
 
     const started = await startProfilerIfReady(
       state,
       ws as unknown as WebSocket,
       {
+        enable: () => {
+          calls.push("enable");
+          return Promise.resolve();
+        },
+        setSamplingInterval: ({ interval }) => {
+          calls.push(`sampling:${interval}`);
+          return Promise.resolve();
+        },
         start: () => {
-          starts += 1;
+          calls.push("start");
           return Promise.resolve();
         },
       },
@@ -545,7 +564,7 @@ describe("capture-deno-inspector-profile helpers", () => {
     );
 
     assertEquals(started, true);
-    assertEquals(starts, 1);
+    expect(calls).toEqual(["enable", "sampling:100", "start"]);
     assertEquals(state.profilerActive, true);
     assertEquals(state.sawProfileStop, false);
     assertEquals(logs, ["profile: profiler started"]);
@@ -560,7 +579,7 @@ describe("capture-deno-inspector-profile helpers", () => {
     const started = await startProfilerIfReady(
       state,
       ws as unknown as WebSocket,
-      { start: () => Promise.resolve() },
+      createProfilerStarter(() => Promise.resolve()),
       () => {},
       { clearStop: false },
     );
@@ -588,12 +607,12 @@ describe("capture-deno-inspector-profile helpers", () => {
     const started = await startProfilerIfReady(
       state,
       ws as unknown as WebSocket,
-      {
-        start: () => {
+      createProfilerStarter(
+        () => {
           starts += 1;
           return Promise.resolve();
         },
-      },
+      ),
     );
 
     assertEquals(started, false);
@@ -605,31 +624,34 @@ describe("capture-deno-inspector-profile helpers", () => {
     const ws = new FakeWebSocket();
     ws.readyState = WebSocket.OPEN;
     let resolveStart: (() => void) | undefined;
+    const startCalled = Promise.withResolvers<void>();
     let starts = 0;
 
     const firstStart = startProfilerIfReady(
       state,
       ws as unknown as WebSocket,
-      {
-        start: () => {
+      createProfilerStarter(
+        () => {
           starts += 1;
+          startCalled.resolve();
           return new Promise<void>((resolve) => {
             resolveStart = resolve;
           });
         },
-      },
+      ),
     );
     assertEquals(state.profilerStarting, true);
+    await startCalled.promise;
 
     const secondStarted = await startProfilerIfReady(
       state,
       ws as unknown as WebSocket,
-      {
-        start: () => {
+      createProfilerStarter(
+        () => {
           starts += 1;
           return Promise.resolve();
         },
-      },
+      ),
     );
     resolveStart?.();
     const firstStarted = await firstStart;
@@ -651,9 +673,7 @@ describe("capture-deno-inspector-profile helpers", () => {
       await startProfilerIfReady(
         state,
         ws as unknown as WebSocket,
-        {
-          start: () => Promise.reject(new Error("closed")),
-        },
+        createProfilerStarter(() => Promise.reject(new Error("closed"))),
       );
     } catch (error) {
       caught = error;
@@ -671,9 +691,7 @@ describe("capture-deno-inspector-profile helpers", () => {
     const started = startProfilerIfReady(
       state,
       ws as unknown as WebSocket,
-      {
-        start: () => new Promise<void>(() => {}),
-      },
+      createProfilerStarter(() => new Promise<void>(() => {})),
     );
     assertEquals(state.profilerStarting, true);
 
@@ -929,7 +947,7 @@ describe("capture-deno-inspector-profile helpers", () => {
     });
   });
 
-  it("starts and stops from console profile markers", async () => {
+  it("enables the profiler as part of a marker-triggered start", async () => {
     await withTempDir(async (tmpDir) => {
       const celestial = new FakeCelestial();
       const logs: string[] = [];
@@ -948,6 +966,7 @@ describe("capture-deno-inspector-profile helpers", () => {
       );
 
       await resumed.promise;
+      celestial.profilerEnabled = false;
       celestial.dispatchConsole({ value: "profile start" });
       await started.promise;
       celestial.dispatchConsole({ value: "profile stop" });
@@ -955,6 +974,16 @@ describe("capture-deno-inspector-profile helpers", () => {
       assertEquals(await done, 0);
       assertEquals(celestial.starts, 1);
       assertEquals(celestial.stops, 1);
+      expect(celestial.calls).toEqual([
+        "Runtime.enable",
+        "Console.enable",
+        "Debugger.enable",
+        "Profiler.enable",
+        "Profiler.setSamplingInterval",
+        "Profiler.start",
+        "Profiler.stop",
+        "close",
+      ]);
       assertEquals(logs.includes("profile: profile stop matched"), true);
     });
   });
@@ -965,6 +994,7 @@ describe("capture-deno-inspector-profile helpers", () => {
       const gate = Promise.withResolvers<void>();
       celestial.profilerEnableGate = gate;
       const logs: string[] = [];
+      const resumed = Promise.withResolvers<void>();
       const started = Promise.withResolvers<void>();
       const done = captureDenoInspectorProfile(
         [
@@ -974,13 +1004,12 @@ describe("capture-deno-inspector-profile helpers", () => {
           "--profile-stop-pattern=profile stop",
           "--websocket-url=ws://127.0.0.1:9333/session",
         ],
-        createCaptureRuntime({ celestial, logs, started }),
+        createCaptureRuntime({ celestial, logs, resumed, started }),
       );
 
-      // `Runtime.enable` has already answered, so console events reach the
-      // capture while `Profiler.enable` is still outstanding.
-      await celestial.profilerEnableCalled.promise;
+      await resumed.promise;
       celestial.dispatchConsole({ value: "profile start" });
+      await celestial.profilerEnableCalled.promise;
       assertEquals(celestial.starts, 0);
 
       gate.resolve();
@@ -999,6 +1028,7 @@ describe("capture-deno-inspector-profile helpers", () => {
       const gate = Promise.withResolvers<void>();
       celestial.profilerEnableGate = gate;
       const logs: string[] = [];
+      const resumed = Promise.withResolvers<void>();
       const started = Promise.withResolvers<void>();
       const done = captureDenoInspectorProfile(
         [
@@ -1008,14 +1038,15 @@ describe("capture-deno-inspector-profile helpers", () => {
           "--profile-stop-pattern=profile stop",
           "--websocket-url=ws://127.0.0.1:9333/session",
         ],
-        createCaptureRuntime({ celestial, logs, started }),
+        createCaptureRuntime({ celestial, logs, resumed, started }),
       );
 
       // A stop that precedes the start marker is stale, and the deferred
       // start carries that answer rather than the default.
-      await celestial.profilerEnableCalled.promise;
+      await resumed.promise;
       celestial.dispatchConsole({ value: "profile stop" });
       celestial.dispatchConsole({ value: "profile start" });
+      await celestial.profilerEnableCalled.promise;
 
       gate.resolve();
       await started.promise;
@@ -1033,6 +1064,7 @@ describe("capture-deno-inspector-profile helpers", () => {
       const gate = Promise.withResolvers<void>();
       celestial.profilerEnableGate = gate;
       const logs: string[] = [];
+      const resumed = Promise.withResolvers<void>();
       const started = Promise.withResolvers<void>();
       const done = captureDenoInspectorProfile(
         [
@@ -1042,13 +1074,14 @@ describe("capture-deno-inspector-profile helpers", () => {
           "--profile-stop-pattern=profile stop",
           "--websocket-url=ws://127.0.0.1:9333/session",
         ],
-        createCaptureRuntime({ celestial, logs, started }),
+        createCaptureRuntime({ celestial, logs, resumed, started }),
       );
 
       // No stop preceded the start marker, so the stop that follows it is the
       // live one and survives the profiler actually starting.
-      await celestial.profilerEnableCalled.promise;
+      await resumed.promise;
       celestial.dispatchConsole({ value: "profile start" });
+      await celestial.profilerEnableCalled.promise;
       celestial.dispatchConsole({ value: "profile stop" });
 
       gate.resolve();

--- a/packages/cli/support/profiling/capture-deno-inspector-profile-lib.test.ts
+++ b/packages/cli/support/profiling/capture-deno-inspector-profile-lib.test.ts
@@ -970,6 +970,7 @@ describe("capture-deno-inspector-profile helpers", () => {
     await withTempDir(async (tmpDir) => {
       const celestial = new FakeCelestial();
       const logs: string[] = [];
+      const errors: string[] = [];
       const resumed = Promise.withResolvers<void>();
       const started = Promise.withResolvers<void>();
       const outputPath = `${tmpDir}/profile.cpuprofile`;
@@ -981,13 +982,21 @@ describe("capture-deno-inspector-profile helpers", () => {
           "--profile-stop-pattern=profile stop",
           "--websocket-url=ws://127.0.0.1:9333/session",
         ],
-        createCaptureRuntime({ celestial, logs, resumed, started }),
+        createCaptureRuntime({ celestial, logs, errors, resumed, started }),
       );
 
       await resumed.promise;
       celestial.profilerEnabled = false;
       celestial.dispatchConsole({ value: "profile start" });
-      await started.promise;
+      const startedBeforeCaptureEnded = await Promise.race([
+        started.promise.then(() => true),
+        done.then(() => false),
+      ]);
+      assertEquals(
+        startedBeforeCaptureEnded,
+        true,
+        `capture ended before profiler started: ${errors.join("\n")}`,
+      );
       celestial.dispatchConsole({ value: "profile stop" });
 
       assertEquals(await done, 0);
@@ -1060,8 +1069,8 @@ describe("capture-deno-inspector-profile helpers", () => {
         createCaptureRuntime({ celestial, logs, resumed, started }),
       );
 
-      // A stop that precedes the start marker is stale, and the deferred
-      // start carries that answer rather than the default.
+      // A stop that precedes the start marker is stale, so the transaction
+      // clears it before enabling the profiler.
       await resumed.promise;
       celestial.dispatchConsole({ value: "profile stop" });
       celestial.dispatchConsole({ value: "profile start" });
@@ -1073,6 +1082,43 @@ describe("capture-deno-inspector-profile helpers", () => {
 
       assertEquals(await done, 0);
       assertEquals(celestial.starts, 1);
+      assertEquals(celestial.stops, 1);
+    });
+  });
+
+  it("preserves a live stop after clearing an earlier stop", async () => {
+    await withTempDir(async (tmpDir) => {
+      const celestial = new FakeCelestial();
+      const gate = Promise.withResolvers<void>();
+      celestial.profilerEnableGate = gate;
+      const logs: string[] = [];
+      const resumed = Promise.withResolvers<void>();
+      const started = Promise.withResolvers<void>();
+      const done = captureDenoInspectorProfile(
+        [
+          `--output=${tmpDir}/profile.cpuprofile`,
+          "--summary-pattern=done",
+          "--profile-start-pattern=profile start",
+          "--profile-stop-pattern=profile stop",
+          "--websocket-url=ws://127.0.0.1:9333/session",
+        ],
+        createCaptureRuntime({ celestial, logs, resumed, started }),
+      );
+
+      await resumed.promise;
+      celestial.dispatchConsole({ value: "profile stop" });
+      celestial.dispatchConsole({ value: "profile start" });
+      await celestial.profilerEnableCalled.promise;
+      celestial.dispatchConsole({ value: "profile stop" });
+
+      gate.resolve();
+      await started.promise;
+      await Promise.resolve();
+      // Bounds the regression if the live stop above is dropped.
+      celestial.dispatchConsole({ value: "done" });
+
+      assertEquals(await done, 0);
+      assertEquals(logs.includes("profile: profile stop matched"), true);
       assertEquals(celestial.stops, 1);
     });
   });

--- a/packages/cli/support/profiling/capture-deno-inspector-profile-lib.test.ts
+++ b/packages/cli/support/profiling/capture-deno-inspector-profile-lib.test.ts
@@ -78,6 +78,8 @@ class FakeCelestial {
   closePromise: Promise<void> | undefined;
   closeStarted: PromiseWithResolvers<void> | undefined;
   closeThrow: unknown;
+  profilerEnableError: unknown;
+  samplingIntervalError: unknown;
   starts = 0;
   stops = 0;
   removedListeners: string[] = [];
@@ -122,6 +124,9 @@ class FakeCelestial {
     enable: () => {
       this.calls.push("Profiler.enable");
       this.profilerEnableCalled.resolve();
+      if (this.profilerEnableError) {
+        return Promise.reject(this.profilerEnableError);
+      }
       const gate = this.profilerEnableGate?.promise ?? Promise.resolve();
       return gate.then(() => {
         this.profilerEnabled = true;
@@ -129,6 +134,9 @@ class FakeCelestial {
     },
     setSamplingInterval: (params: { interval: number }) => {
       this.calls.push("Profiler.setSamplingInterval");
+      if (this.samplingIntervalError) {
+        return Promise.reject(this.samplingIntervalError);
+      }
       this.samplingIntervals.push(params.interval);
       return Promise.resolve();
     },
@@ -679,7 +687,10 @@ describe("capture-deno-inspector-profile helpers", () => {
       caught = error;
     }
 
-    assertEquals((caught as Error).message, "closed");
+    assertEquals(
+      (caught as Error).message,
+      "Profiler.start failed during Profiler.start: Error: closed",
+    );
     assertEquals(state.profilerStarting, false);
     assertEquals(state.profilerActive, false);
   });
@@ -688,12 +699,17 @@ describe("capture-deno-inspector-profile helpers", () => {
     const state = createState();
     const ws = new FakeWebSocket();
     ws.readyState = WebSocket.OPEN;
+    const startCalled = Promise.withResolvers<void>();
     const started = startProfilerIfReady(
       state,
       ws as unknown as WebSocket,
-      createProfilerStarter(() => new Promise<void>(() => {})),
+      createProfilerStarter(() => {
+        startCalled.resolve();
+        return new Promise<void>(() => {});
+      }),
     );
     assertEquals(state.profilerStarting, true);
+    await startCalled.promise;
 
     ws.readyState = WebSocket.CLOSED;
     ws.dispatch("close", new CloseEvent("close"));
@@ -705,7 +721,10 @@ describe("capture-deno-inspector-profile helpers", () => {
       caught = error;
     }
 
-    assertEquals((caught as Error).message, "WebSocket closed");
+    assertEquals(
+      (caught as Error).message,
+      "Profiler.start failed during Profiler.start: Error: WebSocket closed",
+    );
     assertEquals(state.profilerStarting, false);
     assertEquals(state.profilerActive, false);
   });
@@ -1166,33 +1185,64 @@ describe("capture-deno-inspector-profile helpers", () => {
     });
   });
 
-  it("writes a profiler start error and returns failure", async () => {
-    await withTempDir(async (tmpDir) => {
-      const celestial = new FakeCelestial();
-      celestial.startError = new Error("closed");
-      const logs: string[] = [];
-      const errors: string[] = [];
-      const outputPath = `${tmpDir}/profile.cpuprofile`;
+  for (
+    const failure of [
+      {
+        description: "profiler enable",
+        step: "Profiler.enable",
+        fail: (celestial: FakeCelestial) => {
+          celestial.profilerEnableError = new Error("closed");
+        },
+        starts: 0,
+      },
+      {
+        description: "sampling interval",
+        step: "Profiler.setSamplingInterval",
+        fail: (celestial: FakeCelestial) => {
+          celestial.samplingIntervalError = new Error("closed");
+        },
+        starts: 0,
+      },
+      {
+        description: "profiler start",
+        step: "Profiler.start",
+        fail: (celestial: FakeCelestial) => {
+          celestial.startError = new Error("closed");
+        },
+        starts: 1,
+      },
+    ] as const
+  ) {
+    it(`reports the ${failure.description} transaction step`, async () => {
+      await withTempDir(async (tmpDir) => {
+        const celestial = new FakeCelestial();
+        failure.fail(celestial);
+        const logs: string[] = [];
+        const errors: string[] = [];
+        const outputPath = `${tmpDir}/profile.cpuprofile`;
 
-      const code = await captureDenoInspectorProfile(
-        [
-          `--output=${outputPath}`,
-          "--websocket-url=ws://127.0.0.1:9333/session",
-        ],
-        createCaptureRuntime({ celestial, logs, errors }),
-      );
+        const code = await captureDenoInspectorProfile(
+          [
+            `--output=${outputPath}`,
+            "--websocket-url=ws://127.0.0.1:9333/session",
+          ],
+          createCaptureRuntime({ celestial, logs, errors }),
+        );
 
-      assertEquals(code, 1);
-      assertEquals(celestial.starts, 1);
-      assertEquals(celestial.stops, 0);
-      assertStringIncludes(errors.join("\n"), "Profiler.start failed");
-      assertStringIncludes(
-        await Deno.readTextFile(`${tmpDir}/profile.error.txt`),
-        "Profiler.start failed: Error: closed",
-      );
-      assertEquals(logs.includes("profile: profiler-start-failed"), true);
+        const expectedError =
+          `Profiler.start failed during ${failure.step}: Error: closed`;
+        assertEquals(code, 1);
+        assertEquals(celestial.starts, failure.starts);
+        assertEquals(celestial.stops, 0);
+        assertStringIncludes(errors.join("\n"), expectedError);
+        assertStringIncludes(
+          await Deno.readTextFile(`${tmpDir}/profile.error.txt`),
+          expectedError,
+        );
+        assertEquals(logs.includes("profile: profiler-start-failed"), true);
+      });
     });
-  });
+  }
 
   it("ignores profiler start markers after start failure cleanup begins", async () => {
     await withTempDir(async (tmpDir) => {

--- a/packages/cli/support/profiling/capture-deno-inspector-profile-lib.ts
+++ b/packages/cli/support/profiling/capture-deno-inspector-profile-lib.ts
@@ -296,12 +296,24 @@ export async function startProfilerIfReady(
   }
   state.profilerStarting = true;
   try {
-    await settleInspectorCommand(ws, () => profiler.enable());
-    await settleInspectorCommand(
-      ws,
-      () => profiler.setSamplingInterval({ interval: 100 }),
-    );
-    await settleInspectorCommand(ws, () => profiler.start());
+    const steps = [
+      { name: "Profiler.enable", command: () => profiler.enable() },
+      {
+        name: "Profiler.setSamplingInterval",
+        command: () => profiler.setSamplingInterval({ interval: 100 }),
+      },
+      { name: "Profiler.start", command: () => profiler.start() },
+    ] as const;
+    for (const step of steps) {
+      try {
+        await settleInspectorCommand(ws, step.command);
+      } catch (error) {
+        throw new Error(
+          `Profiler.start failed during ${step.name}: ${error}`,
+          { cause: error },
+        );
+      }
+    }
     markProfilerStarted(state, options);
     log("profile: profiler started");
     return true;
@@ -457,7 +469,10 @@ export async function captureDenoInspectorProfile(
     requestStop(reason);
   };
   const recordProfilerStartError = (error: unknown): void => {
-    profilerStartError = `Profiler.start failed: ${error}`;
+    const message = error instanceof Error ? error.message : String(error);
+    profilerStartError = message.startsWith("Profiler.start failed")
+      ? message
+      : `Profiler.start failed: ${message}`;
     output.error(`profile: ${profilerStartError}`);
     requestStop("profiler-start-failed");
   };

--- a/packages/cli/support/profiling/capture-deno-inspector-profile-lib.ts
+++ b/packages/cli/support/profiling/capture-deno-inspector-profile-lib.ts
@@ -23,6 +23,8 @@ export type ProfileStopState = {
 };
 
 type ProfilerController = {
+  enable(): Promise<unknown>;
+  setSamplingInterval(params: { interval: number }): Promise<unknown>;
   start(): Promise<void>;
   stop(): Promise<{ profile: unknown }>;
 };
@@ -30,10 +32,7 @@ type ProfilerController = {
 type ProfileCaptureRuntimeApi = {
   Console: { enable(): Promise<unknown> };
   Debugger: { enable(params: Record<string, unknown>): Promise<unknown> };
-  Profiler: ProfilerController & {
-    enable(): Promise<unknown>;
-    setSamplingInterval(params: { interval: number }): Promise<unknown>;
-  };
+  Profiler: ProfilerController;
   Runtime: { enable(): Promise<unknown> };
   addEventListener: EventTarget["addEventListener"];
   removeEventListener: EventTarget["removeEventListener"];
@@ -274,10 +273,18 @@ export function markProfileStoppedOnce(
   return true;
 }
 
+/**
+ * Enables, configures, and starts the profiler as one guarded transaction.
+ * A marker-triggered start may happen after the debugger resumes, so the
+ * profiler domain is enabled at the point where its active state is required.
+ */
 export async function startProfilerIfReady(
   state: ProfileCaptureState,
   ws: InspectorCommandWebSocket,
-  profiler: Pick<ProfilerController, "start">,
+  profiler: Pick<
+    ProfilerController,
+    "enable" | "setSamplingInterval" | "start"
+  >,
   log: (message: string) => void = () => {},
   options: { clearStop?: boolean } = {},
 ): Promise<boolean> {
@@ -289,6 +296,11 @@ export async function startProfilerIfReady(
   }
   state.profilerStarting = true;
   try {
+    await settleInspectorCommand(ws, () => profiler.enable());
+    await settleInspectorCommand(
+      ws,
+      () => profiler.setSamplingInterval({ interval: 100 }),
+    );
     await settleInspectorCommand(ws, () => profiler.start());
     markProfilerStarted(state, options);
     log("profile: profiler started");
@@ -417,10 +429,6 @@ export async function captureDenoInspectorProfile(
   let pendingProfilerStopReason: string | undefined;
   let profilerStartError: string | undefined;
   let missingProfileStartError: string | undefined;
-  // Whether `Profiler.enable` has answered, and the start options a console
-  // marker recorded before it did.
-  let profilerEnabled = false;
-  let deferredProfilerStartOptions: { clearStop?: boolean } | undefined;
 
   const target = {
     id: websocketUrl,
@@ -496,16 +504,7 @@ export async function captureDenoInspectorProfile(
     );
     if (profileMessage.startedProfile) {
       const startOptions = { clearStop: profileMessage.hadProfileStop };
-      // `Runtime.enable` is what makes console events flow, and it resolves
-      // before `Profiler.enable` does. A target that prints its start marker
-      // in that window reaches here against a profiler the inspector has not
-      // enabled yet, and `Profiler.start` answers -32000. Hold the marker's
-      // options instead; the enable sequence starts the profiler with them.
-      if (profilerEnabled) {
-        void startProfiler(startOptions);
-      } else {
-        deferredProfilerStartOptions ??= startOptions;
-      }
+      void startProfiler(startOptions);
     }
     if (summaryRegex.test(text)) {
       requestProfilerStop("summary-matched");
@@ -586,15 +585,9 @@ export async function captureDenoInspectorProfile(
     output.log("profile: runtime enabled");
     await celestial.Console.enable();
     await celestial.Debugger.enable({});
-    await celestial.Profiler.enable();
-    await celestial.Profiler.setSamplingInterval({ interval: 100 });
-    profilerEnabled = true;
 
-    // Either the run carries no start pattern, so profiling begins at attach
-    // with no marker to answer, or a marker arrived while the enable sequence
-    // was still in flight and left the options it was seen with.
     if (state.sawProfileStart) {
-      await startProfiler(deferredProfilerStartOptions ?? {});
+      await startProfiler();
     }
 
     stopResumeOnPause = resumeDebuggerOnPause(celestial, ws, -2);

--- a/packages/cli/support/profiling/capture-deno-inspector-profile-lib.ts
+++ b/packages/cli/support/profiling/capture-deno-inspector-profile-lib.ts
@@ -277,6 +277,9 @@ export function markProfileStoppedOnce(
  * Enables, configures, and starts the profiler as one guarded transaction.
  * A marker-triggered start may happen after the debugger resumes, so the
  * profiler domain is enabled at the point where its active state is required.
+ * The inspector could still disable the domain between the enable reply and
+ * start command; if that produces -32000 again, prefer a bounded retry of this
+ * transaction over moving the enable earlier in the handshake.
  */
 export async function startProfilerIfReady(
   state: ProfileCaptureState,
@@ -296,6 +299,11 @@ export async function startProfilerIfReady(
   }
   state.profilerStarting = true;
   try {
+    if (options.clearStop ?? true) {
+      // Clear only stops that preceded this transaction. A stop observed while
+      // the inspector commands are in flight must survive the eventual start.
+      state.sawProfileStop = false;
+    }
     const steps = [
       { name: "Profiler.enable", command: () => profiler.enable() },
       {
@@ -314,7 +322,7 @@ export async function startProfilerIfReady(
         );
       }
     }
-    markProfilerStarted(state, options);
+    markProfilerStarted(state, { clearStop: false });
     log("profile: profiler started");
     return true;
   } finally {
@@ -469,10 +477,9 @@ export async function captureDenoInspectorProfile(
     requestStop(reason);
   };
   const recordProfilerStartError = (error: unknown): void => {
-    const message = error instanceof Error ? error.message : String(error);
-    profilerStartError = message.startsWith("Profiler.start failed")
-      ? message
-      : `Profiler.start failed: ${message}`;
+    profilerStartError = error instanceof Error && Object.hasOwn(error, "cause")
+      ? error.message
+      : `Profiler.start failed: ${error}`;
     output.error(`profile: ${profilerStartError}`);
     requestStop("profiler-start-failed");
   };


### PR DESCRIPTION
## Summary

- enable, configure, and start the CPU profiler inside one guarded inspector transaction
- perform that sequence at the actual start point, including marker-triggered starts after the debugger resumes
- add a deterministic regression that invalidates profiler state after resume and requires the full `enable → configure → start` ordering

## Root cause

The capture connected and enabled the profiler domain during setup, then resumed the target before a later console marker triggered `Profiler.start`. That left a gap in which the start could observe the profiler domain as disabled, producing the CI failure `Profiler is not enabled (-32000)`.

This closes the state gap rather than retrying the failed command: every guarded start now establishes the protocol preconditions immediately before `Profiler.start`.

Failing run: https://github.com/commontoolsinc/labs/actions/runs/31210927383/job/92973283497

## Validation

- full CLI package suite on Deno 2.9.4: 1,808 passed / 792 steps / 0 failed
- focused profiler suite: 7 passed / 56 steps / 0 failed
- exact real-inspector regression: 20/20 fresh sessions
- `deno fmt --check`: 4,330 files
- `deno lint`: 4,312 files
- pinned `deno task check`: 443 paths
- no new polling `waitFor`; no conflict markers


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

