### PR TITLE
docs(testing): run browser tests outside agent sandboxes

### DIFF
--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -14,6 +14,17 @@ section routing to coverage, benchmarks, shadow DOM, language-model tests, and
 the pattern-update gates. What follows is only the part you would otherwise
 learn by failing CI, or by shipping a file in the wrong shape.
 
+## Run browser tests outside the macOS agent sandbox
+
+Before the first command that can launch a browser, request unsandboxed
+execution. Known browser-launching paths include the root `deno task test`,
+`deno task demo`, unfiltered browser targets of `deno task integration`,
+`deno-web-test`, `Browser.launch()`, and a bound `ShellIntegration` lifecycle.
+For a filtered integration run, inspect the selected suite's launch path. An
+Astral import alone is not proof that a test starts Chrome. Never try the
+command in the agent sandbox first. The full rule is in
+`docs/development/TESTING.md#browser-tests-in-agent-sandboxes`.
+
 ## Shape of a unit test file
 
 First check which kind of file you are in. A `*.test.tsx` under

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,19 @@ one document per feature or per aspect of the runtime — collection writes,
 identity, ingest, host embedding, and the rest. Read the relevant one before you
 change a subsystem you have not worked on before.
 
+#### Browser tests in agent sandboxes
+
+On macOS, an agent must request unsandboxed execution before its first attempt
+to run a command that can launch a browser. This includes the root
+`deno task test`; the unfiltered root `deno task integration` command;
+unfiltered integration runs for `shell`, `patterns`, or `patterns-reload`;
+`deno task demo`; `deno-web-test`; and focused or filtered tests whose setup
+launches Chrome through Astral or `ShellIntegration`. Never try the command in
+the agent sandbox first. Deno's `-A` flag does not escape the outer sandbox, and
+a browser startup failure caused by that sandbox is not test evidence. The
+complete rule is in
+[`docs/development/TESTING.md`](docs/development/TESTING.md#browser-tests-in-agent-sandboxes).
+
 Three obligations that are easy to miss:
 
 - `docs/README.md` governs everything this repository writes down. It says how

--- a/docs/development/TESTING.md
+++ b/docs/development/TESTING.md
@@ -15,6 +15,42 @@ deno task test
 
 **Important:** Always use `deno task test` from the root, NOT `deno test`, as the task includes necessary flags.
 
+### Browser tests in agent sandboxes
+
+On macOS, an agent must request unsandboxed execution before its first attempt
+to run a command that can launch a browser. Headless Chrome still registers
+with AppKit and needs access to Launch Services and WindowServer. The macOS
+agent sandbox can deny that access and make Chrome abort during startup.
+
+The following repository commands and test paths launch a browser:
+
+- The root `deno task test` command, which reaches browser-backed workspace
+  package tests.
+- The unfiltered root `deno task integration` command. With no target, it
+  includes browser tests from `shell` and `patterns`. Unfiltered target runs
+  for `shell`, `patterns`, and `patterns-reload` also include browser tests.
+- A filtered integration run when the selected test launches a browser. A
+  package name associated with browser tests does not by itself establish that
+  a filtered test launches one.
+- The `deno task demo` command.
+- Tests that run `deno-web-test`, call `Browser.launch()`, or bind a
+  `ShellIntegration` lifecycle.
+
+An `@astral/astral` import alone is not proof that a test launches Chrome. It
+can be a type-only import or support a fake browser. When it is not clear
+whether a focused test starts a browser, inspect its suite setup and launch
+call path before running it.
+
+Use the agent environment's narrowly scoped escalation mechanism for the test
+command. Do not run the command in the sandbox first to see whether it fails.
+Deno's `-A` flag changes Deno's permission checks but does not escape the outer
+agent sandbox. Chrome's `--no-sandbox` flag disables a different protection;
+do not add it as a workaround.
+
+If a browser command was accidentally run inside the agent sandbox, disregard
+its browser-startup failure and rerun it outside the sandbox before
+interpreting the test result.
+
 ### Tests that start Deno
 
 For deliberate import-map and lockfile changes, follow the


### PR DESCRIPTION
Headless Chrome still registers with macOS services that agent sandboxes deny. Browser-backed tests can therefore abort during startup even when Deno has full permissions, producing a failure unrelated to the code under test.

Tell Codex and Claude to request narrowly scoped unsandboxed execution before running commands that launch a browser. List the known browser-backed test paths, distinguish unfiltered integration runs from focused tests, and require inspection of a selected suite's launch path. Document that Deno's -A flag does not escape the outer sandbox and that Chrome's --no-sandbox flag is not a suitable workaround.

Treat sandbox-caused startup failures as invalid test evidence so they are rerun in the correct environment.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

