### PR TITLE
fix(cli): start the profiler from a marker that beat `Profiler.enable`

### DIFF
--- a/packages/cli/support/profiling/capture-deno-inspector-profile-lib.test.ts
+++ b/packages/cli/support/profiling/capture-deno-inspector-profile-lib.test.ts
@@ -76,6 +76,9 @@ class FakeCelestial {
   runtimeEnableError: unknown;
   startError: unknown;
   startPromise: Promise<void> | undefined;
+  profilerEnabled = false;
+  profilerEnableGate: PromiseWithResolvers<void> | undefined;
+  profilerEnableCalled = Promise.withResolvers<void>();
   profile: unknown = { nodes: [] };
   samplingIntervals: number[] = [];
   #listeners = new Map<
@@ -110,7 +113,11 @@ class FakeCelestial {
   Profiler = {
     enable: () => {
       this.calls.push("Profiler.enable");
-      return Promise.resolve();
+      this.profilerEnableCalled.resolve();
+      const gate = this.profilerEnableGate?.promise ?? Promise.resolve();
+      return gate.then(() => {
+        this.profilerEnabled = true;
+      });
     },
     setSamplingInterval: (params: { interval: number }) => {
       this.samplingIntervals.push(params.interval);
@@ -118,6 +125,10 @@ class FakeCelestial {
     },
     start: () => {
       this.starts += 1;
+      // What the inspector answers a `Profiler.start` it has not enabled yet.
+      if (!this.profilerEnabled) {
+        return Promise.reject(new Error("Profiler is not enabled (-32000)"));
+      }
       if (this.startError) return Promise.reject(this.startError);
       return this.startPromise ?? Promise.resolve();
     },
@@ -945,6 +956,74 @@ describe("capture-deno-inspector-profile helpers", () => {
       assertEquals(celestial.starts, 1);
       assertEquals(celestial.stops, 1);
       assertEquals(logs.includes("profile: profile stop matched"), true);
+    });
+  });
+
+  it("starts from a marker that arrives before the profiler is enabled", async () => {
+    await withTempDir(async (tmpDir) => {
+      const celestial = new FakeCelestial();
+      const gate = Promise.withResolvers<void>();
+      celestial.profilerEnableGate = gate;
+      const logs: string[] = [];
+      const started = Promise.withResolvers<void>();
+      const done = captureDenoInspectorProfile(
+        [
+          `--output=${tmpDir}/profile.cpuprofile`,
+          "--summary-pattern=(?!)",
+          "--profile-start-pattern=profile start",
+          "--profile-stop-pattern=profile stop",
+          "--websocket-url=ws://127.0.0.1:9333/session",
+        ],
+        createCaptureRuntime({ celestial, logs, started }),
+      );
+
+      // `Runtime.enable` has already answered, so console events reach the
+      // capture while `Profiler.enable` is still outstanding.
+      await celestial.profilerEnableCalled.promise;
+      celestial.dispatchConsole({ value: "profile start" });
+      assertEquals(celestial.starts, 0);
+
+      gate.resolve();
+      await started.promise;
+      celestial.dispatchConsole({ value: "profile stop" });
+
+      assertEquals(await done, 0);
+      assertEquals(celestial.starts, 1);
+      assertEquals(celestial.stops, 1);
+    });
+  });
+
+  it("keeps a stop seen before the start marker from ending the profile", async () => {
+    await withTempDir(async (tmpDir) => {
+      const celestial = new FakeCelestial();
+      const gate = Promise.withResolvers<void>();
+      celestial.profilerEnableGate = gate;
+      const logs: string[] = [];
+      const started = Promise.withResolvers<void>();
+      const done = captureDenoInspectorProfile(
+        [
+          `--output=${tmpDir}/profile.cpuprofile`,
+          "--summary-pattern=(?!)",
+          "--profile-start-pattern=profile start",
+          "--profile-stop-pattern=profile stop",
+          "--websocket-url=ws://127.0.0.1:9333/session",
+        ],
+        createCaptureRuntime({ celestial, logs, started }),
+      );
+
+      // A stop that precedes the start marker is stale, and the deferred
+      // start carries that answer rather than the default.
+      await celestial.profilerEnableCalled.promise;
+      celestial.dispatchConsole({ value: "profile stop" });
+      celestial.dispatchConsole({ value: "profile start" });
+
+      gate.resolve();
+      await started.promise;
+      celestial.dispatchConsole({ value: "profile stop" });
+
+      assertEquals(await done, 0);
+      assertEquals(celestial.starts, 1);
+      assertEquals(celestial.stops, 1);
     });
   });
 

--- a/packages/cli/support/profiling/capture-deno-inspector-profile-lib.test.ts
+++ b/packages/cli/support/profiling/capture-deno-inspector-profile-lib.test.ts
@@ -1027,6 +1027,43 @@ describe("capture-deno-inspector-profile helpers", () => {
     });
   });
 
