### PR TITLE
refactor(runner,piece,cli): extract the shared loopback-server harness (CT-1962)

### DIFF
--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -11,9 +11,9 @@ import {
 } from "@commonfabric/runner";
 import {
   EmulatedStorageManager,
+  newLoopbackServer,
   StorageManager,
 } from "@commonfabric/runner/storage/cache.deno";
-import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import { FabricError } from "@commonfabric/data-model/fabric-instances";
 import { FabricSpecialObject } from "@commonfabric/data-model/fabric-value";
 import { FabricHash } from "@commonfabric/data-model/fabric-primitives";
@@ -2727,32 +2727,7 @@ describe("cli piece parsing", () => {
       "cf piece search cold runtime test",
     );
     const space = signer.did();
-    const audience = "did:key:z6Mk-runner-emulated-memory";
-    const server = new MemoryV2Server.Server({
-      authorizeSessionOpen(message) {
-        const principal = (message.authorization as { principal?: unknown })
-          ?.principal;
-        return typeof principal === "string" ? principal : undefined;
-      },
-      sessionOpenAuth: { audience },
-    });
-
-    class SharedStorage extends EmulatedStorageManager {
-      static connect(server: MemoryV2Server.Server): SharedStorage {
-        const manager = new SharedStorage(
-          { as: signer, memoryHost: new URL("memory://") } as any,
-          () => server,
-        );
-        manager.#server = server;
-        return manager;
-      }
-
-      #server!: MemoryV2Server.Server;
-
-      protected override server(): MemoryV2Server.Server {
-        return this.#server;
-      }
-    }
+    const server = newLoopbackServer();
 
     const leafSchema = {
       type: "object",
@@ -2769,7 +2744,9 @@ describe("cli piece parsing", () => {
       properties: { middle: { ...middleSchema, asCell: ["cell"] } },
       required: ["middle"],
     } as const satisfies JSONSchema;
-    const writerStorage = SharedStorage.connect(server);
+    const writerStorage = EmulatedStorageManager.connectTo(server, {
+      as: signer,
+    });
     const writer = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager: writerStorage,
@@ -2799,7 +2776,9 @@ describe("cli piece parsing", () => {
     await writeTx.commit();
     await writerStorage.synced();
 
-    const readerStorage = SharedStorage.connect(server);
+    const readerStorage = EmulatedStorageManager.connectTo(server, {
+      as: signer,
+    });
     const reader = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager: readerStorage,

--- a/packages/memory/test/v2-manual-flush.test.ts
+++ b/packages/memory/test/v2-manual-flush.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { FakeTime } from "@std/testing/time";
+import {
+  encodeMemoryBoundary,
+  getMemoryProtocolFlags,
+  MEMORY_PROTOCOL,
+  type ResponseMessage,
+  type ServerMessage,
+  type SessionEffectMessage,
+  type SessionOpenAuthMetadata,
+  type SessionSync,
+} from "../v2.ts";
+import { Server } from "../v2/server.ts";
+import { testSessionOpenServerOptions } from "./v2-auth-test-helpers.ts";
+
+// `subscriptionRefreshDelayMs: "manual"` is the fan-out gate for
+// controlled-staleness tests: the refresh timer is never armed, so dirty
+// spaces accumulate and fan out only through an explicit `flushSessions()`.
+// The FakeTime advances below are the structural negative — firing every
+// armed timer in the system delivers nothing, because there is no timer to
+// fire — paired with a timed-mode control that delivers through the same
+// advance.
+
+const HELLO = {
+  type: "hello",
+  protocol: MEMORY_PROTOCOL,
+  flags: getMemoryProtocolFlags(),
+} as const;
+
+const shiftMessage = (messages: ServerMessage[]): ServerMessage => {
+  const message = messages.shift();
+  expect(message).toBeDefined();
+  return message!;
+};
+
+const openWatchingSession = async (
+  server: Server,
+  space: string,
+  docId: string,
+): Promise<ServerMessage[]> => {
+  const messages: ServerMessage[] = [];
+  const connection = server.connect((message) => messages.push(message));
+  await connection.receive(encodeMemoryBoundary(HELLO));
+  const hello = shiftMessage(messages) as {
+    sessionOpen?: SessionOpenAuthMetadata;
+  };
+  const sessionOpen = hello.sessionOpen!;
+  await connection.receive(encodeMemoryBoundary({
+    type: "session.open",
+    requestId: "open",
+    space,
+    session: {},
+    invocation: {
+      aud: sessionOpen.audience,
+      challenge: sessionOpen.challenge.value,
+    },
+  }));
+  const sessionId =
+    (shiftMessage(messages) as ResponseMessage<{ sessionId: string }>)
+      .ok!.sessionId;
+  await connection.receive(encodeMemoryBoundary({
+    type: "session.watch.set",
+    requestId: "watch",
+    space,
+    sessionId,
+    watches: [{
+      id: "root",
+      kind: "graph",
+      query: {
+        roots: [{ id: docId, selector: { path: [], schema: false } }],
+      },
+    }],
+  }));
+  shiftMessage(messages);
+  return messages;
+};
+
+const deliveredDocIds = (messages: ServerMessage[]): string[] =>
+  messages
+    .filter((message) => message.type === "session/effect")
+    .flatMap((message) =>
+      ((message as SessionEffectMessage).effect as SessionSync).upserts
+        .map((upsert) => upsert.id)
+    );
+
+describe("v2 server manual flush mode", () => {
+  let time: FakeTime;
+
+  beforeEach(() => {
+    time = new FakeTime();
+  });
+
+  afterEach(() => {
+    time.restore();
+  });
+
+  it("holds fan-out until an explicit flush delivers it", async () => {
+    const server = new Server({
+      ...testSessionOpenServerOptions,
+      store: new URL("memory://manual-flush-holds"),
+      subscriptionRefreshDelayMs: "manual",
+    });
+    try {
+      const space = "did:key:z6Mk-manual-flush-holds";
+      const messages = await openWatchingSession(server, space, "of:doc:m");
+
+      await server.writeDocument(space, "of:doc:m", { held: true });
+      // The structural negative: advance far past any plausible coalescing
+      // delay, firing every armed timer — twice, matching the drive the
+      // timed-mode control delivers under. Manual mode armed none.
+      await time.tickAsync(60_000);
+      await time.tickAsync(60_000);
+      expect(deliveredDocIds(messages)).toEqual([]);
+
+      await server.flushSessions([space]);
+      expect(deliveredDocIds(messages)).toEqual(["of:doc:m"]);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("delivers through the same advance when a numeric delay is set", async () => {
+    // The control for the negative above: identical drive, timed mode — the
+    // advance alone must deliver, proving the observation channel works.
+    const server = new Server({
+      ...testSessionOpenServerOptions,
+      store: new URL("memory://manual-flush-control"),
+      subscriptionRefreshDelayMs: 1,
+    });
+    try {
+      const space = "did:key:z6Mk-manual-flush-control";
+      const messages = await openWatchingSession(server, space, "of:doc:c");
+
+      await server.writeDocument(space, "of:doc:c", { timed: true });
+      // Two advances: the first fires the refresh timer; the flush chain may
+      // arm a further zero-delay hop before delivering, which the second
+      // advance fires.
+      await time.tickAsync(60_000);
+      await time.tickAsync(60_000);
+      expect(deliveredDocIds(messages)).toEqual(["of:doc:c"]);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("keeps other dirty spaces held across a partial flush", async () => {
+    const server = new Server({
+      ...testSessionOpenServerOptions,
+      store: new URL("memory://manual-flush-partial"),
+      subscriptionRefreshDelayMs: "manual",
+    });
+    try {
+      const spaceA = "did:key:z6Mk-manual-partial-a";
+      const spaceB = "did:key:z6Mk-manual-partial-b";
+      const messagesA = await openWatchingSession(server, spaceA, "of:doc:a");
+      const messagesB = await openWatchingSession(server, spaceB, "of:doc:b");
+
+      await server.writeDocument(spaceA, "of:doc:a", { space: "a" });
+      await server.writeDocument(spaceB, "of:doc:b", { space: "b" });
+
+      await server.flushSessions([spaceA]);
+      expect(deliveredDocIds(messagesA)).toEqual(["of:doc:a"]);
+      expect(deliveredDocIds(messagesB)).toEqual([]);
+
+      // The partial flush must not have re-armed anything for the residue.
+      await time.tickAsync(60_000);
+      await time.tickAsync(60_000);
+      expect(deliveredDocIds(messagesB)).toEqual([]);
+
+      await server.flushSessions([spaceB]);
+      expect(deliveredDocIds(messagesB)).toEqual(["of:doc:b"]);
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/packages/memory/test/v2-manual-flush.test.ts
+++ b/packages/memory/test/v2-manual-flush.test.ts
@@ -144,6 +144,29 @@ describe("v2 server manual flush mode", () => {
     }
   });
 
+  it("drains held fan-out at idle()", async () => {
+    const server = new Server({
+      ...testSessionOpenServerOptions,
+      store: new URL("memory://manual-flush-idle"),
+      subscriptionRefreshDelayMs: "manual",
+    });
+    try {
+      const space = "did:key:z6Mk-manual-flush-idle";
+      const messages = await openWatchingSession(server, space, "of:doc:i");
+
+      await server.writeDocument(space, "of:doc:i", { held: true });
+      await time.tickAsync(60_000);
+      expect(deliveredDocIds(messages)).toEqual([]);
+
+      // idle() is an explicit synchronization point like flushSessions():
+      // returning with held fan-out would break its quiescence contract.
+      await server.idle();
+      expect(deliveredDocIds(messages)).toEqual(["of:doc:i"]);
+    } finally {
+      await server.close();
+    }
+  });
+
   it("keeps other dirty spaces held across a partial flush", async () => {
     const server = new Server({
       ...testSessionOpenServerOptions,

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -988,11 +988,13 @@ export class Server {
       /**
        * Coalescing delay for the batched subscription fan-out, in
        * milliseconds. `"manual"` never arms the refresh timer: dirty spaces
-       * accumulate and fan out only through an explicit `flushSessions()`
-       * call — the fan-out gate for controlled-staleness tests, immune to
-       * fake-clock auto-advance, which fires any armed timer regardless of
-       * its nominal delay. A partial `flushSessions(spaces)` in manual mode
-       * leaves the other dirty spaces held for the next explicit call.
+       * accumulate and fan out only through the explicit synchronization
+       * points — `flushSessions()`, or `idle()`, which drains held fan-out
+       * to keep its quiescence contract. This is the fan-out gate for
+       * controlled-staleness tests, immune to fake-clock auto-advance,
+       * which fires any armed timer regardless of its nominal delay. A
+       * partial `flushSessions(spaces)` in manual mode leaves the other
+       * dirty spaces held for the next explicit call.
        */
       subscriptionRefreshDelayMs?: number | "manual";
       authorizeSessionOpen: (
@@ -1417,7 +1419,14 @@ export class Server {
   async idle(): Promise<void> {
     await this.drainSpacePublicationLocks();
     await this.drainPostCommitSchedulerSideEffects();
-    if (this.#refreshTimer !== null || this.#refreshing !== null) {
+    // Dirty spaces with no timer armed are manual mode's held fan-out.
+    // idle() is an explicit synchronization point exactly like
+    // flushSessions(), so it drains them rather than returning with
+    // pending work — "manual" gates the TIMER, not the explicit calls.
+    if (
+      this.#refreshTimer !== null || this.#refreshing !== null ||
+      this.#dirtySpaces.size > 0
+    ) {
       await this.flushSessions();
     }
   }

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -985,7 +985,16 @@ export class Server {
     readonly options: {
       sessions?: SessionRegistry;
       store?: URL;
-      subscriptionRefreshDelayMs?: number;
+      /**
+       * Coalescing delay for the batched subscription fan-out, in
+       * milliseconds. `"manual"` never arms the refresh timer: dirty spaces
+       * accumulate and fan out only through an explicit `flushSessions()`
+       * call — the fan-out gate for controlled-staleness tests, immune to
+       * fake-clock auto-advance, which fires any armed timer regardless of
+       * its nominal delay. A partial `flushSessions(spaces)` in manual mode
+       * leaves the other dirty spaces held for the next explicit call.
+       */
+      subscriptionRefreshDelayMs?: number | "manual";
       authorizeSessionOpen: (
         message: SessionOpenRequest,
         context: SessionOpenAuthContext,
@@ -3613,7 +3622,10 @@ export class Server {
   }
 
   private scheduleRefresh(): void {
-    if (this.#dirtySpaces.size === 0 || this.#refreshTimer !== null) {
+    if (
+      this.options.subscriptionRefreshDelayMs === "manual" ||
+      this.#dirtySpaces.size === 0 || this.#refreshTimer !== null
+    ) {
       return;
     }
     this.#refreshTimer = setTimeout(

--- a/packages/piece/test/default-app-golden-replay.test.ts
+++ b/packages/piece/test/default-app-golden-replay.test.ts
@@ -9,6 +9,7 @@ import {
 } from "@commonfabric/runner";
 import {
   EmulatedStorageManager,
+  newLoopbackServer,
 } from "@commonfabric/runner/storage/cache.deno";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import { createSession, Identity } from "@commonfabric/identity";
@@ -32,38 +33,7 @@ const DEFAULT_APP_PATTERN_PATH = resolveSystemPatternSource(
 
 const signer = await Identity.fromPassphrase("default-app golden replay");
 
-const EMULATED_AUDIENCE = "did:key:z6Mk-runner-emulated-memory";
-
-function newSharedServer(): MemoryV2Server.Server {
-  return new MemoryV2Server.Server({
-    authorizeSessionOpen(message) {
-      const principal = (message.authorization as { principal?: unknown })
-        ?.principal;
-      return typeof principal === "string" ? principal : undefined;
-    },
-    sessionOpenAuth: { audience: EMULATED_AUDIENCE },
-  });
-}
-
-class SharedServerStorageManager extends EmulatedStorageManager {
-  static connectTo(
-    server: MemoryV2Server.Server,
-  ): SharedServerStorageManager {
-    const controller = new SharedServerStorageManager(
-      // deno-lint-ignore no-explicit-any
-      { as: signer, memoryHost: new URL("memory://") } as any,
-      () => server,
-    );
-    controller.#sharedServer = server;
-    return controller;
-  }
-
-  #sharedServer!: MemoryV2Server.Server;
-
-  protected override server(): MemoryV2Server.Server {
-    return this.#sharedServer;
-  }
-}
+const newSharedServer = (): MemoryV2Server.Server => newLoopbackServer();
 
 // A default-app-shaped root before and after the registry rename. V2 keeps the
 // old owned-cell cause privately and migrates its contents into the new cell
@@ -162,7 +132,7 @@ function installFetchStub(): StubControls {
 describe("default-app golden replay (state survives an in-place roll-forward)", () => {
   let stub: StubControls;
   let server: MemoryV2Server.Server;
-  let storageManager: SharedServerStorageManager;
+  let storageManager: EmulatedStorageManager;
   let runtime: Runtime;
   let controller: PiecesController;
 
@@ -170,7 +140,7 @@ describe("default-app golden replay (state survives an in-place roll-forward)", 
     stub = installFetchStub();
     stub.setSource(ROOT_V1);
     server = newSharedServer();
-    storageManager = SharedServerStorageManager.connectTo(server);
+    storageManager = EmulatedStorageManager.connectTo(server, { as: signer });
     runtime = new Runtime({
       apiUrl: new URL("http://toolshed.test"),
       storageManager,
@@ -318,7 +288,9 @@ describe("default-app golden replay (state survives an in-place roll-forward)", 
       identity: signer,
       spaceName: controller.getSpaceName()!,
     });
-    const readerStorage = SharedServerStorageManager.connectTo(server);
+    const readerStorage = EmulatedStorageManager.connectTo(server, {
+      as: signer,
+    });
     const freshRuntime = new Runtime({
       apiUrl: new URL("http://toolshed.test"),
       storageManager: readerStorage,

--- a/packages/piece/test/pull-materialization.test.ts
+++ b/packages/piece/test/pull-materialization.test.ts
@@ -23,6 +23,7 @@ import {
 import { defer } from "@commonfabric/utils/defer";
 import {
   EmulatedStorageManager,
+  newLoopbackServer,
   StorageManager,
 } from "@commonfabric/runner/storage/cache.deno";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
@@ -473,40 +474,10 @@ async function withInputRootPullSpy<T>(
 
 // Two-replica harness: a server that several emulated replicas can share, so a
 // fresh reader must fetch cross-replica rather than read its own warm cache.
-// Mirrors newSharedServer/SharedServerStorageManager in
+// Mirrors newSharedServer/EmulatedStorageManager.connectTo in
 // fresh-replica-read-asymmetry.test.ts; the auth matches the server
 // EmulatedStorageManager.emulate builds for itself (v2-emulate.ts).
-const EMULATED_AUDIENCE = "did:key:z6Mk-runner-emulated-memory";
-
-function newSharedServer(): MemoryV2Server.Server {
-  return new MemoryV2Server.Server({
-    authorizeSessionOpen(message) {
-      const principal = (message.authorization as { principal?: unknown })
-        ?.principal;
-      return typeof principal === "string" ? principal : undefined;
-    },
-    sessionOpenAuth: { audience: EMULATED_AUDIENCE },
-  });
-}
-
-class SharedServerStorageManager extends EmulatedStorageManager {
-  static connectTo(
-    server: MemoryV2Server.Server,
-    options: { as: typeof signer },
-  ): SharedServerStorageManager {
-    const pieces = new SharedServerStorageManager(
-      // deno-lint-ignore no-explicit-any
-      { ...options, memoryHost: new URL("memory://") } as any,
-      () => server,
-    );
-    pieces.#sharedServer = server;
-    return pieces;
-  }
-  #sharedServer!: MemoryV2Server.Server;
-  protected override server(): MemoryV2Server.Server {
-    return this.#sharedServer;
-  }
-}
+const newSharedServer = (): MemoryV2Server.Server => newLoopbackServer();
 
 describe("piece link contract localization", () => {
   const contract = (schema: JSONSchema, root: JSONSchema = schema) => ({
@@ -7112,14 +7083,14 @@ describe("piece pull materialization", () => {
 
 describe("piece cold-replica slot read (two replicas, one server)", () => {
   let server: MemoryV2Server.Server;
-  let writerStorage: SharedServerStorageManager;
+  let writerStorage: EmulatedStorageManager;
   let writerRuntime: Runtime;
   let writerPieces: PiecesController;
   let spaceName: string;
 
   beforeEach(async () => {
     server = newSharedServer();
-    writerStorage = SharedServerStorageManager.connectTo(server, {
+    writerStorage = EmulatedStorageManager.connectTo(server, {
       as: signer,
     });
     writerRuntime = new Runtime({
@@ -7162,7 +7133,7 @@ describe("piece cold-replica slot read (two replicas, one server)", () => {
     // never pulled K. Reading the slot by its fid must canonicalize R -> K (a
     // VALUE link) AND cold-fetch K's docs from the server — the end-to-end
     // behavior the local-toolshed run confirmed, now repeatable in-process.
-    const readerStorage = SharedServerStorageManager.connectTo(server, {
+    const readerStorage = EmulatedStorageManager.connectTo(server, {
       as: signer,
     });
     const readerRuntime = new Runtime({
@@ -7236,7 +7207,7 @@ describe("piece cold-replica slot read (two replicas, one server)", () => {
     );
     await writerPieces.synced();
 
-    const readerStorage = SharedServerStorageManager.connectTo(server, {
+    const readerStorage = EmulatedStorageManager.connectTo(server, {
       as: signer,
     });
     const readerRuntime = new Runtime({
@@ -7374,7 +7345,7 @@ describe("piece cold-replica slot read (two replicas, one server)", () => {
     );
     await writerPieces.synced();
 
-    const readerStorage = SharedServerStorageManager.connectTo(server, {
+    const readerStorage = EmulatedStorageManager.connectTo(server, {
       as: signer,
     });
     const readerRuntime = new Runtime({

--- a/packages/runner/src/storage/cache.deno.ts
+++ b/packages/runner/src/storage/cache.deno.ts
@@ -2,7 +2,7 @@ export * from "@commonfabric/memory/interface";
 import * as V2Storage from "./v2.ts";
 import { EmulatedStorageManager } from "./v2-emulate.ts";
 
-export { EmulatedStorageManager } from "./v2-emulate.ts";
+export { EmulatedStorageManager, newLoopbackServer } from "./v2-emulate.ts";
 export { EmulatedStorageManager as StorageManagerEmulator } from "./v2-emulate.ts";
 export { SelectorTracker } from "./selector-tracker.ts";
 export { type Options, type SessionFactory, watchIdForEntry } from "./v2.ts";

--- a/packages/runner/src/storage/v2-emulate.ts
+++ b/packages/runner/src/storage/v2-emulate.ts
@@ -8,8 +8,10 @@ const emulatedMemoryAudience = "did:key:z6Mk-runner-emulated-memory";
 /**
  * Build a stock in-process memory server for loopback storage managers: the
  * principal-passthrough authorizer, an emulated audience, and optionally a
- * fan-out cadence — `"manual"` gates fan-out entirely behind explicit
- * `flushSessions()` calls, the controlled-staleness shape.
+ * fan-out cadence — `"manual"` disables timer-driven fan-out entirely:
+ * either explicit synchronization point (`flushSessions()`, or `idle()`,
+ * which drains held fan-out to keep its quiescence contract) delivers it.
+ * The controlled-staleness shape.
  */
 export const newLoopbackServer = (options?: {
   audience?: string;

--- a/packages/runner/src/storage/v2-emulate.ts
+++ b/packages/runner/src/storage/v2-emulate.ts
@@ -5,6 +5,32 @@ import { type Options, type SessionFactory, StorageManager } from "./v2.ts";
 
 const emulatedMemoryAudience = "did:key:z6Mk-runner-emulated-memory";
 
+/**
+ * Build a stock in-process memory server for loopback storage managers: the
+ * principal-passthrough authorizer, an emulated audience, and optionally a
+ * fan-out cadence — `"manual"` gates fan-out entirely behind explicit
+ * `flushSessions()` calls, the controlled-staleness shape.
+ */
+export const newLoopbackServer = (options?: {
+  audience?: string;
+  subscriptionRefreshDelayMs?: number | "manual";
+  store?: URL;
+}): MemoryV2Server.Server =>
+  new MemoryV2Server.Server({
+    authorizeSessionOpen(message) {
+      const principal = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof principal === "string" ? principal : undefined;
+    },
+    sessionOpenAuth: {
+      audience: options?.audience ?? emulatedMemoryAudience,
+    },
+    ...(options?.subscriptionRefreshDelayMs !== undefined
+      ? { subscriptionRefreshDelayMs: options.subscriptionRefreshDelayMs }
+      : {}),
+    ...(options?.store !== undefined ? { store: options.store } : {}),
+  });
+
 // Nudge the server's session fan-out after each request, on a microtask. A
 // commit promise resolves at marker coverage (CT-1950), and the catch-up
 // marker rides the batched fan-out; behind the server's coalescing TIMER it
@@ -65,6 +91,7 @@ class EmulatedSessionFactory implements SessionFactory {
 export class EmulatedStorageManager extends StorageManager {
   #serverFactory: () => MemoryV2Server.Server;
   #server?: MemoryV2Server.Server;
+  #ownsServer = true;
 
   static emulate(
     options: Omit<Options, "memoryHost" | "spaceHostMap">,
@@ -76,24 +103,35 @@ export class EmulatedStorageManager extends StorageManager {
         // resolves a storage address against this.
         memoryHost: new URL("memory://"),
       },
-      () =>
-        new MemoryV2Server.Server({
-          authorizeSessionOpen(message) {
-            const principal = (message.authorization as { principal?: unknown })
-              ?.principal;
-            return typeof principal === "string" ? principal : undefined;
-          },
-          sessionOpenAuth: {
-            audience: emulatedMemoryAudience,
-          },
-        }),
+      () => newLoopbackServer(),
       // Single-manager emulation wants request-coupled fan-out (see
       // flushOnSendTransport). Harnesses that share one server across
-      // managers use the protected constructor and keep the server's timed
-      // cadence: their controlled-staleness premises depend on frames NOT
-      // spreading until the test lets them.
+      // managers use connectTo() and keep the server's own cadence: their
+      // controlled-staleness premises depend on frames NOT spreading until
+      // the test lets them.
       true,
     );
+  }
+
+  /**
+   * Connect a manager to an externally owned shared server: several managers
+   * on one server model several real sessions, where data written by one
+   * reaches another only through an explicit per-space server
+   * query/subscription. Fan-out keeps the server's own cadence (no
+   * flush-on-send nudge), and the CALLER owns the server's lifecycle —
+   * closing this manager does not close the shared server.
+   */
+  static connectTo(
+    server: MemoryV2Server.Server,
+    options: Omit<Options, "memoryHost" | "spaceHostMap">,
+  ): EmulatedStorageManager {
+    const manager = new this(
+      { ...options, memoryHost: new URL("memory://") },
+      () => server,
+      false,
+    );
+    manager.#ownsServer = false;
+    return manager;
   }
 
   protected constructor(
@@ -125,7 +163,7 @@ export class EmulatedStorageManager extends StorageManager {
 
   override async close(): Promise<void> {
     await super.close();
-    if (this.#server) {
+    if (this.#server && this.#ownsServer) {
       await this.#server.close();
     }
   }

--- a/packages/runner/test/action-result-fabric-values.test.ts
+++ b/packages/runner/test/action-result-fabric-values.test.ts
@@ -11,7 +11,6 @@ import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import { Runtime } from "../src/runtime.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
-import type { Options } from "../src/storage/v2.ts";
 import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
 
 const signer = await Identity.fromPassphrase("action result FabricValues");
@@ -97,27 +96,7 @@ const REEMIT_PROGRAM: RuntimeProgram = {
   }],
 };
 
-class SharedServerStorageManager extends EmulatedStorageManager {
-  static connectTo(
-    server: MemoryV2Server.Server,
-    options: Omit<Options, "memoryHost" | "spaceHostMap">,
-  ): SharedServerStorageManager {
-    const manager = new SharedServerStorageManager(
-      { ...options, memoryHost: new URL("memory://") },
-      () => server,
-    );
-    manager.sharedServer = server;
-    return manager;
-  }
-
-  private sharedServer!: MemoryV2Server.Server;
-
-  protected override server(): MemoryV2Server.Server {
-    return this.sharedServer;
-  }
-}
-
-function newRuntime(storageManager: SharedServerStorageManager): Runtime {
+function newRuntime(storageManager: EmulatedStorageManager): Runtime {
   return new Runtime({
     apiUrl: new URL(import.meta.url),
     storageManager,
@@ -173,17 +152,17 @@ function expectActionValues(value: ActionValues, expectError = true): void {
 
 describe("action results use FabricValue legality", () => {
   let server: MemoryV2Server.Server;
-  let writerStorage: SharedServerStorageManager;
-  let coldStorage: SharedServerStorageManager;
+  let writerStorage: EmulatedStorageManager;
+  let coldStorage: EmulatedStorageManager;
   let writer: Runtime;
   let coldReader: Runtime;
 
   beforeEach(() => {
     server = new MemoryV2Server.Server(TEST_MEMORY_SERVER_AUTH);
-    writerStorage = SharedServerStorageManager.connectTo(server, {
+    writerStorage = EmulatedStorageManager.connectTo(server, {
       as: signer,
     });
-    coldStorage = SharedServerStorageManager.connectTo(server, { as: signer });
+    coldStorage = EmulatedStorageManager.connectTo(server, { as: signer });
     writer = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: writerStorage,

--- a/packages/runner/test/array-push-mergeable.test.ts
+++ b/packages/runner/test/array-push-mergeable.test.ts
@@ -4,7 +4,6 @@ import { Identity } from "@commonfabric/identity";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
-import type { Options } from "../src/storage/v2.ts";
 import type { Cell } from "../src/cell.ts";
 import { Runtime } from "../src/runtime.ts";
 import { TransactionWrapper } from "../src/storage/extended-storage-transaction.ts";
@@ -12,43 +11,8 @@ import {
   getDirectTransactionMergeableOpAddresses,
   getDirectTransactionNativeCommit,
 } from "../src/storage/transaction-inspection.ts";
-import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
+import { newSharedServer } from "./memory-v2-test-utils.ts";
 import { popFrame, pushFrame } from "../src/builder/pattern.ts";
-
-// A storage manager with its OWN per-space client replicas, loopback-connected
-// to a SHARED in-process memory server (mirrors cross-space-value-read.test.ts).
-// Two of these connected to one server model two real sessions: data written by
-// one session reaches the other only through an explicit per-space server
-// query/subscription.
-class SharedServerStorageManager extends EmulatedStorageManager {
-  static connectTo(
-    server: MemoryV2Server.Server,
-    options: Omit<Options, "memoryHost" | "spaceHostMap">,
-  ): SharedServerStorageManager {
-    const manager = new SharedServerStorageManager(
-      { ...options, memoryHost: new URL("memory://") },
-      () => server,
-    );
-    manager.sharedServer = server;
-    return manager;
-  }
-
-  private sharedServer!: MemoryV2Server.Server;
-
-  protected override server(): MemoryV2Server.Server {
-    return this.sharedServer;
-  }
-}
-
-const newSharedServer = () =>
-  new MemoryV2Server.Server({
-    authorizeSessionOpen(message) {
-      const principal = (message.authorization as { principal?: unknown })
-        ?.principal;
-      return typeof principal === "string" ? principal : undefined;
-    },
-    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
-  });
 
 const signer = await Identity.fromPassphrase("array-push-mergeable");
 const space = signer.did();
@@ -84,7 +48,7 @@ const anySchema = {
 async function readDurable(
   server: MemoryV2Server.Server,
 ): Promise<string[]> {
-  const storage = SharedServerStorageManager.connectTo(server, { as: signer });
+  const storage = EmulatedStorageManager.connectTo(server, { as: signer });
   const rt = new Runtime({
     apiUrl: new URL(import.meta.url),
     storageManager: storage,
@@ -105,7 +69,7 @@ async function readDurableNested(
   server: MemoryV2Server.Server,
   cause: string,
 ): Promise<string[][]> {
-  const storage = SharedServerStorageManager.connectTo(server, { as: signer });
+  const storage = EmulatedStorageManager.connectTo(server, { as: signer });
   const rt = new Runtime({
     apiUrl: new URL(import.meta.url),
     storageManager: storage,
@@ -124,7 +88,7 @@ async function readDurableNested(
 async function readDurableNumber(
   server: MemoryV2Server.Server,
 ): Promise<number | undefined> {
-  const storage = SharedServerStorageManager.connectTo(server, { as: signer });
+  const storage = EmulatedStorageManager.connectTo(server, { as: signer });
   const rt = new Runtime({
     apiUrl: new URL(import.meta.url),
     storageManager: storage,
@@ -142,13 +106,13 @@ async function readDurableNumber(
 
 describe("mergeable array appends", () => {
   let server: MemoryV2Server.Server;
-  let storage1: SharedServerStorageManager;
-  let storage2: SharedServerStorageManager;
+  let storage1: EmulatedStorageManager;
+  let storage2: EmulatedStorageManager;
 
   beforeEach(() => {
     server = newSharedServer();
-    storage1 = SharedServerStorageManager.connectTo(server, { as: signer });
-    storage2 = SharedServerStorageManager.connectTo(server, { as: signer });
+    storage1 = EmulatedStorageManager.connectTo(server, { as: signer });
+    storage2 = EmulatedStorageManager.connectTo(server, { as: signer });
   });
   afterEach(async () => {
     await storage1?.close();
@@ -924,7 +888,7 @@ describe("mergeable array appends", () => {
       await tx1.commit({ resolveAt: "verdict" });
       await rt1.storageManager.synced();
 
-      const storage = SharedServerStorageManager.connectTo(server, {
+      const storage = EmulatedStorageManager.connectTo(server, {
         as: signer,
       });
       const rt2 = new Runtime({
@@ -1133,7 +1097,7 @@ describe("mergeable array appends", () => {
       await tx1.commit({ resolveAt: "verdict" });
       await rt1.storageManager.synced();
 
-      const storage = SharedServerStorageManager.connectTo(server, {
+      const storage = EmulatedStorageManager.connectTo(server, {
         as: signer,
       });
       const rt2 = new Runtime({
@@ -1710,7 +1674,7 @@ describe("mergeable array appends", () => {
       await tx1.commit({ resolveAt: "verdict" });
       await rt1.storageManager.synced();
 
-      const storage = SharedServerStorageManager.connectTo(server, {
+      const storage = EmulatedStorageManager.connectTo(server, {
         as: signer,
       });
       const rt2 = new Runtime({
@@ -1765,7 +1729,7 @@ describe("mergeable array appends", () => {
       await tx1.commit({ resolveAt: "verdict" });
       await rt1.storageManager.synced();
 
-      const storage = SharedServerStorageManager.connectTo(server, {
+      const storage = EmulatedStorageManager.connectTo(server, {
         as: signer,
       });
       const rt2 = new Runtime({
@@ -1809,7 +1773,7 @@ describe("mergeable array appends", () => {
     } as any;
     const HOLDER_CAUSE = "sibling-remove-holder";
     const readHolder = async () => {
-      const storage = SharedServerStorageManager.connectTo(server, {
+      const storage = EmulatedStorageManager.connectTo(server, {
         as: signer,
       });
       const rt = new Runtime({
@@ -1952,7 +1916,7 @@ describe("mergeable array appends", () => {
 
       // Durable truth from a fresh session: the concurrent edit AND the
       // added value both survive.
-      const storage3 = SharedServerStorageManager.connectTo(server, {
+      const storage3 = EmulatedStorageManager.connectTo(server, {
         as: signer,
       });
       const rt3 = new Runtime({
@@ -2030,7 +1994,7 @@ const voteListSchema = {
 async function readDurableVotes(
   server: MemoryV2Server.Server,
 ): Promise<Vote[]> {
-  const storage = SharedServerStorageManager.connectTo(server, { as: signer });
+  const storage = EmulatedStorageManager.connectTo(server, { as: signer });
   const rt = new Runtime({
     apiUrl: new URL(import.meta.url),
     storageManager: storage,
@@ -2048,13 +2012,13 @@ async function readDurableVotes(
 
 describe("keyed collections via elementById", () => {
   let server: MemoryV2Server.Server;
-  let storage1: SharedServerStorageManager;
-  let storage2: SharedServerStorageManager;
+  let storage1: EmulatedStorageManager;
+  let storage2: EmulatedStorageManager;
 
   beforeEach(() => {
     server = newSharedServer();
-    storage1 = SharedServerStorageManager.connectTo(server, { as: signer });
-    storage2 = SharedServerStorageManager.connectTo(server, { as: signer });
+    storage1 = EmulatedStorageManager.connectTo(server, { as: signer });
+    storage2 = EmulatedStorageManager.connectTo(server, { as: signer });
   });
   afterEach(async () => {
     await storage1?.close();
@@ -2309,12 +2273,12 @@ describe("keyed collections via elementById", () => {
 // concurrency, only the op machinery, so they run against a single runtime.
 describe("mergeable op guards and single-session branches", () => {
   let server: MemoryV2Server.Server;
-  let storage1: SharedServerStorageManager;
+  let storage1: EmulatedStorageManager;
   let rt: Runtime;
 
   beforeEach(() => {
     server = newSharedServer();
-    storage1 = SharedServerStorageManager.connectTo(server, { as: signer });
+    storage1 = EmulatedStorageManager.connectTo(server, { as: signer });
     rt = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,
@@ -2518,7 +2482,7 @@ describe("mergeable op guards and single-session branches", () => {
     await tx.commit({ resolveAt: "verdict" });
     await rt.storageManager.synced();
 
-    const readBack = SharedServerStorageManager.connectTo(server, {
+    const readBack = EmulatedStorageManager.connectTo(server, {
       as: signer,
     });
     const rt2 = new Runtime({
@@ -2806,7 +2770,7 @@ describe("mergeable op guards and single-session branches", () => {
     await tx.commit({ resolveAt: "verdict" });
     await rt.storageManager.synced();
 
-    const readBack = SharedServerStorageManager.connectTo(server, {
+    const readBack = EmulatedStorageManager.connectTo(server, {
       as: signer,
     });
     const rt2 = new Runtime({
@@ -2838,7 +2802,7 @@ describe("mergeable op guards and single-session branches", () => {
     await tx.commit({ resolveAt: "verdict" });
     await rt.storageManager.synced();
 
-    const readBack = SharedServerStorageManager.connectTo(server, {
+    const readBack = EmulatedStorageManager.connectTo(server, {
       as: signer,
     });
     const rt2 = new Runtime({
@@ -2918,7 +2882,7 @@ const namedListSchema = {
 async function readDurableNamed(
   server: MemoryV2Server.Server,
 ): Promise<NamedEntry[]> {
-  const storage = SharedServerStorageManager.connectTo(server, { as: signer });
+  const storage = EmulatedStorageManager.connectTo(server, { as: signer });
   const rt = new Runtime({
     apiUrl: new URL(import.meta.url),
     storageManager: storage,
@@ -2936,13 +2900,13 @@ async function readDurableNamed(
 
 describe("keyed object list (home spaces shape)", () => {
   let server: MemoryV2Server.Server;
-  let storage1: SharedServerStorageManager;
-  let storage2: SharedServerStorageManager;
+  let storage1: EmulatedStorageManager;
+  let storage2: EmulatedStorageManager;
 
   beforeEach(() => {
     server = newSharedServer();
-    storage1 = SharedServerStorageManager.connectTo(server, { as: signer });
-    storage2 = SharedServerStorageManager.connectTo(server, { as: signer });
+    storage1 = EmulatedStorageManager.connectTo(server, { as: signer });
+    storage2 = EmulatedStorageManager.connectTo(server, { as: signer });
   });
   afterEach(async () => {
     await storage1?.close();
@@ -3184,12 +3148,12 @@ function favoriteKeyFor(piece: { getAsNormalizedFullLink(): unknown }): string {
 
 describe("keyed entity holding a cell reference (home favorites shape)", () => {
   let server: MemoryV2Server.Server;
-  let storage1: SharedServerStorageManager;
+  let storage1: EmulatedStorageManager;
   let rt: Runtime;
 
   beforeEach(() => {
     server = newSharedServer();
-    storage1 = SharedServerStorageManager.connectTo(server, { as: signer });
+    storage1 = EmulatedStorageManager.connectTo(server, { as: signer });
     rt = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storage1,

--- a/packages/runner/test/cell-cache.test.ts
+++ b/packages/runner/test/cell-cache.test.ts
@@ -4,7 +4,6 @@ import { Identity } from "@commonfabric/identity";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
-import type { Options } from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
 import {
   computeModuleHashes,
@@ -29,7 +28,7 @@ import {
   writeCompiledDocs,
   writeSourceDocs,
 } from "../src/compilation-cache/cell-cache.ts";
-import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
+import { newSharedServer } from "./memory-v2-test-utils.ts";
 
 import { ensureCompilerStack } from "../src/harness/deferred-compiler-stack.ts";
 import { buildCfcPolicyArtifactManifest } from "../src/cfc/policy.ts";
@@ -39,45 +38,6 @@ import { pattern } from "../src/builder/pattern.ts";
 // These tests drive the sync parse internals directly (below the async flow
 // boundaries that normally load the deferred compiler stack), so load it here.
 await ensureCompilerStack();
-
-// ---------------------------------------------------------------------------
-// Shared-server helper: two managers with DIFFERENT signers over ONE in-process
-// memory server. Modelled after cross-space-value-read.test.ts. The shared
-// server is closed once by the test's afterEach — each manager's override()
-// returns the same instance without the base class closing it twice.
-// ---------------------------------------------------------------------------
-class SharedServerStorageManager extends EmulatedStorageManager {
-  static connectTo(
-    server: MemoryV2Server.Server,
-    options: Omit<Options, "memoryHost" | "spaceHostMap">,
-  ): SharedServerStorageManager {
-    const manager = new SharedServerStorageManager(
-      { ...options, memoryHost: new URL("memory://") },
-      () => server,
-    );
-    manager._sharedServer = server;
-    return manager;
-  }
-
-  private _sharedServer!: MemoryV2Server.Server;
-
-  protected override server(): MemoryV2Server.Server {
-    return this._sharedServer;
-  }
-  // NOTE: super.close() checks its private `#server` field (never set by this
-  // override), so closing a SharedServerStorageManager only tears down the
-  // per-space client sessions — the shared server is closed once by the test.
-}
-
-const newSharedServer = () =>
-  new MemoryV2Server.Server({
-    authorizeSessionOpen(message) {
-      const principal = (message.authorization as { principal?: unknown })
-        ?.principal;
-      return typeof principal === "string" ? principal : undefined;
-    },
-    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
-  });
 
 const signer = await Identity.fromPassphrase("cell-cache test");
 const resolvedRuntimeVersion = await getCompileCacheRuntimeVersion();
@@ -2175,15 +2135,15 @@ describe("cell-cache: two-identity shared-space compile cache (e2e)", () => {
   };
 
   let server: MemoryV2Server.Server;
-  let smA: SharedServerStorageManager;
-  let smB: SharedServerStorageManager;
+  let smA: EmulatedStorageManager;
+  let smB: EmulatedStorageManager;
   let rtA: Runtime;
   let rtB: Runtime;
 
   beforeEach(() => {
     server = newSharedServer();
-    smA = SharedServerStorageManager.connectTo(server, { as: e2eSignerA });
-    smB = SharedServerStorageManager.connectTo(server, { as: e2eSignerB });
+    smA = EmulatedStorageManager.connectTo(server, { as: e2eSignerA });
+    smB = EmulatedStorageManager.connectTo(server, { as: e2eSignerB });
     rtA = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: smA,

--- a/packages/runner/test/cfc-single-use-grants.test.ts
+++ b/packages/runner/test/cfc-single-use-grants.test.ts
@@ -7,10 +7,8 @@ import { CFC_ATOM_TYPE, cfcAtom } from "@commonfabric/api/cfc";
 import type * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import {
   EmulatedStorageManager,
-  type Options as StorageManagerOptions,
   StorageManager,
 } from "../src/storage/cache.deno.ts";
-import { StorageManager as V2StorageManager } from "../src/storage/v2.ts";
 import { ExtendedStorageTransaction } from "../src/storage/extended-storage-transaction.ts";
 import { isPermanentRejection } from "../src/storage/rejection.ts";
 import { Runtime } from "../src/runtime.ts";
@@ -941,30 +939,12 @@ describe("CFC single-use grants (§2.2 single-use releases)", () => {
       // guard first (previous test). A second storage manager sharing the
       // base manager's in-process server plays the remote releaser whose
       // replica never observed the winner's receipt.
-      class SharedServerStorageManager extends EmulatedStorageManager {
-        static shareServerOf(
-          base: EmulatedStorageManager,
-        ): SharedServerStorageManager {
-          return new SharedServerStorageManager(
-            {
-              as: signer,
-              memoryHost: new URL("memory://"),
-            } satisfies StorageManagerOptions,
-            () =>
-              (base as unknown as { server(): MemoryV2Server.Server })
-                .server(),
-          );
-        }
-        // The server belongs to the base manager; EmulatedStorageManager's
-        // close would close the shared instance's cached reference to it.
-        // Close only the storage-manager half (the grandparent close).
-        override close(): Promise<void> {
-          return V2StorageManager.prototype.close.call(this);
-        }
-      }
-
       const base = StorageManager.emulate({ as: signer });
-      const remote = SharedServerStorageManager.shareServerOf(base);
+      // The server belongs to the base manager; connectTo never closes it.
+      const remote = EmulatedStorageManager.connectTo(
+        (base as unknown as { server(): MemoryV2Server.Server }).server(),
+        { as: signer },
+      );
       const runtime = new Runtime({
         apiUrl: new URL("https://example.com"),
         storageManager: base,

--- a/packages/runner/test/commit-callback-timing.test.ts
+++ b/packages/runner/test/commit-callback-timing.test.ts
@@ -13,48 +13,20 @@ import { Identity } from "@commonfabric/identity";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
-import type { Options } from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
-import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
+import { newSharedServer } from "./memory-v2-test-utils.ts";
 
 const signer = await Identity.fromPassphrase("commit-callback-timing");
 const space = signer.did();
 
-class TimedFanOutStorageManager extends EmulatedStorageManager {
-  static connectTo(
-    server: MemoryV2Server.Server,
-    options: Omit<Options, "memoryHost" | "spaceHostMap">,
-  ): TimedFanOutStorageManager {
-    const manager = new TimedFanOutStorageManager(
-      { ...options, memoryHost: new URL("memory://") },
-      () => server,
-    );
-    manager.sharedServer = server;
-    return manager;
-  }
-
-  private sharedServer!: MemoryV2Server.Server;
-
-  protected override server(): MemoryV2Server.Server {
-    return this.sharedServer;
-  }
-}
-
 describe("commit callback timing", () => {
   let server: MemoryV2Server.Server;
-  let storageManager: TimedFanOutStorageManager;
+  let storageManager: EmulatedStorageManager;
   let runtime: Runtime;
 
   beforeEach(() => {
-    server = new MemoryV2Server.Server({
-      authorizeSessionOpen(message) {
-        const principal = (message.authorization as { principal?: unknown })
-          ?.principal;
-        return typeof principal === "string" ? principal : undefined;
-      },
-      sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
-    });
-    storageManager = TimedFanOutStorageManager.connectTo(server, {
+    server = newSharedServer();
+    storageManager = EmulatedStorageManager.connectTo(server, {
       as: signer,
     });
     runtime = new Runtime({

--- a/packages/runner/test/commit-conflict-reconcile.test.ts
+++ b/packages/runner/test/commit-conflict-reconcile.test.ts
@@ -17,56 +17,24 @@ import { Identity } from "@commonfabric/identity";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
-import type { Options } from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { RuntimeTelemetryEvent } from "../src/telemetry.ts";
-import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
+import { newSharedServer } from "./memory-v2-test-utils.ts";
 
 const signer = await Identity.fromPassphrase("read-repair-strand");
 const space = signer.did();
 
-// Two StorageManagers sharing ONE real server, each with its own replicas.
-class SharedServerStorageManager extends EmulatedStorageManager {
-  static connectTo(
-    server: MemoryV2Server.Server,
-    options: Omit<Options, "memoryHost" | "spaceHostMap">,
-  ): SharedServerStorageManager {
-    const manager = new SharedServerStorageManager(
-      { ...options, memoryHost: new URL("memory://") },
-      () => server,
-    );
-    manager.sharedServer = server;
-    return manager;
-  }
-
-  private sharedServer!: MemoryV2Server.Server;
-
-  protected override server(): MemoryV2Server.Server {
-    return this.sharedServer;
-  }
-}
-
-const newSharedServer = () =>
-  new MemoryV2Server.Server({
-    authorizeSessionOpen(message) {
-      const principal = (message.authorization as { principal?: unknown })
-        ?.principal;
-      return typeof principal === "string" ? principal : undefined;
-    },
-    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
-  });
-
 describe("read-repair: stale read after cross-replica conflict", () => {
   let server: MemoryV2Server.Server;
-  let storageA: SharedServerStorageManager;
-  let storageB: SharedServerStorageManager;
+  let storageA: EmulatedStorageManager;
+  let storageB: EmulatedStorageManager;
   let rtA: Runtime;
   let rtB: Runtime;
 
   beforeEach(() => {
     server = newSharedServer();
-    storageA = SharedServerStorageManager.connectTo(server, { as: signer });
-    storageB = SharedServerStorageManager.connectTo(server, { as: signer });
+    storageA = EmulatedStorageManager.connectTo(server, { as: signer });
+    storageB = EmulatedStorageManager.connectTo(server, { as: signer });
     rtA = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storageA,

--- a/packages/runner/test/compile-cache-incremental-writeback.test.ts
+++ b/packages/runner/test/compile-cache-incremental-writeback.test.ts
@@ -1,10 +1,8 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
-import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
-import type { Options } from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
 import {
   computeModuleHashes,
@@ -23,7 +21,7 @@ import {
   writeSourceDocs,
 } from "../src/compilation-cache/cell-cache.ts";
 import { ensureCompilerStack } from "../src/harness/deferred-compiler-stack.ts";
-import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
+import { newSharedServer } from "./memory-v2-test-utils.ts";
 
 // These tests drive the sync parse internals directly (below the async flow
 // boundaries that normally load the deferred compiler stack), so load it here.
@@ -338,34 +336,6 @@ describe("chunked compile-cache write-back (interruption survivability)", () => 
 // working pattern, never a corrupt load — and the recovery write-back heals
 // the compiled namespace.
 // ---------------------------------------------------------------------------
-class SharedServerStorageManager extends EmulatedStorageManager {
-  static connectTo(
-    server: MemoryV2Server.Server,
-    options: Omit<Options, "memoryHost" | "spaceHostMap">,
-  ): SharedServerStorageManager {
-    const manager = new SharedServerStorageManager(
-      { ...options, memoryHost: new URL("memory://") },
-      () => server,
-    );
-    manager._sharedServer = server;
-    return manager;
-  }
-  private _sharedServer!: MemoryV2Server.Server;
-  protected override server(): MemoryV2Server.Server {
-    return this._sharedServer;
-  }
-}
-
-const newSharedServer = () =>
-  new MemoryV2Server.Server({
-    authorizeSessionOpen(message) {
-      const principal = (message.authorization as { principal?: unknown })
-        ?.principal;
-      return typeof principal === "string" ? principal : undefined;
-    },
-    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
-  });
-
 describe("descendant-missing compiled closure degrades to a clean recompile", () => {
   it("loadPatternByIdentity recompiles from source and heals the compiled set", async () => {
     const RTVER = "test-degrade-1";
@@ -393,12 +363,12 @@ describe("descendant-missing compiled closure degrades to a clean recompile", ()
       ],
     };
 
-    const smA = SharedServerStorageManager.connectTo(server, { as: signer });
+    const smA = EmulatedStorageManager.connectTo(server, { as: signer });
     const runtimeA = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: smA,
     });
-    let smB: SharedServerStorageManager | undefined;
+    let smB: EmulatedStorageManager | undefined;
     let runtimeB: Runtime | undefined;
     try {
       // Real compile for real module bodies, but persist BY HAND: the full
@@ -428,7 +398,7 @@ describe("descendant-missing compiled closure degrades to a clean recompile", ()
       // path — the compiled ENTRY is present (hit test passes) while the
       // descendant is absent. Without this guard a mis-stamped write would
       // silently turn the test into the ordinary absent-entry miss.
-      smB = SharedServerStorageManager.connectTo(server, { as: signer });
+      smB = EmulatedStorageManager.connectTo(server, { as: signer });
       runtimeB = new Runtime({
         apiUrl: new URL(import.meta.url),
         storageManager: smB,

--- a/packages/runner/test/compile-cache-writeback-conflict.test.ts
+++ b/packages/runner/test/compile-cache-writeback-conflict.test.ts
@@ -1,47 +1,14 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
-import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
-import type { Options } from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
 import {
   setCompileCacheRuntimeVersionForTesting,
   sourceDocKey,
   WRITE_TARGET_EDGE_SYNC_SCHEMA,
 } from "../src/compilation-cache/cell-cache.ts";
-import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
-
-// Shared-server helper (same shape as cell-cache.test.ts): several managers —
-// each a SEPARATE client replica — over ONE in-process memory server, so a
-// fresh runtime is genuinely cold the way a fresh browser worker is.
-class SharedServerStorageManager extends EmulatedStorageManager {
-  static connectTo(
-    server: MemoryV2Server.Server,
-    options: Omit<Options, "memoryHost" | "spaceHostMap">,
-  ): SharedServerStorageManager {
-    const manager = new SharedServerStorageManager(
-      { ...options, memoryHost: new URL("memory://") },
-      () => server,
-    );
-    manager._sharedServer = server;
-    return manager;
-  }
-  private _sharedServer!: MemoryV2Server.Server;
-  protected override server(): MemoryV2Server.Server {
-    return this._sharedServer;
-  }
-}
-
-const newSharedServer = () =>
-  new MemoryV2Server.Server({
-    authorizeSessionOpen(message) {
-      const principal = (message.authorization as { principal?: unknown })
-        ?.principal;
-      return typeof principal === "string" ? principal : undefined;
-    },
-    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
-  });
+import { newSharedServer } from "./memory-v2-test-utils.ts";
 
 const signer = await Identity.fromPassphrase("writeback conflict test");
 const space = signer.did();
@@ -79,14 +46,14 @@ describe("compile-cache write-back after a runtime-version bump", () => {
     const restoreVersion = setCompileCacheRuntimeVersionForTesting(
       "test-version-A",
     );
-    const smA = SharedServerStorageManager.connectTo(server, { as: signer });
+    const smA = EmulatedStorageManager.connectTo(server, { as: signer });
     const runtimeA = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: smA,
     });
-    let smB: SharedServerStorageManager | undefined;
+    let smB: EmulatedStorageManager | undefined;
     let runtimeB: Runtime | undefined;
-    let smC: SharedServerStorageManager | undefined;
+    let smC: EmulatedStorageManager | undefined;
     let runtimeC: Runtime | undefined;
     try {
       const txA = runtimeA.edit();
@@ -106,7 +73,7 @@ describe("compile-cache write-back after a runtime-version bump", () => {
       // back source docs (which already exist server-side, with their derived
       // cells this replica has never read) plus compiled docs under vB.
       setCompileCacheRuntimeVersionForTesting("test-version-B");
-      smB = SharedServerStorageManager.connectTo(server, { as: signer });
+      smB = EmulatedStorageManager.connectTo(server, { as: signer });
       runtimeB = new Runtime({
         apiUrl: new URL(import.meta.url),
         storageManager: smB,
@@ -131,7 +98,7 @@ describe("compile-cache write-back after a runtime-version bump", () => {
       // B's write-back died on a deterministic ConflictError (stale seq-0
       // read of a pre-existing derived doc), so C recompiled again — and so
       // did every cold boot after it, forever.
-      smC = SharedServerStorageManager.connectTo(server, { as: signer });
+      smC = EmulatedStorageManager.connectTo(server, { as: signer });
       runtimeC = new Runtime({
         apiUrl: new URL(import.meta.url),
         storageManager: smC,
@@ -199,14 +166,14 @@ describe("write-back pre-sync materializes edge element docs (CT-1848)", () => {
     const restoreVersion = setCompileCacheRuntimeVersionForTesting(
       "ct1848-version-A",
     );
-    const smA = SharedServerStorageManager.connectTo(server, { as: signer });
+    const smA = EmulatedStorageManager.connectTo(server, { as: signer });
     const runtimeA = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: smA,
     });
-    let smB: SharedServerStorageManager | undefined;
+    let smB: EmulatedStorageManager | undefined;
     let runtimeB: Runtime | undefined;
-    let smC: SharedServerStorageManager | undefined;
+    let smC: EmulatedStorageManager | undefined;
     let runtimeC: Runtime | undefined;
     try {
       const txA = runtimeA.edit();
@@ -221,7 +188,7 @@ describe("write-back pre-sync materializes edge element docs (CT-1848)", () => {
 
       // Arm 1 — COLD replica, sync the entry under the one-hop edge schema
       // (what the write-target pre-sync now uses): the element docs arrive.
-      smB = SharedServerStorageManager.connectTo(server, { as: signer });
+      smB = EmulatedStorageManager.connectTo(server, { as: signer });
       runtimeB = new Runtime({
         apiUrl: new URL(import.meta.url),
         storageManager: smB,
@@ -254,7 +221,7 @@ describe("write-back pre-sync materializes edge element docs (CT-1848)", () => {
       // Arm 2 — another COLD replica, schema-less sync (the pre-fix
       // behavior): the root arrives, the element docs do NOT. This is the
       // differential that makes the edge selector load-bearing.
-      smC = SharedServerStorageManager.connectTo(server, { as: signer });
+      smC = EmulatedStorageManager.connectTo(server, { as: signer });
       runtimeC = new Runtime({
         apiUrl: new URL(import.meta.url),
         storageManager: smC,
@@ -286,7 +253,7 @@ describe("write-back pre-sync materializes edge element docs (CT-1848)", () => {
 describe("editWithRetry conflict catch-up", () => {
   it("awaits readyToRetry between attempts and then succeeds", async () => {
     const server = newSharedServer();
-    const sm = SharedServerStorageManager.connectTo(server, { as: signer });
+    const sm = EmulatedStorageManager.connectTo(server, { as: signer });
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: sm,
@@ -345,7 +312,7 @@ describe("editWithRetry conflict catch-up", () => {
 describe("editWithRetry sequential conflict discovery", () => {
   it("pulls each named doc and converges one doc per round", async () => {
     const server = newSharedServer();
-    const sm = SharedServerStorageManager.connectTo(server, { as: signer });
+    const sm = EmulatedStorageManager.connectTo(server, { as: signer });
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: sm,
@@ -420,7 +387,7 @@ describe("editWithRetry sequential conflict discovery", () => {
 
   it("exhausts the default budget when discovery outlasts it", async () => {
     const server = newSharedServer();
-    const sm = SharedServerStorageManager.connectTo(server, { as: signer });
+    const sm = EmulatedStorageManager.connectTo(server, { as: signer });
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: sm,

--- a/packages/runner/test/cross-space-value-read.test.ts
+++ b/packages/runner/test/cross-space-value-read.test.ts
@@ -4,55 +4,13 @@ import { Identity } from "@commonfabric/identity";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
-import type { Options } from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
-import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
+import { newSharedServer } from "./memory-v2-test-utils.ts";
 
 const signer = await Identity.fromPassphrase("cross-space-value-read");
 const spaceH = signer.did(); // "home" — holds the link
 const spaceP = (await Identity.fromPassphrase("cross-space target P")).did();
-
-// A storage manager with its OWN per-space client replicas, loopback-connected
-// to a SHARED in-process memory server. This is what a real browser/CLI
-// session looks like: data written by another session only reaches this one
-// through an explicit per-space server query/subscription. The plain
-// `StorageManager.emulate` masks CT-1667 in the common test shape because a
-// shared manager means shared replicas — reads find data the reader never
-// fetched.
-class SharedServerStorageManager extends EmulatedStorageManager {
-  static connectTo(
-    server: MemoryV2Server.Server,
-    options: Omit<Options, "memoryHost" | "spaceHostMap">,
-  ): SharedServerStorageManager {
-    const manager = new SharedServerStorageManager(
-      { ...options, memoryHost: new URL("memory://") },
-      () => server,
-    );
-    manager.sharedServer = server;
-    return manager;
-  }
-
-  private sharedServer!: MemoryV2Server.Server;
-
-  // The server is SHARED between managers and closed once by the test's
-  // afterEach — serve it without ever initializing the base class's private
-  // `#server`, whose `close()` would otherwise close the shared server once
-  // per manager.
-  protected override server(): MemoryV2Server.Server {
-    return this.sharedServer;
-  }
-}
-
-const newSharedServer = () =>
-  new MemoryV2Server.Server({
-    authorizeSessionOpen(message) {
-      const principal = (message.authorization as { principal?: unknown })
-        ?.principal;
-      return typeof principal === "string" ? principal : undefined;
-    },
-    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
-  });
 
 // CT-1667: a value READ through a cross-space link never materializes the
 // target's fields in a session that didn't create them. The home Profile tab
@@ -117,15 +75,15 @@ const nameSchema = {
 
 describe("cross-space value reads (CT-1667)", () => {
   let server: MemoryV2Server.Server;
-  let writerStorage: SharedServerStorageManager;
-  let readerStorage: SharedServerStorageManager;
+  let writerStorage: EmulatedStorageManager;
+  let readerStorage: EmulatedStorageManager;
 
   beforeEach(() => {
     server = newSharedServer();
-    writerStorage = SharedServerStorageManager.connectTo(server, {
+    writerStorage = EmulatedStorageManager.connectTo(server, {
       as: signer,
     });
-    readerStorage = SharedServerStorageManager.connectTo(server, {
+    readerStorage = EmulatedStorageManager.connectTo(server, {
       as: signer,
     });
   });

--- a/packages/runner/test/effect-conflict-recovery.test.ts
+++ b/packages/runner/test/effect-conflict-recovery.test.ts
@@ -27,7 +27,6 @@ import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
-import type { Options } from "../src/storage/v2.ts";
 import type {
   IStorageNotification,
   StorageNotification,
@@ -35,28 +34,12 @@ import type {
 import { Runtime } from "../src/runtime.ts";
 import type { Action } from "../src/scheduler.ts";
 import { toMemorySpaceAddress } from "../src/link-utils.ts";
-import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
+import { newSharedServer } from "./memory-v2-test-utils.ts";
 
 const signer = await Identity.fromPassphrase("effect-conflict-recovery");
 const space = signer.did();
 
-class SharedServerStorageManager extends EmulatedStorageManager {
-  static connectTo(
-    server: MemoryV2Server.Server,
-    options: Omit<Options, "memoryHost" | "spaceHostMap">,
-  ): SharedServerStorageManager {
-    const manager = new SharedServerStorageManager(
-      { ...options, memoryHost: new URL("memory://") },
-      () => server,
-    );
-    manager.sharedServer = server;
-    return manager;
-  }
-  private sharedServer!: MemoryV2Server.Server;
-  protected override server(): MemoryV2Server.Server {
-    return this.sharedServer;
-  }
-
+class SuppressibleStorageManager extends EmulatedStorageManager {
   // When set, forward storage notifications to subscribers with their `changes`
   // emptied, so they raise no reader-dirty — a deterministic stand-in for a
   // "dataless catch-up" (a conflict whose catch-up carries no diff). Off by
@@ -74,16 +57,6 @@ class SharedServerStorageManager extends EmulatedStorageManager {
   }
 }
 
-const newSharedServer = () =>
-  new MemoryV2Server.Server({
-    authorizeSessionOpen(message) {
-      const principal = (message.authorization as { principal?: unknown })
-        ?.principal;
-      return typeof principal === "string" ? principal : undefined;
-    },
-    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
-  });
-
 const waitFor = async (
   predicate: () => boolean,
   timeout = 2000,
@@ -98,8 +71,8 @@ const waitFor = async (
 
 describe("effect commit-conflict recovery (no retry budget)", () => {
   let server: MemoryV2Server.Server;
-  let storageA: SharedServerStorageManager;
-  let storageB: SharedServerStorageManager;
+  let storageA: SuppressibleStorageManager;
+  let storageB: SuppressibleStorageManager;
   let rtA: Runtime;
   let rtB: Runtime;
   let conflicts: Error[];
@@ -107,8 +80,17 @@ describe("effect commit-conflict recovery (no retry budget)", () => {
   beforeEach(() => {
     conflicts = [];
     server = newSharedServer();
-    storageA = SharedServerStorageManager.connectTo(server, { as: signer });
-    storageB = SharedServerStorageManager.connectTo(server, { as: signer });
+    // The inherited static builds `new this(...)`, so these ARE
+    // SuppressibleStorageManager instances; its declared return type is just
+    // the base class.
+    storageA = SuppressibleStorageManager.connectTo(
+      server,
+      { as: signer },
+    ) as SuppressibleStorageManager;
+    storageB = SuppressibleStorageManager.connectTo(
+      server,
+      { as: signer },
+    ) as SuppressibleStorageManager;
     storageB.subscribe({
       next: (notification: StorageNotification) => {
         if (

--- a/packages/runner/test/emulated-storage-ownership.test.ts
+++ b/packages/runner/test/emulated-storage-ownership.test.ts
@@ -1,0 +1,51 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import type * as MemoryV2Server from "@commonfabric/memory/v2/server";
+
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import { newSharedServer } from "./memory-v2-test-utils.ts";
+
+const signer = await Identity.fromPassphrase("emulated storage ownership");
+
+// Server lifecycle ownership: a `connectTo` manager borrows an externally
+// owned shared server, while an `emulate()` manager owns the one it builds.
+// The close paths must honor that split — a borrowed server outliving its
+// managers is what lets several managers model several sessions on one
+// server, and an owned server leaking past its manager is a resource leak.
+
+const countCloses = (server: MemoryV2Server.Server): () => number => {
+  let closes = 0;
+  const original = server.close.bind(server);
+  server.close = () => {
+    closes++;
+    return original();
+  };
+  return () => closes;
+};
+
+describe("emulated storage server ownership", () => {
+  it("leaves a shared server open when a connectTo manager closes", async () => {
+    const server = newSharedServer();
+    const closes = countCloses(server);
+    const manager = EmulatedStorageManager.connectTo(server, { as: signer });
+    // Force the lazy server memo so close() has an instance to consider.
+    (manager as unknown as { server(): MemoryV2Server.Server }).server();
+
+    await manager.close();
+    expect(closes()).toBe(0);
+
+    await server.close();
+    expect(closes()).toBe(1);
+  });
+
+  it("closes an owned server when an emulate() manager closes", async () => {
+    const manager = EmulatedStorageManager.emulate({ as: signer });
+    const server = (manager as unknown as { server(): MemoryV2Server.Server })
+      .server();
+    const closes = countCloses(server);
+
+    await manager.close();
+    expect(closes()).toBe(1);
+  });
+});

--- a/packages/runner/test/fresh-replica-read-asymmetry.test.ts
+++ b/packages/runner/test/fresh-replica-read-asymmetry.test.ts
@@ -4,12 +4,11 @@ import { Identity } from "@commonfabric/identity";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
-import type { Options } from "../src/storage/v2.ts";
 import type { MemorySpace } from "../src/storage/interface.ts";
 import { Runtime } from "../src/runtime.ts";
 import { resolveCellPath } from "../src/piece-helpers.ts";
 import type { JSONSchema } from "../src/builder/types.ts";
-import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
+import { newSharedServer } from "./memory-v2-test-utils.ts";
 
 // Fresh-replica read asymmetry: writes from one replica commit durably, but a
 // second (fresh) replica's reads of the same data used to come back masked —
@@ -22,36 +21,6 @@ import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
 // `Cell.pull()`'s convergence loop awaits — so schema-less pulls now resolve
 // to the true value. This suite mirrors the CLI `piece get` read path
 // (schema-less cell -> pull() -> resolveCellPath).
-class SharedServerStorageManager extends EmulatedStorageManager {
-  static connectTo(
-    server: MemoryV2Server.Server,
-    options: Omit<Options, "memoryHost" | "spaceHostMap">,
-  ): SharedServerStorageManager {
-    const manager = new SharedServerStorageManager(
-      { ...options, memoryHost: new URL("memory://") },
-      () => server,
-    );
-    manager.sharedServer = server;
-    return manager;
-  }
-
-  private sharedServer!: MemoryV2Server.Server;
-
-  protected override server(): MemoryV2Server.Server {
-    return this.sharedServer;
-  }
-}
-
-const newSharedServer = () =>
-  new MemoryV2Server.Server({
-    authorizeSessionOpen(message) {
-      const principal = (message.authorization as { principal?: unknown })
-        ?.principal;
-      return typeof principal === "string" ? principal : undefined;
-    },
-    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
-  });
-
 const signer = await Identity.fromPassphrase("fresh-replica-read-asymmetry");
 const space = signer.did();
 
@@ -76,12 +45,12 @@ const CONTAINER_CAUSE = "asymmetry-container";
 
 describe("fresh-replica read asymmetry", () => {
   let server: MemoryV2Server.Server;
-  let writerStorage: SharedServerStorageManager;
+  let writerStorage: EmulatedStorageManager;
   let writerRt: Runtime;
 
   beforeEach(async () => {
     server = newSharedServer();
-    writerStorage = SharedServerStorageManager.connectTo(server, {
+    writerStorage = EmulatedStorageManager.connectTo(server, {
       as: signer,
     });
     writerRt = new Runtime({
@@ -121,7 +90,7 @@ describe("fresh-replica read asymmetry", () => {
   });
 
   function freshReader(): { rt: Runtime; close: () => Promise<void> } {
-    const storage = SharedServerStorageManager.connectTo(server, {
+    const storage = EmulatedStorageManager.connectTo(server, {
       as: signer,
     });
     const rt = new Runtime({
@@ -346,7 +315,7 @@ describe("fresh-replica read asymmetry", () => {
     // reservation back — otherwise one transient failure masks the doc for
     // the manager's lifetime. Scope is part of the key: scoped instances
     // are distinct docs.
-    const storage = SharedServerStorageManager.connectTo(server, {
+    const storage = EmulatedStorageManager.connectTo(server, {
       as: signer,
     });
     try {

--- a/packages/runner/test/inspace-child-owner-seed.test.ts
+++ b/packages/runner/test/inspace-child-owner-seed.test.ts
@@ -4,10 +4,9 @@ import { Identity } from "@commonfabric/identity";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
-import type { Options } from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
-import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
+import { newSharedServer } from "./memory-v2-test-utils.ts";
 
 const signer = await Identity.fromPassphrase("inspace-child-owner-seed");
 const spaceA = signer.did(); // "home" — runs the parent, holds the list
@@ -18,35 +17,6 @@ const spaceB = (await Identity.fromPassphrase("owner seed child B")).did();
 // memory server — the real browser/CLI session split. A single emulate
 // manager's shared replicas would mask any "writer never committed X /
 // reader never fetched X" gap.
-class SharedServerStorageManager extends EmulatedStorageManager {
-  static connectTo(
-    server: MemoryV2Server.Server,
-    options: Omit<Options, "memoryHost" | "spaceHostMap">,
-  ): SharedServerStorageManager {
-    const manager = new SharedServerStorageManager(
-      { ...options, memoryHost: new URL("memory://") },
-      () => server,
-    );
-    manager.sharedServer = server;
-    return manager;
-  }
-
-  private sharedServer!: MemoryV2Server.Server;
-
-  protected override server(): MemoryV2Server.Server {
-    return this.sharedServer;
-  }
-}
-
-const newSharedServer = () =>
-  new MemoryV2Server.Server({
-    authorizeSessionOpen(message) {
-      const principal = (message.authorization as { principal?: unknown })
-        ?.principal;
-      return typeof principal === "string" ? principal : undefined;
-    },
-    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
-  });
 
 // The profile-create flow in miniature: a handler pushes an `inSpace` child
 // whose pattern seeds an OWNER-PROTECTED field from its input —
@@ -139,13 +109,13 @@ const childLinkListSchema = {
 
 describe("inSpace child owner-protected seed value (profile name)", () => {
   let server: MemoryV2Server.Server;
-  let managerA: SharedServerStorageManager;
-  let managerB: SharedServerStorageManager;
+  let managerA: EmulatedStorageManager;
+  let managerB: EmulatedStorageManager;
 
   beforeEach(() => {
     server = newSharedServer();
-    managerA = SharedServerStorageManager.connectTo(server, { as: signer });
-    managerB = SharedServerStorageManager.connectTo(server, { as: signer });
+    managerA = EmulatedStorageManager.connectTo(server, { as: signer });
+    managerB = EmulatedStorageManager.connectTo(server, { as: signer });
   });
 
   afterEach(async () => {

--- a/packages/runner/test/inspace-child-owner-write.test.ts
+++ b/packages/runner/test/inspace-child-owner-write.test.ts
@@ -4,10 +4,9 @@ import { Identity } from "@commonfabric/identity";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
-import type { Options } from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
-import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
+import { newSharedServer } from "./memory-v2-test-utils.ts";
 
 // SCOPE (CT-1754): this guards the verified-binding regression only — an
 // inSpace child's owner-protected list, written by a NON-exported mode-bound
@@ -27,35 +26,6 @@ const spaceB = (await Identity.fromPassphrase("owner write child B")).did();
 // memory server — the real browser/CLI session split. A single emulate
 // manager's shared replicas would mask the warm/cached re-load on the reader
 // (where this CFC verified-binding regression lives).
-class SharedServerStorageManager extends EmulatedStorageManager {
-  static connectTo(
-    server: MemoryV2Server.Server,
-    options: Omit<Options, "memoryHost" | "spaceHostMap">,
-  ): SharedServerStorageManager {
-    const manager = new SharedServerStorageManager(
-      { ...options, memoryHost: new URL("memory://") },
-      () => server,
-    );
-    manager.sharedServer = server;
-    return manager;
-  }
-
-  private sharedServer!: MemoryV2Server.Server;
-
-  protected override server(): MemoryV2Server.Server {
-    return this.sharedServer;
-  }
-}
-
-const newSharedServer = () =>
-  new MemoryV2Server.Server({
-    authorizeSessionOpen(message) {
-      const principal = (message.authorization as { principal?: unknown })
-        ?.principal;
-      return typeof principal === "string" ? principal : undefined;
-    },
-    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
-  });
 
 // The profile-create flow in miniature, exercising the OWNER-PROTECTED WRITE
 // path (CT-1754). The child pattern owns an `elements` list that is written
@@ -169,13 +139,13 @@ const itemListSchema = {
 
 describe("inSpace child owner-protected write (profile elements)", () => {
   let server: MemoryV2Server.Server;
-  let managerA: SharedServerStorageManager;
-  let managerB: SharedServerStorageManager;
+  let managerA: EmulatedStorageManager;
+  let managerB: EmulatedStorageManager;
 
   beforeEach(() => {
     server = newSharedServer();
-    managerA = SharedServerStorageManager.connectTo(server, { as: signer });
-    managerB = SharedServerStorageManager.connectTo(server, { as: signer });
+    managerA = EmulatedStorageManager.connectTo(server, { as: signer });
+    managerB = EmulatedStorageManager.connectTo(server, { as: signer });
   });
 
   afterEach(async () => {

--- a/packages/runner/test/linked-stale-read-conflict.test.ts
+++ b/packages/runner/test/linked-stale-read-conflict.test.ts
@@ -21,55 +21,24 @@ import { Identity } from "@commonfabric/identity";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
-import type { Options } from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
-import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
+import { newSharedServer } from "./memory-v2-test-utils.ts";
 
 const signer = await Identity.fromPassphrase("linked-stale-read-strand");
 const space = signer.did();
 
 // Two StorageManagers sharing ONE real server, each with its own replicas.
-class SharedServerStorageManager extends EmulatedStorageManager {
-  static connectTo(
-    server: MemoryV2Server.Server,
-    options: Omit<Options, "memoryHost" | "spaceHostMap">,
-  ): SharedServerStorageManager {
-    const manager = new SharedServerStorageManager(
-      { ...options, memoryHost: new URL("memory://") },
-      () => server,
-    );
-    manager.sharedServer = server;
-    return manager;
-  }
-
-  private sharedServer!: MemoryV2Server.Server;
-
-  protected override server(): MemoryV2Server.Server {
-    return this.sharedServer;
-  }
-}
-
-const newSharedServer = () =>
-  new MemoryV2Server.Server({
-    authorizeSessionOpen(message) {
-      const principal = (message.authorization as { principal?: unknown })
-        ?.principal;
-      return typeof principal === "string" ? principal : undefined;
-    },
-    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
-  });
-
 describe("stale linked read across two clients", () => {
   let server: MemoryV2Server.Server;
-  let storageA: SharedServerStorageManager;
-  let storageB: SharedServerStorageManager;
+  let storageA: EmulatedStorageManager;
+  let storageB: EmulatedStorageManager;
   let rtA: Runtime; // Client 1
   let rtB: Runtime; // Client 2
 
   beforeEach(() => {
     server = newSharedServer();
-    storageA = SharedServerStorageManager.connectTo(server, { as: signer });
-    storageB = SharedServerStorageManager.connectTo(server, { as: signer });
+    storageA = EmulatedStorageManager.connectTo(server, { as: signer });
+    storageB = EmulatedStorageManager.connectTo(server, { as: signer });
     rtA = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storageA,

--- a/packages/runner/test/list-builtin-edge-paths.test.ts
+++ b/packages/runner/test/list-builtin-edge-paths.test.ts
@@ -19,7 +19,7 @@ import { Runtime } from "../src/runtime.ts";
 import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
 import {
-  TEST_MEMORY_SERVER_AUTH,
+  newSharedServer,
   testPrincipalSessionOpenAuthFactory,
 } from "./memory-v2-test-utils.ts";
 
@@ -402,14 +402,7 @@ describe("resume owned-cell walk: scoped sub-pattern", () => {
   let sm2: LoopbackStorageManager;
 
   beforeEach(() => {
-    server = new MemoryV2Server.Server({
-      authorizeSessionOpen(message) {
-        const principal = (message.authorization as { principal?: unknown })
-          ?.principal;
-        return typeof principal === "string" ? principal : undefined;
-      },
-      sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
-    });
+    server = newSharedServer();
     sm1 = LoopbackStorageManager.make(signer, server);
     sm2 = LoopbackStorageManager.make(signer, server);
   });
@@ -488,24 +481,6 @@ describe("resume owned-cell walk: scoped sub-pattern", () => {
 const spaceH = signer.did(); // "home" — holds the link
 const spaceP = (await Identity.fromPassphrase("edge paths target P")).did();
 
-class SharedServerStorageManager extends EmulatedStorageManager {
-  static connectTo(
-    server: MemoryV2Server.Server,
-    options: Omit<Options, "memoryHost" | "spaceHostMap">,
-  ): SharedServerStorageManager {
-    const manager = new SharedServerStorageManager(
-      { ...options, memoryHost: new URL("memory://") },
-      () => server,
-    );
-    manager.sharedServer = server;
-    return manager;
-  }
-  private sharedServer!: MemoryV2Server.Server;
-  protected override server(): MemoryV2Server.Server {
-    return this.sharedServer;
-  }
-}
-
 const CROSS_SPACE_PROGRAM: RuntimeProgram = {
   main: "/main.tsx",
   files: [{
@@ -541,22 +516,15 @@ const crossSpaceLinkListSchema = {
 
 describe("cross-space link load kick", () => {
   let server: MemoryV2Server.Server;
-  let writerStorage: SharedServerStorageManager;
-  let readerStorage: SharedServerStorageManager;
+  let writerStorage: EmulatedStorageManager;
+  let readerStorage: EmulatedStorageManager;
 
   beforeEach(() => {
-    server = new MemoryV2Server.Server({
-      authorizeSessionOpen(message) {
-        const principal = (message.authorization as { principal?: unknown })
-          ?.principal;
-        return typeof principal === "string" ? principal : undefined;
-      },
-      sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
-    });
-    writerStorage = SharedServerStorageManager.connectTo(server, {
+    server = newSharedServer();
+    writerStorage = EmulatedStorageManager.connectTo(server, {
       as: signer,
     });
-    readerStorage = SharedServerStorageManager.connectTo(server, {
+    readerStorage = EmulatedStorageManager.connectTo(server, {
       as: signer,
     });
   });

--- a/packages/runner/test/memory-v2-test-utils.ts
+++ b/packages/runner/test/memory-v2-test-utils.ts
@@ -52,8 +52,10 @@ export const TEST_MEMORY_SERVER_AUTH = {
 /**
  * A shared in-process memory server for multi-manager harnesses (pair with
  * `EmulatedStorageManager.connectTo`), pinned to the runner test audience.
- * `subscriptionRefreshDelayMs: "manual"` gates fan-out entirely behind
- * explicit `flushSessions()` calls — the controlled-staleness shape.
+ * `subscriptionRefreshDelayMs: "manual"` disables timer-driven fan-out
+ * entirely; either explicit synchronization point — `flushSessions()`, or
+ * `idle()`, which drains held fan-out to keep its quiescence contract —
+ * delivers it. The controlled-staleness shape.
  */
 export const newSharedServer = (options?: {
   subscriptionRefreshDelayMs?: number | "manual";

--- a/packages/runner/test/memory-v2-test-utils.ts
+++ b/packages/runner/test/memory-v2-test-utils.ts
@@ -9,6 +9,8 @@ import {
   type SessionSync,
 } from "@commonfabric/memory/v2";
 import * as MemoryV2Client from "@commonfabric/memory/v2/client";
+import type * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import { newLoopbackServer } from "../src/storage/v2-emulate.ts";
 import type {
   IStorageNotification,
   StorageNotification,
@@ -46,6 +48,21 @@ export const TEST_MEMORY_SERVER_AUTH = {
     audience: TEST_SESSION_OPEN_AUDIENCE,
   },
 } as const;
+
+/**
+ * A shared in-process memory server for multi-manager harnesses (pair with
+ * `EmulatedStorageManager.connectTo`), pinned to the runner test audience.
+ * `subscriptionRefreshDelayMs: "manual"` gates fan-out entirely behind
+ * explicit `flushSessions()` calls — the controlled-staleness shape.
+ */
+export const newSharedServer = (options?: {
+  subscriptionRefreshDelayMs?: number | "manual";
+  store?: URL;
+}): MemoryV2Server.Server =>
+  newLoopbackServer({
+    ...options,
+    audience: TEST_SESSION_OPEN_AUDIENCE,
+  });
 
 export const testSessionOpenAuthFactory: MemoryV2Client.SessionOpenAuthFactory =
   (

--- a/packages/runner/test/mergeable-append-multispace-conflict.test.ts
+++ b/packages/runner/test/mergeable-append-multispace-conflict.test.ts
@@ -28,41 +28,12 @@ import { Identity } from "@commonfabric/identity";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
-import type { Options } from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
-import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
+import { newSharedServer } from "./memory-v2-test-utils.ts";
 
 const signer = await Identity.fromPassphrase("mergeable-append-multispace");
 const space = signer.did();
-
-class SharedServerStorageManager extends EmulatedStorageManager {
-  static connectTo(
-    server: MemoryV2Server.Server,
-    options: Omit<Options, "memoryHost" | "spaceHostMap">,
-  ): SharedServerStorageManager {
-    const manager = new SharedServerStorageManager(
-      { ...options, memoryHost: new URL("memory://") },
-      () => server,
-    );
-    manager.sharedServer = server;
-    return manager;
-  }
-  private sharedServer!: MemoryV2Server.Server;
-  protected override server(): MemoryV2Server.Server {
-    return this.sharedServer;
-  }
-}
-
-const newSharedServer = () =>
-  new MemoryV2Server.Server({
-    authorizeSessionOpen(message) {
-      const principal = (message.authorization as { principal?: unknown })
-        ?.principal;
-      return typeof principal === "string" ? principal : undefined;
-    },
-    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
-  });
 
 // A child pattern instantiated in its own anonymous inSpace space, plus a host
 // that holds the home `items` list and an `addItem` handler that pushes a
@@ -136,7 +107,7 @@ function waitForEventCommit(
 async function readDurableItemCount(
   server: MemoryV2Server.Server,
 ): Promise<number> {
-  const storage = SharedServerStorageManager.connectTo(server, { as: signer });
+  const storage = EmulatedStorageManager.connectTo(server, { as: signer });
   const rt = new Runtime({
     apiUrl: new URL(import.meta.url),
     storageManager: storage,
@@ -174,12 +145,12 @@ async function readDurableItemCount(
 
 describe("mergeable append in a multi-space commit survives a transient storm", () => {
   let server: MemoryV2Server.Server;
-  let manager: SharedServerStorageManager;
+  let manager: EmulatedStorageManager;
   let rt: Runtime;
 
   beforeEach(() => {
     server = newSharedServer();
-    manager = SharedServerStorageManager.connectTo(server, { as: signer });
+    manager = EmulatedStorageManager.connectTo(server, { as: signer });
     rt = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: manager,

--- a/packages/runner/test/observation-adoption-live.test.ts
+++ b/packages/runner/test/observation-adoption-live.test.ts
@@ -6,11 +6,10 @@ import { waitForCellValue } from "@commonfabric/integration/wait-for-cell-value"
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
-import type { Options } from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { JSONSchema } from "../src/builder/types.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
-import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
+import { newSharedServer } from "./memory-v2-test-utils.ts";
 
 // Incremental observation adoption
 // (docs/specs/scheduler-v2/incremental-observation-adoption.md): two LIVE
@@ -24,36 +23,6 @@ import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
 
 const signer = await Identity.fromPassphrase("observation adoption live");
 const space = signer.did();
-
-class SharedServerStorageManager extends EmulatedStorageManager {
-  static connectTo(
-    server: MemoryV2Server.Server,
-    options: Omit<Options, "memoryHost" | "spaceHostMap">,
-  ): SharedServerStorageManager {
-    const manager = new SharedServerStorageManager(
-      { ...options, memoryHost: new URL("memory://") },
-      () => server,
-    );
-    manager.sharedServer = server;
-    return manager;
-  }
-
-  private sharedServer!: MemoryV2Server.Server;
-
-  protected override server(): MemoryV2Server.Server {
-    return this.sharedServer;
-  }
-}
-
-const newSharedServer = () =>
-  new MemoryV2Server.Server({
-    authorizeSessionOpen(message) {
-      const principal = (message.authorization as { principal?: unknown })
-        ?.principal;
-      return typeof principal === "string" ? principal : undefined;
-    },
-    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
-  });
 
 const VALUE_SCHEMA: JSONSchema = { type: "number" };
 
@@ -71,7 +40,7 @@ const PROGRAM: RuntimeProgram = {
   }],
 };
 
-function newRuntime(storageManager: SharedServerStorageManager) {
+function newRuntime(storageManager: EmulatedStorageManager) {
   return new Runtime({
     apiUrl: new URL(import.meta.url),
     storageManager,
@@ -102,13 +71,13 @@ function opRuns(
 
 describe("incremental observation adoption (live)", () => {
   let server: MemoryV2Server.Server;
-  let managerA: SharedServerStorageManager;
-  let managerB: SharedServerStorageManager;
+  let managerA: EmulatedStorageManager;
+  let managerB: EmulatedStorageManager;
 
   beforeEach(() => {
     server = newSharedServer();
-    managerA = SharedServerStorageManager.connectTo(server, { as: signer });
-    managerB = SharedServerStorageManager.connectTo(server, { as: signer });
+    managerA = EmulatedStorageManager.connectTo(server, { as: signer });
+    managerB = EmulatedStorageManager.connectTo(server, { as: signer });
   });
 
   afterEach(async () => {

--- a/packages/runner/test/own-write-echo-live.test.ts
+++ b/packages/runner/test/own-write-echo-live.test.ts
@@ -1,12 +1,11 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
-import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import type * as MemoryV2Server from "@commonfabric/memory/v2/server";
 
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
-import type { Options } from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
-import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
+import { newSharedServer } from "./memory-v2-test-utils.ts";
 
 // Own-write echo (CT-1965), end to end over a LIVE in-process server: a
 // session's own accepted patch-produced heads ride its covering frame as full
@@ -15,40 +14,10 @@ import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
 // notification contract: an echo fully shadowed by the write it confirms must
 // not re-notify the writer.
 //
-// The server's flush timer is held (60s) and flushed explicitly, so which
-// commits share a fan-out batch — and therefore whether the dirty-origin
-// survives as this session's own — is deterministic.
-
-class SharedServerStorageManager extends EmulatedStorageManager {
-  static connectTo(
-    server: MemoryV2Server.Server,
-    options: Omit<Options, "memoryHost" | "spaceHostMap">,
-  ): SharedServerStorageManager {
-    const manager = new SharedServerStorageManager(
-      { ...options, memoryHost: new URL("memory://") },
-      () => server,
-    );
-    manager.sharedServer = server;
-    return manager;
-  }
-
-  private sharedServer!: MemoryV2Server.Server;
-
-  protected override server(): MemoryV2Server.Server {
-    return this.sharedServer;
-  }
-}
-
-const newSharedServer = () =>
-  new MemoryV2Server.Server({
-    authorizeSessionOpen(message) {
-      const principal = (message.authorization as { principal?: unknown })
-        ?.principal;
-      return typeof principal === "string" ? principal : undefined;
-    },
-    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
-    subscriptionRefreshDelayMs: 60_000,
-  });
+// Fan-out is gated manually and flushed explicitly, so which commits share a
+// fan-out batch — and therefore whether the dirty-origin survives as this
+// session's own — is deterministic, immune to any clock advancing a held
+// timer.
 
 const signer = await Identity.fromPassphrase("own-write-echo-live");
 const space = signer.did();
@@ -61,13 +30,13 @@ const stringListSchema = {
 
 describe("own-write echo (live)", () => {
   let server: MemoryV2Server.Server;
-  let storage1: SharedServerStorageManager;
-  let storage2: SharedServerStorageManager;
+  let storage1: EmulatedStorageManager;
+  let storage2: EmulatedStorageManager;
 
   beforeEach(() => {
-    server = newSharedServer();
-    storage1 = SharedServerStorageManager.connectTo(server, { as: signer });
-    storage2 = SharedServerStorageManager.connectTo(server, { as: signer });
+    server = newSharedServer({ subscriptionRefreshDelayMs: "manual" });
+    storage1 = EmulatedStorageManager.connectTo(server, { as: signer });
+    storage2 = EmulatedStorageManager.connectTo(server, { as: signer });
   });
 
   afterEach(async () => {

--- a/packages/runner/test/own-write-echo-live.test.ts
+++ b/packages/runner/test/own-write-echo-live.test.ts
@@ -141,6 +141,10 @@ describe("own-write echo (live)", () => {
       rt1.getCell<string[]>(space, "echo-merge-list", stringListSchema, txA)
         .push("A");
       await txA.commit({ resolveAt: "verdict" });
+      // The premise itself, asserted: the manual gate held "A" back. A
+      // server whose option forwarding broke (any timed cadence) delivers
+      // here and fails this, not just the merge assertions below.
+      expect(cell2.get()).toEqual(["seed"]);
 
       const txB = rt2.edit();
       rt2.getCell<string[]>(space, "echo-merge-list", stringListSchema, txB)

--- a/packages/runner/test/profile-create-real-card-add.test.ts
+++ b/packages/runner/test/profile-create-real-card-add.test.ts
@@ -5,10 +5,9 @@ import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import { fromFileUrl } from "@std/path";
 
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
-import type { Options } from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
-import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
+import { newSharedServer } from "./memory-v2-test-utils.ts";
 
 // GOLD-STANDARD end-to-end repro of the profile card-add flow using the REAL
 // shipped patterns (profile-create.tsx + profile-home.tsx) — no synthetic
@@ -25,34 +24,6 @@ import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
 // the injected-form stamp) is a migration boundary, not exercised here.
 const signer = await Identity.fromPassphrase("profile-create-real-card-add");
 const spaceA = signer.did();
-
-class SharedServerStorageManager extends EmulatedStorageManager {
-  static connectTo(
-    server: MemoryV2Server.Server,
-    options: Omit<Options, "memoryHost" | "spaceHostMap">,
-  ): SharedServerStorageManager {
-    const manager = new SharedServerStorageManager(
-      { ...options, memoryHost: new URL("memory://") },
-      () => server,
-    );
-    manager.sharedServer = server;
-    return manager;
-  }
-  private sharedServer!: MemoryV2Server.Server;
-  protected override server(): MemoryV2Server.Server {
-    return this.sharedServer;
-  }
-}
-
-const newSharedServer = () =>
-  new MemoryV2Server.Server({
-    authorizeSessionOpen(message) {
-      const principal = (message.authorization as { principal?: unknown })
-        ?.principal;
-      return typeof principal === "string" ? principal : undefined;
-    },
-    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
-  });
 
 const sysDir = fromFileUrl(
   new URL("../../patterns/system/", import.meta.url),
@@ -100,13 +71,13 @@ const elementsListSchema = {
 
 describe("profile-create real card-add (REAL patterns, cross-space)", () => {
   let server: MemoryV2Server.Server;
-  let managerA: SharedServerStorageManager;
-  let managerB: SharedServerStorageManager;
+  let managerA: EmulatedStorageManager;
+  let managerB: EmulatedStorageManager;
 
   beforeEach(() => {
     server = newSharedServer();
-    managerA = SharedServerStorageManager.connectTo(server, { as: signer });
-    managerB = SharedServerStorageManager.connectTo(server, { as: signer });
+    managerA = EmulatedStorageManager.connectTo(server, { as: signer });
+    managerB = EmulatedStorageManager.connectTo(server, { as: signer });
   });
   afterEach(async () => {
     await managerA?.close();

--- a/packages/runner/test/pull-first-sync-race.test.ts
+++ b/packages/runner/test/pull-first-sync-race.test.ts
@@ -24,40 +24,9 @@ import { Identity } from "@commonfabric/identity";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
-import type { Options } from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { Cell } from "../src/cell.ts";
-import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
-
-class SharedServerStorageManager extends EmulatedStorageManager {
-  static connectTo(
-    server: MemoryV2Server.Server,
-    options: Omit<Options, "memoryHost" | "spaceHostMap">,
-  ): SharedServerStorageManager {
-    const manager = new SharedServerStorageManager(
-      { ...options, memoryHost: new URL("memory://") },
-      () => server,
-    );
-    manager.sharedServer = server;
-    return manager;
-  }
-
-  private sharedServer!: MemoryV2Server.Server;
-
-  protected override server(): MemoryV2Server.Server {
-    return this.sharedServer;
-  }
-}
-
-const newSharedServer = () =>
-  new MemoryV2Server.Server({
-    authorizeSessionOpen(message) {
-      const principal = (message.authorization as { principal?: unknown })
-        ?.principal;
-      return typeof principal === "string" ? principal : undefined;
-    },
-    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
-  });
+import { newSharedServer } from "./memory-v2-test-utils.ts";
 
 const signer = await Identity.fromPassphrase("pull-first-sync-race");
 const space = signer.did();
@@ -67,12 +36,12 @@ const RECEIPT_VALUE = { note: { title: "Original", revision: 1 } };
 
 describe("pull() and the first sync of an unseen doc", () => {
   let server: MemoryV2Server.Server;
-  let writerStorage: SharedServerStorageManager;
+  let writerStorage: EmulatedStorageManager;
   let writerRt: Runtime;
 
   beforeEach(async () => {
     server = newSharedServer();
-    writerStorage = SharedServerStorageManager.connectTo(server, {
+    writerStorage = EmulatedStorageManager.connectTo(server, {
       as: signer,
     });
     writerRt = new Runtime({
@@ -97,7 +66,7 @@ describe("pull() and the first sync of an unseen doc", () => {
   });
 
   it("resolves the doc's value even when the sync answer arrives after idle", async () => {
-    const readerStorage = SharedServerStorageManager.connectTo(server, {
+    const readerStorage = EmulatedStorageManager.connectTo(server, {
       as: signer,
     });
     const readerRt = new Runtime({
@@ -143,7 +112,7 @@ describe("pull() and the first sync of an unseen doc", () => {
     // The swallow arm: a failed first sync must degrade to what the replica
     // holds (here: nothing), never reject or hang the pull. Same stance as
     // link-resolution's kicks — the read still resolves.
-    const readerStorage = SharedServerStorageManager.connectTo(server, {
+    const readerStorage = EmulatedStorageManager.connectTo(server, {
       as: signer,
     });
     const readerRt = new Runtime({

--- a/packages/runner/test/reactive-stale-basis-strand.test.ts
+++ b/packages/runner/test/reactive-stale-basis-strand.test.ts
@@ -30,45 +30,16 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
-import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import type * as MemoryV2Server from "@commonfabric/memory/v2/server";
 
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
-import type { Options } from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
 import { MAX_RETRIES_FOR_REACTIVE } from "../src/scheduler/constants.ts";
-import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
+import { newSharedServer } from "./memory-v2-test-utils.ts";
 
 const signer = await Identity.fromPassphrase("reactive-stale-basis-strand");
 const space = signer.did();
-
-class SharedServerStorageManager extends EmulatedStorageManager {
-  static connectTo(
-    server: MemoryV2Server.Server,
-    options: Omit<Options, "memoryHost" | "spaceHostMap">,
-  ): SharedServerStorageManager {
-    const manager = new SharedServerStorageManager(
-      { ...options, memoryHost: new URL("memory://") },
-      () => server,
-    );
-    manager.sharedServer = server;
-    return manager;
-  }
-  private sharedServer!: MemoryV2Server.Server;
-  protected override server(): MemoryV2Server.Server {
-    return this.sharedServer;
-  }
-}
-
-const newSharedServer = () =>
-  new MemoryV2Server.Server({
-    authorizeSessionOpen(message) {
-      const principal = (message.authorization as { principal?: unknown })
-        ?.principal;
-      return typeof principal === "string" ? principal : undefined;
-    },
-    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
-  });
 
 // Shared `input`; a per-session `output` each session materializes from the input
 // via a lift. The second session reacting to the first session's input change is
@@ -96,7 +67,7 @@ const PROGRAM: RuntimeProgram = {
 const RESULT_CAUSE = "reactive-stale-basis-strand host";
 
 function makeRuntime(server: MemoryV2Server.Server) {
-  const storage = SharedServerStorageManager.connectTo(server, { as: signer });
+  const storage = EmulatedStorageManager.connectTo(server, { as: signer });
   const rt = new Runtime({
     apiUrl: new URL(import.meta.url),
     storageManager: storage,

--- a/packages/runner/test/rehydrate-internal-default.test.ts
+++ b/packages/runner/test/rehydrate-internal-default.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
-import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import type * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import { EmulatedStorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Cell, type Pattern } from "../src/builder/types.ts";
 import { Runtime } from "../src/runtime.ts";
@@ -10,7 +10,7 @@ import { trustExecutable } from "./support/trusted-builder.ts";
 import { JSONValue } from "@commonfabric/runner/shared";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { isPrimitiveCellLink } from "../src/link-types.ts";
-import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
+import { newSharedServer } from "./memory-v2-test-utils.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
@@ -19,19 +19,6 @@ const space = signer.did();
 // boundary) but keep SEPARATE client caches. This models a reload: the second
 // runtime starts cold and must fetch persisted docs from the server, rather
 // than reading the first runtime's warm cache.
-class SharedServerStorageManager extends EmulatedStorageManager {
-  constructor(as: Identity, server: MemoryV2Server.Server) {
-    super({ as, memoryHost: new URL("memory://") }, () => server);
-  }
-  // The shared server is owned by the test, not by either manager. Closing one
-  // manager must not close the server out from under the other; close only this
-  // manager's client by invoking the grandparent (plain StorageManager) close.
-  override close(): Promise<void> {
-    const baseClose = Object.getPrototypeOf(EmulatedStorageManager.prototype)
-      .close as (this: EmulatedStorageManager) => Promise<void>;
-    return baseClose.call(this);
-  }
-}
 
 // Regression coverage for CT-1666.
 //
@@ -57,8 +44,8 @@ class SharedServerStorageManager extends EmulatedStorageManager {
 // cache, exercising the load path the gate is responsible for.
 describe("rehydrate internal default (CT-1666)", () => {
   let server: MemoryV2Server.Server;
-  let sm1: SharedServerStorageManager;
-  let sm2: SharedServerStorageManager;
+  let sm1: EmulatedStorageManager;
+  let sm2: EmulatedStorageManager;
 
   const pattern: Pattern = {
     argumentSchema: {},
@@ -111,16 +98,9 @@ describe("rehydrate internal default (CT-1666)", () => {
   };
 
   beforeEach(() => {
-    server = new MemoryV2Server.Server({
-      authorizeSessionOpen(message) {
-        const principal = (message.authorization as { principal?: unknown })
-          ?.principal;
-        return typeof principal === "string" ? principal : undefined;
-      },
-      sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
-    });
-    sm1 = new SharedServerStorageManager(signer, server);
-    sm2 = new SharedServerStorageManager(signer, server);
+    server = newSharedServer();
+    sm1 = EmulatedStorageManager.connectTo(server, { as: signer });
+    sm2 = EmulatedStorageManager.connectTo(server, { as: signer });
   });
   afterEach(async () => {
     await sm1?.close();

--- a/packages/runner/test/reload-rehydration-map-children.test.ts
+++ b/packages/runner/test/reload-rehydration-map-children.test.ts
@@ -5,14 +5,13 @@ import {
   getLogger,
   getLoggerCountsBreakdown,
 } from "@commonfabric/utils/logger";
-import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import type * as MemoryV2Server from "@commonfabric/memory/v2/server";
 
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
-import type { Options } from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { JSONSchema } from "../src/builder/types.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
-import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
+import { newSharedServer } from "./memory-v2-test-utils.ts";
 
 // F6c (docs/specs/scheduler-v2/per-doc-rehydration.md): a resumed piece with
 // map rows must re-attach the per-element child runs. Dynamic map callbacks do
@@ -30,36 +29,6 @@ const signer = await Identity.fromPassphrase(
   "reload rehydration map children",
 );
 const space = signer.did();
-
-class SharedServerStorageManager extends EmulatedStorageManager {
-  static connectTo(
-    server: MemoryV2Server.Server,
-    options: Omit<Options, "memoryHost" | "spaceHostMap">,
-  ): SharedServerStorageManager {
-    const manager = new SharedServerStorageManager(
-      { ...options, memoryHost: new URL("memory://") },
-      () => server,
-    );
-    manager.sharedServer = server;
-    return manager;
-  }
-
-  private sharedServer!: MemoryV2Server.Server;
-
-  protected override server(): MemoryV2Server.Server {
-    return this.sharedServer;
-  }
-}
-
-const newSharedServer = () =>
-  new MemoryV2Server.Server({
-    authorizeSessionOpen(message) {
-      const principal = (message.authorization as { principal?: unknown })
-        ?.principal;
-      return typeof principal === "string" ? principal : undefined;
-    },
-    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
-  });
 
 const ITEMS_SCHEMA: JSONSchema = {
   type: "array",
@@ -79,7 +48,7 @@ const PROGRAM: RuntimeProgram = {
   }],
 };
 
-function newRuntime(storageManager: SharedServerStorageManager) {
+function newRuntime(storageManager: EmulatedStorageManager) {
   return new Runtime({
     apiUrl: new URL(import.meta.url),
     storageManager,
@@ -106,13 +75,13 @@ function opRuns(trace: readonly { actionId: string }[]): string[] {
 
 describe("reload isolation: map per-element children", () => {
   let server: MemoryV2Server.Server;
-  let managerA: SharedServerStorageManager;
-  let managerB: SharedServerStorageManager;
+  let managerA: EmulatedStorageManager;
+  let managerB: EmulatedStorageManager;
 
   beforeEach(() => {
     server = newSharedServer();
-    managerA = SharedServerStorageManager.connectTo(server, { as: signer });
-    managerB = SharedServerStorageManager.connectTo(server, { as: signer });
+    managerA = EmulatedStorageManager.connectTo(server, { as: signer });
+    managerB = EmulatedStorageManager.connectTo(server, { as: signer });
   });
 
   afterEach(async () => {

--- a/packages/runner/test/replica-eviction-invariants.test.ts
+++ b/packages/runner/test/replica-eviction-invariants.test.ts
@@ -26,7 +26,7 @@ import { expect } from "@std/expect";
 
 import type { OpaqueCell } from "@commonfabric/api";
 import { Identity } from "@commonfabric/identity";
-import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import type * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
 import { type JSONSchema } from "../src/builder/types.ts";
@@ -34,8 +34,7 @@ import { createBuilder } from "../src/builder/factory.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
-import type { Options } from "../src/storage/v2.ts";
-import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
+import { newSharedServer } from "./memory-v2-test-utils.ts";
 
 const signer = await Identity.fromPassphrase("replica eviction invariants");
 const space = signer.did();
@@ -130,44 +129,18 @@ describe("a list projection survives its input emptying", () => {
 
 // Two managers over one in-process server, so a commit on one can conflict with
 // a commit on the other.
-class SharedServerStorageManager extends EmulatedStorageManager {
-  static connectTo(
-    server: MemoryV2Server.Server,
-    options: Omit<Options, "memoryHost" | "spaceHostMap">,
-  ): SharedServerStorageManager {
-    const manager = new SharedServerStorageManager(
-      { ...options, memoryHost: new URL("memory://") },
-      () => server,
-    );
-    manager.sharedServer = server;
-    return manager;
-  }
-
-  private sharedServer!: MemoryV2Server.Server;
-
-  protected override server(): MemoryV2Server.Server {
-    return this.sharedServer;
-  }
-}
 
 describe("a cross-replica conflict settles", () => {
   let server: MemoryV2Server.Server;
-  let storageA: SharedServerStorageManager;
-  let storageB: SharedServerStorageManager;
+  let storageA: EmulatedStorageManager;
+  let storageB: EmulatedStorageManager;
   let rtA: Runtime;
   let rtB: Runtime;
 
   beforeEach(() => {
-    server = new MemoryV2Server.Server({
-      authorizeSessionOpen(message) {
-        const principal = (message.authorization as { principal?: unknown })
-          ?.principal;
-        return typeof principal === "string" ? principal : undefined;
-      },
-      sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
-    });
-    storageA = SharedServerStorageManager.connectTo(server, { as: signer });
-    storageB = SharedServerStorageManager.connectTo(server, { as: signer });
+    server = newSharedServer();
+    storageA = EmulatedStorageManager.connectTo(server, { as: signer });
+    storageB = EmulatedStorageManager.connectTo(server, { as: signer });
     rtA = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storageA,

--- a/packages/runner/test/resume-argument-link-target-presync.test.ts
+++ b/packages/runner/test/resume-argument-link-target-presync.test.ts
@@ -5,14 +5,13 @@ import {
   getLogger,
   getLoggerCountsBreakdown,
 } from "@commonfabric/utils/logger";
-import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import type * as MemoryV2Server from "@commonfabric/memory/v2/server";
 
 import { toMemorySpaceAddress } from "../src/link-utils.ts";
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
-import type { Options } from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
-import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
+import { newSharedServer } from "./memory-v2-test-utils.ts";
 
 const signer = await Identity.fromPassphrase(
   "resume argument link target presync",
@@ -33,35 +32,6 @@ const space = signer.did();
 // Two managers with their OWN replicas loopback-connected to one in-process
 // server (same shape as inspace-child-owner-seed.test.ts): a shared emulate
 // manager's replicas would be warm and mask the cold-read entirely.
-class SharedServerStorageManager extends EmulatedStorageManager {
-  static connectTo(
-    server: MemoryV2Server.Server,
-    options: Omit<Options, "memoryHost" | "spaceHostMap">,
-  ): SharedServerStorageManager {
-    const manager = new SharedServerStorageManager(
-      { ...options, memoryHost: new URL("memory://") },
-      () => server,
-    );
-    manager.sharedServer = server;
-    return manager;
-  }
-
-  private sharedServer!: MemoryV2Server.Server;
-
-  protected override server(): MemoryV2Server.Server {
-    return this.sharedServer;
-  }
-}
-
-const newSharedServer = () =>
-  new MemoryV2Server.Server({
-    authorizeSessionOpen(message) {
-      const principal = (message.authorization as { principal?: unknown })
-        ?.principal;
-      return typeof principal === "string" ? principal : undefined;
-    },
-    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
-  });
 
 // The picker flow in miniature: `profile` is its own document; `def` is its
 // own document whose VALUE is a link to `profile`; the child pattern's
@@ -112,13 +82,13 @@ function commitConflictCount(): number {
 
 describe("resume pre-sync covers argument link targets", () => {
   let server: MemoryV2Server.Server;
-  let managerA: SharedServerStorageManager;
-  let managerB: SharedServerStorageManager;
+  let managerA: EmulatedStorageManager;
+  let managerB: EmulatedStorageManager;
 
   beforeEach(() => {
     server = newSharedServer();
-    managerA = SharedServerStorageManager.connectTo(server, { as: signer });
-    managerB = SharedServerStorageManager.connectTo(server, { as: signer });
+    managerA = EmulatedStorageManager.connectTo(server, { as: signer });
+    managerB = EmulatedStorageManager.connectTo(server, { as: signer });
   });
 
   afterEach(async () => {

--- a/packages/runner/test/scheduler-cold-replica.test.ts
+++ b/packages/runner/test/scheduler-cold-replica.test.ts
@@ -8,7 +8,6 @@ import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import type { RuntimeProgram } from "../src/harness/types.ts";
 import { Runtime } from "../src/runtime.ts";
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
-import type { Options } from "../src/storage/v2.ts";
 
 const signer = await Identity.fromPassphrase("scheduler cold replica");
 const space = signer.did();
@@ -40,30 +39,10 @@ const PROGRAM: RuntimeProgram = {
   }],
 };
 
-class SharedServerStorageManager extends EmulatedStorageManager {
-  static connectTo(
-    server: MemoryV2Server.Server,
-    options: Omit<Options, "memoryHost" | "spaceHostMap">,
-  ): SharedServerStorageManager {
-    const manager = new SharedServerStorageManager(
-      { ...options, memoryHost: new URL("memory://") },
-      () => server,
-    );
-    manager.sharedServer = server;
-    return manager;
-  }
-
-  private sharedServer!: MemoryV2Server.Server;
-
-  protected override server(): MemoryV2Server.Server {
-    return this.sharedServer;
-  }
-}
-
 const newSharedServer = () =>
   new MemoryV2Server.Server(TEST_MEMORY_SERVER_AUTH);
 
-const newRuntime = (storageManager: SharedServerStorageManager) =>
+const newRuntime = (storageManager: EmulatedStorageManager) =>
   new Runtime({
     apiUrl: new URL(import.meta.url),
     storageManager,
@@ -71,15 +50,15 @@ const newRuntime = (storageManager: SharedServerStorageManager) =>
 
 describe("scheduler cold-replica startup", () => {
   let server: MemoryV2Server.Server;
-  let writerStorage: SharedServerStorageManager;
-  let readerStorage: SharedServerStorageManager;
+  let writerStorage: EmulatedStorageManager;
+  let readerStorage: EmulatedStorageManager;
 
   beforeEach(() => {
     server = newSharedServer();
-    writerStorage = SharedServerStorageManager.connectTo(server, {
+    writerStorage = EmulatedStorageManager.connectTo(server, {
       as: signer,
     });
-    readerStorage = SharedServerStorageManager.connectTo(server, {
+    readerStorage = EmulatedStorageManager.connectTo(server, {
       as: signer,
     });
   });

--- a/packages/runner/test/schema-gated-link-coverage.test.ts
+++ b/packages/runner/test/schema-gated-link-coverage.test.ts
@@ -23,45 +23,14 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
-import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import type * as MemoryV2Server from "@commonfabric/memory/v2/server";
 
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
-import type { Options } from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
-import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
+import { newSharedServer } from "./memory-v2-test-utils.ts";
 
 const signer = await Identity.fromPassphrase("schema-gated-link-coverage");
 const space = signer.did();
-
-class SharedServerStorageManager extends EmulatedStorageManager {
-  static connectTo(
-    server: MemoryV2Server.Server,
-    options: Omit<Options, "memoryHost" | "spaceHostMap">,
-  ): SharedServerStorageManager {
-    const manager = new SharedServerStorageManager(
-      { ...options, memoryHost: new URL("memory://") },
-      () => server,
-    );
-    manager.sharedServer = server;
-    return manager;
-  }
-
-  private sharedServer!: MemoryV2Server.Server;
-
-  protected override server(): MemoryV2Server.Server {
-    return this.sharedServer;
-  }
-}
-
-const newSharedServer = () =>
-  new MemoryV2Server.Server({
-    authorizeSessionOpen(message) {
-      const principal = (message.authorization as { principal?: unknown })
-        ?.principal;
-      return typeof principal === "string" ? principal : undefined;
-    },
-    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
-  });
 
 type LinkedDoc = { text?: string };
 type GatedDoc = { mediaType?: string; content?: LinkedDoc };
@@ -95,15 +64,15 @@ const gatedSchema = {
 
 describe("schema-gated link expansion at coverage", () => {
   let server: MemoryV2Server.Server;
-  let storageA: SharedServerStorageManager;
-  let storageB: SharedServerStorageManager;
+  let storageA: EmulatedStorageManager;
+  let storageB: EmulatedStorageManager;
   let rtA: Runtime;
   let rtB: Runtime;
 
   beforeEach(() => {
     server = newSharedServer();
-    storageA = SharedServerStorageManager.connectTo(server, { as: signer });
-    storageB = SharedServerStorageManager.connectTo(server, { as: signer });
+    storageA = EmulatedStorageManager.connectTo(server, { as: signer });
+    storageB = EmulatedStorageManager.connectTo(server, { as: signer });
     rtA = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: storageA,

--- a/packages/runner/test/scoped-link-whole-object-read.test.ts
+++ b/packages/runner/test/scoped-link-whole-object-read.test.ts
@@ -1,10 +1,9 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
-import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import type * as MemoryV2Server from "@commonfabric/memory/v2/server";
 
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
-import type { Options } from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
 import {
   cellWithScopedLinkRequiredsRelaxed,
@@ -14,7 +13,7 @@ import {
 import type { JSONSchema } from "../src/builder/types.ts";
 import type { Cell } from "../src/cell.ts";
 import { dataUriFromValueWithResolvedLinks } from "../src/data-uri.ts";
-import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
+import { newSharedServer } from "./memory-v2-test-utils.ts";
 
 // Whole-object piece reads void on scoped links (CLI `cf piece get` with no
 // path returned undefined while every child path worked).
@@ -38,35 +37,6 @@ import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
 // `required` no longer claims properties stored as narrower-scoped links,
 // and PiecePropIo.get reads both roots and selected subtrees through it —
 // expressing partial visibility in the schema, exactly as #4746 prescribes.
-class SharedServerStorageManager extends EmulatedStorageManager {
-  static connectTo(
-    server: MemoryV2Server.Server,
-    options: Omit<Options, "memoryHost" | "spaceHostMap">,
-  ): SharedServerStorageManager {
-    const manager = new SharedServerStorageManager(
-      { ...options, memoryHost: new URL("memory://") },
-      () => server,
-    );
-    manager.sharedServer = server;
-    return manager;
-  }
-
-  private sharedServer!: MemoryV2Server.Server;
-
-  protected override server(): MemoryV2Server.Server {
-    return this.sharedServer;
-  }
-}
-
-const newSharedServer = () =>
-  new MemoryV2Server.Server({
-    authorizeSessionOpen(message) {
-      const principal = (message.authorization as { principal?: unknown })
-        ?.principal;
-      return typeof principal === "string" ? principal : undefined;
-    },
-    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
-  });
 
 const signer = await Identity.fromPassphrase("scoped-link-whole-object-read");
 const space = signer.did();
@@ -96,12 +66,12 @@ const lenientResultSchema = {
 
 describe("whole-object read over a session-scoped link", () => {
   let server: MemoryV2Server.Server;
-  let writerStorage: SharedServerStorageManager;
+  let writerStorage: EmulatedStorageManager;
   let writerRt: Runtime;
 
   beforeEach(async () => {
     server = newSharedServer();
-    writerStorage = SharedServerStorageManager.connectTo(server, {
+    writerStorage = EmulatedStorageManager.connectTo(server, {
       as: signer,
     });
     writerRt = new Runtime({
@@ -155,7 +125,7 @@ describe("whole-object read over a session-scoped link", () => {
     // A fresh storage manager mints a fresh sessionId — this replica is a
     // DIFFERENT session (the CLI) than the writer (the browser), so the
     // session-scoped draft doc does not exist for it.
-    const storage = SharedServerStorageManager.connectTo(server, {
+    const storage = EmulatedStorageManager.connectTo(server, {
       as: signer,
     });
     const rt = new Runtime({

--- a/packages/runner/test/sqlite-handle-multi-runtime.test.ts
+++ b/packages/runner/test/sqlite-handle-multi-runtime.test.ts
@@ -21,14 +21,9 @@ import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import type { SqliteTableSchemas } from "@commonfabric/api";
 import { Identity } from "@commonfabric/identity";
-import type { MemorySpace, Signer } from "@commonfabric/memory/interface";
-import * as MemoryV2Client from "@commonfabric/memory/v2/client";
-import * as MemoryV2Server from "@commonfabric/memory/v2/server";
-import {
-  type Options,
-  type SessionFactory,
-  StorageManager,
-} from "../src/storage/v2.ts";
+import type * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import { newSharedServer } from "./memory-v2-test-utils.ts";
 import { Runtime } from "../src/runtime.ts";
 import { createCell } from "../src/cell.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
@@ -43,59 +38,9 @@ const signer = await Identity.fromPassphrase(
 );
 const space = signer.did();
 
-// ---------------------------------------------------------------------------
-// Two storage managers, ONE server — the emulated loopback session factory
-// (mirrors v2-emulate.ts) against a caller-owned server, so each manager has
-// its own heap/replica while sharing the durable state.
-// ---------------------------------------------------------------------------
-
-class LoopbackSessionFactory implements SessionFactory {
-  constructor(private readonly server: MemoryV2Server.Server) {}
-
-  async create(space: MemorySpace, signer?: Signer) {
-    const client = await MemoryV2Client.connect({
-      transport: MemoryV2Client.loopback(this.server),
-    });
-    const session = await client.mount(
-      space,
-      {},
-      (_space, _session, context) => ({
-        invocation: {
-          aud: context.audience,
-          challenge: context.challenge.value,
-        },
-        authorization: { principal: signer?.did() },
-      }),
-    );
-    return { client, session };
-  }
-}
-
-class SharedServerStorageManager extends StorageManager {
-  static overServer(
-    options: Omit<Options, "memoryHost">,
-    server: MemoryV2Server.Server,
-  ): SharedServerStorageManager {
-    return new SharedServerStorageManager(
-      // Placeholder: the loopback session factory never resolves an address.
-      { ...options, memoryHost: new URL("memory://") },
-      new LoopbackSessionFactory(server),
-    );
-  }
-}
-
-function newServer(): MemoryV2Server.Server {
-  return new MemoryV2Server.Server({
-    authorizeSessionOpen(message) {
-      const principal = (message.authorization as { principal?: unknown })
-        ?.principal;
-      return typeof principal === "string" ? principal : undefined;
-    },
-    sessionOpenAuth: {
-      audience: "did:key:z6Mk-runner-shared-server-test",
-    },
-  });
-}
+// Two storage managers, ONE server (`EmulatedStorageManager.connectTo`
+// against a caller-owned `newSharedServer()`), so each manager has its own
+// heap/replica while sharing the durable state.
 
 // ---------------------------------------------------------------------------
 // The pattern under test: a rule-bearing db whose rule is a term LIST
@@ -211,13 +156,10 @@ describe("sqlite handle across runtimes (rule term lists)", () => {
   let runtimeB: Runtime | undefined;
 
   beforeEach(() => {
-    server = newServer();
+    server = newSharedServer();
     runtimeA = new Runtime({
       apiUrl: new URL(import.meta.url),
-      storageManager: SharedServerStorageManager.overServer(
-        { as: signer },
-        server,
-      ),
+      storageManager: EmulatedStorageManager.connectTo(server, { as: signer }),
     });
     runtimeB = undefined;
   });
@@ -295,10 +237,7 @@ describe("sqlite handle across runtimes (rule term lists)", () => {
     // (no inputs re-provided — a pure loader, like a second tab).
     runtimeB = new Runtime({
       apiUrl: new URL(import.meta.url),
-      storageManager: SharedServerStorageManager.overServer(
-        { as: signer },
-        server,
-      ),
+      storageManager: EmulatedStorageManager.connectTo(server, { as: signer }),
     });
     // Count B's server reads: with a stable request hash B must DEDUP against
     // the settled shared result, never issue its own request. (The red failure


### PR DESCRIPTION
## Summary

Second of four CT-1962 PRs (stacked on #5547). The 32 byte-identical copy-pasted `SharedServerStorageManager` subclasses (29 runner, 2 piece, 1 cli) collapse into one static: `EmulatedStorageManager.connectTo(server, options)`, plus `newLoopbackServer(options?)` (re-exported via `cache.deno`) and an audience-pinned `newSharedServer(options?)` in the runner test utils. Both accept `subscriptionRefreshDelayMs`, including `"manual"` from #5547.

Two behavior-relevant details, both improvements:
- `connectTo` sets caller-owned server lifecycle (`#ownsServer = false`) — the copies achieved this implicitly by overriding `server()` so the memoized close path never saw the shared server.
- `own-write-echo-live` converts from a 60s held delay to `"manual"`: under the runner's fake-clock auto-advance, a large delay is not a hold — the pump fires any armed timer regardless of nominal delay once macrotask turns exist. The archetypal controlled-staleness fixture now gates fan-out structurally.

Deviations preserved as-is: fixed-principal servers stay local (`action-result-fabric-values`, `scheduler-cold-replica`); `effect-conflict-recovery` keeps its `subscribe()` override as a minimal subclass; `list-builtin-edge-paths`' separate plain-transport harness untouched; `sqlite-handle-multi-runtime`'s audience literal unifies to the shared test audience (inert — the client echoes whatever the server advertises).

## Verification

- runner: full suite 1168 passed / 0 failed (with preload); `deno task check` green
- piece: both converted files, 4 passed (135 steps)
- cli: piece.test.ts, 83 steps green
- fmt/lint clean across all 35 touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

