### PR TITLE
docs: allow a label on one member of an overload set

### DIFF
--- a/docs/development/code-comment-style.md
+++ b/docs/development/code-comment-style.md
@@ -340,9 +340,38 @@ Three shapes break this, each of which looks harmless while being written:
   declaration, so the other is invisible wherever documentation is rendered.
   Merge them if both say something worth keeping.
 
-The one exception is a tool directive — `// deno-lint-ignore`,
-`// deno-fmt-ignore`, `// @ts-types` — which has to sit on the line
-immediately before the code it governs, and so has nowhere else to go.
+Two things are exceptions. A tool directive — `// deno-lint-ignore`,
+`// deno-fmt-ignore`, `// @ts-types` — has to sit on the line immediately
+before the code it governs, and so has nowhere else to go.
+
+The other is a label on one member of a set that a single doc comment covers
+as a whole. An overload list is the case that comes up: the doc comment
+describes the function, and a `//` label picks out which signature is which,
+including the first one. That label is part of the list's own structure rather
+than a note wedged in front of the contract, and it stays:
+
+```ts
+// Shown at module scope.
+
+/**
+ * Fry a donut, in whichever of the shapes the fryer accepts.
+ *
+ * Spelled out per shape rather than over a union, so each call site gets back
+ * exactly the shape it handed in.
+ */
+// The common case.
+export function fry(donut: string): string;
+// A tray, lowered into the oil as one batch.
+export function fry(donuts: string[]): string[];
+export function fry(donuts: string | string[]): string | string[] {
+  return donuts;
+}
+```
+
+A label earns that place by saying which member this is, in a list where the
+signatures are hard to tell apart at a glance. One that only restates the
+signature beneath it is not doing that work, and goes — even if it leaves the
+rest of a numbered series behind, because the numbering was never the point.
 
 A doc comment with no declaration under it at all is the same defect from the
 other direction. To title a region of a file or a class, use a section marker,

--- a/docs/development/code-comment-style.md
+++ b/docs/development/code-comment-style.md
@@ -344,27 +344,32 @@ Two things are exceptions. A tool directive — `// deno-lint-ignore`,
 `// deno-fmt-ignore`, `// @ts-types` — has to sit on the line immediately
 before the code it governs, and so has nowhere else to go.
 
-The other is a label on one member of a set that a single doc comment covers
-as a whole. An overload list is the case that comes up: the doc comment
-describes the function, and a `//` label picks out which signature is which,
-including the first one. That label is part of the list's own structure rather
-than a note wedged in front of the contract, and it stays:
+The other is narrower than it first sounds. One doc comment covers a whole
+overload set, and `//` labels say which signature is which. Every label but
+one follows a declaration, so the rule never reached them; the exception is
+for the first label alone, which has nowhere to sit but between the doc
+comment and the first signature:
 
 ```ts
 // Shown at module scope.
 
 /**
- * Fry a donut, in whichever of the shapes the fryer accepts.
+ * Reads a topping off a donut, by one key or by two.
  *
- * Spelled out per shape rather than over a union, so each call site gets back
- * exactly the shape it handed in.
+ * One signature per depth, so that type evaluation cannot recurse without
+ * bound.
  */
-// The common case.
-export function fry(donut: string): string;
-// A tray, lowered into the oil as one batch.
-export function fry(donuts: string[]): string[];
-export function fry(donuts: string | string[]): string | string[] {
-  return donuts;
+// One key.
+export function topping<T, K1 extends keyof T>(donut: T, k1: K1): T[K1];
+// Two keys.
+export function topping<T, K1 extends keyof T, K2 extends keyof T[K1]>(
+  donut: T,
+  k1: K1,
+  k2: K2,
+): T[K1][K2];
+// deno-lint-ignore no-explicit-any
+export function topping(donut: any, ...keys: PropertyKey[]): any {
+  return keys.reduce((value, key) => value[key], donut);
 }
 ```
 
