### PR TITLE
style(content-hash): conform error messages and test labels

### DIFF
--- a/packages/content-hash/src/BaseIncrementalHasher.ts
+++ b/packages/content-hash/src/BaseIncrementalHasher.ts
@@ -35,7 +35,7 @@ export abstract class BaseIncrementalHasher implements IncrementalHasher {
         return result;
       }
       default: {
-        throw new Error(`Unknown encoding: ${encoding}`);
+        throw new Error(`Unknown encoding: \`${encoding}\``);
       }
     }
   }

--- a/packages/content-hash/src/sha256-deno.ts
+++ b/packages/content-hash/src/sha256-deno.ts
@@ -52,7 +52,7 @@ class DenoHasher extends BaseIncrementalHasher {
         );
       }
       default: {
-        throw new Error(`Unknown encoding: ${encoding}`);
+        throw new Error(`Unknown encoding: \`${encoding}\``);
       }
     }
   }

--- a/packages/content-hash/test/createHasher.test.ts
+++ b/packages/content-hash/test/createHasher.test.ts
@@ -39,26 +39,26 @@ for (const createFunc of createFuncs) {
     let testId = -1;
     let oneLength = 10; // For multi-byte variety; updated pseudorandomly.
 
-    describe("after digest()", () => {
+    describe("after `digest()`", () => {
       const alreadyDone = /`digest\(\)` already done/;
 
       // A small update is the interesting case: implementations that buffer
       // small writes can satisfy one without consulting the underlying hasher.
-      it("rejects a small update()", () => {
+      it("throws given a small `update()`", () => {
         const hasher = createFunc();
         hasher.update(new Uint8Array([1, 2, 3]));
         hasher.digest();
         expect(() => hasher.update(new Uint8Array([4]))).toThrow(alreadyDone);
       });
 
-      it("rejects an update() too large to buffer", () => {
+      it("throws given an `update()` too large to buffer", () => {
         const hasher = createFunc();
         hasher.update(new Uint8Array([1, 2, 3]));
         hasher.digest();
         expect(() => hasher.update(new Uint8Array(4096))).toThrow(alreadyDone);
       });
 
-      it("rejects a second digest()", () => {
+      it("throws given a second `digest()`", () => {
         const hasher = createFunc();
         hasher.update(new Uint8Array([1, 2, 3]));
         hasher.digest();
@@ -72,21 +72,21 @@ for (const createFunc of createFuncs) {
       testId++;
 
       describe(`for fixture #${testId}, hash ${hashMsg}`, () => {
-        it("one-shot use produces expected string hash", () => {
+        it("produces the expected string hash from one-shot use", () => {
           const hasher = createFunc();
           hasher.update(bytes);
           const got = hasher.digest("base64url");
           expect(got).toBe(hashStr);
         });
 
-        it("one-shot use produces expected byte-array hash", () => {
+        it("produces the expected byte-array hash from one-shot use", () => {
           const hasher = createFunc();
           hasher.update(bytes);
           const got = hasher.digest();
           expect(got).toEqual(hashBytes);
         });
 
-        it("byte-at-a-time use produces expected byte-array hash", () => {
+        it("produces the expected byte-array hash from byte-at-a-time use", () => {
           const hasher = createFunc();
           for (let i = 0; i < bytes.length; i++) {
             hasher.update(bytes.subarray(i, i + 1));
@@ -95,7 +95,7 @@ for (const createFunc of createFuncs) {
           expect(got).toEqual(hashBytes);
         });
 
-        it("multi-byte variety use produces expected byte-array hash", () => {
+        it("produces the expected byte-array hash from varied multi-byte use", () => {
           const hasher = createFunc();
           let i = 0;
           while (i < bytes.length) {
@@ -110,7 +110,7 @@ for (const createFunc of createFuncs) {
       });
     }
 
-    it("can operate concurrently", () => {
+    it("produces the expected hashes from interleaved instances", () => {
       const CONCURRENT_COUNT = 10;
       let inProgress: {
         hasher: IncrementalHasher;

--- a/packages/content-hash/test/sha256.test.ts
+++ b/packages/content-hash/test/sha256.test.ts
@@ -30,9 +30,9 @@ for (const shaFunc of sha256Funcs) {
   describe(`${shaFunc.name}()`, () => {
     let i = 1;
     for (const { bytes, sha256: hashStr } of FIXTURES) {
-      const hashMsg = `${hashStr.slice(0, 8)}...`;
+      const hashMsg = `\`${hashStr.slice(0, 8)}...\``;
       const hashBytes = fromBase64url(hashStr);
-      it(`produces expected byte-array hash #${i++}: \`${hashMsg}...\``, () => {
+      it(`produces the expected byte-array hash #${i++}: ${hashMsg}`, () => {
         const got = shaFunc(bytes);
         expect(got).toEqual(hashBytes);
       });


### PR DESCRIPTION
I (agent working on behalf of @danfuzz) went through `packages/content-hash`
for conformance of error-message text and unit-test description strings, against
`docs/development/code-comment-style.md` (§"Error and log messages", §"Markup")
and `docs/development/unit-test-coding-style.md` (§"Writing the description
strings").

This is a text-only change: no control flow, no assertions, and no test
coverage moves.

## Error messages

Two sites, both `` `Unknown encoding: ${encoding}` ``. The interpolated value is
a literal string being named, so it takes backticks —
`` `Unknown encoding: \`${encoding}\`` `` — which is the shape of the guide's own
`Unsupported flavor` example. No test matches either literal (checked
repo-wide).

The package's other three throws were already conformant and are untouched.

## Test labels

* ``describe("after digest()")`` becomes ``describe("after `digest()`")``. The
  "entirely one backticked string" exception covers ``describe("eatDonut()")``,
  not a title with prose around the span.
* `rejects a small update()`, `rejects an update() too large to buffer`, and
  `rejects a second digest()` become `throws given a ...`, with backticks added.
  Each of these asserts `toThrow()`, so "rejects" was ascribing an intent where
  an observable fact was available. `throws given a negative weight` is the
  guide's own form.
* `one-shot use produces expected string hash` and three siblings led with a
  noun phrase, so they did not complete the word "it". They now lead with the
  verb: `produces the expected string hash from one-shot use`.
* `can operate concurrently` becomes `produces the expected hashes from
  interleaved instances`. The old label named a capability no assertion checks;
  the test asserts hashes against fixtures.

## One incidental fix

`sha256.test.ts` computed `hashMsg` as `` `${hashStr.slice(0, 8)}...` `` and then
interpolated it as `` `${hashMsg}...` ``, so all 93 generated labels rendered as
`` `Y32Zsdrb......` ``. The ellipsis now appears once, and the backticks moved
into `hashMsg` alongside it.

## Verification

`deno task test` in `packages/content-hash`: ok, 2 passed (721 steps).
Repo-wide `deno fmt --check`, `deno lint`, `check-docs`,
`check-conflict-markers`, `check-no-waitfor`, and `check-skill-facts` are all
clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

