### PR TITLE
docs(plan): lift reference resolution out of the LLM builtin and into the shared boundary

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -59,14 +59,13 @@ a record: archive it to `docs/history/plans/` following the procedure in
   calling a verb adds — and at
   [CLI surface shape](cli-surface-shape.md) for the command surface and an
   additive path to it. Start here rather than at either part.
-- [References as arguments](references-as-arguments.md) asks approval for one
-  change: carry a declared reference into the emitted event schema so the two
-  boundary sites that read one can honor it. A verb whose event declares
-  `Writable<T>` is uncallable from outside the runtime — including the root
-  pattern's `addPiece` — and the payload the boundary does accept stores a
-  detached copy without reporting an error. It carries the measurement, the
-  size, and the confinement question that has to be answered before the work
-  starts.
+- [References as arguments](references-as-arguments.md) asks approval to lift
+  address resolution out of the LLM dialog builtin, which already does it, and
+  into the boundary every external caller crosses. An LLM can hand a pattern a
+  reference; the CLI, a webhook, and the ingest path cannot reach the same
+  handler the same way, and three encodings for "an address goes here" have
+  already diverged. It carries the measurement, the size, and the confinement
+  question that has to be answered before the work starts.
 - [Verb calls: working notes](verb-result-selection.md) holds the call-specific
   investigation those documents do not carry: what produces a receipt and what
   its existence proves, how a receipt's address is derived, and the error and

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -59,14 +59,14 @@ a record: archive it to `docs/history/plans/` following the procedure in
   calling a verb adds — and at
   [CLI surface shape](cli-surface-shape.md) for the command surface and an
   additive path to it. Start here rather than at either part.
-- [References as arguments](references-as-arguments.md) asks the write-side
-  counterpart of the question the read model answered: a reader can say "an
-  address here, not the contents", and a caller supplying an event has no way to
-  say the same thing. It records what that costs today — a shipped pattern
-  recovering references by scanning prose, and a verb that stores a detached
-  copy without reporting an error — and holds the obvious fix behind one
-  question, whether the argument path lacks a reference vocabulary or refuses
-  one on purpose.
+- [References as arguments](references-as-arguments.md) asks approval for one
+  change: carry a declared reference into the emitted event schema so the two
+  boundary sites that read one can honor it. A verb whose event declares
+  `Writable<T>` is uncallable from outside the runtime — including the root
+  pattern's `addPiece` — and the payload the boundary does accept stores a
+  detached copy without reporting an error. It carries the measurement, the
+  size, and the confinement question that has to be answered before the work
+  starts.
 - [Verb calls: working notes](verb-result-selection.md) holds the call-specific
   investigation those documents do not carry: what produces a receipt and what
   its existence proves, how a receipt's address is derived, and the error and

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -59,6 +59,14 @@ a record: archive it to `docs/history/plans/` following the procedure in
   calling a verb adds — and at
   [CLI surface shape](cli-surface-shape.md) for the command surface and an
   additive path to it. Start here rather than at either part.
+- [References as arguments](references-as-arguments.md) asks the write-side
+  counterpart of the question the read model answered: a reader can say "an
+  address here, not the contents", and a caller supplying an event has no way to
+  say the same thing. It records what that costs today — a shipped pattern
+  recovering references by scanning prose, and a verb that stores a detached
+  copy without reporting an error — and holds the obvious fix behind one
+  question, whether the argument path lacks a reference vocabulary or refuses
+  one on purpose.
 - [Verb calls: working notes](verb-result-selection.md) holds the call-specific
   investigation those documents do not carry: what produces a receipt and what
   its existence proves, how a receipt's address is derived, and the error and

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -59,13 +59,14 @@ a record: archive it to `docs/history/plans/` following the procedure in
   calling a verb adds — and at
   [CLI surface shape](cli-surface-shape.md) for the command surface and an
   additive path to it. Start here rather than at either part.
-- [References as arguments](references-as-arguments.md) asks approval to lift
+- [References as arguments](references-as-arguments.md) proposes lifting
   address resolution out of the LLM dialog builtin, which already does it, and
   into the boundary every external caller crosses. An LLM can hand a pattern a
   reference; the CLI, a webhook, and the ingest path cannot reach the same
   handler the same way, and three encodings for "an address goes here" have
-  already diverged. It carries the measurement, the size, and the confinement
-  question that has to be answered before the work starts.
+  already diverged. It carries the measurement, the size, and the gate-by-gate
+  evidence that the refusal is drift rather than policy — the dispatch gate
+  already accepts link values; the outer gates never got the option.
 - [Verb calls: working notes](verb-result-selection.md) holds the call-specific
   investigation those documents do not carry: what produces a receipt and what
   its existence proves, how a receipt's address is derived, and the error and

--- a/docs/plans/references-as-arguments.md
+++ b/docs/plans/references-as-arguments.md
@@ -2,11 +2,14 @@
 
 ## The short version
 
-`traverseAndCellify` in the LLM dialog builtin resolves `{"@link": "…"}` into a
-live cell before dispatching to a handler. **A model can hand a pattern a
-reference. The CLI, a webhook, and the ingest path reach the same handler and
-cannot** — they validate structurally, and the payload they *do* accept stores a
-detached copy instead of an edge, reporting success.
+**A pattern handler that declares a reference should accept one — a live
+read/write cell — from any external caller. Today only a model can pass one:**
+the LLM dialog builtin resolves `{"@link": "…"}` into a live cell before
+dispatch (`traverseAndCellify`). The CLI, a webhook, and the ingest path reach
+the same handler, and none of them resolves a reference — the CLI rejects the
+address, the webhook sends it through unresolved. **The shape-matching payload
+the CLI does accept stores a detached copy instead of an edge, and reports
+success.**
 
 **The ask:** move that resolution to the boundary every external caller crosses.
 
@@ -16,14 +19,15 @@ the address it was just handed, and the capability does not compose. Which
 spelling wins is the implementer's call.
 
 **Decide first:** whether accepting a caller-named address is a confinement
