### PR TITLE
docs(runner): document why the settleAccept fast path survives #5529 …

### DIFF
--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -4374,6 +4374,15 @@ class SpaceReplica implements ISpaceReplica {
     // Zero-operation commits (scheduler observation batches) carry no state
     // to apply and no view consequences — parking them would only stall
     // synced() on the batch window for nothing.
+    //
+    // The already-caught-up check is NOT wire-reordering tolerance: since
+    // the per-space publication lock (#5529) the marker frame always
+    // FOLLOWS its verdict on the socket. It survives for intra-client
+    // interleaving — the transact awaiter resumes several microtask hops
+    // after its response resolves (request()'s internal awaits), and the
+    // marker frame's processing can integrate in that gap — so by the time
+    // this runs, the marker may already cover this commit and parking
+    // would wait on a frame that has already been consumed.
     if (
       !parkable || operations.length === 0 ||
       this.#caughtUpLocalSeq >= localSeq


### PR DESCRIPTION
…(CT-1872)

The per-space publication lock guarantees verdict-before-marker wire order, but the transact awaiter resumes several microtask hops after its response resolves, so the marker frame can integrate in that gap. Note that the already-caught-up check is intra-client interleaving tolerance, not wire-reordering tolerance.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

