### PR TITLE
feat: re-land #5469 and #5505, with the call tests on the invocation pair

### DIFF
--- a/docs/common/verbs-over-the-cli.md
+++ b/docs/common/verbs-over-the-cli.md
@@ -104,23 +104,79 @@ Anything the *pattern* resolved comes back too. A verb that stamps a write time
 or derives structured authorship from the event returns those in its record;
 the caller could not have computed them.
 
+### Asking for a smaller result
+
+A verb decides what it returns; the caller decides how much of it to look at.
+`--filter`, `--select`, and `--schema` — the same three flags `cf piece get`
+takes, with the same grammar — shape the `result` before it reaches stdout, and
+go before the callable name:
+
+```bash
+cf piece call --piece <topic> --select comment.writtenAt addComment \
+  '{"body":"first","agentName":"Sol"}'
+```
+
+```json
+{
+  "invocation": "0f4c…",
+  "status": "settled",
+  "result": { "comment": { "writtenAt": "2026-08-07T09:15:27Z" } }
+}
+```
+
+This shapes a result that already exists rather than deciding what travels: the
+readback has the whole receipt in hand before the selection runs. So a
+value-less verb keeps reporting no `result` at all — there is nothing for a
+selection to be about — and `--no-wait`, which never reads the receipt back,
+refuses all three flags. `--show-links` composes with a projection, because a
+projection leaves every surviving path where it was; it does not compose with
+`--filter`, which moves the positions a link names.
+
+`packages/cli/README.md` has the grammar and the supported schema subset.
+
 ### Retries are safe, and cheap to reason about
 
-`--invocation <id>` makes a call idempotent. Replaying a settled id returns the
-**original** result rather than re-executing:
+`--invocation <id>` makes a call idempotent. The id is your own word for the
+call — and `add-comment-1` is a word two agents both reach for, so an id on its
+own does not say whose invocation it is. An **invocation session** does. Mint
+one per agent run and carry it on every call of that run:
+
+```bash
+export CF_INVOCATION_SESSION=$(cf invocation-session new)
+```
+
+The environment is where a session belongs, because it is closer to a secret
+than a setting: it is what keeps an outcome's address out of reach of a
+stranger, and a command's arguments are readable in a process listing where its
+environment is not. `--invocation-session <id>` overrides it for one call.
+
+The pair is what names an invocation. Replaying a settled id **from the session
+that chose it** returns the **original** result rather than re-executing:
 
 ```bash
 cf piece call --piece <topic> --invocation add-comment-1 \
   addComment '{"body":"first","agentName":"Sol"}'
 
-# Same id, different payload: the original result comes back, and no second
-# comment is recorded.
+# Same id, same session, different payload: the original result comes back,
+# and no second comment is recorded.
 cf piece call --piece <topic> --invocation add-comment-1 \
   addComment '{"body":"different","agentName":"Sol"}'
 ```
 
 That is the property an agent depends on when it retries a call whose response
 it never saw.
+
+That same id under a **different** session is a different invocation: it
+executes, and returns its own result. So two agents that pick the same word are
+never told each other's calls have settled, and knowing a piece, a verb and an
+id is not enough to read someone else's outcome — the session is the part a
+stranger cannot guess.
+
+`--invocation` therefore requires a session, and a call naming an id without one
+is refused, pointing you at `cf invocation-session new` and
+`CF_INVOCATION_SESSION`. Pass neither and both are minted for that one call: a
+random id names an outcome nothing else will ask for, and a call that never
+intended to replay loses nothing.
 
 A **rejected** call is different from a settled one: it never spends its id. If
 a verb refuses the payload, correct it and retry under the same id.
@@ -203,7 +259,7 @@ API_URL=http://localhost:8000 packages/cli/integration/verbs-over-the-cli.sh
 ```
 
 CI runs it in the `piece-call` shard. It takes under half a minute and around
-twenty `cf` invocations against a warm local toolshed.
+two dozen `cf` invocations against a warm local toolshed.
 
 Each step demonstrates one use case:
 
@@ -214,12 +270,13 @@ Each step demonstrates one use case:
 | 4 | A verb returns what it wrote, including what only it could compute |
 | 5 | A call's result names the document behind each path, and that address calls |
 | 6 | A read returns an address in place of what is behind it |
-| 7 | A replayed id returns the original result; nothing runs twice |
+| 7 | A replayed id returns the original result within its session, and executes as its own call in another |
 | 8 | A piece result survives `plainResultReceipts=false`; a plain record does not — and the write lands either way |
 | 9 | A value-less verb settles with the empty witness |
 | 10 | A refused call does not spend its invocation id |
 | 11 | Reading a verb redirects to `cf piece call` |
 | 12 | Timings on stderr, Invocation JSON still clean on stdout |
+| 13 | An invocation id without a session is refused, and the refusal says how to mint one |
 
 ## Addressing a piece you were handed
 
@@ -254,6 +311,12 @@ one, so a chain of references annotates each hop exactly once. The walk stops at
 any non-plain object: a live runtime object reached through a result gets its
 own entry and nothing below it, because its properties belong to the runtime
 rather than to the result.
+
+The links describe whatever result you were handed, so a projection composes
+with them: a path `--select` or `--schema` dropped simply gets no entry.
+`--filter` is refused alongside `--show-links` — a predicate leaves the elements
+it keeps at positions that are no longer the ones they came from, and every
+address below a filtered array would name the wrong element.
 
 A pattern should not mint identifier fields to make any of this easier —
 rendering identity is the client's job, and a pattern-authored fid is a copy

--- a/docs/development/CONFIGURATION.md
+++ b/docs/development/CONFIGURATION.md
@@ -301,6 +301,7 @@ the labs checkout and dispatches to `packages/cli/mod.ts`.
 |---|---|---|
 | `CF_IDENTITY` | _(none)_ | Path to identity keyfile. Required for `piece`, `acl`, `exec` against a remote toolshed. |
 | `CF_API_URL` | _(none)_ | Toolshed URL. Required for the same commands as above. |
+| `CF_INVOCATION_SESSION` | _(none)_ | Invocation session `cf piece call` scopes an invocation id to. Mint one per agent run with `cf invocation-session new`. Carried here rather than as `--invocation-session <id>` because the session is what makes a call's outcome unguessable, and an argument is readable in a process listing. |
 | `CF_LOG_LEVEL` | `error` | `debug` \| `info` \| `warn` \| `error` \| `silent`. Also settable per-invocation with `--log-level`. |
 | `CF_CLI_NAME` | `cf` | Override the displayed CLI name (for branded builds). |
 | `CF_CLI_TRACE_TIMINGS` | `0` | Set to `1` for detailed timing traces. |

--- a/docs/plans/verb-result-selection.md
+++ b/docs/plans/verb-result-selection.md
@@ -149,15 +149,17 @@ cause           = { ...inputs, $event: tx.dispatchedEventId ?? <random uuid> }
 result cell's space**, not necessarily the caller's, and is created with **no
 scope argument**, so receipts are space-scoped today.
 
-**`$event` is not the caller's id.** A caller-supplied id is bound to the stream
-it was sent to before it becomes an event id: `scopeCallerEventId`
+**`$event` is not the caller's id.** A caller-supplied id is bound to the
+session that chose it and to the stream it was sent to before it becomes an
+event id: `scopeCallerEventId`
 (`packages/runner/src/scheduler/event-identity.ts`) hashes
-`{caller, id, path, space}` — the id string plus the stream link — into
-`evt:caller:<hash>`, and `Cell.send` routes every supplied id through it. That
-binding is deliberate: two verbs sharing input bindings must not collide on one
-receipt. The hash is deterministic across processes, so a retry from a fresh CLI
-invocation derives the same id — which is what makes any re-derivation scheme
-possible at all.
+`{caller, id, path, scope, session, space}` — the id string, the session, and
+the whole stream link — into `evt:caller:<hash>`, and `Cell.send` routes every
+supplied id through it. That binding is deliberate: two verbs sharing input
+bindings must not collide on one receipt, and neither must two callers that
+picked the same word for their own invocation. The hash is deterministic
+across processes, so a retry from a fresh CLI invocation derives the same id —
+which is what makes any re-derivation scheme possible at all.
 
 Where no id is supplied, `mintEventId` produces
 `evt:<per-transaction key>:<seq>:<stream link id>` or

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -139,7 +139,7 @@ standard error and continues searching that piece and the rest of the space.
 - The launcher spawns the child CLI with `deno run --quiet` so Deno's own
   warnings (npm "Ignored build scripts" banner) never reach users.
 
-### Transforming `piece get` output
+### Transforming `piece get` and `piece call` output
 
 `piece get` can filter an array before it reaches stdout and project the result
 to a smaller shape:
@@ -150,6 +150,21 @@ cf piece get --piece ID items \
   --filter '.status == "open" and .score >= 10' \
   --select id,title,author.name
 ```