-question. If it is, this is the wrong-sized change and CFC owns it. If it is
-not, the work is medium and mostly relocating code that already runs in
-production.
+question — noting that the model, the least trusted caller in the system,
+already has this capability. If it is, this is the wrong-sized change and CFC
+owns it. If it is not, the work is medium and mostly relocating code that
+already runs in production.
 
 **True either way:** refusing the structural copy, instead of storing it, needs
 no encoding decision and no confinement ruling.
 
-The rest of this document is the evidence for those four paragraphs.
+The rest of this document is the evidence for the paragraphs above.
 
 ## The team already needed this and already built it
 

--- a/docs/plans/references-as-arguments.md
+++ b/docs/plans/references-as-arguments.md
@@ -1,51 +1,57 @@
 # References as arguments
 
-A caller can be handed an address and cannot hand one back. This document
-states the gap, shows what it already costs, and asks the one question that
-decides whether the obvious fix is the right one.
+**The ask: carry a declared reference into the emitted event schema, and honor
+it at the two boundary sites that read one.**
 
-It is a question, not a proposal. Nothing here amends
-[Reading Fabric data](fabric-read-model.md) or
-[the pattern verb contract](pattern-verb-contract.md).
+A verb whose event declares a reference — `Writable<T>` on an event field —
+cannot be called by anything outside the runtime. The declaration compiles, the
+runtime honors it internally, and the emitted schema drops it, so nothing at the
+serialized boundary can tell a reference position from a value position.
 
-## The asymmetry
+This is one change, and it is the completion of a mechanism that already
+exists rather than a new capability.
 
-[Reading Fabric data](fabric-read-model.md) settles that everything addressable
-is a cell, and [shaped reads](shaped-reads-and-verb-results.md) gives a reader
-a way to say *give me the address at this position, not the contents*. That is
-the `$link` marker, and the reasoning behind it is explicit: `asCell` bundles a
-traversal boundary with a **handle contract**, and a handle cannot cross a
-serialized channel — only its address can.
+## Why this matters, measured
 
-That reasoning is symmetric, and only one side of it was built.
+[The pattern verb contract](pattern-verb-contract.md) states its goal as making
+any pattern agent-drivable through its own verbs. That is currently false for a
+specific and enumerable class of verbs.
 
-| | Read | Argument |
-| --- | --- | --- |
-| Declare "an address sits here" | `$link` beside `properties` | — |
-| Wire encoding | declared `{ id, space, scope, path }` | — |
-| Why not `asCell` | reasoned out, recorded | never asked |
+Every event field across the shipped patterns that declares a reference:
 
-**The runtime is not the limitation.** A pattern hands a piece to another
-pattern constantly — `Item({ title, parent: self })` passes a reference, and
-the graph that results is the normal shape of composed patterns. What has no
-spelling is the *serialized* boundary: how an event type declares a reference
-position, and how a caller outside the runtime encodes one.
-
-## What it costs today
-
-**Measured.** A verb declared to take another piece compiles, and then behaves
-in a way no caller would predict.
-
-```tsx
-// Shown for illustration only.
-interface BlockOnEvent {
-  on: ItemOutput; // the piece itself, not a minted identifier
-}
+```text
+addPiece     Stream<{ piece: MentionablePiece }>
+addPiece     Stream<{ piece: Writable<MentionablePiece> }>
+addPiece     Stream<{ piece: Writable<RecordPiece> }>
+appendLink   Stream<{ piece: Writable<MentionablePiece> }>
+removeEvent  Stream<{ event: EventPiece }>
+removeItem   Stream<{ item: DoItem }>
+removeItem   Stream<{ item: ReadingItemPiece }>
+removeItem   Stream<{ item: TodoItem }>
 ```
 
-The generated event schema renders `on` as `{"$ref": "#/$defs/ItemOutput"}` —
-the *shape*, with no `asCell` — and that definition requires every field of the
-output, recursively. Three payloads, against item A blocking on item B:
+Eight of 238 verb declarations. The count is not the point — the **shape** is.
+Every one is *put this existing thing here* or *take this existing thing out*,
+which is precisely the class of operation that has to name something that
+already exists. None of them can be invoked by an agent, a script, or the CLI.
+
+The sharpest case is the root pattern's, since every space has one:
+
+```bash
+$ cf piece call --piece <root> addPiece '{"piece":"fid1:…"}'
+Invalid input for "addPiece": piece: value does not match type object
+```
+
+`addPiece` on `packages/patterns/system/default-app.tsx` is how a piece is
+registered in a space. It is reachable from inside the runtime — `pieces.add`
+sends to exactly this stream — and unreachable through the verb surface.
+
+## This is a correctness defect, not a missing feature
+
+The boundary does not refuse an unusable payload. It accepts one and stores the
+wrong thing.
+
+Declaring `on: ItemOutput` on an event and calling it three ways:
 
 | Payload | Result |
 | --- | --- |
@@ -53,71 +59,81 @@ output, recursively. Three payloads, against item A blocking on item B:
 | the runtime link envelope | rejected — *missing required property title* |
 | a literal `ItemOutput`-shaped object | **accepted** |
 
-The accepted one is the problem. The call settles, reports a plausible result,
-and stores a **detached copy inside the caller's own document** — the edge does
-not point at B at all. Finishing B would never unblock A, and nothing reports
-an error. Reproduction and measured addresses are on
+The accepted one settles, reports a plausible result, and stores a **detached
+copy inside the caller's own document**. The edge does not point at the target.
+Finishing the target would never unblock the blocked item, and nothing anywhere
+reports an error. Reproduction and measured addresses:
 [#5560](https://github.com/commontoolsinc/labs/issues/5560).
 
-**Already paid, in a shipped pattern.** Topics cannot accept a topic reference,
-so it recovers references by scanning prose. `extractFidPayloads`
-(`packages/patterns/topics/topic.tsx`) matches, in its own words, "bare
-`fid1:X`, storage-form `of:fid1:X`, page URLs `https://host/space/fid1:X`, and
-share links where the colon is percent-encoded." The board's entire
-topic-to-topic reference graph is derived that way.
+So the status quo is not "you cannot do this yet." It is "the obvious attempt
+succeeds and writes a wrong graph."
 
-That is not a stylistic choice. It is the only route available, and it is the
-clearest statement of the cost: a pattern that wants a reference has to
-regex one out of text a human typed.
+## What already exists
 
