### PR TITLE
feat(cli): package tests with deployed piece source

### DIFF
--- a/docs/specs/pattern-imports/README.md
+++ b/docs/specs/pattern-imports/README.md
@@ -185,6 +185,22 @@ preserves the existing locator when the flag is omitted. `set-home --reset`
 rejects the flag because the system pattern was not deployed from the caller's
 repository. No Git remote or revision is inferred automatically.
 
+The same three local deployment commands accept a repeatable
+`--test <path>` flag. Each test entry is resolved under the deployment's
+`--root`, and its reachable imports are merged into the authored `Program` as
+source-only roots. Compilation type-checks and verifies those modules, while
+execution still begins exclusively at `Program.main`. The source-document
+cache retains the test roots through its synthetic retention links. Source
+recovery and `cf piece getsrc` therefore return the executable source and its
+attached tests together. `set-home --reset` rejects `--test` because a reset
+deploys no local source package.
+
+Attached test entry points participate in the deployed source revision's
+identity without becoming runtime imports. Changing, adding, or removing a test
+therefore creates a distinct revision even when the executable source is
+unchanged. Test dependencies remain ordinary source files in that revision, but
+only paths supplied with `--test` are recovered as test entry points.
+
 ## Specifier syntax
 
 ### One grammar, no type tag

--- a/docs/specs/pattern-imports/README.md
+++ b/docs/specs/pattern-imports/README.md
@@ -186,14 +186,15 @@ rejects the flag because the system pattern was not deployed from the caller's
 repository. No Git remote or revision is inferred automatically.
 
 The same three local deployment commands accept a repeatable
-`--test <path>` flag. Each test entry is resolved under the deployment's
-`--root`, and its reachable imports are merged into the authored `Program` as
-source-only roots. Compilation type-checks and verifies those modules, while
-execution still begins exclusively at `Program.main`. The source-document
-cache retains the test roots through its synthetic retention links. Source
-recovery and `cf piece getsrc` therefore return the executable source and its
-attached tests together. `set-home --reset` rejects `--test` because a reset
-deploys no local source package.
+`--test <path>` flag. When `--root` is omitted, the CLI uses the common
+directory containing the main entry and every test entry. An explicit `--root`
+remains authoritative. Each test's reachable imports are merged into the
+authored `Program` as source-only roots. Compilation type-checks and verifies
+those modules, while execution still begins exclusively at `Program.main`.
+The source-document cache retains the test roots through its synthetic
+retention links. Source recovery and `cf piece getsrc` therefore return the
+executable source and its attached tests together. `set-home --reset` rejects
+`--test` because a reset deploys no local source package.
 
 Attached test entry points participate in the deployed source revision's
 identity without becoming runtime imports. Changing, adding, or removing a test

--- a/docs/tutorial/06-workflow.md
+++ b/docs/tutorial/06-workflow.md
@@ -78,6 +78,22 @@ The most common workflow mistake is rerunning `piece new` after each edit —
 that creates a new piece every time, and your space fills with stale
 duplicates. `new` once, `setsrc` forever after.
 
+Use repeatable `--test` flags when the deployed piece should retain its tests
+with its source:
+
+```bash
+deno task cf piece new pattern.tsx --test pattern.test.tsx -s myspace
+deno task cf piece setsrc pattern.tsx --test pattern.test.tsx \
+  --piece fid1:abc... -s myspace
+```
+
+Deployment resolves and type-checks each test and its imports, but does not run
+the tests. Run them locally with `cf test`. The attached files are included by
+`cf piece getsrc`, so another checkout of the piece receives the source and its
+tests together. Test paths use the same `--root` as the main entry. A test-only
+change creates a new source revision, so history and recovery keep each test
+package separate.
+
 ## Drive a deployed piece from the CLI
 
 Everything a pattern exports (Chapter 3) is drivable without a browser:

--- a/docs/tutorial/06-workflow.md
+++ b/docs/tutorial/06-workflow.md
@@ -90,9 +90,10 @@ deno task cf piece setsrc pattern.tsx --test pattern.test.tsx \
 Deployment resolves and type-checks each test and its imports, but does not run
 the tests. Run them locally with `cf test`. The attached files are included by
 `cf piece getsrc`, so another checkout of the piece receives the source and its
-tests together. Test paths use the same `--root` as the main entry. A test-only
-change creates a new source revision, so history and recovery keep each test
-package separate.
+tests together. Without `--root`, the CLI infers the common directory that
+contains the main entry and every test entry. An explicit `--root` applies to
+all of them. A test-only change creates a new source revision, so history and
+recovery keep each test package separate.
 
 ## Drive a deployed piece from the CLI
 

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -154,6 +154,7 @@ export function localPatternEntry(
     mainExport?: string;
     repository?: string;
     root?: string;
+    test?: string[];
   },
 ): EntryConfig {
   return {
@@ -161,6 +162,7 @@ export function localPatternEntry(
     mainExport: options.mainExport,
     repository: options.repository,
     rootPath: options.root ? absPath(options.root) : undefined,
+    testPaths: options.test?.map((path) => absPath(path)),
   };
 }
 
@@ -882,6 +884,11 @@ export const piece = new Command()
     "--repository <repository:string>",
     "Repository locator associated with the authored source (stored exactly as supplied).",
   )
