### PR TITLE
docs(common): a verb session, end to end

### DIFF
--- a/docs/common/README.md
+++ b/docs/common/README.md
@@ -88,6 +88,7 @@ on the Common Fabric runtime.
 - [workflows/pattern-testing.md](workflows/pattern-testing.md) — writing and running pattern tests
 - [workflows/handlers-cli-testing.md](workflows/handlers-cli-testing.md) — invoking mounted callables from the CLI
 - [verbs-over-the-cli.md](verbs-over-the-cli.md) — what a verb hands back: declared results, piece references, idempotent retries, and a runnable walkthrough
+- [verb-session-walkthrough.md](verb-session-walkthrough.md) — a whole session driven through `cf`: discovery, help, completion, and carrying an address from one call into the next, with each step marked for what works today and what is still blocked
 
 [INTRODUCTION.md](INTRODUCTION.md) is a stub kept for older links; this README
 replaces it.

--- a/docs/common/verb-session-walkthrough.md
+++ b/docs/common/verb-session-walkthrough.md
@@ -1,0 +1,203 @@
+# A verb session, end to end
+
+What driving a pattern entirely through `cf` looks like when the verb surface is
+complete: discovery, help, completion, and carrying an address from one call
+into the next.
+
+[Verbs over the CLI](verbs-over-the-cli.md) explains what a verb hands back.
+This walks a whole session using it, and marks where the surface is still
+incomplete.
+
+The subject is a work-item tracker — items in a tree, plus typed cross-links —
+sketched here rather than deployed. No pattern file backs it yet.
+
+**Every step is marked for what is real.** The point of the document is the
+line between them.
+
+| Mark | Meaning |
+| --- | --- |
+| **[today]** | works against a current build |
+| **[stack]** | built and merging incrementally: the `$link` marker has landed, so these steps are reachable today through a full `--schema`. What is pending is the concise `--select` spelling and its arrival on `piece call` ([the verbs plan](../plans/verbs-implementation.md) tracks the order) |
+| **[blocked]** | needs something decided or built |
+
+Section headers inside the help output below are the literal strings
+`renderPieceCallHelp` emits (`packages/cli/lib/exec-schema.ts`). Their contents
+are illustrative.
+
+## 1. Arrive with a slug **[today]**
+
+An address a person can type, rather than a fid from a previous command.
+
+```bash
+cf piece new tracker.tsx --slug board
+cf piece verbs --piece board
+```
+
+```text
+pattern  tracker.tsx @ src:9f2a…
+NAME     KIND     ON
+add      handler  result
+block    handler  result
+note     handler  result
+remove   handler  result
+rollup   tool     result
+```
+
+Slug resolution sits on the shared path (`resolvePieceConfigWithPieces`,
+`packages/cli/lib/piece.ts`), so every command below takes `board` too.
+
+The listing carries the deployed pattern's source identity, which is how a
+client tells it is talking to a newer pattern than it was written against.
+
+## 2. Ask what a verb wants **[today]**
+
+```bash
+cf piece call --piece board add --help
+```
+
+```text
+Usage:
+  cf piece call --piece board add --help
+  cf piece call --piece board add <json>
+  cf piece call --piece board add -- --title <string> [--parent <string>]
+
+JSON input:
+  Pass inline JSON as one positional argument or after `--json`.
+  { title: string; parent?: string }
+
+Flags after `--`:
+  --title <string>    Required. One line naming the work.
+  --parent <string>   Optional. Where the item files. Omit for a root item.
+
+Output:
+  No output on success.
+```
+
+The flags, their types, their required-ness and their descriptions are all
+derived. Nothing is authored per pattern: `parseInputFlags` builds a descriptor
+per input-schema property, and the prose comes from the author's JSDoc, which
+the schema generator attaches as `description`.
+
+```tsx
+// Shown as interface or class members.
+/** One line naming the work. */
+title: string;
+/** Where the item files. Omit for a root item. */
+parent?: string;
+```
+
+Two things are wrong with that page rather than missing from it.
+
+**`Output:` is false.** `add` declares a result and returns one; the value
+arrives on `invocation.result`. The handler branch of `renderPieceCallHelp`
+prints the fixed string regardless.
+
+**The verb's purpose is absent.** A JSDoc comment on the event interface becomes
+a root-level `description` on the schema, and `cf piece verbs --json` carries it
+over the wire — but `schemaDescription` is consulted only per property, so the
+rendered page drops it. `cf` can say what `add` takes and not what it is for.
+
+## 3. Complete against the live piece **[today]**
+
+```bash
+cf piece call --piece board <TAB>
+add  block  note  remove  rollup
+```
+
+Verb names and piece addresses complete against the space
+(`shapeVerbCandidates` / `liveCandidates`,
+`packages/cli/lib/completion/providers.ts`), in bash and zsh.
+
+What does not complete is a result field — `--select 'it<TAB>'` has nothing to
+offer, because nothing in the system knows the result has a field called `item`.
+
+## 4. Create, and carry the address forward **[stack]**
+
+```bash
+EPIC=$(cf piece call --piece board add -- --title "Login rewrite" \
+       --select 'item@' | jq -r '.result.item."$link".id')
+
+cf piece call --piece "$EPIC" add -- --title "Session cookie handling"
+cf piece call --piece "$EPIC" note -- --body "Blocked on the cookie spec"
+```
+
+**This is the composition the surface exists for.** A create hands back the
+piece it made, the address renders in place, and the next call takes it as its
+target. Identity survives the round trip instead of being flattened into a copy
+of the item's contents.
+
+`--show-links` is the **[today]** spelling of the same move: it returns a
+dictionary of RFC 6901 pointers naming the document behind each result path, so
+the address is one `jq` hop further away but reachable.
+
+Neither route needs a verb to declare its result. A `$link` marker on a link
+position renders the address and suppresses the fetch without consulting a
+source schema at all. What a declared result would add is that `cf` could
+derive the selection instead of the caller supplying it.
+
+## 5. Read the tree back, bounded **[stack]**
+
+```bash
+cf piece get --piece board items \
+  --select 'title,status,children@' \
+  --filter '.status != "done"'
+```
+
+`--filter` runs before projection, so `status` decides membership and need not
+appear in the output. A marked collection costs one document read however many
+entries it holds, because the links are stored inline in the document being
+read — subject to the verbs plan's item 3, which is what makes a rejection below
+a link propagate up through the containers holding it.
+
+The same options work on a call's result, on a wish, and on a direct read: one
+read layer, several arrivals.
+
+## 6. Relate two items **[blocked]**
+
+```bash
+cf piece call --piece "$EPIC" block --on "$OTHER"
+```
+
+This is where the session stops.
+
+## The composition axis
+
+Steps 4 and 6 are the same move — take an address out of one command and put it
+into the next — and only one of them works.
+
+| Direction | State |
+| --- | --- |
+| address → `--piece` (the receiver) | works |
+| address → an argument field | refused |
+
+A call payload is plain JSON. `normalizeCallableInputForExecution`
+(`packages/cli/lib/exec-schema.ts`) does nothing with links, so `--on "$OTHER"`
+arrives as a string the pattern cannot resolve into a reference.
+
+A tree mostly hides this, because the natural shape is to call the verb *on* the
+parent — the receiver carries the relationship, so no address needs to be an
+argument. It surfaces the moment two items must be related to each other:
+`block`, `duplicates`, `move`, or a `remove` that names a child rather than an
+index. Indices are not addresses; a position shifts under concurrent writes.
+
+[CLI surface shape](../plans/cli-surface-shape.md) states the property for
+commands — an address printed by one command is accepted by the next. This is
+the same property one level in, on arguments. A second instance sits on
+`cf piece set-slug`, whose source positional resolves through its own path
+rather than the one `--piece` uses.
+
+This gap is independent of whether a verb's declared result reaches the runtime.
+Declared results make an **output** self-describing; this is about what an
+**input** accepts.
+
+## What the session is waiting on
+
+| Gap | Needs |
+| --- | --- |
+| `Output:` claims a handler returns nothing | Nothing — it is wrong, not missing |
+| A verb's purpose absent from its help page | Nothing — the description is already in the schema and on the wire |
+| Result fields listed in help | A declared result |
+| `--select` completion, and refusal before the call | A declared result |
+| An address accepted as an argument | The round-trip property above |
+
+Three of the five need no decision.


