### PR TITLE
docs(utils,data-model,pure-json): conform the inline comments in the doc-swept packages

### DIFF
--- a/packages/data-model/bench/hashing.bench.ts
+++ b/packages/data-model/bench/hashing.bench.ts
@@ -10,9 +10,9 @@
 import { hashOf } from "../src/value-hash.ts";
 import { deepFreeze } from "../src/deep-freeze.ts";
 
-// ---------------------------------------------------------------------------
+//
 // Pre-generated test data
-// ---------------------------------------------------------------------------
+//
 
 const smallObject = {
   name: "Alice",
@@ -88,9 +88,9 @@ for (let i = 0; i < 20; i++) {
   hashOf(smallObject);
 }
 
-// ==========================================================================
+//
 // Same-object benchmarks (measures cache effectiveness)
-// ==========================================================================
+//
 
 Deno.bench({
   name: "small object (5 keys)",
@@ -172,9 +172,9 @@ Deno.bench({
   },
 });
 
-// ==========================================================================
+//
 // Fresh-object benchmarks (no cache benefit -- measures raw hashing speed)
-// ==========================================================================
+//
 
 function freshSmallObject() {
   return {
@@ -249,9 +249,9 @@ Deno.bench({
   },
 });
 
-// ==========================================================================
+//
 // sparse arrays
-// ==========================================================================
+//
 
 const sparseArray = new Array(100);
 for (let i = 0; i < 100; i += 3) {
@@ -266,9 +266,9 @@ Deno.bench({
   },
 });
 
-// ==========================================================================
-// Deep-frozen same-object benchmarks (WeakMap cache should activate)
-// ==========================================================================
+//
+// Deep-frozen same-object benchmarks (the `WeakMap` cache activates)
+//
 
 const frozenSmallFlat = deepFreeze({
   name: "Alice",
@@ -353,9 +353,9 @@ Deno.bench({
   },
 });
 
-// ==========================================================================
+//
 // Deep-frozen fresh-object benchmarks (freeze + hash each iteration)
-// ==========================================================================
+//
 
 Deno.bench({
   name: "frozen small flat (fresh)",
@@ -400,9 +400,9 @@ Deno.bench({
   },
 });
 
-// ==========================================================================
-// {the, of} unclaimed-fact pattern benchmarks
-// ==========================================================================
+//
+// `{the, of}` unclaimed-fact pattern benchmarks
+//
 
 const frozenTheOf = Object.freeze({
   the: "application/json" as const,

--- a/packages/data-model/bench/value-identity-shapes.bench.ts
+++ b/packages/data-model/bench/value-identity-shapes.bench.ts
@@ -23,10 +23,10 @@
 import { hashOf } from "../src/value-hash.ts";
 import { deepFreeze, isDeepFrozen } from "../src/deep-freeze.ts";
 
-// ---------------------------------------------------------------------------
+//
 // Doc-shaped test data, mirroring the default-app integration:
 // a note doc (~30 nodes) and a home-list doc holding N note entries.
-// ---------------------------------------------------------------------------
+//
 
 function makeNoteDoc(i: number): Record<string, unknown> {
   return {
@@ -70,9 +70,9 @@ function makeCopies<T>(make: () => T, freeze: "none" | "plain" | "deep"): T[] {
   return copies;
 }
 
-// ---------------------------------------------------------------------------
-// hashOf
-// ---------------------------------------------------------------------------
+//
+// `hashOf()`
+//
 
 const frozenNote = deepFreeze(makeNoteDoc(1));
 const frozenHome128 = deepFreeze(makeHomeDoc(128));
@@ -125,9 +125,9 @@ Deno.bench({
   b.end();
 });
 
-// ---------------------------------------------------------------------------
-// deep-freeze
-// ---------------------------------------------------------------------------
+//
+// `deepFreeze()`
+//
 
 Deno.bench({
   name: "isDeepFrozen: cached home doc @128 (cache hit)",

--- a/packages/data-model/src/codec-json/JsonCodec.ts
+++ b/packages/data-model/src/codec-json/JsonCodec.ts
@@ -307,7 +307,8 @@ export class JsonCodec implements SerializationContext<string> {
         return Object.freeze(result);
       }
 
-      // Except for `/quote` and `/object`, the `state` needs to be fully decoded.
+      // Except for `/quote` and `/object`, the `state` needs to be fully
+      // decoded.
       const state = this.#decodeValue(rawState, context, registry);
 
       // A bare `"/"` key (empty tag after stripping the leading slash) is

--- a/packages/data-model/src/deep-freeze.ts
+++ b/packages/data-model/src/deep-freeze.ts
@@ -119,10 +119,10 @@ export function isDeepFrozen(value: unknown): boolean {
       // `check`, which shares this call's cycle state. Gating via
       // `BaseFabricInstance.isInstance()` keeps this generic (and enforces the
       // "every `FabricInstance` is a `BaseFabricInstance`" invariant); the
-      // member is abstract on `BaseFabricInstance`, so every instance implements
-      // it. (A `FabricPrimitive` never reaches here: it is necessarily frozen,
-      // so it short-circuits at the `isNecessarilyOrKnownDeepFrozen` check
-      // above.)
+      // member is abstract on `BaseFabricInstance`, so every instance
+      // implements it. (A `FabricPrimitive` never reaches here: it is
+      // necessarily frozen, so it short-circuits at the
+      // `isNecessarilyOrKnownDeepFrozen` check above.)
       result = obj[IS_DEEP_FROZEN](check);
     } else if (Array.isArray(obj)) {
       for (let i = 0; i < obj.length; i++) {

--- a/packages/data-model/src/fabric-primitives/FabricEpochDays.ts
+++ b/packages/data-model/src/fabric-primitives/FabricEpochDays.ts
@@ -94,7 +94,7 @@ export class FabricEpochDays extends BaseFabricPrimitive
   }
 }
 
-// Compile-time check that the exported `FabricEpochDays` constructor matches the
-// `FabricEpochDaysConstructor` declared in `@commonfabric/api`. This catches
-// drift between the public type contract and this implementation.
+// Compile-time check that the exported `FabricEpochDays` constructor matches
+// the `FabricEpochDaysConstructor` declared in `@commonfabric/api`. This
+// catches drift between the public type contract and this implementation.
 FabricEpochDays satisfies ApiFabricEpochDaysConstructor;

--- a/packages/data-model/src/fabric-primitives/FabricEpochNsec.ts
+++ b/packages/data-model/src/fabric-primitives/FabricEpochNsec.ts
@@ -100,7 +100,7 @@ export class FabricEpochNsec extends BaseFabricPrimitive
   }
 }
 
-// Compile-time check that the exported `FabricEpochNsec` constructor matches the
-// `FabricEpochNsecConstructor` declared in `@commonfabric/api`. This catches
-// drift between the public type contract and this implementation.
+// Compile-time check that the exported `FabricEpochNsec` constructor matches
+// the `FabricEpochNsecConstructor` declared in `@commonfabric/api`. This
+// catches drift between the public type contract and this implementation.
 FabricEpochNsec satisfies ApiFabricEpochNsecConstructor;

--- a/packages/data-model/src/native-conversion.ts
+++ b/packages/data-model/src/native-conversion.ts
@@ -245,7 +245,8 @@ export function shallowFabricFromNativeValue(
 
     case NATIVE_TAGS.Uint8Array: {
       // Native `Uint8Array` instances are wrapped in `FabricBytes`.
-      // `FabricBytes` self-freezes in its constructor (`FabricPrimitive` contract).
+      // `FabricBytes` self-freezes in its constructor (`FabricPrimitive`
+      // contract).
       return new FabricBytes(value as Uint8Array);
     }
 
@@ -614,7 +615,8 @@ function isFabricCompatibleInternal(
       // `FabricSpecialObject` -- already a valid `FabricValue`.
       if (value instanceof FabricSpecialObject) return true;
 
-      // `FabricNativeObject` types would be wrapped by `fabricFromNativeValue()`.
+      // `FabricNativeObject` types would be wrapped by
+      // `fabricFromNativeValue()`.
       if (isConvertibleNativeInstance(value)) {
         return true;
       }

--- a/packages/data-model/test/cloneIfNecessary.test.ts
+++ b/packages/data-model/test/cloneIfNecessary.test.ts
@@ -478,15 +478,16 @@ describe("cloneIfNecessary", () => {
   // Per-subclass coverage matrix.
   //
   // Systematically exercises every concrete `FabricInstance` and
-  // `FabricPrimitive` subclass in this package across the full `cloneIfNecessary`
-  // option matrix, and validates the result -- frozenness, identity preservation,
-  // observable state -- or that the call throws when a subclass's protocol
-  // implementation is a documented stub.
+  // `FabricPrimitive` subclass in this package across the full
+  // `cloneIfNecessary` option matrix, and validates the result -- frozenness,
+  // identity preservation, observable state -- or that the call throws when a
+  // subclass's protocol implementation is a documented stub.
   //
   // The point is twofold: (a) make sure existing subclasses behave consistently
   // under every option combination callers in production are likely to use, and
-  // (b) make sure any future subclass added to the package without full protocol
-  // coverage trips this matrix instead of silently breaking call sites.
+  // (b) make sure any future subclass added to the package without full
+  // protocol coverage trips this matrix instead of silently breaking call
+  // sites.
 
   /**
    * Describes what `cloneIfNecessary` is expected to do for a given subclass on

--- a/packages/data-model/test/codec-json/JsonCodec.test.ts
+++ b/packages/data-model/test/codec-json/JsonCodec.test.ts
@@ -246,9 +246,10 @@ describe("JsonCodec", () => {
 
   describe("tagged-type round-trips through the full stack", () => {
     // Representative coverage that the encode→tag-wrap→decode mechanism works
-    // for the standalone-codec and primitive Fabric types, including nesting in
-    // arrays and objects. Per-codec encode/decode detail lives in each type's
-    // own unit test (e.g. `BigIntCodec.test.ts`, `FabricEpochNsec.test.ts`).
+    // for the standalone-codec and primitive Fabric types, including nesting
+    // in arrays and objects. Per-codec encode/decode detail lives in each
+    // type's own unit test (e.g. `BigIntCodec.test.ts`,
+    // `FabricEpochNsec.test.ts`).
 
     it("round-trips `undefined` at top level, in arrays, and as object values", () => {
       expect(roundTrip(undefined)).toBe(undefined);
@@ -723,7 +724,8 @@ describe("JsonCodec", () => {
       it("emits `/quote` for doubly-nested `/`-prefixed literal object (whole subtree is literal)", () => {
         const obj = { "/x": { "/y": 123 } };
         const wire = toWireFormat(obj);
-        // Whole subtree is deep-literal → single /quote wrap of original structure.
+        // Whole subtree is deep-literal, so it takes a single `/quote` wrap of
+        // the original structure.
         expect(wire).toEqual({
           "/quote": { "/x": { "/y": 123 } },
         });
@@ -741,7 +743,8 @@ describe("JsonCodec", () => {
           "/quote": { "/x": { "/y": 123 } },
         });
 
-        // Fabric type as value: /object with the epoch encoded as its tagged form.
+        // Fabric type as value: `/object` with the epoch encoded as its tagged
+        // form.
         const withEpoch = {
           "/x": new FabricEpochDays(42n),
         };
@@ -797,17 +800,18 @@ describe("JsonCodec", () => {
 
     describe("general", () => {
       it("malformed wire: multi-key object with `/`-prefixed key produces `ProblematicValue`", () => {
-        // Wire data without /quote or /object wrapper — decoder must not silently
-        // round-trip it as a plain object.
+        // Wire data without a `/quote` or `/object` wrapper: the decoder must
+        // not silently round-trip it as a plain object.
         const data = { a: 1, "/b": 2 } as JsonCodecValue;
         const result = fromWireFormat(data);
         expect(result).toBeInstanceOf(ProblematicValue);
       });
 
       it("malformed wire: bare `/`-keyed object produces `ProblematicValue`", () => {
-        // Per spec §9, a single-key object whose key is bare "/" (empty tag
-        // after stripping the leading slash) is an encoding error. Decoding must
-        // produce a ProblematicValue, not an UnknownValue with an empty tag.
+        // Per spec §9, a single-key object whose key is bare `/` (empty tag
+        // after stripping the leading slash) is an encoding error. Decoding
+        // must produce a `ProblematicValue`, not an `UnknownValue` with an
+        // empty tag.
         const data = { "/": "x" } as JsonCodecValue;
         const result = fromWireFormat(data);
         expect(result).toBeInstanceOf(ProblematicValue);
@@ -835,9 +839,10 @@ describe("JsonCodec", () => {
       });
 
       it("single-key `/`-prefixed object still routes through `unwrapTag()` (no regression)", () => {
-        // Single-key /Tag@N objects are handled by unwrapTag, not the plain-object
-        // path — confirm they still produce UnknownValue (unrecognized tag), not
-        // ProblematicValue from the new multi-key guard.
+        // Single-key `/Tag@N` objects are handled by `unwrapTag()` rather than
+        // the plain-object path, so they produce an `UnknownValue` for the
+        // unrecognized tag and never reach the multi-key guard's
+        // `ProblematicValue`.
         const data = { "/Future@7": { id: "x" } } as JsonCodecValue;
         const result = fromWireFormat(data);
         expect(result).toBeInstanceOf(UnknownValue);
@@ -847,18 +852,19 @@ describe("JsonCodec", () => {
       });
 
       it("decoder strips exactly one `/quote` layer — inner `/quote` is preserved literally", () => {
-        // Wire form { "/quote": { "/quote": "x" } } is a /quote-wrapped literal
-        // whose content happens to be { "/quote": "x" }. Decoding must return
-        // { "/quote": "x" } as a frozen plain object — NOT recurse into it and
-        // return just "x".
+        // The wire form `{"/quote": {"/quote": "x"}}` is a `/quote`-wrapped
+        // literal whose content happens to be `{"/quote": "x"}`. Decoding must
+        // return that inner object as a frozen plain object, and must _not_
+        // recurse into it and return just `x`.
         const wire = { "/quote": { "/quote": "x" } } as JsonCodecValue;
         const result = fromWireFormat(wire) as Record<string, FabricValue>;
         expect(result["/quote"]).toBe("x");
       });
 
       it("round-trips object whose value is a `/quote`-keyed literal", () => {
-        // { "/x": { "/quote": "inner" } } — the value at "/x" is user data that
-        // happens to have a /quote key. Must survive encode→decode intact.
+        // In `{"/x": {"/quote": "inner"}}`, the value at `/x` is user data
+        // that happens to have a `/quote` key. It must survive encode and
+        // decode intact.
         const obj = { "/x": { "/quote": "inner" } };
         const result = roundTrip(obj) as Record<
           string,
@@ -1081,7 +1087,8 @@ describe("JsonCodec", () => {
     it("allows shared references (same object at multiple positions)", () => {
       const shared = { val: 42 };
       const obj = { a: shared, b: shared };
-      // Should not throw -- shared references are fine, only cycles are rejected.
+      // Should not throw -- shared references are fine, and only cycles are
+      // rejected.
       const result = toWireFormat(obj);
       expect(result).toEqual({ a: { val: 42 }, b: { val: 42 } });
     });
@@ -1236,14 +1243,12 @@ describe("JsonCodec", () => {
     // results: `decode()` (string path) and `decodeFromBytes()` (bytes path
     // via `fromBytes()`).
     //
-    // Regression guard: the `/quote` arm does `return state`, handing back a
-    // node lifted straight out of the parsed codec-value tree (see `unwrapTag`'s
-    // contract). That shortcut is only sound because the parsed tree is
-    // deep-frozen at construction. `fromBytes()` has always done this;
-    // `decode()` once did NOT (it parsed inline without `deepFreeze()`), so a
-    // tweak that removed the `/quote` arm's own `deepFreeze()` made
-    // string-path `/quote` results come back mutable. These tests pin the
-    // symmetry so neither construction site can silently drop the guarantee.
+    // The `/quote` arm does `return state`, handing back a node lifted straight
+    // out of the parsed codec-value tree (see `unwrapTag()`'s contract). That
+    // shortcut is sound only because the parsed tree is deep-frozen at
+    // construction, which both construction sites must therefore do. These
+    // cases pin the symmetry, so that dropping the guarantee at either one
+    // cannot pass unnoticed.
 
     /**
      * Decodes the same codec-value tree both ways. The string path needs the
@@ -1456,8 +1461,10 @@ describe("JsonCodec", () => {
       expect(result.code).toBe(500);
     });
 
-    it("wire format is unchanged (backward compatible)", () => {
-      // FabricError should produce the same wire format as the old ErrorHandler.
+    it("encodes a `FabricError` as `/Error@1` carrying `type` and `message`", () => {
+      // The `@1` in the tag makes this a versioned wire surface, so the exact
+      // shape asserted below is the contract rather than an implementation
+      // detail.
       const se = FabricError.fromNativeError(new TypeError("compat test"));
       const serialized = toWireFormat(
         se,

--- a/packages/data-model/test/deep-freeze.test.ts
+++ b/packages/data-model/test/deep-freeze.test.ts
@@ -259,9 +259,9 @@ describe("deep-freeze", () => {
       });
 
       it("returns `false` for a partially-frozen `FabricInstance` (wrapper frozen but cause not)", () => {
-        // FabricError no longer has a wrapped-native-Error slot; the only
-        // recursing slot is `cause` (and any extras). Construct one whose
-        // `cause` is a mutable plain object, freeze only the wrapper.
+        // The recursing slots on a `FabricError` are `cause` and any extras.
+        // Construct one whose `cause` is a mutable plain object, and freeze
+        // only the wrapper.
         const err = new Error("partial", { cause: { mutable: true } });
         const fe = FabricError.fromNativeError(err);
         Object.freeze(fe);
@@ -324,12 +324,12 @@ describe("deep-freeze", () => {
 
         const result = deepFreeze(fe);
 
-        // Freeze-in-place: same identity, now deep-frozen (wrapper + wrapped
-        // Error + recursed cause).
+        // Freeze-in-place: same identity, deep-frozen across the wrapper and
+        // the recursed `cause`.
         expect(result).toBe(fe);
         expect(Object.isFrozen(fe)).toBe(true);
-        // (FabricError no longer has a wrapped Error slot to check directly;
-        // the native projection is lazy, and any built projection is frozen.)
+        // There is no wrapped-`Error` slot to check directly: the native
+        // projection is lazy, and any projection that gets built is frozen.
         expect(Object.isFrozen(inner)).toBe(true);
       });
 
@@ -339,17 +339,17 @@ describe("deep-freeze", () => {
         deepFreeze(container);
         expect(Object.isFrozen(container)).toBe(true);
         expect(Object.isFrozen(fe)).toBe(true);
-        // (FabricError no longer has a wrapped Error slot to check directly;
-        // the native projection is lazy, and any built projection is frozen.)
+        // There is no wrapped-`Error` slot to check directly: the native
+        // projection is lazy, and any projection that gets built is frozen.
       });
     });
   });
 
   describe("`isDeepFrozenFabricValue()` with `FabricInstance` (R6)", () => {
-    it("no longer throws on a `FabricInstance`; classifies via protocol", () => {
+    it("returns `false` without throwing for an unfrozen `FabricInstance`", () => {
       const fe = FabricError.fromNativeError(new Error("test"));
-      // Pre-freeze: not deep-frozen, but must NOT throw (the #3604
-      // `FabricInstance`-arm throw is retired).
+      // Two separate guarantees, hence two assertions: an unfrozen instance is
+      // classified rather than refused, and the classification is `false`.
       expect(() => isDeepFrozenFabricValue(fe)).not.toThrow();
       expect(isDeepFrozenFabricValue(fe)).toBe(false);
     });

--- a/packages/data-model/test/deep-freeze.test.ts
+++ b/packages/data-model/test/deep-freeze.test.ts
@@ -44,9 +44,9 @@ describe("deep-freeze", () => {
     describe("functions (opaque immutable leaves)", () => {
       // `deepFreeze()`/`isDeepFrozen()` treat a function as an opaque immutable
       // leaf -- a code reference, not fabric data -- so general-purpose callers
-      // that freeze objects-with-methods (e.g. `api/cfc.ts`'s `cfcPattern`) keep
-      // working. Its internal `prototype`/closure mutability is a known
-      // limitation, closed by the strict `FabricValue`-only migration follow-up.
+      // that freeze objects-with-methods keep working. A function's internal
+      // `prototype` and closure state stays mutable, which the opacity does not
+      // and cannot cover.
       it("returns `true` for a function", () => {
         expect(isDeepFrozen(() => {})).toBe(true);
         expect(isDeepFrozen(function () {})).toBe(true);
@@ -231,10 +231,11 @@ describe("deep-freeze", () => {
 
     // Coverage for `isDeepFrozen` on `FabricInstance` and `FabricPrimitive`
     // inputs, including a `FabricInstance` participating in a circular
-    // reference. `isDeepFrozen`'s recursion threads an `inProgress: Set<object>`
-    // for cycle-safety and answers a `FabricInstance` via its `[IS_DEEP_FROZEN]`
-    // protocol member -- inspecting its logical contents, not its enumerable
-    // own-props -- so values held in non-enumerable slots (such as
+    // reference. `isDeepFrozen`'s recursion threads an
+    // `inProgress: Set<object>` for cycle-safety and answers a
+    // `FabricInstance` via its `[IS_DEEP_FROZEN]` protocol member --
+    // inspecting its logical contents, not its enumerable own-props -- so
+    // values held in non-enumerable slots (such as
     // `FabricError`'s private extras `Map`) are checked too.
     // (`isDeepFrozenFabricValue` uses the same protocol dispatch but
     // additionally type-guards the value as a `FabricValue`; it has its own

--- a/packages/data-model/test/fabric-instances/FabricMap.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricMap.test.ts
@@ -65,8 +65,8 @@ describe("FabricMap", () => {
       });
     });
 
-    // FabricMap deliberately keeps throwing stubs for the protocol methods
-    // (per Dan's PR #3612 review: not yet used, reworked separately).
+    // The protocol methods are unimplemented stubs that throw, which these
+    // cases pin at both entry points: dispatch and direct invocation.
     describe("`[DEEP_FREEZE]` / `[IS_DEEP_FROZEN]`", () => {
       it("via dispatch: `[DEEP_FREEZE]` throws not-yet-implemented", () => {
         const fm = new FabricMap(

--- a/packages/data-model/test/fabric-primitives/FabricEpochNsec.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricEpochNsec.test.ts
@@ -120,7 +120,8 @@ describe("FabricEpochNsec", () => {
         });
 
         it("round-trips positive nanosecond timestamp", () => {
-          // 2024-01-01T00:00:00Z = 1704067200 seconds = 1704067200000000000 nsec
+          // 2024-01-01T00:00:00Z is 1704067200 seconds, so
+          // 1704067200000000000 nsec.
           const nsec = 1704067200000000000n;
           const sn = new FabricEpochNsec(nsec);
           const decoded = codec.decode(

--- a/packages/data-model/test/native-conversion.test.ts
+++ b/packages/data-model/test/native-conversion.test.ts
@@ -790,9 +790,8 @@ describe("native-conversion", () => {
 
       it("throws for `constructor`, naming it as the cause", () => {
         // Type dispatch reads the constructor from the prototype, so an own
-        // `constructor` property no longer decides the value's type: it
-        // reaches the object rule and is named, rather than failing as some
-        // unrecognized type or being rebuilt as whatever class it held.
+        // `constructor` property does not decide the value's type. It reaches
+        // the object rule, which names it as the reserved property it is.
         expect(() => fabricFromNativeValue({ ["constructor"]: "c" })).toThrow(
           "Not representable as a `FabricValue`: object with a property name " +
             "this runtime reserves (`constructor`)",

--- a/packages/data-model/test/native-conversion.test.ts
+++ b/packages/data-model/test/native-conversion.test.ts
@@ -1348,7 +1348,8 @@ describe("native-conversion", () => {
         const outer = new Error("outer", { cause: inner });
         fabricFromNativeValue(outer);
 
-        // Original Error's cause should still be the raw Error, not FabricError.
+        // The original `Error`'s cause is still the raw `Error`, not a
+        // `FabricError`.
         expect(outer.cause).toBe(inner);
         expect(outer.cause).not.toBeInstanceOf(FabricError);
       });

--- a/packages/data-model/test/schema-utils.test.ts
+++ b/packages/data-model/test/schema-utils.test.ts
@@ -281,11 +281,12 @@ describe("schema-utils", () => {
 
         const result = toDeepFrozenSchema(schema, true);
 
-        // Same reference — `canShare=true` lets us complete the deep-freeze in
-        // place rather than cloning.
+        // Same reference: `canShare=true` lets us complete the deep-freeze
+        // in place rather than cloning.
         expect(result).toBe(schema);
 
-        // Result (and the previously-unfrozen `inner`) must now be deeply frozen.
+        // The result, and the `inner` that went in unfrozen, must both come
+        // out deeply frozen.
         expect(Object.isFrozen(result)).toBe(true);
         const obj = result as JSONSchemaObj;
         expect(Object.isFrozen(obj.properties)).toBe(true);
@@ -310,8 +311,8 @@ describe("schema-utils", () => {
         // The already-deep-frozen "properties" subtree is reused by reference.
         expect(result.properties).toBe(frozenProperties);
 
-        // The unfrozen "required" is frozen in place (same reference, now frozen)
-        // rather than cloned, since `canShare=true`.
+        // The unfrozen `required` is frozen in place -- same reference, and
+        // frozen on the way out -- rather than cloned, since `canShare=true`.
         expect(result.required).toBe(unfrozenRequired);
 
         // Both are deeply frozen in the result.
@@ -596,7 +597,8 @@ describe("schema-utils", () => {
       const schema: JSONSchemaObj = { type: "string" };
       expect("description" in schema).toBe(false);
 
-      // Setting description to undefined: key is present but value is undefined.
+      // Setting `description` to `undefined`: the key is present, and its
+      // value is `undefined`.
       const withUndefined = schemaWithProperties(schema, {
         description: undefined,
       }) as JSONSchemaObj;
@@ -1129,7 +1131,7 @@ describe("schema-utils", () => {
       const a = internPathSelector({ path: ["x"], schema });
       // A *distinct* selector object carrying a structurally-equal (but
       // separate) schema object must resolve to the very same canonical
-      // instance — not merely the same-object idempotency the test above checks.
+      // instance -- not merely the same-object idempotency checked above.
       const b = internPathSelector({ path: ["x"], schema: { ...schema } });
       expect(b).toBe(a);
     });
@@ -1179,9 +1181,10 @@ describe("schema-utils", () => {
       const schema = uniqueSchema();
       const canonical = internPathSelector({ path: ["x"], schema });
       // A distinct, still-mutable selector with equal content. The canonical
-      // already exists, so the return value is that canonical (not this input) —
-      // but per the pre-cache contract, the input is nonetheless frozen and its
-      // schema canonicalized in place, for callers that keep using their object.
+      // already exists, so the return value is that canonical one rather than
+      // this input. Per the pre-cache contract the input is nonetheless frozen
+      // and its schema canonicalized in place, for callers that keep using
+      // their own object.
       const dup: SchemaPathSelector = { path: ["x"], schema: { ...schema } };
       expect(Object.isFrozen(dup)).toBe(false);
       const result = internPathSelector(dup);

--- a/packages/data-model/test/schema-utils.test.ts
+++ b/packages/data-model/test/schema-utils.test.ts
@@ -936,8 +936,10 @@ describe("schema-utils", () => {
   });
 
   describe("internPathSelector()", () => {
-    // Content-unique markers guarantee no prior interning has seen these
-    // schemas — avoids the flake shape Dan flagged on PR #3335.
+    // Interning is keyed by content and outlives any one case, so a schema
+    // another case already interned comes back as a hit, and these cases stop
+    // exercising the fresh-intern path they mean to. The unique `title`
+    // guarantees a miss.
     const uniqueSchema = (): JSONSchemaObj => ({
       type: "object",
       title: `internPathSelectorTestAt${Date.now()}-${Math.random()}`,

--- a/packages/data-model/test/type-check.test.ts
+++ b/packages/data-model/test/type-check.test.ts
@@ -373,8 +373,9 @@ describe("type-check", () => {
       });
 
       it("returns `true` for an unfrozen `FabricInstance` (member by type)", () => {
-        // A `FabricInstance` is a member by type; membership does not require it
-        // to be deep-frozen and does not recurse into its private interior.
+        // A `FabricInstance` is a member by type. Membership does not require
+        // it to be deep-frozen, and does not recurse into its private
+        // interior.
         const fe = FabricError.fromNativeError(new Error("test"));
         expect(Object.isFrozen(fe)).toBe(false);
         expect(isFabricValue(fe)).toBe(true);
@@ -572,8 +573,8 @@ describe("type-check", () => {
       });
 
       it("returns `false` for a non-plain class instance (`Date`, `Map`, …)", () => {
-        // Not representable as a `FabricPlainObject`; reachable only via an unsound
-        // cast, so the guard is fed them as `unknown`.
+        // Not representable as a `FabricPlainObject`, and reachable only via
+        // an unsound cast, so the guard is fed them as `unknown`.
         expect(isFabricPlainObject(new Date() as unknown as FabricValue))
           .toBe(false);
         expect(isFabricPlainObject(new Map() as unknown as FabricValue))

--- a/packages/data-model/test/value-clone.test.ts
+++ b/packages/data-model/test/value-clone.test.ts
@@ -57,9 +57,9 @@ describe("value-clone", () => {
     });
 
     it("throws rather than overwrite a present non-container leaf with spine structure", () => {
-      // Apparently-unintentional inconsistency now surfaced: descending a write
-      // path *through* a present primitive used to silently clobber it with a
-      // fresh container.
+      // Descending a write path *through* a present non-container leaf would
+      // have to replace that leaf with a fresh container, discarding whatever
+      // it held. Refusing is what keeps the write from destroying it silently.
       expect(() =>
         cloneWithValueAtPath(deepFreeze({ a: "string" }), ["a", "b"], 1)
       )

--- a/packages/data-model/test/value-clone.test.ts
+++ b/packages/data-model/test/value-clone.test.ts
@@ -77,8 +77,8 @@ describe("value-clone", () => {
         cloneWithValueAtPath(root, ["value", "target", "count"], 2),
       );
 
-      // `value` is shallow-cloned (on the spine); its `keep` sibling rides along
-      // by identity rather than being reconstructed/demoted.
+      // `value` is shallow-cloned, being on the spine. Its `keep` sibling
+      // rides along by identity rather than being reconstructed or demoted.
       expect(result.value.keep).toBe(hash);
       expect(result.value.keep).toBeInstanceOf(FabricHash);
       expect(result.value.keep.tag).toBe("sha256");
@@ -155,8 +155,8 @@ describe("value-clone", () => {
       const hash = FabricHash.fromString("sha256:abcd");
       const root = deepFreeze({ value: { wrapper: hash } });
 
-      // There is nothing path-addressable under an opaque wrapper, so removal is
-      // a no-op rather than an attempt to clone/mutate the wrapper.
+      // There is nothing path-addressable under an opaque wrapper, so removal
+      // is a no-op rather than an attempt to clone or mutate the wrapper.
       expect(cloneWithoutValueAtPath(root, ["value", "wrapper", "x"])).toBe(
         root,
       );

--- a/packages/data-model/test/value-hash.test.ts
+++ b/packages/data-model/test/value-hash.test.ts
@@ -137,7 +137,8 @@ describe("value-hash", () => {
 
       it("hashes non-canonical `NaN` bit patterns to the canonical `NaN`", () => {
         // Construct a NaN with a non-zero payload (still a valid quiet NaN) and
-        // confirm it canonicalizes. The hashed bytes must match the literal `NaN`.
+        // confirm it canonicalizes. The hashed bytes must match those of the
+        // literal `NaN`.
         const view = new DataView(new ArrayBuffer(8));
         view.setBigUint64(0, 0x7ff8000000000001n, false);
         const nonCanonicalNaN = view.getFloat64(0, false);
@@ -475,7 +476,8 @@ describe("value-hash", () => {
       it("matches a byte stream built from `[CODEC]` `encode()` output for `FabricError`", () => {
         // Build the expected byte stream programmatically because the encoded
         // state includes `stack` which is environment-dependent.
-        // We construct the stream the same way `hashOf()` does, then SHA-256 it.
+        // We construct the stream the same way `hashOf()` does, then SHA-256
+        // it.
         const error = FabricError.fromNativeError(new Error("test"));
         const enc = new TextEncoder();
 
@@ -905,9 +907,9 @@ describe("value-hash", () => {
       });
 
       it("takes the TAG_STRING_HASH path for a long object key", () => {
-        // utf8Length(100) > MAX_DIRECT_STRING_LENGTH(64). Object keys go through
-        // the same `getStringRep()` codepath as bare string values, so a long
-        // key is fed as `[TAG_STRING_HASH][sha256(utf8)]`.
+        // `utf8Length(100)` exceeds `MAX_DIRECT_STRING_LENGTH` (64). Object
+        // keys go through the same `getStringRep()` codepath as bare string
+        // values, so a long key is fed as `[TAG_STRING_HASH][sha256(utf8)]`.
         const longKey = "x".repeat(100);
         const obj = { [longKey]: 1 };
         const keyHash = sha256(new TextEncoder().encode(longKey));
@@ -985,8 +987,8 @@ describe("value-hash", () => {
       });
 
       it("works for a `FabricHash` inside a plain object (does not throw)", () => {
-        // This is meant to capture the essence of using `FabricHash` instances as
-        // things like content IDs inside `Fact` objects.
+        // This captures the essence of using `FabricHash` instances as things
+        // like content IDs inside `Fact` objects.
         const fact = {
           cause: new FabricHash(new Uint8Array([0x05, 0x06]), "fid1"),
           the: "text/plain",

--- a/packages/pure-json/test/json-faithfulness.test.ts
+++ b/packages/pure-json/test/json-faithfulness.test.ts
@@ -64,7 +64,8 @@ describe("findJsonUnfaithfulValues", () => {
   });
 
   it("catches a sparse array hole (becomes null)", () => {
-    // deno-lint-ignore no-sparse-arrays -- a hole is exactly what is under test.
+    // A hole is exactly what is under test.
+    // deno-lint-ignore no-sparse-arrays
     const holed = [1, , 3];
     const found = findJsonUnfaithfulValues({ default: holed });
     expect(found).toHaveLength(1);

--- a/packages/utils/src/base64url.ts
+++ b/packages/utils/src/base64url.ts
@@ -27,9 +27,9 @@ export function fromBase64url(encoded: string): Uint8Array {
     : Uint8Array.fromBase64(encoded, { alphabet: "base64url" });
 }
 
-// ---------------------------------------------------------------------------
+//
 // Polyfill
-// ---------------------------------------------------------------------------
+//
 
 /** Base64url alphabet (RFC 4648 section 5): `+` -> `-`, `/` -> `_`. */
 const B64_CHARS =

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -4,8 +4,8 @@
 
 /** Indicates whether the current environment is Deno. */
 export function isDeno(): boolean {
-  // Also check for `Deno.build`, because in `deno-web-test`,
-  // a shim of `Deno.test` runs in the browser in order to run the same test suite.
+  // Also check for `Deno.build`, because in `deno-web-test` a shim of
+  // `Deno.test` runs in the browser in order to run the same test suite.
   return ("Deno" in globalThis) && "build" in globalThis.Deno;
 }
 

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -797,9 +797,9 @@ export class Logger {
     }
   }
 
-  // ============================================================
-  // Timing Methods
-  // ============================================================
+  //
+  // Timing methods
+  //
 
   /**
    * Starts a timer for the given key path. Multiple segments name one path,
@@ -924,9 +924,9 @@ export class Logger {
     this._timingBaselineActive = false;
   }
 
-  // ============================================================
-  // Baseline Methods
-  // ============================================================
+  //
+  // Baseline methods
+  //
 
   /**
    * Resets the count baseline to the current counts, so that
@@ -973,9 +973,9 @@ export class Logger {
     };
   }
 
-  // ============================================================
-  // Flag Methods
-  // ============================================================
+  //
+  // Flag methods
+  //
 
   /**
    * Sets or clears the flag `name` for `id`. A flag is named boolean state

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -493,7 +493,8 @@ function getTimeStamp(): string {
 function resolveMessages(messages: LogMessage[]): unknown[] {
   return messages.flatMap((msg) => {
     const resolved = typeof msg === "function" ? msg() : msg;
-    // flatMap expects arrays - it will flatten array results and wrap non-arrays
+    // `flatMap()` flattens an array result and wraps a non-array one, so hand
+    // it an array either way.
     return Array.isArray(resolved) ? resolved : [resolved];
   });
 }
@@ -1173,7 +1174,8 @@ export function getLoggerCountsBreakdown(): Record<string, LoggerBreakdown> & {
     for (const [name, logger] of Object.entries(global.commonfabric.logger)) {
       const loggerBreakdown = { total: 0 } as LoggerBreakdown;
 
-      // Add counts by key (skip "total" to avoid overwriting the reserved property)
+      // Add counts by key, skipping `total` so that the reserved property is
+      // not overwritten.
       for (const [key, counts] of Object.entries(logger.countsByKey)) {
         if (key === "total") {
           continue; // Skip reserved property name

--- a/packages/utils/src/sandbox-contract.ts
+++ b/packages/utils/src/sandbox-contract.ts
@@ -43,10 +43,10 @@ export const SANDBOX_WITHHELD_GLOBALS = Object.freeze(
     // `Float32Array` and `Float64Array` carry the NaN side channel. A NaN's
     // unused mantissa bits can hold a payload, and storing one into a float
     // typed array writes those bits through to the underlying buffer, where a
-    // second view reads them back. Lockdown repairs `DataView.prototype.setFloat*`
-    // to write only canonical NaNs, but a typed-array element store is not a
-    // method and nothing can intercept it, so SES withholds the constructors
-    // instead.
+    // second view reads them back. Lockdown repairs
+    // `DataView.prototype.setFloat*` to write only canonical NaNs, but a
+    // typed-array element store is not a method and nothing can intercept it,
+    // so SES withholds the constructors instead.
     "Float32Array",
     "Float64Array",
     // `Atomics` and `SharedArrayBuffer` combine shared memory with a timing
@@ -73,19 +73,20 @@ export const SANDBOX_WITHHELD_GLOBALS = Object.freeze(
     // `Intl` reaches the host's default locale and time zone whenever a
     // formatter is constructed without explicit arguments, which is both
     // nondeterministic across runtimes and a fingerprinting channel. The
-    // sanitized `toLocale*` methods in `locale-taming.ts` pin those defaults for
-    // the surface a pattern actually uses; the `Intl` constructors have no such
-    // taming, and no pattern needs them, so they stay out. Stripping removes the
-    // namespace's value members (`var Collator`, `var NumberFormat`, ...) while
-    // its interfaces remain, so a pattern can still annotate an
-    // `Intl.NumberFormatOptions` even though it cannot construct a formatter.
+    // sanitized `toLocale*` methods in `locale-taming.ts` pin those defaults
+    // for the surface a pattern actually uses; the `Intl` constructors have no
+    // such taming, and no pattern needs them, so they stay out. Stripping
+    // removes the namespace's value members (`var Collator`,
+    // `var NumberFormat`, ...) while its interfaces remain, so a pattern can
+    // still annotate an `Intl.NumberFormatOptions` even though it cannot
+    // construct a formatter.
     //
-    // If patterns need locale-specific formatting, the intended path is not to
-    // endow `Intl` but to add a capability that carries the user's preferred
-    // locale(s) — a `wish("#locale")` reading them from the user's profile and
-    // falling back to the platform defaults. A pattern passes that locale
-    // explicitly to the sanitized `toLocale*` methods, which already honor one,
-    // so common number, date, and currency formatting needs no `Intl`.
+    // Locale-specific formatting is served by a capability carrying the user's
+    // preferred locales -- a `wish("#locale")` reading them from the user's
+    // profile and falling back to the platform defaults -- rather than by
+    // endowing `Intl`. A pattern passes that locale explicitly to the
+    // sanitized `toLocale*` methods, which already honor one, so common
+    // number, date, and currency formatting needs no `Intl`.
     "Intl",
 
     // Web globals the runtime has never endowed. Unlike the entries above,

--- a/packages/utils/test/base64url.test.ts
+++ b/packages/utils/test/base64url.test.ts
@@ -34,9 +34,9 @@ function arrayString(arr: readonly number[]): string {
   return result.join("");
 }
 
-// ============================================================================
-// toUnpaddedBase64url and polyfill
-// ============================================================================
+//
+// `toUnpaddedBase64url()` and polyfill
+//
 
 for (const toBase64 of [toUnpaddedBase64url, toBase64Polyfill]) {
   describe(`${toBase64.name}`, () => {
@@ -49,9 +49,9 @@ for (const toBase64 of [toUnpaddedBase64url, toBase64Polyfill]) {
   });
 }
 
-// ============================================================================
-// fromBase64url and polyfill
-// ============================================================================
+//
+// `fromBase64url()` and polyfill
+//
 
 for (const fromBase64 of [fromBase64url, fromBase64Polyfill]) {
   describe(`${fromBase64.name}`, () => {
@@ -71,9 +71,9 @@ for (const fromBase64 of [fromBase64url, fromBase64Polyfill]) {
   });
 }
 
-// ============================================================================
+//
 // Base64url round-trip
-// ============================================================================
+//
 
 describe("base64url round-trip", () => {
   it("round-trips various byte arrays", () => {

--- a/packages/utils/test/deep-equal.test.ts
+++ b/packages/utils/test/deep-equal.test.ts
@@ -121,8 +121,9 @@ describe("deepEqual", () => {
     });
 
     it("returns false for hole vs explicit undefined at same index", () => {
-      // Both arrays have 3 keys, but holes and undefineds are in opposite positions.
-      // This exercises the hasOwn check that distinguishes stored undefined from holes.
+      // Both arrays have 3 keys, but the holes and the `undefined`s sit in
+      // opposite positions. This exercises the `hasOwn` check that
+      // distinguishes a stored `undefined` from a hole.
       const a = [1, undefined, , 4]; // keys: 0, 1, 3 - undefined at 1, hole at 2
       const b = [1, , undefined, 4]; // keys: 0, 2, 3 - hole at 1, undefined at 2
       expect(deepEqual(a, b)).toBe(false);
@@ -197,8 +198,9 @@ describe("deepEqual", () => {
     });
 
     it("returns false for same key count but different keys including undefined", () => {
-      // Both have 2 keys, but different keys. Exercises hasOwn check in checkSpecificProps.
-      // Parallel to the array hole-vs-undefined test.
+      // Both have 2 keys, but different ones. This exercises the `hasOwn`
+      // check in `checkSpecificProps()`, in parallel with the array
+      // hole-versus-`undefined` case.
       const a = { x: 1, y: undefined };
       const b = { x: 1, z: 2 };
       expect(deepEqual(a, b)).toBe(false);

--- a/packages/utils/test/logger.test.ts
+++ b/packages/utils/test/logger.test.ts
@@ -1714,10 +1714,10 @@ describe("logger", () => {
         expect(stats?.min).toBe(1);
         expect(stats?.max).toBe(2000);
 
-        // Percentiles should still be approximately correct due to reservoir sampling
-        // With 2000 samples uniformly distributed 1-2000:
-        // p50 should be around 1000, p95 should be around 1900
-        // Allow wider margin due to random sampling
+        // Reservoir sampling keeps the percentiles approximately correct. With
+        // 2000 samples distributed uniformly over 1-2000, p50 lands around
+        // 1000 and p95 around 1900; the margins below are wide enough to
+        // absorb the sampling randomness.
         expect(stats?.p50).toBeGreaterThan(500);
         expect(stats?.p50).toBeLessThan(1500);
         expect(stats?.p95).toBeGreaterThan(1500);

--- a/packages/utils/test/narrowing.test.ts
+++ b/packages/utils/test/narrowing.test.ts
@@ -78,8 +78,9 @@ describe("structural predicate narrowing", () => {
     });
 
     it("narrows `unknown` for `isPlainContainer()`", () => {
-      // This one narrowed before it was overloaded, so it is the only predicate
-      // here whose existing narrowing could have been *lost* rather than gained.
+      // `isPlainContainer()` is an overload pair, and an overload set can fail
+      // to narrow where a lone predicate does. This pins that `unknown` still
+      // narrows through it.
       const value: unknown = { a: 1 };
 
       if (isPlainContainer(value)) {

--- a/packages/utils/test/narrowing.test.ts
+++ b/packages/utils/test/narrowing.test.ts
@@ -61,8 +61,8 @@ describe("structural predicate narrowing", () => {
     it("narrows an `object`-typed caller too", () => {
       // `object` is assignable to neither narrow target, so it selects the
       // narrowing overload rather than the first one. That is what lets
-      // `data-model`'s `type-check.ts` walk a value typed `object` with no cast,
-      // and the module header claims it in as many words.
+      // `data-model`'s `type-check.ts` walk a value typed `object` with no
+      // cast, and the module header claims it in as many words.
       const record: object = { a: 1 };
       const array: object = [1];
 
@@ -124,9 +124,9 @@ describe("structural predicate narrowing", () => {
     });
 
     it("keeps an array usable after a `false` result from `isArrayWithOnlyIndexProperties()`", () => {
-      // This predicate got the overload pair for family consistency rather than
-      // to fix a call site, which makes it the likeliest of the five to have the
-      // pair "simplified away" later. Hence a guard of its own.
+      // This predicate carries the overload pair for consistency with its
+      // family rather than to serve a call site, which makes it the likeliest
+      // one here to have the pair "simplified away". Hence a guard of its own.
       const array: number[] = [1, 2, 3];
       Object.defineProperty(array, "named", { value: 1, enumerable: true });
 

--- a/packages/utils/test/sleep.test.ts
+++ b/packages/utils/test/sleep.test.ts
@@ -11,12 +11,12 @@ import {
 // `sleep` and `timeout` are delay utilities, so their tests want controlled
 // time rather than a padded real-time bound. Each opens a `FakeTime` (from
 // `@std/testing/time`) with `using`, which freezes the real timer `sleep` and
-// `timeout` arm and restores the clock when the block ends. `time.tickAsync(ms)`
-// advances the fake clock and settles the promises the fired timers resolve, and
-// `Date.now()` reports the faked time, so the timing assertions are exact and
-// cannot flake. The suites below that measure real elapsed time or touch real
-// Deno timers — `yieldToEventLoop` and `unrefTimer` — open no `FakeTime` and run
-// on the real clock.
+// `timeout` arm and restores the clock when the block ends.
+// `time.tickAsync(ms)` advances the fake clock and settles the promises the
+// fired timers resolve, and `Date.now()` reports the faked time, so the timing
+// assertions are exact and cannot flake. The suites below that measure real
+// elapsed time or touch real Deno timers -- `yieldToEventLoop` and
+// `unrefTimer` -- open no `FakeTime` and run on the real clock.
 
 /** Hold the event loop synchronously for ~ms, like a CPU-bound compile step. */
 const busySpin = (ms: number) => {

--- a/packages/utils/test/two-level-weak-cache.test.ts
+++ b/packages/utils/test/two-level-weak-cache.test.ts
@@ -53,7 +53,8 @@ describe("TwoLevelWeakCache", () => {
       const key = {};
 
       expect(cache.memoize(outerA, key, () => "a")).toBe("a");
-      // Same inner key, different outer key: a distinct entry, not the cached "a".
+      // Same inner key, different outer key: a distinct entry rather than the
+      // cached `a`.
       expect(cache.memoize(outerB, key, () => "b")).toBe("b");
       expect(cache.memoize(outerA, key, () => "ignored")).toBe("a");
     });


### PR DESCRIPTION
I (agent working on behalf of @danfuzz) picked this up as the leftover residue
of the doc-comment pass (#5524-#5528). That pass was scoped to doc comments and
module headers, so it read every file in `utils`, `data-model`, `leb128`,
`pure-json` and `content-hash` and left the non-conforming `//` comments alone
by instruction. This is those.

Per `code-comment-style.md`: *"converting a whole file is its own change, made
deliberately rather than as a side effect."*

## The scope was undercounted, in both directions

The tracked entry claimed four over-long lines and three horizontal rules. The
real numbers, censused rather than sampled:

| defect | claimed | actual |
| --- | --- | --- |
| `//` lines over 80 columns | "4, and a few other spots" | **56** |
| `// ====` horizontal rules | 3 (in `logger.ts`) | **17**, across 4 files |
| tracker references | 3 | 3 |

The rules were undercounted because the original grep only ever looked at
`logger.ts`. A second artifact is worth naming for whoever measures this next:
`awk 'length($0) > 80'` counts **bytes**, and an em-dash or an arrow is three
of them, so it over-reports. Five of the 61 lines the first pass flagged were
under 80 characters and only over 80 bytes. The 56 above is a character count.

## Three kinds, and the thing that made it not purely mechanical

**Tracker references** (3). Each carried a second defect underneath, so
striking the number alone would have left a worse comment than it found. The
`#3604` one reduces to "the `FabricInstance`-arm throw is retired", which
describes nothing that is in the file. Each is restated as the present-tense
fact that makes the assertion below it make sense.

**Horizontal rules** (17). Converted to the guide's `//`-delimited form.
Genuinely mechanical, and scripted.

**Line width** (56). Rewrapped, not trimmed. One exception, forced: a
`deno-lint-ignore` directive cannot wrap, so its reason moved to its own line
above rather than getting shortened.

**And the part that earned its time.** Rewrapping a line means reflowing a
sentence, which means owning whether the sentence is true. Four turned out to
describe a system that is gone:

- a `/quote` deep-freeze note written as a regression story ("`decode()` once
  did NOT...")
- a wire-format case pinned against `ErrorHandler`, which no longer exists —
  its `it()` said "wire format is unchanged (backward compatible)", unchanged
  from a baseline no reader can reach
- a function-opacity limitation attributed to a migration follow-up
- a predicate's overload pair explained by how it came to be, plus a count of
  "the five" that a refactor would silently falsify

Two `it()` descriptions went with them; the guide is explicit that the rule
reaches description strings. A fifth pair of comments in `deep-freeze.test.ts`
sat eight lines apart contradicting each other about whether a `FabricError`
has a wrapped-`Error` slot. It does not, and the surviving comment now says so
once.

## Verification

Comments only — no code and no assertion changes anywhere in the diff.

- Full workspace suite: **40 packages, all ok**, 242s
- `fmt --check`, `lint`, `check`, `check-docs`, `check-conflict-markers`,
  `check-skill-facts`, `check-no-waitfor`: all clean

The five touched packages were also run individually. Since a comment-only
change cannot be proven by a green suite, the guard here is the census: zero
`//` lines over 80 characters remain in these packages, zero horizontal rules,
zero tracker references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WXGpwWEeCPdgHeH1zhrrz3


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

