### PR TITLE
fix(data-model): make the protocol symbols actually unique

### DIFF
--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -1417,6 +1417,11 @@ lifecycle symbols live on the implementation base class `BaseFabricInstance`
 (Section 2.3), kept off the pure-protocol `FabricInstance` interface as
 implementation plumbing.
 
+Each is a genuinely unique symbol rather than a registry-interned one, so a
+member keyed by it is reachable only by importing the symbol. The string passed
+to `Symbol()` is a description, for debugging; it is not a key anything can look
+the symbol up by.
+
 ```typescript
 // file: packages/data-model/codec-common/interface.ts
 
@@ -1425,7 +1430,7 @@ implementation plumbing.
  * A class hosts its serialization codec as a static getter keyed by this
  * symbol (see Section 2.4).
  */
-export const CODEC: unique symbol = Symbol.for('data-model.codec');
+export const CODEC: unique symbol = Symbol('data-model.codec');
 ```
 
 ```typescript
@@ -1437,7 +1442,7 @@ export const CODEC: unique symbol = Symbol.for('data-model.codec');
  * into any nested `FabricValue`s via a `subFreeze` callback supplied by the
  * generic `deepFreeze()` utility. See Section 8.6.
  */
-export const DEEP_FREEZE = Symbol.for('data-model.deepFreeze');
+export const DEEP_FREEZE: unique symbol = Symbol('data-model.deepFreeze');
 
 /**
  * Well-known symbol for checking whether a fabric instance is already
@@ -1447,7 +1452,7 @@ export const DEEP_FREEZE = Symbol.for('data-model.deepFreeze');
  * via a `subIsDeepFrozen` callback, returning the boolean conjunction.
  * See Section 8.6.
  */
-export const IS_DEEP_FROZEN = Symbol.for('data-model.isDeepFrozen');
+export const IS_DEEP_FROZEN: unique symbol = Symbol('data-model.isDeepFrozen');
 
 /**
  * Well-known symbol for the **internal** shallow-clone hook: a `protected`
@@ -1458,9 +1463,12 @@ export const IS_DEEP_FROZEN = Symbol.for('data-model.isDeepFrozen');
  * `shallowClone()` template method on `BaseFabricInstance` is its only caller
  * (Section 2.3).
  */
-export const SHALLOW_UNFROZEN_CLONE = Symbol.for('data-model.shallowUnfrozenClone');
+export const SHALLOW_UNFROZEN_CLONE: unique symbol = Symbol(
+  'data-model.shallowUnfrozenClone',
+);
 
-// Protocol evolution: Symbol.for('data-model.codec@2'), etc.
+// Protocol evolution: a further exported symbol, e.g.
+// `Symbol('data-model.codec@2')`.
 ```
 
 ### 2.3 Instance Protocol

