### PR TITLE
feat(data-model): add `backtickQuote()`, and quote rendered values with it

### DIFF
--- a/packages/data-model/src/value-clone.ts
+++ b/packages/data-model/src/value-clone.ts
@@ -4,7 +4,7 @@ import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { FabricInstance, FabricValue } from "./interface.ts";
 import { NATIVE_TAGS, tagFromNativeValue } from "./native-type-tags.ts";
 import { deepFreeze, isDeepFrozenFabricValue } from "./deep-freeze.ts";
-import { toDebugKindString } from "./value-debug.ts";
+import { backtickQuote, toDebugKindString } from "./value-debug.ts";
 
 /** Options for `cloneIfNecessary()`. */
 export interface CloneOptions {
@@ -454,7 +454,7 @@ export function cloneForMutation<T extends FabricValue>(
         -1,
         toDebugKindString(value),
         `\`cloneForMutation()\`: cannot mutate ${
-          toDebugKindString(value)
+          backtickQuote(toDebugKindString(value))
         } at root ` +
           `(empty path)`,
       );
@@ -472,7 +472,7 @@ export function cloneForMutation<T extends FabricValue>(
       -1,
       toDebugKindString(value),
       `\`cloneForMutation()\`: cannot descend into ${
-        toDebugKindString(value)
+        backtickQuote(toDebugKindString(value))
       } at ` +
         `root (path has ${path.length} segment${path.length === 1 ? "" : "s"})`,
     );
@@ -521,10 +521,10 @@ export function cloneForMutation<T extends FabricValue>(
           "non-mutable-leaf",
           i,
           toDebugKindString(next),
-          `cloneForMutation: cannot mutate ${
-            toDebugKindString(next)
+          `\`cloneForMutation()\`: cannot mutate ${
+            backtickQuote(toDebugKindString(next))
           } at path ` +
-            `index ${i} (final segment)`,
+            `index \`${i}\` (final segment)`,
         );
       }
     } else {
@@ -533,10 +533,10 @@ export function cloneForMutation<T extends FabricValue>(
           "non-container-descent",
           i,
           toDebugKindString(next),
-          `cloneForMutation: cannot descend into ${
-            toDebugKindString(next)
+          `\`cloneForMutation()\`: cannot descend into ${
+            backtickQuote(toDebugKindString(next))
           } at ` +
-            `path index ${i}`,
+            `path index \`${i}\``,
         );
       }
     }

--- a/packages/data-model/src/value-debug.ts
+++ b/packages/data-model/src/value-debug.ts
@@ -306,3 +306,41 @@ export function toDebugKindString(value: unknown): string {
   if (isPlainObject(value)) return "object";
   return value.constructor?.name ?? "object";
 }
+
+/**
+ * Quotes `text` as a Markdown code span, choosing a delimiter and padding that
+ * survive whatever `text` itself holds. Reach for this whenever a rendered
+ * value is spliced into an error or log message: message text in this project
+ * is Markdown, a rendering can hold a backtick run of any length, and a
+ * hand-written pair of backticks around one produces a span that ends early or
+ * loses its edges.
+ *
+ * Two limits are worth knowing. An empty `text` comes back as a bare pair of
+ * backticks, because Markdown has no way to spell an empty code span. And a
+ * code span is a single line -- a reader turns every line ending inside one
+ * into a space -- so a multi-line rendering wants a fenced block instead.
+ */
+export function backtickQuote(text: string): string {
+  // A code span's delimiter must be a longer backtick run than any inside it,
+  // or the content closes the span early.
+  let longestRun = 0;
+  let run = 0;
+  for (const ch of text) {
+    run = (ch === "`") ? (run + 1) : 0;
+    longestRun = Math.max(longestRun, run);
+  }
+
+  // A reader drops one leading and one trailing space from a span that has
+  // both, unless the span is all spaces. A space on each side therefore buys
+  // back an edge that would otherwise be lost: a backtick that would merge
+  // into the delimiter, or a space of the content's own that the reader would
+  // take for padding.
+  const allSpaces = (text.length !== 0) && !/[^ ]/.test(text);
+  const padded = !allSpaces &&
+    (text.startsWith("`") || text.endsWith("`") ||
+      (text.startsWith(" ") && text.endsWith(" ")));
+  const pad = padded ? " " : "";
+  const delimiter = "`".repeat(longestRun + 1);
+
+  return `${delimiter}${pad}${text}${pad}${delimiter}`;
+}

