### PR TITLE
style(utils): conform error and log message strings

### DIFF
--- a/packages/utils/src/base64url.ts
+++ b/packages/utils/src/base64url.ts
@@ -93,7 +93,7 @@ export function fromBase64Polyfill(encoded: string): Uint8Array {
     inLen--;
   }
   if ((s.length - inLen) > 2) {
-    throw new Error("fromBase64url: too much padding");
+    throw new Error("`fromBase64url()`: too much padding");
   }
 
   // Compute output byte count from the number of base64 characters.
@@ -105,7 +105,9 @@ export function fromBase64Polyfill(encoded: string): Uint8Array {
     switch (val) {
       case undefined:
       case B64_INVALID: {
-        throw new Error(`fromBase64url: invalid character at index ${i}`);
+        throw new Error(
+          `\`fromBase64url()\`: invalid character at index \`${i}\``,
+        );
       }
       default: {
         bitBuf = (bitBuf << 6) | val;

--- a/packages/utils/src/bigint-uint8-direct.ts
+++ b/packages/utils/src/bigint-uint8-direct.ts
@@ -126,7 +126,7 @@ export function bigintToMtcDirect(value: bigint): Uint8Array {
 export function bigintFromMtcDirect(bytes: Uint8Array): bigint {
   switch (bytes.length) {
     case 0: {
-      throw new Error("bigintFromMinimalTwosComplement: empty input");
+      throw new Error("`bigintFromMinimalTwosComplement()`: empty input");
     }
 
     case 1: {

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -655,7 +655,8 @@ export class Logger {
     // Skip reserved key name "total" to prevent corruption of breakdown totals
     if (key === "total") {
       console.warn(
-        `[Logger] Message key "total" is reserved and cannot be used. Please use a different key.`,
+        `[Logger] Message key \`total\` is reserved and cannot be used. ` +
+          `Please use a different key.`,
       );
       return;
     }


### PR DESCRIPTION
I (agent working on behalf of @danfuzz) went through the error and log message
strings in `packages/utils/src`, against `docs/development/code-comment-style.md`
(§"Error and log messages", §"Markup").

The unit-test description strings in this package are a much larger and entirely
separate diff — 118 labels open with "should" — so they are not in this change.

## The four sites

```
bigintFromMinimalTwosComplement: empty input
  ->  `bigintFromMinimalTwosComplement()`: empty input

fromBase64url: too much padding
  ->  `fromBase64url()`: too much padding

fromBase64url: invalid character at index 7
  ->  `fromBase64url()`: invalid character at index `7`

[Logger] Message key "total" is reserved and cannot be used. ...
  ->  [Logger] Message key `total` is reserved and cannot be used. ...
```

The function-name prefix is conformed rather than dropped, the same call made
for `leb128`: it locates the throw when the error crosses a package boundary and
a `catch`-and-rethrow sits between the reader and the throw site. The
interpolated index is a literal value. The logger's reserved key was written as
`"total"`, and the markup rule is that a literal string takes backticks and
drops its quotes.

## Left alone deliberately

Four other messages in the package are already conformant or have nothing
code-like in them: `` Value must not be `null`. `` (`utf8.ts`),
`This component must not run in the browser's main thread.` (`env.ts`),
`Assertion that value is a non-array/non-null object failed` (`types.ts`), and
the barrel-file import message, whose snippet is already a code span.

## What was checked before editing

Every literal was grepped repo-wide for a test that matches it. One does:
`bigint.test.ts` matches the substring `empty input`, which survives. Nothing
outside `packages/utils` asserts on any of them.

## Verification

`deno task test` in `packages/utils`: ok, 95 passed (627 steps). Repo-wide
`deno fmt --check`, `deno lint`, and `deno task check` are clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