+
+`piece call` takes the same three flags, with the same grammar, the same
+conflict rule, and the same error messages, written before the callable name:
+
+```bash
+cf piece call --piece ID --select topic.title addTopic '{"title":"Ship it"}'
+cf piece call --piece ID --filter '.status == "open"' listTopics
+```
+
+Everything below describes both commands. The one difference is what the
+selection is about: `piece get` shapes a cell's value, and `piece call` shapes
+the **result of the call** — a handler's `result` inside the Invocation JSON, or
+a tool's JSON on stdout. See
+[what a selection means for a call](#what-a-selection-means-for-a-call) for the
+three cases where that difference shows.
 
 `--filter` is jq-inspired rather than a full jq interpreter. It applies only to
 arrays and accepts value paths (`.status`, `.author.name`, `.["display-name"]`,
@@ -165,7 +180,7 @@ Two flags project, one per input language:
   also accepts the same field list `--select` takes.
 
 A command that names both has not said which shape it wants, and is refused
-before the read.
+before the read or the call.
 
 For an array result, the field list describes each item. An inline/file JSON
 Schema describes the complete returned value, so a schema combined with
@@ -263,6 +278,35 @@ marked collection therefore costs one document read rather than one per element.
 The marker is a JSON-schema spelling only, and it cannot be combined with
 `--filter`: the elements a predicate keeps no longer say which positions they
 came from, and an address names a position.
+
+#### What a selection means for a call
+
+A selection shapes a result that already exists. It does not narrow what the
+call fetches: the readback materializes the whole receipt before the selection
+runs, and a handling's receipt declares no schema for a selector to narrow
+against. The same holds for a tool, whose result is read off the cell the tool
+wrote. Use a selection to control what reaches stdout, not to control what
+travels.
+
+Three cases follow from that:
+
+- **A value-less verb still reports nothing.** Its receipt is the empty witness,
+  and the Invocation JSON omits `result` to say so. A selection is about a
+  value, so with none there the step never runs and `result` stays absent — it
+  does not become `{}`, and it is not an error. A selection that keeps nothing
+  from a result that _does_ exist is a different fact, and it is refused rather
+  than reported as an absent result.
+- **`--no-wait` refuses all three flags.** That mode exits once the commit is
+  acknowledged and skips the receipt readback, so there is no result to shape.
+  The refusal names the flags that need the readback, alongside `--show-links`
+  for the same reason.
+- **`--show-links` composes with a projection, not with `--filter`.** Links are
+  collected after the selection, over exactly the value the caller is holding: a
+  projection leaves every surviving path where it was, so each address still
+  names the position it annotates, and a path the projection dropped simply gets
+  no entry. A predicate does not — the elements it keeps land at positions that
+  are no longer the ones they came from — so `--filter --show-links` is refused,
+  the same refusal a `$link` marker meets for the same reason.
 
 ## Built Binary
 

--- a/packages/cli/commands/invocation-session.ts
+++ b/packages/cli/commands/invocation-session.ts
@@ -1,0 +1,32 @@
+import { Command } from "@cliffy/command";
+import { cliText } from "../lib/cli-name.ts";
+import { render } from "../lib/render.ts";
+import { newSessionId } from "../lib/session.ts";
+
+/**
+ * Emit a freshly minted invocation session id. Nothing else goes to stdout:
+ * the id is the whole output, so `$(cf invocation-session new)` captures
+ * exactly it.
+ *
+ * The `write` seam is the unit-test hold on the command's output — a command
+ * action body only ever runs under Cliffy, and is therefore unreachable from
+ * the unit suite. Runtime callers use the default.
+ */
+export function renderNewSession(write: (text: string) => void = render): void {
+  write(newSessionId());
+}
+
+export const invocationSession = new Command()
+  .name("invocation-session")
+  .description(
+    "Mint an invocation session: the caller an invocation id passed to " +
+      "`cf piece call` was chosen within. One per agent run.",
+  )
+  .default("help")
+  /* invocation-session new */
+  .command("new", "Output a new invocation session id to stdout.")
+  .example(
+    cliText("export CF_INVOCATION_SESSION=$(cf invocation-session new)"),
+    "Mint a session for this shell, so every call made from it shares one.",
+  )
+  .action(() => renderNewSession());

--- a/packages/cli/commands/main.ts
+++ b/packages/cli/commands/main.ts
@@ -8,6 +8,7 @@ import { exec } from "./exec.ts";
 import { fuse } from "./fuse.ts";
 import { init } from "./init.ts";
 import { inspect } from "./inspect.ts";
+import { invocationSession } from "./invocation-session.ts";
 import { piece } from "./piece.ts";
 import { space } from "./space.ts";
 import { identity } from "./identity.ts";
@@ -167,5 +168,6 @@ export const main = new Command()
   .command("completion", completion)
   .command("id", identity)
   .command("init", init)
+  .command("invocation-session", invocationSession)
   .command("test", test)
   .command("wish", wish);

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -36,7 +36,12 @@ import {
 } from "../lib/piece.ts";
 import type { ExecutedPieceCallable } from "../lib/piece.ts";
 import type { PatternCompatibilityReport } from "@commonfabric/piece/ops";
-import type { InvocationOutcome, InvocationPhase } from "../lib/callable.ts";
+import type {
+  InvocationIdentity,
+  InvocationOutcome,
+  InvocationPhase,
+} from "../lib/callable.ts";
+import { newSessionId } from "../lib/session.ts";
 import { renderPiece } from "../lib/piece-render.ts";
 import { parseSqliteSource } from "../lib/sqlite-source.ts";
 import { render, safeStringify } from "../lib/render.ts";
@@ -50,6 +55,7 @@ import ports from "@commonfabric/ports" with { type: "json" };
 import type { PiecePatternRef } from "@commonfabric/piece/ops";
 import { reservesStdoutForCommandOutput } from "../lib/json-output.ts";
 import {
+  type CellSelection,
   CellSelectionError,
   parseCellSelectionOptions,
 } from "../lib/cell-selection.ts";
@@ -420,21 +426,52 @@ export function pieceCallInvocation(
 }
 
 /**
- * Resolve the invocation id for a handler call: the caller's own id, or a
- * freshly minted one. A blank id is rejected rather than passed down — it
- * would read as "the caller supplied one" while carrying nothing that can
- * distinguish one delivery from another, so the retry it promises to make
- * safe would not be (verb contract WS-D).
+ * Resolve what names a handler call's invocation: the id for this dispatch
+ * and the session it was chosen within (`CF_INVOCATION_SESSION`, or
+ * `--invocation-session`). Both reach the durable event id the handling's
+ * receipt is filed under, so a later call settles on that receipt only by
+ * naming the same pair (verb contract WS-D).
+ *
+ * A caller that names neither gets both minted for this one request. The id
+ * is random, so it names an outcome nothing else will ask for; scoping it to
+ * a session minted alongside it costs such a call nothing, and keeps every
+ * call deriving its address the one way.
+ *
+ * A caller that names an id but no session is refused. Naming an id asks for
+ * an outcome that is addressable and replayable, and a session minted per
+ * request would put that same id on a different outcome next time — so the
+ * request cannot be honored as it was made. Saying so beats accepting it and
+ * letting the caller find out at the retry it was preparing for, when the
+ * verb runs a second time.
+ *
+ * A blank id or session is rejected rather than passed down: either would
+ * read as "the caller named one" while carrying nothing that tells two
+ * deliveries apart.
  */
-export function resolveInvocationId(
-  raw: string | undefined,
-  mint: () => string = () => crypto.randomUUID(),
-): string {
-  if (raw === undefined) return mint();
-  if (!raw.trim()) {
+export function resolveInvocationIdentity(
+  rawInvocation: string | undefined,
+  rawSession: string | undefined,
+  mintInvocationId: () => string = () => crypto.randomUUID(),
+  mintSession: () => string = newSessionId,
+): InvocationIdentity {
+  if (rawInvocation !== undefined && !rawInvocation.trim()) {
     throw new ValidationError("--invocation requires a non-blank id");
   }
-  return raw;
+  if (rawSession !== undefined && !rawSession.trim()) {
+    throw new ValidationError("--invocation-session requires a non-blank id");
+  }
+  if (rawSession === undefined) {
+    if (rawInvocation !== undefined) {
+      throw new ValidationError(
+        "--invocation names an id to replay, and an id is replayable only " +
+          "within the session it was chosen in. Mint a session with " +
+          "`cf invocation-session new` and set `CF_INVOCATION_SESSION`, or " +
+          "pass it as `--invocation-session <id>`.",
+      );
+    }
+    return { id: mintInvocationId(), session: mintSession() };
+  }
+  return { id: rawInvocation ?? mintInvocationId(), session: rawSession };
 }
 
 /**
@@ -444,6 +481,15 @@ export function resolveInvocationId(
  * still holds the exact id to retry with, and the retry deduplicates instead
  * of executing a second time. Announcing once matters: a caller scraping
  * stderr for its id should not have to decide which of several to trust.
+ *
+ * The id is half of what a retry names: it deduplicates only under the session
+ * it was chosen in. So the session is announced beside it, on its own line —
+ * a caller that named no session was minted one for this call, and without
+ * reading it here would hold an id that names nothing it can return to.
+ *
+ * Two lines rather than one because `invocation: <id> phase: <phase>` below is
+ * a parsed shape: appending to the id line would change what a scenario
+ * blocking on a phase reads.
  *
  * `announcePhases` is a test-harness hook (reached via the
  * `CF_TEST_ANNOUNCE_INVOCATION_PHASES` env var at the call site): every phase
@@ -456,7 +502,7 @@ export function resolveInvocationId(
  * byte-identical with the hook absent.
  */
 export function invocationPhaseReporter(
-  invocationId: string,
+  invocation: InvocationIdentity,
   onAdvance: (phase: InvocationPhase) => void,
   announce: (message: string) => void = console.error,
   announcePhases = false,
@@ -465,10 +511,11 @@ export function invocationPhaseReporter(
   return (next) => {
     if (next === "dispatched" && !announced) {
       announced = true;
-      announce(`invocation: ${invocationId}`);
+      announce(`invocation: ${invocation.id}`);
+      announce(`session: ${invocation.session}`);
     }
     if (announcePhases) {
-      announce(`invocation: ${invocationId} phase: ${next}`);
+      announce(`invocation: ${invocation.id} phase: ${next}`);
     }
     onAdvance(next);
   };
@@ -540,7 +587,7 @@ export function renderPieceCallOutcome(
     hint?: (text: string, prefix?: boolean) => void;
     printError?: (text: string) => void;
   } = {},
-  opts: { detached?: boolean; invocationId?: string } = {},
+  opts: { detached?: boolean; invocation?: InvocationIdentity } = {},
 ): void {
   const renderOut = deps.render ?? render;
   const hintOut = deps.hint ?? hint;
@@ -575,11 +622,18 @@ export function renderPieceCallOutcome(
     // prose stays on stderr via hint().
     renderOut(JSON.stringify(invocationJson(result.invocation), null, 2));
     hintOut(
+      // The readback names its session through the environment rather than
+      // `--invocation-session`, because a session is what keeps an outcome's
+      // address out of reach of anyone who can guess a piece, a verb and an
+      // id — and an argument is readable in a process listing where an
+      // environment variable is not.
       opts.detached
         ? cliText(`NEXT STEPS:
-  → Read the outcome: cf piece call --piece ${piece} --invocation ${
-          opts.invocationId ?? "<id>"
-        } ${callableName} ... (the commit is durable; a same-id call deduplicates and returns the settled outcome)
+  → Read the outcome: CF_INVOCATION_SESSION=${
+          opts.invocation?.session ?? "<session>"
+        } cf piece call --piece ${piece} --invocation ${
+          opts.invocation?.id ?? "<id>"
+        } ${callableName} ... (the commit is durable; a call naming this same pair deduplicates and returns the settled outcome)
   → Verify state:     cf piece get --piece ${piece} <path> ...`)
         : nextSteps,
     );
@@ -631,19 +685,45 @@ export interface PieceCallWaitControl {
   boundSeconds?: number;
 }
 
+/** The `cf piece call` flags whose answer needs the receipt readback. */
+export interface PieceCallReadbackFlags {
+  showLinks?: boolean;
+  filter?: string;
+  select?: string;
+  schema?: string;
+}
+
+/**
+ * Those flags paired with the spelling a refusal names them by, in the order a
+ * caller writes them.
+ */
+const READBACK_FLAGS: ReadonlyArray<
+  [keyof PieceCallReadbackFlags, string]
+> = [
+  ["showLinks", "--show-links"],
+  ["filter", "--filter"],
+  ["select", "--select"],
+  ["schema", "--schema"],
+];
+
 /**
  * Resolve the wait flags into one control. `--await` is the explicit spelling
  * of the default (flag parity, so a script can state its intent), which makes
  * `--await --no-wait` a contradiction rather than a precedence puzzle — it is
  * refused. `--await --wait <s>` is fine: both mean "wait", the bound just
  * names the patience. A non-positive bound is refused: it would spell
- * "don't wait" while claiming to be a wait. `--show-links --no-wait` is
- * refused too: the links ride the receipt readback a detached exit skips,
- * so honoring both is impossible — refusing beats silently dropping the
+ * "don't wait" while claiming to be a wait.
+ *
+ * `--no-wait` also refuses every flag that shapes or annotates the outcome —
+ * `--show-links` and the selection flags. All of them are answered from the
+ * receipt a detached exit never reads, so honoring both is impossible;
+ * refusing beats silently handing back an unshaped result or dropping the
  * links.
  */
 export function resolveWaitControl(
-  options: { await?: boolean; wait?: number | boolean; showLinks?: boolean },
+  options:
+    & { await?: boolean; wait?: number | boolean }
+    & PieceCallReadbackFlags,
 ): PieceCallWaitControl {
   if (options.wait === false) {
     if (options.await) {
@@ -651,10 +731,13 @@ export function resolveWaitControl(
         "--await and --no-wait contradict each other; pass one.",
       );
     }
-    if (options.showLinks) {
+    const named = READBACK_FLAGS
+      .filter(([key]) => options[key] !== undefined && options[key] !== false)
+      .map(([, flag]) => flag);
+    if (named.length > 0) {
       throw new ValidationError(
-        "--show-links needs the receipt readback that --no-wait skips; " +
-          "pass one.",
+        `${listFlags(named)} need${named.length === 1 ? "s" : ""} the ` +
+          "receipt readback that --no-wait skips; pass one.",
       );
     }
     return { mode: "commit" };
@@ -668,6 +751,38 @@ export function resolveWaitControl(
     return { mode: "settle", boundSeconds: options.wait };
   }
   return { mode: "settle" };
+}
+
+/** Flag names as prose: "--a", "--a and --b", "--a, --b and --c". */
+function listFlags(flags: readonly string[]): string {
+  if (flags.length <= 1) return flags.join("");
+  return `${flags.slice(0, -1).join(", ")} and ${flags.at(-1)}`;
+}
+
+/**
+ * Parse `cf piece call`'s selection flags into the shape the result should
+ * arrive in, through the same parser `cf piece get` uses — one grammar, one
+ * set of error messages, whichever command a caller reaches for.
+ *
+ * The one combination refused here is `--filter` with `--show-links`. A link
+ * names a position in the result, and a predicate that drops elements leaves
+ * the survivors at positions that are no longer the ones they came from, so
+ * every address below a filtered array would name the wrong element. It is
+ * the same refusal a `$link` marker meets inside the selection step, on the
+ * same grounds.
+ */
+export async function parsePieceCallSelection(
+  options: PieceCallReadbackFlags,
+): Promise<CellSelection | undefined> {
+  const selection = await parseCellSelectionOptions(options);
+  if (options.showLinks && selection?.filter !== undefined) {
+    throw new ValidationError(
+      "--show-links cannot be combined with --filter: a filtered array's " +
+        "elements no longer say which positions they came from, and a link " +
+        "names a position.",
+    );
+  }
+  return selection;
 }
 
 /**
@@ -1577,13 +1692,47 @@ after --. Handlers interpret piped input when no input argument is present.`,
     cliText(`cf piece call ${EX_ID} ${EX_COMP_PIECE} search -- --query milk`),
     `Run the "search" tool using schema-derived flags after "--".`,
   )
+  .example(
+    cliText(
+      `cf piece call ${EX_ID} ${EX_COMP_PIECE} --select topic.title addTopic ` +
+        `'{"title":"Ship it"}'`,
+    ),
+    "Return only the selected fields of the verb's result.",
+  )
+  .example(
+    cliText(
+      `cf piece call ${EX_ID} ${EX_COMP_PIECE} ` +
+        `--schema '{"properties":{"topic":{"$link":true}}}' addTopic ` +
+        `'{"title":"Ship it"}'`,
+    ),
+    "Return the address of what the verb returned instead of its contents.",
+  )
   .option("-c,--piece <piece:string>", "The target piece ID.")
   .option(
     "--invocation <id:string>",
-    "Idempotency key for a handler call (before the callable name). A " +
-      "same-id retry cannot commit twice — it settles on the original " +
-      "outcome — but the handler body does re-run, so effects outside the " +
-      "transaction repeat. Minted automatically when omitted.",
+    "Idempotency key for a handler call (before the callable name), and " +
+      "requires an invocation session. A retry naming the same pair cannot " +
+      "commit twice — it settles on the original outcome — but the " +
+      "handler body does re-run, so effects outside the transaction " +
+      "repeat. Both are minted for the one call when neither is given.",
+  )
+  .env(
+    "CF_INVOCATION_SESSION=<id:string>",
+    "Invocation session that this run's invocation ids belong to. The form " +
+      "to reach for: a session is what makes an outcome's address " +
+      "unguessable, and an environment variable stays out of the process " +
+      "listing an argument shows up in.",
+    { prefix: "CF_" },
+  )
+  .option(
+    "--invocation-session <id:string>",
+    "Override CF_INVOCATION_SESSION for this one call (before the callable " +
+      "name): the session this call's invocation id was chosen within, " +
+      "since an invocation id is the caller's own word and another caller " +
+      "can pick the same one. The pair decides which outcome a replay " +
+      "reads, so the same id under another session is another invocation. " +
+      "Mint a session per agent run with `cf invocation-session new`, and " +
+      "carry that one session on every call of the run.",
   )
   .option(
     "--verbose",
@@ -1601,17 +1750,17 @@ after --. Handlers interpret piped input when no input argument is present.`,
     "Bound the settlement wait by a chosen patience, in seconds (before " +
       "the callable name). On expiry the exit is nonzero with the " +
       "invocation id and furthest phase on stderr; the invocation may not " +
-      "have executed or committed, and re-invoking with the same id is " +
-      "safe in every phase — it finishes the work or reads the outcome " +
-      "back.",
+      "have executed or committed, and re-invoking under the same id and " +
+      "session is safe in every phase — it finishes the work or reads the " +
+      "outcome back.",
   )
   .option(
     "--no-wait",
     "Exit once this handling's commit is acknowledged (before the callable " +
       "name), skipping only the receipt readback: stdout reports status " +
-      '"committed", and a later call with the same --invocation id reads ' +
-      "the outcome back. The handler still executes here and its commit " +
-      "is durable. Handler invocations only.",
+      '"committed", and a later call naming the same invocation session and ' +
+      "--invocation reads the outcome back. The handler still executes here " +
+      "and its commit is durable. Handler invocations only.",
   )
   .option(
     "--show-links",
@@ -1623,18 +1772,56 @@ after --. Handlers interpret piped input when no input argument is present.`,
       "appear only where a path is backed by a different document. Handler " +
       "invocations only — a tool already reports its result cell on stderr.",
   )
+  .option(
+    "--filter <predicate:string>",
+    "Filter an array with a jq-inspired predicate",
+  )
+  .option(
+    "--select <fields:string>",
+    "Project output to comma-separated field paths",
+  )
+  .option(
+    "--schema <schema:string>",
+    "Project output with an inline JSON Schema, @file, or the --select " +
+      "field list",
+    // Both flags carry the one projection, so a command naming both has not
+    // said which shape it wants. Refuse before the call rather than pick.
+    { conflicts: ["select"] },
+  )
   .stopEarly()
   .arguments("<callable:string> [tail...:string]")
   .action(async function (options, callableName, ...tail) {
-    const invocationId = resolveInvocationId(options.invocation);
+    const identity = resolveInvocationIdentity(
+      options.invocation,
+      options.invocationSession,
+    );
+    const invocationId = identity.id;
     const waitControl = resolveWaitControl(options);
     let phase: InvocationPhase = "initial_sync";
     const observer = pieceCallPhaseObserver(
       !!options.verbose,
       (next) => phase = next,
     );
+    setQuietMode(!!options.quiet);
+    // Read outside the invocation's failure wrapper below. Nothing is
+    // dispatched here — no callable resolved, no id spent — so a malformed
+    // selection is a data error about the flags, the same one `cf piece get`
+    // reports. Inside the wrapper it would name an id and a phase to retry
+    // from for a call that was never made; a selection that fails against a
+    // RESULT does sit inside it, and does name one.
+    let selection: CellSelection | undefined;
     try {
-      setQuietMode(!!options.quiet);
+      selection = await parsePieceCallSelection(options);
+    } catch (error) {
+      // Both exits below leave without reaching the action's catch, so the
+      // verbose in-flight span is closed here.
+      observer.finish("failed");
+      if (error instanceof CellSelectionError) {
+        exitWithDataError({ message: error.message });
+      }
+      throw error;
+    }
+    try {
       const invocation = pieceCallInvocation(
         tail,
         this.getLiteralArgs(),
@@ -1649,11 +1836,12 @@ after --. Handlers interpret piped input when no input argument is present.`,
           callableName,
           invocation.rawArgs,
           {
-            invocationId,
+            invocation: identity,
             skipReadback: waitControl.mode === "commit",
             showLinks: !!options.showLinks,
+            ...(selection === undefined ? {} : { selection }),
             onPhase: invocationPhaseReporter(
-              invocationId,
+              identity,
               observer.onPhase,
               undefined,
               Boolean(Deno.env.get("CF_TEST_ANNOUNCE_INVOCATION_PHASES")),
@@ -1675,7 +1863,7 @@ after --. Handlers interpret piped input when no input argument is present.`,
         callableName,
         pieceConfig.piece,
         {},
-        { detached: waitControl.mode === "commit", invocationId },
+        { detached: waitControl.mode === "commit", invocation: identity },
       );
     } catch (error) {
       if (error instanceof ValidationError) {

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -75,6 +75,14 @@ new_invocation_id() {
   fi
 }
 
+# The session this run's invocation ids are chosen within. `cf piece call`
+# takes it from CF_INVOCATION_SESSION, and an id addresses an outcome only
+# within its session — so every retry below has to name the session its
+# original call named. Minted the way an invocation id is: a session is an
+# unguessable string and nothing more, and going through
+# `cf invocation-session new` for it would cost a CLI process.
+export CF_INVOCATION_SESSION="$(new_invocation_id)"
+
 # Kill a backgrounded `cf` invocation. `cf` is a shell function, so $! is the
 # subshell rather than the Deno process doing the work; killing only the
 # subshell would leave that child running and still able to commit. Take the

--- a/packages/cli/integration/verbs-over-the-cli.sh
+++ b/packages/cli/integration/verbs-over-the-cli.sh
@@ -53,9 +53,14 @@ ARGS="--api-url=$API_URL --identity=$CF_IDENTITY --space=$SPACE"
 echo "API_URL=$API_URL"
 echo "SPACE=$SPACE"
 
+# One session for the whole walkthrough, the way an agent run carries one: an
+# invocation id names an outcome within the session it was chosen in, so the
+# replay in step 7 has to be made from the session its original call was.
+export CF_INVOCATION_SESSION=$($CF invocation-session new)
+
 # A plain-JSON result rides the plainResultReceipts option, on by default.
 # Set it explicitly anyway so the walkthrough asserts the same thing whatever a
-# host's environment carries; step 7 sets it false to show the difference
+# host's environment carries; step 8 sets it false to show the difference
 # against a result carrying a piece, which survives either way.
 export EXPERIMENTAL_PLAIN_RESULT_RECEIPTS=true
 
@@ -140,7 +145,7 @@ check "written at create
 appended through the read" "$(echo "$B" | jq -r '.result.body // empty')" \
   "the address a read returned is one a caller can call"
 
-step "7. A replayed invocation id returns the ORIGINAL result"
+step "7. A replayed invocation id returns the ORIGINAL result — in its session"
 # Captured rather than hard-coded: the property is that the replay changes
 # nothing, which stays true however many notes earlier steps created.
 BEFORE=$($CF piece get --quiet --piece "$BOARD" $ARGS noteCount --step 2>/dev/null)
@@ -152,6 +157,22 @@ check "true" "$(echo "$D" | jq -r '.deduplicated // false')" \
   "the call reports itself deduplicated"
 check "$BEFORE" "$($CF piece get --quiet --piece "$BOARD" $ARGS noteCount --step 2>/dev/null)" \
   "the replay created no note (count unchanged at $BEFORE)"
+
+# The same word, from another caller. `create-1` is this session's name for
+# its first create, and nothing stops a second agent picking it: that agent is
+# calling for itself, and must get its own call rather than a report that
+# someone else's had settled.
+OTHER=$(CF_INVOCATION_SESSION=$($CF invocation-session new) $CF piece call \
+  --quiet --piece "$BOARD" \
+  $ARGS --invocation create-1 \
+  createNote '{"title":"Another agent"}' 2>/dev/null)
+check "Another agent" "$(echo "$OTHER" | jq -r '.result.note["$NAME"] // empty')" \
+  "the same id in ANOTHER session executes and returns its own result"
+check "false" "$(echo "$OTHER" | jq -r '.deduplicated // false')" \
+  "and does not report itself deduplicated"
+check "$((BEFORE + 1))" \
+  "$($CF piece get --quiet --piece "$BOARD" $ARGS noteCount --step 2>/dev/null)" \
+  "and created its note, so the write really happened"
 
 step "8. A piece result survives the option being off; a plain record does not"
 P=$(EXPERIMENTAL_PLAIN_RESULT_RECEIPTS=false $CF piece call --quiet \
@@ -201,6 +222,22 @@ echo "$OUT" | jq -e '.status' >/dev/null 2>&1 &&
 grep -qE "[0-9]+ *ms" "$ERR" && ok "per-phase timings on stderr" ||
   bad "no timings on stderr"
 sed 's/^/    /' "$ERR" | grep timing | head -5
+
+step "13. An invocation id without a session is refused"
+# The id is the replay handle, and a session minted for this one request
+# would put that id on a different outcome next time — so the call cannot be
+# honored as it was asked, and the refusal says how to ask again.
+NO_SESSION=$(env -u CF_INVOCATION_SESSION $CF piece call --quiet \
+  --piece "$BOARD" $ARGS \
+  --invocation lonely-1 createNote '{"title":"No session"}' 2>&1)
+rc=$?
+check "1" "$([ "$rc" -ne 0 ] && echo 1 || echo 0)" "the call exits nonzero"
+echo "$NO_SESSION" | grep -q -- "CF_INVOCATION_SESSION" &&
+  ok "the refusal names CF_INVOCATION_SESSION" ||
+  bad "the refusal does not name CF_INVOCATION_SESSION"
+echo "$NO_SESSION" | grep -q "invocation-session new" &&
+  ok "and the command that mints one" ||
+  bad "the refusal does not say how to mint a session"
 
 ELAPSED=$(($(date +%s) - START))
 printf '\n== %d passed, %d failed — %ds wall clock\n' "$PASS" "$FAIL" "$ELAPSED"

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -17,6 +17,11 @@ import {
   type CallableKind,
   classifyCallableEntry,
 } from "../../fuse/callables.ts";
+import {
+  type CellSelection,
+  CellSelectionError,
+  deriveSelectedValue,
+} from "./cell-selection.ts";
 import type { ExecCommandSpec } from "./exec-schema.ts";
 
 export const CF_RUNTIME_ERROR_LOG = Symbol.for("cf.cli.runtimeErrorLog");
@@ -47,17 +52,35 @@ export type InvocationPhase =
   | "committed"
   | "readback";
 
+/**
+ * What names one handler invocation: the caller's idempotency key for a
+ * dispatch, and the session that key was chosen within (`newSessionId`,
+ * ./session.ts).
+ *
+ * The two travel as a pair because an id is the caller's own word — an agent
+ * picks `add-comment-1` — and another caller can pick the same one. The pair
+ * reaches the durable event id, so a retry naming both collides on the
+ * handling's create-only receipt and reads the original outcome back (verb
+ * contract WS-D), while the same id under another session is a different
+ * invocation entirely.
+ *
+ * The guarantee is at-most-once *commit*, not at-most-once *execution* — a
+ * redelivered event re-runs the handler body and loses the race for the
+ * receipt, so a verb whose body has effects outside its transaction (an LLM
+ * call, a fetch) repeats those effects on retry even though nothing commits
+ * twice.
+ */
+export interface InvocationIdentity {
+  id: string;
+  session: string;
+}
+
 export interface CallableExecutionDeps {
   uuid?: () => string;
-  /** Caller-supplied idempotency key for handler sends: threads through as
-   * the durable event id, so a retry of the same id collides on the
-   * handling's create-only receipt and reads the original outcome back
-   * (verb contract WS-D). The guarantee is at-most-once *commit*, not
-   * at-most-once *execution* — a redelivered event re-runs the handler body
-   * and loses the race for the receipt, so a verb whose body has effects
-   * outside its transaction (an LLM call, a fetch) repeats those effects on
-   * retry even though nothing commits twice. */
-  invocationId?: string;
+  /** The id and session naming this call's invocation, for a handler send.
+   * Absent for a call that names no invocation, which is then dispatched
+   * under a runtime-minted event id and has no receipt to come back for. */
+  invocation?: InvocationIdentity;
   /** Phase observer for early-exit reporting. */
   onPhase?: (phase: InvocationPhase) => void;
   /** `--no-wait`: await this handling's transaction-local commit
@@ -81,6 +104,18 @@ export interface CallableExecutionDeps {
    * document, so plain JSON inside one doc adds nothing. Rides the receipt
    * readback, which is why it cannot combine with `--no-wait`. */
   showLinks?: boolean;
+  /** `--filter`/`--select`/`--schema`: the shape the caller asked the result
+   * to arrive in. Answered by the same selection step `cf piece get` reads
+   * through, so one grammar covers reads and calls.
+   *
+   * It shapes a result that exists rather than deciding what is fetched: the
+   * readback has already materialized the whole receipt by the time this
+   * applies, and a receipt declares no schema for a selector to narrow
+   * against. A verb that returns nothing keeps returning nothing — there is
+   * no value for a selection to be about. */
+  selection?: CellSelection;
+  /** @internal Seam for tests, mirroring `getCellValue`'s. */
+  deriveSelectedValue?: typeof deriveSelectedValue;
 }
 
 /** A backing-cell address in an Invocation's `links` dictionary: the same
@@ -555,6 +590,44 @@ export function collectInvocationResultLinks(
   return links;
 }
 
+/**
+ * Shape a call's result the way the caller asked for it, through the same step
+ * `cf piece get` reads through — the one place a `--filter`/`--select`/
+ * `--schema` grammar is interpreted, so a caller learns it once.
+ *
+ * `resultCell` is the cell the value was produced from: a handling's receipt,
+ * or a tool's result cell. The step reads through it and therefore reports the
+ * source's own links and Fabric metadata, which is what makes an address a
+ * caller can act on come back rather than a copy.
+ *
+ * A selection that materializes nothing over a result that exists is refused
+ * rather than reported as an absent result: an omitted `result` key means the
+ * verb returned nothing, and a projection that kept nothing is a different
+ * fact. `cf piece get` refuses the same condition on the same grounds.
+ */
+async function selectCallResult(
+  resolved: CallableResolution,
+  resultCell: Cell<any>,
+  selection: CellSelection,
+  deps: CallableExecutionDeps,
+): Promise<unknown> {
+  const selected = await (deps.deriveSelectedValue ?? deriveSelectedValue)(
+    resolved.pieces.runtime,
+    resolved.space,
+    resultCell,
+    selection,
+  );
+  if (selected === undefined) {
+    throw new CellSelectionError(
+      `Cannot shape the result of "${resolved.cellKey}": the filter/schema ` +
+        "expression did not materialize a JSON-renderable value. This is " +
+        "not JSON null, and it is not the empty receipt a value-less verb " +
+        "settles with — inspect the result and the selection.",
+    );
+  }
+  return selected;
+}
+
 export async function executeResolvedCallable(
   resolved: CallableResolution,
   input: unknown,
@@ -572,19 +645,24 @@ export async function executeResolvedCallable(
     );
     const runtimeErrors = runtimeErrorLog(resolved.pieces.runtime);
     const errorCountBefore = runtimeErrors.length;
-    const invocationId = deps.invocationId;
-    if (deps.skipReadback && invocationId === undefined) {
-      // Refused before dispatch: skipping the readback is only sound when
-      // a later same-id call can fetch the outcome, and that needs the id.
+    const invocation = deps.invocation;
+    const invocationId = invocation?.id;
+    if (deps.skipReadback && invocation === undefined) {
+      // Refused before dispatch: skipping the readback is only sound when a
+      // later call can fetch the outcome, and that needs the pair naming it.
       throw new Error("--no-wait requires an invocation id");
     }
     deps.onPhase?.("dispatched");
     const tx = await new Promise<IExtendedStorageTransaction>(
       (resolve, reject) => {
         try {
-          if (invocationId !== undefined) {
+          if (invocation !== undefined) {
             resolved.callableCell.send(dispatchInput, resolve, {
-              eventId: invocationId,
+              // The id and the session that chose it travel together: an id
+              // is the caller's own word, and only the pair decides which
+              // receipt this handling files under.
+              eventId: invocation.id,
+              session: invocation.session,
             });
           } else {
             resolved.callableCell.send(dispatchInput, resolve);
@@ -649,9 +727,24 @@ export async function executeResolvedCallable(
       ) {
         result = value;
       }
+      if (deps.selection !== undefined && result !== undefined) {
+        // Only where a result exists. Shaping the empty witness would report
+        // `{}` for a verb whose whole answer is that it returned nothing, and
+        // that omission is the distinction the empty receipt exists to draw.
+        result = await selectCallResult(
+          resolved,
+          receipt,
+          deps.selection,
+          deps,
+        );
+      }
       if (deps.showLinks) {
-        // After readback, off the same receipt the result came from: the
-        // links annotate exactly the value the caller is holding.
+        // After readback and after the selection, off the same receipt the
+        // result came from: the links annotate exactly the value the caller
+        // is holding. A projection keeps every surviving path where it was,
+        // so each address still names the position it annotates; a `--filter`
+        // does not, which is why the command refuses that pair rather than
+        // handing back addresses for elements the predicate moved.
         links = collectInvocationResultLinks(link, receipt, result);
       }
     }
@@ -750,6 +843,18 @@ export async function executeResolvedCallable(
     }
   } finally {
     cancelSink();
+  }
+
+  if (deps.selection !== undefined) {
+    // A tool's result reaches stdout through the same selection a handler's
+    // does. It is read off the cell the tool wrote, which is where the value
+    // above came from, so the shaped answer describes the same result.
+    outputValue = await selectCallResult(
+      resolved,
+      resultCell,
+      deps.selection,
+      deps,
+    );
   }
 
   // The result cell's durable address rides along: today the cell is

--- a/packages/cli/lib/session.ts
+++ b/packages/cli/lib/session.ts
@@ -1,0 +1,30 @@
+/**
+ * Mint a session id: the caller identity that an invocation id is chosen
+ * within.
+ *
+ * `cf piece call --invocation <id>` lets a caller name a dispatch so that a
+ * retry settles on the original outcome instead of executing the verb again.
+ * The id is the caller's own word — `add-comment-1` — and nothing stops a
+ * second caller from picking that same word for its own call on the same verb.
+ * The id alone therefore does not say whose invocation it is. A session is
+ * what tells the two callers apart.
+ *
+ * The id is a bare unguessable string. There is no format to parse and no key
+ * material to store — a session signs nothing and authenticates nobody, so
+ * giving it a keyfile shape would only invite storing and handling it as if it
+ * did. Mint one per agent run and let every call of that run share it: one run
+ * is exactly the span over which repeating an id should mean repeating a call.
+ * `CF_INVOCATION_SESSION` is the way to carry it, and
+ * `--invocation-session <id>` the one-call override, because an unguessable
+ * string stays unguessable only while it is out of the process listing an
+ * argument shows up in.
+ *
+ * The session is joined to the address a handling's receipt lands at, so it
+ * decides what a replay finds: the same id under two sessions reaches two
+ * outcomes, and holding an id without the session it was chosen in reaches
+ * nothing. That also makes the address unguessable, where a piece, a verb and
+ * a word like `add-comment-1` are not.
+ */
+export function newSessionId(): string {
+  return crypto.randomUUID();
+}

--- a/packages/cli/test/invocation-session.test.ts
+++ b/packages/cli/test/invocation-session.test.ts
@@ -1,0 +1,56 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  invocationSession,
+  renderNewSession,
+} from "../commands/invocation-session.ts";
+import { newSessionId } from "../lib/session.ts";
+
+// A random (version 4) UUID: the version nibble is 4 and the variant nibble is
+// one of 8/9/a/b, with every other nibble drawn from the CSPRNG.
+const RANDOM_UUID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+describe("invocation-session", () => {
+  describe("newSessionId()", () => {
+    it("returns a distinct id on every call", () => {
+      const minted = new Set(
+        Array.from({ length: 1000 }, () => newSessionId()),
+      );
+      expect(minted.size).toBe(1000);
+    });
+
+    it("returns a random id rather than a countable or timed one", () => {
+      // The shape is the evidence of where the bits came from: a counter, a
+      // timestamp, or a time-ordered UUID (v1, v7) all carry a version other
+      // than 4, and all let a caller who has seen one session id name the
+      // next one. Reusing another caller's session id is reusing its
+      // invocation ids.
+      expect(newSessionId()).toMatch(RANDOM_UUID);
+    });
+  });
+
+  describe("renderNewSession()", () => {
+    it("writes one freshly minted id, and nothing besides", () => {
+      const written: string[] = [];
+      renderNewSession((text) => written.push(text));
+      renderNewSession((text) => written.push(text));
+
+      // Exactly one bare token per call: no prose to strip and no envelope to
+      // parse (`cf id new`'s PEM has one because it carries key material; a
+      // session carries none), so `$(cf invocation-session new)` captures the
+      // id itself.
+      expect(written.length).toBe(2);
+      expect(written[0]).toMatch(RANDOM_UUID);
+      expect(written[1]).toMatch(RANDOM_UUID);
+      // Two runs of the command are two sessions.
+      expect(written[0]).not.toBe(written[1]);
+    });
+  });
+
+  describe("invocationSession", () => {
+    it("registers `new` as a subcommand", () => {
+      expect(invocationSession.getCommand("new")?.getName()).toBe("new");
+    });
+  });
+});

--- a/packages/cli/test/main-command.test.ts
+++ b/packages/cli/test/main-command.test.ts
@@ -134,6 +134,43 @@ describe("main command", () => {
     ]);
   });
 
+  it("reads piece call's invocation session from `CF_INVOCATION_SESSION`, behind `--invocation-session`", async () => {
+    const { piece } = await import(
+      "../commands/piece.ts?piece-call-session-test"
+    );
+    const call = piece.getCommand("call")!;
+    const sessions: Array<string | undefined> = [];
+    call.action((options) => {
+      sessions.push(options.invocationSession);
+    });
+
+    await withEnv("CF_INVOCATION_SESSION", "from-env", async () => {
+      await piece.parse([
+        "call",
+        "--invocation-session",
+        "from-flag",
+        "increment",
+      ]);
+      await piece.parse(["call", "increment"]);
+    });
+    await withEnv("CF_INVOCATION_SESSION", undefined, async () => {
+      await piece.parse(["call", "increment"]);
+    });
+
+    // The environment is the standing default for a shell or an agent run,
+    // and the flag is the one call that departs from it — so the flag wins.
+    // With neither, the option arrives `undefined`: this is the option layer
+    // alone, and `resolveInvocationIdentity` is what goes on to mint a
+    // session for a caller that named none.
+    //
+    // The middle reading is the one that pins the env var to this option:
+    // the variable is declared under the `CF_` prefix, and what reaches
+    // `.invocationSession` is the remainder camel-cased. A name whose
+    // remainder camel-cases to anything else would leave that reading
+    // `undefined` while the flag readings stayed green.
+    expect(sessions).toEqual(["from-flag", "from-env", undefined]);
+  });
+
   it("rejects multiple inline inputs to piece call", async () => {
     const { main } = await import(
       "../commands/main.ts?piece-call-inline-validation-test"

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -1,11 +1,19 @@
-import { describe, it } from "@std/testing/bdd";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import { expect } from "@std/expect";
 import type { JSONSchema } from "@commonfabric/api";
-import type { Cell, NormalizedFullLink } from "@commonfabric/runner";
+import { Identity } from "@commonfabric/identity";
 import {
+  type Cell,
+  type NormalizedFullLink,
+  Runtime,
+} from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import {
+  type CallableResolution,
   CF_RUNTIME_ERROR_LOG,
   collectInvocationResultLinks,
+  executeResolvedCallable,
   normalizeAbsentVerbPayload,
   runtimeErrorLog,
   schemaIsObjectShaped,
@@ -26,6 +34,7 @@ import {
   invocationJson,
   invocationPhaseReporter,
   isPieceGetDataError,
+  parsePieceCallSelection,
   pieceCallInvocation,
   pieceCallPhaseObserver,
   pieceCallRawArgs,
@@ -33,13 +42,23 @@ import {
   pieceLinkDataErrorReport,
   renderPieceCallOutcome,
   reportVerbInputErrorOrRethrow,
-  resolveInvocationId,
+  resolveInvocationIdentity,
   resolveWaitControl,
   verbInputErrorReport,
   WaitBoundExpired,
 } from "../commands/piece.ts";
 import { LinkValidationError } from "../lib/piece.ts";
-import { CellSelectionError } from "../lib/cell-selection.ts";
+import {
+  type CellSelection,
+  CellSelectionError,
+  type deriveSelectedValue,
+  parseCellSelectionOptions,
+} from "../lib/cell-selection.ts";
+import { cf, stripAnsi } from "./utils.ts";
+
+// The session an invocation id is chosen within, for the calls whose subject
+// is something else: a call names the pair or it names no invocation.
+const callerSession = "ses:piece-call-test";
 
 describe("executePieceCallable", () => {
   it("reports not-found when the piece cell has no schema-cast surface", async () => {
@@ -249,7 +268,7 @@ describe("executePieceCallable", () => {
           loadPiece: () => Promise.resolve(harness.piece),
           isStdinTerminal: () => false,
           readTextInput: () => Promise.resolve('{"mesage":"milk"}'),
-          invocationId: "inv-typo-retry",
+          invocation: { id: "inv-typo-retry", session: callerSession },
         },
       ),
     ).rejects.toThrow(/Invalid input for "recordMessage"/);
@@ -301,7 +320,7 @@ describe("executePieceCallable", () => {
           loadPieces: () => Promise.resolve(harness.pieces),
           loadPiece: () => Promise.resolve(harness.piece),
           isStdinTerminal: () => true,
-          invocationId: "inv-absent-retry",
+          invocation: { id: "inv-absent-retry", session: callerSession },
         },
       ),
     ).rejects.toThrow(
@@ -348,7 +367,7 @@ describe("executePieceCallable", () => {
         loadPieces: () => Promise.resolve(harness.pieces),
         loadPiece: () => Promise.resolve(harness.piece),
         isStdinTerminal: () => true,
-        invocationId: "inv-defaulted",
+        invocation: { id: "inv-defaulted", session: callerSession },
       },
     );
 
@@ -932,12 +951,14 @@ describe("executePieceCallable", () => {
       {
         loadPieces: () => Promise.resolve(harness.pieces),
         loadPiece: () => Promise.resolve(harness.piece),
-        invocationId: "inv-123",
+        invocation: { id: "inv-123", session: callerSession },
         onPhase: (phase) => phases.push(phase),
       },
     );
 
-    expect(harness.tracker.sendOptions).toEqual([{ eventId: "inv-123" }]);
+    expect(harness.tracker.sendOptions).toEqual([
+      { eventId: "inv-123", session: callerSession },
+    ]);
     expect(result.invocation).toEqual({
       id: "inv-123",
       status: "settled",
@@ -949,6 +970,86 @@ describe("executePieceCallable", () => {
     // off this handling's commit — never from draining the whole graph.
     expect(harness.tracker.idleCalls).toBe(0);
     expect(harness.tracker.syncedCalls).toBe(0);
+  });
+
+  it("carries the caller's session beside the invocation id to send", async () => {
+    const harness = createPieceCallableHarness({
+      callableKind: "handler",
+      cellKey: "addComment",
+      inputSchema: {
+        type: "object",
+        properties: {
+          message: { type: "string" },
+        },
+        required: ["message"],
+      },
+      receiptValue: { commentId: "c-1" },
+    });
+
+    const result = await executePieceCallable(
+      {
+        apiUrl: "http://localhost:8000",
+        identity: "/tmp/test-identity.pem",
+        piece: "fid1:piece-123",
+        space: "home",
+      },
+      "addComment",
+      ["--message", "milk"],
+      {
+        loadPieces: () => Promise.resolve(harness.pieces),
+        loadPiece: () => Promise.resolve(harness.piece),
+        invocation: { id: "inv-123", session: "ses-abc" },
+      },
+    );
+
+    // An invocation id is the caller's own word, so the session that chose it
+    // travels with it: they reach the send together or the id says nothing
+    // about whose invocation it is.
+    expect(harness.tracker.sendOptions).toEqual([
+      { eventId: "inv-123", session: "ses-abc" },
+    ]);
+    // The outcome a caller reads is its own invocation's, and reports the id
+    // the caller named rather than anything derived from the pair.
+    expect(result.invocation).toEqual({
+      id: "inv-123",
+      status: "settled",
+      result: { commentId: "c-1" },
+    });
+  });
+
+  it("sends no options at all for a call that names no invocation", async () => {
+    const harness = createPieceCallableHarness({
+      callableKind: "handler",
+      cellKey: "addComment",
+      inputSchema: {
+        type: "object",
+        properties: {
+          message: { type: "string" },
+        },
+        required: ["message"],
+      },
+      receiptValue: { commentId: "c-1" },
+    });
+
+    await executePieceCallable(
+      {
+        apiUrl: "http://localhost:8000",
+        identity: "/tmp/test-identity.pem",
+        piece: "fid1:piece-123",
+        space: "home",
+      },
+      "addComment",
+      ["--message", "milk"],
+      {
+        loadPieces: () => Promise.resolve(harness.pieces),
+        loadPiece: () => Promise.resolve(harness.piece),
+      },
+    );
+
+    // Absent, not substituted: the runtime mints the delivery id for such a
+    // call, and nothing downstream is handed a stand-in id or session it
+    // would have to tell apart from a caller's own.
+    expect(harness.tracker.sendOptions).toEqual([undefined]);
   });
 
   it("reclassifies a receipt-exists collision as the original settled outcome", async () => {
@@ -978,7 +1079,7 @@ describe("executePieceCallable", () => {
       {
         loadPieces: () => Promise.resolve(harness.pieces),
         loadPiece: () => Promise.resolve(harness.piece),
-        invocationId: "inv-dup",
+        invocation: { id: "inv-dup", session: callerSession },
       },
     );
 
@@ -1011,7 +1112,7 @@ describe("executePieceCallable", () => {
         loadPieces: () => Promise.resolve(harness.pieces),
         loadPiece: () => Promise.resolve(harness.piece),
         isStdinTerminal: () => true,
-        invocationId: "inv-empty",
+        invocation: { id: "inv-empty", session: callerSession },
       },
     );
 
@@ -1082,7 +1183,9 @@ function createPieceCallableHarness(options: {
       path: (string | number)[] | undefined;
       value: unknown;
     }>,
-    sendOptions: [] as Array<{ eventId?: string } | undefined>,
+    sendOptions: [] as Array<
+      { eventId?: string; session?: string } | undefined
+    >,
     receiptLinkRequested: undefined as { id?: string } | undefined,
     idleCalls: 0,
     syncedCalls: 0,
@@ -1128,7 +1231,7 @@ function createPieceCallableHarness(options: {
                 handlingReceiptLink?: NormalizedFullLink;
               },
             ) => void,
-            sendOptions?: { eventId?: string },
+            sendOptions?: { eventId?: string; session?: string },
           ) => {
             tracker.handlerWrites.push({
               cellProp: "result",
@@ -1524,21 +1627,65 @@ describe("piece call stdin payloads", () => {
     });
   });
 
-  it("mints an invocation id when none is given and rejects a blank one", () => {
-    expect(resolveInvocationId(undefined, () => "minted-1")).toBe("minted-1");
-    expect(resolveInvocationId("caller-supplied")).toBe("caller-supplied");
-    // A blank id would claim caller-supplied idempotency while carrying
-    // nothing that distinguishes deliveries — the retry it promises would
-    // not be safe.
-    expect(() => resolveInvocationId("")).toThrow(/non-blank id/);
-    expect(() => resolveInvocationId("   ")).toThrow(/non-blank id/);
+  it("carries an id named within a named session", () => {
+    expect(
+      resolveInvocationIdentity("add-comment-1", "ses-7"),
+    ).toEqual({ id: "add-comment-1", session: "ses-7" });
   });
 
-  it("announces the invocation id once, at dispatch", () => {
+  it("mints an id for a caller that names only a session", () => {
+    expect(
+      resolveInvocationIdentity(undefined, "ses-7", () => "minted-1"),
+    ).toEqual({ id: "minted-1", session: "ses-7" });
+  });
+
+  it("mints both for a caller that names neither", () => {
+    // A minted id is random, so it addresses an outcome nothing else will
+    // ask for, and minting the session it belongs to alongside it costs such
+    // a call nothing: every call then derives its address the one way.
+    expect(
+      resolveInvocationIdentity(
+        undefined,
+        undefined,
+        () => "minted-1",
+        () => "minted-session-1",
+      ),
+    ).toEqual({ id: "minted-1", session: "minted-session-1" });
+  });
+
+  it("refuses an id named without a session, naming the remedy", () => {
+    // Naming an id asks for an outcome to be replayable, and a session
+    // minted per request would move that outcome each time — so the request
+    // cannot be honored as it was made, and the refusal says what to do.
+    expect(() => resolveInvocationIdentity("add-comment-1", undefined))
+      .toThrow(ValidationError);
+    expect(() => resolveInvocationIdentity("add-comment-1", undefined))
+      .toThrow(/`cf invocation-session new` and set `CF_INVOCATION_SESSION`/);
+  });
+
+  it("rejects a blank id or a blank session", () => {
+    // Either would read as "the caller named one" while carrying nothing
+    // that tells two deliveries apart, so the retry an id promises to make
+    // safe would not be.
+    expect(() => resolveInvocationIdentity("", "ses-7")).toThrow(
+      /--invocation requires a non-blank id/,
+    );
+    expect(() => resolveInvocationIdentity("   ", "ses-7")).toThrow(
+      /--invocation requires a non-blank id/,
+    );
+    expect(() => resolveInvocationIdentity("inv-1", "")).toThrow(
+      /--invocation-session requires a non-blank id/,
+    );
+    expect(() => resolveInvocationIdentity("inv-1", "   ")).toThrow(
+      /--invocation-session requires a non-blank id/,
+    );
+  });
+
+  it("announces the invocation id and its session once, at dispatch", () => {
     const announced: string[] = [];
     const seen: string[] = [];
     const report = invocationPhaseReporter(
-      "inv-9",
+      { id: "inv-9", session: "ses-9" },
       (p) => seen.push(p),
       (m) => announced.push(m),
     );
@@ -1547,13 +1694,15 @@ describe("piece call stdin payloads", () => {
     report("initial_sync");
     expect(announced).toEqual([]);
     report("dispatched");
-    expect(announced).toEqual(["invocation: inv-9"]);
+    // Both halves, because an id deduplicates only under its session: a caller
+    // holding one without the other holds nothing it can retry with.
+    expect(announced).toEqual(["invocation: inv-9", "session: ses-9"]);
     // Later phases, and a second dispatch, must not re-announce — a caller
     // scraping stderr should not have to pick among several ids.
     report("committed");
     report("dispatched");
     report("readback");
-    expect(announced).toEqual(["invocation: inv-9"]);
+    expect(announced).toEqual(["invocation: inv-9", "session: ses-9"]);
     expect(seen).toEqual([
       "initial_sync",
       "dispatched",
@@ -1782,17 +1931,17 @@ describe("piece call stdin payloads", () => {
 
   it("announces per-phase lines only under the test hook", () => {
     // Disabled (the default): no phase lines — normal output stays exactly
-    // the single dispatch announcement.
+    // the dispatch announcement and its session.
     const silent: string[] = [];
     const off = invocationPhaseReporter(
-      "inv-10",
+      { id: "inv-10", session: "ses-10" },
       () => {},
       (m) => silent.push(m),
     );
     off("initial_sync");
     off("dispatched");
     off("committed");
-    expect(silent).toEqual(["invocation: inv-10"]);
+    expect(silent).toEqual(["invocation: inv-10", "session: ses-10"]);
 
     // Enabled: every advance also carries `invocation: <id> phase: <phase>`,
     // the shape failure exits already print. The `committed` line is the one
@@ -1801,7 +1950,7 @@ describe("piece call stdin payloads", () => {
     const announced: string[] = [];
     const seen: string[] = [];
     const on = invocationPhaseReporter(
-      "inv-11",
+      { id: "inv-11", session: "ses-11" },
       (p) => seen.push(p),
       (m) => announced.push(m),
       true,
@@ -1814,6 +1963,7 @@ describe("piece call stdin payloads", () => {
     expect(announced).toEqual([
       "invocation: inv-11 phase: initial_sync",
       "invocation: inv-11",
+      "session: ses-11",
       "invocation: inv-11 phase: dispatched",
       "invocation: inv-11 phase: committed",
       "invocation: inv-11 phase: readback",
@@ -2117,7 +2267,7 @@ describe("piece call wait control", () => {
       {
         loadPieces: () => Promise.resolve(harness.pieces),
         loadPiece: () => Promise.resolve(harness.piece),
-        invocationId: "inv-no-readback",
+        invocation: { id: "inv-no-readback", session: callerSession },
         skipReadback: true,
         onPhase: (phase) => phases.push(phase),
       },
@@ -2132,7 +2282,7 @@ describe("piece call wait control", () => {
     });
     expect(phases).toEqual(["dispatched", "committed"]);
     expect(harness.tracker.sendOptions).toEqual([
-      { eventId: "inv-no-readback" },
+      { eventId: "inv-no-readback", session: callerSession },
     ]);
     // The receipt was never opened — the readback (sync + read) is the whole
     // saving — and no quiescence drain crept in either.
@@ -2163,7 +2313,7 @@ describe("piece call wait control", () => {
       executePieceCallable(config, "addComment", ["--message", "milk"], {
         loadPieces: () => Promise.resolve(harness.pieces),
         loadPiece: () => Promise.resolve(harness.piece),
-        invocationId: "inv-held-commit",
+        invocation: { id: "inv-held-commit", session: callerSession },
         skipReadback: true,
         onPhase: (phase) => phases.push(phase),
       }),
@@ -2199,7 +2349,7 @@ describe("piece call wait control", () => {
       {
         loadPieces: () => Promise.resolve(harness.pieces),
         loadPiece: () => Promise.resolve(harness.piece),
-        invocationId: "inv-dup-no-readback",
+        invocation: { id: "inv-dup-no-readback", session: callerSession },
         skipReadback: true,
       },
     );
@@ -2235,7 +2385,7 @@ describe("piece call wait control", () => {
       executePieceCallable(config, "recordMessage", ["--message", "milk"], {
         loadPieces: () => Promise.resolve(harness.pieces),
         loadPiece: () => Promise.resolve(harness.piece),
-        invocationId: "inv-failed-commit",
+        invocation: { id: "inv-failed-commit", session: callerSession },
         skipReadback: true,
       }),
     ).rejects.toThrow(/Handler "recordMessage" failed: Bad message payload/);
@@ -2283,7 +2433,7 @@ describe("piece call wait control", () => {
         {
           loadPieces: () => Promise.resolve(harness.pieces),
           loadPiece: () => Promise.resolve(harness.piece),
-          invocationId: "inv-no-wait-typo",
+          invocation: { id: "inv-no-wait-typo", session: callerSession },
           skipReadback: true,
         },
       ),
@@ -2324,7 +2474,7 @@ describe("piece call wait control", () => {
       executePieceCallable(config, "search", ["--query", "tea"], {
         loadPieces: () => Promise.resolve(harness.pieces),
         loadPiece: () => Promise.resolve(harness.piece),
-        invocationId: "inv-tool-no-wait",
+        invocation: { id: "inv-tool-no-wait", session: callerSession },
         skipReadback: true,
       }),
     ).rejects.toThrow(/--no-wait is not available for tool "search"/);
@@ -2830,7 +2980,7 @@ describe("piece call --show-links", () => {
       {
         loadPieces: () => Promise.resolve(harness.pieces),
         loadPiece: () => Promise.resolve(harness.piece),
-        invocationId: "inv-links",
+        invocation: { id: "inv-links", session: callerSession },
         showLinks: true,
       },
     );
@@ -2872,7 +3022,7 @@ describe("piece call --show-links", () => {
       {
         loadPieces: () => Promise.resolve(harness.pieces),
         loadPiece: () => Promise.resolve(harness.piece),
-        invocationId: "inv-no-links",
+        invocation: { id: "inv-no-links", session: callerSession },
       },
     );
 
@@ -2899,7 +3049,7 @@ describe("piece call --show-links", () => {
       loadPieces: () => Promise.resolve(harness.pieces),
       loadPiece: () => Promise.resolve(harness.piece),
       isStdinTerminal: () => true,
-      invocationId: "inv-void-links",
+      invocation: { id: "inv-void-links", session: callerSession },
       showLinks: true,
     });
 
@@ -2971,6 +3121,509 @@ describe("piece call --show-links", () => {
       mode: "settle",
       boundSeconds: 5,
     });
+  });
+});
+
+/** What the shared selection step was handed, and the answer it gives back.
+ * Standing in for `deriveSelectedValue` is what makes "which cell did the
+ * call point the step at" observable — the answer itself is the step's own
+ * business, and `piece-get-transform.test.ts` is where it is pinned. */
+function recordingSelector(answer: unknown) {
+  const calls: Array<{
+    space: unknown;
+    cell: unknown;
+    selection: CellSelection;
+  }> = [];
+  const derive = ((
+    _runtime: unknown,
+    space: unknown,
+    cell: unknown,
+    selection: CellSelection,
+  ) => {
+    calls.push({ space, cell, selection });
+    return Promise.resolve(answer);
+  }) as unknown as typeof deriveSelectedValue;
+  return { calls, derive };
+}
+
+describe("piece call selection", () => {
+  const config = {
+    apiUrl: "http://localhost:8000",
+    identity: "/tmp/test-identity.pem",
+    piece: "fid1:piece-123",
+    space: "home",
+  };
+  const addTopic = {
+    callableKind: "handler" as const,
+    cellKey: "addTopic",
+    inputSchema: {
+      type: "object",
+      properties: { title: { type: "string" } },
+      required: ["title"],
+    } as JSONSchema,
+  };
+  const topicResult = {
+    topic: { title: "Ship it", body: "the initial document" },
+  };
+
+  it("points the shared selection step at the receipt the result came from", async () => {
+    // The whole of C2: a call reaches the same step `cf piece get` reads
+    // through, pointed at the cell the value was read from — so the shaped
+    // answer carries the source's own links rather than a copy of a copy.
+    const receiptCell = {
+      get: () => topicResult,
+      pull: () => Promise.resolve(topicResult),
+      key: () => receiptCell,
+    } as unknown as Cell<any>;
+    const harness = createPieceCallableHarness({ ...addTopic, receiptCell });
+    const selector = recordingSelector({ topic: { title: "Ship it" } });
+    const selection = await parseCellSelectionOptions({
+      select: "topic.title",
+    });
+
+    const result = await executePieceCallable(
+      config,
+      "addTopic",
+      ["--title", "Ship it"],
+      {
+        loadPieces: () => Promise.resolve(harness.pieces),
+        loadPiece: () => Promise.resolve(harness.piece),
+        invocation: { id: "inv-select", session: callerSession },
+        selection,
+        deriveSelectedValue: selector.derive,
+      },
+    );
+
+    expect(result.invocation).toEqual({
+      id: "inv-select",
+      status: "settled",
+      result: { topic: { title: "Ship it" } },
+    });
+    expect(selector.calls).toHaveLength(1);
+    expect(selector.calls[0].cell).toBe(receiptCell);
+    expect(selector.calls[0].selection).toBe(selection);
+    expect(selector.calls[0].space).toBe("home");
+  });
+
+  it("leaves the Invocation JSON unshaped when no selection was asked for", async () => {
+    const harness = createPieceCallableHarness({
+      ...addTopic,
+      receiptValue: topicResult,
+    });
+    const selector = recordingSelector("never");
+
+    const result = await executePieceCallable(
+      config,
+      "addTopic",
+      ["--title", "Ship it"],
+      {
+        loadPieces: () => Promise.resolve(harness.pieces),
+        loadPiece: () => Promise.resolve(harness.piece),
+        invocation: { id: "inv-plain", session: callerSession },
+        deriveSelectedValue: selector.derive,
+      },
+    );
+
+    expect(result.invocation).toEqual({
+      id: "inv-plain",
+      status: "settled",
+      result: topicResult,
+    });
+    expect(selector.calls).toEqual([]);
+  });
+
+  it("keeps a value-less verb reporting no result at all", async () => {
+    // The empty witness means "this verb returns nothing". A selection is
+    // about a value, and there is none, so the step never runs — reporting
+    // `{}` here would erase the distinction the empty receipt draws.
+    const harness = createPieceCallableHarness({
+      callableKind: "handler",
+      cellKey: "refresh",
+      inputSchema: { type: "object", properties: {} },
+      receiptValue: {},
+    });
+    const selector = recordingSelector({ never: true });
+
+    const result = await executePieceCallable(config, "refresh", [], {
+      loadPieces: () => Promise.resolve(harness.pieces),
+      loadPiece: () => Promise.resolve(harness.piece),
+      isStdinTerminal: () => true,
+      invocation: { id: "inv-void-select", session: callerSession },
+      selection: await parseCellSelectionOptions({ select: "anything" }),
+      deriveSelectedValue: selector.derive,
+    });
+
+    expect(result.invocation).toEqual({
+      id: "inv-void-select",
+      status: "settled",
+    });
+    expect(invocationJson(result.invocation!)).not.toHaveProperty("result");
+    expect(selector.calls).toEqual([]);
+  });
+
+  it("refuses a selection that materializes nothing over a result that exists", async () => {
+    // Reporting no result here would say "the verb returned nothing", which
+    // is a different fact from "your projection kept nothing".
+    const harness = createPieceCallableHarness({
+      ...addTopic,
+      receiptValue: topicResult,
+    });
+    const selector = recordingSelector(undefined);
+
+    await expect(
+      executePieceCallable(config, "addTopic", ["--title", "Ship it"], {
+        loadPieces: () => Promise.resolve(harness.pieces),
+        loadPiece: () => Promise.resolve(harness.piece),
+        invocation: { id: "inv-empty-select", session: callerSession },
+        selection: await parseCellSelectionOptions({
+          schema: '{"type":"string"}',
+        }),
+        deriveSelectedValue: selector.derive,
+      }),
+    ).rejects.toThrow(CellSelectionError);
+    expect(selector.calls).toHaveLength(1);
+  });
+
+  it("shapes a tool's stdout through the same step", async () => {
+    const harness = createPieceCallableHarness({
+      callableKind: "tool",
+      cellKey: "search",
+      inputSchema: {
+        type: "object",
+        properties: { query: { type: "string" } },
+        required: ["query"],
+      },
+      pattern: {
+        argumentSchema: {
+          type: "object",
+          properties: { query: { type: "string" } },
+          required: ["query"],
+        },
+        resultSchema: { type: "object" },
+      },
+      toolResult: { hits: [{ id: 1, title: "Tea" }], cursor: "abc" },
+    });
+    const selector = recordingSelector({ hits: [{ title: "Tea" }] });
+
+    const result = await executePieceCallable(
+      config,
+      "search",
+      ["--query", "tea"],
+      {
+        loadPieces: () => Promise.resolve(harness.pieces),
+        loadPiece: () => Promise.resolve(harness.piece),
+        uuid: () => "tool-result-id",
+        selection: await parseCellSelectionOptions({ select: "hits.title" }),
+        deriveSelectedValue: selector.derive,
+      },
+    );
+
+    // One grammar covers both callable kinds; the tool's own address surface
+    // is untouched by the shaping.
+    expect(JSON.parse(result.outputText!)).toEqual({
+      hits: [{ title: "Tea" }],
+    });
+    expect(result.resultRef).toEqual({
+      id: "of:tool-result-cell",
+      space: "did:key:test-home",
+      scope: "space",
+    });
+    expect(selector.calls).toHaveLength(1);
+  });
+
+  it("collects --show-links against the shaped result, not the whole receipt", async () => {
+    // Links annotate the value the caller is holding. With a projection that
+    // drops `comment`, an entry for `/comment` would name provenance for
+    // something the caller was not given.
+    const receiptDoc = { id: "of:receipt-1", space: "did:key:test-home" };
+    const stored = { comment: { body: "hi" }, count: 1 };
+    const harness = createPieceCallableHarness({
+      ...addTopic,
+      receiptCell: linkedReceiptCell(receiptDoc, stored, {
+        children: {
+          comment: { doc: { id: "of:comment-1", space: "did:key:test-home" } },
+        },
+      }),
+    });
+    const selector = recordingSelector({ count: 1 });
+
+    const result = await executePieceCallable(
+      config,
+      "addTopic",
+      ["--title", "Ship it"],
+      {
+        loadPieces: () => Promise.resolve(harness.pieces),
+        loadPiece: () => Promise.resolve(harness.piece),
+        invocation: { id: "inv-select-links", session: callerSession },
+        showLinks: true,
+        selection: await parseCellSelectionOptions({ select: "count" }),
+        deriveSelectedValue: selector.derive,
+      },
+    );
+
+    expect(result.invocation).toEqual({
+      id: "inv-select-links",
+      status: "settled",
+      result: { count: 1 },
+      links: {
+        "/": { space: "did:key:test-home", id: "of:receipt-1", scope: "space" },
+      },
+    });
+  });
+
+  describe("flag combinations", () => {
+    it("refuses each selection flag with --no-wait, naming the ones passed", () => {
+      expect(() => resolveWaitControl({ wait: false, filter: ".a" })).toThrow(
+        /^--filter needs the receipt readback that --no-wait skips/,
+      );
+      expect(() => resolveWaitControl({ wait: false, select: "a" })).toThrow(
+        /^--select needs the receipt readback/,
+      );
+      expect(() => resolveWaitControl({ wait: false, schema: "{}" })).toThrow(
+        /^--schema needs the receipt readback/,
+      );
+      expect(() =>
+        resolveWaitControl({
+          wait: false,
+          showLinks: true,
+          filter: ".a",
+          select: "a",
+        })
+      ).toThrow(
+        /^--show-links, --filter and --select need the receipt readback/,
+      );
+    });
+
+    it("allows every selection flag with the default and bounded waits", () => {
+      expect(resolveWaitControl({ filter: ".a", select: "a" })).toEqual({
+        mode: "settle",
+      });
+      expect(resolveWaitControl({ wait: 5, schema: "{}" })).toEqual({
+        mode: "settle",
+        boundSeconds: 5,
+      });
+    });
+
+    it("refuses --filter with --show-links: a predicate moves the positions a link names", async () => {
+      await expect(
+        parsePieceCallSelection({
+          filter: '.status == "open"',
+          showLinks: true,
+        }),
+      ).rejects.toThrow(ValidationError);
+      await expect(
+        parsePieceCallSelection({
+          filter: '.status == "open"',
+          showLinks: true,
+        }),
+      ).rejects.toThrow(/--show-links cannot be combined with --filter/);
+      // A projection keeps every surviving path where it was, so it composes.
+      expect(
+        await parsePieceCallSelection({ select: "title", showLinks: true }),
+      ).toBeDefined();
+    });
+
+    it("parses through the same grammar `cf piece get` reads", async () => {
+      expect(await parsePieceCallSelection({})).toBeUndefined();
+      const selection = await parsePieceCallSelection({
+        filter: ".done == false",
+        select: "id,title",
+      });
+      expect(selection?.filter?.source).toBe(".done == false");
+      expect(selection?.projection?.flag).toBe("--select");
+      // The parser's own refusals arrive unchanged, so a caller reads one
+      // set of messages whichever command produced them.
+      await expect(parsePieceCallSelection({ filter: ".a ==" })).rejects
+        .toThrow(CellSelectionError);
+    });
+
+    it("reports a malformed selection without naming an invocation to retry", async () => {
+      const { code, stderr } = await cf(
+        "piece call " +
+          "--identity ./definitely-missing-piece-call-review.key " +
+          "--api-url https://cf.dev --space common-knowledge " +
+          "--piece fid1:piece-123 --select a..b addTopic",
+      );
+      const errors = stripAnsi(stderr.join("\n"));
+      expect(code).toBe(1);
+      expect(errors).toContain('Invalid --select field path "a..b"');
+      // The selection is read before a callable is resolved and before
+      // anything is sent, so no id has been spent and no phase has been
+      // reached. An `invocation: <id> phase: <phase>` line here would send
+      // the caller to recover a call that was never made.
+      expect(errors).not.toContain("invocation:");
+      expect(errors).not.toContain("phase:");
+    });
+  });
+});
+
+const selectionSigner = await Identity.fromPassphrase(
+  "cf-piece-call-selection",
+);
+
+describe("piece call selection over a live runtime", () => {
+  const signer = selectionSigner;
+  const space = signer.did();
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    const runtimeErrors: Array<{ message: string }> = [];
+    runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "observe",
+      cfcFlowLabels: "persist",
+      errorHandlers: [
+        (error) => runtimeErrors.push({ message: error.message }),
+      ],
+    });
+    (runtime as unknown as Record<symbol, unknown>)[CF_RUNTIME_ERROR_LOG] =
+      runtimeErrors;
+  });
+
+  afterEach(async () => {
+    await runtime.dispose();
+    await storageManager.close();
+  });
+
+  /**
+   * A verb whose handling commits a receipt holding `value`, dispatched
+   * against the real runtime the selection then runs in. The receipt is
+   * written with NO declared schema, which is what a handling's receipt
+   * carries today — so this also pins that a schema-less source still
+   * projects.
+   */
+  async function settleWith(value: unknown): Promise<CallableResolution> {
+    const tx = runtime.edit();
+    const receipt = runtime.getCell(space, "handling-receipt", undefined, tx);
+    receipt.set(value);
+    expect((await tx.commit()).ok).toBeDefined();
+    const handlingReceiptLink = runtime
+      .getCell(space, "handling-receipt")
+      .getAsNormalizedFullLink();
+    return {
+      callableCell: {
+        schema: {
+          type: "object",
+          properties: { title: { type: "string" } },
+          required: ["title"],
+        },
+        send: (
+          _payload: unknown,
+          onCommit?: (tx: unknown) => void,
+        ) =>
+          onCommit?.({
+            status: () => ({ status: "done" }),
+            handlingReceiptLink,
+          }),
+      } as unknown as Cell<any>,
+      callableKind: "handler",
+      cellKey: "addTopic",
+      pieces: { runtime, getSpace: () => space } as never,
+      space,
+    };
+  }
+
+  it("projects a settled result through the real selection step", async () => {
+    const resolved = await settleWith({
+      topics: [
+        { id: 1, title: "First", status: "open" },
+        { id: 2, title: "Second", status: "closed" },
+      ],
+    });
+
+    const executed = await executeResolvedCallable(
+      resolved,
+      { title: "Ship it" },
+      {
+        invocation: { id: "inv-live", session: callerSession },
+        selection: await parseCellSelectionOptions({ select: "topics.title" }),
+      },
+    );
+
+    expect(executed.invocation).toEqual({
+      id: "inv-live",
+      status: "settled",
+      result: { topics: [{ title: "First" }, { title: "Second" }] },
+    });
+  });
+
+  it("filters a settled array result", async () => {
+    const resolved = await settleWith([
+      { id: 1, title: "First", status: "open" },
+      { id: 2, title: "Second", status: "closed" },
+      { id: 3, title: "Third", status: "open" },
+    ]);
+
+    const executed = await executeResolvedCallable(
+      resolved,
+      { title: "Ship it" },
+      {
+        invocation: { id: "inv-live-filter", session: callerSession },
+        selection: await parseCellSelectionOptions({
+          filter: '.status == "open"',
+          select: "id,title",
+        }),
+      },
+    );
+
+    expect(executed.invocation?.result).toEqual([
+      { id: 1, title: "First" },
+      { id: 3, title: "Third" },
+    ]);
+  });
+
+  it("returns the address of what a verb returned, in place of its contents", async () => {
+    // The `$link` marker reaches a call through the same step, which is what
+    // makes `cf piece call --schema '{"properties":{"topic":{"$link":true}}}'`
+    // — the command's own example — an address a later call can use.
+    const tx = runtime.edit();
+    const topic = runtime.getCell(space, "created-topic", undefined, tx);
+    topic.set({ title: "Ship it", body: "the initial document" });
+    expect((await tx.commit()).ok).toBeDefined();
+    const resolved = await settleWith({
+      topic: runtime.getCell(space, "created-topic"),
+    });
+
+    const executed = await executeResolvedCallable(
+      resolved,
+      { title: "Ship it" },
+      {
+        invocation: { id: "inv-live-link", session: callerSession },
+        selection: await parseCellSelectionOptions({
+          schema: '{"properties":{"topic":{"$link":true}}}',
+        }),
+      },
+    );
+
+    expect(executed.invocation?.result).toEqual({
+      topic: {
+        $link: {
+          id: runtime.getCell(space, "created-topic")
+            .getAsNormalizedFullLink().id,
+          space,
+          scope: "space",
+          path: [],
+        },
+      },
+    });
+  });
+
+  it("refuses a selection that materializes nothing over a real result", async () => {
+    const resolved = await settleWith({ topic: { title: "Ship it" } });
+
+    await expect(
+      executeResolvedCallable(resolved, { title: "Ship it" }, {
+        invocation: { id: "inv-live-nothing", session: callerSession },
+        selection: await parseCellSelectionOptions({
+          schema: '{"type":"string"}',
+        }),
+      }),
+    ).rejects.toThrow(
+      /Cannot shape the result of "addTopic".*did not materialize/s,
+    );
   });
 });
 
@@ -3571,6 +4224,32 @@ describe("renderPieceCallOutcome", () => {
     assertEquals(finishes, [undefined]);
     assertEquals(JSON.parse(rendered[0]).invocation, "inv-1");
     assertStringIncludes(hinted[0], "NEXT STEPS");
+  });
+
+  it("names the session as well as the id in the detached next step", () => {
+    const { observer } = observerRecorder();
+    const { deps, hinted } = sinkRecorder();
+    renderPieceCallOutcome(
+      observer,
+      {
+        ...base,
+        invocation: { id: "inv-1", status: "committed" },
+      } as unknown as ExecutedPieceCallable,
+      "addTopic",
+      "fid1:piece",
+      deps,
+      { detached: true, invocation: { id: "inv-1", session: "ses-7" } },
+    );
+    // The hint is a command the caller runs to collect the outcome it chose
+    // not to wait for, and an id reaches that outcome only within the
+    // session it was chosen in — so the hint has to carry both. The session
+    // travels in the environment because it is what makes that outcome's
+    // address unguessable, and an argument is readable in a process listing.
+    assertStringIncludes(
+      hinted[0],
+      "CF_INVOCATION_SESSION=ses-7 cf piece call",
+    );
+    assertStringIncludes(hinted[0], "--invocation inv-1");
   });
 
   it("confirmations route to stderr under JSON input, stdout otherwise", () => {

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -848,6 +848,17 @@ describe("cli piece parsing", () => {
     expect(callFlags).toContain("--show-links");
   });
 
+  it("describes piece call's `--schema` as taking a field list as well", () => {
+    // The call reads its selection through the read's grammar, so the flag
+    // takes every form the read's does. Its own `--help` line is where a
+    // caller learns which, and one naming fewer forms than the parser takes
+    // reads as a narrowing that is not there.
+    const schemaOption = piece.getCommand("call")!.getOptions().find((option) =>
+      option.flags.includes("--schema")
+    )!;
+    expect(schemaOption.description).toContain("--select field list");
+  });
+
   it("steps, reads, syncs, and stops in one get operation", async () => {
     const order: string[] = [];
     const controller = {

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -282,7 +282,16 @@ export const recordRelevantSchemaWritePolicyInput = (
  * Internal-only stream-send options.
  *
  * `eventId` is a caller-supplied durable event id (verb contract WS-D): a
- * same-id retry collides on the handling's create-only receipt.
+ * retry naming the same id and session collides on the handling's create-only
+ * receipt.
+ *
+ * `session` names the caller that chose that `eventId`, and is REQUIRED
+ * alongside it — a send naming an id without one is refused. An ingress
+ * caller's id is its own word — an agent picks `add-comment-1` — and two
+ * agents can pick the same word for two different calls on one verb, so the
+ * id alone does not say whose invocation it is; the session does. Both are
+ * inputs to {@link scopeCallerEventId}, so the pair, and not the id, is what
+ * decides where a handling's receipt lands.
  *
  * `runtimeInjectedEventKeys` names payload keys the RUNTIME itself merged
  * into this send's event value (the LLM tool-call path injects a `result`
@@ -293,17 +302,18 @@ export const recordRelevantSchemaWritePolicyInput = (
  * in-process options argument, never the event value, so no remote or CLI
  * caller can express it — payloads are plain data, and the CLI's invocation
  * engine (`executeResolvedCallable`, packages/cli/lib/callable.ts) builds the
- * send options itself and puts only `eventId` in them. In-process callers are
- * gated too: the value must be an
- * array MINTED by {@link markRuntimeInjectedEventKeys} — the stream-send
- * path drops any other value — and the mint lives in runner internals no
- * pattern compartment can import, so sandboxed pattern code holding a real
- * stream cell still cannot smuggle an undeclared key past closed-world by
- * passing a plain array here. Adding any data-expressible way to set it
- * would reopen the accepted-and-ignored hole C5 closes.
+ * send options itself and puts only the caller's id and session in them.
+ * In-process callers are gated too: the value must be an array MINTED by
+ * {@link markRuntimeInjectedEventKeys} — the stream-send path drops any other
+ * value — and the mint lives in runner internals no pattern compartment can
+ * import, so sandboxed pattern code holding a real stream cell still cannot
+ * smuggle an undeclared key past closed-world by passing a plain array here.
+ * Adding any data-expressible way to set it would reopen the
+ * accepted-and-ignored hole C5 closes.
  */
 export type StreamSendOptions = {
   eventId?: string;
+  session?: string;
   runtimeInjectedEventKeys?: readonly string[];
 };
 
@@ -348,18 +358,15 @@ declare module "@commonfabric/api" {
     set(
       value: AnyCellWrapping<T> | T,
       onCommit?: (tx: IExtendedStorageTransaction) => void,
-      sendOptions?: {
-        eventId?: string;
-        runtimeInjectedEventKeys?: readonly string[];
-      },
+      sendOptions?: StreamSendOptions,
     ): C;
   }
 
   /**
    * Augment Streamable to add onCommit callback and internal send-options
-   * support (see `StreamSendOptions` — `eventId` and the runtime-injected
-   * key marker). Event is optional only when T is void (matching public
-   * API).
+   * support ({@link StreamSendOptions} — the caller's event id and session,
+   * and the runtime-injected key marker). Event is optional only when T is
+   * void (matching public API).
    */
   interface IStreamable<T> {
     send(
@@ -369,7 +376,7 @@ declare module "@commonfabric/api" {
         ] | [
           AnyCellWrapping<T> | T,
           ((tx: IExtendedStorageTransaction) => void) | undefined,
-          { eventId?: string; runtimeInjectedEventKeys?: readonly string[] },
+          StreamSendOptions,
         ]
         : [AnyCellWrapping<T> | T] | [
           AnyCellWrapping<T> | T,
@@ -377,7 +384,7 @@ declare module "@commonfabric/api" {
         ] | [
           AnyCellWrapping<T> | T,
           ((tx: IExtendedStorageTransaction) => void) | undefined,
-          { eventId?: string; runtimeInjectedEventKeys?: readonly string[] },
+          StreamSendOptions,
         ]
     ): void;
   }
@@ -1408,15 +1415,14 @@ export class CellImpl<T extends FabricValue>
     /**
      * Internal-only stream-send options (see {@link StreamSendOptions}).
      * `eventId` supplies the durable event id (spec §7.5) instead of minting
-     * one: an ingress caller that owns a delivery id passes it through so a
-     * retry of the same id collides on the handling's create-only receipt
-     * (verb contract WS-D,
-     * docs/history/plans/pattern-verb-contract-implementation.md). The receipt
-     * is a COMMIT witness, not an execution witness — the redelivered event
-     * still runs the handler body and then loses the race, so effects outside
-     * the transaction repeat. `runtimeInjectedEventKeys` carries the
-     * runtime-injection provenance the closed-world gate consumes. Ignored on
-     * the plain-cell write path.
+     * one: an ingress caller that owns a delivery id passes it, with the
+     * `session` it chose that id within, so a retry of the same pair collides
+     * on the handling's create-only receipt (the verb contract,
+     * docs/plans/pattern-verb-contract.md). The receipt is a COMMIT witness,
+     * not an execution witness — the redelivered event still runs the handler
+     * body and then loses the race, so effects outside the transaction repeat.
+     * `runtimeInjectedEventKeys` carries the runtime-injection provenance the
+     * closed-world gate consumes. Ignored on the plain-cell write path.
      */
     sendOptions?: StreamSendOptions,
   ): Cell<T> {
@@ -1451,6 +1457,33 @@ export class CellImpl<T extends FabricValue>
       ) as AnyCellWrapping<T>;
       propagateRendererTrustedEvent(newValue, event);
 
+      // The caller's key is opaque and unscoped; queueEvent expects a durable
+      // delivery id. Binding it to the session that chose it and to this
+      // stream is what keeps one caller's id from addressing another caller's
+      // receipt, and two verbs that share input bindings from colliding on
+      // one receipt.
+      const callerEventId = sendOptions?.eventId;
+      let deliveryEventId: string | undefined;
+      if (callerEventId !== undefined) {
+        const session = sendOptions?.session;
+        if (session === undefined) {
+          // Refused rather than derived without one: an unscoped address is
+          // reachable by anyone who guesses the id, and the guarantee the id
+          // is passed for — a retry settling on the original outcome — would
+          // then be extended to a caller who made no such call.
+          throw new Error(
+            "A caller-supplied `eventId` requires the `session` it was " +
+              "chosen within: an invocation id is the caller's own word, " +
+              "and the pair is what names one invocation.",
+          );
+        }
+        deliveryEventId = scopeCallerEventId(
+          callerEventId,
+          session,
+          resolvedToValueLink,
+        );
+      }
+
       // Trigger on fully resolved link
       this.runtime.scheduler.queueEvent(
         resolvedToValueLink,
@@ -1459,12 +1492,7 @@ export class CellImpl<T extends FabricValue>
         onCommit,
         false,
         {
-          // The caller's key is opaque and unscoped; queueEvent expects a
-          // durable delivery id. Binding it to this stream is what keeps two
-          // verbs that share input bindings from colliding on one receipt.
-          eventId: sendOptions?.eventId === undefined
-            ? undefined
-            : scopeCallerEventId(sendOptions.eventId, resolvedToValueLink),
+          eventId: deliveryEventId,
           originTx: this.tx ?? undefined,
           // Forward injection provenance only when it carries the mint (see
           // markRuntimeInjectedEventKeys): a plain array here — the shape any
@@ -1581,10 +1609,11 @@ export class CellImpl<T extends FabricValue>
         /**
          * Internal-only stream-send options (see {@link StreamSendOptions}):
          * `eventId` passes a caller-supplied durable event id through to the
-         * scheduler, so a same-id retry collides on the handling's
-         * create-only receipt and cannot commit twice — though the body does
-         * re-run (verb contract WS-D). `runtimeInjectedEventKeys` carries
-         * runtime-injection provenance for the closed-world gate.
+         * scheduler, and `session` the caller that chose it, so a retry of
+         * that pair collides on the handling's create-only receipt and cannot
+         * commit twice — though the body does re-run (verb contract WS-D).
+         * `runtimeInjectedEventKeys` carries runtime-injection provenance for
+         * the closed-world gate.
          */
         StreamSendOptions,
       ]

--- a/packages/runner/src/scheduler/event-identity.ts
+++ b/packages/runner/src/scheduler/event-identity.ts
@@ -36,7 +36,18 @@ export function mintEventId(
 }
 
 /**
- * Binds a caller-supplied delivery id to the stream it was sent to.
+ * Binds a caller-supplied delivery id to the session that chose it and to the
+ * stream it was sent to.
+ *
+ * The session is the half that says WHOSE invocation this is. An ingress
+ * caller's id is its own word — an agent picks `add-comment-1` — and nothing
+ * stops a second caller picking that same word for its own call on the same
+ * verb, so the id alone names no one invocation. Two such callers scoped by
+ * session derive two addresses and each settle on their own receipt; sharing
+ * one address, the second would be told its call settled when it never ran.
+ * The session is also the only unguessable component of the address, so a
+ * caller minting an unguessable one keeps its outcomes out of reach of anyone
+ * who can guess a piece, a verb, and a word like that id.
  *
  * Every minted id above ends in `eventLink.id`, and that is load-bearing: the
  * handling's receipt derives from the handler's input bindings plus the event
@@ -48,29 +59,35 @@ export function mintEventId(
  * collide on the first's receipt and be reported as an already-settled
  * success it never made.
  *
- * Scoping keeps the property the protocol actually wants: the same id sent to
- * the same stream is the same invocation (retries deduplicate), while the same
- * id sent elsewhere is a different one.
+ * Scoping keeps the property the protocol actually wants: the same id, in the
+ * same session, sent to the same stream is the same invocation (retries
+ * deduplicate), while that id under another session or sent elsewhere is a
+ * different one.
  *
  * The binding is a content hash of a structured value rather than delimited
- * concatenation, because the caller's half is opaque: with `a:b` joined by
+ * concatenation, because the caller's halves are opaque: with `a:b` joined by
  * `:`, the pair (`x`, `y:z`) and the pair (`x:y`, `z`) render identically, and
  * a caller choosing its own id chooses which side of that ambiguity to sit on.
- * Hashing also lets the whole link identify the stream — id, path, and space —
- * so this does not quietly depend on stream links always being whole documents
- * at the empty path, which is true today and is not a stated invariant.
- * `hashOf` is type-tagged and length-prefixed, so no component can impersonate
- * another, and it is deterministic across processes: a retry from a fresh CLI
- * invocation derives the same id.
+ * Hashing also lets the whole link identify the stream — id, path, scope, and
+ * space. That keeps this from quietly depending on stream links always being
+ * whole documents at the empty path, which is true today and is not a stated
+ * invariant, and it keeps a per-user stream apart from a per-space one at the
+ * same id and path: those are two streams, and one address across both would
+ * settle one caller's retry on the other's outcome. `hashOf` is type-tagged
+ * and length-prefixed, so no component can impersonate another, and it is
+ * deterministic across processes: a retry from a fresh CLI invocation derives
+ * the same id.
  *
- * The result deliberately does not carry the caller's id in the clear. That
- * costs some greppability — an operator correlating a CLI invocation id with a
- * scheduler log line has to re-derive it — but the id is caller-controlled
- * text that would otherwise reach logs and telemetry verbatim. Do not append
- * the raw id back for convenience.
+ * The result deliberately does not carry the caller's id or session in the
+ * clear. That costs some greppability — an operator correlating a CLI
+ * invocation id with a scheduler log line has to re-derive it — but both are
+ * caller-controlled text that would otherwise reach logs and telemetry
+ * verbatim, and the session is a secret in the sense above. Do not append
+ * either back for convenience.
  */
 export function scopeCallerEventId(
   callerEventId: string,
+  session: string,
   eventLink: NormalizedFullLink,
 ): string {
   return `evt:caller:${
@@ -78,6 +95,8 @@ export function scopeCallerEventId(
       caller: callerEventId,
       id: eventLink.id,
       path: [...eventLink.path],
+      scope: eventLink.scope,
+      session,
       space: eventLink.space,
     })
   }`;

--- a/packages/runner/test/declared-result-e2e.test.ts
+++ b/packages/runner/test/declared-result-e2e.test.ts
@@ -166,12 +166,14 @@ describe("compiled CTS action<E, R> results in receipts", () => {
     eventId: string,
     outcomes: Outcome[],
   ) {
+    // One session throughout: a caller's id addresses its outcome within the
+    // session that chose it, and every id dispatched here is distinct.
     stream.send(payload, (t: IExtendedStorageTransaction) => {
       outcomes.push({
         status: t.status().status,
         receiptLink: t.handlingReceiptLink,
       });
-    }, { eventId });
+    }, { eventId, session: "declared-result-e2e-session" });
   }
 
   it("projects the declared result into the receipt; value-less verb stays {}", async () => {

--- a/packages/runner/test/receipt-schema.test.ts
+++ b/packages/runner/test/receipt-schema.test.ts
@@ -27,6 +27,13 @@ import { defer } from "@commonfabric/utils/defer";
 import { parseLink } from "../src/link-utils.ts";
 import { resolveLink } from "../src/link-resolution.ts";
 
+// The session a caller-supplied id is chosen within, for the sends whose
+// subject is something else: the pair is what a stream send accepts, and one
+// session is all a test needs whose ids never repeat across it — the replay
+// case wants its two sends under the same session, which is what makes them
+// one invocation.
+const callerSession = "ses:receipt-schema";
+
 /** Outcome of one dispatch, as its commit callback reported it. */
 type Outcome = {
   status: string;
@@ -98,7 +105,7 @@ describe("receipt schema", () => {
           ?.precondition,
         receiptLink: t.handlingReceiptLink,
       });
-    }, { eventId });
+    }, { eventId, session: callerSession });
     const outcome = await settled.promise;
     await runtime.scheduler.idleWithPendingCommits();
     return outcome;

--- a/packages/runner/test/scheduler-event-identity.test.ts
+++ b/packages/runner/test/scheduler-event-identity.test.ts
@@ -62,12 +62,42 @@ describe("scheduler event identity", () => {
   it("scopes a caller id deterministically, so a retry re-derives it", () => {
     // A retry may come from a fresh CLI process; same inputs must give the
     // same durable id or the receipt collision never happens.
-    expect(scopeCallerEventId("inv-1", eventLink)).toBe(
-      scopeCallerEventId("inv-1", eventLink),
+    expect(scopeCallerEventId("inv-1", "ses-a", eventLink)).toBe(
+      scopeCallerEventId("inv-1", "ses-a", eventLink),
     );
-    expect(scopeCallerEventId("inv-1", eventLink)).not.toBe(
-      scopeCallerEventId("inv-2", eventLink),
+    expect(scopeCallerEventId("inv-1", "ses-a", eventLink)).not.toBe(
+      scopeCallerEventId("inv-2", "ses-a", eventLink),
     );
+  });
+
+  it("separates one caller id chosen in two different sessions", () => {
+    // An invocation id is the caller's own word, and `add-comment-1` is the
+    // word two agents both reach for. Sharing an address, the second would
+    // read the first's receipt and be told its call had settled.
+    expect(scopeCallerEventId("add-comment-1", "ses-a", eventLink)).not.toBe(
+      scopeCallerEventId("add-comment-1", "ses-b", eventLink),
+    );
+  });
+
+  it("separates one caller id sent to streams differing only by scope", () => {
+    // A per-user, a per-session, and a per-space stream at one id and path
+    // are three streams. Sharing an address, a retry against one would be
+    // told it had settled by the outcome of a call made against another.
+    const perSpace = scopeCallerEventId("inv-1", "ses-a", {
+      ...eventLink,
+      scope: "space",
+    });
+    const perUser = scopeCallerEventId("inv-1", "ses-a", {
+      ...eventLink,
+      scope: "user",
+    });
+    const perSession = scopeCallerEventId("inv-1", "ses-a", {
+      ...eventLink,
+      scope: "session",
+    });
+    expect(perSpace).not.toBe(perUser);
+    expect(perSpace).not.toBe(perSession);
+    expect(perUser).not.toBe(perSession);
   });
 
   it("separates one caller id sent to different streams", () => {
@@ -75,8 +105,8 @@ describe("scheduler event identity", () => {
     // verbs of a piece must not make the second collide on the first's
     // receipt and report as an already-settled success.
     const other: NormalizedFullLink = { ...eventLink, id: "of:other-stream" };
-    expect(scopeCallerEventId("inv-1", eventLink)).not.toBe(
-      scopeCallerEventId("inv-1", other),
+    expect(scopeCallerEventId("inv-1", "ses-a", eventLink)).not.toBe(
+      scopeCallerEventId("inv-1", "ses-a", other),
     );
   });
 
@@ -85,27 +115,32 @@ describe("scheduler event identity", () => {
     // path and space keeps the helper from depending on that quietly.
     const atA: NormalizedFullLink = { ...eventLink, path: ["a"] };
     const atB: NormalizedFullLink = { ...eventLink, path: ["b"] };
-    expect(scopeCallerEventId("inv-1", atA)).not.toBe(
-      scopeCallerEventId("inv-1", atB),
+    expect(scopeCallerEventId("inv-1", "ses-a", atA)).not.toBe(
+      scopeCallerEventId("inv-1", "ses-a", atB),
     );
     const elsewhere: NormalizedFullLink = {
       ...eventLink,
       space: "did:key:z6MkOtherEventIdentity" as MemorySpace,
     };
-    expect(scopeCallerEventId("inv-1", eventLink)).not.toBe(
-      scopeCallerEventId("inv-1", elsewhere),
+    expect(scopeCallerEventId("inv-1", "ses-a", eventLink)).not.toBe(
+      scopeCallerEventId("inv-1", "ses-a", elsewhere),
     );
   });
 
   it("cannot be confused by a caller id that mimics a delimiter", () => {
-    // The caller's half is opaque and caller-chosen. Under delimited
+    // The caller's halves are opaque and caller-chosen. Under delimited
     // concatenation these pairs render identically; hashing keeps them apart.
     // A link id is a URI, so it always carries a colon of its own — the
     // separator is not distinguishable from the payload by inspection.
     const ofYZ: NormalizedFullLink = { ...eventLink, id: "of:y:z" };
     const yZ: NormalizedFullLink = { ...eventLink, id: "y:z" };
-    expect(scopeCallerEventId("x", ofYZ)).not.toBe(
-      scopeCallerEventId("x:of", yZ),
+    expect(scopeCallerEventId("x", "s", ofYZ)).not.toBe(
+      scopeCallerEventId("x:of", "s", yZ),
+    );
+    // The same ambiguity across the id/session boundary: a caller chooses
+    // both halves, and can choose where a delimiter would appear to sit.
+    expect(scopeCallerEventId("inv", "1:ses", eventLink)).not.toBe(
+      scopeCallerEventId("inv:1", "ses", eventLink),
     );
   });
 

--- a/packages/runner/test/scheduler-event-receipts.test.ts
+++ b/packages/runner/test/scheduler-event-receipts.test.ts
@@ -25,6 +25,11 @@ import { scopeCallerEventId } from "../src/scheduler/event-identity.ts";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 
+// The session a caller-supplied id is chosen within, for the sends whose
+// subject is something else: the pair is what a stream send accepts, and one
+// session is all a test needs whose ids never repeat across it.
+const callerSession = "ses:scheduler-event-receipts";
+
 type TransactMessage = { requestId: string };
 type TransactResponse = {
   type: "response";
@@ -989,9 +994,11 @@ describe("scheduler event receipts", () => {
     tx = runtime.edit();
     await root.pull();
 
-    // Ingress-caller path (verb contract WS-D): the id rides cell.send's
-    // internal options instead of queueEvent directly — the CLI's route.
+    // Ingress-caller path (verb contract WS-D): the id and the session that
+    // chose it ride cell.send's internal options instead of queueEvent
+    // directly — the CLI's route.
     const eventId = "evt:receipt-cell-send:0:caller-id-root";
+    const session = "ses:receipt-cell-send";
     const outcomes: Array<{
       status: string;
       precondition?: string;
@@ -1007,16 +1014,16 @@ describe("scheduler event receipts", () => {
       });
     };
     const streamCell = root.key("stream") as Cell<unknown>;
-    streamCell.send({}, record, { eventId });
+    streamCell.send({}, record, { eventId, session });
     await waitForSchedulerCondition(
       runtime,
       () => handlerInvocations === 1 && outcomes.length === 1,
       "cell-send event did not settle",
     );
-    // Same id again: the body re-runs (exactly-once is per commit) but the
-    // create-only receipt collides, and the loser's callback still carries
-    // the SAME receipt address — the winner's original outcome.
-    streamCell.send({}, record, { eventId });
+    // Same id, same session: the body re-runs (exactly-once is per commit)
+    // but the create-only receipt collides, and the loser's callback still
+    // carries the SAME receipt address — the winner's original outcome.
+    streamCell.send({}, record, { eventId, session });
     await waitForSchedulerCondition(
       runtime,
       () => handlerInvocations === 2 && outcomes.length === 2,
@@ -1024,11 +1031,16 @@ describe("scheduler event receipts", () => {
     );
     await runtime.scheduler.idleWithPendingCommits();
 
-    // The caller's id is scoped to the stream before it becomes the durable
-    // event id, so the receipt address derives from the scoped form.
+    // The caller's id is scoped to its session and to the stream before it
+    // becomes the durable event id, so the receipt address derives from the
+    // scoped form.
     const expectedLink = receiptCellForEvent<Record<string, never>>(
       runtime,
-      scopeCallerEventId(eventId, resolvedStreamLink(streamCell, runtime)),
+      scopeCallerEventId(
+        eventId,
+        session,
+        resolvedStreamLink(streamCell, runtime),
+      ),
     ).getAsNormalizedFullLink();
 
     expect(outcomes[0].status).toBe("done");
@@ -1075,16 +1087,24 @@ describe("scheduler event receipts", () => {
           ?.precondition,
       });
     };
-    // The SAME caller id addressed at two different verbs. Each is a distinct
-    // invocation of a distinct verb; neither may deduplicate onto the other.
+    // The SAME caller id, from the same session, addressed at two different
+    // verbs. Each is a distinct invocation of a distinct verb; neither may
+    // deduplicate onto the other.
     const eventId = "caller-shared-id";
-    (root.key("increment") as Cell<unknown>).send({}, record, { eventId });
+    const session = "ses:cross-verb";
+    (root.key("increment") as Cell<unknown>).send({}, record, {
+      eventId,
+      session,
+    });
     await waitForSchedulerCondition(
       runtime,
       () => incremented === 1 && outcomes.length === 1,
       "increment did not settle",
     );
-    (root.key("decrement") as Cell<unknown>).send({}, record, { eventId });
+    (root.key("decrement") as Cell<unknown>).send({}, record, {
+      eventId,
+      session,
+    });
     await waitForSchedulerCondition(
       runtime,
       () => outcomes.length === 2,
@@ -1096,6 +1116,97 @@ describe("scheduler event receipts", () => {
     expect(outcomes[1].precondition).toBeUndefined();
     expect(outcomes[1].status).toBe("done");
     expect(decremented).toBe(1);
+  });
+
+  it("two sessions sharing one caller-supplied id do not collide", async () => {
+    const { commonfabric } = createTrustedBuilder(runtime);
+    const { handler, pattern } = commonfabric;
+    let handlerInvocations = 0;
+    const addComment = handler<unknown, Record<string, never>>(() => {
+      handlerInvocations++;
+    }, { proxy: true });
+    const rootPattern = pattern(() => ({ stream: addComment({}) }));
+    const rootCell = runtime.getCell<{ stream: unknown }>(
+      space,
+      "receipts cross-session caller id root",
+      undefined,
+      tx,
+    );
+    const root = runtime.run(tx, rootPattern, {}, rootCell);
+    await tx.commit();
+    tx = runtime.edit();
+    await root.pull();
+
+    const outcomes: Array<{
+      status: string;
+      precondition?: string;
+      receiptLink?: ReturnType<Cell<unknown>["getAsNormalizedFullLink"]>;
+    }> = [];
+    const record = (t: IExtendedStorageTransaction) => {
+      const status = t.status();
+      outcomes.push({
+        status: status.status,
+        precondition: (status as { error?: { precondition?: string } }).error
+          ?.precondition,
+        receiptLink: t.handlingReceiptLink,
+      });
+    };
+    // One word, two callers: an invocation id is the caller's own, and
+    // `add-comment-1` is the word two agents both reach for. Each names one
+    // invocation of one verb, and neither may deduplicate onto the other.
+    const eventId = "add-comment-1";
+    const streamCell = root.key("stream") as Cell<unknown>;
+    streamCell.send({}, record, { eventId, session: "ses:agent-one" });
+    await waitForSchedulerCondition(
+      runtime,
+      () => handlerInvocations === 1 && outcomes.length === 1,
+      "the first session's event did not settle",
+    );
+    streamCell.send({}, record, { eventId, session: "ses:agent-two" });
+    await waitForSchedulerCondition(
+      runtime,
+      () => handlerInvocations === 2 && outcomes.length === 2,
+      "the second session's event did not settle",
+    );
+    await runtime.scheduler.idleWithPendingCommits();
+
+    expect(outcomes[0].status).toBe("done");
+    // The second commits its own handling rather than losing the race for a
+    // receipt it has no call in, so it is told what its own call did.
+    expect(outcomes[1].precondition).toBeUndefined();
+    expect(outcomes[1].status).toBe("done");
+    expect(outcomes[0].receiptLink?.id).toBeDefined();
+    expect(outcomes[1].receiptLink?.id).not.toBe(outcomes[0].receiptLink?.id);
+  });
+
+  it("refuses a caller-supplied id sent without its session", async () => {
+    const { commonfabric } = createTrustedBuilder(runtime);
+    const { handler, pattern } = commonfabric;
+    let handlerInvocations = 0;
+    const noLaunch = handler<unknown, Record<string, never>>(() => {
+      handlerInvocations++;
+    }, { proxy: true });
+    const rootPattern = pattern(() => ({ stream: noLaunch({}) }));
+    const rootCell = runtime.getCell<{ stream: unknown }>(
+      space,
+      "receipts unsessioned caller id root",
+      undefined,
+      tx,
+    );
+    const root = runtime.run(tx, rootPattern, {}, rootCell);
+    await tx.commit();
+    tx = runtime.edit();
+    await root.pull();
+
+    // Derived without one, the address would be reachable by anyone who
+    // guessed the id, and the guarantee the id buys — a retry settling on
+    // the original outcome — would be handed to whoever got there first.
+    const streamCell = root.key("stream") as Cell<unknown>;
+    expect(() => streamCell.send({}, undefined, { eventId: "add-comment-1" }))
+      .toThrow(/requires the `session`/);
+    await runtime.idle();
+    // Refused at the send, so no delivery was queued for the handler.
+    expect(handlerInvocations).toBe(0);
   });
 
   it("creates a receipt document for handlers that launch nothing", async () => {
@@ -1664,6 +1775,7 @@ describe("scheduler event receipts", () => {
           (t: IExtendedStorageTransaction) => resolve(t.status().status),
           {
             eventId,
+            session: callerSession,
             runtimeInjectedEventKeys: markRuntimeInjectedEventKeys(["result"]),
           },
         );
@@ -1708,7 +1820,11 @@ describe("scheduler event receipts", () => {
         streamCell.send(
           { value: 7, result: holder },
           (t: IExtendedStorageTransaction) => resolve(t.status().status),
-          { eventId, runtimeInjectedEventKeys: ["result"] },
+          {
+            eventId,
+            session: callerSession,
+            runtimeInjectedEventKeys: ["result"],
+          },
         );
       });
 
@@ -1750,6 +1866,7 @@ describe("scheduler event receipts", () => {
           (t: IExtendedStorageTransaction) => resolve(t.status().status),
           {
             eventId,
+            session: callerSession,
             runtimeInjectedEventKeys: markRuntimeInjectedEventKeys(["result"]),
           },
         );
@@ -1795,7 +1912,7 @@ describe("scheduler event receipts", () => {
         streamCell.send(
           { value: 7, result: smuggled },
           (t: IExtendedStorageTransaction) => resolve(t.status().status),
-          { eventId },
+          { eventId, session: callerSession },
         );
       });
 
@@ -1876,7 +1993,10 @@ describe("scheduler event receipts", () => {
     const streamCell = root.key("stream") as Cell<unknown>;
     streamCell.send({}, (t: IExtendedStorageTransaction) => {
       receiptLinks.push(t.handlingReceiptLink);
-    }, { eventId: "evt:receipt-link-off:0:flag-off-root" });
+    }, {
+      eventId: "evt:receipt-link-off:0:flag-off-root",
+      session: callerSession,
+    });
 
     await waitForSchedulerCondition(
       runtime,

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -143,6 +143,7 @@ See `docs/development/EXPERIMENTAL_OPTIONS.md` for available flags.
 | Step + get         | `deno task cf piece get --piece ID fieldPath --step ...`                                             |
 | Set field          | `echo '{"data":...}' \| deno task cf piece set --piece ID path ...`                                  |
 | Call handler       | `deno task cf piece call --piece ID handlerName ...`                                                 |
+| Shape a result     | `deno task cf piece call --piece ID --select topic.title addTopic ...`                               |
 | List verbs         | `deno task cf piece verbs --piece ID --json ...`                                                     |
 | Trigger recompute  | `deno task cf piece step --piece ID ...`                                                             |
 | List pieces        | `deno task cf piece ls -i key -a url -s space`                                                       |
@@ -272,6 +273,25 @@ is never fetched, so a marked collection costs one document read rather than one
 per element; the rendered `id` minus its `of:` prefix is what `--piece` accepts.
 Markers do not compose with `--filter`. See `packages/cli/README.md` for the
 exact syntax and supported schema subset.
+
+`piece call` takes the same three flags, before the callable name, with the same
+grammar, the same `--select`/`--schema` conflict, and the same error messages.
+They shape the result of the call — a handler's `result` inside the Invocation
+JSON, or a tool's JSON on stdout:
+
+```bash
+deno task cf piece call --piece ID --select topic.title addTopic '{"title":"Ship it"}'
+```
+
+A selection shapes a result that already exists; it does not narrow what the
+call fetches, because the readback materializes the whole receipt first and a
+receipt declares no schema to narrow against. A value-less verb therefore still
+reports no `result` at all rather than `{}` — but a selection that keeps nothing
+from a result that does exist is refused, so the two stay distinguishable.
+`--no-wait` refuses all three flags, since it skips the receipt readback they
+are answered from. `--show-links` composes with a projection — links are
+collected after the selection, so each address names a position in the value you
+were handed — but not with `--filter`, which moves the positions a link names.
 
 For `piece call`, options before the callable name configure `piece call`.
 Arguments after the callable name configure the invoked handler or tool. The


### PR DESCRIPTION
## Why

#5582 reverted both because the tree they made *together* type-failed — not
because either was wrong alone. Restoring them is what unblocks item 4 of
`docs/plans/verbs-implementation.md`, which is blocked on #5469 rather than
merely ordered after it.

#5469 replaced `invocationId` with an `invocation: {id, session}` pair. #5505
added nine `piece call` selection tests written against the old name. Each was
green on a base that did not contain the other, and nothing in the checks
catches the meeting: an **excess property is dropped silently rather than
rejected**, so the nine tests dispatched with no invocation at all and awaited
a receipt that could never arrive. Type-checking was the only gate that saw it
— the package suites run `--no-check`, and `172 passed | 0 failed` reads
identically either side of the bug.

**They return in one commit.** Landing them separately recreates the same
window in the other direction, and the ordering guarantee only holds while
both are present.

What comes back:

- `scopeCallerEventId` derives the durable event id over
  `{caller, id, path, scope, session, space}` again. Two callers picking
  `add-comment-1` against the same verb name two invocations instead of
  colliding on one receipt, and a per-user stream stays distinct from a
  per-space one at the same id and path.
- `--invocation-session`, `CF_INVOCATION_SESSION`, and
  `cf invocation-session new`.
- `cf piece call` takes `--select`, `--schema` and `--filter`, so it is shaped
  like `cf piece get` — with the `--filter`/`--show-links` conflict, the
  refusal of all three under `--no-wait`, and an unparseable selection treated
  as a pre-dispatch data error.

## What Changed

A revert of #5582, plus the nine call-selection tests moved onto the
invocation pair — `invocation: { id: "inv-…", session: callerSession }`, the
form this file's other call sites already use and the constant it already
defines at line 61.

The nine conversions are the **only** delta from a mechanical revert of
#5582; everything else is restored byte-for-byte.

## Test plan

- `deno task check` — the gate that caught the original break, and the only
  one that sees an excess property
- `deno task test` in `packages/cli` (173 passed / 0 failed) and
  `packages/runner` (1174 passed / 0 failed)
- `deno fmt --check`, `deno lint`
- `check-docs`, `check-skill-facts`, `check-conflict-markers`,
  `check-no-waitfor`, `check-single-copy-deps`, `check-unused-deps`,
  `check-deno-pins`, `check-baselines-append-only`

Worth a reviewer's eye on the address derivation in
`packages/runner/src/scheduler/event-identity.ts`, since that is the part
whose absence was the deliberate regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

