### PR TITLE
docs(features): pending replay applies ops; it no longer derives paths

### DIFF
--- a/docs/features/mergeable-collection-writes.md
+++ b/docs/features/mergeable-collection-writes.md
@@ -82,10 +82,10 @@ of a clobbering `set`.
 
 A dedicated op kind (rather than a flag on `splice`) cannot represent an invalid
 state: it has no vestigial index or remove count that must be ignored or
-constrained. It also forces every `switch (op.op)` site — op application, the
-conflict-touched-path and scheduler-dirty-path maps, and the client's optimistic
-replay — to handle `append` explicitly rather than silently inheriting `splice`'s
-behavior, which the type checker enforces. Its touched path is exactly the array
+constrained. It also forces every `switch (op.op)` site — op application and the
+conflict-touched-path and scheduler-dirty-path maps — to handle `append`
+explicitly rather than silently inheriting `splice`'s behavior, which the type
+checker enforces. Its touched path is exactly the array
 path, the same as `splice`, so reader-invalidation and scheduler-dirty semantics
 are unchanged. The set-add and counter-increment ops noted under Scope will be
 new op kinds in the same family.
@@ -117,9 +117,9 @@ The same machinery carries three mergeable ops. `append` is described below;
 
 - **`appendAtPath` (`packages/memory/v2/patch.ts`)** — thaws (and creates, if
   missing) the array at `path` and pushes `values` at the tail; `applyPatch`'s
-  `append` case calls it. This one place covers both the server's commit-time
-  materialization and a peer client replaying the revision. The two engine
-  touched-path maps and the client's optimistic-replay path each gain an
+  `append` case calls it. This one place covers the server's commit-time
+  materialization, a peer client replaying the revision, and the writer's own
+  optimistic pending replay. The two engine touched-path maps each gain an
   `append` case that returns the array path, the same as `splice`.
 
 - **Transaction (`packages/runner/src/storage/v2-transaction.ts`)** —
@@ -206,9 +206,8 @@ The same machinery carries three mergeable ops. `append` is described below;
 ### The op family
 
 `add-unique`, `increment`, and `remove-by-value` reuse every part of the above —
-the intent record, the op-builder, the read-set drop, the engine and
-optimistic-replay switch cases — differing only in the op they emit and how it
-applies:
+the intent record, the op-builder, the read-set drop, the engine touched-path
+switch cases — differing only in the op they emit and how it applies:
 
 - **`add-unique`** (`{ op: "add-unique"; path; values }`, `addUniqueAtPath`) —
   appends each value only if no existing element equals it by stored-value

--- a/docs/features/patch-operations.md
+++ b/docs/features/patch-operations.md
@@ -34,7 +34,7 @@ Two overlapping distinctions matter:
 - **Structural vs value-only.** `add`, `remove`, and `move` change a container's
   key-set (they add, drop, or reorder a child key). The rest change a value in
   place or at an array's own path. Structural ops need extra care in the conflict
-  and replay machinery (below).
+  machinery (below).
 - **Generated vs mergeable.** The structural and `replace`/`splice` ops are
   *generated* by diffing a handler's whole-value write against the transaction's
   base snapshot. The **mergeable** ops (`append`, `add-unique`, `increment`,
@@ -93,16 +93,18 @@ compile error). Each descriptor owns:
   leaf paths.
 - `structural` — whether the op changes a container's key-set.
 
-Three separate path computations derive from `pointerFields` + `structural` via
-the exported `touchedPointerPaths` / `patchOpIsStructural` helpers, instead of
+Two path computations derive from `pointerFields` + `structural` via the
+exported `touchedPointerPaths` / `patchOpIsStructural` helpers, instead of
 re-enumerating the ops:
 
 - `engine.ts` `touchedLeafPathsForPatch` — the exact leaf paths, for
   recursive-read commit conflicts and the scheduler reader-dirty index.
 - `engine.ts` `touchedPathsForPatch` — leaf paths plus the parent path for
   structural ops, for shape-only (nonRecursive) readers.
-- `runner storage/v2.ts` `changedPathsForPendingPatch` — leaf paths,
-  replay-resolved for structural ops, for the client's optimistic pending replay.
+
+The client's optimistic pending replay derives no paths: it applies a pending
+layer's ops to the delivered base through the shared `applyPatchToDocument`
+(`memory/v2/patch.ts`), skipping the whole layer when its ops cannot apply.
 
 ### 2. Mergeable-op descriptors — `packages/runner/src/storage/mergeable-ops.ts`
 
@@ -166,7 +168,7 @@ What catches a mistake, and how loudly:
 | Wire shape (`PatchOp` union) | `memory/v2.ts` |
 | Apply + `pointerFields` + `structural` | `memory/v2/patch.ts` (`patchOpDescriptors`) |
 | Conflict / reactivity touched paths | `memory/v2/engine.ts` (derives from the descriptors) |
-| Client pending-replay paths | `runner storage/v2.ts` (derives from the descriptors) |
+| Client pending replay | `runner storage/v2.ts` `applyPendingVersion` (applies ops via the shared `applyPatchToDocument`) |
 | Whole-value diff → structural/`replace`/`splice` ops | `runner storage/v2-transaction.ts` |
 | Mergeable intent fold + build | `runner storage/mergeable-ops.ts` |
 | Intent transport (`recordMergeableOp`) | `runner storage/interface.ts`, `extended-storage-transaction.ts` |


### PR DESCRIPTION
## Summary

#5521 deleted the client's projection replay — `changedPathsForPendingPatch`, `compactChangedPaths`, and the path-projection pass — and made `applyPendingVersion` replay every pending layer's wire ops over the delivered base via the shared `applyPatchToDocument`, skipping the whole layer when its ops cannot apply. Two feature docs still described the deleted machinery; this brings them in line. Surfaced while reviewing #5280, which was closed as superseded by #5521.

## Changes

- **`docs/features/patch-operations.md`**
  - Structural ops need extra care in the *conflict* machinery only; replay applies ops uniformly.
  - The path-computation list drops `changedPathsForPendingPatch` (the two `engine.ts` computations remain) and now states the client contract: pending replay derives no paths — it applies the layer's ops through the shared `applyPatchToDocument`, whole-layer skip on unappliable ops.
  - Ownership table: "Client pending-replay paths" → "Client pending replay" owned by `applyPendingVersion` via the shared apply.
- **`docs/features/mergeable-collection-writes.md`**
  - The `switch (op.op)` site enumeration no longer lists a client optimistic-replay switch (there isn't one).
  - The `appendAtPath` bullet names the one shared apply site's three consumers: server commit-time materialization, peer revision replay, and the writer's own optimistic pending replay.
  - The op-family reuse list says "engine touched-path switch cases".

## Validation

- `deno task check-docs` — all 536 blocks pass
- Docs-only; no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

