### PR TITLE
perf: cede fresh byte arrays, and stop boxing blob uploads

### DIFF
--- a/packages/runner/src/builtins/fetch.ts
+++ b/packages/runner/src/builtins/fetch.ts
@@ -153,9 +153,10 @@ async function processJsonResponse(
 async function processBinaryResponse(
   response: Response,
 ): Promise<FetchBinaryResult> {
-  // `arrayBuffer()` yields a buffer owned by nobody else, and the view over
-  // it is a temporary, so it is ceded rather than copied. A response body is
-  // unbounded, which is what makes the copy worth avoiding.
+  // The `true` below cedes the array to the `FabricBytes` rather than having
+  // it copied. `arrayBuffer()` yields a buffer nobody else holds, and the view
+  // over it is a temporary, so there is nothing left to protect. A response
+  // body is unbounded, which is what makes the copy worth avoiding.
   const bytes = new FabricBytes(
     new Uint8Array(await response.arrayBuffer()),
     true,

--- a/packages/runner/src/builtins/fetch.ts
+++ b/packages/runner/src/builtins/fetch.ts
@@ -153,7 +153,13 @@ async function processJsonResponse(
 async function processBinaryResponse(
   response: Response,
 ): Promise<FetchBinaryResult> {
-  const bytes = new FabricBytes(new Uint8Array(await response.arrayBuffer()));
+  // `arrayBuffer()` yields a buffer owned by nobody else, and the view over
+  // it is a temporary, so it is ceded rather than copied. A response body is
+  // unbounded, which is what makes the copy worth avoiding.
+  const bytes = new FabricBytes(
+    new Uint8Array(await response.arrayBuffer()),
+    true,
+  );
   const contentType = response.headers.get("content-type");
   const mediaType = contentType?.split(";")[0].trim().toLowerCase() ||
     "application/octet-stream";

--- a/packages/runner/src/sandbox/result-normalization.ts
+++ b/packages/runner/src/sandbox/result-normalization.ts
@@ -105,9 +105,10 @@ function normalizeSandboxNativeLeaf(value: unknown): unknown {
     brand === "[object Uint8Array]" && ArrayBuffer.isView(value) &&
     (value as Uint8Array).BYTES_PER_ELEMENT === 1
   ) {
-    // The inner copy is required -- `value` belongs to the sandbox -- but it
-    // is then unshared, so it is ceded rather than copied a second time.
-    return new FabricBytes(new Uint8Array(value as Uint8Array), true);
+    // One copy, made by the constructor: `value` belongs to the sandbox, so it
+    // cannot be ceded. Copying first and then ceding would cost the same copy
+    // and an extra buffer besides.
+    return new FabricBytes(value as Uint8Array);
   }
 
   if (isNativeError(value)) {

--- a/packages/runner/src/sandbox/result-normalization.ts
+++ b/packages/runner/src/sandbox/result-normalization.ts
@@ -105,7 +105,9 @@ function normalizeSandboxNativeLeaf(value: unknown): unknown {
     brand === "[object Uint8Array]" && ArrayBuffer.isView(value) &&
     (value as Uint8Array).BYTES_PER_ELEMENT === 1
   ) {
-    return new FabricBytes(new Uint8Array(value as Uint8Array));
+    // The inner copy is required -- `value` belongs to the sandbox -- but it
+    // is then unshared, so it is ceded rather than copied a second time.
+    return new FabricBytes(new Uint8Array(value as Uint8Array), true);
   }
 
   if (isNativeError(value)) {

--- a/packages/runner/src/sandbox/result-normalization.ts
+++ b/packages/runner/src/sandbox/result-normalization.ts
@@ -105,9 +105,9 @@ function normalizeSandboxNativeLeaf(value: unknown): unknown {
     brand === "[object Uint8Array]" && ArrayBuffer.isView(value) &&
     (value as Uint8Array).BYTES_PER_ELEMENT === 1
   ) {
-    // One copy, made by the constructor: `value` belongs to the sandbox, so it
-    // cannot be ceded. Copying first and then ceding would cost the same copy
-    // and an extra buffer besides.
+    // No second argument, so the constructor makes its own copy: `value`
+    // belongs to the sandbox and cannot be ceded. Copying first and then
+    // ceding would cost the same copy and an extra buffer besides.
     return new FabricBytes(value as Uint8Array);
   }
 

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -1402,7 +1402,9 @@ describe("RuntimeProcessor blob upload IPC", () => {
           type: RequestType.UploadBlob,
           space: "did:key:test-space" as never,
           contentType: "image/png",
-          body: [1, 2, 3],
+          // Freshly allocated, as the transport's clone delivers it: the
+          // handler owns its request's payload.
+          body: new Uint8Array([1, 2, 3]),
           suffix: "png",
         }),
       ).resolves.toEqual({

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -1578,9 +1578,9 @@ export class RuntimeProcessor {
       `/${request.space}/blobs/upload.${encodeURIComponent(suffix)}`,
       host,
     );
-    // `Uint8Array.from()` allocates, and its result goes nowhere but here, so
-    // it is ceded rather than copied a second time.
-    const bytes = new FabricBytes(Uint8Array.from(request.body), true);
+    // Ceded: a request arrives cloned by the transport, so its payload belongs
+    // to this handler and nothing else can be reading it.
+    const bytes = new FabricBytes(request.body, true);
     // Blob upload payloads must preserve FabricBytes even when the wider
     // process is running with legacy memory JSON flags.
     const body = blobUploadCodec.encode({

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -1571,7 +1571,6 @@ export class RuntimeProcessor {
       throw new Error("uploadBlob requires a space DID");
     }
     const suffix = (request.suffix ?? "bin").replace(/^\./, "") || "bin";
-    const bytes = Uint8Array.from(request.body);
     // The blob belongs to the named space, so it uploads to — and its
     // returned URL resolves against — THAT space's host.
     const host = this.runtime.hostForSpace(request.space);
@@ -1579,13 +1578,14 @@ export class RuntimeProcessor {
       `/${request.space}/blobs/upload.${encodeURIComponent(suffix)}`,
       host,
     );
+    // `Uint8Array.from()` allocates, and its result goes nowhere but here, so
+    // it is ceded rather than copied a second time.
+    const bytes = new FabricBytes(Uint8Array.from(request.body), true);
     // Blob upload payloads must preserve FabricBytes even when the wider
     // process is running with legacy memory JSON flags.
     const body = blobUploadCodec.encode({
       type: request.contentType,
-      // `bytes` comes fresh from `Uint8Array.from()` above and is used only
-      // here, so it is ceded rather than copied.
-      body: new FabricBytes(bytes, true),
+      body: bytes,
     });
     const response = await fetch(target, {
       method: "POST",

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -1578,8 +1578,10 @@ export class RuntimeProcessor {
       `/${request.space}/blobs/upload.${encodeURIComponent(suffix)}`,
       host,
     );
-    // Ceded: a request arrives cloned by the transport, so its payload belongs
-    // to this handler and nothing else can be reading it.
+    // The `true` below cedes `request.body` to the `FabricBytes` rather than
+    // having it copied. That is legitimate because a handler owns the values
+    // its request carries, per `BaseRequest`, so nothing else can be reading
+    // this array.
     const bytes = new FabricBytes(request.body, true);
     // Blob upload payloads must preserve FabricBytes even when the wider
     // process is running with legacy memory JSON flags.

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -1583,7 +1583,9 @@ export class RuntimeProcessor {
     // process is running with legacy memory JSON flags.
     const body = blobUploadCodec.encode({
       type: request.contentType,
-      body: new FabricBytes(bytes),
+      // `bytes` comes fresh from `Uint8Array.from()` above and is used only
+      // here, so it is ceded rather than copied.
+      body: new FabricBytes(bytes, true),
     });
     const response = await fetch(target, {
       method: "POST",

--- a/packages/runtime-client/client/transport.ts
+++ b/packages/runtime-client/client/transport.ts
@@ -10,6 +10,15 @@ export type RuntimeTransportEvents = {
 };
 
 export interface RuntimeTransport extends EventEmitter<RuntimeTransportEvents> {
+  /**
+   * Delivers a message to the far end, which must receive it as a value it
+   * owns outright -- unshared with the sender, and not becoming shared
+   * afterwards. `BaseRequest` states what a handler is then entitled to assume.
+   *
+   * Structured cloning satisfies this, so a `postMessage` transport gets it for
+   * nothing. A transport that would instead hand the same object to both ends
+   * does not, and cannot be used as-is.
+   */
   send(data: IPCClientMessage | IPCClientNotification): void;
   dispose(): Promise<void>;
 }

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -541,10 +541,9 @@ export interface UploadBlobRequest extends BaseRequest {
   space: DID;
   contentType: string;
   /**
-   * The blob's bytes. A `Uint8Array` rather than a `number[]` because this
-   * protocol never leaves one runtime instantiation, and structured cloning
-   * carries a typed array intact. Boxing each byte into an array element costs
-   * both the conversion and a far more expensive clone.
+   * The blob's bytes. The type has to stay structured-clone-able, this being an
+   * IPC payload: a class does not survive the crossing, where a typed array
+   * does and carries whole rather than element by element.
    */
   body: Uint8Array;
   suffix?: string;

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -135,6 +135,17 @@ export type IPCRemoteResponse = {
 
 export type IPCRemoteMessage = IPCRemoteNotification | IPCRemoteResponse;
 
+/**
+ * Base of every request a handler receives.
+ *
+ * **Ownership.** Any value reaching a handler implementation is owned outright
+ * by the receiver: it is guaranteed not to be shared elsewhere already, and not
+ * to become shared later, except by the receiver's own action. A handler may
+ * therefore retain, mutate, or cede what it is given without defending itself.
+ *
+ * That is a requirement on whatever delivers a request, not a property of any
+ * particular transport -- see `RuntimeTransport.send()`.
+ */
 export interface BaseRequest {
   type: RequestType;
 }
@@ -529,7 +540,13 @@ export interface UploadBlobRequest extends BaseRequest {
   /** The space the blob belongs to — uploads target ITS host. */
   space: DID;
   contentType: string;
-  body: number[];
+  /**
+   * The blob's bytes. A `Uint8Array` rather than a `number[]` because this
+   * protocol never leaves one runtime instantiation, and structured cloning
+   * carries a typed array intact. Boxing each byte into an array element costs
+   * both the conversion and a far more expensive clone.
+   */
+  body: Uint8Array;
   suffix?: string;
 }
 

--- a/packages/runtime-client/runtime-client.ts
+++ b/packages/runtime-client/runtime-client.ts
@@ -661,6 +661,10 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
     });
   }
 
+  /**
+   * Uploads a blob to the given space. `body` is not consumed -- it crosses to
+   * the runtime as a clone -- so the caller may keep using its array.
+   */
   async uploadBlob(options: {
     space: DID;
     contentType: string;
@@ -671,7 +675,7 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
       type: RequestType.UploadBlob,
       space: options.space,
       contentType: options.contentType,
-      body: Array.from(options.body),
+      body: options.body,
       suffix: options.suffix,
     });
   }


### PR DESCRIPTION
I (agent working on behalf of @danfuzz) started this as a narrow application of
the `transfer` parameter added by #5539 (`BL-007`). Review turned up two larger
things in the same area, so it now carries three related changes.

## 1. Cede where it earns its place

Ceding is worth it only where the array is **already fresh** and the alternative
is a real extra pass over the payload:

| site | source | what ceding saves |
| --- | --- | --- |
| `runner/src/builtins/fetch.ts` | `await response.arrayBuffer()` | `new Uint8Array(buf)` over that buffer is a **view, not a copy**, so ceding costs **zero** copies of an unbounded response body. Not ceding costs one full copy. |
| `runtime-client/backends/runtime-processor.ts` | the request's own payload | avoids a second pass over the blob |

`result-normalization.ts` moves the *other* way. An earlier version of this
description claimed it went "from two copies to one"; that was **wrong**.
`new FabricBytes(new Uint8Array(value), true)` and `new FabricBytes(value)` cost
exactly one copy either way — the constructor makes it when nothing is ceded —
so the first merely spent the same copy outside the constructor and added a
transferred buffer and a wrapper on top. It now reads `new FabricBytes(value)`.

## 2. A blob upload no longer boxes every byte

`UploadBlobRequest.body` was `number[]`. Nothing needed it to be: this protocol
never leaves one runtime instantiation, and its transport is structured cloning,
which carries a `Uint8Array` intact. The public API already took a `Uint8Array`
and converted *down* purely to cross the boundary.

Measured on a 1 MiB blob:

| step | `number[]` (before) | `Uint8Array` (after) |
| --- | --- | --- |
| sender `Array.from()` | 10.37 ms | — |
| transport `structuredClone` | 8.63 ms | 0.08 ms |
| receiver `Uint8Array.from()` | 0.34 ms | — |
| **total** | **19.34 ms** | **0.08 ms** |

`Uint8Array`, not `FabricBytes` — a class does not survive structured cloning,
which is exactly what broke `background-piece-service` and `cli` when tried on
`InsecureCryptoKeyPair` during #5542.

## 3. The ownership rule the cede rests on

The receiver cedes its request payload, which is only sound if nothing else
holds it. That was true because `postMessage` clones — an **implementation
detail of the one transport that exists**, not anything the interface required.
A future transport passing messages by reference would have satisfied
`RuntimeTransport` as written and silently broken the handler.

So it is now stated as a rule rather than relied on as a coincidence:

- **`BaseRequest`** — any value reaching a handler is owned outright by the
  receiver: not already shared, and not becoming shared later, except by the
  receiver's own action. A handler may retain, mutate, or cede without
  defending itself.
- **`RuntimeTransport.send()`** — the matching obligation on whatever delivers a
  request. Structured cloning satisfies it for free; a transport handing one
  object to both ends does not, and cannot be used as-is.

Stating it once at that level, rather than per payload, is what lets the next
binary field inherit it.

The test built its request with a `number[]`, so it did not model what a
transport delivers. It now allocates the array the handler is entitled to
consume — the code should not bend to an unrealistic test.

## Verification

`deno task check`, `deno fmt --check`, `deno lint`, `runner`, `runtime-client`,
and the full workspace suite, with current `main` merged in. `runtime-client`'s
test task runs `--no-check`, so `deno check` was also run directly against the
files it touches.

— Claude

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