--- a/packages/data-model/src/value-debug.ts
+++ b/packages/data-model/src/value-debug.ts
@@ -324,10 +324,8 @@ export function backtickQuote(text: string): string {
   // A code span's delimiter must be a longer backtick run than any inside it,
   // or the content closes the span early.
   let longestRun = 0;
-  let run = 0;
-  for (const ch of text) {
-    run = (ch === "`") ? (run + 1) : 0;
-    longestRun = Math.max(longestRun, run);
+  for (const [run] of text.matchAll(/`+/g)) {
+    longestRun = Math.max(longestRun, run.length);
   }
 
   // A reader drops one leading and one trailing space from a span that has

--- a/packages/data-model/src/valueEqual.ts
+++ b/packages/data-model/src/valueEqual.ts
@@ -7,7 +7,7 @@ import {
   type FabricValue,
 } from "./interface.ts";
 import { hashStringOf } from "./value-hash.ts";
-import { toCompactDebugString } from "./value-debug.ts";
+import { backtickQuote, toCompactDebugString } from "./value-debug.ts";
 
 /**
  * Compares two `FabricValue`s for logical (content) equality.
@@ -146,6 +146,8 @@ function objectSubtypeOf(
   } else if (isPlainObject(value)) {
     return "plain";
   } else {
-    throw new Error(`Cannot compare value ${toCompactDebugString(value)}`);
+    throw new Error(
+      `Cannot compare value ${backtickQuote(toCompactDebugString(value))}`,
+    );
   }
 }

--- a/packages/data-model/test/value-debug.test.ts
+++ b/packages/data-model/test/value-debug.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
 import {
+  backtickQuote,
   toCompactDebugString,
   toDebugKindString,
   toIndentedDebugString,
@@ -12,6 +13,32 @@ import { FabricError } from "@/fabric-instances/FabricError.ts";
 import { FabricMap } from "@/fabric-instances/FabricMap.ts";
 import { FabricRegExp } from "@/fabric-primitives/FabricRegExp.ts";
 import { FabricSpecialObject } from "@/interface.ts";
+
+/**
+ * Reads one Markdown code span: the opening and closing delimiters are
+ * equal-length backtick runs, and a reader drops one leading and one trailing
+ * space when the content has both and is not all spaces.
+ *
+ * Written from the specification rather than from `backtickQuote()`, so that
+ * the round-trip test has an independent other half.
+ */
+function parseCodeSpan(markdown: string): string {
+  const open = /^`+/.exec(markdown)?.[0];
+  const close = /`+$/.exec(markdown)?.[0];
+
+  if ((open === undefined) || (close === undefined)) {
+    throw new Error(`Not a code span: ${markdown}`);
+  } else if (open.length !== close.length) {
+    throw new Error(`Mismatched delimiters: ${markdown}`);
+  }
+
+  const content = markdown.slice(open.length, markdown.length - close.length);
+
+  return (content.startsWith(" ") && content.endsWith(" ") &&
+      /[^ ]/.test(content))
+    ? content.slice(1, -1)
+    : content;
+}
 
 describe("value-debug", () => {
   describe("toCompactDebugString", () => {
@@ -486,6 +513,67 @@ describe("value-debug", () => {
       // fallback.
       const weird = Object.create({ constructor: undefined as unknown });
       expect(toDebugKindString(weird)).toBe("object");
+    });
+  });
+
+  describe("backtickQuote()", () => {
+    it("wraps ordinary text in a single pair of backticks", () => {
+      expect(backtickQuote("hello")).toBe("`hello`");
+      expect(backtickQuote("a b c")).toBe("`a b c`");
+    });
+
+    it("returns a bare pair of backticks for empty text", () => {
+      expect(backtickQuote("")).toBe("``");
+    });
+
+    it("uses a longer delimiter than the longest run inside", () => {
+      expect(backtickQuote("a`b")).toBe("``a`b``");
+      expect(backtickQuote("a``b")).toBe("```a``b```");
+      expect(backtickQuote("a```b``c")).toBe("````a```b``c````");
+    });
+
+    it("pads when the text starts or ends with a backtick", () => {
+      expect(backtickQuote("`x")).toBe("`` `x ``");
+      expect(backtickQuote("x`")).toBe("`` x` ``");
+      expect(backtickQuote("`")).toBe("`` ` ``");
+    });
+
+    it("pads when the text both starts and ends with a space", () => {
+      expect(backtickQuote(" x ")).toBe("`  x  `");
+    });
+
+    it("does not pad when only one end is a space", () => {
+      expect(backtickQuote(" x")).toBe("` x`");
+      expect(backtickQuote("x ")).toBe("`x `");
+    });
+
+    it("does not pad all-space text, which a reader leaves alone", () => {
+      expect(backtickQuote(" ")).toBe("` `");
+      expect(backtickQuote("   ")).toBe("`   `");
+    });
+
+    it("round-trips through a Markdown reader", () => {
+      // The property that matters: parsing the result yields back the input.
+      for (
+        const text of [
+          "hello",
+          "a`b",
+          "a``b",
+          "`x",
+          "x`",
+          "`",
+          "``",
+          " x ",
+          " x",
+          "x ",
+          " ",
+          "   ",
+          '{"a":1}',
+          "Symbol(`odd`)",
+        ]
+      ) {
+        expect(parseCodeSpan(backtickQuote(text))).toBe(text);
+      }
     });
   });
 });

