### PR TITLE
docs(specs): conflict rejections carry retryAfterSeq; repair rides the sync stream

### DIFF
--- a/docs/specs/memory-v2/03-commit-model.md
+++ b/docs/specs/memory-v2/03-commit-model.md
@@ -351,28 +351,28 @@ by the read's shape:
 
 ### 3.6.4 Conflict Response
 
-When validation fails, the server returns a `ConflictError` with enough detail
-for the client to refresh confirmed state and retry.
+When validation fails, the server rejects the commit with a `ConflictError` and
+stages the repair for delivery through the sync stream.
 
 ```typescript
 // Shown at module scope.
 interface ConflictError extends Error {
   name: "ConflictError";
-  commit: ClientCommit;
-  conflicts: ConflictDetail[];
-}
-
-interface ConflictDetail {
-  id: EntityId;
-  branch: BranchId;
-  path: ReadPath;
-  expected: { seq: number };
-  actual: {
-    seq: number;
-    value?: JSONValue;
-  };
+  /**
+   * Server head seq at rejection time. Carried for diagnostics; a sync window
+   * reaching this seq reflects the winning write.
+   */
+  retryAfterSeq: number;
 }
 ```
+
+The rejection carries no document values. Instead the server marks the commit's
+write targets and both read sets (`reads.confirmed` and `reads.pending`) dirty
+for the session — origin-less, so the session's own echo suppression does not
+hide them — and the next sync frame delivers the current documents for all of
+them as ordinary upserts. Repair therefore arrives as a consistent cut over the
+session's watched view — covering stale read dependencies as well as write
+targets, with every document the frame links to delivered in the same cut.
 
 ## 3.7 Server-Side Commit Processing
 
@@ -556,16 +556,23 @@ branches for source, target, and base observations.
 
 ## 3.12 Client Retry Strategy
 
-When a commit is rejected:
+When a commit is rejected with a `ConflictError`:
 
-1. inspect the `ConflictError`
-2. update confirmed state from the returned `actual` values or by fetching
-   current state
-3. discard the rejected pending commit and any dependent stacked commits
-4. rebuild the transaction against the refreshed confirmed state
-5. resubmit
+1. discard the rejected pending commit and any dependent stacked commits
+2. wait for the repair sync: the catch-up marker covering the rejected commit
+   (`caughtUpLocalSeq` reaching its `localSeq`), whose frame delivers current
+   documents for the commit's write targets and read sets (§3.6.4)
+3. rebuild the transaction against the repaired confirmed state
+4. resubmit
 
-The client library SHOULD support automatic retry with a bounded retry count.
+Conflict retries are event-gated, not counted: every conflict raised against a
+repaired read set proves a newer overlapping write, so each round makes
+progress, and waiting on the repair frame bounds the loop without a retry
+budget. Rejections other than `ConflictError` are terminal for the failing run
+— re-running against an unchanged replica recomputes the identical refused
+write. Recovery is owned by reactivity: any server-side change that could make
+the operation valid overlaps state the client subscribes to, and its arrival
+re-triggers the computation.
 
 ## 3.13 Mapping from Current Implementation
 

--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -873,8 +873,8 @@ All errors are returned in `response`.
 // Shown at module scope.
 interface ConflictError extends Error {
   name: "ConflictError";
-  commit: ClientCommit;
-  conflicts: ConflictDetail[];
+  /** Server head seq at rejection time (§3.6.4). */
+  retryAfterSeq: number;
 }
 
 interface TransactionError extends Error {

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -2294,9 +2294,8 @@ export class Server {
           // The frame therefore reflects every decided outcome ≤ W for the
           // docs it covers.
           // The session's own accepted writes are echo-suppressed by
-          // dirty-origin tracking (the parked verdict carries their truth
-          // — with CT-1926's post-apply document where the server provides
-          // it); REJECTED commits' docs are staged origin-less
+          // dirty-origin tracking (the parked verdict carries their truth);
+          // REJECTED commits' docs are staged origin-less
           // (stageConflictRefreshDirtyIds), so repair frames DO cover them.
           session.pendingCaughtUpLocalSeq = Math.max(
             session.pendingCaughtUpLocalSeq,

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -4374,6 +4374,15 @@ class SpaceReplica implements ISpaceReplica {
     // Zero-operation commits (scheduler observation batches) carry no state
     // to apply and no view consequences — parking them would only stall
     // synced() on the batch window for nothing.
+    //
+    // The already-caught-up check is NOT wire-reordering tolerance: since
+    // the per-space publication lock (#5529) the marker frame always
+    // FOLLOWS its verdict on the socket. It survives for intra-client
+    // interleaving — the transact awaiter resumes several microtask hops
+    // after its response resolves (request()'s internal awaits), and the
+    // marker frame's processing can integrate in that gap — so by the time
+    // this runs, the marker may already cover this commit and parking
+    // would wait on a frame that has already been consumed.
     if (
       !parkable || operations.length === 0 ||
       this.#caughtUpLocalSeq >= localSeq


### PR DESCRIPTION
## Summary

`03-commit-model.md` §3.6.4 and §3.12 described a conflict-repair design the implementation never adopted: a `ConflictDetail` array with `actual` values on the rejection, client-side repair from those values, and a bounded retry count. The implementation is value-free rejections plus frame-based repair. This updates the spec to the real contract and removes one stale server comment.

## Changes

- **§3.6.4 Conflict Response**: `ConflictError` is `{ name, retryAfterSeq }` — head seq at rejection time, carried for diagnostics (`server.ts` sets it from `Engine.serverSeq`; the client's `isRetryableConflict` keys off it). New prose documents the real repair channel: `stageConflictRefreshDirtyIds` marks the commit's write targets **and both read sets** dirty origin-less (never echo-suppressed), and the next sync frame delivers current documents for all of them as ordinary upserts — a consistent cut over the watched view, with linked documents in the same cut.
- **§3.12 Client Retry Strategy**: discard → wait for the catch-up marker covering the rejected commit (`caughtUpLocalSeq` reaching its `localSeq`) → rebuild → resubmit. Replaces the bounded-retry-count SHOULD with the resolved classification (CT-1875): conflict retries are event-gated because each repaired-read conflict proves a newer overlapping write; other rejections are terminal for the failing run, with recovery owned by reactivity.
- **§4.7 (`04-protocol.md`)**: the error-list `ConflictError` shape updated to match, cross-referenced to §3.6.4.
- **`packages/memory/v2/server.ts`**: dropped the comment clause claiming accepts carry "CT-1926's post-apply document where the server provides it" — that machinery (#5225) never landed.

## Validation

- `deno task check-docs` — all 536 blocks pass
- `deno fmt --check`, `deno lint`, `packages/memory` `deno task check` — clean
- Comment/spec-only; no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