+  .option(
+    "--test <path:string>",
+    "Attach a test pattern source file to the deployed source package. Repeatable.",
+    { collect: true },
+  )
   .option("--slug <slug:string>", "Slug URL/address for this piece.")
   .option(
     "--dangerously-allow-incompatible-schema",
@@ -1012,6 +1019,11 @@ export const piece = new Command()
   .option(
     "--repository <repository:string>",
     "Repository locator associated with the authored source (stored exactly as supplied).",
+  )
+  .option(
+    "--test <path:string>",
+    "Attach a test pattern source file to the deployed source package. Repeatable.",
+    { collect: true },
   )
   .option(
     "--dangerously-allow-incompatible-schema",
@@ -1860,6 +1872,11 @@ after --. Handlers interpret piped input when no input argument is present.`,
     "--repository <repository:string>",
     "Repository locator associated with the authored source (stored exactly as supplied).",
   )
+  .option(
+    "--test <path:string>",
+    "Attach a test pattern source file to the deployed source package. Repeatable.",
+    { collect: true },
+  )
   .arguments("[main:string]")
   .action(async (options, main?: string) => {
     setQuietMode(!!options.quiet);
@@ -1879,6 +1896,12 @@ after --. Handlers interpret piped input when no input argument is present.`,
     if (options.reset && options.repository !== undefined) {
       throw new ValidationError(
         "Cannot use --repository with --reset.",
+        { exitCode: 1 },
+      );
+    }
+    if (options.reset && options.test !== undefined) {
+      throw new ValidationError(
+        "Cannot use --test with --reset.",
         { exitCode: 1 },
       );
     }
@@ -1908,6 +1931,7 @@ export interface PieceCLIOptions {
   mainExport?: string;
   repository?: string;
   root?: string;
+  test?: string[];
   dangerouslyAllowIncompatibleSchema?: boolean;
   json?: boolean;
 }

--- a/packages/cli/lib/completion/providers.ts
+++ b/packages/cli/lib/completion/providers.ts
@@ -334,6 +334,7 @@ const OPTION_VALUE_PROVIDERS: Readonly<
   "api-url": () => apiUrlCandidates(),
   identity: () => Promise.resolve(directive({ kind: "files", glob: "*.key" })),
   root: () => Promise.resolve(directive({ kind: "dirs" })),
+  test: patternFiles,
   // `cf space clone --to <dir>` builds a clone directory.
   to: () => Promise.resolve(directive({ kind: "dirs" })),
   "log-file": () => Promise.resolve(directive({ kind: "files" })),

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -85,6 +85,8 @@ export interface EntryConfig {
   mainExport?: string;
   repository?: string;
   rootPath?: string;
+  /** Test entry paths whose resolved source closures travel with the piece. */
+  testPaths?: string[];
 }
 
 export interface SpaceConfig {
@@ -435,9 +437,34 @@ export async function getProgramFromFile(
   pieces: PiecesController,
   entry: EntryConfig,
 ): Promise<RuntimeProgram> {
-  const program: RuntimeProgram = await pieces.runtime.harness.resolve(
-    new FileSystemProgramResolver(entry.mainPath, entry.rootPath),
+  const rootPath = entry.rootPath ?? dirname(entry.mainPath);
+  const programs: RuntimeProgram[] = await Promise.all(
+    [entry.mainPath, ...(entry.testPaths ?? [])].map((path) =>
+      pieces.runtime.harness.resolve(
+        new FileSystemProgramResolver(path, rootPath),
+      )
+    ),
   );
+  const [mainProgram, ...testPrograms] = programs;
+  const files = new Map<string, RuntimeProgram["files"][number]>();
+  for (const program of [mainProgram, ...testPrograms]) {
+    for (const file of program.files) {
+      const existing = files.get(file.name);
+      if (existing !== undefined && existing.contents !== file.contents) {
+        throw new Error(
+          `Source package contains conflicting files named "${file.name}".`,
+        );
+      }
+      files.set(file.name, file);
+    }
+  }
+  const program: RuntimeProgram = {
+    main: mainProgram.main,
+    files: [...files.values()],
+    ...(testPrograms.length === 0
+      ? {}
+      : { sourceRoots: testPrograms.map((test) => test.main) }),
+  };
   if (entry.mainExport) {
     program.mainExport = entry.mainExport;
   }

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -39,7 +39,7 @@ import {
   type PiecePatternRef,
   PiecesController,
 } from "@commonfabric/piece/ops";
-import { dirname, join } from "@std/path";
+import { common, dirname, join } from "@std/path";
 import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
 import { setLLMUrl } from "@commonfabric/llm";
 import { FabricSpecialObject } from "@commonfabric/data-model/fabric-value";
@@ -437,9 +437,11 @@ export async function getProgramFromFile(
   pieces: PiecesController,
   entry: EntryConfig,
 ): Promise<RuntimeProgram> {
-  const rootPath = entry.rootPath ?? dirname(entry.mainPath);
+  const entryPaths = [entry.mainPath, ...(entry.testPaths ?? [])];
+  const rootPath = entry.rootPath ??
+    join(common(entryPaths.map((path) => dirname(path))), ".");
   const programs: RuntimeProgram[] = await Promise.all(
-    [entry.mainPath, ...(entry.testPaths ?? [])].map((path) =>
+    entryPaths.map((path) =>
       pieces.runtime.harness.resolve(
         new FileSystemProgramResolver(path, rootPath),
       )

--- a/packages/cli/test/completion-output.test.ts
+++ b/packages/cli/test/completion-output.test.ts
@@ -138,6 +138,12 @@ Deno.test("--root defers to directory completion", async () => {
   assertEquals(await completeFor("cf piece new --root "), [":cf:dirs"]);
 });
 
+Deno.test("--test defers to pattern file completion", async () => {
+  assertEquals(await completeFor("cf piece new --test "), [
+    ":cf:files *.tsx",
+  ]);
+});
+
 Deno.test("a live slot with no resolvable context yields nothing, not an error", async () => {
   // Mid-keystroke with no identity configured: silence is the correct signal.
   const previous = Deno.env.get("CF_IDENTITY");

--- a/packages/cli/test/completion-providers.test.ts
+++ b/packages/cli/test/completion-providers.test.ts
@@ -140,6 +140,7 @@ Deno.test("live candidates: path-shaped slots defer to the shell", async () => {
   const cases: Array<[string, string]> = [
     ["cf piece ls -i ", "files"],
     ["cf piece new --root ", "dirs"],
+    ["cf piece new --test ", "files"],
     ["cf check ", "files"],
     ["cf space verify ", "dirs"],
     ["cf space clone --to ", "dirs"],

--- a/packages/cli/test/piece-source-package.test.ts
+++ b/packages/cli/test/piece-source-package.test.ts
@@ -1,0 +1,169 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import type {
+  Program,
+  ProgramResolver,
+  Source,
+} from "@commonfabric/js-compiler";
+import { join } from "@std/path";
+import { Identity } from "@commonfabric/identity";
+import { Runtime } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { getProgramFromFile } from "../lib/piece.ts";
+
+describe("piece source package", () => {
+  it("includes attached tests and their imports in the authored program", async () => {
+    const root = await Deno.makeTempDir();
+    const testsDirectory = join(root, "tests");
+    await Deno.mkdir(testsDirectory);
+    const mainPath = join(root, "main.tsx");
+    const sharedPath = join(root, "shared.ts");
+    const testPath = join(testsDirectory, "main.test.tsx");
+    await Deno.writeTextFile(mainPath, "export default {};");
+    await Deno.writeTextFile(sharedPath, "export const shared = 1;");
+    await Deno.writeTextFile(testPath, "export default {};");
+
+    const resolve = async (resolver: ProgramResolver): Promise<Program> => {
+      const main = await resolver.main();
+      const files: Source[] = [main];
+      const shared = await resolver.resolveSource("/shared.ts");
+      if (shared !== undefined) files.push(shared);
+      return { main: main.name, files };
+    };
+
+    try {
+      const program = await getProgramFromFile(
+        { runtime: { harness: { resolve } } } as any,
+        {
+          mainPath,
+          mainExport: "piece",
+          rootPath: root,
+          testPaths: [testPath],
+        },
+      );
+
+      expect(program.main).toBe("/main.tsx");
+      expect(program.mainExport).toBe("piece");
+      expect(program.sourceRoots).toEqual(["/tests/main.test.tsx"]);
+      expect(program.files).toEqual([
+        { name: "/main.tsx", contents: "export default {};" },
+        { name: "/shared.ts", contents: "export const shared = 1;" },
+        { name: "/tests/main.test.tsx", contents: "export default {};" },
+      ]);
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+
+  it("recovers attached tests from the fabric source package", async () => {
+    const root = await Deno.makeTempDir();
+    const testsDirectory = join(root, "tests");
+    await Deno.mkdir(testsDirectory);
+    const mainPath = join(root, "main.tsx");
+    const testPath = join(testsDirectory, "main.test.tsx");
+    const helperPath = join(testsDirectory, "helper.ts");
+    const typesPath = join(testsDirectory, "types.d.ts");
+    await Deno.writeTextFile(
+      mainPath,
+      `import { pattern } from "commonfabric";
+export default pattern(() => ({ value: 1 }));`,
+    );
+    await Deno.writeTextFile(
+      testPath,
+      `import "../main.tsx";
+import { pattern } from "commonfabric";
+import { expected } from "./helper.ts";
+import type { Expected } from "./types.d.ts";
+const typed: Expected = expected;
+export default pattern(() => ({ tests: [typed] }));`,
+    );
+    await Deno.writeTextFile(helperPath, 'export const expected = "first";');
+    await Deno.writeTextFile(typesPath, 'export type Expected = "first";');
+
+    const signer = await Identity.fromPassphrase("attached piece tests");
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+    });
+
+    try {
+      const program = await getProgramFromFile(
+        { runtime } as any,
+        { mainPath, rootPath: root, testPaths: [testPath] },
+      );
+      const compiled = await runtime.patternManager.compilePattern(program, {
+        space: signer.did(),
+      });
+      const entry = runtime.patternManager.getArtifactEntryRef(compiled);
+
+      expect(entry).toBeDefined();
+      const recovered = await runtime.patternManager
+        .getPatternSourceProgramByIdentity(
+          entry!.identity,
+          signer.did(),
+        );
+      expect(recovered?.files.map((file) => file.name).sort()).toEqual([
+        "/main.tsx",
+        "/tests/helper.ts",
+        "/tests/main.test.tsx",
+        "/tests/types.d.ts",
+      ]);
+      expect(recovered?.files.map((file) => file.name)).toContain(
+        "/tests/main.test.tsx",
+      );
+      expect(recovered?.files.map((file) => file.name)).toContain(
+        "/tests/helper.ts",
+      );
+      expect(recovered?.files.map((file) => file.name)).toContain(
+        "/tests/types.d.ts",
+      );
+      expect(recovered?.sourceRoots).toEqual(["/tests/main.test.tsx"]);
+
+      const recompiled = await runtime.harness.compileResolvedToRecordGraph(
+        recovered!.files,
+        recovered!.main,
+        { sourceRoots: recovered!.sourceRoots },
+      );
+      expect(recompiled.entryIdentity).toBe(entry!.identity);
+
+      await Deno.writeTextFile(
+        testPath,
+        `import "../main.tsx";
+import { pattern } from "commonfabric";
+export default pattern(() => ({ tests: ["second"] }));`,
+      );
+      const nextProgram = await getProgramFromFile(
+        { runtime } as any,
+        { mainPath, rootPath: root, testPaths: [testPath] },
+      );
+      const nextCompiled = await runtime.patternManager.compilePattern(
+        nextProgram,
+        { space: signer.did() },
+      );
+      const nextEntry = runtime.patternManager.getArtifactEntryRef(
+        nextCompiled,
+      );
+      expect(nextEntry).toBeDefined();
+      expect(nextEntry!.identity).not.toBe(entry!.identity);
+
+      const firstAgain = await runtime.patternManager
+        .getPatternSourceProgramByIdentity(entry!.identity, signer.did());
+      const second = await runtime.patternManager
+        .getPatternSourceProgramByIdentity(nextEntry!.identity, signer.did());
+      expect(
+        firstAgain?.files.find((file) => file.name === "/tests/main.test.tsx")
+          ?.contents,
+      ).toContain("expected");
+      expect(
+        second?.files.find((file) => file.name === "/tests/main.test.tsx")
+          ?.contents,
+      ).toContain('tests: ["second"]');
+    } finally {
+      await runtime.settled();
+      await runtime.dispose({ closeStorage: false });
+      await storageManager.close();
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+});

--- a/packages/cli/test/piece-source-package.test.ts
+++ b/packages/cli/test/piece-source-package.test.ts
@@ -5,13 +5,65 @@ import type {
   ProgramResolver,
   Source,
 } from "@commonfabric/js-compiler";
-import { join } from "@std/path";
+import { dirname, join } from "@std/path";
 import { Identity } from "@commonfabric/identity";
 import { Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { getProgramFromFile } from "../lib/piece.ts";
 
 describe("piece source package", () => {
+  it("infers a shared root for sibling main and test directories", async () => {
+    const root = await Deno.makeTempDir();
+    const patternsDirectory = join(root, "patterns");
+    const testsDirectory = join(root, "tests");
+    await Deno.mkdir(patternsDirectory);
+    await Deno.mkdir(testsDirectory);
+    const mainPath = join(patternsDirectory, "main.tsx");
+    const testPath = join(testsDirectory, "main.test.tsx");
+    await Deno.writeTextFile(mainPath, "export default {};");
+    await Deno.writeTextFile(
+      testPath,
+      'import "../patterns/main.tsx"; export default {};',
+    );
+
+    const resolve = async (resolver: ProgramResolver): Promise<Program> => {
+      const main = await resolver.main();
+      const siblingMain = main.name.endsWith("/tests/main.test.tsx")
+        ? await resolver.resolveSource(
+          main.name.replace(
+            /\/tests\/main\.test\.tsx$/,
+            "/patterns/main.tsx",
+          ),
+        )
+        : undefined;
+      return {
+        main: main.name,
+        files: siblingMain === undefined ? [main] : [main, siblingMain],
+      };
+    };
+
+    try {
+      const inferred = await getProgramFromFile(
+        { runtime: { harness: { resolve } } } as any,
+        { mainPath, testPaths: [testPath] },
+      );
+      expect(inferred.main).toBe("/patterns/main.tsx");
+      expect(inferred.sourceRoots).toEqual(["/tests/main.test.tsx"]);
+
+      const explicit = await getProgramFromFile(
+        { runtime: { harness: { resolve } } } as any,
+        { mainPath, rootPath: dirname(root), testPaths: [testPath] },
+      );
+      const rootName = root.slice(dirname(root).length);
+      expect(explicit.main).toBe(`${rootName}/patterns/main.tsx`);
+      expect(explicit.sourceRoots).toEqual([
+        `${rootName}/tests/main.test.tsx`,
+      ]);
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+
   it("includes attached tests and their imports in the authored program", async () => {
     const root = await Deno.makeTempDir();
     const testsDirectory = join(root, "tests");

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -536,12 +536,14 @@ describe("cli piece parsing", () => {
     expect(newFlags).toContain("--slug");
     expect(newFlags).toContain("--root");
     expect(newFlags).toContain("--repository");
+    expect(newFlags).toContain("--test");
     expect(newFlags).toContain("--dangerously-allow-incompatible-schema");
 
     for (const command of ["setsrc", "set-home"]) {
       const flags = optionFlags(command);
       expect(flags).toContain("--root");
       expect(flags).toContain("--repository");
+      expect(flags).toContain("--test");
     }
     expect(optionFlags("setsrc")).toContain(
       "--dangerously-allow-incompatible-schema",
@@ -1468,16 +1470,31 @@ describe("cli piece parsing", () => {
     ])).rejects.toThrow("Cannot use --repository with --reset");
   });
 
+  it("rejects attached tests when resetting the home pattern", async () => {
+    const { piece: command } = await import(
+      "../commands/piece.ts?test-reset-test"
+    );
+    command.throwErrors();
+    await expect(command.parse([
+      "set-home",
+      "--reset",
+      "--test",
+      "/repo/home.test.tsx",
+    ])).rejects.toThrow("Cannot use --test with --reset");
+  });
+
   it("builds repository-aware entries from deployment flags", () => {
     expect(localPatternEntry("/repo/pattern.tsx", {
       mainExport: "named",
       repository: "https://github.com/commontoolsinc/labs",
       root: "/repo",
+      test: ["/repo/pattern.test.tsx", "/repo/other.test.tsx"],
     })).toEqual({
       mainPath: "/repo/pattern.tsx",
       mainExport: "named",
       repository: "https://github.com/commontoolsinc/labs",
       rootPath: "/repo",
+      testPaths: ["/repo/pattern.test.tsx", "/repo/other.test.tsx"],
     });
   });
 
@@ -1492,6 +1509,7 @@ describe("cli piece parsing", () => {
         mainExport: "named",
         repository: "https://github.com/commontoolsinc/labs",
         root: "/repo",
+        test: ["/repo/pattern.test.tsx"],
         dangerouslyAllowIncompatibleSchema: true,
       },
       "/repo/pattern.tsx",
@@ -1516,6 +1534,7 @@ describe("cli piece parsing", () => {
         mainExport: "named",
         repository: "https://github.com/commontoolsinc/labs",
         rootPath: "/repo",
+        testPaths: ["/repo/pattern.test.tsx"],
       },
       options: { dangerouslyAllowIncompatibleSchema: true },
     });
@@ -1535,6 +1554,7 @@ describe("cli piece parsing", () => {
         mainExport: "named",
         repository: "https://github.com/commontoolsinc/labs",
         root: "/repo",
+        test: ["/repo/pattern.test.tsx"],
       },
       "/repo/pattern.tsx",
       {
@@ -1558,6 +1578,7 @@ describe("cli piece parsing", () => {
         mainExport: "named",
         repository: "https://github.com/commontoolsinc/labs",
         rootPath: "/repo",
+        testPaths: ["/repo/pattern.test.tsx"],
       },
     });
   });

--- a/packages/js-compiler/program.ts
+++ b/packages/js-compiler/program.ts
@@ -1,6 +1,25 @@
 import { isDeno } from "@commonfabric/utils/env";
 import { ProgramResolver, Source } from "./interface.ts";
-import { dirname, join, normalize } from "@std/path/posix";
+import {
+  dirname,
+  isAbsolute,
+  join,
+  normalize,
+  relative,
+  SEPARATOR,
+} from "@std/path";
+
+function isOutsideRoot(relativePath: string): boolean {
+  return relativePath === ".." || relativePath.startsWith(`..${SEPARATOR}`) ||
+    isAbsolute(relativePath);
+}
+
+function groundedSourceName(relativePath: string): string {
+  const portablePath = SEPARATOR === "/"
+    ? relativePath
+    : relativePath.replaceAll(SEPARATOR, "/");
+  return `/${portablePath}`;
+}
 
 export class InMemoryProgram implements ProgramResolver {
   private modules: Record<string, string>;
@@ -12,7 +31,7 @@ export class InMemoryProgram implements ProgramResolver {
 
   main(): Promise<Source> {
     const main = this.modules[this._main];
-    if (!main) {
+    if (main === undefined) {
       throw new Error(`${this._main} not in modules.`);
     }
     return Promise.resolve({ name: this._main, contents: main });
@@ -20,7 +39,7 @@ export class InMemoryProgram implements ProgramResolver {
 
   resolveSource(identifier: string): Promise<Source | undefined> {
     const contents = this.modules[identifier];
-    if (!contents) return Promise.resolve(undefined);
+    if (contents === undefined) return Promise.resolve(undefined);
     return Promise.resolve({ contents, name: identifier });
   }
 }
@@ -29,17 +48,27 @@ export class InMemoryProgram implements ProgramResolver {
 // Deno-only.
 export class FileSystemProgramResolver implements ProgramResolver {
   private fsRoot: string;
+  private realFsRoot: string;
   private _main: Source;
   constructor(mainPath: string, rootPath?: string) {
-    this.fsRoot = rootPath ? normalize(rootPath) : dirname(mainPath);
-    if (rootPath && !mainPath.startsWith(this.fsRoot)) {
+    this.fsRoot = normalize(rootPath ?? dirname(mainPath));
+    const normalizedMainPath = normalize(mainPath);
+    const relativeMainPath = relative(this.fsRoot, normalizedMainPath);
+    if (rootPath && isOutsideRoot(relativeMainPath)) {
+      throw new Error(
+        `Main file "${mainPath}" must be within root directory "${this.fsRoot}".`,
+      );
+    }
+    this.realFsRoot = this.#realPath(this.fsRoot);
+    const realMainPath = this.#realPath(normalizedMainPath);
+    if (isOutsideRoot(relative(this.realFsRoot, realMainPath))) {
       throw new Error(
         `Main file "${mainPath}" must be within root directory "${this.fsRoot}".`,
       );
     }
     this._main = {
-      name: mainPath.substring(this.fsRoot.length),
-      contents: this.#readFile(mainPath),
+      name: groundedSourceName(relativeMainPath),
+      contents: this.#readFile(realMainPath),
     };
   }
 
@@ -52,18 +81,35 @@ export class FileSystemProgramResolver implements ProgramResolver {
       return Promise.resolve(undefined);
     }
     const absPath = normalize(
-      join(this.fsRoot, specifier.substring(1, specifier.length)),
+      join(
+        this.fsRoot,
+        specifier.substring(1, specifier.length).replaceAll("/", SEPARATOR),
+      ),
     );
-    // Ensure the resolved path stays within fsRoot
-    if (!absPath.startsWith(this.fsRoot + "/") && absPath !== this.fsRoot) {
+    if (isOutsideRoot(relative(this.fsRoot, absPath))) {
+      throw new Error(
+        `Import "${specifier}" resolves outside of root directory "${this.fsRoot}".`,
+      );
+    }
+    const realPath = this.#realPath(absPath);
+    if (isOutsideRoot(relative(this.realFsRoot, realPath))) {
       throw new Error(
         `Import "${specifier}" resolves outside of root directory "${this.fsRoot}".`,
       );
     }
     return Promise.resolve({
       name: specifier,
-      contents: this.#readFile(absPath),
+      contents: this.#readFile(realPath),
     });
+  }
+
+  #realPath(path: string): string {
+    if (!isDeno()) {
+      throw new Error(
+        "FileSystemProgramResolver is not supported in this environment.",
+      );
+    }
+    return Deno.realPathSync(path);
   }
 
   #readFile(path: string): string {

--- a/packages/js-compiler/test/program.test.ts
+++ b/packages/js-compiler/test/program.test.ts
@@ -1,6 +1,136 @@
 import { expect } from "@std/expect";
+import * as path from "@std/path";
 import { describe, it } from "@std/testing/bdd";
-import { HttpProgramResolver } from "../program.ts";
+import {
+  FileSystemProgramResolver,
+  HttpProgramResolver,
+  InMemoryProgram,
+} from "../program.ts";
+
+describe("InMemoryProgram", () => {
+  it("resolves empty main and dependency sources", async () => {
+    const resolver = new InMemoryProgram("/main.ts", {
+      "/main.ts": "",
+      "/dependency.ts": "",
+    });
+
+    expect(await resolver.main()).toEqual({
+      name: "/main.ts",
+      contents: "",
+    });
+    expect(await resolver.resolveSource("/dependency.ts")).toEqual({
+      name: "/dependency.ts",
+      contents: "",
+    });
+    expect(await resolver.resolveSource("/missing.ts")).toBeUndefined();
+  });
+});
+
+describe("FileSystemProgramResolver", () => {
+  it("keeps entry and dependency names grounded under filesystem root", async () => {
+    const directory = await Deno.makeTempDir();
+    const mainPath = `${directory}/main.ts`;
+    const dependencyPath = `${directory}/dependency.ts`;
+    await Deno.writeTextFile(mainPath, "export default 1;");
+    await Deno.writeTextFile(dependencyPath, "export default 2;");
+
+    try {
+      const resolver = new FileSystemProgramResolver(mainPath, directory);
+      expect(await resolver.main()).toEqual({
+        name: "/main.ts",
+        contents: "export default 1;",
+      });
+      expect(await resolver.resolveSource("/dependency.ts")).toEqual({
+        name: "/dependency.ts",
+        contents: "export default 2;",
+      });
+
+      const filesystemRoot = path.parse(directory).root;
+      const mainSpecifier = `/${
+        path.relative(filesystemRoot, mainPath)
+          .split(path.SEPARATOR).join("/")
+      }`;
+      const dependencySpecifier = `/${
+        path.relative(filesystemRoot, dependencyPath)
+          .split(path.SEPARATOR).join("/")
+      }`;
+      const rootResolver = new FileSystemProgramResolver(
+        mainPath,
+        filesystemRoot,
+      );
+      expect((await rootResolver.main()).name).toBe(mainSpecifier);
+      expect(await rootResolver.resolveSource(dependencySpecifier)).toEqual({
+        name: dependencySpecifier,
+        contents: "export default 2;",
+      });
+    } finally {
+      await Deno.remove(directory, { recursive: true });
+    }
+  });
+
+  it("rejects a main path that only shares the root's text prefix", async () => {
+    const root = await Deno.makeTempDir();
+    try {
+      expect(() =>
+        new FileSystemProgramResolver(`${root}-sibling/main.ts`, root)
+      ).toThrow("must be within root directory");
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+
+  it("rejects entry and dependency symlinks that leave the root", async () => {
+    const root = await Deno.makeTempDir();
+    const outside = await Deno.makeTempDir();
+    const mainPath = `${root}/main.ts`;
+    const outsideMainPath = `${outside}/main.ts`;
+    const outsideDependencyPath = `${outside}/dependency.ts`;
+    await Deno.writeTextFile(mainPath, "export default 1;");
+    await Deno.writeTextFile(outsideMainPath, "export default 2;");
+    await Deno.writeTextFile(outsideDependencyPath, "export default 3;");
+    await Deno.symlink(outsideMainPath, `${root}/linked-main.ts`, {
+      type: "file",
+    });
+    await Deno.symlink(outsideDependencyPath, `${root}/dependency.ts`, {
+      type: "file",
+    });
+
+    try {
+      expect(() =>
+        new FileSystemProgramResolver(`${root}/linked-main.ts`, root)
+      ).toThrow("must be within root directory");
+
+      const resolver = new FileSystemProgramResolver(mainPath, root);
+      expect(() => resolver.resolveSource("/dependency.ts")).toThrow(
+        "resolves outside of root directory",
+      );
+    } finally {
+      await Deno.remove(root, { recursive: true });
+      await Deno.remove(outside, { recursive: true });
+    }
+  });
+
+  it("retains logical names for symlinks whose targets remain inside the root", async () => {
+    const root = await Deno.makeTempDir();
+    const mainPath = `${root}/main.ts`;
+    const dependencyPath = `${root}/dependency.ts`;
+    await Deno.writeTextFile(mainPath, "export default 1;");
+    await Deno.writeTextFile(dependencyPath, "export default 2;");
+    await Deno.symlink(dependencyPath, `${root}/linked-dependency.ts`, {
+      type: "file",
+    });
+
+    try {
+      const resolver = new FileSystemProgramResolver(mainPath, root);
+      expect(await resolver.resolveSource("/linked-dependency.ts")).toEqual({
+        name: "/linked-dependency.ts",
+        contents: "export default 2;",
+      });
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+});
 
 describe("HttpProgramResolver", () => {
   it("invokes the default fetch with the host global as receiver", async () => {

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -2950,18 +2950,20 @@ export class PieceController<T = unknown> {
   }
 
   /**
-   * The pattern's authored source program (`{ main, mainExport?, files }`),
-   * recovered from the content-addressed `pattern:<identity>` source-doc closure
-   * in the piece's space. Replaces the deleted meta cell's `program`. `main` is
-   * the entry filename; `mainExport` is the pattern pointer's export symbol.
-   * Returns undefined when no verified source closure exists (the source docs
-   * are written by every cold compile).
+   * The pattern's authored source program, recovered from the content-addressed
+   * `pattern:<identity>` source-doc closure in the piece's space. Replaces the
+   * deleted meta cell's `program`. `main` is the executable entry filename;
+   * `mainExport` is the pattern pointer's export symbol; and `sourceRoots` names
+   * retained source entry points such as attached tests. Returns undefined when
+   * no verified source closure exists (the source docs are written by every cold
+   * compile).
    */
   async getPatternSourceProgram(): Promise<
     | {
       main: string;
       mainExport?: string;
       files: { name: string; contents: string }[];
+      sourceRoots?: string[];
     }
     | undefined
   > {

--- a/packages/runner/src/compilation-cache/cell-cache.ts
+++ b/packages/runner/src/compilation-cache/cell-cache.ts
@@ -5,7 +5,10 @@ import type { PatternCoverageSpan } from "@commonfabric/ts-transformers";
 import { normalize } from "@std/path/posix";
 import { computeModuleHashes } from "../harness/module-identity.ts";
 import { ensureCompilerStack } from "../harness/deferred-compiler-stack.ts";
-import { deriveModuleRecordFields } from "../sandbox/module-record-compiler.ts";
+import {
+  deriveModuleRecordFields,
+  SOURCE_ROOT_SPECIFIER,
+} from "../sandbox/module-record-compiler.ts";
 import type { CacheableModule } from "../harness/types.ts";
 import type { MemorySpace, Runtime } from "../runtime.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
@@ -354,6 +357,8 @@ export function compiledDocKey(
  * warm closure would always be incomplete. These links carry no authored
  * specifier, so they are ignored by the Merkle identity recompute (which
  * resolves a module's edges from its own source, not its stored links).
+ * Explicit source-package roots use {@link SOURCE_ROOT_SPECIFIER} instead and
+ * participate in the entry module's identity.
  */
 export const ROOT_LINK_SPECIFIER = "cf:cache-root/";
 
@@ -493,7 +498,8 @@ export interface SourceDocVerification {
  * an import link, makes the recomputed identity diverge from the key.
  *
  * Each document is verified against **its own view**: the documents reachable
- * from it over authored-import edges (root links excluded — a
+ * from it over authored-import and source-package edges (cache root links
+ * excluded — a
  * {@link ROOT_LINK_SPECIFIER} edge is never part of any module's Merkle
  * preimage). One closure may legally hold several generations of the same
  * ambient filename (e.g. two seals' injected `cfc.ts`, each root-linked by a
@@ -564,9 +570,32 @@ export function verifySourceDocs(
       continue;
     }
 
+    const additionalInternalDeps = new Map<
+      string,
+      { specifier: string; target: string }[]
+    >();
+    for (const id of viewIds) {
+      const doc = docsByIdentity.get(id)!;
+      const sourceRoots = doc.imports
+        .filter((imp) => imp.specifier.startsWith(SOURCE_ROOT_SPECIFIER))
+        .flatMap((imp) => {
+          const target = docsByIdentity.get(imp.identity);
+          return target === undefined
+            ? []
+            : [{ specifier: imp.specifier, target: target.filename }];
+        });
+      if (sourceRoots.length > 0) {
+        additionalInternalDeps.set(doc.filename, sourceRoots);
+      }
+    }
     const recomputed = computeModuleHashes(
       { main: rootDoc.filename, files },
-      { runtimeFingerprint },
+      {
+        runtimeFingerprint,
+        ...(additionalInternalDeps.size === 0
+          ? {}
+          : { additionalInternalDeps }),
+      },
     );
     for (const id of viewIds) {
       if (!verdicts.has(id)) {

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -53,6 +53,7 @@ import {
   computeFabricModuleIdentities,
   FABRIC_MOUNT_ROOT,
   type FabricMount,
+  sourceRootSpecifier,
 } from "../sandbox/module-record-compiler.ts";
 import {
   composeBundleSourceMap,
@@ -148,6 +149,65 @@ export class EngineProgramResolver extends InMemoryProgram {
   }
 }
 
+class RootedProgramResolver implements ProgramResolver {
+  constructor(
+    private readonly inner: ProgramResolver,
+    private readonly root: string,
+  ) {}
+
+  async main(): Promise<Source> {
+    const source = await this.inner.resolveSource(this.root);
+    if (source === undefined) {
+      throw new Error(`Source root "${this.root}" could not be resolved.`);
+    }
+    return source;
+  }
+
+  resolveSource(identifier: string): Promise<Source | undefined> {
+    return this.inner.resolveSource(identifier);
+  }
+}
+
+function reachableModuleSpecifiers(
+  records: ReadonlyMap<string, VirtualModuleRecord>,
+  mainSpecifier: string,
+): Set<string> {
+  const reachable = new Set<string>();
+  const pending = [mainSpecifier];
+  while (pending.length > 0) {
+    const specifier = pending.pop()!;
+    if (reachable.has(specifier)) continue;
+    reachable.add(specifier);
+    const record = records.get(specifier);
+    if (record === undefined) continue;
+    for (const importSpecifier of record.imports) {
+      const resolutions = record.resolutions;
+      pending.push(
+        resolutions !== undefined &&
+          Object.hasOwn(resolutions, importSpecifier)
+          ? resolutions[importSpecifier]
+          : importSpecifier,
+      );
+    }
+  }
+  return reachable;
+}
+
+function canonicalSourceRoots(
+  main: string,
+  roots: readonly string[] | undefined,
+): string[] {
+  return [...new Set(roots ?? [])]
+    .filter((root) => root !== main)
+    .sort();
+}
+
+function persistableSourceFiles(files: readonly Source[]): Source[] {
+  return files.filter((file) =>
+    !file.name.endsWith(".d.ts") || file.name.startsWith("/")
+  );
+}
+
 interface RuntimeInternals {
   runtime: SESRuntime;
   runtimeExports: Record<string, any> | undefined;
@@ -233,6 +293,34 @@ export class Engine extends EventTarget {
     }
   }
 
+  private async resolveWithSourceRoots(
+    resolver: ProgramResolver,
+    sourceRoots: readonly string[],
+  ): Promise<RuntimeProgram> {
+    const programs = [await this.resolve(resolver)];
+    for (const root of new Set(sourceRoots)) {
+      if (root === programs[0].main) continue;
+      programs.push(
+        await this.resolve(new RootedProgramResolver(resolver, root)),
+      );
+    }
+
+    const files = new Map<string, Source>();
+    for (const program of programs) {
+      for (const file of program.files) {
+        const existing = files.get(file.name);
+        if (existing !== undefined && existing.contents !== file.contents) {
+          throw new Error(
+            `Resolved source roots produced conflicting files named ` +
+              `"${file.name}".`,
+          );
+        }
+        files.set(file.name, file);
+      }
+    }
+    return { main: programs[0].main, files: [...files.values()] };
+  }
+
   /**
    * Compile a program to a verified ESM module-record graph. Runs the program
    * resolution + CF transformer pipeline, emits per-module CommonJS via
@@ -261,6 +349,10 @@ export class Engine extends EventTarget {
       const id = options.identifier ?? computeId(program);
       assertNoReservedFabricPaths(program.files);
       const mappedProgram = pretransformProgramForModules(program, id);
+      const sourceRoots = canonicalSourceRoots(
+        mappedProgram.main,
+        mappedProgram.sourceRoots,
+      );
       assertFabricImportsHaveSpace(mappedProgram.files, options);
       const engineResolver = new EngineProgramResolver(
         mappedProgram,
@@ -274,7 +366,10 @@ export class Engine extends EventTarget {
         })
         : undefined;
       const resolver = fabricResolver ?? engineResolver;
-      const resolvedProgram = await this.resolve(resolver);
+      const resolvedProgram = await this.resolveWithSourceRoots(
+        resolver,
+        sourceRoots,
+      );
       const mounts = fabricResolver?.mounts() ?? [];
       const specifierAliases = fabricResolver?.specifierAliases() ?? new Map();
       const resolvedPins = fabricResolver?.resolvedPins() ?? [];
@@ -313,8 +408,8 @@ export class Engine extends EventTarget {
           ],
         },
       );
-      const pristineModuleFiles = pristineModuleSources(
-        moduleFiles,
+      const pristineSourceFiles = pristineModuleSources(
+        persistableSourceFiles(resolvedFiles),
         authoredByStoredName,
         (name) => storedFilenameFor(name, id, mounts),
       );
@@ -323,10 +418,18 @@ export class Engine extends EventTarget {
       // (cheap, no TS compile) so the cache-hit check and the write-back
       // descriptors agree with the graph's `cf:module/<hash>` specifiers.
       const identityByPath = computeFabricModuleIdentities(
-        pristineModuleFiles,
+        pristineSourceFiles,
         mounts,
         {
           idPrefix: `/${id}`,
+          ...(sourceRoots.length
+            ? {
+              sourcePackage: {
+                entryPath: mappedProgram.main,
+                rootPaths: sourceRoots,
+              },
+            }
+            : {}),
         },
       );
       const entryIdentity = identityByPath.get(mappedProgram.main)!;
@@ -341,7 +444,11 @@ export class Engine extends EventTarget {
         (options.precompiledModulesFor
           ? await options.precompiledModulesFor({
             entryIdentity,
-            identities: [...new Set(identityByPath.values())],
+            identities: [
+              ...new Set(
+                moduleFiles.map((file) => identityByPath.get(file.name)!),
+              ),
+            ],
           })
           : undefined);
       const cached = patternCoverage !== undefined &&
@@ -545,12 +652,14 @@ export class Engine extends EventTarget {
       // pristine module set so `source` and the edges are over authored bytes.
       const importEdges = resolveModuleImports({
         main: "",
-        files: pristineModuleFiles,
+        files: pristineSourceFiles,
       });
-      const modules: CacheableModule[] = pristineModuleFiles.map((file) => {
+      const modules: CacheableModule[] = pristineSourceFiles.map((file) => {
         const identity = identityByPath.get(file.name)!;
         const sourceMap = precompiledSourceMaps.get(file.name);
-        const patternCoverageSpans = patternCoverage === undefined
+        const emittedBody = precompiledBodies.get(file.name);
+        const patternCoverageSpans = patternCoverage === undefined ||
+            emittedBody === undefined
           ? undefined
           : options.patternCoverage?.spansForFile(
             coverageFilenameFor(file.name, id, mounts),
@@ -561,15 +670,33 @@ export class Engine extends EventTarget {
           identityByPath,
           specifierAliases,
         );
-        const policyManifests = validatePolicyManifestsForModule(
-          identity,
-          precompiledPolicyManifests.get(file.name),
-        );
+        if (file.name === mappedProgram.main) {
+          for (const rootPath of sourceRoots) {
+            const rootIdentity = identityByPath.get(rootPath);
+            if (rootIdentity === undefined) {
+              throw new Error(
+                `Source root '${rootPath}' has no module identity.`,
+              );
+            }
+            imports.push({
+              specifier: sourceRootSpecifier(
+                storedFilenameFor(rootPath, id, mounts),
+              ),
+              targetIdentity: rootIdentity,
+            });
+          }
+        }
+        const policyManifests = emittedBody === undefined
+          ? undefined
+          : validatePolicyManifestsForModule(
+            identity,
+            precompiledPolicyManifests.get(file.name),
+          );
         return {
           identity,
           filename: storedFilenameFor(file.name, id, mounts),
           source: file.contents,
-          js: precompiledBodies.get(file.name)!,
+          js: emittedBody ?? "",
           ...(sourceMap === undefined ? {} : { sourceMap }),
           ...(patternCoverageSpans === undefined
             ? {}
@@ -641,7 +768,10 @@ export class Engine extends EventTarget {
         mapped,
         this.ctRuntime.staticCache,
       );
-      const resolved = await this.resolve(resolver);
+      const resolved = await this.resolveWithSourceRoots(
+        resolver,
+        mapped.sourceRoots ?? [],
+      );
       for (const file of uniqueSourcesByName(resolved.files)) {
         if (!unioned.has(file.name)) unioned.set(file.name, file);
       }
@@ -737,6 +867,7 @@ export class Engine extends EventTarget {
     options: {
       fabricImports?: TypeScriptHarnessProcessOptions["fabricImports"];
       patternCoverage?: PatternCoverageCollector;
+      sourceRoots?: readonly string[];
     } = {},
   ): Promise<{ modules: CacheableModule[]; entryIdentity: string }> {
     const { compiler } = await this.getCompilerInternals();
@@ -759,7 +890,14 @@ export class Engine extends EventTarget {
     const injectedInput = transformInjectHelperModule({
       main: entryFilename,
       files: resolvedFiles,
+      ...(options.sourceRoots === undefined
+        ? {}
+        : { sourceRoots: [...options.sourceRoots] }),
     }, { tolerateStoredLegacyEnvelope: true });
+    const sourceRoots = canonicalSourceRoots(
+      entryFilename,
+      injectedInput.sourceRoots,
+    );
     const engineResolver = new EngineProgramResolver(
       { main: entryFilename, files: injectedInput.files },
       this.ctRuntime.staticCache,
@@ -772,7 +910,10 @@ export class Engine extends EventTarget {
       })
       : undefined;
     const resolver = fabricResolver ?? engineResolver;
-    const resolvedProgram = await this.resolve(resolver);
+    const resolvedProgram = await this.resolveWithSourceRoots(
+      resolver,
+      sourceRoots,
+    );
     const mounts = fabricResolver?.mounts() ?? [];
     const specifierAliases = fabricResolver?.specifierAliases() ?? new Map();
     const resolvedProgramFiles = uniqueSourcesByName(resolvedProgram.files);
@@ -793,14 +934,22 @@ export class Engine extends EventTarget {
     const authoredByStoredName = new Map(
       resolvedFiles.map((f) => [f.name, f.contents]),
     );
-    const pristineModuleFiles = pristineModuleSources(
-      moduleFiles,
+    const pristineSourceFiles = pristineModuleSources(
+      persistableSourceFiles(resolvedProgramFiles),
       authoredByStoredName,
       (name) => storedFilenameFor(name, undefined, mounts),
     );
     const identityByPath = computeFabricModuleIdentities(
-      pristineModuleFiles,
+      pristineSourceFiles,
       mounts,
+      sourceRoots.length
+        ? {
+          sourcePackage: {
+            entryPath: entryFilename,
+            rootPaths: sourceRoots,
+          },
+        }
+        : {},
     );
 
     // Instrumenting does not disturb the identity check below: identity hashes
@@ -811,7 +960,7 @@ export class Engine extends EventTarget {
       {
         id: undefined,
         mounts,
-        sourceFiles: pristineModuleFiles,
+        sourceFiles: pristineSourceFiles,
       },
     );
 
@@ -849,12 +998,13 @@ export class Engine extends EventTarget {
 
     const importEdges = resolveModuleImports({
       main: "",
-      files: pristineModuleFiles,
+      files: pristineSourceFiles,
     });
-    const modules: CacheableModule[] = pristineModuleFiles.map((file) => {
-      const out = emitted.get(file.name)!;
+    const modules: CacheableModule[] = pristineSourceFiles.map((file) => {
+      const out = emitted.get(file.name);
       const identity = identityByPath.get(file.name)!;
-      const patternCoverageSpans = patternCoverage === undefined
+      const patternCoverageSpans = patternCoverage === undefined ||
+          out === undefined
         ? undefined
         : options.patternCoverage?.spansForFile(
           coverageFilenameFor(file.name, undefined, mounts),
@@ -865,16 +1015,31 @@ export class Engine extends EventTarget {
         identityByPath,
         specifierAliases,
       );
-      const policyManifests = validatePolicyManifestsForModule(
-        identity,
-        out.policyManifests,
-      );
+      if (file.name === entryFilename) {
+        for (const rootPath of sourceRoots) {
+          const rootIdentity = identityByPath.get(rootPath);
+          if (rootIdentity === undefined) {
+            throw new Error(
+              `Source root '${rootPath}' has no module identity.`,
+            );
+          }
+          imports.push({
+            specifier: sourceRootSpecifier(
+              storedFilenameFor(rootPath, undefined, mounts),
+            ),
+            targetIdentity: rootIdentity,
+          });
+        }
+      }
+      const policyManifests = out === undefined
+        ? undefined
+        : validatePolicyManifestsForModule(identity, out.policyManifests);
       return {
         identity,
         filename: storedFilenameFor(file.name, undefined, mounts),
         source: file.contents,
-        js: out.js,
-        ...(out.sourceMap === undefined ? {} : { sourceMap: out.sourceMap }),
+        js: out?.js ?? "",
+        ...(out?.sourceMap === undefined ? {} : { sourceMap: out.sourceMap }),
         ...(patternCoverageSpans === undefined ? {} : { patternCoverageSpans }),
         ...(policyManifests === undefined ? {} : { policyManifests }),
         imports,
@@ -1149,7 +1314,12 @@ export class Engine extends EventTarget {
       // information exists right here and was simply not written down.
       const sourcePathByIdentity = new Map<string, string>();
       const MODULE_SPECIFIER_PREFIX = "cf:module/";
+      const reachableSpecifiers = reachableModuleSpecifiers(
+        graph.records,
+        mainSpecifier,
+      );
       for (const [path, specifier] of graph.specifierByPath) {
+        if (!reachableSpecifiers.has(specifier)) continue;
         const namespace = loaded.importNow(specifier) as Exports;
         const fileName = ctx.fileNameForPath(path);
         exportMap[fileName] = namespace;
@@ -1589,10 +1759,12 @@ function validatePolicyManifestsForModule(
   });
 }
 
-function computeId(program: Program): string {
+function computeId(program: RuntimeProgram): string {
+  const sourceRoots = canonicalSourceRoots(program.main, program.sourceRoots);
   const source = [
     program.main,
-    ...program.files.filter(({ name }) => !name.endsWith(".d.ts")),
+    ...(sourceRoots.length === 0 ? [] : [{ sourceRoots }]),
+    ...persistableSourceFiles(program.files),
   ];
   return hashOf(source).toString();
 }

--- a/packages/runner/src/harness/module-identity.ts
+++ b/packages/runner/src/harness/module-identity.ts
@@ -58,6 +58,11 @@ export interface ModuleIdentityOptions {
    * identity. Defaults to the empty string.
    */
   runtimeFingerprint?: string;
+  /** Internal dependency edges that participate in identity without executing. */
+  additionalInternalDeps?: ReadonlyMap<
+    string,
+    readonly { specifier: string; target: string }[]
+  >;
 }
 
 interface ModuleNode {
@@ -128,10 +133,21 @@ export function computeModuleHashes(
 
   for (const file of program.files) {
     const { internalDeps, externalDeps } = edges.get(file.name)!;
+    const additionalInternalDeps = options.additionalInternalDeps?.get(
+      file.name,
+    ) ?? [];
+    for (const dependency of additionalInternalDeps) {
+      if (!edges.has(dependency.target)) {
+        throw new Error(
+          `Additional identity dependency from '${file.name}' targets missing ` +
+            `module '${dependency.target}'.`,
+        );
+      }
+    }
     nodes.set(file.name, {
       path: file.name,
       src: normalizeSource(file.contents),
-      internalDeps,
+      internalDeps: [...internalDeps, ...additionalInternalDeps],
       externalDeps,
     });
   }

--- a/packages/runner/src/harness/pretransform.ts
+++ b/packages/runner/src/harness/pretransform.ts
@@ -76,6 +76,7 @@ export function transformInjectHelperModule(
       };
     }),
     mainExport: program.mainExport,
+    sourceRoots: program.sourceRoots,
   };
 }
 
@@ -104,6 +105,7 @@ export function transformProgramWithPrefix(
   return {
     main: `/index.ts`,
     files,
+    sourceRoots: program.sourceRoots?.map((root) => prefix(root, id)),
   };
 }
 
@@ -124,6 +126,9 @@ export function pretransformProgramForModules(
     })),
     ...(program.mainExport !== undefined
       ? { mainExport: program.mainExport }
+      : {}),
+    ...(program.sourceRoots !== undefined
+      ? { sourceRoots: program.sourceRoots.map((root) => prefix(root, id)) }
       : {}),
   };
 }

--- a/packages/runner/src/harness/types.ts
+++ b/packages/runner/src/harness/types.ts
@@ -9,6 +9,8 @@ export type RuntimeProgram = Program & {
   // The named export from the program's entry file to run.
   // Defaults to "default".
   mainExport?: string;
+  /** Source entry points retained and compiled without being executed. */
+  sourceRoots?: string[];
 };
 
 export interface TypeScriptHarnessProcessOptions {

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -24,7 +24,10 @@ import type {
   TypeScriptHarnessProcessOptions,
 } from "./harness/types.ts";
 import { RuntimeProgram } from "./harness/types.ts";
-import type { CachedCompiledModule } from "./sandbox/module-record-compiler.ts";
+import {
+  type CachedCompiledModule,
+  SOURCE_ROOT_SPECIFIER,
+} from "./sandbox/module-record-compiler.ts";
 import type {
   CommitError,
   IExtendedStorageTransaction,
@@ -528,8 +531,8 @@ export class PatternManager {
         ...(compiled?.policyManifests !== undefined
           ? { policyManifests: compiled.policyManifests }
           : {}),
-        // The write functions re-derive the entry's root links; keep only the
-        // real import edges.
+        // The write functions re-derive cache-retention links. Authored and
+        // source-package identity edges remain attached to the module.
         imports: uniqueCacheableImports([
           ...doc.imports
             .filter((imp) => !imp.specifier.startsWith(ROOT_LINK_SPECIFIER))
@@ -1062,10 +1065,12 @@ export class PatternManager {
         ...(doc.patternCoverageSpans !== undefined
           ? { patternCoverageSpans: doc.patternCoverageSpans }
           : {}),
-        // Drop the synthetic entry→root links (cfc.ts etc.); only real
-        // require/export-* edges resolve module records.
+        // Identity and cache-retention edges do not resolve module records.
         imports: doc.imports
-          .filter((i) => !i.specifier.startsWith(ROOT_LINK_SPECIFIER))
+          .filter((i) =>
+            !i.specifier.startsWith(ROOT_LINK_SPECIFIER) &&
+            !i.specifier.startsWith(SOURCE_ROOT_SPECIFIER)
+          )
           .map((i) => ({ specifier: i.specifier, targetIdentity: i.identity })),
       }),
     );
@@ -1246,7 +1251,10 @@ export class PatternManager {
           ? { patternCoverageSpans: doc.patternCoverageSpans }
           : {}),
         imports: doc.imports
-          .filter((i) => !i.specifier.startsWith(ROOT_LINK_SPECIFIER))
+          .filter((i) =>
+            !i.specifier.startsWith(ROOT_LINK_SPECIFIER) &&
+            !i.specifier.startsWith(SOURCE_ROOT_SPECIFIER)
+          )
           .map((i) => ({ specifier: i.specifier, targetIdentity: i.identity })),
       }),
     );
@@ -1313,6 +1321,10 @@ export class PatternManager {
     const entry = sourceDocs.get(entryIdentity);
     if (entry === undefined) return undefined;
     const moduleDelegations = moduleDelegationsFromDocs(sourceDocs);
+    const sourceRoots = entry.imports
+      .filter((edge) => edge.specifier.startsWith(SOURCE_ROOT_SPECIFIER))
+      .map((edge) => sourceDocs.get(edge.identity)?.filename)
+      .filter((filename): filename is string => filename !== undefined);
 
     const sourceFiles: Source[] = [...sourceDocs.values()].map((doc) => ({
       name: doc.filename,
@@ -1327,6 +1339,7 @@ export class PatternManager {
         {
           fabricImports: { space },
           ...(patternCoverage ? { patternCoverage } : {}),
+          ...(sourceRoots.length === 0 ? {} : { sourceRoots }),
         },
       );
       if (compiled.entryIdentity !== entryIdentity) {
@@ -2082,14 +2095,19 @@ export class PatternManager {
    * closure in `space`. The single-source replacement for the deleted meta
    * cell's `program`: the source docs are written (awaited) by every cold
    * compile, so this returns the same bytes that produced the identity. `main`
-   * is the entry document's authored filename. Returns `undefined` when no
-   * verified source closure exists in the space.
+   * is the executable entry document's authored filename. `sourceRoots` names
+   * retained source entry points such as attached tests. Returns `undefined`
+   * when no verified source closure exists in the space.
    */
   async getPatternSourceProgramByIdentity(
     entryIdentity: string,
     space: MemorySpace,
   ): Promise<
-    { main: string; files: { name: string; contents: string }[] } | undefined
+    {
+      main: string;
+      files: { name: string; contents: string }[];
+      sourceRoots?: string[];
+    } | undefined
   > {
     const readTx = this.runtime.edit();
     let sourceDocs;
@@ -2106,6 +2124,12 @@ export class PatternManager {
     if (sourceDocs === undefined) return undefined;
     const entry = sourceDocs.get(entryIdentity);
     if (entry === undefined) return undefined;
+    const sourceRoots = entry.imports
+      .filter((edge) => edge.specifier.startsWith(SOURCE_ROOT_SPECIFIER))
+      .map((edge) => sourceDocs.get(edge.identity)?.filename)
+      .filter((filename): filename is string =>
+        filename?.startsWith("/") === true
+      );
     // Return only the AUTHORED files — the faithful replacement for the old
     // meta-cell `program`. The verified source closure also contains
     // runtime-INJECTED helper modules (e.g. `cfc.ts`), which the compiler
@@ -2120,6 +2144,7 @@ export class PatternManager {
           name: doc.filename,
           contents: doc.code,
         })),
+      ...(sourceRoots.length === 0 ? {} : { sourceRoots }),
     };
   }
 

--- a/packages/runner/src/sandbox/fabric-import-specifier.ts
+++ b/packages/runner/src/sandbox/fabric-import-specifier.ts
@@ -31,9 +31,12 @@ export function parseFabricRef(specifier: string): FabricRef | undefined {
   if (!specifier.startsWith("cf:")) return undefined;
 
   let rest = specifier.slice("cf:".length);
-  if (rest.startsWith("module/") || rest.startsWith("cache-root/")) {
+  if (
+    rest.startsWith("module/") || rest.startsWith("cache-root/") ||
+    rest.startsWith("source-root/")
+  ) {
     throw new FabricRefError(
-      "'cf:module/...' / 'cf:cache-root/...' are compiler-internal namespaces and cannot be imported",
+      "'cf:module/...', 'cf:cache-root/...', and 'cf:source-root/...' are compiler-internal namespaces and cannot be imported",
       specifier,
     );
   }

--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -30,6 +30,13 @@ import type { VirtualModuleRecord } from "./esm-module-loader.ts";
 
 const logger = getLogger("module-record-compiler");
 
+/** Identity-only import edge for an attached source entry point. */
+export const SOURCE_ROOT_SPECIFIER = "cf:source-root/";
+
+export function sourceRootSpecifier(path: string): string {
+  return `${SOURCE_ROOT_SPECIFIER}${path.replace(/^\/+/, "")}`;
+}
+
 /**
  * Memo of the two pure derivations {@link buildRecordsFromCompiled} extracts
  * from a module's compiled body: its direct export surface (names + `export *`
@@ -445,19 +452,48 @@ function stripIdentityPrefix(name: string, idPrefix?: string): string {
  */
 export function computeModuleIdentities(
   sources: Source[],
-  options: { idPrefix?: string; runtimeFingerprint?: string } = {},
+  options: {
+    idPrefix?: string;
+    runtimeFingerprint?: string;
+    sourcePackage?: { entryPath: string; rootPaths: readonly string[] };
+  } = {},
 ): Map<string, string> {
+  const stripPath = (path: string) =>
+    stripIdentityPrefix(path, options.idPrefix);
+  const additionalInternalDeps = new Map<
+    string,
+    { specifier: string; target: string }[]
+  >();
+  if (options.sourcePackage !== undefined) {
+    const entryPath = stripPath(options.sourcePackage.entryPath);
+    const rootPaths = [
+      ...new Set(options.sourcePackage.rootPaths.map(stripPath)),
+    ]
+      .filter((rootPath) => rootPath !== entryPath);
+    if (rootPaths.length > 0) {
+      additionalInternalDeps.set(
+        entryPath,
+        rootPaths.map((rootPath) => ({
+          specifier: sourceRootSpecifier(rootPath),
+          target: rootPath,
+        })),
+      );
+    }
+  }
   const hashes = computeModuleHashes(
     {
       main: "",
       files: sources.map((s) => ({
         ...s,
-        name: stripIdentityPrefix(s.name, options.idPrefix),
+        name: stripPath(s.name),
       })),
     },
-    options.runtimeFingerprint !== undefined
-      ? { runtimeFingerprint: options.runtimeFingerprint }
-      : {},
+    {
+      ...(options.runtimeFingerprint !== undefined
+        ? { runtimeFingerprint: options.runtimeFingerprint }
+        : {}),
+      ...(additionalInternalDeps.size === 0 ? {} : { additionalInternalDeps }),
+    },
   );
   const identityByPath = new Map<string, string>();
   for (const source of sources) {
@@ -488,7 +524,11 @@ export interface FabricMount {
 export function computeFabricModuleIdentities(
   sources: Source[],
   mounts: readonly FabricMount[],
-  options: { idPrefix?: string; runtimeFingerprint?: string } = {},
+  options: {
+    idPrefix?: string;
+    runtimeFingerprint?: string;
+    sourcePackage?: { entryPath: string; rootPaths: readonly string[] };
+  } = {},
 ): Map<string, string> {
   const authored: Source[] = [];
   const mountFiles = new Map<FabricMount, Source[]>();

--- a/packages/runner/test/cell-cache.test.ts
+++ b/packages/runner/test/cell-cache.test.ts
@@ -34,6 +34,7 @@ import { ensureCompilerStack } from "../src/harness/deferred-compiler-stack.ts";
 import { buildCfcPolicyArtifactManifest } from "../src/cfc/policy.ts";
 import { PatternCoverageCollector } from "../src/pattern-coverage.ts";
 import { pattern } from "../src/builder/pattern.ts";
+import { sourceRootSpecifier } from "../src/sandbox/module-record-compiler.ts";
 
 // These tests drive the sync parse internals directly (below the async flow
 // boundaries that normally load the deferred compiler stack), so load it here.
@@ -232,6 +233,59 @@ describe("cell-cache: verifySourceDocs (Merkle self-verification)", () => {
     const v = verifySourceDocs(entryIdentity, docs);
     expect(v.ok).toBe(false);
     expect(v.missing).toContain(identityOf(PROGRAM, "/util.ts"));
+  });
+
+  it("rejects removing a source-package root edge", () => {
+    const files = [
+      { name: "/main.tsx", contents: "export default 1;" },
+      { name: "/main.test.tsx", contents: "export default 2;" },
+    ];
+    const rootSpecifier = sourceRootSpecifier("/main.test.tsx");
+    const identities = computeModuleHashes(
+      { main: "/main.tsx", files },
+      {
+        additionalInternalDeps: new Map([
+          [
+            "/main.tsx",
+            [{ specifier: rootSpecifier, target: "/main.test.tsx" }],
+          ],
+        ]),
+      },
+    );
+    const entryIdentity = identities.get("/main.tsx")!;
+    const testIdentity = identities.get("/main.test.tsx")!;
+    const docs = buildSourceDocs(
+      [
+        {
+          identity: entryIdentity,
+          filename: "/main.tsx",
+          source: files[0].contents,
+          js: "",
+          imports: [{
+            specifier: rootSpecifier,
+            targetIdentity: testIdentity,
+          }],
+        },
+        {
+          identity: testIdentity,
+          filename: "/main.test.tsx",
+          source: files[1].contents,
+          js: "",
+          imports: [],
+        },
+      ],
+      entryIdentity,
+    );
+    expect(verifySourceDocs(entryIdentity, docs).ok).toBe(true);
+
+    const tampered = new Map(docs);
+    tampered.set(entryIdentity, {
+      ...docs.get(entryIdentity)!,
+      imports: [],
+    });
+    const verification = verifySourceDocs(entryIdentity, tampered);
+    expect(verification.ok).toBe(false);
+    expect(verification.mismatches).toContain(entryIdentity);
   });
 
   it("is entry-point independent (util identity is stable across entries)", () => {

--- a/packages/runner/test/engine-compile-record-graph.test.ts
+++ b/packages/runner/test/engine-compile-record-graph.test.ts
@@ -48,6 +48,31 @@ describe("Engine.compileToRecordGraph()", () => {
     expect(joinedBodies(result.graph).length).toBeGreaterThan(0);
   });
 
+  it("compiles an empty attached source root", async () => {
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      sourceRoots: ["/main.test.ts"],
+      files: [
+        {
+          name: "/main.tsx",
+          contents: "export default 42;",
+        },
+        {
+          name: "/main.test.ts",
+          contents: "",
+        },
+      ],
+    };
+
+    const result = await engine.compileToRecordGraph(program);
+
+    expect(
+      [...result.graph.specifierByPath.keys()].some((path) =>
+        path.endsWith("/main.test.ts")
+      ),
+    ).toBe(true);
+  });
+
   it("compiles a multi-file program", async () => {
     const program: RuntimeProgram = {
       main: "/main.tsx",

--- a/packages/runner/test/engine-evaluate-record-graph.test.ts
+++ b/packages/runner/test/engine-evaluate-record-graph.test.ts
@@ -160,6 +160,118 @@ describe("Engine.evaluateRecordGraph()", () => {
     expect(typeof utilExports["triple"]).toBe("function");
   });
 
+  it("retains source roots without evaluating them", async () => {
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      sourceRoots: ["/main.test.tsx"],
+      files: [
+        {
+          name: "/main.tsx",
+          contents: "export default 42;",
+        },
+        {
+          name: "/main.test.tsx",
+          contents: [
+            'import { pattern } from "commonfabric";',
+            "export default pattern(() => ({ test: true }));",
+          ].join("\n"),
+        },
+      ],
+    };
+
+    const { id, graph, mainSpecifier } = await engine.compileToRecordGraph(
+      program,
+    );
+    expect(
+      [...graph.specifierByPath.keys()].some((path) =>
+        path.endsWith("/main.test.tsx")
+      ),
+    ).toBe(true);
+
+    const result = engine.evaluateRecordGraph(
+      id,
+      graph,
+      mainSpecifier,
+      program.files,
+    );
+    expect(result.main?.default).toBe(42);
+    expect(
+      Object.keys(result.exportMap ?? {}).some((path) =>
+        path.endsWith("/main.test.tsx")
+      ),
+    ).toBe(false);
+    expect(graph.registrationSink.size).toBe(0);
+  });
+
+  it("separates load identities for different source-root sets", async () => {
+    const files = [
+      {
+        name: "/main.tsx",
+        contents: "export default 42;",
+      },
+      {
+        name: "/a.test.tsx",
+        contents: [
+          'import "./b.test.tsx";',
+          'import type { Marker } from "./types.d.ts";',
+          "export type TestMarker = Marker;",
+          "export default 1;",
+        ].join("\n"),
+      },
+      {
+        name: "/b.test.tsx",
+        contents: "export default 2;",
+      },
+      {
+        name: "/types.d.ts",
+        contents: "export interface Marker { value: number; }",
+      },
+    ];
+
+    const aOnly = await engine.compileToRecordGraph({
+      main: "/main.tsx",
+      files,
+      sourceRoots: ["/a.test.tsx"],
+    });
+    const both = await engine.compileToRecordGraph({
+      main: "/main.tsx",
+      files,
+      sourceRoots: ["/a.test.tsx", "/b.test.tsx"],
+    });
+    const reordered = await engine.compileToRecordGraph({
+      main: "/main.tsx",
+      files,
+      sourceRoots: ["/b.test.tsx", "/a.test.tsx", "/a.test.tsx"],
+    });
+    const declarationChanged = await engine.compileToRecordGraph({
+      main: "/main.tsx",
+      files: files.map((file) =>
+        file.name === "/types.d.ts"
+          ? {
+            ...file,
+            contents: "export interface Marker { value: string; }",
+          }
+          : file
+      ),
+      sourceRoots: ["/a.test.tsx", "/b.test.tsx"],
+    });
+
+    expect(aOnly.id).not.toBe(both.id);
+    expect(aOnly.entryIdentity).not.toBe(both.entryIdentity);
+    expect(reordered.id).toBe(both.id);
+    expect(reordered.entryIdentity).toBe(both.entryIdentity);
+    expect(declarationChanged.id).not.toBe(both.id);
+    expect(declarationChanged.entryIdentity).not.toBe(both.entryIdentity);
+    expect(
+      reordered.modules.find((module) =>
+        module.identity === reordered.entryIdentity
+      )?.imports,
+    ).toEqual(
+      both.modules.find((module) => module.identity === both.entryIdentity)
+        ?.imports,
+    );
+  });
+
   it("serializes verified javascript modules by stable $implRef", async () => {
     const program: RuntimeProgram = {
       main: "/main.tsx",

--- a/packages/runner/test/fabric-import-specifier.test.ts
+++ b/packages/runner/test/fabric-import-specifier.test.ts
@@ -182,6 +182,7 @@ describe("fabric import specifiers", () => {
       "cf:data:abc",
       `cf:module/${HASH}`,
       "cf:cache-root/x",
+      "cf:source-root/tests/main.test.tsx",
       "cf:Has_Upper",
       "cf:",
       "cf:/",

--- a/packages/runner/test/load-by-identity.test.ts
+++ b/packages/runner/test/load-by-identity.test.ts
@@ -161,6 +161,96 @@ describe("load by module identity (warm + version-bump recovery)", () => {
     });
   });
 
+  it("cold-loads an exact attached source-root package", async () => {
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      sourceRoots: ["/tests/main.test.tsx"],
+      files: [
+        {
+          name: "/main.tsx",
+          contents: [
+            'import { pattern } from "commonfabric";',
+            "export default pattern(() => ({ value: 1 }));",
+          ].join("\n"),
+        },
+        {
+          name: "/tests/main.test.tsx",
+          contents: [
+            'import { pattern } from "commonfabric";',
+            'import { expected } from "./support.ts";',
+            'import type { Expected } from "./types.d.ts";',
+            "const typed: Expected = expected;",
+            "export default pattern(() => ({ expected: typed }));",
+          ].join("\n"),
+        },
+        {
+          name: "/tests/support.ts",
+          contents: "export const expected = 1;",
+        },
+        {
+          name: "/tests/types.d.ts",
+          contents: "export type Expected = number;",
+        },
+      ],
+    };
+    const compiled = await engine.compileToRecordGraph(program);
+    writeSourceDocs(
+      runtime,
+      space,
+      compiled.modules,
+      compiled.entryIdentity,
+      tx,
+    );
+    runtime.prepareTxForCommit(tx);
+    expect((await tx.commit()).error).toBeUndefined();
+    tx = runtime.edit();
+    await runtime.storageManager.synced();
+
+    const coldRuntime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    try {
+      const loaded = await coldRuntime.patternManager.loadPatternByIdentity(
+        compiled.entryIdentity,
+        "default",
+        space,
+      );
+      expect(typeof loaded).toBe("function");
+      const recovered = await coldRuntime.patternManager
+        .getPatternSourceProgramByIdentity(compiled.entryIdentity, space);
+      expect(recovered?.sourceRoots).toEqual(["/tests/main.test.tsx"]);
+      expect(recovered?.files.map((file) => file.name)).toContain(
+        "/tests/support.ts",
+      );
+      expect(recovered?.files.map((file) => file.name)).toContain(
+        "/tests/types.d.ts",
+      );
+      await coldRuntime.patternManager.flushCompileCacheWrites();
+      await coldRuntime.storageManager.synced();
+
+      const warmRuntime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager,
+      });
+      try {
+        const warm = await warmRuntime.patternManager.loadPatternByIdentity(
+          compiled.entryIdentity,
+          "default",
+          space,
+        );
+        expect(typeof warm).toBe("function");
+        const warmSource = await warmRuntime.patternManager
+          .getPatternSourceProgramByIdentity(compiled.entryIdentity, space);
+        expect(warmSource?.sourceRoots).toEqual(["/tests/main.test.tsx"]);
+      } finally {
+        await warmRuntime.dispose({ closeStorage: false });
+      }
+    } finally {
+      await coldRuntime.dispose({ closeStorage: false });
+    }
+  });
+
   it("trusts integrity-gated cached bodies and skips body re-verification", async () => {
     // Spec (module-loading.md, threat model): a warm hit loaded from the
     // integrity-gated compiled set trusts the CFC label, so `trustedBodies`


### PR DESCRIPTION
Allow piece deployment commands to accept repeatable --test paths. Resolve each test with the main program and retain its source closure without treating it as an executable entry point.

Bind explicit test roots into the source revision identity so test-only changes remain independently recoverable. Preserve local declaration files and carry the package through cold and warm cache recovery.

Add CLI, identity, evaluation, cache verification, and recovery tests.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

