### PR TITLE
docs(utils): conform doc comments to the style guide

### DIFF
--- a/packages/utils/bench/bigint.bench.ts
+++ b/packages/utils/bench/bigint.bench.ts
@@ -64,7 +64,7 @@ function makeRng(seed: number): () => number {
 }
 
 /**
- * Build a positive bigint that requires exactly `bytes` bytes when encoded
+ * Returns a positive bigint that requires exactly `bytes` bytes when encoded
  * as minimal two's complement. Forces bit (8*bytes - 2) so the value lies in
  * the upper half of the band, then fills the remaining magnitude bits from
  * `rng`.

--- a/packages/utils/src/arrays.bench.ts
+++ b/packages/utils/src/arrays.bench.ts
@@ -89,7 +89,9 @@ sparse.length = 100_000;
 sparse[0] = "first";
 sparse[99_999] = "last";
 
-/** The same two elements in a small extent, as the comparison that isolates it. */
+/**
+ * The same two elements in a small extent, as the comparison that isolates it.
+ */
 const compact: unknown[] = ["first", "last"];
 
 /** Rejected for a named property, which short-circuits on the last key. */

--- a/packages/utils/src/arrays.ts
+++ b/packages/utils/src/arrays.ts
@@ -3,9 +3,7 @@
  * array index-only-ness.
  */
 
-/**
- * Character code for digit `0`.
- */
+/** Character code for digit `0`. */
 const CHAR_CODE_0 = "0".charCodeAt(0);
 
 /**
@@ -89,10 +87,11 @@ export function isArrayIndexPropertyName(name: string): boolean {
  * throw from `ownKeys()`. Reporting `false` there would mean reading "this is
  * not an index-only array" into what is actually a failure to find out.
  *
- * **Note:** This function relies on the given array producing `Reflect.ownKeys()`
- * output which agrees with the JavaScript spec with regards to key ordering,
- * namely index keys in ascending numeric order, then the remaining string keys
- * in property-creation order, then symbol keys in property-creation order.
+ * **Note:** This function relies on the given array producing
+ * `Reflect.ownKeys()` output which agrees with the JavaScript spec with
+ * regards to key ordering, namely index keys in ascending numeric order, then
+ * the remaining string keys in property-creation order, then symbol keys in
+ * property-creation order.
  * Built-in arrays of course do this, but it's possible for a `Proxy` to (a)
  * effectively purport to be an array, and yet (b) have an `ownKeys()` trap that
  * diverges from the behavior of built-in arrays. In such cases, this function

--- a/packages/utils/src/async-local-store.ts
+++ b/packages/utils/src/async-local-store.ts
@@ -15,7 +15,10 @@
  *       : FallbackAsyncLocalStore) as new <T>() => AsyncLocalStore<T>;
  */
 export interface AsyncLocalStore<T> {
+  /** Returns the currently bound value, or `undefined` if there is none. */
   getStore(): T | undefined;
+
+  /** Calls `fn` with `value` bound, and returns what it returns. */
   run<R>(value: T, fn: () => R): R;
 }
 

--- a/packages/utils/src/base64url.ts
+++ b/packages/utils/src/base64url.ts
@@ -1,11 +1,8 @@
-/**
- * Base64url helper functions.
- */
+/** Base64url helper functions. */
 
 /**
- * Do we need to use our own implementation of base64url encoding? As of
- * 2024-04, most current browser releases support it directly, but it's not
- * universal.
+ * Whether base64url conversion needs the polyfill below. As of 2024-04, most
+ * current browser releases support it directly, but it is not universal.
  */
 const useBase64Polyfill = !Uint8Array.fromBase64;
 
