### PR TITLE
feat(memory): manual subscription-flush mode for explicit fan-out gating (CT-1962)

### DIFF
--- a/packages/memory/test/v2-manual-flush.test.ts
+++ b/packages/memory/test/v2-manual-flush.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { FakeTime } from "@std/testing/time";
+import {
+  encodeMemoryBoundary,
+  getMemoryProtocolFlags,
+  MEMORY_PROTOCOL,
+  type ResponseMessage,
+  type ServerMessage,
+  type SessionEffectMessage,
+  type SessionOpenAuthMetadata,
+  type SessionSync,
+} from "../v2.ts";
+import { Server } from "../v2/server.ts";
+import { testSessionOpenServerOptions } from "./v2-auth-test-helpers.ts";
+
+// `subscriptionRefreshDelayMs: "manual"` is the fan-out gate for
+// controlled-staleness tests: the refresh timer is never armed, so dirty
+// spaces accumulate and fan out only through an explicit `flushSessions()`.
+// The FakeTime advances below are the structural negative — firing every
+// armed timer in the system delivers nothing, because there is no timer to
+// fire — paired with a timed-mode control that delivers through the same
+// advance.
+
+const HELLO = {
+  type: "hello",
+  protocol: MEMORY_PROTOCOL,
+  flags: getMemoryProtocolFlags(),
+} as const;
+
+const shiftMessage = (messages: ServerMessage[]): ServerMessage => {
+  const message = messages.shift();
+  expect(message).toBeDefined();
+  return message!;
+};
+
+const openWatchingSession = async (
+  server: Server,
+  space: string,
+  docId: string,
+): Promise<ServerMessage[]> => {
+  const messages: ServerMessage[] = [];
+  const connection = server.connect((message) => messages.push(message));
+  await connection.receive(encodeMemoryBoundary(HELLO));
+  const hello = shiftMessage(messages) as {
+    sessionOpen?: SessionOpenAuthMetadata;
+  };
+  const sessionOpen = hello.sessionOpen!;
+  await connection.receive(encodeMemoryBoundary({
+    type: "session.open",
+    requestId: "open",
+    space,
+    session: {},
+    invocation: {
+      aud: sessionOpen.audience,
+      challenge: sessionOpen.challenge.value,
+    },
+  }));
+  const sessionId =
+    (shiftMessage(messages) as ResponseMessage<{ sessionId: string }>)
+      .ok!.sessionId;
+  await connection.receive(encodeMemoryBoundary({
+    type: "session.watch.set",
+    requestId: "watch",
+    space,
+    sessionId,
+    watches: [{
+      id: "root",
+      kind: "graph",
+      query: {
+        roots: [{ id: docId, selector: { path: [], schema: false } }],
+      },
+    }],
+  }));
+  shiftMessage(messages);
+  return messages;
+};
+
+const deliveredDocIds = (messages: ServerMessage[]): string[] =>
+  messages
+    .filter((message) => message.type === "session/effect")
+    .flatMap((message) =>
+      ((message as SessionEffectMessage).effect as SessionSync).upserts
+        .map((upsert) => upsert.id)
+    );
+
+describe("v2 server manual flush mode", () => {
+  let time: FakeTime;
+
+  beforeEach(() => {
+    time = new FakeTime();
+  });
+
+  afterEach(() => {
+    time.restore();
+  });
+
+  it("holds fan-out until an explicit flush delivers it", async () => {
+    const server = new Server({
+      ...testSessionOpenServerOptions,
+      store: new URL("memory://manual-flush-holds"),
+      subscriptionRefreshDelayMs: "manual",
+    });
+    try {
+      const space = "did:key:z6Mk-manual-flush-holds";
+      const messages = await openWatchingSession(server, space, "of:doc:m");
+
+      await server.writeDocument(space, "of:doc:m", { held: true });
+      // The structural negative: advance far past any plausible coalescing
+      // delay, firing every armed timer — twice, matching the drive the
+      // timed-mode control delivers under. Manual mode armed none.
+      await time.tickAsync(60_000);
+      await time.tickAsync(60_000);
+      expect(deliveredDocIds(messages)).toEqual([]);
+
+      await server.flushSessions([space]);
+      expect(deliveredDocIds(messages)).toEqual(["of:doc:m"]);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("delivers through the same advance when a numeric delay is set", async () => {
+    // The control for the negative above: identical drive, timed mode — the
+    // advance alone must deliver, proving the observation channel works.
+    const server = new Server({
+      ...testSessionOpenServerOptions,
+      store: new URL("memory://manual-flush-control"),
+      subscriptionRefreshDelayMs: 1,
+    });
+    try {
+      const space = "did:key:z6Mk-manual-flush-control";
+      const messages = await openWatchingSession(server, space, "of:doc:c");
+
+      await server.writeDocument(space, "of:doc:c", { timed: true });
+      // Two advances: the first fires the refresh timer; the flush chain may
+      // arm a further zero-delay hop before delivering, which the second
+      // advance fires.
+      await time.tickAsync(60_000);
+      await time.tickAsync(60_000);
+      expect(deliveredDocIds(messages)).toEqual(["of:doc:c"]);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("keeps other dirty spaces held across a partial flush", async () => {
+    const server = new Server({
+      ...testSessionOpenServerOptions,
+      store: new URL("memory://manual-flush-partial"),
+      subscriptionRefreshDelayMs: "manual",
+    });
+    try {
+      const spaceA = "did:key:z6Mk-manual-partial-a";
+      const spaceB = "did:key:z6Mk-manual-partial-b";
+      const messagesA = await openWatchingSession(server, spaceA, "of:doc:a");
+      const messagesB = await openWatchingSession(server, spaceB, "of:doc:b");
+
+      await server.writeDocument(spaceA, "of:doc:a", { space: "a" });
+      await server.writeDocument(spaceB, "of:doc:b", { space: "b" });
+
+      await server.flushSessions([spaceA]);
+      expect(deliveredDocIds(messagesA)).toEqual(["of:doc:a"]);
+      expect(deliveredDocIds(messagesB)).toEqual([]);
+
+      // The partial flush must not have re-armed anything for the residue.
+      await time.tickAsync(60_000);
+      await time.tickAsync(60_000);
+      expect(deliveredDocIds(messagesB)).toEqual([]);
+
+      await server.flushSessions([spaceB]);
+      expect(deliveredDocIds(messagesB)).toEqual(["of:doc:b"]);
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/packages/memory/test/v2-manual-flush.test.ts
+++ b/packages/memory/test/v2-manual-flush.test.ts
@@ -144,6 +144,29 @@ describe("v2 server manual flush mode", () => {
     }
   });
 
+  it("drains held fan-out at idle()", async () => {
+    const server = new Server({
+      ...testSessionOpenServerOptions,
+      store: new URL("memory://manual-flush-idle"),
+      subscriptionRefreshDelayMs: "manual",
+    });
+    try {
+      const space = "did:key:z6Mk-manual-flush-idle";
+      const messages = await openWatchingSession(server, space, "of:doc:i");
+
+      await server.writeDocument(space, "of:doc:i", { held: true });
+      await time.tickAsync(60_000);
+      expect(deliveredDocIds(messages)).toEqual([]);
+
+      // idle() is an explicit synchronization point like flushSessions():
+      // returning with held fan-out would break its quiescence contract.
+      await server.idle();
+      expect(deliveredDocIds(messages)).toEqual(["of:doc:i"]);
+    } finally {
+      await server.close();
+    }
+  });
+
   it("keeps other dirty spaces held across a partial flush", async () => {
     const server = new Server({
       ...testSessionOpenServerOptions,

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -988,11 +988,13 @@ export class Server {
       /**
        * Coalescing delay for the batched subscription fan-out, in
        * milliseconds. `"manual"` never arms the refresh timer: dirty spaces
-       * accumulate and fan out only through an explicit `flushSessions()`
-       * call — the fan-out gate for controlled-staleness tests, immune to
-       * fake-clock auto-advance, which fires any armed timer regardless of
-       * its nominal delay. A partial `flushSessions(spaces)` in manual mode
-       * leaves the other dirty spaces held for the next explicit call.
+       * accumulate and fan out only through the explicit synchronization
+       * points — `flushSessions()`, or `idle()`, which drains held fan-out
+       * to keep its quiescence contract. This is the fan-out gate for
+       * controlled-staleness tests, immune to fake-clock auto-advance,
+       * which fires any armed timer regardless of its nominal delay. A
+       * partial `flushSessions(spaces)` in manual mode leaves the other
+       * dirty spaces held for the next explicit call.
        */
       subscriptionRefreshDelayMs?: number | "manual";
       authorizeSessionOpen: (
@@ -1417,7 +1419,14 @@ export class Server {
   async idle(): Promise<void> {
     await this.drainSpacePublicationLocks();
     await this.drainPostCommitSchedulerSideEffects();
-    if (this.#refreshTimer !== null || this.#refreshing !== null) {
+    // Dirty spaces with no timer armed are manual mode's held fan-out.
+    // idle() is an explicit synchronization point exactly like
+    // flushSessions(), so it drains them rather than returning with
+    // pending work — "manual" gates the TIMER, not the explicit calls.
+    if (
+      this.#refreshTimer !== null || this.#refreshing !== null ||
+      this.#dirtySpaces.size > 0
+    ) {
       await this.flushSessions();
     }
   }

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -985,7 +985,16 @@ export class Server {
     readonly options: {
       sessions?: SessionRegistry;
       store?: URL;
-      subscriptionRefreshDelayMs?: number;
+      /**
+       * Coalescing delay for the batched subscription fan-out, in
+       * milliseconds. `"manual"` never arms the refresh timer: dirty spaces
+       * accumulate and fan out only through an explicit `flushSessions()`
+       * call — the fan-out gate for controlled-staleness tests, immune to
+       * fake-clock auto-advance, which fires any armed timer regardless of
+       * its nominal delay. A partial `flushSessions(spaces)` in manual mode
+       * leaves the other dirty spaces held for the next explicit call.
+       */
+      subscriptionRefreshDelayMs?: number | "manual";
       authorizeSessionOpen: (
         message: SessionOpenRequest,
         context: SessionOpenAuthContext,
@@ -3613,7 +3622,10 @@ export class Server {
   }
 
   private scheduleRefresh(): void {
-    if (this.#dirtySpaces.size === 0 || this.#refreshTimer !== null) {
+    if (
+      this.options.subscriptionRefreshDelayMs === "manual" ||
+      this.#dirtySpaces.size === 0 || this.#refreshTimer !== null
+    ) {
       return;
     }
     this.#refreshTimer = setTimeout(


### PR DESCRIPTION
## Summary

First of four CT-1962 PRs (timer-turn loopback delivery). `subscriptionRefreshDelayMs` widens to `number | "manual"`: manual mode never arms the refresh timer, so dirty spaces accumulate and fan out only through explicit `flushSessions()` calls, and a partial `flushSessions(spaces)` leaves the other dirty spaces held.

Why a sentinel and not a large delay: under the runner's fake-clock auto-advance, the pump fires the earliest armed prod timer regardless of its nominal delay — a 60s delay is not a hold once loopback delivery yields real timer turns. The gate has to be structural: no timer exists to fire. (`null` was rejected because `?? SUBSCRIPTION_REFRESH_DELAY_MS` would swallow it silently.)

## Tests

New `v2-manual-flush.test.ts` (BDD): manual mode holds fan-out across two 60s all-timer advances and delivers on explicit flush; a timed-mode control delivers under the identical drive (the negative's paired control); a partial flush keeps other spaces held with nothing re-armed.

Memory suite: 493 passed. `deno task check`, fmt, lint green.

## Follow-ups in this arc

PR 2: shared-harness extraction (32 copy-pasted `SharedServerStorageManager` sites). PR 3: staleness-family conversions to manual flush. PR 4: the loopback timer-turn flip itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

