### PR TITLE
fix(routing): validate per-space host origins

### DIFF
--- a/docs/specs/pattern-imports/README.md
+++ b/docs/specs/pattern-imports/README.md
@@ -102,7 +102,7 @@ general piece origin model is described in `../piece-source-lifecycle.md`.
 | Slug cells: generic **redirect link to any cell** (`setSlugLink` is target-agnostic; only `resolvePieceAddress` layers a "must be a piece" check) | `packages/piece/src/slugs.ts` | Slugs can name pieces *or* patterns today, mechanically |
 | Slug ids: `hashOf({causal:{space, slug}})`; slug grammar `[a-z0-9]+(-[a-z0-9]+)*`, ≤80 chars; **`isSlugAddress(t) = !t.includes(":")`** | `packages/runner/src/slugs.ts` | The existing slug-vs-URI discriminator the grammar reuses |
 | `loadPatternByIdentity(entryIdentity, symbol, space)` | `packages/runner/src/pattern-manager.ts` | Existing by-identity load path the resolver builds on |
-| Per-space host routing: `spaceHostMap` seeds routes, `registerSpaceHost` adds a route, and the home-space site table hydrates durable hints; foreign-host sessions are ordinary authenticated memory sessions | `packages/runner/src/storage/v2-remote-session.ts`, `packages/runner/src/storage/v2.ts`, and `packages/runtime-client/backends/runtime-processor.ts` | Reads work for a foreign space whose route is already known. A seeded route can only be confirmed. An unseeded default-host provider remains provisional until the first hint arrives or its session accepts a stateful operation. A different host cancels unfinished session setup, replaces the provisional replica, makes overlapping read-only callers use the hinted replica, and loads dependencies discovered from the hinted data. Transactions based on the old replica are rejected. A different-host hint conflicts after an ordinary or scheduler transaction, ACL setup transaction, or SQLite source registration is accepted for issue, even if its acknowledgement later fails. The first accepted late hint then remains stable. Initial table hydration selects the last valid HTTP or HTTPS entry for each space without replacing a route already accepted through IPC. A conflicting table route accepted first makes later IPC registration fail. Applying a host from an explicit `cf://` reference remains planned |
+| Per-space host routing: `spaceHostMap` seeds routes, `registerSpaceHost` adds a route, and the home-space site table hydrates durable hints; foreign-host sessions are ordinary authenticated memory sessions | `packages/runner/src/storage/v2-remote-session.ts`, `packages/runner/src/storage/v2.ts`, and `packages/runtime-client/backends/runtime-processor.ts` | Reads work for a foreign space whose route is already known. A seeded route can only be confirmed. An unseeded default-host provider remains provisional until the first hint arrives or its session accepts a stateful operation. A different host cancels unfinished session setup, replaces the provisional replica, makes overlapping read-only callers use the hinted replica, and loads dependencies discovered from the hinted data. Transactions based on the old replica are rejected. A different-host hint conflicts after an ordinary or scheduler transaction, ACL setup transaction, or SQLite source registration is accepted for issue, even if its acknowledgement later fails. The first accepted late hint then remains stable. Seeds, live hints, and initial table hydration accept only an HTTP or HTTPS origin with no credentials, path, query, or fragment. Hydration selects the last accepted entry for each space without replacing a route already accepted through IPC. A conflicting table route accepted first makes later IPC registration fail. Historical lifecycle resolution can apply a host from an explicit `cf://` reference to the live runtime, but durable route persistence remains planned |
 
 ### The two "pattern by hash" handles, explicitly
 
@@ -660,11 +660,11 @@ provenance-relevant flow flagged under § Security.
 A runtime is no longer bound to one memory host. `spaceHostMap` seeds known
 routes when storage is constructed. `registerSpaceHost` can register the first
 later hint even when an unseeded space already opened provisionally through the
-default host. The home-space site table hydrates durable hints into a new
-runtime. A foreign-host connection is an ordinary authenticated memory
-session. These mechanisms remain interim. This design depends only on the
-property that a space's cells are readable wherever the space lives, not on the
-current map or site-table shape.
+default host. These routes contain only an HTTP or HTTPS origin. The home-space
+site table hydrates durable hints into a new runtime. A foreign-host connection
+is an ordinary authenticated memory session. These mechanisms remain interim.
+This design depends only on the property that a space's cells are readable
+wherever the space lives, not on the current map or site-table shape.
 
 Once a route is in effect, a `cf://host/space/ref` reference resolves exactly
 like a local one. Slug chase, piece metadata, and `pattern:<identity>` source

--- a/docs/specs/pattern-imports/implementation-plan.md
+++ b/docs/specs/pattern-imports/implementation-plan.md
@@ -1191,8 +1191,9 @@ One integration test (runner-level, in-process, two "deploys"):
   data. A different-host hint can replace an operation that is waiting for a
   session. The route becomes fixed when the session accepts a stateful
   operation for issue, even if acknowledgement later fails. Initial site-table
-  hydration selects the last valid HTTP or HTTPS entry for each space without
-  replacing a route already accepted through IPC.
+  hydration selects the last entry for each space that contains only an HTTP or
+  HTTPS origin, with no credentials, path, query, or fragment. It does not
+  replace a route already accepted through IPC.
   A conflicting table route accepted first makes later IPC registration fail.
   Dynamic registration and site-table hydration exist as foundations, but
   import-resolver integration, host failure, and replacement of an explicit

--- a/docs/specs/piece-source-lifecycle.md
+++ b/docs/specs/piece-source-lifecycle.md
@@ -31,6 +31,9 @@ An unseeded space now uses the default host provisionally until a stateful
 operation is issued there. Before that cutoff, its first accepted host hint
 replaces the route and replays prior reads, including when a pattern followed a
 link before site-table hydration completed.
+Per-space route seeds, live hints, and durable site-table entries accept only an
+HTTP or HTTPS origin. Host-qualified historical fabric origins use the same
+route parser when they register a hint.
 
 This lifecycle slice is partial. Revisions retain the existing verified
 `pattern:<identity>` source-document closure rather than the complete authored
@@ -789,8 +792,8 @@ replicated-host failover remain open design work.
 | Register a late host hint before a space opens | **Implemented** | `StorageManager.registerSpaceHost` adds the route. A seed can only be confirmed, and the first accepted late hint becomes authoritative |
 | Keep an accepted late hint stable before opening | **Implemented** | `StorageManager.registerSpaceHost` accepts the first late hint and rejects a different hint before or after the space opens |
 | Replace a provisional default route after opening | **Implemented** | The first late hint invalidates an unseeded provider that opened through the default host before its session accepts a stateful operation. It cancels unfinished connection, initial or reconnect session signature creation, mount, and ACL work. Registered document reads, existing sync barriers, and overlapping read-only calls continue through the hinted host, including verified CFC schema documents discovered from the hinted data. Transactions based on the old replica are rejected as inconsistent at issue time, including when they write another space. Invalid scheduler observations do not reject or strand valid observations. A matching default-host hint confirms without reconnecting. Ordinary and scheduler transactions, ACL setup, and SQLite source registration fix the route when issued, even if acknowledgement later fails |
