### PR TITLE
feat(data-model): a `CodecRegistry` can be frozen, and extended without mutation

### DIFF
--- a/packages/data-model/src/codec-common/CodecRegistry.ts
+++ b/packages/data-model/src/codec-common/CodecRegistry.ts
@@ -1,5 +1,9 @@
 import type { FabricValue } from "@/interface.ts";
-import type { FabricCodec } from "./interface.ts";
+import {
+  CODEC,
+  type FabricClassWithCodec,
+  type FabricCodec,
+} from "./interface.ts";
 import type { Constructor } from "@commonfabric/utils/types";
 
 /**
@@ -54,6 +58,12 @@ function constructorOf(
 /**
  * Registry of `FabricCodec`s. Provides tag-based lookup for decoding, and
  * primitive-type and class matching for encoding.
+ *
+ * An instance is mutable while it is being built and immutable once
+ * `Object.freeze()`d: every mutator refuses on a frozen instance. Freezing is
+ * how a registry becomes safe to hand out, since a codec holds the registry it
+ * was constructed with and would otherwise see a later registration. Use
+ * {@link #extend} to build on one that is already frozen.
  */
 export class CodecRegistry {
   /** Tag -> codec map for O(1) decode dispatch. */
@@ -75,6 +85,8 @@ export class CodecRegistry {
    * note that a codec with no `uniqueHandledClass` is unreachable for encoding.
    */
   register(codec: FabricCodec): void {
+    this.#assertNotFrozen();
+
     const uniqueClass = codec.uniqueHandledClass;
     if (uniqueClass !== undefined) {
       this.#classMap.set(uniqueClass, codec);
@@ -92,6 +104,8 @@ export class CodecRegistry {
    * (for O(1) encode dispatch on primitives).
    */
   registerPrimitive(type: PrimitiveTypeName, codec: FabricCodec): void {
+    this.#assertNotFrozen();
+
     this.#primitiveCodecs.set(type, codec);
 
     const tag = codec.recognizedTypeTag;
@@ -109,7 +123,53 @@ export class CodecRegistry {
    * codec); the codec is tried first.
    */
   registerSelfRep(type: PrimitiveTypeName): void {
+    this.#assertNotFrozen();
+
     this.#selfRepTypes.add(type);
+  }
+
+  /**
+   * Creates a frozen copy of this instance with the given classes' codecs
+   * additionally registered. This instance is left untouched, so a shared
+   * registry can be built on without being altered, and the result is frozen
+   * so that it in turn can be shared.
+   *
+   * This is the intended way to add classes to a registry someone else
+   * assembled: extending what a factory returns is what keeps a caller from
+   * omitting, by accident, everything that factory put there.
+   *
+   * @param classes Classes whose static `[CODEC]` is to be registered.
+   */
+  extend(classes: readonly FabricClassWithCodec[]): CodecRegistry {
+    const result = new CodecRegistry();
+
+    for (const [key, value] of this.#tagMap) result.#tagMap.set(key, value);
+    for (const [key, value] of this.#classMap) result.#classMap.set(key, value);
+    for (const [key, value] of this.#primitiveCodecs) {
+      result.#primitiveCodecs.set(key, value);
+    }
+    for (const type of this.#selfRepTypes) result.#selfRepTypes.add(type);
+
+    for (const cls of classes) {
+      result.register(cls[CODEC]);
+    }
+
+    // Frozen as a statement rather than by returning `Object.freeze()`'s
+    // result, whose `Readonly<CodecRegistry>` type drops the private-field
+    // brand and so is not assignable back to `CodecRegistry`.
+    Object.freeze(result);
+    return result;
+  }
+
+  /**
+   * Guards a mutator against a frozen instance.
+   *
+   * @throws If this instance is frozen.
+   */
+  #assertNotFrozen(): void {
+    if (Object.isFrozen(this)) {
+      throw new Error("Cannot modify frozen CodecRegistry");
+    }
   }
 
   /**

--- a/packages/data-model/src/codec-json/JsonCodec.ts
+++ b/packages/data-model/src/codec-json/JsonCodec.ts
@@ -4,7 +4,6 @@ import { utf8SortedKeysOf } from "@commonfabric/utils/utf8";
 import { FabricSpecialObject, type FabricValue } from "@/interface.ts";
 import { toCompactDebugString } from "@/value-debug.ts";
 import {
-  CODEC,
   type ReconstructionContext,
   type SerializationContext,
 } from "@/codec-common/interface.ts";
@@ -459,12 +458,8 @@ export class JsonCodec implements SerializationContext<string> {
    * A helper drawing on a fuller registry would instead accept or reject text
    * according to a roster its caller never chose.
    */
-  static readonly #testingRegistry: CodecRegistry = (() => {
-    const registry = createBaseJsonRegistry();
-    registry.register(UnknownValue[CODEC]);
-    registry.register(ProblematicValue[CODEC]);
-    return registry;
-  })();
+  static readonly #testingRegistry: CodecRegistry = createBaseJsonRegistry()
+    .extend([UnknownValue, ProblematicValue]);
 
   /**
    * Reconstruction context for the throwaway checks in the testing helpers

--- a/packages/data-model/src/codec-json/createBaseJsonRegistry.ts
+++ b/packages/data-model/src/codec-json/createBaseJsonRegistry.ts
@@ -25,6 +25,9 @@ import { CodecRegistry } from "@/codec-common/CodecRegistry.ts";
  * Another wire format makes different choices here, which is what separates
  * this from the class rosters it gets combined with: those stay the same
  * whatever the format.
+ *
+ * The result is frozen, so add classes with `CodecRegistry.extend()` rather
+ * than by registering onto it.
  */
 export function createBaseJsonRegistry(): CodecRegistry {
   const registry = new CodecRegistry();
@@ -44,5 +47,6 @@ export function createBaseJsonRegistry(): CodecRegistry {
   registry.registerSelfRep("number");
   registry.registerSelfRep("string");
 
+  Object.freeze(registry);
   return registry;
 }

--- a/packages/data-model/src/codecs.ts
+++ b/packages/data-model/src/codecs.ts
@@ -15,7 +15,7 @@
 import { isInstance } from "@commonfabric/utils/types";
 
 import type { FabricValue } from "./fabric-value.ts";
-import { CODEC, type ReconstructionContext } from "./codec-common/interface.ts";
+import type { ReconstructionContext } from "./codec-common/interface.ts";
 import { EmptyReconstructionContext } from "./codec-common/EmptyReconstructionContext.ts";
 import type { CodecRegistry } from "./codec-common/CodecRegistry.ts";
 import { JsonCodec } from "./codec-json/JsonCodec.ts";
@@ -40,16 +40,10 @@ import { codecClasses as instanceCodecClasses } from "./fabric-instances/index.t
  * `UnknownValue` by the encoding context rather than tag-routed.
  */
 export function createDefaultJsonRegistry(): CodecRegistry {
-  const registry = createBaseJsonRegistry();
-
-  for (const cls of primitiveCodecClasses()) {
-    registry.register(cls[CODEC]);
-  }
-  for (const cls of instanceCodecClasses()) {
-    registry.register(cls[CODEC]);
-  }
-
-  return registry;
+  return createBaseJsonRegistry().extend([
+    ...primitiveCodecClasses(),
+    ...instanceCodecClasses(),
+  ]);
 }
 
 /**

--- a/packages/data-model/test/codec-common/CodecRegistry.test.ts
+++ b/packages/data-model/test/codec-common/CodecRegistry.test.ts
@@ -6,7 +6,11 @@ import type { Constructor } from "@commonfabric/utils/types";
 import { toCompactDebugString } from "@/value-debug.ts";
 import { CodecRegistry, SELF_REP } from "@/codec-common/CodecRegistry.ts";
 import { BaseFabricCodec } from "@/codec-common/BaseFabricCodec.ts";
-import type { ReconstructionContext } from "@/codec-common/interface.ts";
+import {
+  CODEC,
+  type FabricClassWithCodec,
+  type ReconstructionContext,
+} from "@/codec-common/interface.ts";
 import { UnknownValue } from "@/fabric-instances/UnknownValue.ts";
 import { FabricRegExp } from "@/fabric-primitives/FabricRegExp.ts";
 import { type FabricValue } from "@/interface.ts";
@@ -166,6 +170,89 @@ describe("CodecRegistry", () => {
       registry.registerSelfRep("number");
       expect(registry.codecFromValue(42)).toBe(codec); // codec match
       expect(registry.codecFromValue(99)).toBe(SELF_REP); // self-rep fallback
+    });
+  });
+
+  describe("`extend()`", () => {
+    // A class whose static `[CODEC]` is a `TestCodec`, which is what
+    // `extend()` accepts.
+    function classWithCodec(tag: string): FabricClassWithCodec {
+      const codec = new TestCodec(tag, undefined);
+      return {
+        get [CODEC]() {
+          return codec;
+        },
+      };
+    }
+
+    it("returns a different instance", () => {
+      const base = new CodecRegistry();
+      expect(base.extend([])).not.toBe(base);
+    });
+
+    it("returns a frozen instance", () => {
+      expect(Object.isFrozen(new CodecRegistry().extend([]))).toBe(true);
+    });
+
+    it("carries over every kind of registration the base holds", () => {
+      const base = new CodecRegistry();
+      const codec = new TestCodec("carried@1", undefined);
+      const primitive = new TestCodec("prim@1", undefined);
+      base.register(codec);
+      base.registerPrimitive("bigint", primitive);
+      base.registerSelfRep("string");
+
+      const extended = base.extend([]);
+
+      expect(extended.codecFromTag("carried@1")).toBe(codec);
+      expect(extended.codecFromTag("prim@1")).toBe(primitive);
+      expect(extended.codecFromValue("florp")).toBe(SELF_REP);
+    });
+
+    it("registers the given classes' codecs", () => {
+      const added = classWithCodec("added@1");
+      const extended = new CodecRegistry().extend([added]);
+
+      expect(extended.codecFromTag("added@1")).toBe(added[CODEC]);
+    });
+
+    it("leaves the base without the added registrations", () => {
+      const base = new CodecRegistry();
+      base.extend([classWithCodec("added@1")]);
+
+      expect(base.codecFromTag("added@1")).toBe(undefined);
+    });
+  });
+
+  describe("frozen instances", () => {
+    // `Object.freeze()` cannot reach a private `Map` or `Set`, so each mutator
+    // has to refuse on its own; these cases pin that each one does.
+    it("`register()` throws", () => {
+      const registry = Object.freeze(new CodecRegistry());
+      expect(() => registry.register(new TestCodec("nope@1", undefined)))
+        .toThrow("Cannot modify frozen CodecRegistry");
+    });
+
+    it("`registerPrimitive()` throws", () => {
+      const registry = Object.freeze(new CodecRegistry());
+      expect(() =>
+        registry.registerPrimitive("bigint", new TestCodec("nope@1", undefined))
+      ).toThrow("Cannot modify frozen CodecRegistry");
+    });
+
+    it("`registerSelfRep()` throws", () => {
+      const registry = Object.freeze(new CodecRegistry());
+      expect(() => registry.registerSelfRep("string"))
+        .toThrow("Cannot modify frozen CodecRegistry");
+    });
+
+    it("still answers lookups", () => {
+      const base = new CodecRegistry();
+      const codec = new TestCodec("readable@1", undefined);
+      base.register(codec);
+      Object.freeze(base);
+
+      expect(base.codecFromTag("readable@1")).toBe(codec);
     });
   });
 

--- a/packages/data-model/test/codec-json/createBaseJsonRegistry.test.ts
+++ b/packages/data-model/test/codec-json/createBaseJsonRegistry.test.ts
@@ -1,0 +1,46 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { createBaseJsonRegistry } from "@/codec-json/createBaseJsonRegistry.ts";
+import { SELF_REP } from "@/codec-common/CodecRegistry.ts";
+import { FabricError } from "@/fabric-instances/FabricError.ts";
+
+describe("createBaseJsonRegistry", () => {
+  it("returns a frozen registry", () => {
+    expect(Object.isFrozen(createBaseJsonRegistry())).toBe(true);
+  });
+
+  it("returns a registry that refuses further registration", () => {
+    expect(() => createBaseJsonRegistry().registerSelfRep("string"))
+      .toThrow("Cannot modify frozen CodecRegistry");
+  });
+
+  it("returns a fresh registry on each call", () => {
+    expect(createBaseJsonRegistry()).not.toBe(createBaseJsonRegistry());
+  });
+
+  it("registers the four types JSON cannot carry", () => {
+    const registry = createBaseJsonRegistry();
+
+    expect(registry.codecFromValue(1n)).toBeDefined();
+    expect(registry.codecFromValue(NaN)).toBeDefined();
+    expect(registry.codecFromValue(Symbol.for("florp"))).toBeDefined();
+    expect(registry.codecFromValue(undefined)).toBeDefined();
+  });
+
+  it("reports the JSON scalars as self-representing", () => {
+    const registry = createBaseJsonRegistry();
+
+    expect(registry.codecFromValue(null)).toBe(SELF_REP);
+    expect(registry.codecFromValue(true)).toBe(SELF_REP);
+    expect(registry.codecFromValue(1)).toBe(SELF_REP);
+    expect(registry.codecFromValue("florp")).toBe(SELF_REP);
+  });
+
+  it("registers no fabric class", () => {
+    const registry = createBaseJsonRegistry();
+    const value = FabricError.fromNativeError(new Error("boom"));
+
+    expect(registry.codecFromValue(value)).toBe(undefined);
+  });
+});

--- a/packages/data-model/test/codecs.test.ts
+++ b/packages/data-model/test/codecs.test.ts
@@ -1,7 +1,12 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
-import { jsonFromValue, plainObjectFromJson, valueFromJson } from "@/codecs.ts";
+import {
+  createDefaultJsonRegistry,
+  jsonFromValue,
+  plainObjectFromJson,
+  valueFromJson,
+} from "@/codecs.ts";
 import { seemsLikeJsonEncodedFabricValue } from "@/codec-json/impl.ts";
 import { JsonCodec } from "@/codec-json/JsonCodec.ts";
 import { FabricError } from "@/fabric-instances/FabricError.ts";
@@ -38,6 +43,21 @@ function expectWireFormat(value: FabricValue, expected: unknown): void {
 }
 
 describe("codecs", () => {
+  describe("`createDefaultJsonRegistry()`", () => {
+    it("returns a frozen registry", () => {
+      expect(Object.isFrozen(createDefaultJsonRegistry())).toBe(true);
+    });
+
+    it("registers this package's fabric classes on top of the base", () => {
+      const registry = createDefaultJsonRegistry();
+      const value = FabricError.fromNativeError(new Error("boom"));
+
+      // The base alone reports `undefined` here; see
+      // `createBaseJsonRegistry.test.ts`.
+      expect(registry.codecFromValue(value)).toBeDefined();
+    });
+  });
+
   it("round-trips `undefined`", () => {
     expect(roundTrip(undefined)).toBe(undefined);
   });


### PR DESCRIPTION
I (agent working on behalf of @danfuzz) am closing the immutability gap left
open when the registry became public API. A registry now crosses package
boundaries, and a `JsonCodec` holds the one it was constructed with — but
nothing stopped a caller registering onto a registry a live codec was already
using.

## Two halves, and they need each other

**`Object.freeze()` is the signal; the class enforces it.** `register()`,
`registerPrimitive()` and `registerSelfRep()` each call `#assertNotFrozen()`,
matching what `FabricError` already does for its private extras `Map`. Freezing
on its own would do nothing here: the state is four *private* fields, and
`Object.freeze()` reaches neither a private field nor the contents of a `Map`
or `Set`.

**`extend(classes)` is what makes the guarantee usable.** It copies this
registry's registrations into a new one, adds the given classes' codecs, and
freezes the result before returning. Nothing shared is mutated, and what comes
back is itself safe to share.

Neither half is much good alone. Without the guard, freezing is decorative;
without `extend()`, freezing just makes a registry a dead end.

## It has real customers immediately

`createBaseJsonRegistry()` now freezes what it returns, so the two places that
built on it *have* to change:

- `createDefaultJsonRegistry()` adds the two class rosters via `extend()`.
- `JsonCodec`'s testing registry adds its two fallback classes via `extend()`.

Which is also the shape we want for anyone adding classes of their own:
extending what a factory returns is what stops a caller omitting, by accident,
everything that factory put there.

## Verification

Eleven new cases, and **three ablations, each against a distinct claim**:

| ablation | result |
|---|---|
| drop the three `#assertNotFrozen()` calls | 2 test files red |
| make `extend()` also register onto `this` | 8 red — the base is frozen, so the mutation it exists to avoid throws outright |
| remove the freeze from `createBaseJsonRegistry()` | 1 red |

Restoring returns to 51 files / 2282 steps / 0 failed. A green suite would not
have distinguished any of these on its own.

Full workspace suite green (40 packages, 294s, `cli` included now that `main`
is fixed), plus `fmt --check`, `lint`, `check`, `check-docs`,
`check-conflict-markers`, `check-skill-facts`, `check-no-waitfor`,
`check-unused-deps`, `check-single-copy-deps`.

## One implementation note

`extend()` freezes as a statement rather than returning `Object.freeze(result)`
— that call's `Readonly<CodecRegistry>` type drops the private-field brand and
is not assignable back to `CodecRegistry`. The comment in the code says so, as
it is the sort of thing someone would otherwise "simplify".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WXGpwWEeCPdgHeH1zhrrz3


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

