### PR TITLE
docs(plan): sequence a caller naming a reference, as verbs item 11

### DIFF
--- a/docs/plans/references-as-arguments.md
+++ b/docs/plans/references-as-arguments.md
@@ -182,12 +182,21 @@ before it spends the invocation id. Nothing there elects to refuse references.
 (`packages/toolshed/routes/webhooks/webhooks.utils.ts`) forwards the raw
 payload with no gate and no traversal.
 
-**And "data cannot name a cell" is not a core invariant.** A sigil link is a
-link wherever it appears in stored data (`isLinkRef`,
-`packages/data-model/src/cell-rep.ts`). Whether a sigil riding a webhook
-payload survives `send()` as a live edge is untested; if it does, that door is
-already open under the native spelling, and this plan names a capability rather
-than adds one.
+**And "data cannot name a cell" is not a core invariant — measured.** A sigil
+link is a link wherever it appears in stored data (`isLinkRef`,
+`packages/data-model/src/cell-rep.ts`), and a sigil riding an event payload
+survives `send()` as a **live edge**: probed against a local toolshed with an
+`any`-typed event field, so no gate intervened, the handler received the
+resolved target — its own properties, and its `title` read back. The door is
+already open under the native spelling, so this plan names a capability rather
+than adding one.
+
+That also bounds what the gate change alone buys. The CLI's gate is the only
+thing between a sigil payload and a `send()` that already resolves it, so
+aligning it should make the native spelling work end to end without any
+resolution work — worth confirming against a declared field rather than the
+`any` the probe used. Shared resolution then serves the *other* spellings,
+which is composition rather than basic capability.
 
 What remains for whoever owns CFC is a notification, not a ruling: opening the
 outer doors widens an existing exposure — an external principal, not just the

--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -107,8 +107,8 @@ pricing, so the pricing needs to be the honest one.
 
 ## Ready to build
 
-Unblocked and independent of the decision above. Small, except item 11, which
-is here because nothing gates it rather than because it is quick.
+Unblocked and independent of the decision above. Not all small — items 2 and
+11 are both (M); what these share is that nothing gates them.
 
 **2. An unrecognized projection key is refused.** *(M)* Two denylists are
 consulted and every key in neither is accepted and ignored, so a typo selects
@@ -209,28 +209,38 @@ arguments, so the options object defaults to `{}`. Same validator; the outer
 gate never got the option. The design is
 [references as arguments](references-as-arguments.md).
 
-Four parts, and only the first is independent:
+*Measured: `send()` already resolves a native sigil.* A raw sigil link riding
+an event payload reaches the handler as the **resolved target**, not an
+envelope — probed against a local toolshed with an `any`-typed event field, so
+nothing gated it: the handler saw the target's own properties and read its
+`title`. That settles the question
+[references as arguments](references-as-arguments.md) flagged untested, and it
+means the door is already open under the native spelling. This item names a
+capability rather than adding one.
+
+Four parts. Two are independent of everything:
 
 - **Refuse the structural copy.** Correct under any road, needs no vocabulary
   and no gate change, and converts silent corruption into an error.
 - **Give the CLI gate the option the dispatch gate already passes.** One
-  argument at one call site.
+  argument at one call site — and on the measurement above, *sufficient on its
+  own* for the native sigil spelling, since the gate is the only thing between
+  that payload and a `send()` that already resolves it. Worth confirming
+  against a declared field rather than the `any` the probe used.
 - **Lift resolution to a shared home**, beside `parseLink` and the LLM-friendly
-  pair in `packages/runner/src/link-utils.ts`.
+  pair in `packages/runner/src/link-utils.ts`. This is what admits the *other*
+  spellings — the `$link` shape a read emits, and the LLM-friendly form — so it
+  serves composition rather than basic capability.
 - **Fix event-schema emission.** An inline `Writable<{…}>` disappears from the
