### PR TITLE
dashboard: add a persistent three-state theme

### DIFF
--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -1,6 +1,6 @@
 # Fabric wall — modular dev/company dashboard
 
-A small Deno server that renders a dark, glanceable wall of status tiles and
+A small Deno server that renders a glanceable wall of status tiles and
 updates their markup in place over Server-Sent Events. Every tile is one file
 with a fixed interface; a single file registers them.
 
@@ -25,6 +25,11 @@ deno task watch
 deno task test
 ```
 
+The dashboard uses dark mode on its first visit. The switch at the bottom right
+of each page cycles through dark, light, and the operating-system preference.
+It saves that choice for the dashboard and all of its drill-down pages. Inline
+charts and generated CI Gantt images use the active theme as well.
+
 ## Architecture
 
 ```
@@ -32,6 +37,7 @@ dashboard/
   types.ts      the interface: Tile, TileView, Status, Ctx, Route
   config.ts     port, repo, tunable status thresholds
   palette.ts    THE ONE PLACE status colors, washes and dot shapes are chosen
+  theme.ts      light/dark surface colors, theme switch markup and browser behavior
   lib.ts        shared helpers (github, memo, escapeHtml, sparkline, strip, …)
   blacksmith.ts authenticated read client for Blacksmith billing data
   ctx.ts        shared, memoized data sources handed to every tile (ctx.runs)

--- a/packages/dashboard/ci-job-history.ts
+++ b/packages/dashboard/ci-job-history.ts
@@ -37,6 +37,12 @@ import {
   PERFORMANCE_VIEW_STYLES,
   performanceViewNav,
 } from "./performance-views.ts";
+import {
+  CHART_LINE,
+  DASHBOARD_THEME_CLIENT,
+  DASHBOARD_THEME_HEAD,
+  dashboardThemeToggle,
+} from "./theme.ts";
 
 export const CI_HISTORY_DAYS = 45;
 export const CI_HISTORY_MIN_DAYS = 1;