@@ -372,6 +377,9 @@ A label earns that place by saying which member this is, in a list where the
 signatures are hard to tell apart at a glance. One that only restates the
 signature beneath it is not doing that work, and goes — even if it leaves the
 rest of a numbered series behind, because the numbering was never the point.
+
+A remark about the set as a whole is not a label, whichever line it sits on.
+It belongs in the doc comment, which is the thing that covers the set.
 
 A doc comment with no declaration under it at all is the same defect from the
 other direction. To title a region of a file or a class, use a section marker,

--- a/skills/cf-review/SKILL.md
+++ b/skills/cf-review/SKILL.md
@@ -207,8 +207,9 @@ recurse and time out CI). Run `deno fmt` and `deno lint` on touched files.
 the one place it is easy to see. A definition added directly under an existing
 doc comment takes that comment over and leaves the declaration it was written
 for undocumented; a `//` note wedged in between splits the contract from its
-subject. Two doc comments in a row are the loudest tell — only the nearer one
-survives into rendered documentation. See
+subject, unless it is a label picking out one member of an overload set, which
+is allowed for. Two doc comments in a row are the loudest tell — only the nearer
+one survives into rendered documentation. See
 `docs/development/code-comment-style.md`, "Where one goes".
 
 ### 6. Craft & conventions

--- a/skills/cf-review/SKILL.md
+++ b/skills/cf-review/SKILL.md
@@ -208,8 +208,8 @@ the one place it is easy to see. A definition added directly under an existing
 doc comment takes that comment over and leaves the declaration it was written
 for undocumented; a `//` note wedged in between splits the contract from its
 subject, unless it is a label picking out one member of an overload set, which
-is allowed for. Two doc comments in a row are the loudest tell — only the nearer
-one survives into rendered documentation. See
+is allowed. Two doc comments in a row are the loudest tell — only the nearer one
+survives into rendered documentation. See
 `docs/development/code-comment-style.md`, "Where one goes".
 
 ### 6. Craft & conventions


### PR DESCRIPTION
I (an agent working on behalf of @danfuzz) wrote the adjacency rule in
`docs/development/code-comment-style.md` ("Where one goes") to say that a `//`
comment never sits between a doc comment and its declaration. Applying it
across the tree turned up a shape where that is too strong.

## The shape

Where a single doc comment covers a **set** of declarations, a `//` label
saying which member is which belongs to the list's own structure — and the
first such label necessarily lands between the doc comment and the first
signature. `IKeyable.key` in `packages/api/index.ts` is the case that
motivates it:

```ts
/**
 * Navigate to nested properties by one or more keys.
 * …
 */
// Zero keys
key(this: IsThisObject): Apply<Wrap, T>;
// One key
key<K1 extends keyof T>(this: IsThisObject, k1: K1): Apply<Wrap, T[K1]>;
// Two keys
…
```

Five near-identical generic signatures, told apart only by those labels.
Removing the first breaks the series; removing all five loses real navigation
help. Neither is an improvement over the "defect".

## What this adds

A second exception alongside the tool-directive one, with a worked example,
plus the test that keeps it from swallowing the rule: **a label earns its place
by saying which member this is.** One that merely restates the signature
beneath it is not doing that work and still goes — even if that leaves a
numbered series with a gap, because the numbering was never the point.

That test comes from the counter-case. `action()` in
`packages/runner/src/builder/module.ts` carried
`// Overload 1: Zero-parameter callback returns Stream<void>` above
`action(_event: () => void): Stream<void>`, which says nothing the signature
does not. Those went, in the `runner` cleanup PR; `IKeyable`'s labels stay, in
the `api` one.

`skills/cf-review/SKILL.md` gets the same qualifier, so a reviewer applying the
rule does not raise the allowed shape as a finding.

## Verification

`deno task check-docs` (538 blocks, including the new one),
`deno task check-skill-facts`, `deno fmt --check`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