-  emitted properties entirely — needed under any road, and doubly once event
-  schemas close, since a field the schema does not name cannot be supplied at
-  all. The `asCell` marker is needed only if resolution goes schema-directed.
-
-*Order is not free.* Resolution precedes the gate, which is the order
-`llm-dialog` already proves. Aligning the gate first would pass a raw envelope
-to a handler expecting a cell.
+  emitted properties entirely. That half is independent and needed under any
+  road, doubly once event schemas close, since a field the schema does not name
+  cannot be supplied at all. Only the `asCell` marker hangs on the decision
+  below.
 
 *One decision inside the item:* schema-blind or schema-directed resolution.
 Schema-blind is proven twice — `traverseAndCellify` and the dispatch gate;
 schema-directed is checkable and refuses a typo. It decides whether the `asCell`
-half of emission is required or merely useful, so reach it before starting
-emission.
+marker is required or merely useful, so reach it before starting that half.
 
 *A constraint rather than a decision:* what is accepted inbound must include the
 shape a read emits, or a caller cannot submit the address it was just handed.
@@ -239,8 +249,9 @@ shape a read emits, or a caller cannot submit the address it was just handed.
 the user's own model session to external principals.
 
 *Exit:* `cf piece call --piece <root> addPiece '{"piece": <address>}'` registers
-the piece. That is the root pattern's own verb, reachable today only from inside
-the runtime.
+the piece — the root pattern's own verb, reachable today by `pieces.add` from
+inside the runtime and by a model through the dialog builtin, and by no other
+caller.
 
 ## Landed, and what consumes it
 
@@ -289,7 +300,7 @@ joins them.
 | 5 | 4 | the fourth and fifth arrivals inherit whatever a read costs |
 | 10 | 1 | listing rows carry a handler's `outputSchema`; the plumbing exists for tools already |
 | 1 | — | decided; 8 and 10 are no longer provisional, and item 10 carries the revisit condition |
-| 11 | — | independent of 1: declared results make an *output* self-describing, this is what an *input* accepts. Shares `schema-injection.ts` with item 10's emission, so one holder suits both |
+| 11 | — | independent of 1 in what it decides — declared results make an *output* self-describing, this is what an *input* accepts — but shares `schema-injection.ts` with item 1's emission (#5501), so one holder suits both |
 
 Items 2, 3 and 5 touch one file heavily and want to land one at a time rather
 than in parallel. Item 4 is the only one that touches the call envelope.

--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -107,7 +107,8 @@ pricing, so the pricing needs to be the honest one.
 
 ## Ready to build
 
-Unblocked, small, and independent of the decision above.
+Unblocked and independent of the decision above. Small, except item 11, which
+is here because nothing gates it rather than because it is quick.
 
 **2. An unrecognized projection key is refused.** *(M)* Two denylists are
 consulted and every key in neither is accepted and ignored, so a typo selects
@@ -191,6 +192,56 @@ other command accepts, which this is the occasion to make the declared shape.
 *Exit:* the same cell, reached four ways, renders identically under the same
 selection.
 
