### PR TITLE
refactor(data-model): make a `JsonCodec`'s registry per-instance

### DIFF
--- a/packages/data-model/src/codec-json/JsonCodec.ts
+++ b/packages/data-model/src/codec-json/JsonCodec.ts
@@ -35,12 +35,18 @@ export class JsonCodec implements SerializationContext<string> {
    */
   readonly lenient: boolean;
 
+  /** Registry consulted for per-type encoding and decoding. */
+  readonly #registry: CodecRegistry;
+
   /**
-   * Constructs an instance, optionally configured for lenient mode (which
-   * produces `ProblematicValue` on failed reconstruction instead of throwing).
+   * Constructs an instance. `options.lenient` makes a failed reconstruction
+   * produce a `ProblematicValue` instead of throwing. `options.registry`
+   * supplies the codecs this instance encodes and decodes with, defaulting to
+   * the built-in registry.
    */
-  constructor(options?: { lenient?: boolean }) {
+  constructor(options?: { lenient?: boolean; registry?: CodecRegistry }) {
     this.lenient = options?.lenient ?? false;
+    this.#registry = options?.registry ?? JsonCodec.#defaultRegistry;
   }
 
   //
@@ -137,9 +143,8 @@ export class JsonCodec implements SerializationContext<string> {
   #encodeValue(
     value: FabricValue,
     _seen?: Set<object>,
-    registry: CodecRegistry = JsonCodec.#defaultRegistry,
   ): JsonCodecValue {
-    const codec = registry.codecFromValue(value);
+    const codec = this.#registry.codecFromValue(value);
 
     if (codec === SELF_REP) {
       // A self-representing primitive is its own wire form.
@@ -163,7 +168,7 @@ export class JsonCodec implements SerializationContext<string> {
       const tag = codec.tagForValue(value);
 
       const unprocessedState = codec.encode(value);
-      const finalState = this.#encodeValue(unprocessedState, seen, registry);
+      const finalState = this.#encodeValue(unprocessedState, seen);
       const result: JsonCodecValue = { [`/${tag}`]: finalState };
 
       if (addedToSeen) {
@@ -204,7 +209,7 @@ export class JsonCodec implements SerializationContext<string> {
           result.push(this.wrapTag(CODEC_META_TAGS.hole, count));
         } else {
           result.push(
-            this.#encodeValue(value[i], seen, registry),
+            this.#encodeValue(value[i], seen),
           );
           i++;
         }
@@ -241,7 +246,7 @@ export class JsonCodec implements SerializationContext<string> {
     const result: Record<string, JsonCodecValue> = {};
     const valueRec = value as Record<string, FabricValue>;
     for (const key of utf8SortedKeysOf(valueRec)) {
-      result[key] = this.#encodeValue(valueRec[key], seen, registry);
+      result[key] = this.#encodeValue(valueRec[key], seen);
     }
     seen.delete(value as object);
 
@@ -277,7 +282,6 @@ export class JsonCodec implements SerializationContext<string> {
   #decodeValue(
     data: JsonCodecValue,
     context: ReconstructionContext,
-    registry: CodecRegistry = JsonCodec.#defaultRegistry,
   ): FabricValue {
     const decoded = this.unwrapTag(data);
     if (decoded !== null) {
@@ -302,14 +306,14 @@ export class JsonCodec implements SerializationContext<string> {
               `object contains a key this runtime reserves: "${key}"`,
             );
           }
-          result[key] = this.#decodeValue(val, context, registry);
+          result[key] = this.#decodeValue(val, context);
         }
         return Object.freeze(result);
       }
 
       // Except for `/quote` and `/object`, the `state` needs to be fully
       // decoded.
-      const state = this.#decodeValue(rawState, context, registry);
+      const state = this.#decodeValue(rawState, context);
 
       // A bare `"/"` key (empty tag after stripping the leading slash) is
       // always an encoding error per spec §9 — no valid tag has an empty
@@ -333,7 +337,7 @@ export class JsonCodec implements SerializationContext<string> {
       // lenient-mode `ProblematicValue` fallback. The class-registry
       // fallback below is a separate arm and is intentionally NOT covered by
       // this contract.
-      const codec = registry.codecFromTag(tag);
+      const codec = this.#registry.codecFromTag(tag);
       if (codec) {
         if (this.lenient) {
           try {
@@ -387,7 +391,7 @@ export class JsonCodec implements SerializationContext<string> {
         ) {
           targetIndex += entryDecoded.state as number;
         } else {
-          result[targetIndex] = this.#decodeValue(entry, context, registry);
+          result[targetIndex] = this.#decodeValue(entry, context);
           targetIndex++;
         }
       }
@@ -418,7 +422,7 @@ export class JsonCodec implements SerializationContext<string> {
           `object contains a key this runtime reserves: "${key}"`,
         );
       }
-      result[key] = this.#decodeValue(val, context, registry);
+      result[key] = this.#decodeValue(val, context);
     }
     return Object.freeze(result);
   }

--- a/packages/data-model/test/codec-json/JsonCodec.test.ts
+++ b/packages/data-model/test/codec-json/JsonCodec.test.ts
@@ -19,6 +19,7 @@ import { FabricRegExp } from "@/fabric-primitives/FabricRegExp.ts";
 import { FabricError } from "@/fabric-instances/FabricError.ts";
 import { isDeepFrozen } from "@/deep-freeze.ts";
 import { BaseReconstructionContext } from "@/codec-common/BaseReconstructionContext.ts";
+import { CodecRegistry } from "@/codec-common/CodecRegistry.ts";
 
 /**
  * Shared test `ReconstructionContext`: `getCell()` always throws (no test
@@ -112,6 +113,34 @@ function fromWireFormat(data: JsonCodecValue): FabricValue {
 }
 
 describe("JsonCodec", () => {
+  describe("`registry` constructor option", () => {
+    // An empty registry recognizes no class and no tag, so it differs from the
+    // built-in one on any fabric class. `FabricError` is the probe: the
+    // built-in registry encodes it and decodes it back, and these cases assert
+    // the empty registry's behavior instead, in both directions.
+
+    it("throws on encode for a class the supplied registry lacks", () => {
+      const jsonCodec = new JsonCodec({ registry: new CodecRegistry() });
+      const value = FabricError.fromNativeError(new Error("boom"));
+
+      expect(() => jsonCodec.encode(value)).toThrow(
+        "No codec registered for fabric object class: FabricError",
+      );
+    });
+
+    it("returns an `UnknownValue` on decode for a tag the supplied registry lacks", () => {
+      const wire = new JsonCodec().encode(
+        FabricError.fromNativeError(new Error("boom")),
+      );
+      const jsonCodec = new JsonCodec({ registry: new CodecRegistry() });
+
+      const result = jsonCodec.decode(wire, new TestReconstructionContext());
+
+      expect(result).toBeInstanceOf(UnknownValue);
+      expect((result as UnknownValue).wireTypeTag).toBe("Error@1");
+    });
+  });
+
   describe("`encodeToBytes()` / `decodeFromBytes()` (bytes entry points)", () => {
     it("returns `Uint8Array` from `encodeToBytes()`", () => {
       const { jsonCodec } = makeTestCodec();


### PR DESCRIPTION
I (agent working on behalf of @danfuzz) am doing this as the first of three
staged PRs preparing `codec-*` for the addition of `codec-realm`. This one is
pure groundwork and changes nothing observable.

## What

The registry was a defaulted parameter on the private `#encodeValue()` and
`#decodeValue()`, threaded by hand through every recursive call and falling
back to a static `#defaultRegistry`. It is per-codec configuration rather than
per-call, so it moves to the constructor options next to `lenient`, and the
private recursion reads `this.#registry`.

Effects:

- Seven internal call sites lose their third argument.
- The registry becomes reachable from outside for the first time —
  `new JsonCodec({ registry })` selects which codecs an instance uses. It stays
  **optional**, defaulting to the built-in registry, so no caller changes.

## Why now

The later PRs move the roster of fabric classes out of the base registry and up
a layer, at which point the registry has to be supplied rather than assumed.
Doing the plumbing first keeps that change to the part that is actually
interesting, and keeps every intermediate state green.

## Testing

Two cases, one per direction, because **the existing suite cannot see this
change**: nothing had ever supplied a registry, so the constructor could have
discarded the option entirely and the suite would still pass. Both use an empty
`CodecRegistry`, which differs from the built-in one on any fabric class —
encoding a `FabricError` throws for the unregistered class, and decoding one
back yields an `UnknownValue` for the unrecognized tag. That pair also matches
the deliberate asymmetry of the two paths: encode faults are local bugs and
throw, decode takes untrusted input and must succeed in reporting what arrived.

**Ablation:** making the constructor discard `options.registry` turns both new
cases red and nothing else — 48 passed / 1 failed against 49 / 0. That is the
evidence for both halves of the claim: the tests grip the new wiring, and
moving the parameter changed no existing behavior.

Full workspace suite green (40 packages, 279s), plus `fmt --check`, `lint`,
`check`, `check-docs`, `check-conflict-markers`, `check-skill-facts`,
`check-no-waitfor`.

## Next in the series

2. Move the JSON convenience layer (`jsonFromValue()` and friends) up to a new
   `data-model/src/codecs.ts`, while the built-in default still works. Pure
   relocation.
3. Split `createBaseJsonRegistry()` (format only, no fabric classes) from
   `createDefaultJsonRegistry()` (base + both rosters), and make the registry
   required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WXGpwWEeCPdgHeH1zhrrz3


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

