### PR TITLE
fix(integration): keep trusted clicks on moving controls

### DIFF
--- a/docs/development/UI_TESTING.md
+++ b/docs/development/UI_TESTING.md
@@ -230,12 +230,17 @@ is not bound yet.
 Settling first also keeps a trusted click from missing its target. A trusted
 click resolves the element's layout box and then dispatches the mouse events at
 that point. On a cold load the page keeps reflowing for a few frames as content
-above the control fills in — a topic's markdown body renders, a form or card
-below it appears — so a control that has just become rendered is still moving.
-If the box moves between when the click resolves it and when the mouse events
-fire, the click lands on whatever shifted into that spot instead of the control,
-and nothing happens. Settling the view drains the pending reflow so the target
-is stationary when it is clicked.
+above the control fills in. A topic's markdown body may render, or a form or
+card below it may appear. A control that has just become rendered can therefore
+still be moving. If the box moves between measurement and dispatch, the click
+lands on whatever shifted into the old spot instead of the control. Nothing
+happens.
+
+`clickCfButton` waits for the marked control's box to remain unchanged across
+two consecutive rendering frames. It measures the marked control again just
+before dispatch. If that final measurement finds that the control moved or was
+replaced, the helper settles and marks the current control before dispatching
+one trusted click.
 
 **Use `awaitViewSettled(page)`** from `@commonfabric/integration` as the
 lower-level wait after navigation or a state change. When the next step

--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -130,9 +130,12 @@ before marking any of them. Mark the targets inside the successful predicate so
 the click addresses the elements that passed the settle check.
 
 `clickCfButton` and `clickCfButtonsConcurrently` work this way.
-`clickTrustedAction`, `submitViaEnter`, and `settleAndClickNoteButton` in
-`packages/patterns/integration/note-button-helpers.ts` still settle before
-resolving their target, and carry the gap described above.
+`clickTrustedAction` and `settleAndClickNoteButton` in
+`packages/patterns/integration/note-button-helpers.ts` use `clickMarked` for
+the final geometry check and replacement handling. Their earlier readiness
+checks differ from `clickCfButton`'s settle-and-mark predicate.
+`submitViaEnter` is a keyboard interaction and settles before resolving its
+input.
 
 Ask `probe.isRendered` for that check rather than hand-rolling it, and note that
 it is deliberately not `probe.isVisible`, which additionally requires the
@@ -161,22 +164,29 @@ the click, and the surface the control sits in can still be settling: a join
 card's profile surface toggles display through its entrance, a re-render relays
 out the region, or a piece re-render replaces the control with an equivalent one.
 So `clickMarked` settles the control and works out where to click it in a single
-page turn, and dispatches immediately afterwards. That one turn holds until the
-tagged control's bounding box is unchanged across two consecutive animation
-frames, then scrolls it into view and measures the point, all without handing
-control back to the test process in between. The hold is frame-driven and drops
-its baseline whenever the box disappears, so a control hidden partway through is
-picked up once it returns rather than clicked mid-shift; the stuck-condition net
-bounds a box that never settles.
+page turn. That turn holds until the tagged control's bounding box is unchanged
+across two consecutive animation frames. It then scrolls the control into view
+and measures the point without handing control back to the test process in
+between. The hold is frame-driven and drops its baseline whenever the box
+disappears. A control hidden partway through is picked up once it returns rather
+than clicked mid-shift. The stuck-condition net bounds a box that never settles.
+
+The page can move again after that first measurement. An interaction observer
+also runs before the trusted click and can give the page time to change. Just
+before dispatch, `clickMarked` resolves the marked control in one page turn and
+reads its current center. If the control has moved or disappeared, the helper
+settles it again and applies the caller's tagging predicate to any replacement.
+It takes one final current measurement after that settle, then dispatches the
+single trusted click at that point.
 
 Deciding and measuring in one turn is the point of the design, not an
 optimization. Split across protocol round trips, the measurement describes a
-different moment from the decision, and a control the page dropped in between
-measures as nothing at all — which is what "Unable to get stable box model to
+different moment from the decision. A control the page dropped in between then
+measures as nothing at all. This is what "Unable to get stable box model to
 click on" means. A helper that tags a control by name also passes its tagging
