### PR TITLE
fix(data-model): quote arbitrary message text with `backtickQuote()`

### DIFF
--- a/packages/data-model/src/codec-common/EmptyReconstructionContext.ts
+++ b/packages/data-model/src/codec-common/EmptyReconstructionContext.ts
@@ -8,6 +8,7 @@
 import type { FabricInstance } from "@/interface.ts";
 import type { ReconstructionContext } from "./interface.ts";
 import { BaseReconstructionContext } from "./BaseReconstructionContext.ts";
+import { backtickQuote } from "@/value-debug.ts";
 
 /**
  * `ReconstructionContext` whose `getCell()` always throws. `shouldDeepFreeze`
@@ -32,7 +33,9 @@ export class EmptyReconstructionContext extends BaseReconstructionContext {
     ref: { id: string; path: string[]; space: string },
   ): FabricInstance {
     throw new Error(
-      `Cannot reconstruct cell reference \`${ref.id}\`: ${this.#getCellMessage}`,
+      `Cannot reconstruct cell reference ${
+        backtickQuote(ref.id)
+      }: ${this.#getCellMessage}`,
     );
   }
 }

--- a/packages/data-model/src/codec-json/JsonCodec.ts
+++ b/packages/data-model/src/codec-json/JsonCodec.ts
@@ -70,7 +70,7 @@ export class JsonCodec implements SerializationContext<string> {
     if (!JsonCodec.seemsLikeEncoded(data)) {
       const excerpt = (data.length <= 50) ? data : `${data.slice(0, 50)}...`;
       throw new Error(
-        `Not a JSON-encoded \`FabricValue\` string: \`${excerpt}\``,
+        `Not a JSON-encoded \`FabricValue\` string: ${backtickQuote(excerpt)}`,
       );
     }
 
@@ -183,7 +183,9 @@ export class JsonCodec implements SerializationContext<string> {
       // recognized by a registered codec. Complain here since we didn't find a
       // `codec` above.
       throw new Error(
-        `No codec registered for fabric object class: \`${value.constructor.name}\``,
+        `No codec registered for fabric object class: ${
+          backtickQuote(value.constructor.name)
+        }`,
       );
     }
 
@@ -578,7 +580,9 @@ export class JsonCodec implements SerializationContext<string> {
     if (isMalformed) {
       if (!JsonCodec.seemsLikeEncoded(encoded)) {
         throw new Error(
-          `Not a JSON-encoded \`FabricValue\` string: \`${encoded}\``,
+          `Not a JSON-encoded \`FabricValue\` string: ${
+            backtickQuote(encoded)
+          }`,
         );
       }
     } else {

--- a/packages/data-model/src/fabric-instances/FabricLink.ts
+++ b/packages/data-model/src/fabric-instances/FabricLink.ts
@@ -165,7 +165,9 @@ function assertValidPayload(
   }
   for (const key of Object.keys(payload)) {
     if (isUnsafeObjectKey(key)) {
-      throw new Error(`Link payload has a forbidden key: \`${key}\`.`);
+      throw new Error(
+        `Link payload has a forbidden key: \`${key}\`.`,
+      );
     }
   }
 }

--- a/packages/data-model/src/fabric-instances/FabricNativeWrapper.ts
+++ b/packages/data-model/src/fabric-instances/FabricNativeWrapper.ts
@@ -1,5 +1,6 @@
 import type { FabricInstance } from "@/interface.ts";
 import { BaseFabricInstance, DEEP_CLONE_CORE } from "./BaseFabricInstance.ts";
+import { backtickQuote } from "@/value-debug.ts";
 
 /**
  * Abstract base class for `FabricInstance` wrappers that bridge native JS
@@ -44,7 +45,9 @@ export abstract class FabricNativeWrapper<T extends object>
    */
   protected [DEEP_CLONE_CORE](_frozen: boolean): FabricInstance {
     throw new Error(
-      `Cannot yet handle deep cloning of \`${this.constructor.name}\`.`,
+      `Cannot yet handle deep cloning of ${
+        backtickQuote(this.constructor.name)
+      }.`,
     );
   }
 }

