### PR TITLE
refactor(toolshed): drop the vestigial blob-encoding probe

### DIFF
--- a/packages/toolshed/routes/blobs/blobs.index.ts
+++ b/packages/toolshed/routes/blobs/blobs.index.ts
@@ -9,10 +9,7 @@ import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { hashOf } from "@commonfabric/data-model/value-hash";
 import { JsonCodec } from "@commonfabric/data-model/codec-json";
 import { EmptyReconstructionContext } from "@commonfabric/data-model/codec-common";
-import {
-  decodeMemoryBoundary,
-  encodeMemoryBoundary,
-} from "@commonfabric/memory/v2";
+import { decodeMemoryBoundary } from "@commonfabric/memory/v2";
 import type { Context } from "@hono/hono";
 
 const router = createRouter();
@@ -109,18 +106,6 @@ const asBlobContents = (value: unknown): BlobContents | undefined => {
   }
   return undefined;
 };
-
-const memoryBoundaryPreservesBlobContents = (contents: BlobContents): boolean =>
-  asBlobContents(decodeMemoryBoundary(encodeMemoryBoundary(contents))) !==
-    undefined;
-
-const storedBlobValue = (contents: BlobContents): BlobContents | {
-  type: string;
-  body: number[];
-} =>
-  memoryBoundaryPreservesBlobContents(contents)
-    ? contents
-    : { type: contents.type, body: Array.from(contents.body.slice()) };
 
 const parseBlobName = (
   blobName: string,
@@ -230,11 +215,7 @@ const upload = async (c: Context) => {
   const blobName = c.req.param("blobName") as string | undefined;
   const suffix = suffixFor(blobName, contents.type);
   const hash = id.slice("fid1:".length);
-  await memoryServer.writeDocument(
-    spaceDid,
-    `cid:${id}`,
-    storedBlobValue(contents),
-  );
+  await memoryServer.writeDocument(spaceDid, `cid:${id}`, contents);
 
   return c.json({ id, url: `blobs/${hash}.${suffix}` }, 201);
 };

--- a/packages/toolshed/routes/blobs/blobs.test.ts
+++ b/packages/toolshed/routes/blobs/blobs.test.ts
@@ -92,7 +92,7 @@ describe("Blob Routes", () => {
     expect(new Uint8Array(await get.arrayBuffer())).toEqual(bytes);
   });
 
-  it("accepts blob upload encoding from an explicit codec, without ambient data-model flags", async () => {
+  it("accepts blob upload encoding from an explicit codec", async () => {
     const identity = await Identity.fromPassphrase(
       "toolshed-blob-route-explicit-codec",
     );


### PR DESCRIPTION
Every blob upload encoded and decoded its entire payload, discarded the result,
and boxed the bytes to `number[]` if the round-trip had lost the `FabricBytes`.
Nothing can lose it, and nothing has been able to since May.

I (agent working on behalf of @danfuzz) went looking for why the probe existed
rather than just how much it cost, on @danfuzz's hypothesis that it dated from
the transition to the modern `data-model`. It does:

- `3b47b3a79` (2026-05-04) landed the blob endpoints **with** the probe, when
  `modernDataModel` and `unifiedJsonEncoding` were both live experimental flags.
  That commit's own `EXPERIMENTAL_OPTIONS.md` records `unifiedJsonEncoding` as
  what made "`jsonFromValue()` (etc.) dispatch to modern path" — so with it off,
  a `FabricBytes` genuinely did not survive the boundary. **The probe was
  correct when written.**
- #3557 (2026-05-12) removed the unified JSON flag, eight days later.
- #3821 (2026-06-02) removed `modernDataModel`.

Today `jsonFromValue()` is `jsonCodec.encode(value)` against a module-level
`new JsonCodec()` at `codec-json/impl.ts:9` — constructed with no options, and
reading no ambient state during encode. No configuration remains that could make
the round-trip lose a `FabricBytes`, so the probe always answered the same way
and the boxing arm was unreachable.

### Why the deletion is safe

The suite already proved it, which is why nothing here needed a new test.
`blobs.test.ts` "stores blob contents as a cell document value" POSTs a blob and
asserts `document?.value` **equals** `{type, body: FabricBytes}`, then syncs it
through a `Runtime` and asserts `value.body.constructor.name === "FabricBytes"`.
Had the fallback arm ever been taken, that assertion would have failed on a
`number[]`. The test has been passing since the flags went away.

### What it saves

An encode plus a decode of the whole payload, per upload. Measured before the
change, whole payload against a one-byte sentinel asking the same question:

| payload | whole payload | sentinel |
|---|---|---|
| 1 KiB | 0.028 ms | 0.0042 ms |
| 64 KiB | 0.065 ms | 0.0044 ms |
| 1 MiB | 0.478 ms | 0.0033 ms |

The sentinel is flat; the real probe tracked payload size. A 1 MiB upload also
allocated a ~1.37 MB base64 string and a decoded copy, both discarded.

Also drops a trailing clause from one test name that promised to run "without
ambient data-model flags" — there is no such flag to run without.

### Verification

- Full workspace suite: 40 packages, all ok.
- `toolshed`: 122 passed.
- `deno task check`, `check-docs`, `check-conflict-markers`, `check-skill-facts`,
  `check-no-waitfor`, `fmt --check`, `lint` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgJfXNGF7ApQ21dcxGbgT3


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