--- a/packages/piece/test/state-continuity-harness.ts
+++ b/packages/piece/test/state-continuity-harness.ts
@@ -1058,7 +1058,7 @@ export interface StateFinding {
  *
  * `deepEqual` rather than the data-model's `valueEqual`, which is the more
  * obvious choice. `valueEqual` refuses a materialized root outright — measured,
- * it throws `Cannot compare value {"/":{"link@1":{…}}}` — but NOT for the
+ * it throws ``Cannot compare value `{"/":{"link@1":{…}}}` `` — but NOT for the
  * reason that message reads as: a link sigil compares fine, and the value it
  * actually refused was a live CELL, rendered through its `toJSON()` and so
  * printed as the sigil it points at. That is the same fact `comparableState`


### PR DESCRIPTION
I (agent working on behalf of @danfuzz) added `backtickQuote()` to
`value-debug.ts` and used it at the sites that splice a rendered value into a
message.

The prompt for this was a gap left by the message-conformance pass: I declined
to backtick a `toCompactDebugString()` result there, on the grounds that a code
span would misrepresent a whole rendered value. That reasoning was only half
right. A code span is the correct markup — message text in this project is
Markdown — but the *hand-written pair of backticks* is what cannot be trusted,
because a rendering is arbitrary text and one holding a backtick closes the span
early or loses an edge.

## The function

```ts
backtickQuote("hello")   // `hello`
backtickQuote("a``b")    // ```a``b```
backtickQuote("`x")      // `` `x ``
backtickQuote(" x ")     // `  x  `
```

Two rules, both from CommonMark:

* The delimiter is a backtick run longer than the longest run inside the text,
  or the text closes the span early.
* A reader drops one leading and one trailing space from a span that has both,
  unless the span is all spaces. So a space inside each delimiter buys back an
  edge that would otherwise be lost — either a backtick merging into the
  delimiter, or a space of the text's own that the reader would take for
  padding.

The second rule is the one that is not guessable, and it is why
`` `Object.create(`null`)` `` (the defect cubic caught in #5572) is not fixable
by "add more backticks".

Two limits are documented on the function rather than papered over. Empty text
comes back as a bare pair of backticks, because Markdown has no way to spell an
empty code span. And a code span is a single line — a reader turns line endings
inside one into spaces — so a multi-line rendering wants a fenced block instead.

## Where it is used

Five sites, all in `data-model`:

* `valueEqual()`'s refusal, which interpolates `toCompactDebugString()`. This is
  the site I previously declined.
* The four `cloneForMutation()` failures, which interpolate
  `toDebugKindString()` — whose own doc comment already illustrates its result
  *inside* backticks, so this is what it was asking for.

## A gap in #5575, fixed here

Two of those four `cloneForMutation()` messages still read `cloneForMutation:`
rather than `` `cloneForMutation()` ``, and left their path index unquoted. The
message-conformance pass reached the other two and missed these: `deno fmt` had
wrapped them across lines differently, and the substitution matched on exact
text, so two textually-distinct copies of the same message went by.

One comment in `packages/piece` quotes the `valueEqual()` message verbatim and
moves in step.

## Verification

Nine new tests. The round-trip case parses the output with a code-span reader
written from the Markdown specification rather than from `backtickQuote()`, so
the two halves of the property are stated independently — a parser derived from
the implementation would agree with it no matter what either did.

`deno task test`: `data-model` ok, 50 passed (2271 steps); `runner` ok, 1171
passed (6183 steps); `piece` ok, 36 passed (407 steps). Repo-wide
`deno fmt --check`, `deno lint`, `check-docs`, `check-conflict-markers`, and
`check-no-waitfor` are clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

