### PR TITLE
fix(ui): target nested pieces in the context menu

### DIFF
--- a/docs/common/components/COMPONENTS.md
+++ b/docs/common/components/COMPONENTS.md
@@ -468,7 +468,10 @@ provenance will refuse them.
 
 The menu comes with `cf-render`. Importing the component registers it. It mounts
 itself on `document.body` so a piece's clipping or a tile's scaling cannot reach
-it.
+it. While the menu or one of its panels is open, the addressed piece carries an
+animated light sweep and soft color glow. The visual layer sits over the piece,
+does not receive pointer events, and does not change its size or layout. The
+menu closes if that renderer disconnects or begins showing another piece.
 
 The innermost rendered piece claims the click, so right-clicking a tile inside a
 piece addresses the tile. Three cases keep the browser's own menu instead: a

--- a/docs/features/host-embedding.md
+++ b/docs/features/host-embedding.md
@@ -176,6 +176,17 @@ The menu mounts itself on `document.body`, not inside the piece, because a piece
 own `overflow: hidden` would clip it and the tile variant's
 `transform: scale(0.5)` would shrink it; it copies the `--cf-theme-*` tokens
 across from the element that opened it, so it follows the host's theme.
+While the built-in menu or one of its panels is open, the originating
+`cf-render` shows an animated light sweep and color glow. This visual layer does
+not receive pointer events or affect layout. Closing the menu removes it, and
+opening the shared menu for another piece moves it to that piece. The menu also
+closes if its originating renderer disconnects or begins showing another piece.
+When patterns render other patterns directly, their output shares the outer
+`cf-render` instead of adding a wrapper. The renderer retains each nested
+pattern's result cell on its existing root element through the same standard
+element context protocol used for producing-space inheritance. A right-click
+selects the deepest such root in the click path, and the portalled visual layer
+clips its shine to that root. No element is inserted into the pattern's layout.
 
 Before the menu opens, `cf-render` announces the click. The event is
 **cancellable, and cancelling it takes the click**: the built-in menu does not
@@ -185,9 +196,9 @@ BUBBLES from the DOM (`bubbles`, `composed`), so a host may listen on its mount
 container or on `globalThis`.
 
 Every `cf-render` variant resolves a link-valued cell to the piece it displays
