### PR TITLE
docs(plan): one sequence for verbs, across the two arcs that made it

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -148,7 +148,7 @@ propagate](#how-flags-propagate).
   default in place), so the opt-out while the flag exists is an explicit
   `EXPERIMENTAL_PLAIN_RESULT_RECEIPTS=false`.
 - **Added by.** Mike Salisbury, verb-contract WS-C
-  (`docs/plans/pattern-verb-contract-implementation.md`).
+  (`docs/history/plans/pattern-verb-contract-implementation.md`).
 - **Purpose.** A handler's return value containing reactives/cells projects
   into its per-event receipt cell via the result-pattern path, but a **plain
   JSON return is discarded** — the receipt-only branch writes `{}`. Under this

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -152,6 +152,16 @@ One line per archived document; each document's header carries the fuller
   — the CFC future-work epics (clause core, exchange rules/policy,
   observation classes, integrity floors, sqlite row-set, deployment flips),
   executed 2026-07.
+- [pattern-verb-contract-implementation.md](plans/pattern-verb-contract-implementation.md)
+  — the verb-contract workstreams as built: the `topics` Part 1 rework, the
+  `Stream<E, R>` authoring surface, the invocation protocol with caller-supplied
+  ids and receipt readback, and the client affordances. Records the C3
+  result-schema withdrawal, the closed-world event-emission migration the update
+  gate forced, and the measurements behind each, July–August 2026.
+- [shaped-reads-implementation.md](plans/shaped-reads-implementation.md) — the
+  read-layer stages, the reasoning for ordering session-scoped invocation ids
+  ahead of anything that publishes a receipt address, and the descriptive-receipt
+  decision, August 2026.
 - [retiring-llm-tool-call-deadlines.md](development/proposals/retiring-llm-tool-call-deadlines.md)
   — replacing the LLM tool-call deadline with a run-scoped quiescence barrier,
   and narrowing the dialog message-drop heuristic the deadline's argument did

--- a/docs/history/plans/pattern-verb-contract-implementation.md
+++ b/docs/history/plans/pattern-verb-contract-implementation.md
@@ -1,7 +1,15 @@
+---
+status: historical
+created: 2026-07-24
+archived: 2026-08-07
+reason: "Verb-contract implementation plan; its remaining sequencing moved to the verbs plan and its retention/provenance workstream to a plan of its own."
+superseded-by: docs/plans/verbs-implementation.md
+---
+
 # Pattern verb contract — implementation plan
 
 **Status:** pending. Executes the design in
