### PR TITLE
fix(patterns): retain tests across source updates

### DIFF
--- a/.claude/agents/manual-tester.md
+++ b/.claude/agents/manual-tester.md
@@ -56,16 +56,25 @@ Default URLs (no offset): Toolshed http://localhost:8000, Shell http://localhost
 
 ### 2. Deploy the Pattern
 
-If no piece ID is provided, deploy the pattern:
+Find every authored `*.test.tsx` entry for the pattern and run it before
+manual verification. Manual CLI and browser checks complement automated pattern
+tests; they do not replace them.
 
 ```bash
-deno task cf piece new {pattern-path}/main.tsx \
-  --identity claude.key \
-  --api-url {api-url} \
-  --space {space-name}
+deno task cf test {pattern-path}/main.test.tsx
 ```
 
-Save the piece ID from the output.
+If no piece ID is provided, deploy the pattern with every test entry attached.
+Repeat `--test` when the pattern has more than one test entry:
+
+```bash
+deno task cf piece new {pattern-path}/main.tsx --test {pattern-path}/main.test.tsx --identity claude.key --api-url {api-url} --space {space-name}
+```
+
+Save the piece ID from the output. If debugging changes the source, update the
+existing piece with `setsrc` and the same complete set of `--test` flags.
+Omitting the flags creates a new source revision without those attached test
+roots.
 
 ### 3. CLI Verification (call -> step -> inspect)
 

--- a/.claude/agents/pattern-maker.md
+++ b/.claude/agents/pattern-maker.md
@@ -47,6 +47,10 @@ or changed behavior:
 - User-visible flows that the PR changes
 - Regressions fixed by the PR
 
+Run every authored pattern test with `deno task cf test`. Keep the test entry
+paths with the implementation handoff so the deployment phase can attach every
+entry with repeatable `--test` flags.
+
 ## Updating Existing Code
 
 - Read existing code first
@@ -58,4 +62,5 @@ or changed behavior:
 - Pattern runs without errors
 - Core behavior works (verified by running it)
 - New code and behavior has automated test coverage
+- Every test entry passes and is identified for deployment
 - Ready for user to try

--- a/.claude/agents/pattern-user.md
+++ b/.claude/agents/pattern-user.md
@@ -26,15 +26,23 @@ Load `Skill("cf")` first for cf CLI documentation.
 
 ## Key Commands
 