-| Hydrate durable hints in a new runtime | **Implemented** | The runtime processor watches the home-space site table, selects its last route that passes the current HTTP or HTTPS check for each space, and registers those hints. Hydration can replace a provisional default route. A route already accepted through IPC remains fixed; a conflicting table route accepted first makes later IPC registration fail |
-| Apply one origin-only grammar to every route | **Route normalization required** | `normalizeSpaceHost` checks the HTTP or HTTPS scheme but still accepts credentials, a non-root path, a query, and a fragment. Seeds, live hints, and hydration all use that permissive rule. Bare `cf://` authorities use a lifecycle-local scheme heuristic rather than a shared route rule |
+| Hydrate durable hints in a new runtime | **Implemented** | The runtime processor watches the home-space site table, selects its last origin-only HTTP or HTTPS route for each space, and registers those hints. It ignores credentials, paths, queries, fragments, malformed URLs, unsupported schemes, and entries whose `did` does not start with `did:`. Hydration can replace a provisional default route. A route already accepted through IPC remains fixed; a conflicting table route accepted first makes later IPC registration fail |
+| Apply one origin-only grammar to every route | **Partial** | `normalizeSpaceHost` rejects credentials, a non-root path, a query, and a fragment. Seeds, live hints, and hydration use it. The shared fabric-authority helper defaults to HTTPS and derives HTTP only for loopback when the current runtime route explicitly uses HTTP. Applying the grammar to the default host, future share-link receipt, and future effective-host results remains required |
 | Append an accepted route with commit acknowledgement | **Runtime persistence API required** | Generic `CellHandle` writes either overwrite the table or return before a remote append failure can reach the caller. There is no dedicated operation that synchronizes and applies the table's existing candidate, registers the supplied route, transactionally appends it, inspects the commit result, and reports live conflict separately from persistence failure |
 | Accept a host-qualified piece origin | **Origin integration required** | No source lifecycle operation persists and registers a `cf://` hint before resolving and committing the origin |
 | Receive a host-qualified fabric link in the shell | **Link-receipt integration required** | **Copy link** still copies the frontend URL. No shell path emits or receives the `spaceHost` share-link form, asks the runtime for the effective per-space host, or waits for acknowledged route persistence before navigation |
@@ -1078,7 +1081,7 @@ The implementation evidence for this table is concentrated in:
   implementation and migration input, not a target lifecycle exception.
 - Storage supports late registration of a space-to-host hint before that space
   opens. The runtime processor hydrates durable hints from the home-space site
-  table by selecting its last valid HTTP or HTTPS entry for each space. A
+  table by selecting its last origin-only HTTP or HTTPS entry for each space. A
   seeded route can only be confirmed. An unseeded default-host provider remains
   provisional until its session accepts a stateful operation. The first
   accepted hint can replace it, cancel unfinished session setup, clear its
@@ -1197,17 +1200,16 @@ The implementation evidence for this table is concentrated in:
    table. Design reliable discovery, authenticated route replacement, host
    failover, and explicit close-and-reopen behavior for unavailable or moved
    spaces.
-9. Tighten `normalizeSpaceHost` to the origin-only grammar and use it for the
-   default host, `spaceHostMap` seeds, live registration, site-table hydration,
-   share-link receipt, and effective-host results. Reject invalid defaults and
-   seeds during initialization. Reject an invalid live hint before registration.
-   Ignore invalid legacy site-table entries. Move the `cf://` authority scheme
-   rule into the shared route-normalization module. Use HTTPS by default and
-   permit derived HTTP only for loopback under an explicit local-development or
-   test policy.
-   Test credentials, paths, queries, and fragments through every route input.
-   Test initialization failure, live rejection, legacy-entry filtering, and both
-   transport outcomes for a bare fabric authority.
+9. Apply `normalizeSpaceHost` to the default host, share-link receipt, and
+   effective-host results. `spaceHostMap` seeds, live registration, and
+   site-table hydration already reject credentials, paths, queries, fragments,
+   malformed URLs, and unsupported schemes. The shared `cf://` authority
+   helper defaults to HTTPS. It derives HTTP only for loopback when its caller
+   requests that transport. The historical-origin caller requests HTTP when
+   the configured runtime route already uses HTTP. Add the deployment-level
+   local-development or test policy before another caller selects HTTP. Reject
+   an invalid default during initialization. Test every remaining route input
+   and both default-host transports.
 10. Add a dedicated failure-propagating route operation and expose it through
    the runtime-client protocol. Revalidate its DID and normalized origin in the
    worker. Synchronize the home site table before reading it or registering the

--- a/packages/home-schemas/spaces.ts
+++ b/packages/home-schemas/spaces.ts
@@ -47,17 +47,18 @@ export type SpacesList = Schema<typeof spacesListSchema>;
  * data.
  *
  * Table semantics: an array with no uniqueness constraint. During initial