@@ -38,9 +35,7 @@ export function fromBase64url(encoded: string): Uint8Array {
 const B64_CHARS =
   "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
 
-/**
- * Polyfill for `toUnpaddedBase64url()`. `export`ed just for testing.
- */
+/** Polyfill for `toUnpaddedBase64url()`. `export`ed just for testing. */
 export function toBase64Polyfill(bytes: Uint8Array): string {
   let result = "";
   const len = bytes.length;
@@ -85,9 +80,7 @@ for (let i = 0; i < B64_CHARS.length; i++) {
   B64_DECODE[B64_CHARS.charCodeAt(i)] = i;
 }
 
-/**
- * Polyfill for `fromBase64url()`. `export`ed just for testing.
- */
+/** Polyfill for `fromBase64url()`. `export`ed just for testing. */
 export function fromBase64Polyfill(encoded: string): Uint8Array {
   const s = encoded;
 

--- a/packages/utils/src/bigint-shared-impl.ts
+++ b/packages/utils/src/bigint-shared-impl.ts
@@ -1,20 +1,12 @@
-/**
- * Helpers for both `bigint` codec implementations.
- */
+/** Helpers for both `bigint` codec implementations. */
 
-/**
- * Shared 8-byte scratch buffer.
- */
+/** Shared 8-byte scratch buffer. */
 const dv64Buf = new ArrayBuffer(8);
 
-/**
- * `DataView` of `dv64buf`.
- */
+/** `DataView` of `dv64buf`. */
 const dv64View = new DataView(dv64Buf);
 
-/**
- * `Uint8Array` view of `dv64buf`.
- */
+/** `Uint8Array` view of `dv64buf`. */
 const dv64Bytes = new Uint8Array(dv64Buf);
 
 /**
@@ -58,9 +50,7 @@ export function hexStringFromPositiveValue(value: bigint): string {
   }
 }
 
-/**
- * Converts a value that fits into 64 bits and requires `length >= 5`.
- */
+/** Converts a value that fits into 64 bits and requires `length >= 5`. */
 export function encode5To8Bytes(value: bigint, negative: boolean): Uint8Array {
   const skipByte = negative ? 0xff : 0x00;
   const signBit = skipByte & 0x80;

--- a/packages/utils/src/build-info.ts
+++ b/packages/utils/src/build-info.ts
@@ -1,19 +1,33 @@
 // Reader for the `COMPILED` build-metadata file that `tasks/build-binaries.ts`
 // writes next to a binary's entry package and includes via `deno compile
 // --include`. The values travel with the artifact and identify the commit it
-// was built from. Both the toolshed server and the cf CLI read their own copy
-// through this module.
+// was built from.
 
+/** Build metadata for a compiled binary. */
 export interface BuildInfo {
+  /** Commit the binary was built from, or `null` if not recorded. */
   commitSha: string | null;
+
+  /** Time the binary was built, or `null` if not recorded. */
   builtAt: string | null;
 }
 
+/**
+ * Returns `s` with surrounding whitespace removed, or `null` if what remains
+ * is empty. This is how an absent, blank, or `undefined` field in the metadata
+ * file becomes a single `null`.
+ */
 export function normalize(s: string | null | undefined): string | null {
   const trimmed = s?.trim();
   return trimmed ? trimmed : null;
 }
 
+/**
+ * Reads the build metadata file at `path`. Every failure mode -- an
+ * unreadable file, an empty one, malformed JSON, or JSON that is not an
+ * object -- yields a `BuildInfo` with both fields `null`, on the principle
+ * that missing provenance must not stop a binary from starting.
+ */
 export function readBuildInfoFrom(path: URL | string): BuildInfo {
   let raw: string;
   try {

--- a/packages/utils/src/cache.ts
+++ b/packages/utils/src/cache.ts
@@ -1,7 +1,13 @@
+/** Options common to the caches defined here. */
 export interface CacheOptions {
+  /** Maximum number of entries to hold. */
   capacity?: number;
 }
 
+/**
+ * Options for a cache that bounds the total weight of what it holds, as well
+ * as the number of entries.
+ */
 export interface WeightedCacheOptions<K, V> extends CacheOptions {
   /**
    * Cost of one entry, in whatever unit `maxWeight` is expressed in. Supply
@@ -9,40 +15,55 @@ export interface WeightedCacheOptions<K, V> extends CacheOptions {
    * bounds how many things a cache holds, not how much memory they take.
    */
   weigh?: (key: K, value: V) => number;
+
+  /** Maximum total weight to hold, in the unit `weigh` reports. */
   maxWeight?: number;
 }
 
 /**
- * A Map that drops its oldest key once it holds `limit` of them. Insertion
+ * A `Map` that drops its oldest key once it holds `limit` of them. Insertion
  * order is the eviction order, and re-setting a key refreshes its place, so
  * what goes first is whatever has gone longest without being written.
  *
- * The point of the Map-shaped surface is that an unbounded `Map` field becomes
- * bounded by changing only its declaration. Reach for this where the entries
- * are hints — a value whose loss costs a slower path, never a wrong answer —
- * and where the keys keep arriving: one per instance of something the program
- * creates and discards, rather than one per fixed thing it knows about.
+ * The point of the `Map`-shaped surface is that an unbounded `Map` field
+ * becomes bounded by changing only its declaration. Reach for this where the
+ * entries are hints — a value whose loss costs a slower path, never a wrong
+ * answer — and where the keys keep arriving: one per instance of something
+ * the program creates and discards, rather than one per fixed thing it knows
+ * about.
  */
 export class BoundedKeyMap<K, V> implements ReadonlyMap<K, V> {
   readonly #entries = new Map<K, V>();
   readonly #limit: number;
 
+  /**
+   * Constructs an instance which holds at most `limit` entries. A `limit`
+   * below `1` is taken as `1`, there being no useful cache of size zero.
+   */
   constructor(limit: number) {
     this.#limit = Math.max(limit, 1);
   }
 
+  /** @inheritDoc */
   get size(): number {
     return this.#entries.size;
   }
 
+  /** @inheritDoc */
   has(key: K): boolean {
     return this.#entries.has(key);
   }
 
+  /** @inheritDoc */
   get(key: K): V | undefined {
     return this.#entries.get(key);
   }
 
+  /**
+   * Sets `key` to `value`, dropping the oldest entries as needed to stay
+   * within the limit. Setting a key that is already present refreshes its
+   * place, making it the newest.
+   */
   set(key: K, value: V): void {
     this.#entries.delete(key);
     // Keys come out in insertion order, so this drops the oldest first, and
@@ -54,30 +75,37 @@ export class BoundedKeyMap<K, V> implements ReadonlyMap<K, V> {
     this.#entries.set(key, value);
   }
 
+  /** Removes the entry for `key`, returning whether there was one. */
   delete(key: K): boolean {
     return this.#entries.delete(key);
   }
 
+  /** Removes all entries. */
   clear(): void {
     this.#entries.clear();
   }
 
-  // The read side is the standard ReadonlyMap surface, so a consumer that only
-  // reads takes `ReadonlyMap` and accepts either this or a plain Map. Every
-  // traversal runs oldest first, which is the order entries are dropped in.
+  // The read side is the standard `ReadonlyMap` surface, so a consumer that
+  // only reads takes `ReadonlyMap` and accepts either this or a plain `Map`.
+  // Every traversal runs oldest first, which is the order entries are dropped
+  // in.
 
+  /** @inheritDoc */
   entries(): MapIterator<[K, V]> {
     return this.#entries.entries();
   }
 
+  /** @inheritDoc */
   keys(): MapIterator<K> {
     return this.#entries.keys();
   }
 
+  /** @inheritDoc */
   values(): MapIterator<V> {
     return this.#entries.values();
   }
 
+  /** @inheritDoc */
   forEach(
     callback: (value: V, key: K, map: ReadonlyMap<K, V>) => void,
     thisArg?: unknown,
@@ -87,19 +115,36 @@ export class BoundedKeyMap<K, V> implements ReadonlyMap<K, V> {
     }
   }
 
+  /** @inheritDoc */
   [Symbol.iterator](): MapIterator<[K, V]> {
     return this.#entries.entries();
   }
 }
 
+/** One entry of an `LRUCache`, as a node of its recency list. */
 interface LRUNode<K, V> {
+  /** Key the entry is stored under. */
   key: K;
+
+  /** Value stored. */
   value: V;
+
+  /** Weight of the entry, per the cache's `weigh` option. */
   weight: number;
+
+  /** Adjacent node toward the oldest end, or `null` at that end. */
   prev: LRUNode<K, V> | null;
+
+  /** Adjacent node toward the newest end, or `null` at that end. */
   next: LRUNode<K, V> | null;
 }
 
+/**
+ * Cache which drops its least recently used entry once it is full, where a
+ * successful `get()` and any `put()` both count as a use. Fullness is by
+ * entry count, and additionally by total weight when the `weigh` option is
+ * supplied.
+ */
 export class LRUCache<K, V> {
   #map = new Map<K, LRUNode<K, V>>();
   #head: LRUNode<K, V> | null = null;
@@ -112,12 +157,18 @@ export class LRUCache<K, V> {
   #maxWeight: number;
   #weight = 0;
 
+  /**
+   * Constructs an instance per `options`, holding at most `capacity` entries
+   * (`1000` by default) and, when `weigh` is given, at most `maxWeight` total
+   * weight.
+   */
   constructor(options: WeightedCacheOptions<K, V> = {}) {
     this.#capacity = Math.max(options.capacity ?? 1000, 1);
     this.#weigh = options.weigh;
     this.#maxWeight = options.maxWeight ?? Infinity;
   }
 
+  /** Number of entries currently held. */
   get size(): number {
     return this.#map.size;
   }
@@ -127,10 +178,18 @@ export class LRUCache<K, V> {
     return this.#weight;
   }
 
+  /**
+   * Indicates whether there is an entry for `key`. This does not count as a
+   * use, and so does not affect what gets dropped next.
+   */
   has(key: K): boolean {
     return this.#map.has(key);
   }
 
+  /**
+   * Returns the value for `key`, or `undefined` if there is no entry. A hit
+   * counts as a use.
+   */
   get(key: K): V | undefined {
     const node = this.#map.get(key);
     if (node === undefined) {
@@ -140,6 +199,10 @@ export class LRUCache<K, V> {
     return node.value;
   }
 
+  /**
+   * Sets `key` to `value`, counting as a use, and drops entries as needed to
+   * stay within the capacity and weight bounds.
+   */
   put(key: K, value: V): void {
     const weight = this.#weigh?.(key, value) ?? 0;
     const existingNode = this.#map.get(key);
@@ -163,6 +226,7 @@ export class LRUCache<K, V> {
     this.#evictToFit();
   }
 
+  /** Removes the entry for `key`, returning whether there was one. */
   delete(key: K): boolean {
     const node = this.#map.get(key);
     if (node === undefined) {
@@ -174,6 +238,7 @@ export class LRUCache<K, V> {
     return true;
   }
 
+  /** Removes all entries. */
   clear(): void {
     this.#map.clear();
     this.#head = null;
@@ -181,15 +246,19 @@ export class LRUCache<K, V> {
     this.#weight = 0;
   }
 
-  // Evict from the least-recently-used end until the weight budget is met.
-  // The most recent entry stays even when it alone exceeds the budget, so a
-  // single oversized value cannot leave the cache empty on every put.
+  /**
+   * Helper for `put()`, which drops entries from the oldest end until the
+   * weight budget is met. The newest entry stays even when it alone exceeds
+   * the budget, so a single oversized value cannot leave the cache empty on
+   * every `put()`.
+   */
   #evictToFit(): void {
     while (this.#weight > this.#maxWeight && this.#map.size > 1) {
       this.#evictHead();
     }
   }
 
+  /** Unlinks `node` from the recency list. */
   #removeNode(node: LRUNode<K, V>): void {
     if (node.prev !== null) {
       node.prev.next = node.next;
@@ -205,6 +274,7 @@ export class LRUCache<K, V> {
     node.next = null;
   }
 
+  /** Links `node` in at the newest end of the recency list. */
   #addToTail(node: LRUNode<K, V>): void {
     if (this.#tail === null) {
       this.#head = node;
@@ -216,6 +286,7 @@ export class LRUCache<K, V> {
     }
   }
 
+  /** Moves `node` to the newest end of the recency list. */
   #moveToTail(node: LRUNode<K, V>): void {
     if (node === this.#tail) {
       return;
@@ -224,6 +295,7 @@ export class LRUCache<K, V> {
     this.#addToTail(node);
   }
 
+  /** Drops the entry at the oldest end, if there is one. */
   #evictHead(): void {
     if (this.#head === null) {
       return;

--- a/packages/utils/src/deep-equal.ts
+++ b/packages/utils/src/deep-equal.ts
@@ -18,10 +18,10 @@ import { isRecord } from "./types.ts";
  * `FabricInstance` values compare by internal slots rather than logical
  * contents. Use `data-model`'s `valueEqual()` for any `FabricValue` comparison.
  *
- * This is a property of the function, not a defect awaiting repair: `utils` sits
- * below `data-model` and cannot reach the codecs that decide fabric equality, and
- * a second implementation here would duplicate `valueEqual()` rather than extend
- * it. The scope is the fix.
+ * This is a property of the function, not a defect awaiting repair: `utils`
+ * sits below `data-model` and cannot reach the codecs that decide fabric
+ * equality, and a second implementation here would duplicate `valueEqual()`
+ * rather than extend it. The scope is the fix.
  */
 export function deepEqual(a: any, b: any): boolean {
   if (Object.is(a, b)) return true;

--- a/packages/utils/src/defer.ts
+++ b/packages/utils/src/defer.ts
@@ -1,15 +1,16 @@
-/**
- * Interface for a deferred promise with external resolve/reject control.
- */
+/** Interface for a deferred promise with external resolve/reject control. */
 export interface Deferred<T = void, E = Error> {
+  /** Resolves `promise` with `value`. */
   resolve(value: T): void;
+
+  /** Rejects `promise` with `value`. */
   reject(value?: E): void;
+
+  /** The promise being controlled. */
   promise: Promise<T>;
 }
-/**
- * Creates a deferred promise that can be resolved or rejected externally.
- * @returns A deferred object with resolve, reject, and promise properties
- */
+
+/** Creates a deferred promise, resolvable and rejectable from outside it. */
 export function defer<T = void, E = Error>(): Deferred<T, E> {
   let resolve;
   let reject;

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -1,17 +1,31 @@
+// Predicates for the JavaScript environment the calling code finds itself in.
+// Each is a feature test, not a build-time constant, so a single bundle can
+// ask at runtime which of its supported hosts it landed in.
+
+/** Indicates whether the current environment is Deno. */
 export function isDeno(): boolean {
   // Also check for `Deno.build`, because in `deno-web-test`,
   // a shim of `Deno.test` runs in the browser in order to run the same test suite.
   return ("Deno" in globalThis) && "build" in globalThis.Deno;
 }
 
+/** Indicates whether the current environment is a browser. */
 export function isBrowser(): boolean {
   return !isDeno() && ("fetch" in globalThis);
 }
 
+/**
+ * Indicates whether the current environment is a worker thread, as opposed to
+ * the main thread of its host.
+ */
 export function isWorkerThread(): boolean {
   return isDeno() ? ("close" in globalThis) : ("importScripts" in globalThis);
 }
 
+/**
+ * Throws if the current environment is a browser's main thread, which is the
+ * one thread that must stay free to render.
+ */
 export function ensureNotRenderThread() {
   if (isBrowser() && !isWorkerThread()) {
     throw new Error(

--- a/packages/utils/src/equal-ignoring-symbols.ts
+++ b/packages/utils/src/equal-ignoring-symbols.ts
@@ -3,7 +3,7 @@ import type { Async, Expected } from "@std/expect";
 import { isRecord } from "@commonfabric/utils/types";
 
 /**
- * Strips all symbol properties from an object recursively
+ * Strips all symbol properties from an object, recursively.
  *
  * TODO(danfuzz): `isRecord` admits a `FabricSpecialObject`, and the
  * `Object.keys` rebuild renders one as `{}` — on BOTH sides of the matchers
@@ -29,9 +29,7 @@ export function stripSymbols(obj: unknown): unknown {
   return result;
 }
 
-/**
- * Custom matchers that compare objects while ignoring symbol properties
- */
+/** Custom matchers that compare objects while ignoring symbol properties */
 expect.extend({
   toEqualIgnoringSymbols(
     context,
@@ -137,19 +135,34 @@ expect.extend({
 
 declare module "@std/expect" {
   interface Expected<IsAsync = false> {
+    /**
+     * Like `toEqual()`, except that symbol-keyed properties are stripped from
+     * both sides first.
+     */
     toEqualIgnoringSymbols(expected: unknown): void;
+
+    /**
+     * Like `toMatchObject()`, except that symbol-keyed properties are
+     * stripped from both sides first.
+     */
     toMatchObjectIgnoringSymbols(expected: unknown): void;
   }
 }
 
-// Extend the Expected interface to include our custom matchers
+/** The `expect()` surface, extended with the matchers defined here. */
 export interface ExtendedExpected<IsAsync = false> extends Expected<IsAsync> {
+  /** @inheritDoc */
   toEqualIgnoringSymbols(expected: unknown): void;
+
+  /** @inheritDoc */
   toMatchObjectIgnoringSymbols(expected: unknown): void;
 
-  // Override modifiers to maintain proper typing
+  // The modifiers are restated so that they carry the extended type through.
   not: IsAsync extends true ? Async<ExtendedExpected<true>>
     : ExtendedExpected<false>;
+  /** @inheritDoc */
   resolves: Async<ExtendedExpected<true>>;
+
+  /** @inheritDoc */
   rejects: Async<ExtendedExpected<true>>;
 }

--- a/packages/utils/src/hashtags.ts
+++ b/packages/utils/src/hashtags.ts
@@ -1,6 +1,4 @@
-/**
- * Hashtag lexing for free text.
- */
+/** Hashtag lexing for free text. */
 
 // A hashtag is `#` followed by a run of Unicode letters, combining marks,
 // numbers, and underscores. Letters from any script are accepted (Latin with
@@ -10,10 +8,10 @@
 const HASHTAG_PATTERN = /#([\p{L}\p{M}\p{N}_]+)/gu;
 
 /**
- * Extract hashtag tokens from free text. A token starts at `#` and runs through
- * Unicode letters, combining marks, numbers, and underscores; a hyphen, space,
- * or other punctuation ends it. Returns the tokens lowercased, without the
- * leading `#`, deduplicated, in order of first appearance.
+ * Extracts hashtag tokens from free text. A token starts at `#` and runs
+ * through Unicode letters, combining marks, numbers, and underscores; a
+ * hyphen, space, or other punctuation ends it. Returns the tokens lowercased,
+ * without the leading `#`, deduplicated, in order of first appearance.
  *
  * **Note:** The lexing here is looser than the convention the same syntax
  * implies elsewhere, in ways a caller minting durable tags out of prose is

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -1,5 +1,5 @@
 /**
- * Minimal logging library for both Deno and browser environments
+ * Minimal logging library for both Deno and browser environments.
  *
  * @module
  * This module provides a flexible logging system with:
@@ -28,7 +28,8 @@
  * // Global logger instance - no module tag
  * // First parameter is always a string key for tracking
  * log.info("app-started", "Application started");
- * log.debug("debug-info", "Debug info"); // Won't show unless log.level = "debug"
+ * // Won't show unless `log.level` is `"debug"`.
+ * log.debug("debug-info", "Debug info");
  *
  * // Change global log level
  * log.level = "debug";
@@ -43,7 +44,7 @@
  *
  * // First parameter is the message key for metrics tracking
  * // Logs will show: [INFO][user-service::HH:MM:SS.mmm] key message
- * logger.log("processing-started", "Processing started");     // Same as logger.info()
+ * logger.log("processing-started", "Processing started"); // Same as info().
  * logger.info("processing-user", "Processing user data");
  * logger.debug("cache-hit", "Cache hit for user", userId);
  * logger.warn("rate-limit", "API rate limit approaching");
@@ -55,7 +56,10 @@
  * const logger = getLogger("data-processor");
  *
  * // Function is only called if debug level is active
- * logger.debug("computed-value", () => `Computed value: ${expensiveComputation()}`);
+ * logger.debug(
+ *   "computed-value",
+ *   () => `Computed value: ${expensiveComputation()}`,
+ * );
  *
  * // Works with arrays that get flattened
  * logger.info("processing-items", () => ["Processing", count, "items"]);
@@ -142,7 +146,8 @@
  *
  * // Access individual logger counts by key
  * globalThis.commonfabric.logger["module-name"].countsByKey
- * // Returns: { "user-login": { debug: 5, info: 10, warn: 2, error: 0, total: 17 }, ... }
+ * // Returns:
+ * // { "user-login": { debug: 5, info: 10, warn: 2, error: 0, total: 17 } }
  *
  * // Reset specific logger
  * globalThis.commonfabric.logger["module-name"].resetCounts()
@@ -152,7 +157,9 @@
  * ```typescript
  * // By default, logs a debug message every 100 calls
  * const logger = getLogger("my-module");
- * // After 100 calls: [DEBUG][my-module::HH:MM:SS.mmm] my-module: 100 log calls made (debug: 20, info: 50, warn: 25, error: 5)
+ * // After 100 calls:
+ * //   [DEBUG][my-module::HH:MM:SS.mmm] my-module: 100 log calls made
+ * //   (debug: 20, info: 50, warn: 25, error: 5)
  *
  * // Customize the threshold
  * const customLogger = getLogger("custom-module", { logCountEvery: 50 });
@@ -169,6 +176,10 @@
 
 import { isDeno } from "@commonfabric/utils/env";
 
+/**
+ * A message argument: either the value to log, or a function returning it,
+ * which is called only when the message is actually going to be emitted.
+ */
 export type LogMessage = unknown | (() => unknown);
 
 /** Active log levels used for actual log messages. */
@@ -177,32 +188,58 @@ export type ActiveLogLevel = "debug" | "info" | "warn" | "error";
 /** All log levels including "silent" which suppresses all output. */
 export type LogLevel = ActiveLogLevel | "silent";
 
-/**
- * Point in a CDF (Cumulative Distribution Function)
- */
+/** Point in a CDF (cumulative distribution function). */
 export interface CDFPoint {
-  x: number; // Latency in ms
-  y: number; // Cumulative probability (0-1)
+  /** Latency, in milliseconds. */
+  x: number;
+
+  /** Cumulative probability, from `0` to `1`. */
+  y: number;
 }
 
-/**
- * Statistics for timing measurements
- */
+/** Statistics for timing measurements. */
 export interface TimingStats {
-  count: number; // Total measurements
-  min: number; // Minimum time (ms)
-  max: number; // Maximum time (ms)
-  totalTime: number; // Sum for average calculation
-  average: number; // totalTime / count
-  countSinceBaseline: number; // Measurements since most recent baseline reset
-  totalTimeSinceBaseline: number; // Sum of measurements since baseline reset
-  averageSinceBaseline: number; // totalTimeSinceBaseline / countSinceBaseline
-  p50: number; // Median (50th percentile)
-  p95: number; // 95th percentile
-  lastTime: number; // Most recent measurement
-  lastTimestamp: number; // When last recorded
-  cdf: CDFPoint[]; // CDF of all samples since start
-  cdfSinceBaseline: CDFPoint[] | null; // CDF of samples since baseline reset
+  /** Total number of measurements. */
+  count: number;
+
+  /** Shortest measurement, in milliseconds. */
+  min: number;
+
+  /** Longest measurement, in milliseconds. */
+  max: number;
+
+  /** Sum of all measurements, from which `average` is computed. */
+  totalTime: number;
+
+  /** `totalTime` divided by `count`. */
+  average: number;
+
+  /** Number of measurements since the most recent baseline reset. */
+  countSinceBaseline: number;
+
+  /** Sum of the measurements since the most recent baseline reset. */
+  totalTimeSinceBaseline: number;
+
+  /** `totalTimeSinceBaseline` divided by `countSinceBaseline`. */
+  averageSinceBaseline: number;
+
+  /** Median measurement, that is, the 50th percentile. */
+  p50: number;
+
+  /** 95th percentile measurement. */
+  p95: number;
+
+  /** Most recent measurement. */
+  lastTime: number;
+
+  /** When the most recent measurement was recorded. */
+  lastTimestamp: number;
+
+  /** CDF over every sample taken. */
+  cdf: CDFPoint[];
+
+  /** CDF over the samples since the most recent baseline reset. */
+  cdfSinceBaseline: CDFPoint[] | null;
 }
 
 /**
@@ -231,7 +268,7 @@ class TimingDataStore {
   private deltaCount = 0; // Count of samples since baseline
 
   /**
-   * Record a timing measurement.
+   * Records a timing measurement.
    * @param elapsed - The elapsed time in milliseconds
    */
   record(elapsed: number): void {
@@ -268,7 +305,7 @@ class TimingDataStore {
   }
 
   /**
-   * Set baseline for delta tracking.
+   * Sets the baseline for delta tracking.
    * After calling this, new samples will be tracked separately for delta CDF.
    */
   setBaseline(): void {
@@ -279,9 +316,7 @@ class TimingDataStore {
     this.deltaCount = 0;
   }
 
-  /**
-   * Get computed statistics from the recorded data.
-   */
+  /** Returns computed statistics over the recorded data. */
   getStats(): TimingStats {
     if (this.count === 0) {
       return {
@@ -347,8 +382,9 @@ class TimingDataStore {
   }
 
   /**
-   * Calculate CDF (Cumulative Distribution Function) from sorted samples.
-   * Returns array of points where each point (x, y) means "y fraction of samples <= x ms"
+   * Returns the CDF (cumulative distribution function) of `sorted`, as
+   * points where `(x, y)` means that a `y` fraction of the samples are at
+   * most `x` milliseconds.
    */
   private calculateCDF(sorted: number[]): CDFPoint[] {
     if (sorted.length === 0) return [];
@@ -359,9 +395,7 @@ class TimingDataStore {
     }));
   }
 
-  /**
-   * Reset all timing data.
-   */
+  /** Resets all timing data. */
   reset(): void {
     this.count = 0;
     this.min = Infinity;
@@ -373,9 +407,7 @@ class TimingDataStore {
   }
 }
 
-/**
- * Numeric values for log levels to enable comparison
- */
+/** Numeric values for log levels, so that they can be compared. */
 const LOG_LEVELS: Record<LogLevel, number> = {
   debug: 0,
   info: 1,
@@ -384,9 +416,7 @@ const LOG_LEVELS: Record<LogLevel, number> = {
   silent: 4,
 };
 
-/**
- * Colors for each log level
- */
+/** Colors for each log level. */
 export const LOG_COLORS = {
   debug: "color: #6b7280",
   info: "color: #6b7280",
@@ -401,29 +431,29 @@ export const LOG_COLORS = {
 
 /**
  * Global log level floor. When set, `shouldLog()` uses the more restrictive
- * of (floor, per-logger level). This allows suppressing all logging by default
- * (e.g. in CLI mode) while still letting individual loggers be more restrictive.
+ * of (floor, per-logger level). This allows suppressing all logging by
+ * default (e.g. in CLI mode) while still letting individual loggers be more
+ * restrictive.
  */
 let _globalLevelFloor: LogLevel | undefined;
 
 /**
- * Set (or clear) the global log-level floor.
- * Pass `undefined` to remove the floor entirely.
+ * Sets the global log-level floor. Pass `undefined` to remove the floor
+ * entirely.
  */
 export function setGlobalLogFloor(level: LogLevel | undefined): void {
   _globalLevelFloor = level;
 }
 
-/**
- * Get the current global log-level floor.
- */
+/** Returns the current global log-level floor. */
 export function getGlobalLogFloor(): LogLevel | undefined {
   return _globalLevelFloor;
 }
 
 /**
- * Read `CF_LOG_LEVEL` from the environment (Deno only).
- * Returns undefined when not set or not a valid level.
+ * Returns the log level named by the `CF_LOG_LEVEL` environment variable, or
+ * `undefined` when it is unset, is not a valid level, or cannot be read.
+ * Always `undefined` outside Deno.
  */
 function getEnvFloor(): LogLevel | undefined {
   if (isDeno()) {
@@ -439,9 +469,9 @@ function getEnvFloor(): LogLevel | undefined {
 _globalLevelFloor = getEnvFloor();
 
 /**
- * Check if a message at the given level should be logged.
- * Respects the global floor when set — the effective threshold is the
- * more restrictive of (floor, per-logger level).
+ * Indicates whether a message at the given level should be logged. Respects
+ * the global floor when set — the effective threshold is the more restrictive
+ * of (floor, per-logger level).
  */
 function shouldLog(level: LogLevel, loggerLevel?: LogLevel): boolean {
   const effectiveLevel = loggerLevel ?? "info";
@@ -454,16 +484,12 @@ function shouldLog(level: LogLevel, loggerLevel?: LogLevel): boolean {
   return LOG_LEVELS[level] >= LOG_LEVELS[effectiveLevel];
 }
 
-/**
- * Get current time in HH:MM:SS.mmm format
- */
+/** Returns the current time, in `HH:MM:SS.mmm` format. */
 function getTimeStamp(): string {
   return new Date().toISOString().slice(11, 23);
 }
 
-/**
- * Resolves log messages, evaluating functions if needed
- */
+/** Resolves log messages, evaluating functions where given. */
 function resolveMessages(messages: LogMessage[]): unknown[] {
   return messages.flatMap((msg) => {
     const resolved = typeof msg === "function" ? msg() : msg;
@@ -472,50 +498,51 @@ function resolveMessages(messages: LogMessage[]): unknown[] {
   });
 }
 
-/**
- * Options for creating a logger
- */
+/** Options for creating a logger. */
 export interface GetLoggerOptions {
-  /**
-   * Whether this logger should be enabled
-   * If not specified (undefined), follows default behavior
-   */
+  /** Whether this logger should be enabled. Defaults to `true`. */
   enabled?: boolean;
+
   /**
-   * The minimum log level for this logger
-   * If not specified, uses the global log level
+   * Minimum log level for this logger. Defaults to the level named by the
+   * environment, or `info` when it names none.
    */
   level?: LogLevel;
   /**
-   * Log a debug message every N total calls showing count breakdown.
-   * Set to 0 to disable. Defaults to 100.
+   * How many total calls to go between debug messages summarizing the
+   * counts. `0` disables the summaries entirely. Defaults to `100`.
    */
   logCountEvery?: number;
 }
 
-/**
- * Call counts for each log level
- */
+/** Call counts for each log level. */
 export interface LogCounts {
+  /** Number of debug-level calls. */
   debug: number;
+
+  /** Number of info-level calls. */
   info: number;
+
+  /** Number of warn-level calls. */
   warn: number;
+
+  /** Number of error-level calls. */
   error: number;
+
+  /** Number of calls at any level. */
   readonly total: number;
 }
 
-/**
- * Breakdown of counts by message key for a single logger
- */
+/** Breakdown of counts by message key, for a single logger. */
 export type LoggerBreakdown = {
+  /** Counts for one message key. */
   [messageKey: string]: LogCounts;
 } & {
+  /** Number of calls across every message key. */
   total: number;
 };
 
-/**
- * Logger class that handles both basic and tagged logging
- */
+/** Logger, which handles both basic and tagged logging. */
 export class Logger {
   private _disabled: boolean;
   public level?: LogLevel;
@@ -538,6 +565,10 @@ export class Logger {
   private _flags: Map<string, Map<string, Record<string, unknown> | true>> =
     new Map();
 
+  /**
+   * Constructs an instance which tags its output with `moduleName`, if given,
+   * and which is configured per `options`.
+   */
   constructor(private moduleName?: string, options?: GetLoggerOptions) {
     // Set initial disabled state from options
     // Default to false (enabled) if not specified
@@ -566,12 +597,13 @@ export class Logger {
     return this._disabled;
   }
 
+  /** @inheritDoc */
   set disabled(value: boolean) {
     this._disabled = value;
   }
 
   /**
-   * Get the call counts for each log level, including a computed total.
+   * Call counts for each log level, including a computed total.
    * Counts are incremented even when the logger is disabled or the log level
    * filters out the message.
    */
@@ -588,8 +620,8 @@ export class Logger {
   }
 
   /**
-   * Get the call counts broken down by message key.
-   * Each key contains counts for debug, info, warn, error, and a computed total.
+   * Call counts broken down by message key. Each key holds counts for
+   * `debug`, `info`, `warn`, and `error`, plus a computed total.
    */
   get countsByKey(): Record<string, LogCounts> {
     const result: Record<string, LogCounts> = {};
@@ -607,9 +639,7 @@ export class Logger {
     return result;
   }
 
-  /**
-   * Reset all call counts to zero (both overall and by-key counts)
-   */
+  /** Resets all call counts to zero, both the overall and the by-key ones. */
   resetCounts(): void {
     this._counts.debug = 0;
     this._counts.info = 0;
@@ -619,9 +649,7 @@ export class Logger {
     this._lastLoggedAt = 0;
   }
 
-  /**
-   * Increment the count for a specific message key and log level
-   */
+  /** Increments the count for a specific message key and log level. */
   private incrementKeyCount(key: string, level: ActiveLogLevel): void {
     // Skip reserved key name "total" to prevent corruption of breakdown totals
     if (key === "total") {
@@ -637,8 +665,8 @@ export class Logger {
   }
 
   /**
-   * Check if we should log the count summary and do so if needed.
-   * This is called after incrementing the counter.
+   * Logs the count summary, if incrementing the counter has just carried the
+   * total past another multiple of the configured threshold.
    */
   private maybeLogCountSummary(): void {
     // Skip if disabled or logCountEvery is 0
@@ -662,9 +690,7 @@ export class Logger {
     }
   }
 
-  /**
-   * Get the prefix and color for a log level
-   */
+  /** Returns the prefix and color for a log level. */
   private getLogFormat(
     level: ActiveLogLevel,
   ): { prefix: string; color: string } {
@@ -686,9 +712,7 @@ export class Logger {
     }
   }
 
-  /**
-   * Log a debug message
-   */
+  /** Logs a debug message. */
   debug(key: string, ...messages: LogMessage[]): void {
     this._counts.debug++;
     this.incrementKeyCount(key, "debug");
@@ -708,16 +732,12 @@ export class Logger {
     }
   }
 
-  /**
-   * Log a message at info level (default logging method)
-   */
+  /** Logs a message at info level, this being the default method. */
   log(key: string, ...messages: LogMessage[]): void {
     this.info(key, ...messages);
   }
 
-  /**
-   * Log an info message
-   */
+  /** Logs an info message. */
   info(key: string, ...messages: LogMessage[]): void {
     this._counts.info++;
     this.incrementKeyCount(key, "info");
@@ -737,9 +757,7 @@ export class Logger {
     }
   }
 
-  /**
-   * Log a warning message
-   */
+  /** Logs a warning message. */
   warn(key: string, ...messages: LogMessage[]): void {
     this._counts.warn++;
     this.incrementKeyCount(key, "warn");
@@ -759,9 +777,7 @@ export class Logger {
     }
   }
 
-  /**
-   * Log an error message
-   */
+  /** Logs an error message. */
   error(key: string, ...messages: LogMessage[]): void {
     this._counts.error++;
     this.incrementKeyCount(key, "error");
@@ -786,9 +802,9 @@ export class Logger {
   // ============================================================
 
   /**
-   * Start a timer for the given key path.
-   * Hierarchical keys are supported - passing multiple segments will record
-   * stats at each level when timeEnd is called.
+   * Starts a timer for the given key path. Hierarchical keys are supported:
+   * passing multiple segments records stats at each level when `timeEnd()` is
+   * called.
    *
    * @example
    * logger.timeStart("cell", "get", "user-data");
@@ -802,8 +818,8 @@ export class Logger {
   }
 
   /**
-   * End a timer and record the elapsed time.
-   * Returns the elapsed time in milliseconds, or undefined if no matching timer exists.
+   * Ends a timer and records the elapsed time, returning it in milliseconds,
+   * or `undefined` if there is no matching timer.
    *
    * Stats are recorded to all levels of the hierarchical key path.
    */
@@ -822,8 +838,8 @@ export class Logger {
   }
 
   /**
-   * Record a timing measurement directly.
-   * Useful for measuring IPC latency or other cases where you have explicit timestamps.
+   * Records a timing measurement directly. Useful for measuring IPC latency,
+   * or any other case where the timestamps are already in hand.
    *
    * Overloads:
    * - time(startTime, ...keys) - end time defaults to performance.now()
@@ -859,7 +875,8 @@ export class Logger {
   }
 
   /**
-   * Internal method to record timing to the full key path only (no hierarchical rollup).
+   * Records timing against the full key path only, with no rollup to the
+   * shorter paths.
    */
   private _recordTime(elapsed: number, keys: string[]): void {
     const path = keys.join("/");
@@ -875,7 +892,7 @@ export class Logger {
   }
 
   /**
-   * Get timing statistics for a specific key path.
+   * Returns timing statistics for a specific key path.
    * Accepts either separate key segments or a single "/" joined path.
    *
    * @example
@@ -889,7 +906,7 @@ export class Logger {
   }
 
   /**
-   * Get all timing statistics for this logger.
+   * Returns all timing statistics for this logger.
    * Returns a flat map with "/" joined keys.
    */
   get timeStats(): Record<string, TimingStats> {
@@ -900,9 +917,7 @@ export class Logger {
     return result;
   }
 
-  /**
-   * Reset all timing statistics for this logger.
-   */
+  /** Resets all timing statistics for this logger. */
   resetTimeStats(): void {
     this._timingsByKey.clear();
     this._activeTimers.clear();
@@ -914,16 +929,16 @@ export class Logger {
   // ============================================================
 
   /**
-   * Reset the count baseline to current count values.
-   * After calling this, getCountDeltas() will return counts relative to this baseline.
+   * Resets the count baseline to the current counts, so that
+   * `getCountDeltas()` reports relative to them.
    */
   resetCountBaseline(): void {
     this._countBaseline = { ...this._counts };
   }
 
   /**
-   * Reset the timing baseline to current timing values.
-   * After calling this, CDF delta curves will show samples since this baseline.
+   * Resets the timing baseline to the current timings, so that CDF delta
+   * curves show the samples taken since.
    */
   resetTimingBaseline(): void {
     this._timingBaselineActive = true;
@@ -933,7 +948,7 @@ export class Logger {
   }
 
   /**
-   * Get count deltas since the baseline was set.
+   * Returns count deltas since the baseline was set.
    * If no baseline exists, returns the current counts.
    */
   getCountDeltas(): {
@@ -963,11 +978,12 @@ export class Logger {
   // ============================================================
 
   /**
-   * Set or clear a named boolean flag for a specific ID, with optional metadata.
-   * Flags track named boolean state per ID (e.g. "action invalid input" for "action:myModule").
-   * When value=true and metadata is provided, the metadata is stored with the flag.
-   * When value=true without metadata, stores `true`.
-   * When value=false, the entry is deleted so active flags = present entries.
+   * Sets or clears the flag `name` for `id`. A flag is named boolean state
+   * held per id, such as `action invalid input` for `action:myModule`.
+   *
+   * A `value` of `true` stores `metadata` when given and `true` otherwise; a
+   * `value` of `false` deletes the entry, so that the active flags are exactly
+   * the present entries.
    */
   flag(
     name: string,
@@ -988,9 +1004,9 @@ export class Logger {
   }
 
   /**
-   * Get all active flags as a record of flag name -> { id -> metadata | null }.
-   * Metadata is the object passed to flag() or null if no metadata was provided.
-   * Only includes groups with at least one active flag.
+   * All active flags, as a record from flag name to a record from id to
+   * metadata. The metadata is whatever was passed to `flag()`, or `null` when
+   * none was. A flag name with no active id is omitted entirely.
    */
   get flags(): Record<string, Record<string, Record<string, unknown> | null>> {
     const result: Record<
@@ -1009,29 +1025,25 @@ export class Logger {
     return result;
   }
 
-  /**
-   * Reset all flags for this logger.
-   */
+  /** Resets all flags for this logger. */
   resetFlags(): void {
     this._flags.clear();
   }
 
-  /**
-   * Get the total count of all log calls (debug + info + warn + error).
-   */
+  /** Returns the total count of all log calls, over all four levels. */
   private getTotal(): number {
     return this._counts.debug + this._counts.info + this._counts.warn +
       this._counts.error;
   }
 }
 
-/**
- * Global logger instance for basic logging
- */
+/** Global logger instance, for basic logging. */
 export const log = new Logger();
 
 /**
- * We may want to initialize log level from environment variable if available
+ * Returns the log level named by the `LOG_LEVEL` environment variable, or
+ * `undefined` when it is unset, is `silent`, is not a valid level, or cannot
+ * be read. Always `undefined` outside Deno.
  */
 function getEnvLevel() {
   if (isDeno()) {
@@ -1048,9 +1060,9 @@ function getEnvLevel() {
 }
 
 /**
- * Check if LOG_TO_STDERR environment variable is set.
- * When set, all log output goes to stderr to avoid polluting stdout
- * (useful for CLI tools where stdout is used for machine-readable output).
+ * Indicates whether the `LOG_TO_STDERR` environment variable is set. When it
+ * is, all log output goes to stderr, so that stdout stays clean for a CLI
+ * tool whose real output a caller is parsing.
  */
 function shouldLogToStderr(): boolean {
   if (isDeno()) {
@@ -1064,8 +1076,8 @@ function shouldLogToStderr(): boolean {
 }
 
 /**
- * Log to stderr using Deno.stderr.writeSync.
- * Falls back to console.error if not in Deno or if write fails.
+ * Logs to stderr, via `Deno.stderr.writeSync()`. Falls back to
+ * `console.error()` outside Deno, or if the write fails.
  */
 function logToStderr(...args: unknown[]): void {
   if (isDeno()) {
@@ -1085,11 +1097,9 @@ function logToStderr(...args: unknown[]): void {
 }
 
 /**
- * Create a logger tagged with the specified module name.
- * If a logger with the same module name already exists, returns the existing instance.
- * @param moduleName - The name of the module (will appear in log messages)
- * @param options - Options for configuring the logger (only used if creating a new logger)
- * @returns A logger that prefixes all messages with [moduleName]
+ * Returns the logger tagged with `moduleName`, creating and registering it if
+ * there is not already one. `options` therefore takes effect only on the call
+ * that creates the logger.
  */
 export function getLogger(
   moduleName: string,
@@ -1118,10 +1128,7 @@ export function getLogger(
   return logger;
 }
 
-/**
- * Reset call counts for all registered loggers.
- * Iterates through all loggers in globalThis.commonfabric.logger and resets their counts.
- */
+/** Resets call counts for every registered logger. */
 export function resetAllLoggerCounts(): void {
   const global = globalThis as unknown as {
     commonfabric?: { logger?: Record<string, Logger> };
@@ -1134,8 +1141,8 @@ export function resetAllLoggerCounts(): void {
 }
 
 /**
- * Get the total count of all log calls across all registered loggers.
- * @returns The sum of all log calls (debug + info + warn + error) across all loggers
+ * Returns the sum of all log calls, over all four levels and over every
+ * registered logger.
  */
 export function getTotalLoggerCounts(): number {
   const global = globalThis as unknown as {
@@ -1149,8 +1156,8 @@ export function getTotalLoggerCounts(): number {
 }
 
 /**
- * Get a breakdown of log counts by logger name and message key, plus totals.
- * @returns Object with nested counts per logger/key and a total property
+ * Returns a breakdown of log counts by logger name and message key, with a
+ * `total` alongside each level of nesting.
  */
 export function getLoggerCountsBreakdown(): Record<string, LoggerBreakdown> & {
   total: number;
@@ -1185,27 +1192,28 @@ export function getLoggerCountsBreakdown(): Record<string, LoggerBreakdown> & {
   };
 }
 
-/**
- * Breakdown of timing stats by logger name
- */
+/** Breakdown of timing stats by logger name. */
 export type TimingStatsBreakdown = {
+  /** Stats for one logger, by key path. */
   [loggerName: string]: Record<string, TimingStats>;
 };
 
 /**
- * Get a breakdown of timing statistics by logger name and key.
- * @returns Object with nested timing stats per logger and key
+ * Returns a breakdown of timing statistics by logger name and key.
  *
  * @example
  * getTimingStatsBreakdown()
  * // {
  * //   "runtime-client": {
- * //     "ipc": { count: 2415, min: 0.1, max: 45.2, average: 1.9, p50: 1.5, p95: 6.8, ... },
- * //     "ipc/CellGet": { count: 1523, min: 0.1, max: 45.2, average: 2.3, p50: 1.8, p95: 8.4, ... }
+ * //     "ipc":
+ * //       { count: 2415, min: 0.1, max: 45.2, average: 1.9, p50: 1.5, ... },
+ * //     "ipc/CellGet":
+ * //       { count: 1523, min: 0.1, max: 45.2, average: 2.3, p50: 1.8, ... }
  * //   },
  * //   "runner": {
  * //     "cell": { count: 500, min: 0.1, p50: 2.0, p95: 8.5, max: 45.0, ... },
- * //     "cell/get": { count: 450, min: 0.1, p50: 2.1, p95: 8.7, max: 45.0, ... }
+ * //     "cell/get":
+ * //       { count: 450, min: 0.1, p50: 2.1, p95: 8.7, max: 45.0, ... }
  * //   }
  * // }
  */
@@ -1229,8 +1237,8 @@ export function getTimingStatsBreakdown(): TimingStatsBreakdown {
 }
 
 /**
- * Breakdown of flags by logger name.
- * Structure: { loggerName: { flagName: { id: metadata | null } } }
+ * Breakdown of flags by logger name, shaped as
+ * `{ loggerName: { flagName: { id: metadata | null } } }`.
  */
 export type LoggerFlagsBreakdown = Record<
   string,
@@ -1238,8 +1246,8 @@ export type LoggerFlagsBreakdown = Record<
 >;
 
 /**
- * Get a breakdown of active flags by logger name and flag name.
- * @returns Object with nested flag data per logger: { "runner": { "action invalid input": { "action:myModule": { schema: ..., raw: ... } } } }
+ * Returns a breakdown of active flags by logger name and flag name, e.g.
+ * `{ runner: { "action invalid input": { "action:myModule": {...} } } }`.
  */
 export function getLoggerFlagsBreakdown(): LoggerFlagsBreakdown {
   const global = globalThis as unknown as {
@@ -1260,10 +1268,7 @@ export function getLoggerFlagsBreakdown(): LoggerFlagsBreakdown {
   return breakdown;
 }
 
-/**
- * Reset timing statistics for all registered loggers.
- * Iterates through all loggers in globalThis.commonfabric.logger and resets their timing stats.
- */
+/** Resets timing statistics for every registered logger. */
 export function resetAllTimingStats(): void {
   const global = globalThis as unknown as {
     commonfabric?: { logger?: Record<string, Logger> };
@@ -1276,8 +1281,8 @@ export function resetAllTimingStats(): void {
 }
 
 /**
- * Reset count baseline for all registered loggers.
- * After calling this, each logger's getCountDeltas() will return counts relative to this baseline.
+ * Resets the count baseline for every registered logger, so that each
+ * logger's `getCountDeltas()` reports relative to its current counts.
  */
 export function resetAllCountBaselines(): void {
   const global = globalThis as unknown as {
@@ -1291,8 +1296,8 @@ export function resetAllCountBaselines(): void {
 }
 
 /**
- * Reset timing baseline for all registered loggers.
- * After calling this, each logger's getTimingDeltas() will return timing relative to this baseline.
+ * Resets the timing baseline for every registered logger, so that each
+ * logger's `getTimingDeltas()` reports relative to its current timings.
  */
 export function resetAllTimingBaselines(): void {
   const global = globalThis as unknown as {

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -802,15 +802,16 @@ export class Logger {
   // ============================================================
 
   /**
-   * Starts a timer for the given key path. Hierarchical keys are supported:
-   * passing multiple segments records stats at each level when `timeEnd()` is
-   * called.
+   * Starts a timer for the given key path. Multiple segments name one path,
+   * joined with `/`; they are not a hierarchy that gets rolled up, so
+   * `timeEnd()` records against that single joined path and against nothing
+   * shorter.
    *
    * @example
    * logger.timeStart("cell", "get", "user-data");
    * // ... operation ...
    * logger.timeEnd("cell", "get", "user-data");
-   * // Records to: "cell", "cell/get", "cell/get/user-data"
+   * // Records to `cell/get/user-data`, and not to `cell` or `cell/get`.
    */
   timeStart(...keys: string[]): void {
     const keyPath = keys.join("/");
@@ -819,9 +820,8 @@ export class Logger {
 
   /**
    * Ends a timer and records the elapsed time, returning it in milliseconds,
-   * or `undefined` if there is no matching timer.
-   *
-   * Stats are recorded to all levels of the hierarchical key path.
+   * or `undefined` if there is no matching timer. The time is recorded against
+   * the full joined key path only; see `timeStart()`.
    */
   timeEnd(...keys: string[]): number | undefined {
     const keyPath = keys.join("/");

--- a/packages/utils/src/path-key-map.ts
+++ b/packages/utils/src/path-key-map.ts
@@ -9,11 +9,11 @@
  * - `set(path, value)` / `get(path)` / `has(path)` / `delete(path)` /
  *   `clear()` behave like the corresponding `Map<string[], V>` operations,
  *   except keys are compared by segment-array contents rather than by
- *   reference. Distinct from `set()` is a key's *presence*: a key whose
+ *   reference. Distinct from a key's value is its _presence_: a key whose
  *   value is `undefined` (when `V` admits `undefined`) is still considered
  *   present by `has()`.
  * - `invalidateChain(path)` drops the cached value at every ancestor of
- *   `path` (including the root and `path` itself) AND drops the entire
+ *   `path` (including the root and `path` itself) _and_ drops the entire
  *   subtree rooted at `path`. Sibling subtrees off a divergent ancestor
  *   are preserved.
  *
@@ -77,9 +77,9 @@ export class PathKeyMap<V> {
   }
 
   /**
-   * Drops the cached value at every ancestor of `path` (including the
-   * root and `path` itself) AND drops the entire subtree rooted at
-   * `path`. For `path === []` (root), behaves like `clear()`.
+   * Drops the cached value at every ancestor of `path` (including the root
+   * and `path` itself) _and_ drops the entire subtree rooted at `path`. For
+   * `path === []` (root), behaves like `clear()`.
    */
   invalidateChain(path: readonly string[]): void {
     if (path.length === 0) {
@@ -103,18 +103,20 @@ export class PathKeyMap<V> {
     node.children.delete(path[path.length - 1]!);
   }
 
-  /** Yields every present path in the map. Order is depth-first by
-   *  insertion order of each node's child entries (Map iteration order). */
+  /**
+   * Yields every present path in the map. Order is depth-first by insertion
+   * order of each node's child entries (`Map` iteration order).
+   */
   *keys(): Generator<readonly string[]> {
     yield* this.#root.keys([]);
   }
 
-  /** Yields every `[path, value]` entry in the map. Same ordering as
-   *  `keys()`. */
+  /** Yields every `[path, value]` entry in the map, ordered as `keys()` is. */
   *entries(): Generator<readonly [readonly string[], V]> {
     yield* this.#root.entries([]);
   }
 
+  /** Returns the node at `path`, or `undefined` if there is none. */
   #findNode(path: readonly string[]): PathKeyMapNode<V> | undefined {
     let node: PathKeyMapNode<V> | undefined = this.#root;
     for (const seg of path) {
@@ -125,11 +127,18 @@ export class PathKeyMap<V> {
   }
 }
 
+/** One node of a `PathKeyMap`'s trie, that is, one path prefix. */
 class PathKeyMapNode<V> {
+  /** Whether this node's path is present in the map. */
   hasValue = false;
+
+  /** Value at this node's path, meaningful only when `hasValue` is true. */
   value: V | undefined = undefined;
+
+  /** Child nodes, by the segment that reaches each. */
   children: Map<string, PathKeyMapNode<V>> = new Map();
 
+  /** Indicates whether this node's subtree holds no values at all. */
   isEmpty(): boolean {
     if (this.hasValue) return false;
     for (const child of this.children.values()) {
@@ -138,6 +147,7 @@ class PathKeyMapNode<V> {
     return true;
   }
 
+  /** Yields every present path in this node's subtree, under `prefix`. */
   *keys(prefix: readonly string[]): Generator<readonly string[]> {
     if (this.hasValue) yield prefix;
     for (const [seg, child] of this.children) {
@@ -145,6 +155,7 @@ class PathKeyMapNode<V> {
     }
   }
 
+  /** Yields every present entry in this node's subtree, under `prefix`. */
   *entries(
     prefix: readonly string[],
   ): Generator<readonly [readonly string[], V]> {

--- a/packages/utils/src/sandbox-contract.ts
+++ b/packages/utils/src/sandbox-contract.ts
@@ -1,3 +1,13 @@
+// The contract between the pattern toolchain and the sandbox compartment a
+// pattern runs in: the globals a compartment withholds, the builder and
+// data-helper names that are trusted, the identifiers reserved within a
+// factory's scope, and the source text of the helpers that carry the
+// value-side parts of the contract.
+
+/**
+ * Names that a factory's scope shadows, so that authored code reaching for one
+ * of them finds `undefined` rather than the module loader's binding.
+ */
 export const SHADOWED_FACTORY_BINDINGS = [
   "define",
   "runtimeDeps",
@@ -23,8 +33,8 @@ export const SHADOWED_FACTORY_BINDINGS = [
  * happen.
  *
  * Changing this list also affects the `ts-transformers` and `schema-generator`
- * fixture suites, which type-check their fixtures against the type libraries and
- * are checked only in CI; see `packages/static/README.md`.
+ * fixture suites, which type-check their fixtures against the type libraries
+ * and are checked only in CI; see `packages/static/README.md`.
  */
 export const SANDBOX_WITHHELD_GLOBALS = Object.freeze(
   [
@@ -112,9 +122,14 @@ export const SANDBOX_WITHHELD_GLOBALS = Object.freeze(
     "self",
   ] as const,
 );
+/** Name of a global withheld from a sandbox compartment. */
 export type SandboxWithheldGlobalName =
   (typeof SANDBOX_WITHHELD_GLOBALS)[number];
 
+/**
+ * Names of the builders a pattern may call, whose results the toolchain
+ * treats as trusted.
+ */
 export const TRUSTED_BUILDERS = Object.freeze(
   [
     "action",
@@ -128,40 +143,69 @@ export const TRUSTED_BUILDERS = Object.freeze(
     "pattern",
   ] as const,
 );
+/** Name of a trusted builder. */
 export type TrustedBuilderName = (typeof TRUSTED_BUILDERS)[number];
+
+/** `TRUSTED_BUILDERS`, indexed for lookup. */
 const TRUSTED_BUILDER_SET = new Set<string>(TRUSTED_BUILDERS);
 
+/** Indicates whether `name` is the name of a trusted builder. */
 export function isTrustedBuilder(name: string): name is TrustedBuilderName {
   return TRUSTED_BUILDER_SET.has(name);
 }
 
+/**
+ * Names of the data helpers a pattern may call, whose results the toolchain
+ * treats as trusted.
+ */
 export const TRUSTED_DATA_HELPERS = Object.freeze(
   [
     "schema",
     "__cf_data",
   ] as const,
 );
+/** Name of a trusted data helper. */
 export type TrustedDataHelperName = (typeof TRUSTED_DATA_HELPERS)[number];
+
+/** `TRUSTED_DATA_HELPERS`, indexed for lookup. */
 const TRUSTED_DATA_HELPER_SET = new Set<string>(TRUSTED_DATA_HELPERS);
 
+/** Indicates whether `name` is the name of a trusted data helper. */
 export function isTrustedDataHelper(
   name: string,
 ): name is TrustedDataHelperName {
   return TRUSTED_DATA_HELPER_SET.has(name);
 }
 
+/** Default name of the function-hardening helper. */
 export const FUNCTION_HARDENING_HELPER_NAME = "__cfHardenFn";
+
+/** Default name of the binding-identity helper. */
 export const BINDING_IDENTITY_HELPER_NAME = "__cfBindVerifiedBinding";
+
+/** Default name of the property the binding-identity helper writes. */
 export const VERIFIED_BINDING_METADATA_FIELD = "__cfVerifiedBindingIdentity";
 
+/** Names that authored code must not bind at the top level of a factory. */
 export const RESERVED_FACTORY_BINDINGS = [
   ...SHADOWED_FACTORY_BINDINGS,
 ] as const;
 
+/**
+ * Returns the source lines that shadow each of `SHADOWED_FACTORY_BINDINGS`
+ * with `undefined`, one declaration per line.
+ */
 export function createFactoryShadowGuardSource(): string[] {
   return SHADOWED_FACTORY_BINDINGS.map((name) => `const ${name} = undefined;`);
 }
 
+/**
+ * Returns the source text of the function-hardening helper: a function that
+ * freezes what it is given, freezes its `.prototype` when it has an object
+ * one, and returns it. `helperName` names the declared function, and
+ * `options.typedParameter` annotates the parameter, for a helper emitted into
+ * TypeScript rather than JavaScript.
+ */
 export function createFunctionHardeningHelperSource(
   helperName = FUNCTION_HARDENING_HELPER_NAME,
   options: { typedParameter?: boolean } = {},
@@ -179,6 +223,14 @@ export function createFunctionHardeningHelperSource(
   ].join("\n");
 }
 
+/**
+ * Returns the source text of the binding-identity helper: a function that
+ * stamps `metadataField` onto the value it is given, and onto that value's
+ * `.implementation` when there is a callable one, then returns the value. A
+ * non-extensible target is left alone rather than throwing. `helperName` names
+ * the declared function, and `options.typedParameter` annotates the
+ * parameters, for a helper emitted into TypeScript rather than JavaScript.
+ */
 export function createBindingIdentityHelperSource(
   helperName = BINDING_IDENTITY_HELPER_NAME,
   metadataField = VERIFIED_BINDING_METADATA_FIELD,

--- a/packages/utils/src/sleep.ts
+++ b/packages/utils/src/sleep.ts
@@ -7,12 +7,13 @@ export const sleep = (timeout: number) =>
   new Promise((resolve) => setTimeout(resolve, timeout));
 
 /**
- * Detaches a timer from the event loop's ref-count under Deno (`Deno.unrefTimer`),
- * so a long-lived background/diagnostic interval never keeps the process alive
- * or trips Deno's `--trace-leaks` op sanitizer when a unit test constructs the
- * owner or imports the module without a matching teardown. No-op in the browser
- * (no `Deno.unrefTimer`), where such timers run for the real worker/connection
- * lifetime and are cleared explicitly on dispose. Returns the id for chaining.
+ * Detaches a timer from the event loop's ref-count under Deno, via
+ * `Deno.unrefTimer()`, so a long-lived background/diagnostic interval never
+ * keeps the process alive or trips Deno's `--trace-leaks` op sanitizer when a
+ * unit test constructs the owner or imports the module without a matching
+ * teardown. No-op in the browser (no `Deno.unrefTimer`), where such timers run
+ * for the real worker/connection lifetime and are cleared explicitly on
+ * dispose. Returns the id for chaining.
  */
 export const unrefTimer = (
   id: ReturnType<typeof setInterval>,

--- a/packages/utils/src/two-level-weak-cache.ts
+++ b/packages/utils/src/two-level-weak-cache.ts
@@ -3,8 +3,8 @@
  *
  * The outer key groups entries; the inner key identifies a value within that
  * group. Both levels are WeakMaps, so a whole group is collected once its outer
- * key is unreachable, and an individual entry is collected once its inner key is
- * unreachable while the group is still alive.
+ * key is unreachable, and an individual entry is collected once its inner key
+ * is unreachable while the group is still alive.
  *
  * The TypeScript pipelines use this to memoize a fact derived from a `ts.Type`
  * or AST node — a type's cell brand, a call's kind — against the
@@ -12,8 +12,8 @@
  * within its checker, so keying by the checker first keeps a value from ever
  * being read against a foreign checker.
  *
- * Stored values may be `undefined`. Presence is tracked with `WeakMap.has`, so a
- * computed `undefined` is cached and not recomputed.
+ * Stored values may be `undefined`. Presence is tracked with `WeakMap.has`, so
+ * a computed `undefined` is cached and not recomputed.
  */
 export class TwoLevelWeakCache<
   Outer extends WeakKey,
@@ -33,9 +33,9 @@ export class TwoLevelWeakCache<
   }
 
   /**
-   * The value stored for (`outer`, `key`), computing and storing it on the first
-   * request. `compute` runs at most once per distinct (`outer`, `key`) pair; a
-   * computed `undefined` is cached like any other value.
+   * The value stored for (`outer`, `key`), computing and storing it on the
+   * first request. `compute` runs at most once per distinct (`outer`, `key`)
+   * pair; a computed `undefined` is cached like any other value.
    */
   memoize(outer: Outer, key: Key, compute: () => Value): Value {
     const group = this.groupFor(outer);

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -59,7 +59,9 @@ export function isRecord(
   return typeof value === "object" && value !== null;
 }
 
-/** A record whose string keys can be read but not assigned through this type. */
+/**
+ * A record whose string keys can be read but not assigned through this type.
+ */
 export type ReadonlyRecord = Readonly<Record<string, unknown>>;
 
 /**
@@ -83,7 +85,7 @@ export function isFunction(
 }
 
 /**
- * Check whether the value is a non-`null`, non-plain, non-array `object`.
+ * Indicates whether the value is a non-`null`, non-plain, non-array `object`.
  * @param value - The value to check
  * @returns True if the value is an instance
  */
@@ -96,7 +98,7 @@ export function isInstance(value: unknown): boolean {
 }
 
 /**
- * Check whether a value is a non-array/non-null `object` type.
+ * Indicates whether a value is a non-array, non-`null` `object` type.
  * @param value - The value to check
  * @returns True if the value is an object (not array or null)
  */
@@ -127,7 +129,7 @@ export function isNumber(value: unknown): value is number {
 }
 
 /**
- * Check whether a value is a finite number type
+ * Indicates whether a value is a finite number.
  * @param value - The value to check
  * @returns True if the value is a finite number
  */
@@ -136,7 +138,7 @@ export function isFiniteNumber(value: unknown): boolean {
 }
 
 /**
- * Check whether a value is a plain object: prototype `Object.prototype` or
+ * Indicates whether a value is a plain object: prototype `Object.prototype` or
  * `null`, with no constraint on its properties.
  *
  * This is the shape question -- "may I read this by property name?" -- and is
@@ -178,7 +180,7 @@ export function isPlainObject(
 }
 
 /**
- * Check whether a value is a plain container -- a plain object (per
+ * Indicates whether a value is a plain container -- a plain object (per
  * `isPlainObject`) or an `Array`. Useful when the relevant question is
  * "can I do property-name / array-index member access on this?", since
  * plain objects and arrays are the two value shapes that support that
@@ -221,16 +223,12 @@ export function isBoolean(value: unknown): value is boolean {
   return typeof value === "boolean";
 }
 
-/**
- * Helper type to recursively remove `readonly` properties from type `T`.
- */
+/** Helper type to recursively remove `readonly` properties from type `T`. */
 export type Mutable<T> = T extends ReadonlyArray<infer U> ? Mutable<U>[]
   : T extends object ? ({ -readonly [P in keyof T]: Mutable<T[P]> })
   : T;
 
-/**
- * Helper type to recursively add `readonly` properties to type `T`.
- */
+/** Helper type to recursively add `readonly` properties to type `T`. */
 export type Immutable<T> = T extends ReadonlyArray<infer U>
   ? ReadonlyArray<Immutable<U>>
   : T extends object ? ({ readonly [P in keyof T]: Immutable<T[P]> })
@@ -243,8 +241,9 @@ const UNSAFE_OBJECT_KEYS = new Set(["__proto__", "constructor"]);
 
 /**
  * Indicates whether `key` must never be copied onto an object from untrusted
- * input, because assigning it can pollute the prototype chain. Use at boundaries
- * where external data enters the system (deserialization, structural copying).
+ * input, because assigning it can pollute the prototype chain. Use at
+ * boundaries where external data enters the system (deserialization,
+ * structural copying).
  */
 export function isUnsafeObjectKey(key: string): boolean {
   return UNSAFE_OBJECT_KEYS.has(key);

--- a/packages/utils/src/utf8.ts
+++ b/packages/utils/src/utf8.ts
@@ -16,9 +16,7 @@
  */
 const sortedKeyCache = new WeakMap<object, readonly string[]>();
 
-/**
- * Helper for `utf8Compare()`: Is the given character code a surrogate?
- */
+/** Helper for `utf8Compare()`: Is the given character code a surrogate? */
 function isSurrogateCharCode(c: number) {
   return (c >= 0xd800) && (c <= 0xdfff);
 }
@@ -31,9 +29,7 @@ function hasSurrogateCharCode(value: string) {
   return /[\ud800-\udfff]/.test(value);
 }
 
-/**
- * Compares strings by UTF-8 sort order.
- */
+/** Compares strings by UTF-8 sort order. */
 export function utf8Compare(a: string, b: string): number {
   // Credit where due: Though this started out as an independent implementation
   // of the key insight for fast sorting, this incorporates ideas from

--- a/packages/utils/src/zod-utils.ts
+++ b/packages/utils/src/zod-utils.ts
@@ -1,26 +1,39 @@
-/*
-Vendored via https://github.com/colinhacks/zod/issues/2084
-Usage:
-```
-export type UserModel = {
-  id: string
-  email: string | null
-  name: string
-  firstName: string
-  createdAt: Date
-}
-
-export const UserCreateSchema = toZod<Omit<UserModel, "createdAt" | "id">>().with({
-  email: z.string().email().nullable(),
-  name: z.string(),
-  firstName: z.string(),
-});
-
-export type UserCreatePayload = z.infer<typeof UserCreateSchema>
-```
-*/
+/**
+ * Builder for a Zod schema that is checked at compile time against a model
+ * type: a field of the model with no schema entry, or a schema entry naming
+ * no field of the model, is a type error rather than a shape that diverges
+ * silently at runtime.
+ *
+ * Vendored via https://github.com/colinhacks/zod/issues/2084
+ *
+ * Usage:
+ *
+ * ```
+ * export type UserModel = {
+ *   id: string
+ *   email: string | null
+ *   name: string
+ *   firstName: string
+ *   createdAt: Date
+ * }
+ *
+ * export const UserCreateSchema =
+ *   toZod<Omit<UserModel, "createdAt" | "id">>().with({
+ *     email: z.string().email().nullable(),
+ *     name: z.string(),
+ *     firstName: z.string(),
+ *   });
+ *
+ * export type UserCreatePayload = z.infer<typeof UserCreateSchema>
+ * ```
+ */
 import * as z from "zod";
 
+/**
+ * The Zod schema shape that `Model` demands: one entry per field, wrapped in
+ * `ZodOptional` and `ZodNullable` to match how the field admits `undefined`
+ * and `null`.
+ */
 type Implements<Model> = {
   [key in keyof Model]-?: undefined extends Model[key]
     ? null extends Model[key]
@@ -30,6 +43,12 @@ type Implements<Model> = {
     : z.ZodType<Model[key]>;
 };
 
+/**
+ * Returns a builder whose `with()` method constructs a `z.object()` from the
+ * given schema, accepting it only if it covers `Model` exactly. Written as a
+ * two-step call because TypeScript has no way to infer one type argument
+ * while pinning another.
+ */
 export function toZod<Model = never>() {
   return {
     with: <

--- a/packages/utils/test/bigint.test.ts
+++ b/packages/utils/test/bigint.test.ts
@@ -131,9 +131,7 @@ function fixtureLabel(v: bigint, encoded: Uint8Array): string {
   return `${sign}0x${hex.slice(0, 12)}... (${encoded.length} bytes)`;
 }
 
-/**
- * Makes a fixture, optionally calculating the encoded form.
- */
+/** Makes a fixture, optionally calculating the encoded form. */
 function makeFixture(value: bigint, preEncoded?: number[]): Fixture {
   let encoded: Uint8Array;
 


### PR DESCRIPTION
A doc-comment conformance pass over `packages/utils`, against
`docs/development/code-comment-style.md`. Comments only; no code changes.
`logger.ts` accounts for well over half the diff.

**Format.**

- 44 doc comments whose text fits inside 80 columns were spread over three
  lines; collapsed to the single-line form.
- Two comments in `path-key-map.ts` hung their delimiters on lines with text
  (`/** Yields every present path ... ` / ` *  ... (Map iteration order). */`),
  the shape the guide's counterexample rules out.
- 39 comment lines ran past 80 columns. Most are in `logger.ts`, several of
  them inside `@example` blocks, where a wrapped call or a split `// Returns:`
  line keeps the example readable at width.

**How one starts.** About forty doc comments led with a bare imperative --
`Get the call counts ...`, `Reset all timing data.`, `Log a debug message`,
`Check if a message at the given level should be logged.` -- where the guide
asks for a subjectless third-person singular verb phrase. `logger.ts` holds
nearly all of them. Getters (`counts`, `countsByKey`, `flags`) move to the
noun phrase a property takes rather than `Get the ...`.

Two comments described something other than the code beneath them:

- `useBase64Polyfill` was documented as a question to the reader -- "Do we need
  to use our own implementation of base64url encoding?" -- rather than as what
  the constant holds.
- `getEnvLevel()` was documented as "We may want to initialize log level from
  environment variable if available", which states an intention. It now says
  what the function returns and under which conditions it returns `undefined`.

**What gets one.** `env.ts` had no doc comment on any of its four exports and
no module header at all. `sandbox-contract.ts` had none on thirteen exports.
`cache.ts` had none on either options interface, on `LRUCache`, or on any
member of either class -- the `ReadonlyMap` implementations take
`/** @inheritDoc */`, which the guide has for exactly that case, and the rest
say what they do. `zod-utils.ts` had none on `toZod()` or on `Implements`, and
its module header was a plain `/* ... */` block rather than a doc comment.

`TimingStats`, `CDFPoint`, `LogCounts`, `Deferred`, and `AsyncLocalStore`
carried their member documentation as trailing `//` comments
(`count: number; // Total measurements`). An inline comment explains local
mechanics; what a caller can rely on goes in the doc comment.

**Not a survey of the rest of the system.** `build-info.ts`'s module header
ended "Both the toolshed server and the cf CLI read their own copy through
this module" -- a claim about the far end of the tree that nothing in this
package would keep true, and that no check would catch going stale.

**Deliberately left alone.**

- `SANDBOX_WITHHELD_GLOBALS`' doc comment names the stripper script and the
  contract test that enforce it across packages. That reads like a survey, but
  it is the guide's pairing case: the comment names the thing that keeps a
  subtle invariant from being edited away. Only its over-long line changed.
- `logger.ts` has three section markers drawn as long `// =====` rules, which
  the guide's "no horizontal rules" bans. They are `//` comments rather than
  doc comments or module headers, so they sit outside the scope agreed for
  this pass.
- Error and log message strings, likewise: the guide's markup rules cover them,
  but editing message text is a different kind of change from a comment pass.

**Verified:** repo-wide `deno fmt --check` and `deno lint`, `deno task check`,
and `deno task test` in `packages/utils` (94 tests, 611 steps, ok). The diff
cannot reach runtime behavior.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

