### PR TITLE
fix(cli): name the invocation identity pair in the selection tests

### DIFF
--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -92,7 +92,7 @@ export interface CallableExecutionDeps {
    * fetching the outcome back, because a caller-supplied id keeps that
    * fetch available forever: a later same-id call deduplicates against the
    * create-only receipt and returns the original outcome (verb contract
-   * D1/D3). Requires an `invocationId` — without one there is no receipt to
+   * D1/D3). Requires an `invocation` — without one there is no receipt to
    * come back for — and only the handler send path supports it (a tool's
    * result is delivered by this process, not read back from a receipt). */
   skipReadback?: boolean;

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -3188,7 +3188,7 @@ describe("piece call selection", () => {
       {
         loadPieces: () => Promise.resolve(harness.pieces),
         loadPiece: () => Promise.resolve(harness.piece),
-        invocationId: "inv-select",
+        invocation: { id: "inv-select", session: callerSession },
         selection,
         deriveSelectedValue: selector.derive,
       },
@@ -3219,7 +3219,7 @@ describe("piece call selection", () => {
       {
         loadPieces: () => Promise.resolve(harness.pieces),
         loadPiece: () => Promise.resolve(harness.piece),
-        invocationId: "inv-plain",
+        invocation: { id: "inv-plain", session: callerSession },
         deriveSelectedValue: selector.derive,
       },
     );
@@ -3248,7 +3248,7 @@ describe("piece call selection", () => {
       loadPieces: () => Promise.resolve(harness.pieces),
       loadPiece: () => Promise.resolve(harness.piece),
       isStdinTerminal: () => true,
-      invocationId: "inv-void-select",
+      invocation: { id: "inv-void-select", session: callerSession },
       selection: await parseCellSelectionOptions({ select: "anything" }),
       deriveSelectedValue: selector.derive,
     });
@@ -3274,7 +3274,7 @@ describe("piece call selection", () => {
       executePieceCallable(config, "addTopic", ["--title", "Ship it"], {
         loadPieces: () => Promise.resolve(harness.pieces),
         loadPiece: () => Promise.resolve(harness.piece),
-        invocationId: "inv-empty-select",
+        invocation: { id: "inv-empty-select", session: callerSession },
         selection: await parseCellSelectionOptions({
           schema: '{"type":"string"}',
         }),
@@ -3354,7 +3354,7 @@ describe("piece call selection", () => {
       {
         loadPieces: () => Promise.resolve(harness.pieces),
         loadPiece: () => Promise.resolve(harness.piece),
-        invocationId: "inv-select-links",
+        invocation: { id: "inv-select-links", session: callerSession },
         showLinks: true,
         selection: await parseCellSelectionOptions({ select: "count" }),
         deriveSelectedValue: selector.derive,
@@ -3538,7 +3538,7 @@ describe("piece call selection over a live runtime", () => {
       resolved,
       { title: "Ship it" },
       {
-        invocationId: "inv-live",
+        invocation: { id: "inv-live", session: callerSession },
         selection: await parseCellSelectionOptions({ select: "topics.title" }),
       },
     );
@@ -3561,7 +3561,7 @@ describe("piece call selection over a live runtime", () => {
       resolved,
       { title: "Ship it" },
       {
-        invocationId: "inv-live-filter",
+        invocation: { id: "inv-live-filter", session: callerSession },
         selection: await parseCellSelectionOptions({
           filter: '.status == "open"',
           select: "id,title",
@@ -3591,7 +3591,7 @@ describe("piece call selection over a live runtime", () => {
       resolved,
       { title: "Ship it" },
       {
-        invocationId: "inv-live-link",
+        invocation: { id: "inv-live-link", session: callerSession },
         selection: await parseCellSelectionOptions({
           schema: '{"properties":{"topic":{"$link":true}}}',
         }),
@@ -3616,7 +3616,7 @@ describe("piece call selection over a live runtime", () => {
 
     await expect(
       executeResolvedCallable(resolved, { title: "Ship it" }, {
-        invocationId: "inv-live-nothing",
+        invocation: { id: "inv-live-nothing", session: callerSession },
         selection: await parseCellSelectionOptions({
           schema: '{"type":"string"}',
         }),


### PR DESCRIPTION
## Why

`deno task check` fails on `main`. Two PRs that were each green on their own
base merged twenty-six seconds apart and produced a tree that type-fails:

- **#5469** (18:32:41) replaced `invocationId: string` with
  `invocation: {id, session}` and updated every caller that existed at the time.
- **#5505** (18:33:07) added nine `piece call` selection tests written against
  the old field name.

Neither could have caught it alone, and CI could not either: each PR's checks
ran against a base that did not yet contain the other.

**The runtime cost is larger than the type error.** `invocationId` is an unknown
key that the implementation ignores, so all nine tests dispatched with *no
invocation at all*, then asserted on a receipt that cannot arrive. They do not
merely fail to compile — they fail, and `piece call --select` has no passing
guard on main until this lands. Before: `0 passed | 2 failed (9 steps)`.

This is the same shape #5469 itself hit — a change made a test in main illegal —
so it is worth saying plainly: running the tests a change *touches* is not
enough, you need the tests it *breaks*.

## What Changed

- `packages/cli/test/piece-call.test.ts` — the nine sites pass
  `invocation: { id: …, session: callerSession }`. `callerSession` is the
  module-level constant the file's other invocation sites already use, so the
  nine now match their neighbours rather than introducing a spelling.
- `packages/cli/lib/callable.ts` — the `--no-wait` doc comment required an
  `invocationId`, a field its own interface no longer has.

No production behaviour changes; the guard that was silently absent is restored.

## Test plan

- `deno task check` — fails on `main` with 9 errors, passes here.
- `packages/cli` suite: `172 passed | 0 failed`, with the nine restored steps
  green (`piece call selection` 16 steps, was 0 passed / 2 failed).
- `deno fmt --check`, `deno lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