-[`pattern-verb-contract.md`](pattern-verb-contract.md) (PR #4968). Keep current
+[`pattern-verb-contract.md`](../../plans/pattern-verb-contract.md) (PR #4968). Keep current
 as work proceeds: check off exit criteria, record scope changes.
 
 **Amended 2026-07-31 (second pass)**, C5 measured outcome: dispatch-side

--- a/docs/history/plans/shaped-reads-implementation.md
+++ b/docs/history/plans/shaped-reads-implementation.md
@@ -1,12 +1,20 @@
+---
+status: historical
+created: 2026-08-07
+archived: 2026-08-07
+reason: "Read-layer sequencing plan; its remaining items were folded into the single verbs sequencing plan."
+superseded-by: docs/plans/verbs-implementation.md
+---
+
 # Shaped reads and verb results — implementation plan
 
 Sequences the read layer and the calls layered on it, as designed in
-[Reading Fabric data](fabric-read-model.md) and
-[Shaped reads and verb results](shaped-reads-and-verb-results.md). Read the
+[Reading Fabric data](../../plans/fabric-read-model.md) and
+[Shaped reads and verb results](../../plans/shaped-reads-and-verb-results.md). Read the
 design first; this document assumes it and does not restate it.
 
 The command surface — the third concern in that umbrella,
-[CLI surface shape](cli-surface-shape.md) — is out of scope here and moves on
+[CLI surface shape](../../plans/cli-surface-shape.md) — is out of scope here and moves on
 its own timeline. One piece of it is unavoidable: the concise selection syntax
 needs its own flag before it can grow address notation, so `--select` lands in
 the first stage rather than waiting.
@@ -441,7 +449,7 @@ Each step carries its own, rather than a sweep at the end.
 | Step | Owed |
 | --- | --- |
 | F2 | `packages/cli/README.md` output conventions: two flags, which syntax each takes |
-| A1, A3 | The marker and the suffix, same file; [Verbs over the CLI](../common/verbs-over-the-cli.md), already stale |
+| A1, A3 | The marker and the suffix, same file; [Verbs over the CLI](../../common/verbs-over-the-cli.md), already stale |
 | A4 | Address forms wherever `--piece` is taught — the CLI README and the tutorial's workflow chapter |
 | S1, S2 | `cf invocation-session new`, `CF_INVOCATION_SESSION`, and what an absent session means; the CLI README and the agent-facing skills that teach invocation ids |
 | C1 | What a receipt declares, in the design document's open-question slot |

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -35,9 +35,10 @@ a record: archive it to `docs/history/plans/` following the procedure in
 - [Server-primary execution v2](server-execution-v2.md) sequences the
   greenfield rebuild that executes the server-side-execution v2 spec, with
   per-phase task and success-criteria checkboxes.
-- [Pattern verb contract implementation](pattern-verb-contract-implementation.md)
-  sequences the implementation of the
-  [pattern verb contract](pattern-verb-contract.md).
+- [Retention and CFC execution provenance](retention-and-provenance.md)
+  sequences how long an invocation record is kept and what the runtime knows
+  about who caused it — the `AgentActor` mint, trusted ingress, and metadata
+  confidentiality. Gated on a CFC review that has not happened.
 - [CFC runner implementation](runner_cfc_implementation.md) defines the
   commit-boundary enforcement workstreams and rollout.
 - [Topics migration rehearsal](topics-migration-rehearsal.md) is the concrete,
@@ -66,10 +67,6 @@ a record: archive it to `docs/history/plans/` following the procedure in
   work on verbs across both arcs that produced it: what a verb declares, what a
   caller may ask for, and what comes back. Read it for order; read the designs
   it points at for reasoning.
-- [Shaped reads and verb results — implementation plan](shaped-reads-implementation.md)
-  sequences the read layer, the calls layered on it, and the remaining
-  arrivals, ordering the address change ahead of anything that publishes an
-  address so no caller holds one that moves.
 - [The CLI surface — implementation plan](cli-surface-implementation.md) builds
   the rest of the command surface: positional addresses, the honest top-level
   names, deprecating the spellings they replace, and merging the commands that

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -62,6 +62,10 @@ a record: archive it to `docs/history/plans/` following the procedure in
   investigation those documents do not carry: what produces a receipt and what
   its existence proves, how a receipt's address is derived, and the error and
   exit-status conventions. Sketches to draw from, not a settled contract.
+- [Verbs — implementation plan](verbs-implementation.md) sequences the remaining
+  work on verbs across both arcs that produced it: what a verb declares, what a
+  caller may ask for, and what comes back. Read it for order; read the designs
+  it points at for reasoning.
 - [Shaped reads and verb results — implementation plan](shaped-reads-implementation.md)
   sequences the read layer, the calls layered on it, and the remaining
   arrivals, ordering the address change ahead of anything that publishes an

--- a/docs/plans/cli-surface-implementation.md
+++ b/docs/plans/cli-surface-implementation.md
@@ -2,8 +2,8 @@
 
 [The CLI surface shape](cli-surface-shape.md) describes what `cf` should look
 like and lays out seven steps to get there. Steps 1–3 are the read layer, and
-[shaped reads and verb results](shaped-reads-implementation.md) builds them.
-This plan is steps 4–7: the part that changes what a caller types.
+[the verbs plan](verbs-implementation.md) builds them. This plan is steps 4–7:
+the part that changes what a caller types.
 
 The split is deliberate, though not absolute. The read layer breaks two things,
 both of which it owns and sequences itself. Scoping invocation ids to a session

--- a/docs/plans/pattern-verb-contract.md
+++ b/docs/plans/pattern-verb-contract.md
@@ -954,9 +954,10 @@ client retry needs.
 
 ## Staging
 
-The engineering breakdown — workstreams, phases, issue graph — lives in
-[`pattern-verb-contract-implementation.md`](pattern-verb-contract-implementation.md);
-the steps below are the design-level order.
+The engineering breakdown — what remains, in what order, and what each item
+waits behind — lives in
+[`verbs-implementation.md`](verbs-implementation.md); the steps below are the
+design-level order.
 
 1. Agree this document — particularly the open questions.
 2. Finish the Part 1 rework of `topics` / `topic` — the attribution rules

--- a/docs/plans/retention-and-provenance.md
+++ b/docs/plans/retention-and-provenance.md
@@ -1,0 +1,82 @@
+# Retention and CFC execution provenance — implementation plan
+
+Two related pieces of work on what an invocation leaves behind: how long the
+record of one is kept, and what the runtime knows about who caused it. Both are
+about the invocation surface rather than about verbs, which is why they are
+sequenced here rather than alongside
+[the verbs plan](verbs-implementation.md).
+
+**This plan is gated on a CFC review that has not happened.** Nothing below is
+started, and nothing should be until that review resolves. The verbs plan does
+not advance any of it, and none of it blocks the verbs plan — the two can be
+read, scheduled, and finished independently.
+
+Size L, and more of it is unknown than settled. It touches `packages/runner`,
+`packages/piece`, `packages/cli`, and `packages/patterns/topics`.
+
+## What has to resolve first
+
+The retention half waits on three resolutions, in order:
+
+1. The default retention window, which bounds the idempotency guarantee: a
+   replayed invocation id returns the original outcome only while the record
+   that carries it survives.
+2. The CFC label review for stored invocation records, against
+   [label metadata confidentiality](../specs/cfc-label-metadata-confidentiality.md).
+3. Confirmation of the storage layer's collection story for unreferenced cells.
+   An expiry policy that cannot actually release storage is a policy in name
+   only.
+
+## Retention
+
+**The record itself.** Timestamps and a typed error shape, with the schema
+authored open-world so protocol fields can be added without a migration.
+
+**The collection that holds them.** Linked from the piece, carrying a
+pattern-declared range plus a default, and read-and-expire.
+
+**A single rejection taxonomy.** Two "fix your input" signals reach a caller
+today, and neither carries a stable code: `VerbInputValidationError`, the CLI's
+pre-dispatch refusal, and a thrown `Error` in a verb body, whose typed carrier
+derives from `FabricError`. Codes reach the invocation surface here, and when
+they do both must speak one taxonomy — a reserved `INVALID_INPUT` among them —
+so an agent branches one way rather than two. No code field ships before this.
+
+## Provenance
+
+A separate CFC-gated track, and the four items are ordered by dependency.
+Attribution rides CFC provenance rather than a parallel `actor` field on the
+invocation envelope, which is why the last item can exist at all:
+`topics.agentName` is an interim atomic argument, and it is what the provenance
+path replaces.
+
+- **Specify a runtime-minted provenance atom**, provisionally `AgentActor`, for
+  trusted execution context at ingress. Its metadata may carry an agent role,
+  tool or session context, or a protected reference to the triggering request.
+  It is not reduced to a display name.
+- **Mint it at the external `cf` call boundary** from trusted client context and
+  attach it to the invocation input. The proof is CFC inspection: flow labels
+  carry the atom to every write the input affects.
+- **Define metadata confidentiality and the extraction and display helpers**
+  before any rich context is exposed. Prompt content and user-request content
+  must never be copied into an ordinary invocation payload.
+- **Retire `AgentAuthoredEvent { agentName }` from `topics`** once the
+  provenance path works end to end, and not before — it is the interim carrier
+  of attribution and stays until something else carries it. Dropping the
+  required input field is argument widening, so the update gate permits it.
+
+*Exit:* records are enumerable and expire per policy; CFC inspection proves
+execution provenance reaches affected writes from `cf`; `topics` can omit
+`agentName` without losing display attribution; and the invocation record has
+no independent canonical actor field.
+
+## Issue breakdown
+
+Importable one-to-one into the tracker; `depends on` names the dependency edge.
+
+| id | title | size | depends on |
+| --- | --- | --- | --- |
+| E1 | timestamps, error shape + linked retention collection | L | the retention window, the CFC review, the collection story |
+| E2 | CFC: specify `AgentActor` mint, propagation, metadata protection + extraction | L | CFC review |
+| E3 | cli: trusted ingress provenance for `cf` calls | M | E2 |
+| E4 | topics: retire AgentAuthoredEvent | S | E3 + end-to-end provenance proof |

--- a/docs/plans/space-clone-rehearsal.md
+++ b/docs/plans/space-clone-rehearsal.md
@@ -459,8 +459,8 @@ live) on PR #5009's review threads; paraphrased.
   [#4950] (Topics workload diagnostics — churn's live-runtime neighbor).
 - The interview: [PR #5009 review threads](https://github.com/commontoolsinc/labs/pull/5009)
   (Wilk; Gideon confirmed live).
-- `docs/plans/pattern-verb-contract-implementation.md` — Risks, the write-storm
-  gate.
+- `docs/history/plans/pattern-verb-contract-implementation.md` — Risks, the
+  write-storm gate.
 - `docs/development/LOCAL_DEV_SERVERS.md` — toolshed over a store dir, port
   offsets.
 

--- a/docs/plans/topics-migration-rehearsal.md
+++ b/docs/plans/topics-migration-rehearsal.md
@@ -10,7 +10,7 @@ Three documents already exist and none of them is this one:
   pieces to migrate or what to assert.
 - [`space-clone-rehearsal.md`](space-clone-rehearsal.md) is the **design** of
   that tooling.
-- [`pattern-verb-contract-implementation.md`](pattern-verb-contract-implementation.md)
+- [`pattern-verb-contract-implementation.md`](../history/plans/pattern-verb-contract-implementation.md)
   holds the **live-acceptance checklist** and the **write-storm gate**, spread
   across its Testing and Risks sections.
 

--- a/docs/plans/verb-result-selection.md
+++ b/docs/plans/verb-result-selection.md
@@ -17,7 +17,7 @@ shape bounds a read — has moved. A verb result is the shared read layer applie
 to the receipt cell, not a contract of its own.
 
 This continues the identity work from
-[Pattern verb contract — implementation plan](pattern-verb-contract-implementation.md)
+[Pattern verb contract — implementation plan](../history/plans/pattern-verb-contract-implementation.md)
 (WS-F). The user-facing surface it changes is
 [Verbs over the CLI](../common/verbs-over-the-cli.md).
 

--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -109,8 +109,26 @@ pattern compatibility checker — where the class decides whether adding and
 removing a key are both free, and where getting it wrong is what withdrew the
 July result-schema work. Sibling registries, not one: a projection is supplied
 per read and never compared across versions, so it has no add-and-remove
-semantics to get wrong. What transfers is classify-before-you-accept. #5309
-applied by hand to its two marks.
+semantics to get wrong. What transfers is classify-before-you-accept.
+
+*The two registries meet at lifted schemas, and this item is what couples
+them.* Today a projection ignores every key it does not recognize, so the
+durable dialect can grow freely. Refusing unrecognized keys ends that: a caller
+is told to lift a source schema and prune it, a lifted schema carries every
+keyword the generator emits, and a keyword admitted to the compat dialect
+without also reaching projection tolerance turns a projection over a marked
+schema into a refusal — on exactly the keys made deliberately free elsewhere.
+
+So the tolerated-as-annotation set is **derived from the compat checker's
+annotation keys rather than restating them**. One edit admits a key to both, and
+the vocabulary cannot fork. Where derivation is not possible, the fallback is a
+test asserting every annotation key the checker knows is non-refused by the
+projection reader — which converts a forgotten second list from a silent
+projection failure into a red test naming both registries.
+
+`tier` and `deprecated` are the newest annotation-class keys and the likeliest
+to be missing from a set drafted out of the standard JSON Schema vocabulary.
+They belong in the tolerated set on day one.
 
 *Exit:* an unrecognized key is refused and the message names it; a tolerated
 keyword is accepted and ignored. A command that ran only because a key was

--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -38,7 +38,7 @@ driver needs to know what is already moving before scheduling anything new.
 
 | PR | What | State |
 | --- | --- | --- |
-| #5307 | closed-world verb event schemas | update gate resolved, 336/336 patterns clean; held only for a courtesy nod |
+| #5307 | closed-world verb event schemas | code is gate-clear, 336/336 patterns; held for confirmation of the recorded skew policy, the one question named open |
 | #5309 | wrapper-tier and deprecated listing marks | rebased current; compat classification landed ahead of emission |
 | #5458 | the shared read step, factored out | open |
 | #5459 | `--piece` accepts the `of:` entity URI | open |
@@ -94,7 +94,22 @@ carries), and refused by name.
 
 This is the general form of a failure already fixed twice as instances — a
 missing `type` and an untyped `items` root each returned an empty result and
-reported nothing. It also generalizes the reserve-then-emit discipline #5309
+reported nothing.
+
+*Reservation records a class, not a spelling.* An allowlist that says only
+"allowed" loses why, and a key admitted without its kind has its treatment
+decided by whatever the checker happens to default to — the original trap, one
+level up. So each reservation carries what it is: honored, tolerated because it
+is an annotation, tolerated because it is a validation keyword. A later change
+wanting to honor a tolerated key then knows it was deliberately ignored rather
+than overlooked.
+
+The same discipline, on a different registry, is what classifies keys for the
+pattern compatibility checker — where the class decides whether adding and
+removing a key are both free, and where getting it wrong is what withdrew the
+July result-schema work. Sibling registries, not one: a projection is supplied
+per read and never compared across versions, so it has no add-and-remove
+semantics to get wrong. What transfers is classify-before-you-accept. #5309
 applied by hand to its two marks.
 
 *Exit:* an unrecognized key is refused and the message names it; a tolerated
@@ -153,6 +168,19 @@ anything reactive gets none, which is what item 1 decides.
 verb contract arc. Both unblocked; both wanted a courtesy review rather than a
 gate.
 
+**10. Listing rows carry a handler's declared result.** *(S)* `cf piece verbs`
+already reports an `outputSchema` per row, and the type says why it is empty for
+handlers: *"Tools only, until handlers gain declared results."* Item 1 is what
+supplies them. This is the deferred half of verb discovery finally closing, and
+it is a consumer change — the plumbing is built.
+
+*A terminology collision made this look like more than it is.* A pattern's
+**result-schema literal** is where its stream properties live, and the listing
+marks are stamped there. A **verb's declared result** is what a handler returns.
+The two share the words and nothing else, which is why the listing work and the
+declared-result work read as coupled when they are independent. Only this item
+joins them.
+
 ## Ordering
 
 | Item | After | Why |
@@ -165,7 +193,8 @@ gate.
 | 3 | 6 | completes the suppression property |
 | 4 | 7 | publishes an address, so the address must have stopped moving |
 | 5 | 4 | the fourth and fifth arrivals inherit whatever a read costs |
-| 1 | — | blocks nothing; makes 8 and the verb listing provisional |
+| 10 | 1 | listing rows carry a handler's `outputSchema`; the plumbing exists for tools already |
+| 1 | — | blocks nothing; makes 8 and item 10 provisional |
 
 Items 2, 3 and 5 touch one file heavily and want to land one at a time rather
 than in parallel. Item 4 is the only one that touches the call envelope.
@@ -176,8 +205,23 @@ One agent owns this document and the ordering in it. Work is farmed out per
 item, not per file, and an item comes back with its own tests rather than a
 promise of them.
 
+**This document owns the record as well as the order.** The plans it replaces
+are archived, so there is no longer a live plan for an author to strike a done
+note into as their work lands; done state belongs in the State table above, and
+keeping it current is this document's job rather than each author's. That is
+worth stating because the alternative — several sessions editing one shared
+plan as their PRs land — is the collision the per-agent split exists to avoid.
+
 Two rules earn their place, both from what went wrong when this was three
 plans:
+
+**#5307 and #5501 reconcile rather than order.** They touch no common source
+file and neither depends on the other — a declared result rides a trailing
+options argument, while event stamping keys on the first. But #5501's
+handler-schema fixtures were compiled before event schemas closed, so once
+#5307 lands they gain `additionalProperties: false` on their event literals.
+Whichever merges second owes a golden regeneration. That is a note on the pair,
+not an edge in the table above.
 
 **A shared golden is a coordination point, not a merge conflict.** Two branches
 can modify a generated fixture without conflicting textually and still leave it

--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -1,0 +1,227 @@
+# Verbs — implementation plan
+
+Sequences the remaining work on verbs: what a verb declares, what a caller may
+ask for, and what comes back. It carries the residue of two
+implementation plans whose work is substantially landed —
+[the pattern verb contract](pattern-verb-contract-implementation.md) and
+[shaped reads and verb results](shaped-reads-implementation.md) — which are
+archived once this replaces them.
+
+**The designs are unchanged and are not restated here.**
+[The pattern verb contract](pattern-verb-contract.md) says what a verb is.
+[Reading Fabric data](fabric-read-model.md) and the two documents it points at
+say how a caller reads. Read those for reasoning; read this for order.
+
+## Why one sequencing plan over two
+
+The two arcs describe genuinely different things — one the producer side, one
+the consumer side — and their designs stay apart for that reason. But they meet
+at exactly one point, and everything expensive about running them separately has
+come from that meeting being implicit.
+
+**The one intersection: whether a verb's declared result reaches the runtime.**
+It is the withdrawn result-schema emission, the descriptive receipt schema that
+stands in for it, the open proposal to carry a declared result onto
+`module.resultSchema`, and the verb listing that wants result schemas before it
+is complete. One question, four places.
+
+Three agents rediscovered its consequences independently — the append-only
+lesson, the update-gate refusal, and the withdrawal history — each paying full
+price. That is what a shared sequence prevents. Ordering is temporal, so it
+belongs in one document even when the reasoning belongs in two.
+
+## State
+
+Twelve pull requests are open against this work. They are listed here because a
+driver needs to know what is already moving before scheduling anything new.
+
+| PR | What | State |
+| --- | --- | --- |
+| #5307 | closed-world verb event schemas | update gate resolved, 336/336 patterns clean; held only for a courtesy nod |
+| #5309 | wrapper-tier and deprecated listing marks | rebased current; compat classification landed ahead of emission |
+| #5458 | the shared read step, factored out | open |
+| #5459 | `--piece` accepts the `of:` entity URI | open |
+| #5468 | receipts carry a descriptive schema | open |
+| #5469 | invocation ids scoped to a session | open |
+| #5470 | `$link` marks a position for its address | open |
+| #5497 | a projection keyword names its container | open |
+| #5500 | `--select` and `--schema` split | open |
+| #5501 | a verb's declared result reaches its module | **draft — the open decision** |
+| #5504 | `@` marks a position in a field list | open |
+| #5505 | `piece call` takes the selection flags | open |
+
+## The decision everything else waits behind
+
+**1. Does a verb's declared result reach the runtime?** *(#5501, draft)*
+
+The result-schema emission built in July was withdrawn for three recorded
+reasons: the value path did not need it, a keyword in durable schemas and
+append-only baselines would hard-commit a shape the Fabric-types stream
+evolution is expected to replace, and the compatibility rules built alongside it
+would have refused its later removal.
+
+#5501 is a different road to the same property — an existing field on a node's
+module rather than a new dialect keyword, with the compatibility gate untouched
+— and the first two objections are answered on that road. What it buys is
+narrower than first claimed: a `$link` marker already renders an address and
+already suppresses the fetch without it. What it adds is narrowing on field
+selection, and checking a selection before the call rather than after.
+
+Three things hang off the answer:
+
+- whether `cf piece verbs` can carry result schemas, which its own issue defers
+  until this exists;
+- whether a receipt for a verb returning anything reactive is describable at
+  all, since the descriptive derivation runs only where the result is plain;
+- whether items 8 and 9 below are worth their cost, since both improve a
+  description nothing yet consumes.
+
+It is a draft rather than a proposal because it needs the owner who made the
+withdrawal call. Until then it blocks nothing, but it makes three other
+decisions provisional.
+
+## Ready to build
+
+Unblocked, small, and independent of the decision above.
+
+**2. An unrecognized projection key is refused.** *(M)* Two denylists are
+consulted and every key in neither is accepted and ignored, so a typo selects
+nothing and says nothing, and any keyword given a meaning later changes
+behavior no error ever warned about. Three tiers replace them: honored,
+tolerated (the annotation and validation keywords, which a lifted source schema
+carries), and refused by name.
+
+This is the general form of a failure already fixed twice as instances — a
+missing `type` and an untyped `items` root each returned an empty result and
+reported nothing. It also generalizes the reserve-then-emit discipline #5309
+applied by hand to its two marks.
+
+*Exit:* an unrecognized key is refused and the message names it; a tolerated
+keyword is accepted and ignored. A command that ran only because a key was
+silently dropped now fails loudly, which is the point rather than a regression.
+
+**3. A rejection propagates up through what holds it.** *(S)* The projection
+mask reduces an array whose items reject to `false`, but leaves an object whose
+every property rejects as a live selector. So marking a field below a link loads
+every element document — measured at four reads where one would do. The fix is
+the symmetric reduction, which then cascades to the array above it.
+
+*Exit:* a marked collection is one document read whether the marker sits on the
+link or below it.
+
+**4. `receipt` as a top-level envelope field.** *(S)* Published from the
+handling receipt link, so a caller holds the address before the outcome exists —
+including under `--no-wait`, which returns none today and is therefore a dead
+end for collecting work later.
+
+This is also what gives items 8 and 9 a consumer: a receipt's schema is read by
+`piece get` against the address this publishes, not by the call path.
+
+*Exit:* a detached call returns an address that reads back the outcome it
+names.
+
+**5. `cf wish` and `cf exec` take the read options.** *(S each)* The two
+remaining arrivals. A vocabulary that works from two starting points and
+silently does nothing from the other two teaches a rule that is false half the
+time.
+
+Two constraints carry from the design: a wish's selection runs *before* the walk
+that strips handles, because a marker needs a live cell to read an address from;
+and `exec` already prints its result cell as prose on stderr, in a spelling no
+other command accepts, which this is the occasion to make the declared shape.
+
+*Exit:* the same cell, reached four ways, renders identically under the same
+selection.
+
+## Landed, pending merge
+
+**6. The read layer.** #5458, #5470, #5497, #5500, #5504, #5505, #5459 — the
+shared read step, address markers with the deepest-link rule, container
+inference, the flag split, the `@` suffix, call selection, and entity-URI
+intake. All built and restacked onto current main.
+
+**7. Session-scoped invocation ids.** #5469. The one address-changing commit;
+it lands alone, ahead of anything that publishes a receipt address, so no caller
+holds one that moves.
+
+**8. Descriptive receipt schemas.** #5468. Plain results only — a verb returning
+anything reactive gets none, which is what item 1 decides.
+
+**9. Closed-world event schemas and listing marks.** #5307 and #5309, from the
+verb contract arc. Both unblocked; both wanted a courtesy review rather than a
+gate.
+
+## Ordering
+
+| Item | After | Why |
+| --- | --- | --- |
+| 6 | — | the stack merges bottom-up: #5458 → #5470 → #5497 → #5500 → {#5504, #5505} |
+| 7 | — | independent of 6; must precede 4 |
+| 8, 9 | — | independent |
+| 2 | 6 | changes what the flags accept |
+| 3 | 6 | completes the suppression property |
+| 4 | 7 | publishes an address, so the address must have stopped moving |
+| 5 | 4 | the fourth and fifth arrivals inherit whatever a read costs |
+| 1 | — | blocks nothing; makes 8 and the verb listing provisional |
+
+Items 2, 3 and 5 touch one file heavily and want to land one at a time rather
+than in parallel. Item 4 is the only one that touches the call envelope.
+
+## How this is driven
+
+One agent owns this document and the ordering in it. Work is farmed out per
+item, not per file, and an item comes back with its own tests rather than a
+promise of them.
+
+Two rules earn their place, both from what went wrong when this was three
+plans:
+
+**A shared golden is a coordination point, not a merge conflict.** Two branches
+can modify a generated fixture without conflicting textually and still leave it
+encoding only one change. Whoever lands second regenerates.
+
+**A keyword is classified before it is emitted.** Adding one to a durable schema
+is free and removing one is not, so the classification has to precede the first
+emission or the keyword is permanent by accident. This is what withdrew the
+July result-schema work, and what #5309 got right by hand.
+
+## What comes after
+
+This plan is exhausted when items 1-5 are decided or built and the twelve open
+pull requests have landed. Two arcs are queued behind it, and naming their
+triggers here is what keeps them from being dropped when this document stops
+being read.
+
+**The command surface** —
+[The CLI surface](cli-surface-implementation.md), already sequenced. Its first
+two stages add positional addresses and the top-level names, and they can start
+as soon as the read layer has merged; they touch the same commands, so starting
+earlier means resolving the same files twice. Its deprecation stage carries an
+unanswered question of its own — what "carries traffic" means, given nothing
+measures it — and that wants an answer before the stage rather than during it.
+
+**Retention and CFC execution provenance** — extracted from the verb contract
+arc into its own plan. Gated on a CFC review that has not happened. Nothing in
+this plan advances it, and nothing in it blocks this plan.
+
+Whoever drives this document owns that queue, not just this list. A plan that
+finishes without naming its successor is how an arc goes quiet with work left
+in it.
+
+## Out of scope
+
+**Retention and CFC execution provenance** — the `AgentActor` mint, its
+propagation, metadata confidentiality, and retiring `AgentAuthoredEvent`. Gated
+on a CFC review, sized large, and not about verbs: it is a program that was
+filed under one. It moves to its own plan.
+
+**The command surface** —
+[The CLI surface](cli-surface-implementation.md) sequences positional addresses,
+the top-level names, deprecation, and the merges. Kept apart because it renames
+rather than adds, so every step of it can break a caller who learned the current
+spelling.
+
+**The designs.** Nothing here amends
+[the pattern verb contract](pattern-verb-contract.md) or
+[Reading Fabric data](fabric-read-model.md). An item that needs a design changed
+says so and stops.

--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -1,11 +1,12 @@
 # Verbs — implementation plan
 
 Sequences the remaining work on verbs: what a verb declares, what a caller may
-ask for, and what comes back. It carries the residue of two
-implementation plans whose work is substantially landed —
-[the pattern verb contract](pattern-verb-contract-implementation.md) and
-[shaped reads and verb results](shaped-reads-implementation.md) — which are
-archived once this replaces them.
+ask for, and what comes back. It carries the residue of two implementation
+plans whose work is substantially landed, and which are archived as the record
+of what each decided:
+[the pattern verb contract](../history/plans/pattern-verb-contract-implementation.md)
+and
+[shaped reads and verb results](../history/plans/shaped-reads-implementation.md).
 
 **The designs are unchanged and are not restated here.**
 [The pattern verb contract](pattern-verb-contract.md) says what a verb is.
@@ -138,7 +139,8 @@ selection.
 **6. The read layer.** #5458, #5470, #5497, #5500, #5504, #5505, #5459 — the
 shared read step, address markers with the deepest-link rule, container
 inference, the flag split, the `@` suffix, call selection, and entity-URI
-intake. All built and restacked onto current main.
+intake. All built and restacked onto current main. The first six are one
+stack; #5459 is independent of it and of everything else here.
 
 **7. Session-scoped invocation ids.** #5469. The one address-changing commit;
 it lands alone, ahead of anything that publishes a receipt address, so no caller
@@ -155,7 +157,8 @@ gate.
 
 | Item | After | Why |
 | --- | --- | --- |
-| 6 | — | the stack merges bottom-up: #5458 → #5470 → #5497 → #5500 → {#5504, #5505} |
+| 6 (stack) | — | the stack merges bottom-up: #5458 → #5470 → #5497 → #5500 → {#5504, #5505} |
+| 6 (#5459) | — | not in the stack; entity-URI intake stands alone and merges whenever |
 | 7 | — | independent of 6; must precede 4 |
 | 8, 9 | — | independent |
 | 2 | 6 | changes what the flags accept |
@@ -200,9 +203,9 @@ earlier means resolving the same files twice. Its deprecation stage carries an
 unanswered question of its own — what "carries traffic" means, given nothing
 measures it — and that wants an answer before the stage rather than during it.
 
-**Retention and CFC execution provenance** — extracted from the verb contract
-arc into its own plan. Gated on a CFC review that has not happened. Nothing in
-this plan advances it, and nothing in it blocks this plan.
+**Retention and CFC execution provenance** —
+[its own plan](retention-and-provenance.md). Gated on a CFC review that has not
+happened. Nothing in this plan advances it, and nothing in it blocks this plan.
 
 Whoever drives this document owns that queue, not just this list. A plan that
 finishes without naming its successor is how an arc goes quiet with work left
@@ -213,7 +216,8 @@ in it.
 **Retention and CFC execution provenance** — the `AgentActor` mint, its
 propagation, metadata confidentiality, and retiring `AgentAuthoredEvent`. Gated
 on a CFC review, sized large, and not about verbs: it is a program that was
-filed under one. It moves to its own plan.
+filed under one. It is sequenced in
+[its own plan](retention-and-provenance.md).
 
 **The command surface** —
 [The CLI surface](cli-surface-implementation.md) sequences positional addresses,

--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -241,6 +241,19 @@ handler-schema fixtures were compiled before event schemas closed, so once
 Whichever merges second owes a golden regeneration. That is a note on the pair,
 not an edge in the table above.
 
+**A squash merge invalidates the fork point of everything stacked on it.**
+Rebasing a child with `git rebase <new-base>` then replays commits the base
+already contains, and the duplicate-commit conflicts look like real ones.
+`git rebase --onto <new-base> <the branch's own first commit's parent>` is the
+form that works. The cheapest tell that a fork point was wrong: the branch
+suddenly touches files it has no business in.
+
+**`deno fmt` does not check anything under `docs/`.** The directory is in the
+formatter's exclude list, so a passing `deno fmt --check` after a documentation
+edit says nothing about that edit. The gates that do apply are `check-docs` for
+code blocks, `check-conflict-markers`, and `docs-links --orphan`. Prose wrapping
+is convention here rather than enforcement.
+
 **A shared golden is a coordination point, not a merge conflict.** Two branches
 can modify a generated fixture without conflicting textually and still leave it
 encoding only one change. Whoever lands second regenerates.

--- a/docs/specs/schema-generator/ts_to_json_schema_mapping.md
+++ b/docs/specs/schema-generator/ts_to_json_schema_mapping.md
@@ -398,7 +398,8 @@ type). The verb contract wants event schemas closed-world
 ignored), but emitting that is blocked on a pattern-update-gate migration:
 the argument-role compatibility rule refuses the open→closed direction for
 verbs reachable through a piece's argument schema (plan
-`docs/plans/pattern-verb-contract-implementation.md`, WS-C and Risks). The
+`docs/history/plans/pattern-verb-contract-implementation.md`, WS-C and Risks).
+The
 open event side is pinned as a decision in `test/stream-result.test.ts`; a
 schema that declares the closure by hand is enforced at dispatch by the
 runner (C5).

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -1410,10 +1410,10 @@ export class CellImpl<T extends FabricValue>
      * one: an ingress caller that owns a delivery id passes it through so a
      * retry of the same id collides on the handling's create-only receipt
      * (verb contract WS-D,
-     * docs/plans/pattern-verb-contract-implementation.md). The receipt is a
-     * COMMIT witness, not an execution witness — the redelivered event still
-     * runs the handler body and then loses the race, so effects outside the
-     * transaction repeat. `runtimeInjectedEventKeys` carries the
+     * docs/history/plans/pattern-verb-contract-implementation.md). The receipt
+     * is a COMMIT witness, not an execution witness — the redelivered event
+     * still runs the handler body and then loses the race, so effects outside
+     * the transaction repeat. `runtimeInjectedEventKeys` carries the
      * runtime-injection provenance the closed-world gate consumes. Ignored on
      * the plain-cell write path.
      */

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -218,9 +218,9 @@ export interface ExperimentalOptions {
    * path; this covers plain values, which are otherwise discarded. Defaults
    * to on since the invocation-protocol integration proof (#5244's
    * three-topic fixture; verb contract,
-   * docs/plans/pattern-verb-contract-implementation.md WS-C/WS-D). Pass
-   * `false` (or `EXPERIMENTAL_PLAIN_RESULT_RECEIPTS=false`) as a temporary
-   * rollback override while the flag exists.
+   * docs/history/plans/pattern-verb-contract-implementation.md WS-C/WS-D).
+   * Pass `false` (or `EXPERIMENTAL_PLAIN_RESULT_RECEIPTS=false`) as a
+   * temporary rollback override while the flag exists.
    */
   plainResultReceipts?: boolean | undefined;
   /**

--- a/packages/runner/test/declared-result-e2e.test.ts
+++ b/packages/runner/test/declared-result-e2e.test.ts
@@ -7,7 +7,7 @@
 // exercises only the raw trusted-builder `handler`) with the api's declared-
 // result authoring surface. This is the readback half of WS-C's exit
 // criterion, pinned at the runner in addition to the end-to-end fixture
-// (pattern-verb-contract-implementation.md, D4).
+// (docs/history/plans/pattern-verb-contract-implementation.md, D4).
 //
 // The incidental-cell-return case pins the receipt write's conversion: `set()`
 // returns its cell for chaining, so an expression-body

--- a/packages/schema-generator/test/stream-result.test.ts
+++ b/packages/schema-generator/test/stream-result.test.ts
@@ -130,7 +130,8 @@ interface SchemaRoot {
     // would now be rejected" — measured on calendar/calendar.tsx,
     // lunch-poll/poll-option-card.tsx, notes/note.tsx). Landing the emission
     // needs that migration step first; the sequencing finding is recorded in
-    // docs/plans/pattern-verb-contract-implementation.md (WS-C and Risks).
+    // docs/history/plans/pattern-verb-contract-implementation.md (WS-C and
+    // Risks).
     // Until then this pin makes the open event side an explicit decision, not
     // an omission — dispatch-side enforcement (runner, C5) already honors a
     // schema that declares the closure by hand.


### PR DESCRIPTION
## Why

Three agents have been implementing verbs against two plans. The plans describe genuinely different things — one the producer side (what a verb *is*), one the consumer side (how a caller reads) — and their designs should stay apart for that reason.

But they meet at exactly one point: **whether a verb's declared result reaches the runtime.** That is the withdrawn result-schema emission, the descriptive receipt schema standing in for it, the open proposal to carry a declared result onto `module.resultSchema`, and the verb listing that wants result schemas before it is complete. One question, four places.

That meeting was never written down, and three agents rediscovered its consequences independently — the append-only trap, the update-gate refusal, and the withdrawal history — each paying full price. Ordering is temporal, so it belongs in one document even when the reasoning belongs in two.

## What Changed

One new plan, `docs/plans/verbs-implementation.md`, indexed. **No design document is touched.**

It carries the residue of both implementation plans, using plain numbered ids so nothing collides with either predecessor's `C1`/`C2`/`C3` — a collision that has already cost real confusion in this work.

Six sections: why one sequence, the state of all twelve open PRs, the one decision the rest is provisional on, five ready-to-build items, what has landed pending merge, and the ordering.

## The shape of the claim

**#5501 leads, not the work.** Everything else is either landed or independent of it. That one draft decides whether `cf piece verbs` can carry result schemas, whether a reactive verb's receipt is describable at all, and whether the descriptive receipt schemas earn their keep. It blocks nothing and makes three things provisional, which is a worse state to leave undocumented than a blocker.

**Two rules under "How this is driven,"** both earned rather than invented. A shared golden fixture is a coordination point that does *not* surface as a merge conflict — two branches can modify one and leave it encoding a single change. And a keyword is classified before it is emitted, because adding one to a durable schema is free while removing one is not; that asymmetry withdrew the July work, and #5309 got it right by hand.

**Successors carry triggers.** The CLI surface arc and the extracted retention/provenance work are named with the conditions that start them. A plan that finishes without naming what follows is how an arc goes quiet with work left in it.

## Not done here, deliberately

**Archiving the two predecessors.** `pattern-verb-contract-implementation.md` has **eight** inbound links, including `docs/specs/schema-generator/ts_to_json_schema_mapping.md` and `EXPERIMENTAL_OPTIONS.md`. Each needs a judgment call about whether it wants the frozen record or this plan. That is a larger change than this one and belongs in its own.

**Extracting retention and CFC provenance** into its own plan — same reason, and it means lifting content out of a document being frozen in the same change.

Both are ready to follow once this is agreed.

## Test plan

Documentation only. `deno fmt --check`, `deno task check-docs` (533 blocks) pass.

## Sign-off wanted

This plan takes over PRs owned by other agents (#5307, #5309). It should not land without their owners agreeing to the characterization.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

