### PR TITLE
fix(cf-harness): ground host-command children in the workspace, not the parent cwd

### DIFF
--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -2745,7 +2745,16 @@ export class CfHarnessPromptLoop {
           gatewayAuthMode: this.engine.config.gatewayAuthMode,
         }
         : {}),
-      cwd: parentRunState.currentDir,
+      // A host-command child (non-empty hostToolIds, i.e. the browser
+      // profile) resolves every path — including its cwd — against its own
+      // host-backed mounts, which are workspace-only. Inheriting a parent
+      // cwd outside the workspace (Loom capture runs sit at /file-cabinet)
+      // killed every such child at its first host command with "path
+      // escapes host-backed sandbox roots" (CT-1984). Ground host-command
+      // children in the workspace; sandboxed children keep the parent cwd.
+      cwd: profileConfig.hostToolIds.length > 0
+        ? this.engine.workspaceMountPath
+        : parentRunState.currentDir,
       ...(this.engine.config.skillsRoot !== undefined
         ? { skillsRoot: this.engine.config.skillsRoot }
         : {}),

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -7015,3 +7015,94 @@ Deno.test("CfHarnessPromptLoop keeps a positive threshold off profile-overridden
     );
   }
 });
+
+Deno.test("CfHarnessPromptLoop grounds host-command children in the workspace, not the parent cwd", async () => {
+  // A browser child executes host commands, so its paths — including its
+  // cwd — must resolve against its own host-backed mounts, which are
+  // workspace-only. A parent working elsewhere (Loom capture runs sit at
+  // /file-cabinet) previously killed every browser child at its first host
+  // command with "path escapes host-backed sandbox roots" (CT-1984).
+  const requestBodies: Array<{
+    messages: Array<{ role: string; content: string }>;
+    tools: Array<{ function: { name: string } }>;
+  }> = [];
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    allowedToolIds: ["delegate_task"],
+    allowedSubagentProfiles: ["browser"],
+    engine: new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime(),
+      workspaceHostPath: "/tmp/project",
+      cwd: "/file-cabinet",
+      runId: "run-delegate-browser-cwd",
+      model: "gpt-5.4",
+      cfcEnforcementMode: "enforce-explicit",
+    }),
+    fetchFn: (_input, init) => {
+      const body = JSON.parse(String(init?.body)) as {
+        messages: Array<{ role: string; content: string }>;
+        tools: Array<{ function: { name: string } }>;
+      };
+      requestBodies.push(body);
+      const payload = requestBodies.length === 1
+        ? {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "",
+              tool_calls: [{
+                id: "call-browser-cwd",
+                type: "function",
+                function: {
+                  name: "delegate_task",
+                  arguments: JSON.stringify({
+                    goal: "Snapshot the local app with agent-browser.",
+                    profile: "browser",
+                  }),
+                },
+              }],
+            },
+          }],
+        }
+        : {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: requestBodies.length === 2
+                ? "Browser child completed."
+                : "Parent completed.",
+            },
+          }],
+        };
+      return Promise.resolve(
+        new Response(JSON.stringify(responsesBodyFromChatFixture(payload)), {
+          status: 200,
+        }),
+      );
+    },
+  });
+
+  const result = await loop.runPrompt({
+    prompt: "Delegate browser work from the file cabinet.",
+    promptSlotBinding: directPromptSlotBinding,
+  });
+
+  assertEquals(result.runState.status, "completed");
+  // The parent keeps its own working directory…
+  assertEquals(result.runState.currentDir, "/file-cabinet");
+  // …while the host-command child is grounded in the workspace.
+  assertEquals(
+    chatViewOfRequest(requestBodies[1]).messages[0].content.includes(
+      "Current sandbox directory: /workspace",
+    ),
+    true,
+  );
+  assertEquals(
+    chatViewOfRequest(requestBodies[1]).messages[0].content.includes(
+      "/file-cabinet",
+    ),
+    false,
+  );
+});


### PR DESCRIPTION
## Why

Loom's first live browser-lane probe on the cf-harness wish path (W-917, CT-1984) failed on both dispatch attempts: the parent acquired its Browser Access lease and delegated correctly, but **every browser child died at its first host command** with `path escapes host-backed sandbox roots: /file-cabinet` — before any browsing happened. The agent (reasonably) concluded browser access was broken and escalated.

Mechanism: the child spawn passes `cwd: parentRunState.currentDir` unconditionally. A browser-profile child executes host commands (`bash-no-sandbox`), so its paths — including its cwd — resolve via `#resolveHostMount` against the child's own host-backed mounts, which are workspace-only. Loom's capture dispatch deliberately sets the parent cwd to `/file-cabinet`, which has no host mapping in the child, so the resolution throws. Net effect: every capture-class browser delegation is dead on arrival.

## What Changed

Children whose profile carries host tools (non-empty `hostToolIds`, i.e. the browser profile) now start in the engine's `workspaceMountPath` instead of inheriting the parent cwd. Sandboxed children (default/web profiles) keep inheriting — their docker mounts can serve the parent's cwd. Widening the child's host-backed mounts instead was rejected: the browser child's host filesystem reach should stay narrow.

## Test plan

- New prompt-loop test: parent at `/file-cabinet` delegates to the browser profile; the child's system prompt is grounded at `Current sandbox directory: /workspace` with no `/file-cabinet` reference, while the parent's runState keeps `/file-cabinet`.
- Full `packages/cf-harness` suite: 607 passed, 0 failed; fmt/lint clean.

Fixes CT-1984. Sibling of #5605 in Loom's harness-parity arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

