### PR TITLE
docs: plainResultReceipts is on by default, in the four places that said otherwise

### DIFF
--- a/docs/common/verbs-over-the-cli.md
+++ b/docs/common/verbs-over-the-cli.md
@@ -163,18 +163,20 @@ readback or exits once the commit is acknowledged.
 
 ## Which results arrive, and when
 
-Two paths deliver a result, and they behave differently today:
+Two paths deliver a result, and both arrive by default:
 
 - A result **carrying cells or pieces** — like a create returning the piece it
-  made — arrives on any runtime. It travels the result-pattern projection path.
-- A result that is **plain JSON** — a record of what was written — requires the
-  `plainResultReceipts` runtime option. Until its default flips, enable it per
-  process with `EXPERIMENTAL_PLAIN_RESULT_RECEIPTS=true`
-  ([EXPERIMENTAL_OPTIONS.md](../development/EXPERIMENTAL_OPTIONS.md)).
+  made — travels the result-pattern projection path.
+- A result that is **plain JSON** — a record of what was written — projects into
+  the receipt under the `plainResultReceipts` runtime option, which is on by
+  default ([EXPERIMENTAL_OPTIONS.md](../development/EXPERIMENTAL_OPTIONS.md)).
+  `EXPERIMENTAL_PLAIN_RESULT_RECEIPTS=false` restores the discard, which is a
+  rollback switch rather than something a caller opts into.
 
-With the option off, a plain-record verb still performs its write and simply
-reports no result. **Treat an absent result as "not enabled here", never as
-"the mutation did not land."**
+So a verb that declares a result hands one back. Where a plain record is absent,
+the option was explicitly turned off — the verb still performed its write.
+**Treat an absent result as "not enabled here", never as "the mutation did not
+land."**
 
 One more caveat worth carrying: a verb's result shape is not part of the piece's
 stored schema, so nothing validates it and nothing protects it across a pattern
@@ -213,7 +215,7 @@ Each step demonstrates one use case:
 | 5 | A call's result names the document behind each path, and that address calls |
 | 6 | A read returns an address in place of what is behind it |
 | 7 | A replayed id returns the original result; nothing runs twice |
-| 8 | A piece result needs no option; a plain record does — and the write lands either way |
+| 8 | A piece result survives `plainResultReceipts=false`; a plain record does not — and the write lands either way |
 | 9 | A value-less verb settles with the empty witness |
 | 10 | A refused call does not spend its invocation id |
 | 11 | Reading a verb redirects to `cf piece call` |

--- a/docs/plans/verb-result-selection.md
+++ b/docs/plans/verb-result-selection.md
@@ -452,9 +452,7 @@ first condition arrives on its own.
 
 ## Documentation owed
 
-- [Verbs over the CLI](../common/verbs-over-the-cli.md) is **already stale**:
-  its `plainResultReceipts` note describes a default that has since flipped
-  (`packages/runner/src/runtime.ts` sets it `??= true`). It documents the
+- [Verbs over the CLI](../common/verbs-over-the-cli.md) documents the
   `--show-links` shape, and its examples teach hand-written invocation ids —
   which the namespace question may make actively harmful advice.
 - `packages/cli/README.md` §"Output Conventions" is the source these notes

--- a/packages/cli/integration/verbs-over-the-cli.sh
+++ b/packages/cli/integration/verbs-over-the-cli.sh
@@ -53,9 +53,10 @@ ARGS="--api-url=$API_URL --identity=$CF_IDENTITY --space=$SPACE"
 echo "API_URL=$API_URL"
 echo "SPACE=$SPACE"
 
-# A plain-JSON result rides the plainResultReceipts option, off by default
-# today, so enable it for this process. A result carrying a piece does NOT
-# need it — step 7 proves the difference.
+# A plain-JSON result rides the plainResultReceipts option, on by default.
+# Set it explicitly anyway so the walkthrough asserts the same thing whatever a
+# host's environment carries; step 7 sets it false to show the difference
+# against a result carrying a piece, which survives either way.
 export EXPERIMENTAL_PLAIN_RESULT_RECEIPTS=true
 
 START=$(date +%s)
@@ -152,7 +153,7 @@ check "true" "$(echo "$D" | jq -r '.deduplicated // false')" \
 check "$BEFORE" "$($CF piece get --quiet --piece "$BOARD" $ARGS noteCount --step 2>/dev/null)" \
   "the replay created no note (count unchanged at $BEFORE)"
 