-## Where else the same shape appears
+Three of the four pieces are built. This is why the ask is small.
 
-Any relation between two existing pieces, which is most of what a graph is
-for — a dependency edge, a move between parents, an assignment, a tag, a
-removal that names its target. It is invisible in a pure tree, because the
-natural shape there is to call the verb *on* the parent, so the receiver
-carries the relation and no address needs to be an argument. It appears the
-moment two pieces must be related to each other.
+**The author-facing spelling.** `Writable<T>` on an event field is how a
+reference position is declared, and shipped patterns use it — the list above is
+that spelling in production.
 
-A second instance sits one level out, on a command rather than an event:
-`cf piece set-slug <slug> <source>` resolves its source positional through its
-own path rather than the one `--piece` uses, so work making `--piece` accept an
-entity URI does not reach it.
+**The runtime capability.** Those events carry live cells today. Piece
+registration in every space runs through `addPiece`, so references in event
+payloads are not novel; they are load-bearing.
 
-## The question that decides the shape of the answer
+**The wire encoding.** A rendered address — `{ id, space, scope, path }` — is
+already what a `$link` read emits
+([shaped reads](shaped-reads-and-verb-results.md)). Accepting the same shape
+inbound makes an address round-trip, which is the property
+[CLI surface shape](cli-surface-shape.md) already states for commands: an
+address printed by one command is accepted by the next.
+
+## What is missing
+
+**The marker is dropped in emission.** An event field declared
+`Writable<ItemOutput>` emits as `{"$ref": "#/$defs/ItemOutput"}` with no
+`asCell` anywhere; an inline `Writable<{ title: string }>` disappears from the
+emitted properties entirely. Measured both ways. Nothing downstream can
+distinguish a reference position, because the emitted schema does not say there
+is one.
+
+Everything else follows from that one omission:
+
+| Site | What it needs |
+| --- | --- |
+| handler-schema emission (`packages/ts-transformers/src/transformers/schema-injection.ts`) | carry the marker onto an event property declared `Writable<T>` |
+| verb input validation | accept an address at a marked position instead of validating structurally |
+| dispatch | resolve the address into a cell before the handler runs |
+
+## Size
+
+**Medium.** The emission change is the bulk of it and lands in the same file
+that carries a verb's declared result, so whoever does one is in position to do
+the other. The validation and resolution changes are each small and have
+existing machinery to lean on — the runtime resolves links from addresses
+throughout.
+
+Nothing durable is written and no baseline records it, so the change is
+reversible by assignment rather than migration.
+
+## The one decision that gates the shape
 
 **Is the argument path missing a reference vocabulary, or refusing one?**
 
-The obvious fix is the mirror of `$link`: a way for an event schema to declare
-a reference position, an accepted wire encoding for an address, and resolution
-before the handler sees the value. If nothing objects to that, it is a
-well-understood piece of work whose shape the read side already established.
+Accepting an address as an argument lets a caller aim a pattern at a cell the
+*caller* named, rather than one the pattern reached through its own inputs.
+That is a confinement question, and it belongs to whoever owns CFC rather than
+to the read model or the verb contract.
 
-But accepting an address as an argument lets a caller direct a pattern at a
-cell the *caller* named. That is a capability question, not a serialization
-one, and it sits in CFC's territory rather than the read model's. If the event
-path excludes references deliberately — so that a pattern only ever touches
-cells reached through its own inputs and its own writes — then the answer is
-not "add the marker" but "add it with a rights check," which is a materially
-larger design and belongs to whoever owns confinement.
+If references are excluded from the argument path deliberately, the answer is
+not this change — it is this change plus a rights check, which is a materially
+larger design with a different owner. **That question should be answered before
+the work starts**, because the two roads differ in kind and not only in effort.
 
-**Nobody should build the obvious fix until that is answered**, because the two
-roads differ in more than effort: one is a schema keyword, the other is an
-authorization boundary.
+No evidence was found either way: the emission drops the marker without a
+comment explaining whether that is deliberate.
 
-## What does not wait for the answer
+## What does not wait for that answer
 
-Silently accepting a structural copy where a reference is meant is wrong under
-either road. A caller doing the obvious thing gets a success, a plausible
-result value, and a wrong graph.
-
-Refusing that payload needs no new vocabulary and no decision about
-confinement. It converts a corruption into an error, which is strictly better
-whichever way the question above is settled.
-
-## What this document is not
-
-It is not a proposal to make verb arguments accept addresses. It is the
-observation that the read side answered a question the write side was never
-asked, that the gap is being paid for in production today, and that the
-capability question has to be answered before the obvious fix is the right one.
+Refusing a structural copy where a reference is declared is correct under
+either road. It needs no new vocabulary, no wire format, and no decision about
+confinement — and it converts today's silent corruption into an error.

--- a/docs/plans/references-as-arguments.md
+++ b/docs/plans/references-as-arguments.md
@@ -11,21 +11,27 @@ address, the webhook sends it through unresolved. **The shape-matching payload
 the CLI does accept stores a detached copy instead of an edge, and reports
 success.**
 
-**The ask:** move that resolution to the boundary every external caller crosses.
+**The fix:** move that resolution to the boundary every external caller
+crosses, and give the outer gates the link acceptance the dispatch gate already
+has. Medium work, mostly relocating code that already runs in production.
 
 **One constraint, not a second decision:** what is accepted inbound has to
 include the shape a read already emits. Otherwise a caller still cannot submit
 the address it was just handed, and the capability does not compose. Which
 spelling wins is the implementer's call.
 
-**Decide first:** whether accepting a caller-named address is a confinement
-question — noting that the model, the least trusted caller in the system,
-already has this capability. If it is, this is the wrong-sized change and CFC
-owns it. If it is not, the work is medium and mostly relocating code that
-already runs in production.
+**Not a confinement decision — the runtime already took a position.** The
+dispatch-side closed-world gate accepts a link value opaquely and defers its
+schema check to the handler's own reads (`closedWorldEventRejection`,
+`packages/runner/src/runner.ts`, via its `acceptOpaqueValue: isCellLink`
+option). The CLI's pre-dispatch gate calls the same validator without that
+option (`verbInputSchemaError`, `packages/cli/lib/callable.ts`); the webhook
+path has no gate at all. The refusal is drift between the outer layers and the
+gate they feed, not policy. CFC gets a heads-up — an existing capability
+widening to external principals — not a ruling to wait for.
 
