### PR TITLE
test(runtime-client): make the transport doubles honor the ownership contract

### DIFF
--- a/packages/runtime-client/backends/cell-set-echo-race.test.ts
+++ b/packages/runtime-client/backends/cell-set-echo-race.test.ts
@@ -111,7 +111,11 @@ class InProcessWorkerTransport extends EventEmitter<RuntimeTransportEvents>
     super();
   }
 
-  send(message: IPCClientMessage | IPCClientNotification): void {
+  send(original: IPCClientMessage | IPCClientNotification): void {
+    // Cloned, as a real transport delivers it: `BaseRequest` entitles a handler
+    // to own what its request carries, and handing over the sender's own object
+    // would let a handler that cedes a payload reach back into the sender.
+    const message = structuredClone(original);
     if (!("msgId" in message)) {
       throw new Error("This test sends no one-way client notifications");
     }

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -1396,15 +1396,17 @@ describe("RuntimeProcessor blob upload IPC", () => {
       },
     } as unknown as RuntimeProcessor;
 
+    // Freshly allocated, as the transport's clone delivers it: the handler owns
+    // its request's payload. Kept here so the test can check what became of it.
+    const payload = new Uint8Array([1, 2, 3]);
+
     try {
       await expect(
         RuntimeProcessor.prototype.handleUploadBlob.call(processor, {
           type: RequestType.UploadBlob,
           space: "did:key:test-space" as never,
           contentType: "image/png",
-          // Freshly allocated, as the transport's clone delivers it: the
-          // handler owns its request's payload.
-          body: new Uint8Array([1, 2, 3]),
+          body: payload,
           suffix: "png",
         }),
       ).resolves.toEqual({
@@ -1414,6 +1416,11 @@ describe("RuntimeProcessor blob upload IPC", () => {
     } finally {
       globalThis.fetch = originalFetch;
     }
+
+    // The handler CONSUMES its payload -- `BaseRequest` entitles it to, and it
+    // does, which is what makes the transport's ownership guarantee load-
+    // bearing rather than decorative. A detached array reports zero length.
+    expect(payload.length).toBe(0);
 
     expect(requestedUrl).toBe(
       "http://toolshed.test/did:key:test-space/blobs/upload.png",

--- a/packages/runtime-client/client/connection.test.ts
+++ b/packages/runtime-client/client/connection.test.ts
@@ -474,29 +474,39 @@ describe("RuntimeConnection loop-lag probe", () => {
       globalThis.clearInterval = originalClearInterval;
     }
   });
+});
 
-  describe("the transport contract", () => {
-    it("delivers a message unshared with the sender", () => {
-      // `RuntimeTransport.send()` requires the far end to receive a value it
-      // owns, which is what lets a handler cede a byte payload rather than
-      // copy it. A double that passed the sender's object through would model
-      // something no real transport does.
-      const transport = new FakeTransport();
-      const payload = new Uint8Array([1, 2, 3]);
-      const message = {
-        msgId: 1,
-        data: { type: RequestType.Idle, payload },
-      } as unknown as IPCClientMessage;
+describe("FakeTransport", () => {
+  it("delivers a message unshared with the sender", () => {
+    // `RuntimeTransport.send()` requires the far end to receive a value it
+    // owns, which is what lets a handler cede a byte payload rather than copy
+    // it. A double that passed the sender's object through would model
+    // something no real transport does.
+    const transport = new FakeTransport();
+    const body = new Uint8Array([1, 2, 3]);
+    const message: IPCClientMessage = {
+      msgId: 1,
+      data: {
+        type: RequestType.UploadBlob,
+        space: "did:key:test-space",
+        contentType: "image/png",
+        body,
+      },
+    };
 
-      transport.send(message);
+    transport.send(message);
 
-      const captured = transport.sent[0] as unknown as {
-        data: { payload: Uint8Array };
-      };
-      expect(captured).not.toBe(message);
-      expect(captured.data.payload).not.toBe(payload);
-      payload[0] = 0xff;
-      expect(captured.data.payload[0]).toBe(1);
-    });
+    const captured = transport.sent[0];
+    expect(captured).not.toBe(message);
+    if (
+      !("msgId" in captured) || captured.data.type !== RequestType.UploadBlob
+    ) {
+      throw new Error("Expected the upload request to have been captured.");
+    }
+    expect(captured.data.body).not.toBe(body);
+    // Mutate and re-read, rather than compare identity alone: a shallow copy
+    // differs by identity while still sharing the array.
+    body[0] = 0xff;
+    expect(captured.data.body[0]).toBe(1);
   });
 });

--- a/packages/runtime-client/client/connection.test.ts
+++ b/packages/runtime-client/client/connection.test.ts
@@ -27,7 +27,10 @@ class FakeTransport extends EventEmitter<RuntimeTransportEvents>
     super();
   }
 
-  send(message: IPCClientMessage | IPCClientNotification): void {
+  send(original: IPCClientMessage | IPCClientNotification): void {
+    // Cloned, as a real transport delivers it, so what is captured cannot
+    // change under later mutation by the sender.
+    const message = structuredClone(original);
     this.sent.push(message);
     // Notifications carry no msgId and get no reply.
     if (!("msgId" in message)) return;

--- a/packages/runtime-client/client/connection.test.ts
+++ b/packages/runtime-client/client/connection.test.ts
@@ -474,4 +474,29 @@ describe("RuntimeConnection loop-lag probe", () => {
       globalThis.clearInterval = originalClearInterval;
     }
   });
+
+  describe("the transport contract", () => {
+    it("delivers a message unshared with the sender", () => {
+      // `RuntimeTransport.send()` requires the far end to receive a value it
+      // owns, which is what lets a handler cede a byte payload rather than
+      // copy it. A double that passed the sender's object through would model
+      // something no real transport does.
+      const transport = new FakeTransport();
+      const payload = new Uint8Array([1, 2, 3]);
+      const message = {
+        msgId: 1,
+        data: { type: RequestType.Idle, payload },
+      } as unknown as IPCClientMessage;
+
+      transport.send(message);
+
+      const captured = transport.sent[0] as unknown as {
+        data: { payload: Uint8Array };
+      };
+      expect(captured).not.toBe(message);
+      expect(captured.data.payload).not.toBe(payload);
+      payload[0] = 0xff;
+      expect(captured.data.payload[0]).toBe(1);
+    });
+  });
 });

--- a/packages/runtime-client/client/initialize-init-data.test.ts
+++ b/packages/runtime-client/client/initialize-init-data.test.ts
@@ -19,7 +19,10 @@ import type { RuntimeTransport, RuntimeTransportEvents } from "./transport.ts";
 class CapturingTransport extends EventEmitter<RuntimeTransportEvents>
   implements RuntimeTransport {
   readonly sent: Array<IPCClientMessage | IPCClientNotification> = [];
-  send(message: IPCClientMessage | IPCClientNotification): void {
+  send(original: IPCClientMessage | IPCClientNotification): void {
+    // Cloned, as a real transport delivers it, so what is captured cannot
+    // change under later mutation by the sender.
+    const message = structuredClone(original);
     this.sent.push(message);
     if (!("msgId" in message)) return;
     queueMicrotask(() => {


### PR DESCRIPTION
The IPC contract says a handler owns what its request carries: `BaseRequest`
states that any value reaching a handler is owned outright by the receiver — not
already shared, and not becoming shared — with the matching obligation on
`RuntimeTransport.send()`. That guarantee is what lets `handleUploadBlob` cede a
blob payload into a `FabricBytes` rather than copy it.

Three test doubles did not honor it. I (agent working on behalf of @danfuzz)
found `cell-set-echo-race.test.ts` handing the sender's own object straight to
`handleRequest`, so a handler that cedes its payload reaches back into the
sender's state — and the doubles were the model a future one would be copied
from. All three now `structuredClone` on `send()`, as a real transport does.

Two tests pin the contract rather than the mechanism:

- **The handler consumes its payload.** `payload.length === 0` after
  `handleUploadBlob`, a detached array reporting zero length. This is what makes
  the transport guarantee load-bearing rather than decorative.
- **A transport delivers a message unshared with the sender.** It mutates the
  sender's array and re-reads through the captured message rather than only
  comparing identity — identity alone passes a copy that still shares the byte
  buffer, which is the trap this area keeps producing.

The second sends a real `UploadBlobRequest` — the byte-carrying request the
ownership contract exists for, already a member of the `IPCClientRequest` union
— which type-checks with no cast at either end.

Tests only; no production code changes.

### Verification

- Both tests ablated red, each against the mechanism it names: turning the cede
  into a copy (`new FabricBytes(request.body, false)`) fails the first, and
  replacing the double's `structuredClone` with a passthrough fails the second.
- Full workspace suite on this head: 40 packages, all ok.
- `runtime-client`: 56 passed.
- `deno fmt --check`, `deno lint`, and `deno check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgJfXNGF7ApQ21dcxGbgT3


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