-step "8. A piece result needs no option; a plain record does"
+step "8. A piece result survives the option being off; a plain record does not"
 P=$(EXPERIMENTAL_PLAIN_RESULT_RECEIPTS=false $CF piece call --quiet \
   --piece "$BOARD" $ARGS --invocation create-flagoff \
   createNote '{"title":"Flag-off note"}' 2>/dev/null)

--- a/packages/patterns/topics/README.md
+++ b/packages/patterns/topics/README.md
@@ -152,11 +152,12 @@ appends are mergeable ops, so a length observed inside one handling is not a
 fact about the resulting list — read `commentCount` when you want the count.
 
 A returned value reaches the caller through the handling's receipt. A result
-carrying a piece (`addTopic`) arrives on any runtime; the plain records
-(`addComment`, `addLink`, `setBody`) additionally need `plainResultReceipts`,
-which is `EXPERIMENTAL_PLAIN_RESULT_RECEIPTS=true` until that flag's default
-flips (`docs/development/EXPERIMENTAL_OPTIONS.md`). Without it those three verbs
-still perform their write and simply report no result.
+carrying a piece (`addTopic`) travels the result-pattern projection path; the
+plain records (`addComment`, `addLink`, `setBody`) project into the receipt
+under `plainResultReceipts`, which is on by default
+(`docs/development/EXPERIMENTAL_OPTIONS.md`). Setting
+`EXPERIMENTAL_PLAIN_RESULT_RECEIPTS=false` restores the discard, and those three
+verbs then still perform their write and simply report no result.
 
 `addTopic` takes the body at create (optional): a topic born with a body appears
 with it atomically — no reader observes a title-only halfway state, and no

--- a/skills/topics/SKILL.md
+++ b/skills/topics/SKILL.md
@@ -164,10 +164,10 @@ deno task cf piece get --url "$TOPIC_URL" commentCount --step
 
 Each of these three returns the record it wrote — the appended comment or link,
 or the persisted body plus its attribution — which spares the verification read
-above. That result rides `plainResultReceipts`
-(`EXPERIMENTAL_PLAIN_RESULT_RECEIPTS=true` until the flag's default flips); the
-write happens either way, so treat an absent result as "not enabled here", never
-as "the mutation did not land".
+above. That result rides `plainResultReceipts`, on by default; only an explicit
+`EXPERIMENTAL_PLAIN_RESULT_RECEIPTS=false` discards it. The write happens either
+way, so treat an absent result as "not enabled here", never as "the mutation did
+not land".
 
 The body is the living big-picture document. Replace it in place with the full
 revised body so a reader sees the current state without replaying the thread,


### PR DESCRIPTION
## Why

`plainResultReceipts` defaults on — `Runtime` sets `plainResultReceipts ??= true`, and `docs/development/EXPERIMENTAL_OPTIONS.md` lists it as "implemented, on by default". Four documents still instructed callers to set `EXPERIMENTAL_PLAIN_RESULT_RECEIPTS=true` before a plain-record verb would hand anything back.

A reader following them sets a variable that does nothing, and carries away a rule that is false: that a plain result is opt-in. The one that matters most is `skills/topics/SKILL.md`, which is what an agent reads before driving the live Topics board — it was teaching a precondition that no longer exists, on the path where getting it wrong means misreading whether a mutation landed.

The flag survives as a rollback switch during its bake period: an explicit `false` restores the discard.

## What Changed

Three prose corrections, saying the same thing for three audiences:

- `docs/common/verbs-over-the-cli.md` — "Which results arrive, and when"
- `packages/patterns/topics/README.md` — the `addComment`/`addLink`/`setBody` note
- `skills/topics/SKILL.md` — the agent-facing instruction

All three keep the "an absent result never means the mutation did not land" warning. Still the right thing to tell a caller, now for the opposite reason: someone disabled it, rather than nobody having enabled it.

Two smaller ones:

- The step-6 row of the walkthrough table said "a piece result needs no option; a plain record does". Rephrased against `plainResultReceipts=false`, which is what the script actually exercises.
- `docs/plans/verb-result-selection.md` carried a "Documentation owed" note flagging this exact staleness. That clause is removed; its other two concerns stay.

`packages/cli/integration/verbs-over-the-cli.sh` is a **comment-only** change. The `export` line is untouched and step 7 still sets `false` explicitly, so the walkthrough proves what it always proved.

## Test plan

No behavior changes — documentation, plus one shell comment.

- `deno task check-docs` — 537 blocks
- `deno task check-skill-facts` — 45 documents
- `deno task check-conflict-markers`
- `deno fmt --check` on the two non-`docs/` markdown files
- `bash -n packages/cli/integration/verbs-over-the-cli.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