-before it chooses the menu target. This includes nested pieces rendered with the
-full variant. The renderer observes the link itself and resolves again when its
-target changes.
+before it chooses the menu target. A directly rendered nested pattern is a full
+variant, even when its containing renderer uses another variant. The renderer
+observes the link itself and resolves again when its target changes.
 
 ```ts
 import type { DID } from "@commonfabric/identity";

--- a/packages/html/src/client.ts
+++ b/packages/html/src/client.ts
@@ -1,2 +1,7 @@
 export { render, type RenderOptions } from "./render.ts";
 export { type SetPropHandler } from "./render-utils.ts";
+export {
+  getPieceBoundary,
+  type PieceBoundaryContext,
+  subscribePieceBoundary,
+} from "./main/space-context.ts";

--- a/packages/html/src/main/applicator.ts
+++ b/packages/html/src/main/applicator.ts
@@ -13,7 +13,11 @@ import type { VDomBatch, VDomOp } from "../vdom-ops.ts";
 import { CellHandle, cellRefToKey } from "@commonfabric/runtime-client";
 import { setPropDefault, type SetPropHandler } from "../render-utils.ts";
 import { getLogger } from "@commonfabric/utils/logger";
-import { provideElementSpace } from "./space-context.ts";
+import {
+  clearPieceBoundary,
+  provideElementSpace,
+  providePieceBoundary,
+} from "./space-context.ts";
 
 const logger = getLogger("vdom-applicator", { enabled: false, level: "debug" });
 
@@ -122,7 +126,6 @@ export class DomApplicator {
     if (batch.rootId !== undefined) {
       this.rootNodeId = batch.rootId;
     }
-
     const elapsed = logger.timeEnd("apply-batch");
     logger.debug("apply-batch", () => [
       `Applied ${opCount} ops in ${elapsed?.toFixed(2)}ms`,
@@ -167,6 +170,14 @@ export class DomApplicator {
 
       case "set-binding":
         this.setBinding(op.nodeId, op.propName, op.cellRef);
+        break;
+
+      case "set-piece-boundary":
+        this.setPieceBoundary(op.nodeId, op.cellRef);
+        break;
+
+      case "clear-piece-boundary":
+        this.clearPieceBoundary(op.nodeId);
         break;
 
       case "insert-child":
@@ -229,6 +240,7 @@ export class DomApplicator {
     // Remove all nodes except the container (it's owned by the caller)
     for (const [nodeId, node] of this.nodes) {
       if (nodeId === CONTAINER_NODE_ID) continue;
+      if (isElementNode(node)) clearPieceBoundary(node);
       if (
         node.parentNode &&
         typeof (node.parentNode as ParentNode & { removeChild?: unknown })
@@ -416,6 +428,17 @@ export class DomApplicator {
     this.notifyBoundProperty(node, propName);
   }
 
+  private setPieceBoundary(nodeId: number, cellRef: CellRef): void {
+    const node = this.nodes.get(nodeId);
+    if (!isElementNode(node) || !this.runtimeClient) return;
+    providePieceBoundary(node, new CellHandle(this.runtimeClient, cellRef));
+  }
+
+  private clearPieceBoundary(nodeId: number): void {
+    const node = this.nodes.get(nodeId);
+    if (isElementNode(node)) clearPieceBoundary(node);
+  }
+
   private notifyBoundProperty(
     node: HTMLElement,
     propName: string,
@@ -549,6 +572,8 @@ export class DomApplicator {
       this.eventListeners.delete(nodeId);
     }
 
+    if (isElementNode(node)) clearPieceBoundary(node);
+
     // Remove from DOM
     if (node.parentNode) {
       node.parentNode.removeChild(node);
@@ -592,6 +617,8 @@ export class DomApplicator {
 
       // Clean up this child
       const childNode = this.nodes.get(childId);
+
+      if (isElementNode(childNode)) clearPieceBoundary(childNode);
 
       // Remove event listeners
       const listeners = this.eventListeners.get(childId);

--- a/packages/html/src/main/mod.ts
+++ b/packages/html/src/main/mod.ts
@@ -9,7 +9,15 @@ export { DomApplicator } from "./applicator.ts";
 export type { DomApplicatorOptions } from "./applicator.ts";
 
 export { VDomRenderer } from "./renderer.ts";
-export { provideElementSpace, SPACE_CONTEXT_KEY } from "./space-context.ts";
+export {
+  clearPieceBoundary,
+  getPieceBoundary,
+  type PieceBoundaryContext,
+  provideElementSpace,
+  providePieceBoundary,
+  SPACE_CONTEXT_KEY,
+  subscribePieceBoundary,
+} from "./space-context.ts";
 export type { VDomRendererOptions } from "./renderer.ts";
 
 export {

--- a/packages/html/src/main/space-context.ts
+++ b/packages/html/src/main/space-context.ts
@@ -1,34 +1,137 @@
-/**
- * The element-level "space" context: the worker reconciler stamps each
- * create-element op with the space of the cell whose render produced it
- * (elided when the parent's matches), and the applicator answers the
- * standard context-request protocol for it here — dependency-free.
- *
- * The KEY is the string "space": @lit/context's createContext returns
- * its key argument verbatim, so consumers built with
- * createContext("space") (e.g. @commonfabric/ui's spaceContext) match
- * this provider by value with no shared import. Nearest provider wins
- * by event propagation, which is exactly right for cross-space
- * transclusion: a transcluded subtree's boundary element answers
- * before any outer piece or view provider.
- */
+/** Element-level render contexts supplied through the standard protocol. */
+
+import type { CellHandle } from "@commonfabric/runtime-client";
+
 export const SPACE_CONTEXT_KEY = "space";
+const PIECE_BOUNDARY_CONTEXT_KEY = Symbol("commonfabric-piece-boundary");
+
+export interface PieceBoundaryContext {
+  cell: CellHandle;
+  element: Element;
+}
 
 type ContextRequestEvent = Event & {
   context: unknown;
-  callback: (value: string | undefined, unsubscribe?: () => void) => void;
+  callback: (value: unknown, unsubscribe?: () => void) => void;
   subscribe?: boolean;
+  accept?: (value: PieceBoundaryContext) => boolean;
 };
 
-export function provideElementSpace(element: EventTarget, space: string) {
+interface ElementContextState {
+  space?: string;
+  piece?: PieceBoundaryContext;
+  pieceChanges?: EventTarget;
+}
+
+const elementContexts = new WeakMap<EventTarget, ElementContextState>();
+
+function ensureElementContext(element: EventTarget): ElementContextState {
+  const existing = elementContexts.get(element);
+  if (existing) return existing;
+
+  const state: ElementContextState = {};
+  elementContexts.set(element, state);
   element.addEventListener("context-request", (event) => {
     const request = event as ContextRequestEvent;
-    if (request.context !== SPACE_CONTEXT_KEY) return;
     if (typeof request.callback !== "function") return;
+
+    if (request.context === SPACE_CONTEXT_KEY && state.space !== undefined) {
+      event.stopPropagation();
+      request.callback(state.space, () => {});
+      return;
+    }
+
+    if (
+      request.context !== PIECE_BOUNDARY_CONTEXT_KEY || !state.piece ||
+      (request.accept && !request.accept(state.piece))
+    ) return;
     event.stopPropagation();
-    // The value is fixed for the element's lifetime (the reconciler
-    // replaces the element when its producing cell changes spaces), so
-    // a single callback satisfies both one-shot and subscribe modes.
-    request.callback(space, () => {});
+    if (request.subscribe) {
+      const changes = state.pieceChanges ??= new EventTarget();
+      const notify = () => request.callback(state.piece);
+      changes.addEventListener("change", notify);
+      request.callback(
+        state.piece,
+        () => changes.removeEventListener("change", notify),
+      );
+    } else {
+      request.callback(state.piece);
+    }
   });
+  return state;
+}
+
+/**
+ * Provide the producing space at a render boundary. The string key matches
+ * `createContext("space")` consumers without a shared import.
+ */
+export function provideElementSpace(element: EventTarget, space: string) {
+  ensureElementContext(element).space = space;
+}
+
+/** Provide the piece whose UI begins at an existing render root element. */
+export function providePieceBoundary(element: Element, cell: CellHandle): void {
+  const state = ensureElementContext(element);
+  if (state.piece?.cell.equals(cell)) return;
+  state.piece = { cell, element };
+  state.pieceChanges?.dispatchEvent(new Event("change"));
+}
+
+/** Clear a piece boundary while leaving other element contexts intact. */
+export function clearPieceBoundary(element: Element): void {
+  const state = elementContexts.get(element);
+  if (!state?.piece) return;
+  state.piece = undefined;
+  state.pieceChanges?.dispatchEvent(new Event("change"));
+}
+
+function dispatchPieceBoundaryRequest(
+  target: unknown,
+  callback: ContextRequestEvent["callback"],
+  subscribe = false,
+  accept?: ContextRequestEvent["accept"],
+): void {
+  if (
+    !target || typeof target !== "object" || !("dispatchEvent" in target) ||
+    typeof target.dispatchEvent !== "function"
+  ) return;
+  const event = Object.assign(
+    new Event("context-request", { bubbles: true, composed: true }),
+    { context: PIECE_BOUNDARY_CONTEXT_KEY, callback, subscribe, accept },
+  );
+  target.dispatchEvent(event);
+}
+
+/** Get the nearest piece boundary provided by an element or its ancestors. */
+export function getPieceBoundary(
+  target: unknown,
+  accept?: (piece: PieceBoundaryContext) => boolean,
+): PieceBoundaryContext | undefined {
+  let result: PieceBoundaryContext | undefined;
+  dispatchPieceBoundaryRequest(
+    target,
+    (value) => {
+      result = value as PieceBoundaryContext;
+    },
+    false,
+    accept,
+  );
+  return result;
+}
+
+/** Subscribe to changes from the nearest current piece boundary. */
+export function subscribePieceBoundary(
+  target: unknown,
+  callback: (piece: PieceBoundaryContext | undefined) => void,
+): () => void {
+  let unsubscribe = () => {};
+  dispatchPieceBoundaryRequest(
+    target,
+    (value, dispose) => {
+      if (dispose) unsubscribe = dispose;
+      callback(value as PieceBoundaryContext | undefined);
+    },
+    true,
+  );
+  return () => unsubscribe();
 }

--- a/packages/html/src/vdom-ops.ts
+++ b/packages/html/src/vdom-ops.ts
@@ -93,6 +93,19 @@ export interface SetBindingOp {
   cellRef: CellRef;
 }
 
+/** Associate a rendered nested pattern root with its whole result cell. */
+export interface SetPieceBoundaryOp {
+  op: "set-piece-boundary";
+  nodeId: number;
+  cellRef: CellRef;
+}
+
+/** Remove a nested pattern association from a reused root element. */
+export interface ClearPieceBoundaryOp {
+  op: "clear-piece-boundary";
+  nodeId: number;
+}
+
 /**
  * Insert a child node into a parent.
  * If beforeId is null, appends to the end.
@@ -124,6 +137,8 @@ export type VDomOp =
   | SetEventOp
   | RemoveEventOp
   | SetBindingOp
+  | SetPieceBoundaryOp
+  | ClearPieceBoundaryOp
   | InsertChildOp
   | RemoveNodeOp;
 

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -89,6 +89,23 @@ const TEXT_INTEGRITY_PROP_SINKS: ReadonlyMap<string, ReadonlySet<string>> =
   new Map([
     ["cf-chat-message", new Set(["name", "content"])],
   ]);
+
+function isNestedPatternOutput(value: unknown, cell: Cell<unknown>): boolean {
+  if (
+    typeof value !== "object" || value === null || !(UI in value) ||
+    !(value as Record<PropertyKey, unknown>)[UI]
+  ) return false;
+
+  try {
+    const patternIdentity = cell.getMetaRaw("patternIdentity");
+    return typeof patternIdentity === "object" && patternIdentity !== null &&
+      typeof (patternIdentity as Record<string, unknown>).identity ===
+        "string" &&
+      typeof (patternIdentity as Record<string, unknown>).symbol === "string";
+  } catch {
+    return false;
+  }
+}
 // Props whose live DOM value can drift from the authored VDOM value
 // independently of any worker-side change — user input (`value`), scrolling
 // (`scrollTop`/`scrollLeft`), or browser / custom-element state (`checked`,
@@ -758,6 +775,40 @@ export class WorkerReconciler {
       propName,
       cellRef: this.cellRefForBinding(cell),
     }];
+  }
+
+  /** Keep the nested pattern's whole result cell on its existing root node. */
+  private updatePieceBoundary(
+    childState: ChildNodeState,
+    resolvedChild: unknown,
+    resultCell: Cell<unknown>,
+  ): void {
+    const shouldBind = isNestedPatternOutput(resolvedChild, resultCell);
+    if (!childState.elementState) return;
+
+    if (shouldBind) {
+      childState.hasPieceBoundary = true;
+      this.queueOps([{
+        op: "set-piece-boundary",
+        nodeId: childState.elementState.nodeId,
+        cellRef: this.cellRefForBinding(resultCell),
+      }]);
+    } else if (childState.hasPieceBoundary) {
+      childState.hasPieceBoundary = false;
+      this.queueOps([{
+        op: "clear-piece-boundary",
+        nodeId: childState.elementState.nodeId,
+      }]);
+    }
+  }
+
+  /** Follow a link-valued child to the result cell whose UI is rendered. */
+  private resolveCellForBinding(cell: Cell<unknown>): Cell<unknown> {
+    try {
+      return cell.resolveAsCell();
+    } catch {
+      return cell;
+    }
   }
 
   private cellRefForBinding(cell: Cell<unknown>): CellRef {
@@ -3487,9 +3538,15 @@ export class WorkerReconciler {
       isText: false,
       cancel,
       cell,
+      hasPieceBoundary: false,
     };
 
     let currentCancel: Cancel | undefined;
+    let currentContentState:
+      | "rendered"
+      | "policy-blocked"
+      | "integrity-blocked"
+      | undefined;
 
     // §4.9.3 Stage 2: on each render, watch the ACL docs of the spaces this
     // cell is labeled with, so a fail-closed over-block upgrades to an admit
@@ -3499,16 +3556,11 @@ export class WorkerReconciler {
 
     const renderResolved = (resolvedChild: unknown, forced = false) => {
       const isInitialRender = childState.nodeId === -1;
-
-      // Dedupe updates. A forced re-eval (an ACL sync/change) bypasses the
-      // value-identity check: the value is unchanged but the render DECISION
-      // may have flipped.
-      if (
-        !forced && !isInitialRender &&
-        Object.is(resolvedChild, childState.currentValue)
-      ) {
-        return;
-      }
+      const resultCell = this.resolveCellForBinding(cell);
+      const valueUnchanged = Object.is(
+        resolvedChild,
+        childState.currentValue,
+      );
       childState.currentValue = resolvedChild;
       this.watchCellMembership(
         cell,
@@ -3516,8 +3568,31 @@ export class WorkerReconciler {
         addCancel,
         () => renderResolved(childState.currentValue, true),
       );
+      const blockedByPolicy = !this.canRenderCellUnderPolicy(cell, policy);
+      const blockedByIntegrity = !blockedByPolicy &&
+        this.shouldBlockTextFromCell(resolvedChild, cell, policy);
 
-      if (!this.canRenderCellUnderPolicy(cell, policy)) {
+      if (
+        !forced && !isInitialRender && valueUnchanged
+      ) {
+        if (blockedByPolicy && currentContentState === "policy-blocked") {
+          return;
+        }
+        if (
+          blockedByIntegrity && currentContentState === "integrity-blocked"
+        ) {
+          return;
+        }
+        if (
+          !blockedByPolicy && !blockedByIntegrity &&
+          currentContentState === "rendered"
+        ) {
+          this.updatePieceBoundary(childState, resolvedChild, resultCell);
+          return;
+        }
+      }
+
+      if (blockedByPolicy) {
         if (!isInitialRender) {
           if (currentCancel) {
             currentCancel();
@@ -3530,12 +3605,14 @@ export class WorkerReconciler {
         childState.nodeId = -1;
         childState.elementState = undefined;
         childState.isText = false;
+        childState.hasPieceBoundary = false;
 
         const blockedState = this.createBlockedPlaceholder(ctx, policy);
         childState.nodeId = blockedState.nodeId;
         childState.elementState = blockedState;
         childState.isText = false;
         currentCancel = blockedState.cancel;
+        currentContentState = "policy-blocked";
 
         const beforeId = this.findNextSiblingId(
           parentState.children,
@@ -3550,7 +3627,7 @@ export class WorkerReconciler {
         return;
       }
 
-      if (this.shouldBlockTextFromCell(resolvedChild, cell, policy)) {
+      if (blockedByIntegrity) {
         if (!isInitialRender) {
           if (currentCancel) {
             currentCancel();
@@ -3563,6 +3640,7 @@ export class WorkerReconciler {
         childState.nodeId = -1;
         childState.elementState = undefined;
         childState.isText = false;
+        childState.hasPieceBoundary = false;
 
         const blockedState = this.createBlockedPlaceholder(
           ctx,
@@ -3573,6 +3651,7 @@ export class WorkerReconciler {
         childState.elementState = blockedState;
         childState.isText = false;
         currentCancel = blockedState.cancel;
+        currentContentState = "integrity-blocked";
 
         const beforeId = this.findNextSiblingId(
           parentState.children,
@@ -3607,7 +3686,9 @@ export class WorkerReconciler {
         }
 
         // Case 2: VNode in-place update (same tag)
-        if (childState.elementState) {
+        if (
+          childState.elementState && currentContentState === "rendered"
+        ) {
           const newVNode = this.extractVNode(
             resolvedChild as WorkerRenderNode,
           );
@@ -3638,6 +3719,7 @@ export class WorkerReconciler {
                 policyChildren.blocked;
               childState.elementState.sourceChildren = sanitized.children;
               childState.elementState.sourceProps = sanitized.props;
+              this.updatePieceBoundary(childState, resolvedChild, resultCell);
               // Same tag - update props in place
               this.updatePropsInPlace(
                 ctx,
@@ -3697,6 +3779,8 @@ export class WorkerReconciler {
       childState.nodeId = -1;
       childState.elementState = undefined;
       childState.isText = false;
+      childState.hasPieceBoundary = false;
+      currentContentState = undefined;
 
       if (resolvedChild === null || resolvedChild === undefined) {
         return;
@@ -3730,6 +3814,8 @@ export class WorkerReconciler {
         childState.elementState = newState.elementState;
         childState.isText = newState.isText;
         currentCancel = newState.cancel;
+        currentContentState = "rendered";
+        this.updatePieceBoundary(childState, resolvedChild, resultCell);
 
         // Always insert the child into its parent. On initial render,
         // updateChildren also emits insert-child but may see nodeId=-1

--- a/packages/html/src/worker/types.ts
+++ b/packages/html/src/worker/types.ts
@@ -210,6 +210,9 @@ export interface ChildNodeState {
 
   /** Source cell for reactive child nodes; used to decide same-key reuse. */
   cell?: Cell<unknown>;
+
+  /** Whether this element provides a piece boundary to its descendants. */
+  hasPieceBoundary?: boolean;
 }
 
 /**

--- a/packages/html/test/main-applicator.test.ts
+++ b/packages/html/test/main-applicator.test.ts
@@ -15,6 +15,7 @@ import { DomApplicator } from "../src/main/applicator.ts";
 import type { DomEventMessage } from "../src/main/events.ts";
 import type { VDomBatch } from "../src/vdom-ops.ts";
 import { $conn, type CellRef } from "@commonfabric/runtime-client";
+import { getPieceBoundary } from "../src/main/space-context.ts";
 
 // Mock RuntimeClient for testing
 const createMockRuntimeClient = () => {
@@ -871,6 +872,61 @@ Deno.test("DomApplicator - cell bindings", async (t) => {
 
     assertNotStrictEquals(node.cell, firstHandle);
   });
+
+  await t.step(
+    "keeps a nested pattern binding out of authored properties",
+    () => {
+      const doc = createMockDocument();
+      const applicator = new DomApplicator({
+        document: doc,
+        runtimeClient: createMockRuntimeClient(),
+        onEvent: () => {},
+      });
+
+      applicator.applyBatch({
+        batchId: 1,
+        ops: [
+          { op: "create-element", nodeId: 1, tagName: "section" },
+          { op: "set-piece-boundary", nodeId: 1, cellRef },
+        ],
+      });
+
+      const node = applicator.getNode(1) as Element & Record<string, unknown>;
+      assertExists(getPieceBoundary(node));
+
+      applicator.applyBatch({
+        batchId: 2,
+        ops: [{ op: "clear-piece-boundary", nodeId: 1 }],
+      });
+      assertEquals(getPieceBoundary(node), undefined);
+
+      applicator.applyBatch({
+        batchId: 3,
+        ops: [{
+          op: "set-binding",
+          nodeId: 1,
+          propName: "__commonFabricPieceBoundary",
+          cellRef,
+        }],
+      });
+      assertEquals(
+        getPieceBoundary(node),
+        undefined,
+        "authored bindings cannot create a trusted nested pattern boundary",
+      );
+
+      applicator.applyBatch({
+        batchId: 4,
+        ops: [{ op: "set-piece-boundary", nodeId: 1, cellRef }],
+      });
+      assertExists(getPieceBoundary(node));
+      applicator.applyBatch({
+        batchId: 5,
+        ops: [{ op: "remove-node", nodeId: 1 }],
+      });
+      assertEquals(getPieceBoundary(node), undefined);
+    },
+  );
 });
 
 Deno.test("DomApplicator - batch with rootId", async (t) => {

--- a/packages/html/test/worker-reconciler-cell-child.test.ts
+++ b/packages/html/test/worker-reconciler-cell-child.test.ts
@@ -1389,7 +1389,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
   );
 
   await t.step(
-    "updates same-key subpattern UI payloads without reinserting",
+    "updates same-key subpatterns and retargets unchanged UI",
     async () => {
       const collector = createOpsCollector();
       const reconciler = new WorkerReconciler({
@@ -1403,14 +1403,36 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
         [UI]: node,
       } as unknown as WorkerRenderNode);
 
-      const outputCell = new MockCell(
-        subpatternOutput({
-          type: "vnode",
-          name: "span",
-          props: { "data-row": "same", "data-count": "1" },
-          children: ["one"],
+      const initialOutput = subpatternOutput({
+        type: "vnode",
+        name: "span",
+        props: { "data-row": "same", "data-count": "1" },
+        children: ["one"],
+      });
+      const outputCell = new MockCell(initialOutput);
+      let resolvedOutputId = "of:fid1:nested-pattern";
+      outputCell.getAsNormalizedFullLink = () => ({
+        id: "of:fid1:stable-link-container",
+        space: signer.did(),
+        path: [],
+        scope: "space",
+      });
+      const resolvedOutputCell = {
+        getAsNormalizedFullLink: () => ({
+          id: resolvedOutputId,
+          space: signer.did(),
+          path: [],
+          scope: "space",
         }),
-      );
+        resolveAsCell() {
+          return this;
+        },
+        getMetaRaw: (field: string) =>
+          field === "patternIdentity"
+            ? { identity: "nested-pattern", symbol: "default" }
+            : undefined,
+      } as unknown as Cell<unknown>;
+      outputCell.resolveAsCell = () => resolvedOutputCell;
 
       const rootCell = new MockCell(
         {
@@ -1431,7 +1453,42 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
         throw new Error("Expected initial span to be created");
       }
       const spanNodeId = spanCreate.nodeId;
+      const nestedPatternBinding = collector.getOps().find((op) =>
+        op.op === "set-piece-boundary" && op.nodeId === spanNodeId
+      );
+      assertEquals(
+        nestedPatternBinding && "cellRef" in nestedPatternBinding
+          ? nestedPatternBinding.cellRef.id
+          : undefined,
+        "of:fid1:nested-pattern",
+        "nested pattern root should carry its whole result cell",
+      );
       collector.clear();
+
+      resolvedOutputId = "of:fid1:retargeted-with-same-ui";
+      outputCell.set(initialOutput);
+      await t.settle();
+
+      const unchangedUiBinding = collector.getOps().find((op) =>
+        op.op === "set-piece-boundary" && op.nodeId === spanNodeId
+      );
+      assertEquals(
+        unchangedUiBinding && "cellRef" in unchangedUiBinding
+          ? unchangedUiBinding.cellRef.id
+          : undefined,
+        "of:fid1:retargeted-with-same-ui",
+        "an unchanged UI object should still follow a changed result cell",
+      );
+      assertEquals(
+        collector.getOps().some((op) =>
+          op.op === "create-element" || op.op === "remove-node"
+        ),
+        false,
+        "retargeting unchanged UI should keep its existing element",
+      );
+
+      collector.clear();
+      resolvedOutputId = "of:fid1:retargeted-nested-pattern";
 
       outputCell.set(
         subpatternOutput({
@@ -1442,6 +1499,17 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
         }),
       );
       await t.settle();
+
+      const retargetedBinding = collector.getOps().find((op) =>
+        op.op === "set-piece-boundary" && op.nodeId === spanNodeId
+      );
+      assertEquals(
+        retargetedBinding && "cellRef" in retargetedBinding
+          ? retargetedBinding.cellRef.id
+          : undefined,
+        "of:fid1:retargeted-nested-pattern",
+        "a reused pattern root should follow a changed result-cell target",
+      );
 
       assertEquals(
         collector.getOpsOfType("create-element").some((op) =>
@@ -1472,6 +1540,100 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
         ),
         true,
         "same-key child text should update",
+      );
+
+      collector.clear();
+      outputCell.set(
+        {
+          type: "vnode",
+          name: "span",
+          props: { "data-row": "plain" },
+          children: ["plain vnode"],
+        } satisfies WorkerVNode,
+      );
+      await t.settle();
+      assertEquals(
+        collector.getOps().some((op) =>
+          op.op === "clear-piece-boundary" && op.nodeId === spanNodeId
+        ),
+        true,
+        "the marker should leave a reused root when it stops being a pattern",
+      );
+
+      const blockedCandidate = subpatternOutput({
+        type: "vnode",
+        name: "cf-cfc-blocked",
+        props: { "data-row": "blocked" },
+        children: ["blocked"],
+      });
+      const deniedOutputId = "of:fid1:retargeted-to-blocked";
+      (reconciler as unknown as {
+        canRenderCellUnderPolicy: () => boolean;
+      }).canRenderCellUnderPolicy = () => resolvedOutputId !== deniedOutputId;
+      resolvedOutputId = deniedOutputId;
+      outputCell.set(blockedCandidate);
+      await t.settle();
+
+      resolvedOutputId = "of:fid1:allowed-after-block";
+      outputCell.set(blockedCandidate);
+      await t.settle();
+      collector.clear();
+
+      resolvedOutputId = deniedOutputId;
+      outputCell.set(blockedCandidate);
+      await t.settle();
+
+      assertEquals(
+        collector.hasOp("set-piece-boundary"),
+        false,
+        "a blocked placeholder should not carry the hidden piece boundary",
+      );
+      assertEquals(
+        collector.getOpsOfType("set-prop").some((op) =>
+          "key" in op && op.key === "data-cfc-blocked" &&
+          "value" in op && op.value === "true"
+        ),
+        true,
+        "a same-UI retarget should still re-run the render policy",
+      );
+    },
+  );
+
+  await t.step(
+    "does not mark an ordinary UI-shaped computed cell as a piece",
+    async () => {
+      const collector = createOpsCollector();
+      const reconciler = new WorkerReconciler({ onOps: collector.onOps });
+      const uiShapedDataCell = new MockCell({
+        [UI]: {
+          type: "vnode",
+          name: "span",
+          props: {},
+          children: ["ordinary data"],
+        },
+      });
+      uiShapedDataCell.getAsNormalizedFullLink = () => ({
+        id: "of:fid1:ordinary-ui-shaped-data",
+        space: signer.did(),
+        path: [],
+        scope: "space",
+      });
+      uiShapedDataCell.resolveAsCell = () => uiShapedDataCell;
+      uiShapedDataCell.getMetaRaw = () => undefined;
+      const rootCell = new MockCell({
+        type: "vnode",
+        name: "div",
+        props: {},
+        children: [uiShapedDataCell],
+      } as unknown as WorkerVNode);
+
+      reconciler.mount(rootCell as unknown as Cell<unknown>);
+      await t.settle();
+
+      assertEquals(
+        collector.hasOp("set-piece-boundary"),
+        false,
+        "UI-shaped data without pattern provenance is not a piece",
       );
     },
   );

--- a/packages/html/test/worker-reconciler-space-stamp.test.ts
+++ b/packages/html/test/worker-reconciler-space-stamp.test.ts
@@ -1,7 +1,14 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertStrictEquals } from "@std/assert";
 import { WorkerReconciler } from "../src/worker/reconciler.ts";
 import type { VDomOp } from "../src/vdom-ops.ts";
-import { provideElementSpace } from "../src/main/space-context.ts";
+import {
+  clearPieceBoundary,
+  getPieceBoundary,
+  provideElementSpace,
+  providePieceBoundary,
+  subscribePieceBoundary,
+} from "../src/main/space-context.ts";
+import type { CellHandle } from "@commonfabric/runtime-client";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "@commonfabric/runner";
@@ -120,7 +127,7 @@ Deno.test("worker reconciler - space stamping across transclusion", async (t) =>
   await storageManager.close();
 });
 
-Deno.test("provideElementSpace answers the context protocol for 'space'", () => {
+Deno.test("element render contexts share the standard context protocol", () => {
   const target = new EventTarget();
   provideElementSpace(target, "did:key:z6Mk-ctx");
   let received: string | undefined;
@@ -153,4 +160,20 @@ Deno.test("provideElementSpace answers the context protocol for 'space'", () => 
   });
   target.dispatchEvent(other);
   assertEquals(otherAnswered, false);
+
+  const cell = {} as CellHandle;
+  providePieceBoundary(target as unknown as Element, cell);
+  const piece = getPieceBoundary(target);
+  assertStrictEquals(piece?.cell, cell);
+  assertStrictEquals(piece?.element, target);
+
+  const deliveries: Array<CellHandle | undefined> = [];
+  const unsubscribe = subscribePieceBoundary(target, (value) => {
+    deliveries.push(value?.cell);
+  });
+  clearPieceBoundary(target as unknown as Element);
+  providePieceBoundary(target as unknown as Element, cell);
+  unsubscribe();
+  clearPieceBoundary(target as unknown as Element);
+  assertEquals(deliveries, [cell, undefined, cell]);
 });

--- a/packages/shell/integration/fixtures/nested-piece.tsx
+++ b/packages/shell/integration/fixtures/nested-piece.tsx
@@ -1,0 +1,59 @@
+import { NAME, pattern, UI, type VNode } from "commonfabric";
+
+interface PieceOutput {
+  [NAME]: string;
+  [UI]: VNode;
+}
+
+const InnerPiece = pattern<void, PieceOutput>(() => ({
+  [NAME]: "Inner piece",
+  [UI]: (
+    <>
+      <article
+        id="inner-piece-root"
+        style={{ width: "220px", height: "100px" }}
+      >
+        <button id="inner-piece-button" type="button">Inner action</button>
+      </article>
+    </>
+  ),
+}));
+
+const MiddlePiece = pattern<void, PieceOutput>(() => {
+  const inner = InnerPiece();
+  return {
+    [NAME]: "Middle piece",
+    [UI]: (
+      <section
+        id="middle-piece-root"
+        style={{ width: "240px", height: "120px" }}
+      >
+        {inner}
+      </section>
+    ),
+  };
+});
+
+export default pattern<void, PieceOutput>(() => {
+  const middle = MiddlePiece();
+  return {
+    [NAME]: "Nested piece fixture",
+    [UI]: (
+      <main id="outer-piece-root">
+        <div
+          id="nested-piece-clip"
+          style={{
+            width: "180px",
+            height: "80px",
+            overflow: "auto",
+            border: "4px solid black",
+            transform: "scale(0.75)",
+            transformOrigin: "top left",
+          }}
+        >
+          {middle}
+        </div>
+      </main>
+    ),
+  };
+});

--- a/packages/shell/integration/piece-menu.test.ts
+++ b/packages/shell/integration/piece-menu.test.ts
@@ -1,11 +1,50 @@
 import { env, waitForCondition } from "@commonfabric/integration";
 import { ShellIntegration } from "@commonfabric/integration/shell-utils";
 import { writeTempIdentity } from "@commonfabric/integration/temp-identity";
+import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
+import { join, resolve } from "@std/path";
 import "../src/globals.ts";
 import { clickPierce } from "./shadow-dom.ts";
 
-const { FRONTEND_URL, SPACE_NAME } = env;
+const { API_URL, FRONTEND_URL, SPACE_NAME } = env;
+const REPO_ROOT = resolve(import.meta.dirname!, "../../..");
+const decoder = new TextDecoder();
+
+type MeasuredRect = { x: number; y: number; width: number; height: number };
+
+async function createNestedPiece(
+  identityPath: string,
+  slug: string,
+): Promise<void> {
+  const command = new Deno.Command(Deno.execPath(), {
+    cwd: REPO_ROOT,
+    args: [
+      "run",
+      "-A",
+      join(REPO_ROOT, "packages", "cli", "mod.ts"),
+      "piece",
+      "new",
+      join(import.meta.dirname!, "fixtures", "nested-piece.tsx"),
+      "--identity",
+      identityPath,
+      "--api-url",
+      API_URL,
+      "--space",
+      SPACE_NAME,
+      "--slug",
+      slug,
+    ],
+    env: { CF_LOG_LEVEL: "error" },
+  });
+  const result = await command.output();
+  if (result.success) return;
+  throw new Error(
+    `cf piece new failed with ${result.code}\nstdout:\n${
+      decoder.decode(result.stdout)
+    }\nstderr:\n${decoder.decode(result.stderr)}`,
+  );
+}
 
 /** Wait until the space root piece has rendered into the body view. */
 async function waitForRenderedPiece(
@@ -25,13 +64,51 @@ async function waitForRenderedPiece(
  */
 async function rightClickRenderedPiece(
   page: ReturnType<ShellIntegration["page"]>,
-): Promise<void> {
-  await page.evaluate(() => {
+): Promise<{
+  highlighted: boolean;
+  before: MeasuredRect;
+  after: MeasuredRect;
+  overlay: MeasuredRect;
+  visual: {
+    opacity: string;
+    pointerEvents: string;
+    position: string;
+    zIndex: string;
+    hostPositionBefore: string;
+    hostPosition: string;
+    hostIsolationBefore: string;
+    hostIsolation: string;
+    stackIsolation: string;
+    contentIsolation: string;
+    backgroundImage: string;
+    boxShadow: string;
+    animationName: string;
+    animationIterationCount: string;
+    reducedMotion: boolean;
+  };
+}> {
+  return await page.evaluate(() => {
     const rootView = document.querySelector("x-root-view");
     const appView = rootView?.shadowRoot?.querySelector("x-app-view");
     const bodyView = appView?.shadowRoot?.querySelector("x-body-view");
     const render = bodyView?.shadowRoot?.querySelector("cf-render");
     if (!render) throw new Error("no rendered piece to right-click");
+    const highlight = render.shadowRoot?.querySelector(
+      ".piece-menu-highlight",
+    );
+    const stack = render.shadowRoot?.querySelector(".render-stack");
+    const content = render.shadowRoot?.querySelector(".render-container");
+    if (!highlight || !stack || !content) {
+      throw new Error("no piece highlight layer");
+    }
+    const measure = (element: Element) => {
+      const { x, y, width, height } = element.getBoundingClientRect();
+      return { x, y, width, height };
+    };
+    const before = measure(render);
+    const hostStyleBefore = getComputedStyle(render);
+    const hostPositionBefore = hostStyleBefore.position;
+    const hostIsolationBefore = hostStyleBefore.isolation;
     render.dispatchEvent(
       new MouseEvent("contextmenu", {
         bubbles: true,
@@ -41,6 +118,319 @@ async function rightClickRenderedPiece(
         clientY: 80,
       }),
     );
+    const highlightStyle = getComputedStyle(highlight);
+    return {
+      highlighted: render.hasAttribute("data-cf-piece-menu-open"),
+      before,
+      after: measure(render),
+      overlay: measure(highlight),
+      visual: {
+        opacity: highlightStyle.opacity,
+        pointerEvents: highlightStyle.pointerEvents,
+        position: highlightStyle.position,
+        zIndex: highlightStyle.zIndex,
+        hostPositionBefore,
+        hostPosition: getComputedStyle(render).position,
+        hostIsolationBefore,
+        hostIsolation: getComputedStyle(render).isolation,
+        stackIsolation: getComputedStyle(stack).isolation,
+        contentIsolation: getComputedStyle(content).isolation,
+        backgroundImage: highlightStyle.backgroundImage,
+        boxShadow: highlightStyle.boxShadow,
+        animationName: highlightStyle.animationName,
+        animationIterationCount: highlightStyle.animationIterationCount,
+        reducedMotion: matchMedia("(prefers-reduced-motion: reduce)").matches,
+      },
+    };
+  });
+}
+
+/** Measure the chip baseline and box before and during its highlight. */
+async function measureChipHighlightLayout(
+  page: ReturnType<ShellIntegration["page"]>,
+): Promise<{
+  before: MeasuredRect;
+  after: MeasuredRect;
+  overlay: MeasuredRect;
+  lineBefore: MeasuredRect;
+  lineAfter: MeasuredRect;
+  outerBaselineBefore: number;
+  outerBaselineAfter: number;
+  innerBaselineBefore: number;
+  innerBaselineAfter: number;
+}> {
+  return await page.evaluate(async () => {
+    const line = document.createElement("div");
+    line.style.cssText = [
+      "position: fixed",
+      "left: 0",
+      "top: 0",
+      "visibility: hidden",
+      "white-space: nowrap",
+      "font: 20px/24px sans-serif",
+    ].join(";");
+    const chip = document.createElement("cf-render") as HTMLElement & {
+      updateComplete: Promise<unknown>;
+    };
+    chip.setAttribute("variant", "chip");
+    const baselineProbe = () => {
+      const probe = document.createElement("span");
+      probe.style.cssText = [
+        "display: inline-block",
+        "width: 0",
+        "height: 0",
+        "padding: 0",
+        "margin: 0",
+        "border: 0",
+      ].join(";");
+      return probe;
+    };
+    const outerProbe = baselineProbe();
+    line.append("before ", chip, outerProbe, " after");
+    document.body.appendChild(line);
+
+    try {
+      await chip.updateComplete;
+      const content = chip.shadowRoot?.querySelector(".render-container");
+      const highlight = chip.shadowRoot?.querySelector(
+        ".piece-menu-highlight",
+      );
+      if (!content || !highlight) throw new Error("no chip highlight layer");
+      const innerProbe = baselineProbe();
+      content.append("chip", innerProbe);
+      const measure = (element: Element) => {
+        const { x, y, width, height } = element.getBoundingClientRect();
+        return { x, y, width, height };
+      };
+      const baseline = (probe: Element) => probe.getBoundingClientRect().top;
+      const before = measure(chip);
+      const lineBefore = measure(line);
+      const outerBaselineBefore = baseline(outerProbe);
+      const innerBaselineBefore = baseline(innerProbe);
+
+      chip.setAttribute("data-cf-piece-menu-open", "");
+      return {
+        before,
+        after: measure(chip),
+        overlay: measure(highlight),
+        lineBefore,
+        lineAfter: measure(line),
+        outerBaselineBefore,
+        outerBaselineAfter: baseline(outerProbe),
+        innerBaselineBefore,
+        innerBaselineAfter: baseline(innerProbe),
+      };
+    } finally {
+      line.remove();
+    }
+  });
+}
+
+/** Retarget a followed piece while its menu is open. */
+async function retargetHighlightedPiece(
+  page: ReturnType<ShellIntegration["page"]>,
+): Promise<{
+  before: { highlighted: boolean; menuHidden: boolean };
+  duringReplacementRender: { highlighted: boolean; menuHidden: boolean };
+  after: { highlighted: boolean; menuHidden: boolean };
+  replacementRendered: boolean;
+}> {
+  return await page.evaluate(async () => {
+    const rootView = document.querySelector("x-root-view");
+    const appView = rootView?.shadowRoot?.querySelector("x-app-view");
+    const bodyView = appView?.shadowRoot?.querySelector("x-body-view");
+    const existing = bodyView?.shadowRoot?.querySelector("cf-render") as
+      | (HTMLElement & {
+        _pieceTarget(): {
+          equals(other: unknown): boolean;
+          key(name: string): unknown;
+          space(): unknown;
+        } | undefined;
+      })
+      | null;
+    const firstTarget = existing?._pieceTarget();
+    if (!firstTarget) throw new Error("no piece target for retarget test");
+
+    const cellPrototype = Object.getPrototypeOf(firstTarget);
+    const secondTarget = firstTarget.key(
+      "piece-menu-retarget-test",
+    ) as typeof firstTarget;
+    const link = {
+      equals(other: unknown) {
+        return other === link;
+      },
+      id() {
+        return "of:fid1:followed-piece";
+      },
+      ref() {
+        return { path: ["piece"] };
+      },
+      space() {
+        return firstTarget.space();
+      },
+    };
+    Object.setPrototypeOf(link, cellPrototype);
+    let publish: ((value: typeof firstTarget) => void) | undefined;
+    (link as typeof link & {
+      asSchema(): {
+        sync(): Promise<typeof firstTarget>;
+        subscribe(callback: (value: typeof firstTarget) => void): () => void;
+      };
+    }).asSchema = () => ({
+      sync: () => Promise.resolve(firstTarget),
+      subscribe(callback) {
+        callback(firstTarget);
+        publish = callback;
+        return () => {};
+      },
+    });
+
+    const fixture = document.createElement("div");
+    fixture.style.cssText = "position: fixed; visibility: hidden";
+    const render = document.createElement("cf-render") as HTMLElement & {
+      cell?: unknown;
+      updateComplete: Promise<unknown>;
+      _cleanupLinkTargetSubscription(): void;
+      _renderCell(): Promise<void>;
+      _resolvedCell?: unknown;
+      _watchLinkTarget(cell: unknown, resolved: unknown): Promise<unknown>;
+    };
+    let observeReplacement = false;
+    let duringReplacementRender:
+      | { highlighted: boolean; menuHidden: boolean }
+      | undefined;
+    let replacementRendered = false;
+    render._renderCell = () => {
+      if (observeReplacement) {
+        const menu = document.querySelector("cf-piece-menu") as
+          | HTMLElement
+          | null;
+        if (!menu) throw new Error("piece menu missing at replacement render");
+        duringReplacementRender = {
+          highlighted: render.hasAttribute("data-cf-piece-menu-open"),
+          menuHidden: Boolean(menu.hidden),
+        };
+        const content = render.shadowRoot?.querySelector(".render-container");
+        if (!content) throw new Error("replacement render has no container");
+        content.textContent = "replacement rendered";
+        replacementRendered = true;
+      }
+      return Promise.resolve();
+    };
+    fixture.appendChild(render);
+    document.body.appendChild(fixture);
+
+    try {
+      render.cell = link;
+      await render.updateComplete;
+      render._resolvedCell = await render._watchLinkTarget(link, firstTarget);
+      render.dispatchEvent(
+        new MouseEvent("contextmenu", {
+          bubbles: true,
+          composed: true,
+          cancelable: true,
+        }),
+      );
+      const menu = document.querySelector("cf-piece-menu") as
+        | (HTMLElement & { updateComplete: Promise<unknown> })
+        | null;
+      if (!menu || !publish) {
+        throw new Error("followed piece menu did not open");
+      }
+      await menu.updateComplete;
+      const before = {
+        highlighted: render.hasAttribute("data-cf-piece-menu-open"),
+        menuHidden: Boolean(menu.hidden),
+      };
+
+      observeReplacement = true;
+      publish(secondTarget);
+      observeReplacement = false;
+      await menu.updateComplete;
+      if (!duringReplacementRender) {
+        throw new Error("replacement render did not start");
+      }
+      return {
+        before,
+        duringReplacementRender,
+        after: {
+          highlighted: render.hasAttribute("data-cf-piece-menu-open"),
+          menuHidden: Boolean(menu.hidden),
+        },
+        replacementRendered,
+      };
+    } finally {
+      render._cleanupLinkTargetSubscription();
+      fixture.remove();
+    }
+  });
+}
+
+/** Close a panel and then its menu with the two corresponding Escape presses. */
+async function closePieceMenu(
+  page: ReturnType<ShellIntegration["page"]>,
+): Promise<{ whileOpen: boolean; afterClose: boolean }> {
+  return await page.evaluate(() => {
+    const rootView = document.querySelector("x-root-view");
+    const appView = rootView?.shadowRoot?.querySelector("x-app-view");
+    const bodyView = appView?.shadowRoot?.querySelector("x-body-view");
+    const render = bodyView?.shadowRoot?.querySelector("cf-render");
+    const whileOpen = render?.hasAttribute("data-cf-piece-menu-open") ?? false;
+    globalThis.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", cancelable: true }),
+    );
+    globalThis.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", cancelable: true }),
+    );
+    return {
+      whileOpen,
+      afterClose: render?.hasAttribute("data-cf-piece-menu-open") ?? false,
+    };
+  });
+}
+
+/** Disconnect the highlighted renderer and report its menu's resulting state. */
+async function disconnectRenderedPiece(
+  page: ReturnType<ShellIntegration["page"]>,
+): Promise<{ afterDisconnect: boolean; menuHidden: boolean }> {
+  return await page.evaluate(() => {
+    const rootView = document.querySelector("x-root-view");
+    const appView = rootView?.shadowRoot?.querySelector("x-app-view");
+    const bodyView = appView?.shadowRoot?.querySelector("x-body-view");
+    const render = bodyView?.shadowRoot?.querySelector("cf-render");
+    const menu = document.querySelector("cf-piece-menu") as HTMLElement | null;
+    if (!render || !menu) throw new Error("piece menu is not open");
+    render.remove();
+    return {
+      afterDisconnect: render.hasAttribute("data-cf-piece-menu-open"),
+      menuHidden: Boolean(menu.hidden),
+    };
+  });
+}
+
+/** Clear and restore the renderer's piece, reporting the open menu after clear. */
+async function replaceRenderedPieceCell(
+  page: ReturnType<ShellIntegration["page"]>,
+): Promise<{ highlighted: boolean; menuHidden: boolean }> {
+  return await page.evaluate(async () => {
+    const rootView = document.querySelector("x-root-view");
+    const appView = rootView?.shadowRoot?.querySelector("x-app-view");
+    const bodyView = appView?.shadowRoot?.querySelector("x-body-view");
+    const render = bodyView?.shadowRoot?.querySelector("cf-render") as
+      | (HTMLElement & { cell?: unknown; updateComplete: Promise<unknown> })
+      | null;
+    const menu = document.querySelector("cf-piece-menu") as HTMLElement | null;
+    if (!render || !menu) throw new Error("piece menu is not open");
+    const cell = render.cell;
+    render.cell = undefined;
+    await render.updateComplete;
+    const state = {
+      highlighted: render.hasAttribute("data-cf-piece-menu-open"),
+      menuHidden: Boolean(menu.hidden),
+    };
+    render.cell = cell;
+    await render.updateComplete;
+    return state;
   });
 }
 
@@ -78,7 +468,52 @@ describe("piece context menu", () => {
     });
     await waitForRenderedPiece(page);
 
-    await rightClickRenderedPiece(page);
+    const chipLayout = await measureChipHighlightLayout(page);
+    expect(chipLayout.after).toEqual(chipLayout.before);
+    expect(chipLayout.overlay).toEqual(chipLayout.after);
+    expect(chipLayout.lineAfter).toEqual(chipLayout.lineBefore);
+    expect(
+      Math.abs(
+        chipLayout.innerBaselineBefore - chipLayout.outerBaselineBefore,
+      ) < 0.01,
+    ).toBe(true);
+    expect(chipLayout.outerBaselineAfter).toBe(
+      chipLayout.outerBaselineBefore,
+    );
+    expect(chipLayout.innerBaselineAfter).toBe(
+      chipLayout.innerBaselineBefore,
+    );
+    expect(await retargetHighlightedPiece(page)).toEqual({
+      before: { highlighted: true, menuHidden: false },
+      duringReplacementRender: { highlighted: false, menuHidden: true },
+      after: { highlighted: false, menuHidden: true },
+      replacementRendered: true,
+    });
+
+    const highlight = await rightClickRenderedPiece(page);
+    expect(highlight.highlighted).toBe(true);
+    expect(highlight.after).toEqual(highlight.before);
+    expect(highlight.overlay).toEqual(highlight.after);
+    expect(highlight.visual.opacity).toBe("1");
+    expect(highlight.visual.pointerEvents).toBe("none");
+    expect(highlight.visual.position).toBe("static");
+    expect(highlight.visual.zIndex).toBe("1");
+    expect(highlight.visual.hostPosition).toBe(
+      highlight.visual.hostPositionBefore,
+    );
+    expect(highlight.visual.hostIsolation).toBe(
+      highlight.visual.hostIsolationBefore,
+    );
+    expect(highlight.visual.stackIsolation).toBe("isolate");
+    expect(highlight.visual.contentIsolation).toBe("isolate");
+    expect(highlight.visual.backgroundImage).not.toBe("none");
+    expect(highlight.visual.boxShadow).not.toBe("none");
+    if (highlight.visual.reducedMotion) {
+      expect(highlight.visual.animationName).toBe("none");
+    } else {
+      expect(highlight.visual.animationName).toBe("cf-piece-menu-shine");
+      expect(highlight.visual.animationIterationCount).toBe("infinite");
+    }
     await clickPierce(page, '[test-id="piece-menu-source"]');
     // The space root runs the default app, so its entry file is that pattern.
     await waitForPanelText(
@@ -96,5 +531,220 @@ describe("piece context menu", () => {
       "piece-panel-origin",
       "/api/patterns/system/default-app.tsx",
     );
+
+    expect(await closePieceMenu(page)).toEqual({
+      whileOpen: true,
+      afterClose: false,
+    });
+
+    expect((await rightClickRenderedPiece(page)).highlighted).toBe(true);
+    expect(await replaceRenderedPieceCell(page)).toEqual({
+      highlighted: false,
+      menuHidden: true,
+    });
+
+    expect((await rightClickRenderedPiece(page)).highlighted).toBe(true);
+    expect(await disconnectRenderedPiece(page)).toEqual({
+      afterDisconnect: false,
+      menuHidden: true,
+    });
+  });
+
+  it("targets and highlights the innermost nested piece", async () => {
+    const page = shell.page();
+    const slug = `nested-piece-menu-${crypto.randomUUID()}`;
+    const { identity, path: identityPath } = await writeTempIdentity({
+      implementation: "noble",
+    });
+
+    try {
+      await createNestedPiece(identityPath, slug);
+      await shell.goto({
+        frontendUrl: FRONTEND_URL,
+        view: { spaceName: SPACE_NAME, pieceSlug: slug },
+        identity,
+      });
+      await waitForCondition(
+        page,
+        (probe) => probe.collect("#inner-piece-button").length === 1,
+      );
+
+      const result = await page.evaluate(async () => {
+        const rootView = document.querySelector("x-root-view");
+        const appView = rootView?.shadowRoot?.querySelector("x-app-view");
+        const bodyView = appView?.shadowRoot?.querySelector("x-body-view");
+        const render = bodyView?.shadowRoot?.querySelector("cf-render") as
+          | (HTMLElement & {
+            cell?: { id(): string };
+          })
+          | null;
+        const inner = render?.shadowRoot?.querySelector(
+          "#inner-piece-root",
+        ) as HTMLElement | null;
+        const middle = render?.shadowRoot?.querySelector(
+          "#middle-piece-root",
+        ) as HTMLElement | null;
+        const button = render?.shadowRoot?.querySelector(
+          "#inner-piece-button",
+        );
+        const clip = render?.shadowRoot?.querySelector(
+          "#nested-piece-clip",
+        ) as HTMLElement | null;
+        if (!render || !inner || !middle || !button || !clip) {
+          throw new Error("nested piece fixture did not render");
+        }
+
+        const measure = (element: Element): MeasuredRect => {
+          const { x, y, width, height } = element.getBoundingClientRect();
+          return { x, y, width, height };
+        };
+        const outerBefore = measure(render);
+        const middleBefore = measure(middle);
+        const innerBefore = measure(inner);
+        const clipBorder = clip.getBoundingClientRect();
+        const clipScaleX = clipBorder.width / clip.offsetWidth;
+        const clipScaleY = clipBorder.height / clip.offsetHeight;
+        const clipBefore = {
+          x: clipBorder.x + clip.clientLeft * clipScaleX,
+          y: clipBorder.y + clip.clientTop * clipScaleY,
+          width: clip.clientWidth * clipScaleX,
+          height: clip.clientHeight * clipScaleY,
+        };
+        let middlePieceId: string | undefined;
+        render.addEventListener("cf-piece-context-menu", (event) => {
+          event.preventDefault();
+          middlePieceId = (event as CustomEvent<{ pieceId: string }>).detail
+            .pieceId;
+        }, { once: true });
+        middle.dispatchEvent(
+          new MouseEvent("contextmenu", {
+            bubbles: true,
+            composed: true,
+            cancelable: true,
+          }),
+        );
+
+        let innerPieceId: string | undefined;
+        render.addEventListener("cf-piece-context-menu", (event) => {
+          event.preventDefault();
+          innerPieceId = (event as CustomEvent<{ pieceId: string }>).detail
+            .pieceId;
+        }, { once: true });
+        inner.dispatchEvent(
+          new MouseEvent("contextmenu", {
+            bubbles: true,
+            composed: true,
+            cancelable: true,
+          }),
+        );
+
+        let announcedPieceId: string | undefined;
+        render.addEventListener("cf-piece-context-menu", (event) => {
+          announcedPieceId = (event as CustomEvent<{ pieceId: string }>).detail
+            .pieceId;
+        }, { once: true });
+
+        button.dispatchEvent(
+          new MouseEvent("contextmenu", {
+            bubbles: true,
+            composed: true,
+            cancelable: true,
+            clientX: innerBefore.x + 4,
+            clientY: innerBefore.y + 4,
+          }),
+        );
+        const menu = document.querySelector("cf-piece-menu") as
+          | (HTMLElement & { updateComplete: Promise<unknown> })
+          | null;
+        if (!menu) throw new Error("nested piece menu did not open");
+        await menu.updateComplete;
+        const overlay = menu.shadowRoot?.querySelector(
+          ".nested-piece-highlight",
+        );
+        if (!overlay) throw new Error("nested highlight did not render");
+        const overlayStyle = getComputedStyle(overlay);
+        const outerAfter = measure(render);
+        const middleAfter = measure(middle);
+        const innerAfter = measure(inner);
+        const overlayBeforeScroll = measure(overlay);
+        clip.scrollLeft = 24;
+        clip.dispatchEvent(new Event("scroll"));
+        await new Promise<void>((resolve) =>
+          requestAnimationFrame(() => resolve())
+        );
+        await menu.updateComplete;
+        const innerAfterScroll = measure(inner);
+        const overlayAfterScroll = measure(overlay);
+
+        return {
+          outerId: render.cell?.id(),
+          middleId: middlePieceId,
+          innerId: innerPieceId,
+          announcedPieceId,
+          outerMarked: render.hasAttribute("data-cf-piece-menu-open"),
+          innerMarked: inner.hasAttribute("data-cf-piece-menu-open"),
+          outerBefore,
+          outerAfter,
+          middleBefore,
+          middleAfter,
+          innerBefore,
+          innerAfter,
+          clipBefore,
+          overlayBeforeScroll,
+          innerAfterScroll,
+          overlayAfterScroll,
+          visual: {
+            position: overlayStyle.position,
+            pointerEvents: overlayStyle.pointerEvents,
+            backgroundImage: overlayStyle.backgroundImage,
+            boxShadow: overlayStyle.boxShadow,
+            animationName: overlayStyle.animationName,
+            animationIterationCount: overlayStyle.animationIterationCount,
+            reducedMotion: matchMedia("(prefers-reduced-motion: reduce)")
+              .matches,
+          },
+        };
+      });
+
+      expect(result.outerId).toBeDefined();
+      expect(result.middleId).toBeDefined();
+      expect(result.innerId).toBeDefined();
+      expect(result.innerId).not.toBe(result.middleId);
+      expect(result.innerId).not.toBe(result.outerId);
+      expect(result.middleId).not.toBe(result.outerId);
+      expect(result.announcedPieceId).toBe(result.innerId);
+      expect(result.outerMarked).toBe(false);
+      expect(result.innerMarked).toBe(false);
+      expect(result.outerAfter).toEqual(result.outerBefore);
+      expect(result.middleAfter).toEqual(result.middleBefore);
+      expect(result.innerAfter).toEqual(result.innerBefore);
+      const visibleRect = (inner: MeasuredRect, clip: MeasuredRect) => {
+        const x = Math.max(inner.x, clip.x);
+        const y = Math.max(inner.y, clip.y);
+        const right = Math.min(inner.x + inner.width, clip.x + clip.width);
+        const bottom = Math.min(inner.y + inner.height, clip.y + clip.height);
+        return { x, y, width: right - x, height: bottom - y };
+      };
+      expect(result.overlayBeforeScroll).toEqual(
+        visibleRect(result.innerBefore, result.clipBefore),
+      );
+      expect(result.overlayAfterScroll).toEqual(
+        visibleRect(result.innerAfterScroll, result.clipBefore),
+      );
+      expect(result.visual.position).toBe("fixed");
+      expect(result.visual.pointerEvents).toBe("none");
+      expect(result.visual.backgroundImage).not.toBe("none");
+      expect(result.visual.boxShadow).not.toBe("none");
+      if (result.visual.reducedMotion) {
+        expect(result.visual.animationName).toBe("none");
+      } else {
+        expect(result.visual.animationName).toBe(
+          "cf-nested-piece-menu-shine",
+        );
+        expect(result.visual.animationIterationCount).toBe("infinite");
+      }
+    } finally {
+      await Deno.remove(identityPath).catch(() => {});
+    }
   });
 });

--- a/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.test.ts
+++ b/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.test.ts
@@ -18,6 +18,10 @@ import {
   formatTimestamp,
   shortIdentity,
 } from "./origin-view.ts";
+import {
+  clearPieceBoundary,
+  providePieceBoundary,
+} from "../../../../../html/src/main/space-context.ts";
 
 // The menu renders through Lit templates rather than into a real DOM here: the
 // assertions read the template a render produced, which is enough to say what
@@ -139,6 +143,9 @@ function pieceCell(
         aborted: typeof aborted === "function" ? aborted() : aborted,
       },
     }),
+    equals(other: unknown) {
+      return other === this;
+    },
   } as unknown as CellHandle;
 }
 
@@ -158,6 +165,31 @@ function openMenu(cell: CellHandle = pieceCell()): CFPieceMenu {
   const menu = newMenu();
   menu.open({ cell, x: 40, y: 60 });
   return menu;
+}
+
+/** An element stub that records the attributes the menu changes. */
+function highlightProbe(): {
+  element: Element;
+  has: (name: string) => boolean;
+} {
+  const attributes = new Set<string>();
+  return {
+    element: {
+      setAttribute: (name: string) => attributes.add(name),
+      removeAttribute: (name: string) => attributes.delete(name),
+    } as unknown as Element,
+    has: (name: string) => attributes.has(name),
+  };
+}
+
+function geometryProbe(
+  rect: { left: number; top: number; right: number; bottom: number },
+): Element {
+  return Object.assign(new EventTarget(), {
+    getBoundingClientRect: () => rect,
+    setAttribute: () => {},
+    removeAttribute: () => {},
+  }) as unknown as Element;
 }
 
 describe("piece menu entries", () => {
@@ -219,6 +251,133 @@ describe("the menu a right-click opens", () => {
     // Clamped rather than drawn off-screen, wherever the click landed.
     expect(placement).toContain("left: ");
     expect(placement).not.toContain("left: 1000000px");
+  });
+
+  it("moves the highlight to the addressed piece and removes it on close", () => {
+    const menu = newMenu();
+    const first = highlightProbe();
+    const second = highlightProbe();
+
+    menu.open({
+      cell: pieceCell(),
+      x: 0,
+      y: 0,
+      highlightedPiece: first.element,
+    });
+    expect(first.has("data-cf-piece-menu-open")).toBe(true);
+
+    menu.open({
+      cell: pieceCell(),
+      x: 0,
+      y: 0,
+      highlightedPiece: second.element,
+    });
+    expect(first.has("data-cf-piece-menu-open")).toBe(false);
+    expect(second.has("data-cf-piece-menu-open")).toBe(true);
+
+    menu.close();
+    expect(second.has("data-cf-piece-menu-open")).toBe(false);
+  });
+
+  it("closes only for the render element it highlights", () => {
+    const menu = newMenu();
+    const piece = highlightProbe();
+    const other = highlightProbe();
+    menu.open({
+      cell: pieceCell(),
+      x: 0,
+      y: 0,
+      highlightedPiece: piece.element,
+    });
+
+    menu.closeFor(other.element);
+    expect(shows(menu)).toContain("View source");
+    expect(piece.has("data-cf-piece-menu-open")).toBe(true);
+
+    menu.closeFor(piece.element);
+    expect(shows(menu)).toBe("");
+    expect(piece.has("data-cf-piece-menu-open")).toBe(false);
+  });
+
+  it("removes the highlight when its overlay disconnects", () => {
+    const menu = newMenu();
+    const piece = highlightProbe();
+    menu.open({
+      cell: pieceCell(),
+      x: 0,
+      y: 0,
+      highlightedPiece: piece.element,
+    });
+
+    menu.disconnectedCallback();
+
+    expect(piece.has("data-cf-piece-menu-open")).toBe(false);
+  });
+
+  it("draws a clipped fixed highlight over a nested pattern root", () => {
+    const menu = newMenu();
+    const owner = geometryProbe({
+      left: 10,
+      top: 20,
+      right: 210,
+      bottom: 220,
+    });
+    const target = geometryProbe({
+      left: 0,
+      top: 40,
+      right: 160,
+      bottom: 260,
+    });
+    const cell = pieceCell();
+    providePieceBoundary(target, cell);
+
+    menu.open({
+      cell,
+      x: 0,
+      y: 0,
+      highlightedPiece: owner,
+      highlightTarget: target,
+    });
+
+    const rendered = shows(menu);
+    expect(rendered).toContain("nested-piece-highlight");
+    expect(rendered).toContain(
+      "left: 10px; top: 40px; width: 150px; height: 180px",
+    );
+
+    menu.closeFor(target);
+    expect(shows(menu)).toContain("View source");
+    menu.closeFor(owner);
+    expect(shows(menu)).toBe("");
+  });
+
+  it("closes when the nested root stops representing the open piece", () => {
+    const menu = newMenu();
+    const cell = pieceCell();
+    const owner = geometryProbe({
+      left: 0,
+      top: 0,
+      right: 200,
+      bottom: 200,
+    });
+    const target = geometryProbe({
+      left: 10,
+      top: 10,
+      right: 100,
+      bottom: 100,
+    });
+    providePieceBoundary(target, cell);
+    menu.open({
+      cell,
+      x: 0,
+      y: 0,
+      highlightedPiece: owner,
+      highlightTarget: target,
+    });
+
+    clearPieceBoundary(target);
+
+    expect(shows(menu)).toBe("");
   });
 
   it("shows the detach action after reading a followed piece", async () => {

--- a/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.ts
+++ b/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.ts
@@ -14,10 +14,17 @@ import type {
   PieceSourceView,
 } from "@commonfabric/runtime-client";
 import {
+  getPieceBoundary,
+  subscribePieceBoundary,
+} from "@commonfabric/html/client";
+import {
   describeOrigin,
   formatTimestamp,
   shortIdentity,
 } from "./origin-view.ts";
+
+/** The marker on the rendered piece while its built-in menu is open. */
+export const PIECE_MENU_OPEN_ATTRIBUTE = "data-cf-piece-menu-open";
 
 /** Which panel is showing, if any. */
 export type Panel = "source" | "origin" | "data" | "actions";
@@ -214,6 +221,7 @@ export class CFPieceMenu extends BaseElement {
     .backdrop {
       position: absolute;
       inset: 0;
+      z-index: 1;
     }
 
     .backdrop.dimmed {
@@ -222,6 +230,7 @@ export class CFPieceMenu extends BaseElement {
 
     .menu {
       position: absolute;
+      z-index: 2;
       min-width: 15rem;
       padding: 0.25rem;
       background: var(--cf-theme-color-surface, #ffffff);
@@ -260,6 +269,7 @@ export class CFPieceMenu extends BaseElement {
 
     .panel {
       position: absolute;
+      z-index: 2;
       top: 50%;
       left: 50%;
       transform: translate(-50%, -50%);
@@ -271,6 +281,55 @@ export class CFPieceMenu extends BaseElement {
       border-radius: 12px;
       box-shadow: 0 10px 24px rgba(0, 0, 0, 0.24);
       overflow: hidden;
+    }
+
+    .nested-piece-highlight {
+      position: fixed;
+      z-index: 0;
+      pointer-events: none;
+      background-color: rgba(99, 102, 241, 0.14);
+      background-image: linear-gradient(
+        135deg,
+        rgba(255, 255, 255, 0) 26%,
+        rgba(255, 255, 255, 0.64) 48%,
+        rgba(103, 232, 249, 0.36) 54%,
+        rgba(255, 255, 255, 0) 72%
+      );
+      background-position: 200% 0;
+      background-repeat: no-repeat;
+      background-size: 250% 100%;
+      box-shadow: inset 0 0 2.5rem rgba(129, 140, 248, 0.38);
+      animation: cf-nested-piece-menu-shine 1.7s ease-in-out infinite;
+    }
+
+    @keyframes cf-nested-piece-menu-shine {
+      from {
+        background-position: 200% 0;
+      }
+      to {
+        background-position: -200% 0;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .nested-piece-highlight {
+        animation: none;
+        background-position: 50% 0;
+      }
+    }
+
+    @media (forced-colors: active) {
+      .nested-piece-highlight {
+        forced-color-adjust: none;
+        background-color: transparent;
+        background-image: linear-gradient(
+          135deg,
+          transparent 26%,
+          Highlight 48%,
+          transparent 72%
+        );
+        box-shadow: inset 0 0 0 0.25rem Highlight;
+      }
     }
 
     .panel-head {
@@ -644,6 +703,20 @@ export class CFPieceMenu extends BaseElement {
   /** True while a dispatch is in flight, so a rapid double-click sends once. */
   #dispatching = false;
 
+  /** The renderer that owns the open menu. */
+  #menuOwner: Element | undefined;
+
+  /** The element whose rendered area receives the visual highlight. */
+  #highlightTarget: Element | undefined;
+
+  /** A top-level renderer marked so its shadow-root highlight becomes visible. */
+  #markedPiece: Element | undefined;
+
+  #highlightMutationObserver: MutationObserver | undefined;
+  #highlightPieceSubscription: (() => void) | undefined;
+  #highlightAnimationFrame: number | undefined;
+  #nestedHighlightGeometry: string[] = [];
+
   constructor() {
     super();
     this.x = 0;
@@ -657,13 +730,31 @@ export class CFPieceMenu extends BaseElement {
 
   override disconnectedCallback() {
     globalThis.removeEventListener("keydown", this.#onKeyDown);
+    this.#setHighlightedPiece(undefined, undefined);
     this.#resetPieceState();
     super.disconnectedCallback();
   }
 
   /** Show the menu for `cell` at a click position. */
-  open({ cell, x, y }: { cell: CellHandle; x: number; y: number }): void {
+  open(
+    { cell, x, y, highlightedPiece, highlightTarget }: {
+      cell: CellHandle;
+      x: number;
+      y: number;
+      highlightedPiece?: Element;
+      highlightTarget?: Element;
+    },
+  ): void {
+    const target = highlightTarget ?? highlightedPiece;
+    if (
+      highlightedPiece && target && target !== highlightedPiece &&
+      !this.#elementRepresentsPiece(target, cell)
+    ) {
+      this.close();
+      return;
+    }
     this.cell = cell;
+    this.#setHighlightedPiece(highlightedPiece, target);
     this.x = x;
     this.y = y;
     this.panel = undefined;
@@ -684,6 +775,7 @@ export class CFPieceMenu extends BaseElement {
 
   /** Hide the menu and forget the piece it was describing. */
   close(): void {
+    this.#setHighlightedPiece(undefined, undefined);
     this.hidden = true;
     this.panel = undefined;
     this.cell = undefined;
@@ -695,6 +787,240 @@ export class CFPieceMenu extends BaseElement {
     this.sourceExecutionWarning = undefined;
     this.compatibilityWarning = undefined;
     this.readToken++;
+  }
+
+  /** Close when `piece` is the render element this menu addresses. */
+  closeFor(piece: Element): void {
+    if (piece === this.#menuOwner) this.close();
+  }
+
+  /** Move the visual highlight to the element the menu addresses. */
+  #setHighlightedPiece(
+    owner: Element | undefined,
+    target: Element | undefined,
+  ): void {
+    this.#markedPiece?.removeAttribute(PIECE_MENU_OPEN_ATTRIBUTE);
+    this.#markedPiece = undefined;
+    this.#highlightMutationObserver?.disconnect();
+    this.#highlightMutationObserver = undefined;
+    this.#highlightPieceSubscription?.();
+    this.#highlightPieceSubscription = undefined;
+    if (this.#highlightAnimationFrame !== undefined) {
+      globalThis.cancelAnimationFrame?.(this.#highlightAnimationFrame);
+      this.#highlightAnimationFrame = undefined;
+    }
+    this.#nestedHighlightGeometry = [];
+    this.#menuOwner = owner;
+    this.#highlightTarget = target;
+
+    if (owner && target === owner) {
+      owner.setAttribute(PIECE_MENU_OPEN_ATTRIBUTE, "");
+      this.#markedPiece = owner;
+    }
+    if (
+      owner && target && target !== owner &&
+      typeof MutationObserver !== "undefined"
+    ) {
+      this.#highlightMutationObserver = new MutationObserver(() => {
+        if (this.#highlightTarget?.isConnected === false) this.close();
+        else if (!this.#highlightTargetMatchesPiece()) this.close();
+        else this.#updateNestedHighlightGeometry();
+      });
+      for (const root of this.#composedShadowRoots(target)) {
+        this.#highlightMutationObserver.observe(root, {
+          attributes: true,
+          characterData: true,
+          childList: true,
+          subtree: true,
+        });
+      }
+    }
+    if (target && target !== owner) {
+      this.#highlightPieceSubscription = subscribePieceBoundary(
+        target,
+        (piece) => {
+          if (
+            this.cell &&
+            (piece?.element !== target || !piece.cell.equals(this.cell))
+          ) this.close();
+        },
+      );
+      if (typeof globalThis.requestAnimationFrame === "function") {
+        this.#highlightAnimationFrame = globalThis.requestAnimationFrame(
+          this.#trackHighlightGeometry,
+        );
+      }
+      this.#updateNestedHighlightGeometry();
+    }
+    this.requestUpdate();
+  }
+
+  #trackHighlightGeometry = (): void => {
+    this.#highlightAnimationFrame = undefined;
+    if (
+      !this.#menuOwner || !this.#highlightTarget ||
+      this.#menuOwner === this.#highlightTarget
+    ) return;
+    if (this.#highlightTarget.isConnected === false) {
+      this.close();
+      return;
+    }
+    if (!this.#highlightTargetMatchesPiece()) {
+      this.close();
+      return;
+    }
+    this.#updateNestedHighlightGeometry();
+    if (typeof globalThis.requestAnimationFrame === "function") {
+      this.#highlightAnimationFrame = globalThis.requestAnimationFrame(
+        this.#trackHighlightGeometry,
+      );
+    }
+  };
+
+  #highlightTargetMatchesPiece(): boolean {
+    if (!this.#highlightTarget || !this.cell) return true;
+    return this.#elementRepresentsPiece(this.#highlightTarget, this.cell);
+  }
+
+  #elementRepresentsPiece(target: Element, cell: CellHandle): boolean {
+    const piece = getPieceBoundary(target);
+    return piece?.element === target && piece.cell.equals(cell);
+  }
+
+  #updateNestedHighlightGeometry(): void {
+    const next = this.#computeNestedHighlightGeometry();
+    if (
+      next.length === this.#nestedHighlightGeometry.length &&
+      next.every((style, index) =>
+        style === this.#nestedHighlightGeometry[index]
+      )
+    ) return;
+    this.#nestedHighlightGeometry = next;
+    this.requestUpdate();
+  }
+
+  /** Ancestors along the rendered tree, including slots and shadow hosts. */
+  #composedAncestors(element: Element): Element[] {
+    const ancestors: Element[] = [];
+    const visited = new Set<Element>([element]);
+    let current: Element | null = element;
+    while (current) {
+      const root: Node | undefined = typeof current.getRootNode === "function"
+        ? current.getRootNode()
+        : undefined;
+      const shadowHost: Element | null = root && "host" in root
+        ? (root as ShadowRoot).host
+        : null;
+      const next: Element | null = current.assignedSlot ??
+        current.parentElement ??
+        shadowHost;
+      if (!next || visited.has(next)) break;
+      ancestors.push(next);
+      visited.add(next);
+      current = next;
+    }
+    return ancestors;
+  }
+
+  #composedShadowRoots(element: Element): ShadowRoot[] {
+    const roots = new Set<ShadowRoot>();
+    for (const item of [element, ...this.#composedAncestors(element)]) {
+      if (typeof item.getRootNode !== "function") continue;
+      const root = item.getRootNode();
+      if (root && "host" in root) roots.add(root as ShadowRoot);
+    }
+    return [...roots];
+  }
+
+  /** Fixed overlay geometry clipped to rendered overflow and the viewport. */
+  #computeNestedHighlightGeometry(): string[] {
+    const owner = this.#menuOwner;
+    const target = this.#highlightTarget;
+    if (!owner || !target || owner === target) return [];
+
+    const ownerRect = owner.getBoundingClientRect();
+    const viewportWidth = globalThis.innerWidth ?? Number.POSITIVE_INFINITY;
+    const viewportHeight = globalThis.innerHeight ?? Number.POSITIVE_INFINITY;
+    const targetRects = typeof target.getClientRects === "function"
+      ? Array.from(target.getClientRects())
+      : [];
+    if (targetRects.every((rect) => rect.width <= 0 || rect.height <= 0)) {
+      targetRects.length = 0;
+      const range = globalThis.document?.createRange?.();
+      if (range) {
+        range.selectNodeContents(target);
+        targetRects.push(...Array.from(range.getClientRects()));
+        range.detach();
+      }
+    }
+    if (targetRects.length === 0) {
+      targetRects.push(target.getBoundingClientRect());
+    }
+
+    const clippingAncestors: Array<{
+      rect: { left: number; top: number; right: number; bottom: number };
+      clipX: boolean;
+      clipY: boolean;
+    }> = [];
+    if (typeof globalThis.getComputedStyle === "function") {
+      for (const ancestor of this.#composedAncestors(target)) {
+        const style = globalThis.getComputedStyle(ancestor);
+        const clips = (value: string) =>
+          value === "auto" || value === "scroll" || value === "hidden" ||
+          value === "clip";
+        const clipX = clips(style.overflowX);
+        const clipY = clips(style.overflowY);
+        if (clipX || clipY) {
+          const borderRect = ancestor.getBoundingClientRect();
+          const element = ancestor as HTMLElement;
+          const scaleX = element.offsetWidth > 0
+            ? borderRect.width / element.offsetWidth
+            : 1;
+          const scaleY = element.offsetHeight > 0
+            ? borderRect.height / element.offsetHeight
+            : 1;
+          const left = borderRect.left + ancestor.clientLeft * scaleX;
+          const top = borderRect.top + ancestor.clientTop * scaleY;
+          clippingAncestors.push({
+            rect: {
+              left,
+              top,
+              right: left + ancestor.clientWidth * scaleX,
+              bottom: top + ancestor.clientHeight * scaleY,
+            },
+            clipX,
+            clipY,
+          });
+        }
+      }
+    }
+
+    return targetRects.flatMap((targetRect) => {
+      let left = Math.max(0, ownerRect.left, targetRect.left);
+      let top = Math.max(0, ownerRect.top, targetRect.top);
+      let right = Math.min(viewportWidth, ownerRect.right, targetRect.right);
+      let bottom = Math.min(
+        viewportHeight,
+        ownerRect.bottom,
+        targetRect.bottom,
+      );
+      for (const ancestor of clippingAncestors) {
+        if (ancestor.clipX) {
+          left = Math.max(left, ancestor.rect.left);
+          right = Math.min(right, ancestor.rect.right);
+        }
+        if (ancestor.clipY) {
+          top = Math.max(top, ancestor.rect.top);
+          bottom = Math.min(bottom, ancestor.rect.bottom);
+        }
+      }
+      return right > left && bottom > top
+        ? [
+          `left: ${left}px; top: ${top}px; width: ${right - left}px; ` +
+          `height: ${bottom - top}px`,
+        ]
+        : [];
+    });
   }
 
   /** Drop everything the data/actions panels read, and their subscriptions. */
@@ -1048,7 +1374,28 @@ export class CFPieceMenu extends BaseElement {
 
   protected override render() {
     if (this.hidden || !this.cell) return nothing;
-    return this.panel ? this.#renderPanel(this.panel) : this.#renderMenu();
+    return html`
+      ${this.#renderNestedHighlight()} ${this.panel
+        ? this.#renderPanel(this.panel)
+        : this.#renderMenu()}
+    `;
+  }
+
+  #renderNestedHighlight(): TemplateResult | typeof nothing {
+    const styles = this.#nestedHighlightGeometry;
+    return styles.length > 0
+      ? html`
+        ${styles.map((style) =>
+          html`
+            <div
+              class="nested-piece-highlight"
+              aria-hidden="true"
+              style="${style}"
+            ></div>
+          `
+        )}
+      `
+      : nothing;
   }
 
   #renderMenu(): TemplateResult {
@@ -1556,19 +1903,23 @@ function copyThemeVariables(from: Element, to: HTMLElement): void {
 /**
  * The one menu element, mounted on `document.body`. A single shared instance
  * means a right-click while a menu is open replaces it rather than stacking
- * another overlay, and the element outlives the `cf-render` that opened it (a
- * piece can re-render, or stop, while its menu is up).
+ * another overlay. The shared element stays mounted between openings, including
+ * when the `cf-render` that opened it disconnects and closes it.
  */
 let shared: CFPieceMenu | undefined;
 
 /** Show the piece menu for `cell` at a click position. */
 export function openPieceMenu(
-  { cell, x, y, themeFrom }: {
+  { cell, x, y, themeFrom, highlightedPiece, highlightTarget }: {
     cell: CellHandle;
     x: number;
     y: number;
     /** The element the click came from, whose theme the menu adopts. */
     themeFrom?: Element;
+    /** The rendered piece to highlight while the menu remains open. */
+    highlightedPiece?: Element;
+    /** A nested pattern root to highlight within the rendered piece. */
+    highlightTarget?: Element;
   },
 ): CFPieceMenu {
   if (!shared || !shared.isConnected) {
@@ -1576,6 +1927,11 @@ export function openPieceMenu(
     globalThis.document.body.appendChild(shared);
   }
   if (themeFrom) copyThemeVariables(themeFrom, shared);
-  shared.open({ cell, x, y });
+  shared.open({ cell, x, y, highlightedPiece, highlightTarget });
   return shared;
+}
+
+/** Close the shared menu if `piece` is the render element that opened it. */
+export function closePieceMenuFor(piece: Element): void {
+  shared?.closeFor(piece);
 }

--- a/packages/ui/src/v2/components/cf-render/cf-render.test.ts
+++ b/packages/ui/src/v2/components/cf-render/cf-render.test.ts
@@ -3,6 +3,7 @@ import { expect } from "@std/expect";
 import { defer } from "@commonfabric/utils/defer";
 import { createMockCellHandle } from "../../test-utils/mock-cell-handle.ts";
 import type { CellHandle } from "@commonfabric/runtime-client";
+import { providePieceBoundary } from "../../../../../html/src/main/space-context.ts";
 import {
   CFRender,
   hasVariantValue,
@@ -1034,6 +1035,7 @@ describe("CFRender piece context menu", () => {
   function contextMenuEvent(
     deepestTarget?: EventTarget,
     modifiers: { shiftKey?: boolean } = {},
+    ancestors: EventTarget[] = [],
   ): MouseEvent & { defaultPrevented: boolean; propagationStopped: boolean } {
     const event = {
       clientX: 120,
@@ -1041,7 +1043,7 @@ describe("CFRender piece context menu", () => {
       shiftKey: modifiers.shiftKey ?? false,
       defaultPrevented: false,
       propagationStopped: false,
-      composedPath: () => (deepestTarget ? [deepestTarget] : []),
+      composedPath: () => (deepestTarget ? [deepestTarget, ...ancestors] : []),
       preventDefault() {
         event.defaultPrevented = true;
       },
@@ -1207,6 +1209,90 @@ describe("CFRender piece context menu", () => {
 
     const detail = rightClick(element, contextMenuEvent());
     expect(detail?.pieceId).toBe("of:fid1:tile-piece");
+    expect(detail?.variant).toBe("full");
+  });
+
+  it("reports the innermost nested pattern in the click path", () => {
+    const element = new CFRender();
+    element.variant = "tile";
+    element.cell = createMockCellHandle({ name: "outer" }, {
+      id: "of:fid1:outer-piece" as never,
+      space: "did:key:zSpace" as never,
+    }) as CellHandle;
+    const inner = createMockCellHandle({ name: "inner" }, {
+      id: "of:fid1:inner-piece" as never,
+      space: "did:key:zSpace" as never,
+    }) as CellHandle;
+    const innerRoot = new EventTarget() as unknown as Element;
+    providePieceBoundary(innerRoot, inner);
+
+    const detail = rightClick(
+      element,
+      contextMenuEvent(innerRoot, {}, [element]),
+    );
+
+    expect(detail?.pieceId).toBe("of:fid1:inner-piece");
+    expect(detail?.variant).toBe("full");
+  });
+
+  it("does not inherit a piece boundary outside this renderer", () => {
+    const element = new CFRender();
+    element.cell = createMockCellHandle({ name: "inner" }, {
+      id: "of:fid1:inner-piece" as never,
+      space: "did:key:zSpace" as never,
+    }) as CellHandle;
+    const outer = createMockCellHandle({ name: "outer" }, {
+      id: "of:fid1:outer-piece" as never,
+      space: "did:key:zSpace" as never,
+    }) as CellHandle;
+    const outerRoot = new EventTarget() as unknown as Element;
+    providePieceBoundary(outerRoot, outer);
+    const innerTarget = {
+      dispatchEvent: (event: Event) => outerRoot.dispatchEvent(event),
+    } as EventTarget;
+
+    const detail = rightClick(
+      element,
+      contextMenuEvent(innerTarget, {}, [element, outerRoot]),
+    );
+
+    expect(detail?.pieceId).toBe("of:fid1:inner-piece");
+    expect(detail?.variant).toBe("full");
+  });
+
+  it("skips a nested provider that is not a whole piece", () => {
+    const element = new CFRender();
+    element.cell = createMockCellHandle({ name: "renderer" }, {
+      id: "of:fid1:renderer-piece" as never,
+      space: "did:key:zSpace" as never,
+    }) as CellHandle;
+    const outer = createMockCellHandle({ name: "outer" }, {
+      id: "of:fid1:outer-piece" as never,
+      space: "did:key:zSpace" as never,
+    }) as CellHandle;
+    const field = createMockCellHandle({ name: "field" }, {
+      id: "of:fid1:field-piece" as never,
+      space: "did:key:zSpace" as never,
+      path: ["value"],
+    }) as CellHandle;
+    const outerRoot = new EventTarget() as unknown as Element;
+    const fieldRoot = new EventTarget() as unknown as Element;
+    providePieceBoundary(outerRoot, outer);
+    providePieceBoundary(fieldRoot, field);
+    const deepestTarget = {
+      dispatchEvent(event: Event) {
+        fieldRoot.dispatchEvent(event);
+        if (!event.cancelBubble) outerRoot.dispatchEvent(event);
+        return !event.defaultPrevented;
+      },
+    } as EventTarget;
+
+    const detail = rightClick(
+      element,
+      contextMenuEvent(deepestTarget, {}, [fieldRoot, outerRoot, element]),
+    );
+
+    expect(detail?.pieceId).toBe("of:fid1:outer-piece");
     expect(detail?.variant).toBe("full");
   });
 });

--- a/packages/ui/src/v2/components/cf-render/cf-render.ts
+++ b/packages/ui/src/v2/components/cf-render/cf-render.ts
@@ -2,7 +2,7 @@ import { css, html, PropertyValues } from "lit";
 import { createRef, type Ref, ref } from "lit/directives/ref.js";
 import { state } from "lit/decorators.js";
 import { BaseElement } from "../../core/base-element.ts";
-import { render } from "@commonfabric/html/client";
+import { getPieceBoundary, render } from "@commonfabric/html/client";
 import {
   type CellHandle,
   CHIP_UI,
@@ -15,7 +15,10 @@ import type { DID } from "@commonfabric/identity";
 import "../cf-loader/index.ts";
 import "../cf-cell-link/index.ts";
 import "../cf-piece-menu/index.ts";
-import { openPieceMenu } from "../cf-piece-menu/cf-piece-menu.ts";
+import {
+  closePieceMenuFor,
+  openPieceMenu,
+} from "../cf-piece-menu/cf-piece-menu.ts";
 
 // Set to true to enable debug logging
 const DEBUG_LOGGING = false;
@@ -132,6 +135,21 @@ export class CFRender extends BaseElement {
       overflow: visible;
     }
 
+    .render-stack {
+      display: grid;
+      width: 100%;
+      height: 100%;
+      min-width: 0;
+      min-height: 0;
+    }
+
+    .render-container,
+    .piece-menu-highlight {
+      grid-area: 1 / 1;
+      min-width: 0;
+      min-height: 0;
+    }
+
     .render-container {
       display: flex;
       flex-direction: column;
@@ -140,11 +158,81 @@ export class CFRender extends BaseElement {
       overflow: auto;
     }
 
+    .piece-menu-highlight {
+      z-index: 1;
+      pointer-events: none;
+      opacity: 0;
+    }
+
+    :host([data-cf-piece-menu-open]) .render-stack,
+    :host([data-cf-piece-menu-open]) .render-container {
+      isolation: isolate;
+    }
+
+    :host([data-cf-piece-menu-open]) .piece-menu-highlight {
+      opacity: 1;
+      background-color: rgba(99, 102, 241, 0.14);
+      background-image: linear-gradient(
+        135deg,
+        rgba(255, 255, 255, 0) 26%,
+        rgba(255, 255, 255, 0.64) 48%,
+        rgba(103, 232, 249, 0.36) 54%,
+        rgba(255, 255, 255, 0) 72%
+      );
+      background-position: 200% 0;
+      background-repeat: no-repeat;
+      background-size: 250% 100%;
+      box-shadow: inset 0 0 2.5rem rgba(129, 140, 248, 0.38);
+      animation: cf-piece-menu-shine 1.7s ease-in-out infinite;
+    }
+
+    @keyframes cf-piece-menu-shine {
+      from {
+        background-position: 200% 0;
+      }
+      to {
+        background-position: -200% 0;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      :host([data-cf-piece-menu-open]) .piece-menu-highlight {
+        animation: none;
+        background-position: 50% 0;
+      }
+    }
+
+    @media (forced-colors: active) {
+      :host([data-cf-piece-menu-open]) .piece-menu-highlight {
+        forced-color-adjust: none;
+        background-color: transparent;
+        background-image: linear-gradient(
+          135deg,
+          transparent 26%,
+          Highlight 48%,
+          transparent 72%
+        );
+        box-shadow: inset 0 0 0 0.25rem Highlight;
+      }
+    }
+
     :host([variant="chip"]) .render-container {
       display: inline-block;
       width: auto;
       height: auto;
       overflow: visible;
+    }
+
+    :host([variant="chip"]) .render-stack {
+      display: inline-grid;
+      width: auto;
+      height: auto;
+      align-items: baseline;
+      vertical-align: baseline;
+    }
+
+    :host([variant="chip"]) .piece-menu-highlight {
+      align-self: stretch;
     }
 
     /* Tile default: a fixed, clickable preview that navigates to the piece.
@@ -233,7 +321,10 @@ export class CFRender extends BaseElement {
           </div>
         `
         : null}
