### PR TITLE
docs(history): finish the archive #5556 only half-landed

### DIFF
--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -212,6 +212,10 @@ One line per archived document; each document's header carries the fuller
 
 - [action-id-per-instance-decision.md](specs/action-id-per-instance-decision.md)
   — per-instance action identity.
+- [declared-verb-results-case.md](plans/declared-verb-results-case.md) — the
+  case for carrying a verb's declared result on `module.resultSchema` in the
+  interim rather than waiting for the Fabric-types stream; decided yes,
+  conditionally, August 2026.
 - [cfc-render-membership-lookup.md](specs/cfc-render-membership-lookup.md) —
   render-time space-membership lookup.
 - [cfc-s16-default-transition-design.md](specs/cfc-s16-default-transition-design.md)

--- a/docs/history/plans/declared-verb-results-case.md
+++ b/docs/history/plans/declared-verb-results-case.md
@@ -1,7 +1,36 @@
+---
+status: historical
+created: 2026-08-10
+archived: 2026-08-10
+reason: "Argument for carrying a verb's declared result on `module.resultSchema` in the interim; decided yes, conditionally, on 2026-08-10."
+---
+
 # What a declared verb result buys
 
+## Outcome
+
+**Decided yes, with a condition, on 2026-08-10** — Bernhard Seefeld, on #5501,
+in reply to the one-page form of this argument:
+
+> If it's easy to add `.resultSchema` now, let's go for it, it's where it'll
+> eventually land. Just wary of that creating more things to chase down, so if
+> that happens, revisit.
+
+Two things travel with that. The timing framing this document argues from is
+confirmed rather than merely accepted — the durable form is where it lands
+eventually, and the question was only whether to wire it before then. And the
+approval is **conditional on the work staying cheap**: if carrying the field
+starts generating follow-on work, the decision is open again rather than
+settled. That condition is a live constraint and belongs with the sequencing,
+not in this record.
+
+The rest of this document is the argument as it stood when the decision was
+made, frozen.
+
+---
+
 The case for the one decision
-[the verbs plan](verbs-implementation.md) says everything else waits behind:
+[the verbs plan](../../plans/verbs-implementation.md) says everything else waits behind:
 **does a verb's declared result reach the runtime now, or only when the
 Fabric-types stream supplies a durable one?**
 
@@ -16,15 +45,15 @@ it will cost to replace, and it costs little to replace precisely because of
 the property that makes it safe.
 
 It is an argument, not a plan — the sequencing lives in the verbs plan, and the
-model lives in [the pattern verb contract](pattern-verb-contract.md) and
-[shaped reads and verb results](shaped-reads-and-verb-results.md).
+model lives in [the pattern verb contract](../../plans/pattern-verb-contract.md) and
+[shaped reads and verb results](../../plans/shaped-reads-and-verb-results.md).
 
 The argument is told as a walkthrough of a session that does not run yet: a
 work-item tracker driven entirely through `cf`, shown twice. Once as it reads
 today, once as it reads with declared results. Nothing separates the two
 except one field.
 
-[A verb session, end to end](../common/verb-session-walkthrough.md) walks that
+[A verb session, end to end](../../common/verb-session-walkthrough.md) walks that
 session in full, marking each step for whether it works today, is built and
 merging, or is blocked. This document takes the one step the decision turns on.
 
@@ -318,7 +347,7 @@ what the paragraph above shows a module field does not trip. So the thing that
 answers the withdrawal is also the thing that makes the swap cheap: there is
 no permanence to unwind.
 
-[Shaped reads](shaped-reads-and-verb-results.md) already records the shape of
+[Shaped reads](../../plans/shaped-reads-and-verb-results.md) already records the shape of
 that swap for the receipt half — when declared result schemas arrive, "the same
 slot takes a better-sourced value — a change to one argument, not a migration."
 The command-surface half is the same story: `callableCommandSpec` reads the
@@ -431,5 +460,5 @@ one.
 
 Declared results make an **output** self-describing. This is about what an
 **input** accepts, and it stays open whichever way the timing question is
-settled. [A verb session, end to end](../common/verb-session-walkthrough.md)
+settled. [A verb session, end to end](../../common/verb-session-walkthrough.md)
 works the case through.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -67,13 +67,6 @@ a record: archive it to `docs/history/plans/` following the procedure in
   work on verbs across both arcs that produced it: what a verb declares, what a
   caller may ask for, and what comes back. Read it for order; read the designs
   it points at for reasoning.
-- [What a declared verb result buys](declared-verb-results-case.md) is the case
-  for the one decision the verbs plan waits behind: whether a verb's declared
-  result reaches the runtime now, on an interim module field, or only when the
-  Fabric-types stream supplies a durable one. It argues timing rather than
-  principle — every consumer is already built and already working for tools, and
-  the interim road commits nothing durable, so replacing it later is an
-  assignment rather than a migration.
 - [The CLI surface — implementation plan](cli-surface-implementation.md) builds
   the rest of the command surface: positional addresses, the honest top-level
   names, deprecating the spellings they replace, and merging the commands that


### PR DESCRIPTION
## Why

#5556 moved `declared-verb-results-case.md` into `docs/history/plans/` and carried none of the edits that make a move an *archive*. The commit staged the rename and nothing else, so what shipped is the file in a new directory with its old contents.

My error, and the mechanism is worth recording: a `git add -A && git commit` was interrupted by an `index.lock` collision, `&&` short-circuited so the commit never ran, and the retry was `git commit` alone — committing only what `git mv` had already staged. The gates I cited passed because I ran them against the working tree, which had the content the commit didn't.

Four things are missing on `main` today:

- **The metadata header.** `docs/history/README.md` requires one on every document in the tree, including the `reason` line a reader uses to decide whether the document matters to them. There is none.
- **The Outcome section.** The decision the document argues for was made — and without that recorded, an archived argument reads as an open question forever, which is the one thing it must not do.
- **Working links.** Four relative links still resolve as though the file sits in `docs/plans/`.
- **The index moves.** `docs/plans/README.md` still has an entry pointing at the old path, and `docs/history/README.md` has none, so the archived document is unindexed.

## What Changed

Exactly the four above. The body is otherwise untouched and still frozen as it stood when the decision was made.

The Outcome section quotes the decision verbatim, including the condition attached to it — approval holds while the work stays cheap, and if carrying the field starts generating follow-on work the decision reopens.

## Test plan

- `deno task check-docs` — 537 blocks
- `deno task docs-links --orphan`
- `deno task check-conflict-markers`
- All four repointed link targets checked individually to resolve from the archived path
- Staged diffstat inspected before committing, which is the check whose absence caused this

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

