### PR TITLE
docs: nothing comes between a doc comment and its declaration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,9 +99,11 @@ If you are developing runtime code, start with:
 - `docs/development/DEVELOPMENT.md` - Coding style, design principles, and best
   practices
 - `docs/development/code-comment-style.md` - How a comment is written, both the
-  `//` kind and the JSDoc kind. The rule that catches people out is that a
-  comment describes the system as it stands: not its own past, not the road not
-  taken, not the plan that got it here
+  `//` kind and the JSDoc kind. Two rules catch people out. A comment describes
+  the system as it stands: not its own past, not the road not taken, not the
+  plan that got it here. And nothing comes between a doc comment and the
+  declaration it documents — adding a definition means placing it after the
+  whole of the declaration above it, doc comment included
 - `docs/development/LOCAL_DEV_SERVERS.md` - **CRITICAL**: How to start local dev
   servers correctly (use `dev-local` for shell, not `dev`)
 - `docs/development/TESTING.md` - Running the test suites and the general unit

--- a/cubic.yaml
+++ b/cubic.yaml
@@ -29,7 +29,10 @@ reviews:
         transformer pipeline / reactive-graph model (error-swallowing try/catch,
         singletons, async/await in handlers, transformer escape hatches). (3) Coherence — a change to runtime
         semantics must update the docs, comments, and examples it makes stale,
-        so someone searching later is not misled. (4) Test rigor — each touched
+        so someone searching later is not misled; watch too for a doc comment
+        detached from the declaration it documents, most often by a new
+        definition inserted directly beneath it, which leaves the original
+        declaration undocumented. (4) Test rigor — each touched
         test should guard a nameable principle. (5) Bandwidth — separate
         blocking bugs from non-blocking improvements and optional nits.
       file_paths:

--- a/docs/development/code-comment-style.md
+++ b/docs/development/code-comment-style.md
@@ -318,6 +318,36 @@ open or close marker is _not_ on its own line, e.g. don't do this:
  */
 ```
 
+### Where one goes
+
+A doc comment binds to whatever follows it. Nothing comes between one and the
+declaration it documents: no blank line, no `//` comment, no second doc
+comment, and above all no other declaration. Tooling associates the two by
+adjacency, and so does a reader.
+
+Three shapes break this, each of which looks harmless while being written:
+
+- **A `//` note about the whole declaration, written above it.** The doc
+  comment now reads as a description of the note, and the contract is visually
+  detached from the thing it is a contract for. Open the declaration's body
+  with the note instead. When the declaration has no body — a type, an
+  interface property — fold what the note says into the doc comment.
+- **A new definition placed directly under an existing doc comment.** The doc
+  comment now documents the new definition, and the declaration it was written
+  for is left with none. Adding a definition means placing it after the whole
+  of the declaration above it, doc comment included.
+- **Two doc comments in a row.** TypeScript keeps only the one nearest the
+  declaration, so the other is invisible wherever documentation is rendered.
+  Merge them if both say something worth keeping.
+
+The one exception is a tool directive — `// deno-lint-ignore`,
+`// deno-fmt-ignore`, `// @ts-types` — which has to sit on the line
+immediately before the code it governs, and so has nowhere else to go.
+
+A doc comment with no declaration under it at all is the same defect from the
+other direction. To title a region of a file or a class, use a section marker,
+which is a `//` block; see [Section markers](#section-markers) above.
+
 ### What gets one
 
 - Every exported symbol: variable, function, class, type.

--- a/skills/cf-review/SKILL.md
+++ b/skills/cf-review/SKILL.md
@@ -203,6 +203,14 @@ stopgaps, abandoned TODOs. A new workspace package must register in the root
 `deno.jsonc` and carry its own `tasks.test` (a missing one makes the root runner
 recurse and time out CI). Run `deno fmt` and `deno lint` on touched files.
 
+**A doc comment detached from its declaration** belongs here too, and a diff is
+the one place it is easy to see. A definition added directly under an existing
+doc comment takes that comment over and leaves the declaration it was written
+for undocumented; a `//` note wedged in between splits the contract from its
+subject. Two doc comments in a row are the loudest tell — only the nearer one
+survives into rendered documentation. See
+`docs/development/code-comment-style.md`, "Where one goes".
+
 ### 6. Craft & conventions
 
 Mostly Improvement / Nit — don't drown the report in these. Dead code, unused


### PR DESCRIPTION
I (an agent working on behalf of @danfuzz) swept the repository for doc comments
that have been separated from the declaration they document, and found about
thirty. The written guidance did not rule the shape out, and nothing pointed a
reviewer at it. This change closes that gap; the fixes themselves are a separate
piece of work.

## The defect

A doc comment binds to whatever follows it. A definition placed directly under
an existing doc comment takes that comment over, and the declaration the comment
was written for is left with none — a contract silently deleted, with a plausible
replacement standing where it used to be. Two doc comments in a row are the
visible residue, and TypeScript keeps only the nearer one, so the other never
reaches rendered documentation.

A `//` note wedged between a doc comment and its declaration is the same
detachment reached a different way: the doc comment reads as a description of
the note.

## What changed

- **`docs/development/code-comment-style.md`** — a new "Where one goes" section
  under "Doc comments" states the adjacency rule, the three shapes that break
  it, the tool-directive exception (`// deno-lint-ignore` and friends have to sit
  on the line before the code they govern), and where a comment that documents
  nothing belongs instead.
- **`skills/cf-review/SKILL.md`** — the defect is named under changeset hygiene,
  which is where a reviewer is already looking at diff shape rather than at
  semantics. A diff is the one place this is easy to see.
- **`cubic.yaml`** — folded into the coherence lens. Per the file's own comment
  the skill is the single source of truth and `file_paths` carries it in full;
  the `description` restates only what has to survive truncation, and this is a
  clause rather than a sixth lens for that reason.
- **`AGENTS.md`** — the always-loaded line for `code-comment-style.md` now names
  two rules that catch people out instead of one.

## What deliberately did not change

No `.claude/rules/` entry. Per `.claude/rules/README.md` a rule earns its place
by applying to a recognizable set of files rather than to the repository as a
whole, and by a failing gate or a real cost behind getting it wrong. This applies
to every TypeScript file in the tree and has no gate behind it.

A mechanical gate is possible — the scan that found the thirty is a line-based
walk over `/** … */` blocks, checking what follows the closing marker — and is
worth considering as a follow-up once the existing instances are cleaned up.
Without that cleanup a gate would fail on day one.

## Verification

`deno fmt --check`, `deno task check-skill-facts`, `deno task check-docs`, and
`deno task check-conflict-markers` all pass. Markdown and YAML only, no code
touched, so the unit suites were not run.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

