### PR TITLE
style(pure-json): conform diagnostic messages and test labels

### DIFF
--- a/packages/pure-json/src/json-faithfulness.ts
+++ b/packages/pure-json/src/json-faithfulness.ts
@@ -55,7 +55,7 @@ import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 export interface JsonUnfaithfulValue {
   /** RFC 6901 JSON Pointer to the value; `""` is the whole input. */
   readonly pointer: string;
-  /** Why JSON would not carry it, e.g. `NaN (becomes null)`. */
+  /** Why JSON would not carry it, e.g. `NaN` (becomes `null`). */
   readonly reason: string;
 }
 
@@ -73,10 +73,10 @@ function pointerChild(base: string, token: string | number): string {
  * faithfully, or `null` if it would.
  */
 function numberReason(value: number): string | null {
-  if (Number.isNaN(value)) return "NaN (becomes null)";
-  if (value === Infinity) return "Infinity (becomes null)";
-  if (value === -Infinity) return "-Infinity (becomes null)";
-  if (Object.is(value, -0)) return "-0 (loses its sign)";
+  if (Number.isNaN(value)) return "`NaN` (becomes `null`)";
+  if (value === Infinity) return "`Infinity` (becomes `null`)";
+  if (value === -Infinity) return "`-Infinity` (becomes `null`)";
+  if (Object.is(value, -0)) return "`-0` (loses its sign)";
   return null;
 }
 
@@ -103,19 +103,22 @@ function walk(
       return;
     }
     case "bigint":
-      out.push({ pointer, reason: `bigint ${value}n (not representable)` });
+      out.push({
+        pointer,
+        reason: `\`bigint\` value \`${value}n\` (not representable)`,
+      });
       return;
     case "undefined":
       out.push({
         pointer,
-        reason: "undefined (dropped from an object, null in an array)",
+        reason: "`undefined` (dropped from an object, `null` in an array)",
       });
       return;
     case "symbol":
-      out.push({ pointer, reason: "symbol (not representable)" });
+      out.push({ pointer, reason: "`symbol` (not representable)" });
       return;
     case "function":
-      out.push({ pointer, reason: "function (not representable)" });
+      out.push({ pointer, reason: "`function` (not representable)" });
       return;
   }
 