-**True either way:** refusing the structural copy, instead of storing it, needs
-no encoding decision and no confinement ruling.
+**Independent of all of it:** refusing the structural copy, instead of storing
+it, needs no encoding decision and no gate change.
 
 The rest of this document is the evidence for the paragraphs above.
 
@@ -120,20 +126,26 @@ invoke it. A webhook could not, and neither can the CLI.
 
 **Resolution at the shared boundary rather than in one consumer.**
 `traverseAndCellify` is the working reference implementation; what it needs is a
-home where every caller reaches it.
+home where every caller reaches it. Beside it, the CLI's pre-dispatch gate
+needs the `acceptOpaqueValue` option the dispatch gate already passes, so the
+two gates stop disagreeing about link values.
 
-**A marker in the emitted event schema.** An event field declared
-`Writable<ItemOutput>` emits as `{"$ref": "#/$defs/ItemOutput"}` with no
-`asCell`; an inline `Writable<{ title: string }>` disappears from the emitted
-properties entirely. Measured both ways. `llm-dialog` sidesteps this by
-resolving schema-blind — it cellifies any `@link` it finds — but a boundary with
-closed-world input validation cannot, because the gate has to know the position
-takes an address before it can accept one there.
+**A schema emission fix, and a marker for one road only.** An event field
+declared `Writable<ItemOutput>` emits as `{"$ref": "#/$defs/ItemOutput"}` with
+no `asCell`; an inline `Writable<{ title: string }>` disappears from the
+emitted properties entirely. Measured both ways. The disappearance needs fixing
+under any road: a field the schema does not name cannot be validated or
+documented, and once event schemas close (verb contract WS-C) cannot be
+supplied at all. The `asCell` marker is needed only if resolution becomes
+schema-directed — schema-blind acceptance already composes with closed-world
+validation, as `closedWorldEventRejection` demonstrates: a link value passes
+opaquely in any declared position while an undeclared key still rejects.
 
 *Whether resolution should stay schema-blind or become schema-directed is an
 implementation question this document does not settle.* Schema-blind is proven
-and simpler; schema-directed is checkable and refuses a typo. The answer decides
-whether the emission change is required or merely useful.
+twice — `traverseAndCellify` and the dispatch gate; schema-directed is
+checkable and refuses a typo. The answer decides whether the `asCell` emission
+is required or merely useful.
 
 ## Size
 
@@ -141,29 +153,50 @@ whether the emission change is required or merely useful.
 emission change lands in
 `packages/ts-transformers/src/transformers/schema-injection.ts`, the same file
 that carries a verb's declared result. Resolution is a lift-and-share of
-existing, exercised code. Nothing durable is written, so it reverses by
-assignment rather than migration.
+existing, exercised code, and the gate alignment is one option at one call
+site — pass the `acceptOpaqueValue` the dispatch gate already passes. Nothing
+durable is written, so it reverses by assignment rather than migration.
 
-## The decision that gates the shape
+## The refusal is drift, not policy
 
-**Is the argument path missing a reference vocabulary, or refusing one?**
+At what layer are references disallowed? None of them chooses to. The layers
+disagree, and the innermost one already ruled in favor.
 
-Accepting an address lets a caller aim a pattern at a cell the *caller* named
-rather than one the pattern reached through its own inputs. That is a
-confinement question and belongs to whoever owns CFC.
+**The dispatch-side gate accepts links.** `closedWorldEventRejection`
+(`packages/runner/src/runner.ts`) validates a present event payload with
+`acceptOpaqueValue: (value) => isCellLink(value)`: a link value passes
+unjudged, because its target cannot be read at dispatch and its schema check
+belongs to the handler's own reactive reads. The same gate works out how to
+stop a caller smuggling undeclared *keys* through links without ever banning
+link *values*. That is a considered position on exactly this question, taken in
+the layer most careful about what a caller may submit.
 
-It is sharpened rather than answered by the LLM precedent: a model — the least
-trusted caller in the system — can already do this. Either that is a considered
-position and the same reasoning extends to other callers, or it is an
-inconsistency worth knowing about. Both readings argue for deciding it
-deliberately rather than leaving one door open and the rest shut by omission.
+**The CLI gate is the same validator minus the option.** `verbInputSchemaError`
+(`packages/cli/lib/callable.ts`) calls the identical `validateSchemaValue` with
+no `acceptOpaqueValue`. It has no link concept, so it descends into a link
+envelope as if it were the declared object — the measured rejections above.
+The comments around that gate give its purpose: refuse a malformed payload
+before it spends the invocation id. Nothing there elects to refuse references.
 
-**This wants answering before the work starts.** If references are excluded
-deliberately, the answer is not this change but this change plus a rights
-check — a materially larger design with a different owner.
+**The webhook path takes no position.** `sendToStream`
+(`packages/toolshed/routes/webhooks/webhooks.utils.ts`) forwards the raw
+payload with no gate and no traversal.
 
-## What does not wait for that answer
+**And "data cannot name a cell" is not a core invariant.** A sigil link is a
+link wherever it appears in stored data (`isLinkRef`,
+`packages/data-model/src/cell-rep.ts`). Whether a sigil riding a webhook
+payload survives `send()` as a live edge is untested; if it does, that door is
+already open under the native spelling, and this plan names a capability rather
+than adds one.
 
-Refusing a structural copy where a reference is declared is correct under either
-road. It needs no new vocabulary, no encoding decision, and no confinement
-ruling, and it converts today's silent corruption into an error.
+What remains for whoever owns CFC is a notification, not a ruling: opening the
+outer doors widens an existing exposure — an external principal, not just the
+user's own model session, gets to name an address a handler will act on with
+its own authority. They should hear that and can object. But the precedent this
+change extends is the runtime's own gate, not a workaround.
+
+## What is correct regardless
+
+Refusing a structural copy where a reference is declared stands on its own: no
+new vocabulary, no encoding decision, no gate change, and it converts today's
+silent corruption into an error.

