### PR TITLE
docs(api,html,ui,shell,runtime-client): reattach doc comments to their declarations

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -757,13 +757,12 @@ export interface IKeyable<out T, Wrap extends HKT> {
   /**
    * Navigate to nested properties by one or more keys.
    *
-   * Overloads to avoid recursive type evaluation which causes stack overflow.
-   *
    * @example
    * cell.key("user")                      // Cell<User>
    * cell.key("user", "profile")           // Cell<Profile>
    * cell.key("user", "profile", "name")   // Cell<string>
    */
+  // Overloads to avoid recursive type evaluation which causes stack overflow
   // Zero keys
   key(this: IsThisObject): Apply<Wrap, T>;
   // One key
@@ -983,9 +982,8 @@ export type KeyResultTypeOpaque<
 export interface IKeyableOpaque<T> {
   /**
    * Navigate to nested properties by one or more keys.
-   *
-   * Overloads to avoid recursive type evaluation which causes stack overflow.
    */
+  // Overloads to avoid recursive type evaluation which causes stack overflow
   key(this: IsThisObject): OpaqueCell<T>;
   key<K1 extends keyof UnwrapCell<T>>(
     this: IsThisObject,

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -757,12 +757,13 @@ export interface IKeyable<out T, Wrap extends HKT> {
   /**
    * Navigate to nested properties by one or more keys.
    *
+   * Overloads to avoid recursive type evaluation which causes stack overflow.
+   *
    * @example
    * cell.key("user")                      // Cell<User>
    * cell.key("user", "profile")           // Cell<Profile>
    * cell.key("user", "profile", "name")   // Cell<string>
    */
-  // Overloads to avoid recursive type evaluation which causes stack overflow
   // Zero keys
   key(this: IsThisObject): Apply<Wrap, T>;
   // One key
@@ -982,8 +983,9 @@ export type KeyResultTypeOpaque<
 export interface IKeyableOpaque<T> {
   /**
    * Navigate to nested properties by one or more keys.
+   *
+   * Overloads to avoid recursive type evaluation which causes stack overflow.
    */
-  // Overloads to avoid recursive type evaluation which causes stack overflow
   key(this: IsThisObject): OpaqueCell<T>;
   key<K1 extends keyof UnwrapCell<T>>(
     this: IsThisObject,
@@ -1638,10 +1640,6 @@ export type FactoryInput<T> =
     : T extends object ? { [K in keyof T]: FactoryInput<T[K]> }
     : T);
 
-/**
- * Matches any non-opaque Cell type (Cell, Stream, ComparableCell, etc.) that may be
- * wrapped in any number of Reactive layers. Excludes OpaqueCell and AnyCell (since OpaqueCell extends AnyCell).
- */
 /**
  * Recursively unwraps AnyBrandedCell types at any nesting level.
  * UnwrapCell<AnyBrandedCell<AnyBrandedCell<string>>> = string
@@ -2611,8 +2609,7 @@ export interface HandlerFunction {
  * The transformer extracts closures and makes them explicit, just like how
  * computed(() => expr) becomes a lift-applied computation with closure
  * extraction.
- */
-/**
+ *
  * This is the surface a PATTERN sees — `commonfabric` resolves to this file, so
  * these overloads and `builder/module.ts`'s `action()` must carry the same
  * signatures. They are maintained by hand and drift silently: an overload

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -2617,9 +2617,7 @@ export interface HandlerFunction {
  * result overload below was initially missed.
  */
 export type ActionFunction = {
-  // Overload 1: Zero-parameter callback returns Stream<void>
   (fn: () => void): Stream<void>;
-  // Overload 2: Parameterized callback returns Stream<E>
   <E>(fn: (event: E) => void): Stream<E>;
   // Overload 3: a declared result, reached only by naming both type arguments.
   // Never inferred — a concise arrow body returns whatever its last call

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -2607,13 +2607,12 @@ export interface HandlerFunction {
  * The transformer extracts closures and makes them explicit, just like how
  * computed(() => expr) becomes a lift-applied computation with closure
  * extraction.
- *
- * This is the surface a PATTERN sees — `commonfabric` resolves to this file, so
- * these overloads and `builder/module.ts`'s `action()` must carry the same
- * signatures. They are maintained by hand and drift silently: an overload
- * present only in the builder is invisible to every pattern, which is how the
- * result overload below was initially missed.
  */
+// This is the surface a PATTERN sees — `commonfabric` resolves to this file, so
+// these overloads and `builder/module.ts`'s `action()` must carry the same
+// signatures. They are maintained by hand and drift silently: an overload
+// present only in the builder is invisible to every pattern, which is how the
+// result overload below was initially missed.
 export type ActionFunction = {
   (fn: () => void): Stream<void>;
   <E>(fn: (event: E) => void): Stream<E>;

--- a/packages/html/src/h.ts
+++ b/packages/html/src/h.ts
@@ -59,9 +59,6 @@ function bindingTargetLink(value: unknown): unknown {
  * @param props - Element properties
  * @param children - Child elements
  * @returns A virtual DOM node or JSX element (for component functions)
- *
- * Implementation uses broader types than overloads - assertion needed for TS
- * compatibility.
  */
 export const h: HFunction = Object.assign(
   function h(
@@ -69,6 +66,8 @@ export const h: HFunction = Object.assign(
     props: { [key: string]: any } | null,
     ...children: RenderNode[]
   ): JSXElement {
+    // Implementation uses broader types than overloads - assertion needed for
+    // TS compatibility.
     if (typeof name === "function") {
       return name({
         ...(props ?? {}),

--- a/packages/html/src/h.ts
+++ b/packages/html/src/h.ts
@@ -59,8 +59,10 @@ function bindingTargetLink(value: unknown): unknown {
  * @param props - Element properties
  * @param children - Child elements
  * @returns A virtual DOM node or JSX element (for component functions)
+ *
+ * Implementation uses broader types than overloads - assertion needed for TS
+ * compatibility.
  */
-// Implementation uses broader types than overloads - assertion needed for TS compatibility
 export const h: HFunction = Object.assign(
   function h(
     name: string | ((...args: any[]) => JSXElement),

--- a/packages/html/src/jsx.d.ts
+++ b/packages/html/src/jsx.d.ts
@@ -1453,7 +1453,6 @@ declare namespace CFDOM {
      * presented if they are made.
      */
     "aria-autocomplete"?: "none" | "inline" | "list" | "both" | undefined;
-    /** Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user. */
     /**
      * Defines a string value that labels the current element, which is intended to be converted into Braille.
      * @see aria-label.
@@ -1464,6 +1463,7 @@ declare namespace CFDOM {
      * @see aria-roledescription.
      */
     "aria-brailleroledescription"?: string | undefined;
+    /** Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user. */
     "aria-busy"?: Booleanish | undefined;
     /**
      * Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -201,13 +201,6 @@ export class WorkerReconciler {
     };
   }
 
-  /**
-   * Mount a VDOM tree, starting the reconciliation process.
-   * Children are inserted directly into the container (CONTAINER_NODE_ID).
-   *
-   * @param vnode - The root VNode, Cell<VNode>, or Cell<unknown> to mount
-   * @returns A cancel function to unmount the tree
-   */
   /** Best-effort space of a cell; undefined when it can't name one. */
   private spaceOfCell(cell: Cell<unknown>): string | undefined {
     try {
@@ -217,6 +210,13 @@ export class WorkerReconciler {
     }
   }
 
+  /**
+   * Mount a VDOM tree, starting the reconciliation process.
+   * Children are inserted directly into the container (CONTAINER_NODE_ID).
+   *
+   * @param vnode - The root VNode, Cell<VNode>, or Cell<unknown> to mount
+   * @returns A cancel function to unmount the tree
+   */
   mount(vnode: WorkerVNode | Cell<WorkerVNode> | Cell<unknown>): Cancel {
     logger.debug(
       "mount",
@@ -1870,9 +1870,6 @@ export class WorkerReconciler {
   }
 
   /**
-   * Update an event prop.
-   */
-  /**
    * Helper to get a debug ID for a cell (space/id or similar).
    */
   private getCellDebugId(cell: Cell<unknown>): string {
@@ -1886,6 +1883,9 @@ export class WorkerReconciler {
     }
   }
 
+  /**
+   * Update an event prop.
+   */
   private updateEventProp(
     ctx: ReconcileContext,
     state: NodeState,

--- a/packages/runtime-client/cell-handle.ts
+++ b/packages/runtime-client/cell-handle.ts
@@ -255,12 +255,6 @@ export class CellHandle<T = unknown> {
     );
   }
 
-  /**
-   * Subscribe to cell value changes.
-   * The callback is called immediately with the current value (even if undefined)
-   * and whenever the value changes.
-   * The callback's return value (if a Cancel function) is called before the next update.
-   */
   /** The cell's current display CFC label, for label-aware subscribers. */
   get cfcLabel(): CfcLabelView | undefined {
     return this.#cfcLabel;
@@ -271,6 +265,12 @@ export class CellHandle<T = unknown> {
     return this.#wantsCfcLabel;
   }
 
+  /**
+   * Subscribe to cell value changes.
+   * The callback is called immediately with the current value (even if undefined)
+   * and whenever the value changes.
+   * The callback's return value (if a Cancel function) is called before the next update.
+   */
   subscribe(
     callback: (
       value: T | undefined,

--- a/packages/shell/src/views/SchedulerGraphView.ts
+++ b/packages/shell/src/views/SchedulerGraphView.ts
@@ -47,15 +47,15 @@ interface LayoutEdge {
 const NODE_WIDTH = 140;
 const NODE_HEIGHT = 36;
 
-/**
- * Scheduler Graph visualization component.
- * Shows dependency graph with effects and computations.
- */
 // Entity-scheme parsers derived from the canonical scheme set, so a new
 // entity kind cannot leave a stale `of|computed` alternation here.
 const ENTITY_SCHEME_ALT = ENTITY_URI_SCHEMES.join("|");
 const ENTITY_SCHEME_PART_RE = new RegExp(`^(?:${ENTITY_SCHEME_ALT}):(.*)$`);
 
+/**
+ * Scheduler Graph visualization component.
+ * Shows dependency graph with effects and computations.
+ */
 export class XSchedulerGraph extends LitElement {
   static override styles = css`
     :host {

--- a/packages/ui/src/v2/components/cf-textarea/cf-textarea.ts
+++ b/packages/ui/src/v2/components/cf-textarea/cf-textarea.ts
@@ -53,7 +53,6 @@ export type TimingStrategy = "immediate" | "debounce" | "throttle" | "blur";
  * <!-- Debounced input - waits 500ms after user stops typing -->
  * <cf-textarea timingStrategy="debounce" timingDelay="500" placeholder="Search..."></cf-textarea>
  */
-
 export class CFTextarea extends BaseElement {
   static formAssociated = true;
 


### PR DESCRIPTION
I (an agent working on behalf of @danfuzz) swept the repository for doc comments
separated from the declaration they document, after the rule for this landed in
`docs/development/code-comment-style.md` ("Where one goes"). This covers `api`,
`html`, `ui`, `shell` and `runtime-client`; other packages follow separately.

Seven sites. In most, a definition had been added directly beneath an existing
doc comment, so the comment attached to the newcomer and the declaration it was
written for was left with none.

## Straight moves

`mount` and `updateEventProp` (`html/src/worker/reconciler.ts`), `subscribe`
(`runtime-client/cell-handle.ts`), `"aria-busy"` (`html/src/jsx.d.ts` — the
alphabetically-earlier `aria-braillelabel` / `aria-brailleroledescription`
were inserted underneath its doc), and `XSchedulerGraph`
(`shell/src/views/SchedulerGraphView.ts`, taken over by two inserted regex
consts).

## Folded into the doc comment

Where a `//` note is about the declaration as a whole and the declaration has
no body to hold it, the note becomes part of the doc comment with its wording
unchanged: the broader-types assertion on `h` (`html/src/h.ts`), and the
per-arity rationale on `IKeyable.key` and `IKeyableOpaque.key`
(`api/index.ts`).

`IKeyable`'s `// Zero keys` / `// One key` / … labels **stay put**, including
the first one, which sits between the doc comment and the first signature.
They identify individual members of an overload set the doc comment covers as
a whole, and they form a series — removing only the first would break it, and
removing all five would lose real navigation help across near-identical
generic signatures. I think the guidance wants a carve-out for that shape;
raising it separately.

## Two that are not moves

- **A doc comment for a deleted type.** `api/index.ts` carried
  "Matches any non-opaque Cell type … Excludes OpaqueCell and AnyCell", which
  documented `AnyCellWrappedInOpaqueRef` (added in #2027). That type and its
  `UnwrapOpaqueRefLayers*` helpers are gone from the tree, so the comment had
  come to sit on `UnwrapCell` instead. Deleted. Worth noting that a later
  wording sweep updated its "OpaqueRef layers" to "Reactive layers" — the
  comment was maintained for a year after its subject stopped existing.
- **`ActionFunction` carried two doc comments** (`api/index.ts`), so only the
  second reached rendered documentation. Merged into one.

## One deletion for symmetry

`ActionFunction` and `builder/module.ts`'s `action()` are hand-maintained
twins — `ActionFunction`'s own doc comment says so. The `// Overload 1` and
`// Overload 2` labels on each restate the signature directly beneath them and
add no "why", so they are dropped from both copies (the `action()` half is in
the `runner` PR). The third label stays in both: it carries the reasoning for
why a declared result is never inferred from the callback. This is the one
change here that is not an adjacency fix.

## One blank line

`CFTextarea`'s doc comment was separated from the class by a stray blank line.

## Verification

`deno task check`, `deno lint`, `deno fmt --check`, and the `api`, `html`,
`runtime-client` and `shell` suites plus `ui`'s non-browser half: **337
passed, 0 failed**. `ui`'s browser tests were not run — every change here is
to a comment, and the three browser files are untouched.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


