### PR TITLE
docs(data-model): conform doc comments to the style guide

### DIFF
--- a/packages/data-model/bench/hashing.bench.ts
+++ b/packages/data-model/bench/hashing.bench.ts
@@ -1,7 +1,10 @@
 /**
  * Hashing Performance Benchmarks
  *
- * Run with: deno bench --allow-read --allow-write --allow-net --allow-ffi --allow-env --no-check bench/hashing.bench.ts
+ * Run with:
+ *
+ *     deno bench --allow-read --allow-write --allow-net --allow-ffi \
+ *       --allow-env --no-check bench/hashing.bench.ts
  */
 
 import { hashOf } from "../src/value-hash.ts";

--- a/packages/data-model/bench/value-identity-shapes.bench.ts
+++ b/packages/data-model/bench/value-identity-shapes.bench.ts
@@ -2,21 +2,22 @@
  * Identity-shape benchmarks for value hashing and deep-freeze.
  *
  * Motivated by CPU profiles of the default-app integration test
- * (docs/history/development/performance/default-app-note-create.md): in steady-state
- * note creation, ~29% of runtime-worker busy CPU is value hashing
+ * (docs/history/development/performance/default-app-note-create.md): in
+ * steady-state note creation, ~29% of runtime-worker busy CPU is value hashing
  * (`feedPlainObject` + wasm SHA-256) and ~12% is deep-freeze walks
  * (`deepFreeze()`/`isDeepFrozen()`).
  *
  * Both subsystems cache by OBJECT IDENTITY (`WeakMap`/`WeakSet`), so any
  * fresh-identity but structurally-equal value — e.g. query results, specs, or
- * vdom built anew on every render — pays a full O(tree) walk every time.
- * These benches separate the cache-hit identity path from the cache-defeating
+ * vdom built anew on every render — pays a full O(tree) walk every time. These
+ * benches separate the cache-hit identity path from the cache-defeating
  * fresh-identity path so the gap (and any future structural-caching fix) is
  * measurable in isolation.
  *
  * Run with:
- *   deno bench --allow-read --allow-write --allow-net --allow-ffi --allow-env \
- *     --no-check bench/value-identity-shapes.bench.ts
+ *
+ *     deno bench --allow-read --allow-write --allow-net --allow-ffi \
+ *       --allow-env --no-check bench/value-identity-shapes.bench.ts
  */
 
 import { hashOf } from "../src/value-hash.ts";

