### PR TITLE
Order memory verdicts before fan-out

### DIFF
--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -981,14 +981,19 @@ Clients MUST:
 The server processes writes serially within a branch, or with equivalent
 serializable isolation.
 
-For live sync, transact verdicts return INLINE and the fan-out stays
-batched: N commits can apply against one watch-union recompute, which is
-where the subscription pipeline's throughput comes from. The ordering
-contract is enforced through the catch-up marker and CLIENT-side verdict
-parking instead of server-side response queuing (CT-1927):
+For live sync, transact verdicts return INLINE before the independently batched
+fan-out: N commits can apply against one watch-union recompute, which is where
+the subscription pipeline's throughput comes from. A per-space publication lock
+orders transactions and fan-out: the server sends the verdict while holding the
+lock, completes the transaction's post-commit scheduler bookkeeping, and then
+releases the lock for fan-out. Locks for other spaces remain independent. The
+remaining ordering contract is enforced through the catch-up marker and
+CLIENT-side verdict parking (CT-1927):
 
 - the server MAY coalesce multiple successful commits into one `SessionSync`
   frame
+- on a live connection, the server MUST send a commit's transact response
+  before any `SessionSync` frame whose `caughtUpLocalSeq` covers that commit
 - for every accept and every `ConflictError` rejection, the server MUST
   stage a catch-up obligation for the committing session, and the next
   frame the batched fan-out sends that session MUST carry

--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -987,8 +987,9 @@ the subscription pipeline's throughput comes from. A per-space publication lock
 orders transactions and fan-out: the server sends the verdict while holding the
 lock, completes the transaction's post-commit scheduler bookkeeping, and then
 releases the lock for fan-out. Locks for other spaces remain independent. The
-remaining ordering contract is enforced through the catch-up marker and
-CLIENT-side verdict parking (CT-1927):
+lock covers each complete turn, so a transaction arriving during fan-out for
+its space waits for that fan-out to finish. The remaining ordering contract is
+enforced through the catch-up marker and CLIENT-side verdict parking (CT-1927):
 
 - the server MAY coalesce multiple successful commits into one `SessionSync`
   frame

--- a/docs/specs/memory-v2/10-implementation-guidance.md
+++ b/docs/specs/memory-v2/10-implementation-guidance.md
@@ -239,12 +239,14 @@ Return transact verdicts inline before the independently batched fan-out — N
 commits share one watch-union recompute. Use one publication lock per space for
 transactions, direct writes, and fan-out. Send a transaction's verdict while it
 holds the lock, complete its post-commit scheduler bookkeeping, and release the
-lock before fan-out evaluates the live space state. Stage a catch-up obligation
-for accepts and conflict rejections so the next batched frame to the committing
-session carries `caughtUpLocalSeq`; the client parks each accept's state
-application until that marker covers it, and the read-repair gate holds conflict
-drops the same way (04-protocol.md section 4.11.2, CT-1927). Other rejection
-kinds carry no marker obligation and apply immediately.
+lock before fan-out evaluates the live space state. A transaction arriving
+during same-space fan-out waits for that turn; locks for other spaces remain
+independent. Stage a catch-up obligation for accepts and conflict rejections so
+the next batched frame to the committing session carries `caughtUpLocalSeq`; the
+client parks each accept's state application until that marker covers it, and
+the read-repair gate holds conflict drops the same way (04-protocol.md section
+4.11.2, CT-1927). Other rejection kinds carry no marker obligation and apply
+immediately.
 
 ## 11. Query / Traversal Reuse
 

--- a/docs/specs/memory-v2/10-implementation-guidance.md
+++ b/docs/specs/memory-v2/10-implementation-guidance.md
@@ -235,13 +235,16 @@ Practical guidance:
 - keep the client watch view incrementally ordered instead of rebuilding and
   sorting the full entity set on every emit
 
-Return transact verdicts inline and keep the fan-out batched — N commits
-share one watch-union recompute. Stage a catch-up obligation for accepts
-and conflict rejections so the next batched frame to the committing session
-carries `caughtUpLocalSeq`; the client parks each accept's state
-application until that marker covers it, and the read-repair gate holds
-conflict drops the same way (04-protocol.md section 4.11.2, CT-1927).
-Other rejection kinds carry no marker obligation and apply immediately.
+Return transact verdicts inline before the independently batched fan-out — N
+commits share one watch-union recompute. Use one publication lock per space for
+transactions, direct writes, and fan-out. Send a transaction's verdict while it
+holds the lock, complete its post-commit scheduler bookkeeping, and release the
+lock before fan-out evaluates the live space state. Stage a catch-up obligation
+for accepts and conflict rejections so the next batched frame to the committing
+session carries `caughtUpLocalSeq`; the client parks each accept's state
+application until that marker covers it, and the read-repair gate holds conflict
+drops the same way (04-protocol.md section 4.11.2, CT-1927). Other rejection
+kinds carry no marker obligation and apply immediately.
 
 ## 11. Query / Traversal Reuse
 

--- a/docs/specs/memory-v2/implementation-plan.md
+++ b/docs/specs/memory-v2/implementation-plan.md
@@ -128,10 +128,13 @@ memory route.
 - Recompute watch-union results per session and emit:
   - `upserts` for relevant current entity state
   - `removes` when an entity leaves the watch union
-- Return transact verdicts inline; stage a `caughtUpLocalSeq` catch-up
-  obligation for accepts and conflict rejections (CT-1927), delivered by the
-  batched fan-out, so the CLIENT parks each verdict's state application
-  until the marker covers it.
+- Return transact verdicts inline before the independently batched fan-out;
+  serialize transaction publication and fan-out with one lock per space. Send
+  the verdict while the transaction holds the lock, finish its post-commit
+  scheduler bookkeeping, and release the lock for fan-out. Stage a
+  `caughtUpLocalSeq` catch-up obligation for accepts and conflict rejections
+  (CT-1927), delivered by the batched fan-out, so the CLIENT parks each verdict's
+  state application until the marker covers it.
 
 ## Phase 3: Client Rewrite
 

--- a/packages/memory/test/v2-scheduler-state.test.ts
+++ b/packages/memory/test/v2-scheduler-state.test.ts
@@ -3170,12 +3170,18 @@ Deno.test("memory v2 server serializes scheduler side effects per owner space", 
       new Map(),
       session,
     );
+    let idleSettled = false;
+    const idle = server.idle().then(() => {
+      idleSettled = true;
+    });
     await Promise.resolve();
     assertEquals(mirroredSequences, [1]);
+    assertEquals(idleSettled, false);
 
     releaseFirst.resolve();
-    await Promise.all([first, second]);
+    await Promise.all([first, second, idle]);
     assertEquals(mirroredSequences, [1, 2]);
+    assertEquals(idleSettled, true);
   } finally {
     releaseFirst.resolve();
     await server.close().catch(() => {});

--- a/packages/memory/test/v2-server.test.ts
+++ b/packages/memory/test/v2-server.test.ts
@@ -240,6 +240,45 @@ const assertCommitBurstBeforeFanout = async (
   }
 };
 
