### PR TITLE
Shell: deliver a ?path= deep link into the loaded piece (one-shot)

### DIFF
--- a/packages/shell/shared/app/view.ts
+++ b/packages/shell/shared/app/view.ts
@@ -16,6 +16,14 @@ export type AppViewModeRef = {
   mode?: AppViewMode;
 };
 
+export type AppOpenPathRef = {
+  /** One-shot deep link: a target the piece should open on load, captured
+   * from `?path=` at boot. Consumed by the shell after the piece loads and
+   * never re-emitted into a URL (`appViewToUrlPath` ignores it), so
+   * reloads and internal navigation stay clean. */
+  openPath?: string;
+};
+
 export type AppView =
   | {
     builtin: AppBuiltInView;
@@ -26,6 +34,7 @@ export type AppView =
     }
     & PieceViewRef
     & AppViewModeRef
+    & AppOpenPathRef
   )
   | (
     & {
@@ -33,6 +42,7 @@ export type AppView =
     }
     & PieceViewRef
     & AppViewModeRef
+    & AppOpenPathRef
   );
 
 export function isAppBuiltInView(view: unknown): view is AppBuiltInView {
@@ -126,19 +136,24 @@ export function urlToAppView(url: URL): AppView {
   if (mode) segments.shift();
   const [first, pieceId] = [segments[0], segments[1]];
   const modeRef: AppViewModeRef = mode ? { mode } : {};
+  // `?path=` is the piece deep link (e.g. a cabinet page Mobile Loom should
+  // open). Captured here — the only place the query survives boot — and
+  // delivered once by the shell after the piece loads.
+  const openPath = url.searchParams.get("path") || undefined;
+  const openRef: AppOpenPathRef = openPath ? { openPath } : {};
 
   if (!first) {
     return { builtin: "home" };
   }
   if (isDID(first)) {
-    if (!pieceId) return { spaceDid: first, ...modeRef };
+    if (!pieceId) return { spaceDid: first, ...modeRef, ...openRef };
     return isSlugAddress(pieceId)
-      ? { spaceDid: first, pieceSlug: pieceId, ...modeRef }
-      : { spaceDid: first, pieceId, ...modeRef };
+      ? { spaceDid: first, pieceSlug: pieceId, ...modeRef, ...openRef }
+      : { spaceDid: first, pieceId, ...modeRef, ...openRef };
   } else {
-    if (!pieceId) return { spaceName: first, ...modeRef };
+    if (!pieceId) return { spaceName: first, ...modeRef, ...openRef };
     return isSlugAddress(pieceId)
-      ? { spaceName: first, pieceSlug: pieceId, ...modeRef }
-      : { spaceName: first, pieceId, ...modeRef };
+      ? { spaceName: first, pieceSlug: pieceId, ...modeRef, ...openRef }
+      : { spaceName: first, pieceId, ...modeRef, ...openRef };
   }
 }

--- a/packages/shell/src/views/AppView.ts
+++ b/packages/shell/src/views/AppView.ts
@@ -102,6 +102,31 @@ export class XAppView extends BaseView {
     args: () => [this.app, this.rt, this.space],
   });
 
