### PR TITLE
fix(integration): deliver every marked click to a control that acts

### DIFF
--- a/docs/development/UI_TESTING.md
+++ b/docs/development/UI_TESTING.md
@@ -240,7 +240,10 @@ happens.
 two consecutive rendering frames. It measures the marked control again just
 before dispatch. If that final measurement finds that the control moved or was
 replaced, the helper settles and marks the current control before dispatching
-one trusted click.
+one trusted click. A page that moves the control after even that last
+measurement is caught as well: the helper stops an interaction that misses
+before the page sees it, and aims again.
+`docs/development/waiting-in-tests.md` describes how.
 
 **Use `awaitViewSettled(page)`** from `@commonfabric/integration` as the
 lower-level wait after navigation or a state change. When the next step
@@ -263,11 +266,12 @@ await waitForCondition(page, (probe) =>
 Pattern integration tests can use the higher-level wrappers in
 `packages/patterns/integration/cfc-browser-helpers.ts` — `waitForText`,
 `fillCfInput`, `clickCfButton`, `clickCfButtonAndWaitForText` — which bundle
-the common waiting and interaction sequences. `clickCfButton` proceeds only
-when the same target remains rendered before and after a settle. It marks that
-target inside the successful predicate. See
+the common waiting and interaction sequences. Every one of them that clicks
+proceeds only when the same target remains rendered before and after a settle,
+and marks that target inside the successful predicate — the helpers that reach a
+control by index, by `data-ui-action`, or by its button text included. See
 `docs/development/waiting-in-tests.md` for why that ordering is the load-bearing
-part, and for which helpers do not yet have it.
+part.
 
 ### Do not reach for these instead
 

--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -129,13 +129,15 @@ When several controls are clicked as a group, prove that every target is stable
 before marking any of them. Mark the targets inside the successful predicate so
 the click addresses the elements that passed the settle check.
 
-`clickCfButton` and `clickCfButtonsConcurrently` work this way.
-`clickTrustedAction` and `settleAndClickNoteButton` in
-`packages/patterns/integration/note-button-helpers.ts` use `clickMarked` for
-the final geometry check and replacement handling. Their earlier readiness
-checks differ from `clickCfButton`'s settle-and-mark predicate.
-`submitViaEnter` is a keyboard interaction and settles before resolving its
-input.
+Every marked click runs the same step to get there, `settleAndMarkTargets`, so
+`clickCfButton`, `clickCfButtonsConcurrently`, `clickNthCfButton`,
+`clickTrustedAction` and the note-button helpers in
+`packages/patterns/integration/note-button-helpers.ts` all mark under these
+rules. A helper supplies only a finder: which elements qualify, answered from
+the page. Resolving them either side of the settle, requiring the same elements
+both times, and marking them is the shared step's work. `submitViaEnter`
+focuses a field and presses Enter rather than clicking, and goes through the
+same step to resolve that field.
 
 Ask `probe.isRendered` for that check rather than hand-rolling it, and note that
 it is deliberately not `probe.isVisible`, which additionally requires the
@@ -187,6 +189,65 @@ click on" means. A helper that tags a control by name also passes its tagging
 predicate to `clickMarked`. A control the page rebuilt is therefore tagged
 again on whatever took its place, under that helper's own readiness rules,
 rather than reported as gone.
+
+The dispatch that follows still crosses the protocol, and the page keeps running
+while it does. A surface that relays out in that crossing carries the control
+off the point the click is already aimed at, and the click lands on whatever
+moved into the space. So the same page turn that measures the point also arms an
+interceptor: it watches the window, in the capture phase, for the pointer and
+mouse events of that one click. The first of them to arrive decides what happens
+to the rest. If the mark is on its composed path, every event of the interaction
+goes through to the page. If it is not, every event is stopped at the window.
+One decision for the whole interaction is what makes the control take the press
+and the release together or take neither.
+
+Whether the click was delivered is decided separately, at the click event,
+because that is the event a control acts on. The press and the release cross the
+protocol one at a time, so the page can carry the control away between them, and
+the browser then raises the click on the nearest ancestor the two have in common
+rather than on the control. A click that does not carry the mark is stopped like
+any other miss. So is a control that declines the interaction outright: a
+disabled one takes the press and raises no click at all.
+
+What the interceptor stops is the press, the release and the click — the events
+a control acts on. The pointer moves to the point before it presses, and the
+hover events that produces reach the page like any other. It also leaves the
+page's own clicks alone: a label forwarding to its control, or a component
+clicking itself from a key handler, raises an untrusted event, which the
+interceptor passes through and does not read a verdict from.
+
+A miss did not activate the control, so `clickMarked` aims again at wherever the
+control now stands and dispatches again. What bounds that is progress: the aim
+has to answer a pixel no dispatch has lost yet. A control that has not moved
+answers the same pixel, and a page that shuffles a control between a few
+positions comes back to one of them, so both stop at the second aim that repeats
+itself. The report then names every pixel tried and what the click reached at
+each, which says whether the control was covered, was declining the click, or
+was being carried around the page.
+
+This is the one place in the interaction helpers where a failed operation is
+retried. It is not the kind of retry the rule above forbids, because a click the
+interceptor stopped is not a failed attempt that might have worked — it provably
+did nothing to the page — and because it cannot repeat itself: a second dispatch
+only happens at a pixel that has never been dispatched at.
+
+Those steps look like one another and are not. Each answers a different question
+about the control, and dropping any of them leaves a click that quietly does
+nothing:
+
+- Is it wired up? The settle either side of the mark answers this, and nothing
+  later can. A click that reaches a control whose handler has not been bound is
+  delivered and discarded, so every other check passes and the test waits on an
+  effect that will not come.
+- Is it the control the settle ran for? Resolving before and after the settle
+  and requiring the same elements answers this. A surface that rebuilt its
+  control mid-settle otherwise hands the mark to an element that never settled.
+- Is there a point to aim at? The single page turn that holds for a stable box
+  and measures it answers this. A control with no box makes the measurement come
+  back empty and the click throw before any of it reaches the page.
+- Did the click land on it? The interceptor answers this, and only this. It is
+  what turns a click carried off its target into a re-aim rather than a silent
+  success.
 
 That error message covers more than a missing layout box: the underlying
 `DOM.getBoxModel` reports a node the browser's DOM agent no longer knows about

--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -96,13 +96,16 @@ Waits split into two groups with different primitives.
   signal.
 - The higher-level wrappers in
   `packages/patterns/integration/cfc-browser-helpers.ts` compose the two
-  primitives above for common waits and interactions. `clickCfButton` and
-  `clickCfButtonsConcurrently` settle and mark the exact rendered targets before
-  clicking them. `clickCfButton` takes the first match and reaches through a
-  host's shadow root for its inner `[data-cf-button]`.
-  `clickNthCfButton` takes the `index`-th match of a selector that already
-  resolves to the buttons themselves. It does not yet have the same settlement
-  guarantee.
+  primitives above for common waits and interactions. Each of them settles and
+  marks the exact rendered target before acting on it; what differs between them
+  is only how they recognize that target. `clickCfButton` takes the first match
+  and reaches through a host's shadow root for its inner `[data-cf-button]`, and
+  `clickCfButtonsConcurrently` does the same for a group. `clickNthCfButton`
+  takes the `index`-th match of a selector that already resolves to the buttons
+  themselves. `clickTrustedAction` takes the first enabled match of a
+  `data-ui-action` value. The note-button helpers take a button by its text or
+  its title. `submitViaEnter` focuses a field and presses Enter rather than
+  clicking, and settles around resolving that field the same way.
 
 To click a control that appears asynchronously, follow the `clickCfButton`
 shape rather than a find-and-click retry loop: a `waitForCondition` predicate

--- a/packages/patterns/integration/cfc-browser-helpers.test.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.test.ts
@@ -18,6 +18,7 @@ import {
   clickNthCfButton,
   clickTrustedAction,
   fillCfInput,
+  submitViaEnter,
   waitForSettledText,
 } from "./cfc-browser-helpers.ts";
 import { clickButtonWithText } from "./note-button-helpers.ts";
@@ -1069,6 +1070,65 @@ describe("CFC browser helpers", () => {
       "the click reached no handler: the named button was marked and " +
         "clicked without a settle to bind it",
     );
+    assertEquals(result.settleCalls, 2);
+  });
+
+  it("settles the view before pressing Enter in a submit input", async () => {
+    await page.evaluate(() => {
+      const host = document.createElement("div");
+      const root = host.attachShadow({ mode: "open" });
+      const form = document.createElement("form");
+      const input = document.createElement("input");
+      input.id = "late-submit-input";
+      const submit = document.createElement("button");
+      submit.type = "submit";
+      form.append(input, submit);
+      root.append(form);
+      document.body.append(host);
+
+      let settleCalls = 0;
+      let submittedAtSettle = 0;
+      let bound = false;
+      (globalThis as typeof globalThis & {
+        commonfabric: { viewSettled: () => Promise<void> };
+      }).commonfabric = {
+        viewSettled: () => {
+          settleCalls++;
+          if (!bound) {
+            bound = true;
+            form.addEventListener("submit", (event) => {
+              event.preventDefault();
+              submittedAtSettle = settleCalls;
+            }, { once: true });
+          }
+          return Promise.resolve();
+        },
+      };
+      (globalThis as typeof globalThis & {
+        __lateSubmitResult: () => {
+          settleCalls: number;
+          submittedAtSettle: number;
+        };
+      }).__lateSubmitResult = () => ({ settleCalls, submittedAtSettle });
+    });
+
+    await submitViaEnter(page, "#late-submit-input");
+
+    const result = await page.evaluate(() =>
+      (globalThis as typeof globalThis & {
+        __lateSubmitResult: () => {
+          settleCalls: number;
+          submittedAtSettle: number;
+        };
+      }).__lateSubmitResult()
+    );
+    assertEquals(
+      result.submittedAtSettle,
+      1,
+      "the Enter reached no handler: the field was focused and pressed " +
+        "without a settle to wire its form up",
+    );
+    // One settle wires the form up, and one follows the submission.
     assertEquals(result.settleCalls, 2);
   });
 

