### PR TITLE
feat(runner): editWithRetry can abandon before its commit

### DIFF
--- a/docs/specs/space-model/5-transactions.md
+++ b/docs/specs/space-model/5-transactions.md
@@ -155,6 +155,30 @@ const result = await runtime.editWithRetry(async (tx) => {
 
 The scheduler also provides automatic retry for handlers on transaction conflict.
 
+#### Abandoning an edit
+
+A caller whose work can become obsolete while the edit is outstanding passes a
+`shouldCommit` predicate. It is called once per attempt, immediately before that
+attempt's commit, and returning false aborts the staged transaction instead of
+committing it. The result is then `{ abandoned: true }`, which carries neither
+`ok` nor `error`, and no retry follows.
+
+```typescript
+// Shown for illustration only.
+const result = await runtime.editWithRetry((tx) => {
+  cell.withTx(tx).set(1);
+}, { shouldCommit: () => stillWanted });
+```
+
+The predicate narrows the window in which an obsolete write can still land, and
+leaves a residual window open. Committing is a round trip to storage, and a
+transaction that has entered it is no longer abortable: `abort()` applies only
+to a transaction still in its `ready` state, and returns
+`InactiveTransactionError` otherwise. So an attempt already committing when the
+predicate turns false writes anyway. What the predicate guarantees is that no
+attempt begins committing after that point. A caller for which a write inside
+the residual window is more than a lost race reconciles that value itself.
+
 ### Relationship to Handlers
 
 Handlers execute within transaction context:

--- a/packages/runner/src/builtins/filter.ts
+++ b/packages/runner/src/builtins/filter.ts
@@ -95,9 +95,12 @@ export function filter(
   const elementRuns = new Map<string, ElementRun>();
 
   // Cleared when the coordinator is torn down, so the asynchronous resume work
-  // below stops writing to a result container nothing owns any more. The same
-  // teardown releases the children the coordinator still holds; the ones whose
-  // elements left the list were released when they left.
+  // below stops writing to a result container nothing owns any more. Each of
+  // those edits passes it as `shouldCommit`, so one that staged before the
+  // teardown aborts instead of committing. One already committing at that
+  // moment still writes, and a later coordinator start reconciles over that
+  // value. The same teardown releases the children the coordinator still
+  // holds; the ones whose elements left the list were released when they left.
   let active = true;
   addCancel(() => {
     active = false;
@@ -168,7 +171,7 @@ export function filter(
                     .set([]),
               );
             }
-          }).then(({ error }) => {
+          }, { shouldCommit: () => active }).then(({ error }) => {
             if (error) {
               logger.warn("resume-input", "settling the resumed input failed", {
                 error,
@@ -314,7 +317,7 @@ export function filter(
           if (!active) return;
           const container = result!.withTx(seedTx);
           if (container.getRaw() === undefined) container.set([]);
-        }).then(({ error }) => {
+        }, { shouldCommit: () => active }).then(({ error }) => {
           if (error) {
             logger.warn(
               "resume-seed",

--- a/packages/runner/src/builtins/flatmap.ts
+++ b/packages/runner/src/builtins/flatmap.ts
@@ -115,9 +115,12 @@ export function flatMap(
   const elementRuns = new Map<string, ElementRun>();
 
   // Cleared when the coordinator is torn down, so the asynchronous resume work
-  // below stops writing to a result container nothing owns any more. The same
-  // teardown releases the children the coordinator still holds; the ones whose
-  // elements left the list were released when they left.
+  // below stops writing to a result container nothing owns any more. Each of
+  // those edits passes it as `shouldCommit`, so one that staged before the
+  // teardown aborts instead of committing. One already committing at that
+  // moment still writes, and a later coordinator start reconciles over that
+  // value. The same teardown releases the children the coordinator still
+  // holds; the ones whose elements left the list were released when they left.
   let active = true;
   addCancel(() => {
     active = false;
@@ -179,7 +182,7 @@ export function flatMap(
                     .set([]),
               );
             }
-          }).then(({ error }) => {
+          }, { shouldCommit: () => active }).then(({ error }) => {
             if (error) {
               logger.warn("resume-input", "settling the resumed input failed", {
                 error,
@@ -320,7 +323,7 @@ export function flatMap(
           if (!active) return;
           const container = result!.withTx(seedTx);
           if (container.getRaw() === undefined) container.set([]);
-        }).then(({ error }) => {
+        }, { shouldCommit: () => active }).then(({ error }) => {
           if (error) {
             logger.warn(
               "resume-seed",

--- a/packages/runner/src/builtins/map.ts
+++ b/packages/runner/src/builtins/map.ts
@@ -101,9 +101,12 @@ export function map(
   const elementRuns = new Map<string, ElementRun>();
 
   // Cleared when the coordinator is torn down, so the asynchronous resume work
-  // below stops writing to a container nothing owns any more. The same teardown
-  // releases the children the coordinator still holds; the ones whose elements
-  // left the list were released when they left.
+  // below stops writing to a container nothing owns any more. Each of those
+  // edits passes it as `shouldCommit`, so one that staged before the teardown
+  // aborts instead of committing. One already committing at that moment still
+  // writes, and a later coordinator start reconciles over that value. The same
+  // teardown releases the children the coordinator still holds; the ones whose
+  // elements left the list were released when they left.
   let active = true;
   addCancel(() => {
     active = false;
@@ -143,7 +146,7 @@ export function map(
                   ),
               );
             }
-          }).then(({ error }) => {
+          }, { shouldCommit: () => active }).then(({ error }) => {
             if (error) {
               logger.warn("resume-input", "settling the resumed input failed", {
                 error,
@@ -299,7 +302,7 @@ export function map(
           if (!active) return;
           const container = result!.withTx(seedTx);
           if (container.getRaw() === undefined) container.set([]);
-        }).then(({ error }) => {
+        }, { shouldCommit: () => active }).then(({ error }) => {
           if (error) {
             logger.warn(
               "resume-seed",

--- a/packages/runner/src/builtins/resume-republish.ts
+++ b/packages/runner/src/builtins/resume-republish.ts
@@ -49,7 +49,9 @@ export interface ResumeRepublisherOptions {
   /**
    * False once the coordinator is torn down. A republish outstanding at that
    * moment has a container nothing owns any more, so it is dropped rather than
-   * written.
+   * written. It is also the republish edit's `shouldCommit`, so a republish
+   * that staged before the teardown aborts instead of committing; one already
+   * committing at that moment still writes.
    */
   isActive: () => boolean;
   /**
@@ -173,7 +175,7 @@ export function createResumeRepublisher(
         () => result.asSchema(resultSchema).withTx(tx).set(out),
       );
       return [];
-    }).then(({ ok, error }) => {
+    }, { shouldCommit: isActive }).then(({ ok, error }) => {
       if (error) {
         logger.warn(
           "resume-republish",

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -1,8 +1,11 @@
 export { Runtime } from "./runtime.ts";
 export { normalizeSpaceHost } from "./space-host.ts";
 export type {
+  CommittedEditResult,
   ConsoleHandler,
   ConsoleHandlerOutput,
+  EditWithRetryOptions,
+  EditWithRetryResult,
   ErrorHandler,
   ErrorWithContext as RuntimeErrorWithContext,
   ExperimentalOptions, // Space-model feature flags; see ExperimentalOptions in runtime.ts

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -167,6 +167,45 @@ export const DEFAULT_MAX_RETRIES = 5;
 
 export type { IExtendedStorageTransaction, MemorySpace };
 
+export interface EditWithRetryOptions {
+  /**
+   * How many times to re-run the action against a fresh transaction after a
+   * failed commit. Defaults to {@link DEFAULT_MAX_RETRIES}.
+   */
+  maxRetries?: number;
+  /**
+   * Whether the work this edit carries is still wanted. Called once per
+   * attempt, immediately before that attempt's commit; returning false aborts
+   * the staged transaction and yields `{ abandoned: true }`. See
+   * {@link Runtime.editWithRetry} for the window this narrows and the window it
+   * leaves open. A caller holding an `AbortSignal` passes
+   * `() => !signal.aborted`.
+   */
+  shouldCommit?: () => boolean;
+}
+
+/**
+ * The outcome of an {@link Runtime.editWithRetry} that reached a commit: the
+ * action's return value once its transaction committed, or the commit error
+ * once the retries were spent. An `error` of `undefined` implies an `ok`, which
+ * is what lets a caller narrow with `if (result.error) ...` and then read
+ * `result.ok`.
+ */
+export type CommittedEditResult<T> =
+  | { ok: T; error?: undefined; abandoned?: undefined }
+  | { ok?: undefined; error: CommitError; abandoned?: undefined };
+
+/**
+ * The outcome of an {@link Runtime.editWithRetry} that supplied a
+ * `shouldCommit`: either a commit outcome, or the abandonment that predicate
+ * produces by returning false, which carries neither `ok` nor `error`. An edit
+ * without a `shouldCommit` is typed as {@link CommittedEditResult} instead, so
+ * the abandonment reaches only the callers that can produce one.
+ */
+export type EditWithRetryResult<T> =
+  | CommittedEditResult<T>
+  | { ok?: undefined; error?: undefined; abandoned: true };
+
 export interface ConsoleHandlerOutput {
   method: ConsoleMethod;
   args: any[];
@@ -1637,18 +1676,71 @@ export class Runtime {
    * locally replicated memory spaces. Transaction allows reading from many
    * multiple spaces but writing only to one space.
    *
-   * If the transaction fails, it will be retried up to maxRetries times.
+   * If the transaction fails, it will be retried up to `maxRetries` times. Each
+   * retry runs `fn` again against a fresh transaction.
+   *
+   * A caller whose work can become obsolete while the edit is outstanding
+   * supplies `shouldCommit`. It is called once per attempt, immediately before
+   * that attempt's `tx.commit()`. Returning false discards the staged writes:
+   * the transaction is aborted, `fn` is not retried, and the result is
+   * `{ abandoned: true }`, carrying neither `ok` nor `error`.
+   *
+   * `shouldCommit` narrows the window in which an obsolete write can still
+   * land, and leaves a residual window open. Once `tx.commit()` has been
+   * called, the transaction has left its `ready` state, and `abort()` on it
+   * returns `InactiveTransactionError` and discards nothing. An attempt whose
+   * commit is already in flight therefore lands whatever `shouldCommit` would
+   * say now. The residual window is one in-flight commit per attempt, which
+   * spans the round trip to storage. What `shouldCommit` guarantees is
+   * narrower: no attempt begins committing after it turns false. A caller for
+   * which a write inside that window is more than a lost race needs its own
+   * reconciliation for the value that lands there.
+   *
+   * A caller holding an `AbortSignal` passes `() => !signal.aborted`.
+   *
+   * The second argument also accepts a bare number, which means `maxRetries`.
    *
    * @param fn - Function to execute with the transaction.
-   * @param maxRetries - Maximum number of retries.
-   * @returns Promise<boolean> that resolves to true on success, or false after exhausting retries.
+   * @param options - Retry count, or the options described above.
+   * @returns The value `fn` returned once its transaction committed, the commit
+   * error once the retries were spent, or `{ abandoned: true }` when
+   * `shouldCommit` turned an attempt away.
    */
   editWithRetry<T = void>(
     fn: (tx: IExtendedStorageTransaction) => T,
-    maxRetries: number = DEFAULT_MAX_RETRIES,
-  ): Promise<
-    { ok: T; error?: undefined } | { ok?: undefined; error: CommitError }
-  > {
+    options: EditWithRetryOptions & { shouldCommit: () => boolean },
+  ): Promise<EditWithRetryResult<T>>;
+  /**
+   * An edit with no `shouldCommit`, which therefore always reaches a commit and
+   * never abandons. See the overload above for the full contract.
+   */
+  editWithRetry<T = void>(
+    fn: (tx: IExtendedStorageTransaction) => T,
+    options?: number | (EditWithRetryOptions & { shouldCommit?: undefined }),
+  ): Promise<CommittedEditResult<T>>;
+  /**
+   * An edit whose options are only known to be one or the other at the call
+   * site, so both outcomes stay in the result. See the first overload for the
+   * full contract.
+   */
+  editWithRetry<T = void>(
+    fn: (tx: IExtendedStorageTransaction) => T,
+    options?: number | EditWithRetryOptions,
+  ): Promise<EditWithRetryResult<T>>;
+  editWithRetry<T = void>(
+    fn: (tx: IExtendedStorageTransaction) => T,
+    options: number | EditWithRetryOptions = DEFAULT_MAX_RETRIES,
+  ): Promise<EditWithRetryResult<T>> {
+    const { maxRetries = DEFAULT_MAX_RETRIES, shouldCommit } =
+      typeof options === "number" ? { maxRetries: options } : options;
+    return this.runEditWithRetry(fn, maxRetries, shouldCommit);
+  }
+
+  private runEditWithRetry<T>(
+    fn: (tx: IExtendedStorageTransaction) => T,
+    maxRetries: number,
+    shouldCommit: (() => boolean) | undefined,
+  ): Promise<EditWithRetryResult<T>> {
     const tx = this.edit();
     tx.tx.immediate = true;
     (tx.tx as { deferRunnerStartUntilCommit?: boolean })
@@ -1669,6 +1761,30 @@ export class Runtime {
       });
     }
     this.prepareTxForCommit(tx);
+    if (shouldCommit !== undefined) {
+      // The last point at which the staged writes can still be discarded: from
+      // the commit below onwards the transaction has left its ready state and
+      // abort() no longer applies to it. A predicate that throws aborts the
+      // transaction and surfaces the error as a Result, the same as an fn that
+      // throws.
+      let proceed: boolean;
+      try {
+        proceed = shouldCommit();
+      } catch (error) {
+        tx.abort(error);
+        return Promise.resolve({
+          error: {
+            name: "StorageTransactionAborted" as const,
+            message: `editWithRetry shouldCommit threw: ${error}`,
+            reason: error,
+          },
+        });
+      }
+      if (!proceed) {
+        tx.abort(new Error("editWithRetry abandoned before commit"));
+        return Promise.resolve({ abandoned: true as const });
+      }
+    }
     return tx.commit().then(async ({ error }) => {
       if (error) {
         if (maxRetries > 0) {
@@ -1715,7 +1831,11 @@ export class Runtime {
               // Pull failed — the retry's commit decides.
             }
           }
-          return this.editWithRetry<T>(fn, maxRetries - 1);
+          return this.runEditWithRetry<T>(
+            fn,
+            maxRetries - 1,
+            shouldCommit,
+          );
         } else {
           return { error };
         }

--- a/packages/runner/test/runtime-edit-with-retry.test.ts
+++ b/packages/runner/test/runtime-edit-with-retry.test.ts
@@ -295,4 +295,134 @@ describe("Runtime.editWithRetry", () => {
     expect(statuses).toEqual(["done"]);
     expect(cell.get()).toBe(1);
   });
+
+  describe("shouldCommit", () => {
+    it("commits and returns the action's value while it holds", async () => {
+      const cell = runtime.getCell<number>(
+        space,
+        "editWithRetry-should-commit-true",
+        undefined,
+        tx,
+      );
+      cell.set(0);
+      await tx.commit();
+
+      const result = await runtime.editWithRetry((t) => {
+        cell.withTx(t).send(1);
+        return "committed";
+      }, { shouldCommit: () => true });
+
+      expect(result.ok).toBe("committed");
+      expect(result.error).toBeUndefined();
+      expect(result.abandoned).toBeUndefined();
+      expect(cell.get()).toBe(1);
+    });
+
+    it("discards the staged writes and returns `{ abandoned: true }` once it turns false", async () => {
+      const cell = runtime.getCell<number>(
+        space,
+        "editWithRetry-should-commit-false",
+        undefined,
+        tx,
+      );
+      cell.set(0);
+      await tx.commit();
+
+      let attempts = 0;
+      const result = await runtime.editWithRetry((t) => {
+        attempts++;
+        cell.withTx(t).send(1);
+        return "committed";
+      }, { shouldCommit: () => false });
+
+      // The action ran and staged its write; only the commit was withheld.
+      expect(attempts).toBe(1);
+      expect(result.abandoned).toBe(true);
+      expect(result.ok).toBeUndefined();
+      expect(result.error).toBeUndefined();
+      expect(cell.get()).toBe(0);
+    });
+
+    it("is consulted again on the retry that follows a failed commit", async () => {
+      const cell = runtime.getCell<number>(
+        space,
+        "editWithRetry-should-commit-retry",
+        undefined,
+        tx,
+      );
+      cell.set(0);
+      await tx.commit();
+
+      let attempts = 0;
+      let allowed = true;
+      const result = await runtime.editWithRetry((t) => {
+        attempts++;
+        if (attempts === 1) {
+          t.abort("force retry");
+          return;
+        }
+        // The teardown lands while the retry is staging its write.
+        allowed = false;
+        cell.withTx(t).send(1);
+      }, { maxRetries: 3, shouldCommit: () => allowed });
+
+      expect(attempts).toBe(2);
+      expect(result.abandoned).toBe(true);
+      expect(result.error).toBeUndefined();
+      expect(cell.get()).toBe(0);
+    });
+
+    it("does not stop an attempt whose commit is already in flight", async () => {
+      const cell = runtime.getCell<number>(
+        space,
+        "editWithRetry-should-commit-in-flight",
+        undefined,
+        tx,
+      );
+      cell.set(0);
+      await tx.commit();
+
+      let allowed = true;
+      // The action, the predicate and `tx.commit()` all run in the synchronous
+      // part of the call, so the next statement runs with the commit in flight.
+      // That is the residual window the predicate does not cover.
+      const pending = runtime.editWithRetry((t) => {
+        cell.withTx(t).send(1);
+        return "committed";
+      }, { shouldCommit: () => allowed });
+      allowed = false;
+      const result = await pending;
+
+      expect(result.ok).toBe("committed");
+      expect(result.abandoned).toBeUndefined();
+      expect(cell.get()).toBe(1);
+    });
+
+    it("returns a `StorageTransactionAborted` and settles the transaction when it throws", async () => {
+      const cell = runtime.getCell<number>(
+        space,
+        "editWithRetry-should-commit-throws",
+        undefined,
+        tx,
+      );
+      cell.set(0);
+      await tx.commit();
+
+      let staged: IExtendedStorageTransaction | undefined;
+      const result = await runtime.editWithRetry((t) => {
+        staged = t;
+        cell.withTx(t).send(1);
+      }, {
+        shouldCommit: () => {
+          throw new Error("predicate failed");
+        },
+      });
+
+      expect(result.error?.name).toBe("StorageTransactionAborted");
+      expect(result.error?.message).toContain("shouldCommit threw");
+      expect(result.abandoned).toBeUndefined();
+      expect(staged?.status().status).toBe("error");
+      expect(cell.get()).toBe(0);
+    });
+  });
 });


### PR DESCRIPTION
`Runtime.editWithRetry` creates a transaction, runs the caller's action synchronously to stage its writes, and then commits, retrying on conflict. It returned only a promise of the outcome, so a caller whose work became obsolete while the edit was outstanding had no way to say so.

The list builtins need exactly that. filter, flatMap and map each run asynchronous resume work that outlives the reconcile that started it: settling the result container once the input list confirms, seeding an empty container when the resume pull finds nothing to stream in, and — for filter and flatMap — republishing the aggregate once the per-element results confirm. All of it writes to the coordinator's result container, and all of it must stop when the coordinator is torn down. The `active` flag those coordinators clear on teardown could only gate staging: it was checked before calling `editWithRetry` and again inside the action. The flag had no say over the commit itself, so a retry running after a teardown staged nothing and committed an empty transaction, and the intent "do not write this" could only be approximated by writing nothing.

The second argument now also accepts an options object carrying a `shouldCommit` predicate alongside the retry count. It is consulted once per attempt, immediately before that attempt's `tx.commit()`. Returning false aborts the staged transaction and resolves, without retrying, to a third result variant that carries neither `ok` nor `error`. A caller's existing "log the error" branch therefore stays quiet for what is a deliberate stand-down rather than a failure. A predicate that throws aborts the transaction and surfaces the error as a result, the same as an action that throws, so neither path leaves a transaction orphaned.

Each of the four resume edits now passes the coordinator's `active` flag as that predicate. The window this covers is the one inside the retry loop: a conflicted commit awaits the catch-up gate, then a pull of the conflicted document, before re-running the action. A teardown landing in either wait now abandons the retry instead of committing an empty transaction. On the first attempt the action, the predicate and the commit all run in one synchronous block, so the predicate there sees what the caller's own check saw a moment earlier.

That window is reachable rather than theoretical, because the frame that unblocks the retry can be the same frame that tears the coordinator down. Two clients have the same piece open, so each runs its own filter coordinator writing the same result container. One client resumes, its per-element predicates confirm, and the republish commits — and loses to the other client's write, so the commit comes back a conflict. The retry waits on the conflict's catch-up gate, which resolves only when a server frame advances this replica past the commit that won. If someone has meanwhile updated the piece's pattern source, that same inbound frame carries the piece's new pattern identity. The pattern watcher sinks on exactly that, hot-swaps the piece to the new program, and tears down the old nodes, clearing the coordinator's flag. The gate resolves, the retry runs, and the predicate turns it away. The two events are correlated rather than independently racing, which is what makes the sequence an ordinary one. Any piece stop or runtime dispose landing in that same wait reaches the other three edits the same way.

The predicate sits as late as it can, and one window stays open even so. Once `commit()` runs, the transaction leaves its `ready` state, and `abort()` on it returns `InactiveTransactionError` and discards nothing: an attempt whose commit is already in flight writes regardless. The value such an edit writes is the one that was correct for the state it read, and a later coordinator start reconciles over it, which keeps the consequence bounded. The guarantee is therefore that no attempt begins committing after the predicate turns false, not that no write lands after that moment. The API documentation, the transactions spec and each coordinator's comment all say so rather than implying the window is closed, and a test pins the residual window as behavior.

Three overloads keep this off the existing callers. A call with no `shouldCommit` — including the bare-number form, which every current caller uses — is typed to a result without the abandoned variant, so narrowing on `result.error` and then reading `result.ok` still works the way it does today. The new option and result types join the package's type exports, alongside the option and result types of the other public members: they appear in the signature of a public method, so a consumer outside the package should be able to name them.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