+Before deploying new or changed pattern source, find every authored
+`*.test.tsx` entry that covers it and run each one with `cf test`. Stop if any
+entry fails. Once all entries pass, attach every authored test entry to the
+source package by repeating `--test`.
+
 ```bash
 # Check compilation only (no server, no deploy)
 deno task cf check main.tsx --no-run
 
+# Run the authored pattern test
+deno task cf test main.test.tsx
+
 # Deploy to toolshed (this is how you "run" it)
-API_URL=<url> deno task cf piece new main.tsx --identity <key_path>
+API_URL=<url> deno task cf piece new main.tsx --test main.test.tsx --identity <key_path>
 
 # Update existing piece
-API_URL=<url> deno task cf piece setsrc main.tsx --piece <piece_id> --identity <key_path>
+API_URL=<url> deno task cf piece setsrc main.tsx --test main.test.tsx --piece <piece_id> --identity <key_path>
 
 # Inspect state / call handler
 API_URL=<url> deno task cf piece inspect --piece <piece_id> --identity <key_path>
@@ -45,10 +53,17 @@ API_URL=<url> deno task cf piece call <handler> --piece <piece_id> --identity <k
 
 1. **Ask for config** (key, API URL, space)
 2. **Check compilation** (`cf check --no-run`)
-3. **Deploy** (`cf piece new`) — this gives you a piece ID and URL
-4. **Give user the link** to test in browser
-5. **Debug** with `inspect` and `call` as needed
+3. **Write or update automated tests** for changed behavior
+4. **Run every test entry** with `cf test`
+5. **Deploy with every test attached** using repeatable `--test`
+6. **Give user the link** to test in browser
+7. **Debug** with `inspect` and `call` as needed
+
+`--test` packages and type-checks the test; it does not run it. Repeat the
+same test flags on every `setsrc`, because each update defines the complete
+source package for that revision.
 
 ## Done When
 
-Piece deployed, user has link to test.
+Automated tests pass, every test entry is attached to the deployed source
+revision, the piece is deployed, and the user has the link.

--- a/.claude/scripts/pattern-user-post-bash.test.ts
+++ b/.claude/scripts/pattern-user-post-bash.test.ts
@@ -1,6 +1,9 @@
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
-import { suggestionForPatternUserCommand } from "./pattern-user-post-bash.ts";
+import {
+  parseShellCommandSegments,
+  suggestionForPatternUserCommand,
+} from "./pattern-user-post-bash.ts";
 
 describe("pattern-user-post-bash", () => {
   describe("suggestionForPatternUserCommand()", () => {
@@ -21,7 +24,46 @@ describe("pattern-user-post-bash", () => {
         suggestionForPatternUserCommand(
           "cf piece new main.tsx --test main.test.tsx",
         ),
-      ).toContain("Attached tests are packaged, not run");
+      ).toContain("The command attaches tests for packaging");
+    });
+
+    it("does not count a bare trailing test option as an attachment", () => {
+      for (
+        const command of [
+          "cf piece new main.tsx --test",
+          "cf piece new main.tsx --test 2>/dev/null",
+          "cf piece new main.tsx --test >output",
+          "cf piece new main.tsx --test | head -1",
+          'cf piece new main.tsx --test=""',
+        ]
+      ) {
+        expect(suggestionForPatternUserCommand(command)).toContain(
+          "No tests were attached",
+        );
+      }
+    });
+
+    it("accepts explicit and escaped test paths", () => {
+      for (
+        const command of [
+          "cf piece new main.tsx --test=-smoke.test.tsx",
+          String.raw`cf piece new main.tsx --test=\#smoke.test.tsx`,
+          String.raw`cf piece new main.tsx --test \>smoke.test.tsx`,
+        ]
+      ) {
+        expect(suggestionForPatternUserCommand(command)).toContain(
+          "The command attaches tests for packaging",
+        );
+      }
+    });
+
+    it("does not treat a malformed diagnostic deployment as successful", () => {
+      const suggestion = suggestionForPatternUserCommand(
+        "cf piece new ./main.test.tsx --test",
+      );
+
+      expect(suggestion).toContain("No tests were attached");
+      expect(suggestion).not.toContain("Test pattern deployed");
     });
 
     it("warns when a custom home pattern omits attached tests", () => {
@@ -46,8 +88,202 @@ describe("pattern-user-post-bash", () => {
           "cf piece setsrc b.tsx --piece B",
       );
 
-      expect(suggestion).toContain("Attached tests are packaged, not run");
+      expect(suggestion).toContain("The command attaches tests for packaging");
       expect(suggestion).toContain("No tests were attached");
+    });
+
+    it("checks every deployment separated by a background operator", () => {
+      for (
+        const command of [
+          "cf piece setsrc a.tsx --test a.test.tsx --piece A & cf piece setsrc b.tsx --piece B",
+          "cf piece setsrc a.tsx --piece A & cf piece setsrc b.tsx --test b.test.tsx --piece B",
+        ]
+      ) {
+        const suggestion = suggestionForPatternUserCommand(command);
+        expect(suggestion).toContain(
+          "The command attaches tests for packaging",
+        );
+        expect(suggestion).toContain("No tests were attached");
+      }
+    });
+
+    it("checks every deployment separated by a pipeline", () => {
+      const suggestion = suggestionForPatternUserCommand(
+        "cf piece setsrc a.tsx --test a.test.tsx --piece A | " +
+          "cf piece setsrc b.tsx --piece B",
+      );
+
+      expect(suggestion).toContain("The command attaches tests for packaging");
+      expect(suggestion).toContain("No tests were attached");
+    });
+
+    it("ignores deployments inside shell comments", () => {
+      const suggestion = suggestionForPatternUserCommand(
+        "cf piece new main.tsx --test main.test.tsx " +
+          "# old note & cf piece setsrc old.tsx",
+      );
+
+      expect(suggestion).toContain("The command attaches tests for packaging");
+      expect(suggestion).not.toContain("No tests were attached");
+    });
+
+    it("checks background deployments inside command substitutions", () => {
+      const suggestion = suggestionForPatternUserCommand(
+        'result="$(cf piece setsrc a.tsx --test a.test.tsx --piece A & ' +
+          'cf piece setsrc b.tsx --piece B)"',
+      );
+
+      expect(suggestion).toContain("The command attaches tests for packaging");
+      expect(suggestion).toContain("No tests were attached");
+    });
+
+    it("checks deployments inside backtick command substitutions", () => {
+      const suggestion = suggestionForPatternUserCommand(
+        "result=`cf piece setsrc main.tsx --piece ID`",
+      );
+
+      expect(suggestion).toContain("No tests were attached");
+    });
+
+    it("checks deployments inside top-level subshells", () => {
+      const suggestion = suggestionForPatternUserCommand(
+        "(cf piece setsrc a.tsx --test a.test.tsx --piece A & " +
+          "cf piece setsrc b.tsx --piece B)",
+      );
+
+      expect(suggestion).toContain("The command attaches tests for packaging");
+      expect(suggestion).toContain("No tests were attached");
+    });
+
+    it("ignores commands in heredoc bodies", () => {
+      for (
+        const opener of [
+          "cat <<EOF",
+          "cat <<'EOF'",
+          'cat <<"EOF"',
+          String.raw`cat <<\EOF`,
+          'cat <<E"OF"',
+        ]
+      ) {
+        const suggestion = suggestionForPatternUserCommand(
+          `${opener}\ncf piece new ignored.tsx\nEOF\n` +
+            "cf piece new main.tsx --test main.test.tsx",
+        );
+
+        expect(suggestion).toContain(
+          "The command attaches tests for packaging",
+        );
+        expect(suggestion).not.toContain("No tests were attached");
+      }
+    });
+
+    it("preserves ordinary backslashes in double-quoted delimiters", () => {
+      const suggestion = suggestionForPatternUserCommand(
+        String.raw`cat <<"E\OF"` +
+          "\ncf piece new ignored.tsx\n" +
+          String.raw`E\OF` +
+          "\ncf piece new main.tsx --test main.test.tsx",
+      );
+
+      expect(suggestion).toContain("The command attaches tests for packaging");
+      expect(suggestion).not.toContain("No tests were attached");
+    });
+
+    it("ignores heredoc markers in comments after shell operators", () => {
+      expect(
+        suggestionForPatternUserCommand(
+          "true;# example: cat <<NEVER\ncf piece new main.tsx",
+        ),
+      ).toContain("No tests were attached");
+    });
+
+    it("ignores heredoc bodies inside double-quoted substitutions", () => {
+      for (
+        const command of [
+          'result="$(cat <<EOF\ncf piece new ignored.tsx\nEOF\n)"',
+          'result="`cat <<EOF\ncf piece new ignored.tsx\nEOF\n`"',
+        ]
+      ) {
+        const suggestion = suggestionForPatternUserCommand(
+          command + "\ncf piece new main.tsx --test main.test.tsx",
+        );
+
+        expect(suggestion).toContain(
+          "The command attaches tests for packaging",
+        );
+        expect(suggestion).not.toContain("No tests were attached");
+      }
+    });
+
+    it("checks substitutions in expandable heredoc bodies", () => {
+      for (
+        const body of [
+          "$(cf piece new main.tsx)",
+          "$(\ncf piece new main.tsx\n)",
+          "$(\n# ) explanatory comment\ncf piece new main.tsx\n)",
+          "$(\necho `echo )`\ncf piece new main.tsx\n)",
+        ]
+      ) {
+        expect(
+          suggestionForPatternUserCommand(`cat <<EOF\n${body}\nEOF`),
+        ).toContain("No tests were attached");
+      }
+    });
+
+    it("does not mistake arithmetic shifts for heredocs", () => {
+      for (
+        const expression of [
+          "$((1 << 2))",
+          "$((1<<2))",
+          "$((\n1 << 2\n))",
+        ]
+      ) {
+        expect(
+          suggestionForPatternUserCommand(
+            `mask=${expression}\ncf piece new main.tsx`,
+          ),
+        ).toContain("No tests were attached");
+      }
+    });
+
+    it("does not mistake multiline quoted text for a heredoc", () => {
+      expect(
+        suggestionForPatternUserCommand(
+          'echo "literal\n<<NEVER\n"\ncf piece new main.tsx',
+        ),
+      ).toContain("No tests were attached");
+    });
+
+    it("checks substitutions used as redirection targets", () => {
+      const suggestion = suggestionForPatternUserCommand(
+        'echo >"$(cf piece setsrc main.tsx --piece ID)"',
+      );
+
+      expect(suggestion).toContain("No tests were attached");
+    });
+
+    it("ignores substitutions quoted literally in redirection targets", () => {
+      for (
+        const command of [
+          "echo >'$(cf piece new ignored.tsx)'",
+          "echo >'`cf piece new ignored.tsx`'",
+        ]
+      ) {
+        expect(suggestionForPatternUserCommand(command)).toBe("");
+      }
+    });
+
+    it("ignores test-like text in quoted arguments and comments", () => {
+      for (
+        const command of [
+          'cf piece new main.tsx "--test fake.test.tsx"',
+          "cf piece new main.tsx # --test fake.test.tsx",
+        ]
+      ) {
+        expect(suggestionForPatternUserCommand(command)).toContain(
+          "No tests were attached",
+        );
+      }
     });
 
     it("keeps a line-continuation deployment in one command segment", () => {
@@ -55,8 +291,18 @@ describe("pattern-user-post-bash", () => {
         "cf piece new main.tsx \\\n  --test main.test.tsx",
       );
 
-      expect(suggestion).toContain("Attached tests are packaged, not run");
+      expect(suggestion).toContain("The command attaches tests for packaging");
       expect(suggestion).not.toContain("No tests were attached");
+    });
+
+    it("keeps an even backslash run from continuing the next line", () => {
+      const suggestion = suggestionForPatternUserCommand(
+        "cf piece setsrc a.tsx --test a.test.tsx --piece A \\\\\n" +
+          "cf piece setsrc b.tsx --piece B",
+      );
+
+      expect(suggestion).toContain("The command attaches tests for packaging");
+      expect(suggestion).toContain("No tests were attached");
     });
 
     it("does not let a reset exempt another custom home deployment", () => {
@@ -68,9 +314,30 @@ describe("pattern-user-post-bash", () => {
     });
 
     it("allows a test pattern to be the executable diagnostic entry", () => {
-      expect(
-        suggestionForPatternUserCommand("cf piece new ./main.test.tsx"),
-      ).toContain("Test pattern deployed as the executable diagnostic entry");
+      for (
+        const command of [
+          "cf piece new ./main.test.tsx",
+          "cf piece new --url https://host/space ./main.test.tsx",
+          "cf piece new ./main.test.tsx -u https://host/space",
+        ]
+      ) {
+        expect(suggestionForPatternUserCommand(command)).toContain(
+          "Test pattern deployed as the executable diagnostic entry",
+        );
+      }
+    });
+
+    it("only exempts the positional diagnostic entry", () => {
+      for (
+        const command of [
+          "cf piece new main.tsx --repository mirror.test.tsx",
+          "cf piece new main.tsx 2>deploy.test.tsx",
+        ]
+      ) {
+        const suggestion = suggestionForPatternUserCommand(command);
+        expect(suggestion).toContain("No tests were attached");
+        expect(suggestion).not.toContain("Test pattern deployed");
+      }
     });
 
     it("keeps the recomputation guidance for state writes", () => {
@@ -81,6 +348,26 @@ describe("pattern-user-post-bash", () => {
 
     it("returns no suggestion for unrelated commands", () => {
       expect(suggestionForPatternUserCommand("git status")).toBe("");
+    });
+  });
+
+  describe("parseShellCommandSegments()", () => {
+    it("does not split quoted or escaped ampersands", () => {
+      expect(
+        parseShellCommandSegments(String.raw`echo "a & b" & echo a\&b`),
+      ).toEqual([["echo", "a & b"], ["echo", "a&b"]]);
+    });
+
+    it("does not split file-descriptor redirections", () => {
+      expect(
+        parseShellCommandSegments("one 2>&1; two >&2; three &>output"),
+      ).toEqual([["one"], ["two"], ["three"]]);
+    });
+
+    it("preserves logical and line separators", () => {
+      expect(
+        parseShellCommandSegments("one && two || three;\r\nfour"),
+      ).toEqual([["one"], ["two"], ["three"], ["four"]]);
     });
   });
 });

--- a/.claude/scripts/pattern-user-post-bash.test.ts
+++ b/.claude/scripts/pattern-user-post-bash.test.ts
@@ -1,0 +1,86 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import { suggestionForPatternUserCommand } from "./pattern-user-post-bash.ts";
+
+describe("pattern-user-post-bash", () => {
+  describe("suggestionForPatternUserCommand()", () => {
+    it("warns when a new piece omits attached tests", () => {
+      expect(
+        suggestionForPatternUserCommand("cf piece new main.tsx"),
+      ).toContain("No tests were attached");
+    });
+
+    it("warns when a source update omits attached tests", () => {
+      expect(
+        suggestionForPatternUserCommand("cf piece setsrc main.tsx --piece ID"),
+      ).toContain("No tests were attached");
+    });
+
+    it("reminds the agent that attached tests still need to run", () => {
+      expect(
+        suggestionForPatternUserCommand(
+          "cf piece new main.tsx --test main.test.tsx",
+        ),
+      ).toContain("Attached tests are packaged, not run");
+    });
+
+    it("warns when a custom home pattern omits attached tests", () => {
+      expect(
+        suggestionForPatternUserCommand(
+          "cf piece set-home --identity key main.tsx",
+        ),
+      ).toContain("No tests were attached");
+    });
+
+    it("does not require tests when resetting the home pattern", () => {
+      expect(
+        suggestionForPatternUserCommand(
+          "cf piece set-home --identity key --reset",
+        ),
+      ).toBe("");
+    });
+
+    it("checks every deployment in a compound command", () => {
+      const suggestion = suggestionForPatternUserCommand(
+        "cf piece setsrc a.tsx --test a.test.tsx --piece A; " +
+          "cf piece setsrc b.tsx --piece B",
+      );
+
+      expect(suggestion).toContain("Attached tests are packaged, not run");
+      expect(suggestion).toContain("No tests were attached");
+    });
+
+    it("keeps a line-continuation deployment in one command segment", () => {
+      const suggestion = suggestionForPatternUserCommand(
+        "cf piece new main.tsx \\\n  --test main.test.tsx",
+      );
+
+      expect(suggestion).toContain("Attached tests are packaged, not run");
+      expect(suggestion).not.toContain("No tests were attached");
+    });
+
+    it("does not let a reset exempt another custom home deployment", () => {
+      expect(
+        suggestionForPatternUserCommand(
+          "cf piece set-home --reset; cf piece set-home main.tsx",
+        ),
+      ).toContain("No tests were attached");
+    });
+
+    it("allows a test pattern to be the executable diagnostic entry", () => {
+      expect(
+        suggestionForPatternUserCommand("cf piece new ./main.test.tsx"),
+      ).toContain("Test pattern deployed as the executable diagnostic entry");
+    });
+
+    it("keeps the recomputation guidance for state writes", () => {
+      expect(
+        suggestionForPatternUserCommand("cf piece set --piece ID title"),
+      ).toContain("Run 'cf piece step'");
+    });
+
+    it("returns no suggestion for unrelated commands", () => {
+      expect(suggestionForPatternUserCommand("git status")).toBe("");
+    });
+  });
+});

--- a/.claude/scripts/pattern-user-post-bash.ts
+++ b/.claude/scripts/pattern-user-post-bash.ts
@@ -3,42 +3,670 @@
  * .claude/scripts/pattern-user-post-bash.ts
  *
  * Claude Code PostToolUse hook for Bash on pattern-user subagent.
- * - Parses cf command output and suggests next steps.
+ * - Parses cf commands and suggests next steps.
  */
 
-function suggestionForCommandSegment(command: string): string {
-  const attachedTests = /(?:^|\s)--test(?:=|\s)/.test(command);
+type ShellQuote = "'" | '"';
+
+interface ShellParseContext {
+  words: string[];
+  word: string;
+  wordStarted: boolean;
+  quote?: ShellQuote;
+  parenthesisDepth: number;
+}
+
+interface ShellParseFrame {
+  context: ShellParseContext;
+  terminator: ")" | "`";
+}
+
+function newShellParseContext(): ShellParseContext {
+  return { words: [], word: "", wordStarted: false, parenthesisDepth: 0 };
+}
+
+interface HeredocDelimiter {
+  value: string;
+  stripTabs: boolean;
+  expand: boolean;
+}
+
+interface HeredocScanState {
+  quote?: ShellQuote;
+  arithmeticDepth: number;
+  substitutionFrames: Array<{
+    outerQuote?: ShellQuote;
+    parenthesisDepth: number;
+    terminator: ")" | "`";
+  }>;
+}
+
+function newHeredocScanState(): HeredocScanState {
+  return { arithmeticDepth: 0, substitutionFrames: [] };
+}
+
+function heredocDelimiters(
+  line: string,
+  state: HeredocScanState,
+): HeredocDelimiter[] {
+  const delimiters: HeredocDelimiter[] = [];
+  let { quote, arithmeticDepth } = state;
+  const { substitutionFrames } = state;
+
+  for (let index = 0; index < line.length; index++) {
+    const character = line[index];
+    const next = line[index + 1];
+
+    if (character === "\\" && quote !== "'") {
+      index++;
+      continue;
+    }
+    if (quote === "'") {
+      if (character === "'") quote = undefined;
+      continue;
+    }
+    if (character === "$" && next === "(" && line[index + 2] === "(") {
+      arithmeticDepth++;
+      index += 2;
+      continue;
+    }
+    if (arithmeticDepth > 0) {
+      if (character === ")" && next === ")") {
+        arithmeticDepth--;
+        index++;
+      }
+      continue;
+    }
+    if (character === "`") {
+      const frame = substitutionFrames.at(-1);
+      if (frame?.terminator === "`") {
+        quote = substitutionFrames.pop()!.outerQuote;
+      } else {
+        substitutionFrames.push({
+          outerQuote: quote,
+          parenthesisDepth: 0,
+          terminator: "`",
+        });
+        quote = undefined;
+      }
+      continue;
+    }
+    if (
+      character === "$" && next === "(" && line[index + 2] !== "("
+    ) {
+      substitutionFrames.push({
+        outerQuote: quote,
+        parenthesisDepth: 0,
+        terminator: ")",
+      });
+      quote = undefined;
+      index++;
+      continue;
+    }
+    if (quote === '"') {
+      if (character === '"') quote = undefined;
+      continue;
+    }
+    if (character === "'" || character === '"') {
+      quote = character;
+      continue;
+    }
+    if (character === "(" && next === "(") {
+      arithmeticDepth++;
+      index++;
+      continue;
+    }
+    const substitutionFrame = substitutionFrames.at(-1);
+    if (substitutionFrame?.terminator === ")" && character === "(") {
+      substitutionFrame.parenthesisDepth++;
+      continue;
+    }
+    if (substitutionFrame?.terminator === ")" && character === ")") {
+      if (substitutionFrame.parenthesisDepth > 0) {
+        substitutionFrame.parenthesisDepth--;
+      } else {
+        quote = substitutionFrames.pop()!.outerQuote;
+      }
+      continue;
+    }
+    if (
+      character === "#" &&
+      (index === 0 || /[\s;&|()]/.test(line[index - 1]))
+    ) {
+      break;
+    }
+    if (character !== "<" || next !== "<" || line[index + 2] === "<") {
+      continue;
+    }
+
+    index += 2;
+    const stripTabs = line[index] === "-";
+    if (stripTabs) index++;
+    while (index < line.length && /[ \t]/.test(line[index])) index++;
+
+    let value = "";
+    let delimiterQuote: ShellQuote | undefined;
+    let quoted = false;
+    for (; index < line.length; index++) {
+      const delimiterCharacter = line[index];
+      if (delimiterQuote) {
+        if (delimiterCharacter === delimiterQuote) {
+          delimiterQuote = undefined;
+        } else if (delimiterCharacter === "\\" && delimiterQuote === '"') {
+          const escapedCharacter = line[index + 1];
+          if (
+            escapedCharacter !== undefined &&
+            /[$`"\\]/.test(escapedCharacter)
+          ) {
+            value += escapedCharacter;
+            index++;
+          } else {
+            value += delimiterCharacter;
+          }
+        } else {
+          value += delimiterCharacter;
+        }
+        continue;
+      }
+      if (/[\s;&|()]/.test(delimiterCharacter)) break;
+      if (delimiterCharacter === "'" || delimiterCharacter === '"') {
+        quoted = true;
+        delimiterQuote = delimiterCharacter;
+      } else if (
+        delimiterCharacter === "\\" && line[index + 1] !== undefined
+      ) {
+        quoted = true;
+        value += line[++index];
+      } else {
+        value += delimiterCharacter;
+      }
+    }
+    if (value) delimiters.push({ value, stripTabs, expand: !quoted });
+  }
+  state.quote = quote;
+  state.arithmeticDepth = arithmeticDepth;
+  return delimiters;
+}
+
+function commandSubstitutionEnd(text: string, start: number): number {
+  const frames: Array<{
+    quote?: ShellQuote;
+    terminator: ")" | "`";
+    parenthesisDepth: number;
+  }> = [{ terminator: ")", parenthesisDepth: 0 }];
+
+  for (let index = start + 2; index < text.length; index++) {
+    const frame = frames.at(-1)!;
+    const character = text[index];
+    const next = text[index + 1];
+    if (character === "\\" && frame.quote !== "'") {
+      index++;
+      continue;
+    }
+    if (frame.quote === "'") {
+      if (character === "'") frame.quote = undefined;
+      continue;
+    }
+    if (frame.quote === '"') {
+      if (character === '"') {
+        frame.quote = undefined;
+      } else if (
+        character === "$" && next === "(" && text[index + 2] !== "("
+      ) {
+        frames.push({ terminator: ")", parenthesisDepth: 0 });
+        index++;
+      } else if (character === "`") {
+        frames.push({ terminator: "`", parenthesisDepth: 0 });
+      }
+      continue;
+    }
+    if (frame.terminator === "`" && character === "`") {
+      frames.pop();
+      continue;
+    }
+    if (
+      character === "#" &&
+      (index === 0 || /[\s;&|()]/.test(text[index - 1]))
+    ) {
+      while (
+        index + 1 < text.length &&
+        text[index + 1] !== "\n" &&
+        text[index + 1] !== "\r"
+      ) index++;
+      continue;
+    }
+    if (character === "'" || character === '"') {
+      frame.quote = character;
+      continue;
+    }
+    if (character === "`") {
+      frames.push({ terminator: "`", parenthesisDepth: 0 });
+      continue;
+    }
+    if (
+      character === "$" && next === "(" && text[index + 2] !== "("
+    ) {
+      frames.push({ terminator: ")", parenthesisDepth: 0 });
+      index++;
+      continue;
+    }
+    if (frame.terminator === ")" && character === "(") {
+      frame.parenthesisDepth++;
+      continue;
+    }
+    if (frame.terminator === ")" && character === ")") {
+      if (frame.parenthesisDepth > 0) {
+        frame.parenthesisDepth--;
+      } else {
+        frames.pop();
+        if (frames.length === 0) return index + 1;
+      }
+    }
+  }
+  return text.length;
+}
+
+function commandSubstitutions(text: string, shellQuotes = false): string {
+  const substitutions: string[] = [];
+  let outerQuote: ShellQuote | undefined;
+  for (let index = 0; index < text.length; index++) {
+    if (shellQuotes) {
+      const character = text[index];
+      if (character === "\\" && outerQuote !== "'") {
+        const escapedCharacter = text[index + 1];
+        if (
+          outerQuote !== '"' || escapedCharacter === undefined ||
+          /[$`"\\\n]/.test(escapedCharacter)
+        ) index++;
+        continue;
+      }
+      if (outerQuote === "'") {
+        if (character === "'") outerQuote = undefined;
+        continue;
+      }
+      if (character === '"') {
+        outerQuote = outerQuote === '"' ? undefined : '"';
+        continue;
+      }
+      if (!outerQuote && character === "'") {
+        outerQuote = "'";
+        continue;
+      }
+    }
+    if (text[index] === "\\") {
+      index++;
+      continue;
+    }
+    if (text[index] === "`") {
+      const start = index++;
+      while (index < text.length) {
+        if (text[index] === "\\") index++;
+        else if (text[index] === "`") break;
+        index++;
+      }
+      substitutions.push(text.slice(start, index + 1));
+      continue;
+    }
+    if (
+      text[index] !== "$" || text[index + 1] !== "(" ||
+      text[index + 2] === "("
+    ) continue;
+
+    const end = commandSubstitutionEnd(text, index);
+    substitutions.push(text.slice(index, end));
+    index = end - 1;
+  }
+  return substitutions.join(";");
+}
+
+function removeHeredocBodies(command: string): string {
+  const pending: HeredocDelimiter[] = [];
+  const state = newHeredocScanState();
+  const output: string[] = [];
+  let body: string[] = [];
+  for (const line of command.split(/\r?\n/)) {
+    const delimiter = pending[0];
+    if (delimiter) {
+      const candidate = delimiter.stripTabs ? line.replace(/^\t+/, "") : line;
+      if (candidate === delimiter.value) {
+        if (delimiter.expand) {
+          output.push(commandSubstitutions(body.join("\n")));
+        } else {
+          output.push("");
+        }
+        body = [];
+        pending.shift();
+      } else {
+        body.push(line);
+        output.push("");
+      }
+      continue;
+    }
+    pending.push(...heredocDelimiters(line, state));
+    output.push(line);
+  }
+  if (pending[0]?.expand && body.length > 0) {
+    output.push(commandSubstitutions(body.join("\n")));
+  }
+  return output.join("\n");
+}
+
+interface ShellRedirection {
+  end: number;
+  target: string;
+}
+
+function shellRedirection(command: string, start: number): ShellRedirection {
+  let index = start + 1;
+  while (index < command.length && /[<>&|]/.test(command[index])) index++;
+  if (command[index] === "-") index++;
+  while (index < command.length && /[ \t]/.test(command[index])) index++;
+
+  const targetStart = index;
+  let quote: ShellQuote | undefined;
+  let substitutionDepth = 0;
+  let backtick = false;
+  for (; index < command.length; index++) {
+    const character = command[index];
+    if (character === "\\" && quote !== "'") {
+      index++;
+      continue;
+    }
+    if (backtick) {
+      if (character === "`") backtick = false;
+      continue;
+    }
+    if (quote) {
+      if (character === quote) quote = undefined;
+      continue;
+    }
+    if (character === "'" || character === '"') {
+      quote = character;
+      continue;
+    }
+    if (character === "`") {
+      backtick = true;
+      continue;
+    }
+    if (character === "$" && command[index + 1] === "(") {
+      substitutionDepth++;
+      index++;
+      continue;
+    }
+    if (substitutionDepth > 0 && character === "(") {
+      substitutionDepth++;
+      continue;
+    }
+    if (substitutionDepth > 0 && character === ")") {
+      substitutionDepth--;
+      continue;
+    }
+    if (
+      substitutionDepth === 0 &&
+      (/\s/.test(character) || /[;&|()]/.test(character))
+    ) break;
+  }
+  return { end: index - 1, target: command.slice(targetStart, index) };
+}
+
+export function parseShellCommandSegments(command: string): string[][] {
+  const segments: string[][] = [];
+  const stack: ShellParseFrame[] = [];
+  let context = newShellParseContext();
+
+  const finishWord = () => {
+    if (!context.wordStarted) return;
+    context.words.push(context.word);
+    context.word = "";
+    context.wordStarted = false;
+  };
+  const finishSegment = () => {
+    finishWord();
+    if (context.words.length > 0) segments.push(context.words);
+    context.words = [];
+  };
+
+  for (let index = 0; index < command.length; index++) {
+    const character = command[index];
+    const previous = command[index - 1];
+    const next = command[index + 1];
+
+    if (character === "\\" && context.quote !== "'") {
+      if (next === "\n") {
+        index++;
+      } else if (next === "\r" && command[index + 2] === "\n") {
+        index += 2;
+      } else if (next !== undefined) {
+        context.word += next;
+        context.wordStarted = true;
+        index++;
+      }
+      continue;
+    }
+    if (context.quote === "'") {
+      if (character === "'") context.quote = undefined;
+      else context.word += character;
+      continue;
+    }
+    if (context.quote === '"') {
+      if (character === '"') {
+        context.quote = undefined;
+      } else if (character === "$" && next === "(") {
+        context.word += "$()";
+        context.wordStarted = true;
+        stack.push({ context, terminator: ")" });
+        context = newShellParseContext();
+        index++;
+      } else if (character === "`") {
+        context.word += "$()";
+        context.wordStarted = true;
+        stack.push({ context, terminator: "`" });
+        context = newShellParseContext();
+      } else {
+        context.word += character;
+      }
+      continue;
+    }
+    if (character === "'" || character === '"') {
+      context.quote = character;
+      context.wordStarted = true;
+      continue;
+    }
+    if (character === "$" && next === "(") {
+      context.word += "$()";
+      context.wordStarted = true;
+      stack.push({ context, terminator: ")" });
+      context = newShellParseContext();
+      index++;
+      continue;
+    }
+    if (character === "`") {
+      const frame = stack.at(-1);
+      if (frame?.terminator === "`") {
+        finishSegment();
+        context = stack.pop()!.context;
+      } else {
+        context.word += "$()";
+        context.wordStarted = true;
+        stack.push({ context, terminator: "`" });
+        context = newShellParseContext();
+      }
+      continue;
+    }
+    if (stack.at(-1)?.terminator === ")" && character === "(") {
+      context.parenthesisDepth++;
+      context.word += character;
+      context.wordStarted = true;
+      continue;
+    }
+    if (stack.at(-1)?.terminator === ")" && character === ")") {
+      if (context.parenthesisDepth > 0) {
+        context.parenthesisDepth--;
+        context.word += character;
+        context.wordStarted = true;
+      } else {
+        finishSegment();
+        context = stack.pop()!.context;
+      }
+      continue;
+    }
+    if (
+      character === "#" &&
+      (index === 0 || /[\s;&|()]/.test(previous))
+    ) {
+      finishSegment();
+      while (
+        index + 1 < command.length &&
+        command[index + 1] !== "\n" &&
+        command[index + 1] !== "\r"
+      ) index++;
+      continue;
+    }
+    if (
+      character === "<" || character === ">" ||
+      (character === "&" && next === ">")
+    ) {
+      if (context.wordStarted && /^\d+$/.test(context.word)) {
+        context.word = "";
+        context.wordStarted = false;
+      } else {
+        finishWord();
+      }
+      const redirection = shellRedirection(command, index);
+      const substitutions = commandSubstitutions(redirection.target, true);
+      if (substitutions) {
+        segments.push(...parseShellCommandSegments(substitutions));
+      }
+      index = redirection.end;
+      continue;
+    }
+    if (/\s/.test(character)) {
+      if (character === "\n" || character === "\r") finishSegment();
+      else finishWord();
+      continue;
+    }
+
+    let separatorLength = 0;
+    if (character === ";") {
+      separatorLength = 1;
+    } else if (character === "&") {
+      if (next === "&") {
+        separatorLength = 2;
+      } else if (previous !== ">" && previous !== "<" && next !== ">") {
+        separatorLength = 1;
+      }
+    } else if (character === "|") {
+      separatorLength = next === "|" ? 2 : 1;
+    }
+
+    if (separatorLength > 0) {
+      finishSegment();
+      index += separatorLength - 1;
+      continue;
+    }
+
+    context.word += character;
+    context.wordStarted = true;
+  }
+
+  finishSegment();
+  while (stack.length > 0) {
+    context = stack.pop()!.context;
+    finishSegment();
+  }
+  return segments;
+}
+
+function isTestPath(word: string | undefined): boolean {
+  return word !== undefined && word.length > 0 && !word.startsWith("-");
+}
+
+const PIECE_NEW_VALUE_OPTIONS = new Set([
+  "--main-export",
+  "--root",
+  "--repository",
+  "--test",
+  "--slug",
+  "--identity",
+  "-i",
+  "--api-url",
+  "-a",
+  "--url",
+  "-u",
+  "--space",
+  "-s",
+]);
+
+function pieceNewMain(commandWords: string[]): string | undefined {
+  const positional: string[] = [];
+  for (let index = 3; index < commandWords.length; index++) {
+    const word = commandWords[index];
+    if (word === "--") {
+      positional.push(...commandWords.slice(index + 1));
+      break;
+    }
+    if (word.startsWith("-")) {
+      if (!word.includes("=") && PIECE_NEW_VALUE_OPTIONS.has(word)) index++;
+      continue;
+    }
+    positional.push(word);
+  }
+  return positional.length === 1 ? positional[0] : undefined;
+}
+
+function suggestionForCommandSegment(words: string[]): string {
+  const normalizedWords = words.map((word) =>
+    word.replace(/^\(+/, "").replace(/\)+$/, "")
+  );
+  const cfIndex = normalizedWords.findIndex((word, index) =>
+    word === "cf" && normalizedWords[index + 1] === "piece"
+  );
+  if (cfIndex < 0) return "";
+
+  const commandWords = normalizedWords.slice(cfIndex);
+  const pieceCommand = commandWords[2];
+  const testOptions = commandWords.flatMap((word, index) => {
+    if (word === "--test") {
+      return [{ value: commandWords[index + 1], inline: false }];
+    }
+    if (word.startsWith("--test=")) {
+      return [{ value: word.slice("--test=".length), inline: true }];
+    }
+    return [];
+  });
+  const hasTestOption = testOptions.length > 0;
+  const attachedTests = hasTestOption &&
+    testOptions.every(({ value, inline }) =>
+      inline ? value.length > 0 : isTestPath(value)
+    );
   const testSuggestion = attachedTests
-    ? "Attached tests are packaged, not run. Confirm every entry passed with 'cf test'."
+    ? "The command attaches tests for packaging, but does not run them. Confirm every entry passed with 'cf test'."
     : "No tests were attached. For new or changed source, write and run pattern tests, then deploy with repeatable '--test'.";
 
-  if (command.includes("piece new")) {
-    if (!attachedTests && /\.test\.[cm]?[jt]sx?["']?(?:\s|$)/.test(command)) {
+  if (pieceCommand === "new") {
+    const main = pieceNewMain(commandWords);
+    if (!hasTestOption && main && /\.test\.[cm]?[jt]sx?$/.test(main)) {
       return "Test pattern deployed as the executable diagnostic entry. Next, inspect its action and assertion cells.";
     }
     return `${testSuggestion} Next, use 'cf piece inspect' to view state or 'cf piece call' to test handlers.`;
   }
-  if (command.includes("piece setsrc")) {
+  if (pieceCommand === "setsrc") {
     return `${testSuggestion} Next, use 'cf piece step' to trigger re-evaluation, then 'cf piece inspect' to verify.`;
   }
-  if (command.includes("piece set-home") && !command.includes("--reset")) {
+  if (pieceCommand === "set-home" && !commandWords.includes("--reset")) {
     return `${testSuggestion} Next, open the home space and verify the custom home pattern.`;
   }
-  if (command.includes("piece set ")) {
+  if (pieceCommand === "set") {
     return "State set. Run 'cf piece step' to trigger re-evaluation before reading computed values.";
   }
-  if (command.includes("piece inspect")) {
+  if (pieceCommand === "inspect") {
     return "State inspected. Use 'cf piece call handlerName' to test handlers or 'cf piece set' to modify state.";
   }
   return "";
 }
 
 export function suggestionForPatternUserCommand(command: string): string {
-  if (!command.includes("cf piece")) return "";
-
-  return command
-    .replace(/\\\r?\n/g, " ")
-    .split(/&&|\|\||[;\r\n]/)
+  return parseShellCommandSegments(removeHeredocBodies(command))
     .map((segment) => suggestionForCommandSegment(segment))
     .filter(Boolean)
     .join(" ");

--- a/.claude/scripts/pattern-user-post-bash.ts
+++ b/.claude/scripts/pattern-user-post-bash.ts
@@ -6,48 +6,66 @@
  * - Parses cf command output and suggests next steps.
  */
 
-const rawInput = await new Response(Deno.stdin.readable).text();
-let input: {
-  tool_input?: { command?: string };
-  tool_response?: { stdout?: string; stderr?: string };
-} = {};
+function suggestionForCommandSegment(command: string): string {
+  const attachedTests = /(?:^|\s)--test(?:=|\s)/.test(command);
+  const testSuggestion = attachedTests
+    ? "Attached tests are packaged, not run. Confirm every entry passed with 'cf test'."
+    : "No tests were attached. For new or changed source, write and run pattern tests, then deploy with repeatable '--test'.";
 
-try {
-  input = JSON.parse(rawInput);
-} catch {
-  Deno.exit(0);
+  if (command.includes("piece new")) {
+    if (!attachedTests && /\.test\.[cm]?[jt]sx?["']?(?:\s|$)/.test(command)) {
+      return "Test pattern deployed as the executable diagnostic entry. Next, inspect its action and assertion cells.";
+    }
+    return `${testSuggestion} Next, use 'cf piece inspect' to view state or 'cf piece call' to test handlers.`;
+  }
+  if (command.includes("piece setsrc")) {
+    return `${testSuggestion} Next, use 'cf piece step' to trigger re-evaluation, then 'cf piece inspect' to verify.`;
+  }
+  if (command.includes("piece set-home") && !command.includes("--reset")) {
+    return `${testSuggestion} Next, open the home space and verify the custom home pattern.`;
+  }
+  if (command.includes("piece set ")) {
+    return "State set. Run 'cf piece step' to trigger re-evaluation before reading computed values.";
+  }
+  if (command.includes("piece inspect")) {
+    return "State inspected. Use 'cf piece call handlerName' to test handlers or 'cf piece set' to modify state.";
+  }
+  return "";
 }
 
-const command = input.tool_input?.command || "";
+export function suggestionForPatternUserCommand(command: string): string {
+  if (!command.includes("cf piece")) return "";
 
-// Only process cf commands.
-if (!command.includes("cf piece")) {
-  Deno.exit(0);
+  return command
+    .replace(/\\\r?\n/g, " ")
+    .split(/&&|\|\||[;\r\n]/)
+    .map((segment) => suggestionForCommandSegment(segment))
+    .filter(Boolean)
+    .join(" ");
 }
 
-let suggestion = "";
+if (import.meta.main) {
+  const rawInput = await new Response(Deno.stdin.readable).text();
+  let input: {
+    tool_input?: { command?: string };
+    tool_response?: { stdout?: string; stderr?: string };
+  } = {};
 
-if (command.includes("piece new")) {
-  suggestion =
-    "Piece created. Next: use 'cf piece inspect' to view state or 'cf piece call' to test handlers.";
-} else if (command.includes("piece setsrc")) {
-  suggestion =
-    "Source updated. Next: use 'cf piece step' to trigger re-evaluation, then 'cf piece inspect' to verify.";
-} else if (command.includes("piece set ")) {
-  suggestion =
-    "State set. Run 'cf piece step' to trigger re-evaluation before reading computed values.";
-} else if (command.includes("piece inspect")) {
-  suggestion =
-    "State inspected. Use 'cf piece call handlerName' to test handlers or 'cf piece set' to modify state.";
+  try {
+    input = JSON.parse(rawInput);
+  } catch {
+    Deno.exit(0);
+  }
+
+  const suggestion = suggestionForPatternUserCommand(
+    input.tool_input?.command || "",
+  );
+  if (suggestion) {
+    console.log(JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "PostToolUse",
+        additionalContext: suggestion,
+      },
+    }));
+  }
 }
-
-if (suggestion) {
-  console.log(JSON.stringify({
-    hookSpecificOutput: {
-      hookEventName: "PostToolUse",
-      additionalContext: suggestion,
-    },
-  }));
-}
-
-Deno.exit(0);

--- a/docs/common/conventions/HOME_SPACE.md
+++ b/docs/common/conventions/HOME_SPACE.md
@@ -129,12 +129,20 @@ The home space's default pattern is the home experience itself — by default,
 the CF CLI:
 
 ```bash
-# Deploy a custom home pattern
-cf piece set-home -i ./my.key -a http://localhost:8000 ./my-home.tsx
+# Run its automated pattern test
+cf test ./my-home.test.tsx
+
+# Deploy a custom home pattern with the test attached
+cf piece set-home -i ./my.key -a http://localhost:8000 \
+  --test ./my-home.test.tsx ./my-home.tsx
 
 # Reset to the system default
 cf piece set-home -i ./my.key -a http://localhost:8000 --reset
 ```
+
+Write automated tests for new or changed home-pattern behavior. Repeat
+`--test` for every authored test entry. Deployment packages and type-checks
+the tests but does not run them, so run each entry with `cf test` first.
 
 Under the hood, `set-home` calls `PiecesController.recreateDefaultPattern()`
 with the compiled program. This tears down the existing default pattern, creates
@@ -172,8 +180,9 @@ To share identity between browser and CLI:
 #    history and the process list:
 deno run -A packages/cli/mod.ts id from-mnemonic -- phrase.txt > ./browser.key
 
-# 3. Use that key with cf
-cf piece set-home -i ./browser.key -a http://localhost:8000 ./my-home.tsx
+# 3. Use that key with cf, retaining the tested source package
+cf piece set-home -i ./browser.key -a http://localhost:8000 \
+  --test ./my-home.test.tsx ./my-home.tsx
 ```
 
 Note: `cf id derive <passphrase>` will NOT produce the same identity as the

--- a/docs/common/verb-session-walkthrough.md
+++ b/docs/common/verb-session-walkthrough.md
@@ -147,7 +147,8 @@ say what it does. Step 2 has the measurement.
 An address a person can type, rather than a fid from a previous command.
 
 ```bash
-cf piece new tracker.tsx --slug board
+cf test tracker.test.tsx
+cf piece new tracker.tsx --test tracker.test.tsx --slug board
 cf piece verbs --piece board
 ```
 

--- a/docs/common/workflows/development.md
+++ b/docs/common/workflows/development.md
@@ -4,14 +4,17 @@
 # Check syntax (fast)
 deno task cf check pattern.tsx --no-run
 
-# Test locally
+# Check graph construction
 deno task cf check pattern.tsx
 
-# Deploy
-deno task cf piece new ... pattern.tsx
+# Run every authored automated pattern test
+deno task cf test pattern.test.tsx
 
-# Update existing (faster iteration)
-deno task cf piece setsrc ... --piece PIECE_ID pattern.tsx
+# Deploy with every test entry attached
+deno task cf piece new ... --test pattern.test.tsx pattern.tsx
+
+# Update existing and retain the complete test package
+deno task cf piece setsrc ... --test pattern.test.tsx --piece PIECE_ID pattern.tsx
 
 # Inspect data
 deno task cf piece inspect ... --piece PIECE_ID
@@ -22,7 +25,12 @@ deno task cf piece link ... editor-id/items viewer-id/items
 
 **Tips:**
 - Use `check` first to catch TypeScript errors
+- Write automated pattern tests for new or changed behavior, run every test
+  entry with `cf test`, and repeat `--test` for every entry during deployment.
+  Deployment packages and type-checks attached tests but does not run them.
 - Deploy once, then use `setsrc` for updates
+- Repeat the complete set of `--test` flags on every `setsrc`. Each update
+  defines a complete source revision, so omitted test roots are not retained.
 - `setsrc` preserves `WriteAuthorizedBy` authority across changed modules when
   the old and new recursive source closures contain the same normalized module
   path. The handoff is scoped to the space whose authenticated cache documents
@@ -71,4 +79,5 @@ deno task cf piece link ... editor-id/items viewer-id/items
   bypass compilation, normal value validation, or atomic stale-update checks.
   `piece new` accepts the same flag for deploy-script symmetry, but a fresh
   piece has no predecessor schema to compare.
-- Test one feature at a time
+- Test one feature at a time. Manual CLI and browser checks complement automated
+  pattern tests; they do not replace them.

--- a/docs/common/workflows/handlers-cli-testing.md
+++ b/docs/common/workflows/handlers-cli-testing.md
@@ -53,10 +53,16 @@ export default pattern<Input, Output>(({ items }) => {
 
 ## CLI Commands
 
+Run every authored pattern test first. Attach each test entry to both the first
+deployment and every later source update:
+
 ```bash
+# Run automated pattern tests
+deno task cf test pattern.test.tsx
+
 # Deploy or update the pattern
-deno task cf piece new ... pattern.tsx
-deno task cf piece setsrc ... pattern.tsx
+deno task cf piece new ... --test pattern.test.tsx pattern.tsx
+deno task cf piece setsrc ... --test pattern.test.tsx pattern.tsx
 
 # Call a handler directly with JSON payload
 deno task cf piece call ... addItem '{"title": "Test Item", "category": "demo"}'
@@ -82,12 +88,19 @@ deno task cf exec /tmp/cf/<space>/pieces/<piece>/result/search.tool --query "dem
 deno task cf exec /tmp/cf/<space>/entities/<piece-id>/result/search.tool --query "demo"
 ```
 
+Repeat `--test` for multiple test entries. These flags package and type-check
+the tests but do not run them, so the `cf test` command remains required.
+Handler calls below are runtime checks, not replacements for automated coverage.
+
 ## Workflow
 
-1. Deploy pattern: `cf piece new`
-2. Either call the handler directly with `cf piece call` or mount the space with `cf fuse mount`
-3. Use `cf exec <mounted-callable-file> --help` to inspect the mounted schema-derived interface without invoking it
-4. Execute `*.handler` or `*.tool` via `cf exec`; after the verb, schema-derived flags own the namespace, so a tool input field named `help` is parsed normally
-5. Legacy `echo ... > file.handler` still works for handlers
-6. Inspect state with `cf piece inspect` or `cf piece get`
-7. Iterate until the callable works correctly, then build UI on top
+1. Write or update automated tests for changed behavior
+2. Run every test entry with `cf test`
+3. Deploy with every test attached using repeatable `--test`
+4. Either call the handler directly with `cf piece call` or mount the space with `cf fuse mount`
+5. Use `cf exec <mounted-callable-file> --help` to inspect the mounted schema-derived interface without invoking it
+6. Execute `*.handler` or `*.tool` via `cf exec`; after the verb, schema-derived flags own the namespace, so a tool input field named `help` is parsed normally
+7. Legacy `echo ... > file.handler` still works for handlers
+8. Inspect state with `cf piece inspect` or `cf piece get`
+9. Iterate until the callable works correctly, running tests and retaining every
+   `--test` flag on `setsrc`, then build UI on top

--- a/docs/common/workflows/pattern-testing.md
+++ b/docs/common/workflows/pattern-testing.md
@@ -365,6 +365,11 @@ deno task cf piece step --piece <PIECE_ID>
 deno task cf piece get tests/1/assertion --piece <PIECE_ID>
 ```
 
+This diagnostic command deliberately deploys the test pattern as the executable
+entry so its action and assertion cells can be inspected. A normal deployment
+uses the subject pattern as the executable entry and attaches this test with
+`--test ./main.test.tsx`.
+
 ### 3. Expose Debug Data
 
 Add extra fields to your test pattern for debugging:

--- a/docs/development/debugging/cli-debugging.md
+++ b/docs/development/debugging/cli-debugging.md
@@ -8,8 +8,11 @@ When patterns misbehave, the CLI often provides faster diagnosis than browser De
 # Check syntax only (fast)
 deno task cf check pattern.tsx --no-run
 
-# Run locally
+# Check graph construction
 deno task cf check pattern.tsx
+
+# Run every authored automated pattern test
+deno task cf test pattern.test.tsx
 
 # View transformer output (debug compile issues — see below)
 deno task cf check pattern.tsx --show-transformed
@@ -35,13 +38,18 @@ operator key, reserved for operator actions.
 ## Deploying a Test Piece
 
 ```bash
-# Deploy — returns a piece-id used by all commands below
-deno task cf piece new -i "$CF_IDENTITY" --api-url URL --space SPACE pattern.tsx
+# Deploy with every test entry attached — returns the piece id used below
+deno task cf piece new -i "$CF_IDENTITY" --api-url URL --space SPACE \
+  --test pattern.test.tsx pattern.tsx
 
 # Set test data
 echo '{"title": "Test", "done": false}' | \
   deno task cf piece set -i "$CF_IDENTITY" --api-url URL --space SPACE --piece ID testItem
 ```
+
+Write automated tests for new or changed pattern behavior and run every entry
+before deployment. Repeat `--test` for multiple entries. The deployment command
+packages and type-checks attached tests but does not run them.
 
 ## When to Use CLI vs Browser
 
@@ -148,14 +156,18 @@ deno task cf piece get --piece <piece-id> itemCount -i "$CF_IDENTITY" -a URL -s 
 When iterating on fixes, always use `setsrc` instead of `new`:
 
 ```bash
-# Make a fix to your pattern, then:
-deno task cf piece setsrc --piece <piece-id> pattern.tsx -i "$CF_IDENTITY" -a URL -s space
+# Make a fix, rerun every test, then retain the complete attached test package:
+deno task cf test pattern.test.tsx
+deno task cf piece setsrc --piece <piece-id> pattern.tsx \
+  --test pattern.test.tsx -i "$CF_IDENTITY" -a URL -s space
 
 # Test again
 deno task cf piece get --piece <piece-id> brokenField -i "$CF_IDENTITY" -a URL -s space
 ```
 
 This keeps you working with the same piece instance, preserving any test data you've set up.
+Repeat the complete set of `--test` flags on every update. Omitted test roots are
+not retained in the new source revision.
 
 ## See Also
 

--- a/docs/development/space-clone-rehearsal.md
+++ b/docs/development/space-clone-rehearsal.md
@@ -78,9 +78,15 @@ not see it, you are pointed at something else — stop and check before writing.
 deno task cf space verify $CLONE
 deno task cf inspect churn $DB --bucket 60 --until "$(date -u '+%Y-%m-%d %H:%M:%S')"
 
-# 4. Run the update against the CLONE's api-url. Children first, board last,
-#    serially — the parent's result recomputation is what storms.
-deno task cf piece setsrc … --api-url http://localhost:8010 …
+# 4. Run every authored test locally. Then update against the CLONE's api-url
+#    once, with one --test flag per entry. Children first, board last, serially
+#    — the parent's result recomputation is what storms.
+deno task cf test <pattern.test.tsx>
+deno task cf test <pattern.integration.test.tsx>
+deno task cf piece setsrc <pattern.tsx> \
+  --test <pattern.test.tsx> \
+  --test <pattern.integration.test.tsx> \
+  --api-url http://localhost:8010 …
 
 # 5. Judge it. --expect-migration gates on removal, not on change.
 deno task cf space verify $CLONE --expect-migration
@@ -91,6 +97,10 @@ deno task cf inspect churn $DB --bucket 60 \
 ./scripts/stop-local-dev.sh --port-offset 10
 deno task cf space reset $CLONE
 ```
+
+Add one `cf test` command and one `--test` flag for every authored test entry.
+Run `setsrc` once per piece with the complete flag set. Deployment packages and
+type-checks the tests but does not run them.
 
 ### Stop the server before resetting
 

--- a/docs/plans/topics-migration-rehearsal.md
+++ b/docs/plans/topics-migration-rehearsal.md
@@ -171,12 +171,33 @@ Do generation A's 39 first, then generation B's 34, then the board. Keeping
 the two transitions separable means that if one storms you know which;
 interleaving them blurs that signal for no benefit.
 
+Run every authored test against the migration source before changing the clone.
+Stop if any test fails. Keep the complete flag set on every topic and board
+revision:
+
+```bash
+deno task cf test packages/patterns/topics/multi-user.test.tsx
+deno task cf test packages/patterns/topics/topics-rejections.test.tsx
+deno task cf test packages/patterns/topics/topics.test.tsx
+
+TOPICS_TEST_ARGS=(
+  --test packages/patterns/topics/multi-user.test.tsx
+  --test packages/patterns/topics/topics-rejections.test.tsx
+  --test packages/patterns/topics/topics.test.tsx
+)
+```
+
+The quoted `"${TOPICS_TEST_ARGS[@]}"` expansion repeats every `--test` entry.
+Deployment packages and type-checks attached tests but does not run them.
+
 ```bash
 # each of the 73 topics, one at a time, against the CLONE's api-url
 deno task cf piece setsrc packages/patterns/topics/topic.tsx \
+  "${TOPICS_TEST_ARGS[@]}" \
   --piece <topic-fid> --api-url http://localhost:8010 --space <did> …
 # then, last:
 deno task cf piece setsrc packages/patterns/topics/main.tsx \
+  "${TOPICS_TEST_ARGS[@]}" \
   --piece fid1:jtdD-… --api-url http://localhost:8010 --space <did> …
 ```
 

--- a/docs/specs/pattern-imports/README.md
+++ b/docs/specs/pattern-imports/README.md
@@ -191,6 +191,9 @@ directory containing the main entry and every test entry. An explicit `--root`
 remains authoritative. Each test's reachable imports are merged into the
 authored `Program` as source-only roots. Compilation type-checks and verifies
 those modules, while execution still begins exclusively at `Program.main`.
+Run each authored test entry separately with `cf test`; attaching it does not
+execute it. Repeat the complete set of `--test` flags on every `setsrc` because
+each update defines a complete source revision.
 The source-document cache retains the test roots through its synthetic
 retention links. Source recovery and `cf piece getsrc` therefore return the
 executable source and its attached tests together. `set-home --reset` rejects

--- a/docs/tutorial/06-workflow.md
+++ b/docs/tutorial/06-workflow.md
@@ -1,7 +1,7 @@
 # Chapter 6 — The Development Workflow
 
 You now know the language; this chapter is the toolchain. The loop is:
-**sketch → check → deploy → drive → test**, all through the `cf` CLI
+**sketch → check → test → deploy → drive**, all through the `cf` CLI
 (run as `deno task cf ...` from the repo root). Keep this chapter open while
 you build your first pattern.
 
@@ -67,33 +67,43 @@ See `cf completion --help`.
 ## Deploy and iterate
 
 ```bash
-# First deploy only — SAVE THE PRINTED PIECE ID
-deno task cf piece new pattern.tsx -s myspace
+# Run every authored pattern test before deployment
+deno task cf test pattern.test.tsx
 
-# Every iteration after that: update the SAME piece in place
-deno task cf piece setsrc pattern.tsx --piece fid1:abc... -s myspace
+# First deploy only — SAVE THE PRINTED PIECE ID
+deno task cf piece new pattern.tsx --test pattern.test.tsx -s myspace
+
+# Every iteration after that: rerun tests, then update the SAME piece in place
+deno task cf test pattern.test.tsx
+deno task cf piece setsrc pattern.tsx --test pattern.test.tsx \
+  --piece fid1:abc... -s myspace
 ```
 
 The most common workflow mistake is rerunning `piece new` after each edit —
 that creates a new piece every time, and your space fills with stale
 duplicates. `new` once, `setsrc` forever after.
 
-Use repeatable `--test` flags when the deployed piece should retain its tests
-with its source:
+Write automated pattern tests for new or changed behavior. Repeat `cf test` and
+`--test` for every authored test entry. The deployment command packages and
+type-checks attached tests but does not run them. Repeat the complete set of
+flags on every `setsrc`; each update defines a complete source revision, so an
+omitted test entry is not retained.
+
+For example, a second test entry is run and attached separately:
 
 ```bash
-deno task cf piece new pattern.tsx --test pattern.test.tsx -s myspace
-deno task cf piece setsrc pattern.tsx --test pattern.test.tsx \
+deno task cf test pattern.integration.test.tsx
+deno task cf piece setsrc pattern.tsx \
+  --test pattern.test.tsx \
+  --test pattern.integration.test.tsx \
   --piece fid1:abc... -s myspace
 ```
 
-Deployment resolves and type-checks each test and its imports, but does not run
-the tests. Run them locally with `cf test`. The attached files are included by
-`cf piece getsrc`, so another checkout of the piece receives the source and its
-tests together. Without `--root`, the CLI infers the common directory that
-contains the main entry and every test entry. An explicit `--root` applies to
-all of them. A test-only change creates a new source revision, so history and
-recovery keep each test package separate.
+The attached files are included by `cf piece getsrc`, so another checkout of
+the piece receives the source and its tests together. Without `--root`, the CLI
+infers the common directory that contains the main entry and every test entry.
+An explicit `--root` applies to all of them. A test-only change creates a new
+source revision, so history and recovery keep each test package separate.
 
 ## Drive a deployed piece from the CLI
 

--- a/packages/fuse/mod.test.ts
+++ b/packages/fuse/mod.test.ts
@@ -161,6 +161,18 @@ Deno.test("source writeback re-encodes decoded source relpaths for tree lookup",
   );
 });
 
+Deno.test("source writeback retains attached test roots", async () => {
+  const source = await Deno.readTextFile(new URL("./mod.ts", import.meta.url));
+  const sourceWriteback = source.slice(
+    source.indexOf('if (writeTarget?.kind === "source")'),
+  );
+
+  assert(
+    sourceWriteback.includes("sourceRoots: program.sourceRoots"),
+    "source writeback must pass the recovered source roots to setPattern",
+  );
+});
+
 Deno.test("no-handle truncate opens only the bounded target prefix", () => {
   const content = new Uint8Array([1, 2, 3, 4, 5]);
   assertEquals([...bufferForNoHandleTruncate(content, 2)], [1, 2]);

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -1801,6 +1801,7 @@ export async function main(argv: string[] = Deno.args) {
             main: baseMain,
             mainExport: baseMainExport,
             files: updatedFiles,
+            sourceRoots: program.sourceRoots,
           }, { dangerouslyAllowIncompatibleSchema });
           // Clear error.log on success
           const errorLogIno = tree.lookup(srcIno, "error.log");

--- a/packages/patterns/cozy-poll/DEPLOY-AND-SHARE.md
+++ b/packages/patterns/cozy-poll/DEPLOY-AND-SHARE.md
@@ -31,7 +31,25 @@ export CF_API_URL=https://<your-toolshed-host>/
 export CF_IDENTITY=/path/to/your-identity.key   # e.g. ~/.config/commonfabric/identity.key
 PIECE=<fid1:… from `cf piece new`>
 SPACE=<your-space>
+
+# Keep this complete set on every source deployment in this guide.
+COZY_POLL_TEST_ARGS=(
+  --test packages/patterns/cozy-poll/main.test.tsx
+  --test packages/patterns/cozy-poll/multi-user.test.tsx
+)
 ```
+
+Before any `piece new` or `piece setsrc` command below, run every authored
+pattern test and stop if one fails:
+
+```bash
+deno task cf test packages/patterns/cozy-poll/main.test.tsx
+deno task cf test packages/patterns/cozy-poll/multi-user.test.tsx
+```
+
+The quoted `"${COZY_POLL_TEST_ARGS[@]}"` expansion below repeats every `--test`
+entry. Deployment packages and type-checks the tests but does not run them,
+which is why both the test commands and the flags are required.
 
 ## Option A — deploy your version onto the shared state (recommended)
 
@@ -41,6 +59,7 @@ empty instance.
 
 ```bash
 deno task cf piece setsrc --piece "$PIECE" -s "$SPACE" \
+  "${COZY_POLL_TEST_ARGS[@]}" \
   packages/patterns/cozy-poll/main.tsx
 ```
 
@@ -65,6 +84,7 @@ experiment without touching the shared poll):
 ```bash
 # 1. Create your own empty piece (note the new ID it prints).
 MINE=$(deno task cf piece new packages/patterns/cozy-poll/main.tsx \
+  "${COZY_POLL_TEST_ARGS[@]}" \
   -s "$SPACE" | grep '^fid1:')
 
 # 2. Copy each PerSpace field from the canonical piece into yours.
@@ -128,7 +148,8 @@ browser identity.
 ## Re-establishing the canonical piece (if it's lost)
 
 ```bash
-deno task cf piece new packages/patterns/cozy-poll/main.tsx -s "$SPACE"
+deno task cf piece new packages/patterns/cozy-poll/main.tsx \
+  "${COZY_POLL_TEST_ARGS[@]}" -s "$SPACE"
 # → prints a new fid1:… — update PIECE above and the "canonical piece" section.
 ```
 
@@ -149,6 +170,7 @@ cell, so the bad reactive state persists. The cure is a fresh process:
 # 1. Confirm it's instance-specific: deploy the same code to a NEW piece and
 #    open it. If the fresh piece works, the old one's process is wedged.
 NEW=$(deno task cf piece new packages/patterns/cozy-poll/main.tsx \
+  "${COZY_POLL_TEST_ARGS[@]}" \
   -s "$SPACE" | grep '^fid1:')
 
 # 2. The data usually survives in the old piece's cells — copy it across with

--- a/packages/patterns/google/README.md
+++ b/packages/patterns/google/README.md
@@ -253,12 +253,26 @@ pieces via CLI.
 #### 1. Deploy both pieces
 
 ```bash
-# Deploy google-auth
-cf piece new google-auth.tsx
+# Run the authored pattern tests
+deno task cf test packages/patterns/google/core/auth-pieces.test.tsx \
+  --root packages/patterns
+deno task cf test packages/patterns/google/core/gmail-importer.test.tsx \
+  --root packages/patterns
 
-# Deploy gmail-importer
-cf piece new gmail-importer.tsx
+# Deploy google-auth with its test attached
+deno task cf piece new packages/patterns/google/core/google-auth.tsx \
+  --root packages/patterns \
+  --test packages/patterns/google/core/auth-pieces.test.tsx
+
+# Deploy gmail-importer with its test attached
+deno task cf piece new packages/patterns/google/core/gmail-importer.tsx \
+  --root packages/patterns \
+  --test packages/patterns/google/core/gmail-importer.test.tsx
 ```
+
+Deployment packages and type-checks attached tests but does not run them. If
+either source changes, rerun its test before deployment. Repeat the complete set
+of `--test` flags on every later `piece setsrc`.
 
 #### 2. Authenticate with Google Auth piece
 

--- a/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
+++ b/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
@@ -101,7 +101,35 @@ export CF_API_URL=https://rapids.saga-castor.ts.net/   # fast-moving instance; e
 export CF_IDENTITY=./your-identity.key
 PIECE=fid1:bRHO0S5yN6Zuyct8MWgmIJgYpKkj5d2yiCCjNW1QulQ    # rapids; current as of 2026-08-03
 SPACE=team-lunch
+
+# Keep this complete set on every source deployment in this guide.
+LUNCH_POLL_TEST_ARGS=(
+  --test packages/patterns/lunch-poll/art-sync.test.tsx
+  --test packages/patterns/lunch-poll/generated-art.test.tsx
+  --test packages/patterns/lunch-poll/lunch-stats.test.tsx
+  --test packages/patterns/lunch-poll/main.test.tsx
+  --test packages/patterns/lunch-poll/multi-user.test.tsx
+  --test packages/patterns/lunch-poll/participant-identity-card.test.tsx
+  --test packages/patterns/lunch-poll/poll-option-card.test.tsx
+)
 ```
+
+Before any `piece new` or `piece setsrc` command below, run every authored
+pattern test and stop if one fails:
+
+```bash
+deno task cf test packages/patterns/lunch-poll/art-sync.test.tsx --root packages/patterns
+deno task cf test packages/patterns/lunch-poll/generated-art.test.tsx --root packages/patterns
+deno task cf test packages/patterns/lunch-poll/lunch-stats.test.tsx --root packages/patterns
+deno task cf test packages/patterns/lunch-poll/main.test.tsx --root packages/patterns
+deno task cf test packages/patterns/lunch-poll/multi-user.test.tsx --root packages/patterns
+deno task cf test packages/patterns/lunch-poll/participant-identity-card.test.tsx --root packages/patterns
+deno task cf test packages/patterns/lunch-poll/poll-option-card.test.tsx --root packages/patterns
+```
+
+The quoted `"${LUNCH_POLL_TEST_ARGS[@]}"` expansion below repeats every `--test`
+entry. Deployment packages and type-checks the tests but does not run them,
+which is why both the test commands and the flags are required.
 
 **Identity key:**
 
@@ -151,6 +179,8 @@ instance.
 
 ```bash
 deno task cf piece setsrc --piece "$PIECE" -s "$SPACE" \
+  --root packages/patterns \
+  "${LUNCH_POLL_TEST_ARGS[@]}" \
   packages/patterns/lunch-poll/main.tsx
 deno task cf piece step --piece "$PIECE" -s "$SPACE"
 ```
@@ -186,6 +216,8 @@ without touching the shared poll):
 ```bash
 # 1. Create your own empty piece (note the new ID it prints).
 MINE=$(deno task cf piece new packages/patterns/lunch-poll/main.tsx \
+  --root packages/patterns \
+  "${LUNCH_POLL_TEST_ARGS[@]}" \
   -s "$SPACE" | grep -oE 'fid1:[A-Za-z0-9_-]+' | head -1)
 
 # 2. Copy each PerSpace field from the shared piece into yours.
@@ -294,7 +326,8 @@ everyone sees, and direct `set` races anyone's live browser session.**
 ### Re-establishing (if it's lost / 404s)
 
 ```bash
-deno task cf piece new packages/patterns/lunch-poll/main.tsx -s "$SPACE"
+deno task cf piece new packages/patterns/lunch-poll/main.tsx \
+  --root packages/patterns "${LUNCH_POLL_TEST_ARGS[@]}" -s "$SPACE"
 # → prints a new fid1:… — update the "live pieces" block above.
 ```
 
@@ -312,6 +345,8 @@ once when a "reset votes" click wedged the running instance. `setsrc` does
 # 1. Confirm it's instance-specific: deploy the same code to a NEW piece. If the
 #    fresh piece works, the old one's process is wedged.
 NEW=$(deno task cf piece new packages/patterns/lunch-poll/main.tsx \
+  --root packages/patterns \
+  "${LUNCH_POLL_TEST_ARGS[@]}" \
   -s "$SPACE" | grep -oE 'fid1:[A-Za-z0-9_-]+' | head -1)
 
 # 2. Copy the PerSpace state across with the Option B loop (history carries too,

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -130,26 +130,27 @@ See `docs/development/EXPERIMENTAL_OPTIONS.md` for available flags.
 
 ## Quick Command Reference
 
-| Operation          | Command                                                                                              |
-| ------------------ | ---------------------------------------------------------------------------------------------------- |
-| Type check         | `deno task cf check pattern.tsx --no-run`                                                            |
-| Deploy new         | `deno task cf piece new pattern.tsx --root . --repository REPO -i key -a url -s space`               |
-| Update existing    | `deno task cf piece setsrc pattern.tsx --root . --repository REPO --piece ID -i key -a url -s space` |
-| Inspect state      | `deno task cf piece inspect --piece ID ...`                                                          |
-| Get field          | `deno task cf piece get --piece ID fieldPath ...`                                                    |
-| Filter array       | `deno task cf piece get --piece ID items --filter '.active == true' ...`                             |
-| Project fields     | `deno task cf piece get --piece ID items --select id,title ...`                                      |
-| Read an address    | `deno task cf piece get --piece ID --select 'topic@,topic.title' ...`                                |
-| Read addresses     | `deno task cf piece get --piece ID items --schema '{"type":"array","items":{"$link":true}}' ...`     |
-| Step + get         | `deno task cf piece get --piece ID fieldPath --step ...`                                             |
-| Set field          | `echo '{"data":...}' \| deno task cf piece set --piece ID path ...`                                  |
-| Call handler       | `deno task cf piece call --piece ID handlerName ...`                                                 |
-| Shape a result     | `deno task cf piece call --piece ID --select topic.title addTopic ...`                               |
-| List verbs         | `deno task cf piece verbs --piece ID --json ...`                                                     |
-| Trigger recompute  | `deno task cf piece step --piece ID ...`                                                             |
-| List pieces        | `deno task cf piece ls -i key -a url -s space`                                                       |
-| Visualize          | `deno task cf piece map ...`                                                                         |
-| Rehearse an update | `deno task cf space clone <did> --from <snapshot> --to <dir>` (then `verify` / `reset`)              |
+| Operation          | Command                                                                                                                      |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| Type check         | `deno task cf check pattern.tsx --no-run`                                                                                    |
+| Test pattern       | `deno task cf test pattern.test.tsx`                                                                                         |
+| Deploy new         | `deno task cf piece new pattern.tsx --test pattern.test.tsx --root . --repository REPO -i key -a url -s space`               |
+| Update existing    | `deno task cf piece setsrc pattern.tsx --test pattern.test.tsx --root . --repository REPO --piece ID -i key -a url -s space` |
+| Inspect state      | `deno task cf piece inspect --piece ID ...`                                                                                  |
+| Get field          | `deno task cf piece get --piece ID fieldPath ...`                                                                            |
+| Filter array       | `deno task cf piece get --piece ID items --filter '.active == true' ...`                                                     |
+| Project fields     | `deno task cf piece get --piece ID items --select id,title ...`                                                              |
+| Read an address    | `deno task cf piece get --piece ID --select 'topic@,topic.title' ...`                                                        |
+| Read addresses     | `deno task cf piece get --piece ID items --schema '{"type":"array","items":{"$link":true}}' ...`                             |
+| Step + get         | `deno task cf piece get --piece ID fieldPath --step ...`                                                                     |
+| Set field          | `echo '{"data":...}' \| deno task cf piece set --piece ID path ...`                                                          |
+| Call handler       | `deno task cf piece call --piece ID handlerName ...`                                                                         |
+| Shape a result     | `deno task cf piece call --piece ID --select topic.title addTopic ...`                                                       |
+| List verbs         | `deno task cf piece verbs --piece ID --json ...`                                                                             |
+| Trigger recompute  | `deno task cf piece step --piece ID ...`                                                                                     |
+| List pieces        | `deno task cf piece ls -i key -a url -s space`                                                                               |
+| Visualize          | `deno task cf piece map ...`                                                                                                 |
+| Rehearse an update | `deno task cf space clone <did> --from <snapshot> --to <dir>` (then `verify` / `reset`)                                      |
 
 ## Check Command Flags
 
@@ -183,18 +184,26 @@ deno task cf check pattern.tsx --verbose-errors     # Detailed error context
 
 ## Core Workflow: setsrc vs new
 
-**Critical pattern:** After initial deployment, use `setsrc` to iterate:
+**Critical pattern:** Run every authored test before deployment. After initial
+deployment, use `setsrc` to iterate and repeat the complete set of attached test
+entries:
 
 ```bash
+# Before every deployment
+deno task cf test pattern.test.tsx
+
 # First time only
-deno task cf piece new pattern.tsx ...
+deno task cf piece new pattern.tsx --test pattern.test.tsx ...
 # Output: Created piece bafyreia... <- Save this ID!
 
 # ALL subsequent iterations
-deno task cf piece setsrc pattern.tsx --piece bafyreia... ...
+deno task cf piece setsrc pattern.tsx --test pattern.test.tsx --piece bafyreia... ...
 ```
 
-**Why:** `new` creates duplicate pieces. `setsrc` updates in-place.
+**Why:** `new` creates duplicate pieces. `setsrc` updates in-place. `--test`
+packages and type-checks a test entry but does not run it. Repeat the flag for
+every authored test entry. Each `setsrc` describes a complete new source
+revision, so omitting the flags drops those test roots from that revision.
 
 `setsrc` normally rejects incompatible argument/result schema changes and
 retained links whose durable contracts no longer fit. For an intentional
@@ -209,11 +218,13 @@ intentional breaking migration.
 ### Source location metadata
 
 The local-source deployment commands `piece new`, `piece setsrc`, and custom
-`piece set-home` accept `--root` plus `--repository`. Use the repository
-checkout root for `--root`; this preserves `source.entry` as a path inside the
+`piece set-home` accept repeatable `--test` flags as well as `--root` and
+`--repository`. Attach every authored pattern test. Use the repository checkout
+root for `--root`; this preserves `source.entry` as a path inside the
 repository. `--repository` is stored exactly as supplied in `source.repository`
 and is never inferred from Git configuration. On `setsrc`, omitting
 `--repository` preserves the existing value; supplying it replaces the value.
+Test flags are different: every source update must repeat the complete list.
 `piece inspect --json` and `piece ls --json` expose the resulting structured
 source locator.
 
@@ -359,18 +370,20 @@ deno task cf piece step --piece ID ...  # Required!
 deno task cf piece inspect --piece ID ...
 ```
 
-**Handler testing workflow** (deploy → call → step → inspect):
+**Handler testing workflow** (automated test → deploy → call → step → inspect):
 
 ```bash
-# 1. Deploy
-deno task cf piece new pattern.tsx -i key -a url -s space
-# 2. Call a handler
+# 1. Run the authored automated test
+deno task cf test pattern.test.tsx
+# 2. Deploy with the test attached
+deno task cf piece new pattern.tsx --test pattern.test.tsx -i key -a url -s space
+# 3. Call a handler
 deno task cf piece call --piece ID handlerName '{"arg": "value"}' ...
-# 3. Step to process
+# 4. Step to process
 deno task cf piece step --piece ID ...
-# 4. Inspect result
+# 5. Inspect result
 deno task cf piece inspect --piece ID ...
-# 5. Repeat 2-4 for each handler
+# 6. Repeat 3-5 for each handler
 ```
 
 See `docs/common/workflows/handlers-cli-testing.md` for the full workflow and

--- a/skills/fuse-agent/SKILL.md
+++ b/skills/fuse-agent/SKILL.md
@@ -256,9 +256,10 @@ wishes. Use them to leave notes about things noticed without necessarily acting.
 
 **Deploy and configure via CF CLI:**
 
-`annotation.tsx` is an existing support pattern in this workflow. If it is
-changed, add and run automated pattern tests first, then attach every new test
-entry with repeatable `--test` flags here and on later `setsrc` updates.
+`annotation.tsx` currently has no authored test entry, so the unchanged support
+pattern deployment below has no `--test` flag. If you change its behavior, first
+create and run an automated pattern test. Then attach every test entry with
+repeatable `--test` flags here and on every later `setsrc` update.
 
 ```bash
 ID=$(cf piece new packages/patterns/annotation.tsx \

--- a/skills/fuse-agent/SKILL.md
+++ b/skills/fuse-agent/SKILL.md
@@ -21,19 +21,28 @@ FUSE mounting, filesystem layout, and low-level read/write mechanics, see the
 cd ~/code/labs
 export CF_IDENTITY=./shared.key CF_API_URL=http://localhost:8000
 
-# 1. Deploy and capture piece ID
+# 1. Run every authored pattern test
+deno task cf test packages/patterns/<path>.test.tsx
+
+# 2. Deploy with every test entry attached and capture the piece ID
 ID=$(cf piece new packages/patterns/<path>.tsx \
+  --test packages/patterns/<path>.test.tsx \
   --space SPACE --root packages/patterns 2>/dev/null | head -1)
 
-# 2. Set title
+# 3. Set title
 cf piece call --quiet --piece $ID --space SPACE setTitle -- --value "My Title"
 
-# 3. Step to materialise
+# 4. Step to materialise
 cf piece step --piece $ID --space SPACE
 
-# 4. Re-read pieces.json immediately — stale after deploy
+# 5. Re-read pieces.json immediately — stale after deploy
 cat "MOUNT/SPACE/pieces/pieces.json"
 ```
+
+For new or changed pattern behavior, write an authored pattern test before
+deploying. Repeat `--test` for multiple entries and pass the same complete set
+on every later `piece setsrc`. Deployment packages and type-checks attached
+tests but does not run them.
 
 **Pattern index:** `cat ~/code/labs/packages/patterns/index.md`
 
@@ -246,6 +255,10 @@ Annotations (`annotation.tsx`) are pieces that record observations, flags, and
 wishes. Use them to leave notes about things noticed without necessarily acting.
 
 **Deploy and configure via CF CLI:**
+
+`annotation.tsx` is an existing support pattern in this workflow. If it is
+changed, add and run automated pattern tests first, then attach every new test
+entry with repeatable `--test` flags here and on later `setsrc` updates.
 
 ```bash
 ID=$(cf piece new packages/patterns/annotation.tsx \

--- a/skills/fuse-workflow/SKILL.md
+++ b/skills/fuse-workflow/SKILL.md
@@ -111,22 +111,30 @@ The power is in combining FUSE, CLI, and browser simultaneously:
 # 1. Develop a pattern
 deno task cf check packages/patterns/my-app/main.tsx --no-run
 
-# 2. Deploy to a space
-deno task cf piece new packages/patterns/my-app/main.tsx -s my-space
+# 2. Run its automated pattern tests
+deno task cf test packages/patterns/my-app/main.test.tsx
+
+# 3. Deploy to a space with the tests attached
+deno task cf piece new packages/patterns/my-app/main.tsx \
+  --test packages/patterns/my-app/main.test.tsx -s my-space
 # => Created piece bafyreia...
 
-# 3. Mount and interact via filesystem
+# 4. Mount and interact via filesystem
 deno task cf fuse mount /tmp/cf
 ls /tmp/cf/my-space/pieces/my-app/result/
 
-# 4. Edit cells from terminal while viewing in browser
+# 5. Edit cells from terminal while viewing in browser
 echo -n "Updated content" > /tmp/cf/my-space/pieces/my-app/input/title
 # => Browser shows the change within ~1 second
 
-# 5. Iterate on the pattern
-deno task cf piece setsrc packages/patterns/my-app/main.tsx --piece bafyreia...
+# 6. Iterate on the pattern and retain its tests
+deno task cf piece setsrc packages/patterns/my-app/main.tsx \
+  --test packages/patterns/my-app/main.test.tsx --piece bafyreia...
 # => Result updates in both browser AND filesystem
 ```
+
+For multiple authored test entries, repeat `--test`. Run every entry locally
+before deployment and repeat the complete flag set on every `setsrc`.
 
 ### Cross-Space Operations
 
@@ -186,15 +194,18 @@ Combine pattern-dev with FUSE for a tight feedback loop:
 # 1. Write pattern in packages/patterns/my-pattern/main.tsx
 # 2. Type check
 deno task cf check packages/patterns/my-pattern/main.tsx --no-run
-# 3. Deploy
-deno task cf piece new packages/patterns/my-pattern/main.tsx -s dev-space
-# 4. Mount
+# 3. Write and run automated pattern tests
+deno task cf test packages/patterns/my-pattern/main.test.tsx
+# 4. Deploy with every test entry attached
+deno task cf piece new packages/patterns/my-pattern/main.tsx \
+  --test packages/patterns/my-pattern/main.test.tsx -s dev-space
+# 5. Mount
 deno task cf fuse mount /tmp/cf
-# 5. Set input via filesystem (faster than cf piece set for complex data)
+# 6. Set input via filesystem (faster than cf piece set for complex data)
 cat test-data.json > /tmp/cf/dev-space/pieces/my-pattern/input.json
-# 6. Read result
+# 7. Read result
 cat /tmp/cf/dev-space/pieces/my-pattern/result.json | jq '.'
-# 7. Iterate: edit pattern → setsrc → result updates automatically
+# 8. Iterate: edit, run tests, then setsrc with every --test flag
 ```
 
 ## Important Gotchas
@@ -375,7 +386,8 @@ MOUNT/SPACE/pieces/My Piece/
 cat "MOUNT/SPACE/pieces/My Piece/.src/main.tsx"
 ```
 
-**Modify source** (use Python — shell redirect fails on FUSE):
+**Temporarily modify live source for diagnosis** (use Python — shell redirect
+fails on FUSE):
 
 ```python
 path = "MOUNT/SPACE/pieces/My Piece/.src/main.tsx"
@@ -384,6 +396,12 @@ src = open(path).read()
 open(path, "w").write(modified_src)
 # Write triggers setsrc automatically — no cf piece setsrc needed
 ```
+
+FUSE preserves the existing attached test roots during this write, but it does
+not run them and cannot change which entries are attached. Treat the live edit
+as a diagnostic experiment. Before completing the change, make it in the
+repository checkout, run every test against that changed source, and deploy it
+with explicit `cf piece setsrc` plus the complete set of `--test` flags.
 
 **Check for errors after modifying:**
 

--- a/skills/pattern-deploy/SKILL.md
+++ b/skills/pattern-deploy/SKILL.md
@@ -43,21 +43,35 @@ With `CF_API_URL` and `CF_IDENTITY` exported (see the cf skill), you can drop
 deno task cf check pattern.tsx --no-run
 ```
 
+**Run and collect automated pattern tests:**
+
+```bash
+deno task cf test packages/patterns/[name]/main.test.tsx
+```
+
+New or changed pattern behavior must have automated coverage. Find every
+authored `*.test.tsx` entry, run each one, and repeat `--test` for each entry in
+the deployment commands below. Manual handler checks do not replace this step.
+
 **Deploy new pattern (first time only):**
 
 ```bash
-deno task cf piece new packages/patterns/[name]/main.tsx --identity cf.key --api-url $CF_API_URL --space <space>
+deno task cf piece new packages/patterns/[name]/main.tsx --test packages/patterns/[name]/main.test.tsx --identity cf.key --api-url $CF_API_URL --space <space>
 # Output: Created piece bafyreia... <- SAVE this piece ID
 ```
 
 **Update deployed pattern (all subsequent iterations):**
 
 ```bash
-deno task cf piece setsrc packages/patterns/[name]/main.tsx --piece <ID> --identity cf.key --api-url $CF_API_URL --space <space>
+deno task cf piece setsrc packages/patterns/[name]/main.tsx --test packages/patterns/[name]/main.test.tsx --piece <ID> --identity cf.key --api-url $CF_API_URL --space <space>
 ```
 
 `--piece` is required for `setsrc` — never "update" by re-running `piece new`,
 which creates a duplicate piece.
+
+`--test` packages and type-checks a test but does not run it. Every `setsrc`
+defines the complete source revision, so repeat all test flags on every update
+or the new revision will omit those test roots.
 
 **Inspect piece state:**
 
@@ -94,5 +108,7 @@ deno task cf piece --help
 ## Done When
 
 - Piece deploys without errors
+- Every automated pattern test passes
+- Every authored test entry is attached to the deployed source revision
 - State inspects correctly
 - Handlers respond to CLI calls

--- a/skills/pattern-dev/SKILL.md
+++ b/skills/pattern-dev/SKILL.md
@@ -9,6 +9,13 @@ Start with the shared pattern development guidance in:
 
 Read that guide first. It is the canonical reference.
 
+For new or changed behavior, completion includes the whole source lifecycle:
+write automated pattern tests, run every test entry with `cf test`, and attach
+every entry with repeatable `--test` flags on `piece new` and every later
+`piece setsrc`. Manual browser or CLI verification does not replace the
+automated tests. Deployment packages and type-checks attached tests but does not
+run them.
+
 Also read the foundational reactivity references before implementing or
 debugging pattern state:
 
@@ -157,7 +164,7 @@ Task({
 })
 
 Task({
-  prompt: "Deploy and test [pattern].",
+  prompt: "Run every authored test, then deploy [pattern] with each test attached.",
   subagent_type: "pattern-user"
 })
 

--- a/skills/pattern-test/SKILL.md
+++ b/skills/pattern-test/SKILL.md
@@ -16,6 +16,19 @@ Run tests with:
 deno task cf test <pattern>.test.tsx
 ```
 
+Keep the complete list of test entry paths for deployment. A deployed source
+revision carries those tests only when each entry is supplied with a repeatable
+`--test` flag:
+
+```bash
+deno task cf piece new <pattern>.tsx --test <pattern>.test.tsx ...
+deno task cf piece setsrc <pattern>.tsx --test <pattern>.test.tsx --piece <piece-id> ...
+```
+
+Repeat `--test` for multiple entry files and repeat the complete flag set on
+every `setsrc`. The deployment command packages and type-checks attached tests
+but does not execute them, so a successful `cf test` run remains required.
+
 When working in a Pattern Factory Build workspace, also follow
 `docs/common/ai/pattern-factory-build-guide.md` (as mandated by pattern-dev). It
 defines Pattern Factory's build completion gate and expected coverage shape.
@@ -52,3 +65,5 @@ Runtime notes:
   from the spec).
 - The pattern still compiles after any interface changes made to support
   testing.
+- Every authored test entry is handed to deployment for attachment to the source
+  revision.


### PR DESCRIPTION
Pattern authoring guidance required automated coverage, but deployment examples often omitted test entries. Following those examples produced source revisions that excluded authored tests. FUSE source writes also rebuilt programs without their recovered test roots.

Make agent roles, skills, workflow docs, tutorials, and live runbooks describe one process: run every test, stop on failure, and attach every entry to each new or updated source revision. Explain that attachment type-checks and packages tests but does not execute them.

Preserve source roots during FUSE writeback. Extend the pattern-user hook to warn for each deployment command while allowing resets and intentional test pattern diagnostics. Add focused regressions for FUSE preservation and hook guidance.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

