### PR TITLE
docs(plan): archiving a document does not protect it from a rebase

### DIFF
--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -248,6 +248,14 @@ already contains, and the duplicate-commit conflicts look like real ones.
 form that works. The cheapest tell that a fork point was wrong: the branch
 suddenly touches files it has no business in.
 
+**Archiving a document does not protect it from a rebase.** Git follows the
+rename, so a branch that edited the live document applies its edit inside the
+frozen copy — with no conflict, which is what makes it dangerous. Three separate
+branches did this the day the predecessors were archived, and every one of them
+rebased cleanly. After archiving anything, check whether an open branch still
+edits it; the edit belongs wherever the live successor keeps that kind of
+content, not in the record.
+
 **`deno fmt` does not check anything under `docs/`.** The directory is in the
 formatter's exclude list, so a passing `deno fmt --check` after a documentation
 edit says nothing about that edit. The gates that do apply are `check-docs` for


### PR DESCRIPTION
## Why

Three separate branches landed edits **inside** a frozen historical document on the day its predecessors were archived — #5309, #5501, and #5307. Every one of them rebased cleanly, with no conflict. Git follows the rename, so a branch that edited the live plan applies its edit to the archived copy without complaint.

Clean-looking and wrong is the worst failure mode a rebase has, and this one is a direct consequence of archiving. The next person to archive anything will meet it.

## What Changed

One paragraph in the verbs plan's operating rules, beside the squash-rebase trap already recorded there. It names the check that would have caught it: after archiving, look for open branches that still edit what you just froze.

## Test plan

`deno task check-docs` (536 blocks) passes. Documentation only.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