--- a/docs/specs/space-model/1-data-model.md
+++ b/docs/specs/space-model/1-data-model.md
@@ -342,10 +342,14 @@ well-known symbols:
 
 ```typescript
 // Shown inside a pattern body.
-const CODEC = Symbol.for('data-model.codec');
-const DEEP_FREEZE = Symbol.for('data-model.deepFreeze');
-const IS_DEEP_FROZEN = Symbol.for('data-model.isDeepFrozen');
-// If protocol evolution is needed: Symbol.for('data-model.codec@2')
+// Unique symbols, not registry-interned ones: a member keyed by one is
+// reachable only by importing the symbol, and the string is a description
+// rather than a lookup key.
+const CODEC: unique symbol = Symbol('data-model.codec');
+const DEEP_FREEZE: unique symbol = Symbol('data-model.deepFreeze');
+const IS_DEEP_FROZEN: unique symbol = Symbol('data-model.isDeepFrozen');
+// If protocol evolution is needed: a further symbol,
+// e.g. `Symbol('data-model.codec@2')`.
 
 // Instance protocol: "here's how to freeze me deeply, and here's how to
 // clone me." (In-process lifecycle only -- serialization is class-level.)

--- a/packages/data-model/src/codec-common/interface.ts
+++ b/packages/data-model/src/codec-common/interface.ts
@@ -3,7 +3,7 @@ import type { Constructor } from "@commonfabric/utils/types";
 import type { FabricInstance, FabricValue } from "@/interface.ts";
 
 /** Well-known symbol for binding the getter `FabricClassWithCodec[CODEC]`. */
-export const CODEC: unique symbol = Symbol.for("data-model.codec");
+export const CODEC: unique symbol = Symbol("data-model.codec");
 
 /**
  * Interface for codecs (encoder-decoder objects). These are object which can

--- a/packages/data-model/src/fabric-instances/BaseFabricInstance.ts
+++ b/packages/data-model/src/fabric-instances/BaseFabricInstance.ts
@@ -16,7 +16,7 @@ import { deepFreeze, isDeepFrozen } from "@/deep-freeze.ts";
  * Distinct from `deepClone()`: `[DEEP_FREEZE]` freezes the existing instance
  * in place; `deepClone()` constructs a new instance.
  */
-export const DEEP_FREEZE: unique symbol = Symbol.for("data-model.deepFreeze");
+export const DEEP_FREEZE: unique symbol = Symbol("data-model.deepFreeze");
 
 /**
  * Well-known symbol for checking whether a fabric instance is already deeply
@@ -34,7 +34,7 @@ export const DEEP_FREEZE: unique symbol = Symbol.for("data-model.deepFreeze");
  * crash. (`[DEEP_FREEZE]` is a mutator and uses "death before confusion" on
  * a malformed internal slot; a status check must not.)
  */
-export const IS_DEEP_FROZEN: unique symbol = Symbol.for(
+export const IS_DEEP_FROZEN: unique symbol = Symbol(
   "data-model.isDeepFrozen",
 );
 
@@ -46,7 +46,7 @@ export const IS_DEEP_FROZEN: unique symbol = Symbol.for(
  * `[DEEP_FREEZE]` / `[IS_DEEP_FROZEN]`), while `shallowClone()` stays a
  * regular-named client method.
  */
-export const SHALLOW_UNFROZEN_CLONE: unique symbol = Symbol.for(
+export const SHALLOW_UNFROZEN_CLONE: unique symbol = Symbol(
   "data-model.shallowUnfrozenClone",
 );
 
@@ -63,7 +63,7 @@ export const SHALLOW_UNFROZEN_CLONE: unique symbol = Symbol.for(
  * sharing" the `deepClone()` contract promises -- but must be force-copied
  * when `frozen` is `false`).
  */
-export const DEEP_CLONE_CORE: unique symbol = Symbol.for(
+export const DEEP_CLONE_CORE: unique symbol = Symbol(
   "data-model.deepCloneCore",
 );
 

--- a/packages/data-model/src/fabric-primitives/BaseFabricPrimitive.ts
+++ b/packages/data-model/src/fabric-primitives/BaseFabricPrimitive.ts
@@ -14,7 +14,7 @@ import { toCompactDebugString } from "@/value-debug.ts";
  * negative branch collapse to `never`). Replace it with the first real
  * primitive-plumbing member once one is identified.
  */
-export const EXAMPLE_METHOD: unique symbol = Symbol.for(
+export const EXAMPLE_METHOD: unique symbol = Symbol(
   "data-model.exampleMethod",
 );
 


### PR DESCRIPTION
I (agent working on behalf of @danfuzz) am fixing a mismatch @danfuzz spotted:
six symbols are declared `unique symbol` but constructed with `Symbol.for()`,
which returns a **registry-interned** symbol — the same value for that key
anywhere in the realm, obtainable by anyone who guesses the string. The type
annotation says the opposite of what the value is.

These are implementation-plumbing keys, so uniqueness is the point: a protocol
member should be reachable only through the export, not forgeable from a
string. `Symbol()` keeps the description for debugging while making the value
genuinely unique.

| symbol | file |
|---|---|
| `DEEP_FREEZE`, `IS_DEEP_FROZEN`, `SHALLOW_UNFROZEN_CLONE`, `DEEP_CLONE_CORE` | `fabric-instances/BaseFabricInstance.ts` |
| `CODEC` | `codec-common/interface.ts` |
| `EXAMPLE_METHOD` | `fabric-primitives/BaseFabricPrimitive.ts` |

## Why this is safe

**Nothing re-derives these keys.** The only `Symbol.for("data-model.*")` calls
in the tree were the six declarations themselves, so no lookup anywhere changes
meaning and no behavior does. The one thing `Symbol.for()` would have bought —
two copies of `data-model` in one realm agreeing on a key — has no customer
here, and these symbols never cross a boundary that could produce that
situation (a structured-clone boundary does not carry a class instance at all).

## Deliberately left as `Symbol.for()`

Each of these genuinely wants the registry:

- the two `[Symbol.for("Deno.customInspect")]` members, which must match the
  host's well-known key;
- `SymbolCodec.decode()` and `value-debug`'s renderer, which handle
  registry-interned symbols as *user data* — that's the feature.

## Left alone as a different question

`ses-runtime.ts`, `astral-adapter.ts` and `cli/lib/callable.ts` each call
`Symbol.for()` without claiming `unique symbol`, so they don't have this
mismatch. The first two plausibly want a key that survives module duplication.
Worth a look someday, but not this.

## Verification

Full workspace suite green (40 packages, 281s), plus `fmt --check`, `lint`,
`check`. Ran the whole suite rather than `data-model` alone because these keys
are protocol members other packages dispatch on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WXGpwWEeCPdgHeH1zhrrz3


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

