### PR TITLE
fix(piece): prove nested Cell wrappers symmetrically when restoring supplied links

### DIFF
--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -1936,7 +1936,12 @@ export function assertSuppliedLinkSchemasCompatible(
       // same lens, or a destination's nested `asCell` fails the exact-match
       // comparison against the sanitized source — refusing, among others,
       // every same-schema source update of a piece whose roster array stores
-      // elements with a Cell-typed `profile` field.
+      // elements with a Cell-typed `profile` field. Capability kinds such as
+      // `sqlite` strip here too: the payload proof deliberately ignores them
+      // at nested positions. Capability policing is the OUTER-level rules'
+      // job (a capability source refuses exposure as an ordinary alias
+      // above), and no supported flow places a connector wrapper below a
+      // link payload.
       const proofTargets = preservesDirectHandle
         ? targetContracts
         : targetContracts.map((contract) => ({

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -1927,7 +1927,27 @@ export function assertSuppliedLinkSchemasCompatible(
       !preservesDirectHandle || targetOuter.kind !== "writeonly" &&
         targetOuter.kind !== "stream"
     ) {
-      assertContractSubset(sourceContracts, targetContracts, label);
+      // Nested (non-stream) Cell wrappers are read-side projections, not part
+      // of the payload contract: a wrapper-declaring source may serve a plain
+      // slot, and a plain source may serve a wrapper-declaring slot (the
+      // destination materializes the handle through its own schema either
+      // way). The source contracts above are already sanitized on the
+      // non-preserving path; the proof must see the destination through the
+      // same lens, or a destination's nested `asCell` fails the exact-match
+      // comparison against the sanitized source — refusing, among others,
+      // every same-schema source update of a piece whose roster array stores
+      // elements with a Cell-typed `profile` field.
+      const proofTargets = preservesDirectHandle
+        ? targetContracts
+        : targetContracts.map((contract) => ({
+          ...contract,
+          schema: sanitizeSchemaForLinks(
+            contract.schema,
+            KeepAsCell.OnlyStream,
+          ),
+          root: sanitizeSchemaForLinks(contract.root, KeepAsCell.OnlyStream),
+        }));
+      assertContractSubset(sourceContracts, proofTargets, label);
     }
     if (preservesDirectHandle && cellKindCanWrite(targetOuter.kind)) {
       // A writable handle can send values back to the producer, so the

--- a/packages/piece/test/pull-materialization.test.ts
+++ b/packages/piece/test/pull-materialization.test.ts
@@ -1280,8 +1280,11 @@ describe("piece pull materialization", () => {
     expect(isLink(raw.participants[0])).toBe(true);
     expect(isCell(raw.participants[0])).toBe(false);
 
-    // The source-update restore path: identical contract on both sides,
-    // envelopes preserved verbatim.
+    // The source-update call-site shape: `setPattern` declares
+    // `linksPreservedVerbatim`, but the element's slot declares no outer Cell
+    // wrapper, so the preserve branch never engages and the link faces the
+    // sanitizing proof regardless — which is exactly how a source update
+    // reaches the asymmetry this test pins.
     expect(() =>
       assertSuppliedLinkSchemasCompatible(
         [{ path: ["participants", 0], value: raw.participants[0] }],
@@ -1295,8 +1298,8 @@ describe("piece pull materialization", () => {
       )
     ).not.toThrow();
 
-    // The rebuild path agrees: a nested wrapper the destination declares does
-    // not demand one from the source's payload contract.
+    // Without the flag the same proof runs: a nested wrapper the destination
+    // declares does not demand one from the source's payload contract.
     expect(() =>
       assertSuppliedLinkSchemasCompatible(
         [{ path: ["participants", 0], value: raw.participants[0] }],

--- a/packages/piece/test/pull-materialization.test.ts
+++ b/packages/piece/test/pull-materialization.test.ts
@@ -1223,6 +1223,91 @@ describe("piece pull materialization", () => {
     ).toThrow(/sqlite capability cannot be exposed as an ordinary alias/);
   });
 
+  it("restores retained links whose payload nests a Cell-typed property", async () => {
+    // The roster shape: a plain array element whose `profile` field is a
+    // Cell (`asCell: ["cell"]`). The element link's contract carries the
+    // nested wrapper; the non-preserving path sanitizes it away from the
+    // SOURCE side only, and the exact-match `asCell` comparison then refused
+    // the destination's own wrapper — so a piece whose roster held one such
+    // element could never have its source updated in place, even with the
+    // byte-identical source (`asCell changed` at participants.0.profile).
+    // Nested non-stream wrappers are read-side projections, so the proof
+    // sees both sides through the same sanitizing lens.
+    const profileSchema: JSONSchema = {
+      type: "object",
+      properties: { name: { type: "string" }, avatar: { type: "string" } },
+    };
+    const elementSchema: JSONSchema = {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        profile: { ...profileSchema, asCell: ["cell"] },
+      },
+      required: ["name", "profile"],
+    };
+    const argumentSchema: JSONSchema = {
+      type: "object",
+      properties: {
+        participants: { type: "array", items: elementSchema },
+      },
+      required: ["participants"],
+    };
+
+    const profileDoc = runtime.getCell(
+      pieces.getSpace(),
+      "roster-profile-" + crypto.randomUUID(),
+    );
+    await runtime.editWithRetry((tx) => {
+      profileDoc.withTx(tx).set({ name: "Robin", avatar: "" });
+    });
+    const element = runtime.getCell(
+      pieces.getSpace(),
+      "roster-element-" + crypto.randomUUID(),
+    );
+    await runtime.editWithRetry((tx) => {
+      element.withTx(tx).set({ name: "Robin", profile: profileDoc });
+    });
+    const base = runtime.getCell(
+      pieces.getSpace(),
+      "roster-argument-" + crypto.randomUUID(),
+    );
+    await runtime.editWithRetry((tx) => {
+      base.withTx(tx).set({ participants: [element] });
+    });
+
+    const raw = base.getRaw() as { participants: unknown[] };
+    // Guard the premise: the restore path sees a SERIALIZED link.
+    expect(isLink(raw.participants[0])).toBe(true);
+    expect(isCell(raw.participants[0])).toBe(false);
+
+    // The source-update restore path: identical contract on both sides,
+    // envelopes preserved verbatim.
+    expect(() =>
+      assertSuppliedLinkSchemasCompatible(
+        [{ path: ["participants", 0], value: raw.participants[0] }],
+        argumentSchema,
+        base,
+        pieces,
+        {
+          priorArgumentSchema: argumentSchema,
+          linksPreservedVerbatim: true,
+        },
+      )
+    ).not.toThrow();
+
+    // The rebuild path agrees: a nested wrapper the destination declares does
+    // not demand one from the source's payload contract.
+    expect(() =>
+      assertSuppliedLinkSchemasCompatible(
+        [{ path: ["participants", 0], value: raw.participants[0] }],
+        argumentSchema,
+        base,
+        pieces,
+        { priorArgumentSchema: argumentSchema },
+      )
+    ).not.toThrow();
+  });
+
   it("refuses a preserved link whose carried wrapper widens its contract", async () => {
     // The envelope on a SERIALIZED link is caller-written bytes. Declaring
     // that links are preserved verbatim must not become a way to smuggle a


### PR DESCRIPTION
## Why

A piece whose argument holds a link to an element carrying a nested Cell-typed property — the profile-roster shape: a plain `participants` array element whose `profile` field is `Cell<...>` — could never have its source updated again, even with the byte-identical source. The team-lunch poll on rapids hit this after one profile-first join: every `cf piece setsrc` failed with

```
input link at participantProfiles.participants.0 schema is not compatible:
  input link at participantProfiles.participants.0.profile: asCell changed
```

Reproduced locally against a fresh deploy: a guest-only poll updates fine; after a single "Create profile" join, every source update — including a no-op redeploy of the identical source — is refused.

## Root cause

In `assertSuppliedLinkSchemasCompatible`, the element's slot is not itself Cell-typed, so `preservesDirectHandle` fails its `targetOuter !== undefined` guard even when the link is preserved verbatim (`linksPreservedVerbatim` set and the bytes identical to committed state — both verified in the failing run). The source contract then goes through `sanitizeSchemaForLinks(…, KeepAsCell.OnlyStream)`, stripping the nested `asCell: ["cell"]` from the `profile` field — while the destination contract keeps declaring it. The subset proof's exact-match `asCell` comparison (`SEMANTIC_EXTENSION_KEYS`) then refuses, unconditionally.

## Fix

Nested non-stream Cell wrappers are read-side projections, not payload contract: a wrapper-declaring source may serve a plain slot — pinned by the existing "projects nested Cell wrappers with the canonical link schema" test — and a plain source contract must equally serve a wrapper-declaring slot, because the destination materializes the handle through its own schema either way. The proof now views the destination through the same sanitizing lens the source already passes through on the non-preserving path.

An earlier attempt (skip source sanitization for preserved links) broke the projection test above; the symmetric form keeps both directions working. The capability-laundering refusals (outer wrappers, carried envelopes, ordinary-alias exposure) are untouched and still covered by their existing tests.

## Testing

- New focused regression test `restores retained links whose payload nests a Cell-typed property` — red without the fix, green with it (both directions: the verbatim restore path and the rebuild path).
- `packages/piece`: full `deno task test` green; `deno task check`, `deno fmt --check`, `deno lint` clean.
- Live validation: with this fix, `cf piece setsrc` on the affected rapids poll succeeded and the piece recomputed cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