- * hydration, the last valid HTTP or HTTPS entry for a DID is the candidate
- * route. A seed or accepted hint remains fixed. A default-host fallback is
- * provisional until the first hint is accepted. Removing an entry does not
- * unregister an accepted route until the runtime restarts.
+ * hydration, the last entry for a DID that contains only an HTTP or HTTPS
+ * origin is the candidate route. Credentials, paths, queries, and fragments
+ * make an entry invalid. A seed or accepted hint remains fixed. A default-host
+ * fallback is provisional until the first hint is accepted. Removing an entry
+ * does not unregister an accepted route until the runtime restarts.
  */
 export const spaceHostEntrySchema = {
   type: "object",
   properties: {
     /** The space DID this fact is about — the table key. */
     did: { type: "string" },
-    /** Base URL of the host currently serving the space. */
+    /** HTTP or HTTPS origin currently serving the space. */
     host: { type: "string" },
     /** ISO timestamp of when this fact was recorded. */
     updatedAt: { type: "string" },

--- a/packages/lib-shell/src/runtime.ts
+++ b/packages/lib-shell/src/runtime.ts
@@ -118,8 +118,8 @@ export type RuntimeInternalsCreateOptions = RuntimeInternalsCallbacks & {
   identity: Identity;
   apiUrl: URL;
   /**
-   * Optional space DID → host base URL map forwarded to the worker.
-   * Spaces absent from the map resolve to `apiUrl` (the default host).
+   * Optional map from space DIDs to HTTP or HTTPS origins, forwarded to the
+   * worker. Spaces absent from the map resolve to `apiUrl`, the default host.
    */
   spaceHostMap?: Record<string, string>;
   experimental?: ExperimentalRuntimeFlags;

--- a/packages/piece/src/ops/piece-origin.ts
+++ b/packages/piece/src/ops/piece-origin.ts
@@ -9,6 +9,7 @@
 
 import {
   type Cell,
+  fabricAuthorityMatchesSpaceHost,
   type FabricRef,
   getPatternIdentityRef,
   getPatternRepository,
@@ -20,6 +21,7 @@ import {
   resolveSystemPatternSource,
   type Runtime,
   type RuntimeProgram,
+  spaceHostFromFabricAuthority,
 } from "@commonfabric/runner";
 import { nameSchema } from "@commonfabric/runner/schemas";
 import { HttpProgramResolver } from "@commonfabric/js-compiler/program";
@@ -113,7 +115,7 @@ type StableFabricRef = FabricRef & {
 };
 
 /**
- * Resolve an origin now, returning the authored program and selected export a
+ * Resolves an origin now, returning the authored program and selected export a
  * repoint transition should apply.
  */
 export async function resolvePieceOriginSource(
@@ -168,10 +170,14 @@ export async function resolvePieceOriginSource(
       runtime.mappedHostFor(sourceSpace) ??
         runtime.hostForSpace(sourceSpace),
     );
-    const explicitHost = new URL(`${routedUrl.protocol}//${ref.host}`).host;
-    if (routedUrl.host !== explicitHost) {
-      const scheme = fabricHostScheme(ref.host);
-      if (!runtime.registerSpaceHost(sourceSpace, `${scheme}//${ref.host}`)) {
+    const explicitRoute = spaceHostFromFabricAuthority(ref.host, {
+      useLoopbackHttp: routedUrl.protocol === "http:",
+    });
+    const matchesCurrentRoute =
+      (routedUrl.protocol === "http:" || routedUrl.protocol === "https:") &&
+      fabricAuthorityMatchesSpaceHost(ref.host, routedUrl.origin);
+    if (!matchesCurrentRoute) {
+      if (!runtime.registerSpaceHost(sourceSpace, explicitRoute.toString())) {
         throw new PieceOriginError(
           `the host ${ref.host} is not available for ${sourceSpace}`,
         );
@@ -216,13 +222,6 @@ async function mutableFabricOriginPattern(
   );
   await target.sync();
   return getPatternIdentityRef(target);
-}
-
-function fabricHostScheme(host: string): "http:" | "https:" {
-  const hostname = new URL(`https://${host}`).hostname;
-  const loopback = hostname === "localhost" || hostname === "[::1]" ||
-    /^127(?:\.\d{1,3}){3}$/.test(hostname);
-  return loopback ? "http:" : "https:";
 }
 
 /**

--- a/packages/piece/test/piece-origin.test.ts
+++ b/packages/piece/test/piece-origin.test.ts
@@ -260,7 +260,92 @@ describe("resolvePieceOriginSource", () => {
     }
   });
 
-  it("registers an explicit source host using its transport scheme", async () => {
+  it("compares a fabric authority with a default base URL by origin", async () => {
+    const registrations: string[] = [];
+    const runtime = {
+      hostForSpace: () => new URL("https://toolshed.test/api/"),
+      mappedHostFor: () => undefined,
+      registerSpaceHost: (_space: MemorySpace, host: string) => {
+        registrations.push(host);
+        return true;
+      },
+      patternManager: {
+        getPatternSourceProgramByIdentity: () =>
+          Promise.resolve({ main: "/main.tsx", files: [] }),
+      },
+    } as unknown as Runtime;
+
+    const resolved = await resolvePieceOriginSource(
+      runtime,
+      SPACE,
+      `cf://toolshed.test/${SPACE}/pattern:${HASH}`,
+      "named",
+    );
+
+    expect(resolved.pattern).toEqual({ identity: HASH, symbol: "named" });
+    expect(registrations).toEqual([]);
+  });
+
+  it("registers a fabric authority when the default has no HTTP origin", async () => {
+    const registrations: string[] = [];
+    const runtime = {
+      hostForSpace: () => new URL("file:///tmp/toolshed"),
+      mappedHostFor: () => undefined,
+      registerSpaceHost: (_space: MemorySpace, host: string) => {
+        registrations.push(host);
+        return true;
+      },
+      patternManager: {
+        getPatternSourceProgramByIdentity: () =>
+          Promise.resolve({ main: "/main.tsx", files: [] }),
+      },
+    } as unknown as Runtime;
+
+    const resolved = await resolvePieceOriginSource(
+      runtime,
+      SPACE,
+      `cf://source.test/${SPACE}/pattern:${HASH}`,
+      "named",
+    );
+
+    expect(resolved.pattern).toEqual({ identity: HASH, symbol: "named" });
+    expect(registrations).toEqual(["https://source.test/"]);
+  });
+
+  it("registers an explicit source host using the runtime transport policy", async () => {
+    const registrations: string[] = [];
+    const runtime = {
+      hostForSpace: () => new URL("http://toolshed.test"),
+      mappedHostFor: () => undefined,
+      registerSpaceHost: (_space: MemorySpace, host: string) => {
+        registrations.push(host);
+        return true;
+      },
+      patternManager: {
+        getPatternSourceProgramByIdentity: () =>
+          Promise.resolve({ main: "/main.tsx", files: [] }),
+      },
+    } as unknown as Runtime;
+
+    for (
+      const [host, registered] of [
+        ["source.test", "https://source.test/"],
+        ["localhost:8787", "http://localhost:8787/"],
+        ["127.0.0.1:8787", "http://127.0.0.1:8787/"],
+      ]
+    ) {
+      const resolved = await resolvePieceOriginSource(
+        runtime,
+        SPACE,
+        `cf://${host}/${SPACE}/pattern:${HASH}`,
+        "named",
+      );
+      expect(resolved.pattern).toEqual({ identity: HASH, symbol: "named" });
+      expect(registrations.at(-1)).toBe(registered);
+    }
+  });
+
+  it("defaults a loopback source authority to HTTPS", async () => {
     const registrations: string[] = [];
     const runtime = {
       hostForSpace: () => new URL("https://toolshed.test"),
@@ -275,22 +360,13 @@ describe("resolvePieceOriginSource", () => {
       },
     } as unknown as Runtime;
 
-    for (
-      const [host, registered] of [
-        ["source.test", "https://source.test"],
-        ["localhost:8787", "http://localhost:8787"],
-        ["127.0.0.1:8787", "http://127.0.0.1:8787"],
-      ]
-    ) {
-      const resolved = await resolvePieceOriginSource(
-        runtime,
-        SPACE,
-        `cf://${host}/${SPACE}/pattern:${HASH}`,
-        "named",
-      );
-      expect(resolved.pattern).toEqual({ identity: HASH, symbol: "named" });
-      expect(registrations.at(-1)).toBe(registered);
-    }
+    await resolvePieceOriginSource(
+      runtime,
+      SPACE,
+      `cf://localhost:8787/${SPACE}/pattern:${HASH}`,
+      "named",
+    );
+    expect(registrations).toEqual(["https://localhost:8787/"]);
   });
 
   it("rejects an explicit source host the runtime cannot register", async () => {

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -1,5 +1,11 @@
 export { Runtime } from "./runtime.ts";
-export { normalizeSpaceHost } from "./space-host.ts";
+export {
+  fabricAuthorityMatchesSpaceHost,
+  type FabricSpaceHostOptions,
+  normalizeSpaceHost,
+  spaceHostFromFabricAuthority,
+  SpaceHostValidationError,
+} from "./space-host.ts";
 export type {
   ConsoleHandler,
   ConsoleHandlerOutput,

--- a/packages/runner/src/runtime-presets.ts
+++ b/packages/runner/src/runtime-presets.ts
@@ -317,7 +317,7 @@ export interface PatternTestPresetParams extends CoreParams {
 }
 
 export interface BrowserWorkerPresetParams extends CoreParams {
-  /** Space DID → host base URL map (federation); decided by the shell host. */
+  /** Map from space DIDs to HTTP or HTTPS origins selected by the shell host. */
   spaceHostMap?: Record<string, string>;
   /** Host-controlled rollout dials, from `InitializationData`. */
   cfcEnforcementMode?: CfcEnforcementMode;

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -130,7 +130,7 @@ import {
   type UnsafeHostTrust,
   type UnsafeHostTrustOptions,
 } from "./unsafe-host-trust.ts";
-import { normalizeSpaceHost } from "./space-host.ts";
+import { normalizeSpaceHost, SpaceHostValidationError } from "./space-host.ts";
 
 const isFullNormalizedLinkShape = (
   value: unknown,
@@ -318,8 +318,8 @@ export type PatternInstantiationObserver = (
 export interface RuntimeOptions {
   apiUrl: URL;
   /**
-   * Optional space DID → host base URL map (federation). Space-bound
-   * work (LLM calls, fetches, blob uploads) for a mapped space targets
+   * Optional map from space DIDs to HTTP or HTTPS origins. Space-bound work
+   * (LLM calls, fetches, blob uploads) for a mapped space targets
    * that host; absent map or entry ⇒ `apiUrl`. Mirrors the storage
    * layer's map (StorageManager Options.spaceHostMap) — pass the same
    * one. Fixed for the runtime's lifetime.
@@ -1020,14 +1020,17 @@ export class Runtime {
     // space, not mid-builtin as a bare Invalid URL.
     const normalizedSpaceHostMap: Record<string, string> = {};
     for (const [space, host] of Object.entries(options.spaceHostMap ?? {})) {
+      let route: URL;
       try {
-        normalizedSpaceHostMap[space] = normalizeSpaceHost(host).toString();
+        route = normalizeSpaceHost(host);
       } catch (cause) {
+        if (!(cause instanceof SpaceHostValidationError)) throw cause;
         throw new Error(
-          `Invalid spaceHostMap entry for ${space}: "${host}"`,
+          `Invalid spaceHostMap entry for ${space}`,
           { cause },
         );
       }
+      normalizedSpaceHostMap[space] = route.toString();
     }
     // Snapshot + freeze: the map is fixed for the runtime's lifetime
     // (the per-space provider cache and routing decisions assume
@@ -2211,7 +2214,7 @@ export class Runtime {
   }
 
   /**
-   * Record a runtime-learned HTTP or HTTPS host hint for a space (the v0
+   * Records a runtime-learned HTTP or HTTPS origin for a space (the v0
    * site-table flow). Storage decides first. A seed or an accepted late hint
    * fixes the route for the session. A default-host provider stays provisional
    * while it is read-only. The first hint can replace it and replay its reads.
@@ -2219,15 +2222,17 @@ export class Runtime {
    * storage accepted or confirmed the hint.
    */
   registerSpaceHost(space: MemorySpace, host: string): boolean {
-    let normalized: string;
+    let route: URL;
     try {
-      normalized = normalizeSpaceHost(host).toString();
+      route = normalizeSpaceHost(host);
     } catch (cause) {
+      if (!(cause instanceof SpaceHostValidationError)) throw cause;
       throw new Error(
-        `Invalid host for space ${space}: "${host}"`,
+        `Invalid host for space ${space}`,
         { cause },
       );
     }
+    const normalized = route.toString();
     const accept = this.storageManager.registerSpaceHost?.(space, normalized);
     if (accept === undefined) return false; // manager has no remote resolution
     if (accept) this.#dynamicHosts.set(space, normalized);

--- a/packages/runner/src/space-host.ts
+++ b/packages/runner/src/space-host.ts
@@ -73,6 +73,7 @@ export const fabricAuthorityMatchesSpaceHost = (
 
 /** Returns whether `hostname` names the local machine. */
 function isLoopbackHostname(hostname: string): boolean {
-  return hostname === "localhost" || hostname === "[::1]" ||
+  return hostname === "localhost" || hostname === "localhost." ||
+    hostname === "[::1]" ||
     /^127(?:\.\d{1,3}){3}$/.test(hostname);
 }

--- a/packages/runner/src/space-host.ts
+++ b/packages/runner/src/space-host.ts
@@ -1,13 +1,78 @@
+/** Options for deriving a route from a scheme-less fabric authority. */
+export interface FabricSpaceHostOptions {
+  /** Whether derived loopback routes use HTTP. */
+  useLoopbackHttp?: boolean;
+}
+
+/** A space host value that does not describe an HTTP or HTTPS origin. */
+export class SpaceHostValidationError extends TypeError {
+  override name = "SpaceHostValidationError";
+}
+
 /**
- * Parse a shared per-space host route. Storage and compute requests use the
- * same route, so only HTTP and HTTPS base URLs are valid.
+ * Parses a shared per-space host route. Storage and compute requests use the
+ * same route, so the value contains only an HTTP or HTTPS origin.
  */
 export const normalizeSpaceHost = (host: string | URL): URL => {
-  const parsed = new URL(host);
+  const source = typeof host === "string" ? host.trim() : host.href;
+  let parsed: URL;
+  try {
+    parsed = new URL(source);
+  } catch (cause) {
+    if (!(cause instanceof TypeError)) throw cause;
+    throw new SpaceHostValidationError("Invalid space host URL");
+  }
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-    throw new TypeError(
-      `Unsupported space host protocol: ${parsed.protocol}`,
+    throw new SpaceHostValidationError("Unsupported space host protocol");
+  }
+  if (parsed.username !== "" || parsed.password !== "") {
+    throw new SpaceHostValidationError(
+      "Space host must not include credentials",
+    );
+  }
+  if (parsed.pathname !== "/") {
+    throw new SpaceHostValidationError("Space host must not include a path");
+  }
+  if (parsed.search !== "") {
+    throw new SpaceHostValidationError("Space host must not include a query");
+  }
+  if (parsed.hash !== "") {
+    throw new SpaceHostValidationError(
+      "Space host must not include a fragment",
+    );
+  }
+  if (!/^https?:\/\/[^/?#\\@\s]+\/?$/i.test(source)) {
+    throw new SpaceHostValidationError(
+      "Space host must contain only an origin",
     );
   }
   return parsed;
 };
+
+/** Derives the shared host route represented by a `cf://` authority. */
+export const spaceHostFromFabricAuthority = (
+  authority: string,
+  options: FabricSpaceHostOptions = {},
+): URL => {
+  const route = normalizeSpaceHost(`https://${authority}`);
+  if (options.useLoopbackHttp && isLoopbackHostname(route.hostname)) {
+    return normalizeSpaceHost(`http://${authority}`);
+  }
+  return route;
+};
+
+/** Returns whether a scheme-less `cf://` authority names a host route. */
+export const fabricAuthorityMatchesSpaceHost = (
+  authority: string,
+  host: string | URL,
+): boolean => {
+  const route = normalizeSpaceHost(host);
+  const candidate = normalizeSpaceHost(`${route.protocol}//${authority}`);
+  return candidate.origin === route.origin;
+};
+
+/** Returns whether `hostname` names the local machine. */
+function isLoopbackHostname(hostname: string): boolean {
+  return hostname === "localhost" || hostname === "[::1]" ||
+    /^127(?:\.\d{1,3}){3}$/.test(hostname);
+}

--- a/packages/runner/src/storage/v2-remote-session.ts
+++ b/packages/runner/src/storage/v2-remote-session.ts
@@ -3,7 +3,7 @@ import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { type MemorySpace, type Signer } from "@commonfabric/memory/interface";
 import * as MemoryClient from "@commonfabric/memory/v2/client";
 import { MEMORY_PROTOCOL } from "@commonfabric/memory/v2";
-import { normalizeSpaceHost } from "../space-host.ts";
+import { normalizeSpaceHost, SpaceHostValidationError } from "../space-host.ts";
 
 export interface SessionFactory {
   /** Opt in to StorageManager's ACL genesis handshake. Scripted factories used
@@ -44,7 +44,7 @@ export const toSpaceWebSocketAddress = (
 export const MEMORY_STORAGE_PATH = "/api/storage/memory";
 
 /**
- * Resolve a shared HTTP or HTTPS space host to the memory storage endpoint.
+ * Resolves a shared HTTP or HTTPS space host to the memory storage endpoint.
  * Space hosts also serve compute requests, so WebSocket-only URLs are not
  * valid routes.
  */
@@ -75,8 +75,8 @@ const storageAddressForMemoryHost = (host: URL): URL => {
 export const SESSION_OPEN_TTL_SECONDS = 300;
 
 /**
- * Build the per-space storage-endpoint resolver: a space present in
- * `spaceHostMap` resolves against that host's base URL, everything else
+ * Builds the per-space storage-endpoint resolver: a space present in
+ * `spaceHostMap` resolves against that host's origin, everything else
  * against `defaultHost`. Host selection lives here, next to the
  * websocket address builders, so the storage-endpoint join happens in
  * exactly one place.
@@ -89,8 +89,8 @@ export const createStorageAddressResolver = (
   defaultHost: URL,
   spaceHostMap?: Record<string, string>,
   /**
-   * Late-bound host hints mapping a space DID to a host base URL, learned at
-   * runtime, e.g. from the home-space site table. Consulted AFTER the
+   * Late-bound host hints mapping a space DID to an HTTP or HTTPS origin.
+   * Learned at runtime, e.g. from the home-space site table. Consulted AFTER the
    * seed map and BEFORE the default. The caller keeps the first accepted
    * hint stable, including after the space opens.
    */
@@ -98,14 +98,17 @@ export const createStorageAddressResolver = (
 ): (space: MemorySpace) => URL => {
   const overrides = new Map<string, URL>();
   for (const [space, host] of Object.entries(spaceHostMap ?? {})) {
+    let route: URL;
     try {
-      overrides.set(space, storageAddressForHost(host));
+      route = normalizeSpaceHost(host);
     } catch (cause) {
+      if (!(cause instanceof SpaceHostValidationError)) throw cause;
       throw new Error(
-        `Invalid spaceHostMap entry for ${space}: "${host}"`,
+        `Invalid spaceHostMap entry for ${space}`,
         { cause },
       );
     }
+    overrides.set(space, new URL(MEMORY_STORAGE_PATH, route));
   }
   const fallback = storageAddressForMemoryHost(defaultHost);
   return (space) => {

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -141,6 +141,7 @@ import {
 } from "./v2-remote-session.ts";
 import * as V2Transaction from "./v2-transaction.ts";
 import { normalizeCellScope } from "../scope.ts";
+import { normalizeSpaceHost, SpaceHostValidationError } from "../space-host.ts";
 import { hasDataUriScheme } from "@commonfabric/data-model/data-uri-codec";
 
 export { watchIdForEntry } from "./v2-watch.ts";
@@ -515,8 +516,8 @@ export interface Options {
    */
   memoryHost: URL;
   /**
-   * Optional space DID → host base URL overrides. A space listed here
-   * opens its storage connection against that host; absent map or
+   * Optional map from space DIDs to HTTP or HTTPS origin overrides. A space
+   * listed here opens its storage connection against that host; absent map or
    * absent entry initially resolves to `memoryHost`. The map is fixed for
    * the manager's lifetime. A first late hint can replace a provisional
    * `memoryHost` route for an unseeded space before that route issues a
@@ -870,7 +871,7 @@ export class StorageManager implements IStorageManager {
   }
 
   /**
-   * Record a runtime-learned HTTP or HTTPS host hint for a space (e.g. from
+   * Records a runtime-learned HTTP or HTTPS origin for a space (e.g. from
    * the home-space site table). Returns true when the hint is accepted or
    * confirms a configured or previously accepted route. Refusals:
    *
@@ -885,17 +886,17 @@ export class StorageManager implements IStorageManager {
    * Idempotent when the hint matches what is already in effect.
    */
   registerSpaceHost(space: MemorySpace, host: string): boolean {
-    let normalized: string;
+    let route: URL;
     try {
-      const parsed = new URL(host);
-      storageAddressForHost(parsed);
-      normalized = parsed.toString();
+      route = normalizeSpaceHost(host);
     } catch (cause) {
+      if (!(cause instanceof SpaceHostValidationError)) throw cause;
       throw new Error(
-        `Invalid host for space ${space}: "${host}"`,
+        `Invalid host for space ${space}`,
         { cause },
       );
     }
+    const normalized = route.toString();
     const seeded = this.#seedHosts[space];
     if (seeded !== undefined) {
       return new URL(seeded).toString() === normalized;

--- a/packages/runner/test/memory-v2-remote-session.test.ts
+++ b/packages/runner/test/memory-v2-remote-session.test.ts
@@ -17,8 +17,40 @@ import {
   toWebSocketAddress,
   WebSocketTransport,
 } from "../src/storage/v2-remote-session.ts";
+import { SpaceHostValidationError } from "../src/space-host.ts";
 import { StorageManager } from "../src/storage/v2.ts";
 import { TEST_HELLO_SESSION_OPEN } from "./memory-v2-test-utils.ts";
+
+function captureError(run: () => unknown): Error {
+  try {
+    run();
+  } catch (error) {
+    if (error instanceof Error) return error;
+    throw error;
+  }
+  throw new Error("Expected call to throw");
+}
+
+function expectSafeValidationCause(
+  error: Error,
+  secret: string,
+  message: string,
+): void {
+  expect(error.message).not.toContain(secret);
+  expect(error.cause).toBeInstanceOf(SpaceHostValidationError);
+  expect((error.cause as Error).message).toBe(message);
+  expect((error.cause as Error).message).not.toContain(secret);
+}
+
+function urlWithThrowingHref(cause: Error): URL {
+  const host = new URL("https://host-b.test/");
+  Object.defineProperty(host, "href", {
+    get() {
+      throw cause;
+    },
+  });
+  return host;
+}
 
 describe("memory v2 remote session websocket address", () => {
   it("upgrades http and https urls to websocket protocols", () => {
@@ -148,6 +180,73 @@ describe("per-space storage address resolution", () => {
         { [spaceB]: "ftp://host-b.test" },
       )
     ).toThrow(`Invalid spaceHostMap entry for ${spaceB}`);
+  });
+
+  it("rejects route components beyond the origin", () => {
+    for (
+      const host of [
+        "https://user@host-b.test/",
+        "https://host-b.test/api",
+        "https://host-b.test/api/..",
+        "https://host-b.test/?region=west",
+        "https://host-b.test/#primary",
+      ]
+    ) {
+      expect(() => storageAddressForHost(host)).toThrow();
+      expect(() =>
+        createStorageAddressResolver(
+          new URL("https://host-a.test"),
+          { [spaceB]: host },
+        )
+      ).toThrow(`Invalid spaceHostMap entry for ${spaceB}`);
+    }
+  });
+
+  it("preserves safe validation causes without repeating route secrets", () => {
+    const hosts = [
+      [
+        "https://user:storage-password-sentinel@host-b.test/",
+        "storage-password-sentinel",
+        "Space host must not include credentials",
+      ],
+      [
+        "https://host-b.test/?token=storage-query-sentinel",
+        "storage-query-sentinel",
+        "Space host must not include a query",
+      ],
+      [
+        "https://user:storage-parse-password-sentinel@[/",
+        "storage-parse-password-sentinel",
+        "Invalid space host URL",
+      ],
+    ] as const;
+    for (const [host, secret, message] of hosts) {
+      const error = captureError(() =>
+        createStorageAddressResolver(
+          new URL("https://host-a.test"),
+          { [spaceB]: host },
+        )
+      );
+      expectSafeValidationCause(error, secret, message);
+    }
+  });
+
+  it("propagates non-validation errors unchanged", () => {
+    for (
+      const cause of [
+        new Error("unexpected route read failure"),
+        new TypeError("unexpected route read type failure"),
+      ]
+    ) {
+      const host = urlWithThrowingHref(cause) as unknown as string;
+      const error = captureError(() =>
+        createStorageAddressResolver(
+          new URL("https://host-a.test"),
+          { [spaceB]: host },
+        )
+      );
+      expect(error).toBe(cause);
+    }
   });
 });
 
@@ -298,16 +397,54 @@ describe("StorageManager.registerSpaceHost", () => {
 
   it("rejects an unusable first hint without fixing the route", async () => {
     const manager = await makeManager();
-    expect(() =>
-      manager.registerSpaceHost(
-        spaceLearned,
+    for (
+      const host of [
         "mailto:memory@example.test",
-      )
-    ).toThrow(`Invalid host for space ${spaceLearned}`);
-    expect(() => manager.registerSpaceHost(spaceLearned, "wss://host-b.test"))
-      .toThrow(`Invalid host for space ${spaceLearned}`);
+        "wss://host-b.test",
+        "https://user@host-b.test/",
+        "https://host-b.test/api",
+        "https://host-b.test/%2e%2e/",
+        "https://host-b.test/?region=west",
+        "https://host-b.test/#primary",
+      ]
+    ) {
+      expect(() => manager.registerSpaceHost(spaceLearned, host))
+        .toThrow(`Invalid host for space ${spaceLearned}`);
+    }
     expect(manager.registerSpaceHost(spaceLearned, "https://host-b.test"))
       .toBe(true);
+  });
+
+  it("preserves safe live validation causes without repeating route secrets", async () => {
+    const manager = await makeManager();
+    try {
+      for (
+        const [host, secret, message] of [
+          [
+            "https://user:live-password-sentinel@host-b.test/",
+            "live-password-sentinel",
+            "Space host must not include credentials",
+          ],
+          [
+            "https://host-b.test/?token=live-query-sentinel",
+            "live-query-sentinel",
+            "Space host must not include a query",
+          ],
+          [
+            "https://user:live-parse-password-sentinel@[/",
+            "live-parse-password-sentinel",
+            "Invalid space host URL",
+          ],
+        ] as const
+      ) {
+        const error = captureError(() =>
+          manager.registerSpaceHost(spaceLearned, host)
+        );
+        expectSafeValidationCause(error, secret, message);
+      }
+    } finally {
+      await manager.closeNow();
+    }
   });
 });
 

--- a/packages/runner/test/runtime-host-for-space.test.ts
+++ b/packages/runner/test/runtime-host-for-space.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import type { MemorySpace } from "@commonfabric/memory/interface";
-import { Runtime } from "@commonfabric/runner";
+import { Runtime, SpaceHostValidationError } from "@commonfabric/runner";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 
 const signer = await Identity.fromPassphrase("runtime-host-for-space");
@@ -16,6 +16,27 @@ function makeRuntime(spaceHostMap?: Record<string, string>) {
     spaceHostMap,
     storageManager,
   });
+}
+
+function captureError(run: () => unknown): Error {
+  try {
+    run();
+  } catch (error) {
+    if (error instanceof Error) return error;
+    throw error;
+  }
+  throw new Error("Expected call to throw");
+}
+
+function expectSafeValidationCause(
+  error: Error,
+  secret: string,
+  message: string,
+): void {
+  expect(error.message).not.toContain(secret);
+  expect(error.cause).toBeInstanceOf(SpaceHostValidationError);
+  expect((error.cause as Error).message).toBe(message);
+  expect((error.cause as Error).message).not.toContain(secret);
 }
 
 describe("Runtime.registerSpaceHost", () => {
@@ -63,7 +84,7 @@ describe("Runtime.registerSpaceHost", () => {
     }
   });
 
-  it("rejects non-HTTP hints before forwarding them to storage", async () => {
+  it("rejects non-origin hints before forwarding them to storage", async () => {
     const storageVerdicts: Array<[string, string]> = [];
     const storageManager = Object.assign(
       StorageManager.emulate({ as: signer }),
@@ -84,6 +105,11 @@ describe("Runtime.registerSpaceHost", () => {
           "ws://host-b.test",
           "wss://host-b.test",
           "ftp://host-b.test",
+          "https://user@host-b.test/",
+          "https://host-b.test/api",
+          "https://host-b.test/api/..",
+          "https://host-b.test/?region=west",
+          "https://host-b.test/#primary",
         ]
       ) {
         expect(() => runtime.registerSpaceHost(spaceB, host))
@@ -101,6 +127,42 @@ describe("Runtime.registerSpaceHost", () => {
       await runtime.dispose();
     }
   });
+
+  it("preserves safe validation causes without repeating route secrets", async () => {
+    const hosts = [
+      [
+        "https://user:route-password-sentinel@host-b.test/",
+        "route-password-sentinel",
+        "Space host must not include credentials",
+      ],
+      [
+        "https://host-b.test/?token=route-query-sentinel",
+        "route-query-sentinel",
+        "Space host must not include a query",
+      ],
+      [
+        "https://user:route-parse-password-sentinel@[/",
+        "route-parse-password-sentinel",
+        "Invalid space host URL",
+      ],
+    ] as const;
+    const runtime = makeRuntime();
+    try {
+      for (const [host, secret, message] of hosts) {
+        const error = captureError(() =>
+          runtime.registerSpaceHost(spaceB, host)
+        );
+        expectSafeValidationCause(error, secret, message);
+      }
+    } finally {
+      await runtime.dispose();
+    }
+
+    for (const [host, secret, message] of hosts) {
+      const error = captureError(() => makeRuntime({ [spaceB]: host }));
+      expectSafeValidationCause(error, secret, message);
+    }
+  });
 });
 
 describe("Runtime.hostForSpace", () => {
@@ -110,6 +172,11 @@ describe("Runtime.hostForSpace", () => {
         "ws://host-b.test",
         "wss://host-b.test",
         "ftp://host-b.test",
+        "https://user@host-b.test/",
+        "https://host-b.test/api",
+        "https://host-b.test/%2e%2e/",
+        "https://host-b.test/?region=west",
+        "https://host-b.test/#primary",
       ]
     ) {
       expect(() => makeRuntime({ [spaceB]: host }))

--- a/packages/runner/test/space-host.test.ts
+++ b/packages/runner/test/space-host.test.ts
@@ -125,11 +125,13 @@ describe("space-host", () => {
           }).protocol,
         ).toBe("http:");
       }
-      expect(
-        spaceHostFromFabricAuthority("route.example:8787", {
-          useLoopbackHttp: true,
-        }).protocol,
-      ).toBe("https:");
+      for (const authority of ["route.example:8787", "route.example.:8787"]) {
+        expect(
+          spaceHostFromFabricAuthority(authority, {
+            useLoopbackHttp: true,
+          }).protocol,
+        ).toBe("https:");
+      }
       expect(
         spaceHostFromFabricAuthority("localhost:443", {
           useLoopbackHttp: true,

--- a/packages/runner/test/space-host.test.ts
+++ b/packages/runner/test/space-host.test.ts
@@ -1,0 +1,182 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  fabricAuthorityMatchesSpaceHost,
+  normalizeSpaceHost,
+  spaceHostFromFabricAuthority,
+  SpaceHostValidationError,
+} from "../src/space-host.ts";
+
+/** Returns the `Error` thrown by `run`. */
+function captureError(run: () => unknown): Error {
+  try {
+    run();
+  } catch (error) {
+    if (error instanceof Error) return error;
+    throw error;
+  }
+  throw new Error("Expected call to throw");
+}
+
+/** Returns a URL whose `.href` getter throws `cause`. */
+function urlWithThrowingHref(cause: Error): URL {
+  const host = new URL("https://route.example/");
+  Object.defineProperty(host, "href", {
+    get() {
+      throw cause;
+    },
+  });
+  return host;
+}
+
+describe("space-host", () => {
+  describe("normalizeSpaceHost()", () => {
+    it("returns the canonical HTTP or HTTPS origin", () => {
+      expect(normalizeSpaceHost("HTTPS://ROUTE.EXAMPLE:443").toString()).toBe(
+        "https://route.example/",
+      );
+      expect(
+        normalizeSpaceHost(new URL("http://route.example:8080")).toString(),
+      )
+        .toBe("http://route.example:8080/");
+    });
+
+    it("throws for every component beyond the origin", () => {
+      for (
+        const host of [
+          "https://@route.example/",
+          "https://:@route.example/",
+          "https://user@route.example/",
+          "https://user:secret@route.example/",
+          "https://route.example/api",
+          "https://route.example/api/..",
+          "https://route.example/%2e%2e/",
+          "https://route.example/?region=west",
+          "https://route.example/?",
+          "https://route.example/#primary",
+          "https://route.example/#",
+        ]
+      ) {
+        expect(() => normalizeSpaceHost(host)).toThrow();
+      }
+    });
+
+    it("throws for protocols that cannot serve shared space routes", () => {
+      for (
+        const host of [
+          "ws://route.example/",
+          "wss://route.example/",
+          "ftp://route.example/",
+        ]
+      ) {
+        expect(() => normalizeSpaceHost(host)).toThrow(
+          "Unsupported space host protocol",
+        );
+      }
+    });
+
+    it("propagates errors while reading URL objects unchanged", () => {
+      for (
+        const cause of [
+          new Error("unexpected URL read failure"),
+          new TypeError("unexpected URL read type failure"),
+        ]
+      ) {
+        expect(
+          captureError(() => normalizeSpaceHost(urlWithThrowingHref(cause))),
+        )
+          .toBe(cause);
+      }
+    });
+
+    it("throws a sanitized validation error for malformed strings", () => {
+      const secret = "parser-password-sentinel";
+      const error = captureError(() =>
+        normalizeSpaceHost(`https://user:${secret}@[`)
+      );
+      expect(error).toBeInstanceOf(SpaceHostValidationError);
+      expect(error.message).toBe("Invalid space host URL");
+      expect(error.message).not.toContain(secret);
+    });
+  });
+
+  describe("spaceHostFromFabricAuthority()", () => {
+    it("returns an HTTPS origin for a bare fabric authority", () => {
+      expect(spaceHostFromFabricAuthority("ROUTE.EXAMPLE:443").toString()).toBe(
+        "https://route.example/",
+      );
+      expect(spaceHostFromFabricAuthority("localhost:8787").toString()).toBe(
+        "https://localhost:8787/",
+      );
+    });
+
+    it("returns an HTTP origin for a requested loopback route", () => {
+      for (
+        const authority of ["localhost:8787", "127.0.0.1:8787", "[::1]:8787"]
+      ) {
+        expect(
+          spaceHostFromFabricAuthority(authority, {
+            useLoopbackHttp: true,
+          }).protocol,
+        ).toBe("http:");
+      }
+      expect(
+        spaceHostFromFabricAuthority("route.example:8787", {
+          useLoopbackHttp: true,
+        }).protocol,
+      ).toBe("https:");
+      expect(
+        spaceHostFromFabricAuthority("localhost:443", {
+          useLoopbackHttp: true,
+        }).toString(),
+      ).toBe("http://localhost:443/");
+    });
+
+    it("throws for authority components beyond the origin", () => {
+      for (
+        const authority of [
+          "user@route.example",
+          "route.example/api",
+          "route.example?region=west",
+          "route.example#primary",
+        ]
+      ) {
+        expect(() => spaceHostFromFabricAuthority(authority)).toThrow();
+      }
+    });
+  });
+
+  describe("fabricAuthorityMatchesSpaceHost()", () => {
+    it("compares an authority using the route's configured transport", () => {
+      expect(
+        fabricAuthorityMatchesSpaceHost(
+          "ROUTE.EXAMPLE:80",
+          "http://route.example/",
+        ),
+      ).toBe(true);
+      expect(
+        fabricAuthorityMatchesSpaceHost(
+          "ROUTE.EXAMPLE:443",
+          "https://route.example/",
+        ),
+      ).toBe(true);
+      expect(
+        fabricAuthorityMatchesSpaceHost(
+          "other.example",
+          "https://route.example/",
+        ),
+      ).toBe(false);
+    });
+
+    it("throws for non-authority components", () => {
+      for (const authority of ["user@route.example", "route.example/api"]) {
+        expect(() =>
+          fabricAuthorityMatchesSpaceHost(
+            authority,
+            "https://route.example/",
+          )
+        ).toThrow();
+      }
+    });
+  });
+});

--- a/packages/runner/test/space-host.test.ts
+++ b/packages/runner/test/space-host.test.ts
@@ -112,7 +112,12 @@ describe("space-host", () => {
 
     it("returns an HTTP origin for a requested loopback route", () => {
       for (
-        const authority of ["localhost:8787", "127.0.0.1:8787", "[::1]:8787"]
+        const authority of [
+          "localhost:8787",
+          "localhost.:8787",
+          "127.0.0.1:8787",
+          "[::1]:8787",
+        ]
       ) {
         expect(
           spaceHostFromFabricAuthority(authority, {

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -3029,6 +3029,17 @@ describe("RuntimeProcessor per-space piece contexts", () => {
       { did: "did:key:z6Mk-table-c", host: "http://host-c.test/" },
       { did: "did:key:z6Mk-table-a", host: "http://host-a-new.test/" },
       { did: "did:key:z6Mk-table-a", host: "not a url" },
+      {
+        did: "did:key:z6Mk-table-credentials",
+        host: "http://user@credentials.test/",
+      },
+      { did: "did:key:z6Mk-table-path", host: "http://path.test/api" },
+      {
+        did: "did:key:z6Mk-table-dot-path",
+        host: "http://dot-path.test/api/..",
+      },
+      { did: "did:key:z6Mk-table-query", host: "http://query.test/?x=1" },
+      { did: "did:key:z6Mk-table-fragment", host: "http://hash.test/#x" },
     ]);
     await tx.commit();
 

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -40,6 +40,7 @@ import {
   setBlindStructuralTarget,
   setPatternEnvironment,
   type SigilLink,
+  SpaceHostValidationError,
   unmarkUiInputBlindWriteTx,
 } from "@commonfabric/runner";
 import { linkRefPayload } from "@commonfabric/runner/shared";
@@ -657,9 +658,9 @@ export class RuntimeProcessor {
   #siteTableWarned = new Set<string>();
 
   /**
-   * Subscribe to the home-space site table and register the last valid HTTP or
-   * HTTPS entry for each space as a host hint. Fire-and-forget: resolution
-   * hints are an enhancement, never a boot dependency.
+   * Subscribes to the home-space site table and registers the last entry for
+   * each space that contains only an HTTP or HTTPS origin. Fire-and-forget:
+   * resolution hints are an enhancement, never a boot dependency.
    *
    * ORDERING CONTRACT for embedders: push a newly learned hint through the
    * RegisterSpaceHost IPC before relying on that space, and proceed only when
@@ -695,18 +696,21 @@ export class RuntimeProcessor {
               ) {
                 continue;
               }
+              let host: URL;
               try {
-                const host = normalizeSpaceHost(entry.host);
-                latestEntries.set(entry.did, {
-                  did: entry.did as DID,
-                  host: host.toString(),
-                });
+                host = normalizeSpaceHost(entry.host);
               } catch (error) {
+                if (!(error instanceof SpaceHostValidationError)) throw error;
                 console.warn(
                   `[RuntimeProcessor] Ignoring invalid site-table entry for ${entry.did}:`,
-                  error instanceof Error ? error.message : error,
+                  error.message,
                 );
+                continue;
               }
+              latestEntries.set(entry.did, {
+                did: entry.did as DID,
+                host: host.toString(),
+              });
             }
             for (const entry of latestEntries.values()) {
               try {

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -154,8 +154,8 @@ export interface InitializationData {
   // URL of backend server. Also the default host for spaces absent from
   // `spaceHostMap`.
   apiUrl: string;
-  // Optional space DID → host base URL map. A space listed here has its
-  // storage resolved against that host instead of `apiUrl`. Absent map or
+  // Optional map from space DIDs to HTTP or HTTPS origins. A listed space has
+  // its storage resolved against that host instead of `apiUrl`. Absent map or
   // absent entry ⇒ `apiUrl`, byte-identical to the single-host behavior.
   // Plain record: structured-clone-safe — no functions cross the worker
   // IPC boundary. Fixed for the connection's lifetime.


### PR DESCRIPTION
Space host hints accepted any HTTP or HTTPS URL even though storage and compute share each value as a host origin. Credentials, paths, queries, and fragments could therefore enter routing state and be interpreted inconsistently by different consumers.

Validate seeded, learned, and hydrated routes with one origin-only grammar before URL normalization can erase forbidden syntax. Derive fabric routes over HTTPS by default, select HTTP only for loopback when the caller requests it, preserve explicit ports, and retain compatibility with existing source origins. Name the selector useLoopbackHttp so its call sites describe that choice directly.

Represent rejected routes with a dedicated validation error. Sanitize native parser failures that can contain credentials or query values, retain the safe validation error as the cause of space-specific failures, and propagate unexpected errors unchanged. Keep endpoint construction and routing state updates outside validation catches.

Expand runtime, storage, hydration, and piece lifecycle coverage. Align the piece-source lifecycle, pattern-import, home-space schema, worker, and shell documentation with the shared origin routing contract.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

