### PR TITLE
fix(cf-harness): snapshot view_image attachments so agents can iterate on rendered images

### DIFF
--- a/packages/cf-harness/src/artifacts.ts
+++ b/packages/cf-harness/src/artifacts.ts
@@ -79,6 +79,13 @@ const writeJsonFile = async (path: string, value: unknown): Promise<void> => {
 export interface HarnessArtifactStore {
   readonly artifactRoot: string;
   readonly runRoot: string;
+  /**
+   * Host directory where image-attachment snapshots may be written, for
+   * stores backed by a writable filesystem. Stores without a writable
+   * location omit it; view_image attachments then stay locked to their
+   * source file's bytes instead of snapshotting.
+   */
+  readonly imageAttachmentSnapshotDir?: string;
   persistRunState(state: HarnessRunState): Promise<string>;
   persistTranscript(
     transcript: readonly HarnessTranscriptMessage[],
@@ -123,10 +130,12 @@ export interface FileSystemHarnessArtifactStoreOptions {
 export class FileSystemHarnessArtifactStore implements HarnessArtifactStore {
   readonly artifactRoot: string;
   readonly runRoot: string;
+  readonly imageAttachmentSnapshotDir: string;
 
   constructor(options: FileSystemHarnessArtifactStoreOptions) {
     this.artifactRoot = resolve(options.artifactRoot);
     this.runRoot = join(this.artifactRoot, assertValidRunId(options.runId));
+    this.imageAttachmentSnapshotDir = join(this.runRoot, "image-attachments");
   }
 
   async persistRunState(state: HarnessRunState): Promise<string> {

--- a/packages/cf-harness/src/contracts/image.ts
+++ b/packages/cf-harness/src/contracts/image.ts
@@ -12,4 +12,14 @@ export interface HarnessImageAttachment {
   mediaType: HarnessImageMediaType;
   bytes: number;
   digest: string;
+  /**
+   * Content-addressed copy of the image taken when the attachment was
+   * created. When present, materialization reads this snapshot instead of
+   * `hostPath`, so the working file may be regenerated mid-run (e.g. an
+   * agent iterating on a rendered image it already viewed) without
+   * invalidating the attachment. Absent on run-start `--image` inputs,
+   * which stay integrity-locked to their source file, and on attachments
+   * persisted by older versions.
+   */
+  snapshotPath?: string;
 }

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -1275,9 +1275,7 @@ export class CfHarnessEngine {
         path: string,
         options?: { allowMissing?: boolean },
       ) => this.#isHostPathWithinArtifactRoot(path, options),
-      imageAttachmentSnapshotDir: this.artifactStore === undefined
-        ? undefined
-        : joinHostPath(this.artifactStore.runRoot, "image-attachments"),
+      imageAttachmentSnapshotDir: this.artifactStore?.imageAttachmentSnapshotDir,
       doesHostPathIntersectArtifactRoot: (
         path: string,
         options?: { allowMissing?: boolean },

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -1275,7 +1275,8 @@ export class CfHarnessEngine {
         path: string,
         options?: { allowMissing?: boolean },
       ) => this.#isHostPathWithinArtifactRoot(path, options),
-      imageAttachmentSnapshotDir: this.artifactStore?.imageAttachmentSnapshotDir,
+      imageAttachmentSnapshotDir: this.artifactStore
+        ?.imageAttachmentSnapshotDir,
       doesHostPathIntersectArtifactRoot: (
         path: string,
         options?: { allowMissing?: boolean },

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -1275,6 +1275,9 @@ export class CfHarnessEngine {
         path: string,
         options?: { allowMissing?: boolean },
       ) => this.#isHostPathWithinArtifactRoot(path, options),
+      imageAttachmentSnapshotDir: this.artifactStore === undefined
+        ? undefined
+        : joinHostPath(this.artifactStore.runRoot, "image-attachments"),
       doesHostPathIntersectArtifactRoot: (
         path: string,
         options?: { allowMissing?: boolean },

--- a/packages/cf-harness/src/image-attachments.ts
+++ b/packages/cf-harness/src/image-attachments.ts
@@ -1,5 +1,5 @@
 import { encodeBase64 } from "@std/encoding/base64";
-import { extname, isAbsolute, relative, resolve } from "@std/path";
+import { extname, isAbsolute, join, relative, resolve } from "@std/path";
 import {
   HARNESS_IMAGE_ATTACHMENT_TYPE,
   type HarnessImageAttachment,
@@ -145,11 +145,60 @@ export const parseImageAttachmentPaths = (
   return paths;
 };
 
+const extensionForMediaType = (
+  mediaType: HarnessImageMediaType,
+): string => {
+  switch (mediaType) {
+    case "image/gif":
+      return ".gif";
+    case "image/jpeg":
+      return ".jpg";
+    case "image/png":
+      return ".png";
+    case "image/webp":
+      return ".webp";
+  }
+};
+
+// Content-addressed by digest, so a re-view of identical bytes reuses the
+// same snapshot file and differing bytes can never collide.
+const writeImageAttachmentSnapshot = async (
+  snapshotDir: string,
+  bytes: Uint8Array,
+  digest: string,
+  mediaType: HarnessImageMediaType,
+): Promise<string> => {
+  const snapshotPath = join(
+    snapshotDir,
+    `${digest.replace(/^sha256:/, "")}${extensionForMediaType(mediaType)}`,
+  );
+  try {
+    const stat = await Deno.stat(snapshotPath);
+    if (stat.isFile && stat.size === bytes.byteLength) {
+      return snapshotPath;
+    }
+  } catch {
+    // Missing snapshot — write it below.
+  }
+  await Deno.mkdir(snapshotDir, { recursive: true });
+  const tempPath = `${snapshotPath}.tmp-${crypto.randomUUID()}`;
+  await Deno.writeFile(tempPath, bytes);
+  await Deno.rename(tempPath, snapshotPath);
+  return snapshotPath;
+};
+
 export const createHarnessImageAttachment = async (
   options: {
     workspaceHostPath: string;
     cwd: string;
     path: string;
+    /**
+     * Directory to snapshot the image bytes into. When provided, the
+     * attachment materializes from the snapshot for the rest of the run and
+     * the source file may change freely afterwards. When absent, the
+     * attachment stays locked to the source file's bytes and digest.
+     */
+    snapshotDir?: string;
   },
 ): Promise<HarnessImageAttachment> => {
   const workspaceHostPath = await Deno.realPath(options.workspaceHostPath);
@@ -174,28 +223,55 @@ export const createHarnessImageAttachment = async (
       `--image path is not a supported image type: ${options.path}`,
     );
   }
+  const digest = await sha256Digest(bytes);
+  const snapshotPath = options.snapshotDir === undefined
+    ? undefined
+    : await writeImageAttachmentSnapshot(
+      options.snapshotDir,
+      bytes,
+      digest,
+      mediaType,
+    );
   return {
     type: HARNESS_IMAGE_ATTACHMENT_TYPE,
     hostPath,
     mediaType,
     bytes: bytes.byteLength,
-    digest: await sha256Digest(bytes),
+    digest,
+    ...(snapshotPath === undefined ? {} : { snapshotPath }),
   };
 };
 
 export const materializeImageAttachmentContentPart = async (
   attachment: HarnessImageAttachment,
 ): Promise<OpenAIChatMessageContentPart> => {
-  const bytes = await Deno.readFile(attachment.hostPath);
+  const sourceLabel = attachment.snapshotPath === undefined
+    ? "image attachment"
+    : "image attachment snapshot";
+  const sourcePath = attachment.snapshotPath ?? attachment.hostPath;
+  let bytes: Uint8Array;
+  try {
+    bytes = await Deno.readFile(sourcePath);
+  } catch (error) {
+    if (
+      attachment.snapshotPath !== undefined &&
+      error instanceof Deno.errors.NotFound
+    ) {
+      throw new Error(
+        `image attachment snapshot missing: ${attachment.snapshotPath}`,
+      );
+    }
+    throw error;
+  }
   if (bytes.byteLength !== attachment.bytes) {
     throw new Error(
-      `image attachment changed after run start: ${attachment.hostPath}`,
+      `${sourceLabel} changed after run start: ${sourcePath}`,
     );
   }
   const digest = await sha256Digest(bytes);
   if (digest !== attachment.digest) {
     throw new Error(
-      `image attachment digest changed after run start: ${attachment.hostPath}`,
+      `${sourceLabel} digest changed after run start: ${sourcePath}`,
     );
   }
   return {

--- a/packages/cf-harness/src/image-attachments.ts
+++ b/packages/cf-harness/src/image-attachments.ts
@@ -177,8 +177,12 @@ const writeImageAttachmentSnapshot = async (
     if (stat.isFile && stat.size === bytes.byteLength) {
       return snapshotPath;
     }
-  } catch {
-    // Missing snapshot — write it below.
+  } catch (error) {
+    // A missing snapshot is written below; anything else (permissions,
+    // I/O) must surface as itself rather than as a later write failure.
+    if (!(error instanceof Deno.errors.NotFound)) {
+      throw error;
+    }
   }
   await Deno.mkdir(snapshotDir, { recursive: true });
   const tempPath = `${snapshotPath}.tmp-${crypto.randomUUID()}`;

--- a/packages/cf-harness/src/tools/types.ts
+++ b/packages/cf-harness/src/tools/types.ts
@@ -45,6 +45,12 @@ export interface HarnessToolContext {
     path: string,
     options?: { allowMissing?: boolean },
   ): Promise<boolean>;
+  /**
+   * Host directory for image-attachment snapshots (under the artifact
+   * root). Undefined when the run has no artifact store; attachments then
+   * stay locked to their source file's bytes.
+   */
+  imageAttachmentSnapshotDir?: string;
   doesHostPathIntersectArtifactRoot(
     path: string,
     options?: { allowMissing?: boolean },

--- a/packages/cf-harness/src/tools/view-image.ts
+++ b/packages/cf-harness/src/tools/view-image.ts
@@ -142,6 +142,7 @@ export const viewImageTool: HarnessToolDefinition<
         workspaceHostPath: hostRootPath,
         cwd: hostRootPath,
         path: hostPath,
+        snapshotDir: context.imageAttachmentSnapshotDir,
       });
       return {
         outputId: context.nextOutputId("view_image"),

--- a/packages/cf-harness/src/tools/view-image.ts
+++ b/packages/cf-harness/src/tools/view-image.ts
@@ -83,6 +83,7 @@ export const viewImageToolDescriptor: HarnessToolDescriptor = {
             },
             bytes: { type: "integer", minimum: 1 },
             digest: { type: "string" },
+            snapshotPath: { type: "string" },
           },
           required: ["type", "hostPath", "mediaType", "bytes", "digest"],
           additionalProperties: false,

--- a/packages/cf-harness/test/artifacts.test.ts
+++ b/packages/cf-harness/test/artifacts.test.ts
@@ -1894,3 +1894,26 @@ Deno.test({
     }
   },
 });
+
+Deno.test({
+  name:
+    "filesystem artifact store advertises an image-attachment snapshot dir under its run root",
+  permissions: { read: true, write: true },
+  async fn() {
+    const artifactRoot = await Deno.makeTempDir({
+      prefix: "cf-harness-artifacts-",
+    });
+    try {
+      const store = createFileSystemHarnessArtifactStore({
+        artifactRoot,
+        runId: "run-snapshot-dir",
+      });
+      assertEquals(
+        store.imageAttachmentSnapshotDir,
+        join(store.runRoot, "image-attachments"),
+      );
+    } finally {
+      await Deno.remove(artifactRoot, { recursive: true });
+    }
+  },
+});

--- a/packages/cf-harness/test/image-attachments.test.ts
+++ b/packages/cf-harness/test/image-attachments.test.ts
@@ -1,5 +1,33 @@
-import { assertEquals } from "@std/assert";
-import { isRelativePathWithinWorkspace } from "../src/image-attachments.ts";
+import {
+  assert,
+  assertEquals,
+  assertNotEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "@std/assert";
+import { encodeBase64 } from "@std/encoding/base64";
+import { join } from "@std/path";
+import {
+  createHarnessImageAttachment,
+  isRelativePathWithinWorkspace,
+  materializeImageAttachmentContentPart,
+} from "../src/image-attachments.ts";
+
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+const pngBytes = (...payload: number[]): Uint8Array =>
+  new Uint8Array([...PNG_SIGNATURE, ...payload]);
+
+const dataUrl = (bytes: Uint8Array): string =>
+  `data:image/png;base64,${encodeBase64(bytes)}`;
+
+const makeWorkspaceImage = async (
+  bytes: Uint8Array,
+): Promise<{ workspace: string; imagePath: string }> => {
+  const workspace = await Deno.makeTempDir();
+  const imagePath = join(workspace, "render.png");
+  await Deno.writeFile(imagePath, bytes);
+  return { workspace, imagePath };
+};
 
 Deno.test("isRelativePathWithinWorkspace rejects escaped and absolute relative results", () => {
   const cases: Array<[string, boolean]> = [
@@ -19,4 +47,122 @@ Deno.test("isRelativePathWithinWorkspace rejects escaped and absolute relative r
   for (const [relativePath, expected] of cases) {
     assertEquals(isRelativePathWithinWorkspace(relativePath), expected);
   }
+});
+
+Deno.test("snapshot attachment survives regeneration of the source image", async () => {
+  const original = pngBytes(1, 2, 3);
+  const { workspace, imagePath } = await makeWorkspaceImage(original);
+  const snapshotDir = join(await Deno.makeTempDir(), "image-attachments");
+
+  const attachment = await createHarnessImageAttachment({
+    workspaceHostPath: workspace,
+    cwd: workspace,
+    path: imagePath,
+    snapshotDir,
+  });
+  assert(attachment.snapshotPath !== undefined);
+  assertStringIncludes(attachment.snapshotPath, snapshotDir);
+
+  // The agent regenerates the image it already viewed — the run must not die.
+  await Deno.writeFile(imagePath, pngBytes(9, 9, 9, 9));
+
+  const part = await materializeImageAttachmentContentPart(attachment);
+  assertEquals(part.type, "image_url");
+  assertEquals(
+    (part as { image_url: { url: string } }).image_url.url,
+    dataUrl(original),
+  );
+});
+
+Deno.test("identical re-view reuses the content-addressed snapshot file", async () => {
+  const bytes = pngBytes(4, 5, 6);
+  const { workspace, imagePath } = await makeWorkspaceImage(bytes);
+  const snapshotDir = join(await Deno.makeTempDir(), "image-attachments");
+
+  const first = await createHarnessImageAttachment({
+    workspaceHostPath: workspace,
+    cwd: workspace,
+    path: imagePath,
+    snapshotDir,
+  });
+  const second = await createHarnessImageAttachment({
+    workspaceHostPath: workspace,
+    cwd: workspace,
+    path: imagePath,
+    snapshotDir,
+  });
+  assertEquals(first.snapshotPath, second.snapshotPath);
+
+  // Different content must land in a different snapshot file, so
+  // re-materializing `first` still sees its original bytes.
+  const revisedPath = join(workspace, "render-v2.png");
+  await Deno.writeFile(revisedPath, pngBytes(7, 8));
+  const changed = await createHarnessImageAttachment({
+    workspaceHostPath: workspace,
+    cwd: workspace,
+    path: revisedPath,
+    snapshotDir,
+  });
+  assertNotEquals(first.snapshotPath, changed.snapshotPath);
+});
+
+Deno.test("without a snapshot dir, source mutation still fails closed", async () => {
+  const { workspace, imagePath } = await makeWorkspaceImage(pngBytes(1));
+
+  const attachment = await createHarnessImageAttachment({
+    workspaceHostPath: workspace,
+    cwd: workspace,
+    path: imagePath,
+  });
+  assertEquals(attachment.snapshotPath, undefined);
+
+  await Deno.writeFile(imagePath, pngBytes(2, 2));
+
+  await assertRejects(
+    () => materializeImageAttachmentContentPart(attachment),
+    Error,
+    "image attachment changed after run start",
+  );
+});
+
+Deno.test("tampered snapshot fails closed with a snapshot-specific error", async () => {
+  const { workspace, imagePath } = await makeWorkspaceImage(pngBytes(3, 1));
+  const snapshotDir = join(await Deno.makeTempDir(), "image-attachments");
+
+  const attachment = await createHarnessImageAttachment({
+    workspaceHostPath: workspace,
+    cwd: workspace,
+    path: imagePath,
+    snapshotDir,
+  });
+  assert(attachment.snapshotPath !== undefined);
+
+  // Same length, different content: only the digest check can catch it.
+  await Deno.writeFile(attachment.snapshotPath, pngBytes(3, 2));
+
+  await assertRejects(
+    () => materializeImageAttachmentContentPart(attachment),
+    Error,
+    "image attachment snapshot digest changed after run start",
+  );
+});
+
+Deno.test("missing snapshot fails closed with a clear error", async () => {
+  const { workspace, imagePath } = await makeWorkspaceImage(pngBytes(6));
+  const snapshotDir = join(await Deno.makeTempDir(), "image-attachments");
+
+  const attachment = await createHarnessImageAttachment({
+    workspaceHostPath: workspace,
+    cwd: workspace,
+    path: imagePath,
+    snapshotDir,
+  });
+  assert(attachment.snapshotPath !== undefined);
+  await Deno.remove(attachment.snapshotPath);
+
+  await assertRejects(
+    () => materializeImageAttachmentContentPart(attachment),
+    Error,
+    "image attachment snapshot missing",
+  );
 });


### PR DESCRIPTION
## Why

An agent that renders an image, calls `view_image` on it, and then regenerates the same file kills its own run. `HarnessImageAttachment` stores only `{hostPath, bytes, digest}`, and `materializeImageAttachmentContentPart` re-reads the file from disk on **every subsequent model request**, throwing `image attachment changed after run start` once the bytes differ. That makes any render → view → revise loop on a stable filename structurally fatal — and the model has no way to know the invariant exists.

Observed live on a Loom Visualize capture wish (CT-1983): two consecutive runs produced a correct PNG, viewed it to verify text wasn't clipped, revised the render script, re-rendered — and died with `prompt_loop_error` (~10 productive turns and $0.53 each). Claude/Codex harnesses have no such invariant, so this is also a behavioral gap for harness parity.

## What Changed

- `view_image` attachments are now **content-addressed snapshots**: bytes are copied to `<runRoot>/image-attachments/<digest>.<ext>` at attach time, and materialization reads the snapshot. The working file can be regenerated freely afterwards.
- The size/digest integrity guard is preserved, now pointed at the snapshot (which never legitimately changes). Tampered or missing snapshots fail closed with snapshot-specific error messages.
- Run-start `--image` inputs are **unchanged** — they stay integrity-locked to their source file, preserving the original TOCTOU intent.
- Back-compat: attachments persisted by older versions have no `snapshotPath` and keep the current behavior, so resume of existing runs is unaffected. Runs without an artifact store also keep the current behavior.
- The snapshot dir lives inside the artifact root, which is already reserved from model-facing tools.

## Test plan

- New tests in `test/image-attachments.test.ts`: snapshot survives source regeneration (returns original bytes); identical re-view reuses the content-addressed file while different content gets a distinct one; no-snapshot mutation still fails closed; tampered snapshot fails on digest; missing snapshot fails with a clear error.
- Full `packages/cf-harness` suite: 605 passed, 0 failed. `deno check src/main.ts` clean; `deno fmt --check` / `deno lint` clean on changed files.

Fixes CT-1983.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