--- a/packages/data-model/src/SchemaAndHash.ts
+++ b/packages/data-model/src/SchemaAndHash.ts
@@ -24,7 +24,7 @@ export class SchemaAndHash {
   readonly #hash: FabricHash;
 
   /**
-   * Constructs a `SchemaAndHash` from an already-deep-frozen schema and
+   * Constructs an instance, from an already-deep-frozen schema and
    * its pre-computed hash. Throws if the schema is not deep-frozen.
    * Prefer `internSchema()` from `schema-hash.ts` for the friendly entry
    * point that handles freezing, hashing, and interning.

--- a/packages/data-model/src/cell-rep.ts
+++ b/packages/data-model/src/cell-rep.ts
@@ -17,9 +17,7 @@ import type { FabricPlainObject } from "@/interface.ts";
 // Configuration flags
 //
 
-/**
- * Module-level flag for the modern cell representation.
- */
+/** Module-level flag for the modern cell representation. */
 let modernCellRepEnabled = false;
 
 /** Activates or deactivates the modern cell representation flag. */
@@ -115,9 +113,9 @@ export const LINK_V1_TAG = "link@1" as const;
 /**
  * A link reference, wrapping a link payload. Its concrete shape is
  * flag-dispatched: with the modern cell representation _off_ it is the plain
- * `{ "/": { "link@1": … } }` envelope; with it _on_ it is a {@link FabricLink}
- * instance. This is the link analog of {@link EntityRef}'s `{ "/": string }` →
- * {@link FabricHash}.
+ * `{ "/": { "link@1": … } }` envelope; with it _on_ it is a
+ * {@link FabricLink} instance. This is the link analog of
+ * {@link EntityRef}'s `{ "/": string }` → {@link FabricHash}.
  *
  * Construction ({@link linkRefFrom}), recognition ({@link isLinkRef}) and
  * extraction ({@link linkRefPayload}) are gathered here so this chokepoint is
@@ -129,8 +127,9 @@ export const LINK_V1_TAG = "link@1" as const;
  * stored/serialized fabric record) but otherwise open, so this layer needn't
  * know the exact field types (URI / MemorySpace / JSONSchema — those stay in
  * `runner`). In modern mode the payload type is erased: a {@link FabricLink}
- * holds an unparameterized {@link FabricPlainObject}, just as {@link FabricHash} is
- * unparameterized on the modern arm of {@link EntityRef}.
+ * holds an unparameterized {@link FabricPlainObject}, just as
+ * {@link FabricHash} is unparameterized on the modern arm of
+ * {@link EntityRef}.
  */
 export type LinkRef<Payload extends FabricPlainObject> =
   | FabricLink
@@ -187,16 +186,16 @@ export function linkRefPayload<Payload extends FabricPlainObject>(
 /**
  * The storage sub-path, relative to a value's position in the document tree, at
  * which a link rooted there exposes its recognizable form. This encodes the
- * link layout for consumers that navigate _into_ the document tree (notably link
- * resolution), so they need not hardcode the layout — or the link tag —
+ * link layout for consumers that navigate _into_ the document tree (notably
+ * link resolution), so they need not hardcode the layout — or the link tag —
  * themselves.
  *
  * The sub-path is flag-dispatched to match the regime's storage layout. In
  * legacy mode a link is a decomposed plain-object envelope
  * (`{ "/": { "link@1": … } }`), so the recognizable payload sits two segments
- * down at `["/", "link@1"]`. In modern mode a link is an atomic {@link FabricLink}
- * value at the position itself, so the sub-path is empty. Pair with
- * {@link linkPayloadAtProbe} to interpret whatever is read at
+ * down at `["/", "link@1"]`. In modern mode a link is an atomic
+ * {@link FabricLink} value at the position itself, so the sub-path is empty.
+ * Pair with {@link linkPayloadAtProbe} to interpret whatever is read at
  * `position + linkProbeSubPath()`.
  */
 export function linkProbeSubPath(): readonly string[] {
@@ -235,13 +234,13 @@ export function linkPayloadAtProbe(
 const CELL_LINK_WIRE_PREFIX = "fcl1:";
 
 /**
- * A cell-link payload in its wire-transmissible form: a plain object whose every
- * property value is a string or an array of strings. This is the subset of a
- * link payload that is provably plain JSON — the addressing fields (id, space,
- * scope, path, overwrite). Richer payload fields (a `schema`, which can carry an
- * arbitrary {@link FabricValue} default, or cfc side-channels) are deliberately
- * NOT in this form: they are not plain JSON and have no role at a string
- * boundary. The exact field set is a consumer concern (e.g. runner's
+ * A cell-link payload in its wire-transmissible form: a plain object whose
+ * every property value is a string or an array of strings. This is the subset
+ * of a link payload that is provably plain JSON — the addressing fields (id,
+ * space, scope, path, overwrite). Richer payload fields (a `schema`, which can
+ * carry an arbitrary {@link FabricValue} default, or cfc side-channels) are
+ * deliberately NOT in this form: they are not plain JSON and have no role at a
+ * string boundary. The exact field set is a consumer concern (e.g. runner's
  * `WebhookCellLinkRefPayload`); this layer enforces only the generic shape.
  */
 export type WireLinkRefPayload = {
@@ -279,8 +278,9 @@ function assertWireLinkRefPayloadShape(
 /**
  * Serializes a link payload to a wire string for transport across a string
  * boundary (e.g. an HTTP body), tagged with the `fcl1:` prefix. The payload
- * must satisfy {@link WireLinkRefPayload}; throws otherwise (so a non-transmissible
- * payload fails here, at the producer, rather than corrupting silently).
+ * must satisfy {@link WireLinkRefPayload}; throws otherwise (so a
+ * non-transmissible payload fails here, at the producer, rather than corrupting
+ * silently).
  */
 export function linkRefPayloadToString(payload: WireLinkRefPayload): string {
   assertWireLinkRefPayloadShape(payload);

--- a/packages/data-model/src/codec-common/BaseFabricCodec.ts
+++ b/packages/data-model/src/codec-common/BaseFabricCodec.ts
@@ -9,9 +9,7 @@ export abstract class BaseFabricCodec implements FabricCodec {
   #recognizedTypeTag: string | undefined;
   #uniqueHandledClass: Constructor | undefined;
 
-  /**
-   * Constructs an instance.
-   */
+  /** Constructs an instance. */
   constructor(
     /**
      * The wire type tag this codec recognizes, or `undefined` for a codec with

--- a/packages/data-model/src/codec-common/BaseReconstructionContext.ts
+++ b/packages/data-model/src/codec-common/BaseReconstructionContext.ts
@@ -16,6 +16,10 @@ export abstract class BaseReconstructionContext
   implements ReconstructionContext {
   readonly #shouldDeepFreeze: boolean;
 
+  /**
+   * Constructs an instance which reports `shouldDeepFreeze` for the frozenness
+   * of what it reconstructs.
+   */
   constructor(shouldDeepFreeze: boolean) {
     this.#shouldDeepFreeze = shouldDeepFreeze;
   }

--- a/packages/data-model/src/codec-common/BigIntCodec.ts
+++ b/packages/data-model/src/codec-common/BigIntCodec.ts
@@ -28,6 +28,7 @@ import { ProblematicValue } from "@/fabric-instances/ProblematicValue.ts";
  * confirms via `typeof`.
  */
 export class BigIntCodec extends BaseFabricCodec {
+  /** Constructs an instance. */
   constructor() {
     super(CODEC_TYPE_TAGS.BigInt, BigInt as unknown as Constructor);
   }

--- a/packages/data-model/src/codec-common/CodecRegistry.ts
+++ b/packages/data-model/src/codec-common/CodecRegistry.ts
@@ -62,14 +62,10 @@ export class CodecRegistry {
   /** Class -> codec map for O(1) encode dispatch on object values. */
   readonly #classMap = new Map<Constructor, FabricCodec>();
 
-  /**
-   * Primitive `type` -> codec map for O(1) encode dispatch on primitives.
-   */
+  /** Primitive `type` -> codec map for O(1) encode dispatch on primitives. */
   readonly #primitiveCodecs = new Map<PrimitiveTypeName, FabricCodec>();
 
-  /**
-   * Primitive `type`s that are self-representing (encoded as-is).
-   */
+  /** Primitive `type`s that are self-representing (encoded as-is). */
   readonly #selfRepTypes = new Set<PrimitiveTypeName>();
 
   /**

--- a/packages/data-model/src/codec-common/SpecialNumberCodec.ts
+++ b/packages/data-model/src/codec-common/SpecialNumberCodec.ts
@@ -18,6 +18,7 @@ import { ProblematicValue } from "@/fabric-instances/ProblematicValue.ts";
  * back to `Number.NaN`.
  */
 export class SpecialNumberCodec extends BaseFabricCodec {
+  /** Constructs an instance. */
   constructor() {
     super(CODEC_TYPE_TAGS.SpecialNumber, Number);
   }

--- a/packages/data-model/src/codec-common/SymbolCodec.ts
+++ b/packages/data-model/src/codec-common/SymbolCodec.ts
@@ -22,6 +22,7 @@ import { ProblematicValue } from "@/fabric-instances/ProblematicValue.ts";
  * confirms via `typeof`.
  */
 export class SymbolCodec extends BaseFabricCodec {
+  /** Constructs an instance. */
   constructor() {
     super(CODEC_TYPE_TAGS.Symbol, Symbol as unknown as Constructor);
   }

--- a/packages/data-model/src/codec-common/UndefinedCodec.ts
+++ b/packages/data-model/src/codec-common/UndefinedCodec.ts
@@ -9,6 +9,7 @@ import { CODEC_TYPE_TAGS } from "@/codec-common/codec-type-tags.ts";
  * matching is by `canEncode()`. See Section 1.4.1 of the formal spec.
  */
 export class UndefinedCodec extends BaseFabricCodec {
+  /** Constructs an instance. */
   constructor() {
     super(CODEC_TYPE_TAGS.Undefined, undefined);
   }

--- a/packages/data-model/src/codec-common/createDefaultRegistry.ts
+++ b/packages/data-model/src/codec-common/createDefaultRegistry.ts
@@ -23,10 +23,11 @@ import { CodecRegistry } from "./CodecRegistry.ts";
  * reports them directly; arrays and plain objects are handled structurally by
  * the serializer after no codec matches.
  *
- * `UnknownValue` / `ProblematicValue` are registered (via `instanceCodecClasses`)
- * but their codecs recognize no single wire tag: the encode path resolves each
- * instance's tag with `tagForValue()`, and an unrecognized tag on decode is
- * wrapped in an `UnknownValue` by the encoding context rather than tag-routed.
+ * `UnknownValue` / `ProblematicValue` are registered (via
+ * `instanceCodecClasses`) but their codecs recognize no single wire tag: the
+ * encode path resolves each instance's tag with `tagForValue()`, and an
+ * unrecognized tag on decode is wrapped in an `UnknownValue` by the encoding
+ * context rather than tag-routed.
  */
 export function createDefaultRegistry(): CodecRegistry {
   const registry = new CodecRegistry();

--- a/packages/data-model/src/codec-common/interface.ts
+++ b/packages/data-model/src/codec-common/interface.ts
@@ -2,9 +2,7 @@ import type { Constructor } from "@commonfabric/utils/types";
 
 import type { FabricInstance, FabricValue } from "@/interface.ts";
 
-/**
- * Well-known symbol for binding the getter `FabricClassWithCodec[CODEC]`.
- */
+/** Well-known symbol for binding the getter `FabricClassWithCodec[CODEC]`. */
 export const CODEC: unique symbol = Symbol.for("data-model.codec");
 
 /**
@@ -32,9 +30,7 @@ export interface FabricCodec {
    */
   get recognizedTypeTag(): string | undefined;
 
-  /**
-   * Returns `true` if this handler can encode the state of the given value.
-   */
+  /** Returns `true` if this handler can encode the state of the given value. */
   canEncode(value: FabricValue): boolean;
 
   /**
@@ -47,15 +43,15 @@ export interface FabricCodec {
   tagForValue(value: FabricValue): string;
 
   /**
-   * Decodes a value from the given essential state, which is (alleged / supposed)
-   * to be a value that was produced by an earlier call to {@link #encode} on
-   * a compatible class to this one. The result is expected to be a _shallow_
-   * decoding. The codec system handles recursively converting `state` contents
-   * as necessary.
+   * Decodes a value from the given essential state, which is (alleged /
+   * supposed) to be a value that was produced by an earlier call to
+   * {@link #encode} on a compatible class to this one. The result is expected
+   * to be a _shallow_ decoding. The codec system handles recursively
+   * converting `state` contents as necessary.
    *
-   * The given `typeTag` is what was associated with the given `state` and
-   * does not necessarily correspond to {@link #recognizedTypeTag} (depending on
-   * how an instance of this class got hooked up).
+   * The given `typeTag` is what was associated with the given `state` and does
+   * not necessarily correspond to {@link #recognizedTypeTag} (depending on how
+   * an instance of this class got hooked up).
    */
   decode(
     typeTag: string,
@@ -88,8 +84,10 @@ export interface FabricClassWithCodec {
  * See Section 2.5 of the formal spec.
  */
 export interface ReconstructionContext {
-  /** Resolves a cell reference. Used by types that need to intern or look up
-   *  existing instances during reconstruction. */
+  /**
+   * Resolves a cell reference, for a type that needs to intern or look up an
+   * existing instance during reconstruction.
+   */
   getCell(
     ref: { id: string; path: string[]; space: string },
   ): FabricInstance;
@@ -122,8 +120,12 @@ export interface ReconstructionContext {
  * machinery is private to the context implementation.
  */
 export interface SerializationContext<SerializedForm = unknown> {
-  /** Whether failed reconstructions produce `ProblematicValue` instead of
-   *  throwing. @default false */
+  /**
+   * Whether a failed reconstruction produces a `ProblematicValue` instead of
+   * throwing.
+   *
+   * @default false
+   */
   readonly lenient: boolean;
 
   /** Encodes a fabric value into serialized form for boundary crossing. */

--- a/packages/data-model/src/codec-json/JsonCodec.ts
+++ b/packages/data-model/src/codec-json/JsonCodec.ts
@@ -29,8 +29,10 @@ import { CODEC_META_TAGS } from "@/codec-common/codec-meta-tags.ts";
  * the `CodecRegistry`.
  */
 export class JsonCodec implements SerializationContext<string> {
-  /** Whether failed reconstructions produce `ProblematicValue` instead of
-   *  throwing. */
+  /**
+   * Whether a failed reconstruction produces a `ProblematicValue` instead of
+   * throwing.
+   */
   readonly lenient: boolean;
 
   /**
@@ -70,17 +72,12 @@ export class JsonCodec implements SerializationContext<string> {
     return this.#decodeValue(parsed, context);
   }
 
-  /**
-   * Serializes a fabric value to UTF-8 JSON bytes. (Public for now -- used by
-   * byte-level round-trip tests.)
-   */
+  /** Serializes a fabric value to UTF-8 JSON bytes. */
   encodeToBytes(value: FabricValue): Uint8Array {
     return this.toBytes(this.#encodeValue(value));
   }
 
-  /**
-   * Deserializes UTF-8 JSON bytes back into a fabric value.
-   */
+  /** Deserializes UTF-8 JSON bytes back into a fabric value. */
   decodeFromBytes(
     bytes: Uint8Array,
     context: ReconstructionContext,
@@ -612,9 +609,7 @@ export class JsonCodec implements SerializationContext<string> {
     return encoded;
   }
 
-  /**
-   * Parses the JSON-text wire form, _without_ a tag prefix.
-   */
+  /** Parses the JSON-text wire form, _without_ a tag prefix. */
   static #parseWireText(jsonText: string): JsonCodecValue {
     return deepFreeze(JSON.parse(jsonText) as JsonCodecValue);
   }

--- a/packages/data-model/src/deep-freeze.ts
+++ b/packages/data-model/src/deep-freeze.ts
@@ -7,22 +7,18 @@ import {
 import { BaseFabricPrimitive } from "./fabric-primitives/BaseFabricPrimitive.ts";
 import { isFabricValue } from "./type-check.ts";
 
-/**
- * Cache of confirmed deep-frozen objects.
- */
+/** Cache of confirmed deep-frozen objects. */
 const deepFrozenCache = new WeakSet<object>();
 
 /**
  * Object graphs proven to be deep-frozen `FabricValue`s, memoized by root
  * identity for `isDeepFrozenFabricValue()`. Sound to cache because the
- * deep-frozen-honesty mandate makes such a proof permanent (see `[IS_DEEP_FROZEN]`
- * on `BaseFabricInstance` and the `FabricValue` doc).
+ * deep-frozen-honesty mandate makes such a proof permanent (see
+ * `[IS_DEEP_FROZEN]` on `BaseFabricInstance` and the `FabricValue` doc).
  */
 const deepFrozenFabricValueCache = new WeakSet<object>();
 
-/**
- * Adds a value which has been determined to be deep-frozen to the cache.
- */
+/** Adds a value which has been determined to be deep-frozen to the cache. */
 function addToDeepFrozenCache(obj: object) {
   deepFrozenCache.add(obj);
 }
@@ -37,20 +33,21 @@ function isInDeepFrozenCache(obj: object): boolean {
 
 /**
  * Indicates whether the given value is "necessarily frozen" -- immutable by its
- * very nature, without any `Object.freeze()` having been applied. Reports `true`
- * for every primitive (`null`, `undefined`, booleans, numbers, strings,
+ * very nature, without any `Object.freeze()` having been applied. Reports
+ * `true` for every primitive (`null`, `undefined`, booleans, numbers, strings,
  * `bigint`s, symbols) and `FabricPrimitive` instances (which self-freeze at
- * construction and hold no outbound references). Ordinary objects and arrays are
- * `false`, as are `FabricInstance`s (whose frozen-ness depends on
+ * construction and hold no outbound references). Ordinary objects and arrays
+ * are `false`, as are `FabricInstance`s (whose frozen-ness depends on
  * `Object.freeze()` and their `[IS_DEEP_FROZEN]` report).
  *
  * KNOWN LIMITATION -- these do the wrong thing for `function`s, specifically. A
- * function reports `true` here (its `typeof` is not `"object"`), so `deepFreeze()`
- * and `isDeepFrozen()` treat it as an opaque immutable leaf: `isDeepFrozen(fn)` is
- * `true`, and a frozen graph reaching a function reads as deep-frozen, even
- * though the function's internals -- its `prototype` object and closure state --
- * remain mutable. This is deliberate, so general-purpose callers that freeze
- * objects-with-methods (e.g. `api/cfc.ts`'s `cfcPattern`) keep working.
+ * function reports `true` here (its `typeof` is not `"object"`), so
+ * `deepFreeze()` and `isDeepFrozen()` treat it as an opaque immutable leaf:
+ * `isDeepFrozen(fn)` is `true`, and a frozen graph reaching a function reads as
+ * deep-frozen, even though the function's internals -- its `prototype` object
+ * and closure state -- remain mutable. This is deliberate, so general-purpose
+ * callers that freeze objects-with-methods (e.g. `api/cfc.ts`'s `cfcPattern`)
+ * keep working.
  *
  * TODO(danfuzz): Migrate `deepFreeze()` to accept `FabricValue` only. A
  * function is not a `FabricValue`, so a strict signature removes the case
@@ -253,8 +250,8 @@ export function deepFreeze<T>(value: T): T {
 
 /**
  * Indicates whether the value is a deep-frozen `FabricValue`: both a
- * `FabricValue` (`isFabricValue()`) and deeply frozen (`isDeepFrozen()`), with an
- * identity-cached fast path. The cache is sound per the deep-frozen-honesty
+ * `FabricValue` (`isFabricValue()`) and deeply frozen (`isDeepFrozen()`), with
+ * an identity-cached fast path. The cache is sound per the deep-frozen-honesty
  * mandate (see `[IS_DEEP_FROZEN]` and the `FabricValue` doc), which makes a
  * deep-frozen proof permanent.
  */

--- a/packages/data-model/src/fabric-instances/BaseFabricInstance.ts
+++ b/packages/data-model/src/fabric-instances/BaseFabricInstance.ts
@@ -86,8 +86,8 @@ export abstract class BaseFabricInstance extends FabricInstance {
    * which have no enumerable own properties for an inspector to find.
    *
    * Delegates to the canonical debug renderer rather than formatting here, so
-   * that this surface improves whenever that one does -- including the state
-   * rendering its own `TODO` describes, currently elided as `(...)`.
+   * that this surface improves whenever that one does. Instance state is
+   * elided as `(...)`.
    *
    * Duplicated on `BaseFabricPrimitive`, unavoidably. There is no shared base
    * class below `FabricSpecialObject`, and `FabricSpecialObject` itself is the
@@ -113,28 +113,28 @@ export abstract class BaseFabricInstance extends FabricInstance {
   ): FabricValue;
 
   /**
-   * Indicates whether this instance is already deeply frozen, without
-   * mutating it. Checks this instance's own internal slot(s) are in
-   * canonical deep-frozen form and recurses into each nested `FabricValue`
-   * via the provided `subIsDeepFrozen` callback, returning the boolean
-   * conjunction. Implementations must NOT import or call the deep-frozen
-   * type guard directly -- recursion is handed through the callback,
-   * mirroring `[DEEP_FREEZE]`'s callback shape and avoiding an import cycle.
+   * Indicates whether this instance is already deeply frozen, without mutating
+   * it. Checks this instance's own internal slot(s) are in canonical
+   * deep-frozen form and recurses into each nested `FabricValue` via the
+   * provided `subIsDeepFrozen` callback, returning the boolean conjunction.
+   * Implementations must NOT import or call the deep-frozen type guard directly
+   * -- recursion is handed through the callback, mirroring `[DEEP_FREEZE]`'s
+   * callback shape and avoiding an import cycle.
    *
-   * Side-effect-free and must not throw: an instance that is not in
-   * canonical deep-frozen form returns `false`.
+   * Side-effect-free and must not throw: an instance that is not in canonical
+   * deep-frozen form returns `false`.
    *
    * **Deep-frozen honesty (mandatory).** This report must be truthful and
    * permanent: an implementation must not return `true` unless the instance is,
    * and will remain, deeply immutable (including its private slots). Once it
-   * reports deep-frozen, that is permanent for the life of the instance.
-   * The rest of the system -- the data model in general and `isDeepFrozen()`
+   * reports deep-frozen, that is permanent for the life of the instance. The
+   * rest of the system -- the data model in general and `isDeepFrozen()`
    * specifically, but also the entire codebase that _uses_ the data model -- is
-   * entitled to rely on this: a deep-frozen proof is cached by root identity and
-   * not re-validated, so an instance that lies here (reports deep-frozen while
-   * still mutable) can corrupt data-model invariants, exactly as any other
-   * broken class contract can. Making this correct is the implementing class's
-   * responsibility, not something the freeze-checking code papers over.
+   * entitled to rely on this: a deep-frozen proof is cached by root identity
+   * and not re-validated, so an instance that lies here (reports deep-frozen
+   * while still mutable) can corrupt data-model invariants, exactly as any
+   * other broken class contract can. Making this correct is the implementing
+   * class's responsibility, not something the freeze-checking code papers over.
    */
   abstract [IS_DEEP_FROZEN](
     subIsDeepFrozen: (value: FabricValue) => boolean,

--- a/packages/data-model/src/fabric-instances/ExplicitTagValue.ts
+++ b/packages/data-model/src/fabric-instances/ExplicitTagValue.ts
@@ -19,6 +19,7 @@ export abstract class ExplicitTagValue extends BaseFabricInstance {
   /** The value of {@link #state}. */
   readonly #state;
 
+  /** Constructs an instance with the given tag and state. */
   constructor(
     /** The original wire type tag, e.g. `"FutureType@2"`. */
     wireTypeTag: string,

--- a/packages/data-model/src/fabric-instances/FabricError.ts
+++ b/packages/data-model/src/fabric-instances/FabricError.ts
@@ -45,7 +45,7 @@ const FABRIC_ERROR_RESERVED_KEYS: FrozenSet<string> = new FrozenSet([
  * instance; they are not exposed as an own property.
  */
 export type FabricErrorState = {
-  /** Constructor name of the originating native `Error` (e.g. `"TypeError"`). */
+  /** Constructor name of the originating native `Error`, e.g. `TypeError`. */
   readonly type: string;
   /**
    * The `.name` property. Pass `null` (or omit) to mean "same as `type`"; the
@@ -90,7 +90,7 @@ export type FabricErrorState = {
  */
 export class FabricError extends FabricNativeWrapper<Error>
   implements ApiFabricError {
-  /** Constructor name of the originating native `Error` (e.g. `"TypeError"`). */
+  /** Constructor name of the originating native `Error`, e.g. `TypeError`. */
   #type: string;
 
   /** The `.name` property (always a concrete string). */
@@ -117,7 +117,8 @@ export class FabricError extends FabricNativeWrapper<Error>
   #nativeFrozen: Error | undefined;
 
   /**
-   * Constructs from a `FabricErrorState` record. All state values must already
+   * Constructs an instance from a `FabricErrorState` record. All state values
+   * must already
    * be in `FabricValue` form -- the conversion layer is responsible for
    * ensuring this when constructing from a native `Error`. Use
    * `FabricError.fromNativeError()` for shallow conversion from a native
@@ -146,7 +147,7 @@ export class FabricError extends FabricNativeWrapper<Error>
     }
   }
 
-  /** Constructor name of the originating native `Error` (e.g. `"TypeError"`). */
+  /** Constructor name of the originating native `Error`, e.g. `TypeError`. */
   get type(): string {
     return this.#type;
   }
@@ -415,10 +416,10 @@ export class FabricError extends FabricNativeWrapper<Error>
    * this clone's `frozen` intent (the `deepClone()` template owns the final
    * top-level freeze).
    *
-   * KNOWN GAP (pre-existing): `encode()` passes `cause` and the extras through
-   * by reference, so an unfrozen clone still SHARES those nested values with
-   * the original -- it is not yet fully deeply independent. Pinned by a test
-   * in `FabricError.test.ts`.
+   * Known gap: `encode()` passes `cause` and the extras through by reference,
+   * so an unfrozen clone still _shares_ those nested values with the original,
+   * and is to that extent not deeply independent. Pinned by a test in
+   * `FabricError.test.ts`.
    */
   protected override [DEEP_CLONE_CORE](frozen: boolean): FabricError {
     const codec = FabricError[CODEC];
@@ -435,6 +436,7 @@ export class FabricError extends FabricNativeWrapper<Error>
 
   static #codec = Object.freeze(
     new (class FabricErrorCodec extends BaseFabricCodec {
+      /** Constructs an instance. */
       constructor() {
         super(CODEC_TYPE_TAGS.Error, FabricError);
       }

--- a/packages/data-model/src/fabric-instances/FabricLink.ts
+++ b/packages/data-model/src/fabric-instances/FabricLink.ts
@@ -26,24 +26,25 @@ import { ProblematicValue } from "./ProblematicValue.ts";
 /**
  * A link value in the fabric type system: the modern, object-shaped form of a
  * `{ "/": { "link@1": … } }` link reference. It wraps the link's payload — a
- * {@link FabricPlainObject} of addressing fields (`id`, `space`, `scope`, `path`,
- * `overwrite`) plus an optional `schema` — as its sole nested value. The
- * data-model layer does not constrain the field set; that is a consumer concern
- * (e.g. runner's `CellLinkRefPayload`).
+ * {@link FabricPlainObject} of addressing fields (`id`, `space`, `scope`,
+ * `path`, `overwrite`) plus an optional `schema` — as its sole nested value.
+ * The data-model layer does not constrain the field set; that is a consumer
+ * concern (e.g. runner's `CellLinkRefPayload`).
  *
- * It is a {@link FabricInstance} (not a `FabricPrimitive`) precisely because the
- * payload is an **outgoing reference**: a link may carry a `schema`, an arbitrary
- * `FabricValue` that is not leaf data, so a link is a small object graph rather
- * than an immutable scalar. Like every instance, a `FabricLink` is wholeheartedly
- * mutable until frozen and immutable thereafter; the payload it holds is its one
- * nested `FabricValue`, frozen and cloned recursively by the protocol members.
+ * It is a {@link FabricInstance} (not a `FabricPrimitive`) precisely because
+ * the payload is an **outgoing reference**: a link may carry a `schema`, an
+ * arbitrary `FabricValue` that is not leaf data, so a link is a small object
+ * graph rather than an immutable scalar. Like every instance, a `FabricLink` is
+ * wholeheartedly mutable until frozen and immutable thereafter; the payload it
+ * holds is its one nested `FabricValue`, frozen and cloned recursively by the
+ * protocol members.
  */
 export class FabricLink extends BaseFabricInstance implements ApiFabricLink {
   /** The wrapped addressing payload (this link's sole outgoing reference). */
   #payload: FabricPlainObject;
 
   /**
-   * Constructs a `FabricLink` wrapping `payload`. The payload must be a plain
+   * Constructs an instance wrapping `payload`. The payload must be a plain
    * object with no prototype-pollution keys; otherwise the constructor throws
    * (death before confusion). The payload is held by reference — like every
    * `FabricInstance`, the instance is mutable until frozen, so the caller must
@@ -80,7 +81,8 @@ export class FabricLink extends BaseFabricInstance implements ApiFabricLink {
 
   /**
    * Side-effect-free check mirroring `[DEEP_FREEZE]`'s canonical form: this
-   * instance is frozen and its payload is recursively deep-frozen. Never throws.
+   * instance is frozen and its payload is recursively deep-frozen. Never
+   * throws.
    */
   [IS_DEEP_FROZEN](
     subIsDeepFrozen: (value: FabricValue) => boolean,
@@ -110,6 +112,7 @@ export class FabricLink extends BaseFabricInstance implements ApiFabricLink {
 
   static #codec = Object.freeze(
     new (class LinkCodec extends BaseFabricCodec {
+      /** Constructs an instance. */
       constructor() {
         super(CODEC_TYPE_TAGS.Link, FabricLink);
       }

--- a/packages/data-model/src/fabric-instances/FabricMap.ts
+++ b/packages/data-model/src/fabric-instances/FabricMap.ts
@@ -21,14 +21,15 @@ import { FabricNativeWrapper } from "./FabricNativeWrapper.ts";
  */
 export class FabricMap
   extends FabricNativeWrapper<Map<FabricValue, FabricValue>> {
+  /** Constructs an instance wrapping `map`. */
   constructor(readonly map: Map<FabricValue, FabricValue>) {
     super();
   }
 
   /**
-   * Stub -- throws until `Map` support is fully implemented. `FabricMap` is
-   * not yet used and is being reworked separately; the protocol methods are
-   * deliberately left as throwing stubs (per Dan's PR #3612 review).
+   * Stub -- throws until `Map` support is fully implemented. The protocol
+   * methods throw rather than approximate, so that no caller can come to depend
+   * on an answer that would have to be taken back.
    */
   [DEEP_FREEZE](
     _subFreeze: (value: FabricValue) => FabricValue,
@@ -68,6 +69,7 @@ export class FabricMap
 
   static #codec = Object.freeze(
     new (class FabricMapCodec extends BaseFabricCodec {
+      /** Constructs an instance. */
       constructor() {
         super(CODEC_TYPE_TAGS.Map, FabricMap);
       }

--- a/packages/data-model/src/fabric-instances/FabricNativeWrapper.ts
+++ b/packages/data-model/src/fabric-instances/FabricNativeWrapper.ts
@@ -10,13 +10,22 @@ import { BaseFabricInstance, DEEP_CLONE_CORE } from "./BaseFabricInstance.ts";
  */
 export abstract class FabricNativeWrapper<T extends object>
   extends BaseFabricInstance {
-  /** The wrapped native value, used by `toNativeValue` for freeze-state checks. */
+  /**
+   * The wrapped native value, used by `toNativeValue()` for freeze-state
+   * checks.
+   */
   protected abstract get wrappedValue(): T;
 
-  /** Converts the wrapped value to frozen form (only called on state mismatch). */
+  /**
+   * Converts the wrapped value to frozen form. Only called on a state
+   * mismatch.
+   */
   protected abstract toNativeFrozen(): T;
 
-  /** Converts the wrapped value to thawed form (only called on state mismatch). */
+  /**
+   * Converts the wrapped value to thawed form. Only called on a state
+   * mismatch.
+   */
   protected abstract toNativeThawed(): T;
 
   /** Returns the underlying native value, optionally frozen. */

--- a/packages/data-model/src/fabric-instances/FabricSet.ts
+++ b/packages/data-model/src/fabric-instances/FabricSet.ts
@@ -20,14 +20,15 @@ import { FabricNativeWrapper } from "./FabricNativeWrapper.ts";
  * beyond the wrapped collection are not supported on non-`Error` wrappers.
  */
 export class FabricSet extends FabricNativeWrapper<Set<FabricValue>> {
+  /** Constructs an instance wrapping `set`. */
   constructor(readonly set: Set<FabricValue>) {
     super();
   }
 
   /**
-   * Stub -- throws until `Set` support is fully implemented. `FabricSet` is
-   * not yet used and is being reworked separately; the protocol methods are
-   * deliberately left as throwing stubs (per Dan's PR #3612 review).
+   * Stub -- throws until `Set` support is fully implemented. The protocol
+   * methods throw rather than approximate, so that no caller can come to depend
+   * on an answer that would have to be taken back.
    */
   [DEEP_FREEZE](
     _subFreeze: (value: FabricValue) => FabricValue,
@@ -67,6 +68,7 @@ export class FabricSet extends FabricNativeWrapper<Set<FabricValue>> {
 
   static #codec = Object.freeze(
     new (class FabricSetCodec extends BaseFabricCodec {
+      /** Constructs an instance. */
       constructor() {
         super(CODEC_TYPE_TAGS.Set, FabricSet);
       }

--- a/packages/data-model/src/fabric-instances/ProblematicValue.ts
+++ b/packages/data-model/src/fabric-instances/ProblematicValue.ts
@@ -24,6 +24,10 @@ export class ProblematicValue extends ExplicitTagValue {
   /** Value for {@link #error}. */
   readonly #error;
 
+  /**
+   * Constructs an instance for the given tag and state, with `error`
+   * describing what went wrong.
+   */
   constructor(
     wireTypeTag: string,
     state: FabricValue,
@@ -40,9 +44,7 @@ export class ProblematicValue extends ExplicitTagValue {
     return this.#error;
   }
 
-  /**
-   * Deep-freezes in place.
-   */
+  /** Deep-freezes in place. */
   [DEEP_FREEZE](
     subFreeze: (value: FabricValue) => FabricValue,
   ): FabricValue {
@@ -71,6 +73,7 @@ export class ProblematicValue extends ExplicitTagValue {
 
   static #codec = Object.freeze(
     new (class ProblematicValueCodec extends BaseFabricCodec {
+      /** Constructs an instance. */
       constructor() {
         // No preferred wire tag: a `ProblematicValue` round-trips to its
         // *preserved* tag, which varies per instance.

--- a/packages/data-model/src/fabric-instances/UnknownValue.ts
+++ b/packages/data-model/src/fabric-instances/UnknownValue.ts
@@ -21,13 +21,12 @@ import { deepFreeze } from "@/deep-freeze.ts";
  * to produce the original wire format. See Section 3.3 of the formal spec.
  */
 export class UnknownValue extends ExplicitTagValue {
+  /** Constructs an instance for the given unrecognized tag and its state. */
   constructor(wireTypeTag: string, state: FabricValue) {
     super(wireTypeTag, state);
   }
 
-  /**
-   * Deep-freezes in place.
-   */
+  /** Deep-freezes in place. */
   [DEEP_FREEZE](
     subFreeze: (value: FabricValue) => FabricValue,
   ): FabricValue {
@@ -56,6 +55,7 @@ export class UnknownValue extends ExplicitTagValue {
 
   static #codec = Object.freeze(
     new (class UnknownValueCodec extends BaseFabricCodec {
+      /** Constructs an instance. */
       constructor() {
         // No preferred wire tag: an `UnknownValue` round-trips to its
         // *preserved* tag, which varies per instance.

--- a/packages/data-model/src/fabric-primitives/BaseFabricPrimitive.ts
+++ b/packages/data-model/src/fabric-primitives/BaseFabricPrimitive.ts
@@ -38,11 +38,11 @@ export abstract class BaseFabricPrimitive extends FabricPrimitive {
    * which have no enumerable own properties for an inspector to find.
    *
    * Delegates to the canonical debug renderer rather than formatting here, so
-   * that this surface improves whenever that one does -- including the state
-   * rendering its own `TODO` describes, currently elided as `(...)`.
+   * that this surface improves whenever that one does. Instance state is
+   * elided as `(...)`.
    *
-   * Duplicated on `BaseFabricInstance`, unavoidably. There is no shared base class
-   * below `FabricSpecialObject`, and `FabricSpecialObject` itself is the
+   * Duplicated on `BaseFabricInstance`, unavoidably. There is no shared base
+   * class below `FabricSpecialObject`, and `FabricSpecialObject` itself is the
    * runtime-import-free abstract contract, so it cannot reach `value-debug`.
    */
   [Symbol.for("Deno.customInspect")](): string {

--- a/packages/data-model/src/fabric-primitives/FabricBytes.ts
+++ b/packages/data-model/src/fabric-primitives/FabricBytes.ts
@@ -32,7 +32,7 @@ export class FabricBytes extends BaseFabricPrimitive {
   readonly #bytes: Uint8Array;
 
   /**
-   * Constructs a `FabricBytes` from raw bytes. The input is copied;
+   * Constructs an instance from raw bytes. The input is copied;
    * the caller may freely mutate the original after construction.
    *
    * @param bytes - The raw bytes to wrap (copied, not shared).
@@ -67,8 +67,10 @@ export class FabricBytes extends BaseFabricPrimitive {
    * Copies bytes from this instance into a caller-provided buffer.
    *
    * @param target - The destination buffer.
-   * @param offset - Byte offset in the source to start copying from (default 0).
-   * @param length - Number of bytes to copy (default: all remaining from offset).
+   * @param offset - Byte offset in the source to start copying from
+   *   (default `0`).
+   * @param length - Number of bytes to copy (default: all remaining from
+   *   `offset`).
    * @returns The number of bytes actually copied.
    */
   copyInto(target: Uint8Array, offset = 0, length?: number): number {
@@ -95,6 +97,7 @@ export class FabricBytes extends BaseFabricPrimitive {
 
   static #codec = Object.freeze(
     new (class BytesCodec extends BaseFabricCodec {
+      /** Constructs an instance. */
       constructor() {
         super(CODEC_TYPE_TAGS.Bytes, FabricBytes);
       }

--- a/packages/data-model/src/fabric-primitives/FabricEpochDays.ts
+++ b/packages/data-model/src/fabric-primitives/FabricEpochDays.ts
@@ -32,6 +32,7 @@ export class FabricEpochDays extends BaseFabricPrimitive
   /** Days from POSIX Epoch. Negative values represent pre-epoch dates. */
   readonly #value: bigint;
 
+  /** Constructs an instance representing `value` days from the Epoch. */
   constructor(value: bigint) {
     super();
     this.#value = value;
@@ -49,6 +50,7 @@ export class FabricEpochDays extends BaseFabricPrimitive
 
   static #codec = Object.freeze(
     new (class EpochDaysCodec extends BaseFabricCodec {
+      /** Constructs an instance. */
       constructor() {
         super(CODEC_TYPE_TAGS.EpochDays, FabricEpochDays);
       }

--- a/packages/data-model/src/fabric-primitives/FabricEpochNsec.ts
+++ b/packages/data-model/src/fabric-primitives/FabricEpochNsec.ts
@@ -23,22 +23,29 @@ import { ProblematicValue } from "@/fabric-instances/ProblematicValue.ts";
 import { CODEC_TYPE_TAGS } from "@/codec-common/codec-type-tags.ts";
 
 /**
- * Temporal type representing nanoseconds from the POSIX Epoch (1970-01-01T00:00:00Z).
- * Wraps a `bigint` value. Used for high-precision timestamps.
- * See Section 1.4.6 of the formal spec.
+ * Temporal type representing nanoseconds from the POSIX Epoch
+ * (1970-01-01T00:00:00Z). Wraps a `bigint` value. Used for high-precision
+ * timestamps. See Section 1.4.6 of the formal spec.
  */
 export class FabricEpochNsec extends BaseFabricPrimitive
   implements ApiFabricEpochNsec {
-  /** Nanoseconds from POSIX Epoch. Negative values represent pre-epoch timestamps. */
+  /**
+   * Nanoseconds from the POSIX Epoch. A negative value represents a pre-epoch
+   * timestamp.
+   */
   readonly #value: bigint;
 
+  /** Constructs an instance representing `value` nanoseconds from the Epoch. */
   constructor(value: bigint) {
     super();
     this.#value = value;
     Object.freeze(this);
   }
 
-  /** Nanoseconds from POSIX Epoch. Negative values represent pre-epoch timestamps. */
+  /**
+   * Nanoseconds from the POSIX Epoch. A negative value represents a pre-epoch
+   * timestamp.
+   */
   get value(): bigint {
     return this.#value;
   }
@@ -49,6 +56,7 @@ export class FabricEpochNsec extends BaseFabricPrimitive
 
   static #codec = Object.freeze(
     new (class EpochNsecCodec extends BaseFabricCodec {
+      /** Constructs an instance. */
       constructor() {
         super(CODEC_TYPE_TAGS.EpochNsec, FabricEpochNsec);
       }

--- a/packages/data-model/src/fabric-primitives/FabricHash.ts
+++ b/packages/data-model/src/fabric-primitives/FabricHash.ts
@@ -39,7 +39,7 @@ export class FabricHash extends BaseFabricPrimitive implements ApiFabricHash {
   readonly #fullStringForm: string;
 
   /**
-   * Constructs a `FabricHash` from raw hash bytes and an algorithm tag.
+   * Constructs an instance from raw hash bytes and an algorithm tag.
    * The instance is frozen after construction.
    *
    * **Ownership transfer:** the caller must not mutate `hash` after passing
@@ -96,7 +96,10 @@ export class FabricHash extends BaseFabricPrimitive implements ApiFabricHash {
     return this.#fullStringForm;
   }
 
-  /** Copies the hash bytes into `target` starting at offset 0. Returns `target`. */
+  /**
+   * Copies the hash bytes into `target` starting at offset `0`, and returns
+   * `target`.
+   */
   copyInto(target: Uint8Array): Uint8Array {
     target.set(this.#hash);
     return target;
@@ -131,6 +134,7 @@ export class FabricHash extends BaseFabricPrimitive implements ApiFabricHash {
 
   static #codec = Object.freeze(
     new (class HashCodec extends BaseFabricCodec {
+      /** Constructs an instance. */
       constructor() {
         super(CODEC_TYPE_TAGS.Hash, FabricHash);
       }

--- a/packages/data-model/src/fabric-primitives/FabricRegExp.ts
+++ b/packages/data-model/src/fabric-primitives/FabricRegExp.ts
@@ -58,7 +58,7 @@ export class FabricRegExp extends BaseFabricPrimitive
   readonly #value: RegExp | undefined;
 
   /**
-   * Constructs a `FabricRegExp`, either from a native `RegExp` (implying the
+   * Constructs an instance, either from a native `RegExp` (implying the
    * `"es2025"` flavor) or from explicit `flavor` / `source` / `flags`.
    *
    * When the resulting flavor is `"es2025"`, the `source` and `flags` are
@@ -133,6 +133,7 @@ export class FabricRegExp extends BaseFabricPrimitive
 
   static #codec = Object.freeze(
     new (class RegExpCodec extends BaseFabricCodec {
+      /** Constructs an instance. */
       constructor() {
         super(CODEC_TYPE_TAGS.RegExp, FabricRegExp);
       }

--- a/packages/data-model/src/frozen-builtins.ts
+++ b/packages/data-model/src/frozen-builtins.ts
@@ -11,14 +11,27 @@
 
 type MapBacking<K, V> = Map<K, V>;
 type SetBacking<T> = Set<T>;
+/** Builder for a `FrozenMap`, which fills it before it is handed out. */
 type MapBuilder<K, V> = {
+  /** The map being built. */
   readonly wrapper: FrozenMap<K, V>;
+
+  /** Sets `key` to `value`. */
   set(key: K, value: V): void;
+
+  /** Seals the map and returns it. */
   finish(): FrozenMap<K, V>;
 };
+
+/** Builder for a `FrozenSet`, which fills it before it is handed out. */
 type SetBuilder<T> = {
+  /** The set being built. */
   readonly wrapper: FrozenSet<T>;
+
+  /** Adds `value`. */
   add(value: T): void;
+
+  /** Seals the set and returns it. */
   finish(): FrozenSet<T>;
 };
 
@@ -27,12 +40,18 @@ const SET_BACKING = new WeakMap<object, SetBacking<unknown>>();
 const INTERNAL_MAP_BUILDER = Symbol("FrozenMapBuilder");
 const INTERNAL_SET_BUILDER = Symbol("FrozenSetBuilder");
 
-/** Helper for the mutator methods, which throws to signal a frozen-mutation attempt. */
+/**
+ * Helper for the mutator methods, which throws to signal a frozen-mutation
+ * attempt.
+ */
 function throwFrozenMutation(typeName: string): never {
   throw new TypeError(`Cannot mutate a ${typeName}`);
 }
 
-/** Helper for builders, which throws to signal a post-`finish()` mutation attempt. */
+/**
+ * Helper for builders, which throws to signal a post-`finish()` mutation
+ * attempt.
+ */
 function throwFinalizedBuilderMutation(typeName: string): never {
   throw new TypeError(`Cannot mutate a finalized ${typeName} builder`);
 }
@@ -85,9 +104,9 @@ function forEachSetLikeValue<T>(
 
 /**
  * Effectively-immutable `Map` wrapper. Read methods delegate to a
- * module-private backing `Map`; mutator methods (`set()`, `delete()`, `clear()`,
- * etc.) throw. Instances are frozen at construction time (or at builder
- * `finish()` time, see `createBuilder()`).
+ * module-private backing `Map`; mutator methods (`set()`, `delete()`,
+ * `clear()`, etc.) throw. Instances are frozen at construction time (or at
+ * builder `finish()` time, see `createBuilder()`).
  */
 export class FrozenMap<K, V> implements Map<K, V> {
   /**
@@ -216,8 +235,8 @@ Object.setPrototypeOf(FrozenMap, Map);
 /**
  * Effectively-immutable `Set` wrapper. Read methods and set-algebra methods
  * delegate to a module-private backing `Set`; mutator methods (`add()`,
- * `delete()`, `clear()`) throw. Instances are frozen at construction time (or at
- * builder `finish()` time, see `createBuilder()`).
+ * `delete()`, `clear()`) throw. Instances are frozen at construction time (or
+ * at builder `finish()` time, see `createBuilder()`).
  */
 export class FrozenSet<T> implements Set<T> {
   /**
@@ -350,7 +369,10 @@ export class FrozenSet<T> implements Set<T> {
     return result;
   }
 
-  /** Same as `Set.prototype.symmetricDifference`. Returns a new (mutable) `Set`. */
+  /**
+   * Same as `Set.prototype.symmetricDifference`. Returns a new (mutable)
+   * `Set`.
+   */
   symmetricDifference<U>(other: ReadonlySetLike<U>): Set<T | U> {
     const result = new Set<T | U>(this.values());
     forEachSetLikeValue(other, (value) => {

--- a/packages/data-model/src/interface.ts
+++ b/packages/data-model/src/interface.ts
@@ -72,16 +72,16 @@ export abstract class FabricInstance extends FabricSpecialObject {
   /**
    * Returns a new deep clone of this instance with equivalent data but no
    * shared structure for any unfrozen data in the original. When `frozen ===
-   * true`, produces a frozen instance with maximal structural sharing, including
-   * returning `this` if it is already deep-frozen. When `frozen === false`,
-   * produces a deeply-mutable instance with no visible shared reference
+   * true`, produces a frozen instance with maximal structural sharing,
+   * including returning `this` if it is already deep-frozen. When `frozen ===
+   * false`, produces a deeply-mutable instance with no visible shared reference
    * structure with the original.
    *
-   * The concrete template-method implementation lives on
-   * `BaseFabricInstance` (deferring to the `[DEEP_CLONE_CORE]` sibling,
-   * mirroring the `shallowClone()`/`[SHALLOW_UNFROZEN_CLONE]()` split); this
-   * declaration just pins the protocol surface so that callers can invoke it
-   * through a `FabricInstance` reference.
+   * The concrete template-method implementation lives on `BaseFabricInstance`
+   * (deferring to the `[DEEP_CLONE_CORE]` sibling, mirroring the
+   * `shallowClone()`/`[SHALLOW_UNFROZEN_CLONE]()` split); this declaration just
+   * pins the protocol surface so that callers can invoke it through a
+   * `FabricInstance` reference.
    */
   abstract deepClone(frozen: boolean): FabricInstance;
 
@@ -116,6 +116,7 @@ export abstract class FabricInstance extends FabricSpecialObject {
  * See Section 1.4.5 and 1.4.6 of the formal spec.
  */
 export abstract class FabricPrimitive extends FabricSpecialObject {
+  /** Constructs an instance. */
   constructor() {
     super();
   }
@@ -126,29 +127,31 @@ export abstract class FabricPrimitive extends FabricSpecialObject {
 //
 
 /**
- * The full set of values that the fabric storage layer can represent. This
- * is the strongly-typed "middle layer" of the three-layer architecture:
+ * The full set of values that the fabric storage layer can represent. This is
+ * the strongly-typed "middle layer" of the three-layer architecture:
  *
- *   JavaScript "wild west" (`unknown`) <-> `FabricValue` <-> Serialized (`Uint8Array`)
+ *     JavaScript "wild west" (`unknown`)
+ *       <-> `FabricValue`
+ *       <-> serialized (`Uint8Array`)
  *
- * Most native JS object types enter the fabric layer via wrapper classes
- * that extend `FabricInstance`; other special values extend `FabricPrimitive`.
- * Both of those reach `FabricValue` through the common `FabricSpecialObject`
- * arm. The non-object values (`bigint` and the other scalars) are direct
- * members of the union instead, not routed through that arm. Some native types
- * are converted to fabric primitives during conversion.
+ * Most native JS object types enter the fabric layer via wrapper classes that
+ * extend `FabricInstance`; other special values extend `FabricPrimitive`. Both
+ * of those reach `FabricValue` through the common `FabricSpecialObject` arm.
+ * The non-object values (`bigint` and the other scalars) are direct members of
+ * the union instead, not routed through that arm. Some native types are
+ * converted to fabric primitives during conversion.
  *
  * `undefined` is preserved.
  *
- * `symbol` values are restricted at runtime to **registry-interned** symbols
- * -- those for which `Symbol.keyFor(s)` returns a string. These are
- * portable across realms and processes via their registry key. Unique
- * symbols (`Symbol(desc)`) are not portable and are rejected at the fabric
- * boundary. TypeScript's `symbol` type cannot distinguish the two, so the
- * gate is a runtime one. Note also that the fabric-value path
- * separately rejects all symbols at the entrance (relaxation deferred to a
- * follow-up); the type union admits `symbol` so the lower layers (hashing,
- * JSON encoding) can be written and tested ahead of that gate change.
+ * `symbol` values are restricted at runtime to **registry-interned** symbols --
+ * those for which `Symbol.keyFor(s)` returns a string. These are portable
+ * across realms and processes via their registry key. Unique symbols
+ * (`Symbol(desc)`) are not portable and are rejected at the fabric boundary.
+ * TypeScript's `symbol` type cannot distinguish the two, so the gate is a
+ * runtime one. Note also that the fabric-value path separately rejects all
+ * symbols at its entrance, so this union is wider than what that gate admits:
+ * the lower layers (hashing, JSON encoding) accept a registry-interned symbol
+ * even though the entrance does not.
  *
  * **Deep-frozen honesty (mandatory).** A `FabricValue` must report its frozen
  * state truthfully and permanently. In particular, a fabric record or array is

--- a/packages/data-model/src/interface.ts
+++ b/packages/data-model/src/interface.ts
@@ -148,10 +148,8 @@ export abstract class FabricPrimitive extends FabricSpecialObject {
  * across realms and processes via their registry key. Unique symbols
  * (`Symbol(desc)`) are not portable and are rejected at the fabric boundary.
  * TypeScript's `symbol` type cannot distinguish the two, so the gate is a
- * runtime one. Note also that the fabric-value path separately rejects all
- * symbols at its entrance, so this union is wider than what that gate admits:
- * the lower layers (hashing, JSON encoding) accept a registry-interned symbol
- * even though the entrance does not.
+ * runtime one, and it is the same gate at every point a symbol is admitted or
+ * refused: `Symbol.keyFor(value) !== undefined`.
  *
  * **Deep-frozen honesty (mandatory).** A `FabricValue` must report its frozen
  * state truthfully and permanently. In particular, a fabric record or array is

--- a/packages/data-model/src/schema-utils.ts
+++ b/packages/data-model/src/schema-utils.ts
@@ -1,6 +1,4 @@
-/**
- * Runtime utilities for working with JSONSchema values.
- */
+/** Runtime utilities for working with JSONSchema values. */
 
 import type {
   JSONSchema,
@@ -289,9 +287,7 @@ export function schemaForValueType(
   return getBasicSchema(type);
 }
 
-/**
- * Gets the standard interned empty schema _object_, a literal `{}`.
- */
+/** Gets the standard interned empty schema _object_, a literal `{}`. */
 export function emptySchemaObject() {
   const key = "emptySchema";
   const found = BASIC_SCHEMAS[key];
@@ -305,15 +301,18 @@ export function emptySchemaObject() {
 
 /**
  * Common shape of the two canonical-selector maps. Its key type spans both
- * maps' keys, so a single variable selected between the object `WeakMap` and the
- * primitive `Map` accepts the un-narrowed interned schema as a key — without
- * TypeScript collapsing the two maps' key types to `never` (which is what a bare
- * `WeakMap | Map` union does).
+ * maps' keys, so a single variable selected between the object `WeakMap` and
+ * the primitive `Map` accepts the un-narrowed interned schema as a key —
+ * without TypeScript collapsing the two maps' key types to `never` (which is
+ * what a bare `WeakMap | Map` union does).
  */
 type CanonicalSelectorMap = {
+  /** Returns the selectors for `key`, or `undefined` if there are none. */
   get(
     key: JSONSchema | undefined,
   ): Map<string, WeakRef<SchemaPathSelector>> | undefined;
+
+  /** Sets the selectors for `key`. */
   set(
     key: JSONSchema | undefined,
     value: Map<string, WeakRef<SchemaPathSelector>>,
@@ -334,8 +333,8 @@ type CanonicalSelectorMap = {
  * reference its schema — the outer `WeakMap` key — pinning both forever.
  * Dead refs are dropped lazily on lookup.
  *
- * As a `WeakMap`, this can only map from GC-able objects, so {@link
- * #canonicalSelectorsByPrimitiveSchema} handles primitives.
+ * As a `WeakMap`, this can only map from GC-able objects, so primitives are
+ * handled by {@link #canonicalSelectorsByPrimitiveSchema}.
  */
 const canonicalSelectorsByObjectSchema = new WeakMap<
   object,
@@ -343,8 +342,8 @@ const canonicalSelectorsByObjectSchema = new WeakMap<
 >();
 
 /**
- * Like {@link #canonicalSelectorsByObjectSchema}, except for primitive-valued schemas
- * including the "schema" `undefined`.
+ * Like {@link #canonicalSelectorsByObjectSchema}, except for primitive-valued
+ * schemas including the "schema" `undefined`.
  */
 const canonicalSelectorsByPrimitiveSchema = new Map<
   boolean | undefined,

--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -74,20 +74,19 @@ export function isFabricValueLayer(
  * Indicates whether the value is a `FabricValue` -- a recursive check of exact
  * structural membership in the `FabricValue` type, independent of frozen-ness.
  *
- * Returns `true` for any scalar (`null`, `undefined`, `boolean`, `number`
- * -- including `-0`, `NaN`, and `±Infinity` -- `string`, `bigint`, and
+ * Returns `true` for any scalar (`null`, `undefined`, `boolean`, `number` --
+ * including `-0`, `NaN`, and `±Infinity` -- `string`, `bigint`, and
  * registry-interned (`Symbol.for(...)`) symbols), any `FabricInstance` or
  * `FabricPrimitive`, a direct `Array` instance holding `FabricValue`s with no
- * named or symbol-keyed properties, `length` aside (sparse holes allowed), or
- * a plain object whose values are all
- * `FabricValue`s. Returns `false` for a `function` or a unique (uninterned)
- * symbol -- whether the value itself or reached anywhere within it -- for an
- * accessor-backed (getter/setter) property anywhere, plain-object keyed or
- * array-indexed alike, which makes its container non-inert, for an `Array`
- * subclass instance or other indirectly-rooted array, whose prototype is live
- * code the same way an accessor is, and for any
- * other class instance (`Date`, `Map`, ...) not representable as a
- * `FabricValue`. Handles circular references.
+ * named or symbol-keyed properties, `length` aside (sparse holes allowed), or a
+ * plain object whose values are all `FabricValue`s. Returns `false` for a
+ * `function` or a unique (uninterned) symbol -- whether the value itself or
+ * reached anywhere within it -- for an accessor-backed (getter/setter) property
+ * anywhere, plain-object keyed or array-indexed alike, which makes its
+ * container non-inert, for an `Array` subclass instance or other
+ * indirectly-rooted array, whose prototype is live code the same way an
+ * accessor is, and for any other class instance (`Date`, `Map`, ...) not
+ * representable as a `FabricValue`. Handles circular references.
  *
  * This is a *membership* check, not a frozen-ness check: a structurally-valid
  * but unfrozen object or array is still a `FabricValue`. For the deep-frozen
@@ -98,8 +97,8 @@ export function isFabricValueLayer(
  * membership check must not invoke.
  *
  * Contrast the shallow, single-level sibling `isFabricValueLayer()` and
- * `isFabricCompatible()` (which additionally accepts native values *convertible*
- * to fabric form).
+ * `isFabricCompatible()` (which additionally accepts native values
+ * *convertible* to fabric form).
  */
 export function isFabricValue(value: unknown): value is FabricValue {
   // Fast leaf paths first, so a function or a primitive answers without
@@ -198,18 +197,18 @@ export function isFabricObjectOrArray(
 }
 
 /**
- * Narrows to the plain-record arm of `FabricValue` (`FabricPlainObject`): an object
- * whose prototype is `Object.prototype` or `null`. This rejects arrays,
+ * Narrows to the plain-record arm of `FabricValue` (`FabricPlainObject`): an
+ * object whose prototype is `Object.prototype` or `null`. This rejects arrays,
  * `FabricSpecialObject`s, and other class instances (`Date`, `Map`, …), none of
- * which are representable as a `FabricPlainObject`. Unlike a bare `isRecord()` check,
- * it preserves the value type — `FabricPlainObject`'s string index of `FabricValue`
- * keeps an indexed value typed as a `FabricValue`.
+ * which are representable as a `FabricPlainObject`. Unlike a bare `isRecord()`
+ * check, it preserves the value type — `FabricPlainObject`'s string index of
+ * `FabricValue` keeps an indexed value typed as a `FabricValue`.
  *
  * This asks a shape question -- "may I read this by property name?" -- of a
  * value the type already says is a `FabricValue`, and a null-prototype object
- * answers yes as readily as any other record. That makes it deliberately
- * looser than membership: a `FabricPlainObject` is `Object.prototype`-rooted,
- * so `isFabricValue()` refuses the null-prototype object this accepts. The
+ * answers yes as readily as any other record. That makes it deliberately looser
+ * than membership: a `FabricPlainObject` is `Object.prototype`-rooted, so
+ * `isFabricValue()` refuses the null-prototype object this accepts. The
  * looseness costs nothing, the input being out of contract either way, and it
  * keeps callers holding un-validated values from losing a reader they can use.
  */

--- a/packages/data-model/src/value-clone.ts
+++ b/packages/data-model/src/value-clone.ts
@@ -6,9 +6,7 @@ import { NATIVE_TAGS, tagFromNativeValue } from "./native-type-tags.ts";
 import { deepFreeze, isDeepFrozenFabricValue } from "./deep-freeze.ts";
 import { toDebugKindString } from "./value-debug.ts";
 
-/**
- * Options for `cloneIfNecessary()`.
- */
+/** Options for `cloneIfNecessary()`. */
 export interface CloneOptions {
   /** Whether the result should be frozen. Default: `true`. */
   frozen?: boolean;
@@ -58,11 +56,12 @@ function trackForCircularity(
  * fabric wrappers), this function assumes the input is already a valid
  * `FabricValue` and only adjusts frozenness by cloning where necessary.
  *
- * Cyclic values are not yet supported: a deep clone (the default) throws on a
- * detected cycle. Handling cycles here is intended future work.
+ * Cyclic values are not supported: a deep clone (the default) throws on a
+ * detected cycle.
  *
  * @param value - An already-valid `FabricValue`.
- * @param options - See `CloneOptions`. Defaults: `{ frozen: true, deep: true }`.
+ * @param options - See `CloneOptions`. Defaults to
+ *   `{ frozen: true, deep: true }`.
  */
 export function cloneIfNecessary<T extends FabricValue>(
   value: T,
@@ -109,10 +108,10 @@ export function cloneIfNecessary<T extends FabricValue>(
  * `Object.freeze()` (or `deepFreeze()`) on the result to obtain a
  * fully-deep-frozen value, with no leftover mutable bits hiding underneath.
  *
- * Children are made safe via `cloneIfNecessary()` with its default (deep-frozen)
- * options, so already-deep-frozen children are identity-passed (zero-copy) while
- * mutable children are deep-cloned-and-frozen. The input is never mutated:
- * mutable children are cloned, not frozen in place.
+ * Children are made safe via `cloneIfNecessary()` with its default
+ * (deep-frozen) options, so already-deep-frozen children are identity-passed
+ * (zero-copy) while mutable children are deep-cloned-and-frozen. The input is
+ * never mutated: mutable children are cloned, not frozen in place.
  *
  * Inherently-immutable inputs (primitives, `FabricPrimitive`s) are returned
  * as-is, since there is no mutable top level to produce.
@@ -283,6 +282,7 @@ export type CloneForMutationErrorKind =
  *   `toDebugKindString()`).
  */
 export class CloneForMutationError extends Error {
+  /** Constructs an instance describing one clone-for-mutation failure. */
   constructor(
     readonly kind: CloneForMutationErrorKind,
     readonly pathIndex: number,
@@ -294,9 +294,7 @@ export class CloneForMutationError extends Error {
   }
 }
 
-/**
- * Options for `cloneForMutation()`.
- */
+/** Options for `cloneForMutation()`. */
 export interface CloneForMutationOptions {
   /**
    * Force fresh shallow copies of every spine container, even when the
@@ -319,8 +317,8 @@ export interface CloneForMutationOptions {
   force?: boolean;
 
   /**
-   * Create missing intermediate containers along `path` as the helper
-   * descends. Default: `false` (throws `CloneForMutationError` with kind
+   * Whether to create missing intermediate containers along `path` as the
+   * helper descends. Default: `false` (throws `CloneForMutationError` with kind
    * `"missing-segment"` on the first missing slot).
    *
    * When `createMissing: true`, at each path step where the container at
@@ -396,9 +394,11 @@ export interface CloneForMutationResult<T extends FabricValue> {
  *
  * ### Mutation patterns supported via the returned `pathValue`
  *
- * - Object property add / set / delete: `pathValue.k = v`, `delete pathValue.k`.
+ * - Object property add / set / delete: `pathValue.k = v`, and
+ *   `delete pathValue.k`.
  * - Array set-element / push / splice / length: `pathValue[i] = v`,
- *   `pathValue.push(v)`, `pathValue.splice(i, n, ...add)`, `pathValue.length = n`.
+ *   `pathValue.push(v)`, `pathValue.splice(i, n, ...add)`, and
+ *   `pathValue.length = n`.
  * - "Replace the value at some slot": pass the parent's path as `path`,
  *   then assign through `pathValue[lastKey] = newValue`.
  *
@@ -625,7 +625,8 @@ const hasChildAt = (
  * Like `cloneForMutation`, descent through a *present* non-container along the
  * path -- a primitive, or a `FabricInstance`/`FabricPrimitive` -- throws a
  * `CloneForMutationError` rather than silently replacing that leaf with fresh
- * spine structure. Cyclic values are not yet supported (see `cloneIfNecessary`).
+ * spine structure. Cyclic values are not yet supported (see
+ * `cloneIfNecessary`).
  */
 export function cloneWithValueAtPath(
   root: FabricValue,

--- a/packages/data-model/src/value-debug.ts
+++ b/packages/data-model/src/value-debug.ts
@@ -1,6 +1,4 @@
-/**
- * Debugging-ish helpers for `FabricValue`s.
- */
+/** Debugging-ish helpers for `FabricValue`s. */
 
 import { isPlainObject } from "@commonfabric/utils/types";
 
@@ -47,15 +45,17 @@ function unquoteMarked(json: string): string {
   });
 }
 
-/**
- * Helper class for rendering debug-string representations of values.
- */
+/** Helper class for rendering debug-string representations of values. */
 class DebugStringifier {
   #circles = new Set<object>();
   #unusedCircles = new Set<object>();
   #indent: number | undefined;
   #value: unknown;
 
+  /**
+   * Constructs an instance which renders `value`, using `indent` spaces per
+   * level when given and a single-line rendering when not.
+   */
   constructor(value: unknown, indent?: number) {
     this.#value = value;
     this.#indent = indent;

--- a/packages/data-model/src/value-hash.ts
+++ b/packages/data-model/src/value-hash.ts
@@ -89,9 +89,7 @@ const TAG_REGEXP_BYTES = new Uint8Array([TAG_REGEXP]);
  */
 const MAX_DIRECT_STRING_LENGTH = 64;
 
-/**
- * Maximum value (inclusive) of the small-length-number cache.
- */
+/** Maximum value (inclusive) of the small-length-number cache. */
 const MAX_CACHED_SMALL_LENGTH = 500;
 
 /** Shared TextEncoder for UTF-8 string encoding. */
@@ -350,9 +348,7 @@ function feedObjectValue(
   }
 }
 
-/**
- * Feed an array value with sparse hole handling, terminated by `TAG_END`.
- */
+/** Feed an array value with sparse hole handling, terminated by `TAG_END`. */
 function feedArray(hasher: IncrementalHasher, value: unknown[]): void {
   hasher.update(TAG_ARRAY_BYTES);
   let i = 0;
@@ -404,9 +400,7 @@ function feedPlainObject(
 // Uncached hash computation
 //
 
-/**
- * Computes the hash of a value without consulting or populating any cache.
- */
+/** Computes the hash of a value without consulting or populating any cache. */
 function computeHash(value: unknown): FabricHash {
   const hasher = createHasher();
   feedValue(hasher, value);

--- a/packages/data-model/test/cloneIfNecessary.test.ts
+++ b/packages/data-model/test/cloneIfNecessary.test.ts
@@ -490,9 +490,9 @@ describe("cloneIfNecessary", () => {
 
   /**
    * Describes what `cloneIfNecessary` is expected to do for a given subclass on
-   * a given option vector. `kind: "ok"` means the call returns; `kind: "throws"`
-   * means it throws (we don't pin the exact message -- subclass stubs use
-   * varying phrasing).
+   * a given option vector. `kind: "ok"` means the call returns; `kind:
+   * "throws"` means it throws (we don't pin the exact message -- subclass stubs
+   * use varying phrasing).
    */
   type ExpectedOutcome =
     | { kind: "ok" }
@@ -583,7 +583,7 @@ describe("cloneIfNecessary", () => {
   ];
 
   /**
-   * Compute the expected outcome of a `cloneIfNecessary(value, opts)` call for
+   * Computes the expected outcome of a `cloneIfNecessary(value, opts)` call for
    * a given subclass, by inspecting the *actual* value to predict which
    * `cloneHelper` arm is reached. The point of computing rather than tabulating
    * is so that adding a new subclass to `subclassCases` (or changing what its

--- a/packages/data-model/test/codec-json/impl.test.ts
+++ b/packages/data-model/test/codec-json/impl.test.ts
@@ -24,14 +24,14 @@ class MockRuntime extends BaseReconstructionContext {
 }
 const mockRuntime = new MockRuntime();
 
-/** Encode then decode a value through the current dispatch configuration. */
+/** Encodes and then decodes a value, per the current dispatch configuration. */
 function roundTrip(value: FabricValue): FabricValue {
   return valueFromJson(jsonFromValue(value), mockRuntime);
 }
 
 /**
- * Assert that encoding a value produces the expected JSON wire format
- * (compared as parsed structure, after stripping the modern encoding prefix).
+ * Asserts that encoding a value produces the expected JSON wire format,
+ * compared as parsed structure, after stripping the modern encoding prefix.
  */
 function expectWireFormat(value: FabricValue, expected: unknown): void {
   const json = jsonFromValue(value);

--- a/packages/data-model/test/value-hash.test.ts
+++ b/packages/data-model/test/value-hash.test.ts
@@ -17,8 +17,8 @@ import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
 const nodeCrypto = await import("node:crypto");
 
 /**
- * Compute the SHA-256 hash of a raw byte sequence (for verifying against
- * byte-level spec examples).
+ * Returns the SHA-256 hash of a raw byte sequence, for verifying against
+ * byte-level spec examples.
  */
 function sha256(bytes: number[] | Uint8Array): Uint8Array {
   // node:crypto digest() returns Buffer; normalize to plain Uint8Array so
@@ -29,12 +29,13 @@ function sha256(bytes: number[] | Uint8Array): Uint8Array {
   return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
 }
 
+/** Returns the lowercase hex rendering of `hash`. */
 function hex(hash: Uint8Array): string {
   return Array.from(hash).map((b) => b.toString(16).padStart(2, "0")).join("");
 }
 
 /**
- * Extract the raw hash bytes from `hashOf()` for comparison. Takes `unknown`,
+ * Returns the raw hash bytes from `hashOf()`, for comparison. Takes `unknown`,
  * as `hashOf()` itself does: the native-instance cases below hash a native
  * `Date` / `RegExp` / `Uint8Array`, none of which is a `FabricValue`.
  */


### PR DESCRIPTION
A doc-comment conformance pass over `packages/data-model`, against
`docs/development/code-comment-style.md`. Comments only; no code changes.

**Format.**

- 22 doc comments whose text fits inside 80 columns were spread over three
  lines; collapsed to the single-line form.
- Three comments hung their delimiters on lines with text -- two in
  `codec-common/interface.ts`, one in `codec-json/JsonCodec.ts` -- the shape
  the guide's counterexample rules out. One of them had `@default false`
  trailing the prose on the closing line.
- 58 comment lines ran past 80 columns.

Two of the width fixes needed a display block rather than a rewrap, since
reflowing them as prose destroys what they are: the `FabricValue` three-layer
diagram in `interface.ts`, and the `deno bench` invocation in each of the two
bench file headers (one of which had a shell line-continuation backslash that
a naive rewrap would have left mid-line).

**What gets one.**

- Sixteen zero-argument codec constructors had none. Each now carries exactly
  `Constructs an instance.` -- the form the guide names for the case where
  there is genuinely nothing more to say, and which distinguishes "nothing to
  add" from "nobody wrote one".
- Ten constructors that do take arguments had none; they now say what the
  instance is made of.
- Six opened `Constructs a `FabricBytes` from ...`, restating the type the
  declaration already gives. The guide asks for `Constructs an instance`.
- `MapBuilder`, `SetBuilder`, and `CanonicalSelectorMap` had undocumented
  members.

**Describe the system as it is.** Seven doc comments described something other
than the code under them:

- `FabricMap` and `FabricSet` explained their throwing protocol methods with
  "(per Dan's PR #3612 review)". A pull request number has no referent for a
  later reader, and the reason it stands in for is short enough to just say:
  these throw rather than approximate, so no caller comes to depend on an
  answer that would have to be taken back.
- `JsonCodec.encodeToBytes()` was "Public for now -- used by byte-level
  round-trip tests" -- a claim about the test suite, and a claim about the
  future, neither of which anything here keeps true.
- `FabricValue`'s doc parenthesized "relaxation deferred to a follow-up" and
  explained the union's width as staging for a gate change. The width is a
  present-tense fact about which layers accept a registry-interned symbol and
  which do not; that is what it says now.
- `cloneIfNecessary()` said handling cycles "is intended future work". The
  limitation itself stays; the intention was the part with no reader.
- `FabricError`'s deep-clone gap was labeled "KNOWN GAP (pre-existing)". The
  gap is real and still documented; "(pre-existing)" attributes it to the
  code's past and changes nothing for someone reading the method.
- The custom inspectors on `BaseFabricInstance` and `BaseFabricPrimitive`
  pointed at a `TODO` living in a different file.

**Markup.** Emphasis carried by capital letters (`KNOWN GAP`, `SHARES`) moves
to underscores.

**Deliberately left alone.**

- `FabricError`'s pointer to the test in `FabricError.test.ts` that pins the
  known gap. It is a cross-file reference, but it is the same-named companion
  test in the same package, and it is what stops the gap from being quietly
  closed-by-accident and left documented.
- "Legacy mode" and "not yet supported" throughout `cell-rep.ts` and
  `value-clone.ts`: both describe the system as it currently stands, which is
  the rule, not a violation of it.
- Three `// ... PR #3335 / #3604 / #3612` references in test files. They are
  `//` comments rather than doc comments or module headers, so they sit
  outside the scope agreed for this pass -- but they are the same defect and
  worth a follow-up.

**Verified:** repo-wide `deno fmt --check`, `deno lint` over the package, and
`deno task test` in `packages/data-model` (49 tests, 2252 steps, ok). Note
that `data-model` is not in `tasks/check.sh`'s path list, so the package test
run is what type-checks it. The diff cannot reach runtime behavior.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