@@ -2822,7 +2828,7 @@ function renderSeries(
   const xs = times.map((at) => (at - axisStart) / axisSpan);
   const spark = sparkline(
     values,
-    "#727882",
+    CHART_LINE,
     undefined,
     SPARK_FADE[status],
     xs,
@@ -3170,13 +3176,14 @@ export function ciJobHistoryPage(
   </div>`;
   if (options.fragment) return rangeContent;
   return `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>CI job history</title>
+${DASHBOARD_THEME_HEAD}
 <style>
   ${PERFORMANCE_VIEW_STYLES}
-  .coverage{font-size:11px;color:#c7ccd4;font-variant-numeric:tabular-nums;margin:0 0 12px}
-  h2 span{font-family:-apple-system,Segoe UI,Roboto,sans-serif;font-weight:400;color:#666c76;margin-left:6px}
+  .coverage{font-size:11px;color:var(--text-secondary);font-variant-numeric:tabular-nums;margin:0 0 12px}
+  h2 span{font-family:-apple-system,Segoe UI,Roboto,sans-serif;font-weight:400;color:var(--text-faint);margin-left:6px}
   .crow.aggregate{border-left-width:4px}
-  .crow.overall{border-left:4px solid #6ea8fe}.overall-section{margin-bottom:20px}
-  .cdetail{font-size:11px;color:#777d87}
+  .crow.overall{border-left:4px solid var(--accent)}.overall-section{margin-bottom:20px}
+  .cdetail{font-size:11px;color:var(--text-subtle)}
   .cval{flex:none;display:flex;flex-direction:column;align-items:flex-end;text-decoration:none}
   body.hide-green .crow.good{display:none}body.hide-green section:has(.clist):not(:has(.crow:not(.good))){display:none}
   .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
@@ -3210,6 +3217,8 @@ export function ciJobHistoryPage(
     sort === "trend" ? ' aria-current="true"' : ""
   }>trend</a></nav><label class="check trailing"><input type="checkbox" id="hg"> hide green</label></form>
   ${rangeContent}
+${dashboardThemeToggle()}
+${DASHBOARD_THEME_CLIENT}
 <script>
   const hg = document.getElementById("hg"), days = document.getElementById("days"), daysv = document.getElementById("daysv"), repo = document.getElementById("repo"), controls = days.form, KEY = "ciJobsHideGreen", DEFAULT_DAYS = days.value;
   let rangeContent = document.getElementById("range-content"), fetchProgress = document.getElementById("fetch-progress"), title = document.getElementById("fetch-title"), total = document.getElementById("fetch-total"), detail = document.getElementById("fetch-detail"), bar = document.getElementById("fetch-bar"), pageVersion = fetchProgress.dataset.snapshotVersion, appliedDays = days.value;

--- a/packages/dashboard/deno.jsonc
+++ b/packages/dashboard/deno.jsonc
@@ -14,7 +14,7 @@
     // A task line runs the Deno running the task, so asking that Deno for its
     // own path allows exactly the one binary the tests start.
     "test-favicon-raster": "deno test --allow-read --allow-write --allow-run=$(deno eval \"console.log(Deno.execPath())\") --allow-ffi --allow-sys=cpus,networkInterfaces,hostname favicon-raster.test.ts regenerate-favicons.test.ts",
-    "test-browser": "deno run --allow-env --allow-read --allow-write --allow-run --allow-net ../deno-web-test/cli.ts favicon-client.browser.test.ts",
+    "test-browser": "deno run --allow-env --allow-read --allow-write --allow-run --allow-net ../deno-web-test/cli.ts favicon-client.browser.test.ts theme.browser.test.ts",
     "regenerate-favicons": "deno run --allow-read --allow-write=favicon-png.generated.ts --allow-ffi --allow-sys=cpus,networkInterfaces,hostname regenerate-favicons.ts"
   }
 }

--- a/packages/dashboard/lib.test.ts
+++ b/packages/dashboard/lib.test.ts
@@ -303,6 +303,18 @@ Deno.test("multiSparkline: highlight redraws the trailing slice in a lighter tin
   assertEquals([...plain.matchAll(/<polyline/g)].length, 1);
 });
 
+Deno.test("multiSparkline: a series can supply a theme-aware highlight", () => {
+  const svg = multiSparkline(
+    [{
+      vals: [1, 2, 3],
+      color: "light-dark(#07523f,#10a37f)",
+      highlightColor: "light-dark(#063e30,#a0dcca)",
+    }],
+    { highlight: { count: 2 } },
+  );
+  assert(svg.includes('stroke="light-dark(#063e30,#a0dcca)"'));
+});
+
 Deno.test("a slice covering the whole series leaves the line in its own color", () => {
   // A window at least as long as the series marks nothing off, so drawing it would
   // repaint the whole line in the tint and lose the line's own color.

--- a/packages/dashboard/lib.ts
+++ b/packages/dashboard/lib.ts
@@ -1,7 +1,6 @@
 // Shared helpers used across tiles and the core.
 import type { Status } from "./types.ts";
 import { PROD_SERVICE } from "./config.ts";
-import { RUNNING_COLOR, STATUS_COLOR } from "./palette.ts";
 import { CHART_HIGHLIGHT } from "./theme.ts";
 import {
   type GitHubPrimaryRateLimit,
@@ -552,12 +551,12 @@ export function strip(cells: { outcome: string; href: string }[], cols: number):
   if (!cells.length) return "";
   const col = (d: string) =>
     d === "green"
-      ? STATUS_COLOR.good
+      ? "var(--status-good)"
       : d === "red"
-      ? STATUS_COLOR.bad
+      ? "var(--status-bad)"
       : d === "run"
-      ? RUNNING_COLOR
-      : STATUS_COLOR.unknown;
+      ? "var(--running)"
+      : "var(--status-unknown)";
   const html = cells.map((c) =>
     `<a class="cell" href="${escapeHtml(c.href)}" target="_blank" rel="noopener" style="background:${col(c.outcome)}"></a>`
   ).join("");

--- a/packages/dashboard/lib.ts
+++ b/packages/dashboard/lib.ts
@@ -2,6 +2,7 @@
 import type { Status } from "./types.ts";
 import { PROD_SERVICE } from "./config.ts";
 import { RUNNING_COLOR, STATUS_COLOR } from "./palette.ts";
+import { CHART_HIGHLIGHT } from "./theme.ts";
 import {
   type GitHubPrimaryRateLimit,
   performanceGitHubRateLimit,
@@ -151,7 +152,7 @@ export const STATUS_DOT: Record<Status, string> = { good: "green", warn: "amber"
 export const escapeHtml = (s: string) =>
   s.replace(/[<>&"]/g, (c) => ({ "<": "&lt;", ">": "&gt;", "&": "&amp;", '"': "&quot;" }[c]!));
 
-export { SPARK_FADE } from "./palette.ts";
+export { SPARK_FADE_CSS as SPARK_FADE } from "./palette.ts";
 
 // How a sparkline caption spells a day span, consistently across tiles:
 // "5 days", "1 day", "<1 day".
@@ -247,7 +248,7 @@ export function lighten(hex: string, amount = 0.6): string {
 // slot; standalone chart pages (the bench drill-down) reuse it directly. Its
 // container must be position:relative.
 export function durationTag(ms: number): string {
-  return `<span style="position:absolute;left:1px;bottom:0;font-size:9px;line-height:1;color:#c7ccd4;pointer-events:none">${escapeHtml(humanSpan(ms))}</span>`;
+  return `<span style="position:absolute;left:1px;bottom:0;font-size:9px;line-height:1;color:${CHART_HIGHLIGHT};pointer-events:none">${escapeHtml(humanSpan(ms))}</span>`;
 }
 
 function scaleValues(
@@ -348,6 +349,7 @@ export function multiSparkline(
   series: {
     vals: number[];
     color: string;
+    highlightColor?: string;
     label?: string;
     xs?: number[];
     highlightCount?: number;
@@ -479,7 +481,9 @@ export function multiSparkline(
     if (start === undefined) return "";
     return splitPoints(points.slice(start), s.maxXGap)
       .filter((segment) => segment.length >= 2)
-      .map((segment) => poly(segment.map(svgPoint), lighten(s.color)))
+      .map((segment) =>
+        poly(segment.map(svgPoint), s.highlightColor ?? lighten(s.color))
+      )
       .join("");
   }).join("");
   const isolatedMarkers = drawn.map(({ s, points, segments }) => {
@@ -491,7 +495,7 @@ export function multiSparkline(
         const point = segment[0];
         const color = highlightStart !== undefined &&
             point.index >= highlightStart
-          ? lighten(s.color)
+          ? s.highlightColor ?? lighten(s.color)
           : s.color;
         return marker(point, color);
       })

--- a/packages/dashboard/palette.test.ts
+++ b/packages/dashboard/palette.test.ts
@@ -7,6 +7,8 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import type { Status } from "./types.ts";
 import {
+  LIGHT_STATUS_TEXT,
+  LIGHT_TILE_BASE,
   rgba,
   STATUS_COLOR,
   STATUS_EDGE,
@@ -18,14 +20,24 @@ type Triple = [number, number, number];
 
 function channels(hex: string): Triple {
   const n = parseInt(hex.slice(1), 16);
-  return [(n >> 16) & 255, (n >> 8) & 255, n & 255].map((c) => c / 255) as
-    Triple;
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255].map((c) =>
+    c / 255
+  ) as Triple;
 }
 
 // sRGB stores a color with a curve applied, so light has to be taken back out
 // of that curve before any of it can be added up or mixed.
 const toLinear = (c: number) =>
   c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+
+function contrastRatio(first: string, second: string): number {
+  const luminance = (color: string) => {
+    const [red, green, blue] = channels(color).map(toLinear);
+    return 0.2126 * red + 0.7152 * green + 0.0722 * blue;
+  };
+  const values = [luminance(first), luminance(second)].sort((a, b) => b - a);
+  return (values[0] + 0.05) / (values[1] + 0.05);
+}
 
 function apply(m: readonly Triple[], rgb: Triple): Triple {
   const linear = rgb.map(toLinear) as Triple;
@@ -109,7 +121,8 @@ function difference(first: Triple, second: Triple): number {
   const t = 1 - 0.17 * Math.cos(rad(hMean - 30)) +
     0.24 * Math.cos(rad(2 * hMean)) + 0.32 * Math.cos(rad(3 * hMean + 6)) -
     0.20 * Math.cos(rad(4 * hMean - 63));
-  const sL = 1 + (0.015 * (lMean - 50) ** 2) / Math.sqrt(20 + (lMean - 50) ** 2);
+  const sL = 1 +
+    (0.015 * (lMean - 50) ** 2) / Math.sqrt(20 + (lMean - 50) ** 2);
   const sC = 1 + 0.045 * cpMean;
   const sH = 1 + 0.015 * cpMean * t;
   const rT = -2 * Math.sqrt(cpMean ** 7 / (cpMean ** 7 + 25 ** 7)) *
@@ -172,6 +185,36 @@ describe("palette", () => {
         const [text] = lab(apply(TRICHROMAT, channels(STATUS_TEXT[status])));
         const [base] = lab(apply(TRICHROMAT, channels(STATUS_COLOR[status])));
         expect(text).toBeGreaterThan(base);
+      }
+    });
+  });
+
+  describe("LIGHT_STATUS_TEXT", () => {
+    for (const [name, vision] of Object.entries(VISION)) {
+      for (const [first, second] of PAIRS) {
+        it(`tells ${first} from ${second} under ${name}`, () => {
+          expect(
+            apart(LIGHT_STATUS_TEXT[first], LIGHT_STATUS_TEXT[second], vision),
+          )
+            .toBeGreaterThan(LEGIBLE);
+        });
+      }
+    }
+
+    it("is darker than the status color it carries on a light tile", () => {
+      for (const status of STATUSES) {
+        const [text] = lab(
+          apply(TRICHROMAT, channels(LIGHT_STATUS_TEXT[status])),
+        );
+        const [base] = lab(apply(TRICHROMAT, channels(STATUS_COLOR[status])));
+        expect(text).toBeLessThan(base);
+      }
+    });
+
+    it("keeps small text and status indicators legible on a light tile", () => {
+      for (const status of STATUSES) {
+        expect(contrastRatio(LIGHT_STATUS_TEXT[status], LIGHT_TILE_BASE))
+          .toBeGreaterThanOrEqual(4.5);
       }
     });
   });

--- a/packages/dashboard/palette.ts
+++ b/packages/dashboard/palette.ts
@@ -29,6 +29,15 @@ export const STATUS_TEXT: Record<Status, string> = {
   unknown: "#9aa0ab",
 };
 
+// Headline shades for text on a light tile. They retain the status hues while
+// carrying enough weight to read against white.
+export const LIGHT_STATUS_TEXT: Record<Status, string> = {
+  good: "#0f765d",
+  warn: "#985000",
+  bad: "#a51f45",
+  unknown: "#59616e",
+};
+
 // How much of its color a tile's background carries, and how much its border
 // does. The three rise together with the seriousness of the status, so the
 // tiles separate by weight as well as by hue. An unknown tile takes no color
@@ -64,6 +73,7 @@ export const RUNNING_COLOR = "#6ea8fe";
 // The flat surface a status tints: the tile itself, and the rows of the
 // drill-down pages that wear a status the same way.
 export const TILE_BASE = "#16181d";
+export const LIGHT_TILE_BASE = "#ffffff";
 
 function channels(hex: string): [number, number, number] {
   const n = parseInt(hex.slice(1), 16);
@@ -80,11 +90,11 @@ function hex(channels: readonly number[]): string {
 const FADE_DEPTH = 0.6;
 
 /** The shade a sparkline fades up out of, on a tile of the given status. */
-function fadeUnder(status: Status): string {
-  const base = channels(TILE_BASE);
+function fadeUnder(status: Status, tileBase: string, depth: number): string {
+  const base = channels(tileBase);
   const tint = channels(STATUS_COLOR[status]);
   return hex(
-    base.map((b, i) => (b + (tint[i] - b) * STATUS_WASH[status]) * FADE_DEPTH),
+    base.map((b, i) => (b + (tint[i] - b) * STATUS_WASH[status]) * depth),
   );
 }
 
@@ -93,10 +103,26 @@ function fadeUnder(status: Status): string {
 // and the tile's wash rather than written down beside them, so a change to
 // either carries here on its own.
 export const SPARK_FADE: Record<Status, string> = {
-  good: fadeUnder("good"),
-  warn: fadeUnder("warn"),
-  bad: fadeUnder("bad"),
-  unknown: fadeUnder("unknown"),
+  good: fadeUnder("good", TILE_BASE, FADE_DEPTH),
+  warn: fadeUnder("warn", TILE_BASE, FADE_DEPTH),
+  bad: fadeUnder("bad", TILE_BASE, FADE_DEPTH),
+  unknown: fadeUnder("unknown", TILE_BASE, FADE_DEPTH),
+};
+
+// On a light tile the line can disappear into the tile's own tinted surface.
+// The CSS theme chooses between these shades and the dark ones above.
+export const LIGHT_SPARK_FADE: Record<Status, string> = {
+  good: fadeUnder("good", LIGHT_TILE_BASE, 1),
+  warn: fadeUnder("warn", LIGHT_TILE_BASE, 1),
+  bad: fadeUnder("bad", LIGHT_TILE_BASE, 1),
+  unknown: fadeUnder("unknown", LIGHT_TILE_BASE, 1),
+};
+
+export const SPARK_FADE_CSS: Record<Status, string> = {
+  good: "var(--spark-fade-good)",
+  warn: "var(--spark-fade-warn)",
+  bad: "var(--spark-fade-bad)",
+  unknown: "var(--spark-fade-unknown)",
 };
 
 /** A `#rrggbb` color as a CSS `rgba()` at the given alpha. */

--- a/packages/dashboard/performance-views.ts
+++ b/packages/dashboard/performance-views.ts
@@ -1,11 +1,9 @@
 import { escapeHtml } from "./lib.ts";
 import {
-  rgba,
-  STATUS_COLOR,
   STATUS_EDGE,
   STATUS_WASH,
 } from "./palette.ts";
-import { DASHBOARD_THEME_STYLES } from "./theme.ts";
+import { DASHBOARD_THEME_STYLES, statusLayer } from "./theme.ts";
 
 export type PerformanceView = "runtime" | "ci" | "gantt";
 
@@ -16,8 +14,8 @@ const ROW_WASH = 0.75;
 
 const ROW_RULES = (["good", "warn", "bad"] as const).map((s) =>
   `  .brow.${s},.crow.${s}{border-color:${
-    rgba(STATUS_COLOR[s], STATUS_EDGE[s])
-  };background:${rgba(STATUS_COLOR[s], STATUS_WASH[s] * ROW_WASH)}}`
+    statusLayer(s, STATUS_EDGE[s])
+  };background:${statusLayer(s, STATUS_WASH[s] * ROW_WASH)}}`
 ).join("\n");
 
 export interface PerformanceViewState {
@@ -33,7 +31,7 @@ export const PERFORMANCE_HISTORY_SCALE_TRIM = 2;
 
 export const PERFORMANCE_PROGRESS_STYLES = `
   .fetch-progress{background:var(--surface);border:1px solid var(--border-strong);border-radius:10px;padding:10px 12px;margin:0 0 12px}
-  .fetch-progress.error,.fetch-progress.warning{border-color:${rgba(STATUS_COLOR.warn, STATUS_EDGE.warn)}}
+  .fetch-progress.error,.fetch-progress.warning{border-color:${statusLayer("warn", STATUS_EDGE.warn)}}
   .fetch-head{display:flex;justify-content:space-between;gap:12px;align-items:baseline;font-size:12px;color:var(--text-secondary)}
   .fetch-head strong{font-weight:600}.fetch-head span,#fetch-detail{font-variant-numeric:tabular-nums;color:var(--text-subtle)}
   .fetch-progress progress{display:block;width:100%;height:7px;margin:7px 0 6px;accent-color:var(--accent)}

--- a/packages/dashboard/performance-views.ts
+++ b/packages/dashboard/performance-views.ts
@@ -4,8 +4,8 @@ import {
   STATUS_COLOR,
   STATUS_EDGE,
   STATUS_WASH,
-  TILE_BASE,
 } from "./palette.ts";
+import { DASHBOARD_THEME_STYLES } from "./theme.ts";
 
 export type PerformanceView = "runtime" | "ci" | "gantt";
 
@@ -32,45 +32,46 @@ export const PERFORMANCE_HISTORY_SCALE_MIN_VALUES = 20;
 export const PERFORMANCE_HISTORY_SCALE_TRIM = 2;
 
 export const PERFORMANCE_PROGRESS_STYLES = `
-  .fetch-progress{background:#16181d;border:1px solid #2f333c;border-radius:10px;padding:10px 12px;margin:0 0 12px}
+  .fetch-progress{background:var(--surface);border:1px solid var(--border-strong);border-radius:10px;padding:10px 12px;margin:0 0 12px}
   .fetch-progress.error,.fetch-progress.warning{border-color:${rgba(STATUS_COLOR.warn, STATUS_EDGE.warn)}}
-  .fetch-head{display:flex;justify-content:space-between;gap:12px;align-items:baseline;font-size:12px;color:#c7ccd4}
-  .fetch-head strong{font-weight:600}.fetch-head span,#fetch-detail{font-variant-numeric:tabular-nums;color:#878d97}
-  .fetch-progress progress{display:block;width:100%;height:7px;margin:7px 0 6px;accent-color:#6ea8fe}
+  .fetch-head{display:flex;justify-content:space-between;gap:12px;align-items:baseline;font-size:12px;color:var(--text-secondary)}
+  .fetch-head strong{font-weight:600}.fetch-head span,#fetch-detail{font-variant-numeric:tabular-nums;color:var(--text-subtle)}
+  .fetch-progress progress{display:block;width:100%;height:7px;margin:7px 0 6px;accent-color:var(--accent)}
   #fetch-detail{font-size:11px;margin:0}`;
 
 export const PERFORMANCE_VIEW_STYLES = `
-  body{box-sizing:border-box;width:100%;margin:0 auto;background:#0d0e11;color:#e7e9ee;font-family:-apple-system,Segoe UI,Roboto,sans-serif;padding:18px 20px 26px;max-width:1100px}
+  ${DASHBOARD_THEME_STYLES}
+  body{box-sizing:border-box;width:100%;margin:0 auto;background:var(--page);color:var(--text);font-family:-apple-system,Segoe UI,Roboto,sans-serif;padding:18px 20px 26px;max-width:1100px}
   .top{display:flex;align-items:baseline;gap:10px;margin-bottom:14px;flex-wrap:wrap}
-  .top b{font-size:16px;font-weight:600}.top span{font-size:12px;color:#6f757f}
-  a.back{color:#6ea8fe;text-decoration:none;font-size:13px}
+  .top b{font-size:16px;font-weight:600}.top span{font-size:12px;color:var(--text-faint)}
+  a.back{color:var(--accent);text-decoration:none;font-size:13px}
   .views{display:flex;gap:6px;margin:0 0 14px}
-  .views a,.controls a{font-size:13px;color:#c7ccd4;text-decoration:none;border:1px solid #2f333c;border-radius:6px;padding:4px 10px}
-  .controls a{font-variant-numeric:tabular-nums}.controls a:hover{border-color:#3a4150}
-  .views a.on,.controls a.on{background:#6ea8fe;border-color:#6ea8fe;color:#0d0e11}
-  .controls{display:flex;flex-wrap:wrap;align-items:center;gap:6px;background:#16181d;border:1px solid #23262d;border-radius:12px;padding:12px 14px;margin-bottom:8px}
-  .controls .lbl{font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:#878d97;margin-right:6px}
-  .controls .field{display:flex;align-items:center;gap:7px;font-size:12px;color:#9aa0ab;margin-right:8px}
+  .views a,.controls a{font-size:13px;color:var(--text-secondary);text-decoration:none;border:1px solid var(--border-strong);border-radius:6px;padding:4px 10px}
+  .controls a{font-variant-numeric:tabular-nums}.controls a:hover{border-color:var(--border-hover)}
+  .views a.on,.controls a.on{background:var(--accent);border-color:var(--accent);color:var(--accent-contrast)}
+  .controls{display:flex;flex-wrap:wrap;align-items:center;gap:6px;background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:12px 14px;margin-bottom:8px}
+  .controls .lbl{font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:var(--text-subtle);margin-right:6px}
+  .controls .field{display:flex;align-items:center;gap:7px;font-size:12px;color:var(--text-muted);margin-right:8px}
   .controls .choice-group{display:flex;flex-wrap:wrap;align-items:center;gap:6px}
-  .controls select{background:#0d0e11;color:#c7ccd4;border:1px solid #2f333c;border-radius:6px;padding:4px 7px}
-  .controls input[type=range]{width:150px}.controls output{color:#c7ccd4;min-width:46px;font-variant-numeric:tabular-nums}
-  .controls label.check{font-size:13px;color:#c7ccd4;display:inline-flex;align-items:center;gap:6px;cursor:pointer;user-select:none}
+  .controls select{background:var(--page);color:var(--text-secondary);border:1px solid var(--border-strong);border-radius:6px;padding:4px 7px}
+  .controls input[type=range]{width:150px}.controls output{color:var(--text-secondary);min-width:46px;font-variant-numeric:tabular-nums}
+  .controls label.check{font-size:13px;color:var(--text-secondary);display:inline-flex;align-items:center;gap:6px;cursor:pointer;user-select:none}
   .controls label.trailing{margin-left:auto}
-  .legend{font-size:11px;color:#777d87;margin:0 0 12px}
+  .legend{font-size:11px;color:var(--text-subtle);margin:0 0 12px}
   ${PERFORMANCE_PROGRESS_STYLES}
-  .axisrow{display:flex;gap:18px;margin:0 14px 4px}.timeaxis{flex:0 0 42%;display:flex;justify-content:space-between;color:#666c76;font-size:10px}
-  h2{font-size:12px;letter-spacing:.04em;color:#878d97;font-weight:600;margin:20px 0 8px;font-family:ui-monospace,Menlo,monospace}
+  .axisrow{display:flex;gap:18px;margin:0 14px 4px}.timeaxis{flex:0 0 42%;display:flex;justify-content:space-between;color:var(--text-faint);font-size:10px}
+  h2{font-size:12px;letter-spacing:.04em;color:var(--text-subtle);font-weight:600;margin:20px 0 8px;font-family:ui-monospace,Menlo,monospace}
   .blist,.clist{display:flex;flex-direction:column;gap:7px}
-  .brow,.crow{display:flex;align-items:center;gap:18px;background:${TILE_BASE};border:1px solid #23262d;border-radius:10px;padding:8px 14px}
+  .brow,.crow{display:flex;align-items:center;gap:18px;background:var(--surface);border:1px solid var(--border);border-radius:10px;padding:8px 14px}
 ${ROW_RULES}
   .bspark,.cspark{flex:0 0 42%;min-width:0;position:relative}
   .bspark>div,.bspark>svg,.cspark>div,.cspark>svg{margin-top:0!important}
   .bmeta,.cmeta{flex:1 1 auto;min-width:0;display:flex;flex-direction:column;gap:2px}
-  .bname,.cname{font-size:13px;color:#c7ccd4;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-  .bval,.cval{color:#e7e9ee;font-size:18px;font-weight:600;font-variant-numeric:tabular-nums}
-  .btrend,.ctrend{font-size:11px;font-weight:400;color:#9aa0ab}
-  .empty,.refresh-error{color:#9aa0ab;font-size:14px}.refresh-error{color:${STATUS_COLOR.warn}}
-  .note{font-size:11px;color:#666c76;margin-top:22px}.note a{color:#6ea8fe;text-decoration:none}
+  .bname,.cname{font-size:13px;color:var(--text-secondary);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .bval,.cval{color:var(--text);font-size:18px;font-weight:600;font-variant-numeric:tabular-nums}
+  .btrend,.ctrend{font-size:11px;font-weight:400;color:var(--text-muted)}
+  .empty,.refresh-error{color:var(--text-muted);font-size:14px}.refresh-error{color:var(--status-warn-text)}
+  .note{font-size:11px;color:var(--text-faint);margin-top:22px}.note a{color:var(--accent);text-decoration:none}
   @media(max-width:640px){.timeaxis{flex:1}.brow,.crow{align-items:stretch;gap:7px;flex-wrap:wrap}.bspark,.cspark{flex:1 0 100%}.controls .field,.controls .choice-group{flex:1 1 100%}.controls input[type=range]{flex:1;width:auto;min-width:0}.controls label.trailing{margin-left:0}}`;
 
 const labels: Record<PerformanceView, string> = {

--- a/packages/dashboard/render.test.ts
+++ b/packages/dashboard/render.test.ts
@@ -251,11 +251,12 @@ Deno.test("shell: the page watches its own stream and reopens one that stops del
 // anything outside the function is a name the page does not have. Neither
 // property is visible to a test that only looks for substrings.
 Deno.test("shell: the injected script is JavaScript, and each injected function stands alone", () => {
-  const script = shell("", "", 0, 45_000, TEST_VERSION, "good")
-    .match(/<script>([\s\S]*)<\/script>/)![1];
-  // Parses the whole body without running it, which is where a leftover type
+  const scripts = [...shell("", "", 0, 45_000, TEST_VERSION, "good")
+    .matchAll(/<script>([\s\S]*?)<\/script>/g)].map((match) => match[1]);
+  // Parses every script without running it, which is where a leftover type
   // annotation or generic parameter would show up.
-  new Function(script);
+  for (const script of scripts) new Function(script);
+  const script = scripts.at(-1)!;
 
   // Evaluated on its own, outside its module, so a reference to anything at
   // module scope throws instead of quietly resolving.
@@ -449,7 +450,10 @@ Deno.test("shell: a tile's wash and border grow with the seriousness of its stat
     assert(alphas[i].wash > alphas[i - 1].wash, "each wash is stronger than the last");
   }
   // A tile that cannot tell takes no color at all.
-  assertStringIncludes(html, ".tile.unknown,.tile.wide.unknown{border-color:#2f333c}");
+  assertStringIncludes(
+    html,
+    ".tile.unknown,.tile.wide.unknown{border-color:var(--border-strong)}",
+  );
 });
 
 Deno.test("shell: server-measured red age changes the favicon after one hour", () => {

--- a/packages/dashboard/render.test.ts
+++ b/packages/dashboard/render.test.ts
@@ -9,7 +9,12 @@ import {
   shell,
 } from "./render.ts";
 import { humanSpan, STATUS_DOT } from "./lib.ts";
-import { TEXTURE_WIDTH } from "./palette.ts";
+import {
+  STATUS_EDGE,
+  STATUS_WASH,
+  TEXTURE_ALPHA,
+  TEXTURE_WIDTH,
+} from "./palette.ts";
 import { FAVICON_VERSION } from "./favicon.ts";
 import { liveUpdateStream } from "./stream-client.ts";
 
@@ -379,12 +384,39 @@ Deno.test("shell: the texture fades out towards the bottom of its own tile", () 
   const strokes = [...html.matchAll(/stroke-width%3D%22([\d.]+)%22/g)];
   assertEquals(strokes.length, 2, "one stroked texture each for warn and bad");
   for (const stroke of strokes) assertEquals(Number(stroke[1]), TEXTURE_WIDTH);
+  assertEquals(
+    [...html.matchAll(/stroke%3D%22black%22/g)].length,
+    2,
+    "texture masks use opaque strokes and take their color from the page theme",
+  );
+  assertEquals(
+    [...html.matchAll(/;mask-image:var\(--texture-mask\)/g)].length,
+    2,
+    "both textures apply their generated mask",
+  );
+  assertEquals(
+    [...html.matchAll(/-webkit-mask-image:var\(--texture-mask\)/g)].length,
+    2,
+    "both textures apply their generated mask in WebKit",
+  );
+  for (const status of ["warn", "bad"]) {
+    assertStringIncludes(
+      html,
+      `background-color:color-mix(in srgb,var(--status-${status}) ${
+        TEXTURE_ALPHA * 100
+      }%,transparent)`,
+    );
+  }
+  assertStringIncludes(
+    html,
+    "radial-gradient(color-mix(in srgb,var(--status-unknown) 15%,transparent) 1px,transparent 1px)",
+  );
   // A pattern repeats at the size of the artwork that draws it. The two are
   // written separately into the CSS, and a pattern drawn at one size and tiled
   // at another is stretched.
   const tiles = [
     ...html.matchAll(
-      /width%3D%22(\d+)%22%20height%3D%22(\d+)%22[^;]*;background-size:(\d+)px (\d+)px/g,
+      /width%3D%22(\d+)%22%20height%3D%22(\d+)%22[^;]*;mask-size:(\d+)px (\d+)px/g,
     ),
   ];
   assertEquals(tiles.length, 2, "both stroked textures set their own size");
@@ -440,10 +472,14 @@ Deno.test("shell: a tile's wash and border grow with the seriousness of its stat
   const html = shell("", "", 0, 30_000, TEST_VERSION, "good");
   const alphas = (["good", "warn", "bad"] as Status[]).map((status) => {
     const rule = new RegExp(
-      `\\.tile\\.${status},\\.tile\\.wide\\.${status}\\{border-color:rgba\\([\\d,]+,([\\d.]+)\\);background:rgba\\([\\d,]+,([\\d.]+)\\)\\}`,
+      `\\.tile\\.${status},\\.tile\\.wide\\.${status}\\{border-color:color-mix\\(in srgb,var\\(--status-${status}\\) ([\\d.]+)%,transparent\\);background:color-mix\\(in srgb,var\\(--status-${status}\\) ([\\d.]+)%,transparent\\)\\}`,
     ).exec(html);
     assert(rule, `${status} has a tile rule`);
-    return { edge: Number(rule[1]), wash: Number(rule[2]) };
+    const edge = Number(rule[1]);
+    const wash = Number(rule[2]);
+    assertEquals(edge, Math.round(STATUS_EDGE[status] * 100));
+    assertEquals(wash, Math.round(STATUS_WASH[status] * 100));
+    return { edge, wash };
   });
   for (let i = 1; i < alphas.length; i++) {
     assert(alphas[i].edge > alphas[i - 1].edge, "each border is stronger than the last");
@@ -519,8 +555,10 @@ Deno.test("shell: server-measured red age changes the favicon after one hour", (
 });
 
 Deno.test("shell: the header names the Fabric Wall shortcut", () => {
+  const html = shell("", "", 0, 1000, TEST_VERSION, "good");
+  assertStringIncludes(html, "<span>go/fabricwall</span>");
   assertStringIncludes(
-    shell("", "", 0, 1000, TEST_VERSION, "good"),
-    "<span>go/fabricwall</span>",
+    html,
+    ".badge{font-size:11px;color:var(--status-good-text);border:1px solid color-mix(in srgb,var(--status-good) 40%,transparent)",
   );
 });

--- a/packages/dashboard/render.ts
+++ b/packages/dashboard/render.ts
@@ -4,18 +4,21 @@ import type { Status, TileView } from "./types.ts";
 import { durationTag, escapeHtml, STATUS_DOT } from "./lib.ts";
 import {
   rgba,
-  RUNNING_COLOR,
   STATUS_COLOR,
   STATUS_EDGE,
-  STATUS_TEXT,
   STATUS_WASH,
   TEXTURE_ALPHA,
   TEXTURE_WIDTH,
-  TILE_BASE,
 } from "./palette.ts";
 import { faviconHref, faviconLink, type FaviconStatus } from "./favicon.ts";
 import { paintStatusFavicon } from "./favicon-client.ts";
 import { liveUpdateStream } from "./stream-client.ts";
+import {
+  DASHBOARD_THEME_CLIENT,
+  DASHBOARD_THEME_HEAD,
+  DASHBOARD_THEME_STYLES,
+  dashboardThemeToggle,
+} from "./theme.ts";
 
 const FAVICON_PNG_HREFS = JSON.stringify({
   good: faviconHref("good"),
@@ -122,7 +125,9 @@ const TILE_RULES = STATUSES.filter((s) => s !== "unknown").map((s) =>
   };background:${rgba(STATUS_COLOR[s], STATUS_WASH[s])}}`
 ).join("\n");
 
-const BIG_RULES = STATUSES.map((s) => `.big.${s}{color:${STATUS_TEXT[s]}}`)
+const BIG_RULES = STATUSES.map((s) =>
+  `.big.${s}{color:var(--status-${s}-text)}`
+)
   .join("");
 
 // The header dot's shape, which says the same thing its color does without
@@ -137,14 +142,15 @@ const DOT_SHAPE: Record<Status, string> = {
   unknown: "border-radius:50%",
 };
 
-const DOT_RULES = STATUSES.map((s) =>
-  `.dot.${STATUS_DOT[s]}::before{${DOT_SHAPE[s]};${
-    s === "unknown"
-      ? `border:2px solid ${STATUS_COLOR[s]}`
-      : `background:${STATUS_COLOR[s]}`
-  }}`
-).join("") +
-  `.dot.run::before{border-radius:50%;background:${RUNNING_COLOR}}`;
+const DOT_RULES =
+  STATUSES.map((s) =>
+    `.dot.${STATUS_DOT[s]}::before{${DOT_SHAPE[s]};${
+      s === "unknown"
+        ? `border:2px solid var(--status-${s})`
+        : `background:var(--status-${s})`
+    }}`
+  ).join("") +
+  `.dot.run::before{border-radius:50%;background:var(--running)}`;
 
 type ViewerTimeElement = Pick<HTMLTimeElement, "dateTime" | "textContent">;
 
@@ -215,21 +221,23 @@ function renderShell(
   serverRedSince: number | null = null,
   serverRedAgeMs: number | null = null,
 ): string {
-  return `<!doctype html><html><head><meta charset="utf-8"><title>Fabric wall — LIVE</title>
+  return `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>Fabric wall — LIVE</title>
+${DASHBOARD_THEME_HEAD}
 ${faviconLink(status)}
 <style>
-  body{margin:0;background:#0d0e11;color:#e7e9ee;font-family:-apple-system,Segoe UI,Roboto,sans-serif;padding:18px 20px 26px;max-width:1100px;margin:0 auto}
+${DASHBOARD_THEME_STYLES}
+  body{margin:0;background:var(--page);color:var(--text);font-family:-apple-system,Segoe UI,Roboto,sans-serif;padding:18px 20px 26px;max-width:1100px;margin:0 auto}
   .top{display:flex;justify-content:space-between;align-items:center;margin-bottom:14px}
-  .brand b{font-size:16px;font-weight:600}.brand span{font-size:12px;color:#6f757f;margin-left:8px}
-  .badge{font-size:11px;color:${STATUS_TEXT.good};border:1px solid ${
+  .brand b{font-size:16px;font-weight:600}.brand span{font-size:12px;color:var(--text-faint);margin-left:8px}
+  .badge{font-size:11px;color:var(--status-good-text);border:1px solid ${
     rgba(STATUS_COLOR.good, 0.4)
   };border-radius:6px;padding:2px 8px;margin-left:8px}
-  .live{font-size:12px;color:#9aa0ab}
+  .top-actions{display:flex;align-items:center;gap:12px}.live{font-size:12px;color:var(--text-muted)}
   .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:12px;margin-bottom:12px}
-  .tile{background:${TILE_BASE};border:1px solid #23262d;border-radius:12px;padding:14px 16px;position:relative;isolation:isolate;overflow:hidden}
+  .tile{background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:14px 16px;position:relative;isolation:isolate;overflow:hidden}
   .tile.wide{margin-bottom:12px}
 ${TILE_RULES}
-  .tile.unknown,.tile.wide.unknown{border-color:#2f333c}
+  .tile.unknown,.tile.wide.unknown{border-color:var(--border-strong)}
   /* Each status carries a texture as well as a colour, so the wall reads at a
      glance and without relying on colour alone: dots for gray, waves for
      amber, zig-zags for red. The waves run across the zig-zags, a quarter turn
@@ -249,25 +257,25 @@ ${TILE_RULES}
   .tile.unknown .texture::before{${DOT_TEXTURE}}
   .tile.warn .texture::before{${WAVE_TEXTURE};--turn:120deg}
   .tile.bad .texture::before{${ZIGZAG_TEXTURE}}
-  .lbl{font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:#a5adb9;margin:0 0 7px;display:flex;align-items:center;gap:7px}
+  .lbl{font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:var(--text-muted);margin:0 0 7px;display:flex;align-items:center;gap:7px}
   .lbl .spacer{flex:1}
-  .drill{font-size:10px;color:#9ba3b0;letter-spacing:0;text-transform:none}
-  .hmtd{font-size:11px;color:#9aa0ab;letter-spacing:0;text-transform:none;font-variant-numeric:tabular-nums;margin-right:8px}
+  .drill{font-size:10px;color:var(--text-muted);letter-spacing:0;text-transform:none}
+  .hmtd{font-size:11px;color:var(--text-muted);letter-spacing:0;text-transform:none;font-variant-numeric:tabular-nums;margin-right:8px}
   /* Fixed line-height so the headline's line box is the same height regardless of
      which font the glyph comes from: the ▲/▼ trend arrows fall back to a taller
      symbol font, and under line-height:normal that stretched the tile. */
   .big{font-size:30px;font-weight:600;margin:0;line-height:1.2}
   ${BIG_RULES}
-  .sub{font-size:13px;color:#9aa0ab;margin:5px 0 0}
-  .running{display:inline-flex;align-items:center;gap:5px;font-size:10px;color:#9ba3b0;letter-spacing:.02em;text-transform:none;margin-top:10px}
+  .sub{font-size:13px;color:var(--text-muted);margin:5px 0 0}
+  .running{display:inline-flex;align-items:center;gap:5px;font-size:10px;color:var(--text-muted);letter-spacing:.02em;text-transform:none;margin-top:10px}
   /* In the header the badge is a facet of a single line, not a block under the
      chart, so it takes the line's own vertical rhythm. */
   .lbl .running{margin-top:0;margin-right:8px}
-  .rdot{width:7px;height:7px;border-radius:50%;background:${RUNNING_COLOR};flex:none}
+  .rdot{width:7px;height:7px;border-radius:50%;background:var(--running);flex:none}
   .cells{display:grid;gap:1px;margin-top:10px}
   .cell{aspect-ratio:1;border-radius:1px}
   a.cell{display:block}
-  a.cell:hover{outline:1px solid #6ea8fe;outline-offset:-1px}
+  a.cell:hover{outline:1px solid var(--accent);outline-offset:-1px}
   /* The dot is drawn by its own layer so each status can take a shape as well
      as a color. The shape carries the same signal the color does, which is
      what a viewer who cannot separate the hues reads instead. */
@@ -275,35 +283,45 @@ ${TILE_RULES}
   .dot::before{content:"";position:absolute;inset:0}
   ${DOT_RULES}
   a.tile.link{display:block;text-decoration:none;color:inherit;cursor:pointer;transition:border-color .12s}
-  a.tile.link:hover{border-color:#3a4150}
+  a.tile.link:hover{border-color:var(--border-hover)}
   .evscroll{max-height:340px;overflow:auto}
-  .ev{display:flex;align-items:center;gap:11px;padding:6px 0;font-size:13px;border-top:1px solid rgba(255,255,255,.09)}.ev:first-child{border-top:0}
-  .ev .t{color:#9ba3b0;min-width:54px;flex:none}
+  .ev{display:flex;align-items:center;gap:11px;padding:6px 0;font-size:13px;border-top:1px solid var(--divider)}.ev:first-child{border-top:0}
+  .ev .t{color:var(--text-muted);min-width:54px;flex:none}
   .evtxt{color:inherit;text-decoration:none;flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;transition:color .1s}
-  .evtxt:hover{color:#fff}
-  .evdur{color:#a1a9b6;text-decoration:none;text-align:right;min-width:64px;flex:none;font-variant-numeric:tabular-nums}
-  a.evdur:hover{color:#6ea8fe}
-  .evarrow{color:rgba(255,255,255,.40);text-decoration:none;flex:none;font-size:11px;transition:color .1s}
-  .evarrow:hover{color:#8a93a5}
+  .evtxt:hover{color:var(--text-strong)}
+  .evdur{color:var(--text-muted);text-decoration:none;text-align:right;min-width:64px;flex:none;font-variant-numeric:tabular-nums}
+  a.evdur:hover{color:var(--accent)}
+  .evarrow{color:var(--icon-subtle);text-decoration:none;flex:none;font-size:11px;transition:color .1s}
+  .evarrow:hover{color:var(--text-subtle)}
   .swatch{display:inline-block;width:8px;height:8px;border-radius:2px;vertical-align:middle}
-  .note{font-size:11px;color:#666c76;margin-top:14px}
-  code{background:#1b1e24;padding:1px 5px;border-radius:4px}
+  .note{font-size:11px;color:var(--text-faint);margin-top:14px}
+  code{background:var(--surface-code);padding:1px 5px;border-radius:4px}
+  @media(max-width:560px){.top{align-items:flex-start;gap:10px}.brand span:last-child{display:none}.top-actions{gap:8px}}
 </style></head><body>
   <div class="top">
     <div class="brand"><b>Fabric wall</b><span class="badge" id="livebadge">● LIVE</span><span>go/fabricwall</span></div>
-    <div class="live"><span class="dot green" id="freshdot"></span> <span id="agotext">updated ${ago}s ago</span></div>
+    <div class="top-actions"><div class="live"><span class="dot green" id="freshdot"></span> <span id="agotext">updated ${ago}s ago</span></div></div>
   </div>
   <div class="grid" id="dashboard-grid">${gridHtml}</div>
   <div id="dashboard-wide">${wideHtml}</div>
+${dashboardThemeToggle()}
+${DASHBOARD_THEME_CLIENT}
 <script>
   const REFRESH = ${refreshMs};
   const RED_AFTER = REFRESH + ${STALE_GRACE_MS};
   const SHELL_VERSION = ${JSON.stringify(shellVersion)};
   const COL = ${
     JSON.stringify({
-      green: STATUS_COLOR.good,
-      amber: STATUS_COLOR.warn,
-      red: STATUS_COLOR.bad,
+      green: "var(--status-good-text)",
+      amber: "var(--status-warn-text)",
+      red: "var(--status-bad-text)",
+    })
+  };
+  const EDGE = ${
+    JSON.stringify({
+      green: "var(--status-good)",
+      amber: "var(--status-warn)",
+      red: "var(--status-bad)",
     })
   };
   const FAVICONS = ${FAVICON_PNG_HREFS};
@@ -336,9 +354,9 @@ ${TILE_RULES}
     // LIVE badge: green only when fresh AND no tile is gray; gray if a tile is gray;
     // when stale, the border takes the orange/red and the contents go gray.
     const anyGray = document.querySelector('.tile.unknown') !== null;
-    if (state !== 'green') { badge.style.borderColor = COL[state]; badge.style.color = '${STATUS_COLOR.unknown}'; }
-    else if (anyGray) { badge.style.borderColor = '${STATUS_COLOR.unknown}'; badge.style.color = '${STATUS_COLOR.unknown}'; }
-    else { badge.style.borderColor = '${STATUS_TEXT.good}'; badge.style.color = '${STATUS_TEXT.good}'; }
+    if (state !== 'green') { badge.style.borderColor = EDGE[state]; badge.style.color = 'var(--status-unknown-text)'; }
+    else if (anyGray) { badge.style.borderColor = 'var(--status-unknown)'; badge.style.color = 'var(--status-unknown-text)'; }
+    else { badge.style.borderColor = 'var(--status-good-text)'; badge.style.color = 'var(--status-good-text)'; }
     paintStatusFavicon(
       FAVICONS,
       FAVICON_CRY_AFTER_MS,

--- a/packages/dashboard/render.ts
+++ b/packages/dashboard/render.ts
@@ -3,8 +3,6 @@
 import type { Status, TileView } from "./types.ts";
 import { durationTag, escapeHtml, STATUS_DOT } from "./lib.ts";
 import {
-  rgba,
-  STATUS_COLOR,
   STATUS_EDGE,
   STATUS_WASH,
   TEXTURE_ALPHA,
@@ -18,6 +16,7 @@ import {
   DASHBOARD_THEME_HEAD,
   DASHBOARD_THEME_STYLES,
   dashboardThemeToggle,
+  statusLayer,
 } from "./theme.ts";
 
 const FAVICON_PNG_HREFS = JSON.stringify({
@@ -42,26 +41,26 @@ export const FAVICON_CRY_AFTER_MS = 60 * 60 * 1000;
 const TEXTURE_HEIGHT = 24;
 
 /**
- * A tiling background of one stroked path, for the texture that sits behind a
- * tile's flat colour wash. Returns the whole background declaration, because
- * the size the tile repeats at is part of the pattern rather than a separate
- * choice. The path is drawn in a `period` by `TEXTURE_HEIGHT` space, and its
- * corners come to a point.
+ * A tiling mask of one stroked path, for the texture that sits behind a tile's
+ * flat colour wash. The mask lets CSS paint the path with the active theme's
+ * status color. The path is drawn in a `period` by `TEXTURE_HEIGHT` space, and
+ * its corners come to a point.
  *
  * A path has to begin and end on the left and right edges of that space,
  * heading the same way at both, so the two ends butt together where the
  * pattern repeats. The round cap is what makes that joint clean: it fills the
  * stroke out to the edge, and the part that reaches past is clipped away.
  */
-function strokeTexture(path: string, stroke: string, period: number): string {
+function strokeTexture(path: string, period: number): string {
   const svg = `<svg xmlns="http://www.w3.org/2000/svg" ` +
     `width="${period}" height="${TEXTURE_HEIGHT}" ` +
     `viewBox="0 0 ${period} ${TEXTURE_HEIGHT}">` +
-    `<path d="${path}" fill="none" stroke="${stroke}" ` +
+    `<path d="${path}" fill="none" stroke="black" ` +
     `stroke-width="${TEXTURE_WIDTH}" stroke-linecap="round"/></svg>`;
-  return `background-image:url("data:image/svg+xml,${
-    encodeURIComponent(svg)
-  }");background-size:${period}px ${TEXTURE_HEIGHT}px`;
+  const mask = `url("data:image/svg+xml,${encodeURIComponent(svg)}")`;
+  return `--texture-mask:${mask};mask-size:${period}px ${TEXTURE_HEIGHT}px;` +
+    `-webkit-mask-size:${period}px ${TEXTURE_HEIGHT}px;` +
+    `mask-image:var(--texture-mask);-webkit-mask-image:var(--texture-mask)`;
 }
 
 // The wave rises and falls once across its period, which is long enough for a
@@ -70,17 +69,15 @@ function strokeTexture(path: string, stroke: string, period: number): string {
 const WAVE_PERIOD = 60;
 const WAVE_TEXTURE = strokeTexture(
   `M0 12q${WAVE_PERIOD / 4} -8 ${WAVE_PERIOD / 2} 0t${WAVE_PERIOD / 2} 0`,
-  rgba(STATUS_COLOR.warn, TEXTURE_ALPHA),
   WAVE_PERIOD,
-);
+) + `;background-color:${statusLayer("warn", TEXTURE_ALPHA)}`;
 // Two turns of the zig-zag, which puts its period at half the tile. It starts
 // and ends halfway along a run rather than on a corner, which keeps every
 // corner inside a tile, where the join between its two runs draws the point.
 const ZIGZAG_TEXTURE = strokeTexture(
   "M0 12l6-6 12 12 12-12 12 12 6-6",
-  rgba(STATUS_COLOR.bad, TEXTURE_ALPHA),
   48,
-);
+) + `;background-color:${statusLayer("bad", TEXTURE_ALPHA)}`;
 // Two copies of the same dot grid make a triangular lattice, where each dot has
 // six neighbours at one distance rather than a square lattice's four near ones
 // and four far ones. The copies are one dot spacing apart across, one spacing
@@ -91,7 +88,7 @@ const ZIGZAG_TEXTURE = strokeTexture(
 const DOT_SPACING_PX = 16;
 const DOT_ROW_PX = DOT_SPACING_PX * Math.sqrt(3);
 const DOT_STIPPLE = `radial-gradient(${
-  rgba(STATUS_COLOR.unknown, 0.15)
+  statusLayer("unknown", 0.15)
 } 1px,transparent 1px)`;
 const DOT_TEXTURE = [
   `background-image:${DOT_STIPPLE},${DOT_STIPPLE};`,
@@ -121,8 +118,8 @@ const STATUSES: readonly Status[] = ["good", "warn", "bad", "unknown"];
 // keeps the neutral border below.
 const TILE_RULES = STATUSES.filter((s) => s !== "unknown").map((s) =>
   `  .tile.${s},.tile.wide.${s}{border-color:${
-    rgba(STATUS_COLOR[s], STATUS_EDGE[s])
-  };background:${rgba(STATUS_COLOR[s], STATUS_WASH[s])}}`
+    statusLayer(s, STATUS_EDGE[s])
+  };background:${statusLayer(s, STATUS_WASH[s])}}`
 ).join("\n");
 
 const BIG_RULES = STATUSES.map((s) =>
@@ -230,7 +227,7 @@ ${DASHBOARD_THEME_STYLES}
   .top{display:flex;justify-content:space-between;align-items:center;margin-bottom:14px}
   .brand b{font-size:16px;font-weight:600}.brand span{font-size:12px;color:var(--text-faint);margin-left:8px}
   .badge{font-size:11px;color:var(--status-good-text);border:1px solid ${
-    rgba(STATUS_COLOR.good, 0.4)
+    statusLayer("good", 0.4)
   };border-radius:6px;padding:2px 8px;margin-left:8px}
   .top-actions{display:flex;align-items:center;gap:12px}.live{font-size:12px;color:var(--text-muted)}
   .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:12px;margin-bottom:12px}

--- a/packages/dashboard/spend.ts
+++ b/packages/dashboard/spend.ts
@@ -6,6 +6,7 @@
 // another source's line runs further.
 import type { Status } from "./types.ts";
 import { multiSparkline, SPARK_FADE } from "./lib.ts";
+import { themedChartSeries } from "./theme.ts";
 
 export const DAY_MS = 86_400_000;
 export const MIN_SPEND_WINDOW_DAYS = 14;
@@ -236,7 +237,7 @@ export function spendChart(
       xs: covered === grid.length
         ? undefined
         : days.map((_, index) => index / (grid.length - 1)),
-      color: source.color,
+      ...themedChartSeries(source.color),
       label: source.label,
       highlightCount: Math.max(0, covered - (grid.length - highlightDays)),
       showSinglePoint: true,

--- a/packages/dashboard/test/runner.ts
+++ b/packages/dashboard/test/runner.ts
@@ -10,6 +10,7 @@ export const TEST_COMMANDS = [
     "--allow-write",
     `--allow-run=${Deno.execPath()},git`,
     "--ignore=favicon-client.browser.test.ts",
+    "--ignore=theme.browser.test.ts",
     "--ignore=favicon-raster.test.ts",
     "--ignore=regenerate-favicons.test.ts",
   ],

--- a/packages/dashboard/test/theme.test.ts
+++ b/packages/dashboard/test/theme.test.ts
@@ -10,6 +10,7 @@ import {
   LIGHT_THEME_COLORS,
   themedChartSeries,
 } from "../theme.ts";
+import { LIGHT_STATUS_TEXT, STATUS_COLOR } from "../palette.ts";
 
 function contrastRatio(first: string, second: string): number {
   const luminance = (color: string) => {
@@ -42,8 +43,21 @@ describe("theme", () => {
       );
     });
 
-    it("defines every status text and sparkline color in both themes", () => {
-      for (const status of ["good", "warn", "bad", "unknown"]) {
+    it("defines every status color, text color, and sparkline color in both themes", () => {
+      for (const status of ["good", "warn", "bad", "unknown"] as const) {
+        expect(
+          DASHBOARD_THEME_STYLES.match(
+            new RegExp(`--status-${status}:${STATUS_COLOR[status]}`, "g"),
+          )?.length,
+        ).toBe(2);
+        expect(
+          DASHBOARD_THEME_STYLES.match(
+            new RegExp(
+              `--status-${status}:${LIGHT_STATUS_TEXT[status]}`,
+              "g",
+            ),
+          )?.length,
+        ).toBe(1);
         expect(
           DASHBOARD_THEME_STYLES.match(
             new RegExp(`--status-${status}-text:`, "g"),

--- a/packages/dashboard/test/theme.test.ts
+++ b/packages/dashboard/test/theme.test.ts
@@ -1,0 +1,130 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  chartColorForLightTheme,
+  DASHBOARD_THEME_CLIENT,
+  DASHBOARD_THEME_HEAD,
+  DASHBOARD_THEME_STYLES,
+  dashboardThemeToggle,
+  initializeDashboardTheme,
+  LIGHT_THEME_COLORS,
+  themedChartSeries,
+} from "../theme.ts";
+
+function contrastRatio(first: string, second: string): number {
+  const luminance = (color: string) => {
+    const value = parseInt(color.slice(1), 16);
+    const channels = [(value >> 16) & 255, (value >> 8) & 255, value & 255]
+      .map((channel) => {
+        const normalized = channel / 255;
+        return normalized <= 0.04045
+          ? normalized / 12.92
+          : ((normalized + 0.055) / 1.055) ** 2.4;
+      });
+    return 0.2126 * channels[0] + 0.7152 * channels[1] +
+      0.0722 * channels[2];
+  };
+  const values = [luminance(first), luminance(second)].sort((a, b) => b - a);
+  return (values[0] + 0.05) / (values[1] + 0.05);
+}
+
+describe("theme", () => {
+  describe("DASHBOARD_THEME_STYLES", () => {
+    it("defines explicit light and dark themes", () => {
+      expect(DASHBOARD_THEME_STYLES).not.toContain(
+        "@media(prefers-color-scheme:light)",
+      );
+      expect(DASHBOARD_THEME_STYLES).toContain(
+        ':root[data-theme="light"]{color-scheme:light',
+      );
+      expect(DASHBOARD_THEME_STYLES).toContain(
+        ':root[data-theme="dark"]{color-scheme:dark',
+      );
+    });
+
+    it("defines every status text and sparkline color in both themes", () => {
+      for (const status of ["good", "warn", "bad", "unknown"]) {
+        expect(
+          DASHBOARD_THEME_STYLES.match(
+            new RegExp(`--status-${status}-text:`, "g"),
+          )?.length,
+        ).toBe(3);
+        expect(
+          DASHBOARD_THEME_STYLES.match(
+            new RegExp(`--spark-fade-${status}:`, "g"),
+          )?.length,
+        ).toBe(3);
+      }
+    });
+
+    it("aligns the theme control at the bottom-right of the document", () => {
+      expect(DASHBOARD_THEME_STYLES).toContain(
+        ".theme-toggle{display:flex;width:88px;box-sizing:border-box;margin:16px 0 0 auto;align-items:center;justify-content:center",
+      );
+      expect(DASHBOARD_THEME_STYLES).not.toContain("position:fixed");
+    });
+
+    it("keeps every light-theme text token readable on its surfaces", () => {
+      const textColors = Object.entries(LIGHT_THEME_COLORS).filter(([name]) =>
+        name.startsWith("text")
+      );
+      for (const [, color] of textColors) {
+        expect(contrastRatio(color, LIGHT_THEME_COLORS.page))
+          .toBeGreaterThanOrEqual(4.5);
+        expect(contrastRatio(color, LIGHT_THEME_COLORS.surface))
+          .toBeGreaterThanOrEqual(4.5);
+      }
+    });
+  });
+
+  describe("themedChartSeries()", () => {
+    it("darkens pale lines enough for small light-theme labels", () => {
+      const pale = "#fabfd2";
+      const light = chartColorForLightTheme(pale);
+      expect(contrastRatio(light, LIGHT_THEME_COLORS.page))
+        .toBeGreaterThanOrEqual(4.8);
+      expect(themedChartSeries(pale).color).toBe(
+        `light-dark(${light},${pale})`,
+      );
+    });
+  });
+
+  describe("dashboardThemeToggle()", () => {
+    it("returns a dark-mode button with separate icon and text targets", () => {
+      const html = dashboardThemeToggle();
+      expect(html).toContain(
+        'data-theme-toggle aria-label="Theme: Dark. Switch to light mode"',
+      );
+      expect(html).toContain("data-theme-icon");
+      expect(html).toContain("data-theme-label");
+    });
+  });
+
+  describe("browser scripts", () => {
+    it("defaults to dark and loads the saved theme before painting", () => {
+      expect(DASHBOARD_THEME_HEAD).toContain(
+        'document.documentElement.dataset.theme="dark"',
+      );
+      expect(DASHBOARD_THEME_HEAD).toContain(
+        'localStorage.getItem("fabricWallTheme")',
+      );
+      expect(DASHBOARD_THEME_HEAD).toContain(
+        't==="light"||t==="system"',
+      );
+      expect(DASHBOARD_THEME_HEAD).toContain(
+        'matchMedia("(prefers-color-scheme: light)").matches',
+      );
+    });
+
+    it("injects a stand-alone browser function", () => {
+      expect(DASHBOARD_THEME_CLIENT).toContain(
+        initializeDashboardTheme.toString(),
+      );
+      const source = DASHBOARD_THEME_CLIENT.match(
+        /^<script>\((.*)\)\(\)<\/script>$/s,
+      )?.[1];
+      expect(source).toBeDefined();
+      expect(() => new Function(`return (${source})`)).not.toThrow();
+    });
+  });
+});

--- a/packages/dashboard/theme.browser.test.ts
+++ b/packages/dashboard/theme.browser.test.ts
@@ -1,0 +1,74 @@
+import { assertEquals } from "@std/assert";
+import { initializeDashboardTheme } from "./theme.ts";
+
+Deno.test("theme switch cycles through dark, light, and system", () => {
+  const root = document.documentElement;
+  root.dataset.theme = "dark";
+  localStorage.removeItem("fabricWallTheme");
+  let prefersLight = false;
+  let preferenceChanged: (() => void) | undefined;
+  const preference = {
+    get matches() {
+      return prefersLight;
+    },
+    addEventListener(_type: string, listener: () => void) {
+      preferenceChanged = listener;
+    },
+  } as unknown as MediaQueryList;
+  const fixture = document.createElement("div");
+  fixture.innerHTML =
+    "<button data-theme-toggle><span data-theme-icon></span><span data-theme-label></span></button>";
+  document.body.append(fixture);
+  const button = fixture.querySelector("button")!;
+  let announced = "";
+  let announcementCount = 0;
+  const listener = (event: Event) => {
+    announced = (event as CustomEvent<{ theme: string }>).detail.theme;
+    announcementCount++;
+  };
+  addEventListener("dashboardthemechange", listener);
+
+  try {
+    initializeDashboardTheme(preference);
+    assertEquals(button.ariaLabel, "Theme: Dark. Switch to light mode");
+    assertEquals(button.textContent, "☾Dark");
+
+    button.click();
+    assertEquals(root.dataset.theme, "light");
+    assertEquals(localStorage.getItem("fabricWallTheme"), "light");
+    assertEquals(button.ariaLabel, "Theme: Light. Switch to system mode");
+    assertEquals(button.textContent, "☀Light");
+    assertEquals(announced, "light");
+
+    button.click();
+    assertEquals(root.dataset.theme, "dark");
+    assertEquals(localStorage.getItem("fabricWallTheme"), "system");
+    assertEquals(button.ariaLabel, "Theme: System. Switch to dark mode");
+    assertEquals(button.textContent, "◐System");
+    assertEquals(announced, "dark");
+
+    prefersLight = true;
+    preferenceChanged!();
+    assertEquals(root.dataset.theme, "light");
+    assertEquals(announced, "light");
+
+    button.click();
+    assertEquals(root.dataset.theme, "dark");
+    assertEquals(localStorage.getItem("fabricWallTheme"), "dark");
+    assertEquals(button.ariaLabel, "Theme: Dark. Switch to light mode");
+    assertEquals(button.textContent, "☾Dark");
+    assertEquals(announced, "dark");
+
+    const explicitDarkAnnouncementCount = announcementCount;
+    prefersLight = false;
+    preferenceChanged!();
+    assertEquals(root.dataset.theme, "dark");
+    assertEquals(announced, "dark");
+    assertEquals(announcementCount, explicitDarkAnnouncementCount);
+  } finally {
+    removeEventListener("dashboardthemechange", listener);
+    fixture.remove();
+    delete root.dataset.theme;
+    localStorage.removeItem("fabricWallTheme");
+  }
+});

--- a/packages/dashboard/theme.ts
+++ b/packages/dashboard/theme.ts
@@ -60,6 +60,14 @@ export const LIGHT_THEME_COLORS: ThemeColors = {
   "chart-highlight": "#374151",
 };
 
+/** A transparent status color layer painted from the active theme. */
+export function statusLayer(status: Status, alpha: number): string {
+  const percent = Number((alpha * 100).toFixed(4));
+  return `color-mix(in srgb,var(--status-${status}) ${
+    percent
+  }%,transparent)`;
+}
+
 const STATUSES: readonly Status[] = ["good", "warn", "bad", "unknown"];
 
 function variables(

--- a/packages/dashboard/theme.ts
+++ b/packages/dashboard/theme.ts
@@ -1,0 +1,267 @@
+import type { Status } from "./types.ts";
+import {
+  LIGHT_SPARK_FADE,
+  LIGHT_STATUS_TEXT,
+  SPARK_FADE,
+  STATUS_COLOR,
+  STATUS_TEXT,
+} from "./palette.ts";
+
+export type DashboardTheme = "dark" | "light";
+export type DashboardThemeMode = DashboardTheme | "system";
+
+const THEME_STORAGE_KEY = "fabricWallTheme";
+
+const DARK_COLORS = {
+  page: "#0d0e11",
+  text: "#e7e9ee",
+  "text-strong": "#ffffff",
+  "text-secondary": "#c7ccd4",
+  "text-muted": "#9aa0ab",
+  "text-subtle": "#878d97",
+  "text-faint": "#666c76",
+  surface: "#16181d",
+  "surface-deep": "#0c0d11",
+  "surface-code": "#1b1e24",
+  border: "#23262d",
+  "border-strong": "#2f333c",
+  "border-hover": "#3a4150",
+  divider: "rgba(255,255,255,.09)",
+  "icon-subtle": "rgba(255,255,255,.40)",
+  accent: "#6ea8fe",
+  "accent-contrast": "#0d0e11",
+  running: "#6ea8fe",
+  "chart-line": "#727882",
+  "chart-highlight": "#c7ccd4",
+} as const;
+
+type ThemeColors = { [Key in keyof typeof DARK_COLORS]: string };
+
+export const LIGHT_THEME_COLORS: ThemeColors = {
+  page: "#f5f7fa",
+  text: "#202630",
+  "text-strong": "#10151c",
+  "text-secondary": "#3f4a59",
+  "text-muted": "#5f6b7a",
+  "text-subtle": "#647080",
+  "text-faint": "#666f7b",
+  surface: "#ffffff",
+  "surface-deep": "#eef2f6",
+  "surface-code": "#e9edf2",
+  border: "#d7dce3",
+  "border-strong": "#bdc5d0",
+  "border-hover": "#8e9bad",
+  divider: "rgba(20,30,45,.12)",
+  "icon-subtle": "rgba(25,35,48,.45)",
+  accent: "#2667b8",
+  "accent-contrast": "#ffffff",
+  running: "#3979c9",
+  "chart-line": "#6b7280",
+  "chart-highlight": "#374151",
+};
+
+const STATUSES: readonly Status[] = ["good", "warn", "bad", "unknown"];
+
+function variables(
+  colors: ThemeColors,
+  statusText: Record<Status, string>,
+  sparkFade: Record<Status, string>,
+  statusIndicator: Record<Status, string>,
+): string {
+  const neutral = Object.entries(colors).map(([name, value]) =>
+    `--${name}:${value}`
+  );
+  const statuses = STATUSES.flatMap((status) => [
+    `--status-${status}:${statusIndicator[status]}`,
+    `--status-${status}-text:${statusText[status]}`,
+    `--spark-fade-${status}:${sparkFade[status]}`,
+  ]);
+  return [...neutral, ...statuses].join(";");
+}
+
+const DARK_VARIABLES = variables(
+  DARK_COLORS,
+  STATUS_TEXT,
+  SPARK_FADE,
+  STATUS_COLOR,
+);
+const LIGHT_VARIABLES = variables(
+  LIGHT_THEME_COLORS,
+  LIGHT_STATUS_TEXT,
+  LIGHT_SPARK_FADE,
+  LIGHT_STATUS_TEXT,
+);
+
+function colorChannels(hex: string): [number, number, number] {
+  const value = parseInt(hex.slice(1), 16);
+  return [(value >> 16) & 255, (value >> 8) & 255, value & 255];
+}
+
+function colorHex(channels: readonly number[]): string {
+  return `#${
+    channels.map((channel) => Math.round(channel).toString(16).padStart(2, "0"))
+      .join("")
+  }`;
+}
+
+function mixColor(color: string, target: string, amount: number): string {
+  const source = colorChannels(color);
+  const destination = colorChannels(target);
+  return colorHex(
+    source.map((channel, index) =>
+      channel + (destination[index] - channel) * amount
+    ),
+  );
+}
+
+function luminance(color: string): number {
+  const channels = colorChannels(color).map((channel) => {
+    const value = channel / 255;
+    return value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * channels[0] + 0.7152 * channels[1] +
+    0.0722 * channels[2];
+}
+
+function contrast(first: string, second: string): number {
+  const values = [luminance(first), luminance(second)].sort((a, b) => b - a);
+  return (values[0] + 0.05) / (values[1] + 0.05);
+}
+
+/** Darken a chart color until small labels remain readable in light mode. */
+export function chartColorForLightTheme(color: string): string {
+  if (!/^#[0-9a-f]{6}$/i.test(color)) return color;
+  if (contrast(color, LIGHT_THEME_COLORS.page) >= 4.8) return color;
+  let lower = 0;
+  let upper = 1;
+  for (let step = 0; step < 12; step++) {
+    const amount = (lower + upper) / 2;
+    if (
+      contrast(mixColor(color, "#000000", amount), LIGHT_THEME_COLORS.page) >=
+        4.8
+    ) {
+      upper = amount;
+    } else {
+      lower = amount;
+    }
+  }
+  return mixColor(color, "#000000", upper);
+}
+
+/** A chart line and its emphasized recent segment in both color schemes. */
+export function themedChartSeries(color: string): {
+  color: string;
+  highlightColor: string;
+} {
+  if (!/^#[0-9a-f]{6}$/i.test(color)) {
+    return { color, highlightColor: color };
+  }
+  const light = chartColorForLightTheme(color);
+  const lightHighlight = mixColor(light, "#000000", 0.2);
+  const darkHighlight = mixColor(color, "#ffffff", 0.6);
+  return {
+    color: `light-dark(${light},${color})`,
+    highlightColor: `light-dark(${lightHighlight},${darkHighlight})`,
+  };
+}
+
+export const DASHBOARD_THEME_HEAD =
+  `<meta name="color-scheme" content="dark light"><script>` +
+  `document.documentElement.dataset.theme="dark";` +
+  `try{const t=localStorage.getItem(${JSON.stringify(THEME_STORAGE_KEY)});` +
+  `if(t==="light"||t==="system")document.documentElement.dataset.theme=` +
+  `t==="light"||matchMedia("(prefers-color-scheme: light)").matches?"light":"dark"}catch{}` +
+  `</script>`;
+
+export const DASHBOARD_THEME_STYLES = `
+  :root{color-scheme:dark;${DARK_VARIABLES}}
+  :root[data-theme="dark"]{color-scheme:dark;${DARK_VARIABLES}}
+  :root[data-theme="light"]{color-scheme:light;${LIGHT_VARIABLES}}
+  .theme-toggle{display:flex;width:88px;box-sizing:border-box;margin:16px 0 0 auto;align-items:center;justify-content:center;gap:6px;background:var(--surface);color:var(--text-secondary);border:1px solid var(--border-strong);border-radius:999px;padding:6px 11px;font:inherit;font-size:11px;line-height:1.2;cursor:pointer;white-space:nowrap}
+  .theme-toggle:hover{border-color:var(--border-hover);color:var(--text-strong)}
+  .theme-toggle:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .theme-toggle [data-theme-icon]{font-size:13px;line-height:1}`;
+
+export const dashboardThemeToggle = (): string =>
+  `<button class="theme-toggle" type="button" data-theme-toggle aria-label="Theme: Dark. Switch to light mode" title="Theme: Dark. Switch to light mode"><span data-theme-icon aria-hidden="true">☾</span><span data-theme-label>Dark</span></button>`;
+
+/** Connect every theme switch on the page to the saved dashboard theme. */
+export function initializeDashboardTheme(
+  preference = matchMedia("(prefers-color-scheme: light)"),
+): void {
+  const storageKey = "fabricWallTheme";
+  const root = document.documentElement;
+  const modes: DashboardThemeMode[] = ["dark", "light", "system"];
+  let mode: DashboardThemeMode = "dark";
+  try {
+    const saved = localStorage.getItem(storageKey);
+    if (saved === "dark" || saved === "light" || saved === "system") {
+      mode = saved;
+    }
+  } catch {
+    // A storage failure uses the dark default.
+  }
+  const resolved = (): DashboardTheme =>
+    mode === "system" ? (preference.matches ? "light" : "dark") : mode;
+  const apply = (): void => {
+    root.dataset.theme = resolved();
+  };
+  const paint = (): void => {
+    const next = modes[(modes.indexOf(mode) + 1) % modes.length];
+    const label = mode[0].toUpperCase() + mode.slice(1);
+    const icons: Record<DashboardThemeMode, string> = {
+      dark: "☾",
+      light: "☀",
+      system: "◐",
+    };
+    for (
+      const button of document.querySelectorAll<HTMLButtonElement>(
+        "[data-theme-toggle]",
+      )
+    ) {
+      const labelTarget = button.querySelector<HTMLElement>(
+        "[data-theme-label]",
+      );
+      const icon = button.querySelector<HTMLElement>("[data-theme-icon]");
+      if (labelTarget) labelTarget.textContent = label;
+      if (icon) icon.textContent = icons[mode];
+      button.ariaLabel = `Theme: ${label}. Switch to ${next} mode`;
+      button.title = `Theme: ${label}. Switch to ${next} mode`;
+    }
+  };
+  const announce = (): void => {
+    apply();
+    paint();
+    dispatchEvent(
+      new CustomEvent("dashboardthemechange", {
+        detail: { theme: resolved() },
+      }),
+    );
+  };
+  for (
+    const button of document.querySelectorAll<HTMLButtonElement>(
+      "[data-theme-toggle]",
+    )
+  ) {
+    button.addEventListener("click", () => {
+      mode = modes[(modes.indexOf(mode) + 1) % modes.length];
+      try {
+        localStorage.setItem(storageKey, mode);
+      } catch {
+        // A storage failure leaves the document theme in place.
+      }
+      announce();
+    });
+  }
+  preference.addEventListener("change", () => {
+    if (mode === "system") announce();
+  });
+  apply();
+  paint();
+}
+
+export const DASHBOARD_THEME_CLIENT =
+  `<script>(${initializeDashboardTheme.toString()})()</script>`;
+
+export const CHART_LINE = "var(--chart-line)";
+export const CHART_HIGHLIGHT = "var(--chart-highlight)";

--- a/packages/dashboard/tiles.test.ts
+++ b/packages/dashboard/tiles.test.ts
@@ -18,7 +18,6 @@ import {
   githubCiSpend,
 } from "./tiles/github-ci-spend.ts";
 import { projectMonthly, settled } from "./spend.ts";
-import { RUNNING_COLOR, STATUS_COLOR } from "./palette.ts";
 import { modelSpend } from "./tiles/model-spend.ts";
 import {
   benchmark,
@@ -113,7 +112,7 @@ Deno.test(
       "first-try green · 199 of last 200 runs",
     );
     assert(
-      !(view.extra ?? "").includes(STATUS_COLOR.bad),
+      !(view.extra ?? "").includes("var(--status-bad)"),
       "the 201st run must be outside the grid and percentage window",
     );
   },
@@ -131,14 +130,14 @@ Deno.test("labs ci trust grid: cell colors match trust scoring", async () => {
   ];
   const view = await labsCiTrust.collect(ctx(runs));
   const colors = [
-    ...(view.extra ?? "").matchAll(/background:(#[0-9a-f]+)/g),
+    ...(view.extra ?? "").matchAll(/background:(var\(--[^)]+\))/g),
   ].map((match) => match[1]);
   assertEquals(view.value, "25.0%");
-  assertEquals(colors.filter((color) => color === STATUS_COLOR.good).length, 1);
-  assertEquals(colors.filter((color) => color === STATUS_COLOR.bad).length, 3);
-  assertEquals(colors.filter((color) => color === RUNNING_COLOR).length, 1);
+  assertEquals(colors.filter((color) => color === "var(--status-good)").length, 1);
+  assertEquals(colors.filter((color) => color === "var(--status-bad)").length, 3);
+  assertEquals(colors.filter((color) => color === "var(--running)").length, 1);
   assertEquals(
-    colors.filter((color) => color === STATUS_COLOR.unknown).length,
+    colors.filter((color) => color === "var(--status-unknown)").length,
     2,
   );
 });

--- a/packages/dashboard/tiles/benchmark.test.ts
+++ b/packages/dashboard/tiles/benchmark.test.ts
@@ -2052,9 +2052,17 @@ Deno.test("benchmark: CPU lines split across large gaps and use distinct colors"
       assertEquals(legendColors.length, 18);
       assertEquals(new Set(legendColors).size, 18);
       for (const color of legendColors) {
+        const pair = color.match(
+          /^light-dark\((#[0-9a-f]{6}),(#[0-9a-f]{6})\)$/i,
+        );
+        assert(pair, `${color} is not a light and dark chart color`);
         assert(
-          contrastRatio(color, "#16181d") >= 3,
-          `${color} does not contrast with the CPU legend background`,
+          contrastRatio(pair[1], "#f5f7fa") >= 4.5,
+          `${pair[1]} does not contrast with the light CPU legend background`,
+        );
+        assert(
+          contrastRatio(pair[2], "#16181d") >= 3,
+          `${pair[2]} does not contrast with the dark CPU legend background`,
         );
       }
       const rowCpuIds = [

--- a/packages/dashboard/tiles/benchmark.ts
+++ b/packages/dashboard/tiles/benchmark.ts
@@ -93,6 +93,12 @@ import {
   trendStatus,
 } from "../trend.ts";
 import { ciGanttPage } from "./ci-duration.ts";
+import {
+  DASHBOARD_THEME_CLIENT,
+  DASHBOARD_THEME_HEAD,
+  dashboardThemeToggle,
+  themedChartSeries,
+} from "../theme.ts";
 
 export { trendPct, trendStatus } from "../trend.ts";
 
@@ -1026,7 +1032,7 @@ function benchmarkIndexView(
   // the same style, and names the failure there.
   const countLine = failed
     ? ""
-    : `<div style="font-size:13px;color:#9aa0ab;margin:5px 0 0">${count} benchmark${
+    : `<div style="font-size:13px;color:var(--text-muted);margin:5px 0 0">${count} benchmark${
       count === 1 ? "" : "s"
     }${windowLabel}</div>`;
   const allPoints = indices.flatMap((series) => series.points);
@@ -1037,7 +1043,7 @@ function benchmarkIndexView(
   const chart = multiSparkline(
     indices.map((series) => ({
       vals: series.points.map((point) => point.index),
-      color: series.color,
+      ...themedChartSeries(series.color),
       xs: series.points.map((point) => (point.at - chartStart) / chartAxis),
       highlightCount: series.windowCount,
       maxXGap: CPU_LINE_MAX_X_GAP,
@@ -1742,7 +1748,7 @@ export function benchPage(
       const spark = multiSparkline(
         cpus.map((series) => ({
           vals: series.values,
-          color: series.color,
+          ...themedChartSeries(series.color),
           xs: series.points.map((point) => (point.at - axisStart) / axisSpan),
           maxXGap: CPU_LINE_MAX_X_GAP,
           showSinglePoint: true,
@@ -1801,6 +1807,7 @@ export function benchPage(
           [...cpuDetails]
             .sort(([a], [b]) => a.localeCompare(b))
             .map(([cpu, detail]) => {
+              const displayColor = themedChartSeries(detail.color).color;
               const benchmarks = `${detail.benchmarks} benchmark${
                 detail.benchmarks === 1 ? "" : "s"
               }`;
@@ -1814,9 +1821,9 @@ export function benchPage(
                 }`;
               const { label: cpuId, anchor } = cpuKeys.get(cpu)!;
               return `<div class="cpu-key" id="${anchor}" data-cpu-id="${cpuId}"><span class="swatch" style="background:${
-                escapeHtml(detail.color)
+                escapeHtml(displayColor)
               }"></span><span class="cpu-id" style="--cpu-color:${
-                escapeHtml(detail.color)
+                escapeHtml(displayColor)
               }">${cpuId}</span><span class="cpu-description"><span class="cpu-name">${
                 escapeHtml(cpu)
               }</span><span class="cpu-detail">${benchmarks} · ${runs} · ${observed}</span></span></div>`;
@@ -1825,6 +1832,7 @@ export function benchPage(
     }
     const rowHtml = (r: (typeof rows)[number], label: string) => {
       const series = r.representative;
+      const displayColor = themedChartSeries(series.color).color;
       const { label: cpuId, anchor } = cpuKeys.get(series.cpu)!;
       const latest = formatNs(series.latest);
       const sampleCount = series.sampleCount;
@@ -1834,7 +1842,7 @@ export function benchPage(
       return `<div class="brow ${r.st}"><div class="bspark">${r.spark}${r.dur}</div><div class="bmeta">` +
         `<span class="bname">${escapeHtml(label)}</span>` +
         `<span class="bval" data-cpu-id="${cpuId}" data-sample-count="${sampleCount}" style="--cpu-color:${
-          escapeHtml(series.color)
+          escapeHtml(displayColor)
         }" title="${
           escapeHtml(`${series.cpu} · ${samples}`)
         }" aria-label="${
@@ -1902,28 +1910,29 @@ export function benchPage(
   return `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>Benchmarks — ${
     escapeHtml(stat.label)
   }</title>
+${DASHBOARD_THEME_HEAD}
 <style>
   ${PERFORMANCE_VIEW_STYLES}
   .bval{display:flex;align-items:baseline;min-width:0}
   .bval .cpu-id{margin-right:7px;align-self:center}
   .bval a.cpu-id{text-decoration:none}
-  .bval a.cpu-id:hover{border-color:#6ea8fe;color:#fff}
-  .bval a.cpu-id:focus-visible{outline:2px solid #6ea8fe;outline-offset:2px}
+  .bval a.cpu-id:hover{border-color:var(--accent);color:var(--text-strong)}
+  .bval a.cpu-id:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
   .btrend{margin-left:8px}
-  .swatch{display:inline-block;width:8px;height:8px;border-radius:2px;flex:none;box-shadow:0 0 0 1px rgba(255,255,255,.42)}
-  .cpu-id{display:inline-flex;align-items:center;justify-content:center;border:1px solid var(--cpu-color,#454b56);border-radius:4px;padding:1px 4px;font-size:9px;line-height:1.2;font-weight:500;color:#c7ccd4;white-space:nowrap}
+  .swatch{display:inline-block;width:8px;height:8px;border-radius:2px;flex:none;box-shadow:0 0 0 1px var(--icon-subtle)}
+  .cpu-id{display:inline-flex;align-items:center;justify-content:center;border:1px solid var(--cpu-color,var(--border-hover));border-radius:4px;padding:1px 4px;font-size:9px;line-height:1.2;font-weight:500;color:var(--text-secondary);white-space:nowrap}
   .cpu-legend{margin-top:22px}.cpu-legend-title{margin:0 0 8px}
   .handoff{display:flex;align-items:center;flex-wrap:wrap;gap:10px;margin-top:10px}
-  .handoff a{font-size:13px;color:#c7ccd4;text-decoration:none;border:1px solid #2f333c;border-radius:6px;padding:4px 10px}
-  .handoff a:hover{border-color:#6ea8fe;color:#fff}
-  .handoff a:focus-visible{outline:2px solid #6ea8fe;outline-offset:2px}
-  .handoff span{font-size:11px;color:#666c76}
+  .handoff a{font-size:13px;color:var(--text-secondary);text-decoration:none;border:1px solid var(--border-strong);border-radius:6px;padding:4px 10px}
+  .handoff a:hover{border-color:var(--accent);color:var(--text-strong)}
+  .handoff a:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .handoff span{font-size:11px;color:var(--text-faint)}
   .cpu-keys{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:7px}
-  .cpu-key{display:flex;align-items:flex-start;gap:8px;background:#16181d;border:1px solid #23262d;border-radius:8px;padding:8px 10px}
-  .cpu-key:target{border-color:#6ea8fe;box-shadow:0 0 0 1px rgba(110,168,254,.24);scroll-margin-top:16px}
+  .cpu-key{display:flex;align-items:flex-start;gap:8px;background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:8px 10px}
+  .cpu-key:target{border-color:var(--accent);box-shadow:0 0 0 1px color-mix(in srgb,var(--accent) 24%,transparent);scroll-margin-top:16px}
   .cpu-key>.swatch,.cpu-key>.cpu-id{margin-top:3px}.cpu-description{min-width:0}
-  .cpu-name{display:block;font-size:12px;color:#c7ccd4;overflow-wrap:anywhere}
-  .cpu-detail{display:block;font-size:10px;color:#878d97;margin-top:2px}
+  .cpu-name{display:block;font-size:12px;color:var(--text-secondary);overflow-wrap:anywhere}
+  .cpu-detail{display:block;font-size:10px;color:var(--text-subtle);margin-top:2px}
   body.hide-green .brow.good{display:none}
   body.hide-green .benchmark-group:not(:has(.brow:not(.good))){display:none}
 </style></head><body data-snapshot-version="${escapeHtml(version)}">
@@ -1937,6 +1946,8 @@ export function benchPage(
     days === 1 ? "" : "s"
   }</output><input type="range" id="days" name="days" min="${CI_HISTORY_MIN_DAYS}" max="${CI_HISTORY_DAYS}" step="1" value="${days}"></label><nav class="choice-group" aria-label="Benchmark metric"><span class="lbl">metric</span>${statSel}</nav><nav class="choice-group" aria-label="Sort benchmarks"><span class="lbl">sort</span>${sortSel}</nav><label class="check trailing"><input type="checkbox" id="hg"> hide green</label></form>
   ${rangeContent}
+${dashboardThemeToggle()}
+${DASHBOARD_THEME_CLIENT}
 <script>
   const hg = document.getElementById("hg"), days = document.getElementById("days"), daysv = document.getElementById("daysv"), controls = days.form, KEY = "benchHideGreen", DEFAULT_DAYS = days.value;
   let rangeContent = document.getElementById("range-content"), fetchProgress = document.getElementById("fetch-progress"), title = document.getElementById("fetch-title"), total = document.getElementById("fetch-total"), detail = document.getElementById("fetch-detail"), bar = document.getElementById("fetch-bar"), pageVersion = fetchProgress.dataset.snapshotVersion, appliedDays = days.value;

--- a/packages/dashboard/tiles/ci-duration.test.ts
+++ b/packages/dashboard/tiles/ci-duration.test.ts
@@ -14,6 +14,7 @@ import {
   ciCommitGanttPage,
   type CiGanttDataProvider,
   ciGanttPage,
+  commitGanttUrl,
   labsCiDuration,
   loomCiDuration,
   median,
@@ -21,6 +22,7 @@ import {
   renderGanttRoute,
 } from "./ci-duration.ts";
 import { PERFORMANCE_VIEW_STYLES } from "../performance-views.ts";
+import { STATUS_EDGE, STATUS_WASH } from "../palette.ts";
 
 const SVG = new TextEncoder().encode(
   '<svg xmlns="http://www.w3.org/2000/svg"><text>chart</text></svg>',
@@ -215,6 +217,22 @@ Deno.test("the Gantt page shares the performance view selector", async () => {
   );
   assertStringIncludes(html, "<title>CI run Gantt</title>");
   assertStringIncludes(html, PERFORMANCE_VIEW_STYLES);
+  for (const status of ["good", "warn", "bad"] as const) {
+    assertStringIncludes(
+      html,
+      `.brow.${status},.crow.${status}{border-color:color-mix(in srgb,var(--status-${status}) ${
+        Number((STATUS_EDGE[status] * 100).toFixed(4))
+      }%,transparent);background:color-mix(in srgb,var(--status-${status}) ${
+        Number((STATUS_WASH[status] * 0.75 * 100).toFixed(4))
+      }%,transparent)}`,
+    );
+  }
+  assertStringIncludes(
+    html,
+    `.fetch-progress.error,.fetch-progress.warning{border-color:color-mix(in srgb,var(--status-warn) ${
+      Number((STATUS_EDGE.warn * 100).toFixed(4))
+    }%,transparent)}`,
+  );
   assertStringIncludes(html, `${REPO} · ${CI_WORKFLOW}`);
   assertStringIncludes(html, `href="/"`); // a way back to the dashboard
   assertStringIncludes(
@@ -375,6 +393,23 @@ Deno.test("the commit Gantt page contains only one commit selection", () => {
     "No successful main CI runs were supplied for this commit.",
   );
   assert(!empty.includes("/ci-gantt.svg?"));
+});
+
+Deno.test("commit Gantt URL normalization preserves only renderer themes", () => {
+  const selection = `repo=labs&sha=${"e".repeat(40)}&run=42:1`;
+  for (const theme of ["dark", "light"]) {
+    const normalized = commitGanttUrl(
+      new URL(`http://d/ci-gantt.svg?${selection}&theme=${theme}`),
+    );
+    assert(normalized);
+    assertEquals(normalized.searchParams.get("theme"), theme);
+  }
+
+  const unknown = commitGanttUrl(
+    new URL(`http://d/ci-gantt.svg?${selection}&theme=sepia`),
+  );
+  assert(unknown);
+  assertEquals(unknown.searchParams.has("theme"), false);
 });
 
 Deno.test("commit Gantt data routes start the exact selected collection", async () => {

--- a/packages/dashboard/tiles/ci-duration.test.ts
+++ b/packages/dashboard/tiles/ci-duration.test.ts
@@ -231,6 +231,7 @@ Deno.test("the Gantt page shares the performance view selector", async () => {
   );
   assertStringIncludes(html, '<option value="labs" selected>labs</option>');
   assertStringIncludes(html, "/bench/gantt.svg?"); // the controls point at the image route
+  assertStringIncludes(html, "p.set('theme', document.documentElement.dataset.theme");
   assertStringIncludes(html, 'id="fetch-progress"');
   assertStringIncludes(html, 'id="fetch-title">Idle</strong>');
   assertStringIncludes(html, 'aria-label="CI Gantt fetch progress"');
@@ -355,10 +356,14 @@ Deno.test("the commit Gantt page contains only one commit selection", () => {
   assertStringIncludes(html, "const image = new Image()");
   assertStringIncludes(html, "image.onerror = () =>");
   assertStringIncludes(html, "URL.revokeObjectURL(src)");
+  assertStringIncludes(html, "url.searchParams.set('theme'");
   assertStringIncludes(html, "if (chartSrc) URL.revokeObjectURL(chartSrc)");
   assertStringIncludes(html, "if (chartSettled) return");
   assertStringIncludes(html, "chartSettled = true");
-  assertStringIncludes(html, "stream.close();\n    chartSrc = src");
+  assertStringIncludes(
+    html,
+    "stream.close();\n    if (chartSrc) URL.revokeObjectURL(chartSrc);\n    chartSrc = src",
+  );
   assert(!html.includes('class="controls"'));
   assert(!html.includes('aria-label="Performance view"'));
 
@@ -449,6 +454,7 @@ Deno.test("/bench/gantt.svg: a successful render returns SVG uncached", async ()
   assertEquals(opt(args, "--repo"), REPO);
   assertEquals(opt(args, "--workflow"), CI_WORKFLOW);
   assertEquals(opt(args, "--limit"), "30");
+  assertEquals(opt(args, "--theme"), "dark");
   assertEquals(opt(args, "--out"), "/fake-tmp/ci-gantt-2.svg"); // the bytes come from where it was told to write
   assertEquals(opt(args, "--input"), "/fake-tmp/ci-gantt-input-1.json");
   assert(!args.includes("--allow-net"));
@@ -468,6 +474,9 @@ Deno.test("/bench/gantt.svg: a successful render returns SVG uncached", async ()
     allConclusions: false,
   });
   assertEquals(leftover, []); // the temp file is cleaned up on the way out
+
+  const light = await gantt("?limit=1&theme=light");
+  assertEquals(opt(light.args, "--theme"), "default");
 });
 
 Deno.test("/bench/gantt.svg includes chart labels without server fonts", async () => {

--- a/packages/dashboard/tiles/ci-duration.ts
+++ b/packages/dashboard/tiles/ci-duration.ts
@@ -584,9 +584,11 @@ ${DASHBOARD_THEME_HEAD}
 </body></html>`;
 }
 
-function commitGanttUrl(url: URL): URL | null {
+export function commitGanttUrl(url: URL): URL | null {
   const parameters = commitGanttParameters(url);
   if (!parameters) return null;
+  const theme = url.searchParams.get("theme");
+  if (theme === "dark" || theme === "light") parameters.set("theme", theme);
   const normalized = new URL(url);
   normalized.search = parameters.toString();
   return normalized;

--- a/packages/dashboard/tiles/ci-duration.ts
+++ b/packages/dashboard/tiles/ci-duration.ts
@@ -37,10 +37,16 @@ import {
   GANTT_MAX_RUNS,
 } from "../ci-job-history.ts";
 import {
-  PERFORMANCE_PROGRESS_STYLES,
   PERFORMANCE_VIEW_STYLES,
   performanceViewNav,
 } from "../performance-views.ts";
+import {
+  CHART_HIGHLIGHT,
+  CHART_LINE,
+  DASHBOARD_THEME_CLIENT,
+  DASHBOARD_THEME_HEAD,
+  dashboardThemeToggle,
+} from "../theme.ts";
 
 const CIGANTT = fromFileUrl(
   new URL("../../../scripts/ci-gantt.ts", import.meta.url),
@@ -93,7 +99,7 @@ export async function renderGantt(
       "--limit",
       String(limit),
       "--theme",
-      "dark",
+      p.get("theme") === "light" ? "default" : "dark",
       "--out",
       out,
     ];
@@ -179,14 +185,17 @@ export function ciGanttPage(url: URL): string {
     stat,
   });
   return `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>CI run Gantt</title>
+${DASHBOARD_THEME_HEAD}
 <style>
   ${PERFORMANCE_VIEW_STYLES}
-  .imgwrap{background:#0c0d11;border:1px solid #23262d;border-radius:12px;padding:10px;overflow:auto;min-height:60px}
+  .imgwrap{background:var(--surface-deep);border:1px solid var(--border);border-radius:12px;padding:10px;overflow:auto;min-height:60px}
   #g{width:100%;height:auto;display:none}
 </style></head><body>
   <div class="top"><a class="back" href="/">← dashboard</a><b>Performance history</b><span>${
     escapeHtml(source.repo)
-  } · ${escapeHtml(source.workflow)} · scripts/ci-gantt.ts</span></div>
+  } · ${
+    escapeHtml(source.workflow)
+  } · scripts/ci-gantt.ts</span></div>
   ${viewNav}
   <div class="controls">
     <label class="field" for="repo">repository <select id="repo"><option value="labs"${
@@ -201,6 +210,8 @@ export function ciGanttPage(url: URL): string {
   ${ciFetchProgressPanel(undefined, { ariaLabel: "CI Gantt fetch progress" })}
   <div class="imgwrap"><img id="g" alt="CI Gantt chart"></div>
   <p class="note">Run, job, and step timings share the persistent server cache used by CI history. Regeneration reads cached past runs and fetches only missing runs or newer attempts.</p>
+${dashboardThemeToggle()}
+${DASHBOARD_THEME_CLIENT}
 <script>
   const $ = (id) => document.getElementById(id);
   const g = $('g'), fetchProgress = $('fetch-progress'), title = $('fetch-title'), total = $('fetch-total'), detail = $('fetch-detail'), bar = $('fetch-bar');
@@ -214,6 +225,7 @@ export function ciGanttPage(url: URL): string {
   }
   function imageUrl(){
     const p = parameters();
+    p.set('theme', document.documentElement.dataset.theme || (matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark'));
     p.set('t', Date.now());
     return '/bench/gantt.svg?' + p.toString();
   }
@@ -377,6 +389,7 @@ export function ciGanttPage(url: URL): string {
   $('limit').addEventListener('input', () => { $('limitv').textContent = $('limit').value; });
   $('limit').addEventListener('change', regen);
   ['mainOnly','allConcl'].forEach((id) => $(id).addEventListener('change', regen));
+  addEventListener('dashboardthemechange', regen);
   regen();
   setInterval(() => {
     if (document.visibilityState === 'visible') regen();
@@ -439,6 +452,7 @@ export function ciCommitGanttPage(url: URL): string {
   const chart = document.getElementById('g');
   let collectionWarning = '';
   let chartSettled = false;
+  let chartLoad = 0;
   const stream = new EventSource(${JSON.stringify(progressUrl)});
   const idle = (message, warning = '', error = false) => {
     fetchProgress.classList.remove('error', 'warning');
@@ -496,9 +510,11 @@ export function ciCommitGanttPage(url: URL): string {
     idle('Progress connection closed; collection continues on the server.', '', true);
   };
   let chartSrc = '';
-  fetch(${
-      JSON.stringify(imageUrl)
-    }, { cache: 'no-store' }).then(async (response) => {
+  const loadChart = () => {
+    const load = ++chartLoad;
+    const url = new URL(${JSON.stringify(imageUrl)}, location.href);
+    url.searchParams.set('theme', document.documentElement.dataset.theme || (matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark'));
+    fetch(url, { cache: 'no-store' }).then(async (response) => {
     if (!response.ok) throw new Error((await response.text()).trim());
     const src = URL.createObjectURL(await response.blob());
     return await new Promise((resolve, reject) => {
@@ -510,20 +526,26 @@ export function ciCommitGanttPage(url: URL): string {
       };
       image.src = src;
     });
-  }).then((src) => {
+    }).then((src) => {
+    if (load !== chartLoad) { URL.revokeObjectURL(src); return; }
     chartSettled = true;
     stream.close();
+    if (chartSrc) URL.revokeObjectURL(chartSrc);
     chartSrc = src;
     chart.src = src;
     chart.style.display = 'block';
     idle('Chart includes ${runCount} successful run${
       runCount === 1 ? "" : "s"
     } for this commit.', collectionWarning);
-  }).catch((error) => {
+    }).catch((error) => {
+    if (load !== chartLoad) return;
     chartSettled = true;
     stream.close();
     idle('Last collection stopped: ' + (error.message || 'failed to generate chart'), '', true);
-  });
+    });
+  };
+  addEventListener('dashboardthemechange', loadChart);
+  loadChart();
   window.addEventListener('pagehide', () => {
     stream.close();
     if (chartSrc) URL.revokeObjectURL(chartSrc);
@@ -533,27 +555,31 @@ export function ciCommitGanttPage(url: URL): string {
   return `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>CI Gantt · ${
     escapeHtml(shortSha)
   }</title>
+${DASHBOARD_THEME_HEAD}
 <style>
-  body{margin:0;background:#0d0e11;color:#e7e9ee;font-family:-apple-system,Segoe UI,Roboto,sans-serif;padding:18px 20px 26px;max-width:1400px;margin:0 auto}
+  ${PERFORMANCE_VIEW_STYLES}
+  body{max-width:1400px}
   .top{display:flex;align-items:baseline;gap:10px;margin-bottom:14px;flex-wrap:wrap}
-  .top b{font-size:16px;font-weight:600}.top span{font-size:12px;color:#6f757f}
-  a{color:#6ea8fe;text-decoration:none}.back{font-size:13px}.commit{font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
-  ${PERFORMANCE_PROGRESS_STYLES}
-  .imgwrap{background:#0c0d11;border:1px solid #23262d;border-radius:12px;padding:10px;overflow:auto;min-height:60px}
+  a{color:var(--accent);text-decoration:none}.back{font-size:13px}.commit{font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+  .imgwrap{background:var(--surface-deep);border:1px solid var(--border);border-radius:12px;padding:10px;overflow:auto;min-height:60px}
   #g{width:100%;height:auto;display:none}
-  .empty{background:#16181d;border:1px solid #2f333c;border-radius:12px;padding:18px;color:#9aa0ab}
+  .empty{background:var(--surface);border:1px solid var(--border-strong);border-radius:12px;padding:18px;color:var(--text-muted)}
 </style></head><body>
   <div class="top"><a class="back" href="/">← dashboard</a><b>CI Gantt</b><span>${
     escapeHtml(source.repo)
   } · <a class="commit" href="${
     escapeHtml(commitUrl)
-  }" target="_blank" rel="noopener">${escapeHtml(shortSha)} ↗</a></span></div>
+  }" target="_blank" rel="noopener">${
+    escapeHtml(shortSha)
+  } ↗</a></span></div>
   ${
     ciFetchProgressPanel(undefined, {
       ariaLabel: "Commit CI Gantt fetch progress",
     })
   }
   ${chart}
+  ${dashboardThemeToggle()}
+  ${DASHBOARD_THEME_CLIENT}
   ${script}
 </body></html>`;
 }
@@ -713,9 +739,9 @@ function makeCiDuration(
         sub: usingTime
           ? `median · ${window.length} passing runs in the last ${DUR_MAX_AGE_HOURS}h`
           : `median · last ${window.length} passing runs`,
-        extra: sparkline(series, "#727882", {
+        extra: sparkline(series, CHART_LINE, {
           count: window.length,
-          color: "#c7ccd4",
+          color: CHART_HIGHLIGHT,
         }, SPARK_FADE[s]),
         duration: spanMs,
         href: opts.href,

--- a/packages/dashboard/tiles/dau.ts
+++ b/packages/dashboard/tiles/dau.ts
@@ -26,6 +26,7 @@
 // is still switched off and light up on its own when it is turned on.
 import type { Status, Tile, TileView } from "../types.ts";
 import { serviceName, SPARK_FADE, sparkline } from "../lib.ts";
+import { CHART_LINE } from "../theme.ts";
 
 const TIMEOUT = 15_000;
 const DAY_MS = 86_400_000;
@@ -167,7 +168,7 @@ export const dau: Tile = {
     const value = series[series.length - 1];
     // One day is a number, not a trend, so there is no line to draw and no span to
     // report: the span describes the chart.
-    const chart = sparkline(series, "#727882", undefined, SPARK_FADE.good);
+    const chart = sparkline(series, CHART_LINE, undefined, SPARK_FADE.good);
 
     return {
       ...drill,

--- a/packages/dashboard/tiles/discord-online.test.ts
+++ b/packages/dashboard/tiles/discord-online.test.ts
@@ -3,7 +3,12 @@
 // driven frame by frame, the timers fire on demand, the clock is fixed, and the
 // file reads and writes are captured in memory. No network, no filesystem, no
 // waiting.
-import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import {
+  assert,
+  assertEquals,
+  assertMatch,
+  assertStringIncludes,
+} from "@std/assert";
 import type { Ctx } from "../types.ts";
 import { buildSnapshot, discordOnline, loadHistory } from "./discord-online.ts";
 
@@ -304,8 +309,14 @@ Deno.test("discord online: a snapshot -> good; the reloaded history draws the ch
     // because the file was reloaded.
     assertEquals(v.duration, 2 * DAY);
     assertStringIncludes(v.extra ?? "", "<svg");
-    assertStringIncludes(v.extra ?? "", `background:${VISITOR_GREY}`);
-    assertStringIncludes(v.extra ?? "", "background:#2ecc71"); // the team role's own color
+    assertMatch(
+      v.extra ?? "",
+      new RegExp(`background:light-dark\\(#[0-9a-f]{6},${VISITOR_GREY}\\)`),
+    );
+    assertMatch(
+      v.extra ?? "",
+      /background:light-dark\(#[0-9a-f]{6},#2ecc71\)/,
+    ); // the team role's own color
     // With the chart drawn the counts sit at each line's end, not in the subline.
     assertStringIncludes(v.extra ?? "", "team + ");
 

--- a/packages/dashboard/tiles/discord-online.ts
+++ b/packages/dashboard/tiles/discord-online.ts
@@ -10,8 +10,9 @@
 // the Discord developer portal (privileged intents); without them the gateway
 // closes with 4014.
 import type { Status, Tile, TileView } from "../types.ts";
-import { escapeHtml, multiSparkline, thin } from "../lib.ts";
+import { escapeHtml, multiSparkline, SPARK_FADE, thin } from "../lib.ts";
 import { dashboardCacheFile } from "../history-files.ts";
+import { themedChartSeries } from "../theme.ts";
 
 const GATEWAY = "wss://gateway.discord.gg/?v=10&encoding=json";
 const SNAPSHOT_TIMEOUT_MS = 12_000;
@@ -24,11 +25,6 @@ const INTENTS = 259;
 const TEAM_ROLE_NAME = "Team";
 const TEAM_ROLE_NAMES = new Set([TEAM_ROLE_NAME, "Team Member"]);
 const VISITOR_COLOR = "#7c828c";
-// The chart lines fade from this (a shade darker than the good-status tile
-// background) on the far left up to their own color, matching the ci-duration
-// sparkline.
-const LINE_FADE = "#0e1915";
-
 // A rolling series of timestamped samples, charted as two lines. Samples are
 // retained for up to HISTORY_MAX_AGE_DAYS (~2 months) and persisted to disk in
 // the dashboard cache directory, reloaded on start so a relaunch keeps the
@@ -265,19 +261,21 @@ export const discordOnline: Tile = {
     // history feeds the span.
     const spanMs = history.length >= 2 ? history[history.length - 1].t - history[0].t : 0;
     const plot = thin(history, PLOT_POINTS);
+    const teamSeries = themedChartSeries(snap.teamColor);
+    const visitorSeries = themedChartSeries(VISITOR_COLOR);
     const chart = multiSparkline(
       [
-        { vals: plot.map((h) => h.team), color: snap.teamColor, label: String(snap.team) },
-        { vals: plot.map((h) => h.visitors), color: VISITOR_COLOR, label: String(snap.visitors) },
+        { vals: plot.map((h) => h.team), ...teamSeries, label: String(snap.team) },
+        { vals: plot.map((h) => h.visitors), ...visitorSeries, label: String(snap.visitors) },
       ],
-      { fadeFrom: LINE_FADE },
+      { fadeFrom: SPARK_FADE.good },
     );
     const swatch = (c: string) => `<span class="swatch" style="background:${escapeHtml(c)}"></span>`;
     // With the chart drawn, the counts sit at each line's end; until there are
     // two samples show them inline so the tile is never numberless.
     const subline = chart
-      ? `<p class="sub">${swatch(snap.teamColor)} team + ${swatch(VISITOR_COLOR)} visitors</p>`
-      : `<p class="sub">${swatch(snap.teamColor)} team ${snap.team} + ${swatch(VISITOR_COLOR)} visitors ${snap.visitors}</p>`;
+      ? `<p class="sub">${swatch(teamSeries.color)} team + ${swatch(visitorSeries.color)} visitors</p>`
+      : `<p class="sub">${swatch(teamSeries.color)} team ${snap.team} + ${swatch(visitorSeries.color)} visitors ${snap.visitors}</p>`;
 
     return {
       label,

--- a/packages/dashboard/tiles/github-ci-spend.test.ts
+++ b/packages/dashboard/tiles/github-ci-spend.test.ts
@@ -6,10 +6,14 @@ import type { Ctx, TileView } from "../types.ts";
 import { REPO } from "../config.ts";
 import { blacksmithRoutes } from "../blacksmith.ts";
 import { projectMonthly } from "../spend.ts";
+import { themedChartSeries } from "../theme.ts";
 import { githubCiSpend } from "./github-ci-spend.ts";
 
 const ORG = "acme";
 const D = 86_400_000;
+
+const themedSwatch = (color: string) =>
+  `<span class="swatch" style="background:${themedChartSeries(color).color}"></span>`;
 
 const pad = (n: number) => String(n).padStart(2, "0");
 
@@ -372,7 +376,7 @@ Deno.test("ci spend: both billing endpoints unreachable -> gray with a calm reas
   );
   assertStringIncludes(
     v.extra ?? "",
-    '<span class="swatch" style="background:#58a6ff"></span> GitHub $??? • Budget $???',
+    `${themedSwatch("#58a6ff")} GitHub $??? • Budget $???`,
   );
 });
 
@@ -394,7 +398,7 @@ Deno.test("ci spend: every failed provider retains the combined middle line", as
   assertEquals(result.value, "—");
   assertStringIncludes(
     result.extra ?? "",
-    '<p class="sub"><span class="swatch" style="background:#58a6ff"></span> GitHub $??? • <span class="swatch" style="background:#f59e0b"></span> Blacksmith $??? • Budget $500</p>',
+    `<p class="sub">${themedSwatch("#58a6ff")} GitHub $??? • ${themedSwatch("#f59e0b")} Blacksmith $??? • Budget $500</p>`,
   );
 });
 
@@ -461,7 +465,7 @@ Deno.test("ci spend: a Blacksmith invoice without daily history still supplies M
   assertEquals(early.status, "warn");
   assertEquals(
     early.extra,
-    '<p class="sub"><span class="swatch" style="background:#f59e0b"></span> Blacksmith $150 • Budget $300</p>',
+    `<p class="sub">${themedSwatch("#f59e0b")} Blacksmith $150 • Budget $300</p>`,
   );
   assertEquals(early.duration, 0);
   assertEquals(early.href, "https://app.blacksmith.sh/");
@@ -715,7 +719,7 @@ Deno.test("ci spend: GitHub and Blacksmith share totals, chart, and combined bud
   assertEquals(v.href, undefined);
   assertStringIncludes(
     v.extra ?? "",
-    '<p class="sub"><span class="swatch" style="background:#58a6ff"></span> GitHub • <span class="swatch" style="background:#f59e0b"></span> Blacksmith • Budget $350</p>',
+    `<p class="sub">${themedSwatch("#58a6ff")} GitHub • ${themedSwatch("#f59e0b")} Blacksmith • Budget $350</p>`,
   );
   assertStringIncludes(v.extra ?? "", "$180");
   assertStringIncludes(v.extra ?? "", "$50");
@@ -806,7 +810,7 @@ Deno.test("ci spend: one failed configured source leaves a gray lower bound", as
   assertEquals(v.status, "unknown");
   assertStringIncludes(
     v.extra ?? "",
-    '<span class="swatch" style="background:#f59e0b"></span> Blacksmith $???',
+    `${themedSwatch("#f59e0b")} Blacksmith $???`,
   );
   assertStringIncludes(v.extra ?? "", "GitHub");
   assertStringIncludes(v.extra ?? "", "Budget $1");

--- a/packages/dashboard/tiles/github-ci-spend.ts
+++ b/packages/dashboard/tiles/github-ci-spend.ts
@@ -26,6 +26,7 @@ import {
   spendChart,
   summarizeDailySpend,
 } from "../spend.ts";
+import { themedChartSeries } from "../theme.ts";
 
 interface UsageItem {
   date: string;
@@ -443,7 +444,7 @@ export const githubCiSpend: Tile = {
       : blacksmithBudget;
     const budget = hasCombinedBudget ? combinedBudget : providerBudget;
     const swatch = (color: string) =>
-      `<span class="swatch" style="background:${color}"></span>`;
+      `<span class="swatch" style="background:${themedChartSeries(color).color}"></span>`;
     const legendItem = (
       configured: boolean,
       spend: DailySpend | null,

--- a/packages/dashboard/tiles/github-members.test.ts
+++ b/packages/dashboard/tiles/github-members.test.ts
@@ -1,7 +1,12 @@
 // github users: GitHub and the history file are replaced with in-memory
 // stand-ins. The tests cover pagination, both organization rosters, retained
 // history, and the gray states for unavailable data.
-import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import {
+  assert,
+  assertEquals,
+  assertMatch,
+  assertStringIncludes,
+} from "@std/assert";
 import { REPO } from "../config.ts";
 import { dashboardCacheFile } from "../history-files.ts";
 import type { Ctx } from "../types.ts";
@@ -212,8 +217,14 @@ Deno.test("github users: transitional overlap counts once and draws retained his
     assertStringIncludes(view.extra ?? "", "<svg");
     assertStringIncludes(view.extra ?? "", "members ·");
     assertStringIncludes(view.extra ?? "", "collaborators");
-    assertStringIncludes(view.extra ?? "", "background:#58a6ff");
-    assertStringIncludes(view.extra ?? "", "background:#a371f7");
+    assertMatch(
+      view.extra ?? "",
+      /background:light-dark\(#[0-9a-f]{6},#58a6ff\)/,
+    );
+    assertMatch(
+      view.extra ?? "",
+      /background:light-dark\(#[0-9a-f]{6},#a371f7\)/,
+    );
 
     assertEquals(wire.calls.length, 2);
     assertEquals(

--- a/packages/dashboard/tiles/github-members.ts
+++ b/packages/dashboard/tiles/github-members.ts
@@ -9,12 +9,13 @@ import {
   friendlyError,
   github,
   multiSparkline,
+  SPARK_FADE,
   thin,
 } from "../lib.ts";
+import { themedChartSeries } from "../theme.ts";
 
 const MEMBERS_COLOR = "#58a6ff";
 const COLLABORATORS_COLOR = "#a371f7";
-const LINE_FADE = "#0e1915";
 
 const HISTORY_MAX_AGE_DAYS = 60;
 const PLOT_POINTS = 500;
@@ -172,29 +173,31 @@ export function createGithubMembers(): Tile {
         ? history.points[history.points.length - 1].t - history.points[0].t
         : 0;
       const plot = thin(history.points, PLOT_POINTS);
+      const membersSeries = themedChartSeries(MEMBERS_COLOR);
+      const collaboratorsSeries = themedChartSeries(COLLABORATORS_COLOR);
       const chart = multiSparkline(
         [
           {
             vals: plot.map((point) => point.members),
-            color: MEMBERS_COLOR,
+            ...membersSeries,
             label: String(members),
           },
           {
             vals: plot.map((point) => point.collaborators),
-            color: COLLABORATORS_COLOR,
+            ...collaboratorsSeries,
             label: String(collaborators),
           },
         ],
-        { fadeFrom: LINE_FADE },
+        { fadeFrom: SPARK_FADE.good },
       );
       const swatch = (color: string) =>
         `<span class="swatch" style="background:${escapeHtml(color)}"></span>`;
       const subline = chart
-        ? `<p class="sub">${swatch(MEMBERS_COLOR)} members · ${
-          swatch(COLLABORATORS_COLOR)
+        ? `<p class="sub">${swatch(membersSeries.color)} members · ${
+          swatch(collaboratorsSeries.color)
         } collaborators</p>`
-        : `<p class="sub">${swatch(MEMBERS_COLOR)} members ${members} · ${
-          swatch(COLLABORATORS_COLOR)
+        : `<p class="sub">${swatch(membersSeries.color)} members ${members} · ${
+          swatch(collaboratorsSeries.color)
         } collaborators ${collaborators}</p>`;
 
       return {

--- a/packages/dashboard/tiles/model-spend.test.ts
+++ b/packages/dashboard/tiles/model-spend.test.ts
@@ -4,7 +4,11 @@
 // this month and how far back to ask.
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import type { Ctx } from "../types.ts";
+import { themedChartSeries } from "../theme.ts";
 import { modelSpend } from "./model-spend.ts";
+
+const themedSwatch = (color: string) =>
+  `<span class="swatch" style="background:${themedChartSeries(color).color}"></span>`;
 
 function ctx(env: Record<string, string> = {}): Ctx {
   return {
@@ -118,8 +122,8 @@ Deno.test("model spend: all three providers read -> green, combined MTD, a line 
       // line ends), OpenRouter's total inline since it has no line.
       assertStringIncludes(
         v.extra ?? "",
-        `<p class="sub"><span class="swatch" style="background:#10a37f"></span> OpenAI • ` +
-          `<span class="swatch" style="background:#d97757"></span> Anthropic • OR $5</p>`,
+        `<p class="sub">${themedSwatch("#10a37f")} OpenAI • ` +
+          `${themedSwatch("#d97757")} Anthropic • OR $5</p>`,
       );
       // Each line is drawn in its provider's color and labelled with its own MTD.
       assertStringIncludes(v.extra ?? "", `pointer-events:none">$${DOM}</span>`);
@@ -157,7 +161,7 @@ Deno.test("model spend: a provider that errors -> $??? and gray, the rest still 
       assert(v.value?.startsWith("≥"), `the total is a lower bound, got ${v.value}`);
       assertStringIncludes(
         v.extra ?? "",
-        `<p class="sub"><span class="swatch" style="background:#10a37f"></span> OpenAI • Anthropic $??? • OR $5</p>`,
+        `<p class="sub">${themedSwatch("#10a37f")} OpenAI • Anthropic $??? • OR $5</p>`,
       );
       assertEquals(v.duration, 45 * DAY); // OpenAI's line is still drawn
       assertStringIncludes(v.extra ?? "", "#10a37f");
@@ -182,7 +186,7 @@ Deno.test("model spend: one day of data draws no chart, so the provider's total 
   await withFetch({ "api.openai.com": () => json({ data: [oaBucket(today, 12)] }) }, async () => {
     const v = await modelSpend.collect(ctx({ OPENAI_ADMIN_KEY: "oa" }));
     assertEquals(v.status, "good");
-    assertEquals(v.extra, `<p class="sub"><span class="swatch" style="background:#10a37f"></span> OpenAI $12</p>`);
+    assertEquals(v.extra, `<p class="sub">${themedSwatch("#10a37f")} OpenAI $12</p>`);
     assertEquals(v.aside, `<span class="hmtd">$12 MTD</span>`);
     assertEquals(v.duration, 0);
   });

--- a/packages/dashboard/tiles/model-spend.ts
+++ b/packages/dashboard/tiles/model-spend.ts
@@ -21,6 +21,7 @@
 import type { Status, Tile, TileView } from "../types.ts";
 import { budgetStatus, readBudget, usd } from "../lib.ts";
 import { DAY_MS, SPEND_HISTORY_DAYS, spendChart, summarizeDailySpend } from "../spend.ts";
+import { themedChartSeries } from "../theme.ts";
 
 // The provider billing APIs are slow — OpenAI's costs endpoint alone takes ~12-16s
 // for a 46-day query and slows further under repeated calls — and this tile pages
@@ -184,7 +185,8 @@ export const modelSpend: Tile = {
     // abbreviated "OR") and any provider we couldn't read show their value inline
     // ("$???" when missing). Items are bullet-separated. The combined MTD is in the
     // header aside; the span the chart covers goes to the tile's duration slot.
-    const swatch = (c: string) => `<span class="swatch" style="background:${c}"></span>`;
+    const swatch = (c: string) =>
+      `<span class="swatch" style="background:${themedChartSeries(c).color}"></span>`;
     const charted = (p: { mtd: number } | null, name: string, color: string) =>
       p ? (chart.chart ? `${swatch(color)} ${name}` : `${swatch(color)} ${name} ${usd(p.mtd)}`) : `${name} $???`;
     const seg: string[] = [];

--- a/packages/dashboard/tiles/prod-errors.ts
+++ b/packages/dashboard/tiles/prod-errors.ts
@@ -20,6 +20,7 @@
 // actually-high error rate.
 import type { Status, Tile, TileView } from "../types.ts";
 import { serviceName, SPARK_FADE, sparkline } from "../lib.ts";
+import { CHART_HIGHLIGHT, CHART_LINE } from "../theme.ts";
 
 const RECENT_MS = 12 * 60 * 60 * 1000; // headline number: last 12 hours
 const TREND_MS = 14 * 24 * 60 * 60 * 1000; // sparkline reach (capped by ~15-day trace retention)
@@ -140,7 +141,7 @@ export const prodErrors: Tile = {
     // Brighten the trailing last-12h hours, but keep the whole retained range in
     // view (scaleAll) — the recent window can sit near zero while history spikes.
     const highlight = recent.length >= 2
-      ? { count: recent.length, color: "#c7ccd4", scaleAll: true }
+      ? { count: recent.length, color: CHART_HIGHLIGHT, scaleAll: true }
       : undefined;
     return {
       ...drill,
@@ -148,7 +149,7 @@ export const prodErrors: Tile = {
       status,
       value: rate === undefined ? "—" : `${rate.toFixed(2)}%`,
       sub: rate === undefined ? "no traces · last 12h" : `${recentErr} err / ${recentTotal} spans · last 12h`,
-      extra: sparkline(series, "#727882", highlight, SPARK_FADE[status]),
+      extra: sparkline(series, CHART_LINE, highlight, SPARK_FADE[status]),
       duration: span,
     };
   },

--- a/scripts/ci-gantt.test.ts
+++ b/scripts/ci-gantt.test.ts
@@ -63,14 +63,15 @@ function inputRun(databaseId: number, jobs: TestJob[]) {
   };
 }
 
-async function render(input: unknown): Promise<string> {
-  const result = await runGantt(input);
+async function render(input: unknown, theme = "dark"): Promise<string> {
+  const result = await runGantt(input, theme);
   assert(result.success, result.stderr);
   return result.svg;
 }
 
 async function runGantt(
   input: unknown,
+  theme = "dark",
 ): Promise<{ success: boolean; stderr: string; svg: string }> {
   const directory = await Deno.makeTempDir({ prefix: "ci-gantt-test-" });
   const inputPath = `${directory}/input.json`;
@@ -88,7 +89,7 @@ async function runGantt(
         "--out",
         outputPath,
         "--theme",
-        "dark",
+        theme,
         "--min-runs",
         "1",
       ],
@@ -201,6 +202,16 @@ Deno.test("single-run CI Gantt draws every rerun attempt on one row", async () =
   assertStringIncludes(successfulAttempt, ">2:00</text>");
   assertEquals(successfulAttempt.includes("attempt-failure"), false);
   assertStringIncludes(svg, "failed attempts end in ×");
+});
+
+Deno.test("CI Gantt light theme paints a light SVG", async () => {
+  const svg = await render({
+    runs: [inputRun(42, [job("Test", 1, 60, 120)])],
+  }, "default");
+
+  assertStringIncludes(svg, 'fill="#ffffff"');
+  assertStringIncludes(svg, 'fill="#1f2328"');
+  assertEquals(svg.includes('fill="#0d0e11"'), false);
 });
 
 Deno.test("CI Gantt rejects a rerun whose jobs carry no attempt", async () => {


### PR DESCRIPTION
The dashboard used only dark surfaces and generated dark CI Gantt images. It had no persistent way to select a light palette. Following the operating-system preference on first visit would also make the initial appearance vary.

Define light colors for page surfaces, status treatments, and chart series. Add a theme chip at the bottom-right of the document that cycles through Dark, Light, and System, keeps the same width in every mode, and saves the selection. Default an unsaved preference to dark and resolve System changes live.

Expose the resolved dark or light theme to chart renderers. Regenerate aggregate and commit Gantt images when that resolved theme changes, and pass the script's existing light-theme option when needed.

Cover the palettes, persistence, three-state browser behavior, route mapping, and generated light Gantt SVG in tests. Document the dashboard theme behavior.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5588?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