--- a/docs/plans/references-as-arguments.md
+++ b/docs/plans/references-as-arguments.md
@@ -1,11 +1,26 @@
 # References as arguments
 
-**The ask: lift address resolution out of the LLM builtin and into the boundary
-every external caller crosses, and settle one encoding for it.**
+## The short version
 
-A caller outside the runtime can be *handed* an address and cannot hand one
-back — unless that caller is an LLM, which can, because the LLM dialog builtin
-solved this for itself.
+`traverseAndCellify` in the LLM dialog builtin resolves `{"@link": "…"}` into a
+live cell before dispatching to a handler. **A model can hand a pattern a
+reference. The CLI, a webhook, and the ingest path reach the same handler and
+cannot** — they validate structurally, and the payload they *do* accept stores a
+detached copy instead of an edge, reporting success.
+
+**The ask:** move that resolution to the boundary every external caller crosses,
+and settle one encoding. There are three spellings of "an address goes here" and
+only one is accepted inbound.
+
+**Decide first:** whether accepting a caller-named address is a confinement
+question. If it is, this is the wrong-sized change and CFC owns it. If it is
+not, the work is medium and mostly relocating code that already runs in
+production.
+
+**True either way:** refusing the structural copy, instead of storing it, needs
+no encoding decision and no confinement ruling.
+
+The rest of this document is the evidence for those four paragraphs.
 
 ## The team already needed this and already built it
 

