### PR TITLE
fix(dashboard): keep benchmark colors settled

### DIFF
--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -55,7 +55,9 @@ A later ticker pass skips a tile or shared workflow fetch that is still
 updating. It starts every other due collection, so pending work does not pause
 the rest of the dashboard. A collection that remains active for one minute
 turns its tile gray with "refresh still pending" while retaining its last value
-and visuals. Its completed view replaces that pending state.
+and visuals. Its completed view replaces that pending state. A tile with
+`showOnlyCompletedViews` keeps its last completed color and values, ignores
+intermediate views, and still shows the pending warning.
 A tile whose `collect()` throws is desaturated to a gray "unknown" — it keeps
 its last-known value and shows a short reason (e.g. "source unreachable"), with
 the full error in the server log — so one unreachable source never blanks or
@@ -644,12 +646,15 @@ Notes:
   run's wall clock therefore barely moves with performance. The per-operation
   times do move, so the tile trends those values instead. Because the index
   comes from artifacts, the tile turns gray when no in-window run has readable
-  data and the latest run is neither failed nor empty. It shows
-  **collecting…** while a fetch is in progress. This state appears before the
-  run list is fetched, so a newly loaded dashboard is never blank. It shows
-  **benchmark data unavailable** after an empty fetch finishes. Adding or
-  removing a benchmark does not move an index. The benchmark is absent from
-  one side of that adjacent comparison, so it drops out of the geometric mean.
+  data and the latest run is neither failed nor empty. A collection leaves its
+  last completed color and values in place until the workflow status and
+  artifact refresh have both settled. A collection that takes more than a
+  minute says **refresh still pending** without changing that color. A newly
+  loaded dashboard keeps its neutral placeholder until its first collection
+  settles. An empty completed fetch shows **benchmark data unavailable**.
+  Adding or removing a benchmark does not move an index. The benchmark is
+  absent from one side of that adjacent comparison, so it drops out of the
+  geometric mean.
   A CPU change starts another line instead of connecting measurements from
   unlike machines. A gap longer than one fifth of the chart width breaks a
   CPU's line. Any sample isolated by those breaks appears as a point. A CPU
@@ -679,9 +684,11 @@ Notes:
   - The tile collects every minute, which is what the run state needs: a
     benchmark run lasts about an hour, so a slower collection could miss one from
     start to finish and never show its **running** badge. Each collection pages
-    the run list. The artifact history behind it is left alone while the last
-    refresh is recent and already covers the runs that list names — nothing new
-    has been sampled, so there is nothing to download.
+    the run list. It publishes only the completed view, so a partial refresh
+    cannot temporarily replace the last settled status. The artifact history
+    behind it is left alone while the last refresh is recent and already covers
+    the runs that list names. Nothing new has been sampled, so there is nothing
+    to download.
   - The tile drills through to the per-benchmark history behind `/bench`, which the
     tile's collection keeps warm in the background. The collection lists
     benchmark runs on main. It samples one run per shortest-view bucket,

--- a/packages/dashboard/server.test.ts
+++ b/packages/dashboard/server.test.ts
@@ -440,7 +440,7 @@ Deno.test("an update still running after one minute stays gray until it complete
   }
 });
 
