### PR TITLE
test(runner): pin the deferred default-route resolution

### DIFF
--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -308,6 +308,11 @@ One line per archived document; each document's header carries the fuller
   — why reading a list, changing one element, and writing it back grew seven
   times more expensive: the builder-artifact walk on the raw write path read
   into the query results a read hands out, August 2026.
+- [2026-08-storage-manager-construction-cost.md](development/performance/2026-08-storage-manager-construction-cost.md)
+  — the tenfold step in the immutable-cell storage-manager benchmark traced to
+  an eager default-route resolution in the constructor, why the benchmark
+  times only construction, and why the guard for it counts URL parses rather
+  than comparing values, August 2026.
 - [coverage-ratchet-noise-2026-07-28.md](development/coverage-ratchet-noise-2026-07-28.md)
   — why a rename-only pull request owed coverage debt: a wall-clock-guarded
   diagnostic and a shard re-partition each moved the `packages/runner`

--- a/docs/history/development/performance/2026-08-storage-manager-construction-cost.md
+++ b/docs/history/development/performance/2026-08-storage-manager-construction-cost.md
@@ -13,8 +13,7 @@ The benchmark `Immutable cell - storage manager setup and cleanup only`, in
 `packages/runner/test/cell-immutable.bench.ts`, rose about tenfold between the
 benchmark runs for `ae805e236` and `de7465bb3` on 3 and 4 August 2026. It is
 the largest single step in the window the dashboard's benchmark headline was
-decomposed over, recorded in
-[`2026-08-benchmark-headline-decomposition.md`](2026-08-benchmark-headline-decomposition.md).
+decomposed over on 7 August 2026.
 
 Each row below is the nearest benchmark run either side of the boundary on
 that processor. The runners take turns, so the two runs in a row are days