--- a/packages/patterns/integration/cfc-browser-helpers.test.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.test.ts
@@ -20,6 +20,7 @@ import {
   fillCfInput,
   waitForSettledText,
 } from "./cfc-browser-helpers.ts";
+import { clickButtonWithText } from "./note-button-helpers.ts";
 
 /** One element's live click marks, in attribute order. */
 type MarkProbe = { clicks: number; marksAtClick: string[]; marks: string[] };
@@ -820,6 +821,9 @@ describe("CFC browser helpers", () => {
       document.body.append(host);
 
       (globalThis as typeof globalThis & {
+        commonfabric: { viewSettled: () => Promise<void> };
+      }).commonfabric = { viewSettled: () => Promise.resolve() };
+      (globalThis as typeof globalThis & {
         __indexedMarkProbe: () => unknown;
       }).__indexedMarkProbe = () => ({
         clicks,
@@ -868,6 +872,9 @@ describe("CFC browser helpers", () => {
       document.body.append(host);
 
       (globalThis as typeof globalThis & {
+        commonfabric: { viewSettled: () => Promise<void> };
+      }).commonfabric = { viewSettled: () => Promise.resolve() };
+      (globalThis as typeof globalThis & {
         __trustedMarkProbe: () => unknown;
       }).__trustedMarkProbe = () => ({
         clicks,
@@ -890,6 +897,179 @@ describe("CFC browser helpers", () => {
     );
     assertEquals(result.marksAtClick.length, 2);
     assertEquals(result.marks, ["held-by-another-click"]);
+  });
+
+  // The three tests below cover the click helpers that reach their control by
+  // index, by `data-ui-action`, and by button text. Each drives a control that
+  // is in the DOM from the start but receives its click handler only when the
+  // view settles — the ordinary case of a vdom batch that has not yet crossed
+  // to the main thread. A helper that marks its control without settling around
+  // it clicks an element with nothing bound, and `clickedAtSettle` stays zero.
+
+  it("settles the view before clicking an indexed control", async () => {
+    await page.evaluate(() => {
+      const host = document.createElement("div");
+      const root = host.attachShadow({ mode: "open" });
+      for (const label of ["first", "second"]) {
+        const button = document.createElement("button");
+        button.className = "late-indexed-target";
+        button.textContent = label;
+        root.append(button);
+      }
+      document.body.append(host);
+
+      let settleCalls = 0;
+      let clickedAtSettle = 0;
+      let bound = false;
+      (globalThis as typeof globalThis & {
+        commonfabric: { viewSettled: () => Promise<void> };
+      }).commonfabric = {
+        viewSettled: () => {
+          settleCalls++;
+          if (!bound) {
+            bound = true;
+            root.querySelectorAll(".late-indexed-target")[1]
+              .addEventListener("click", () => {
+                clickedAtSettle = settleCalls;
+              }, { once: true });
+          }
+          return Promise.resolve();
+        },
+      };
+      (globalThis as typeof globalThis & {
+        __lateIndexedResult: () => {
+          settleCalls: number;
+          clickedAtSettle: number;
+        };
+      }).__lateIndexedResult = () => ({ settleCalls, clickedAtSettle });
+    });
+
+    await clickNthCfButton(page, ".late-indexed-target", 1);
+
+    const result = await page.evaluate(() =>
+      (globalThis as typeof globalThis & {
+        __lateIndexedResult: () => {
+          settleCalls: number;
+          clickedAtSettle: number;
+        };
+      }).__lateIndexedResult()
+    );
+    assertEquals(
+      result.clickedAtSettle,
+      1,
+      "the click reached no handler: the indexed target was marked and " +
+        "clicked without a settle to bind it",
+    );
+    // One settle binds the control, and one follows the click.
+    assertEquals(result.settleCalls, 2);
+  });
+
+  it("settles the view before clicking a trusted action", async () => {
+    await page.evaluate(() => {
+      const host = document.createElement("div");
+      const root = host.attachShadow({ mode: "open" });
+      const button = document.createElement("button");
+      button.setAttribute("data-ui-action", "late-save");
+      button.textContent = "Save";
+      root.append(button);
+      document.body.append(host);
+
+      let settleCalls = 0;
+      let clickedAtSettle = 0;
+      let bound = false;
+      (globalThis as typeof globalThis & {
+        commonfabric: { viewSettled: () => Promise<void> };
+      }).commonfabric = {
+        viewSettled: () => {
+          settleCalls++;
+          if (!bound) {
+            bound = true;
+            button.addEventListener("click", () => {
+              clickedAtSettle = settleCalls;
+            }, { once: true });
+          }
+          return Promise.resolve();
+        },
+      };
+      (globalThis as typeof globalThis & {
+        __lateActionResult: () => {
+          settleCalls: number;
+          clickedAtSettle: number;
+        };
+      }).__lateActionResult = () => ({ settleCalls, clickedAtSettle });
+    });
+
+    await clickTrustedAction(page, "late-save");
+
+    const result = await page.evaluate(() =>
+      (globalThis as typeof globalThis & {
+        __lateActionResult: () => {
+          settleCalls: number;
+          clickedAtSettle: number;
+        };
+      }).__lateActionResult()
+    );
+    assertEquals(
+      result.clickedAtSettle,
+      1,
+      "the click reached no handler: the trusted action was marked and " +
+        "clicked without a settle to bind it",
+    );
+    assertEquals(result.settleCalls, 2);
+  });
+
+  it("settles the view before clicking a button found by text", async () => {
+    await page.evaluate(() => {
+      const host = document.createElement("div");
+      const root = host.attachShadow({ mode: "open" });
+      const button = document.createElement("button");
+      button.id = "late-note-button";
+      button.textContent = "Publish the late note";
+      root.append(button);
+      document.body.append(host);
+
+      let settleCalls = 0;
+      let clickedAtSettle = 0;
+      let bound = false;
+      (globalThis as typeof globalThis & {
+        commonfabric: { viewSettled: () => Promise<void> };
+      }).commonfabric = {
+        viewSettled: () => {
+          settleCalls++;
+          if (!bound) {
+            bound = true;
+            button.addEventListener("click", () => {
+              clickedAtSettle = settleCalls;
+            }, { once: true });
+          }
+          return Promise.resolve();
+        },
+      };
+      (globalThis as typeof globalThis & {
+        __lateNoteResult: () => {
+          settleCalls: number;
+          clickedAtSettle: number;
+        };
+      }).__lateNoteResult = () => ({ settleCalls, clickedAtSettle });
+    });
+
+    await clickButtonWithText(page, "Publish the late note");
+
+    const result = await page.evaluate(() =>
+      (globalThis as typeof globalThis & {
+        __lateNoteResult: () => {
+          settleCalls: number;
+          clickedAtSettle: number;
+        };
+      }).__lateNoteResult()
+    );
+    assertEquals(
+      result.clickedAtSettle,
+      1,
+      "the click reached no handler: the named button was marked and " +
+        "clicked without a settle to bind it",
+    );
+    assertEquals(result.settleCalls, 2);
   });
 
   it("drives the page to settle before filling a cf input", async () => {
@@ -1374,6 +1554,336 @@ describe("CFC browser helpers", () => {
       1,
       "the click never reached the control the surface rebuilt under it",
     );
+  });
+
+  it("clicks the control its surface relaid out under the aim", async () => {
+    // The aim measures the control inside the page and hands the point back to
+    // the test process, which then dispatches the trusted click over a separate
+    // protocol round trip. The page runs freely across that gap. A re-render
+    // arriving in it — a roster update crossing from another browser, say —
+    // relays the surface out and carries the control away from the point the
+    // click is already aimed at, so the click lands on whatever moved into that
+    // space and the control is never clicked.
+    //
+    // The relayout is driven from the interaction observer's `beforeClick`,
+    // which the dispatch awaits, so it lands strictly between the measurement
+    // and the click with no timing to align. It fires once: the second aim
+    // measures the control where it now sits, and the click that follows has
+    // nothing left to move it.
+    await page.evaluate(() => {
+      const host = document.createElement("div");
+      const root = host.attachShadow({ mode: "open" });
+      const surface = document.createElement("div");
+      // Fixed and on screen, so the aim's scroll cannot move it and the
+      // content earlier cases leave on the shared page cannot reach it.
+      Object.assign(surface.style, {
+        position: "fixed",
+        left: "400px",
+        top: "300px",
+        width: "220px",
+      });
+      root.append(surface);
+      document.body.append(host);
+
+      // The block that grows into the space the control vacates. A click that
+      // went to the control's old point landed here, which is what tells the
+      // two failures apart: a click that reached nothing at all, and a click
+      // that reached the wrong control.
+      const filler = document.createElement("button");
+      filler.id = "relaid-out-filler";
+      Object.assign(filler.style, {
+        display: "block",
+        width: "200px",
+        height: "0px",
+        padding: "0",
+        margin: "0",
+        border: "none",
+      });
+      const button = document.createElement("button");
+      button.id = "relaid-out-guest-button";
+      button.textContent = "Continue as guest";
+      Object.assign(button.style, {
+        display: "block",
+        width: "200px",
+        height: "40px",
+        padding: "0",
+        margin: "0",
+      });
+      surface.append(filler, button);
+
+      let buttonClicks = 0;
+      let fillerClicks = 0;
+      button.addEventListener("click", () => void buttonClicks++);
+      filler.addEventListener("click", () => void fillerClicks++);
+
+      (globalThis as typeof globalThis & {
+        commonfabric: { viewSettled: () => Promise<void> };
+      }).commonfabric = { viewSettled: () => Promise.resolve() };
+      (globalThis as typeof globalThis & {
+        __relaidOutRelayout: () => void;
+        __relaidOutClicks: () => { button: number; filler: number };
+      }).__relaidOutRelayout = () => {
+        // 100px of filler covers the whole 40px box the control has left.
+        filler.style.height = "100px";
+      };
+      (globalThis as typeof globalThis & {
+        __relaidOutClicks: () => { button: number; filler: number };
+      }).__relaidOutClicks = () => ({
+        button: buttonClicks,
+        filler: fillerClicks,
+      });
+    });
+
+    let relaidOut = false;
+    page.setInteractionObserver({
+      beforeClick: async () => {
+        if (relaidOut) return;
+        relaidOut = true;
+        await page.evaluate(() =>
+          (globalThis as typeof globalThis & {
+            __relaidOutRelayout: () => void;
+          }).__relaidOutRelayout()
+        );
+      },
+    });
+    try {
+      await clickCfButton(page, "#relaid-out-guest-button");
+    } finally {
+      page.setInteractionObserver(undefined);
+    }
+
+    const clicks = await page.evaluate(() =>
+      (globalThis as typeof globalThis & {
+        __relaidOutClicks: () => { button: number; filler: number };
+      }).__relaidOutClicks()
+    );
+    assertEquals(
+      clicks,
+      { button: 1, filler: 0 },
+      "the click did not reach the control after its surface relaid out",
+    );
+  });
+
+  it("clicks the control its surface moved between press and release", async () => {
+    // A trusted click is a press and a release, dispatched over two protocol
+    // round trips. A surface that relays out between them leaves the release
+    // somewhere the press was not, and the browser raises the click on the
+    // nearest ancestor the two have in common rather than on the control. The
+    // control is never clicked.
+    //
+    // The relayout is driven from the control's own mousedown, so it lands
+    // strictly between the two dispatches with no timing to align. It fires
+    // once, so the click that follows has a control standing still to reach.
+    await page.evaluate(() => {
+      const host = document.createElement("div");
+      const root = host.attachShadow({ mode: "open" });
+      const surface = document.createElement("div");
+      Object.assign(surface.style, {
+        position: "fixed",
+        left: "400px",
+        top: "80px",
+        width: "220px",
+      });
+      root.append(surface);
+      document.body.append(host);
+
+      const filler = document.createElement("div");
+      Object.assign(filler.style, { display: "block", height: "0px" });
+      const button = document.createElement("button");
+      button.id = "split-guest-button";
+      button.textContent = "Continue as guest";
+      Object.assign(button.style, {
+        display: "block",
+        width: "200px",
+        height: "40px",
+        padding: "0",
+        margin: "0",
+      });
+      surface.append(filler, button);
+
+      let buttonClicks = 0;
+      let strayClicks = 0;
+      button.addEventListener("click", () => void buttonClicks++);
+      // Clicks the browser raised somewhere other than the control. The one a
+      // split press and release produces lands here, on the surface the two
+      // targets have in common.
+      surface.addEventListener("click", (event) => {
+        if (event.target !== button) strayClicks++;
+      });
+      button.addEventListener("mousedown", () => {
+        filler.style.height = "100px";
+      }, { once: true });
+
+      (globalThis as typeof globalThis & {
+        commonfabric: { viewSettled: () => Promise<void> };
+      }).commonfabric = { viewSettled: () => Promise.resolve() };
+      (globalThis as typeof globalThis & {
+        __splitClicks: () => { button: number; stray: number };
+      }).__splitClicks = () => ({ button: buttonClicks, stray: strayClicks });
+    });
+
+    await clickCfButton(page, "#split-guest-button");
+
+    const clicks = await page.evaluate(() =>
+      (globalThis as typeof globalThis & {
+        __splitClicks: () => { button: number; stray: number };
+      }).__splitClicks()
+    );
+    assertEquals(
+      clicks,
+      { button: 1, stray: 0 },
+      "the click did not reach the control after the press and release split",
+    );
+  });
+
+  it("leaves the page's own clicks to the page while a click is in flight", async () => {
+    // Components raise clicks of their own — a label forwarding to its control,
+    // a component clicking itself from a key handler. One of those arriving
+    // while a trusted click is crossing the protocol is not that click, and is
+    // none of the helper's business: it must reach its own listeners, and it
+    // must not answer for the interaction the helper is waiting on.
+    //
+    // The page's click is raised from the interaction observer's `beforeClick`,
+    // which the dispatch awaits, so it lands in exactly that window.
+    await page.evaluate(() => {
+      const host = document.createElement("div");
+      const root = host.attachShadow({ mode: "open" });
+      const surface = document.createElement("div");
+      Object.assign(surface.style, {
+        position: "fixed",
+        left: "700px",
+        top: "300px",
+        width: "220px",
+      });
+      root.append(surface);
+      document.body.append(host);
+
+      const elsewhere = document.createElement("button");
+      elsewhere.id = "page-raised-elsewhere";
+      const button = document.createElement("button");
+      button.id = "page-raised-guest-button";
+      button.textContent = "Continue as guest";
+      Object.assign(button.style, {
+        display: "block",
+        width: "200px",
+        height: "40px",
+        padding: "0",
+        margin: "0",
+      });
+      surface.append(elsewhere, button);
+
+      let buttonClicks = 0;
+      let elsewhereClicks = 0;
+      button.addEventListener("click", () => void buttonClicks++);
+      elsewhere.addEventListener("click", () => void elsewhereClicks++);
+
+      (globalThis as typeof globalThis & {
+        commonfabric: { viewSettled: () => Promise<void> };
+      }).commonfabric = { viewSettled: () => Promise.resolve() };
+      (globalThis as typeof globalThis & {
+        __pageRaisedClick: () => void;
+        __pageRaisedClicks: () => { button: number; elsewhere: number };
+      }).__pageRaisedClick = () => elsewhere.click();
+      (globalThis as typeof globalThis & {
+        __pageRaisedClicks: () => { button: number; elsewhere: number };
+      }).__pageRaisedClicks = () => ({
+        button: buttonClicks,
+        elsewhere: elsewhereClicks,
+      });
+    });
+
+    let raised = false;
+    page.setInteractionObserver({
+      beforeClick: async () => {
+        if (raised) return;
+        raised = true;
+        await page.evaluate(() =>
+          (globalThis as typeof globalThis & {
+            __pageRaisedClick: () => void;
+          }).__pageRaisedClick()
+        );
+      },
+    });
+    try {
+      await clickCfButton(page, "#page-raised-guest-button");
+    } finally {
+      page.setInteractionObserver(undefined);
+    }
+
+    const clicks = await page.evaluate(() =>
+      (globalThis as typeof globalThis & {
+        __pageRaisedClicks: () => { button: number; elsewhere: number };
+      }).__pageRaisedClicks()
+    );
+    assertEquals(
+      clicks,
+      { button: 1, elsewhere: 1 },
+      "the page's own click was swallowed, or answered for the trusted one",
+    );
+  });
+
+  it("reports a control that keeps taking the click nowhere", async () => {
+    // A control a click cannot reach — covered, or declining pointer events —
+    // is aimed at, missed, and aimed at again in the same place. The second aim
+    // repeats a pixel a dispatch already lost, which is where the helper stops
+    // and says so, rather than dispatching at it forever.
+    await page.evaluate(() => {
+      const host = document.createElement("div");
+      const root = host.attachShadow({ mode: "open" });
+      const surface = document.createElement("div");
+      Object.assign(surface.style, {
+        position: "fixed",
+        left: "700px",
+        top: "80px",
+        width: "220px",
+        height: "40px",
+      });
+      root.append(surface);
+      document.body.append(host);
+
+      const button = document.createElement("button");
+      button.id = "unreachable-guest-button";
+      button.textContent = "Continue as guest";
+      Object.assign(button.style, {
+        display: "block",
+        width: "200px",
+        height: "40px",
+        padding: "0",
+        margin: "0",
+      });
+      const cover = document.createElement("div");
+      Object.assign(cover.style, {
+        position: "absolute",
+        inset: "0",
+      });
+      surface.append(button, cover);
+
+      let buttonClicks = 0;
+      button.addEventListener("click", () => void buttonClicks++);
+
+      (globalThis as typeof globalThis & {
+        commonfabric: { viewSettled: () => Promise<void> };
+      }).commonfabric = { viewSettled: () => Promise.resolve() };
+      (globalThis as typeof globalThis & {
+        __unreachableClicks: () => number;
+      }).__unreachableClicks = () => buttonClicks;
+    });
+
+    const error = await assertRejects(
+      () => clickCfButton(page, "#unreachable-guest-button"),
+      Error,
+    );
+    assertStringIncludes(
+      error.message,
+      "again, where a trusted click already failed to reach it",
+    );
+
+    const clicks = await page.evaluate(() =>
+      (globalThis as typeof globalThis & {
+        __unreachableClicks: () => number;
+      }).__unreachableClicks()
+    );
+    assertEquals(clicks, 0, "the covered control should have taken no click");
   });
 
   it("tells the interaction observer where a marked click landed", async () => {

--- a/packages/patterns/integration/cfc-browser-helpers.test.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.test.ts
@@ -48,6 +48,13 @@ describe("CFC browser helpers", () => {
   beforeAll(async () => {
     browser = await Browser.launch({ headless: true });
     page = await browser.newPage();
+    // These tests place controls at chosen coordinates and then check where a
+    // trusted click landed, so the viewport they are placed in has to be a
+    // known size. A browser's default viewport is not: the widest surface below
+    // reaches x=920, which is off-screen in an 800-wide default, and a click
+    // aimed at a control's middle then lands outside the page and reaches
+    // nothing.
+    await page.setViewportSize({ width: 1280, height: 800 });
   });
 
   afterAll(async () => {
@@ -1937,6 +1944,10 @@ describe("CFC browser helpers", () => {
       error.message,
       "again, where a trusted click already failed to reach it",
     );
+    // The click has to have been stopped by the cover, not by landing outside
+    // the page: a point off the viewport reaches nothing, which would satisfy
+    // every other assertion here while testing none of what this test is for.
+    assertStringIncludes(error.message, "the click reached div");
 
     const clicks = await page.evaluate(() =>
       (globalThis as typeof globalThis & {

--- a/packages/patterns/integration/cfc-browser-helpers.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.ts
@@ -281,98 +281,173 @@ const fillAndVerify = async (
   return verified;
 };
 
-// Resolve every click target before settling the view. Mark them only when the
-// same rendered elements remain afterward. The resolution is spelled out here
-// because this predicate is serialized into the page and closes over nothing
-// in this module.
-//
-// A target introduced or replaced during the settle is checked again when the
-// DOM mutation triggers the next evaluation. That evaluation gives the exact
-// element a full settle before marking it.
-//
-// The settle also drives the page forward. Asking the worker whether it is idle
-// queues runnable pull work that nothing else would start. A target reached
-// only by the page's pending work arrives on a settling check.
-const settleAndMarkClickTargets = async (
+/**
+ * Which elements a marked click is about to be aimed at.
+ *
+ * A finder answers with the elements to mark, in the order their tokens were
+ * supplied, or `undefined` when the page does not yet present all of them. It
+ * decides only which elements qualify — being rendered, surviving a settle, and
+ * carrying the mark are {@link settleAndMarkTargets}'s business, and every
+ * marked click goes through that one shared step.
+ *
+ * A finder is serialized into the page as its own source, so it closes over
+ * nothing in this module and reads only what it is passed.
+ */
+export type ClickTargetFinder<A extends readonly unknown[]> = (
   probe: ProbeApi,
-  selectors: readonly string[],
+  ...args: A
+) => readonly HTMLElement[] | undefined;
+
+/** What {@link settleAndMarkTargets} is called with, ready to serialize. */
+export type MarkTargetsArgs = [
+  finderSource: string,
+  finderArgs: readonly unknown[],
   tokens: readonly string[],
   attr: string,
+  onMarkSource: string | null,
+];
+
+/**
+ * Spell out one call to {@link settleAndMarkTargets}. The wait that places the
+ * mark and the aim that places it again on whatever replaced a rebuilt control
+ * both run these same arguments, so they mark under the same rules.
+ */
+export const markTargetsArgs = <A extends readonly unknown[]>(
+  finder: ClickTargetFinder<A>,
+  finderArgs: A,
+  tokens: readonly string[],
+  onMark?: (target: HTMLElement) => void,
+): MarkTargetsArgs => [
+  finder.toString(),
+  finderArgs,
+  tokens,
+  CLICK_TARGET_ATTR,
+  onMark ? onMark.toString() : null,
+];
+
+/**
+ * Resolve every click target with `finderSource`, settle the view, and mark the
+ * targets only when the same rendered elements survive the settle.
+ *
+ * Being in the DOM is not being clickable. The reactive scheduler runs in a
+ * worker while the DOM lives on the main thread, so a control can be found by a
+ * selector while the vdom batch that binds its click handler is still crossing
+ * to the main thread, and while the Lit update cycle that removes its
+ * `pointer-events: none` is still pending. A click delivered to that control is
+ * dropped without a trace. Settling covers all three stages, and a click helper
+ * that skips it can hand a test a control that takes the click and does nothing
+ * with it.
+ *
+ * The settle sits between two resolutions rather than before the wait, because
+ * a target that arrives partway through a settle was never covered by it. Both
+ * resolutions have to answer the same elements, so what gets marked is the
+ * element the settle ran for. A target introduced or replaced during the settle
+ * fails that comparison, and the next DOM mutation re-enters this predicate and
+ * gives whatever took its place a settle of its own.
+ *
+ * The settle also drives the page forward rather than watching it. Asking the
+ * worker whether it is idle queues runnable pull work that nothing else would
+ * start, so a target reached only by the page's own pending work arrives on a
+ * settling check and never on one that reads the DOM alone.
+ *
+ * `onMarkSource`, when supplied, runs on each element once it carries its mark
+ * and inside this same page turn — for a caller that has to attach something to
+ * the exact element the click will reach.
+ */
+export const settleAndMarkTargets = async (
+  probe: ProbeApi,
+  finderSource: string,
+  finderArgs: readonly unknown[],
+  tokens: readonly string[],
+  attr: string,
+  onMarkSource: string | null,
 ): Promise<boolean> => {
   const settle = (globalThis as typeof globalThis & {
     commonfabric?: { viewSettled?: () => Promise<void> };
   }).commonfabric?.viewSettled;
-  if (!settle || selectors.length !== tokens.length) return false;
+  if (!settle) return false;
 
-  const resolveClickTarget = (
-    selector: string,
-  ): HTMLElement | undefined => {
-    const target = probe.collect(selector)[0] as HTMLElement | undefined;
-    if (!target) return undefined;
-    return (target.shadowRoot?.querySelector("[data-cf-button]") as
-      | HTMLElement
-      | null) ?? target;
-  };
-  const targetsBefore = selectors.map(resolveClickTarget);
-  const renderedBefore = targetsBefore.map((target) =>
-    target !== undefined &&
-    target.isConnected &&
-    probe.isRendered(target)
-  );
+  const finder = new Function("return (" + finderSource + ")")() as (
+    probe: ProbeApi,
+    ...args: readonly unknown[]
+  ) => readonly HTMLElement[] | undefined;
+  const onMark = onMarkSource === null ? undefined : new Function(
+    "return (" + onMarkSource + ")",
+  )() as (target: HTMLElement) => void;
+  const clickable = (target: HTMLElement): boolean =>
+    target.isConnected && probe.isRendered(target);
+
+  // The settle runs whether or not the targets are there yet, because it is
+  // what drives the page: a target reached only by the page's own pending work
+  // arrives on a settle, and a predicate that returned early on a missing
+  // target would be waiting for a page nothing is moving.
+  const before = finder(probe, ...finderArgs);
+  const readyBefore = before !== undefined &&
+    before.length === tokens.length &&
+    before.every(clickable);
 
   await settle();
 
-  const settledTargets = selectors.map(resolveClickTarget);
-  const ready = settledTargets.every((target, index) => {
-    return renderedBefore[index] === true &&
-      target !== undefined &&
-      target === targetsBefore[index] &&
-      target.isConnected &&
-      probe.isRendered(target);
-  });
-  if (!ready) return false;
+  if (!readyBefore || before === undefined) return false;
+  const after = finder(probe, ...finderArgs);
+  if (!after || after.length !== before.length) return false;
+  if (
+    !after.every((target, index) =>
+      target === before[index] && clickable(target)
+    )
+  ) return false;
 
-  for (let index = 0; index < settledTargets.length; index++) {
-    const target = settledTargets[index];
+  for (let index = 0; index < after.length; index++) {
+    const target = after[index];
     const token = tokens[index];
     if (target === undefined || token === undefined) return false;
     probe.addToken(target, attr, token);
+    onMark?.(target);
   }
   return true;
 };
 
-// Tag the `index`-th element matching `selector` once it is rendered. The
-// selector already resolves to clickable elements, so the match is tagged
-// directly rather than reached through a host's shadow root. The rendered check
-// is viewport-independent. The click scrolls the element into view.
-const markNthForClick = (
+// The first element matching each selector, reached through a host's shadow
+// root when the host wraps the control that takes the click.
+const findSelectorClickTargets = (
+  probe: ProbeApi,
+  selectors: readonly string[],
+): readonly HTMLElement[] | undefined => {
+  const targets: HTMLElement[] = [];
+  for (const selector of selectors) {
+    const host = probe.collect(selector)[0] as HTMLElement | undefined;
+    if (!host) return undefined;
+    targets.push(
+      (host.shadowRoot?.querySelector("[data-cf-button]") as
+        | HTMLElement
+        | null) ?? host,
+    );
+  }
+  return targets;
+};
+
+// The `index`-th element matching `selector`. The selector already resolves to
+// clickable elements, so the match is taken directly rather than reached
+// through a host's shadow root.
+const findNthClickTarget = (
   probe: ProbeApi,
   selector: string,
   index: number,
-  token: string,
-  attr: string,
-): boolean => {
+): readonly HTMLElement[] | undefined => {
   const target = probe.collect(selector)[index] as HTMLElement | undefined;
-  if (!target) return false;
-  if (!target.isConnected || !probe.isRendered(target)) return false;
-  probe.addToken(target, attr, token);
-  return true;
+  return target ? [target] : undefined;
 };
 
-// Tag the first rendered, enabled element carrying `data-ui-action="<action>"`
-// for a single trusted click, and record the next click's provenance so a
-// failure can show whether the dispatch was trusted and where it landed.
+// The first rendered, enabled element carrying `data-ui-action="<action>"`.
 // Rendered-ness is asked of the resolved click target, which covers the host:
 // hiding the host reaches the inner control either way. It is asked without an
 // on-screen requirement, since the trusted click scrolls the target into view
 // before dispatching. Disabled-ness is asked of both, because a host can carry
 // an `aria-disabled` its inner control does not.
-const markTrustedAction = (
+const findTrustedActionTarget = (
   probe: ProbeApi,
   action: string,
-  token: string,
-  attr: string,
-): boolean => {
+): readonly HTMLElement[] | undefined => {
   const isDisabled = (element: HTMLElement): boolean =>
     element.hasAttribute("disabled") ||
     element.getAttribute("aria-disabled") === "true";
@@ -386,34 +461,40 @@ const markTrustedAction = (
       probe.isRendered(clickTarget) &&
       !isDisabled(target) && !isDisabled(clickTarget)
     ) {
-      probe.addToken(clickTarget, attr, token);
-      clickTarget.addEventListener(
-        "click",
-        (event) => {
-          (globalThis as typeof globalThis & {
-            __lastCfcTrustedActionClick?: TrustedActionProbe["lastClick"];
-          }).__lastCfcTrustedActionClick = {
-            trusted: event.isTrusted,
-            path: event.composedPath().flatMap((node) => {
-              if (!(node instanceof HTMLElement)) return [];
-              const dataset: Record<string, string> = {};
-              for (const key in node.dataset) {
-                dataset[key] = node.dataset[key] ?? "";
-              }
-              return [{
-                tagName: node.tagName.toLowerCase(),
-                id: node.id,
-                dataset,
-              }];
-            }),
-          };
-        },
-        { capture: true, once: true },
-      );
-      return true;
+      return [clickTarget];
     }
   }
-  return false;
+  return undefined;
+};
+
+// Record the provenance of the next click the marked control receives, so a
+// failure can show whether the dispatch was trusted and where it landed.
+// Attached to the control that carries the mark, which is the control the
+// trusted click is aimed at.
+const recordTrustedActionClick = (clickTarget: HTMLElement): void => {
+  clickTarget.addEventListener(
+    "click",
+    (event) => {
+      (globalThis as typeof globalThis & {
+        __lastCfcTrustedActionClick?: TrustedActionProbe["lastClick"];
+      }).__lastCfcTrustedActionClick = {
+        trusted: event.isTrusted,
+        path: event.composedPath().flatMap((node) => {
+          if (!(node instanceof HTMLElement)) return [];
+          const dataset: Record<string, string> = {};
+          for (const key in node.dataset) {
+            dataset[key] = node.dataset[key] ?? "";
+          }
+          return [{
+            tagName: node.tagName.toLowerCase(),
+            id: node.id,
+            dataset,
+          }];
+        }),
+      };
+    },
+    { capture: true, once: true },
+  );
 };
 
 // Resolve once the shell's reactive view has caught up to runtime state and is
@@ -470,19 +551,21 @@ export async function clickTrustedAction(
   const token = `trusted-action-${crypto.randomUUID()}`;
   let probe: TrustedActionProbe | undefined;
   try {
-    // Wait until a visible, enabled instance of the action can be marked, then
-    // click it exactly once. Marking attaches the provenance listener, so the
-    // single click is the trusted dispatch we record.
-    await waitForCondition(page, markTrustedAction, {
-      args: [action, token, CLICK_TARGET_ATTR],
-    });
+    // Wait until a visible, enabled instance of the action has settled and can
+    // be marked, then click it exactly once. Marking attaches the provenance
+    // listener, so the single click is the trusted dispatch we record.
+    const args = markTargetsArgs(
+      findTrustedActionTarget,
+      [action],
+      [token],
+      recordTrustedActionClick,
+    );
+    await waitForCondition(page, settleAndMarkTargets, { args });
     await clickMarked(page, {
       token,
-      remark: {
-        predicate: markTrustedAction,
-        args: [action, token, CLICK_TARGET_ATTR],
-      },
+      remark: { predicate: settleAndMarkTargets, args },
     });
+    await settleView(page);
   } catch (cause) {
     probe ??= await readTrustedActionProbe(page, action).catch(() => undefined);
     // Indented for readable test-log output
@@ -752,8 +835,8 @@ async function settleWithClickTargets(
 ): Promise<string[]> {
   const tokens = selectors.map(() => `cf-button-${crypto.randomUUID()}`);
   try {
-    await waitForCondition(page, settleAndMarkClickTargets, {
-      args: [selectors, tokens, CLICK_TARGET_ATTR],
+    await waitForCondition(page, settleAndMarkTargets, {
+      args: markTargetsArgs(findSelectorClickTargets, [selectors], tokens),
     });
   } catch (cause) {
     await Promise.all(
@@ -799,8 +882,8 @@ export async function clickCfButton(
   await clickMarked(page, {
     token,
     remark: {
-      predicate: settleAndMarkClickTargets,
-      args: [[selector], [token], CLICK_TARGET_ATTR],
+      predicate: settleAndMarkTargets,
+      args: markTargetsArgs(findSelectorClickTargets, [[selector]], [token]),
     },
   });
   await settleView(page);
@@ -877,8 +960,10 @@ export async function clickCfButtonsConcurrently(
  * across a rendered piece) rather than to a host wrapping one.
  *
  * The wait is the mark: a `waitForCondition` predicate re-checks on each DOM
- * mutation until the indexed element is present and visible, then tags it, and
- * the test dispatches a single trusted click on the tagged element.
+ * mutation until the indexed element is present and visible, settles the view
+ * around it, and tags it. The test then dispatches a single trusted click on
+ * the tagged element and settles the view again so the click's local effect is
+ * in the DOM when the next step looks for it.
  */
 export async function clickNthCfButton(
   page: Page,
@@ -886,10 +971,9 @@ export async function clickNthCfButton(
   index: number,
 ) {
   const token = `cf-nth-button-${crypto.randomUUID()}`;
+  const args = markTargetsArgs(findNthClickTarget, [selector, index], [token]);
   try {
-    await waitForCondition(page, markNthForClick, {
-      args: [selector, index, token, CLICK_TARGET_ATTR],
-    });
+    await waitForCondition(page, settleAndMarkTargets, { args });
   } catch (cause) {
     const probe = await readTextProbe(page, selector).catch(() => undefined);
     throw new Error(
@@ -901,11 +985,9 @@ export async function clickNthCfButton(
   }
   await clickMarked(page, {
     token,
-    remark: {
-      predicate: markNthForClick,
-      args: [selector, index, token, CLICK_TARGET_ATTR],
-    },
+    remark: { predicate: settleAndMarkTargets, args },
   });
+  await settleView(page);
 }
 
 // Where a trusted click is about to be aimed, or why the marked control could
@@ -913,6 +995,23 @@ export async function clickNthCfButton(
 type ClickAim =
   | { x: number; y: number; targetId: number }
   | { missing: true; sawTarget: boolean };
+
+/**
+ * What became of the trusted click the aim armed for.
+ *
+ * `hit` means the click reached the marked control. `missed` means it reached
+ * something else. `pending` means no click event was raised at all, which is
+ * what a control that declines the interaction leaves behind — a disabled one
+ * takes the press and produces no click.
+ *
+ * Neither `missed` nor `pending` activated the control, so the click can be
+ * aimed again.
+ */
+type ClickLanding = {
+  verdict: "pending" | "hit" | "missed";
+  /** The innermost few elements the interaction did reach, outward. */
+  path: string;
+};
 
 // Resolve the marked control, hold until it has a settled layout box, scroll it
 // into view, and answer with the point to click — all inside one page turn.
@@ -938,6 +1037,11 @@ type ClickAim =
 // the caller supplies it, is the mark predicate's own source; running it again
 // re-establishes the mark on whatever control took the old one's place, so a
 // rebuilt surface is clicked rather than reported.
+//
+// Answering also arms the landing interceptor, which decides the trusted click
+// that follows. The interceptor is armed here rather than by the test process
+// so that it is in place from the instant the point is measured, leaving no
+// window in which an interaction could arrive unwatched.
 const aimAtMarkedTarget = async (
   probe: ProbeApi,
   selector: string,
@@ -951,6 +1055,117 @@ const aimAtMarkedTarget = async (
   }).__cfAimDiag ??= {});
   const diag: AimDiag = { phase: "resolving", frames: 0, lastBox: "none" };
   registry[selector] = diag;
+
+  type Landing = {
+    verdict: "pending" | "hit" | "missed";
+    /** Whether the interaction's first event carried the mark. */
+    onTarget: boolean | undefined;
+    path: string;
+    armed: boolean;
+    detach: () => void;
+  };
+  const landings = ((globalThis as typeof globalThis & {
+    __cfClickLanding?: Record<string, Landing>;
+  }).__cfClickLanding ??= {});
+  const open = ((globalThis as typeof globalThis & {
+    __cfClickLandingOpen?: Record<string, true>;
+  }).__cfClickLandingOpen ??= {});
+
+  // Watch the pointer and mouse events of one trusted click, at the window and
+  // in the capture phase.
+  //
+  // The first event decides what happens to the rest: its composed path either
+  // carries the mark, and every event of the interaction goes through, or it
+  // does not, and every event is stopped there. One decision covers the whole
+  // interaction, so the control takes the press and the release together or
+  // takes neither.
+  //
+  // The verdict is settled at the click event, which is the event a control
+  // acts on. The press and the release cross the protocol separately, so the
+  // page can carry the control away between them, and the browser then raises
+  // the click on the nearest ancestor the two have in common. A click that does
+  // not carry the mark is stopped like any other miss.
+  //
+  // What is stopped is the press, the release and the click. The pointer moves
+  // to the point before the press, and the hover events that produces are the
+  // page's to handle.
+  //
+  // Only trusted events are watched. The page raises clicks of its own — a
+  // label forwarding to its control, a component clicking itself from a key
+  // handler — and those pass through untouched and leave the verdict alone.
+  //
+  // Arming is gated on the entry the test process opens for this click and
+  // removes when the click is done, so a wait that outlived its caller cannot
+  // leave an interceptor behind.
+  const arm = (): void => {
+    if (!open[selector]) return;
+    landings[selector]?.detach();
+    const carriesMark = (event: Event): boolean =>
+      event.composedPath().some((node) =>
+        node instanceof Element && node.matches(selector)
+      );
+    const describe = (event: Event): string =>
+      event.composedPath()
+        .flatMap((node) =>
+          node instanceof Element
+            ? [node.tagName.toLowerCase() + (node.id ? `#${node.id}` : "")]
+            : []
+        )
+        .slice(0, 4)
+        .join(" < ");
+    const block = (event: Event): void => {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    };
+    const onEvent = (event: Event): void => {
+      if (!landing.armed || !event.isTrusted) return;
+      if (landing.onTarget === undefined) {
+        landing.onTarget = carriesMark(event);
+        landing.path = describe(event);
+      }
+      if (!landing.onTarget) block(event);
+      if (
+        event.type === "click" || event.type === "auxclick" ||
+        event.type === "contextmenu"
+      ) {
+        if (landing.onTarget && carriesMark(event)) {
+          landing.verdict = "hit";
+        } else {
+          landing.verdict = "missed";
+          landing.path = describe(event);
+          block(event);
+        }
+        // One trusted click ends at its click event, whether that event reached
+        // the page or was stopped here.
+        landing.armed = false;
+      }
+    };
+    const types = [
+      "pointerdown",
+      "mousedown",
+      "pointerup",
+      "mouseup",
+      "click",
+      "auxclick",
+      "contextmenu",
+    ];
+    const landing: Landing = {
+      verdict: "pending",
+      onTarget: undefined,
+      path: "",
+      armed: true,
+      detach: () => {
+        landing.armed = false;
+        for (const type of types) {
+          globalThis.removeEventListener(type, onEvent, { capture: true });
+        }
+      },
+    };
+    landings[selector] = landing;
+    for (const type of types) {
+      globalThis.addEventListener(type, onEvent, { capture: true });
+    }
+  };
 
   const find = (): HTMLElement | undefined =>
     probe.collect(selector)[0] as HTMLElement | undefined;
@@ -1076,6 +1291,7 @@ const aimAtMarkedTarget = async (
       behavior: "instant",
     });
     const rect = target.getBoundingClientRect();
+    arm();
     diag.phase = "aimed";
     return {
       x: rect.x + rect.width / 2,
@@ -1179,6 +1395,21 @@ export interface ClickMark {
  * measured again in one page turn immediately before the trusted click, after
  * any interaction observer has finished. A moved or missing target goes
  * through the same settle and replacement handling before dispatch.
+ *
+ * That last measurement still crosses the protocol before the mouse events do,
+ * and the page keeps running while it does, so a surface that relays out in
+ * that crossing carries the control off the point the click is aimed at. The
+ * aim leaves an interceptor watching for the interaction it armed for: one that
+ * does not reach the marked control is stopped at the window, so the control
+ * was not activated and it can be aimed at and clicked again where it now
+ * stands. The loop ends on the first click the control receives, so the control
+ * is activated exactly once.
+ *
+ * Clicking again requires a pixel no dispatch has lost yet. A control that has
+ * not moved is dispatched at the same pixel, and a page that shuffles a control
+ * around a few positions comes back to one of them, so both stop at the second
+ * dispatch that repeats itself rather than dispatching forever. What is
+ * reported then names every pixel tried and what the click reached at each.
  */
 export async function clickMarked(
   page: Page,
@@ -1187,7 +1418,11 @@ export async function clickMarked(
   const { token, remark } = typeof mark === "string" ? { token: mark } : mark;
   const markSelector = `[${CLICK_TARGET_ATTR}~="${token}"]`;
   const identityKey = `__commonToolsClickIdentity_${crypto.randomUUID()}`;
+  // Pixels a dispatch has already lost this click at, and what it reached
+  // there.
+  const lost = new Map<string, string>();
   try {
+    await openClickLanding(page, markSelector);
     const measureAim = async (): Promise<{
       x: number;
       y: number;
@@ -1222,8 +1457,8 @@ export async function clickMarked(
           undefined
         );
         throw new Error(
-          `The control marked for click was replaced before the click could ` +
-            `be aimed at it${
+          `The control marked for click was replaced before the click ` +
+            `could be aimed at it${
               aim?.sawTarget ? " while its box was settling" : ""
             }. Last probe: ${toIndentedDebugString(probe)}`,
         );
@@ -1231,31 +1466,67 @@ export async function clickMarked(
       return aim;
     };
 
-    const aim = await measureAim();
-    await page.clickPoint({ x: aim.x, y: aim.y }, {
-      refreshPoint: async () => {
-        const current = await readMarkedClickPoint(
-          page,
-          markSelector,
-          identityKey,
+    for (;;) {
+      const aim = await measureAim();
+      // Where the mouse events actually went. The refresh below runs after this
+      // point was chosen and can move it, and what the interceptor reports on
+      // is whatever was dispatched last.
+      let dispatched = { x: aim.x, y: aim.y };
+      await page.clickPoint({ x: aim.x, y: aim.y }, {
+        refreshPoint: async () => {
+          const current = await readMarkedClickPoint(
+            page,
+            markSelector,
+            identityKey,
+          );
+          if (
+            current?.targetId === aim.targetId && current.x === aim.x &&
+            current.y === aim.y
+          ) {
+            return dispatched;
+          }
+          if (remark) {
+            await clearClickMark(page, token);
+            await waitForCondition(page, remark.predicate, {
+              args: [...remark.args],
+            });
+          }
+          const settled = await measureAim();
+          dispatched = { x: settled.x, y: settled.y };
+          return dispatched;
+        },
+      });
+      const landing = await readClickLanding(page, markSelector);
+      if (landing.verdict === "hit") return;
+      // The click did not reach the control, so the control did not act on it.
+      const pixel = `${Math.round(dispatched.x)},${Math.round(dispatched.y)}`;
+      const reached = landing.verdict === "missed"
+        ? `the click reached ${landing.path || "nothing"}`
+        : `no click was raised; the interaction reached ${
+          landing.path || "nothing"
+        }`;
+      const lostBefore = lost.get(pixel);
+      if (lostBefore !== undefined) {
+        const progress = await readAimProgress(page, markSelector).catch(() =>
+          undefined
         );
-        if (
-          current?.targetId === aim.targetId && current.x === aim.x &&
-          current.y === aim.y
-        ) {
-          return { x: current.x, y: current.y };
-        }
-        if (remark) {
-          await clearClickMark(page, token);
-          await waitForCondition(page, remark.predicate, {
-            args: [...remark.args],
-          });
-        }
-        const settled = await measureAim();
-        return { x: settled.x, y: settled.y };
-      },
-    });
+        const probe = await readTextProbe(page, markSelector).catch(() =>
+          undefined
+        );
+        throw new Error(
+          `${markSelector} is aimed at ${pixel} again, where a trusted click ` +
+            `already failed to reach it (${lostBefore}). Every pixel tried: ${
+              toIndentedDebugString(Object.fromEntries(lost))
+            }. Aim reached: ${toIndentedDebugString(progress)}. ` +
+            `Last probe: ${toIndentedDebugString(probe)}`,
+        );
+      }
+      lost.set(pixel, reached);
+      // Aim again: the page has had the whole dispatch to move the control, and
+      // the next aim finds where it went.
+    }
   } finally {
+    await closeClickLanding(page, markSelector).catch(() => {});
     await Promise.all([
       clearClickMark(page, token).catch(() => {}),
       clearClickIdentityState(page, identityKey).catch(() => {}),
@@ -2256,6 +2527,56 @@ async function clearClickMark(
       }
     }
   }, { args: [token, CLICK_TARGET_ATTR] });
+}
+
+// What the interceptor the aim armed made of the trusted click that followed.
+async function readClickLanding(
+  page: Page,
+  selector: string,
+): Promise<ClickLanding> {
+  return await page.evaluate((targetSelector: string) => {
+    const landing = (globalThis as typeof globalThis & {
+      __cfClickLanding?: Record<
+        string,
+        { verdict: "pending" | "hit" | "missed"; path: string }
+      >;
+    }).__cfClickLanding?.[targetSelector];
+    return {
+      verdict: landing?.verdict ?? "pending",
+      path: landing?.path ?? "",
+    };
+  }, { args: [selector] });
+}
+
+// Let the aim arm an interceptor for this mark. An aim that runs outside this
+// window — one whose wait the test process has already given up on — leaves the
+// page alone.
+async function openClickLanding(
+  page: Page,
+  selector: string,
+): Promise<void> {
+  await page.evaluate((targetSelector: string) => {
+    ((globalThis as typeof globalThis & {
+      __cfClickLandingOpen?: Record<string, true>;
+    }).__cfClickLandingOpen ??= {})[targetSelector] = true;
+  }, { args: [selector] });
+}
+
+// Close the window and take the interceptor off the page, so the page's own
+// clicks are watched by nothing.
+async function closeClickLanding(
+  page: Page,
+  selector: string,
+): Promise<void> {
+  await page.evaluate((targetSelector: string) => {
+    const global = globalThis as typeof globalThis & {
+      __cfClickLanding?: Record<string, { detach: () => void }>;
+      __cfClickLandingOpen?: Record<string, true>;
+    };
+    delete global.__cfClickLandingOpen?.[targetSelector];
+    global.__cfClickLanding?.[targetSelector]?.detach();
+    delete global.__cfClickLanding?.[targetSelector];
+  }, { args: [selector] });
 }
 
 async function readTrustedActionProbe(

--- a/packages/patterns/integration/cfc-browser-helpers.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.ts
@@ -426,6 +426,23 @@ const findSelectorClickTargets = (
   return targets;
 };
 
+// The first element matching `selector`, taken directly. The selector resolves
+// to the field itself, since a `cf-submit-input` forwards its `inputId` to the
+// inner `<input>`.
+const findKeyboardTarget = (
+  probe: ProbeApi,
+  selector: string,
+): readonly HTMLElement[] | undefined => {
+  const target = probe.collect(selector)[0] as HTMLElement | undefined;
+  return target ? [target] : undefined;
+};
+
+// Focus the field that carries the mark, so the key press that follows reaches
+// the element the settle ran for.
+const focusMarkedTarget = (target: HTMLElement): void => {
+  target.focus();
+};
+
 // The `index`-th element matching `selector`. The selector already resolves to
 // clickable elements, so the match is taken directly rather than reached
 // through a host's shadow root.
@@ -587,20 +604,37 @@ export async function clickTrustedAction(
  * scripted `KeyboardEvent` does not trigger implicit submission, which is why an
  * earlier dispatched-keydown attempt never reached the create handler.
  *
- * The view is settled first so the form is interactive, and the inner input is
- * resolved by piercing shadow roots (the `inputId` is forwarded to the inner
- * `<input>`, so the selector matches it directly).
+ * The field is resolved either side of a settle and focused only once the same
+ * element survives it, the way a marked click resolves the control it clicks.
+ * A field focused without that is a field whose form may not be wired up yet,
+ * and the Enter then reaches a submit button with no handler bound.
  */
 export async function submitViaEnter(
   page: Page,
   inputSelector: string,
 ) {
-  await settleView(page);
-  const input = await page.waitForSelector(inputSelector, {
-    strategy: "pierce",
-  });
-  await input.focus();
+  const token = `cf-submit-input-${crypto.randomUUID()}`;
+  const args = markTargetsArgs(
+    findKeyboardTarget,
+    [inputSelector],
+    [token],
+    focusMarkedTarget,
+  );
+  try {
+    await waitForCondition(page, settleAndMarkTargets, { args });
+  } catch (cause) {
+    const probe = await readTextProbe(page, inputSelector).catch(() =>
+      undefined
+    );
+    throw new Error(
+      `Timed out waiting for ${inputSelector} to settle before pressing ` +
+        `Enter. Last probe: ${toIndentedDebugString(probe)}`,
+      { cause },
+    );
+  }
   await page.keyboard.press("Enter");
+  await clearClickMark(page, token).catch(() => {});
+  await settleView(page);
 }
 
 export async function clickTrustedActionAndWaitForText(

--- a/packages/patterns/integration/note-button-helpers.ts
+++ b/packages/patterns/integration/note-button-helpers.ts
@@ -4,52 +4,50 @@ import {
   waitForCondition,
 } from "@commonfabric/integration";
 import {
-  CLICK_TARGET_ATTR,
   clickMarked,
+  markTargetsArgs,
+  settleAndMarkTargets,
   settleView,
 } from "./cfc-browser-helpers.ts";
 
 // Find-and-click-a-button-by-text helpers shared by the default-app
-// integration tests. The predicate below stamps the button it resolved with
-// CLICK_TARGET_ATTR, and clickMarked then resolves that exact element and
-// dispatches a single trusted click on it. The predicate is what this module
-// adds: it picks a button by its text, its exact text, or its title, where the
-// predicates in cfc-browser-helpers.ts pick one by CSS selector, by index
-// within a selector, or by data-ui-action value.
+// integration tests. What this module adds is the finder below: it picks a
+// button by its text, its exact text, or its title, where the finders in
+// cfc-browser-helpers.ts pick one by CSS selector, by index within a selector,
+// or by data-ui-action value. Settling around the match, marking it, and
+// clicking it are that module's shared step, which every marked click runs.
 
-// Serialized into the page by waitForCondition: find the first rendered
-// button/link whose text or title matches and stamp its inner click target with
-// `token`. "Rendered" means laid out and not display:none/visibility:hidden —
-// the same elements the innerText scan the poll used could see — and is
-// viewport-independent, so a match below the fold is still tagged: the click
-// scrolls the element into view itself. Returns false until a match exists, so
-// the wait re-checks on the next DOM mutation instead of the caller retrying a
-// bare find-and-click loop. Self-contained — it closes over nothing in this
-// module — so it can be serialized and run in the page.
-const markNoteButton = (
+// Serialized into the page: the first rendered button or link whose text or
+// title matches, reached through its host's shadow root when the host wraps the
+// control that takes the click. "Rendered" means laid out and not
+// display:none/visibility:hidden — the same elements the innerText scan the
+// poll used could see — and is viewport-independent, so a match below the fold
+// still qualifies: the click scrolls the element into view itself. Answers
+// `undefined` until a match exists, so the wait re-checks on the next DOM
+// mutation instead of the caller retrying a bare find-and-click loop.
+// Self-contained — it closes over nothing in this module — so it can be
+// serialized and run in the page.
+const findNoteButton = (
   probe: ProbeApi,
   selector: string,
   match: "includes" | "exact" | "title",
   needle: string,
-  token: string,
-  attr: string,
-): boolean => {
+): readonly HTMLElement[] | undefined => {
   const target = probe.collect(selector).find((element) => {
     if (!probe.isRendered(element)) return false;
     if (match === "title") return element.getAttribute("title") === needle;
     const text = (element.textContent ?? "").trim();
     return match === "exact" ? text === needle : text.includes(needle);
   }) as HTMLElement | undefined;
-  if (!target) return false;
-  const clickTarget = (target.shadowRoot?.querySelector("[data-cf-button]") as
-    | HTMLElement
-    | null) ?? target;
-  if (!clickTarget.isConnected || !probe.isRendered(clickTarget)) return false;
-  probe.addToken(clickTarget, attr, token);
-  return true;
+  if (!target) return undefined;
+  return [
+    (target.shadowRoot?.querySelector("[data-cf-button]") as
+      | HTMLElement
+      | null) ?? target,
+  ];
 };
 
-// Settle the view, tag a matching button, and dispatch a single trusted click
+// Settle around a matching button, tag it, and dispatch a single trusted click
 // on it. Throws if no matching button becomes clickable.
 async function settleAndClickNoteButton(
   page: Page,
@@ -57,14 +55,12 @@ async function settleAndClickNoteButton(
   match: "includes" | "exact" | "title",
   needle: string,
 ): Promise<void> {
-  // Settle before tagging so the tagged button is the final rendered node, laid
-  // out and still attached when the click resolves its box model.
-  await settleView(page);
   const token = `cfc-note-button-${crypto.randomUUID()}`;
+  const args = markTargetsArgs(findNoteButton, [selector, match, needle], [
+    token,
+  ]);
   try {
-    await waitForCondition(page, markNoteButton, {
-      args: [selector, match, needle, token, CLICK_TARGET_ATTR],
-    });
+    await waitForCondition(page, settleAndMarkTargets, { args });
   } catch (cause) {
     throw new Error(
       `Unable to find a ${
@@ -75,11 +71,9 @@ async function settleAndClickNoteButton(
   }
   await clickMarked(page, {
     token,
-    remark: {
-      predicate: markNoteButton,
-      args: [selector, match, needle, token, CLICK_TARGET_ATTR],
-    },
+    remark: { predicate: settleAndMarkTargets, args },
   });
+  await settleView(page);
 }
 
 // The click helpers resolve `true` once the single click has landed (they throw


### PR DESCRIPTION
The lunch-poll two-browser vote test intermittently failed at the guest's "Continue as guest" press. The typed-name field that press reveals never appeared, and the fill after it ran to its safety net with the field absent. The browser's runtime was idle throughout and the join card's surface was unchanged, so nothing in the page was working on an effect that had yet to arrive. The press never reached the button.

What carries the button away is in the poll's own header. The participants strip is rendered only once somebody has joined, so on the guest's page it does not exist until the host's join arrives over the network. When it appears it adds a name chip and the margin above it, the header grows by around thirty pixels, and the whole scrolling body below it — the join card included — moves down by that much. The test waits for the host's join to land on the host's page and then presses the guest's button straight away, so that join is still crossing to the guest's browser while the press is being aimed and dispatched. A small button is twenty-four pixels tall, so the point already aimed at its middle ends up above its top edge. The click lands on the card above the button, the button is never pressed, and the helper reports success.

Five earlier changes tried to close that window by measuring more carefully: #5086, #5152, #5169, #5352 and #5456. Each one narrowed the gap between deciding a control was ready and measuring where it sat, and the last of them removed that gap entirely by doing both in one page turn. None of them could touch the gap that remains, because the dispatch has to leave the page and come back over the protocol while the page keeps running. Nor can a wait close it. The settle these helpers hold for is a bounding box unchanged across two consecutive frames, about sixteen milliseconds of quiet, and the thing that moves the button is a message from another machine, which is bounded by nothing. Waiting harder makes the failure rarer and leaves it possible.

So the page turn that measures the point now also arms an interceptor: window-level capture listeners for the pointer and mouse events of that one click. The first of them to arrive decides what happens to the rest. If the marked control is on its composed path, every event of the interaction goes through. If it is not, every event is stopped there. One decision for the whole interaction is what makes the control take the press and the release together or take neither.

Whether the click was delivered is decided separately, at the click event, because that is the event a control acts on. The press and the release cross the protocol one at a time, so the page can carry the control away between them, and the browser then raises the click on the nearest ancestor the two have in common rather than on the control. A click that does not carry the mark is stopped like any other miss. So is a control that declines the interaction outright: a disabled one takes the press and raises no click at all.

What the interceptor stops is the press, the release and the click. The pointer moves to the point before it presses, and the hover events that produces reach the page like any other. It also leaves the page's own clicks alone: a label forwarding to its control, or a component clicking itself from a key handler, raises an untrusted event, and one of those arriving while the trusted click is still crossing the protocol is not that click. Reading a verdict from it, or stopping it, would both be wrong.

A miss did not activate the control, so the click is aimed again at wherever the control now stands and dispatched again. What bounds that is progress: the aim has to answer a pixel no dispatch has lost yet. A control that has not moved answers the same pixel, and a page that shuffles a control between a few positions comes back to one of them, so both stop at the second aim that repeats itself. The report then names every pixel tried and what the click reached at each, and says whether the click went somewhere else or was never raised, which distinguishes a covered control from one that declines the click from one being carried around the page. Arming is gated on an entry the test process opens for the click and removes when it is done, so an aim whose wait has already timed out cannot leave an interceptor on the page to swallow a later click.

Landing on the control is not the same as the control acting on it, and the second half of this change is the other way a marked click could quietly do nothing. The reactive scheduler runs in a worker while the DOM lives on the main thread, so a selector can resolve a control while the vdom batch that binds its click handler is still crossing to the main thread, and while the Lit update cycle that removes its `pointer-events: none` is still pending. Settling the view covers all three stages, and the settle has to sit either side of the mark rather than in front of the wait: a control that arrives partway through a settle was never covered by it, so both resolutions have to answer the same element before that element is marked.

Only the helper that reaches a control by CSS selector did that. The helpers that reach one by index, by `data-ui-action`, and by button text each resolved their control, checked it was rendered, and marked it, with no settle around any of it; the note-button helper settled once before its wait, which is the ordering the settle was moved out of. So those three could hand a test a control that takes the click and does nothing with it. The interceptor makes that failure look more like success than it did before, because the click does reach the control and the control is not listening.

Marking is now one step that every marked click runs. A helper supplies a finder — which elements qualify, answered from inside the page — and the shared step resolves them either side of the settle, requires the same elements both times, and marks them. What varies between helpers is only how a control is recognized, which is the part that differed for a reason. The trusted-action helper also has to attach its provenance listener to the exact element the click will reach, so the shared step takes an optional hook that runs on each element once it carries its mark, inside the same page turn.

The settle runs whether or not the finder found anything, because the settle is also what drives the page: asking the worker whether it is idle queues runnable pull work that nothing else would start, so a control reached only by the page's own pending work arrives on a settling check and never on one that reads the DOM alone. A predicate that returned early on a missing control would be waiting for a page nothing was moving. The indexed helper and the note-button helper also settle after their click, which the selector helper already did, so a click's local effect is in the DOM when the next step looks for it.

The tests for the interceptor drive each of its windows from something the dispatch awaits, so each lands where it must with no timing to align: the interaction observer's beforeClick for the gap between the measurement and the click and for a click the page raises itself, and the control's own mousedown for the gap between the press and the release. The tests for the settle drive a control that is in the DOM from the start and receives its click handler only when the view settles, one per helper that lacked the guarantee; without a settle around the mark the click lands on an element with nothing bound.

deflaked by Hixie's agent (Claude Opus 5)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

