### PR TITLE
docs(runner): reattach doc comments to the declarations they document

### DIFF
--- a/packages/runner/src/builder/action-context.ts
+++ b/packages/runner/src/builder/action-context.ts
@@ -1,3 +1,18 @@
+import { isDeno } from "@commonfabric/utils/env";
+import {
+  type AsyncLocalStore,
+  FallbackAsyncLocalStore,
+} from "@commonfabric/utils/async-local-store";
+import { getTopFrame } from "./pattern.ts";
+
+// Deno/Node `AsyncLocalStorage` when available, the promise-aware fallback
+// otherwise. The `await import` stays here (not in the shared utils module): a
+// top-level await in widely-imported utils stalls Deno module evaluation.
+const ActionWindowStorage =
+  (isDeno()
+    ? (await import("node:async_hooks")).AsyncLocalStorage
+    : FallbackAsyncLocalStore) as new <T>() => AsyncLocalStore<T>;
+
 /**
  * Ambient marker for "a runner Action (lift/handler invocation) is currently
  * executing user code" — the window in which minting NEW builder artifacts is
@@ -22,22 +37,6 @@
  * mints — including under the non-Deno fallback store, whose window
  * conservatively spans the whole pending action promise.
  */
-
-import { isDeno } from "@commonfabric/utils/env";
-import {
-  type AsyncLocalStore,
-  FallbackAsyncLocalStore,
-} from "@commonfabric/utils/async-local-store";
-import { getTopFrame } from "./pattern.ts";
-
-// Deno/Node `AsyncLocalStorage` when available, the promise-aware fallback
-// otherwise. The `await import` stays here (not in the shared utils module): a
-// top-level await in widely-imported utils stalls Deno module evaluation.
-const ActionWindowStorage =
-  (isDeno()
-    ? (await import("node:async_hooks")).AsyncLocalStorage
-    : FallbackAsyncLocalStore) as new <T>() => AsyncLocalStore<T>;
-
 const actionWindow = new ActionWindowStorage<true>();
 
 /**

--- a/packages/runner/src/builder/action-context.ts
+++ b/packages/runner/src/builder/action-context.ts
@@ -1,10 +1,3 @@
-import { isDeno } from "@commonfabric/utils/env";
-import {
-  type AsyncLocalStore,
-  FallbackAsyncLocalStore,
-} from "@commonfabric/utils/async-local-store";
-import { getTopFrame } from "./pattern.ts";
-
 /**
  * Ambient marker for "a runner Action (lift/handler invocation) is currently
  * executing user code" — the window in which minting NEW builder artifacts is
@@ -29,6 +22,14 @@ import { getTopFrame } from "./pattern.ts";
  * mints — including under the non-Deno fallback store, whose window
  * conservatively spans the whole pending action promise.
  */
+
+import { isDeno } from "@commonfabric/utils/env";
+import {
+  type AsyncLocalStore,
+  FallbackAsyncLocalStore,
+} from "@commonfabric/utils/async-local-store";
+import { getTopFrame } from "./pattern.ts";
+
 // Deno/Node `AsyncLocalStorage` when available, the promise-aware fallback
 // otherwise. The `await import` stays here (not in the shared utils module): a
 // top-level await in widely-imported utils stalls Deno module evaluation.

--- a/packages/runner/src/builder/module.ts
+++ b/packages/runner/src/builder/module.ts
@@ -322,19 +322,21 @@ export function resolveSourceLocationFromStack(
   return { location: null };
 }
 
-/** Declare a module
+/**
+ * Declare a module
+ *
+ * Function-first form, matching pattern()/handler() convention: the callback
+ * leads, schemas trail and are optional. The argument/result schemas are plain
+ * JSONSchema values that are NOT materialized into the callback input type —
+ * the callback's own (or transformer-inferred) type stands. The no-input form
+ * is `lift(fn, false)`: argumentSchema:false makes the no-arg application valid
+ * (the runner's isValidArgument check passes on `argumentSchema === false`),
+ * which is how computed-origin (zero-capture) lifts lower.
  *
  * @param implementation A function that takes an input and returns a result
  *
  * @returns A module node factory that also serializes as module.
  */
