### PR TITLE
fix(shell): show space and piece load failures

### DIFF
--- a/packages/shell/integration/load-errors.test.ts
+++ b/packages/shell/integration/load-errors.test.ts
@@ -1,0 +1,153 @@
+import { env, waitForCondition } from "@commonfabric/integration";
+import { ShellIntegration } from "@commonfabric/integration/shell-utils";
+import { Identity } from "@commonfabric/identity";
+import { NotificationType } from "@commonfabric/runtime-client";
+import { describe, it } from "@std/testing/bdd";
+import "../src/globals.ts";
+
+const { FRONTEND_URL, SPACE_NAME } = env;
+
+describe("shell load errors", () => {
+  const shell = new ShellIntegration({
+    allowedConsoleErrors: [
+      "[AppView] Failed to load space root pattern:",
+      "[AppView] Failed to load selected piece:",
+      "[RuntimeClient Error]",
+    ],
+  });
+  shell.bindLifecycle();
+
+  it("shows an informative alert when a space cannot be loaded", async () => {
+    const page = shell.page();
+    const identity = await Identity.generate({ implementation: "noble" });
+
+    await shell.goto({
+      frontendUrl: FRONTEND_URL,
+      view: { spaceDid: identity.did() },
+      identity,
+    });
+    await page.evaluate(async () => {
+      const root = document.querySelector("x-root-view");
+      const appView = root?.shadowRoot?.querySelector("x-app-view") as
+        | {
+          rt?: {
+            getSpaceRootPattern: (...args: unknown[]) => Promise<unknown>;
+          };
+          _spaceRootPattern?: {
+            run(): void;
+            taskComplete: Promise<unknown>;
+          };
+        }
+        | null;
+      const runtime = appView?.rt;
+      const task = appView?._spaceRootPattern;
+      if (!runtime || !task) throw new Error("App view was not ready");
+
+      const getSpaceRootPattern = runtime.getSpaceRootPattern;
+      runtime.getSpaceRootPattern = () =>
+        Promise.reject(new Error("Space storage is unavailable"));
+      try {
+        task.run();
+        await task.taskComplete;
+      } catch {
+        // The task's error state is the condition this test renders.
+      } finally {
+        runtime.getSpaceRootPattern = getSpaceRootPattern;
+      }
+    });
+
+    await waitForCondition(
+      page,
+      (probe) =>
+        probe.collect(".load-error").some((element) => {
+          const text = probe.deepText(element).replace(/\s+/g, " ").trim();
+          return text.includes("We could not load this space") &&
+            text.includes("Space storage is unavailable");
+        }),
+    );
+    await waitForCondition(
+      page,
+      (probe) => probe.collect('[role="alert"]').length === 1,
+    );
+  });
+
+  it("shows an informative alert when a piece cannot be loaded", async () => {
+    const page = shell.page();
+    const identity = await Identity.generate({ implementation: "noble" });
+
+    await shell.goto({
+      frontendUrl: FRONTEND_URL,
+      view: {
+        spaceName: SPACE_NAME,
+        pieceId: "fid1:missing:piece",
+      },
+      identity,
+    });
+
+    await waitForCondition(
+      page,
+      (probe) =>
+        probe.collect(".load-error").some((element) => {
+          const text = probe.deepText(element).replace(/\s+/g, " ").trim();
+          return text.includes("We could not load this piece") &&
+            text.includes("Error details");
+        }),
+    );
+    await waitForCondition(
+      page,
+      (probe) => probe.collect('[role="alert"]').length === 1,
+    );
+    await waitForCondition(
+      page,
+      (probe) =>
+        probe.collect(".load-error-details code").some((element) =>
+          probe.deepText(element).trim().length > 0
+        ),
+    );
+  });
+
+  it("shows an asynchronous runtime failure for the selected piece", async () => {
+    const page = shell.page();
+    const identity = await Identity.generate({ implementation: "noble" });
+    const pieceId = "fid1:UagUTyzWNqugXzSpu3JH4Sso9lF_tmGQgwtdIL87mZs";
+
+    await shell.goto({
+      frontendUrl: FRONTEND_URL,
+      view: { spaceDid: identity.did(), pieceId },
+      identity,
+    });
+    await page.evaluate((type, pieceId, space) => {
+      const root = document.querySelector("x-root-view") as
+        | {
+          _handleRuntimeError?: (event: {
+            type: string;
+            message: string;
+            pieceId: string;
+            space: string;
+          }) => void;
+        }
+        | null;
+      if (!root?._handleRuntimeError) {
+        throw new Error("Root view was not ready");
+      }
+      root._handleRuntimeError({
+        type,
+        message: "The selected piece failed while it was starting",
+        pieceId: `of:${pieceId}`,
+        space,
+      });
+    }, {
+      args: [NotificationType.ErrorReport, pieceId, identity.did()],
+    });
+
+    await waitForCondition(
+      page,
+      (probe) =>
+        probe.collect(".runtime-error").some((element) => {
+          const text = probe.deepText(element).replace(/\s+/g, " ").trim();
+          return text.includes("This piece encountered an error") &&
+            text.includes("The selected piece failed while it was starting");
+        }),
+    );
+  });
+});

--- a/packages/shell/integration/load-errors.test.ts
+++ b/packages/shell/integration/load-errors.test.ts
@@ -1,18 +1,28 @@
 import { env, waitForCondition } from "@commonfabric/integration";
 import { ShellIntegration } from "@commonfabric/integration/shell-utils";
 import { Identity } from "@commonfabric/identity";
-import { NotificationType } from "@commonfabric/runtime-client";
 import { describe, it } from "@std/testing/bdd";
 import "../src/globals.ts";
 
 const { FRONTEND_URL, SPACE_NAME } = env;