-predicate to `clickMarked`, so a control the page rebuilt is tagged again on
-whatever took its place, under that helper's own readiness rules, rather than
-reported as gone.
+predicate to `clickMarked`. A control the page rebuilt is therefore tagged
+again on whatever took its place, under that helper's own readiness rules,
+rather than reported as gone.
 
 That error message covers more than a missing layout box: the underlying
 `DOM.getBoxModel` reports a node the browser's DOM agent no longer knows about

--- a/packages/integration/page.ts
+++ b/packages/integration/page.ts
@@ -441,13 +441,22 @@ export class Page extends EventTarget {
   //
   // For a caller that has already worked out where to click — a wait that
   // measured its target at the instant the target was ready, say — this is the
-  // dispatch on its own, with no measurement of its own to go stale.
+  // dispatch on its own. A caller whose target can move may provide a function
+  // that refreshes the point after the interaction observer has finished.
   // The interaction observer sees this dispatch as it sees an element's, with
   // no element to name, so a presentation recording still moves and pulses its
   // cursor over a click aimed by coordinates.
-  async clickPoint(point: { x: number; y: number }): Promise<void> {
+  async clickPoint(
+    point: { x: number; y: number },
+    options?: { refreshPoint?: () => Promise<{ x: number; y: number }> },
+  ): Promise<void> {
     this.checkIsOk();
-    await this.dispatchObservedClick(undefined, point);
+    await this.dispatchObservedClick(
+      undefined,
+      point,
+      undefined,
+      options?.refreshPoint,
+    );
   }
 
   // Passthru of `@astral/astral`'s `Page#close`
@@ -556,22 +565,34 @@ export class Page extends EventTarget {
   }
 
   // Dispatch one trusted click at `point`, with the interaction observer told
-  // before and after. The observer's failure is reported only when the click
-  // itself succeeded, so a recording problem never masks a click problem.
+  // before and after. The point can be refreshed after the observer has
+  // finished. The observer's failure is reported only when the click itself
+  // succeeded, so a recording problem never masks a click problem.
   private async dispatchObservedClick(
     element: ElementHandle | undefined,
     point: { x: number; y: number },
     options?: Parameters<AstralElementHandle["click"]>[0],
+    refreshPoint?: () => Promise<{ x: number; y: number }>,
   ): Promise<void> {
     await this.interactionObserver?.beforeClick?.(element, point);
+    let dispatchPoint = point;
     let actionError: unknown;
     try {
-      await this.page!.mouse.click(point.x, point.y, options);
+      dispatchPoint = await refreshPoint?.() ?? point;
+      await this.page!.mouse.click(
+        dispatchPoint.x,
+        dispatchPoint.y,
+        options,
+      );
     } catch (error) {
       actionError = error;
     }
     try {
-      await this.interactionObserver?.afterClick?.(element, point, actionError);
+      await this.interactionObserver?.afterClick?.(
+        element,
+        dispatchPoint,
+        actionError,
+      );
     } catch (observerError) {
       if (actionError === undefined) throw observerError;
     }

--- a/packages/integration/presentation/interactions.ts
+++ b/packages/integration/presentation/interactions.ts
@@ -52,7 +52,7 @@ export class PresentationInteractions {
     this.#page.setDefaultTypeDelay(this.#config.typingDelayMs);
     const observer: InteractionObserver = {
       beforeClick: (_element, point) => this.#moveCursor(point.x, point.y),
-      afterClick: () => this.#pulseCursor(),
+      afterClick: (_element, point) => this.#pulseCursor(point.x, point.y),
       beforeType: (element) => this.#moveCursorToElement(element),
     };
     this.#page.setInteractionObserver(observer);
@@ -262,15 +262,19 @@ export class PresentationInteractions {
     }, { args: [this.#participant.label, this.#participant.color] });
   }
 
-  async #pulseCursor(): Promise<void> {
-    await this.#page.evaluate(async (duration) => {
+  async #pulseCursor(x: number, y: number): Promise<void> {
+    await this.#page.evaluate(async (x, y, duration) => {
       const host = document.getElementById("__cf_demo_presentation_overlay");
-      const cursor = host?.shadowRoot?.getElementById("cursor");
+      const cursor = host?.shadowRoot?.getElementById("cursor") as
+        | HTMLElement
+        | undefined;
       if (!cursor) return;
+      cursor.style.transitionDuration = "0ms";
+      cursor.style.transform = `translate3d(${x}px, ${y}px, 0)`;
       cursor.classList.add("pulse");
       await new Promise((resolve) => setTimeout(resolve, duration));
       cursor.classList.remove("pulse");
-    }, { args: [this.#config.clickPulseMs] });
+    }, { args: [x, y, this.#config.clickPulseMs] });
   }
 }
 

--- a/packages/patterns/integration/cfc-browser-helpers.test.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.test.ts
@@ -9,6 +9,7 @@ import {
   assertRejects,
   assertStringIncludes,
 } from "@std/assert";
+import { expect } from "@std/expect";
 import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 import {
   CLICK_TARGET_ATTR,
@@ -269,6 +270,408 @@ describe("CFC browser helpers", () => {
       "the click reached the replacement before its handler was bound",
     );
     assertEquals(result.settleCalls, 3);
+  });
+
+  it("delivers a click when the control moves after aiming", async () => {
+    await page.evaluate(() => {
+      const host = document.createElement("div");
+      host.id = "moving-click-host";
+      const root = host.attachShadow({ mode: "open" });
+      const button = document.createElement("button");
+      button.id = "moving-guest-button";
+      button.textContent = "Continue as guest";
+      Object.assign(button.style, {
+        display: "block",
+        width: "200px",
+        height: "32px",
+      });
+      root.append(button);
+      document.body.append(host);
+
+      let clicks = 0;
+      let ready = false;
+      button.addEventListener("click", () => {
+        if (!ready) return;
+        clicks++;
+        const input = document.createElement("input");
+        input.id = "moving-join-name";
+        document.body.append(input);
+      });
+      (globalThis as typeof globalThis & {
+        commonfabric: { viewSettled: () => Promise<void> };
+        __moveClickTarget: () => void;
+        __movingClickResult: () => {
+          clicks: number;
+          inputPresent: boolean;
+        };
+      }).commonfabric = {
+        viewSettled: () => {
+          ready = true;
+          return Promise.resolve();
+        },
+      };
+      (globalThis as typeof globalThis & {
+        __moveClickTarget: () => void;
+      }).__moveClickTarget = () => {
+        ready = false;
+        button.style.transform = "translateX(400px)";
+      };
+      (globalThis as typeof globalThis & {
+        __movingClickResult: () => {
+          clicks: number;
+          inputPresent: boolean;
+        };
+      }).__movingClickResult = () => ({
+        clicks,
+        inputPresent: document.querySelector("#moving-join-name") !== null,
+      });
+    });
+
+    let moved = false;
+    page.setInteractionObserver({
+      beforeClick: async () => {
+        if (moved) return;
+        moved = true;
+        // Move the target after the helper measures it and before the browser
+        // dispatches the trusted click.
+        await page.evaluate(() =>
+          (globalThis as typeof globalThis & {
+            __moveClickTarget: () => void;
+          }).__moveClickTarget()
+        );
+      },
+    });
+    try {
+      await clickCfButton(page, "#moving-guest-button");
+    } finally {
+      page.setInteractionObserver();
+    }
+
+    const result = await page.evaluate(() =>
+      (globalThis as typeof globalThis & {
+        __movingClickResult: () => {
+          clicks: number;
+          inputPresent: boolean;
+        };
+      }).__movingClickResult()
+    );
+    expect(result.clicks).toBe(1);
+    expect(result.inputPresent).toBe(true);
+  });
+
+  it("preserves page state and coordinates for a moved control", async () => {
+    await page.evaluate(() => {
+      const host = document.createElement("div");
+      host.id = "native-moved-click-host";
+      const root = host.attachShadow({ mode: "open" });
+      const style = document.createElement("style");
+      style.textContent = `
+        #native-moved-click-button::after { content: "AUTHOR"; }
+      `;
+      const button = document.createElement("button");
+      button.id = "native-moved-click-button";
+      button.textContent = "Continue";
+      const sibling = document.createElement("button");
+      sibling.id = "native-moved-click-sibling";
+      sibling.textContent = "Other";
+      Object.assign(button.style, {
+        position: "fixed",
+        left: "40px",
+        top: "120px",
+        width: "120px",
+        height: "40px",
+        margin: "0",
+      });
+      Object.assign(sibling.style, {
+        position: "fixed",
+        left: "40px",
+        top: "220px",
+        width: "120px",
+        height: "40px",
+        margin: "0",
+      });
+      root.append(style, button, sibling);
+      document.body.append(host);
+
+      let result: {
+        clicks: number;
+        trusted: boolean;
+        pointInside: boolean;
+        pseudoContent: string;
+        siblingPointerEvents: string;
+        siblingHit: boolean;
+      } | undefined;
+      button.addEventListener("click", (event) => {
+        const rect = button.getBoundingClientRect();
+        const siblingRect = sibling.getBoundingClientRect();
+        result = {
+          clicks: 1,
+          trusted: event.isTrusted,
+          pointInside: event.clientX >= rect.left &&
+            event.clientX <= rect.right && event.clientY >= rect.top &&
+            event.clientY <= rect.bottom,
+          pseudoContent: getComputedStyle(button, "::after").content,
+          siblingPointerEvents: getComputedStyle(sibling).pointerEvents,
+          siblingHit: root.elementFromPoint(
+            siblingRect.x + siblingRect.width / 2,
+            siblingRect.y + siblingRect.height / 2,
+          ) === sibling,
+        };
+      });
+      (globalThis as typeof globalThis & {
+        commonfabric: { viewSettled: () => Promise<void> };
+        __nativeMovedClickResult: () => typeof result;
+      }).commonfabric = { viewSettled: () => Promise.resolve() };
+      (globalThis as typeof globalThis & {
+        __nativeMovedClickResult: () => typeof result;
+      }).__nativeMovedClickResult = () => result;
+    });
+
+    page.setInteractionObserver({
+      beforeClick: () =>
+        page.evaluate(() => {
+          const button = document.querySelector("#native-moved-click-host")
+            ?.shadowRoot?.querySelector<HTMLElement>(
+              "#native-moved-click-button",
+            );
+          if (!button) throw new Error("Moved click target is missing");
+          button.style.transform = "translateX(400px)";
+        }),
+    });
+    try {
+      await clickCfButton(page, "#native-moved-click-button");
+    } finally {
+      page.setInteractionObserver();
+    }
+
+    const result = await page.evaluate(() => {
+      const result = (globalThis as typeof globalThis & {
+        __nativeMovedClickResult: () => {
+          clicks: number;
+          trusted: boolean;
+          pointInside: boolean;
+          pseudoContent: string;
+          siblingPointerEvents: string;
+          siblingHit: boolean;
+        } | undefined;
+      }).__nativeMovedClickResult();
+      document.querySelector("#native-moved-click-host")?.remove();
+      return result;
+    });
+    expect(result).toEqual({
+      clicks: 1,
+      trusted: true,
+      pointInside: true,
+      pseudoContent: '"AUTHOR"',
+      siblingPointerEvents: "auto",
+      siblingHit: true,
+    });
+  });
+
+  it("settles a same-position replacement before clicking it", async () => {
+    await page.evaluate(() => {
+      const host = document.createElement("div");
+      host.id = "same-position-host";
+      const root = host.attachShadow({ mode: "open" });
+      const button = document.createElement("button");
+      button.id = "same-position-button";
+      button.textContent = "Continue";
+      Object.assign(button.style, {
+        position: "fixed",
+        left: "40px",
+        top: "40px",
+        width: "120px",
+        height: "40px",
+        margin: "0",
+      });
+      root.append(button);
+      document.body.append(host);
+
+      let clicks = 0;
+      let bound: HTMLButtonElement | undefined;
+      const bind = () => {
+        const current = root.querySelector<HTMLButtonElement>(
+          "#same-position-button",
+        );
+        if (current && current !== bound) {
+          bound = current;
+          current.addEventListener("click", () => clicks++);
+        }
+      };
+      (globalThis as typeof globalThis & {
+        commonfabric: { viewSettled: () => Promise<void> };
+        __samePositionClicks: () => number;
+      }).commonfabric = {
+        viewSettled: () => {
+          bind();
+          return Promise.resolve();
+        },
+      };
+      (globalThis as typeof globalThis & {
+        __samePositionClicks: () => number;
+      }).__samePositionClicks = () => clicks;
+    });
+
+    page.setInteractionObserver({
+      beforeClick: async () => {
+        await page.evaluate(() => {
+          const current = document.querySelector("#same-position-host")
+            ?.shadowRoot?.querySelector<HTMLButtonElement>(
+              "#same-position-button",
+            );
+          if (!current) throw new Error("Same-position target is missing");
+          current.replaceWith(current.cloneNode(true));
+        });
+      },
+    });
+    try {
+      await clickCfButton(page, "#same-position-button");
+    } finally {
+      page.setInteractionObserver();
+    }
+
+    const clicks = await page.evaluate(() => {
+      const clicks = (globalThis as typeof globalThis & {
+        __samePositionClicks: () => number;
+      }).__samePositionClicks();
+      document.querySelector("#same-position-host")?.remove();
+      return clicks;
+    });
+    expect(clicks).toBe(1);
+  });
+
+  it("clicks the current selector match when the old control remains", async () => {
+    await page.evaluate(() => {
+      const host = document.createElement("div");
+      host.id = "retargeted-click-host";
+      const root = host.attachShadow({ mode: "open" });
+      const oldButton = document.createElement("button");
+      oldButton.id = "retargeted-old-button";
+      oldButton.className = "retargeted-click-target";
+      oldButton.textContent = "Old";
+      const newButton = document.createElement("button");
+      newButton.id = "retargeted-new-button";
+      newButton.textContent = "New";
+      Object.assign(oldButton.style, {
+        position: "fixed",
+        left: "40px",
+        top: "320px",
+        width: "120px",
+        height: "40px",
+        margin: "0",
+      });
+      Object.assign(newButton.style, {
+        position: "fixed",
+        left: "240px",
+        top: "320px",
+        width: "120px",
+        height: "40px",
+        margin: "0",
+      });
+      root.append(oldButton, newButton);
+      document.body.append(host);
+
+      let oldClicks = 0;
+      let newClicks = 0;
+      oldButton.addEventListener("click", () => oldClicks++);
+      newButton.addEventListener("click", () => newClicks++);
+      const pageState = globalThis as typeof globalThis & {
+        commonfabric: { viewSettled: () => Promise<void> };
+        __retargetClick: () => void;
+        __retargetClickResult: () => {
+          oldClicks: number;
+          newClicks: number;
+        };
+      };
+      pageState.commonfabric = { viewSettled: () => Promise.resolve() };
+      pageState.__retargetClick = () => {
+        oldButton.classList.remove("retargeted-click-target");
+        oldButton.style.transform = "translateX(400px)";
+        newButton.classList.add("retargeted-click-target");
+      };
+      pageState.__retargetClickResult = () => ({ oldClicks, newClicks });
+    });
+
+    page.setInteractionObserver({
+      beforeClick: () =>
+        page.evaluate(() =>
+          (globalThis as typeof globalThis & {
+            __retargetClick: () => void;
+          }).__retargetClick()
+        ),
+    });
+    try {
+      await clickCfButton(page, ".retargeted-click-target");
+    } finally {
+      page.setInteractionObserver();
+    }
+
+    const result = await page.evaluate(() => {
+      const result = (globalThis as typeof globalThis & {
+        __retargetClickResult: () => {
+          oldClicks: number;
+          newClicks: number;
+        };
+      }).__retargetClickResult();
+      document.querySelector("#retargeted-click-host")?.remove();
+      return result;
+    });
+    expect(result).toEqual({ oldClicks: 0, newClicks: 1 });
+  });
+
+  it("preserves page-owned click identity globals", async () => {
+    const identityPage = await browser.newPage();
+    try {
+      await identityPage.evaluate(() => {
+        const button = document.createElement("button");
+        button.id = "identity-global-button";
+        button.textContent = "Continue";
+        document.body.append(button);
+
+        let clicks = 0;
+        button.addEventListener("click", () => clicks++);
+        const ownedIds = new WeakMap<Element, number>();
+        const pageState = globalThis as typeof globalThis & {
+          commonfabric: { viewSettled: () => Promise<void> };
+          __cfClickTargetIds: WeakMap<Element, number>;
+          __cfClickTargetIdNext: number;
+          __identityGlobalResult: () => {
+            clicks: number;
+            idsPreserved: boolean;
+            next: number;
+          };
+        };
+        pageState.commonfabric = {
+          viewSettled: () => Promise.resolve(),
+        };
+        pageState.__cfClickTargetIds = ownedIds;
+        pageState.__cfClickTargetIdNext = 47;
+        pageState.__identityGlobalResult = () => ({
+          clicks,
+          idsPreserved: pageState.__cfClickTargetIds === ownedIds,
+          next: pageState.__cfClickTargetIdNext,
+        });
+      });
+
+      await clickCfButton(identityPage, "#identity-global-button");
+
+      const result = await identityPage.evaluate(() =>
+        (globalThis as typeof globalThis & {
+          __identityGlobalResult: () => {
+            clicks: number;
+            idsPreserved: boolean;
+            next: number;
+          };
+        }).__identityGlobalResult()
+      );
+      expect(result).toEqual({
+        clicks: 1,
+        idsPreserved: true,
+        next: 47,
+      });
+    } finally {
+      await identityPage.close();
+    }
   });
 
   it("drives the page while waiting for text", async () => {
@@ -1018,6 +1421,109 @@ describe("CFC browser helpers", () => {
       assertEquals({ x: observed[1].x, y: observed[1].y }, { x: 100, y: 60 });
     } finally {
       page.setInteractionObserver(undefined);
+    }
+  });
+
+  it("places the presentation cursor where a refreshed click lands", async () => {
+    const presentationPage = await browser.newPage();
+    const presentation = installPresentationInteractions(
+      presentationPage,
+      testPresentationConfig,
+      { label: "Guest", color: "#2563eb" },
+    );
+    try {
+      await presentationPage.evaluate(() => {
+        const button = document.createElement("button");
+        button.id = "presentation-moving-button";
+        button.textContent = "Continue";
+        Object.assign(button.style, {
+          position: "fixed",
+          left: "40px",
+          top: "40px",
+          width: "120px",
+          height: "40px",
+          margin: "0",
+        });
+        document.body.append(button);
+
+        let clicks = 0;
+        let clickX = 0;
+        button.addEventListener("click", (event) => {
+          clicks++;
+          clickX = event.clientX;
+        });
+        (globalThis as typeof globalThis & {
+          commonfabric: { viewSettled: () => Promise<void> };
+          __presentationClickResult: () => {
+            clicks: number;
+            clickX: number;
+            cursorX: number;
+            cursorY: number;
+          };
+        }).commonfabric = { viewSettled: () => Promise.resolve() };
+        (globalThis as typeof globalThis & {
+          __presentationClickResult: () => {
+            clicks: number;
+            clickX: number;
+            cursorX: number;
+            cursorY: number;
+          };
+        }).__presentationClickResult = () => {
+          const cursor = document.getElementById(
+            "__cf_demo_presentation_overlay",
+          )?.shadowRoot?.getElementById("cursor");
+          if (!cursor) throw new Error("Presentation cursor is missing");
+          const transform = new DOMMatrix(getComputedStyle(cursor).transform);
+          return {
+            clicks,
+            clickX,
+            cursorX: transform.m41,
+            cursorY: transform.m42,
+          };
+        };
+      });
+      await presentation.prepareDocument();
+      await presentationPage.evaluate(() => {
+        const button = document.querySelector<HTMLElement>(
+          "#presentation-moving-button",
+        );
+        const cursor = document.getElementById(
+          "__cf_demo_presentation_overlay",
+        )?.shadowRoot?.getElementById("cursor");
+        if (!button || !cursor) {
+          throw new Error("Presentation click fixture is incomplete");
+        }
+        const observer = new MutationObserver(() => {
+          observer.disconnect();
+          button.style.transform = "translateX(400px)";
+        });
+        observer.observe(cursor, {
+          attributes: true,
+          attributeFilter: ["style"],
+        });
+      });
+
+      await clickCfButton(presentationPage, "#presentation-moving-button");
+
+      const result = await presentationPage.evaluate(() =>
+        (globalThis as typeof globalThis & {
+          __presentationClickResult: () => {
+            clicks: number;
+            clickX: number;
+            cursorX: number;
+            cursorY: number;
+          };
+        }).__presentationClickResult()
+      );
+      expect(result).toEqual({
+        clicks: 1,
+        clickX: 500,
+        cursorX: 500,
+        cursorY: 60,
+      });
+    } finally {
+      presentation.uninstall();
+      await presentationPage.close();
     }
   });
 

--- a/packages/patterns/integration/cfc-browser-helpers.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.ts
@@ -911,7 +911,7 @@ export async function clickNthCfButton(
 // Where a trusted click is about to be aimed, or why the marked control could
 // not be aimed at.
 type ClickAim =
-  | { x: number; y: number }
+  | { x: number; y: number; targetId: number }
   | { missing: true; sawTarget: boolean };
 
 // Resolve the marked control, hold until it has a settled layout box, scroll it
@@ -943,6 +943,7 @@ const aimAtMarkedTarget = async (
   selector: string,
   remarkSource: string | null,
   remarkArgs: readonly unknown[],
+  identityKey: string,
 ): Promise<ClickAim | false> => {
   type AimDiag = { phase: string; frames: number; lastBox: string };
   const registry = ((globalThis as typeof globalThis & {
@@ -953,6 +954,26 @@ const aimAtMarkedTarget = async (
 
   const find = (): HTMLElement | undefined =>
     probe.collect(selector)[0] as HTMLElement | undefined;
+  type IdentityState = {
+    identities: WeakMap<Element, number>;
+    next: number;
+  };
+  const pageState = globalThis as unknown as Record<string, unknown>;
+  let identityState = pageState[identityKey] as IdentityState | undefined;
+  if (identityState === undefined) {
+    identityState = { identities: new WeakMap(), next: 0 };
+    Object.defineProperty(pageState, identityKey, {
+      configurable: true,
+      value: identityState,
+    });
+  }
+  const identify = (target: Element): number => {
+    const known = identityState.identities.get(target);
+    if (known !== undefined) return known;
+    const created = ++identityState.next;
+    identityState.identities.set(target, created);
+    return created;
+  };
   const remark = remarkSource === null ? null : new Function(
     "return (" + remarkSource + ")",
   )() as (
@@ -1056,8 +1077,74 @@ const aimAtMarkedTarget = async (
     });
     const rect = target.getBoundingClientRect();
     diag.phase = "aimed";
-    return { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 };
+    return {
+      x: rect.x + rect.width / 2,
+      y: rect.y + rect.height / 2,
+      targetId: identify(target),
+    };
   }
+};
+
+// Read the marked control's current center in one page turn for a coordinate
+// refresh after any interaction observer has finished.
+const readMarkedClickPoint = async (
+  page: Page,
+  selector: string,
+  identityKey: string,
+): Promise<{ x: number; y: number; targetId: number } | undefined> => {
+  return await page.evaluate((targetSelector: string, identityKey: string) => {
+    function find(root: Document | ShadowRoot): HTMLElement | undefined {
+      for (const element of root.querySelectorAll("*")) {
+        if (element.matches(targetSelector)) return element as HTMLElement;
+        if (element.shadowRoot) {
+          const match = find(element.shadowRoot);
+          if (match) return match;
+        }
+      }
+    }
+
+    const target = find(document);
+    if (!target) return undefined;
+    const identityState = (globalThis as unknown as Record<string, unknown>)[
+      identityKey
+    ] as {
+      identities: WeakMap<Element, number>;
+      next: number;
+    } | undefined;
+    if (identityState === undefined) return undefined;
+    let targetId = identityState.identities.get(target);
+    if (targetId === undefined) {
+      targetId = ++identityState.next;
+      identityState.identities.set(target, targetId);
+    }
+    target.scrollIntoView({
+      block: "nearest",
+      inline: "nearest",
+      behavior: "instant",
+    });
+    const style = globalThis.getComputedStyle(target);
+    const rect = target.getBoundingClientRect();
+    if (
+      style.display === "none" || style.visibility === "hidden" ||
+      rect.width === 0 || rect.height === 0
+    ) {
+      return undefined;
+    }
+    return {
+      x: rect.x + rect.width / 2,
+      y: rect.y + rect.height / 2,
+      targetId,
+    };
+  }, { args: [selector, identityKey] });
+};
+
+const clearClickIdentityState = async (
+  page: Page,
+  identityKey: string,
+): Promise<void> => {
+  await page.evaluate((key: string) => {
+    delete (globalThis as unknown as Record<string, unknown>)[key];
+  }, { args: [identityKey] });
 };
 
 /**
@@ -1088,9 +1175,10 @@ export interface ClickMark {
  * target through its own predicate, and the aim/click/untag tail is the same
  * for all of them.
  *
- * One wait settles the control and measures where to click it; one dispatch
- * follows. Nothing separates the measurement from the decision that produced
- * it, so the coordinates describe the control as the wait left it.
+ * One wait settles the control and measures where to click it. The point is
+ * measured again in one page turn immediately before the trusted click, after
+ * any interaction observer has finished. A moved or missing target goes
+ * through the same settle and replacement handling before dispatch.
  */
 export async function clickMarked(
   page: Page,
@@ -1098,44 +1186,80 @@ export async function clickMarked(
 ): Promise<void> {
   const { token, remark } = typeof mark === "string" ? { token: mark } : mark;
   const markSelector = `[${CLICK_TARGET_ATTR}~="${token}"]`;
+  const identityKey = `__commonToolsClickIdentity_${crypto.randomUUID()}`;
   try {
-    let aim: ClickAim | undefined;
-    try {
-      aim = await waitForCondition(page, aimAtMarkedTarget, {
-        args: [
+    const measureAim = async (): Promise<{
+      x: number;
+      y: number;
+      targetId: number;
+    }> => {
+      let aim: ClickAim | undefined;
+      try {
+        aim = await waitForCondition(page, aimAtMarkedTarget, {
+          args: [
+            markSelector,
+            remark ? remark.predicate.toString() : null,
+            remark ? remark.args : [],
+            identityKey,
+          ],
+        });
+      } catch (cause) {
+        const probe = await readTextProbe(page, markSelector).catch(() =>
+          undefined
+        );
+        const progress = await readAimProgress(page, markSelector).catch(() =>
+          undefined
+        );
+        throw new Error(
+          `Marked click target ${markSelector} never presented a stable box. ` +
+            `Aim reached: ${toIndentedDebugString(progress)}. ` +
+            `Last probe: ${toIndentedDebugString(probe)}`,
+          { cause },
+        );
+      }
+      if (aim === undefined || "missing" in aim) {
+        const probe = await readTextProbe(page, markSelector).catch(() =>
+          undefined
+        );
+        throw new Error(
+          `The control marked for click was replaced before the click could ` +
+            `be aimed at it${
+              aim?.sawTarget ? " while its box was settling" : ""
+            }. Last probe: ${toIndentedDebugString(probe)}`,
+        );
+      }
+      return aim;
+    };
+
+    const aim = await measureAim();
+    await page.clickPoint({ x: aim.x, y: aim.y }, {
+      refreshPoint: async () => {
+        const current = await readMarkedClickPoint(
+          page,
           markSelector,
-          remark ? remark.predicate.toString() : null,
-          remark ? remark.args : [],
-        ],
-      });
-    } catch (cause) {
-      const probe = await readTextProbe(page, markSelector).catch(() =>
-        undefined
-      );
-      const progress = await readAimProgress(page, markSelector).catch(() =>
-        undefined
-      );
-      throw new Error(
-        `Marked click target ${markSelector} never presented a stable box. ` +
-          `Aim reached: ${toIndentedDebugString(progress)}. ` +
-          `Last probe: ${toIndentedDebugString(probe)}`,
-        { cause },
-      );
-    }
-    if (aim === undefined || "missing" in aim) {
-      const probe = await readTextProbe(page, markSelector).catch(() =>
-        undefined
-      );
-      throw new Error(
-        `The control marked for click was replaced before the click could be ` +
-          `aimed at it${
-            aim?.sawTarget ? " while its box was settling" : ""
-          }. Last probe: ${toIndentedDebugString(probe)}`,
-      );
-    }
-    await page.clickPoint(aim);
+          identityKey,
+        );
+        if (
+          current?.targetId === aim.targetId && current.x === aim.x &&
+          current.y === aim.y
+        ) {
+          return { x: current.x, y: current.y };
+        }
+        if (remark) {
+          await clearClickMark(page, token);
+          await waitForCondition(page, remark.predicate, {
+            args: [...remark.args],
+          });
+        }
+        const settled = await measureAim();
+        return { x: settled.x, y: settled.y };
+      },
+    });
   } finally {
-    await clearClickMark(page, token).catch(() => {});
+    await Promise.all([
+      clearClickMark(page, token).catch(() => {}),
+      clearClickIdentityState(page, identityKey).catch(() => {}),
+    ]);
   }
 }
 


### PR DESCRIPTION
A marked control can move or rebuild while a presentation observer animates its cursor between the readiness check and the trusted mouse dispatch. The old coordinates can then land on empty space or the wrong control, leaving the requested action unhandled.

Settle and measure marked controls inside the page, then refresh the point after the before-click observer finishes. Track same-position replacements, clear stale marks before applying the caller's selector again, and rerun the caller's readiness check when the target changes. Keep identity bookkeeping private to one click and remove it afterward.

Use the final dispatch point for the presentation cursor. Add deterministic coverage for moved, replaced, and retargeted controls while preserving native pointer behavior and page state. Document the final click-settling behavior.

deflaked by Hixie's agent Agent: OpenAI Codex (GPT-5)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