@@ -124,7 +127,10 @@ function walk(
   // than rejects -- is fine; only an actual cycle is reported.
   const obj = value as object;
   if (ancestors.has(obj)) {
-    out.push({ pointer, reason: "circular reference (JSON.stringify throws)" });
+    out.push({
+      pointer,
+      reason: "circular reference (`JSON.stringify()` throws)",
+    });
     return;
   }
   ancestors.add(obj);
@@ -137,7 +143,8 @@ function walk(
     if (toJson !== undefined && typeof toJson.value === "function") {
       out.push({
         pointer,
-        reason: "toJSON method (JSON.stringify would replace this value)",
+        reason:
+          "`toJSON()` method (`JSON.stringify()` would replace this value)",
       });
       return;
     }
@@ -170,7 +177,7 @@ function walk(
         if (!(i in obj)) {
           out.push({
             pointer: pointerChild(pointer, i),
-            reason: "array hole (becomes null)",
+            reason: "array hole (becomes `null`)",
           });
           continue;
         }
@@ -183,7 +190,8 @@ function walk(
       const name = obj.constructor?.name ?? "object";
       out.push({
         pointer,
-        reason: `non-plain object (${name}; JSON.stringify sees no own data)`,
+        reason:
+          `non-plain object (\`${name}\`; \`JSON.stringify()\` sees no own data)`,
       });
       return;
     }

--- a/packages/pure-json/src/json-faithfulness.ts
+++ b/packages/pure-json/src/json-faithfulness.ts
@@ -55,7 +55,7 @@ import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 export interface JsonUnfaithfulValue {
   /** RFC 6901 JSON Pointer to the value; `""` is the whole input. */
   readonly pointer: string;
-  /** Why JSON would not carry it, e.g. `NaN` (becomes `null`). */
+  /** Why JSON would not carry it, e.g. `` `NaN` (becomes `null`) ``. */
   readonly reason: string;
 }
 

--- a/packages/pure-json/test/json-faithfulness.test.ts
+++ b/packages/pure-json/test/json-faithfulness.test.ts
@@ -3,8 +3,8 @@ import { expect } from "@std/expect";
 
 import { findJsonUnfaithfulValues, isPureJson } from "@commonfabric/pure-json";
 
-describe("findJsonUnfaithfulValues", () => {
-  it("accepts JSON-faithful shapes", () => {
+describe("findJsonUnfaithfulValues()", () => {
+  it("returns an empty list for JSON-faithful shapes", () => {
     // The whitelist: null, booleans, strings, finite numbers other than -0,
     // dense arrays of accepted values, plain objects of accepted values.
     const schema = {
@@ -23,12 +23,12 @@ describe("findJsonUnfaithfulValues", () => {
     expect(findJsonUnfaithfulValues(schema)).toEqual([]);
   });
 
-  it("treats a bare boolean as faithful", () => {
+  it("returns an empty list for a bare boolean", () => {
     expect(findJsonUnfaithfulValues(true)).toEqual([]);
     expect(findJsonUnfaithfulValues(false)).toEqual([]);
   });
 
-  it("catches each non-finite and signed zero", () => {
+  it("reports each non-finite and signed zero", () => {
     for (const value of [NaN, Infinity, -Infinity, -0]) {
       const found = findJsonUnfaithfulValues({
         type: "number",
@@ -39,17 +39,17 @@ describe("findJsonUnfaithfulValues", () => {
     }
   });
 
-  it("catches a bigint", () => {
+  it("reports a `bigint`", () => {
     // JSON.stringify throws on a bigint; caught here so the failure names the
     // value rather than surfacing as an opaque serialization error.
     const found = findJsonUnfaithfulValues({ default: 42n });
     expect(found).toEqual([{
       pointer: "/default",
-      reason: "bigint 42n (not representable)",
+      reason: "`bigint` value `42n` (not representable)",
     }]);
   });
 
-  it("catches undefined -- dropped, not a bad number", () => {
+  it("reports `undefined` -- dropped, not a bad number", () => {
     // A blacklist of bad numbers would miss this: `{ default: undefined }`
     // serializes to `{}`, silently losing the default.
     const found = findJsonUnfaithfulValues({ default: undefined });
@@ -57,13 +57,13 @@ describe("findJsonUnfaithfulValues", () => {
     expect(found[0]!.pointer).toBe("/default");
   });
 
-  it("catches undefined inside an array (becomes null)", () => {
+  it("reports `undefined` inside an array (becomes `null`)", () => {
     const found = findJsonUnfaithfulValues({ default: [1, undefined, 3] });
     expect(found).toHaveLength(1);
     expect(found[0]!.pointer).toBe("/default/1");
   });
 
-  it("catches a sparse array hole (becomes null)", () => {
+  it("reports a sparse array hole (becomes `null`)", () => {
     // A hole is exactly what is under test.
     // deno-lint-ignore no-sparse-arrays
     const holed = [1, , 3];
@@ -73,18 +73,18 @@ describe("findJsonUnfaithfulValues", () => {
     expect(found[0]!.reason).toContain("hole");
   });
 
-  it("catches symbol and function values", () => {
+  it("reports `symbol` and `function` values", () => {
     expect(findJsonUnfaithfulValues({ a: Symbol("s") })).toHaveLength(1);
     expect(findJsonUnfaithfulValues({ a: () => 1 })).toHaveLength(1);
   });
 
-  it("catches a symbol-keyed property", () => {
+  it("reports a symbol-keyed property", () => {
     const found = findJsonUnfaithfulValues({ [Symbol("s")]: 1, ok: 2 });
     expect(found).toHaveLength(1);
     expect(found[0]!.reason).toContain("symbol-keyed");
   });
 
-  it("catches a non-index property on an array", () => {
+  it("reports a non-index property on an array", () => {
     // `JSON.stringify` serializes an array's indices only; an extra own
     // property is dropped. The indices themselves stay faithful.
     const withExtra = Object.assign([1, 2], { foo: 3 });
@@ -94,7 +94,7 @@ describe("findJsonUnfaithfulValues", () => {
     expect(found[0]!.reason).toContain("non-index");
   });
 
-  it("catches a NON-enumerable non-index property on an array", () => {
+  it("reports a _non-enumerable_ non-index property on an array", () => {
     // `JSON.stringify` drops it just the same, so an enumerable-only walk
     // would certify a value that JSON demonstrably mangles.
     const withHidden: unknown[] = [1, 2];
@@ -123,7 +123,7 @@ describe("findJsonUnfaithfulValues", () => {
     expect(findJsonUnfaithfulValues({ default: arr })).toHaveLength(0);
   });
 
-  it("catches a toJSON hook, even non-enumerable", () => {
+  it("reports a `toJSON()` hook, even non-enumerable", () => {
     // `toJSON` replaces the value before JSON sees its contents, so the walk
     // cannot certify what would be sent.
     expect(findJsonUnfaithfulValues({ a: 1, toJSON: () => 5 })).toHaveLength(1);
@@ -139,7 +139,7 @@ describe("findJsonUnfaithfulValues", () => {
     expect(found[0]!.reason).toContain("toJSON");
   });
 
-  it("catches a non-plain object (a class instance)", () => {
+  it("reports a non-plain object (a class instance)", () => {
     // A class instance keeps its data in private fields, so `JSON.stringify`
     // finds nothing to emit. Any class instance is rejected.
     class Holder {
@@ -176,7 +176,7 @@ describe("findJsonUnfaithfulValues", () => {
     ]);
   });
 
-  it("escapes ~ and / in pointer tokens", () => {
+  it("escapes `~` and `/` in pointer tokens", () => {
     // RFC 6901: `~` -> `~0`, `/` -> `~1`. A property named `a/b` must not read
     // as two path steps.
     const found = findJsonUnfaithfulValues({ "a/b~c": NaN });
@@ -184,8 +184,8 @@ describe("findJsonUnfaithfulValues", () => {
   });
 });
 
-describe("isPureJson", () => {
-  it("accepts what JSON carries faithfully", () => {
+describe("isPureJson()", () => {
+  it("returns `true` for what JSON carries faithfully", () => {
     expect(isPureJson(null)).toBe(true);
     expect(isPureJson("text")).toBe(true);
     expect(isPureJson(1)).toBe(true);
@@ -193,7 +193,7 @@ describe("isPureJson", () => {
     expect(isPureJson({ a: [1, "two", { b: null }] })).toBe(true);
   });
 
-  it("rejects what JSON would alter or drop", () => {
+  it("returns `false` for what JSON would alter or drop", () => {
     expect(isPureJson(undefined)).toBe(false);
     expect(isPureJson(Number.NaN)).toBe(false);
     expect(isPureJson(-0)).toBe(false);


### PR DESCRIPTION
I (agent working on behalf of @danfuzz) went through `packages/pure-json` for
conformance of message text and unit-test description strings, against
`docs/development/code-comment-style.md` (§"Error and log messages", §"Markup")
and `docs/development/unit-test-coding-style.md` (§"Writing the description
strings").

This is a text-only change: no control flow, no assertions, and no test
coverage moves.

## Diagnostic messages

`pure-json` throws nothing, but it produces message text all the same: the
`reason` on a `JsonUnfaithfulValue`. `llm`'s `assertJsonTransportSafe()` builds
its thrown error by concatenating these, so a `reason` is an error message that
happens to travel as data, and the same markup rules reach it.

Thirteen strings, all unmarked. For example:

```
NaN (becomes null)                          ->  `NaN` (becomes `null`)
undefined (dropped from an object, null...) ->  `undefined` (dropped from an object, `null`...)
toJSON method (JSON.stringify would...)     ->  `toJSON()` method (`JSON.stringify()` would...)
circular reference (JSON.stringify throws)  ->  circular reference (`JSON.stringify()` throws)
```

The `bigint` reason is the one that needed a judgment call. Backticking both
parts gives `` `bigint` `42n` ``, two backticked spans in a row, which the
markup rules tell you to avoid. It reads `` `bigint` value `42n` (not
representable) `` instead.

The doc comment on `.reason` cites one of these strings as its example, so it
moves in step.

## Test labels

* `describe("findJsonUnfaithfulValues")` and `describe("isPureJson")` name
  functions, which take their parentheses.
* Four labels ascribed an intent where a return value was available:
  `accepts JSON-faithful shapes` and `treats a bare boolean as faithful` both
  assert `toEqual([])`, so they now read `returns an empty list for ...`; the
  two `isPureJson()` labels become `` returns `true` for ... `` and
  `` returns `false` for ... ``.
* Eleven `catches X` labels become `reports X`. The function returns a list of
  findings, so "reports" is the observable fact — and one label in the file
  (`reports a cycle, but not a shared reference`) already said so, which split
  the file's own vocabulary.
* Backticks added around `undefined`, `null`, `bigint`, `symbol`, `function`,
  `toJSON()`, `~`, and `/`.
* `catches a NON-enumerable non-index property` becomes
  `reports a _non-enumerable_ non-index property` — the markup rule for emphasis
  is underscores, not capitals.

## What was checked before editing

The only assertion that matches a message exactly is the `bigint` reason
(`toEqual`), updated in step. The rest match substrings that survive: `hole`,
`symbol-keyed`, `non-index`, `toJSON`, `non-plain object`, `circular`.

Outside the package, `llm` is the only consumer. Its
`schema-transport.test.ts` matches on `NaN`, which survives backticking.
Verified by running that file: 3 passed.

## Deliberately not done

The file has two top-level `describe()` calls, where the guide wants one named
for the file under test with the rest nested inside. Fixing that reindents the
whole file, and the guide is explicit that converting a file is its own change
rather than a side effect of one. Filed for a follow-up rather than folded in
here, so this PR stays reviewable as pure text.

## Verification

`deno task test` in `packages/pure-json`: ok, 2 passed (21 steps). In
`packages/llm`: ok, 7 passed (29 steps), plus the 3 `Deno.test` cases in
`src/schema-transport.test.ts`. Repo-wide `deno fmt --check` and `deno lint`
are clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

