### PR TITLE
style(leb128): conform error messages and test labels

### DIFF
--- a/packages/leb128/src/index.ts
+++ b/packages/leb128/src/index.ts
@@ -20,12 +20,13 @@ const MAX_UINT32 = 0xFFFFFFFF;
 export function encodeULEB128(value: number): Uint8Array {
   if (value < 0 || !Number.isInteger(value)) {
     throw new Error(
-      `encodeULEB128: expected non-negative integer, got ${value}`,
+      `\`encodeULEB128()\`: expected non-negative integer, got \`${value}\``,
     );
   }
   if (value > MAX_UINT32) {
     throw new Error(
-      `encodeULEB128: value ${value} exceeds 32-bit range (max ${MAX_UINT32})`,
+      `\`encodeULEB128()\`: value \`${value}\` exceeds 32-bit range ` +
+        `(max \`${MAX_UINT32}\`)`,
     );
   }
 
@@ -71,16 +72,16 @@ export function decodeULEB128(
 
   do {
     if (index >= buffer.length) {
-      throw new Error("decodeULEB128: unexpected end of buffer");
+      throw new Error("`decodeULEB128()`: unexpected end of `buffer`");
     }
     byte = buffer[index]!;
     // At shift 28, only 4 bits remain in a 32-bit value; reject if
     // the payload bits would overflow.
     if (shift >= 28 && (byte & 0x7f) > 0x0f) {
-      throw new Error("decodeULEB128: value exceeds 32-bit range");
+      throw new Error("`decodeULEB128()`: value exceeds 32-bit range");
     }
     if (shift >= 35) {
-      throw new Error("decodeULEB128: value exceeds 32-bit range");
+      throw new Error("`decodeULEB128()`: value exceeds 32-bit range");
     }
     result |= (byte & 0x7f) << shift;
     shift += 7;
@@ -102,11 +103,12 @@ const MAX_INT32 = 0x7FFFFFFF;
  */
 export function encodeSLEB128(value: number): Uint8Array {
   if (!Number.isInteger(value)) {
-    throw new Error(`encodeSLEB128: expected integer, got ${value}`);
+    throw new Error(`\`encodeSLEB128()\`: expected integer, got \`${value}\``);
   }
   if (value < MIN_INT32 || value > MAX_INT32) {
     throw new Error(
-      `encodeSLEB128: value ${value} exceeds signed 32-bit range (${MIN_INT32}..${MAX_INT32})`,
+      `\`encodeSLEB128()\`: value \`${value}\` exceeds signed 32-bit range ` +
+        `(\`${MIN_INT32}..${MAX_INT32}\`)`,
     );
   }
 
@@ -150,11 +152,11 @@ export function decodeSLEB128(
 
   do {
     if (index >= buffer.length) {
-      throw new Error("decodeSLEB128: unexpected end of buffer");
+      throw new Error("`decodeSLEB128()`: unexpected end of `buffer`");
     }
     byte = buffer[index]!;
     if (shift >= 35) {
-      throw new Error("decodeSLEB128: value exceeds signed 32-bit range");
+      throw new Error("`decodeSLEB128()`: value exceeds signed 32-bit range");
     }
     result |= (byte & 0x7f) << shift;
     shift += 7;

--- a/packages/leb128/test/leb128.test.ts
+++ b/packages/leb128/test/leb128.test.ts
@@ -9,40 +9,40 @@ import {
 
 describe("leb128", () => {
   describe("encodeULEB128()", () => {
-    it("encodes 0", () => {
+    it("encodes `0`", () => {
       expect(encodeULEB128(0)).toEqual(new Uint8Array([0x00]));
     });
 
-    it("encodes 1", () => {
+    it("encodes `1`", () => {
       expect(encodeULEB128(1)).toEqual(new Uint8Array([0x01]));
     });
 
-    it("encodes 127 (max single byte)", () => {
+    it("encodes `127` (max single byte)", () => {
       expect(encodeULEB128(127)).toEqual(new Uint8Array([0x7f]));
     });
 
-    it("encodes 128 (first two-byte value)", () => {
+    it("encodes `128` (first two-byte value)", () => {
       expect(encodeULEB128(128)).toEqual(new Uint8Array([0x80, 0x01]));
     });
 
-    it("encodes 624485 (Wikipedia example)", () => {
+    it("encodes `624485` (Wikipedia example)", () => {
       // 624485 = 0x98765 -> LEB128: [0xe5, 0x8e, 0x26]
       expect(encodeULEB128(624485)).toEqual(new Uint8Array([0xe5, 0x8e, 0x26]));
     });
 
-    it("encodes 255", () => {
+    it("encodes `255`", () => {
       expect(encodeULEB128(255)).toEqual(new Uint8Array([0xff, 0x01]));
     });
 
-    it("encodes 16383 (max two-byte value)", () => {
+    it("encodes `16383` (max two-byte value)", () => {
       expect(encodeULEB128(16383)).toEqual(new Uint8Array([0xff, 0x7f]));
     });
 
-    it("encodes 16384 (first three-byte value)", () => {
+    it("encodes `16384` (first three-byte value)", () => {
       expect(encodeULEB128(16384)).toEqual(new Uint8Array([0x80, 0x80, 0x01]));
     });
 
-    it("encodes 0xffffffff (max 32-bit unsigned)", () => {
+    it("encodes `0xffffffff` (max 32-bit unsigned)", () => {
       expect(encodeULEB128(0xffffffff)).toEqual(
         new Uint8Array([0xff, 0xff, 0xff, 0xff, 0x0f]),
       );
@@ -68,28 +68,28 @@ describe("leb128", () => {
   });
 
   describe("decodeULEB128()", () => {
-    it("decodes 0", () => {
+    it("decodes `0`", () => {
       expect(decodeULEB128(new Uint8Array([0x00]))).toEqual({
         value: 0,
         nextIndex: 1,
       });
     });
 
-    it("decodes 127", () => {
+    it("decodes `127`", () => {
       expect(decodeULEB128(new Uint8Array([0x7f]))).toEqual({
         value: 127,
         nextIndex: 1,
       });
     });
 
-    it("decodes 128", () => {
+    it("decodes `128`", () => {
       expect(decodeULEB128(new Uint8Array([0x80, 0x01]))).toEqual({
         value: 128,
         nextIndex: 2,
       });
     });
 
-    it("decodes 624485 (Wikipedia example)", () => {
+    it("decodes `624485` (Wikipedia example)", () => {
       expect(decodeULEB128(new Uint8Array([0xe5, 0x8e, 0x26]))).toEqual({
         value: 624485,
         nextIndex: 3,
@@ -102,7 +102,7 @@ describe("leb128", () => {
         .toEqual({ value: 128, nextIndex: 4 });
     });
 
-    it("decodes 0xffffffff (max 32-bit unsigned)", () => {
+    it("decodes `0xffffffff` (max 32-bit unsigned)", () => {
       expect(decodeULEB128(new Uint8Array([0xff, 0xff, 0xff, 0xff, 0x0f])))
         .toEqual({ value: 0xffffffff, nextIndex: 5 });
     });
@@ -145,7 +145,7 @@ describe("leb128", () => {
         0xffffffff,
       ];
       for (const v of values) {
-        it(`recovers ${v}`, () => {
+        it(`recovers \`${v}\``, () => {
           const encoded = encodeULEB128(v);
           const decoded = decodeULEB128(encoded);
           expect(decoded.value).toBe(v);
@@ -156,35 +156,35 @@ describe("leb128", () => {
   });
 
   describe("encodeSLEB128()", () => {
-    it("encodes 0", () => {
+    it("encodes `0`", () => {
       expect(encodeSLEB128(0)).toEqual(new Uint8Array([0x00]));
     });
 
-    it("encodes -1", () => {
+    it("encodes `-1`", () => {
       expect(encodeSLEB128(-1)).toEqual(new Uint8Array([0x7f]));
     });
 
-    it("encodes 1", () => {
+    it("encodes `1`", () => {
       expect(encodeSLEB128(1)).toEqual(new Uint8Array([0x01]));
     });
 
-    it("encodes 63 (max positive single byte)", () => {
+    it("encodes `63` (max positive single byte)", () => {
       expect(encodeSLEB128(63)).toEqual(new Uint8Array([0x3f]));
     });
 
-    it("encodes 64 (first positive two-byte)", () => {
+    it("encodes `64` (first positive two-byte)", () => {
       expect(encodeSLEB128(64)).toEqual(new Uint8Array([0xc0, 0x00]));
     });
 
-    it("encodes -64 (min negative single byte)", () => {
+    it("encodes `-64` (min negative single byte)", () => {
       expect(encodeSLEB128(-64)).toEqual(new Uint8Array([0x40]));
     });
 
-    it("encodes -65 (first negative two-byte)", () => {
+    it("encodes `-65` (first negative two-byte)", () => {
       expect(encodeSLEB128(-65)).toEqual(new Uint8Array([0xbf, 0x7f]));
     });
 
-    it("encodes -123456 (Wikipedia example)", () => {
+    it("encodes `-123456` (Wikipedia example)", () => {
       // -123456 -> signed LEB128: [0xc0, 0xbb, 0x78]
       expect(encodeSLEB128(-123456)).toEqual(
         new Uint8Array([0xc0, 0xbb, 0x78]),
@@ -205,35 +205,35 @@ describe("leb128", () => {
   });
 
   describe("decodeSLEB128()", () => {
-    it("decodes 0", () => {
+    it("decodes `0`", () => {
       expect(decodeSLEB128(new Uint8Array([0x00]))).toEqual({
         value: 0,
         nextIndex: 1,
       });
     });
 
-    it("decodes -1", () => {
+    it("decodes `-1`", () => {
       expect(decodeSLEB128(new Uint8Array([0x7f]))).toEqual({
         value: -1,
         nextIndex: 1,
       });
     });
 
-    it("decodes 63", () => {
+    it("decodes `63`", () => {
       expect(decodeSLEB128(new Uint8Array([0x3f]))).toEqual({
         value: 63,
         nextIndex: 1,
       });
     });
 
-    it("decodes -64", () => {
+    it("decodes `-64`", () => {
       expect(decodeSLEB128(new Uint8Array([0x40]))).toEqual({
         value: -64,
         nextIndex: 1,
       });
     });
 
-    it("decodes -123456 (Wikipedia example)", () => {
+    it("decodes `-123456` (Wikipedia example)", () => {
       expect(decodeSLEB128(new Uint8Array([0xc0, 0xbb, 0x78]))).toEqual({
         value: -123456,
         nextIndex: 3,
@@ -263,7 +263,7 @@ describe("leb128", () => {
         -1000,
       ];
       for (const v of values) {
-        it(`recovers ${v}`, () => {
+        it(`recovers \`${v}\``, () => {
           const encoded = encodeSLEB128(v);
           const decoded = decodeSLEB128(encoded);
           expect(decoded.value).toBe(v);


### PR DESCRIPTION
I (agent working on behalf of @danfuzz) went through `packages/leb128` for
conformance of error-message text and unit-test description strings, against
`docs/development/code-comment-style.md` (§"Error and log messages", §"Markup")
and `docs/development/unit-test-coding-style.md` (§"Writing the description
strings").

This is a text-only change: no control flow, no assertions, and no test
coverage moves.

## Error messages

All nine throws carried a bare function-name prefix and no markup at all:

```
encodeULEB128: value 4294967296 exceeds 32-bit range (max 4294967295)
decodeULEB128: unexpected end of buffer
```

The prefix is worth keeping — it locates the throw when the error crosses a
package boundary and the stack has a `catch`-and-rethrow between the reader and
the throw site — so it is conformed rather than dropped. A callable takes its
parentheses, and interpolated values are literals being named, so:

```
`encodeULEB128()`: value `4294967296` exceeds 32-bit range (max `4294967295`)
`decodeULEB128()`: unexpected end of `buffer`
```

`buffer` is backticked because it names the parameter, not a generic noun. The
signed-range message renders its bounds as a single span,
`` `-2147483648..2147483647` ``, rather than two adjacent spans, which the
markup rules tell you to avoid.

## Test labels

29 sites, all the same defect: a label naming a literal value without backticks.
`encodes 0xffffffff (max 32-bit unsigned)` becomes
`` encodes `0xffffffff` (max 32-bit unsigned) ``, and the two generated
round-trip labels `` `recovers ${v}` `` become `` recovers `${v}` ``.

The `describe()` titles are already correct: `describe("encodeULEB128()")` and
its three siblings fall under the "entirely one backticked string" exception,
so they take no backticks.

## What was checked before editing

Every message literal was grepped for test matches first. The tests match on
five substrings — `non-negative`, `non-negative integer`,
`exceeds 32-bit range`, `unexpected end`, and `exceeds signed 32-bit range` —
and all five survive the rewrite unchanged. No package outside `leb128` asserts
on any of these messages.

## Verification

`deno task test` in `packages/leb128`: ok, 1 passed (70 steps). Repo-wide
`deno fmt --check`, `deno lint`, `check-conflict-markers`, and
`check-no-waitfor` are clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5566?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