--- a/packages/data-model/src/fabric-primitives/FabricHash.ts
+++ b/packages/data-model/src/fabric-primitives/FabricHash.ts
@@ -19,6 +19,7 @@ import {
 } from "@/codec-common/interface.ts";
 import { ProblematicValue } from "@/fabric-instances/ProblematicValue.ts";
 import { CODEC_TYPE_TAGS } from "@/codec-common/codec-type-tags.ts";
+import { backtickQuote } from "@/value-debug.ts";
 
 /**
  * Content-addressed identifier: a hash digest paired with an algorithm tag.
@@ -125,7 +126,9 @@ export class FabricHash extends BaseFabricPrimitive implements ApiFabricHash {
   static fromString(source: string): FabricHash {
     const colonIndex = source.indexOf(":");
     if (colonIndex === -1) {
-      throw new ReferenceError(`Invalid content hash string: \`${source}\``);
+      throw new ReferenceError(
+        `Invalid content hash string: ${backtickQuote(source)}`,
+      );
     }
     const tag = source.substring(0, colonIndex);
     const hashBase64url = source.substring(colonIndex + 1);

--- a/packages/data-model/src/fabric-primitives/FabricRegExp.ts
+++ b/packages/data-model/src/fabric-primitives/FabricRegExp.ts
@@ -14,6 +14,7 @@ import {
 import { ProblematicValue } from "@/fabric-instances/ProblematicValue.ts";
 import { CODEC_TYPE_TAGS } from "@/codec-common/codec-type-tags.ts";
 import { isPlainObject } from "@commonfabric/utils/types";
+import { backtickQuote } from "@/value-debug.ts";
 
 /** The only regex flavor currently representable as a native `RegExp`. */
 const DEFAULT_FLAVOR = "es2025";