--- a/docs/plans/references-as-arguments.md
+++ b/docs/plans/references-as-arguments.md
@@ -1,0 +1,123 @@
+# References as arguments
+
+A caller can be handed an address and cannot hand one back. This document
+states the gap, shows what it already costs, and asks the one question that
+decides whether the obvious fix is the right one.
+
+It is a question, not a proposal. Nothing here amends
+[Reading Fabric data](fabric-read-model.md) or
+[the pattern verb contract](pattern-verb-contract.md).
+
+## The asymmetry
+
+[Reading Fabric data](fabric-read-model.md) settles that everything addressable
+is a cell, and [shaped reads](shaped-reads-and-verb-results.md) gives a reader
+a way to say *give me the address at this position, not the contents*. That is
+the `$link` marker, and the reasoning behind it is explicit: `asCell` bundles a
+traversal boundary with a **handle contract**, and a handle cannot cross a
+serialized channel — only its address can.
+
+That reasoning is symmetric, and only one side of it was built.
+
+| | Read | Argument |
+| --- | --- | --- |
+| Declare "an address sits here" | `$link` beside `properties` | — |
+| Wire encoding | declared `{ id, space, scope, path }` | — |
+| Why not `asCell` | reasoned out, recorded | never asked |
+
+**The runtime is not the limitation.** A pattern hands a piece to another
+pattern constantly — `Item({ title, parent: self })` passes a reference, and
+the graph that results is the normal shape of composed patterns. What has no
+spelling is the *serialized* boundary: how an event type declares a reference
+position, and how a caller outside the runtime encodes one.
+
+## What it costs today
+
+**Measured.** A verb declared to take another piece compiles, and then behaves
+in a way no caller would predict.
+
+```tsx
+// Shown for illustration only.
+interface BlockOnEvent {
+  on: ItemOutput; // the piece itself, not a minted identifier
+}
+```
+
+The generated event schema renders `on` as `{"$ref": "#/$defs/ItemOutput"}` —
+the *shape*, with no `asCell` — and that definition requires every field of the
+output, recursively. Three payloads, against item A blocking on item B:
+
+| Payload | Result |
+| --- | --- |
+| `{"on": "fid1:…"}` | rejected — *value does not match type object* |
+| the runtime link envelope | rejected — *missing required property title* |
+| a literal `ItemOutput`-shaped object | **accepted** |
+
+The accepted one is the problem. The call settles, reports a plausible result,
+and stores a **detached copy inside the caller's own document** — the edge does
+not point at B at all. Finishing B would never unblock A, and nothing reports
+an error. Reproduction and measured addresses are on
+[#5560](https://github.com/commontoolsinc/labs/issues/5560).
+
+**Already paid, in a shipped pattern.** Topics cannot accept a topic reference,
+so it recovers references by scanning prose. `extractFidPayloads`
+(`packages/patterns/topics/topic.tsx`) matches, in its own words, "bare
+`fid1:X`, storage-form `of:fid1:X`, page URLs `https://host/space/fid1:X`, and
+share links where the colon is percent-encoded." The board's entire
+topic-to-topic reference graph is derived that way.
+
+That is not a stylistic choice. It is the only route available, and it is the
+clearest statement of the cost: a pattern that wants a reference has to
+regex one out of text a human typed.
+
+## Where else the same shape appears
+
+Any relation between two existing pieces, which is most of what a graph is
+for — a dependency edge, a move between parents, an assignment, a tag, a
+removal that names its target. It is invisible in a pure tree, because the
+natural shape there is to call the verb *on* the parent, so the receiver
+carries the relation and no address needs to be an argument. It appears the
+moment two pieces must be related to each other.
+
+A second instance sits one level out, on a command rather than an event:
+`cf piece set-slug <slug> <source>` resolves its source positional through its
+own path rather than the one `--piece` uses, so work making `--piece` accept an
+entity URI does not reach it.
+
+## The question that decides the shape of the answer
+
+**Is the argument path missing a reference vocabulary, or refusing one?**
+
+The obvious fix is the mirror of `$link`: a way for an event schema to declare
+a reference position, an accepted wire encoding for an address, and resolution
+before the handler sees the value. If nothing objects to that, it is a
+well-understood piece of work whose shape the read side already established.
+
+But accepting an address as an argument lets a caller direct a pattern at a
+cell the *caller* named. That is a capability question, not a serialization
+one, and it sits in CFC's territory rather than the read model's. If the event
+path excludes references deliberately — so that a pattern only ever touches
+cells reached through its own inputs and its own writes — then the answer is
+not "add the marker" but "add it with a rights check," which is a materially
+larger design and belongs to whoever owns confinement.
+
+**Nobody should build the obvious fix until that is answered**, because the two
+roads differ in more than effort: one is a schema keyword, the other is an
+authorization boundary.
+
+## What does not wait for the answer
+
+Silently accepting a structural copy where a reference is meant is wrong under
+either road. A caller doing the obvious thing gets a success, a plausible
+result value, and a wrong graph.
+
+Refusing that payload needs no new vocabulary and no decision about
+confinement. It converts a corruption into an error, which is strictly better
+whichever way the question above is settled.
+
+## What this document is not
+
+It is not a proposal to make verb arguments accept addresses. It is the
+observation that the read side answered a question the write side was never
+asked, that the gap is being paid for in production today, and that the
+capability question has to be answered before the obvious fix is the right one.

--- a/docs/plans/references-as-arguments.md
+++ b/docs/plans/references-as-arguments.md
@@ -8,9 +8,12 @@ reference. The CLI, a webhook, and the ingest path reach the same handler and
 cannot** — they validate structurally, and the payload they *do* accept stores a
 detached copy instead of an edge, reporting success.
 
-**The ask:** move that resolution to the boundary every external caller crosses,
-and settle one encoding. There are three spellings of "an address goes here" and
-only one is accepted inbound.
+**The ask:** move that resolution to the boundary every external caller crosses.
+
+**One constraint, not a second decision:** what is accepted inbound has to
+include the shape a read already emits. Otherwise a caller still cannot submit
+the address it was just handed, and the capability does not compose. Which
+spelling wins is the implementer's call.
 
 **Decide first:** whether accepting a caller-named address is a confinement
 question. If it is, this is the wrong-sized change and CFC owns it. If it is
@@ -50,20 +53,20 @@ second-class:
 The same handler, reached two ways, accepts a reference from one and not the
 other. Nothing about the verb differs; only the door the caller came through.
 
-## One concept, three encodings
+### Why the round trip is a constraint rather than a preference
 
-The divergence has already started, which is the more expensive half.
+Two spellings of an address are already in use, and they do not meet:
 
 | Spelling | Where | Direction |
 | --- | --- | --- |
 | `{"@link": "…"}` | `llm-dialog` | in **and** out |
 | `{"$link": {id, space, scope, path}}` | shaped reads ([shaped reads](shaped-reads-and-verb-results.md)) | out only |
-| `{"/": {"link@1": {…}}}` | the runtime's internal envelope | neither — internal form |
 
-Three ways to write "an address goes here," none of them agreeing, and only one
-accepted inbound. A consumer that renders with one and submits with another —
-which is what any caller reading a `$link` result and calling a verb would do —
-has no route that works.
+So a caller that reads a result and submits the address it was handed has no
+route that works — the form it received is not a form anything accepts. Picking
+a spelling is the implementer's call; accepting the one a read emits is what
+makes the capability compose, and it is the property
+[CLI surface shape](cli-surface-shape.md) already states for commands.
 
 ## What this costs today, measured
 

--- a/docs/plans/references-as-arguments.md
+++ b/docs/plans/references-as-arguments.md
@@ -1,23 +1,75 @@
 # References as arguments
 
-**The ask: carry a declared reference into the emitted event schema, and honor
-it at the two boundary sites that read one.**
+**The ask: lift address resolution out of the LLM builtin and into the boundary
+every external caller crosses, and settle one encoding for it.**
 
-A verb whose event declares a reference — `Writable<T>` on an event field —
-cannot be called by anything outside the runtime. The declaration compiles, the
-runtime honors it internally, and the emitted schema drops it, so nothing at the
-serialized boundary can tell a reference position from a value position.
+A caller outside the runtime can be *handed* an address and cannot hand one
+back — unless that caller is an LLM, which can, because the LLM dialog builtin
+solved this for itself.
 
-This is one change, and it is the completion of a mechanism that already
-exists rather than a new capability.
+## The team already needed this and already built it
 
-## Why this matters, measured
+`traverseAndCellify` (`packages/runner/src/builtins/llm-dialog.ts`) walks an LLM
+tool call's input, finds `{"@link": "…"}`, and resolves it through
+`runtime.getCellFromLink()` before dispatch. Its output becomes
+`invocationArgs`, which goes into the `handler` branch's stream send. Its
+counterpart `traverseAndSerialize` renders cells *out* in the same shape, so
+the LLM boundary has a complete round trip: a model is handed an address and
+can hand it back.
 
-[The pattern verb contract](pattern-verb-contract.md) states its goal as making
-any pattern agent-drivable through its own verbs. That is currently false for a
-specific and enumerable class of verbs.
+That is proof of need from inside the codebase. Somebody hit this wall on a
+surface that matters and built the resolution rather than working around it.
 
-Every event field across the shipped patterns that declares a reference:
+**The problem is where it lives.** It sits inside one builtin, so it serves one
+consumer. Every other caller that crosses the same serialized boundary is
+second-class:
+
+| Consumer | Can pass a reference? |
+| --- | --- |
+| LLM tool call (`llm-dialog`) | **yes** — `@link`, resolved before dispatch |
+| `cf piece call` | no — validated structurally, an address is rejected |
+| Webhook POST (`sendToStream`, `packages/toolshed/routes/webhooks/`) | no — the raw payload is sent unresolved |
+| [Ingest channels](ingest-channels-journal-sink.md) | no — builds on the same dispatch |
+| `cf exec` and the FUSE projection | no — JSON in, same path as the CLI |
+
+The same handler, reached two ways, accepts a reference from one and not the
+other. Nothing about the verb differs; only the door the caller came through.
+
+## One concept, three encodings
+
+The divergence has already started, which is the more expensive half.
+
+| Spelling | Where | Direction |
+| --- | --- | --- |
+| `{"@link": "…"}` | `llm-dialog` | in **and** out |
+| `{"$link": {id, space, scope, path}}` | shaped reads ([shaped reads](shaped-reads-and-verb-results.md)) | out only |
+| `{"/": {"link@1": {…}}}` | the runtime's internal envelope | neither — internal form |
+
+Three ways to write "an address goes here," none of them agreeing, and only one
+accepted inbound. A consumer that renders with one and submits with another —
+which is what any caller reading a `$link` result and calling a verb would do —
+has no route that works.
+
+## What this costs today, measured
+
+Not "you cannot do this yet." The boundary **accepts a wrong payload and stores
+the wrong thing.**
+
+Declaring a reference on an event and calling it three ways:
+
+| Payload | Result |
+| --- | --- |
+| `{"on": "fid1:…"}` | rejected — *value does not match type object* |
+| the runtime link envelope | rejected — *missing required property title* |
+| a literal shape-matching object | **accepted** |
+
+The accepted one settles, reports a plausible result, and stores a **detached
+copy inside the caller's own document**. The edge does not point at the target.
+Nothing reports an error. Measured addresses and reproduction:
+[#5560](https://github.com/commontoolsinc/labs/issues/5560).
+
+The verbs this reaches are not hypothetical. Every event field across the
+shipped patterns that declares a reference:
 
 ```text
 addPiece     Stream<{ piece: MentionablePiece }>
@@ -30,110 +82,66 @@ removeItem   Stream<{ item: ReadingItemPiece }>
 removeItem   Stream<{ item: TodoItem }>
 ```
 
-Eight of 238 verb declarations. The count is not the point — the **shape** is.
-Every one is *put this existing thing here* or *take this existing thing out*,
-which is precisely the class of operation that has to name something that
-already exists. None of them can be invoked by an agent, a script, or the CLI.
-
-The sharpest case is the root pattern's, since every space has one:
+Every one is *put this existing thing here* or *take this existing thing out* —
+the class of operation that must name something that already exists. The
+sharpest is the root pattern's, since every space has one:
 
 ```bash
 $ cf piece call --piece <root> addPiece '{"piece":"fid1:…"}'
 Invalid input for "addPiece": piece: value does not match type object
 ```
 
-`addPiece` on `packages/patterns/system/default-app.tsx` is how a piece is
-registered in a space. It is reachable from inside the runtime — `pieces.add`
-sends to exactly this stream — and unreachable through the verb surface.
-
-## This is a correctness defect, not a missing feature
-
-The boundary does not refuse an unusable payload. It accepts one and stores the
-wrong thing.
-
-Declaring `on: ItemOutput` on an event and calling it three ways:
-
-| Payload | Result |
-| --- | --- |
-| `{"on": "fid1:…"}` | rejected — *value does not match type object* |
-| the runtime link envelope | rejected — *missing required property title* |
-| a literal `ItemOutput`-shaped object | **accepted** |
-
-The accepted one settles, reports a plausible result, and stores a **detached
-copy inside the caller's own document**. The edge does not point at the target.
-Finishing the target would never unblock the blocked item, and nothing anywhere
-reports an error. Reproduction and measured addresses:
-[#5560](https://github.com/commontoolsinc/labs/issues/5560).
-
-So the status quo is not "you cannot do this yet." It is "the obvious attempt
-succeeds and writes a wrong graph."
-
-## What already exists
-
-Three of the four pieces are built. This is why the ask is small.
-
-**The author-facing spelling.** `Writable<T>` on an event field is how a
-reference position is declared, and shipped patterns use it — the list above is
-that spelling in production.
-
-**The runtime capability.** Those events carry live cells today. Piece
-registration in every space runs through `addPiece`, so references in event
-payloads are not novel; they are load-bearing.
-
-**The wire encoding.** A rendered address — `{ id, space, scope, path }` — is
-already what a `$link` read emits
-([shaped reads](shaped-reads-and-verb-results.md)). Accepting the same shape
-inbound makes an address round-trip, which is the property
-[CLI surface shape](cli-surface-shape.md) already states for commands: an
-address printed by one command is accepted by the next.
+`pieces.add` sends to that exact stream from inside the runtime. An LLM could
+invoke it. A webhook could not, and neither can the CLI.
 
 ## What is missing
 
-**The marker is dropped in emission.** An event field declared
+**Resolution at the shared boundary rather than in one consumer.**
+`traverseAndCellify` is the working reference implementation; what it needs is a
+home where every caller reaches it.
+
+**A marker in the emitted event schema.** An event field declared
 `Writable<ItemOutput>` emits as `{"$ref": "#/$defs/ItemOutput"}` with no
-`asCell` anywhere; an inline `Writable<{ title: string }>` disappears from the
-emitted properties entirely. Measured both ways. Nothing downstream can
-distinguish a reference position, because the emitted schema does not say there
-is one.
+`asCell`; an inline `Writable<{ title: string }>` disappears from the emitted
+properties entirely. Measured both ways. `llm-dialog` sidesteps this by
+resolving schema-blind — it cellifies any `@link` it finds — but a boundary with
+closed-world input validation cannot, because the gate has to know the position
+takes an address before it can accept one there.
 
-Everything else follows from that one omission:
-
-| Site | What it needs |
-| --- | --- |
-| handler-schema emission (`packages/ts-transformers/src/transformers/schema-injection.ts`) | carry the marker onto an event property declared `Writable<T>` |
-| verb input validation | accept an address at a marked position instead of validating structurally |
-| dispatch | resolve the address into a cell before the handler runs |
+*Whether resolution should stay schema-blind or become schema-directed is an
+implementation question this document does not settle.* Schema-blind is proven
+and simpler; schema-directed is checkable and refuses a typo. The answer decides
+whether the emission change is required or merely useful.
 
 ## Size
 
-**Medium.** The emission change is the bulk of it and lands in the same file
-that carries a verb's declared result, so whoever does one is in position to do
-the other. The validation and resolution changes are each small and have
-existing machinery to lean on — the runtime resolves links from addresses
-throughout.
+**Medium**, and smaller than it looks because the hard part is written. The
+emission change lands in
+`packages/ts-transformers/src/transformers/schema-injection.ts`, the same file
+that carries a verb's declared result. Resolution is a lift-and-share of
+existing, exercised code. Nothing durable is written, so it reverses by
+assignment rather than migration.
 
-Nothing durable is written and no baseline records it, so the change is
-reversible by assignment rather than migration.
-
-## The one decision that gates the shape
+## The decision that gates the shape
 
 **Is the argument path missing a reference vocabulary, or refusing one?**
 
-Accepting an address as an argument lets a caller aim a pattern at a cell the
-*caller* named, rather than one the pattern reached through its own inputs.
-That is a confinement question, and it belongs to whoever owns CFC rather than
-to the read model or the verb contract.
+Accepting an address lets a caller aim a pattern at a cell the *caller* named
+rather than one the pattern reached through its own inputs. That is a
+confinement question and belongs to whoever owns CFC.
 
-If references are excluded from the argument path deliberately, the answer is
-not this change — it is this change plus a rights check, which is a materially
-larger design with a different owner. **That question should be answered before
-the work starts**, because the two roads differ in kind and not only in effort.
+It is sharpened rather than answered by the LLM precedent: a model — the least
+trusted caller in the system — can already do this. Either that is a considered
+position and the same reasoning extends to other callers, or it is an
+inconsistency worth knowing about. Both readings argue for deciding it
+deliberately rather than leaving one door open and the rest shut by omission.
 
-No evidence was found either way: the emission drops the marker without a
-comment explaining whether that is deliberate.
+**This wants answering before the work starts.** If references are excluded
+deliberately, the answer is not this change but this change plus a rights
+check — a materially larger design with a different owner.
 
 ## What does not wait for that answer
 
-Refusing a structural copy where a reference is declared is correct under
-either road. It needs no new vocabulary, no wire format, and no decision about
-confinement — and it converts today's silent corruption into an error.
+Refusing a structural copy where a reference is declared is correct under either
+road. It needs no new vocabulary, no encoding decision, and no confinement
+ruling, and it converts today's silent corruption into an error.


### PR DESCRIPTION
> Stacked on #5606 (both touch `docs/plans/README.md`). Review this on its own merits; the base is an unrelated correction.

## The short version

`traverseAndCellify` in the LLM dialog builtin resolves `{"@link": "…"}` into a live cell before dispatching to a handler. **A model can hand a pattern a reference. The CLI, a webhook, and the ingest path reach the same handler and cannot** — they validate structurally, and the payload they *do* accept stores a detached copy instead of an edge, reporting success.

**The ask:** move that resolution to the boundary every external caller crosses.

**One constraint, not a second decision:** what is accepted inbound has to include the shape a read already emits, or a caller still cannot submit the address it was just handed. Which spelling wins is the implementer's call.

**Decide first:** whether accepting a caller-named address is a confinement question. If it is, this is the wrong-sized change and CFC owns it. If not, the work is medium and mostly relocating code that already runs in production.

**True either way:** refusing the structural copy, instead of storing it, needs no encoding decision and no confinement ruling.

---

## Why

**The LLM dialog builtin already solved this. It solved it for one consumer, and every other caller that crosses the same boundary is left out.**

`traverseAndCellify` (`packages/runner/src/builtins/llm-dialog.ts`) walks an LLM tool call's input, finds `{"@link": "…"}`, and resolves it through `runtime.getCellFromLink()` before dispatch. Its output becomes `invocationArgs`, which flows into the `handler` branch's stream send. `traverseAndSerialize` does the reverse. So a model can be handed an address and hand it back — a complete round trip.

Somebody hit this wall on a surface that mattered and built the resolution. The need is demonstrated from inside the codebase.

The problem is where it lives:

| Consumer | Can pass a reference? |
| --- | --- |
| LLM tool call | **yes** — `@link`, resolved before dispatch |
| `cf piece call` | no — validated structurally, an address is rejected |
| Webhook POST (`sendToStream`) | no — raw payload sent unresolved |
| Ingest channels (planned) | no — builds on the same dispatch |
| `cf exec` / FUSE | no — same path as the CLI |

The same handler, reached two ways, accepts a reference from one door and not the other.

## Why the round trip is a constraint, not a preference

Two caller-facing spellings are in use and they do not meet: `llm-dialog` accepts and emits `{"@link": "…"}`, while a shaped read emits `{"$link": {id, space, scope, path}}` and nothing accepts it. So a caller that reads a result and submits the address it was handed has no route that works — the form it received is not a form anything takes.

## It is a correctness defect, not a gap

The boundary does not refuse the unusable payload — it accepts one and stores the wrong thing. A literal shape-matching object is **accepted**, settles, reports a plausible result, and writes a **detached copy inside the caller's own document**. Nothing errors. Reproduction: #5560.

The verbs affected are real — every reference-declaring event field in the shipped patterns is `addPiece` ×3, `appendLink`, `removeEvent`, `removeItem` ×3. All of them "add an existing thing" or "remove an existing thing". Including the root pattern's `addPiece`, which `pieces.add` drives from inside and which an LLM could invoke:

```
$ cf piece call --piece <root> addPiece '{"piece":"fid1:…"}'
Invalid input for "addPiece": piece: value does not match type object
```

## What is missing

Resolution at the shared boundary rather than in one consumer — `traverseAndCellify` is the working reference implementation needing a home every caller reaches.

Plus a marker in the emitted event schema: `Writable<ItemOutput>` emits as a bare `$ref` with no `asCell`, and an inline `Writable<{…}>` disappears from the emitted properties entirely (measured both ways). `llm-dialog` sidesteps this by resolving schema-blind; a boundary with closed-world validation cannot.

**Whether resolution stays schema-blind or becomes schema-directed is left open** — schema-blind is proven and simpler, schema-directed refuses a typo. That answer decides whether the emission change is required or merely useful.

## Size

**Medium**, and smaller than it looks: the hard part is written and exercised. Emission lands in the same file that carries a verb's declared result. Nothing durable is written, so it reverses by assignment.

## The decision that gates the shape

Accepting an address lets a caller aim a pattern at a cell the *caller* named. That is a confinement question and belongs to whoever owns CFC.

The LLM precedent sharpens it: a model is the least trusted caller in the system and is the one that can already do this. Either the reasoning extends to other callers, or it is an inconsistency worth knowing about. **Wants answering before the work starts** — if references are excluded deliberately, the answer is this change plus a rights check, a different and larger design.

## What does not wait

Refusing a structural copy where a reference is declared is right under either road, needs no encoding decision, and turns silent corruption into an error.

## Test plan

Documentation only. `deno task check-docs` (537 blocks), `docs-links --orphan`, `check-conflict-markers`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
