### PR TITLE
fix(inspect): preserve exact paths and compatible results

### DIFF
--- a/packages/cli/commands/inspect.ts
+++ b/packages/cli/commands/inspect.ts
@@ -19,9 +19,8 @@ import {
   commitChurn,
   commitsPerMinute,
   contendedEntities,
-  convergence,
-  type ConvergenceResult,
-  convergenceScan,
+  convergenceExact,
+  convergenceScanExact,
   // Remote acquisition (`cf inspect --remote` / `pull`).
   defaultCacheDir,
   describeIdentity,
@@ -31,6 +30,8 @@ import {
   entityConflicts,
   entityHistory,
   entityTimeline,
+  escapeTerminalText,
+  type ExactConvergenceResult,
   fetchSpaceDb,
   getValueAt,
   graphToDot,
@@ -78,6 +79,85 @@ function out(json: boolean, data: unknown, render: () => void): void {
 
 function splitPath(p?: string): string[] {
   return p ? p.split("/").filter(Boolean) : [];
+}
+
+interface PathOptions {
+  path?: string;
+  pathJson?: string;
+  doc?: boolean;
+}
+
+/**
+ * Parses one of the supported path options into exact string segments.
+ *
+ * @throws {ValidationError} When path options conflict or `pathJson` is not a
+ * JSON array of strings.
+ */
+function parsePathOptions(options: PathOptions): string[] {
+  if (options.path !== undefined && options.pathJson !== undefined) {
+    throw new ValidationError(
+      "Use either `--path` or `--path-json`, not both.",
+    );
+  }
+  if (
+    options.doc &&
+    (options.path !== undefined || options.pathJson !== undefined)
+  ) {
+    throw new ValidationError(
+      "Use `--doc` without `--path` or `--path-json`.",
+    );
+  }
+  if (options.pathJson === undefined) return splitPath(options.path);
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(options.pathJson);
+  } catch {
+    throw new ValidationError(
+      "`--path-json` must contain a JSON array of string segments.",
+    );
+  }
+  if (
+    !Array.isArray(parsed) ||
+    !parsed.every((segment) => typeof segment === "string")
+  ) {
+    throw new ValidationError(
+      "`--path-json` must contain a JSON array of string segments.",
+    );
+  }
+  return parsed;
+}
+
+const SAFE_PATH_SEGMENT = /^[A-Za-z0-9_$@.:%+~-]+$/;
+
+function stringifyPathSegments(segments: string[]): string {
+  return JSON.stringify(segments).replace(
+    /[^\x20-\x7E]/g,
+    (character) =>
+      `\\u${character.charCodeAt(0).toString(16).padStart(4, "0")}`,
+  );
+}
+
+function formatChangePath(path: string, segments: string[]): string {
+  if (segments.length === 0) return "(root)";
+  return segments.every((segment) => SAFE_PATH_SEGMENT.test(segment))
+    ? path
+    : stringifyPathSegments(segments);
+}
+
+function formatSelectedPath(segments: string[], exact: boolean): string {
+  return exact || !segments.every((segment) => SAFE_PATH_SEGMENT.test(segment))
+    ? stringifyPathSegments(segments)
+    : `/${segments.join("/")}`;
+}
+
+function summarizeChangeValue(
+  value: unknown,
+  isUndefined?: true,
+  valueKind?: string,
+): string {
+  const summary = isUndefined ? "undefined" : summarize(value);
+  return valueKind ? `${summary} [${valueKind}]` : summary;
 }
 
 // did:key:z6Mk…wQ2n  ->  z6Mk…wQ2n  (compact, still recognizable)
@@ -201,16 +281,39 @@ async function resolveMultiSpaces(opts: {
   remote?: string | boolean;
   identity?: string;
 }): Promise<SpaceRef[]> {
+  const spaceTokens = opts.spaces?.split(",").map((token) => token.trim())
+    .filter(Boolean);
+  const selectorCount = Number(opts.all === true) +
+    Number(opts.spaces !== undefined) + Number(opts.dir !== undefined);
+  if (selectorCount > 1) {
+    throw new ValidationError(
+      "Use only one of `--all`, `--spaces`, or `--dir`.",
+    );
+  }
+  if (selectorCount === 0) {
+    throw new ValidationError(
+      "Use one of `--all`, `--spaces`, or `--dir`.",
+    );
+  }
+  if (opts.spaces !== undefined && spaceTokens?.length === 0) {
+    throw new ValidationError(
+      "`--spaces` must contain at least one space.",
+    );
+  }
+  if (
+    opts.dir !== undefined && opts.remote !== undefined && opts.remote !== false
+  ) {
+    throw new ValidationError("`--dir` cannot be used with `--remote`.");
+  }
   const base = remoteBaseUrl(opts);
   if (base) {
     const sign = await remoteSigner(opts);
     let dids: string[];
     if (opts.all) {
       dids = (await listRemoteSpaces(base, { sign })).map((s) => s.space);
-    } else if (opts.spaces) {
+    } else if (spaceTokens) {
       dids = await Promise.all(
-        opts.spaces.split(",").map((t) => t.trim()).filter(Boolean)
-          .map((t) => resolveRemoteDid(t, base, sign)),
+        spaceTokens.map((token) => resolveRemoteDid(token, base, sign)),
       );
     } else {
       throw new Error("with --remote, provide --all or --spaces <a,b,…>.");
@@ -221,21 +324,17 @@ async function resolveMultiSpaces(opts: {
   }
   if (opts.dir) return openSpaces(listSqliteFiles(opts.dir));
   if (opts.all) return openSpaces(discoverSpaceDbs().map((s) => s.path));
-  if (opts.spaces) {
+  if (spaceTokens) {
     const discovered = discoverSpaceDbs();
     const paths = await Promise.all(
-      opts.spaces
-        .split(",")
-        .map((t) => t.trim())
-        .filter(Boolean)
-        .map((t) => resolveSpace(t, discovered)),
+      spaceTokens.map((token) => resolveSpace(token, discovered)),
     );
     return openSpaces(paths);
   }
   throw new Error("provide --all, --spaces <a,b,…>, or --dir <dir>");
 }
 
-function relTag(r: ConvergenceResult): string {
+function relTag(r: ExactConvergenceResult): string {
   return r.relationship === "cross-space-linked"
     ? "DRIFT"
     : r.relationship === "no-cross-space-link"
@@ -1133,6 +1232,10 @@ export const inspect = new Command()
     "Reconstruct as of this commit seq (default: latest).",
   )
   .option("--path <path:string>", "Navigate into value, e.g. value/count.")
+  .option(
+    "--path-json <segments:string>",
+    'Navigate with an exact JSON string array, e.g. ["value","count"].',
+  )
   .option("--scope <scope:string>", "Raw scope key (default: space).")
   .option(
     "--as <did:string>",
@@ -1143,20 +1246,41 @@ export const inspect = new Command()
   .option("--branch <branch:string>", "Branch (default: '').")
   .option("--doc", "Show the whole document, not just value.")
   .action(async (options, space, entity) => {
+    const path = parsePathOptions(options);
+    if (options.as !== undefined && options.as.length === 0) {
+      throw new ValidationError("`--as` must not be empty.");
+    }
+    if (options.session !== undefined && options.session.length === 0) {
+      throw new ValidationError("`--session` must not be empty.");
+    }
+    if (options.as !== undefined && options.scope !== undefined) {
+      throw new ValidationError(
+        "Use either `--as` or `--scope`, not both.",
+      );
+    }
+    if (options.as === undefined && options.session !== undefined) {
+      throw new ValidationError("`--session` requires `--as`.");
+    }
     const s = await openByToken(space, options);
     try {
       // --as composes the per-identity overlay; otherwise a single raw scope.
-      if (options.as) {
+      if (options.as !== undefined) {
         const r = valueAsIdentity(s, {
           id: entity,
           identity: options.as,
           sessionId: options.session,
           branch: options.branch,
           atSeq: options.seq,
+          path: options.doc ? undefined : path,
+          doc: !!options.doc,
         });
         out(!!options.json, r, () => {
           if (!r.exists) {
             console.log("(absent for this identity)");
+            return;
+          }
+          if (!options.doc && !r.pathExists) {
+            console.log("(entity present, but nothing at that path)");
             return;
           }
           console.log(
@@ -1176,15 +1300,16 @@ export const inspect = new Command()
           branch: options.branch,
           atSeq: options.seq,
         },
-        splitPath(options.path),
+        path,
       );
       const shown = options.doc ? res.document : res.value;
+      const pathExists = options.doc ? res.exists : res.pathExists;
       out(
         !!options.json,
-        { exists: res.exists, value: annotate(shown) },
+        { exists: res.exists, pathExists, value: annotate(shown) },
         () => {
           if (!res.exists) console.log("(absent at this seq)");
-          else if (shown === undefined) {
+          else if (!pathExists) {
             console.log("(entity present, but nothing at that path)");
           } else console.log(JSON.stringify(annotate(shown), null, 2));
         },
@@ -1241,10 +1366,15 @@ export const inspect = new Command()
   .option("--from <n:number>", "From seq (default: entity's birth / seq 0).")
   .option("--to <n:number>", "To seq (default: latest).")
   .option("--path <path:string>", "Focus inside value, e.g. items/0/title.")
+  .option(
+    "--path-json <segments:string>",
+    'Focus with an exact JSON string array, e.g. ["items","0","title"].',
+  )
   .option("--doc", "Diff the whole document, not just value.")
   .option("--scope <scope:string>", "Scope key (default: space).")
   .option("--branch <branch:string>", "Branch (default: '').")
   .action(async (options, space, entity) => {
+    const path = parsePathOptions(options);
     const s = await openByToken(space, options);
     try {
       const d = diffEntity(s, {
@@ -1253,7 +1383,7 @@ export const inspect = new Command()
         branch: options.branch,
         fromSeq: options.from,
         toSeq: options.to,
-        path: splitPath(options.path),
+        path: options.doc ? undefined : path,
         doc: !!options.doc,
       });
       out(!!options.json, d, () => {
@@ -1266,15 +1396,33 @@ export const inspect = new Command()
           return;
         }
         for (const c of d.changes) {
-          const at = c.path || "(root)";
+          const at = formatChangePath(c.path, c.pathSegments);
           if (c.kind === "changed") {
             console.log(
-              `  ~ ${at}: ${summarize(c.before)} → ${summarize(c.after)}`,
+              `  ~ ${at}: ${
+                summarizeChangeValue(
+                  c.before,
+                  c.beforeIsUndefined,
+                  c.beforeValueKind,
+                )
+              } → ${
+                summarizeChangeValue(
+                  c.after,
+                  c.afterIsUndefined,
+                  c.afterValueKind,
+                )
+              }${c.annotationCollision ? " (display annotations match)" : ""}`,
             );
           } else if (c.kind === "added") {
-            console.log(`  + ${at}: ${summarize(c.after)}`);
+            console.log(
+              `  + ${at}: ${summarizeChangeValue(c.after, c.afterIsUndefined)}`,
+            );
           } else {
-            console.log(`  - ${at}: ${summarize(c.before)}`);
+            console.log(
+              `  - ${at}: ${
+                summarizeChangeValue(c.before, c.beforeIsUndefined)
+              }`,
+            );
           }
         }
       });
@@ -1305,7 +1453,11 @@ export const inspect = new Command()
           for (const st of steps) {
             console.log(
               `  seq=${st.seq}\t${st.op}\t${
-                st.changes ? `${st.changes} changes` : "—"
+                st.changesKnown === false
+                  ? "? changes"
+                  : st.changes
+                  ? `${st.changes} changes`
+                  : "—"
               }\t${st.summary}\t${fmtSession(st.session)}\t${st.createdAt}`,
             );
           }
@@ -1341,22 +1493,27 @@ export const inspect = new Command()
   .option("--spaces <list:string>", "Comma-separated DIDs/prefixes/paths.")
   .option("--dir <dir:string>", "Directory of *.sqlite files.")
   .option("--path <path:string>", "Navigate into value, e.g. value/count.")
+  .option(
+    "--path-json <segments:string>",
+    'Navigate with an exact JSON string array, e.g. ["value","count"].',
+  )
   .option("--scope <scope:string>", "Scope key (default: space).")
   .option("--branch <branch:string>", "Branch (default: '').")
   .action(async (options, entity) => {
+    const path = parsePathOptions(options);
     const refs = await resolveMultiSpaces(options);
     try {
       const index = buildCrossSpaceLinkIndex(refs, {
         scope: options.scope,
         branch: options.branch,
       });
-      const r = convergence(
+      const r = convergenceExact(
         refs,
         {
           id: entity,
           scope: options.scope,
           branch: options.branch,
-          path: splitPath(options.path),
+          path,
         },
         index,
       );
@@ -1369,20 +1526,38 @@ export const inspect = new Command()
         );
         console.log(
           `entity:  ${r.id}` +
-            (r.path.length ? `  path=/${r.path.join("/")}` : ""),
+            (r.path.length
+              ? `  path=${
+                formatSelectedPath(
+                  r.path,
+                  options.pathJson !== undefined,
+                )
+              }`
+              : ""),
         );
         for (const v of r.views) {
           if (!v.present) {
-            console.log(`  ${v.label}\tABSENT`);
+            console.log(`  ${escapeTerminalText(v.label)}\tABSENT`);
+            continue;
+          }
+          if (v.error) {
+            console.log(
+              `  ${escapeTerminalText(v.label)}\tERROR\t${
+                escapeTerminalText(v.error)
+              }`,
+            );
             continue;
           }
           const cluster = r.clusters.findIndex((c) =>
             c.valueKey === v.valueKey
           ) + 1;
           console.log(
-            `  ${v.label}\thead=${v.headSeq}\trevs=${v.revisions}\tlast=${
+            `  ${
+              escapeTerminalText(v.label)
+            }\thead=${v.headSeq}\trevs=${v.revisions}\tlast=${
               v.lastSession ? fmtSession(v.lastSession) : "?"
-            }\tcluster#${cluster}`,
+            }\tcluster#${cluster}` +
+              (v.pathExists === false ? "\tpath=MISSING" : ""),
           );
         }
         console.log(`note: ${r.caveat}`);
@@ -1401,7 +1576,7 @@ export const inspect = new Command()
   .action(async (options) => {
     const refs = await resolveMultiSpaces(options);
     try {
-      const result = convergenceScan(refs, {
+      const result = convergenceScanExact(refs, {
         limit: options.limit,
         branch: options.branch,
       });
@@ -1411,9 +1586,13 @@ export const inspect = new Command()
         );
         console.log(
           `cross-space link edges: ${result.crossSpaceLinkEdges}  ` +
-            `(${result.linkedFindings} real-drift / ${result.unlinkedFindings} likely-independent)`,
+            `(${result.linkedFindings} real-drift / ` +
+            `${result.unlinkedFindings} likely-independent / ` +
+            `${result.unknownFindings} unknown)`,
         );
-        console.log(`findings (diverged/partial): ${result.findings.length}`);
+        console.log(
+          `findings (diverged/partial/unknown): ${result.findings.length}`,
+        );
         for (const f of result.findings) {
           const present = f.views.filter((v) => v.present).length;
           const missing = f.views.length - present;

--- a/packages/cli/test/inspect-remote.test.ts
+++ b/packages/cli/test/inspect-remote.test.ts
@@ -301,6 +301,24 @@ describe("cf inspect --remote", () => {
     assertEquals(identitySlashPath.resolvedKind, "user");
     assertEquals(identitySlashPath.value, "identity nested key");
 
+    const primitivePath = JSON.parse(
+      await run([
+        "value-at",
+        DID_A,
+        "of:a",
+        "--remote",
+        BASE,
+        "--as",
+        VIEWER_DID,
+        "--path",
+        "nested/leaf/length",
+        "--json",
+      ]),
+    );
+    assertEquals(primitivePath.resolvedKind, "user");
+    assertEquals(primitivePath.pathExists, true);
+    assertEquals(primitivePath.value, 19);
+
     const sessionPath = JSON.parse(
       await run([
         "value-at",

--- a/packages/cli/test/inspect-remote.test.ts
+++ b/packages/cli/test/inspect-remote.test.ts
@@ -7,14 +7,18 @@
 import { afterAll, afterEach, beforeAll, describe, it } from "@std/testing/bdd";
 import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
 import { Database } from "@db/sqlite";
+import { ValidationError } from "@cliffy/command";
 import { Identity } from "@commonfabric/identity";
 import { defaultCacheDir } from "@commonfabric/state-inspector";
+import { jsonFromValue } from "@commonfabric/data-model/codecs";
 import { inspect } from "../commands/inspect.ts";
 
 const DUMP_BASE = "/api/storage/memory/dump";
 const BASE = "http://cli-remote-test.invalid:9999";
 const DID_A = "did:key:z6MkCliRemoteTestSpaceAAAAAAAAAAAAAAAAAAAAAAAAAA";
 const DID_B = "did:key:z6MkCliRemoteTestSpaceBBBBBBBBBBBBBBBBBBBBBBBBBB";
+const VIEWER_DID = "did:key:zInspector";
+const VIEWER_SESSION = "viewer-session";
 
 // Minimal valid memory-v2 space DB (schema mirrors state-inspector/test/cli.test.ts).
 const SCHEMA = `
@@ -36,7 +40,7 @@ CREATE TABLE branch (
   fork_seq INTEGER, created_seq INTEGER NOT NULL DEFAULT 0,
   head_seq INTEGER NOT NULL DEFAULT 0, status TEXT NOT NULL DEFAULT 'active'
 );
-INSERT INTO branch (name, head_seq, status) VALUES ('', 1, 'active');
+INSERT INTO branch (name, head_seq, status) VALUES ('', 2, 'active');
 `;
 
 let dbBytes: Uint8Array;
@@ -58,7 +62,58 @@ async function buildDbBytes(): Promise<Uint8Array> {
   db.prepare(
     `INSERT INTO revision (id, seq, op_index, op, data, commit_seq)
      VALUES ('of:a', 1, 0, 'set', ?, 1)`,
-  ).run(JSON.stringify({ value: { n: 1 } }));
+  ).run(jsonFromValue({
+    value: {
+      n: 1,
+      "a/b": "literal slash key",
+      a: { b: "nested keys" },
+      "": "empty key",
+      items: ["zero", "one"],
+      "(root)": "reserved-looking key",
+      "line\nforged": "\u001b[2Jforged\nline",
+      "bidi\u202Eforged": "bidi one",
+      collision: undefined,
+    },
+  }));
+  db.prepare(
+    `INSERT INTO revision
+       (id, scope_key, seq, op_index, op, data, commit_seq)
+     VALUES ('of:a', 'user:did%3Akey%3AzInspector', 1, 0, 'set', ?, 1)`,
+  ).run(jsonFromValue({
+    value: {
+      n: 2,
+      "a/b": "identity slash key",
+      "": "identity empty key",
+      nested: { leaf: "identity nested key" },
+    },
+  }));
+  db.prepare(
+    `INSERT INTO revision
+       (id, scope_key, seq, op_index, op, data, commit_seq)
+     VALUES ('of:a', 'session:did%3Akey%3AzInspector:viewer-session', 1, 0, 'set', ?, 1)`,
+  ).run(JSON.stringify({
+    value: { "a/b": "session slash key" },
+  }));
+  db.prepare(
+    `INSERT INTO "commit" (seq, session_id, local_seq, original, resolution)
+     VALUES (2, 'session:did:key:zX:u', 2, '{"reads":{"confirmed":[],"pending":[]}}', '{}')`,
+  ).run();
+  db.prepare(
+    `INSERT INTO revision (id, seq, op_index, op, data, commit_seq)
+     VALUES ('of:a', 2, 0, 'set', ?, 2)`,
+  ).run(jsonFromValue({
+    value: {
+      n: 1,
+      "a/b": "literal slash key changed",
+      a: { b: "nested keys changed" },
+      "": "empty key changed",
+      items: ["zero", "one"],
+      "(root)": "reserved-looking key changed",
+      "line\nforged": "\u001b[31mother\rline",
+      "bidi\u202Eforged": "bidi two",
+      collision: { $undefined: true },
+    },
+  }));
   db.close();
   const bytes = await Deno.readFile(path);
   await Deno.remove(dir, { recursive: true });
@@ -69,10 +124,16 @@ interface StubOpts {
   status?: number;
   spaces?: { space: string; sizeBytes: number; mtimeMs: number }[];
 }
-function stubFetch(opts: StubOpts = {}): void {
+interface StubState {
+  requests: number;
+}
+
+function stubFetch(opts: StubOpts = {}): StubState {
+  const state: StubState = { requests: 0 };
   const spaces = opts.spaces ??
     [{ space: DID_A, sizeBytes: dbBytes.length, mtimeMs: 1 }];
   globalThis.fetch = ((input: string | URL | Request) => {
+    state.requests++;
     const url = new URL(typeof input === "string" ? input : input.toString());
     if (opts.status && opts.status !== 200) {
       return Promise.resolve(
@@ -95,6 +156,7 @@ function stubFetch(opts: StubOpts = {}): void {
     }
     return Promise.resolve(new Response("nope", { status: 404 }));
   }) as typeof fetch;
+  return state;
 }
 
 /** Run a subcommand, capturing stdout. */
@@ -198,8 +260,409 @@ describe("cf inspect --remote", () => {
     stubFetch();
     const out = await run(["summary", DID_A, "--remote", BASE, "--json"]);
     const s = JSON.parse(out);
-    assertEquals(s.commits, 1);
+    assertEquals(s.commits, 2);
     assertEquals(s.entities, 1);
+  });
+
+  it("value-at applies exact and slash paths to identity views", async () => {
+    stubFetch();
+    const identityPath = JSON.parse(
+      await run([
+        "value-at",
+        DID_A,
+        "of:a",
+        "--remote",
+        BASE,
+        "--as",
+        VIEWER_DID,
+        "--path-json",
+        '["a/b"]',
+        "--json",
+      ]),
+    );
+    assertEquals(identityPath.resolvedKind, "user");
+    assertEquals(identityPath.pathExists, true);
+    assertEquals(identityPath.value, "identity slash key");
+
+    const identitySlashPath = JSON.parse(
+      await run([
+        "value-at",
+        DID_A,
+        "of:a",
+        "--remote",
+        BASE,
+        "--as",
+        VIEWER_DID,
+        "--path",
+        "nested/leaf",
+        "--json",
+      ]),
+    );
+    assertEquals(identitySlashPath.resolvedKind, "user");
+    assertEquals(identitySlashPath.value, "identity nested key");
+
+    const sessionPath = JSON.parse(
+      await run([
+        "value-at",
+        DID_A,
+        "of:a",
+        "--remote",
+        BASE,
+        "--as",
+        VIEWER_DID,
+        "--session",
+        VIEWER_SESSION,
+        "--path-json",
+        '["a/b"]',
+        "--json",
+      ]),
+    );
+    assertEquals(sessionPath.resolvedKind, "session");
+    assertEquals(sessionPath.pathExists, true);
+    assertEquals(sessionPath.value, "session slash key");
+
+    const identityDocument = JSON.parse(
+      await run([
+        "value-at",
+        DID_A,
+        "of:a",
+        "--remote",
+        BASE,
+        "--as",
+        VIEWER_DID,
+        "--doc",
+        "--json",
+      ]),
+    );
+    assertEquals(identityDocument.resolvedKind, "user");
+    assertEquals(identityDocument.value.value["a/b"], "identity slash key");
+  });
+
+  it("value-at --path-json preserves exact and root paths", async () => {
+    stubFetch();
+    const slash = JSON.parse(
+      await run([
+        "value-at",
+        DID_A,
+        "of:a",
+        "--remote",
+        BASE,
+        "--path-json",
+        '["a/b"]',
+        "--json",
+      ]),
+    );
+    assertEquals(slash.pathExists, true);
+    assertEquals(slash.value, "literal slash key changed");
+
+    const empty = JSON.parse(
+      await run([
+        "value-at",
+        DID_A,
+        "of:a",
+        "--remote",
+        BASE,
+        "--path-json",
+        '[""]',
+        "--json",
+      ]),
+    );
+    assertEquals(empty.pathExists, true);
+    assertEquals(empty.value, "empty key changed");
+
+    const root = JSON.parse(
+      await run([
+        "value-at",
+        DID_A,
+        "of:a",
+        "--remote",
+        BASE,
+        "--path-json",
+        "[]",
+        "--json",
+      ]),
+    );
+    assertEquals(root.pathExists, true);
+    assertEquals(root.value.n, 1);
+  });
+
+  it("value-at does not coerce array segments", async () => {
+    stubFetch();
+    const result = JSON.parse(
+      await run([
+        "value-at",
+        DID_A,
+        "of:a",
+        "--remote",
+        BASE,
+        "--path-json",
+        '["items","01"]',
+        "--json",
+      ]),
+    );
+    assertEquals(result.pathExists, false);
+    assertEquals(result.value, { $undefined: true });
+
+    const slashResult = JSON.parse(
+      await run([
+        "value-at",
+        DID_A,
+        "of:a",
+        "--remote",
+        BASE,
+        "--path",
+        "items/01",
+        "--json",
+      ]),
+    );
+    assertEquals(slashResult.pathExists, false);
+  });
+
+  it("diff preserves exact input and result path segments", async () => {
+    stubFetch();
+    const result = JSON.parse(
+      await run([
+        "diff",
+        DID_A,
+        "of:a",
+        "--remote",
+        BASE,
+        "--from",
+        "1",
+        "--to",
+        "2",
+        "--json",
+      ]),
+    );
+    assertEquals(
+      result.changes.map((change: { pathSegments: string[] }) =>
+        JSON.stringify(change.pathSegments)
+      ).sort(),
+      [
+        ["a/b"],
+        ["a", "b"],
+        [""],
+        ["(root)"],
+        ["line\nforged"],
+        ["bidi\u202Eforged"],
+        ["collision"],
+      ].map((segments) => JSON.stringify(segments)).sort(),
+    );
+    const collision = result.changes.find(
+      (change: { pathSegments: string[] }) =>
+        change.pathSegments.length === 1 &&
+        change.pathSegments[0] === "collision",
+    );
+    assertEquals(collision, {
+      path: "collision",
+      pathSegments: ["collision"],
+      kind: "changed",
+      before: { $undefined: true },
+      beforeIsUndefined: true,
+      after: { $undefined: true },
+      annotationCollision: true,
+      beforeValueKind: "undefined",
+      afterValueKind: "object",
+    });
+
+    const focused = JSON.parse(
+      await run([
+        "diff",
+        DID_A,
+        "of:a",
+        "--remote",
+        BASE,
+        "--from",
+        "1",
+        "--to",
+        "2",
+        "--path-json",
+        '["a/b"]',
+        "--json",
+      ]),
+    );
+    assertEquals(focused.changes, [{
+      path: "",
+      pathSegments: [],
+      kind: "changed",
+      before: "literal slash key",
+      after: "literal slash key changed",
+    }]);
+
+    const document = JSON.parse(
+      await run([
+        "diff",
+        DID_A,
+        "of:a",
+        "--remote",
+        BASE,
+        "--from",
+        "1",
+        "--to",
+        "2",
+        "--doc",
+        "--json",
+      ]),
+    );
+    const documentChange = document.changes.find(
+      (change: { pathSegments: string[] }) =>
+        JSON.stringify(change.pathSegments) ===
+          JSON.stringify(["value", "a/b"]),
+    );
+    assertEquals(documentChange, {
+      path: "value/a/b",
+      pathSegments: ["value", "a/b"],
+      kind: "changed",
+      before: "literal slash key",
+      after: "literal slash key changed",
+    });
+
+    const human = await run([
+      "diff",
+      DID_A,
+      "of:a",
+      "--remote",
+      BASE,
+      "--from",
+      "1",
+      "--to",
+      "2",
+    ]);
+    assertStringIncludes(human, '["a/b"]');
+    assertStringIncludes(human, "  ~ a/b:");
+    assertStringIncludes(human, '[""]');
+    assertStringIncludes(human, '["(root)"]');
+    assertStringIncludes(human, '["line\\nforged"]');
+    assertStringIncludes(human, '["bidi\\u202eforged"]');
+    assertStringIncludes(
+      human,
+      "  ~ collision: undefined [undefined] → {$undefined} [object] " +
+        "(display annotations match)",
+    );
+    assertStringIncludes(human, '"\\u001b[2Jforged\\nline"');
+    assertStringIncludes(human, '"\\u001b[31mother\\rline"');
+    assertEquals(human.includes("\u001b"), false);
+  });
+
+  it("value-at rejects ambiguous or invalid exact paths", async () => {
+    stubFetch();
+    await assertRejects(
+      () =>
+        run([
+          "value-at",
+          DID_A,
+          "of:a",
+          "--remote",
+          BASE,
+          "--path",
+          "a/b",
+          "--path-json",
+          '["a/b"]',
+          "--json",
+        ]),
+      ValidationError,
+      "either `--path` or `--path-json`",
+    );
+    await assertRejects(
+      () =>
+        run([
+          "value-at",
+          DID_A,
+          "of:a",
+          "--remote",
+          BASE,
+          "--path-json",
+          '["a/b",0]',
+          "--json",
+        ]),
+      ValidationError,
+      "JSON array of string segments",
+    );
+    await assertRejects(
+      () =>
+        run([
+          "value-at",
+          DID_A,
+          "of:a",
+          "--remote",
+          BASE,
+          "--doc",
+          "--path-json",
+          '["a/b"]',
+          "--json",
+        ]),
+      ValidationError,
+      "`--doc` without `--path` or `--path-json`",
+    );
+  });
+
+  it("value-at rejects selectors that cannot affect its view", async () => {
+    const fetchState = stubFetch();
+    await assertRejects(
+      () =>
+        run([
+          "value-at",
+          DID_A,
+          "of:a",
+          "--remote",
+          BASE,
+          "--as",
+          VIEWER_DID,
+          "--scope",
+          "space",
+          "--json",
+        ]),
+      ValidationError,
+      "either `--as` or `--scope`",
+    );
+    await assertRejects(
+      () =>
+        run([
+          "value-at",
+          DID_A,
+          "of:a",
+          "--remote",
+          BASE,
+          "--session",
+          VIEWER_SESSION,
+          "--json",
+        ]),
+      ValidationError,
+      "`--session` requires `--as`",
+    );
+    await assertRejects(
+      () =>
+        run([
+          "value-at",
+          DID_A,
+          "of:a",
+          "--remote",
+          BASE,
+          "--as",
+          "",
+          "--json",
+        ]),
+      ValidationError,
+      'Missing value for option "--as"',
+    );
+    await assertRejects(
+      () =>
+        run([
+          "value-at",
+          DID_A,
+          "of:a",
+          "--remote",
+          BASE,
+          "--as",
+          VIEWER_DID,
+          "--session",
+          "",
+          "--json",
+        ]),
+      ValidationError,
+      'Missing value for option "--session"',
+    );
+    assertEquals(fetchState.requests, 0);
   });
 
   it("resolveRemoteDid: a unique prefix resolves via the remote list", async () => {
@@ -271,6 +734,70 @@ describe("cf inspect --remote", () => {
     assertEquals(JSON.parse(out).id, "of:a");
   });
 
+  it("converge preserves exact path segments", async () => {
+    stubFetch({
+      spaces: [
+        { space: DID_A, sizeBytes: 10, mtimeMs: 2 },
+        { space: DID_B, sizeBytes: 10, mtimeMs: 1 },
+      ],
+    });
+    const result = JSON.parse(
+      await run([
+        "converge",
+        "of:a",
+        "--spaces",
+        `${DID_A},${DID_B}`,
+        "--remote",
+        BASE,
+        "--path-json",
+        '["a/b"]',
+        "--json",
+      ]),
+    );
+    assertEquals(result.path, ["a/b"]);
+    assertEquals(
+      result.views.map((view: { value: unknown }) => view.value),
+      ["literal slash key changed", "literal slash key changed"],
+    );
+
+    const exactHuman = await run([
+      "converge",
+      "of:a",
+      "--spaces",
+      `${DID_A},${DID_B}`,
+      "--remote",
+      BASE,
+      "--path-json",
+      '["a/b"]',
+    ]);
+    assertStringIncludes(exactHuman, 'path=["a/b"]');
+
+    const legacyHuman = await run([
+      "converge",
+      "of:a",
+      "--spaces",
+      `${DID_A},${DID_B}`,
+      "--remote",
+      BASE,
+      "--path",
+      "a/b",
+    ]);
+    assertStringIncludes(legacyHuman, "path=/a/b");
+
+    const unsafeLegacyHuman = await run([
+      "converge",
+      "of:a",
+      "--spaces",
+      `${DID_A},${DID_B}`,
+      "--remote",
+      BASE,
+      "--path",
+      "line\nforged",
+    ]);
+    assertStringIncludes(unsafeLegacyHuman, 'path=["line\\nforged"]');
+    assertEquals(unsafeLegacyHuman.includes("path=/line\nforged"), false);
+  });
+
   it("converge --all over --remote uses the remote listing", async () => {
     stubFetch({
       spaces: [
@@ -289,13 +816,83 @@ describe("cf inspect --remote", () => {
     assertEquals(JSON.parse(out).id, "of:a");
   });
 
-  it("converge --remote with neither --all nor --spaces errors", async () => {
-    stubFetch();
+  it("converge rejects conflicting selectors before remote I/O", async () => {
+    const fetchState = stubFetch();
     await assertRejects(
-      () => run(["converge", "of:a", "--remote", BASE, "--json"]),
-      Error,
-      "--all or --spaces",
+      () =>
+        run([
+          "converge",
+          "of:a",
+          "--all",
+          "--spaces",
+          DID_A,
+          "--remote",
+          BASE,
+          "--json",
+        ]),
+      ValidationError,
+      "only one",
     );
+    assertEquals(fetchState.requests, 0);
+  });
+
+  it("converge rejects a local directory in remote mode before I/O", async () => {
+    const fetchState = stubFetch();
+    await assertRejects(
+      () =>
+        run([
+          "converge",
+          "of:a",
+          "--dir",
+          tmpRoot,
+          "--remote",
+          BASE,
+          "--json",
+        ]),
+      ValidationError,
+      "cannot be used",
+    );
+    assertEquals(fetchState.requests, 0);
+  });
+
+  it("converge validates a missing selector before identity I/O", async () => {
+    const fetchState = stubFetch();
+    await assertRejects(
+      () =>
+        run([
+          "converge",
+          "of:a",
+          "--remote",
+          BASE,
+          "--identity",
+          `${tmpRoot}/missing.key`,
+          "--json",
+        ]),
+      ValidationError,
+      "Use one of",
+    );
+    assertEquals(fetchState.requests, 0);
+  });
+
+  it("converge rejects an empty spaces list before identity I/O", async () => {
+    const fetchState = stubFetch();
+    await assertRejects(
+      () =>
+        run([
+          "converge",
+          "of:a",
+          "--spaces",
+          " , ",
+          "--remote",
+          BASE,
+          "--identity",
+          `${tmpRoot}/missing.key`,
+          "--json",
+        ]),
+      ValidationError,
+      "must contain at least one space",
+    );
+    assertEquals(fetchState.requests, 0);
   });
 
   it("resolveRemoteDid: a token matching nothing errors", async () => {

--- a/packages/cli/test/inspect-value-at-validation.test.ts
+++ b/packages/cli/test/inspect-value-at-validation.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { assertEquals, assertRejects } from "@std/assert";
+import { ValidationError } from "@cliffy/command";
+
+import { inspect } from "../commands/inspect.ts";
+
+const BASE = "http://inspect-validation.invalid:9999";
+const SPACE = "did:key:z6MkInspectValidation";
+
+const EXACT_PATH_CASES = [
+  {
+    description: "rejects conflicting path options before inspecting a space",
+    args: ["--path", "value", "--path-json", '["value"]'],
+    message: "either `--path` or `--path-json`",
+  },
+  {
+    description: "rejects malformed exact path JSON before inspecting a space",
+    args: ["--path-json", "["],
+    message: "JSON array of string segments",
+  },
+  {
+    description:
+      "rejects non-string exact path segments before inspecting a space",
+    args: ["--path-json", '["value",0]'],
+    message: "JSON array of string segments",
+  },
+  {
+    description: "rejects an empty slash path before inspecting a space",
+    args: ["--path", ""],
+    message: 'Missing value for option "--path"',
+  },
+];
+
+const DOCUMENT_PATH_CASES = [
+  {
+    description: "rejects a slash path with `--doc` before inspecting a space",
+    args: ["--doc", "--path", "value"],
+    message: "`--doc` without `--path` or `--path-json`",
+  },
+  {
+    description: "rejects an exact path with `--doc` before inspecting a space",
+    args: ["--doc", "--path-json", '["value"]'],
+    message: "`--doc` without `--path` or `--path-json`",
+  },
+];
+
+const COMMAND_CASES = [
+  {
+    name: "value-at",
+    args: ["value-at", SPACE, "of:a"],
+    cases: [...EXACT_PATH_CASES, ...DOCUMENT_PATH_CASES],
+  },
+  {
+    name: "diff",
+    args: ["diff", SPACE, "of:a"],
+    cases: [...EXACT_PATH_CASES, ...DOCUMENT_PATH_CASES],
+  },
+  {
+    name: "converge",
+    args: ["converge", "of:a", "--spaces", SPACE],
+    cases: EXACT_PATH_CASES,
+  },
+];
+
+let originalFetch: typeof fetch;
+let fetches: number;
+let tempDirectory: string;
+let missingIdentity: string;
+
+describe("inspect path validation", () => {
+  beforeEach(async () => {
+    originalFetch = globalThis.fetch;
+    fetches = 0;
+    tempDirectory = await Deno.makeTempDir({
+      prefix: "inspect-validation-",
+    });
+    missingIdentity = `${tempDirectory}/missing-identity.key`;
+    globalThis.fetch = (() => {
+      fetches++;
+      return Promise.resolve(
+        new Response("unexpected request", { status: 500 }),
+      );
+    }) as typeof fetch;
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = originalFetch;
+    await Deno.remove(tempDirectory, { recursive: true });
+  });
+
+  for (const command of COMMAND_CASES) {
+    describe(`${command.name} path options`, () => {
+      for (const testCase of command.cases) {
+        it(testCase.description, async () => {
+          fetches = 0;
+          await assertRejects(
+            () =>
+              inspect.parse([
+                ...command.args,
+                "--remote",
+                BASE,
+                "--identity",
+                missingIdentity,
+                "--json",
+                ...testCase.args,
+              ]),
+            ValidationError,
+            testCase.message,
+          );
+          assertEquals(fetches, 0);
+        });
+      }
+    });
+  }
+});

--- a/packages/state-inspector/README.md
+++ b/packages/state-inspector/README.md
@@ -62,7 +62,8 @@ failure mode it guards against:
   concurrency." The writer-timeline / `multiUser` contention view is the
   normal-history side.
 - **`converge` is server-view only** — durable values compared; client cursor
-  lag and optimistic writes aren't visible.
+  lag and optimistic writes aren't visible. A reconstruction failure produces an
+  `unknown` verdict instead of treating unavailable data as equal or different.
 - **Same id across spaces is usually independent instances**, not replica drift
   (content-addressed ids). The scan labels `cross-space-linked` (real replica →
   drift bug) vs `no-cross-space-link` (likely instance).
@@ -142,6 +143,25 @@ deno task cf space reset  <dir>
 deno task cf space fingerprint <space> [--per-entity] [--include-generated]
 ```
 
+The `cf inspect value-at`, `diff`, and `converge` commands accept `--path-json`
+when a path must preserve its segments exactly. The standalone `value-at` and
+`converge` commands accept the same option. The value is a JSON array of
+strings, such as `--path-json '["value","a/b",""]'`. Use this form for property
+names that contain `/` or are empty strings. The shorter `--path value/count`
+form splits on `/`. Path options cannot be combined with `--doc`, which selects
+the whole document. Array segments use canonical decimal indexes such as `"0"`
+and `"1"`; a segment such as `"01"` does not select an array element.
+
+Diff results contain a slash-delimited `path` field and an exact `pathSegments`
+JSON string array. Human output keeps the slash form for safe, ordinary paths.
+It uses an ASCII-escaped JSON array for ambiguous or terminal-unsafe property
+names. Value inspection JSON includes `pathExists`, which distinguishes a
+missing property from a stored `undefined` value.
+
+Diffs compare stored values rather than their display annotations. When two
+different values have the same annotation, the change includes
+`annotationCollision` and the stored value kind for each side.
+
 ### Remote (`--remote`) — inspect a staging/server without SSH
 
 Any command takes `--remote [url]` (defaults to `CF_API_URL`). Instead of
@@ -188,9 +208,9 @@ A standalone `cli.ts` entry exists for use outside the `cf` CLI (local only;
 - **Lists and the HTML bundle are capped** for cost; un-analyzed cells are
   marked rather than shown as clean. A count at a round cap may be truncated —
   narrow with flags or a per-entity command.
-- **Reads DBs it didn't write**: a corrupt/partial row degrades that one entity,
-  not the whole command. If a value looks absent where you expect data, check
-  for a decode error before concluding the entity is empty.
+- **Reads DBs it didn't write**: cross-space comparisons identify an unavailable
+  view and return `unknown`. Per-entity diffs stop with the reconstruction error
+  instead of reporting the value as absent.
 
 ## Not yet built
 

--- a/packages/state-inspector/cli.ts
+++ b/packages/state-inspector/cli.ts
@@ -8,14 +8,16 @@
 //   inspect commits  <db> [--session <prefix>] [--limit <n>]
 //   inspect hot      <db> [--limit <n>] [--branch <b>]
 //   inspect history  <db> <entity-id> [--scope <s>] [--branch <b>]
-//   inspect value-at <db> <entity-id> [--seq <n>] [--path a/b/c] [--doc]
+//   inspect value-at <db> <entity-id> [--seq <n>] [--path a/b/c]
+//                    [--path-json '["a/b",""]'] [--doc]
 // Multi-space (cross-space convergence):
 //   inspect converge      <entity-id> --spaces a.sqlite,b.sqlite [--path a/b/c]
+//                        [--path-json '["a/b",""]']
 //   inspect converge      <entity-id> --dir <dir-of-sqlite>
 //   inspect converge-scan --dir <dir> [--limit <n>] [--branch <b>]
 
 import { openSpace } from "./db.ts";
-import { annotate, summarize } from "./decode.ts";
+import { annotate, escapeTerminalText, summarize } from "./decode.ts";
 import {
   entityHistory,
   hotEntities,
@@ -25,8 +27,8 @@ import {
 import { getValueAt } from "./reconstruct.ts";
 import {
   buildCrossSpaceLinkIndex,
-  convergence,
-  convergenceScan,
+  convergenceExact,
+  convergenceScanExact,
   listSqliteFiles,
   openSpaces,
   type SpaceRef,
@@ -38,31 +40,90 @@ interface Args {
 }
 
 /** Flags that never take a value — so `--json <db>` doesn't eat the db arg. */
-const BOOLEAN_FLAGS = new Set(["json", "doc"]);
+const BOOLEAN_FLAGS = new Set(["json", "doc", "help"]);
 
+/** Value-taking flags for which an empty string has defined semantics. */
+const FLAGS_ALLOWING_EMPTY_VALUES = new Set(["branch", "path", "scope"]);
+
+const COMMAND_FLAGS = new Map<string, ReadonlySet<string>>([
+  ["summary", new Set(["json"])],
+  ["commits", new Set(["session", "limit", "json"])],
+  ["hot", new Set(["limit", "branch", "json"])],
+  ["history", new Set(["scope", "branch", "limit", "json"])],
+  [
+    "value-at",
+    new Set([
+      "seq",
+      "path",
+      "path-json",
+      "scope",
+      "branch",
+      "doc",
+      "json",
+    ]),
+  ],
+  [
+    "converge",
+    new Set([
+      "spaces",
+      "dir",
+      "path",
+      "path-json",
+      "scope",
+      "branch",
+      "json",
+    ]),
+  ],
+  [
+    "converge-scan",
+    new Set([
+      "spaces",
+      "dir",
+      "limit",
+      "scope",
+      "branch",
+      "json",
+    ]),
+  ],
+]);
+
+/**
+ * Separates positional arguments from flags and validates flag values.
+ *
+ * @throws {Error} When a value-taking flag omits its value.
+ */
 function parseArgs(argv: string[]): Args {
   const positional: string[] = [];
-  const flags: Record<string, string | boolean> = {};
+  const flags = Object.create(null) as Record<string, string | boolean>;
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a.startsWith("--")) {
       const key = a.slice(2);
       const next = argv[i + 1];
-      // Boolean flags are always boolean — a following positional (e.g. the db
-      // path after `--json`) must NOT be consumed as the flag's value.
-      if (
-        !BOOLEAN_FLAGS.has(key) && next !== undefined && !next.startsWith("--")
-      ) {
-        flags[key] = next;
-        i++;
-      } else {
+      if (BOOLEAN_FLAGS.has(key)) {
         flags[key] = true;
+        continue;
       }
+      if (next === undefined || next.startsWith("--")) {
+        throw new Error(`\`--${key}\` requires a value.`);
+      }
+      flags[key] = next;
+      i++;
     } else {
       positional.push(a);
     }
   }
   return { positional, flags };
+}
+
+function validateEmptyFlagValues(
+  flags: Record<string, string | boolean>,
+): void {
+  for (const [name, value] of Object.entries(flags)) {
+    if (value === "" && !FLAGS_ALLOWING_EMPTY_VALUES.has(name)) {
+      throw new Error(`\`--${name}\` requires a value.`);
+    }
+  }
 }
 
 const str = (v: string | boolean | undefined): string | undefined =>
@@ -71,6 +132,79 @@ const num = (v: string | boolean | undefined): number | undefined =>
   typeof v === "string" ? Number(v) : undefined;
 const splitPath = (v: string | boolean | undefined): string[] =>
   str(v) ? str(v)!.split("/").filter(Boolean) : [];
+const SAFE_PATH_SEGMENT = /^[A-Za-z0-9_$@.:%+~-]+$/;
+
+function stringifyPathSegments(segments: string[]): string {
+  return JSON.stringify(segments).replace(
+    /[^\x20-\x7E]/g,
+    (character) =>
+      `\\u${character.charCodeAt(0).toString(16).padStart(4, "0")}`,
+  );
+}
+
+function formatSelectedPath(segments: string[], exact: boolean): string {
+  return exact || !segments.every((segment) => SAFE_PATH_SEGMENT.test(segment))
+    ? stringifyPathSegments(segments)
+    : `/${segments.join("/")}`;
+}
+
+function validateNumericFlags(
+  flags: Record<string, string | boolean>,
+): void {
+  for (const name of ["seq", "limit"]) {
+    const raw = flags[name];
+    if (raw === undefined) continue;
+    const value = typeof raw === "string" ? Number(raw) : Number.NaN;
+    if (
+      typeof raw !== "string" || raw.trim() === "" ||
+      !Number.isSafeInteger(value) || value < 0
+    ) {
+      throw new Error(`\`--${name}\` must be a non-negative integer.`);
+    }
+  }
+}
+
+/**
+ * Parses one of the supported path flags into exact string segments.
+ *
+ * @throws {Error} When path flags conflict, omit a value, or `path-json` is
+ * not a JSON array of strings.
+ */
+function parsePathFlags(flags: Record<string, string | boolean>): string[] {
+  const path = flags.path;
+  const pathJson = flags["path-json"];
+  if (path !== undefined && pathJson !== undefined) {
+    throw new Error("Use either `--path` or `--path-json`, not both.");
+  }
+  if (flags.doc === true && (path !== undefined || pathJson !== undefined)) {
+    throw new Error("Use `--doc` without `--path` or `--path-json`.");
+  }
+  if (path !== undefined && typeof path !== "string") {
+    throw new Error("`--path` requires a value.");
+  }
+  if (pathJson === undefined) return splitPath(path);
+  if (typeof pathJson !== "string") {
+    throw new Error("`--path-json` requires a value.");
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(pathJson);
+  } catch {
+    throw new Error(
+      "`--path-json` must contain a JSON array of string segments.",
+    );
+  }
+  if (
+    !Array.isArray(parsed) ||
+    !parsed.every((segment) => typeof segment === "string")
+  ) {
+    throw new Error(
+      "`--path-json` must contain a JSON array of string segments.",
+    );
+  }
+  return parsed;
+}
 
 function out(json: boolean, data: unknown, render: () => void) {
   if (json) console.log(JSON.stringify(data, null, 2));
@@ -85,21 +219,30 @@ single-space:
   hot      <db> [--limit <n>] [--branch <b>] [--json]
   history  <db> <entity-id> [--scope <s>] [--branch <b>] [--limit <n>] [--json]
   value-at <db> <entity-id> [--seq <n>] [--path a/b/c] [--scope <s>]
-                            [--branch <b>] [--doc] [--json]
+                            [--path-json '["a/b",""]'] [--branch <b>]
+                            [--doc] [--json]
 
 cross-space convergence:
   converge      <entity-id> (--spaces a,b,… | --dir <dir>) [--path a/b/c]
-                            [--scope <s>] [--branch <b>] [--json]
+                            [--path-json '["a/b",""]'] [--scope <s>]
+                            [--branch <b>] [--json]
   converge-scan (--spaces a,b,… | --dir <dir>) [--limit <n>] [--scope <s>]
                             [--branch <b>] [--json]
 `;
 
 function resolveSpaces(flags: Record<string, string | boolean>): SpaceRef[] {
+  if (flags.dir !== undefined && flags.spaces !== undefined) {
+    throw new Error("Use either `--dir` or `--spaces`, not both.");
+  }
   const dir = str(flags.dir);
   const spaces = str(flags.spaces);
   if (dir) return openSpaces(listSqliteFiles(dir));
-  if (spaces) {
-    return openSpaces(spaces.split(",").map((s) => s.trim()).filter(Boolean));
+  if (spaces !== undefined) {
+    const paths = spaces.split(",").map((path) => path.trim()).filter(Boolean);
+    if (paths.length === 0) {
+      throw new Error("`--spaces` must contain at least one space.");
+    }
+    return openSpaces(paths);
   }
   throw new Error("provide --spaces a,b,… or --dir <dir>");
 }
@@ -109,7 +252,13 @@ function runMultiSpace(
   rest: string[],
   flags: Record<string, string | boolean>,
   json: boolean,
+  path: string[] = [],
 ): number {
+  const id = rest[0];
+  if (cmd === "converge" && !id) {
+    console.error("error: converge needs <entity-id>");
+    return 1;
+  }
   let refs: SpaceRef[];
   try {
     refs = resolveSpaces(flags);
@@ -123,20 +272,15 @@ function runMultiSpace(
   }
   try {
     if (cmd === "converge") {
-      const id = rest[0];
-      if (!id) {
-        console.error("error: converge needs <entity-id>");
-        return 1;
-      }
       const index = buildCrossSpaceLinkIndex(refs, {
         scope: str(flags.scope),
         branch: str(flags.branch),
       });
-      const result = convergence(refs, {
+      const result = convergenceExact(refs, {
         id,
         scope: str(flags.scope),
         branch: str(flags.branch),
-        path: splitPath(flags.path),
+        path,
       }, index);
       out(json, result, () => {
         console.log(
@@ -149,27 +293,47 @@ function runMultiSpace(
           `entity:  ${result.id}  scope=${result.scope}  branch=${
             result.branch || "(default)"
           }` +
-            (result.path.length ? `  path=/${result.path.join("/")}` : ""),
+            (result.path.length
+              ? `  path=${
+                formatSelectedPath(
+                  result.path,
+                  flags["path-json"] !== undefined,
+                )
+              }`
+              : ""),
         );
         for (const v of result.views) {
           if (!v.present) {
-            console.log(`  ${v.label}\tABSENT`);
+            console.log(`  ${escapeTerminalText(v.label)}\tABSENT`);
+            continue;
+          }
+          if (v.error) {
+            console.log(
+              `  ${escapeTerminalText(v.label)}\tERROR\t${
+                escapeTerminalText(v.error)
+              }`,
+            );
             continue;
           }
           const cluster = result.clusters.findIndex((c) =>
             c.valueKey === v.valueKey
           ) + 1;
           console.log(
-            `  ${v.label}\thead=${v.headSeq}\trevs=${v.revisions}\tlast=${
+            `  ${
+              escapeTerminalText(v.label)
+            }\thead=${v.headSeq}\trevs=${v.revisions}\tlast=${
               (v.lastSession ?? "?").slice(0, 14)
-            }@${v.lastWriteAt ?? "?"}\tcluster#${cluster}`,
+            }@${v.lastWriteAt ?? "?"}\tcluster#${cluster}` +
+              (v.pathExists === false ? "\tpath=MISSING" : ""),
           );
         }
         if (result.clusters.length > 1) {
           console.log("clusters:");
           result.clusters.forEach((c, i) =>
             console.log(
-              `  #${i + 1} [${c.labels.length}]\t${summarize(c.value)}`,
+              `  #${i + 1} [${c.labels.length}]\t${
+                c.pathExists === false ? "(path missing)" : summarize(c.value)
+              }`,
             )
           );
         }
@@ -178,7 +342,7 @@ function runMultiSpace(
       return 0;
     }
     if (cmd === "converge-scan") {
-      const result = convergenceScan(refs, {
+      const result = convergenceScanExact(refs, {
         scope: str(flags.scope),
         branch: str(flags.branch),
         limit: num(flags.limit),
@@ -189,9 +353,13 @@ function runMultiSpace(
         );
         console.log(
           `cross-space link edges: ${result.crossSpaceLinkEdges}` +
-            `  (${result.linkedFindings} real-drift / ${result.unlinkedFindings} likely-independent-instances)`,
+            `  (${result.linkedFindings} real-drift / ` +
+            `${result.unlinkedFindings} likely-independent-instances / ` +
+            `${result.unknownFindings} unknown)`,
         );
-        console.log(`findings (diverged/partial): ${result.findings.length}`);
+        console.log(
+          `findings (diverged/partial/unknown): ${result.findings.length}`,
+        );
         for (const f of result.findings) {
           const present = f.views.filter((v) => v.present).map((v) => v.label);
           const absent = f.views.filter((v) => !v.present).map((v) => v.label);
@@ -217,16 +385,54 @@ function runMultiSpace(
 }
 
 export function main(argv: string[]): number {
-  const { positional, flags } = parseArgs(argv);
+  let parsed: Args;
+  try {
+    parsed = parseArgs(argv);
+  } catch (e) {
+    console.error(`error: ${(e as Error).message}`);
+    return 1;
+  }
+  const { positional, flags } = parsed;
   const [cmd, ...rest] = positional;
   const json = flags.json === true;
 
   if (!cmd || cmd === "help" || flags.help) {
     console.log(USAGE);
-    return cmd ? 0 : 1;
+    return cmd || flags.help ? 0 : 1;
   }
 
-  if (cmd === "converge" || cmd === "converge-scan") {
+  const allowedFlags = COMMAND_FLAGS.get(cmd);
+  if (allowedFlags === undefined) {
+    console.error(`unknown command: ${cmd}\n`);
+    console.log(USAGE);
+    return 1;
+  }
+  const unsupportedFlag = Object.keys(flags).find((flag) =>
+    !allowedFlags.has(flag)
+  );
+  if (unsupportedFlag !== undefined) {
+    console.error(`error: \`--${unsupportedFlag}\` is not valid for ${cmd}.`);
+    return 1;
+  }
+  try {
+    validateEmptyFlagValues(flags);
+    validateNumericFlags(flags);
+  } catch (e) {
+    console.error(`error: ${(e as Error).message}`);
+    return 1;
+  }
+
+  if (cmd === "converge") {
+    let path: string[];
+    try {
+      path = parsePathFlags(flags);
+    } catch (e) {
+      console.error(`error: ${(e as Error).message}`);
+      return 1;
+    }
+    return runMultiSpace(cmd, rest, flags, json, path);
+  }
+  if (cmd === "converge-scan") {
     return runMultiSpace(cmd, rest, flags, json);
   }
 
@@ -237,6 +443,24 @@ export function main(argv: string[]): number {
     console.error("error: missing <db> path\n");
     console.log(USAGE);
     return 1;
+  }
+  if (cmd === "history" && !tail[0]) {
+    console.error("error: history needs <entity-id>");
+    return 1;
+  }
+  if (cmd === "value-at" && !tail[0]) {
+    console.error("error: value-at needs <entity-id>");
+    return 1;
+  }
+
+  let valuePath: string[] | undefined;
+  if (cmd === "value-at") {
+    try {
+      valuePath = parsePathFlags(flags);
+    } catch (e) {
+      console.error(`error: ${(e as Error).message}`);
+      return 1;
+    }
   }
 
   const space = openSpace(dbPath);
@@ -308,10 +532,6 @@ export function main(argv: string[]): number {
       }
       case "history": {
         const id = tail[0];
-        if (!id) {
-          console.error("error: history needs <entity-id>");
-          return 1;
-        }
         const rows = entityHistory(space, {
           id,
           scope: str(flags.scope),
@@ -331,10 +551,6 @@ export function main(argv: string[]): number {
       }
       case "value-at": {
         const id = tail[0];
-        if (!id) {
-          console.error("error: value-at needs <entity-id>");
-          return 1;
-        }
         const res = getValueAt(
           space,
           {
@@ -343,20 +559,25 @@ export function main(argv: string[]): number {
             branch: str(flags.branch),
             atSeq: num(flags.seq),
           },
-          splitPath(flags.path),
+          valuePath ?? [],
         );
         const shown = flags.doc === true ? res.document : res.value;
-        out(json, { exists: res.exists, value: annotate(shown) }, () => {
-          if (!res.exists) {
-            console.log("(absent at this seq)");
-            return;
-          }
-          if (shown === undefined) {
-            console.log("(entity present, but nothing at that path)");
-            return;
-          }
-          console.log(JSON.stringify(annotate(shown), null, 2));
-        });
+        const pathExists = flags.doc === true ? res.exists : res.pathExists;
+        out(
+          json,
+          { exists: res.exists, pathExists, value: annotate(shown) },
+          () => {
+            if (!res.exists) {
+              console.log("(absent at this seq)");
+              return;
+            }
+            if (!pathExists) {
+              console.log("(entity present, but nothing at that path)");
+              return;
+            }
+            console.log(JSON.stringify(annotate(shown), null, 2));
+          },
+        );
         return 0;
       }
       default:

--- a/packages/state-inspector/decode.ts
+++ b/packages/state-inspector/decode.ts
@@ -18,6 +18,7 @@ import { seemsLikeJsonEncodedFabricValue } from "@commonfabric/data-model/codec-
 import { valueFromJson } from "@commonfabric/data-model/codecs";
 import { FabricLink } from "@commonfabric/data-model/fabric-instances";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
+import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { isPlainObject } from "@commonfabric/utils/types";
 
 /** Decode a stored payload string, routing the `data-model` codec envelope. */
@@ -47,6 +48,15 @@ type Json = unknown;
  */
 function isNameWalkable(v: Json): v is Record<string, Json> {
   return isPlainObject(v);
+}
+
+function setOwn(target: Record<string, Json>, key: string, value: Json): void {
+  Object.defineProperty(target, key, {
+    value,
+    enumerable: true,
+    configurable: true,
+    writable: true,
+  });
 }
 
 function payloadToLink(payload: Record<string, Json>): DecodedLink {
@@ -127,11 +137,46 @@ function shortId(id?: string): string | undefined {
   return body.length > 14 ? `${body.slice(0, 8)}…${body.slice(-4)}` : body;
 }
 
+const SAFE_SUMMARY_SEGMENT = /^[A-Za-z0-9_$@.:%+~-]+$/;
+const UNSAFE_TERMINAL_UNICODE =
+  /[\u007f-\u009f\u00ad\u061c\u180e\u200b-\u200f\u2028-\u202e\u2060-\u206f\ufeff]/g;
+
+function escapeUnsafeTerminalUnicode(value: string): string {
+  return value.replace(
+    UNSAFE_TERMINAL_UNICODE,
+    (character) =>
+      `\\u${character.charCodeAt(0).toString(16).padStart(4, "0")}`,
+  );
+}
+
+/** Escape text for safe inclusion within one line of terminal output. */
+export function escapeTerminalText(value: string): string {
+  const quoted = escapeUnsafeTerminalUnicode(JSON.stringify(value));
+  return quoted.slice(1, -1);
+}
+
+function quoteTerminalText(value: string): string {
+  return escapeUnsafeTerminalUnicode(JSON.stringify(value));
+}
+
+function summarizePath(path: readonly string[]): string {
+  if (path.every((segment) => SAFE_SUMMARY_SEGMENT.test(segment))) {
+    return `/${path.join("/")}`;
+  }
+  return escapeUnsafeTerminalUnicode(JSON.stringify(path));
+}
+
+function summarizeKey(key: string): string {
+  return SAFE_SUMMARY_SEGMENT.test(key) ? key : quoteTerminalText(key);
+}
+
 /** One-line, human-readable summary of a link for tables. */
 export function summarizeLink(link: DecodedLink): string {
-  const id = shortId(link.id) ?? "?";
-  const path = link.path && link.path.length ? `/${link.path.join("/")}` : "";
-  const space = link.space ? ` @${shortDid(link.space)}` : "";
+  const id = escapeTerminalText(shortId(link.id) ?? "?");
+  const path = link.path && link.path.length ? summarizePath(link.path) : "";
+  const space = link.space
+    ? ` @${escapeTerminalText(shortDid(link.space) ?? "")}`
+    : "";
   const schema = link.hasSchema ? " +schema" : "";
   return `🔗 ${id}${path}${space}${schema}`;
 }
@@ -170,11 +215,38 @@ export function annotate(v: Json, maxDepth = 8): Json {
   if (typeof v === "symbol") return String(v);
   if (typeof v === "function") return "[function]";
 
-  if (Array.isArray(v)) return v.map((x) => annotate(x, maxDepth - 1));
+  if (Array.isArray(v)) {
+    const keys = Object.keys(v);
+    if (
+      keys.length === v.length && keys.every(isArrayIndexPropertyName)
+    ) {
+      return v.map((x) => annotate(x, maxDepth - 1));
+    }
+    const entries: Record<string, Json> = {};
+    const properties: Record<string, Json> = {};
+    for (const key of keys) {
+      const target = isArrayIndexPropertyName(key) ? entries : properties;
+      setOwn(
+        target,
+        key,
+        annotate(
+          (v as unknown as Record<string, Json>)[key],
+          maxDepth - 1,
+        ),
+      );
+    }
+    return {
+      $sparseArray: {
+        length: v.length,
+        entries,
+        ...(Object.keys(properties).length > 0 ? { properties } : {}),
+      },
+    };
+  }
   if (isNameWalkable(v)) {
     const out: Record<string, Json> = {};
     for (const [k, val] of Object.entries(v)) {
-      out[k] = annotate(val, maxDepth - 1);
+      setOwn(out, k, annotate(val, maxDepth - 1));
     }
     return out;
   }
@@ -192,16 +264,21 @@ export function summarize(v: Json): string {
   if (link) return summarizeLink(link);
   if (isStream(v)) return "⊙ stream";
   const ref = parseEntityRef(v);
-  if (ref !== null) return `#${shortId(ref) ?? ref}`;
+  if (ref !== null) return `#${escapeTerminalText(shortId(ref) ?? ref)}`;
   if (v === null) return "null";
   if (typeof v === "bigint") return `${v}n`;
   if (Array.isArray(v)) return `[${v.length}]`;
-  if (isNameWalkable(v)) return `{${Object.keys(v).join(", ")}}`;
-  if (typeof v === "object") return toCompactDebugString(v);
-  if (typeof v === "string") {
-    return v.length > 40 ? `"${v.slice(0, 37)}…"` : `"${v}"`;
+  if (isNameWalkable(v)) {
+    return `{${Object.keys(v).map(summarizeKey).join(", ")}}`;
   }
-  return String(v);
+  if (typeof v === "object") {
+    return escapeTerminalText(toCompactDebugString(v));
+  }
+  if (typeof v === "string") {
+    const preview = v.length > 40 ? `${v.slice(0, 37)}…` : v;
+    return quoteTerminalText(preview);
+  }
+  return escapeTerminalText(String(v));
 }
 
 /** Collect every link reachable in a value (does not descend into links). */

--- a/packages/state-inspector/multispace.ts
+++ b/packages/state-inspector/multispace.ts
@@ -47,6 +47,8 @@ export interface SpaceEntityView {
   lastWriteAt: string | null;
   /** Annotated value at the requested path (links/streams normalized). */
   value?: unknown;
+  /** Whether the requested path exists within a present entity. */
+  pathExists?: boolean;
   /** Canonical key used for clustering equal values. */
   valueKey?: string;
   /** Set if reconstruction/decode threw for this space (entity still counts as present). */
@@ -59,16 +61,21 @@ export type ConvergenceVerdict =
   | "partial"
   | "absent";
 
+/** A verdict that also represents values which could not be reconstructed. */
+export type ExactConvergenceVerdict = ConvergenceVerdict | "unknown";
+
 export interface ValueCluster {
   valueKey: string;
   value: unknown;
   labels: string[];
+  /** Whether this cluster represents values found at the requested path. */
+  pathExists?: boolean;
 }
 
 export type ConvergenceRelationship =
   | "cross-space-linked" // a space links to this entity@another-space → real replica drift
   | "no-cross-space-link" // shared id, no cross-space link → likely independent instances
-  | "n/a"; // converged/absent — relationship not meaningful
+  | "n/a"; // converged, absent, or unknown — relationship not meaningful
 
 export interface ConvergenceResult {
   id: string;
@@ -81,6 +88,12 @@ export interface ConvergenceResult {
   caveat: string;
   /** Set when a link index is supplied — distinguishes drift from instances. */
   relationship?: ConvergenceRelationship;
+}
+
+/** A convergence result that distinguishes unavailable values. */
+export interface ExactConvergenceResult
+  extends Omit<ConvergenceResult, "verdict"> {
+  verdict: ExactConvergenceVerdict;
 }
 
 export interface CrossSpaceEdge {
@@ -117,6 +130,10 @@ const CAVEAT =
 function canonical(v: unknown): string {
   return v === undefined ? "undefined" : hashStringOf(v);
 }
+
+const MISSING_PATH_KEY = "«missing-path»";
+const MISSING_PATH_VALUE = Object.freeze({ $missing: true } as const);
+const DECODE_ERROR_KEY = "«decode-error»";
 
 interface MetaRow {
   headSeq: number | null;
@@ -175,12 +192,12 @@ export interface ConvergenceOptions {
   path?: string[];
 }
 
-/** Compare one entity's value across the given spaces and classify. */
-export function convergence(
+/** Compare one entity and report unavailable values as an exact verdict. */
+export function convergenceExact(
   spaces: SpaceRef[],
   opts: ConvergenceOptions,
   index?: CrossSpaceLinkIndex,
-): ConvergenceResult {
+): ExactConvergenceResult {
   const scope = opts.scope ?? "space";
   const branch = opts.branch ?? "";
   const path = opts.path ?? [];
@@ -190,9 +207,7 @@ export function convergence(
     view.label = label;
     if (view.present) {
       // Decode can throw (e.g. an encoded payload referencing a live cell).
-      // Keep the entity counted as present but isolate the failure, so that one
-      // bad row doesn't abort a whole scan; errored spaces cluster together by
-      // a distinct key.
+      // Keep the entity counted as present and expose the unavailable view.
       try {
         const res = getValueAt(space, { id: opts.id, scope, branch }, path);
         if (!res.exists) {
@@ -204,38 +219,47 @@ export function convergence(
           // Cluster on the RAW value (depth-complete, fabric-aware). Annotate is
           // for DISPLAY only — hashing it would falsely converge values that
           // differ below the annotate depth cap or only by BigInt vs its tag.
-          view.value = annotate(res.value);
-          view.valueKey = canonical(res.value);
+          view.pathExists = res.pathExists;
+          view.value = res.pathExists
+            ? annotate(res.value)
+            : MISSING_PATH_VALUE;
+          view.valueKey = res.pathExists
+            ? canonical(res.value)
+            : MISSING_PATH_KEY;
         }
       } catch (e) {
         view.error = (e as Error).message;
-        view.valueKey = "«decode-error»";
       }
     }
     return view;
   });
 
   const present = views.filter((v) => v.present);
+  const available = present.filter((view) => view.error === undefined);
   const clusterMap = new Map<string, ValueCluster>();
-  for (const v of present) {
+  for (const v of available) {
     const key = v.valueKey!;
     const c = clusterMap.get(key);
     if (c) c.labels.push(v.label);
-    else {clusterMap.set(key, {
+    else {
+      clusterMap.set(key, {
         valueKey: key,
         value: v.value,
         labels: [v.label],
-      });}
+        pathExists: v.pathExists,
+      });
+    }
   }
   const clusters = [...clusterMap.values()];
 
-  let verdict: ConvergenceVerdict;
-  if (present.length === 0) verdict = "absent";
+  let verdict: ExactConvergenceVerdict;
+  if (present.some((view) => view.error !== undefined)) verdict = "unknown";
+  else if (present.length === 0) verdict = "absent";
   else if (clusters.length > 1) verdict = "diverged";
   else if (present.length < views.length) verdict = "partial";
   else verdict = "converged";
 
-  const result: ConvergenceResult = {
+  const result: ExactConvergenceResult = {
     id: opts.id,
     scope,
     branch,
@@ -244,6 +268,49 @@ export function convergence(
     views,
     clusters,
     caveat: CAVEAT,
+  };
+  if (index) result.relationship = classifyRelationship(result, index);
+  return result;
+}
+
+/** Compare one entity using the published convergence verdicts. */
+export function convergence(
+  spaces: SpaceRef[],
+  opts: ConvergenceOptions,
+  index?: CrossSpaceLinkIndex,
+): ConvergenceResult {
+  const exact = convergenceExact(spaces, opts);
+  const views = exact.views.map((view) =>
+    view.error === undefined ? view : { ...view, valueKey: DECODE_ERROR_KEY }
+  );
+  const present = views.filter((view) => view.present);
+  const clusterMap = new Map<string, ValueCluster>();
+  for (const view of present) {
+    const valueKey = view.valueKey!;
+    const cluster = clusterMap.get(valueKey);
+    if (cluster) {
+      cluster.labels.push(view.label);
+    } else {
+      clusterMap.set(valueKey, {
+        valueKey,
+        value: view.error === undefined ? view.value : undefined,
+        labels: [view.label],
+        pathExists: view.error === undefined ? view.pathExists : undefined,
+      });
+    }
+  }
+  const clusters = [...clusterMap.values()];
+  let verdict: ConvergenceVerdict;
+  if (present.length === 0) verdict = "absent";
+  else if (clusters.length > 1) verdict = "diverged";
+  else if (present.length < views.length) verdict = "partial";
+  else verdict = "converged";
+
+  const result: ConvergenceResult = {
+    ...exact,
+    verdict,
+    views,
+    clusters,
   };
   if (index) result.relationship = classifyRelationship(result, index);
   return result;
@@ -300,10 +367,13 @@ export function buildCrossSpaceLinkIndex(
 
 /** Label a divergence as real replica drift vs. likely independent instances. */
 export function classifyRelationship(
-  result: ConvergenceResult,
+  result: ConvergenceResult | ExactConvergenceResult,
   index: CrossSpaceLinkIndex,
 ): ConvergenceRelationship {
-  if (result.verdict === "converged" || result.verdict === "absent") {
+  if (
+    result.verdict === "converged" || result.verdict === "absent" ||
+    result.verdict === "unknown"
+  ) {
     return "n/a";
   }
   // A cross-space link to (space, id) makes the relationship a replica link
@@ -318,7 +388,7 @@ export function classifyRelationship(
 export interface ScanOptions {
   scope?: string;
   branch?: string;
-  /** Max diverged/partial findings to return. */
+  /** Max diverged, partial, or unknown findings to return. */
   limit?: number;
   /** Max shared entities to reconstruct (cost guard). */
   examineCap?: number;
@@ -340,11 +410,18 @@ export interface ScanResult {
   findings: ConvergenceResult[];
 }
 
-/** Find entities present in >=2 spaces and report those that diverge. */
-export function convergenceScan(
+/** A scan result that distinguishes unavailable values from known findings. */
+export interface ExactScanResult extends Omit<ScanResult, "findings"> {
+  /** Findings whose values could not all be reconstructed. */
+  unknownFindings: number;
+  findings: ExactConvergenceResult[];
+}
+
+/** Find shared entities with values that differ, are missing, or are unavailable. */
+export function convergenceScanExact(
   spaces: SpaceRef[],
   opts: ScanOptions = {},
-): ScanResult {
+): ExactScanResult {
   const scope = opts.scope ?? "space";
   const branch = opts.branch ?? "";
   const limit = opts.limit ?? 50;
@@ -368,6 +445,65 @@ export function convergenceScan(
     id
   );
 
+  const findings: ExactConvergenceResult[] = [];
+  let examined = 0;
+  for (const id of shared) {
+    if (examined >= examineCap) break;
+    examined++;
+    const result = convergenceExact(spaces, { id, scope, branch }, index);
+    if (
+      result.verdict === "diverged" || result.verdict === "partial" ||
+      result.verdict === "unknown"
+    ) {
+      findings.push(result);
+      if (findings.length >= limit) break;
+    }
+  }
+
+  const linkedFindings =
+    findings.filter((f) => f.relationship === "cross-space-linked").length;
+  const unlinkedFindings =
+    findings.filter((f) => f.relationship === "no-cross-space-link").length;
+  const unknownFindings =
+    findings.filter((f) => f.verdict === "unknown").length;
+  return {
+    sharedEntities: shared.length,
+    examined,
+    examineCapped: examined >= examineCap && shared.length > examineCap,
+    crossSpaceLinkEdges: index?.edges.length ?? 0,
+    linkedFindings,
+    unlinkedFindings,
+    unknownFindings,
+    findings,
+  };
+}
+
+/** Find shared entities using the published convergence verdicts. */
+export function convergenceScan(
+  spaces: SpaceRef[],
+  opts: ScanOptions = {},
+): ScanResult {
+  const scope = opts.scope ?? "space";
+  const branch = opts.branch ?? "";
+  const limit = opts.limit ?? 50;
+  const examineCap = opts.examineCap ?? 1000;
+
+  const index = opts.linkIndex === false
+    ? undefined
+    : buildCrossSpaceLinkIndex(spaces, { scope, branch });
+  const counts = new Map<string, number>();
+  for (const { space } of spaces) {
+    const ids = space.db
+      .prepare(
+        `SELECT DISTINCT id FROM revision WHERE branch = ? AND scope_key = ?`,
+      )
+      .all<{ id: string }>(branch, scope);
+    for (const { id } of ids) counts.set(id, (counts.get(id) ?? 0) + 1);
+  }
+  const shared = [...counts.entries()].filter(([, count]) => count >= 2).map(
+    ([id]) => id,
+  );
+
   const findings: ConvergenceResult[] = [];
   let examined = 0;
   for (const id of shared) {
@@ -381,14 +517,18 @@ export function convergenceScan(
   }
 
   const linkedFindings =
-    findings.filter((f) => f.relationship === "cross-space-linked").length;
+    findings.filter((finding) => finding.relationship === "cross-space-linked")
+      .length;
+  const unlinkedFindings =
+    findings.filter((finding) => finding.relationship === "no-cross-space-link")
+      .length;
   return {
     sharedEntities: shared.length,
     examined,
     examineCapped: examined >= examineCap && shared.length > examineCap,
     crossSpaceLinkEdges: index?.edges.length ?? 0,
     linkedFindings,
-    unlinkedFindings: findings.length - linkedFindings,
+    unlinkedFindings,
     findings,
   };
 }

--- a/packages/state-inspector/reconstruct.ts
+++ b/packages/state-inspector/reconstruct.ts
@@ -20,6 +20,7 @@
 import { applyPatch } from "@commonfabric/memory/v2/patch";
 import type { PatchOp } from "@commonfabric/memory/v2";
 import type { FabricValue } from "@commonfabric/api";
+import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 
 import type { SpaceDb } from "./db.ts";
 import { decodeStored } from "./decode.ts";
@@ -42,20 +43,52 @@ export type EntityDocument =
     unknown
   >;
 
-/** Navigate into a value by a JSON path (array of keys). Display-only. */
-export function getAtPath(root: unknown, path: string[]): unknown {
+export interface PathSelection {
+  /** Whether every segment selected an own property. */
+  found: boolean;
+  /** The selected value. This can be `undefined` when `found` is true. */
+  value: unknown;
+}
+
+/**
+ * Navigates own properties using exact string segments and reports whether the
+ * selected property exists. Array segments must be canonical array-index
+ * property names.
+ */
+export function selectAtPath(
+  root: unknown,
+  path: string[],
+): PathSelection {
   let cur: unknown = root;
   for (const key of path) {
-    if (cur == null) return undefined;
+    if (cur == null) return { found: false, value: undefined };
     if (Array.isArray(cur)) {
-      cur = cur[key === "-" ? cur.length : Number(key)];
+      if (!isArrayIndexPropertyName(key)) {
+        return { found: false, value: undefined };
+      }
+      const index = Number(key);
+      if (!Object.hasOwn(cur, index)) {
+        return { found: false, value: undefined };
+      }
+      cur = cur[index];
     } else if (typeof cur === "object") {
+      if (!Object.hasOwn(cur, key)) {
+        return { found: false, value: undefined };
+      }
       cur = (cur as Record<string, unknown>)[key];
     } else {
-      return undefined;
+      return { found: false, value: undefined };
     }
   }
-  return cur;
+  return { found: true, value: cur };
+}
+
+/**
+ * Navigates own properties using exact string segments. Array segments must be
+ * canonical array-index property names.
+ */
+export function getAtPath(root: unknown, path: string[]): unknown {
+  return selectAtPath(root, path).value;
 }
 
 interface RevRow {
@@ -245,14 +278,28 @@ export interface ValueAtResult {
   value?: unknown;
 }
 
+/** A reconstructed value result that distinguishes a missing selected path. */
+export interface SelectedValueAtResult extends ValueAtResult {
+  /** Whether the requested path exists within a reconstructed document. */
+  pathExists: boolean;
+}
+
 /** Reconstruct then navigate into `document.value` by path. */
 export function getValueAt(
   space: SpaceDb,
   opts: ReconstructOptions,
   path: string[] = [],
-): ValueAtResult {
+): SelectedValueAtResult {
   const document = reconstructDocument(space, opts);
-  if (document === undefined) return { exists: false };
-  const value = getAtPath(document.value, path);
-  return { exists: true, document, value };
+  if (document === undefined) return { exists: false, pathExists: false };
+  if (!Object.hasOwn(document, "value")) {
+    return { exists: true, document, pathExists: false };
+  }
+  const selected = selectAtPath(document.value, path);
+  return {
+    exists: true,
+    document,
+    pathExists: selected.found,
+    value: selected.value,
+  };
 }

--- a/packages/state-inspector/reconstruct.ts
+++ b/packages/state-inspector/reconstruct.ts
@@ -71,13 +71,12 @@ export function selectAtPath(
         return { found: false, value: undefined };
       }
       cur = cur[index];
-    } else if (typeof cur === "object") {
-      if (!Object.hasOwn(cur, key)) {
+    } else {
+      const boxed = Object(cur) as Record<string, unknown>;
+      if (!Object.hasOwn(boxed, key)) {
         return { found: false, value: undefined };
       }
-      cur = (cur as Record<string, unknown>)[key];
-    } else {
-      return { found: false, value: undefined };
+      cur = boxed[key];
     }
   }
   return { found: true, value: cur };

--- a/packages/state-inspector/scopes.ts
+++ b/packages/state-inspector/scopes.ts
@@ -26,7 +26,11 @@ import type { SpaceDb } from "./db.ts";
 import { resolveScopeKey } from "@commonfabric/memory/v2/engine";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import { annotate, summarize } from "./decode.ts";
-import { type EntityDocument, reconstructDocument } from "./reconstruct.ts";
+import {
+  type EntityDocument,
+  reconstructDocument,
+  selectAtPath,
+} from "./reconstruct.ts";
 
 export type ScopeKind = "space" | "user" | "session" | "other";
 
@@ -104,11 +108,19 @@ export function listScopes(
  * sessionId: `[session:X:sid, user:X, space]`; without: `[user:X, space]`.
  * Encoding goes through the engine's `resolveScopeKey`, so the keys are exactly
  * what the runtime writes (no hand-rolled %-encoding to drift).
+ *
+ * @throws {Error} When `identity` or a provided `sessionId` is empty.
  */
 export function resolveScopeChain(
   identity: string,
   sessionId?: string,
 ): string[] {
+  if (identity.length === 0) {
+    throw new Error("`identity` must not be empty.");
+  }
+  if (sessionId !== undefined && sessionId.length === 0) {
+    throw new Error("`sessionId` must not be empty.");
+  }
   const chain: string[] = [];
   if (sessionId) {
     chain.push(
@@ -130,6 +142,12 @@ export interface IdentityValue {
   overrides?: boolean;
   /** Honest reminder this is an approximation, not the runtime read path. */
   approximation: true;
+}
+
+/** An identity view that distinguishes a missing selected path. */
+export interface SelectedIdentityValue extends IdentityValue {
+  /** Whether the requested path exists within the resolved document. */
+  pathExists: boolean;
 }
 
 /**
@@ -161,6 +179,8 @@ function scopeHasEntity(
  * alone, know which declared scope a real read would target, nor follow the
  * base-scope link the runtime uses. Use {@link scopeOverlay} for the ground
  * truth. The `approximation` flag is here so callers can't forget that.
+ *
+ * @throws {Error} When selectors conflict or identity/session values are empty.
  */
 export function valueAsIdentity(
   space: SpaceDb,
@@ -170,8 +190,15 @@ export function valueAsIdentity(
     sessionId?: string;
     branch?: string;
     atSeq?: number;
+    /** Exact path segments within the resolved value. */
+    path?: string[];
+    /** Return the resolved document instead of selecting within its value. */
+    doc?: boolean;
   },
-): IdentityValue {
+): SelectedIdentityValue {
+  if (opts.doc && opts.path !== undefined) {
+    throw new Error("`doc` and `path` cannot be used together.");
+  }
   const branch = opts.branch ?? "";
   const chain = resolveScopeChain(opts.identity, opts.sessionId);
   for (let i = 0; i < chain.length; i++) {
@@ -191,16 +218,24 @@ export function valueAsIdentity(
     const overrides = chain
       .slice(i + 1)
       .some((s) => scopeHasEntity(space, opts.id, s, branch, opts.atSeq));
+    const selected = doc === undefined
+      ? { found: false, value: undefined }
+      : opts.doc
+      ? { found: true, value: doc }
+      : Object.hasOwn(doc, "value")
+      ? selectAtPath(doc.value, opts.path ?? [])
+      : { found: false, value: undefined };
     return {
       exists: doc !== undefined,
       resolvedScope: scope,
       resolvedKind: parseScope(scope).kind,
-      value: doc === undefined ? undefined : annotate(doc.value),
+      pathExists: selected.found,
+      value: doc === undefined ? undefined : annotate(selected.value),
       overrides,
       approximation: true,
     };
   }
-  return { exists: false, approximation: true };
+  return { exists: false, pathExists: false, approximation: true };
 }
 
 export interface Participant {

--- a/packages/state-inspector/test/classification.test.ts
+++ b/packages/state-inspector/test/classification.test.ts
@@ -9,7 +9,7 @@ import { Database } from "@db/sqlite";
 import {
   buildCrossSpaceLinkIndex,
   convergence,
-  convergenceScan,
+  convergenceScanExact,
   openSpaces,
 } from "../multispace.ts";
 
@@ -98,10 +98,11 @@ Deno.test("cross-space replica classification", async (t) => {
       );
 
       await t.step("scan tallies one drift, one instance", () => {
-        const scan = convergenceScan(refs);
+        const scan = convergenceScanExact(refs);
         assertEquals(scan.crossSpaceLinkEdges, 1);
         assertEquals(scan.linkedFindings, 1);
         assertEquals(scan.unlinkedFindings, 1);
+        assertEquals(scan.unknownFindings, 0);
       });
     } finally {
       for (const r of refs) r.space.close();

--- a/packages/state-inspector/test/cli.test.ts
+++ b/packages/state-inspector/test/cli.test.ts
@@ -3,8 +3,9 @@
 // the flag-parsing fix — a boolean flag (`--json`) before the <db> positional
 // must not swallow the path.
 
-import { assert, assertEquals } from "@std/assert";
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import { Database } from "@db/sqlite";
+import { jsonFromValue } from "@commonfabric/data-model/codecs";
 
 import { main } from "../cli.ts";
 
@@ -42,7 +43,21 @@ function seed(path: string) {
      VALUES (?, ?, 0, ?, ?, ?)`,
   );
   commit.run(1, 1);
-  rev.run("of:a", 1, "set", JSON.stringify({ value: { n: 1 } }), 1);
+  rev.run(
+    "of:a",
+    1,
+    "set",
+    jsonFromValue({
+      value: {
+        n: 1,
+        "a/b": "literal slash key",
+        a: { b: "nested key" },
+        "": "empty key",
+        storedUndefined: undefined,
+      },
+    }),
+    1,
+  );
   commit.run(2, 2);
   rev.run(
     "of:a",
@@ -54,16 +69,20 @@ function seed(path: string) {
   db.close();
 }
 
-/** Run `main` while capturing stdout lines. */
-function run(argv: string[]): { code: number; out: string } {
-  const lines: string[] = [];
-  const orig = console.log;
-  console.log = (...a: unknown[]) => lines.push(a.join(" "));
+/** Run `main` while capturing its output. */
+function run(argv: string[]): { code: number; out: string; err: string } {
+  const out: string[] = [];
+  const err: string[] = [];
+  const originalLog = console.log;
+  const originalError = console.error;
+  console.log = (...args: unknown[]) => out.push(args.join(" "));
+  console.error = (...args: unknown[]) => err.push(args.join(" "));
   try {
     const code = main(argv);
-    return { code, out: lines.join("\n") };
+    return { code, out: out.join("\n"), err: err.join("\n") };
   } finally {
-    console.log = orig;
+    console.log = originalLog;
+    console.error = originalError;
   }
 }
 
@@ -93,6 +112,386 @@ Deno.test("cli: single-space commands dispatch over a seeded DB", async (t) => {
       const r = JSON.parse(out);
       // the patch took n to 2
       assertEquals((r.value as { n: number }).n, 2);
+    });
+
+    await t.step("value-at --doc returns the reconstructed document", () => {
+      const result = run(["value-at", db, "of:a", "--doc", "--json"]);
+      assertEquals(result.code, 0);
+      assertEquals(JSON.parse(result.out).pathExists, true);
+      assertEquals(JSON.parse(result.out).value.value.n, 2);
+    });
+
+    await t.step("an empty path selects the root value", () => {
+      const result = run([
+        "value-at",
+        db,
+        "of:a",
+        "--path",
+        "",
+        "--json",
+      ]);
+      assertEquals(result.code, 0);
+      assertEquals(JSON.parse(result.out).pathExists, true);
+      assertEquals(JSON.parse(result.out).value.n, 2);
+    });
+
+    await t.step("an empty branch selects the default branch", () => {
+      const result = run([
+        "value-at",
+        db,
+        "of:a",
+        "--branch",
+        "",
+        "--json",
+      ]);
+      assertEquals(result.code, 0);
+      assertEquals(JSON.parse(result.out).value.n, 2);
+    });
+
+    await t.step("an empty scope remains available for raw inspection", () => {
+      const result = run([
+        "value-at",
+        db,
+        "of:a",
+        "--scope",
+        "",
+        "--json",
+      ]);
+      assertEquals(result.code, 0);
+      assertEquals(JSON.parse(result.out).exists, false);
+    });
+
+    await t.step("value-at preserves exact path segments", () => {
+      const slash = run([
+        "value-at",
+        db,
+        "of:a",
+        "--path-json",
+        '["a/b"]',
+        "--json",
+      ]);
+      assertEquals(slash.code, 0);
+      assertEquals(JSON.parse(slash.out).pathExists, true);
+      assertEquals(JSON.parse(slash.out).value, "literal slash key");
+
+      const empty = run([
+        "value-at",
+        db,
+        "of:a",
+        "--path-json",
+        '[""]',
+        "--json",
+      ]);
+      assertEquals(empty.code, 0);
+      assertEquals(JSON.parse(empty.out).pathExists, true);
+      assertEquals(JSON.parse(empty.out).value, "empty key");
+
+      const missing = run([
+        "value-at",
+        db,
+        "of:a",
+        "--path-json",
+        '["missing"]',
+        "--json",
+      ]);
+      assertEquals(missing.code, 0);
+      assertEquals(JSON.parse(missing.out).pathExists, false);
+
+      const storedUndefined = run([
+        "value-at",
+        db,
+        "of:a",
+        "--path-json",
+        '["storedUndefined"]',
+        "--json",
+      ]);
+      assertEquals(storedUndefined.code, 0);
+      assertEquals(JSON.parse(storedUndefined.out), {
+        exists: true,
+        pathExists: true,
+        value: { $undefined: true },
+      });
+    });
+
+    await t.step("converge preserves exact path segments", () => {
+      const result = run([
+        "converge",
+        "of:a",
+        "--spaces",
+        db,
+        "--path-json",
+        '["a/b"]',
+        "--json",
+      ]);
+      assertEquals(result.code, 0);
+      const parsed = JSON.parse(result.out);
+      assertEquals(parsed.path, ["a/b"]);
+      assertEquals(parsed.views[0].value, "literal slash key");
+
+      const exactHuman = run([
+        "converge",
+        "of:a",
+        "--spaces",
+        db,
+        "--path-json",
+        '["a/b"]',
+      ]);
+      assertStringIncludes(exactHuman.out, 'path=["a/b"]');
+
+      const legacyHuman = run([
+        "converge",
+        "of:a",
+        "--spaces",
+        db,
+        "--path",
+        "a/b",
+      ]);
+      assertStringIncludes(legacyHuman.out, "path=/a/b");
+    });
+
+    await t.step("path options reject ambiguous and invalid input", () => {
+      const conflict = run([
+        "value-at",
+        db,
+        "of:a",
+        "--path",
+        "a/b",
+        "--path-json",
+        '["a/b"]',
+      ]);
+      assertEquals(conflict.code, 1);
+      assertStringIncludes(
+        conflict.err,
+        "either `--path` or `--path-json`",
+      );
+
+      const invalid = run([
+        "value-at",
+        db,
+        "of:a",
+        "--path-json",
+        '["a/b",0]',
+      ]);
+      assertEquals(invalid.code, 1);
+      assertStringIncludes(invalid.err, "JSON array of string segments");
+
+      const documentPath = run([
+        "value-at",
+        db,
+        "of:a",
+        "--doc",
+        "--path-json",
+        '["a/b"]',
+      ]);
+      assertEquals(documentPath.code, 1);
+      assertStringIncludes(
+        documentPath.err,
+        "`--doc` without `--path` or `--path-json`",
+      );
+
+      const missingDb = `${dir}/missing.sqlite`;
+      const earlyConflict = run([
+        "value-at",
+        missingDb,
+        "of:a",
+        "--doc",
+        "--path",
+        "n",
+      ]);
+      assertEquals(earlyConflict.code, 1);
+      assertStringIncludes(
+        earlyConflict.err,
+        "`--doc` without `--path` or `--path-json`",
+      );
+
+      const convergeConflict = run([
+        "converge",
+        "of:a",
+        "--spaces",
+        missingDb,
+        "--path",
+        "a/b",
+        "--path-json",
+        '["a/b"]',
+      ]);
+      assertEquals(convergeConflict.code, 1);
+      assertStringIncludes(
+        convergeConflict.err,
+        "either `--path` or `--path-json`",
+      );
+
+      const convergeDocument = run([
+        "converge",
+        "of:a",
+        "--spaces",
+        missingDb,
+        "--doc",
+      ]);
+      assertEquals(convergeDocument.code, 1);
+      assertStringIncludes(
+        convergeDocument.err,
+        "`--doc` is not valid for converge",
+      );
+    });
+
+    await t.step("value-taking flags reject missing values", () => {
+      const missingDb = `${dir}/missing.sqlite`;
+      const result = run([
+        "value-at",
+        missingDb,
+        "of:a",
+        "--scope",
+      ]);
+      assertEquals(result.code, 1);
+      assertStringIncludes(result.err, "`--scope` requires a value");
+    });
+
+    await t.step("meaningless empty flag values are rejected", () => {
+      const missingDb = `${dir}/missing.sqlite`;
+      for (
+        const [argv, flag] of [
+          [["commits", missingDb, "--session", ""], "--session"],
+          [["value-at", missingDb, "of:a", "--seq", ""], "--seq"],
+          [
+            ["value-at", missingDb, "of:a", "--path-json", ""],
+            "--path-json",
+          ],
+        ] as const
+      ) {
+        const result = run([...argv]);
+        assertEquals(result.code, 1);
+        assertStringIncludes(result.err, `\`${flag}\` requires a value`);
+      }
+    });
+
+    await t.step(
+      "unknown and inapplicable flags are rejected before I/O",
+      () => {
+        const missingDb = `${dir}/missing.sqlite`;
+        const typo = run([
+          "value-at",
+          missingDb,
+          "of:a",
+          "--path-josn",
+          '["a/b"]',
+        ]);
+        assertEquals(typo.code, 1);
+        assertStringIncludes(
+          typo.err,
+          "`--path-josn` is not valid for value-at",
+        );
+
+        const inapplicable = run(["summary", missingDb, "--scope", "space"]);
+        assertEquals(inapplicable.code, 1);
+        assertStringIncludes(
+          inapplicable.err,
+          "`--scope` is not valid for summary",
+        );
+
+        const emptyInapplicable = run([
+          "summary",
+          missingDb,
+          "--session",
+          "",
+        ]);
+        assertEquals(emptyInapplicable.code, 1);
+        assertStringIncludes(
+          emptyInapplicable.err,
+          "`--session` is not valid for summary",
+        );
+
+        const prototypeFlag = run([
+          "summary",
+          missingDb,
+          "--__proto__",
+          "value",
+        ]);
+        assertEquals(prototypeFlag.code, 1);
+        assertStringIncludes(
+          prototypeFlag.err,
+          "`--__proto__` is not valid for summary",
+        );
+
+        const prototypeCommand = run(["toString", "--json"]);
+        assertEquals(prototypeCommand.code, 1);
+        assertStringIncludes(prototypeCommand.err, "unknown command: toString");
+      },
+    );
+
+    await t.step("numeric flags are validated before I/O", () => {
+      const missingDb = `${dir}/missing.sqlite`;
+      for (
+        const [argv, flag] of [
+          [["value-at", missingDb, "of:a", "--seq", "NaN"], "--seq"],
+          [["commits", missingDb, "--limit", "Infinity"], "--limit"],
+          [["hot", missingDb, "--limit", "1.5"], "--limit"],
+          [["history", missingDb, "of:a", "--limit", "-1"], "--limit"],
+          [["history", missingDb, "of:a", "--limit", "   "], "--limit"],
+        ] as const
+      ) {
+        const result = run([...argv]);
+        assertEquals(result.code, 1);
+        assertStringIncludes(
+          result.err,
+          `\`${flag}\` must be a non-negative integer`,
+        );
+      }
+    });
+
+    await t.step("multi-space selectors are mutually exclusive", () => {
+      const result = run([
+        "converge",
+        "of:a",
+        "--spaces",
+        `${dir}/missing.sqlite`,
+        "--dir",
+        `${dir}/missing`,
+      ]);
+      assertEquals(result.code, 1);
+      assertStringIncludes(result.err, "either `--dir` or `--spaces`");
+    });
+
+    await t.step("empty multi-space selectors are rejected", () => {
+      const result = run([
+        "converge",
+        "of:a",
+        "--spaces",
+        " , ",
+      ]);
+      assertEquals(result.code, 1);
+      assertStringIncludes(
+        result.err,
+        "must contain at least one space",
+      );
+    });
+
+    await t.step("unsafe convergence paths use escaped exact output", () => {
+      const result = run([
+        "converge",
+        "of:a",
+        "--spaces",
+        db,
+        "--path",
+        "line\nforged",
+      ]);
+      assertEquals(result.code, 0);
+      assertStringIncludes(result.out, 'path=["line\\nforged"]');
+      assertEquals(result.out.includes("path=/line\nforged"), false);
+    });
+
+    await t.step("required entity arguments are checked before I/O", () => {
+      const missingDb = `${dir}/missing.sqlite`;
+      const valueAt = run(["value-at", missingDb]);
+      assertEquals(valueAt.code, 1);
+      assertStringIncludes(valueAt.err, "value-at needs <entity-id>");
+
+      const history = run(["history", missingDb]);
+      assertEquals(history.code, 1);
+      assertStringIncludes(history.err, "history needs <entity-id>");
+    });
+
+    await t.step("--help exits successfully without a command", () => {
+      assertEquals(run(["--help"]).code, 0);
     });
 
     await t.step("hot + history + commits succeed", () => {

--- a/packages/state-inspector/test/convergence.test.ts
+++ b/packages/state-inspector/test/convergence.test.ts
@@ -4,8 +4,35 @@
 
 import { assert, assertEquals } from "@std/assert";
 import { Database } from "@db/sqlite";
+import type { FabricValue } from "@commonfabric/api";
+import { jsonFromValue } from "@commonfabric/data-model/codecs";
 
-import { convergence, convergenceScan, openSpaces } from "../multispace.ts";
+import {
+  convergence,
+  convergenceExact,
+  type ConvergenceResult,
+  convergenceScan,
+  convergenceScanExact,
+  type ConvergenceVerdict,
+  type ExactConvergenceResult,
+  type ExactScanResult,
+  openSpaces,
+  type ScanResult,
+} from "../multispace.ts";
+
+function describeLegacyVerdict(verdict: ConvergenceVerdict): string {
+  switch (verdict) {
+    case "converged":
+    case "diverged":
+    case "partial":
+    case "absent":
+      return verdict;
+    default: {
+      const exhaustive: never = verdict;
+      return exhaustive;
+    }
+  }
+}
 
 const SCHEMA = `
 CREATE TABLE "commit" (
@@ -24,7 +51,10 @@ CREATE TABLE revision (
 `;
 
 // Write a single set of an entity's value into a fresh space DB.
-function makeSpace(path: string, entries: { id: string; value: unknown }[]) {
+function makeSpace(
+  path: string,
+  entries: { id: string; value: FabricValue }[],
+) {
   const db = new Database(path, { create: true });
   db.exec(SCHEMA);
   const commit = db.prepare(
@@ -38,14 +68,46 @@ function makeSpace(path: string, entries: { id: string; value: unknown }[]) {
   entries.forEach((e, i) => {
     const seq = i + 1;
     commit.run(seq, `session-${i}`, 1, JSON.stringify({ seq }));
-    rev.run(e.id, seq, JSON.stringify({ value: e.value }), seq);
+    rev.run(e.id, seq, jsonFromValue({ value: e.value }), seq);
   });
+  db.close();
+}
+
+function corruptEntity(path: string, id: string): void {
+  const db = new Database(path);
+  db.prepare("UPDATE revision SET data = ? WHERE id = ?").run("{", id);
   db.close();
 }
 
 Deno.test("cross-space convergence", async (t) => {
   const dir = await Deno.makeTempDir({ prefix: "state-inspector-converge-" });
   try {
+    await t.step("base scan results omit the exact unknown count", () => {
+      const legacyFinding: ConvergenceResult = {
+        id: "of:legacy",
+        scope: "space",
+        branch: "",
+        path: [],
+        verdict: "converged",
+        views: [],
+        clusters: [],
+        caveat: "",
+      };
+      const baseResult: ScanResult = {
+        sharedEntities: 0,
+        examined: 0,
+        examineCapped: false,
+        crossSpaceLinkEdges: 0,
+        linkedFindings: 0,
+        unlinkedFindings: 0,
+        findings: [legacyFinding],
+      };
+      assertEquals(
+        describeLegacyVerdict(baseResult.findings[0].verdict),
+        "converged",
+      );
+    });
+
     // X agrees in A & B, disagrees in C; Y is present only in A & B (partial); Z only in A.
     makeSpace(`${dir}/A.sqlite`, [
       { id: "of:X", value: { n: 1 } },
@@ -59,6 +121,23 @@ Deno.test("cross-space convergence", async (t) => {
     makeSpace(`${dir}/C.sqlite`, [
       { id: "of:X", value: { n: 999 } },
     ]);
+    makeSpace(`${dir}/U1.sqlite`, [
+      { id: "of:U", value: { maybe: undefined } },
+    ]);
+    makeSpace(`${dir}/U2.sqlite`, [
+      { id: "of:U", value: {} },
+    ]);
+    makeSpace(`${dir}/Error1.sqlite`, [
+      { id: "of:Error", value: { n: 1 } },
+    ]);
+    makeSpace(`${dir}/Error2.sqlite`, [
+      { id: "of:Error", value: { n: 1 } },
+    ]);
+    makeSpace(`${dir}/ErrorGood.sqlite`, [
+      { id: "of:Error", value: { n: 1 } },
+    ]);
+    corruptEntity(`${dir}/Error1.sqlite`, "of:Error");
+    corruptEntity(`${dir}/Error2.sqlite`, "of:Error");
 
     const refs = openSpaces([
       `${dir}/A.sqlite`,
@@ -67,7 +146,7 @@ Deno.test("cross-space convergence", async (t) => {
     ]);
     try {
       await t.step("diverged: X differs in C", () => {
-        const r = convergence(refs, { id: "of:X" });
+        const r: ConvergenceResult = convergence(refs, { id: "of:X" });
         assertEquals(r.verdict, "diverged");
         assertEquals(r.clusters.length, 2);
         // the {n:1} cluster holds A and B
@@ -97,8 +176,84 @@ Deno.test("cross-space convergence", async (t) => {
         assertEquals(c?.value, 999);
       });
 
+      await t.step("missing paths differ visibly from stored undefined", () => {
+        const presenceRefs = openSpaces([
+          `${dir}/U1.sqlite`,
+          `${dir}/U2.sqlite`,
+        ]);
+        try {
+          const result = convergence(presenceRefs, {
+            id: "of:U",
+            path: ["maybe"],
+          });
+          assertEquals(result.verdict, "diverged");
+          assertEquals(
+            result.views.map((view) => view.pathExists),
+            [true, false],
+          );
+          assertEquals(
+            result.clusters.map((cluster) => cluster.value),
+            [{ $undefined: true }, { $missing: true }],
+          );
+          assertEquals(
+            result.clusters.map((cluster) => cluster.pathExists),
+            [true, false],
+          );
+          assert(Object.isFrozen(result.views[1].value));
+        } finally {
+          for (const ref of presenceRefs) ref.space.close();
+        }
+      });
+
+      await t.step("decode failures make convergence unknown", () => {
+        const allErrored = openSpaces([
+          `${dir}/Error1.sqlite`,
+          `${dir}/Error2.sqlite`,
+        ]);
+        const partlyErrored = openSpaces([
+          `${dir}/Error1.sqlite`,
+          `${dir}/ErrorGood.sqlite`,
+        ]);
+        try {
+          const failed: ExactConvergenceResult = convergenceExact(allErrored, {
+            id: "of:Error",
+          });
+          assertEquals(failed.verdict, "unknown");
+          assertEquals(failed.clusters, []);
+          assert(failed.views.every((view) => view.error !== undefined));
+
+          const mixed = convergenceExact(partlyErrored, { id: "of:Error" });
+          assertEquals(mixed.verdict, "unknown");
+          assertEquals(mixed.clusters.length, 1);
+
+          const legacy: ConvergenceResult = convergence(allErrored, {
+            id: "of:Error",
+          });
+          assertEquals(legacy.verdict, "converged");
+          assertEquals(legacy.clusters.length, 1);
+          assertEquals(
+            legacy.views.map((view) => view.valueKey),
+            ["«decode-error»", "«decode-error»"],
+          );
+
+          const scan: ExactScanResult = convergenceScanExact(allErrored, {
+            linkIndex: false,
+          });
+          assertEquals(scan.findings.map((finding) => finding.verdict), [
+            "unknown",
+          ]);
+          assertEquals(scan.linkedFindings, 0);
+          assertEquals(scan.unlinkedFindings, 0);
+          assertEquals(scan.unknownFindings, 1);
+        } finally {
+          for (const ref of [...allErrored, ...partlyErrored]) {
+            ref.space.close();
+          }
+        }
+      });
+
       await t.step("scan surfaces X (diverged) and Y (partial), not Z", () => {
-        const scan = convergenceScan(refs);
+        const scan: ScanResult = convergenceScan(refs);
         const ids = scan.findings.map((f) => f.id).sort();
         assertEquals(ids, ["of:X", "of:Y"]);
         // Z is solo (present in only one space) → not a shared entity

--- a/packages/state-inspector/test/decode.test.ts
+++ b/packages/state-inspector/test/decode.test.ts
@@ -141,3 +141,45 @@ Deno.test("decode: a present `undefined` is not silently dropped on export", () 
     "the undefined field survives JSON round-trip",
   );
 });
+
+Deno.test("decode: sparse arrays keep holes without scanning their length", () => {
+  const sparse: unknown[] = [];
+  sparse.length = 1_000_000_000;
+  sparse[5] = undefined;
+  Object.defineProperty(sparse, "__proto__", {
+    value: "own property",
+    enumerable: true,
+  });
+
+  const annotated = annotate(sparse) as {
+    $sparseArray: {
+      length: number;
+      entries: Record<string, unknown>;
+      properties: Record<string, unknown>;
+    };
+  };
+  assertEquals(annotated, {
+    $sparseArray: {
+      length: 1_000_000_000,
+      entries: { "5": { $undefined: true } },
+      properties: JSON.parse('{"__proto__":"own property"}'),
+    },
+  });
+  assert(Object.hasOwn(annotated.$sparseArray.properties, "__proto__"));
+  const ordinary = annotate(
+    JSON.parse('{"ordinary":true,"__proto__":"own property"}'),
+  ) as Record<string, unknown>;
+  assertEquals(Object.getPrototypeOf(ordinary), Object.prototype);
+  assert(Object.hasOwn(ordinary, "__proto__"));
+});
+
+Deno.test("decode: summaries escape terminal control characters", () => {
+  assertEquals(
+    summarize("\u001b[2Jforged\nline"),
+    '"\\u001b[2Jforged\\nline"',
+  );
+  assertEquals(
+    summarize(JSON.parse('{"line\\nforged":1,"bidi‮forged":2}')),
+    '{"line\\nforged", "bidi\\u202eforged"}',
+  );
+});

--- a/packages/state-inspector/test/get-at-path.test.ts
+++ b/packages/state-inspector/test/get-at-path.test.ts
@@ -1,0 +1,45 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { getAtPath, selectAtPath } from "../reconstruct.ts";
+
+describe("getAtPath()", () => {
+  it("returns the root for an empty path", () => {
+    const root = { value: "root" };
+    expect(getAtPath(root, [])).toBe(root);
+  });
+
+  it("returns values at canonical array indexes", () => {
+    expect(getAtPath(["zero", "one"], ["1"])).toBe("one");
+  });
+
+  it("returns `undefined` for noncanonical array segments", () => {
+    const array = ["zero", "one"];
+    for (const segment of ["", "01", "1e0", "-", "length"]) {
+      expect(getAtPath(array, [segment])).toBeUndefined();
+    }
+  });
+
+  it("reads only own array indexes and object properties", () => {
+    const sparse = new Array<string>(1);
+    const arrayPrototype = Object.create(Array.prototype) as string[];
+    arrayPrototype[0] = "inherited";
+    Object.setPrototypeOf(sparse, arrayPrototype);
+    expect(getAtPath(sparse, ["0"])).toBeUndefined();
+
+    expect(getAtPath({}, ["toString"])).toBeUndefined();
+    expect(getAtPath({ toString: "own" }, ["toString"])).toBe("own");
+    expect(getAtPath({ "": "empty" }, [""])).toBe("empty");
+  });
+
+  it("distinguishes stored undefined from a missing property", () => {
+    expect(selectAtPath({ value: undefined }, ["value"])).toEqual({
+      found: true,
+      value: undefined,
+    });
+    expect(selectAtPath({}, ["value"])).toEqual({
+      found: false,
+      value: undefined,
+    });
+  });
+});

--- a/packages/state-inspector/test/get-at-path.test.ts
+++ b/packages/state-inspector/test/get-at-path.test.ts
@@ -32,6 +32,25 @@ describe("getAtPath()", () => {
     expect(getAtPath({ "": "empty" }, [""])).toBe("empty");
   });
 
+  it("reads own properties exposed by primitive values", () => {
+    expect(selectAtPath("tea", ["length"])).toEqual({
+      found: true,
+      value: 3,
+    });
+    expect(selectAtPath("tea", ["1"])).toEqual({
+      found: true,
+      value: "e",
+    });
+    expect(selectAtPath({ title: "tea" }, ["title", "length"])).toEqual({
+      found: true,
+      value: 3,
+    });
+    expect(selectAtPath("tea", ["toString"])).toEqual({
+      found: false,
+      value: undefined,
+    });
+  });
+
   it("distinguishes stored undefined from a missing property", () => {
     expect(selectAtPath({ value: undefined }, ["value"])).toEqual({
       found: true,

--- a/packages/state-inspector/test/scopes.test.ts
+++ b/packages/state-inspector/test/scopes.test.ts
@@ -3,13 +3,14 @@
 // surface the per-scope divergence of one cell. Scope keys are stored %-encoded
 // (as in real DBs) to exercise the encode/decode path.
 
-import { assert, assertEquals } from "@std/assert";
+import { assert, assertEquals, assertThrows } from "@std/assert";
 import { Database } from "@db/sqlite";
 
 import { openSpace } from "../db.ts";
 import {
   listScopes,
   parseScope,
+  resolveScopeChain,
   scopeOverlay,
   spaceParticipants,
   valueAsIdentity,
@@ -55,7 +56,11 @@ function seed(path: string) {
   put("of:B", "space", "space-B");
   put("of:B", USER, "user-B");
   put("of:B", SESS, "session-B");
-  put("of:C", USER, "user-only-C");
+  put("of:C", USER, {
+    "a/b": "literal slash key",
+    a: { b: "nested key" },
+    "": "empty key",
+  });
   db.close();
 }
 
@@ -111,6 +116,63 @@ Deno.test("scope awareness: enumerate, compose, diverge", async (t) => {
         const userOnly = valueAsIdentity(space, { id: "of:C", identity: DID });
         assert(userOnly.exists);
         assertEquals(userOnly.resolvedKind, "user");
+
+        const slashKey = valueAsIdentity(space, {
+          id: "of:C",
+          identity: DID,
+          path: ["a/b"],
+        });
+        assertEquals(slashKey.value, "literal slash key");
+        assertEquals(slashKey.pathExists, true);
+
+        const emptyKey = valueAsIdentity(space, {
+          id: "of:C",
+          identity: DID,
+          path: [""],
+        });
+        assertEquals(emptyKey.value, "empty key");
+        assertEquals(emptyKey.pathExists, true);
+
+        const missingKey = valueAsIdentity(space, {
+          id: "of:C",
+          identity: DID,
+          path: ["missing"],
+        });
+        assertEquals(missingKey.pathExists, false);
+
+        const document = valueAsIdentity(space, {
+          id: "of:C",
+          identity: DID,
+          doc: true,
+        });
+        assertEquals(document.value, {
+          value: {
+            "a/b": "literal slash key",
+            a: { b: "nested key" },
+            "": "empty key",
+          },
+        });
+        assertThrows(
+          () =>
+            valueAsIdentity(space, {
+              id: "of:C",
+              identity: DID,
+              doc: true,
+              path: [],
+            }),
+          Error,
+          "cannot be used together",
+        );
+        assertThrows(
+          () => resolveScopeChain(""),
+          Error,
+          "`identity` must not be empty",
+        );
+        assertThrows(
+          () => resolveScopeChain(DID, ""),
+          Error,
+          "`sessionId` must not be empty",
+        );
       });
 
       await t.step("spaceParticipants lists the space's identities", () => {

--- a/packages/state-inspector/test/scopes.test.ts
+++ b/packages/state-inspector/test/scopes.test.ts
@@ -112,6 +112,14 @@ Deno.test("scope awareness: enumerate, compose, diverge", async (t) => {
         assertEquals(spaceOnly.value, "shared-A");
         assertEquals(spaceOnly.overrides, false);
 
+        const stringLength = valueAsIdentity(space, {
+          id: "of:A",
+          identity: DID,
+          path: ["length"],
+        });
+        assertEquals(stringLength.pathExists, true);
+        assertEquals(stringLength.value, 8);
+
         // C: user-only — still visible AS the identity (space would miss it).
         const userOnly = valueAsIdentity(space, { id: "of:C", identity: DID });
         assert(userOnly.exists);

--- a/packages/state-inspector/test/timetravel.test.ts
+++ b/packages/state-inspector/test/timetravel.test.ts
@@ -437,6 +437,15 @@ Deno.test("time travel: diff + timelines", async (t) => {
             }),
           SyntaxError,
         );
+        assertThrows(
+          () =>
+            diffEntity(space, {
+              id: "of:E",
+              fromSeq: 2,
+              toSeq: 4,
+            }),
+          SyntaxError,
+        );
       });
 
       await t.step("entityTimeline lists each write with change counts", () => {

--- a/packages/state-inspector/test/timetravel.test.ts
+++ b/packages/state-inspector/test/timetravel.test.ts
@@ -2,13 +2,15 @@
 // seqs, entity timeline (write-by-write), and space-growth timeline. Seeds an
 // entity edited by a patch and another that is created then deleted.
 
-import { assert, assertEquals } from "@std/assert";
+import { assert, assertEquals, assertThrows } from "@std/assert";
 import { Database } from "@db/sqlite";
+import { jsonFromValue } from "@commonfabric/data-model/codecs";
 
 import { openSpace } from "../db.ts";
 import {
   diffEntity,
   diffValues,
+  type EntityDiff,
   entityTimeline,
   spaceTimeline,
 } from "../timetravel.ts";
@@ -41,30 +43,104 @@ function seed(path: string) {
      VALUES (?, ?, 0, ?, ?, ?)`,
   );
 
-  // commit 1: create A
+  const sparse = new Array(10);
+  sparse[5] = "before";
+
+  // commit 1: create A and E
   commit.run(1, "session:did:key:zX:u", 1);
   rev.run(
     "of:A",
     1,
     "set",
-    JSON.stringify({ value: { count: 0, title: "a" } }),
+    jsonFromValue({
+      value: {
+        count: 0,
+        title: "a",
+        "a/b": { "": 1 },
+        a: { b: { "": 10 } },
+        storedUndefined: undefined,
+        removedUndefined: undefined,
+        sparse,
+      },
+    }),
     1,
   );
-  // commit 2: create B
+  rev.run(
+    "of:E",
+    1,
+    "set",
+    jsonFromValue({ value: { n: 1, m: 1 } }),
+    1,
+  );
+  // commit 2: create B and encounter an invalid E patch
   commit.run(2, "session:did:key:zX:u", 2);
   rev.run("of:B", 2, "set", JSON.stringify({ value: { x: 1 } }), 2);
-  // commit 3: patch A.count -> 2
+  rev.run("of:E", 2, "patch", "{", 2);
+  // commit 3: patch A and E
   commit.run(3, "session:did:key:zX:u", 3);
   rev.run(
     "of:A",
     3,
     "patch",
-    JSON.stringify([{ op: "replace", path: "/value/count", value: 2 }]),
+    JSON.stringify([
+      { op: "replace", path: "/value/count", value: 2 },
+      { op: "replace", path: "/value/a~1b/", value: 2 },
+      {
+        op: "replace",
+        path: "/value/storedUndefined",
+        value: { $undefined: true },
+      },
+      { op: "remove", path: "/value/removedUndefined" },
+      { op: "replace", path: "/value/sparse/5", value: "after" },
+    ]),
     3,
   );
-  // commit 4: delete B
+  rev.run(
+    "of:E",
+    3,
+    "patch",
+    JSON.stringify([
+      { op: "replace", path: "/value/n", value: 2 },
+      { op: "replace", path: "/value/m", value: 2 },
+    ]),
+    3,
+  );
+  // commit 4: delete B and restore E with a complete value
   commit.run(4, "session:did:key:zX:u", 4);
   rev.run("of:B", 4, "delete", null, 4);
+  rev.run(
+    "of:E",
+    4,
+    "set",
+    jsonFromValue({ value: { n: 10, m: 10 } }),
+    4,
+  );
+  // commit 5: a patch after the set can be reconstructed
+  commit.run(5, "session:did:key:zX:u", 5);
+  rev.run(
+    "of:E",
+    5,
+    "patch",
+    JSON.stringify([{ op: "replace", path: "/value/n", value: 11 }]),
+    5,
+  );
+  // commit 6: another invalid patch makes E unknown again
+  commit.run(6, "session:did:key:zX:u", 6);
+  rev.run("of:E", 6, "patch", "{", 6);
+  // commit 7: a delete establishes the complete state
+  commit.run(7, "session:did:key:zX:u", 7);
+  rev.run("of:E", 7, "delete", null, 7);
+  // commit 8: a patch after the delete starts from an empty document
+  commit.run(8, "session:did:key:zX:u", 8);
+  rev.run(
+    "of:E",
+    8,
+    "patch",
+    JSON.stringify([
+      { op: "add", path: "/value", value: { afterDelete: true } },
+    ]),
+    8,
+  );
 
   db.close();
 }
@@ -77,33 +153,265 @@ Deno.test("time travel: diff + timelines", async (t) => {
     const space = openSpace(dbPath);
     try {
       await t.step("diffValues classifies add/remove/change", () => {
+        const legacyShape: EntityDiff = {
+          id: "of:legacy",
+          fromSeq: 1,
+          toSeq: 2,
+          fromExists: true,
+          toExists: true,
+          changes: [{ path: "value/count", kind: "changed" }],
+        };
+        assertEquals(legacyShape.changes[0].path, "value/count");
+
         const changes = diffValues(
           { a: 1, b: 2, list: [1, 2] },
           { a: 1, b: 3, c: 9, list: [1, 5] },
         );
-        const byPath = Object.fromEntries(changes.map((c) => [c.path, c]));
-        assertEquals(byPath["b"].kind, "changed");
-        assertEquals(byPath["c"].kind, "added");
-        assertEquals(byPath["list/1"].kind, "changed");
-        assert(!("a" in byPath));
+        assertEquals(
+          changes.map((change) => ({
+            path: change.path,
+            pathSegments: change.pathSegments,
+            kind: change.kind,
+          })),
+          [
+            { path: "b", pathSegments: ["b"], kind: "changed" },
+            {
+              path: "list/1",
+              pathSegments: ["list", "1"],
+              kind: "changed",
+            },
+            { path: "c", pathSegments: ["c"], kind: "added" },
+          ],
+        );
+      });
+
+      await t.step("diffValues preserves ambiguous path segments", () => {
+        const changes = diffValues(
+          { "a/b": 1, a: { b: 1 }, "": 1 },
+          { "a/b": 2, a: { b: 2 }, "": 2 },
+        );
+        assertEquals(changes.map((change) => change.pathSegments), [
+          ["a/b"],
+          ["a", "b"],
+          [""],
+        ]);
+        assertEquals(changes.map((change) => change.path), ["a/b", "a/b", ""]);
+        assertEquals(
+          diffValues(1, 2, ["a/b", ""])[0].pathSegments,
+          ["a/b", ""],
+        );
+      });
+
+      await t.step("diffValues preserves property and array presence", () => {
+        assertEquals(diffValues({}, {}, [], 0), []);
+        assertEquals(
+          diffValues({ child: {} }, { child: {} }, [], 1),
+          [],
+        );
+        assertEquals(diffValues({}, { toString: 1 }), [{
+          path: "toString",
+          pathSegments: ["toString"],
+          kind: "added",
+          after: 1,
+        }]);
+        assertEquals(diffValues({ valueOf: 1 }, {}), [{
+          path: "valueOf",
+          pathSegments: ["valueOf"],
+          kind: "removed",
+          before: 1,
+        }]);
+        assertEquals(diffValues({ stored: undefined }, {}), [{
+          path: "stored",
+          pathSegments: ["stored"],
+          kind: "removed",
+          before: { $undefined: true },
+          beforeIsUndefined: true,
+        }]);
+        assertEquals(diffValues(1n, { $bigint: "1" }), [{
+          path: "",
+          pathSegments: [],
+          kind: "changed",
+          before: { $bigint: "1" },
+          after: { $bigint: "1" },
+          annotationCollision: true,
+          beforeValueKind: "bigint",
+          afterValueKind: "object",
+        }]);
+        assertEquals(diffValues({ $stream: true }, "$stream"), [{
+          path: "",
+          pathSegments: [],
+          kind: "changed",
+          before: "$stream",
+          after: "$stream",
+          annotationCollision: true,
+          beforeValueKind: "stream",
+          afterValueKind: "string",
+        }]);
+        assertEquals(
+          diffValues(
+            { nested: undefined },
+            { nested: { $undefined: true } },
+            [],
+            0,
+          ),
+          [{
+            path: "",
+            pathSegments: [],
+            kind: "changed",
+            before: { nested: { $undefined: true } },
+            after: { nested: { $undefined: true } },
+            annotationCollision: true,
+            beforeValueKind: "object",
+            afterValueKind: "object",
+          }],
+        );
+
+        const sparseBefore = new Array(1_000_000_000);
+        const sparseAfter = new Array(1_000_000_001);
+        const sparseChanges = diffValues(sparseBefore, sparseAfter);
+        assertEquals(sparseChanges, [{
+          path: "",
+          pathSegments: [],
+          kind: "changed",
+          before: {
+            $sparseArray: { length: 1_000_000_000, entries: {} },
+          },
+          after: {
+            $sparseArray: { length: 1_000_000_001, entries: {} },
+          },
+        }]);
+        assertEquals(
+          JSON.stringify(sparseChanges).includes("null"),
+          false,
+        );
+
+        const nestedBefore = new Array(1_000_000_000);
+        const nestedAfter = new Array(1_000_000_000);
+        nestedBefore[5] = undefined;
+        nestedAfter[5] = undefined;
+        (nestedAfter as unknown as Record<string, unknown>).label = "current";
+        assertEquals(
+          diffValues({ items: nestedBefore }, { items: nestedAfter }),
+          [{
+            path: "items/label",
+            pathSegments: ["items", "label"],
+            kind: "added",
+            after: "current",
+          }],
+        );
+
+        const changedNestedBefore = new Array(1_000_000_000);
+        const changedNestedAfter = new Array(1_000_000_000);
+        changedNestedBefore[5] = "before";
+        changedNestedAfter[5] = "after";
+        assertEquals(
+          diffValues(
+            { items: changedNestedBefore },
+            { items: changedNestedAfter },
+          ),
+          [{
+            path: "items/5",
+            pathSegments: ["items", "5"],
+            kind: "changed",
+            before: "before",
+            after: "after",
+          }],
+        );
       });
 
       await t.step("diffEntity across seqs shows the changed leaf", () => {
-        // Default diffs the value; change paths are value-relative ("count").
+        // Default diffs the value; change paths are value-relative.
         const d = diffEntity(space, { id: "of:A", fromSeq: 1, toSeq: 3 });
         assert(d.fromExists && d.toExists);
-        const c = d.changes.find((x) => x.path === "count");
+        const c = d.changes.find((x) =>
+          x.pathSegments.length === 1 && x.pathSegments[0] === "count"
+        );
         assert(c, "expected value.count to change");
         assertEquals(c!.kind, "changed");
         assertEquals(c!.after, 2);
-        // With --doc, paths are document-relative ("value/count").
+        // With --doc, paths are document-relative.
         const dd = diffEntity(space, {
           id: "of:A",
           fromSeq: 1,
           toSeq: 3,
           doc: true,
         });
-        assert(dd.changes.some((x) => x.path === "value/count"));
+        assert(
+          dd.changes.some((x) =>
+            x.pathSegments.length === 2 && x.pathSegments[0] === "value" &&
+            x.pathSegments[1] === "count"
+          ),
+        );
+        assertThrows(
+          () =>
+            diffEntity(space, {
+              id: "of:A",
+              doc: true,
+              path: [],
+            }),
+          Error,
+          "cannot be used together",
+        );
+
+        const exact = diffEntity(space, {
+          id: "of:A",
+          fromSeq: 1,
+          toSeq: 3,
+          path: ["a/b", ""],
+        });
+        assertEquals(exact.changes, [{
+          path: "",
+          pathSegments: [],
+          kind: "changed",
+          before: 1,
+          after: 2,
+        }]);
+
+        const removedUndefined = diffEntity(space, {
+          id: "of:A",
+          fromSeq: 1,
+          toSeq: 3,
+          path: ["removedUndefined"],
+        });
+        assertEquals(removedUndefined.changes, [{
+          path: "",
+          pathSegments: [],
+          kind: "removed",
+          before: { $undefined: true },
+          beforeIsUndefined: true,
+        }]);
+
+        const collision = diffEntity(space, {
+          id: "of:A",
+          fromSeq: 1,
+          toSeq: 3,
+          path: ["storedUndefined"],
+        });
+        assertEquals(collision.changes, [{
+          path: "",
+          pathSegments: [],
+          kind: "changed",
+          before: { $undefined: true },
+          beforeIsUndefined: true,
+          after: { $undefined: true },
+          annotationCollision: true,
+          beforeValueKind: "undefined",
+          afterValueKind: "object",
+        }]);
+
+        const sparse = diffEntity(space, {
+          id: "of:A",
+          fromSeq: 1,
+          toSeq: 3,
+          path: ["sparse"],
+        });
+        assertEquals(sparse.changes, [{
+          path: "5",
+          pathSegments: ["5"],
+          kind: "changed",
+          before: "before",
+          after: "after",
+        }]);
       });
 
       await t.step("diffEntity birth→latest reports creation", () => {
@@ -119,23 +427,67 @@ Deno.test("time travel: diff + timelines", async (t) => {
         assertEquals(d.toExists, false);
       });
 
+      await t.step("diffEntity propagates reconstruction errors", () => {
+        assertThrows(
+          () =>
+            diffEntity(space, {
+              id: "of:E",
+              fromSeq: 1,
+              toSeq: 2,
+            }),
+          SyntaxError,
+        );
+      });
+
       await t.step("entityTimeline lists each write with change counts", () => {
         const steps = entityTimeline(space, { id: "of:A" });
         assertEquals(steps.length, 2);
         assertEquals(steps[0].op, "set");
         assertEquals(steps[1].op, "patch");
-        // the patch changed exactly one path (count)
-        assertEquals(steps[1].changes, 1);
+        // The patch changed count, the empty key below "a/b", both
+        // undefined-valued properties, and the sparse array entry.
+        assertEquals(steps[1].changes, 5);
+      });
+
+      await t.step("entityTimeline keeps state unknown until recovery", () => {
+        const steps = entityTimeline(space, { id: "of:E" });
+        assertEquals(steps.length, 8);
+        assertEquals(steps[0].changes, 1);
+        assertEquals(steps[1].changes, 0);
+        assertEquals(steps[1].changesKnown, false);
+        assertEquals(steps[1].stateKnown, false);
+        assert(typeof steps[1].error === "string" && steps[1].error.length > 0);
+
+        assertEquals(steps[2].changes, 0);
+        assertEquals(steps[2].changesKnown, false);
+        assertEquals(steps[2].stateKnown, false);
+        assert(typeof steps[2].error === "string" && steps[2].error.length > 0);
+
+        assertEquals(steps[3].exists, true);
+        assertEquals(steps[3].changes, 0);
+        assertEquals(steps[3].changesKnown, false);
+        assertEquals(steps[3].stateKnown, undefined);
+        assertEquals(steps[4].changes, 1);
+        assertEquals(steps[4].changesKnown, undefined);
+
+        assertEquals(steps[5].stateKnown, false);
+        assertEquals(steps[6].exists, false);
+        assertEquals(steps[6].changesKnown, false);
+        assertEquals(steps[6].stateKnown, undefined);
+        assertEquals(steps[7].exists, true);
+        assertEquals(steps[7].changes, 1);
+        assertEquals(steps[7].changesKnown, undefined);
       });
 
       await t.step("spaceTimeline tracks created + cumulative growth", () => {
         const t1 = spaceTimeline(space);
-        assertEquals(t1.length, 4);
-        assertEquals(t1[0].created, 1); // A
+        assertEquals(t1.length, 8);
+        assertEquals(t1[0].created, 2); // A and E
         assertEquals(t1[1].created, 1); // B
         assertEquals(t1[2].created, 0); // patch A
-        assertEquals(t1[3].created, 0); // delete B
-        assertEquals(t1[3].cumulativeEntities, 2);
+        assertEquals(t1[3].created, 0); // delete B and set E
+        assertEquals(t1[7].created, 0); // patch E after its delete
+        assertEquals(t1[7].cumulativeEntities, 3);
       });
     } finally {
       space.close();

--- a/packages/state-inspector/timetravel.ts
+++ b/packages/state-inspector/timetravel.ts
@@ -14,87 +14,320 @@ import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import { applyPatch } from "@commonfabric/memory/v2/patch";
 import type { PatchOp } from "@commonfabric/memory/v2";
 import type { FabricValue } from "@commonfabric/api";
+import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
+import { isPlainObject } from "@commonfabric/utils/types";
 
 import type { SpaceDb } from "./db.ts";
-import { annotate, decodeStored, summarize } from "./decode.ts";
-import { getAtPath, reconstructDocument } from "./reconstruct.ts";
+import {
+  annotate,
+  decodedLinkOf,
+  decodeStored,
+  escapeTerminalText,
+  isStream,
+  parseEntityRef,
+  summarize,
+} from "./decode.ts";
+import { reconstructDocument, selectAtPath } from "./reconstruct.ts";
 
-/** Annotate depth for value COMPARISON — deep enough that the depth cap never
- * hides a real diff (well past diffValues' own recursion bound). */
+/** Annotation depth used for values included in diff output. */
 const COMPARE_DEPTH = 32;
+const DEFAULT_DIFF_DEPTH = 12;
 
 export type ChangeKind = "added" | "removed" | "changed";
+export type StoredValueKind =
+  | "array"
+  | "bigint"
+  | "boolean"
+  | "fabric"
+  | "function"
+  | "link"
+  | "null"
+  | "number"
+  | "object"
+  | "reference"
+  | "stream"
+  | "string"
+  | "symbol"
+  | "undefined";
 
 export interface ValueChange {
-  /** JSON path of the change, e.g. `value/items/0/title`. */
+  /** Slash-delimited path of the change. */
   path: string;
+  /** Exact path segments, e.g. `["value", "items", "0"]`. */
+  pathSegments?: string[];
   kind: ChangeKind;
   before?: unknown;
   after?: unknown;
+  /** Set when `before` is the annotation for a stored `undefined` value. */
+  beforeIsUndefined?: true;
+  /** Set when `after` is the annotation for a stored `undefined` value. */
+  afterIsUndefined?: true;
+  /** Set when different stored values have equal display annotations. */
+  annotationCollision?: true;
+  /** Stored value kind for `before` when display annotations collide. */
+  beforeValueKind?: StoredValueKind;
+  /** Stored value kind for `after` when display annotations collide. */
+  afterValueKind?: StoredValueKind;
+}
+
+/** A value change whose path is available as exact string segments. */
+export interface ExactValueChange extends ValueChange {
+  pathSegments: string[];
 }
 
 function isObj(v: unknown): v is Record<string, unknown> {
-  return typeof v === "object" && v !== null && !Array.isArray(v);
+  return isPlainObject(v);
 }
 
-// Canonical content key for leaf/subtree equality. Reuses the data-model's
-// fabric-aware hash (`hashStringOf`) rather than a hand-rolled sorted
-// `JSON.stringify`, which throws on BigInt and erases Fabric instances/symbols
-// — the exact value-model fork a debugger must not introduce.
+// The data-model hash defines equality for Fabric leaves, including BigInt,
+// symbols, and Fabric instances.
 function canonical(v: unknown): string {
   return v === undefined ? "undefined" : hashStringOf(v);
 }
 
+function storedValueKind(value: unknown): StoredValueKind {
+  if (value === null) return "null";
+  if (decodedLinkOf(value) !== null) return "link";
+  if (isStream(value)) return "stream";
+  if (parseEntityRef(value) !== null) return "reference";
+  if (Array.isArray(value)) return "array";
+  if (typeof value === "object") {
+    return isObj(value) ? "object" : "fabric";
+  }
+  return typeof value;
+}
+
+function valuesEqual(a: unknown, b: unknown): boolean {
+  const pending: [unknown, unknown][] = [[a, b]];
+  const compared = new WeakMap<object, WeakSet<object>>();
+  const alreadyCompared = (left: object, right: object): boolean => {
+    let rights = compared.get(left);
+    if (rights?.has(right)) return true;
+    if (rights === undefined) {
+      rights = new WeakSet<object>();
+      compared.set(left, rights);
+    }
+    rights.add(right);
+    return false;
+  };
+
+  while (pending.length > 0) {
+    const [left, right] = pending.pop()!;
+    if (Object.is(left, right)) continue;
+    if (Array.isArray(left) || Array.isArray(right)) {
+      if (
+        !Array.isArray(left) || !Array.isArray(right) ||
+        left.length !== right.length
+      ) {
+        return false;
+      }
+      const leftKeys = Object.keys(left);
+      const rightKeys = Object.keys(right);
+      if (leftKeys.length !== rightKeys.length) return false;
+      if (alreadyCompared(left, right)) continue;
+      for (const key of leftKeys) {
+        if (!Object.hasOwn(right, key)) return false;
+        pending.push([
+          (left as unknown as Record<string, unknown>)[key],
+          (right as unknown as Record<string, unknown>)[key],
+        ]);
+      }
+      continue;
+    }
+    const leftIsObject = isObj(left);
+    const rightIsObject = isObj(right);
+    if (leftIsObject || rightIsObject) {
+      if (!leftIsObject || !rightIsObject) return false;
+      const leftKeys = Object.keys(left);
+      const rightKeys = Object.keys(right);
+      if (leftKeys.length !== rightKeys.length) return false;
+      if (alreadyCompared(left, right)) continue;
+      for (const key of leftKeys) {
+        if (!Object.hasOwn(right, key)) return false;
+        pending.push([left[key], right[key]]);
+      }
+      continue;
+    }
+    if (canonical(left) !== canonical(right)) return false;
+  }
+  return true;
+}
+
+function beforeOutput(
+  value: unknown,
+): Pick<ValueChange, "before" | "beforeIsUndefined"> {
+  return {
+    before: annotate(value, COMPARE_DEPTH),
+    ...(value === undefined ? { beforeIsUndefined: true as const } : {}),
+  };
+}
+
+function afterOutput(
+  value: unknown,
+): Pick<ValueChange, "after" | "afterIsUndefined"> {
+  return {
+    after: annotate(value, COMPARE_DEPTH),
+    ...(value === undefined ? { afterIsUndefined: true as const } : {}),
+  };
+}
+
+function changedOutput(
+  before: unknown,
+  after: unknown,
+): Pick<
+  ValueChange,
+  | "before"
+  | "beforeIsUndefined"
+  | "after"
+  | "afterIsUndefined"
+  | "annotationCollision"
+  | "beforeValueKind"
+  | "afterValueKind"
+> {
+  const beforeFields = beforeOutput(before);
+  const afterFields = afterOutput(after);
+  const annotationCollision = valuesEqual(
+    beforeFields.before,
+    afterFields.after,
+  );
+  return {
+    ...beforeFields,
+    ...afterFields,
+    ...(annotationCollision
+      ? {
+        annotationCollision: true as const,
+        beforeValueKind: storedValueKind(before),
+        afterValueKind: storedValueKind(after),
+      }
+      : {}),
+  };
+}
+
+interface SelectedDiffValue {
+  present: boolean;
+  value: unknown;
+}
+
+function diffSelectedValues(
+  before: SelectedDiffValue,
+  after: SelectedDiffValue,
+  basePath: string[],
+  maxDepth: number,
+): ExactValueChange[] {
+  const out: ExactValueChange[] = [];
+  const walk = (
+    a: unknown,
+    b: unknown,
+    path: string[],
+    depth: number,
+    aPresent: boolean,
+    bPresent: boolean,
+  ) => {
+    const here = { path: path.join("/"), pathSegments: [...path] };
+    if (!aPresent && !bPresent) return;
+    if (!aPresent) {
+      out.push({ ...here, kind: "added", ...afterOutput(b) });
+      return;
+    }
+    if (!bPresent) {
+      out.push({ ...here, kind: "removed", ...beforeOutput(a) });
+      return;
+    }
+    if (valuesEqual(a, b)) return;
+    if (depth <= 0) {
+      out.push({
+        ...here,
+        kind: "changed",
+        ...changedOutput(a, b),
+      });
+      return;
+    }
+    if (isObj(a) && isObj(b)) {
+      for (const key of new Set([...Object.keys(a), ...Object.keys(b)])) {
+        const aHasKey = Object.hasOwn(a, key);
+        const bHasKey = Object.hasOwn(b, key);
+        walk(
+          aHasKey ? a[key] : undefined,
+          bHasKey ? b[key] : undefined,
+          [...path, key],
+          depth - 1,
+          aHasKey,
+          bHasKey,
+        );
+      }
+      return;
+    }
+    if (Array.isArray(a) && Array.isArray(b)) {
+      const aKeys = Object.keys(a);
+      const bKeys = Object.keys(b);
+      const aIndexes = aKeys.filter(isArrayIndexPropertyName);
+      const bIndexes = bKeys.filter(isArrayIndexPropertyName);
+      if (
+        a.length !== b.length &&
+        (aIndexes.length !== a.length || bIndexes.length !== b.length)
+      ) {
+        out.push({
+          ...here,
+          kind: "changed",
+          ...changedOutput(a, b),
+        });
+        return;
+      }
+      const keys = [...new Set([...aKeys, ...bKeys])].sort((left, right) => {
+        const leftIsIndex = isArrayIndexPropertyName(left);
+        const rightIsIndex = isArrayIndexPropertyName(right);
+        if (leftIsIndex && rightIsIndex) return Number(left) - Number(right);
+        if (leftIsIndex) return -1;
+        if (rightIsIndex) return 1;
+        return left < right ? -1 : left > right ? 1 : 0;
+      });
+      for (const key of keys) {
+        const aHasKey = Object.hasOwn(a, key);
+        const bHasKey = Object.hasOwn(b, key);
+        walk(
+          aHasKey ? (a as unknown as Record<string, unknown>)[key] : undefined,
+          bHasKey ? (b as unknown as Record<string, unknown>)[key] : undefined,
+          [...path, key],
+          depth - 1,
+          aHasKey,
+          bHasKey,
+        );
+      }
+      return;
+    }
+    out.push({
+      ...here,
+      kind: "changed",
+      ...changedOutput(a, b),
+    });
+  };
+  walk(
+    before.value,
+    after.value,
+    basePath,
+    maxDepth,
+    before.present,
+    after.present,
+  );
+  return out;
+}
+
 /**
- * Structural diff of two already-annotated values. Recurses through objects and
- * arrays; leaves compare by canonical JSON. `maxDepth` bounds recursion (deeper
- * differences collapse to a single `changed` at the boundary).
+ * Structurally diff two values. `maxDepth` bounds the reported path depth.
+ * Deeper differences collapse to a single `changed` entry at the boundary.
  */
 export function diffValues(
   before: unknown,
   after: unknown,
   basePath: string[] = [],
-  maxDepth = 12,
-): ValueChange[] {
-  const out: ValueChange[] = [];
-  const walk = (a: unknown, b: unknown, path: string[], depth: number) => {
-    const here = path.join("/");
-    // TODO(danfuzz): a fabric value reaches this walk only through
-    // `annotate()`, which renders it without its contents — so two
-    // different fabric values annotate alike, compare equal here, and the
-    // diff reports no change. Seeing a fabric change needs a
-    // contents-bearing rendering (the value-debug elision TODO) or a diff
-    // over the decoded values themselves.
-    if (canonical(a) === canonical(b)) return;
-    if (a === undefined) {
-      out.push({ path: here, kind: "added", after: b });
-      return;
-    }
-    if (b === undefined) {
-      out.push({ path: here, kind: "removed", before: a });
-      return;
-    }
-    if (depth <= 0) {
-      out.push({ path: here, kind: "changed", before: a, after: b });
-      return;
-    }
-    if (isObj(a) && isObj(b)) {
-      for (const k of new Set([...Object.keys(a), ...Object.keys(b)])) {
-        walk(a[k], b[k], [...path, k], depth - 1);
-      }
-      return;
-    }
-    if (Array.isArray(a) && Array.isArray(b)) {
-      const n = Math.max(a.length, b.length);
-      for (let i = 0; i < n; i++) {
-        walk(a[i], b[i], [...path, String(i)], depth - 1);
-      }
-      return;
-    }
-    out.push({ path: here, kind: "changed", before: a, after: b });
-  };
-  walk(before, after, basePath, maxDepth);
-  return out;
+  maxDepth = DEFAULT_DIFF_DEPTH,
+): ExactValueChange[] {
+  return diffSelectedValues(
+    { present: before !== undefined, value: before },
+    { present: after !== undefined, value: after },
+    basePath,
+    maxDepth,
+  );
 }
 
 export interface EntityDiff {
@@ -106,9 +339,16 @@ export interface EntityDiff {
   changes: ValueChange[];
 }
 
+/** An entity diff whose changes include exact path segments. */
+export interface ExactEntityDiff extends EntityDiff {
+  changes: ExactValueChange[];
+}
+
 /**
- * Diff an entity between two seqs. By default diffs the whole document (so
- * lineage/schema changes show too); pass a `path` to focus inside `value`.
+ * Diff an entity between two seqs. By default diffs `value`; pass `doc` to
+ * include the whole document or a `path` to focus within `value`.
+ *
+ * @throws {Error} When `doc` and `path` are both provided.
  */
 export function diffEntity(
   space: SpaceDb,
@@ -121,31 +361,41 @@ export function diffEntity(
     path?: string[];
     doc?: boolean;
   },
-): EntityDiff {
+): ExactEntityDiff {
+  if (opts.doc && opts.path !== undefined) {
+    throw new Error("`doc` and `path` cannot be used together.");
+  }
   const { id } = opts;
   const scope = opts.scope ?? "space";
   const branch = opts.branch ?? "";
   const path = opts.path ?? [];
   // `from` defaults to birth (seq 0 = empty baseline), NOT latest — omitting
   // atSeq would reconstruct the head, making a no-`--from` diff always empty.
-  // A decode failure on a corrupt row shouldn't crash the whole diff — treat an
-  // un-reconstructable side as absent (the diff then reports add/remove).
-  const safeReconstruct = (atSeq: number | undefined) => {
-    try {
-      return reconstructDocument(space, { id, scope, branch, atSeq });
-    } catch {
-      return undefined;
+  const before = reconstructDocument(space, {
+    id,
+    scope,
+    branch,
+    atSeq: opts.fromSeq ?? 0,
+  });
+  const after = reconstructDocument(space, {
+    id,
+    scope,
+    branch,
+    atSeq: opts.toSeq,
+  });
+  const pick = (doc: typeof before): SelectedDiffValue => {
+    if (doc === undefined) return { present: false, value: undefined };
+    if (opts.doc) {
+      return { present: true, value: doc };
     }
-  };
-  const before = safeReconstruct(opts.fromSeq ?? 0);
-  const after = safeReconstruct(opts.toSeq);
-  // Annotate DEEPLY for diffing: the default depth-8 cap would collapse two
-  // values that differ only deeper into a single `"…"`, silently dropping a real
-  // change. COMPARE_DEPTH is well past diffValues' own recursion bound.
-  const pick = (doc: typeof before) => {
-    if (doc === undefined) return undefined;
-    if (opts.doc) return annotate(doc, COMPARE_DEPTH);
-    return annotate(getAtPath(doc.value, path), COMPARE_DEPTH);
+    if (!Object.hasOwn(doc, "value")) {
+      return { present: false, value: undefined };
+    }
+    const selected = selectAtPath(doc.value, path);
+    return {
+      present: selected.found,
+      value: selected.value,
+    };
   };
   return {
     id,
@@ -153,7 +403,12 @@ export function diffEntity(
     toSeq: opts.toSeq ?? null,
     fromExists: before !== undefined,
     toExists: after !== undefined,
-    changes: diffValues(pick(before), pick(after)),
+    changes: diffSelectedValues(
+      pick(before),
+      pick(after),
+      [],
+      DEFAULT_DIFF_DEPTH,
+    ),
   };
 }
 
@@ -166,10 +421,16 @@ export interface TimelineStep {
   createdAt: string;
   /** One-line summary of the entity's value after this write. */
   summary: string;
-  /** Whether the entity exists after this write (false = delete tombstone). */
+  /** Whether the entity is known to exist after this write. */
   exists: boolean;
-  /** Number of value changes introduced by this write (vs the previous state). */
+  /** Number of changes from the preceding state. */
   changes: number;
+  /** Set when the preceding or current state could not be reconstructed. */
+  changesKnown?: false;
+  /** Set when the entity's state after this write could not be reconstructed. */
+  stateKnown?: false;
+  /** The reconstruction error, when this write could not establish state. */
+  error?: string;
 }
 
 /**
@@ -213,25 +474,52 @@ export function entityTimeline(
   // delete=tombstone (a later patch then starts from {}, as the engine does).
   const steps: TimelineStep[] = [];
   let doc: FabricValue | undefined = undefined;
-  let prevValue: unknown = undefined;
+  let stateKnown = true;
+  let previousValue: SelectedDiffValue = {
+    present: false,
+    value: undefined,
+  };
   for (const r of rows) {
-    let decodeErr: string | undefined;
-    try {
-      if (r.op === "set") {
-        doc = r.data ? (decodeStored(r.data) as FabricValue) : undefined;
-      } else if (r.op === "patch") {
-        const ops = r.data ? (decodeStored(r.data) as PatchOp[]) : [];
-        doc = applyPatch(doc ?? {}, ops);
-      } else if (r.op === "delete") {
+    const previousStateKnown = stateKnown;
+    let reconstructionError: string | undefined;
+    if (r.op === "patch" && !stateKnown) {
+      reconstructionError =
+        "State remains unknown because an earlier write could not be reconstructed.";
+    } else {
+      try {
+        if (r.op === "set") {
+          doc = r.data ? (decodeStored(r.data) as FabricValue) : undefined;
+          stateKnown = true;
+        } else if (r.op === "patch") {
+          const ops = r.data ? (decodeStored(r.data) as PatchOp[]) : [];
+          doc = applyPatch(doc ?? {}, ops);
+          stateKnown = true;
+        } else if (r.op === "delete") {
+          doc = undefined;
+          stateKnown = true;
+        } else {
+          throw new Error(`Unsupported revision operation: ${r.op}`);
+        }
+      } catch (e) {
+        reconstructionError = (e as Error).message;
         doc = undefined;
+        stateKnown = false;
       }
-    } catch (e) {
-      decodeErr = (e as Error).message; // one bad row doesn't abort the timeline
     }
-    const exists = doc !== undefined && !decodeErr;
-    const docValue = exists ? (doc as { value?: unknown }).value : undefined;
-    const value = exists ? annotate(docValue, COMPARE_DEPTH) : undefined;
-    const changes = diffValues(prevValue, value).length;
+    const exists = stateKnown && doc !== undefined;
+    const hasValue = exists && typeof doc === "object" && doc !== null &&
+      Object.hasOwn(doc, "value");
+    const docValue = hasValue ? (doc as { value: unknown }).value : undefined;
+    const value = { present: hasValue, value: docValue };
+    const changesKnown = previousStateKnown && stateKnown;
+    const changes = changesKnown
+      ? diffSelectedValues(
+        previousValue,
+        value,
+        [],
+        DEFAULT_DIFF_DEPTH,
+      ).length
+      : 0;
     steps.push({
       seq: r.seq,
       opIndex: r.op_index,
@@ -239,15 +527,18 @@ export function entityTimeline(
       commitSeq: r.commit_seq,
       session: r.session_id,
       createdAt: r.created_at,
-      summary: decodeErr
-        ? `«decode-error: ${decodeErr}»`
+      summary: reconstructionError
+        ? `«unknown: ${escapeTerminalText(reconstructionError)}»`
         : exists
         ? summarize(docValue)
         : "(deleted)",
       exists,
       changes,
+      ...(!changesKnown ? { changesKnown: false as const } : {}),
+      ...(!stateKnown ? { stateKnown: false as const } : {}),
+      ...(reconstructionError ? { error: reconstructionError } : {}),
     });
-    prevValue = value;
+    if (stateKnown) previousValue = value;
   }
   return steps;
 }

--- a/packages/state-inspector/timetravel.ts
+++ b/packages/state-inspector/timetravel.ts
@@ -349,6 +349,7 @@ export interface ExactEntityDiff extends EntityDiff {
  * include the whole document or a `path` to focus within `value`.
  *
  * @throws {Error} When `doc` and `path` are both provided.
+ * @throws {Error} When either selected document cannot be reconstructed.
  */
 export function diffEntity(
   space: SpaceDb,


### PR DESCRIPTION
Inspector paths previously used slash-delimited strings for both input and output. Keys containing slashes or empty strings became ambiguous, missing properties could be confused with stored undefined values, and malformed path options could reach database or remote operations before being rejected.

Add exact JSON path segments across the standalone and public command surfaces. Preserve property presence through reconstruction, value selection, diffs, convergence clustering, scope overlays, and rendered output. Validate conflicting, empty, and malformed selectors before any local or remote access.

Keep the published result shapes available for existing callers. Add exact result types and producers for exact path segments and unknown convergence states. Timeline reconstruction now remains unknown after a corrupt row until a complete set or delete establishes state again.

Cover ambiguous keys, empty segments, array indexes, missing values, public parser ordering, reconstruction failures, timeline recovery, and legacy type compatibility.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