+const ASYNC_FAILURE_MESSAGE = "The selected piece failed while it was starting";
+const ASYNC_FAILURE_SOURCE = `
+  import { computed, pattern, UI } from "commonfabric";
+
+  export default pattern(() => {
+    const failed = computed(() => {
+      throw new Error("${ASYNC_FAILURE_MESSAGE}");
+    });
+    return { [UI]: <div>{failed}</div> };
+  });
+`;
 
 describe("shell load errors", () => {
   const shell = new ShellIntegration({
     allowedConsoleErrors: [
       "[AppView] Failed to load space root pattern:",
       "[AppView] Failed to load selected piece:",
-      "[RuntimeClient Error]",
+      ASYNC_FAILURE_MESSAGE,
     ],
   });
   shell.bindLifecycle();
@@ -109,45 +119,57 @@ describe("shell load errors", () => {
   it("shows an asynchronous runtime failure for the selected piece", async () => {
     const page = shell.page();
     const identity = await Identity.generate({ implementation: "noble" });
-    const pieceId = "fid1:UagUTyzWNqugXzSpu3JH4Sso9lF_tmGQgwtdIL87mZs";
 
     await shell.goto({
       frontendUrl: FRONTEND_URL,
-      view: { spaceDid: identity.did(), pieceId },
+      view: { spaceDid: identity.did() },
       identity,
     });
-    await page.evaluate((type, pieceId, space) => {
-      const root = document.querySelector("x-root-view") as
+    await waitForCondition(page, () => {
+      const root = document.querySelector("x-root-view");
+      const appView = root?.shadowRoot?.querySelector("x-app-view") as
         | {
-          _handleRuntimeError?: (event: {
-            type: string;
-            message: string;
-            pieceId: string;
-            space: string;
-          }) => void;
+          rt?: {
+            createPiece(
+              space: string,
+              source: string,
+              options: { run: boolean },
+            ): Promise<{ id(): string }>;
+          };
         }
         | null;
-      if (!root?._handleRuntimeError) {
-        throw new Error("Root view was not ready");
-      }
-      root._handleRuntimeError({
-        type,
-        message: "The selected piece failed while it was starting",
-        pieceId: `of:${pieceId}`,
-        space,
-      });
-    }, {
-      args: [NotificationType.ErrorReport, pieceId, identity.did()],
+      return !!appView?.rt;
     });
+    const pieceId = await page.evaluate(async (space, source) => {
+      const root = document.querySelector("x-root-view");
+      const appView = root?.shadowRoot?.querySelector("x-app-view") as
+        | {
+          rt?: {
+            createPiece(
+              space: string,
+              source: string,
+              options: { run: boolean },
+            ): Promise<{ id(): string }>;
+          };
+        }
+        | null;
+      if (!appView?.rt) throw new Error("Runtime was not ready");
+      const piece = await appView.rt.createPiece(space, source, { run: false });
+      return piece.id();
+    }, { args: [identity.did(), ASYNC_FAILURE_SOURCE] });
+    await page.evaluate(async (space, pieceId) => {
+      await globalThis.app.setView({ spaceDid: space, pieceId });
+    }, { args: [identity.did(), pieceId] });
 
     await waitForCondition(
       page,
-      (probe) =>
+      (probe, expectedMessage) =>
         probe.collect(".runtime-error").some((element) => {
           const text = probe.deepText(element).replace(/\s+/g, " ").trim();
           return text.includes("This piece encountered an error") &&
-            text.includes("The selected piece failed while it was starting");
+            text.includes(expectedMessage);
         }),
+      { args: [ASYNC_FAILURE_MESSAGE] },
     );
   });
 });

--- a/packages/shell/integration/piece.test.ts
+++ b/packages/shell/integration/piece.test.ts
@@ -152,15 +152,15 @@ describe("shell piece tests", () => {
                 value?: {
                   id(): string;
                 };
+                error?: {
+                  message?: string;
+                };
               };
               _spaceRootPattern?: {
                 status?: unknown;
                 value?: {
                   id(): string;
                 };
-              };
-              _patternError?: {
-                message?: string;
               };
             }
             | null;
@@ -179,7 +179,7 @@ describe("shell piece tests", () => {
             activePatternId: appView?._patterns?.value?.activePattern?.id?.(),
             selectedPatternId: appView?._selectedPattern?.value?.id?.(),
             spaceRootPatternId: appView?._spaceRootPattern?.value?.id?.(),
-            patternError: appView?._patternError?.message,
+            patternError: appView?._selectedPattern?.error?.message,
             bodyText: document.body.textContent?.trim().slice(0, 200),
           };
         }),

--- a/packages/shell/src/views/AppView.ts
+++ b/packages/shell/src/views/AppView.ts
@@ -15,8 +15,14 @@ import {
   updatePageTitle,
 } from "../../shared/mod.ts";
 import { GlobalShortcutsController } from "../lib/global-shortcuts-controller.ts";
-import { type Cancel, NAME, PageHandle } from "@commonfabric/runtime-client";
+import {
+  type Cancel,
+  type ErrorNotification,
+  NAME,
+  PageHandle,
+} from "@commonfabric/runtime-client";
 import { prepareNamedSpace } from "../lib/named-space.ts";
+import type { LoadError } from "./BodyView.ts";
 
 export class XAppView extends BaseView {
   static override styles = css`
@@ -58,15 +64,22 @@ export class XAppView extends BaseView {
   @property({ attribute: false })
   accessor keyStore: KeyStore | undefined = undefined;
 
+  @property({ attribute: false })
+  accessor spaceLoadError: LoadError | undefined = undefined;
+
+  @property({ attribute: false })
+  accessor runtimeLoadErrors: readonly ErrorNotification[] = [];
+
+  @property({ attribute: false })
+  accessor preserveRuntimeErrorsForNextViewChange: (() => void) | undefined =
+    undefined;
+
   @state()
   accessor pieceTitle: string | undefined = undefined;
 
   @property({ attribute: false })
   private accessor titleSubscription: CellEventTarget<string> | undefined =
     undefined;
-
-  @state()
-  private accessor _patternError: Error | undefined = undefined;
 
   @state()
   private accessor _slugRevision = 0;
@@ -77,6 +90,7 @@ export class XAppView extends BaseView {
   private slugSubscriptionKey: string | undefined = undefined;
   private slugSubscriptionToken = 0;
   private slugTargetKey: string | undefined = undefined;
+  private selectedPatternTargetId: string | undefined = undefined;
 
   private debuggerController = new DebuggerController(this);
   private _keyboard = new GlobalShortcutsController(this);
@@ -111,24 +125,26 @@ export class XAppView extends BaseView {
       | undefined
     > => {
       if (!rt || !space) return;
-      this._patternError = undefined;
-      await prepareNamedSpace(app, rt, space);
-      if ("pieceSlug" in app.view && app.view.pieceSlug) {
-        try {
+      this.selectedPatternTargetId = undefined;
+      try {
+        await prepareNamedSpace(app, rt, space);
+        if ("pieceSlug" in app.view && app.view.pieceSlug) {
           const pieceId = slugIdForSpace(space, app.view.pieceSlug);
+          const target = await rt.getPattern(space, pieceId, { start: false });
+          if (signal.aborted) return;
+          this.selectedPatternTargetId = target.id();
           const pattern = await rt.getPattern(space, pieceId);
           // Track as recently visited (fire-and-forget) — but not after
           // the view moved on, or the write lands in the wrong space.
           if (!signal.aborted) rt.trackRecentPiece(space, pieceId);
           return pattern;
-        } catch (e) {
-          if (!signal.aborted) {
-            this._patternError = e as any;
-          }
         }
-      }
-      if ("pieceId" in app.view && app.view.pieceId) {
-        try {
+        if ("pieceId" in app.view && app.view.pieceId) {
+          const target = await rt.getPattern(space, app.view.pieceId, {
+            start: false,
+          });
+          if (signal.aborted) return;
+          this.selectedPatternTargetId = target.id();
           const pattern = await rt.getPattern(space, app.view.pieceId);
           const slug = await rt.getSlug(space, app.view.pieceId);
           if (!signal.aborted && slug) {
@@ -137,11 +153,12 @@ export class XAppView extends BaseView {
           // Track as recently visited (fire-and-forget)
           if (!signal.aborted) rt.trackRecentPiece(space, app.view.pieceId);
           return pattern;
-        } catch (e) {
-          if (!signal.aborted) {
-            this._patternError = e as any;
-          }
         }
+      } catch (error) {
+        if (!signal.aborted && !rt.signal.aborted) {
+          console.error("[AppView] Failed to load selected piece:", error);
+        }
+        throw error;
       }
     },
     // _slugRevision is a rerun trigger only — keep it after the
@@ -277,10 +294,9 @@ export class XAppView extends BaseView {
 
     let targetKey: string;
     try {
-      const pattern = await rt.refreshPattern(
-        space,
-        slugIdForSpace(space, slug),
-      );
+      const slugId = slugIdForSpace(space, slug);
+      rt.invalidatePattern(space, slugId);
+      const pattern = await rt.getPattern(space, slugId, { start: false });
       targetKey = pattern.id();
     } catch (error) {
       if (rt.signal.aborted) {
@@ -358,6 +374,7 @@ export class XAppView extends BaseView {
     } catch {
       return;
     }
+    this.preserveRuntimeErrorsForNextViewChange?.();
     if ("spaceName" in view) {
       replaceNavigation({ spaceName: view.spaceName, pieceSlug: slug });
     } else if ("spaceDid" in view) {
@@ -458,10 +475,73 @@ export class XAppView extends BaseView {
     }
   }
 
+  private getRuntimeLoadError(): LoadError | undefined {
+    const event = this.runtimeLoadErrors.findLast((candidate) =>
+      this.runtimeErrorMatchesView(candidate)
+    );
+    if (!event) return;
+
+    return {
+      kind: event.pieceId && !isViewingDefaultPatternView(this.app.view)
+        ? "piece"
+        : "space",
+      error: event,
+    };
+  }
+
+  private runtimeErrorMatchesView(event: ErrorNotification): boolean {
+    if (!event.space || event.space !== this.space) return false;
+
+    const isDefaultView = isViewingDefaultPatternView(this.app.view);
+    const reportedPieceId = event.pieceId?.replace(/^of:/, "");
+    if (reportedPieceId) {
+      const addressedPieceIds = isDefaultView
+        ? [this._spaceRootPattern.value?.id()]
+        : "pieceSlug" in this.app.view
+        ? [
+          this.slugTargetKey ?? this.selectedPatternTargetId ??
+            (this._selectedPattern.status === TaskStatus.COMPLETE
+              ? this._selectedPattern.value?.id()
+              : undefined),
+        ]
+        : [
+          this._selectedPattern.status === TaskStatus.COMPLETE
+            ? this._selectedPattern.value?.id()
+            : undefined,
+          this.selectedPatternTargetId,
+          "pieceId" in this.app.view ? this.app.view.pieceId : undefined,
+        ];
+      const knownPieceIds = addressedPieceIds.filter((id) => id !== undefined);
+      if (
+        knownPieceIds.length > 0 &&
+        !knownPieceIds.some((id) => id?.replace(/^of:/, "") === reportedPieceId)
+      ) {
+        return false;
+      }
+      if (
+        knownPieceIds.length === 0
+      ) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
   override render() {
     const config = this.app.config ?? {};
     const { activePattern, spaceRootPattern } = this._patterns.value ?? {};
     const embedded = isEmbeddedView(this.app.view);
+    const isViewingDefaultPattern = isViewingDefaultPatternView(this.app.view);
+    const patternLoadError: LoadError | undefined = isViewingDefaultPattern
+      ? this._spaceRootPattern.status === TaskStatus.ERROR
+        ? { kind: "space", error: this._spaceRootPattern.error }
+        : undefined
+      : this._selectedPattern.status === TaskStatus.ERROR
+      ? { kind: "piece", error: this._selectedPattern.error }
+      : undefined;
+    const loadError = this.spaceLoadError ?? patternLoadError;
+    const runtimeLoadError = loadError ? undefined : this.getRuntimeLoadError();
     this.#setTitleSubscription(activePattern);
 
     const authenticated = html`
@@ -469,7 +549,8 @@ export class XAppView extends BaseView {
         .rt="${this.rt}"
         .activePattern="${activePattern}"
         .spaceRootPattern="${spaceRootPattern}"
-        .patternError="${this._patternError}"
+        .loadError="${loadError}"
+        .runtimeError="${runtimeLoadError}"
         .showShellPieceListView="${config.showShellPieceListView ?? false}"
         .showSidebar="${config.showSidebar ?? false}"
         .embedded="${embedded}"
@@ -489,7 +570,6 @@ export class XAppView extends BaseView {
     const spaceDid = this.app && "spaceDid" in this.app.view
       ? this.app.view.spaceDid
       : undefined;
-    const isViewingDefaultPattern = isViewingDefaultPatternView(this.app.view);
     const content = this.app?.identity ? authenticated : unauthenticated;
     return html`
       <div class="shell-container">

--- a/packages/shell/src/views/BodyView.ts
+++ b/packages/shell/src/views/BodyView.ts
@@ -13,6 +13,11 @@ type SubPages = {
   fabUI?: VNode;
 };
 
+export type LoadError = {
+  kind: "space" | "piece";
+  error: unknown;
+};
+
 const SubPagesSchema = {
   type: "object",
   properties: {
@@ -68,23 +73,60 @@ export class XBodyView extends BaseView {
       min-height: 0;
     }
 
-    .pattern-error {
+    .load-error {
       display: flex;
-      flex-direction: column;
       align-items: center;
       justify-content: center;
-      padding: 2rem;
-      color: #c00;
-      text-align: center;
+      min-height: 100%;
+      padding: clamp(1rem, 5vw, 3rem);
+      box-sizing: border-box;
     }
 
-    .pattern-error h2 {
-      margin: 0 0 1rem;
+    .load-error cf-alert {
+      width: min(100%, 42rem);
     }
 
-    .pattern-error p {
+    .load-error h2 {
       margin: 0;
-      font-family: monospace;
+      font: inherit;
+      font-weight: 600;
+    }
+
+    .load-error-icon {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: 700;
+    }
+
+    .load-error-details {
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+      margin-top: 0.75rem;
+      padding: 0.75rem;
+      border: 1px solid currentColor;
+      border-radius: 0.375rem;
+      text-align: left;
+    }
+
+    .load-error-details span {
+      font-size: 0.75rem;
+      font-weight: 600;
+    }
+
+    .load-error-details code {
+      font-family: var(--font-primary, ui-monospace, monospace);
+      font-size: 0.8rem;
+      font-weight: 400;
+      line-height: 1.5;
+      overflow-wrap: anywhere;
+      white-space: pre-wrap;
+    }
+
+    .runtime-error {
+      flex: none;
+      margin: 1rem 0 0;
     }
   `;
 
@@ -104,7 +146,10 @@ export class XBodyView extends BaseView {
   accessor showSidebar = false;
 
   @property({ attribute: false })
-  accessor patternError: Error | undefined = undefined;
+  accessor loadError: LoadError | undefined = undefined;
+
+  @property({ attribute: false })
+  accessor runtimeError: LoadError | undefined = undefined;
 
   @property({ type: Boolean })
   accessor embedded = false;
@@ -136,12 +181,25 @@ export class XBodyView extends BaseView {
   });
 
   override render() {
-    // Show error if pattern failed to start
-    const mainContent = this.patternError
+    const mainContent = this.loadError
       ? html`
-        <div slot="main" class="pattern-error">
-          <h2>Failed to load piece</h2>
-          <p>${this.patternError.message}</p>
+        <div slot="main" class="load-error">
+          <cf-alert status="error">
+            <span slot="icon" class="load-error-icon" aria-hidden="true">
+              !
+            </span>
+            <h2 slot="title">
+              We could not load this ${this.loadError.kind}
+            </h2>
+            <span slot="description">
+              Try reloading the page. If the problem continues, check that the link is
+              correct and that you have access.
+            </span>
+            <div class="load-error-details">
+              <span>Error details</span>
+              <code>${loadErrorMessage(this.loadError.error)}</code>
+            </div>
+          </cf-alert>
         </div>
       `
       : this.activePattern
@@ -156,9 +214,28 @@ export class XBodyView extends BaseView {
       ? undefined
       : this._subPages?.value?.sidebarUI;
     const fab = this.embedded ? undefined : this._subPages?.value?.fabUI;
+    const runtimeError = this.runtimeError
+      ? html`
+        <cf-alert class="runtime-error" status="error">
+          <span slot="icon" class="load-error-icon" aria-hidden="true">!</span>
+          <h2 slot="title">
+            This ${this.runtimeError.kind} encountered an error
+          </h2>
+          <span slot="description">
+            Some content may not be available. Try reloading the page if the problem
+            continues.
+          </span>
+          <div class="load-error-details">
+            <span>Error details</span>
+            <code>${loadErrorMessage(this.runtimeError.error)}</code>
+          </div>
+        </cf-alert>
+      `
+      : null;
 
     return html`
       <div class="content ${this.embedded ? "embedded" : ""}">
+        ${runtimeError}
         <x-omni-layout .sidebarOpen="${!this.embedded && this.showSidebar}">
           ${mainContent} ${sidebar
             ? html`
@@ -172,6 +249,26 @@ export class XBodyView extends BaseView {
         </x-omni-layout>
       </div>
     `;
+  }
+}
+
+/** Return the useful detail carried by an unknown thrown value. */
+function loadErrorMessage(error: unknown): string {
+  try {
+    let message: string | undefined;
+    if (error instanceof Error) {
+      message = error.message;
+    } else if (
+      typeof error === "object" && error !== null && "message" in error &&
+      typeof error.message === "string"
+    ) {
+      message = error.message;
+    } else if (error !== undefined && error !== null) {
+      message = String(error);
+    }
+    return message?.trim() || "No additional error details were provided.";
+  } catch {
+    return "No additional error details were provided.";
   }
 }
 

--- a/packages/shell/src/views/RootView.ts
+++ b/packages/shell/src/views/RootView.ts
@@ -25,7 +25,7 @@ import {
   type TransferrableInsecureCryptoKeyPair,
 } from "@commonfabric/identity";
 import { property, state } from "lit/decorators.js";
-import { Task } from "@lit/task";
+import { Task, TaskStatus } from "@lit/task";
 import {
   type ErrorNotification,
   type RuntimeClient,
@@ -48,6 +48,7 @@ import {
 import { COMMIT_SHA, ENVIRONMENT, EXPERIMENTAL } from "../lib/env.ts";
 import { runtimeHostFlags } from "../lib/host-toggles.ts";
 import { type BrowserTelemetry, initBrowserOtel } from "../lib/otel.ts";
+import type { LoadError } from "./BodyView.ts";
 
 function getCommonfabricGlobal(): typeof globalThis & {
   commonfabric?: CommonfabricDebugState;
@@ -84,20 +85,43 @@ export class XRootView extends BaseView implements ShellApp {
   @state()
   private accessor _themePreference: ThemePreference = getThemePreference();
 
+  @state()
+  private accessor _spaceResolutionError: LoadError | undefined = undefined;
+
+  @state()
+  private accessor _runtimeLoadErrors: readonly ErrorNotification[] = [];
+
   // Invalidates callbacks from replaced workers. A coded compiler-load error
   // can arrive through either a request reply or an asynchronous runtime error;
   // only the currently-owned worker may trigger one replacement.
   private _runtimeGeneration = 0;
+  private _preserveRuntimeErrorsForNextViewChange = false;
+
+  readonly preserveRuntimeErrorsForNextViewChange = (): void => {
+    this._preserveRuntimeErrorsForNextViewChange = true;
+  };
 
   readonly _handleRuntimeError = (
     event: ErrorNotification,
     generation = this._runtimeGeneration,
   ): void => {
     console.error("[RuntimeClient Error]", event);
-    if (
-      event.code !== RuntimeErrorCode.CompilerStackLoadFailed ||
-      generation !== this._runtimeGeneration
-    ) {
+    if (generation !== this._runtimeGeneration) {
+      return;
+    }
+
+    if (event.code !== RuntimeErrorCode.CompilerStackLoadFailed) {
+      if (!event.space || event.space !== this.space) return;
+      const sameContext = (candidate: ErrorNotification) =>
+        candidate.space === event.space &&
+        candidate.pieceId === event.pieceId &&
+        candidate.patternId === event.patternId;
+      this._runtimeLoadErrors = [
+        ...this._runtimeLoadErrors.filter((candidate) =>
+          !sameContext(candidate)
+        ).slice(-19),
+        event,
+      ];
       return;
     }
 
@@ -105,6 +129,7 @@ export class XRootView extends BaseView implements ShellApp {
     // RuntimeInternals.dispose() asks the worker to flush pending storage writes
     // before terminating it; the replacement gets a fresh module map and can
     // retry the compiler chunk when the user retries the operation.
+    this._runtimeLoadErrors = [];
     this._runtimeGeneration++;
     this._rt.run([this.app]);
   };
@@ -136,6 +161,7 @@ export class XRootView extends BaseView implements ShellApp {
       // like previous app state.
       task: async ([app]: [AppState | undefined], { signal }) => {
         const generation = ++this._runtimeGeneration;
+        this._runtimeLoadErrors = [];
         const previous = this._rt.value;
         if (previous) {
           previous.dispose().catch(console.error);
@@ -257,6 +283,13 @@ export class XRootView extends BaseView implements ShellApp {
   // and treats a space name that disagrees with a space DID as an error.
   protected override willUpdate(changedProperties: PropertyValues<this>): void {
     if (changedProperties.has("app")) {
+      const previous = changedProperties.get("app");
+      if (JSON.stringify(previous?.view) !== JSON.stringify(this.app?.view)) {
+        if (!this._preserveRuntimeErrorsForNextViewChange) {
+          this._runtimeLoadErrors = [];
+        }
+        this._preserveRuntimeErrorsForNextViewChange = false;
+      }
       this.#syncViewSpace(this.app);
     }
   }
@@ -317,6 +350,7 @@ export class XRootView extends BaseView implements ShellApp {
       return;
     }
 
+    this._spaceResolutionError = undefined;
     this.#resolvedSpaceName = undefined;
     this.#spaceResolution = undefined;
     let space: DID | undefined;
@@ -332,6 +366,7 @@ export class XRootView extends BaseView implements ShellApp {
 
   #resolveNamedSpace(identity: Identity, spaceName: string): void {
     const token = ++this.#resolveSpaceToken;
+    this._spaceResolutionError = undefined;
     this.#resolvedSpaceName = spaceName;
     // The lookup is asynchronous, so the view addresses no space until it
     // completes. The space of the view being replaced is not it.
@@ -341,6 +376,7 @@ export class XRootView extends BaseView implements ShellApp {
       (error) => {
         console.error("[RootView] Failed to resolve space name:", error);
         if (token !== this.#resolveSpaceToken) return;
+        this._spaceResolutionError = { kind: "space", error };
         this.#resolvedSpaceName = undefined;
         this.#setSpace(undefined, token);
       },
@@ -433,6 +469,10 @@ export class XRootView extends BaseView implements ShellApp {
   }
 
   override render() {
+    const loadError: LoadError | undefined = this._spaceResolutionError ??
+      (this._rt.status === TaskStatus.ERROR
+        ? { kind: "space", error: this._rt.error }
+        : undefined);
     return html`
       <cf-theme .theme="${{ colorScheme: this._themePreference }}">
         <x-app-view
@@ -440,6 +480,10 @@ export class XRootView extends BaseView implements ShellApp {
           .keyStore="${this.keyStore}"
           .rt="${this._rt.value}"
           .space="${this.space}"
+          .spaceLoadError="${loadError}"
+          .runtimeLoadErrors="${this._runtimeLoadErrors}"
+          .preserveRuntimeErrorsForNextViewChange="${this
+            .preserveRuntimeErrorsForNextViewChange}"
         ></x-app-view>
       </cf-theme>
     `;

--- a/packages/shell/test/load-errors.test.ts
+++ b/packages/shell/test/load-errors.test.ts
@@ -1,0 +1,527 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { type DID, Identity } from "@commonfabric/identity";
+import { NotificationType } from "@commonfabric/runtime-client";
+
+/** Install the browser globals Lit reads and return a restoration function. */
+function installBrowserGlobals(
+  overrides: Record<string, unknown> = {},
+): () => void {
+  const originals = new Map<string, PropertyDescriptor | undefined>();
+  function setGlobal(name: string, value: unknown): void {
+    originals.set(name, Object.getOwnPropertyDescriptor(globalThis, name));
+    Object.defineProperty(globalThis, name, {
+      configurable: true,
+      writable: true,
+      value,
+    });
+  }
+  class TestHTMLElement extends EventTarget {
+    attachShadow() {
+      return {
+        adoptedStyleSheets: [],
+        appendChild() {},
+        append() {},
+      };
+    }
+  }
+  setGlobal("window", globalThis);
+  setGlobal("HTMLElement", TestHTMLElement);
+  setGlobal("customElements", {
+    define() {},
+    get() {},
+    whenDefined: () => Promise.resolve(),
+  });
+  setGlobal("document", {
+    documentElement: { style: {} },
+    addEventListener() {},
+    removeEventListener() {},
+    createElement: () => ({
+      style: {},
+      setAttribute() {},
+      append() {},
+      appendChild() {},
+    }),
+    createTreeWalker: () => ({}),
+  });
+  setGlobal("devicePixelRatio", 1);
+  setGlobal("screen", { deviceXDPI: 1, logicalXDPI: 1 });
+  setGlobal("navigator", { platform: "", userAgent: "deno" });
+  setGlobal("location", {
+    protocol: "http:",
+    host: "localhost:8000",
+    hostname: "localhost",
+    href: "http://localhost:8000/did:key:z6Mk-shell-load-error",
+  });
+  for (const [name, value] of Object.entries(overrides)) {
+    setGlobal(name, value);
+  }
+
+  return () => {
+    for (const [name, descriptor] of originals) {
+      if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+      else Reflect.deleteProperty(globalThis, name);
+    }
+  };
+}
+
+/** Return the rendered text of nested Lit template results. */
+function templateText(value: unknown): string {
+  if (value == null) return "";
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) return value.map(templateText).join("");
+  if (typeof value !== "object") return String(value);
+  const template = value as {
+    strings?: readonly string[];
+    values?: readonly unknown[];
+  };
+  const strings = template.strings ?? [];
+  const values = template.values ?? [];
+  let text = "";
+  for (let index = 0; index < strings.length; index++) {
+    text += strings[index];
+    if (index < values.length) text += templateText(values[index]);
+  }
+  return text;
+}
+
+/** Find the load-error value passed through a nested Lit template. */
+function findLoadError(value: unknown): unknown {
+  if (value == null || typeof value !== "object") return undefined;
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const result = findLoadError(item);
+      if (result) return result;
+    }
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  if (
+    (record.kind === "space" || record.kind === "piece") &&
+    "error" in record
+  ) {
+    return value;
+  }
+  const values = record.values;
+  if (!Array.isArray(values)) return undefined;
+  for (const item of values) {
+    const result = findLoadError(item);
+    if (result) return result;
+  }
+  return undefined;
+}
+
+describe("load-errors", () => {
+  describe("XRootView", () => {
+    describe("instance members", () => {
+      describe("render()", () => {
+        it("passes a named-space resolution error to the app view", async () => {
+          const error = new Error("The named space could not be resolved");
+          const restore = installBrowserGlobals({
+            crypto: {
+              subtle: {
+                digest: () => Promise.reject(error),
+              },
+            },
+          });
+          const originalError = console.error;
+          console.error = () => {};
+          try {
+            const { XRootView } = await import("../src/views/RootView.ts");
+            const view = new XRootView();
+            view.app = {
+              ...view.app,
+              identity: {} as never,
+              view: { spaceName: "unavailable-space" },
+            };
+            const lifecycle = view as unknown as {
+              willUpdate(changed: Map<string, unknown>): void;
+            };
+
+            lifecycle.willUpdate(new Map([["app", undefined]]));
+            await view.spaceResolved();
+
+            expect(findLoadError(view.render())).toEqual({
+              kind: "space",
+              error,
+            });
+          } finally {
+            console.error = originalError;
+            restore();
+          }
+        });
+
+        it("passes a runtime startup error to the app view", async () => {
+          const restore = installBrowserGlobals();
+          const originalError = console.error;
+          console.error = () => {};
+          const { RuntimeInternals } = await import("@commonfabric/lib-shell");
+          const originalCreate = RuntimeInternals.create;
+          const error = new Error("The runtime could not start");
+          RuntimeInternals.create =
+            (() => Promise.reject(error)) as typeof RuntimeInternals.create;
+          try {
+            const { XRootView } = await import("../src/views/RootView.ts");
+            const view = new XRootView();
+            view.app = {
+              ...view.app,
+              identity: await Identity.generate({ implementation: "noble" }),
+            };
+            const task = (view as unknown as {
+              _rt: {
+                run(args: [typeof view.app]): void;
+                taskComplete: Promise<unknown>;
+              };
+            })._rt;
+
+            task.run([view.app]);
+            await task.taskComplete.catch(() => undefined);
+
+            expect(findLoadError(view.render())).toEqual({
+              kind: "space",
+              error,
+            });
+          } finally {
+            RuntimeInternals.create = originalCreate;
+            console.error = originalError;
+            restore();
+          }
+        });
+      });
+    });
+  });
+
+  describe("XAppView", () => {
+    describe("instance members", () => {
+      describe("render()", () => {
+        it("passes a space root load error to the body view", async () => {
+          const restore = installBrowserGlobals();
+          const originalError = console.error;
+          console.error = () => {};
+          try {
+            const { XAppView } = await import("../src/views/AppView.ts");
+            const space = "did:key:z6Mk-shell-space-load-error" as DID;
+            const error = new Error("Space storage is unavailable");
+            const view = new XAppView();
+            view.app = {
+              identity: {},
+              config: {},
+              view: { spaceDid: space },
+            } as never;
+            view.space = space;
+            view.rt = {
+              signal: new AbortController().signal,
+              getSpaceRootPattern: () => Promise.reject(error),
+            } as never;
+
+            view._spaceRootPattern.run();
+            await view._spaceRootPattern.taskComplete.catch(() => undefined);
+
+            expect(findLoadError(view.render())).toEqual({
+              kind: "space",
+              error,
+            });
+          } finally {
+            console.error = originalError;
+            restore();
+          }
+        });
+
+        it("passes a selected piece load error to the body view", async () => {
+          const restore = installBrowserGlobals();
+          const originalError = console.error;
+          console.error = () => {};
+          try {
+            const { XAppView } = await import("../src/views/AppView.ts");
+            const space = "did:key:z6Mk-shell-piece-load-error" as DID;
+            const error = new Error("Piece data could not be read");
+            const view = new XAppView();
+            view.app = {
+              identity: {},
+              config: {},
+              view: { spaceDid: space, pieceId: "fid1:missing-piece" },
+            } as never;
+            view.space = space;
+            view.rt = {
+              signal: new AbortController().signal,
+              getPattern: () => Promise.reject(error),
+            } as never;
+
+            view._selectedPattern.run();
+            await view._selectedPattern.taskComplete.catch(() => undefined);
+
+            expect(findLoadError(view.render())).toEqual({
+              kind: "piece",
+              error,
+            });
+          } finally {
+            console.error = originalError;
+            restore();
+          }
+        });
+
+        it("passes an earlier space load error to the body view", async () => {
+          const restore = installBrowserGlobals();
+          try {
+            const { XAppView } = await import("../src/views/AppView.ts");
+            const error = new Error("The space address could not be resolved");
+            const view = new XAppView();
+            view.app = {
+              identity: {},
+              config: {},
+              view: { spaceName: "unavailable-space" },
+            } as never;
+            view.spaceLoadError = { kind: "space", error };
+
+            expect(findLoadError(view.render())).toEqual({
+              kind: "space",
+              error,
+            });
+          } finally {
+            restore();
+          }
+        });
+
+        it("passes a runtime error for the selected piece to the body view", async () => {
+          const restore = installBrowserGlobals();
+          try {
+            const { XAppView } = await import("../src/views/AppView.ts");
+            const space = "did:key:z6Mk-shell-runtime-piece-error" as DID;
+            const view = new XAppView();
+            view.app = {
+              identity: {},
+              config: {},
+              view: { spaceDid: space, pieceId: "fid1:broken-piece" },
+            } as never;
+            view.space = space;
+            view.runtimeLoadErrors = [{
+              type: NotificationType.ErrorReport,
+              message: "The piece failed while it was starting",
+              space,
+              pieceId: "of:fid1:broken-piece",
+            }];
+
+            expect(findLoadError(view.render())).toEqual({
+              kind: "piece",
+              error: view.runtimeLoadErrors[0],
+            });
+          } finally {
+            restore();
+          }
+        });
+
+        it("ignores a runtime error from another piece", async () => {
+          const restore = installBrowserGlobals();
+          try {
+            const { XAppView } = await import("../src/views/AppView.ts");
+            const space = "did:key:z6Mk-shell-other-piece-error" as DID;
+            const view = new XAppView();
+            view.app = {
+              identity: {},
+              config: {},
+              view: { spaceDid: space, pieceId: "fid1:working-piece" },
+            } as never;
+            view.space = space;
+            view.runtimeLoadErrors = [{
+              type: NotificationType.ErrorReport,
+              message: "A background piece failed",
+              space,
+              pieceId: "of:fid1:background-piece",
+            }];
+
+            expect(findLoadError(view.render())).toBeUndefined();
+          } finally {
+            restore();
+          }
+        });
+
+        it("keeps a matching error when a background piece fails later", async () => {
+          const restore = installBrowserGlobals();
+          try {
+            const { XAppView } = await import("../src/views/AppView.ts");
+            const space = "did:key:z6Mk-shell-preserved-piece-error" as DID;
+            const view = new XAppView();
+            view.app = {
+              identity: {},
+              config: {},
+              view: { spaceDid: space, pieceId: "fid1:selected-piece" },
+            } as never;
+            view.space = space;
+            const selectedError = {
+              type: NotificationType.ErrorReport,
+              message: "The selected piece failed",
+              space,
+              pieceId: "of:fid1:selected-piece",
+            } as const;
+            view.runtimeLoadErrors = [selectedError, {
+              type: NotificationType.ErrorReport,
+              message: "A background piece failed later",
+              space,
+              pieceId: "of:fid1:background-piece",
+            }];
+
+            expect(findLoadError(view.render())).toEqual({
+              kind: "piece",
+              error: selectedError,
+            });
+          } finally {
+            restore();
+          }
+        });
+
+        it("resolves a slug target before starting its piece", async () => {
+          const restore = installBrowserGlobals();
+          try {
+            const { XAppView } = await import("../src/views/AppView.ts");
+            const space = "did:key:z6Mk-shell-slug-target-error" as DID;
+            const calls: unknown[][] = [];
+            const view = new XAppView();
+            view.app = {
+              identity: {},
+              config: {},
+              view: { spaceDid: space, pieceSlug: "broken-piece" },
+            } as never;
+            view.space = space;
+            view.rt = {
+              signal: new AbortController().signal,
+              getPattern: (...args: unknown[]) => {
+                calls.push(args);
+                return Promise.resolve({ id: () => "fid1:slug-target" });
+              },
+              trackRecentPiece: () => {},
+            } as never;
+
+            view._selectedPattern.run();
+            await view._selectedPattern.taskComplete;
+
+            expect(calls).toHaveLength(2);
+            expect(calls[0]?.[2]).toEqual({ start: false });
+            expect(calls[1]?.[2]).toBeUndefined();
+          } finally {
+            restore();
+          }
+        });
+
+        it("ignores a runtime error without space context", async () => {
+          const restore = installBrowserGlobals();
+          try {
+            const { XAppView } = await import("../src/views/AppView.ts");
+            const space = "did:key:z6Mk-shell-context-free-error" as DID;
+            const view = new XAppView();
+            view.app = {
+              identity: {},
+              config: {},
+              view: { spaceDid: space, pieceId: "fid1:working-piece" },
+            } as never;
+            view.space = space;
+            view.runtimeLoadErrors = [{
+              type: NotificationType.ErrorReport,
+              message: "An unrelated renderer failed",
+            }];
+
+            expect(findLoadError(view.render())).toBeUndefined();
+          } finally {
+            restore();
+          }
+        });
+      });
+    });
+  });
+
+  describe("XBodyView", () => {
+    describe("instance members", () => {
+      describe("render()", () => {
+        it("shows a clear space error with the reported detail", async () => {
+          const restore = installBrowserGlobals();
+          try {
+            const { XBodyView } = await import("../src/views/BodyView.ts");
+            const view = new XBodyView();
+            Object.assign(view, {
+              loadError: {
+                kind: "space",
+                error: new Error("Access to the space was denied"),
+              },
+            });
+
+            const text = templateText(view.render());
+            expect(text).toContain("We could not load this space");
+            expect(text).toContain("Try reloading the page");
+            expect(text).toContain("Error details");
+            expect(text).toContain("Access to the space was denied");
+          } finally {
+            restore();
+          }
+        });
+
+        it("shows a clear piece error with a string detail", async () => {
+          const restore = installBrowserGlobals();
+          try {
+            const { XBodyView } = await import("../src/views/BodyView.ts");
+            const view = new XBodyView();
+            Object.assign(view, {
+              loadError: {
+                kind: "piece",
+                error: "The piece does not exist",
+              },
+            });
+
+            const text = templateText(view.render());
+            expect(text).toContain("We could not load this piece");
+            expect(text).toContain("The piece does not exist");
+          } finally {
+            restore();
+          }
+        });
+
+        it("shows a runtime error without replacing the main content", async () => {
+          const restore = installBrowserGlobals();
+          try {
+            const { XBodyView } = await import("../src/views/BodyView.ts");
+            const view = new XBodyView();
+            Object.assign(view, {
+              activePattern: {
+                id: () => "fid1:partly-working-piece",
+                cell: () => ({}),
+              },
+              runtimeError: {
+                kind: "piece",
+                error: new Error("A computed value failed"),
+              },
+            });
+
+            const text = templateText(view.render());
+            expect(text).toContain("This piece encountered an error");
+            expect(text).toContain("A computed value failed");
+            expect(text).toContain("cf-piece");
+          } finally {
+            restore();
+          }
+        });
+
+        it("falls back when an error cannot be inspected", async () => {
+          const restore = installBrowserGlobals();
+          try {
+            const { XBodyView } = await import("../src/views/BodyView.ts");
+            const view = new XBodyView();
+            Object.assign(view, {
+              loadError: {
+                kind: "space",
+                error: new Proxy({}, {
+                  getPrototypeOf: () => {
+                    throw new Error("The error object cannot be inspected");
+                  },
+                }),
+              },
+            });
+
+            expect(templateText(view.render())).toContain(
+              "No additional error details were provided.",
+            );
+          } finally {
+            restore();
+          }
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Space and piece loading failures could leave the shell blank while the only explanation appeared in the browser console. This included rejected storage requests, named-space resolution failures, runtime startup failures, and asynchronous failures reported while a piece was starting.

Carry load failures through the shell view hierarchy and render an accessible error with safe details. Retain contextual runtime errors per space and piece. Resolve redirected targets before starting them so asynchronous errors can be matched to the visible piece. Show these errors in a non-destructive banner so working content remains available, and ignore unrelated background failures.

Add unit and browser integration coverage for space and piece failures, redirected targets, asynchronous runtime notifications, unrelated errors, and safe rendering of unusual thrown values.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