-      <div class="render-container" ${ref(this._containerRef)}></div>
+      <div class="render-stack">
+        <div class="render-container" ${ref(this._containerRef)}></div>
+        <div class="piece-menu-highlight" aria-hidden="true"></div>
+      </div>
     `;
   }
 
@@ -256,6 +347,7 @@ export class CFRender extends BaseElement {
         this._log("cell property changed, should rerender:", shouldRerender);
 
         if (shouldRerender) {
+          closePieceMenuFor(this);
           // Reset render state when cell changes - ensures we'll render the new cell
           this._cleanupLinkTargetSubscription();
           this._hasRendered = false;
@@ -409,9 +501,10 @@ export class CFRender extends BaseElement {
         ) {
           return;
         }
-        observedTarget = validTarget;
         if (this._linkTargetToken !== token) return;
         if (!this.cell?.equals(cell)) return;
+        closePieceMenuFor(this);
+        observedTarget = validTarget;
         this._linkTargetObserved = validTarget;
         this._resolvedCell = undefined;
         if (validTarget === undefined) {
@@ -511,6 +604,27 @@ export class CFRender extends BaseElement {
     }
   }
 
+  /** The deepest nested pattern root in the click path, when there is one. */
+  private _nestedPieceTarget(
+    event: MouseEvent,
+  ): { cell: CellHandle; element: Element } | undefined {
+    const path = event.composedPath();
+    const rendererIndex = path.indexOf(this);
+    if (rendererIndex < 0) return undefined;
+    return getPieceBoundary(path[0], (target) => {
+      const providerIndex = path.indexOf(target.element);
+      if (
+        providerIndex < 0 || providerIndex >= rendererIndex ||
+        !isCellHandle(target.cell)
+      ) return false;
+      try {
+        return target.cell.ref().path.length === 0;
+      } catch {
+        return false;
+      }
+    });
+  }
+
   /**
    * Open the piece's menu on right-click. The innermost rendered piece claims
    * the click, so right-clicking a tile inside a piece addresses the tile.
@@ -525,14 +639,15 @@ export class CFRender extends BaseElement {
    */
   private _onContextMenu = (e: MouseEvent) => {
     if (e.shiftKey || isTextEntry(e.composedPath()[0])) return;
-    const target = this._pieceTarget();
+    const nestedTarget = this._nestedPieceTarget(e);
+    const target = nestedTarget?.cell ?? this._pieceTarget();
     if (!target) return;
     const detail: PieceContextMenuDetail = {
       space: target.space(),
       pieceId: target.id(),
       x: e.clientX,
       y: e.clientY,
-      variant: normalizeVariant(this.variant),
+      variant: nestedTarget ? "full" : normalizeVariant(this.variant),
     };
     const claimed = !this.dispatchEvent(
       new CustomEvent<PieceContextMenuDetail>(PIECE_CONTEXT_MENU_EVENT, {
@@ -551,6 +666,8 @@ export class CFRender extends BaseElement {
       x: e.clientX,
       y: e.clientY,
       themeFrom: this,
+      highlightedPiece: this,
+      highlightTarget: nestedTarget?.element,
     });
   };
 
@@ -608,6 +725,7 @@ export class CFRender extends BaseElement {
 
   override disconnectedCallback() {
     this._log("disconnectedCallback called");
+    closePieceMenuFor(this);
     this.removeEventListener("contextmenu", this._onContextMenu);
     super.disconnectedCallback();
     this._renderGeneration++;


### PR DESCRIPTION
Right-clicking content rendered by a nested pattern opened the context menu for the outer piece. Source, history, data, and action controls could therefore address a different piece from the one under the pointer.

Preserve each trusted nested pattern's whole result cell as a piece boundary on its existing root element. Resolve the nearest valid boundary through the standard element context protocol, while skipping field-level boundaries and boundaries outside the current renderer. Subscribe to boundary changes so an open menu closes synchronously when its target is replaced or removed.

Highlight the selected piece while its menu or a menu panel is open. Use an animated light sweep and color glow for the outer renderer, and a fixed portalled overlay clipped to nested roots. Neither form receives pointer events or changes the rendered layout.

Cover direct nested patterns, nested renderers, retargeting, lifecycle cleanup, layout stability, and the full browser interaction.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

