### PR TITLE
fix(cli): a wait expiry names the pair a retry has to name

### DIFF
--- a/packages/cli/commands/invocation-session.ts
+++ b/packages/cli/commands/invocation-session.ts
@@ -19,8 +19,8 @@ export function renderNewSession(write: (text: string) => void = render): void {
 export const invocationSession = new Command()
   .name("invocation-session")
   .description(
-    "Mint an invocation session: the caller an invocation id passed to " +
-      "`cf piece call` was chosen within. One per agent run.",
+    "Mint an invocation session: the caller identity that an invocation id " +
+      "passed to `cf piece call` is chosen within. One per agent run.",
   )
   .default("help")
   /* invocation-session new */

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -793,16 +793,22 @@ export async function parsePieceCallSelection(
  * acknowledged abandons un-executed work rather than leaving it settling
  * elsewhere: before the `committed` phase, the invocation may not have
  * executed or committed at all. The recovery is re-invoking with the SAME
- * id — safe in every phase, because it deduplicates against the create-only
- * receipt when the commit landed and re-executes when it never did. The
- * exit reports the id and the furthest phase so the caller can.
+ * id AND session — safe in every phase, because it deduplicates against the
+ * create-only receipt when the commit landed and re-executes when it never
+ * did.
+ *
+ * Both halves are named because both reach the address: an id alone is
+ * replayable within no session, and `resolveInvocationIdentity` refuses one
+ * offered without its session rather than putting that id on a different
+ * outcome. The dispatch announcement puts the pair on stderr, which is where
+ * a caller acting on this recovers them from.
  */
 export class WaitBoundExpired extends Error {
   constructor(readonly seconds: number) {
     super(
       `--wait bound of ${seconds}s expired: the invocation may not have ` +
-        "executed or committed — re-invoke with the same invocation id " +
-        "to finish it or read the outcome back",
+        "executed or committed — re-invoke with the same invocation id and " +
+        "session to finish it or read the outcome back",
     );
     this.name = "WaitBoundExpired";
   }

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -2238,9 +2238,13 @@ describe("piece call wait control", () => {
     expect(error).toBeInstanceOf(WaitBoundExpired);
     // The wording is pinned: the handler runs in THIS process, so an expiry
     // must not claim the invocation "continues settling" — it may never have
-    // executed or committed, and the same-id re-invoke is the recovery.
+    // executed or committed, and re-invoking the same pair is the recovery.
+    // The pair is anchored to the end of the string: an id on its own names
+    // no address, and `resolveInvocationIdentity` refuses one offered without
+    // its session, so guidance that stopped at the id would send a caller
+    // into a rejected retry.
     expect((error as WaitBoundExpired).message).toMatch(
-      /--wait bound of 0\.01s expired: the invocation may not have executed or committed — re-invoke with the same invocation id/,
+      /--wait bound of 0\.01s expired: the invocation may not have executed or committed — re-invoke with the same invocation id and session to finish it or read the outcome back$/,
     );
     expect((error as WaitBoundExpired).seconds).toBe(0.01);
   });


### PR DESCRIPTION
## Why

Two findings from the cubic review on #5610, taken as a follow-up because that
PR's value was being a verified mechanical restore — folding fixes in would
have destroyed the one property that made it cheap to review. Both predate the
revert: they were on main until #5582 removed them, and returned with #5610.

**`WaitBoundExpired` instructs an action the CLI rejects.** It tells a caller
to "re-invoke with the same invocation id", but the durable address is the
`{id, session}` pair, and `resolveInvocationIdentity` refuses an id offered
without its session rather than putting that id on a different outcome:

> `--invocation` names an id to replay, and an id is replayable only within
> the session it was chosen in.

So a caller following the expiry message verbatim gets a validation error
instead of the retry the message promised. #5469 moved the address and left
this user-facing string naming the old one — the coherence ripple, on the path
where getting it wrong means a caller believes work may be unfinished and
cannot act on it.

The session is not missing from output, which was the reviewer's framing:
`invocationPhaseReporter` announces it beside the id at dispatch
(`piece.ts:515`). The defect is the guidance, not the diagnostics.

**The `invocation-session` help description is missing a word.** "the caller an
invocation id passed to `cf piece call` was chosen within" reads
ungrammatically in user-facing output.

## What Changed

- The expiry message and its doc name the id **and** the session, with the
  reason both are required stated where the next reader of that message will
  be.
- The help description mirrors `lib/session.ts`, which already carries the
  intended phrasing ("the caller identity that an invocation id is chosen
  within"), rather than inventing a second wording for one concept.
- The test pinning the expiry wording matched an **unanchored prefix**, so it
  passed against both the old and new text and guarded nothing. It is anchored
  to the end of the message now.

A third finding in that review — that `--show-links` must be refused alongside
a `$link`-marked projection — is not acted on here. The contract says the
opposite in two places (`docs/common/verbs-over-the-cli.md:131` and `:314`): a
projection composes with `--show-links` because it leaves every surviving path
where it was. `--filter` is the only refusal, which is what
`parsePieceCallSelection` already enforces.

## Test plan

- The anchored assertion was mutation-checked: it **fails** against the
  id-only message and passes with the pair, so it now guards the wording
  rather than agreeing with either spelling.
- `deno task test` in packages/cli — 173 passed / 0 failed
- `deno task check`, `deno fmt --check`, `deno lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