-Deno.test("a completed-views-only tile keeps its settled color while collection is stale", async () => {
+Deno.test("a completed-views-only tile suppresses intermediate views and keeps its settled color", async () => {
   const realNow = Date.now;
   const startedAt = realNow() - 61_000;
   let now = startedAt;

--- a/packages/dashboard/server.test.ts
+++ b/packages/dashboard/server.test.ts
@@ -10,6 +10,7 @@ import {
   assertRejects,
   assertStringIncludes,
 } from "@std/assert";
+import { expect } from "@std/expect";
 import {
   broadcast,
   clients,
@@ -428,6 +429,78 @@ Deno.test("an update still running after one minute stays gray until it complete
     assert(fresh.startsWith(`good" data-tile-id="model-spend">`));
     assertStringIncludes(fresh, "fresh value");
     assertStringIncludes(fresh, "fresh detail");
+  } finally {
+    clients.delete(client);
+    final.resolve(finalView);
+    try {
+      await collection;
+    } finally {
+      Date.now = realNow;
+    }
+  }
+});
+
+Deno.test("a completed-views-only tile keeps its settled color while collection is stale", async () => {
+  const realNow = Date.now;
+  const startedAt = realNow() - 61_000;
+  let now = startedAt;
+  Date.now = () => now;
+  const lastView: TileView = {
+    label: "settled benchmark",
+    status: "bad",
+    value: "failed",
+    sub: "last completed result",
+  };
+  const finalView: TileView = {
+    label: "settled benchmark",
+    status: "warn",
+    value: "slower",
+    sub: "new completed result",
+  };
+  const final = deferred<TileView>();
+  let receivedPublisher = false;
+  const tile: Tile = {
+    id: "benchmark",
+    intervalMs: 0,
+    showOnlyCompletedViews: true,
+    async collect(_ctx, publish) {
+      receivedPublisher = publish !== undefined;
+      return await final.promise;
+    },
+  };
+  const messages: string[] = [];
+  const client = {
+    enqueue(value: Uint8Array) {
+      messages.push(dec.decode(value));
+    },
+  } as unknown as ReadableStreamDefaultController<Uint8Array>;
+  let collection: Promise<void> | undefined;
+  try {
+    await tick([fake("benchmark", () => lastView)]);
+    clients.add(client);
+    now++;
+    collection = tick([tile]);
+
+    expect(receivedPublisher).toBe(false);
+    expect(tileHtml("settled benchmark")).toContain(
+      `bad\" data-tile-id=\"benchmark\">`,
+    );
+    expect(messages).toEqual([]);
+
+    now += 60_000;
+    await tick([tile]);
+    expect(tileHtml("settled benchmark")).toContain(
+      `bad\" data-tile-id=\"benchmark\">`,
+    );
+    expect(tileHtml("settled benchmark")).toContain("refresh still pending");
+    expect(messages).toHaveLength(1);
+
+    final.resolve(finalView);
+    await collection;
+    expect(tileHtml("settled benchmark")).toContain(
+      `warn\" data-tile-id=\"benchmark\">`,
+    );
+    expect(messages).toHaveLength(2);
   } finally {
     clients.delete(client);
     final.resolve(finalView);

--- a/packages/dashboard/server.ts
+++ b/packages/dashboard/server.ts
@@ -160,9 +160,10 @@ const STALE_UPDATE_MS = 60_000;
 const STALE_UPDATE_SUB = "refresh still pending";
 
 function activeTileView(tile: Tile, view: TileView): TileView {
-  return activeTileUpdates.get(tile.id)?.stale
-    ? { ...view, status: "unknown", sub: STALE_UPDATE_SUB }
-    : view;
+  if (!activeTileUpdates.get(tile.id)?.stale) return view;
+  return tile.showOnlyCompletedViews
+    ? { ...view, sub: STALE_UPDATE_SUB }
+    : { ...view, status: "unknown", sub: STALE_UPDATE_SUB };
 }
 
 function grayStaleTileUpdates(now: number): void {
@@ -240,7 +241,7 @@ async function collectView(
     try {
       return await tile.collect(
         collectionCtx,
-        publish
+        publish && !tile.showOnlyCompletedViews
           ? (intermediate) => {
             if (acceptingIntermediate) publish(intermediate);
           }

--- a/packages/dashboard/tiles/benchmark.test.ts
+++ b/packages/dashboard/tiles/benchmark.test.ts
@@ -14,6 +14,7 @@ import {
   assertStringIncludes,
   assertThrows,
 } from "@std/assert";
+import { expect } from "@std/expect";
 import type { Ctx, TileView } from "../types.ts";
 import { REPO } from "../config.ts";
 import { BenchmarkHistoryStore } from "../benchmark-history-cache.ts";
@@ -1054,203 +1055,81 @@ Deno.test("benchmark: the trend reads the recent window only, not the whole hist
   });
 });
 
-Deno.test("benchmark: the tile paints its headline from cache before the backfill finishes", async () => {
-  const directory = await Deno.makeTempDir({ prefix: "benchmark-early-" });
+Deno.test("benchmark: returns a failed rising view without publishing intermediate data", async () => {
+  const directory = await Deno.makeTempDir({
+    prefix: "benchmark-settled-view-",
+  });
   const previousCacheDirectory = Deno.env.get("DASHBOARD_CACHE_DIR");
   const originalFetch = globalThis.fetch;
-  const token = `benchmark-early-${crypto.randomUUID()}`;
+  const token = `benchmark-settled-view-${crypto.randomUUID()}`;
   Deno.env.set("DASHBOARD_CACHE_DIR", directory);
-  // Seed a warm cache: two runs whose one benchmark averages 5ms, so a restart has
-  // a 5.0ms total to headline immediately, before the new run's artifact arrives.
   const key = "packages/a/x.bench.ts > b";
-  const stats = {
-    min: 5e6,
-    avg: 5e6,
-    max: 5e6,
-    p75: 5e6,
-    p99: 5e6,
-    p995: 5e6,
-    p999: 5e6,
-  };
   const seed = new BenchmarkHistoryStore();
   await seed.load();
-  const cachedRuns = [
-    {
-      runId: 84_001,
+  const cachedRuns = Array.from({ length: 8 }, (_, day) => {
+    const avg = (5 + day) * 1e6;
+    return {
+      runId: 84_001 + day,
       runAttempt: 1,
-      at: BASE - 2 * DAY,
+      at: SAMPLED_BASE - (7 - day) * DAY,
       cpu: TEST_CPU,
-      metrics: new Map([[key, stats]]),
-    },
-    {
-      runId: 84_002,
-      runAttempt: 1,
-      at: BASE - DAY,
-      cpu: TEST_CPU,
-      metrics: new Map([[key, stats]]),
-    },
-  ];
+      metrics: new Map([[key, {
+        min: avg,
+        avg,
+        max: avg,
+        p75: avg,
+        p99: avg,
+        p995: avg,
+        p999: avg,
+      }]]),
+    };
+  });
   for (const cachedRun of cachedRuns) seed.set(cachedRun);
-  seed.markRefreshed(BASE - DAY, cachedRuns);
-  await seed.save(BASE - DAY);
+  seed.markRefreshed(Date.now(), cachedRuns);
+  await seed.save();
 
-  const runId = 84_003;
-  let releaseArtifact!: (response: Response) => void;
-  const heldArtifact = new Promise<Response>((resolve) => {
-    releaseArtifact = resolve;
-  });
-  globalThis.fetch = ((input: RequestInfo | URL) => {
-    const url = new URL(input instanceof Request ? input.url : String(input));
-    if (url.pathname.endsWith("/actions/workflows/benchmarks.yml/runs")) {
-      return Promise.resolve(Response.json({
-        workflow_runs: [
-          ghRun(runId, BASE),
-          ghRun(84_002, BASE - DAY),
-          ghRun(84_001, BASE - 2 * DAY),
-        ],
-      }));
-    }
-    if (url.pathname.endsWith(`/actions/runs/${runId}/artifacts`)) {
-      return heldArtifact; // the drill-down backfill blocks here
-    }
-    throw new Error(`unexpected request ${url.pathname}`);
-  }) as typeof fetch;
-  let collection: Promise<TileView> | undefined;
-  try {
-    const isolated = await import(`./benchmark.ts?early=${crypto.randomUUID()}`);
-    let published: TileView | undefined;
-    let markPublished!: () => void;
-    const painted = new Promise<void>((resolve) => {
-      markPublished = resolve;
-    });
-    const active: Promise<TileView> = isolated.benchmark.collect(
-      ctx({ GH_TOKEN: token }),
-      (view: TileView) => {
-        published = view;
-        markPublished();
-      },
-    );
-    collection = active;
-    // The headline is painted from the seeded cache while the new artifact is held.
-    await painted;
-    assertStringIncludes(published?.value ?? "", "new"); // two seeded runs: the trend reads "new"
-    assertEquals(published?.status, "good");
-
-    releaseArtifact(Response.json({ artifacts: [] })); // the new run has no usable artifact
-    const final = await active;
-    assertStringIncludes(final.value ?? "", "new"); // still the cached runs' trend
-  } finally {
-    releaseArtifact(Response.json({ artifacts: [] }));
-    await collection?.catch(() => {});
-    globalThis.fetch = originalFetch;
-    if (previousCacheDirectory === undefined) {
-      Deno.env.delete("DASHBOARD_CACHE_DIR");
-    } else Deno.env.set("DASHBOARD_CACHE_DIR", previousCacheDirectory);
-    await Deno.remove(directory, { recursive: true });
-  }
-});
-
-Deno.test("benchmark: a cold fetch reads 'collecting…' in flight, then reports empty", async () => {
-  // Cold cache, no seed. The early paint has the run list but no artifacts yet, so
-  // the tile says it is collecting — distinct from a finished, empty fetch.
-  const directory = await Deno.makeTempDir({ prefix: "benchmark-collecting-" });
-  const previousCacheDirectory = Deno.env.get("DASHBOARD_CACHE_DIR");
-  const originalFetch = globalThis.fetch;
-  const token = `benchmark-collecting-${crypto.randomUUID()}`;
-  Deno.env.set("DASHBOARD_CACHE_DIR", directory);
-  const runId = 85_001;
-  let releaseArtifact!: (response: Response) => void;
-  const heldArtifact = new Promise<Response>((resolve) => {
-    releaseArtifact = resolve;
-  });
-  globalThis.fetch = ((input: RequestInfo | URL) => {
-    const url = new URL(input instanceof Request ? input.url : String(input));
-    if (url.pathname.endsWith("/actions/workflows/benchmarks.yml/runs")) {
-      return Promise.resolve(
-        Response.json({ workflow_runs: [ghRun(runId, BASE)] }),
-      );
-    }
-    if (url.pathname.endsWith(`/actions/runs/${runId}/artifacts`)) {
-      return heldArtifact;
-    }
-    throw new Error(`unexpected request ${url.pathname}`);
-  }) as typeof fetch;
-  let collection: Promise<TileView> | undefined;
-  try {
-    const isolated = await import(`./benchmark.ts?collecting=${crypto.randomUUID()}`);
-    let published: TileView | undefined;
-    let markPublished!: () => void;
-    const painted = new Promise<void>((resolve) => {
-      markPublished = resolve;
-    });
-    const active: Promise<TileView> = isolated.benchmark.collect(
-      ctx({ GH_TOKEN: token }),
-      (view: TileView) => {
-        published = view;
-        markPublished();
-      },
-    );
-    collection = active;
-    await painted;
-    assertEquals(published?.status, "unknown");
-    assertEquals(published?.sub, "collecting…"); // fetch still in flight
-
-    // The listing errors, so nothing settles; the finished fetch found no data.
-    releaseArtifact(new Response("no", { status: 500 }));
-    const final = await active;
-    assertEquals(final.status, "unknown");
-    assertEquals(final.sub, "benchmark data unavailable"); // done, and empty
-  } finally {
-    releaseArtifact(new Response("no", { status: 500 }));
-    await collection?.catch(() => {});
-    globalThis.fetch = originalFetch;
-    if (previousCacheDirectory === undefined) {
-      Deno.env.delete("DASHBOARD_CACHE_DIR");
-    } else Deno.env.set("DASHBOARD_CACHE_DIR", previousCacheDirectory);
-    await Deno.remove(directory, { recursive: true });
-  }
-});
-
-Deno.test("benchmark: the tile reads 'collecting…' from the first paint, before the run list arrives", async () => {
-  // Cold cache, and even the run-list fetch is held open. The tile paints
-  // "collecting…" at once — before GitHub has answered with any runs — so a freshly
-  // loaded dashboard is never blank while the first collection gets under way.
-  const directory = await Deno.makeTempDir({ prefix: "benchmark-start-" });
-  const previousCacheDirectory = Deno.env.get("DASHBOARD_CACHE_DIR");
-  const originalFetch = globalThis.fetch;
-  const token = `benchmark-start-${crypto.randomUUID()}`;
-  Deno.env.set("DASHBOARD_CACHE_DIR", directory);
+  const failedRun = ghRun(84_099, SAMPLED_BASE + HOUR, "failure");
   let releaseRuns!: (response: Response) => void;
   const heldRuns = new Promise<Response>((resolve) => {
     releaseRuns = resolve;
   });
+  let markRunsRequested!: () => void;
+  const runsRequested = new Promise<void>((resolve) => {
+    markRunsRequested = resolve;
+  });
   globalThis.fetch = ((input: RequestInfo | URL) => {
     const url = new URL(input instanceof Request ? input.url : String(input));
-    if (url.pathname === "/rate_limit") return Promise.resolve(serve({})(url));
     if (url.pathname.endsWith("/actions/workflows/benchmarks.yml/runs")) {
-      return heldRuns; // the run list stays held until the finally block
+      markRunsRequested();
+      return heldRuns;
     }
     throw new Error(`unexpected request ${url.pathname}`);
   }) as typeof fetch;
   let collection: Promise<TileView> | undefined;
   try {
-    const isolated = await import(`./benchmark.ts?start=${crypto.randomUUID()}`);
-    let first: TileView | undefined;
-    let markPublished!: () => void;
-    const painted = new Promise<void>((resolve) => {
-      markPublished = resolve;
-    });
-    collection = isolated.benchmark.collect(
-      ctx({ GH_TOKEN: token }),
-      (view: TileView) => {
-        first ??= view; // capture the very first paint
-        markPublished();
-      },
+    const isolated = await import(
+      `./benchmark.ts?settled-view=${crypto.randomUUID()}`
     );
-    await painted;
-    assertEquals(first?.status, "unknown");
-    assertEquals(first?.sub, "collecting…"); // painted before any run list arrives
-    assertEquals(first?.label, "benchmarks"); // and under the new name
+    expect(isolated.benchmark.showOnlyCompletedViews).toBe(true);
+    const published: TileView[] = [];
+    const active: Promise<TileView> = isolated.benchmark.collect(
+      ctx({ GH_TOKEN: token }),
+      (view: TileView) => published.push(view),
+    );
+    collection = active;
+    await runsRequested;
+    expect(published).toEqual([]);
+
+    releaseRuns(Response.json({
+      workflow_runs: [
+        failedRun,
+        ...cachedRuns.toReversed().map((run) => ghRun(run.runId, run.at)),
+      ],
+    }));
+    const final = await active;
+    expect(published).toEqual([]);
+    expect(final.status).toBe("bad");
+    expect(final.value).toContain("▲");
   } finally {
     releaseRuns(Response.json({ workflow_runs: [] }));
     await collection?.catch(() => {});
@@ -2975,54 +2854,6 @@ Deno.test("benchmark: a fresh marker then an unreachable direct read grays with 
   }
 });
 
-Deno.test("benchmark: an early-paint publish that throws is caught, and the collection still finishes", async () => {
-  // The immediate paint publishes once; when the run list is paged, paintEarly
-  // publishes again. A publish that throws on that second call is swallowed by the
-  // run-list notifier, so one bad paint never breaks the collection.
-  const directory = await Deno.makeTempDir({ prefix: "benchmark-paint-throw-" });
-  const previousCacheDirectory = Deno.env.get("DASHBOARD_CACHE_DIR");
-  const originalFetch = globalThis.fetch;
-  const token = `benchmark-paint-throw-${crypto.randomUUID()}`;
-  Deno.env.set("DASHBOARD_CACHE_DIR", directory);
-  const key = "packages/a/x.bench.ts";
-  const healthy = serve({
-    pages: { 1: [ghRun(7_801, BASE - DAY), ghRun(7_802, BASE)] },
-    artifacts: {
-      7_801: [{ id: 78_010, name: "bench-results", expired: false }],
-      7_802: [{ id: 78_020, name: "bench-results", expired: false }],
-    },
-    zips: {
-      78_010: await benchZip(report([bench(key, null, "b", timings(1_000))])),
-      78_020: await benchZip(report([bench(key, null, "b", timings(1_000))])),
-    },
-  });
-  try {
-    const isolated = await import(
-      `./benchmark.ts?paint-throw=${crypto.randomUUID()}`
-    );
-    globalThis.fetch = ((input: RequestInfo | URL) => {
-      const url = new URL(input instanceof Request ? input.url : String(input));
-      if (url.pathname === "/rate_limit") return Promise.resolve(serve({})(url));
-      return Promise.resolve(healthy(url));
-    }) as typeof fetch;
-    let calls = 0;
-    const final = await isolated.benchmark.collect(
-      ctx({ GH_TOKEN: token }),
-      () => {
-        if (++calls > 1) throw new Error("publish boom"); // throw on paintEarly
-      },
-    );
-    assert(calls >= 2); // the immediate paint and the paged-run-list paintEarly
-    assertEquals(final.status, "good"); // the thrown paint did not break the run
-  } finally {
-    globalThis.fetch = originalFetch;
-    if (previousCacheDirectory === undefined) {
-      Deno.env.delete("DASHBOARD_CACHE_DIR");
-    } else Deno.env.set("DASHBOARD_CACHE_DIR", previousCacheDirectory);
-    await Deno.remove(directory, { recursive: true });
-  }
-});
-
 Deno.test("benchmark: the drill-down keeps one-sample benchmarks", async () => {
   // Each run reports a different benchmark. The tile still indexes both runs.
   // The drill-down shows each benchmark's one sample as a point.
@@ -3547,6 +3378,119 @@ Deno.test("a queued runtime history refresh reuses a dashboard refresh that just
   } finally {
     resolveRuns(Response.json({ workflow_runs: [] }));
     await dashboard?.catch(() => {});
+    globalThis.fetch = originalFetch;
+    if (previousCacheDirectory === undefined) {
+      Deno.env.delete("DASHBOARD_CACHE_DIR");
+    } else Deno.env.set("DASHBOARD_CACHE_DIR", previousCacheDirectory);
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("a queued dashboard refresh checks that the drill-down covers its runs", async () => {
+  const directory = await Deno.makeTempDir({
+    prefix: "benchmark-queued-dashboard-",
+  });
+  const previousCacheDirectory = Deno.env.get("DASHBOARD_CACHE_DIR");
+  const originalFetch = globalThis.fetch;
+  const oldRun = ghRun(131_001, SAMPLED_BASE - DAY);
+  const newRun = ghRun(131_002, SAMPLED_BASE);
+  const oldArchive = await totalZip(5e6);
+  const newArchive = await totalZip(10e6);
+  let releaseOldArtifact!: (response: Response) => void;
+  const heldOldArtifact = new Promise<Response>((resolve) => {
+    releaseOldArtifact = resolve;
+  });
+  let markOldArtifactRequested!: () => void;
+  const oldArtifactRequested = new Promise<void>((resolve) => {
+    markOldArtifactRequested = resolve;
+  });
+  let markDashboardRunsRequested!: () => void;
+  const dashboardRunsRequested = new Promise<void>((resolve) => {
+    markDashboardRunsRequested = resolve;
+  });
+  let workflowRequests = 0;
+  let newArtifactRequests = 0;
+  Deno.env.set("DASHBOARD_CACHE_DIR", directory);
+  globalThis.fetch = ((input: RequestInfo | URL) => {
+    const url = new URL(input instanceof Request ? input.url : String(input));
+    if (url.pathname === "/rate_limit") {
+      return Promise.resolve(serve({})(url));
+    }
+    if (url.pathname.endsWith("/actions/workflows/benchmarks.yml/runs")) {
+      workflowRequests++;
+      if (workflowRequests === 1) {
+        return Promise.resolve(Response.json({ workflow_runs: [oldRun] }));
+      }
+      if (workflowRequests === 2) {
+        markDashboardRunsRequested();
+        return Promise.resolve(Response.json({
+          workflow_runs: [newRun, oldRun],
+        }));
+      }
+      throw new Error("unexpected third workflow request");
+    }
+    if (url.pathname.endsWith(`/actions/runs/${oldRun.id}/artifacts`)) {
+      markOldArtifactRequested();
+      return heldOldArtifact;
+    }
+    if (url.pathname.endsWith(`/actions/runs/${newRun.id}/artifacts`)) {
+      newArtifactRequests++;
+      return Promise.resolve(Response.json({
+        artifacts: [{
+          id: newRun.id * 10,
+          name: "bench-results",
+          expired: false,
+        }],
+      }));
+    }
+    if (url.pathname.endsWith(`/actions/artifacts/${oldRun.id * 10}/zip`)) {
+      return Promise.resolve(new Response(oldArchive));
+    }
+    if (url.pathname.endsWith(`/actions/artifacts/${newRun.id * 10}/zip`)) {
+      return Promise.resolve(new Response(newArchive));
+    }
+    throw new Error(`unexpected request ${url.pathname}`);
+  }) as typeof fetch;
+
+  let dashboard: Promise<TileView> | undefined;
+  let drillDown: Promise<string> | undefined;
+  try {
+    const isolated = await import(
+      `./benchmark.ts?queued-dashboard=${crypto.randomUUID()}`
+    );
+    const tokenContext = ctx({
+      GH_TOKEN: `queued-dashboard-${crypto.randomUUID()}`,
+    });
+    const page = await isolated.benchmarkHistoryResponse(
+      new URL("http://x/bench?view=runtime"),
+      tokenContext,
+    );
+    const html = await page.text();
+    const id = html.match(/runtime-progress\?id=([^"&]+)/)?.[1];
+    assert(id);
+    drillDown = isolated.benchmarkHistoryProgressResponse(
+      new URL(`http://x/bench/runtime-progress?id=${id}`),
+    ).text();
+    await oldArtifactRequested;
+
+    dashboard = isolated.benchmark.collect(tokenContext);
+    await dashboardRunsRequested;
+    releaseOldArtifact(Response.json({
+      artifacts: [{
+        id: oldRun.id * 10,
+        name: "bench-results",
+        expired: false,
+      }],
+    }));
+
+    await dashboard;
+    await drillDown;
+    expect(workflowRequests).toBe(2);
+    expect(newArtifactRequests).toBe(1);
+  } finally {
+    releaseOldArtifact(Response.json({ artifacts: [] }));
+    await dashboard?.catch(() => {});
+    await drillDown?.catch(() => {});
     globalThis.fetch = originalFetch;
     if (previousCacheDirectory === undefined) {
       Deno.env.delete("DASHBOARD_CACHE_DIR");

--- a/packages/dashboard/tiles/benchmark.test.ts
+++ b/packages/dashboard/tiles/benchmark.test.ts
@@ -1055,7 +1055,7 @@ Deno.test("benchmark: the trend reads the recent window only, not the whole hist
   });
 });
 
-Deno.test("benchmark: returns a failed rising view without publishing intermediate data", async () => {
+Deno.test("benchmark: returns a failed rising view after the run list settles", async () => {
   const directory = await Deno.makeTempDir({
     prefix: "benchmark-settled-view-",
   });
@@ -1111,14 +1111,11 @@ Deno.test("benchmark: returns a failed rising view without publishing intermedia
       `./benchmark.ts?settled-view=${crypto.randomUUID()}`
     );
     expect(isolated.benchmark.showOnlyCompletedViews).toBe(true);
-    const published: TileView[] = [];
     const active: Promise<TileView> = isolated.benchmark.collect(
       ctx({ GH_TOKEN: token }),
-      (view: TileView) => published.push(view),
     );
     collection = active;
     await runsRequested;
-    expect(published).toEqual([]);
 
     releaseRuns(Response.json({
       workflow_runs: [
@@ -1127,7 +1124,6 @@ Deno.test("benchmark: returns a failed rising view without publishing intermedia
       ],
     }));
     const final = await active;
-    expect(published).toEqual([]);
     expect(final.status).toBe("bad");
     expect(final.value).toContain("▲");
   } finally {

--- a/packages/dashboard/tiles/benchmark.ts
+++ b/packages/dashboard/tiles/benchmark.ts
@@ -21,9 +21,9 @@
 // BENCH_TREND_MIN_RUNS, whichever is larger. The full line spans about 45 days.
 // The failed state reads the workflow-run list and the latest run's cached
 // result. It therefore works when artifacts cannot be read. Without usable
-// data, the tile reads "collecting…" during a fetch. It reads "benchmark data
-// unavailable" after an empty fetch. A failed fetch keeps the last-known
-// processor lines gray and names the reason.
+// data, the dashboard keeps the last completed color and values while a fetch
+// runs. It reads "benchmark data unavailable" after an empty fetch. A failed
+// fetch keeps the last-known processor lines gray and names the reason.
 //
 // Every collection pages the run list, once a minute, which is the cadence the
 // run state needs. The artifact history behind the tile moves with the runs
@@ -945,7 +945,6 @@ const RUNNING_BADGE =
 function benchmarkIndexView(
   runs: Run[],
   now: number,
-  collecting = false,
   offline?: string,
 ): TileView {
   const cutoff = now - SPARK_DAYS * 86_400_000;
@@ -988,10 +987,8 @@ function benchmarkIndexView(
         aside,
       };
     }
-    // No data yet: "collecting…" while a fetch is still in progress (the early paints,
-    // including the one before the run list is fetched), "benchmark data unavailable"
-    // once a fetch has finished empty, "no benchmark runs" when it found none at all.
-    if (collecting) return benchmarkUnavailable("collecting…", aside);
+    // A completed fetch with runs but no readable artifacts reports the missing
+    // data. A completed fetch with no runs reports the missing run history.
     return benchmarkUnavailable(
       runs.length ? "benchmark data unavailable" : "no benchmark runs",
       aside,
@@ -1220,13 +1217,6 @@ function startBenchmarkRefresh(
   });
   const collection = async (): Promise<BenchmarkCollectionOutcome> => {
     await previousCollection;
-    if (
-      queuedBehindOtherScope && benchmarkRefreshedAt &&
-      Date.now() - benchmarkRefreshedAt >= 0 &&
-      Date.now() - benchmarkRefreshedAt < BENCHMARK_REFRESH_MS
-    ) {
-      return {};
-    }
     let known: Run[] | undefined;
     if (knownRuns) {
       known = await knownRuns;
@@ -1240,6 +1230,10 @@ function startBenchmarkRefresh(
       ) {
         return {};
       }
+    } else if (queuedBehindOtherScope && benchmarkSnapshotIsFresh()) {
+      // A queued refresh with no run list reuses the fresh shared artifact
+      // history.
+      return {};
     }
     return await collectBenchmark(token, progress, github, known);
   };
@@ -1334,6 +1328,7 @@ export const benchmark: Tile = {
   // hour, so an hourly collection can miss one from start to finish. The
   // artifact reads behind the tile keep their own, slower gate.
   intervalMs: 60_000,
+  showOnlyCompletedViews: true,
   routes: [
     {
       path: "/bench",
@@ -1373,26 +1368,10 @@ export const benchmark: Tile = {
       handler: (_req, url) => benchmarkHistoryProgressResponse(url),
     },
   ] satisfies Route[],
-  async collect(ctx, publish): Promise<TileView> {
+  async collect(ctx): Promise<TileView> {
     const token = ctx.env("GH_TOKEN") ?? ctx.env("GITHUB_TOKEN");
     if (!token) return benchmarkUnavailable("set GH_TOKEN");
     await loadCachedBenchmarkSnapshot();
-    // A painted frame is not what the collection returns, so one that throws is
-    // one bad frame rather than a failed collection.
-    const paint = (view: TileView) => {
-      if (!publish) return;
-      try {
-        publish(view);
-      } catch {
-        // The next paint, or the return value, carries the tile instead.
-      }
-    };
-    // Paint at once, before the run list is even fetched, so a freshly loaded
-    // dashboard shows the cached headline immediately (warm) or "collecting…" (cold)
-    // rather than a blank tile while the first collection gets under way. The empty
-    // run list carries no failed state yet; the paint below and the final return
-    // supply it.
-    paint(benchmarkIndexView([], Date.now(), true));
     // The run list is the tile's own read, made by every collection. This is the
     // part that keeps up with a run starting: the artifact history behind it moves
     // far more slowly than the tile's cadence.
@@ -1422,14 +1401,10 @@ export const benchmark: Tile = {
       return benchmarkIndexView(
         [],
         Date.now(),
-        false,
         friendlyError(errorMessage(listError)),
       );
     }
     latestBenchmarkRuns = runs;
-    // The headline stands on the run list alone, so paint it before waiting on the
-    // artifact work behind it.
-    paint(benchmarkIndexView(runs, Date.now(), true));
     await refresh;
     return benchmarkIndexView(runs, Date.now());
   },

--- a/packages/dashboard/types.ts
+++ b/packages/dashboard/types.ts
@@ -34,6 +34,8 @@ export interface Tile {
   id: string; // unique, stable key for this tile's scheduling + latest-view state
   intervalMs: number; // how often collect() runs, per source when runSources is set
   wide?: boolean; // render full-width below the grid, including before collection
+  // Keep the last completed status and values while ignoring intermediate views.
+  showOnlyCompletedViews?: boolean;
   // GitHub workflow snapshots that drive this tile. The scheduler refreshes
   // each source independently and publishes its due dependent tiles together.
   runSources?: readonly RunSource[];


### PR DESCRIPTION
The benchmark collector published cached trend data before its workflow run list and artifact refresh had finished. A failed latest run could therefore appear red, turn orange from the partial cache, and return to red at the end of every collection.

Make the benchmark tile publish completed views only. The scheduler now keeps its last completed status and values during collection, while still reporting a refresh that remains pending for one minute. Other tiles retain their existing stale-collection behavior.

Require a queued dashboard refresh to verify that the preceding drill-down refresh covers its own run list before reusing artifacts. This prevents a completed view from mixing current workflow state with older benchmark data.

Add regressions for the red-and-rising case, the one-minute scheduler state, and cross-scope refresh coverage. Update the dashboard documentation to describe the completed-view behavior.

Tests: deno task test (packages/dashboard)
Tests: deno lint
Tests: deno task check
Tests: deno task check-docs

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