@@ -121,7 +122,9 @@ export class FabricRegExp extends BaseFabricPrimitive
   get value(): RegExp {
     if (this.#value === undefined) {
       throw new Error(
-        `Cannot represent flavor \`${this.#flavor}\` as a native \`RegExp\`.`,
+        `Cannot represent flavor ${
+          backtickQuote(this.#flavor)
+        } as a native \`RegExp\`.`,
       );
     }
     return new RegExp(this.#value);

--- a/packages/data-model/src/fabric-primitives/index.ts
+++ b/packages/data-model/src/fabric-primitives/index.ts
@@ -7,6 +7,7 @@ import { FabricEpochDays } from "./FabricEpochDays.ts";
 import { FabricEpochNsec } from "./FabricEpochNsec.ts";
 import { FabricHash } from "./FabricHash.ts";
 import { FabricRegExp } from "./FabricRegExp.ts";
+import { backtickQuote } from "@/value-debug.ts";
 
 export { BaseFabricPrimitive } from "./BaseFabricPrimitive.ts";
 export { FabricBytes } from "./FabricBytes.ts";
@@ -59,7 +60,7 @@ export function schemaTypeOfFabricPrimitive(
   if (value instanceof FabricRegExp) return "FabricRegExp";
   throw new Error(
     `Shouldn't happen: \`FabricPrimitive\` subclass without a schema type ` +
-      `name: \`${value.constructor.name}\`. Add it to ` +
+      `name: ${backtickQuote(value.constructor.name)}. Add it to ` +
       "`schemaTypeOfFabricPrimitive()` and `FABRIC_PRIMITIVE_SCHEMA_TYPES`.",
   );
 }

--- a/packages/data-model/src/native-conversion.ts
+++ b/packages/data-model/src/native-conversion.ts
@@ -24,6 +24,7 @@ import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
 import { NATIVE_TAGS, tagFromNativeValue } from "./native-type-tags.ts";
 import { cloneHelper } from "./value-clone.ts";
 import { isDeepFrozenFabricValue } from "./deep-freeze.ts";
+import { backtickQuote } from "./value-debug.ts";
 
 /**
  * Helper for `shallowFabricFromNativeValue()`, which rejects native objects
@@ -363,9 +364,9 @@ export function shallowFabricFromNativeValue(
       // Unrecognized object types (`Map`, `Set`, class instances, etc.) --
       // not valid `FabricValue`. Death before confusion!
       throw new Error(
-        `Not representable as a \`FabricValue\`: \`${
-          (value as object).constructor?.name ?? typeof value
-        }\` (not a recognized fabric type)`,
+        `Not representable as a \`FabricValue\`: ${
+          backtickQuote((value as object).constructor?.name ?? typeof value)
+        } (not a recognized fabric type)`,
       );
   }
 }

--- a/packages/data-model/src/value-clone.ts
+++ b/packages/data-model/src/value-clone.ts
@@ -242,9 +242,9 @@ export function cloneHelper(
     default:
       // All valid `FabricValue` types are handled above.
       throw new Error(
-        `Cannot clone: \`${
-          (value as object).constructor?.name ?? typeof value
-        }\``,
+        `Cannot clone: ${
+          backtickQuote((value as object).constructor?.name ?? typeof value)
+        }`,
       );
   }
 }
@@ -510,7 +510,9 @@ export function cloneForMutation<T extends FabricValue>(
         "missing-segment",
         i,
         "undefined",
-        `\`cloneForMutation()\`: missing path segment \`${key}\` at ` +
+        `\`cloneForMutation()\`: missing path segment ${
+          backtickQuote(key)
+        } at ` +
           `index \`${i}\``,
       );
     }

--- a/packages/data-model/src/value-hash.ts
+++ b/packages/data-model/src/value-hash.ts
@@ -25,6 +25,7 @@ import { BaseFabricInstance } from "@/fabric-instances/BaseFabricInstance.ts";
 import { codecOf } from "@/codec-common/index.ts";
 import { shallowFabricFromNativeValue } from "./native-conversion.ts";
 import { NATIVE_TAGS, tagFromNativeValue } from "./native-type-tags.ts";
+import { backtickQuote } from "./value-debug.ts";
 
 //
 // Type tag bytes (Section 2 of the byte-level spec)
@@ -340,9 +341,9 @@ function feedObjectValue(
       // Nothing else is handled. As of this writing, specifically missing are
       // `Map`, `Set`, and `Error`.
       throw new Error(
-        `\`hashOf()\`: unsupported object type \`${
-          value?.constructor?.name ?? typeof value
-        }\``,
+        `\`hashOf()\`: unsupported object type ${
+          backtickQuote(value?.constructor?.name ?? typeof value)
+        }`,
       );
     }
   }

--- a/packages/data-model/test/message-quoting.test.ts
+++ b/packages/data-model/test/message-quoting.test.ts
@@ -1,0 +1,87 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { cloneIfNecessary } from "@/value-clone.ts";
+import { FabricHash } from "@/fabric-primitives/FabricHash.ts";
+import { hashOf } from "@/value-hash.ts";
+import { newDefaultJsonCodec } from "@/codecs.ts";
+import { EmptyReconstructionContext } from "@/codec-common/index.ts";
+import { codeSpanIn } from "./parse-code-span.ts";
+
+/**
+ * Builds a class instance whose `constructor.name` holds the given text.
+ * `Function.prototype.name` is configurable, so a value arriving from user
+ * data can carry any name at all -- including backticks.
+ */
+function instanceNamed(name: string): object {
+  class Named {}
+  Object.defineProperty(Named, "name", { value: name });
+  return new Named();
+}
+
+// Text that breaks a hand-written pair of backticks: a lone backtick closes
+// the span early, a doubled run defeats a two-backtick delimiter, and a
+// leading backtick merges into the opening delimiter.
+const HOSTILE = ["a`b", "a``b", "`lead", "trail`", "`", "``"];
+
+describe("message quoting", () => {
+  describe("`FabricHash.fromString()`", () => {
+    it("hands back the source it refused, whatever backticks it held", () => {
+      for (const source of HOSTILE) {
+        let message = "";
+        try {
+          FabricHash.fromString(source);
+        } catch (e) {
+          message = (e as Error).message;
+        }
+        expect(codeSpanIn(message, "Invalid content hash string: "))
+          .toBe(source);
+      }
+    });
+  });
+
+  describe("`hashOf()`", () => {
+    it("hands back the class name it refused", () => {
+      for (const name of HOSTILE) {
+        let message = "";
+        try {
+          hashOf(instanceNamed(name) as never);
+        } catch (e) {
+          message = (e as Error).message;
+        }
+        expect(codeSpanIn(message, "unsupported object type ")).toBe(name);
+      }
+    });
+  });
+
+  describe("`cloneIfNecessary()`", () => {
+    it("hands back the class name it refused", () => {
+      for (const name of HOSTILE) {
+        let message = "";
+        try {
+          cloneIfNecessary(instanceNamed(name) as never);
+        } catch (e) {
+          message = (e as Error).message;
+        }
+        expect(codeSpanIn(message, "Cannot clone: ")).toBe(name);
+      }
+    });
+  });
+
+  describe("`JsonCodec.decode()`", () => {
+    it("hands back the excerpt it refused", () => {
+      const context = new EmptyReconstructionContext(false);
+      for (const data of HOSTILE) {
+        let message = "";
+        try {
+          newDefaultJsonCodec().decode(data, context);
+        } catch (e) {
+          message = (e as Error).message;
+        }
+        expect(
+          codeSpanIn(message, "Not a JSON-encoded `FabricValue` string: "),
+        ).toBe(data);
+      }
+    });
+  });
+});

--- a/packages/data-model/test/parse-code-span.ts
+++ b/packages/data-model/test/parse-code-span.ts
@@ -1,0 +1,55 @@
+/**
+ * Test-only reader for a Markdown code span, used to check that a message
+ * carrying arbitrary text still hands that text back intact.
+ */
+
+/**
+ * Reads one Markdown code span: the opening and closing delimiters are
+ * equal-length backtick runs, and a reader drops one leading and one trailing
+ * space when the content has both and is not all spaces.
+ *
+ * Written from the specification rather than from `backtickQuote()`, so that a
+ * round-trip test has an independent other half. A parser derived from that
+ * function would agree with it whatever either one did.
+ */
+export function parseCodeSpan(markdown: string): string {
+  const open = /^`+/.exec(markdown)?.[0];
+  const close = /`+$/.exec(markdown)?.[0];
+
+  if ((open === undefined) || (close === undefined)) {
+    throw new Error(`Not a code span: ${markdown}`);
+  } else if (open.length !== close.length) {
+    throw new Error(`Mismatched delimiters: ${markdown}`);
+  }
+
+  const content = markdown.slice(open.length, markdown.length - close.length);
+
+  return (content.startsWith(" ") && content.endsWith(" ") &&
+      /[^ ]/.test(content))
+    ? content.slice(1, -1)
+    : content;
+}
+
+/**
+ * Extracts the single code span embedded in `message`, given the `before` and
+ * `after` text that brackets it. Throws if the message does not have that
+ * shape, which is itself the failure a caller wants reported.
+ */
+export function codeSpanIn(
+  message: string,
+  before: string,
+  after: string = "",
+): string {
+  const start = message.indexOf(before);
+  if (start === -1) {
+    throw new Error(`Message does not contain ${before}: ${message}`);
+  }
+
+  const from = start + before.length;
+  const to = (after === "") ? message.length : message.indexOf(after, from);
+  if (to === -1) {
+    throw new Error(`Message does not contain ${after}: ${message}`);
+  }
+
+  return parseCodeSpan(message.slice(from, to));
+}

--- a/packages/data-model/test/value-debug.test.ts
+++ b/packages/data-model/test/value-debug.test.ts
@@ -13,32 +13,7 @@ import { FabricError } from "@/fabric-instances/FabricError.ts";
 import { FabricMap } from "@/fabric-instances/FabricMap.ts";
 import { FabricRegExp } from "@/fabric-primitives/FabricRegExp.ts";
 import { FabricSpecialObject } from "@/interface.ts";
-
-/**
- * Reads one Markdown code span: the opening and closing delimiters are
- * equal-length backtick runs, and a reader drops one leading and one trailing
- * space when the content has both and is not all spaces.
- *
- * Written from the specification rather than from `backtickQuote()`, so that
- * the round-trip test has an independent other half.
- */
-function parseCodeSpan(markdown: string): string {
-  const open = /^`+/.exec(markdown)?.[0];
-  const close = /`+$/.exec(markdown)?.[0];
-
-  if ((open === undefined) || (close === undefined)) {
-    throw new Error(`Not a code span: ${markdown}`);
-  } else if (open.length !== close.length) {
-    throw new Error(`Mismatched delimiters: ${markdown}`);
-  }
-
-  const content = markdown.slice(open.length, markdown.length - close.length);
-
-  return (content.startsWith(" ") && content.endsWith(" ") &&
-      /[^ ]/.test(content))
-    ? content.slice(1, -1)
-    : content;
-}
+import { parseCodeSpan } from "./parse-code-span.ts";
 
 describe("value-debug", () => {
   describe("toCompactDebugString", () => {


### PR DESCRIPTION
I (agent working on behalf of @danfuzz) re-audited every interpolation that
lands in a message string across the five packages of the conformance sweep —
`content-hash`, `leb128`, `pure-json`, `utils`, `data-model` — asking one
question of each: **can the text it splices in hold a backtick?**

53 interpolations. The answer splits cleanly.

## Twelve sites can, and were quoting by hand

All in `data-model`, all now going through `backtickQuote()`:

* **Text arriving from outside** — a hash string (`FabricHash.fromString()`), a
  `data:` payload excerpt (`JsonCodec.decode()`), a decoded regexp flavor, an
  entity id, a `cloneForMutation()` path segment.
* **A class name.** `Function.prototype.name` is a configurable own property,
  so an instance arriving from user data can report any name at all —
  backticks included. I confirmed that with a probe rather than assuming it:

```
name = "a`b``c"
descriptor = {"value":"a`b``c","writable":false,"enumerable":false,"configurable":true}
```

## Four that look identical are deliberately left alone

`FabricError`'s two extras-key messages, `FabricLink`'s forbidden-key message,
and `native-conversion`'s reserved-name message all interpolate a key — but
each is reached only through a set-membership test (`isUnsafeObjectKey()`,
`FABRIC_ERROR_RESERVED_KEYS.has()`, `unsafeObjectKeyIn()`), so the key is
always one of a fixed roster of names, none containing a backtick. Same for
every `typeof` result, every number (`leb128` is all numbers), and
`frozen-builtins`' `FrozenMap`/`FrozenSet` literal.

The rule I applied: quote with the function when the text comes from outside
the program, hand-quote when it comes from a closed vocabulary the code owns.

## What gives the change grip

`message-quoting.test.ts` is new. It drives four entry points with text a
hand-written pair of backticks cannot survive — `` a`b ``, `` a``b ``, a
leading backtick, a trailing one, a lone one, a doubled one — and parses the
span back out of each thrown message.

**Ablated to check it is not vacuous.** Reverting all four guarded sites to
hand-written backticks turns it red on all four steps; restoring them turns it
green. A test that passes either way would have been worse than none.

The code-span reader moves to `test/parse-code-span.ts` so the two test files
needing it share one copy — still written from the Markdown specification
rather than from `backtickQuote()`, so the round-trip has an independent other
half.

## One finding this PR does not act on

`backtickQuote()` lives in `data-model`, and **none of `utils`, `leb128`,
`pure-json`, or `content-hash` depends on `data-model`** — nor can they, since
`data-model` depends on `utils`. So the helper is unreachable from four of the
five packages the sweep covered.

Only one site out there needs it today: `content-hash`'s
`` `Unknown encoding: \`${encoding}\`` ``, where `encoding` is a caller-supplied
string. That is a small hazard, and the fix is a layering decision rather than
a cleanup — moving `backtickQuote()` to `utils` would put it where every
package can reach it. Flagging rather than doing, since you placed it in
`value-debug.ts` deliberately.

## Verification

`deno task test` in `packages/data-model`: ok, 52 passed (2299 steps). In
`packages/runner`: ok, 1174 passed (6228 steps). Repo-wide `deno fmt --check`,
`deno lint`, `check-no-waitfor`, and `check-conflict-markers` are clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