+  // One-shot ?path= deep-link delivery (set after the first send so slug
+  // re-resolutions and task reruns never re-fire it).
+  #openPathDelivered = false;
+
+  /** Deliver a `?path=` deep link into the loaded piece, once.
+   *
+   * Opt-in by contract: the piece must export an `openPath` stream on its
+   * result (e.g. Mobile Loom opens the given cabinet path in its page
+   * viewer). Pieces without the stream are untouched — the field simply
+   * goes undelivered. Fire-and-forget; a failed send must never affect
+   * pattern loading. */
+  #maybeDeliverOpenPath(pattern: PageHandle<NameSchema>): void {
+    if (this.#openPathDelivered) return;
+    const view = this.app?.view;
+    if (!view || !("openPath" in view) || !view.openPath) return;
+    const data = pattern.cell().get() as Record<string, unknown> | undefined;
+    if (!data || typeof data !== "object" || !("openPath" in data)) return;
+    this.#openPathDelivered = true;
+    (pattern.cell() as unknown as {
+      key(k: string): { send(v: unknown): Promise<void> };
+    })
+      .key("openPath")
+      .send({ path: view.openPath });
+  }
+
   _selectedPattern = new Task(this, {
     task: async (
       [app, rt, space],
@@ -120,6 +145,7 @@ export class XAppView extends BaseView {
           // Track as recently visited (fire-and-forget) — but not after
           // the view moved on, or the write lands in the wrong space.
           if (!signal.aborted) rt.trackRecentPiece(space, pieceId);
+          if (!signal.aborted) this.#maybeDeliverOpenPath(pattern);
           return pattern;
         } catch (e) {
           if (!signal.aborted) {
@@ -136,6 +162,7 @@ export class XAppView extends BaseView {
           }
           // Track as recently visited (fire-and-forget)
           if (!signal.aborted) rt.trackRecentPiece(space, app.view.pieceId);
+          if (!signal.aborted) this.#maybeDeliverOpenPath(pattern);
           return pattern;
         } catch (e) {
           if (!signal.aborted) {

--- a/packages/shell/test/app-state.test.ts
+++ b/packages/shell/test/app-state.test.ts
@@ -147,7 +147,9 @@ describe("AppState", () => {
     assert(
       JSON.stringify(
         urlToAppView(
-          new URL("http://common.test/space/loom?path=People%2FZora%2Fabout.md"),
+          new URL(
+            "http://common.test/space/loom?path=People%2FZora%2Fabout.md",
+          ),
         ),
       ) === JSON.stringify({
         spaceName: "space",

--- a/packages/shell/test/app-state.test.ts
+++ b/packages/shell/test/app-state.test.ts
@@ -143,6 +143,32 @@ describe("AppState", () => {
     );
   });
 
+  it("captures ?path= as a one-shot openPath deep link", () => {
+    assert(
+      JSON.stringify(
+        urlToAppView(
+          new URL("http://common.test/space/loom?path=People%2FZora%2Fabout.md"),
+        ),
+      ) === JSON.stringify({
+        spaceName: "space",
+        pieceSlug: "loom",
+        openPath: "People/Zora/about.md",
+      }),
+    );
+    // Never re-emitted: reloads and internal navigation stay clean.
+    assert(
+      appViewToUrlPath({
+        spaceName: "space",
+        pieceSlug: "loom",
+        openPath: "People/Zora/about.md",
+      }) === "/space/loom",
+    );
+    // No param, no field.
+    assert(
+      !("openPath" in urlToAppView(new URL("http://common.test/space/loom"))),
+    );
+  });
+
   it("parses and serializes embedded routes", () => {
     const spaceDid = "did:key:z6MkjosLwWEobyT9T6RqLTdaEhFrXAZUNkRZJuUae2ukgfEa";
 


### PR DESCRIPTION
## Why
A URL cannot carry anything to a piece today: `urlToAppView` reads exactly two path segments, the boot `replaceState` strips the query, and piece code has no `location`. So an external surface (Loom's Signal texting channel) cannot mint a link that opens a specific page inside Mobile Loom — per-page links are impossible on a phone.

Discussed with Tony today — this is the small shell half; Loom's consumer half (an `openPath` result stream on cf-loom-mobile reusing its existing open-file flow) is ready to land the day this rolls.

## What Changed
- `AppView` gains optional `openPath` (`AppOpenPathRef`); `urlToAppView` captures `?path=` (parse happens before the boot strip, so it survives naturally); `appViewToUrlPath` never emits it — one-shot by construction.
- The shell delivers it once after the piece loads: if the piece's result exports an `openPath` stream, `send({ path })` (CellSend). Opt-in by contract; pieces without the stream are untouched; guarded against task reruns; fire-and-forget.

Bonus: device-link QR pairing already preserves `pathname + search`, so these links survive first-time phone login.

## Test plan
- `deno test packages/shell/test/app-state.test.ts` — 10 steps pass (new: captured / never re-emitted / absent without the param).
- `deno check` on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