+**11. A caller may name a reference.** *(M)* A verb whose event declares
+`Writable<T>` is callable by a model and by nothing else. `traverseAndCellify`
+(`packages/runner/src/builtins/llm-dialog.ts`) resolves `{"@link": …}` into a
+live cell before dispatch, so the LLM boundary has a complete round trip; the
+CLI rejects the address and the webhook path forwards it unresolved. The
+shape-matching payload the CLI *does* accept stores a detached copy and reports
+success.
+
+*The refusal is drift, not policy.* `closedWorldEventRejection`
+(`packages/runner/src/runner.ts`) validates a present event payload with
+`acceptOpaqueValue: (value) => isCellLink(value)` — a link passes unjudged,
+because its target cannot be read at dispatch. `verbInputSchemaError`
+(`packages/cli/lib/callable.ts`) calls the same `validateSchemaValue` with two
+arguments, so the options object defaults to `{}`. Same validator; the outer
+gate never got the option. The design is
+[references as arguments](references-as-arguments.md).
+
+Four parts, and only the first is independent:
+
+- **Refuse the structural copy.** Correct under any road, needs no vocabulary
+  and no gate change, and converts silent corruption into an error.
+- **Give the CLI gate the option the dispatch gate already passes.** One
+  argument at one call site.
+- **Lift resolution to a shared home**, beside `parseLink` and the LLM-friendly
+  pair in `packages/runner/src/link-utils.ts`.
+- **Fix event-schema emission.** An inline `Writable<{…}>` disappears from the
+  emitted properties entirely — needed under any road, and doubly once event
+  schemas close, since a field the schema does not name cannot be supplied at
+  all. The `asCell` marker is needed only if resolution goes schema-directed.
+
+*Order is not free.* Resolution precedes the gate, which is the order
+`llm-dialog` already proves. Aligning the gate first would pass a raw envelope
+to a handler expecting a cell.
+
+*One decision inside the item:* schema-blind or schema-directed resolution.
+Schema-blind is proven twice — `traverseAndCellify` and the dispatch gate;
+schema-directed is checkable and refuses a typo. It decides whether the `asCell`
+half of emission is required or merely useful, so reach it before starting
+emission.
+
+*A constraint rather than a decision:* what is accepted inbound must include the
+shape a read emits, or a caller cannot submit the address it was just handed.
+
+*CFC gets a notification, not a ruling* — an existing capability widening from
+the user's own model session to external principals.
+
+*Exit:* `cf piece call --piece <root> addPiece '{"piece": <address>}'` registers
+the piece. That is the root pattern's own verb, reachable today only from inside
+the runtime.
+
 ## Landed, and what consumes it
 
 **6. The read layer.** The shared read step, address markers with the
@@ -238,6 +289,7 @@ joins them.
 | 5 | 4 | the fourth and fifth arrivals inherit whatever a read costs |
 | 10 | 1 | listing rows carry a handler's `outputSchema`; the plumbing exists for tools already |
 | 1 | — | decided; 8 and 10 are no longer provisional, and item 10 carries the revisit condition |
+| 11 | — | independent of 1: declared results make an *output* self-describing, this is what an *input* accepts. Shares `schema-injection.ts` with item 10's emission, so one holder suits both |
 
 Items 2, 3 and 5 touch one file heavily and want to land one at a time rather
 than in parallel. Item 4 is the only one that touches the call envelope.


### PR DESCRIPTION
> **This edits a document another session has been maintaining** (#5519, #5573). That session has ended, so this is an addition rather than a concurrent edit — one new item, one ordering row, one clause in a section intro. Nothing existing is rewritten.

## Why

The reference-arguments design (#5607) needed a place in the sequence rather than beside it, and it is verb work: **a verb whose event declares `Writable<T>` is callable by a model and by nothing else**, so the surface this plan exists to close is incomplete by exactly that set.

It is placed under **Ready to build** because nothing gates it. The confinement question that looked like a blocker turned out to be drift between two gates:

- `closedWorldEventRejection` (`packages/runner/src/runner.ts`) validates a present event payload with `acceptOpaqueValue: (value) => isCellLink(value)` — a link passes unjudged.
- `verbInputSchemaError` (`packages/cli/lib/callable.ts`) calls the **same** `validateSchemaValue` with two arguments, so the options object defaults to `{}`.

Same validator; the outer gate never got the option.

## What Changed

- **Item 11**, under Ready to build: the four parts, which one is independent, the order constraint, and the exit.
- **One ordering row.** It is independent of item 1 — declared results make an *output* self-describing, this decides what an *input* accepts — but shares `schema-injection.ts` with item 10's emission, so one holder suits both.
- **One clause in the section intro.** That list said "unblocked, small"; item 11 is unblocked but not small, and saying so is cheaper than a reader discovering it.

The item keeps its own internal decision — schema-blind or schema-directed resolution — rather than resolving it here, because that answer decides how much of the emission work is required and wants reaching before emission starts.

## Test plan

Documentation only.

- `deno task check-docs` — 537 blocks
- `deno task docs-links --orphan`
- `deno task check-conflict-markers`

The load-bearing claim is checkable in a minute: compare the two `validateSchemaValue` call sites named above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