+Deno.test("memory v2 server keeps publication locks independent per space", async () => {
+  const server = createServer("memory://memory-v2-publication-lock-spaces");
+  const internals = server as unknown as {
+    withSpacePublicationLock<T>(
+      space: string,
+      run: () => Promise<T>,
+    ): Promise<T>;
+  };
+  const firstEntered = Promise.withResolvers<void>();
+  const releaseFirst = Promise.withResolvers<void>();
+  let sameSpaceEntered = false;
+  let otherSpaceEntered = false;
+
+  const first = internals.withSpacePublicationLock("space-a", async () => {
+    firstEntered.resolve();
+    await releaseFirst.promise;
+  });
+  await firstEntered.promise;
+  const sameSpace = internals.withSpacePublicationLock("space-a", () => {
+    sameSpaceEntered = true;
+    return Promise.resolve();
+  });
+  const otherSpace = internals.withSpacePublicationLock("space-b", () => {
+    otherSpaceEntered = true;
+    return Promise.resolve();
+  });
+
+  try {
+    await otherSpace;
+    assertEquals(otherSpaceEntered, true);
+    assertEquals(sameSpaceEntered, false);
+  } finally {
+    releaseFirst.resolve();
+    await Promise.all([first, sameSpace]);
+    await server.close();
+  }
+  assertEquals(sameSpaceEntered, true);
+});
+
 Deno.test("memory v2 server stateless respond does not issue hello.ok", async () => {
   const server = createServer("memory://memory-v2-server-stateless-respond");
   try {
@@ -2962,13 +3001,14 @@ Deno.test("memory v2 server processes back-to-back websocket messages in receive
 
   (server as unknown as {
     transact(
-      message: Parameters<Server["transact"]>[0],
+      ...args: Parameters<Server["transact"]>
     ): ReturnType<Server["transact"]>;
-  }).transact = async (message) => {
+  }).transact = async (...args) => {
+    const [message] = args;
     if (message.requestId === "tx-2") {
       await releaseTx2.promise;
     }
-    return await originalTransact(message);
+    return await originalTransact(...args);
   };
 
   try {
@@ -3129,13 +3169,14 @@ Deno.test("memory v2 server waits for queued receives before rerunning scheduled
 
   (server as unknown as {
     transact(
-      message: Parameters<Server["transact"]>[0],
+      ...args: Parameters<Server["transact"]>
     ): ReturnType<Server["transact"]>;
-  }).transact = async (message) => {
+  }).transact = async (...args) => {
+    const [message] = args;
     if (message.requestId === "tx-3") {
       await releaseTx3.promise;
     }
-    return await originalTransact(message);
+    return await originalTransact(...args);
   };
 
   try {
@@ -3224,7 +3265,7 @@ Deno.test("memory v2 server waits for queued receives before rerunning scheduled
     await time.tickAsync(1);
     await time.tickAsync(0);
 
-    await writer.receive(encodeMemoryBoundary({
+    const tx2 = writer.receive(encodeMemoryBoundary({
       type: "transact",
       requestId: "tx-2",
       space,
@@ -3239,10 +3280,6 @@ Deno.test("memory v2 server waits for queued receives before rerunning scheduled
         }],
       },
     }));
-    assertEquals(
-      nextResponse<any>(writerMessages).requestId,
-      "tx-2",
-    );
 
     const tx3 = writer.receive(encodeMemoryBoundary({
       type: "transact",
@@ -3265,7 +3302,7 @@ Deno.test("memory v2 server waits for queued receives before rerunning scheduled
     await time.tickAsync(0);
 
     const firstEffect = assertEffect(shiftMessage(messages));
-    assertEquals(firstEffect.effect.toSeq, 2);
+    assertEquals(firstEffect.effect.toSeq, 1);
     assertEquals(firstEffect.effect.upserts, [{
       branch: "",
       id: "of:doc:1",
@@ -3277,8 +3314,15 @@ Deno.test("memory v2 server waits for queued receives before rerunning scheduled
     }]);
     assertEquals(messages, []);
 
+    await tx2;
+    assertEquals(
+      nextResponse<any>(writerMessages).requestId,
+      "tx-2",
+    );
+
     releaseTx3.resolve();
     await tx3;
+    await time.tickAsync(1);
     await time.tickAsync(0);
 
     assertEquals(
@@ -3344,13 +3388,14 @@ Deno.test("memory v2 server reruns scheduled watch refresh after max deferral", 
 
   (server as unknown as {
     transact(
-      message: Parameters<Server["transact"]>[0],
+      ...args: Parameters<Server["transact"]>
     ): ReturnType<Server["transact"]>;
-  }).transact = async (message) => {
+  }).transact = async (...args) => {
+    const [message] = args;
     if (message.requestId === "tx-3") {
       await releaseTx3.promise;
     }
-    return await originalTransact(message);
+    return await originalTransact(...args);
   };
 
   try {
@@ -3439,7 +3484,7 @@ Deno.test("memory v2 server reruns scheduled watch refresh after max deferral", 
     await time.tickAsync(1);
     await time.tickAsync(0);
 
-    await writer.receive(encodeMemoryBoundary({
+    const tx2 = writer.receive(encodeMemoryBoundary({
       type: "transact",
       requestId: "tx-2",
       space,
@@ -3454,10 +3499,6 @@ Deno.test("memory v2 server reruns scheduled watch refresh after max deferral", 
         }],
       },
     }));
-    assertEquals(
-      nextResponse<any>(writerMessages).requestId,
-      "tx-2",
-    );
 
     const tx3 = writer.receive(encodeMemoryBoundary({
       type: "transact",
@@ -3480,7 +3521,7 @@ Deno.test("memory v2 server reruns scheduled watch refresh after max deferral", 
     await time.tickAsync(0);
 
     const firstEffect = assertEffect(shiftMessage(messages));
-    assertEquals(firstEffect.effect.toSeq, 2);
+    assertEquals(firstEffect.effect.toSeq, 1);
     assertEquals(firstEffect.effect.upserts, [{
       branch: "",
       id: "of:doc:1",
@@ -3490,6 +3531,23 @@ Deno.test("memory v2 server reruns scheduled watch refresh after max deferral", 
         value: { version: 1 },
       },
     }]);
+    assertEquals(messages, []);
+
+    await tx2;
+    assertEquals(
+      nextResponse<any>(writerMessages).requestId,
+      "tx-2",
+    );
+
+    await time.tickAsync(1);
+    await time.tickAsync(0);
+
+    await time.tickAsync(499);
+    await time.tickAsync(0);
+    assertEquals(messages, []);
+
+    await time.tickAsync(1);
+    await time.tickAsync(0);
     assertEquals(messages, []);
 
     await time.tickAsync(499);

--- a/packages/memory/test/v2-verdict-catchup.test.ts
+++ b/packages/memory/test/v2-verdict-catchup.test.ts
@@ -395,6 +395,10 @@ Deno.test("memory v2 server: a verdict precedes fan-out held by scheduler bookke
     runPostCommitSchedulerSideEffects: (
       ...args: unknown[]
     ) => Promise<void>;
+    withSpacePublicationLock<T>(
+      space: string,
+      run: () => Promise<T>,
+    ): Promise<T>;
   };
   const originalSideEffects = serverInternals.runPostCommitSchedulerSideEffects
     .bind(server);
@@ -428,6 +432,21 @@ Deno.test("memory v2 server: a verdict precedes fan-out held by scheduler bookke
     },
   }));
   await reached.promise;
+
+  const fanoutLockAttempted = Promise.withResolvers<void>();
+  let fanoutEntered = false;
+  const originalPublicationLock = serverInternals.withSpacePublicationLock
+    .bind(server);
+  serverInternals.withSpacePublicationLock = <T>(
+    space: string,
+    run: () => Promise<T>,
+  ) => {
+    fanoutLockAttempted.resolve();
+    return originalPublicationLock(space, async () => {
+      fanoutEntered = true;
+      return await run();
+    });
+  };
   let fanout: Promise<void> | undefined;
   try {
     // Scheduler bookkeeping begins only after the verdict is published.
@@ -440,12 +459,19 @@ Deno.test("memory v2 server: a verdict precedes fan-out held by scheduler bookke
     // An explicit flush uses the same per-space publication lock. It cannot
     // consume the dirty batch while this transaction still owns the lock.
     fanout = server.flushSessions([space]);
+    await fanoutLockAttempted.promise;
+    assertEquals(fanoutEntered, false);
     assertEquals(committerMessages.length, 0);
   } finally {
     gate.resolve();
-    await Promise.all([commit, completed.promise, fanout]);
+    try {
+      await Promise.all([commit, completed.promise, fanout]);
+    } finally {
+      serverInternals.withSpacePublicationLock = originalPublicationLock;
+    }
   }
 
+  assertEquals(fanoutEntered, true);
   const effect = assertEffect(shiftMessage(committerMessages));
   const sync = effect.effect as SessionSync;
   assertEquals(sync.caughtUpLocalSeq, 1);

--- a/packages/memory/test/v2-verdict-catchup.test.ts
+++ b/packages/memory/test/v2-verdict-catchup.test.ts
@@ -1,12 +1,11 @@
-// CT-1927: transact verdicts return INLINE — the fan-out stays batched, so
-// N commits can apply against one watch-union recompute — and the ordering
-// contract is enforced through the catch-up marker instead: every verdict
+// CT-1927: transact verdicts return before the independently batched fan-out,
+// so N commits can apply against one watch-union recompute. Every verdict
 // (accepts as well as conflict rejections) stages a `caughtUpLocalSeq`
 // obligation, and the batched fan-out stamps the marker on the next frame to
 // the committing session — an otherwise-empty frame if nothing it watches is
-// dirty. The CLIENT parks each accept's promotion until the marker covers
-// it (04-protocol.md §4.11.2); these tests pin the server half: the marker
-// rides the frame that reflects the decided outcomes, and it always arrives.
+// dirty. The CLIENT parks each accept's promotion until the marker covers it
+// (04-protocol.md §4.11.2); these tests pin the server half: verdict ordering,
+// frame coverage, and eventual marker delivery.
 //
 // The long refresh delay parks the writer's novelty behind a timer so each
 // test drives delivery explicitly with flushSessions().
@@ -381,33 +380,17 @@ Deno.test("memory v2 server: same-doc foreign novelty is not echo-suppressed by 
   );
 });
 
-Deno.test("memory v2 server: a durable write is visible to a concurrent flush while its side effects await", async () => {
+Deno.test("memory v2 server: a verdict precedes fan-out held by scheduler bookkeeping", async () => {
   const context = await setup({
     subscriptionRefreshDelayMs: 60_000,
     store: "memory://verdict-catchup-durable-visibility",
   });
-  const { server, space, committerMessages } = context;
-
-  // Second session, gated in its post-commit side effects AFTER the durable
-  // apply. Installed after setup so the fixture's writeDocument is not
-  // gated.
-  const secondMessages: ServerMessage[] = [];
-  const second = server.connect((message) => secondMessages.push(message));
-  await second.receive(encodeMemoryBoundary(HELLO));
-  const secondSessionOpen = expectHelloOk(secondMessages);
-  await second.receive(encodeMemoryBoundary({
-    type: "session.open",
-    requestId: "second-open",
-    space,
-    session: {},
-    invocation: authInvocation(secondSessionOpen),
-  }));
-  const secondSessionId =
-    assertResponse<{ sessionId: string }>(shiftMessage(secondMessages))
-      .ok!.sessionId;
+  const { server, space, committer, committerMessages, committerSessionId } =
+    context;
 
   const gate = Promise.withResolvers<void>();
   const reached = Promise.withResolvers<void>();
+  const completed = Promise.withResolvers<void>();
   const serverInternals = server as unknown as {
     runPostCommitSchedulerSideEffects: (
       ...args: unknown[]
@@ -415,67 +398,70 @@ Deno.test("memory v2 server: a durable write is visible to a concurrent flush wh
   };
   const originalSideEffects = serverInternals.runPostCommitSchedulerSideEffects
     .bind(server);
-  let gated = false;
   serverInternals.runPostCommitSchedulerSideEffects = async (...args) => {
-    if (!gated) {
-      gated = true;
-      reached.resolve();
-      await gate.promise;
+    reached.resolve();
+    await gate.promise;
+    try {
+      return await originalSideEffects(...args);
+    } finally {
+      completed.resolve();
     }
-    return await originalSideEffects(...args);
   };
 
-  // The second session's write to WATCHED doc:a becomes durable, then parks
-  // in its side-effect await — its verdict has not been sent.
-  const secondCommit = second.receive(encodeMemoryBoundary({
+  // setup() left foreign novelty for doc:b behind the fan-out timer. This
+  // session's patch gives that document mixed provenance, so its next frame
+  // includes the authoritative post-commit document instead of suppressing
+  // the writer's own echo.
+  const commit = committer.receive(encodeMemoryBoundary({
     type: "transact",
-    requestId: "second-a",
+    requestId: "committer-b-gated",
     space,
-    sessionId: secondSessionId,
+    sessionId: committerSessionId,
     commit: {
       localSeq: 1,
       reads: { confirmed: [], pending: [] },
       operations: [{
-        op: "set",
-        id: "of:doc:a",
-        value: { value: { from: "second" } },
+        op: "patch",
+        id: "of:doc:b",
+        patches: [{ op: "add", path: "/value/mine", value: true }],
       }],
     },
   }));
   await reached.promise;
+  let fanout: Promise<void> | undefined;
+  try {
+    // Scheduler bookkeeping begins only after the verdict is published.
+    const verdict = assertResponse<{ seq: number }>(
+      shiftMessage(committerMessages),
+    );
+    assertEquals(verdict.ok?.seq, 2);
+    assertEquals(committerMessages.length, 0);
 
-  // A flush during the await must see the durable doc:a: dirty-marking
-  // happens before the first await, so a batch pass can never miss earlier
-  // durable watched novelty.
-  await server.flushSessions([space]);
+    // An explicit flush uses the same per-space publication lock. It cannot
+    // consume the dirty batch while this transaction still owns the lock.
+    fanout = server.flushSessions([space]);
+    assertEquals(committerMessages.length, 0);
+  } finally {
+    gate.resolve();
+    await Promise.all([commit, completed.promise, fanout]);
+  }
+
   const effect = assertEffect(shiftMessage(committerMessages));
   const sync = effect.effect as SessionSync;
+  assertEquals(sync.caughtUpLocalSeq, 1);
   assertEquals(
-    sync.upserts.map((upsert) => ({ id: upsert.id, seq: upsert.seq }))
-      .toSorted((left, right) => left.id < right.id ? -1 : 1),
-    [
-      { id: "of:doc:a", seq: 2 },
-      { id: "of:doc:b", seq: 1 },
-    ],
+    sync.upserts.map((upsert) => ({
+      id: upsert.id,
+      seq: upsert.seq,
+      doc: upsert.doc,
+    })),
+    [{
+      id: "of:doc:b",
+      seq: 2,
+      doc: { value: { from: "writer", mine: true } },
+    }],
   );
-
-  // The gated writer's marker was staged SYNCHRONOUSLY with its dirty
-  // marking — before the side-effect await — so the concurrent flush above
-  // already delivered it (an otherwise-empty frame, own write suppressed)
-  // even though the verdict is still parked. Staged any later, that flush
-  // would have consumed the dirty batch and the obligation would ride
-  // nothing: the parked promotion would strand (CT-1927 review, round 5).
-  const marker = assertEffect(shiftMessage(secondMessages));
-  assertEquals((marker.effect as SessionSync).caughtUpLocalSeq, 1);
-  assertEquals((marker.effect as SessionSync).upserts, []);
-
-  gate.resolve();
-  await secondCommit;
-  const verdict = assertResponse<{ seq: number }>(
-    shiftMessage(secondMessages),
-  );
-  assertEquals(verdict.ok?.seq, 2);
-  assertEquals(secondMessages.length, 0);
+  assertEquals(committerMessages.length, 0);
 });
 
 Deno.test("memory v2 server: a failed send rolls back delivery state; the next flush recomputes and delivers", async () => {

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -1390,6 +1390,9 @@ export class Server {
    * has no pending work. Tests use this to prevent the module-level singleton's
    * work from leaking across Deno test boundaries.
    *
+   * Callers stop submitting work before awaiting this method. A sustained
+   * stream of new work can extend the drain indefinitely.
+   *
    * `flushSessions()` (called with no `spaces` argument) cancels any
    * pending timer, runs the refresh loop to completion, and intentionally
    * does not reschedule, so a single call is sufficient.
@@ -2080,10 +2083,25 @@ export class Server {
   ): Promise<ResponseMessage<Engine.AppliedCommit>> {
     return await this.withSpacePublicationLock(message.space, async () => {
       const decision = await this.decideTransaction(message);
+      let verdictError: { value: unknown } | undefined;
       try {
         publishVerdict?.(decision.response);
-      } finally {
+      } catch (error) {
+        verdictError = { value: error };
+      }
+      try {
         await decision.postCommit?.();
+      } catch (postCommitError) {
+        if (verdictError !== undefined) {
+          throw new AggregateError(
+            [verdictError.value, postCommitError],
+            "Verdict publication and post-commit bookkeeping both failed",
+          );
+        }
+        throw postCommitError;
+      }
+      if (verdictError !== undefined) {
+        throw verdictError.value;
       }
       return decision.response;
     });
@@ -3628,7 +3646,13 @@ export class Server {
     }
   }
 
-  /** Runs one transaction or fan-out turn at a time for `space`. */
+  /**
+   * Runs one transaction or fan-out turn at a time for `space`.
+   *
+   * A transaction arriving during fan-out waits for that turn to finish. Locks
+   * for other spaces remain independent, so the latency coupling is local to
+   * one space.
+   */
   private async withSpacePublicationLock<T>(
     space: string,
     run: () => Promise<T>,

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -341,6 +341,15 @@ const sessionKey = (space: string, sessionId: string): string =>
 
 type Send = (message: ServerMessage) => void;
 
+type PublishTransactVerdict = (
+  response: ResponseMessage<Engine.AppliedCommit>,
+) => void;
+
+type TransactDecision = {
+  response: ResponseMessage<Engine.AppliedCommit>;
+  postCommit?: () => Promise<void>;
+};
+
 type SessionOpenAuthContext = {
   audience: string;
   challenge: SessionOpenChallenge;
@@ -649,16 +658,11 @@ class Connection {
         ) {
           return;
         }
-        // CT-1927: the verdict returns inline — batching amortization is
-        // the point of the fan-out timer (N commits apply, ONE watch-union
-        // recompute covers the batch). The ordering contract is enforced
-        // client-side instead: accepts and conflict rejections stage a
-        // catch-up obligation (`pendingCaughtUpLocalSeq`), the batched
-        // fan-out stamps `caughtUpLocalSeq` on the frame that reflects the
-        // decided outcomes, and the CLIENT parks each verdict's state
-        // application (accept promotion / rejection drop) until that marker
-        // covers it. See 04-protocol.md §4.11.2.
-        this.send(await this.server.transact(parsed));
+        // Publishing inside the per-space transaction lock makes the verdict
+        // visible before any fan-out for the same space can acquire that lock.
+        await this.server.transact(parsed, (verdict) => {
+          this.send(verdict);
+        });
         // A self-deauthorizing ACL commit defers the writer's terminal
         // session/revoked until after its verdict; deliver it now.
         this.server.deliverDeferredSelfRevocation(
@@ -931,6 +935,10 @@ export class Server {
   #dirtyOriginsBySpace = new Map<string, Map<string, DirtyOrigin>>();
   #refreshTimer: ReturnType<typeof setTimeout> | null = null;
   #refreshing: Promise<void> | null = null;
+  // Transactions and fan-out share one publication turn per space. A verdict
+  // is sent while its transaction owns the turn, so a sync frame cannot expose
+  // the decision first. Different spaces retain independent turns.
+  #publicationBySpace = new Map<string, Promise<void>>();
   // The owner commit is synchronous, but cross-space scheduler fan-out awaits
   // other engines. Preserve owner apply order across concurrent connections so
   // an older mirror cannot land after a newer one.
@@ -1366,6 +1374,8 @@ export class Server {
   async close(): Promise<void> {
     this.cancelScheduledRefresh();
     await this.#refreshing;
+    await this.drainSpacePublicationLocks();
+    await this.drainPostCommitSchedulerSideEffects();
     for (const engine of this.#engines.values()) {
       Engine.close(await engine);
     }
@@ -1375,17 +1385,18 @@ export class Server {
   }
 
   /**
-   * Drains any in-flight or scheduled subscription refresh, returning when
-   * the server has no pending work. Tests use this to drain the
-   * module-level singleton's `#refreshTimer` between cases so it doesn't
-   * leak across the Deno test boundary -- the singleton survives across
-   * tests but its pending timer must not.
+   * Drains per-space publication turns, post-commit scheduler bookkeeping, and
+   * any in-flight or scheduled subscription refresh, returning when the server
+   * has no pending work. Tests use this to prevent the module-level singleton's
+   * work from leaking across Deno test boundaries.
    *
    * `flushSessions()` (called with no `spaces` argument) cancels any
    * pending timer, runs the refresh loop to completion, and intentionally
    * does not reschedule, so a single call is sufficient.
    */
   async idle(): Promise<void> {
+    await this.drainSpacePublicationLocks();
+    await this.drainPostCommitSchedulerSideEffects();
     if (this.#refreshTimer !== null || this.#refreshing !== null) {
       await this.flushSessions();
     }
@@ -1404,53 +1415,52 @@ export class Server {
     id: string,
     value: EntityDocument["value"],
   ): Promise<Engine.AppliedCommit> {
-    const engine = await this.openEngine(space);
-    if (this.#aclMode() !== "off") {
-      if (id === aclDocId(space)) {
-        throw new Engine.ProtocolError(
-          "direct writes may not mutate the ACL document",
-        );
+    return await this.withSpacePublicationLock(space, async () => {
+      const engine = await this.openEngine(space);
+      if (this.#aclMode() !== "off") {
+        if (id === aclDocId(space)) {
+          throw new Engine.ProtocolError(
+            "direct writes may not mutate the ACL document",
+          );
+        }
+        const aclState = this.#aclState(engine, space);
+        if (aclState.kind === "invalid") {
+          throw new Engine.ProtocolError(
+            `space ${space} has invalid ACL state`,
+          );
+        }
+        if (
+          aclState.kind === "missing" &&
+          Engine.serverSeq(engine) === 0
+        ) {
+          throw new Engine.ProtocolError(
+            `space ${space} requires an ACL genesis commit before direct writes`,
+          );
+        }
       }
-      const aclState = this.#aclState(engine, space);
-      if (aclState.kind === "invalid") {
-        throw new Engine.ProtocolError(
-          `space ${space} has invalid ACL state`,
-        );
-      }
-      if (
-        aclState.kind === "missing" &&
-        Engine.serverSeq(engine) === 0
-      ) {
-        throw new Engine.ProtocolError(
-          `space ${space} requires an ACL genesis commit before direct writes`,
-        );
-      }
-    }
-    const commit = Engine.applyCommit(engine, {
-      sessionId: this.#directSessionId,
-      space,
-      commit: {
-        localSeq: ++this.#directLocalSeq,
-        reads: { confirmed: [], pending: [] },
-        operations: [{
-          op: "set",
-          id,
-          value: { value },
-        }],
-      },
+      const commit = Engine.applyCommit(engine, {
+        sessionId: this.#directSessionId,
+        space,
+        commit: {
+          localSeq: ++this.#directLocalSeq,
+          reads: { confirmed: [], pending: [] },
+          operations: [{
+            op: "set",
+            id,
+            value: { value },
+          }],
+        },
+      });
+      this.markSpaceDirty(space, [toDirtyKey(id)]);
+      await this.runPostCommitSchedulerSideEffects(
+        space,
+        commit,
+        [],
+        new Map(),
+        undefined,
+      );
+      return commit;
     });
-    // Dirty BEFORE the side-effect await, matching the transact path
-    // (CT-1927): a batch pass running during the await must see this
-    // durable write.
-    this.markSpaceDirty(space, [toDirtyKey(id)]);
-    await this.runPostCommitSchedulerSideEffects(
-      space,
-      commit,
-      [],
-      new Map(),
-      undefined,
-    );
-    return commit;
   }
 
   /**
@@ -2057,18 +2067,42 @@ export class Server {
     }
   }
 
-  transact(
+  /**
+   * Decides a transaction under its space's publication lock.
+   *
+   * `publishVerdict`, when provided by a live connection, runs while the lock
+   * is held and before post-commit scheduler bookkeeping. Fan-out for the space
+   * begins only after both steps finish and the lock is released.
+   */
+  async transact(
     message: TransactRequest,
+    publishVerdict?: PublishTransactVerdict,
   ): Promise<ResponseMessage<Engine.AppliedCommit>> {
+    return await this.withSpacePublicationLock(message.space, async () => {
+      const decision = await this.decideTransaction(message);
+      try {
+        publishVerdict?.(decision.response);
+      } finally {
+        await decision.postCommit?.();
+      }
+      return decision.response;
+    });
+  }
+
+  private async decideTransaction(
+    message: TransactRequest,
+  ): Promise<TransactDecision> {
     const session = this.#sessions.get(message.space, message.sessionId);
     if (session === null) {
-      return Promise.resolve(respondTypedError<Engine.AppliedCommit>(
-        message.requestId,
-        toError("SessionError", "Unknown session for space"),
-      ));
+      return {
+        response: respondTypedError<Engine.AppliedCommit>(
+          message.requestId,
+          toError("SessionError", "Unknown session for space"),
+        ),
+      };
     }
-
-    return tracer.startActiveSpan(
+    let postCommit: (() => Promise<void>) | undefined;
+    const response = await tracer.startActiveSpan(
       "memory.transact",
       async (span): Promise<ResponseMessage<Engine.AppliedCommit>> => {
         span.setAttribute("space.did", message.space);
@@ -2105,7 +2139,10 @@ export class Server {
           ) {
             return respondTypedError<Engine.AppliedCommit>(
               message.requestId,
-              toError("SessionError", "Unknown or replaced session for space"),
+              toError(
+                "SessionError",
+                "Unknown or replaced session for space",
+              ),
             );
           }
           const invalid = this.#validateAclCommit(
@@ -2215,11 +2252,8 @@ export class Server {
               detachDatabase(engine.database, alias);
             }
           }
-          // Mark dirty IMMEDIATELY after the durable apply, before the first
-          // await (CT-1927): a batch pass running during the scheduler
-          // side-effect await below must see this durable write's dirty
-          // ids — otherwise a frame whose marker claims to reflect decided
-          // outcomes could miss earlier durable watched novelty.
+          // Mark dirty immediately after the durable apply so the next batch
+          // reflects this write and can carry its catch-up marker.
           this.markSpaceDirty(
             message.space,
             message.commit.operations
@@ -2232,23 +2266,15 @@ export class Server {
               seq: commit.seq,
             },
           );
-          // CT-1927: stage the accept's catch-up obligation SYNCHRONOUSLY
-          // with the dirty-marking above — before any await. A flush pass
-          // running during the scheduler side-effect await below consumes
-          // the dirty batch; an obligation staged only afterwards would
-          // ride nothing and schedule nothing, stranding the client's
-          // parked promotion forever (CT-1927 review, round 5). Staged
-          // here, the obligation either rides that concurrent pass (the
-          // marker may then precede the verdict on the socket — the client
-          // handles both orders) or the still-scheduled batch timer. The
-          // batched fan-out stamps `caughtUpLocalSeq >= this localSeq` on
-          // the next frame to this session (an otherwise-empty frame if
-          // nothing it watches is dirty), and the CLIENT holds the
-          // accepted commit's promotion — pending overlay to confirmed
-          // mirror — until that marker arrives, so promotion always
-          // extrapolates over a base that reflects the foreign novelty the
-          // accept was applied on top of. The stamping contract: the frame
-          // reflects every decided outcome ≤ W for the docs it COVERS.
+          // Stage the accept's catch-up obligation with the dirty mark. The
+          // verdict response leaves this request before the independently
+          // scheduled batch can send its covering frame. The batched fan-out
+          // stamps `caughtUpLocalSeq >= this localSeq` on the next frame to
+          // this session (an otherwise-empty frame if nothing it watches is
+          // dirty), and the CLIENT holds the accepted commit's promotion —
+          // pending overlay to confirmed mirror — until that marker arrives.
+          // The frame therefore reflects every decided outcome ≤ W for the
+          // docs it covers.
           // The session's own accepted writes are echo-suppressed by
           // dirty-origin tracking (the parked verdict carries their truth
           // — with CT-1926's post-apply document where the server provides
@@ -2275,13 +2301,6 @@ export class Server {
               message.sessionId,
             );
           }
-          await this.runPostCommitSchedulerSideEffects(
-            message.space,
-            commit,
-            schedulerObservations,
-            previousReadSpaces,
-            session,
-          );
           span.setAttribute("commit.seq", commit.seq);
           span.setAttribute(
             "entity.count",
@@ -2289,6 +2308,16 @@ export class Server {
               operation.op !== "sqlite"
             ).length,
           );
+          // The verdict is published before this work begins, while the
+          // per-space lock continues to exclude document fan-out.
+          postCommit = () =>
+            this.runPostCommitSchedulerSideEffects(
+              message.space,
+              commit,
+              schedulerObservations,
+              previousReadSpaces,
+              session,
+            );
           return {
             type: "response",
             requestId: message.requestId,
@@ -2336,7 +2365,10 @@ export class Server {
           span.recordException(
             error instanceof Error ? error : new Error(messageText),
           );
-          span.setStatus({ code: SpanStatusCode.ERROR, message: messageText });
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: messageText,
+          });
           return respondTypedError<Engine.AppliedCommit>(
             message.requestId,
             responseError,
@@ -2346,6 +2378,7 @@ export class Server {
         }
       },
     );
+    return { response, postCommit };
   }
 
   async graphQuery(
@@ -3595,6 +3628,34 @@ export class Server {
     }
   }
 
+  /** Runs one transaction or fan-out turn at a time for `space`. */
+  private async withSpacePublicationLock<T>(
+    space: string,
+    run: () => Promise<T>,
+  ): Promise<T> {
+    const previous = this.#publicationBySpace.get(space) ?? Promise.resolve();
+    const release = Promise.withResolvers<void>();
+    const queued = previous.then(() => release.promise);
+    this.#publicationBySpace.set(space, queued);
+
+    await previous;
+    try {
+      return await run();
+    } finally {
+      release.resolve();
+      if (this.#publicationBySpace.get(space) === queued) {
+        this.#publicationBySpace.delete(space);
+      }
+    }
+  }
+
+  /** Waits until every queued per-space publication turn has settled. */
+  private async drainSpacePublicationLocks(): Promise<void> {
+    while (this.#publicationBySpace.size > 0) {
+      await Promise.all(this.#publicationBySpace.values());
+    }
+  }
+
   private async refreshLoop(initial?: Set<string>): Promise<void> {
     let pending = initial;
     while (true) {
@@ -3614,89 +3675,95 @@ export class Server {
       pending = undefined;
 
       for (const space of spaces) {
-        // Removed at its own processing turn (CT-1927): pre-deleting the
-        // whole selection meant a failure mid-batch stranded every
-        // not-yet-processed space — dirty maps intact but the space no
-        // longer discoverable.
-        this.#dirtySpaces.delete(space);
-        const dirtyIds = this.#dirtyDocsBySpace.get(space);
-        if (dirtyIds !== undefined) {
-          this.#dirtyDocsBySpace.delete(space);
-        }
-        const dirtyOrigins = this.#dirtyOriginsBySpace.get(space);
-        if (dirtyOrigins !== undefined) {
-          this.#dirtyOriginsBySpace.delete(space);
-        }
-        // Fan-out is a scheduled/batched timer decoupled from transact, so it
-        // must be its own root span. `root: true` makes that explicit — the
-        // context manager propagates the active context into timer callbacks,
-        // so without it this span could parent under whichever memory.transact
-        // happened to schedule the refresh.
-        try {
-          await tracer.startActiveSpan(
-            "memory.fanout",
-            { root: true },
-            async (span) => {
-              span.setAttribute("space.did", space);
-              span.setAttribute("subscriber.count", this.#connections.size);
-              span.setAttribute("dirty.count", dirtyIds?.size ?? 0);
-              try {
-                for (const connection of this.#connections.values()) {
-                  await connection.refreshDirty(space, dirtyIds, dirtyOrigins);
-                }
-              } finally {
-                span.end();
-              }
-            },
-          );
-        } catch (error) {
-          // Requeue the consumed batch (CT-1927): the dirty state was taken
-          // before fan-out, so a failure here would otherwise orphan it —
-          // no later refresh fires unless another write happens, and the
-          // batched refresh is the delivery path the staged catch-up
-          // markers rely on. Merge UNDER anything that accrued meanwhile
-          // (newer provenance wins), reschedule, and rethrow so callers
-          // see the failure.
-          this.#dirtySpaces.add(space);
+        await this.withSpacePublicationLock(space, async () => {
+          // Removed at its own processing turn (CT-1927): pre-deleting the
+          // whole selection meant a failure mid-batch stranded every
+          // not-yet-processed space — dirty maps intact but the space no
+          // longer discoverable.
+          this.#dirtySpaces.delete(space);
+          const dirtyIds = this.#dirtyDocsBySpace.get(space);
           if (dirtyIds !== undefined) {
-            let current = this.#dirtyDocsBySpace.get(space);
-            if (current === undefined) {
-              current = new Set();
-              this.#dirtyDocsBySpace.set(space, current);
-            }
-            let currentOrigins = this.#dirtyOriginsBySpace.get(space);
-            for (const id of dirtyIds) {
-              if (current.has(id)) {
-                // The id was re-dirtied while the failed batch was in
-                // flight. Provenance survives only when BOTH batches agree
-                // on the same session; otherwise the merged novelty is
-                // mixed and must fan out authoritatively — restoring the
-                // newer origin alone would echo-suppress the consumed
-                // batch's foreign/unattributed novelty (CT-1927 review).
-                const restoredOrigin = dirtyOrigins?.get(id);
-                const currentOrigin = currentOrigins?.get(id);
-                if (
-                  currentOrigin !== undefined &&
-                  restoredOrigin?.sessionId !== currentOrigin.sessionId
-                ) {
-                  currentOrigins?.delete(id);
-                }
-                continue;
-              }
-              current.add(id);
-              const origin = dirtyOrigins?.get(id);
-              if (origin !== undefined) {
-                if (currentOrigins === undefined) {
-                  currentOrigins = new Map();
-                  this.#dirtyOriginsBySpace.set(space, currentOrigins);
-                }
-                currentOrigins.set(id, origin);
-              }
-            }
+            this.#dirtyDocsBySpace.delete(space);
           }
-          this.scheduleRefresh();
-          throw error;
-        }
+          const dirtyOrigins = this.#dirtyOriginsBySpace.get(space);
+          if (dirtyOrigins !== undefined) {
+            this.#dirtyOriginsBySpace.delete(space);
+          }
+          // Fan-out is a scheduled/batched timer decoupled from transact, so it
+          // must be its own root span. `root: true` makes that explicit — the
+          // context manager propagates the active context into timer callbacks,
+          // so without it this span could parent under whichever memory.transact
+          // happened to schedule the refresh.
+          try {
+            await tracer.startActiveSpan(
+              "memory.fanout",
+              { root: true },
+              async (span) => {
+                span.setAttribute("space.did", space);
+                span.setAttribute("subscriber.count", this.#connections.size);
+                span.setAttribute("dirty.count", dirtyIds?.size ?? 0);
+                try {
+                  for (const connection of this.#connections.values()) {
+                    await connection.refreshDirty(
+                      space,
+                      dirtyIds,
+                      dirtyOrigins,
+                    );
+                  }
+                } finally {
+                  span.end();
+                }
+              },
+            );
+          } catch (error) {
+            // Requeue the consumed batch (CT-1927): the dirty state was taken
+            // before fan-out, so a failure here would otherwise orphan it —
+            // no later refresh fires unless another write happens, and the
+            // batched refresh is the delivery path the staged catch-up
+            // markers rely on. Merge UNDER anything that accrued meanwhile
+            // (newer provenance wins), reschedule, and rethrow so callers
+            // see the failure.
+            this.#dirtySpaces.add(space);
+            if (dirtyIds !== undefined) {
+              let current = this.#dirtyDocsBySpace.get(space);
+              if (current === undefined) {
+                current = new Set();
+                this.#dirtyDocsBySpace.set(space, current);
+              }
+              let currentOrigins = this.#dirtyOriginsBySpace.get(space);
+              for (const id of dirtyIds) {
+                if (current.has(id)) {
+                  // The id was re-dirtied while the failed batch was in
+                  // flight. Provenance survives only when BOTH batches agree
+                  // on the same session; otherwise the merged novelty is
+                  // mixed and must fan out authoritatively — restoring the
+                  // newer origin alone would echo-suppress the consumed
+                  // batch's foreign/unattributed novelty (CT-1927 review).
+                  const restoredOrigin = dirtyOrigins?.get(id);
+                  const currentOrigin = currentOrigins?.get(id);
+                  if (
+                    currentOrigin !== undefined &&
+                    restoredOrigin?.sessionId !== currentOrigin.sessionId
+                  ) {
+                    currentOrigins?.delete(id);
+                  }
+                  continue;
+                }
+                current.add(id);
+                const origin = dirtyOrigins?.get(id);
+                if (origin !== undefined) {
+                  if (currentOrigins === undefined) {
+                    currentOrigins = new Map();
+                    this.#dirtyOriginsBySpace.set(space, currentOrigins);
+                  }
+                  currentOrigins.set(id, origin);
+                }
+              }
+            }
+            this.scheduleRefresh();
+            throw error;
+          }
+        });
       }
 
       if (initial !== undefined) {
@@ -3791,6 +3858,13 @@ export class Server {
     });
     this.#schedulerSideEffectsByOwnerSpace.set(ownerSpace, tracked);
     return tracked;
+  }
+
+  /** Waits until every queued owner-space scheduler update has settled. */
+  private async drainPostCommitSchedulerSideEffects(): Promise<void> {
+    while (this.#schedulerSideEffectsByOwnerSpace.size > 0) {
+      await Promise.all(this.#schedulerSideEffectsByOwnerSpace.values());
+    }
   }
 
   private async applyPostCommitSchedulerSideEffects(

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -4451,10 +4451,10 @@ class SpaceReplica implements ISpaceReplica {
   }
 
   // CT-1927 client half: an accept's promotion waits for marker coverage.
-  // Immediate application remains for markers already observed (the frame
-  // can outrun the verdict handler on the same socket) and for servers that
-  // predate per-verdict markers (verdictCatchUpMarkers absent: an older
-  // server stamps markers only for conflicts, so parking would hang).
+  // Immediate application remains for a marker already observed before this
+  // replica begins settlement and for servers that predate per-verdict markers
+  // (verdictCatchUpMarkers absent: an older server stamps markers only for
+  // conflicts, so parking would hang).
   private settleAccept(
     localSeq: number,
     operations: NativeCommitOperation[],

--- a/packages/runner/test/child-pattern-start-ownership.test.ts
+++ b/packages/runner/test/child-pattern-start-ownership.test.ts
@@ -25,8 +25,12 @@ type TransactResponse = {
   ok?: unknown;
   error?: { name: string; message: string };
 };
+type PublishTransactVerdict = (response: TransactResponse) => void;
 type TestMemoryServer = {
-  transact(message: TransactMessage): Promise<TransactResponse>;
+  transact(
+    message: TransactMessage,
+    publishVerdict?: PublishTransactVerdict,
+  ): Promise<TransactResponse>;
 };
 
 // Hold the first commit whose payload mentions a marker, and decide its outcome
@@ -47,20 +51,24 @@ function holdCommitCarrying(
   const release = Promise.withResolvers<void>();
   let holding = false;
 
-  server.transact = (message) => {
+  server.transact = (message, publishVerdict) => {
     if (!holding && JSON.stringify(message).includes(marker)) {
       holding = true;
       held.resolve();
-      return release.promise.then(() => ({
-        type: "response" as const,
-        requestId: message.requestId,
-        error: {
-          name: "ConflictError",
-          message: "forced child ownership test conflict",
-        },
-      }));
+      return release.promise.then(() => {
+        const response: TransactResponse = {
+          type: "response",
+          requestId: message.requestId,
+          error: {
+            name: "ConflictError",
+            message: "forced child ownership test conflict",
+          },
+        };
+        publishVerdict?.(response);
+        return response;
+      });
     }
-    return original(message);
+    return original(message, publishVerdict);
   };
 
   return {

--- a/packages/runner/test/navigate-handler.test.ts
+++ b/packages/runner/test/navigate-handler.test.ts
@@ -17,13 +17,17 @@ type TransactResponse = {
   ok?: unknown;
   error?: { name: string; message: string };
 };
+type PublishTransactVerdict = (response: TransactResponse) => void;
 
 function delayNextServerTransact(
   storageManager: ReturnType<typeof StorageManager.emulate>,
 ) {
   const server = (storageManager as unknown as {
     server(): {
-      transact(message: TransactMessage): Promise<TransactResponse>;
+      transact(
+        message: TransactMessage,
+        publishVerdict?: PublishTransactVerdict,
+      ): Promise<TransactResponse>;
     };
   }).server();
   const original = server.transact.bind(server);
@@ -31,12 +35,12 @@ function delayNextServerTransact(
   const release = Promise.withResolvers<void>();
   let shouldDelay = true;
 
-  server.transact = async (message) => {
-    if (!shouldDelay) return await original(message);
+  server.transact = async (message, publishVerdict) => {
+    if (!shouldDelay) return await original(message, publishVerdict);
     shouldDelay = false;
     started.resolve();
     await release.promise;
-    return await original(message);
+    return await original(message, publishVerdict);
   };
 
   return {

--- a/packages/runner/test/pending-commit-durability.test.ts
+++ b/packages/runner/test/pending-commit-durability.test.ts
@@ -39,8 +39,12 @@ type TransactResponse = {
   ok?: unknown;
   error?: { name: string; message: string; precondition?: string };
 };
+type PublishTransactVerdict = (response: TransactResponse) => void;
 type TestMemoryServer = {
-  transact(message: TransactMessage): Promise<TransactResponse>;
+  transact(
+    message: TransactMessage,
+    publishVerdict?: PublishTransactVerdict,
+  ): Promise<TransactResponse>;
 };
 
 function emulatedServer(
@@ -62,10 +66,10 @@ function holdServerTransacts(
   const original = server.transact.bind(server);
   let held = 0;
   const gates: (() => void)[] = [];
-  server.transact = async (message) => {
+  server.transact = async (message, publishVerdict) => {
     held++;
     await new Promise<void>((resolve) => gates.push(resolve));
-    return original(message);
+    return original(message, publishVerdict);
   };
   return {
     held: () => held,
@@ -90,16 +94,18 @@ function rejectServerTransacts(
   const server = emulatedServer(storageManager);
   const original = server.transact.bind(server);
   let rejected = 0;
-  server.transact = (message) => {
+  server.transact = (message, publishVerdict) => {
     if (rejected < count) {
       rejected++;
-      return Promise.resolve({
+      const response: TransactResponse = {
         type: "response",
         requestId: message.requestId,
         error,
-      });
+      };
+      publishVerdict?.(response);
+      return Promise.resolve(response);
     }
-    return original(message);
+    return original(message, publishVerdict);
   };
   return {
     rejected: () => rejected,

--- a/packages/runner/test/scheduler-commit-backpressure.test.ts
+++ b/packages/runner/test/scheduler-commit-backpressure.test.ts
@@ -51,8 +51,12 @@ type TransactResponse = {
   ok?: unknown;
   error?: { name: string; message: string; precondition?: string };
 };
+type PublishTransactVerdict = (response: TransactResponse) => void;
 type TestMemoryServer = {
-  transact(message: TransactMessage): Promise<TransactResponse>;
+  transact(
+    message: TransactMessage,
+    publishVerdict?: PublishTransactVerdict,
+  ): Promise<TransactResponse>;
 };
 
 function emulatedServer(
@@ -74,16 +78,18 @@ function rejectServerTransacts(
   const server = emulatedServer(storageManager);
   const original = server.transact.bind(server);
   let rejected = 0;
-  server.transact = (message) => {
+  server.transact = (message, publishVerdict) => {
     if (rejected < count) {
       rejected++;
-      return Promise.resolve({
+      const response: TransactResponse = {
         type: "response",
         requestId: message.requestId,
         error,
-      });
+      };
+      publishVerdict?.(response);
+      return Promise.resolve(response);
     }
-    return original(message);
+    return original(message, publishVerdict);
   };
   return {
     rejected: () => rejected,

--- a/packages/runner/test/scheduler-event-lineage.test.ts
+++ b/packages/runner/test/scheduler-event-lineage.test.ts
@@ -35,8 +35,12 @@ type TransactResponse = {
   ok?: unknown;
   error?: { name: string; message: string };
 };
+type PublishTransactVerdict = (response: TransactResponse) => void;
 type TestMemoryServer = {
-  transact(message: TransactMessage): Promise<TransactResponse>;
+  transact(
+    message: TransactMessage,
+    publishVerdict?: PublishTransactVerdict,
+  ): Promise<TransactResponse>;
 };
 
 function emulatedServer(
@@ -52,11 +56,11 @@ function rejectNextServerTransact(
   const original = server.transact.bind(server);
   const rejected = Promise.withResolvers<void>();
   let shouldReject = true;
-  server.transact = async (message) => {
+  server.transact = async (message, publishVerdict) => {
     if (shouldReject) {
       shouldReject = false;
       rejected.resolve();
-      return {
+      const response: TransactResponse = {
         type: "response",
         requestId: message.requestId,
         error: {
@@ -64,8 +68,10 @@ function rejectNextServerTransact(
           message: "forced scheduler lineage test conflict",
         },
       };
+      publishVerdict?.(response);
+      return response;
     }
-    return await original(message);
+    return await original(message, publishVerdict);
   };
 
   return {
@@ -81,15 +87,17 @@ function rejectServerTransacts(
 ): () => void {
   const server = emulatedServer(storageManager);
   const original = server.transact.bind(server);
-  server.transact = (message) => {
-    return Promise.resolve({
+  server.transact = (message, publishVerdict) => {
+    const response: TransactResponse = {
       type: "response",
       requestId: message.requestId,
       error: {
         name: "ConflictError",
         message: "forced scheduler lineage test conflict",
       },
-    });
+    };
+    publishVerdict?.(response);
+    return Promise.resolve(response);
   };
 
   return () => {
@@ -106,15 +114,15 @@ function delayNextServerTransact(
   const release = Promise.withResolvers<"confirm" | "fail">();
   let shouldDelay = true;
 
-  server.transact = async (message) => {
+  server.transact = async (message, publishVerdict) => {
     if (!shouldDelay) {
-      return await original(message);
+      return await original(message, publishVerdict);
     }
     shouldDelay = false;
     started.resolve();
     const outcome = await release.promise;
     if (outcome === "fail") {
-      return {
+      const response: TransactResponse = {
         type: "response",
         requestId: message.requestId,
         error: {
@@ -122,8 +130,10 @@ function delayNextServerTransact(
           message: "forced scheduler lineage test conflict",
         },
       };
+      publishVerdict?.(response);
+      return response;
     }
-    return await original(message);
+    return await original(message, publishVerdict);
   };
 
   return {

--- a/packages/runner/test/scheduler-event-receipts.test.ts
+++ b/packages/runner/test/scheduler-event-receipts.test.ts
@@ -32,8 +32,12 @@ type TransactResponse = {
   ok?: unknown;
   error?: { name: string; message: string };
 };
+type PublishTransactVerdict = (response: TransactResponse) => void;
 type TestMemoryServer = {
-  transact(message: TransactMessage): Promise<TransactResponse>;
+  transact(
+    message: TransactMessage,
+    publishVerdict?: PublishTransactVerdict,
+  ): Promise<TransactResponse>;
 };
 
 function emulatedServer(
@@ -48,10 +52,10 @@ function rejectNextServerTransact(
   const server = emulatedServer(storageManager);
   const original = server.transact.bind(server);
   let shouldReject = true;
-  server.transact = async (message) => {
+  server.transact = async (message, publishVerdict) => {
     if (shouldReject) {
       shouldReject = false;
-      return {
+      const response: TransactResponse = {
         type: "response",
         requestId: message.requestId,
         error: {
@@ -59,8 +63,10 @@ function rejectNextServerTransact(
           message: "forced scheduler receipt test conflict",
         },
       };
+      publishVerdict?.(response);
+      return response;
     }
-    return await original(message);
+    return await original(message, publishVerdict);
   };
 
   return () => {
@@ -77,12 +83,12 @@ function delayNextServerTransact(
   const release = Promise.withResolvers<void>();
   let shouldDelay = true;
 
-  server.transact = async (message) => {
-    if (!shouldDelay) return await original(message);
+  server.transact = async (message, publishVerdict) => {
+    if (!shouldDelay) return await original(message, publishVerdict);
     shouldDelay = false;
     started.resolve();
     await release.promise;
-    return await original(message);
+    return await original(message, publishVerdict);
   };
 
   return {


### PR DESCRIPTION
## Summary

- serialize transaction publication and fan-out with a per-space lock
- publish the transaction verdict before post-commit scheduler bookkeeping completes and before the lock is released
- keep locks independent across spaces and apply the same ordering to direct writes and explicit flushes
- update protocol documentation and regression coverage for verdict-before-fan-out ordering

## Root cause

Scheduler dirty marking could trigger an independent fan-out after durable commit but before the originating connection received its verdict. Connection-local queue ordering was therefore not authoritative for the transaction result.

## Impact

Clients now receive a transaction verdict before any covering fan-out result for the same space, without blocking work in unrelated spaces.

## Validation

- memory package: 487 passed, 0 failed
- focused runner tests: 86 passed, 0 failed
- documentation checks: 536 code blocks passed
- repository lint passed
- changed-file formatting, type checks, conflict-marker check, no-waitfor check, and diff checks passed

Repository-wide formatting currently reports unrelated pre-existing formatting differences; this branch does not modify those files.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