--- a/docs/history/development/performance/2026-08-storage-manager-construction-cost.md
+++ b/docs/history/development/performance/2026-08-storage-manager-construction-cost.md
@@ -1,0 +1,167 @@
+---
+status: historical
+created: 2026-08-07
+archived: 2026-08-07
+reason: "Investigation of the tenfold step in the immutable-cell storage-manager benchmark, and what the fix for it left unguarded."
+---
+
+# What made constructing a storage manager ten times slower, August 2026
+
+## Result
+
+The benchmark `Immutable cell - storage manager setup and cleanup only`, in
+`packages/runner/test/cell-immutable.bench.ts`, rose about tenfold between the
+benchmark runs for `ae805e236` and `de7465bb3` on 3 and 4 August 2026. It is
+the largest single step in the window the dashboard's benchmark headline was
+decomposed over, recorded in
+[`2026-08-benchmark-headline-decomposition.md`](2026-08-benchmark-headline-decomposition.md).
+
+Each row below is the nearest benchmark run either side of the boundary on
+that processor. The runners take turns, so the two runs in a row are days
+apart on the thinner lines.
+
+| Processor | Before | After |
+| --- | ---: | ---: |
+| AMD EPYC 7763 | 1.34 µs | 10.83 µs |
+| AMD EPYC 9V74 | 1.35 µs | 10.51 µs |
+| Intel Xeon Platinum 8573C | 0.79 µs | 7.78 µs |
+
+The cause is [#5173](https://github.com/commontoolsinc/labs/pull/5173),
+`fix(storage): keep the first accepted space host route`, which is `87beb5f78`
+and the fourth of the twenty commits in that range. The commit named as the
+first suspect, `de7465bb3`, is the twentieth, and is not involved.
+
+The regression was already fixed on `main` when this investigation ran, by
+[#5428](https://github.com/commontoolsinc/labs/pull/5428), `perf(runner):
+resolve the default storage route when it is read`, which is `09970c125` and
+landed on 6 August 2026. Nothing pinned the behavior that fix restored, and
+that is what this change adds.
+
+## What the benchmark actually exercises
+
+Its name overstates it. The body constructs an emulated storage manager and
+closes it:
+
+```ts
+const storageManager = StorageManager.emulate({ as: signer });
+await storageManager.close();
+```
+
+`close()` returns immediately when the manager holds no providers, and this
+manager never opens one. The emulated memory server is built on first use by
+the session factory, so it is never built either, and `EmulatedStorageManager.close()`
+finds nothing to shut down. The benchmark therefore times the constructor and
+nothing else.
+
+That is why a tenfold rise here does not imply anything dramatic happened.
+Constructing a manager costs about a microsecond, so a few microseconds of new
+work in the constructor is a tenfold rise. It is also why the change that
+touches the immutable-cell path was the wrong first suspect: no value walking
+happens in this benchmark at all.
+
+## Cause
+
+`#5173` added this to the `StorageManager` constructor:
+
+```ts
+try {
+  const resolveDefault = createStorageAddressResolver(options.memoryHost);
+  this.#defaultStorageRoute = toWebSocketAddress(
+    resolveDefault("did:key:route-comparison" as MemorySpace),
+  ).toString();
+} catch {
+  // A custom session factory may use a non-network memoryHost placeholder.
+}
+```
+
+The memory host is turned into the WebSocket storage endpoint that an
+unseeded, unhinted space would open against. Doing that parses the host, joins
+the storage path onto it, copies the result, parses that copy once more to
+swap the scheme, and stringifies it. Four URL parses in all. The answer has
+exactly one reader: the comparison in `registerSpaceHost()` that decides
+whether a late host hint replaces the default route. Most managers never call
+`registerSpaceHost()`, so for them the address was resolved and thrown away.
+
+The emulated manager pays twice over. `EmulatedStorageManager.emulate()`
+passes `memory://` as its memory host, a placeholder that exists only because
+`Options` requires one; its sessions are loopback and resolve no address. The
+resolver rejects that scheme, so every construction built a `TypeError`,
+captured a stack trace for it, unwound two frames, and discarded it.
+
+Measured on an Apple M5 Max, one run each of the benchmark on its own:
+
+| Constructor | Time |
+| --- | ---: |
+| without the eager resolution | 463 ns |
+| with it, against a host that resolves | 2.0 µs |
+| with it, against the `memory://` placeholder | 4.9 µs |
+
+So the URL work accounts for about a microsecond and a half, and the rejected
+placeholder for about three more. For comparison, on the same machine,
+building a `TypeError` and discarding it costs about 1.2 µs, and resolving a
+host that parses costs about the same.
+
+## How the commit was found
+
+Each of the twenty-one commits from `ae805e236` through `de7465bb3` was
+checked out in turn and measured with a bench file cut down to this one
+benchmark, which takes under two seconds per commit. The step is a single
+clean boundary:
+
+```
+a3dcbb28b       448 ns  test(memory): allow commit bursts before fan-out (#5292)
+87beb5f78      4929 ns  fix(storage): keep the first accepted space host route (#5173)
+7cc8a4077      5068 ns  feat(cli): toggle Markdown and test files in cf view (#5293)
+```
+
+Removing the eager resolution at `87beb5f78` and measuring again returned the
+benchmark to 463 ns, which attributes the whole step to that block rather than
+to anything else in the commit.
+
+## The fix, and what it left unguarded
+
+`#5428` moved the resolution into a private method that runs on the first read
+and keeps its answer, and it holds the memory host as text so the answer comes
+from the host the manager was constructed with. In the benchmark artifacts the
+step disappears at the first run to carry it, on 6 August 2026 at 20:59 UTC:
+the Intel Xeon Platinum 8573C reads 1.08 µs, against 7.76 µs in its previous
+run, and the AMD EPYC 7763 reads 1.34 and 1.38 µs on 7 August against 11.42 µs
+on 6 August. The one other run in that stretch, an Intel run 48 minutes after
+the first recovered one, reads 1.91 µs off 36 iterations where the runs either
+side of it get several hundred thousand, so it says nothing either way.
+Running the benchmark locally at `ae805e236` and at `65d34e146`, alternating
+between them so machine drift could not favour either side, gives 650, 696 and
+717 nanoseconds against 681, 702 and 1132 — the level before the regression,
+with no residue.
+
+What `#5428` did not leave behind is anything that fails when the resolution
+moves back into the constructor. It could not, through the ordinary surface:
+the two shapes agree on every value they produce. Both compute the same route
+from the same host, both swallow a resolution failure and leave the route
+undefined, and both read the caller's host object exactly once — the eager
+shape to parse it, the lazy shape to snapshot it as text. A test that counts
+those reads passes either way, which is what the first attempt at this test
+did.
+
+What separates them is work rather than results, so the test counts the work.
+It installs a `URL` subclass over the global for the duration of the
+constructor call, counts the parses, and requires zero. The lazy shape parses
+none; the eager shape parses four. The test then opens a provider and hints
+the space at the default host, and requires the hint to read as a confirmation
+that leaves the replica in place — a route that was never resolved would
+compare unequal, and the hint would be taken as a replacement. That second
+half is what keeps the test from passing on an implementation that deferred
+the resolution by deleting it.
+
+Verified in both directions: the test passes on `main`, and on `main` with the
+production half of `#5428` reversed it fails with four parses where it wants
+none.
+
+## One thing found along the way, not changed here
+
+This benchmark's name promises cleanup it does not measure, as described
+above. Correcting the body would put a step into the series the dashboard
+reads, and the series is what makes a regression like this visible in the
+first place, so the name is left as it is. A benchmark that covers tearing
+down a manager that has actually opened something would have to be a new
+entry under its own name.

--- a/packages/runner/test/space-host-late-hint.test.ts
+++ b/packages/runner/test/space-host-late-hint.test.ts
@@ -192,6 +192,81 @@ describe("late space host hints", () => {
     }
   });
 
+  it("resolves the default route when a hint reads it, not at construction", async () => {
+    const signer = await Identity.fromPassphrase("deferred-default-route");
+    const targetSpace = (await Identity.fromPassphrase(
+      "deferred-default-route-target",
+    )).did();
+    const targetId = "of:deferred-default-route-target" as URI;
+    const defaultServer = makeServer("deferred-default-route");
+    const memoryHost = new URL("https://default-toolshed.test");
+    let targetSessions = 0;
+    const sessionFactory = new LoopbackSessionFactory(() => {
+      targetSessions++;
+      return defaultServer;
+    });
+
+    // Turning the memory host into the WebSocket storage endpoint an
+    // unseeded, unhinted space opens against parses the host, joins the
+    // storage path onto it, copies the result, and parses that copy again to
+    // swap the scheme. The manager holds the host as text and does none of
+    // that until registerSpaceHost() compares against the route, so a URL
+    // parsed while the constructor runs is that resolution back inside it.
+    // Counting parses is what separates the two shapes: both read the
+    // caller's host object exactly once, one to snapshot it and the other to
+    // resolve it.
+    const RealURL = globalThis.URL;
+    let parsedWhileConstructing = 0;
+    class CountingURL extends RealURL {
+      constructor(url: string | URL, base?: string | URL) {
+        parsedWhileConstructing += 1;
+        super(url, base);
+      }
+    }
+    globalThis.URL = CountingURL as unknown as typeof URL;
+    let manager: TestStorageManager;
+    try {
+      manager = TestStorageManager.create(
+        signer,
+        sessionFactory,
+        memoryHost,
+      );
+    } finally {
+      globalThis.URL = RealURL;
+    }
+
+    try {
+      expect(parsedWhileConstructing).toBe(0);
+
+      const provider = manager.open(targetSpace);
+      const provisionalReplica = provider.replica;
+      const firstRead = await provider.sync(targetId, {
+        path: [],
+        schema: true,
+      });
+      expect(firstRead.error).toBeUndefined();
+      expect(targetSessions).toBe(1);
+
+      // The hint reads the route, so by now the route has to be there. A
+      // route that was never resolved compares unequal to the hint, which
+      // makes the hint a replacement: the replica is rebuilt and a second
+      // session opens.
+      expect(
+        manager.registerSpaceHost(
+          targetSpace,
+          "https://default-toolshed.test",
+        ),
+      ).toBe(true);
+      await manager.crossSpaceSettled();
+
+      expect(provider.replica).toBe(provisionalReplica);
+      expect(targetSessions).toBe(1);
+    } finally {
+      await manager.close();
+      await defaultServer.close();
+    }
+  });
+
   it("replays a read that first opened against the default host", async () => {
     const signer = await Identity.fromPassphrase("late-space-host-hint");
     const targetSpace = (await Identity.fromPassphrase(


### PR DESCRIPTION
The benchmark "Immutable cell - storage manager setup and cleanup only" rose about tenfold on 4 August 2026: from 1.34 to 10.83 microseconds on the AMD EPYC 7763, and from 0.79 to 7.78 on the Intel Xeon Platinum 8573C. Bisecting the twenty commits it is confined to lands on #5173, which added a resolution of the memory host into the WebSocket storage endpoint to the StorageManager constructor.

That benchmark times the constructor and nothing else. close() returns immediately for a manager that holds no providers, this one never opens any, and the emulated memory server is built on first use and so is never built at all. Constructing a manager costs about a microsecond, so the few microseconds the resolution adds are the whole tenfold rise. The emulated manager pays double, because its memory host is a placeholder the resolver rejects: every construction also built a TypeError, captured a stack trace for it, and discarded it.

#5428 has already fixed this, by moving the resolution to the first read and keeping its answer. Nothing guards it, and no comparison of results can. The two shapes agree on every value they produce. Both compute the same route from the same host, both swallow a resolution failure and leave the route undefined, and both read the caller's host object exactly once, the eager shape to parse it and the lazy shape to snapshot it as text. A test that counted reads of that object passed either way.

What separates the two is work rather than results, so count the work. Install a URL subclass over the global for the duration of the constructor call and require it to see no parses; the eager shape makes four. Then open a provider and hint the space at the default host, and require the hint to read as a confirmation that leaves the replica in place, which a route that was never resolved could not do. That second half is what stops the test passing on an implementation that deferred the resolution by deleting it.

Verified in both directions: the test passes on main, and on main with the production half of #5428 reversed it fails with four parses where it wants none.

Record the investigation under docs/history/development/performance/ and add it to the index in docs/history/README.md.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

