### PR TITLE
feat(runner): lazy materialization on by default

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -35,7 +35,7 @@ was last checked against the code.
 | [`eagerSourceAnnotation`](#eagersourceannotation)                           | `EXPERIMENTAL_EAGER_SOURCE_ANNOTATION` env, or `RuntimeOptions.experimental`                                                                    | off in production, on in shell dev builds                                            | gideon (#4458)                                        | permanent debug toggle, not slated for removal                                                                                                                                                                                    | implemented                                                                     |
 | [`systemPatternAutoUpdate`](#systempatternautoupdate)                       | `EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE` env / shell build define, or `RuntimeOptions.experimental`                                             | on in the shell (same-toolshed system sources, including all roots); off server-side | Bernhard Seefeld (#4611; shell default-on #4619)      | graduate to always-on, then delete flag                                                                                                                                                                                           | implemented, on in the shell                                                    |
 | [`computedCellIds`](#computedcellids)                                       | `EXPERIMENTAL_COMPUTED_CELL_IDS` env, or `RuntimeOptions.experimental`                                                                          | on                                                                                   | Robin McCollum (#4659)                                | graduate to unconditional behavior, then delete flag                                                                                                                                                                              | implemented, on by default                                                      |
-| [`lazyMaterialization`](#lazymaterialization)                               | `EXPERIMENTAL_LAZY_MATERIALIZATION` env, or `RuntimeOptions.experimental`                                                                       | off                                                                                  | Bernhard Seefeld                                      | graduate to always-on, then delete flag                                                                                                                                                                                           | implemented, off by default; suites green both ways                                   |
+| [`lazyMaterialization`](#lazymaterialization)                               | `EXPERIMENTAL_LAZY_MATERIALIZATION` env, or `RuntimeOptions.experimental`                                                                       | on                                                                                   | Bernhard Seefeld                                      | fold into base read semantics, then delete flag                                                             | implemented, on by default                                         |
 | [`cfcEnforcementMode`](#cfcenforcementmode)                                 | `RuntimeOptions.cfcEnforcementMode` (`CF_CFC_MODE` in the cf-harness / fuse)                                                                    | `enforce-explicit`                                                                   | Bernhard Seefeld (#3263)                              | tighten default toward `enforce-strict`                                                                                                                                                                                           | active; ladder is permanent                                                     |
 | [`cfcFlowLabels`](#cfcflowlabels)                                           | `RuntimeOptions.cfcFlowLabels`                                                                                                                  | `off`                                                                                | Bernhard Seefeld (#4011)                              | move toward `persist`                                                                                                                                                                                                             | implemented, staged rollout                                                     |
 | [`cfcWriteFloor`](#cfcwritefloor)                                           | `RuntimeOptions.cfcWriteFloor`                                                                                                                  | `off`                                                                                | Bernhard Seefeld (#4479)                              | move toward `enforce`                                                                                                                                                                                                             | implemented, staged rollout                                                     |
@@ -364,10 +364,11 @@ value is ignored with a warning rather than coerced. See
 
 ### `lazyMaterialization`
 
-**Last checked:** 2026-08-09. **Status:** implemented, off by default.
+**Last checked:** 2026-08-09. **Status:** implemented, on by default.
 
 - **Toggle via.** `EXPERIMENTAL_LAZY_MATERIALIZATION` environment variable, or
-  `new Runtime({ experimental: { lazyMaterialization: true } })`.
+  `new Runtime({ experimental: { lazyMaterialization: false } })` as a temporary
+  rollback override.
 - **Purpose.** Materialize a lift's argument lazily. The runner marks the
   action's transaction (`markLazyMaterialize`), and `Cell.get()` on a marked
   transaction hands back a schema-observing view instead of building everything
@@ -958,10 +959,10 @@ useful part of the remaining work for that flag.
 The environment-backed flags (`EXPERIMENTAL_MODERN_CELL_REP`,
 `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE`,
 `EXPERIMENTAL_EAGER_SOURCE_ANNOTATION`,
-`EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE`,
-`EXPERIMENTAL_LAZY_MATERIALIZATION`) reach the runtime through the deployed
-processes. The runtime-only flags (`commitPreconditions`, the CFC dials) reach
-it only through the `RuntimeOptions` passed to `new Runtime(...)`.
+`EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE`, `EXPERIMENTAL_LAZY_MATERIALIZATION`)
+reach the runtime through the deployed processes. The runtime-only flags
+(`commitPreconditions`, the CFC dials) reach it only through the
+`RuntimeOptions` passed to `new Runtime(...)`.
 
 All first-party processes build their `RuntimeOptions` through a construction
 preset in

--- a/docs/plans/lazy-cell-materialization.md
+++ b/docs/plans/lazy-cell-materialization.md
@@ -1,7 +1,8 @@
 # Lazy, schema-observing cell materialization
 
-Status: built end to end behind `lazyMaterialization`, off by default. Stage 6
-(graduation) is what remains.
+Status: built end to end and on by default behind `lazyMaterialization`. What
+remains is removing the flag and the eager path for lift arguments, plus the two
+pieces listed under Stages 3 and 5.
 
 `Cell.get()` materializes everything its schema selects, in one pass, before the
 reader touches any of it. A lift declaring a list of a thousand entries gets a
@@ -437,15 +438,14 @@ diffing and the scheduler's own reads keep eager semantics.
       reachable by `EXPERIMENTAL_LAZY_MATERIALIZATION` or
       `RuntimeOptions.experimental`.
 - [x] Landed default-off with both suites green.
-- [ ] Default-on. Every divergence that stood in the way is closed, and both
-      suites pass with the flag on; flipping the default is its own change.
-      Each divergence was a place a view answered from less than an eager read
-      had: the schema of the last link hop uncombined, a `default` read out of a
-      union branch an eager read never evaluates, an optional property refused
-      where an eager read drops it, and three reads that were answered without
-      being registered. None of them was the "argument refused for a missing
-      field" story the earlier note here guessed at — that disposition worked
-      from the start.
+- [x] Default-on, both suites green. Every divergence that stood in the way was
+      a place a view answered from less than an eager read had: the schema of
+      the last link hop uncombined, a `default` read out of a union branch an
+      eager read never evaluates, an optional property refused where an eager
+      read drops it, and three reads that were answered without being
+      registered. None of them was the "argument refused for a missing field"
+      story the earlier note here guessed at — that disposition worked from the
+      start.
 - [x] Read `.length` off a string. `.length` on a string output lowers to a link
       ending in that segment, and a string's `length` is not a stored path, so
       the store cannot serve the address the link resolves to. Eager traversal

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -236,8 +236,9 @@ export interface ExperimentalOptions {
    * Materialize a lift's argument lazily: the body reads the paths it touches
    * and nothing else, instead of the whole of what its schema selects. A
    * reader that touches data the schema no longer describes refuses, and the
-   * run is disposed of as an argument that did not resolve. Off by default
-   * while it soaks; see `docs/plans/lazy-cell-materialization.md`.
+   * run is disposed of as an argument that did not resolve. On by default; pass
+   * `false` as a temporary rollback override. See
+   * `docs/plans/lazy-cell-materialization.md`.
    */
   lazyMaterialization?: boolean | undefined;
   /**
@@ -995,7 +996,7 @@ export class Runtime {
     // `true` override.
     this.experimental.computedCellIds ??= true;
     this.experimental.plainResultReceipts ??= true;
-    this.experimental.lazyMaterialization ??= false;
+    this.experimental.lazyMaterialization ??= true;
 
     // Propagate experimental flags to their ambient control points, then read
     // back the effective state so `experimental.*` reflects what is actually in

--- a/packages/runner/test/experimental-options.test.ts
+++ b/packages/runner/test/experimental-options.test.ts
@@ -39,6 +39,7 @@ describe("ExperimentalOptions", () => {
           commitPreconditions: false,
           plainResultReceipts: false,
           computedCellIds: false,
+          lazyMaterialization: false,
         },
       });
       expect(runtime.experimental).toEqual({
@@ -71,7 +72,7 @@ describe("ExperimentalOptions", () => {
         commitPreconditions: true,
         plainResultReceipts: true,
         computedCellIds: true,
-        lazyMaterialization: false,
+        lazyMaterialization: true,
         eagerSourceAnnotation: false,
       });
       await runtime.dispose();
@@ -91,7 +92,7 @@ describe("ExperimentalOptions", () => {
         commitPreconditions: true,
         plainResultReceipts: true,
         computedCellIds: true,
-        lazyMaterialization: false,
+        lazyMaterialization: true,
         // Read back from the ambient flag (a test seam that deliberately does
         // NOT reset on dispose — see ExperimentalOptions.eagerSourceAnnotation).
         eagerSourceAnnotation: false,


### PR DESCRIPTION
Stacked on #5551. Flips `lazyMaterialization` to on by default, keeping the flag as a rollback override.

Green: runner unit suite 1189/0, `deno task integration` 7/7, 120/120 pattern tests, rebased on current `main`.

## What the blocker turned out to be

This PR previously described a scheduling-contract decision it needed — whether a lift may observe a transient state, or whether the root guard should resolve `required` properties one level. Neither was the problem, and no decision was needed.

Every failure was a place a lazy read answered from **less than an eager read had**, and each fix is in #5551:

- the schema of the last link hop was not combined into the reader's, so a property the link's own schema does not name read as one the schema does not select;
- an absent value did not take the schema's declared `default`, and once it did, it did not register the read the default stood in for — so the reader kept reading its default however late the value arrived;
- an optional property that stopped matching refused, where an eager read drops it from its object and carries on;
- a union narrowed to a branch dropped the enclosing schema's own `properties`, `required` and `$defs`;
- a string's `length` resolved to an address the store cannot serve, which is the `proxy-length-repro` case this description listed as separate — the same fix corrects the eager path, which also answered `undefined` for such a link;
- an unresolvable `$ref` read as *no schema at all* rather than as one nothing matches.

The "argument refused for a missing field" story the earlier text built on was never the cause: that disposition worked from the start.

## Unchanged from the plan

Handlers stay eager. The write-epoch snapshot is not built — a view handed out before a write still tracks that write, which does not bite the lift case since no writes precede the argument read.

Soak on default-on before removing the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
