### PR TITLE
fix(cli): a rejected position is not a required one

### DIFF
--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -1418,7 +1418,12 @@ export function selectSourceSchema(
       purpose,
     );
   }
-  const selectedRequired = required?.filter((key) => key in properties);
+  // A rejected position holds nothing to require. Keeping it required makes
+  // the object unsatisfiable, which reads as an absent value for the whole
+  // selection rather than for the one position that declined to be read.
+  const selectedRequired = required?.filter((key) =>
+    key in properties && properties[key] !== false
+  );
   return {
     ...metadata,
     properties,

--- a/packages/cli/test/piece-get-transform.test.ts
+++ b/packages/cli/test/piece-get-transform.test.ts
@@ -2201,6 +2201,36 @@ describe("cf piece get transforms", () => {
       ).toEqual({ topic: { $link: addressOf(notes[0]) } });
     });
 
+    /**
+     * The board reopened under a schema that marks its fields required. A
+     * generated pattern schema does this and `boardSchema` above does not,
+     * which is the whole reason a rejected position surviving into `required`
+     * stayed invisible to these tests while breaking a live read.
+     */
+    const requiredBoardSchema = {
+      ...boardSchema,
+      required: ["topic", "label"],
+    } as const satisfies JSONSchema;
+
+    it("reads a required sibling beside a marked position", async () => {
+      const { notes } = await seedBoard("link-marker-required", true);
+      const board = runtime.getCell(
+        space,
+        "link-marker-required-board",
+        requiredBoardSchema,
+      );
+      expect(
+        await deriveSelectedValue(runtime, space, board, {
+          projection: await parseSelectionProjection(
+            '{"properties":{"topic":{"$link":true},"label":true}}',
+          ),
+        }),
+      ).toEqual({
+        topic: { $link: addressOf(notes[0]) },
+        label: "Field notes",
+      });
+    });
+
     it("returns the address and the contents asked for beside it", async () => {
       const { board, notes } = await seedBoard("link-marker-beside", true);
       expect(


### PR DESCRIPTION
## Why

A `$link` marker beside any other projection key silently returns **nothing** on
current main.

`selectSourceSchema` filters the source's `required` down to keys that survive
into the selection, but a rejected position is still *present* — its value is
`false`. So `{"properties":{"topic":{"$link":true},"label":true}}` projects to
`required: ["topic","label"]` with `topic: false`: an unsatisfiable object. The
read comes back absent for the **whole selection** rather than for the one
position that declined to be read.

Silent-empty is the worst failure mode this could have picked. Nothing errors,
and a caller cannot tell the difference between "the marker suppressed the
fetch" and "there was no data".

Split out of #5504 so it can land on its own — the defect is on main today and
the rest of that branch is an unrelated feature.

## What Changed

`packages/cli/lib/cell-selection.ts` — a rejected position is dropped from the
selected `required`, since it holds nothing to require.

## Test plan

A regression test that **was verified to fail without the fix**, not assumed to.

The reason it was needed is the reason none of the existing tests caught it:
the `boardSchema` fixture declares no `required` at all, while a generated
pattern schema marks its fields required. Every fixture in that file agreed
with the bug. The test reopens the same board under a schema carrying
`required`, marks one position with `$link`, and asserts the sibling still
reads.

- `packages/cli` suite green; `piece-get-transform.test.ts` 80 steps, 0 failed
- pre-fix filter restored locally → the new test FAILS; fix restored → passes
- `deno task check`, `deno fmt --check`, `deno lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

