### PR TITLE
fix(runner): keep converging retries below warning level

### DIFF
--- a/packages/runner/src/scheduler/events.ts
+++ b/packages/runner/src/scheduler/events.ts
@@ -1215,7 +1215,7 @@ export async function dispatchQueuedEvent(state: {
           );
           break;
         case "backoff":
-          logger.warn(
+          logger.debug(
             "scheduler",
             `Event handler commit failed transiently; backing off ` +
               `${Math.round(disposition.delayMs)}ms ` +

--- a/packages/runner/test/scheduler-commit-backpressure.test.ts
+++ b/packages/runner/test/scheduler-commit-backpressure.test.ts
@@ -38,6 +38,7 @@ import type {
 } from "./scheduler-test-utils.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
 import { defer } from "@commonfabric/utils/defer";
+import { getLoggerCountsBreakdown } from "@commonfabric/utils/logger";
 import { resolveLink } from "../src/link-resolution.ts";
 import {
   computeBackoffDelayMs,
@@ -121,6 +122,10 @@ function collectEventCommitMarkers(runtime: Runtime): {
     firstMarker: firstMarker.promise,
     dispose: () => runtime.telemetry.removeEventListener("telemetry", listener),
   };
+}
+
+function schedulerWarningCount(): number {
+  return getLoggerCountsBreakdown().scheduler?.scheduler?.warn ?? 0;
 }
 
 async function waitFor(
@@ -322,6 +327,52 @@ describe("committed-write backpressure", () => {
         // The write converged, so no terminal error.
         expect(terminalErrors).toHaveLength(0);
       } finally {
+        injector.restore();
+      }
+    },
+  );
+
+  it(
+    "does not warn when a transient conflict converges on retry",
+    async () => {
+      const piece = buildCounterPiece(runtime, tx, "backpressure-warning-root");
+      await tx.commit();
+      tx = runtime.edit();
+      await runtime.idle();
+
+      const warningBaseline = schedulerWarningCount();
+      const injector = rejectServerTransacts(storageManager, 1, {
+        name: "ConflictError",
+        message: "forced transient conflict",
+      });
+      const converged = defer<void>();
+      const listener = (event: Event) => {
+        const marker = (event as CustomEvent<{
+          marker: RuntimeTelemetryMarker;
+        }>).detail.marker;
+        if (
+          marker.type === "scheduler.event.commit" &&
+          marker.error === undefined
+        ) {
+          converged.resolve();
+        }
+      };
+      runtime.telemetry.addEventListener("telemetry", listener);
+
+      try {
+        piece.queueAdd(
+          3,
+          "evt:backpressure-warning:0:backpressure-warning-root",
+        );
+
+        await converged.promise;
+        await runtime.idle();
+
+        expect(piece.total()).toBe(3);
+        expect(injector.rejected()).toBe(1);
+        expect(schedulerWarningCount() - warningBaseline).toBe(0);
+      } finally {
+        runtime.telemetry.removeEventListener("telemetry", listener);
         injector.restore();
       }
     },


### PR DESCRIPTION
Stale-basis conflicts are an expected part of optimistic event commits. The scheduler retries them and records each outcome in structured telemetry, but logging every retry as a warning makes strict pattern tests fail whenever normal multi-user contention occurs.

Record transient retries at debug level. Keep terminal, permanent, and dropped commit outcomes at their existing warning or error levels.

Add a deterministic regression test that injects one stale-basis conflict, waits for the retry to commit, and verifies that the write converges without increasing the scheduler warning count.

deflaked by Hixie's agent

Agent: Codex

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