### PR DESCRIPTION
## Why

[`verbs-over-the-cli.md`](https://github.com/commontoolsinc/labs/blob/main/docs/common/verbs-over-the-cli.md) explains what a single call hands back. What a reader does not have anywhere is the shape of a whole session: arrive at a piece, learn what it can do, call something, and carry the address it returns into the next command.

Writing that out turned up two things worth having on record, neither of which is visible from any single command:

**The help page a caller meets first contains two defects.** `Output:` prints `"No output on success."` for every handler — false for one declaring a result, whose value arrives on `invocation.result`. And a verb's *purpose* never renders, even though the author's JSDoc reaches the schema as a root `description` and rides `cf piece verbs --json` over the wire; `schemaDescription` is only ever consulted per property. So `cf` can say what `add` takes and not what it is for.

**Composition stops in a specific place.** An address flows into `--piece` and chains — that part works well. But a call payload is plain JSON and `normalizeCallableInputForExecution` does nothing with links, so an address cannot be an *argument*. A tree hides this, because the natural shape is to call the verb on the parent. It surfaces the moment two items must be related to each other: `block`, `duplicates`, or a `remove` naming a child.

## What Changed

One new document, `docs/common/verb-session-walkthrough.md`, indexed in `docs/common/README.md`.

Six steps over a work-item tracker — sketched, not deployed; the document says so, and no pattern file backs it. Each step is marked `[today]` / `[stack]` / `[blocked]`, and the line between those marks is the point: the surface is further along than it reads, and the two places it stops are specific rather than general.

Help-page section headers are the literal strings `renderPieceCallHelp` emits; their contents are labeled illustrative.

This is descriptive documentation — it records what the CLI does now and where it stops, and is unaffected by any pending design decision.

## Test plan

Documentation only.

- `deno task check-docs` — 537 blocks, including the TSX fragment under the interface-members scaffold
- `deno task docs-links --orphan` — indexed
- `deno task check-conflict-markers`

Claims verified against `main` at `a6d71be6d`, after #5470, #5468, #5497 and #5459 landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