+  it("stops from a marker that arrived while the profiler was still enabling", async () => {
+    await withTempDir(async (tmpDir) => {
+      const celestial = new FakeCelestial();
+      const gate = Promise.withResolvers<void>();
+      celestial.profilerEnableGate = gate;
+      const logs: string[] = [];
+      const started = Promise.withResolvers<void>();
+      const done = captureDenoInspectorProfile(
+        [
+          `--output=${tmpDir}/profile.cpuprofile`,
+          "--summary-pattern=done",
+          "--profile-start-pattern=profile start",
+          "--profile-stop-pattern=profile stop",
+          "--websocket-url=ws://127.0.0.1:9333/session",
+        ],
+        createCaptureRuntime({ celestial, logs, started }),
+      );
+
+      // No stop preceded the start marker, so the stop that follows it is the
+      // live one and survives the profiler actually starting.
+      await celestial.profilerEnableCalled.promise;
+      celestial.dispatchConsole({ value: "profile start" });
+      celestial.dispatchConsole({ value: "profile stop" });
+
+      gate.resolve();
+      await started.promise;
+      await Promise.resolve();
+      // Ends the run if the stop above was dropped, so the reason below is
+      // what distinguishes the two outcomes rather than a hang.
+      celestial.dispatchConsole({ value: "done" });
+
+      assertEquals(await done, 0);
+      assertEquals(logs.includes("profile: profile stop matched"), true);
+      assertEquals(celestial.stops, 1);
+    });
+  });
+
   it("stops from a marker that arrives while profiler start is in flight", async () => {
     await withTempDir(async (tmpDir) => {
       const celestial = new FakeCelestial();

--- a/packages/cli/support/profiling/capture-deno-inspector-profile-lib.ts
+++ b/packages/cli/support/profiling/capture-deno-inspector-profile-lib.ts
@@ -417,6 +417,10 @@ export async function captureDenoInspectorProfile(
   let pendingProfilerStopReason: string | undefined;
   let profilerStartError: string | undefined;
   let missingProfileStartError: string | undefined;
+  // Whether `Profiler.enable` has answered, and the start options a console
+  // marker recorded before it did.
+  let profilerEnabled = false;
+  let deferredProfilerStartOptions: { clearStop?: boolean } | undefined;
 
   const target = {
     id: websocketUrl,
@@ -491,7 +495,17 @@ export async function captureDenoInspectorProfile(
       profileStopRegex,
     );
     if (profileMessage.startedProfile) {
-      void startProfiler({ clearStop: profileMessage.hadProfileStop });
+      const startOptions = { clearStop: profileMessage.hadProfileStop };
+      // `Runtime.enable` is what makes console events flow, and it resolves
+      // before `Profiler.enable` does. A target that prints its start marker
+      // in that window reaches here against a profiler the inspector has not
+      // enabled yet, and `Profiler.start` answers -32000. Hold the marker's
+      // options instead; the enable sequence starts the profiler with them.
+      if (profilerEnabled) {
+        void startProfiler(startOptions);
+      } else {
+        deferredProfilerStartOptions ??= startOptions;
+      }
     }
     if (summaryRegex.test(text)) {
       requestProfilerStop("summary-matched");
@@ -574,9 +588,13 @@ export async function captureDenoInspectorProfile(
     await celestial.Debugger.enable({});
     await celestial.Profiler.enable();
     await celestial.Profiler.setSamplingInterval({ interval: 100 });
+    profilerEnabled = true;
 
+    // Either the run carries no start pattern, so profiling begins at attach
+    // with no marker to answer, or a marker arrived while the enable sequence
+    // was still in flight and left the options it was seen with.
     if (state.sawProfileStart) {
-      await startProfiler();
+      await startProfiler(deferredProfilerStartOptions ?? {});
     }
 
     stopResumeOnPause = resumeDebuggerOnPause(celestial, ws, -2);


### PR DESCRIPTION
## Why

`Test (N/6)` is failing on main. The profiled target prints its start marker
early, and the capture answers:

```
profile: runtime enabled
profile: Profiler.start failed: Error: Profiler is not enabled (-32000)
...
error: Error: Unexpected EOF
```

`Runtime.enable` is what makes console events flow, and it answers several
commands before `Profiler.enable` does. The console listener is registered
ahead of both, deliberately — a target paused on `--inspect-wait` has buffered
messages that `Runtime.enable` flushes, and a listener registered later would
miss them. That leaves a window between the two enables in which a start
marker reaches `startProfiler` against a profiler the inspector has not
enabled, and the inspector refuses the command. The socket then closes and the
run reports `Unexpected EOF`, which is the symptom rather than the cause.

The enable sequence already knew what to do — it starts the profiler itself
when a marker has been seen — so the marker only needed to reach it instead of
dispatching its own `Profiler.start`.

This is the fourth fix of one shape in this file: an event arriving before the
setup that makes handling it valid (#4524 signal race during cleanup, #4526
help-capture stabilization, #4814 late stop-signal). Worth noting for whoever
meets the fifth — the pattern is that every listener here is registered before
the command that authorizes what it does.

## What Changed

- The console handler holds the marker's start options when `Profiler.enable`
  has not yet answered; the enable sequence then starts the profiler with
  them. Holding the options rather than a bare flag is what keeps a stop seen
  *before* the start marker stale and a stop seen *after* it live — the
  distinction `clearStop` carries, added in #4814.
- `FakeCelestial.Profiler.start` now rejects with the inspector's own `-32000`
  when `enable` has not resolved. The ordering is now a property the suite
  enforces rather than one it happened to satisfy: without it, this bug is
  invisible to a fake whose `start` always succeeds.

## Test plan

- Two new cases, each verified to fail without the source change and pass with
  it — I reverted the source and re-ran to confirm they were not tests that
  cannot fail:
  - a marker arriving before the profiler is enabled still starts it
  - a stop preceding that marker does not end the profile
- `deno task test` in packages/cli — 172 passed / 0 failed, with both new
  cases confirmed present in the run output
- `support/profiling/cf-profile.test.ts` (the end-to-end test failing in CI) —
  6 passed / 0 failed
- `deno task check`, `deno fmt --check`, `deno lint`, `check-no-waitfor`,
  `check-conflict-markers`

Note this is a race: local runs passed both before and after, so the CI result
on this PR is the real evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

