### PR TITLE
perf(toolshed): serve a blob without copying it twice

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -174,7 +174,7 @@ export declare const FabricLink: FabricLinkConstructor;
  */
 export interface FabricBytes extends FabricPrimitive {
   readonly length: number;
-  slice(start?: number, end?: number): Uint8Array;
+  slice(start?: number, end?: number): Uint8Array<ArrayBuffer>;
   copyInto(target: Uint8Array, offset?: number, length?: number): number;
 }
 

--- a/packages/data-model/src/fabric-primitives/FabricBytes.ts
+++ b/packages/data-model/src/fabric-primitives/FabricBytes.ts
@@ -57,12 +57,14 @@ export class FabricBytes extends BaseFabricPrimitive {
 
   /**
    * Returns a copy of the bytes (or a sub-range). The returned array is
-   * unshared -- the caller may mutate it freely.
+   * unshared -- the caller may mutate it freely -- and is backed by a plain
+   * `ArrayBuffer`, never a `SharedArrayBuffer`, so it is usable wherever one
+   * is required.
    *
    * @param start - Start index (inclusive, default 0).
    * @param end - End index (exclusive, default `length`).
    */
-  slice(start?: number, end?: number): Uint8Array {
+  slice(start?: number, end?: number): Uint8Array<ArrayBuffer> {
     return this.#bytes.slice(start, end);
   }
 

--- a/packages/toolshed/routes/blobs/blobs.index.ts
+++ b/packages/toolshed/routes/blobs/blobs.index.ts
@@ -258,11 +258,10 @@ router.get("/:spaceDid/blobs/:blobName", async (c) => {
     return c.text("Blob not found", 404);
   }
 
-  // `slice()` already yields an unshared array, so it goes to the response
-  // as-is rather than being copied again. The cast says what `slice()` cannot
-  // yet declare: a typed array's `slice()` always allocates a fresh, unshared
-  // `ArrayBuffer`, never a `SharedArrayBuffer`, which is what a body requires.
-  const body = contents.body.slice() as Uint8Array<ArrayBuffer>;
+  // `slice()` already yields an unshared array backed by a plain
+  // `ArrayBuffer`, which is what a body requires, so it goes to the response
+  // as-is rather than being copied again.
+  const body = contents.body.slice();
   return new Response(body, {
     status: 200,
     headers: {

--- a/packages/toolshed/routes/blobs/blobs.index.ts
+++ b/packages/toolshed/routes/blobs/blobs.index.ts
@@ -258,8 +258,11 @@ router.get("/:spaceDid/blobs/:blobName", async (c) => {
     return c.text("Blob not found", 404);
   }
 
-  const bytes = contents.body.slice();
-  const body = new Uint8Array(bytes).buffer;
+  // `slice()` already yields an unshared array, so it goes to the response
+  // as-is rather than being copied again. The cast says what `slice()` cannot
+  // yet declare: a typed array's `slice()` always allocates a fresh, unshared
+  // `ArrayBuffer`, never a `SharedArrayBuffer`, which is what a body requires.
+  const body = contents.body.slice() as Uint8Array<ArrayBuffer>;
   return new Response(body, {
     status: 200,
     headers: {

--- a/packages/toolshed/routes/blobs/blobs.index.ts
+++ b/packages/toolshed/routes/blobs/blobs.index.ts
@@ -258,9 +258,6 @@ router.get("/:spaceDid/blobs/:blobName", async (c) => {
     return c.text("Blob not found", 404);
   }
 
-  // `slice()` already yields an unshared array backed by a plain
-  // `ArrayBuffer`, which is what a body requires, so it goes to the response
-  // as-is rather than being copied again.
   const body = contents.body.slice();
   return new Response(body, {
     status: 200,


### PR DESCRIPTION
I (agent working on behalf of @danfuzz) found this sweeping for byte copies
standing immediately in front of a consumer that copies anyway.

Every blob download copied its payload **twice**:

```ts
const bytes = contents.body.slice();        // fresh, whole-buffer, unshared
const body = new Uint8Array(bytes).buffer;  // copied again
```

`slice()` already returns an array covering a buffer nothing else holds, so the
second copy bought nothing but a type. Blob bodies run to megabytes, and serving
one is pure data movement — no computation to hide a copy behind, which per the
measurements in #5539 is the only situation where removing one is worth
anything.

## The type was the real problem

That second copy existed to obtain an `ArrayBuffer`-typed buffer, because
`FabricBytes.slice()` was declared as returning plain `Uint8Array` — which
permits a `SharedArrayBuffer` backing, and a response body will not accept one.

But a typed array's `slice()` **always** allocates a fresh, unshared
`ArrayBuffer`; it cannot produce a shared one. The declaration understated the
method, and the copy (and later a cast) were paying for that understatement.

`slice()` now declares `Uint8Array<ArrayBuffer>`. The blob route needs neither
copy nor cast, and every caller wanting a `BodyInit` or `BufferSource` gains the
same. The new type is strictly more specific than what it replaces, so it cannot
break an existing caller.

That widens this PR to three files across three packages, which is worth
weighing in review. An earlier version of this description proposed the
tightening and then declined it as out of scope; on reflection that left the
symptom in place while naming the cause, which seemed the worse trade for two
declaration lines.

## Scope note

A second, similar double copy exists at `ui/.../cf-image.ts:66`, where the
result is handed to `new Blob()`, which copies regardless. It is **deliberately
not** here: `cf-image.test.ts:47` pins that copy explicitly ("A copy, not the
same backing buffer"), so removing it means deciding that stated contract is
wider than it needs to be — a `ui` call, not a byte-ownership one. Recorded in
the backlog instead.

## Verification

`deno task check`, `deno fmt --check`, `deno lint`, `data-model`, `api`,
`toolshed`, and the full workspace suite (`All tests passing!`), with current
`main` merged in.

— Claude

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5545?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