-// Function-first form, matching pattern()/handler() convention: the callback
-// leads, schemas trail and are optional. The argument/result schemas are plain
-// JSONSchema values that are NOT materialized into the callback input type — the
-// callback's own (or transformer-inferred) type stands. The no-input form is
-// `lift(fn, false)`: argumentSchema:false makes the no-arg application valid
-// (the runner's isValidArgument check passes on `argumentSchema === false`),
-// which is how computed-origin (zero-capture) lifts lower.
 export function lift<T, R>(
   implementation: (input: T) => R,
   argumentSchema?: JSONSchema,
@@ -662,9 +664,7 @@ export const assert: (fn: () => boolean) => Reactive<AssertRecord> = (
  * @param _event - A function that receives an event and performs side effects
  * @throws Error if called directly (CTS must be enabled for action() to work)
  */
-// Overload 1: Zero-parameter callback returns Stream<void>
 export function action(_event: () => void): Stream<void>;
-// Overload 2: Parameterized callback returns Stream<E>
 export function action<E>(_event: (event: E) => void): Stream<E>;
 // Overload 3: a declared result, reached only by supplying both type arguments
 // explicitly — `action<AddTopic, TopicRef>((e) => { ...; return ref })`.

--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -869,25 +869,6 @@ export function llm(
 }
 
 /**
- * Generate text via an LLM.
- *
- * A simplified alternative to `llm` that takes a single prompt string and
- * optional system message, returning plain text rather than a structured
- * content array.
- *
- * Returns the complete result as `result` (string) and the incremental result
- * as `partial` (string). `pending` is true while a request is pending.
- *
- * @param prompt - The user prompt/message to send to the LLM.
- * @param system - Optional system message.
- * @param model - Model to use (defaults to DEFAULT_MODEL_NAME).
- * @param maxTokens - Maximum number of tokens to generate (defaults to 4096).
- *
- * @returns { pending: boolean, result?: string, partial?: string, requestHash?: string } -
- *   As individual docs, representing `pending` state, final `result` and
- *   incrementally updating `partial` result.
- */
-/**
  * Resolve the effective native-model-tool ids for a request from the friendly
  * `search` flag (shorthand for Google Search grounding) plus any explicit
  * `nativeModelToolIds`. Returns undefined when none are requested.
@@ -942,6 +923,25 @@ function extractGroundingSources(
   return out.length > 0 ? out : undefined;
 }
 
+/**
+ * Generate text via an LLM.
+ *
+ * A simplified alternative to `llm` that takes a single prompt string and
+ * optional system message, returning plain text rather than a structured
+ * content array.
+ *
+ * Returns the complete result as `result` (string) and the incremental result
+ * as `partial` (string). `pending` is true while a request is pending.
+ *
+ * @param prompt - The user prompt/message to send to the LLM.
+ * @param system - Optional system message.
+ * @param model - Model to use (defaults to DEFAULT_MODEL_NAME).
+ * @param maxTokens - Maximum number of tokens to generate (defaults to 4096).
+ *
+ * @returns { pending: boolean, result?: string, partial?: string, requestHash?: string } -
+ *   As individual docs, representing `pending` state, final `result` and
+ *   incrementally updating `partial` result.
+ */
 export function generateText(
   inputsCell: Cell<BuiltInGenerateTextParams>,
   sendResult: (tx: IExtendedStorageTransaction, result: any) => void,

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -349,7 +349,6 @@ const mintedRuntimeInjectedEventKeys = (
  * Module augmentation for runtime-specific cell methods.
  * These augmentations add implementation details specific to the runner runtime.
  */
-
 declare module "@commonfabric/api" {
   /**
    * Augment Writable to add runtime-specific write methods with onCommit callbacks
@@ -660,6 +659,20 @@ function parseSqliteInsertColumns(sql: string): string[] | undefined {
 }
 
 /**
+ * Recover a Cell from a value that is a Cell or carries a `toCell` back-pointer
+ * (delegating the back-pointer case to query-result-proxy's `getCellOrThrow`).
+ * Shared by the write path (`encodeSqliteParams`) and `cf-link.ts`'s
+ * `encodeCfLinkValue` so `db.exec` and the `sqliteQuery` builtin agree on what
+ * counts as a bound cell. (Lives here because it needs `isCell` /
+ * `instanceof CellImpl`; cf-link.ts already imports from cell.ts.)
+ */
+export function asBoundCell(value: unknown): Cell<unknown> | undefined {
+  if (isCell(value)) return value as Cell<unknown>;
+  if (isCellResultForDereferencing(value)) return getCellOrThrow(value);
+  return undefined;
+}
+
+/**
  * Encode SQLite bind params for the wire: a cell bound to a `_cf_link` column is
  * encoded to an absolute sigil-link string; a cell bound to any other column
  * throws; an `undefined` value throws (the pending-value guard — `null` is
@@ -674,20 +687,6 @@ function parseSqliteInsertColumns(sql: string): string[] | undefined {
  * would corrupt a non-link column). Use an explicit column list or named params
  * (`:col`) to bind a Cell in those statements.
  */
-/**
- * Recover a Cell from a value that is a Cell or carries a `toCell` back-pointer
- * (delegating the back-pointer case to query-result-proxy's `getCellOrThrow`).
- * Shared by the write path (`encodeSqliteParams`) and `cf-link.ts`'s
- * `encodeCfLinkValue` so `db.exec` and the `sqliteQuery` builtin agree on what
- * counts as a bound cell. (Lives here because it needs `isCell` /
- * `instanceof CellImpl`; cf-link.ts already imports from cell.ts.)
- */
-export function asBoundCell(value: unknown): Cell<unknown> | undefined {
-  if (isCell(value)) return value as Cell<unknown>;
-  if (isCellResultForDereferencing(value)) return getCellOrThrow(value);
-  return undefined;
-}
-
 export function encodeSqliteParams(
   sql: string,
   params?: ReadonlyArray<unknown> | Record<string, unknown>,
@@ -2740,10 +2739,6 @@ export class CellImpl<T extends FabricValue>
   }
 
   /**
-   * Map over an array cell, creating a new derived array.
-   * Similar to Array.prototype.map but works with Reactives.
-   */
-  /**
    * SqliteDb reactive read (`db.query<Row>`): builds a `sqliteQuery` node with
    * this DB handle as the `db` input (sugar over the `sqliteQuery` factory,
    * mirroring how `.map` threads `this` as `list`). The `<Row>` result schema is
@@ -2785,6 +2780,10 @@ export class CellImpl<T extends FabricValue>
     >;
   }
 
+  /**
+   * Map over an array cell, creating a new derived array.
+   * Similar to Array.prototype.map but works with Reactives.
+   */
   map<S>(
     _fn: (
       element: T extends Array<infer U> ? Reactive<U> : Reactive<T>,

--- a/packages/runner/src/cfc/atom-pattern.ts
+++ b/packages/runner/src/cfc/atom-pattern.ts
@@ -41,10 +41,11 @@ import {
  * across one match (or across patterns in a conjunction) must bind
  * structurally equal values — this IS the post-match equality constraint
  * between variables (§4.3.3 `constraints`, plan B1 "constraint correlation").
+ *
+ * NOT a `CfcAtom`: a pattern is atom-shaped but admits things an atom cannot
+ * -- `{ var }` placeholders, and an explicitly-`undefined` field, which is an
+ * absence check (`CfcJsonValue` has no `undefined`).
  */
-// NOT a `CfcAtom`: a pattern is atom-shaped but admits things an atom cannot
-// -- `{ var }` placeholders, and an explicitly-`undefined` field, which is an
-// absence check (`CfcJsonValue` has no `undefined`).
 export type AtomPattern = unknown;
 
 /** A binding environment produced by matching (spec §4.3.3 `Bindings`). */

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -1081,14 +1081,6 @@ export class Engine extends EventTarget {
   }
 
   /**
-   * Evaluate a verified ESM record graph: load it synchronously via `importNow`
-   * in a locked-down compartment whose globals are the hardened runtime globals
-   * (runtime-module records, already in the graph, supply the trusted host
-   * APIs), and return the entry namespace as `main` plus the per-module export
-   * map. The graph was security-verified at compile time, so verification is
-   * not repeated.
-   */
-  /**
    * Evaluate a verified ESM record graph (public so the PatternManager can run
    * compile → cache write-back → evaluate as discrete steps). Thin wrapper over
    * {@link evaluateGraph} with the source-compile registration strategy: module
@@ -1131,6 +1123,11 @@ export class Engine extends EventTarget {
    * ({@link evaluateCachedModules}); `ctx` supplies the path/identity handling
    * that differs between them (prefixed authored paths vs prefix-free cached
    * identities). The graph is assumed already security-verified.
+   *
+   * The graph loads synchronously via `importNow` in a locked-down compartment
+   * whose globals are the hardened runtime globals (runtime-module records,
+   * already in the graph, supply the trusted host APIs). The entry namespace
+   * comes back as `main`, alongside the per-module export map.
    */
   private evaluateGraph(
     graph: CompiledModuleGraph,

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -652,6 +652,17 @@ export class PatternManager {
   }
 
   /**
+   * The pattern-coverage collector to instrument a compile with: a per-call
+   * option wins, else the runtime-level default (`RuntimeOptions.patternCoverage`).
+   * Undefined leaves the compile uninstrumented.
+   */
+  private patternCoverageFor(
+    options?: TypeScriptHarnessProcessOptions,
+  ): PatternCoverageCollector | undefined {
+    return options?.patternCoverage ?? this.runtime.patternCoverage;
+  }
+
+  /**
    * Compile + evaluate a program's modules AND register the evaluated artifacts,
    * returning the full module namespace (`EvaluateResult`).
    *
@@ -670,17 +681,6 @@ export class PatternManager {
    * `Engine.compileAndEvaluateModules` only to inspect serialized/verified output
    * *without running* (engine unit tests), where stamping entry refs is unwanted.
    */
-  /**
-   * The pattern-coverage collector to instrument a compile with: a per-call
-   * option wins, else the runtime-level default (`RuntimeOptions.patternCoverage`).
-   * Undefined leaves the compile uninstrumented.
-   */
-  private patternCoverageFor(
-    options?: TypeScriptHarnessProcessOptions,
-  ): PatternCoverageCollector | undefined {
-    return options?.patternCoverage ?? this.runtime.patternCoverage;
-  }
-
   async compileAndRegisterModules(
     program: RuntimeProgram,
     options?: TypeScriptHarnessProcessOptions,

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -5299,12 +5299,13 @@ export class Runner {
    * replace the order with `[child2, parent]`, dropping `child1` to after the
    * parent (orderedCommitSpaces appends unlisted written spaces), which would
    * make the parent's link to `child1` durable before `child1`'s target.
+   *
+   * Public so the pattern builder (builder/pattern.ts
+   * `optIntoInSpaceMultiSpaceCommit`) can opt a transaction into a multi-space
+   * commit the moment a handler's `.inSpace(...)` target resolves — before the
+   * cross-space write executes (e.g. appending to the home `profiles` list,
+   * whose elements live in their own spaces).
    */
-  // Public so the pattern builder (builder/pattern.ts
-  // `optIntoInSpaceMultiSpaceCommit`) can opt a transaction into a multi-space
-  // commit the moment a handler's `.inSpace(...)` target resolves — before the
-  // cross-space write executes (e.g. appending to the home `profiles` list,
-  // whose elements live in their own spaces).
   enableCrossSpaceChildCommit(
     tx: IExtendedStorageTransaction,
     childSpace: MemorySpace,

--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -120,15 +120,6 @@ export function deriveModuleRecordFields(code: string): {
 }
 
 /**
- * Create a write-once exports target for a module body. Re-assigning,
- * redefining, or deleting a property that already holds a real (non-`undefined`)
- * value throws. A `void 0` placeholder — the TS `exports.x = void 0;` forward
- * declaration — leaves the property unlocked so the subsequent real assignment
- * is permitted, and the real assignment then locks it. This blocks export
- * corruption smuggled into the evaluation of an otherwise-accepted expression,
- * which the (deliberately AST-free) verifier cannot detect.
- */
-/**
  * Run a compiled module factory against a write-once exports object and snapshot
  * the declared exports onto `moduleExports` (the SES namespace target).
  *
@@ -225,23 +216,6 @@ function stampDefiningModule(
 export type HoistRegistrationSink = Map<string, Map<string, unknown>>;
 
 /**
- * Build the per-module `__cfReg` registrar (the module factory's 4th parameter)
- * plus a `commit` hook. The registrar enforces the integrity invariants that let
- * the verifier stay simple:
- *
- * - **Run-once**: a second `__cfReg(...)` call throws — an injected/duplicate
- *   registration aborts the import (which is terminal for the module).
- * - **Closed window**: calls after the module body returns throw, so a closure
- *   that captured `__cfReg` cannot register late (e.g. from a handler callback).
- * - **Transactional**: entries are staged locally and only flushed into `sink`
- *   by `commit()`, which the caller invokes ONLY after the factory returns
- *   normally. A throw (including the run-once trap) therefore leaves nothing
- *   behind.
- *
- * Security (trust of the registered values) is enforced separately, per value,
- * by the PatternManager — not here.
- */
-/**
  * The registrar handed to a module the verifier did NOT approve for hoist
  * registration (no valid top-level `__cfReg({ … })` call). Any invocation throws
  * — so a `__cfReg` reference the verifier's static check failed to reject still
@@ -262,6 +236,23 @@ export function createRejectingRegistrar(): {
   };
 }
 
+/**
+ * Build the per-module `__cfReg` registrar (the module factory's 4th parameter)
+ * plus a `commit` hook. The registrar enforces the integrity invariants that let
+ * the verifier stay simple:
+ *
+ * - **Run-once**: a second `__cfReg(...)` call throws — an injected/duplicate
+ *   registration aborts the import (which is terminal for the module).
+ * - **Closed window**: calls after the module body returns throw, so a closure
+ *   that captured `__cfReg` cannot register late (e.g. from a handler callback).
+ * - **Transactional**: entries are staged locally and only flushed into `sink`
+ *   by `commit()`, which the caller invokes ONLY after the factory returns
+ *   normally. A throw (including the run-once trap) therefore leaves nothing
+ *   behind.
+ *
+ * Security (trust of the registered values) is enforced separately, per value,
+ * by the PatternManager — not here.
+ */
 export function createHoistRegistrar(
   identity: string,
   sink: HoistRegistrationSink,
@@ -327,6 +318,15 @@ function hardenExportedValue<T>(value: T): T {
   }
 }
 
+/**
+ * Create a write-once exports target for a module body. Re-assigning,
+ * redefining, or deleting a property that already holds a real (non-`undefined`)
+ * value throws. A `void 0` placeholder — the TS `exports.x = void 0;` forward
+ * declaration — leaves the property unlocked so the subsequent real assignment
+ * is permitted, and the real assignment then locks it. This blocks export
+ * corruption smuggled into the evaluation of an otherwise-accepted expression,
+ * which the (deliberately AST-free) verifier cannot detect.
+ */
 export function createWriteOnceExports(): Record<string, unknown> {
   const target: Record<string, unknown> = {};
   const locked = new Set<string | symbol>();
@@ -1192,17 +1192,17 @@ function collectBindingNames(name: ts.BindingName, out: Set<string>): void {
   }
 }
 
-/**
- * Statically collect the names a module exports (named, default, enum,
- * namespace, destructured). Throws loudly on forms this adapter does not yet
- * support, rather than producing a silently-incomplete namespace.
- */
 /** Direct export names of a module plus the specifiers it `export *`s from. */
 interface ModuleExports {
   names: string[];
   starTargets: string[];
 }
 
+/**
+ * Statically collect the names a module exports (named, default, enum,
+ * namespace, destructured). Throws loudly on forms this adapter does not yet
+ * support, rather than producing a silently-incomplete namespace.
+ */
 function collectModuleExports(source: Source): ModuleExports {
   const { ts: tsc } = compilerStack();
   const sourceFile = tsc.createSourceFile(

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -1496,11 +1496,11 @@ class TransformObjectCreator
  * This assumes that there will not be a conflict in definitions between the
  * eventSchema and the stateSchema.
  */
-// TODO(@ubik2): We also need to re-write any relative refs
 export function generateHandlerSchema(
   eventSchema?: JSONSchema,
   stateSchema?: JSONSchema,
 ): JSONSchema | undefined {
+  // TODO(@ubik2): We also need to re-write any relative refs
   if (eventSchema === undefined && stateSchema === undefined) {
     return undefined;
   }

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -690,19 +690,6 @@ export type StorageTransactionStatus =
   };
 
 /**
- * Representation of a storage transaction, which can be used to query facts and
- * assert / retract while maintaining consistency guarantees. Storage ensures
- * that transactions retain consistent view of the whole storage through it's
- * lifetime by notifying pending transaction of every change that is integrated
- * into the storage, if changes affect any data read through a transaction
- * lifecycle it can not be committed because it would violate consistency. If
- * no change occurs or changes do not affect any data reading it would not
- * affect transaction consistency guarantees and therefor committing transaction
- * will send it to an upstream storage provider which will either accept, if no
- * invariants have being invalidated, or reject and fail commit.
- */
-
-/**
  * Options for {@link IStorageTransaction.commit}.
  */
 export interface TransactionCommitOptions {
@@ -727,6 +714,18 @@ export interface TransactionCommitOptions {
   resolveAt?: "coverage" | "verdict";
 }
 
+/**
+ * Representation of a storage transaction, which can be used to query facts and
+ * assert / retract while maintaining consistency guarantees. Storage ensures
+ * that transactions retain consistent view of the whole storage through it's
+ * lifetime by notifying pending transaction of every change that is integrated
+ * into the storage, if changes affect any data read through a transaction
+ * lifecycle it can not be committed because it would violate consistency. If
+ * no change occurs or changes do not affect any data reading it would not
+ * affect transaction consistency guarantees and therefor committing transaction
+ * will send it to an upstream storage provider which will either accept, if no
+ * invariants have being invalidated, or reject and fail commit.
+ */
 export interface IStorageTransaction {
   /**
    * Optional change group used to associate commits with scheduler actions.
@@ -1205,36 +1204,36 @@ export interface IExtendedStorageTransaction extends IStorageTransaction {
   getNarrowestReadScope(): CellScope;
   resetNarrowestReadScope(scope?: CellScope): void;
 
-  /**
-   * CFC recording / ownership-transfer API.
-   *
-   * The methods below all hand a caller-constructed record into the CFC
-   * subsystem's transaction-scoped state. Each one establishes an
-   * ownership transfer at the call boundary: from the moment the call
-   * returns, the supplied record is owned by the transaction. Callers
-   * MUST NOT subsequently mutate it (or any object reachable from it),
-   * and MUST NOT retain it for use anywhere else that depends on it
-   * remaining mutable.
-   *
-   * The CFC subsystem treats these records as identity-stable structural
-   * fingerprints — they participate in canonicalization, sorting, and
-   * `hashStringOf()`-based equality. The CFC implementation is therefore
-   * permitted to `deepFreeze()` the record on entry, both as a tripwire
-   * for accidental mutation and to make it eligible for the
-   * `hashStringOf()` WeakMap cache. The
-   * `record*` methods that take a structurally-shaped record
-   * (`recordCfcDereferenceTrace()` and `recordCfcWritePolicyInput()`)
-   * actively do this on entry; the contract applies uniformly to every
-   * method in the group.
-   *
-   * Callers do not need to freeze the record themselves — the CFC
-   * implementation will, where it's useful. Freezing on the caller side
-   * is equally welcome though, and is often a reasonable choice when
-   * the same record (or sub-objects) is also handed to other consumers
-   * with similar contracts; `deepFreeze()` short-circuits on input
-   * that's already deeply frozen, so a redundant freeze costs almost
-   * nothing.
-   */
+  //
+  // CFC recording / ownership-transfer API
+  //
+  // The methods below all hand a caller-constructed record into the CFC
+  // subsystem's transaction-scoped state. Each one establishes an
+  // ownership transfer at the call boundary: from the moment the call
+  // returns, the supplied record is owned by the transaction. Callers
+  // MUST NOT subsequently mutate it (or any object reachable from it),
+  // and MUST NOT retain it for use anywhere else that depends on it
+  // remaining mutable.
+  //
+  // The CFC subsystem treats these records as identity-stable structural
+  // fingerprints — they participate in canonicalization, sorting, and
+  // `hashStringOf()`-based equality. The CFC implementation is therefore
+  // permitted to `deepFreeze()` the record on entry, both as a tripwire
+  // for accidental mutation and to make it eligible for the
+  // `hashStringOf()` WeakMap cache. The
+  // `record*` methods that take a structurally-shaped record
+  // (`recordCfcDereferenceTrace()` and `recordCfcWritePolicyInput()`)
+  // actively do this on entry; the contract applies uniformly to every
+  // method in the group.
+  //
+  // Callers do not need to freeze the record themselves — the CFC
+  // implementation will, where it's useful. Freezing on the caller side
+  // is equally welcome though, and is often a reasonable choice when
+  // the same record (or sub-objects) is also handed to other consumers
+  // with similar contracts; `deepFreeze()` short-circuits on input
+  // that's already deeply frozen, so a redundant freeze costs almost
+  // nothing.
+  //
 
   /**
    * Records a CFC dereference trace produced by following a write


### PR DESCRIPTION
I (an agent working on behalf of @danfuzz) swept the repository for doc comments
separated from the declaration they document, after the rule for this landed in
`docs/development/code-comment-style.md` ("Where one goes"). This is the
`runner` share of the cleanup; other packages follow separately.

Eleven sites. In most, a definition had been added directly beneath an existing
doc comment, so the comment attached to the newcomer and the declaration it was
written for was left undocumented. Each moves to its subject.

## Straight moves

`encodeSqliteParams` and `CellImpl.map` (`cell.ts`), `generateText`
(`builtins/llm.ts`), `compileAndRegisterModules` (`pattern-manager.ts`),
`createWriteOnceExports`, `createHoistRegistrar` and `collectModuleExports`
(`sandbox/module-record-compiler.ts`), `IStorageTransaction`
(`storage/interface.ts`). Every one of these declarations had no doc comment
of its own before this change.

## Folded into the doc comment

Where a `//` note was about the declaration as a whole and the declaration has
no body to hold it, the note becomes part of the doc comment, wording
unchanged: the function-first form of `lift()` (`builder/module.ts`), the
visibility rationale on `enableCrossSpaceChildCommit` (`runner.ts`), and the
"not a `CfcAtom`" note on `AtomPattern` (`cfc/atom-pattern.ts`). The
`// TODO(@ubik2)` on `generateHandlerSchema` (`schema.ts`) moves into the
body instead, since there is one.

## Three judgement calls worth a look

- **`harness/engine.ts`** — two doc comments sat on `evaluateRecordGraph`. The
  first describes `evaluateGraph`, which already has its own doc, so this was
  not a move but a merge: the mechanism paragraph is folded into
  `evaluateGraph`'s doc and the duplicate opener dropped. I verified each claim
  against that method's body rather than trusting the prose —
  `createModuleCompartmentGlobals`, `loadModuleGraph(..., verify: false)`,
  `loaded.importNow(specifier)`, and a return of `main` (the loaded namespace)
  plus the per-module export map.
- **`builder/action-context.ts`** — the "Ambient marker for …" block sat
  between the imports and `ActionWindowStorage`, which had taken it over. It
  reads like a file-level explainer, but `git log` says otherwise: it was
  written against `interface ActionWindowStore` in #4110, and that interface
  plus its fallback class later moved to
  `@commonfabric/utils/async-local-store`, which is what stranded it. It goes
  onto `actionWindow` — the surviving declaration it describes, and the one the
  `AsyncLocalStorage` paragraph is about. The `//` note about the `await
  import` stays on the const it actually describes.
- **`storage/interface.ts`** — the CFC recording/ownership-transfer banner
  introduces a group of methods and documented nothing. It becomes a `//`
  section marker, which is the form `code-comment-style.md` specifies for
  titling a region of a class.

## One deletion

`builder/module.ts` drops `// Overload 1: …` and `// Overload 2: …` from
`action()`. Each restated the signature directly beneath it with no added
"why". The third label stays: it carries the reasoning for why a declared
result is never inferred from the callback.

## Left alone deliberately

- `builder/pattern.ts` — `// Function-only overloads (most common)` splits
  `pattern()`'s doc comment from its first overload, but it labels a *group*
  within an overload set the doc comment covers as a whole, and "(most
  common)" is not in the signatures. The carve-out for labels of that kind is
  #5621; under it this one stays as written.
- `path-utils.ts` — `// deno-lint-ignore` has to sit on the line before the
  code it governs; already an explicit exception in the guidance.
- Module-level explainers placed after the imports (`cfc/*.ts`,
  `compilation-cache/cell-cache.ts`, `schema.ts`, and ~35 others across the
  tree). These document the file rather than a declaration. Whether they
  should be section markers instead is a separate question, and a repo-wide
  one.

## Verification

`deno task check`, `deno lint packages/runner`, `deno fmt --check`, and the
full `runner` suite: **1185 passed, 0 failed**.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


