### PR TITLE
docs(memory,piece,cli,cf-harness): reattach doc comments to their declarations

### DIFF
--- a/packages/cf-harness/src/model/openai-compatible-gateway.ts
+++ b/packages/cf-harness/src/model/openai-compatible-gateway.ts
@@ -168,16 +168,6 @@ export const usesResponsesApi = (
 ): boolean => nativeModelToolIds.length === 0 && model.startsWith("gpt-");
 
 /**
- * `gpt-*` models reason by default, and Chat Completions rejects function
- * tools whenever reasoning is active. Provider-native tools force a turn onto
- * Chat Completions, so combining them with an OpenAI model would route
- * straight into that 400 with cf-harness's function tools attached.
- *
- * Nothing produces this combination today — the only native-tool profile is
- * `web_search`, which overrides the model to Gemini — so this fails loudly
- * rather than letting a future profile discover it as a provider error.
- */
-/**
  * Rejects a compaction threshold on a turn that cannot honour it.
  *
  * `context_management` is only sent on the Responses path, so a chat-routed
@@ -199,6 +189,16 @@ export const assertCompactThresholdSupported = (
   }
 };
 
+/**
+ * `gpt-*` models reason by default, and Chat Completions rejects function
+ * tools whenever reasoning is active. Provider-native tools force a turn onto
+ * Chat Completions, so combining them with an OpenAI model would route
+ * straight into that 400 with cf-harness's function tools attached.
+ *
+ * Nothing produces this combination today — the only native-tool profile is
+ * `web_search`, which overrides the model to Gemini — so this fails loudly
+ * rather than letting a future profile discover it as a provider error.
+ */
 const assertSupportedToolCombination = (
   model: string,
   nativeModelToolIds: readonly LLMNativeModelToolId[],

--- a/packages/cli/lib/fuse.ts
+++ b/packages/cli/lib/fuse.ts
@@ -350,19 +350,21 @@ function openGetfsstat():
 }
 
 /**
- * Reads the darwin kernel mount table via getfsstat(MNT_NOWAIT) and returns the
- * canonical f_mntonname of every mount. Returns null (→ caller reports
- * "unknown") if FFI is unavailable or the call fails — never a partial or empty
- * list masquerading as "no mounts" on error.
+ * The libc getfsstat signature we depend on. Injectable so the error-mapping
+ * path (native failure → null) is testable without a real syscall.
  */
-// The libc getfsstat signature we depend on. Injectable so the error-mapping
-// path (native failure → null) is testable without a real syscall.
 export type GetfsstatFn = (
   buf: Deno.PointerValue,
   bytes: number,
   flags: number,
 ) => number;
 
+/**
+ * Reads the darwin kernel mount table via getfsstat(MNT_NOWAIT) and returns the
+ * canonical f_mntonname of every mount. Returns null (→ caller reports
+ * "unknown") if FFI is unavailable or the call fails — never a partial or empty
+ * list masquerading as "no mounts" on error.
+ */
 export function readDarwinMountpoints(call?: GetfsstatFn): string[] | null {
   let fn = call;
   let close = () => {};

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -1687,16 +1687,6 @@ export function partitionVerbListing(
   return { shown, wrapper, deprecated };
 }
 
-/**
- * Enumerate every callable a piece exposes (verb contract: Verb discovery,
- * docs/plans/pattern-verb-contract.md). Everything in the durable schema is
- * listed — hiding is a display default driven by the listing marks
- * (`tier: "wrapper"`, `deprecated: true`), never a capability boundary: the
- * rows carry the marks, `partitionVerbListing` decides the default view, and
- * `--all` shows the full surface. Walks result then input with the same classification
- * `cf piece call` resolves through, so the listing and the dispatcher can
- * never disagree about what is callable.
- */
 /** The listing marks as they appear on the durable schema's property. */
 function listingMarks(
   rootSchema: unknown,
@@ -1711,6 +1701,16 @@ function listingMarks(
   };
 }
 
+/**
+ * Enumerate every callable a piece exposes (verb contract: Verb discovery,
+ * docs/plans/pattern-verb-contract.md). Everything in the durable schema is
+ * listed — hiding is a display default driven by the listing marks
+ * (`tier: "wrapper"`, `deprecated: true`), never a capability boundary: the
+ * rows carry the marks, `partitionVerbListing` decides the default view, and
+ * `--all` shows the full surface. Walks result then input with the same classification
+ * `cf piece call` resolves through, so the listing and the dispatcher can
+ * never disagree about what is callable.
+ */
 export async function listPieceCallables(
   config: PieceConfig,
   deps: PieceCallableDependencies = {},

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -1687,6 +1687,16 @@ export function partitionVerbListing(
   return { shown, wrapper, deprecated };
 }
 
+/**
+ * Enumerate every callable a piece exposes (verb contract: Verb discovery,
+ * docs/plans/pattern-verb-contract.md). Everything in the durable schema is
+ * listed — hiding is a display default driven by the listing marks
+ * (`tier: "wrapper"`, `deprecated: true`), never a capability boundary: the
+ * rows carry the marks, `partitionVerbListing` decides the default view, and
+ * `--all` shows the full surface. Walks result then input with the same classification
+ * `cf piece call` resolves through, so the listing and the dispatcher can
+ * never disagree about what is callable.
+ */
 /** The listing marks as they appear on the durable schema's property. */
 function listingMarks(
   rootSchema: unknown,
@@ -1701,16 +1711,6 @@ function listingMarks(
   };
 }
 
-/**
- * Enumerate every callable a piece exposes (verb contract: Verb discovery,
- * docs/plans/pattern-verb-contract.md). Everything in the durable schema is
- * listed — hiding is a display default driven by the listing marks
- * (`tier: "wrapper"`, `deprecated: true`), never a capability boundary: the
- * rows carry the marks, `partitionVerbListing` decides the default view, and
- * `--all` shows the full surface. Walks result then input with the same classification
- * `cf piece call` resolves through, so the listing and the dispatcher can
- * never disagree about what is callable.
- */
 export async function listPieceCallables(
   config: PieceConfig,
   deps: PieceCallableDependencies = {},

--- a/packages/cli/lib/view/languages/typescript/parse.ts
+++ b/packages/cli/lib/view/languages/typescript/parse.ts
@@ -689,8 +689,6 @@ function tokenAt(sf: ts.SourceFile, pos: number): ts.Node {
   }
 }
 
-/** Leaf tokens whose start lies in [from, to). The walk prunes subtrees that do
- * not overlap the range, so it costs the range size, not the document size. */
 /** Whether `kind` is a JSDoc node. The token walk does not descend into these:
  * a `{@link Name}` tag parses `Name` as an Identifier leaf, which would split
  * the comment and leave the text after it uncoloured — a JSDoc comment stays
@@ -699,6 +697,8 @@ function isJSDocNode(kind: ts.SyntaxKind): boolean {
   return kind >= SK.FirstJSDocNode && kind <= SK.LastJSDocNode;
 }
 
+/** Leaf tokens whose start lies in [from, to). The walk prunes subtrees that do
+ * not overlap the range, so it costs the range size, not the document size. */
 function collectTokensInRange(
   sf: ts.SourceFile,
   from: number,

--- a/packages/memory/v2/patch.ts
+++ b/packages/memory/v2/patch.ts
@@ -36,26 +36,6 @@ const MAX_ARRAY_INDEX = 2 ** 32 - 2;
 const cloneValue = (value: FabricValue): FabricValue => cloneIfNecessary(value);
 
 /**
- * Applies a sequence of RFC 6902 JSON Patch operations (`replace`, `add`,
- * `remove`, `move`, `splice`) to a document tree, returning a new document
- * tree with the patches applied in order. JSON Pointer paths in the ops are
- * parsed via `parsePointer()` from `./path.ts`.
- *
- * Used during document materialization: `engine.ts` walks the stored patch
- * sequence for a branch and rebuilds the current document by replaying each
- * patch on top of the previous state (`applyPatchDocument` → `applyPatch`).
- * The function is therefore on the hot path for any read that reconstructs
- * a document from its stored patch list.
- *
- * Mutation discipline: each op is applied via a copy-on-write descent. The
- * spine of containers from the root down to the mutated container is thawed to
- * fresh mutable copies (via `cloneForMutation()`), the leaf operation is applied
- * to that mutable container, and subtrees off the spine stay frozen-by-reference
- * (structural sharing). The assembled tree is then fully deep-frozen at the
- * `applyPatch` boundary, so callers can rely on the return value being deeply
- * frozen.
- */
-/**
  * A patch that cannot apply to the given base: a path descending through a
  * non-container, a kind mismatch (append onto a non-array), an invalid
  * pointer or index, or a root op producing a non-envelope result. Callers
@@ -96,6 +76,26 @@ export const applyPatchToDocument = (
   return patched;
 };
 
+/**
+ * Applies a sequence of RFC 6902 JSON Patch operations (`replace`, `add`,
+ * `remove`, `move`, `splice`) to a document tree, returning a new document
+ * tree with the patches applied in order. JSON Pointer paths in the ops are
+ * parsed via `parsePointer()` from `./path.ts`.
+ *
+ * Used during document materialization: `engine.ts` walks the stored patch
+ * sequence for a branch and rebuilds the current document by replaying each
+ * patch on top of the previous state (`applyPatchDocument` → `applyPatch`).
+ * The function is therefore on the hot path for any read that reconstructs
+ * a document from its stored patch list.
+ *
+ * Mutation discipline: each op is applied via a copy-on-write descent. The
+ * spine of containers from the root down to the mutated container is thawed to
+ * fresh mutable copies (via `cloneForMutation()`), the leaf operation is applied
+ * to that mutable container, and subtrees off the spine stay frozen-by-reference
+ * (structural sharing). The assembled tree is then fully deep-frozen at the
+ * `applyPatch` boundary, so callers can rely on the return value being deeply
+ * frozen.
+ */
 export const applyPatch = (
   state: FabricValue,
   ops: PatchOp[],

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -308,7 +308,6 @@ function missingTableName(error: unknown): string | undefined {
  *  full-Unicode `toLowerCase()` would over-match — SQLite treats e.g. `Ü` and
  *  `ü` as distinct tables, so folding them together here would mask a genuine
  *  "no such table" error as an empty result. */
-
 function isDeclaredTable(
   tables: Record<string, unknown> | undefined,
   name: string,
@@ -1285,16 +1284,6 @@ export class Server {
     return null;
   }
 
-  /** After an ACL change, drop live sessions whose principal no longer
-   *  holds READ (enforce mode only): per-message gating alone would still
-   *  let their already-registered subscriptions receive pushes. The owning
-   *  connection gets a session/revoked("unauthorized"), which the client
-   *  treats as a terminal session close (no reopen loop — a reopen attempt
-   *  is denied at session.open). The session that made the triggering ACL
-   *  write (`writerSessionId`) is still dropped from the registry — so it
-   *  receives no further pushes — but is NOT sent the terminal revocation, so
-   *  it gets this transact's response first (a self-removal otherwise reads as
-   *  a failure). Its next message fails closed as an unknown session. */
   // Writer sessions that de-authorized themselves in a commit: their
   // session/revoked is held until after the transact verdict goes out.
   #deferredSelfRevocations = new Map<string, string | null>();
@@ -1315,6 +1304,18 @@ export class Server {
     }
   }
 
+  /**
+   * After an ACL change, drop live sessions whose principal no longer holds
+   * READ (enforce mode only): per-message gating alone would still let their
+   * already-registered subscriptions receive pushes. The owning connection
+   * gets a session/revoked("unauthorized"), which the client treats as a
+   * terminal session close (no reopen loop — a reopen attempt is denied at
+   * session.open). The session that made the triggering ACL write
+   * (`writerSessionId`) is still dropped from the registry — so it receives no
+   * further pushes — but is NOT sent the terminal revocation, so it gets this
+   * transact's response first (a self-removal otherwise reads as a failure).
+   * Its next message fails closed as an unknown session.
+   */
   #revokeDeauthorizedSessions(
     engine: Engine.Engine,
     space: string,

--- a/packages/memory/v2/sqlite/write-targets.ts
+++ b/packages/memory/v2/sqlite/write-targets.ts
@@ -92,9 +92,6 @@ function unquoteIdent(raw: string): string {
   return raw.trim().replace(/^["'`[]|["'`\]]$/g, "");
 }
 
-/** The single target table of a write (`INSERT INTO t`, `UPDATE t`,
- *  `DELETE FROM t`), unquoted; undefined if it can't be confidently extracted
- *  (e.g. a schema-qualified or unusual form). Used to resolve a column's `ifc`. */
 /** Blank string literals/comments so the structural parsers can't be fooled by
  *  `?`/keywords/commas inside them. Exposed so a caller parsing the SAME SQL for
  *  both table and param-columns can blank once and pass it to both. */
@@ -102,6 +99,9 @@ export function blankWriteSql(sql: string): string {
   return blankStringsAndComments(sql);
 }
 
+/** The single target table of a write (`INSERT INTO t`, `UPDATE t`,
+ *  `DELETE FROM t`), unquoted; undefined if it can't be confidently extracted
+ *  (e.g. a schema-qualified or unusual form). Used to resolve a column's `ifc`. */
 export function parseWriteTable(
   sql: string,
   blanked: string = blankStringsAndComments(sql),

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -668,8 +668,9 @@ export function selectCurrentContainerSchema(
  * This is deliberately a current-value proof, not a future-value link proof:
  * every currently matching anyOf branch remains a separate conjunct so an
  * overlapping ordinary alternative cannot erase a restricted Cell capability.
+ *
+ * @internal Exported for focused correlated-write contract tests.
  */
-/** @internal Exported for focused correlated-write contract tests. */
 export function currentValuePathContracts(
   unresolved: PathSchemaContract,
   segment: string | number,
@@ -856,8 +857,9 @@ function outerCellShapesMatch(
   return left.kind === right.kind && left.scope === right.scope;
 }
 
-/** Consume a uniform outer Cell wrapper through refs and compositions. */
-/** @internal Exported for focused Cell-capability contract tests. */
+/** Consume a uniform outer Cell wrapper through refs and compositions. *
+ * @internal Exported for focused Cell-capability contract tests.
+ */
 export function localizeOuterCellContract(
   unresolved: PathSchemaContract,
   stored: StoredCellTopology | undefined = undefined,
@@ -1236,8 +1238,9 @@ function canFollowSourceScope(
  * Recover a producer contract from durable Piece metadata, ignoring any schema
  * carried by the supplied alias. A caller can narrow a Cell view before
  * serializing it, so the envelope itself is not evidence about future writes.
+ *
+ * @internal Exported for focused producer-topology contract tests.
  */
-/** @internal Exported for focused producer-topology contract tests. */
 export function durableSourceContract(
   linkedCell: Cell<unknown>,
   pieces: PiecesController,

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -857,7 +857,9 @@ function outerCellShapesMatch(
   return left.kind === right.kind && left.scope === right.scope;
 }
 
-/** Consume a uniform outer Cell wrapper through refs and compositions. *
+/**
+ * Consume a uniform outer Cell wrapper through refs and compositions.
+ *
  * @internal Exported for focused Cell-capability contract tests.
  */
 export function localizeOuterCellContract(

--- a/packages/piece/test/state-continuity-harness.ts
+++ b/packages/piece/test/state-continuity-harness.ts
@@ -829,15 +829,6 @@ export async function readStateUnder(
 }
 
 /**
- * A captured root's state, read the way the version that WROTE it saw it.
- *
- * Read under the root's OWN stored result schema, which it carries in meta — so
- * the writing version's view of its data is recoverable without its source, and
- * without this replay having to decide what that view should be. Relaxed at its
- * `unknown` positions first — see `schemaRelaxedForComparison` for what that
- * buys and why it is still the writer's own schema.
- */
-/**
  * The result schema a root carries in meta, or `undefined` if it carries none.
  *
  * Split out so a caller reporting a failed read can say WHICH half failed —
@@ -864,6 +855,15 @@ export async function readStoredResultSchema(
   }
 }
 
+/**
+ * A captured root's state, read the way the version that WROTE it saw it.
+ *
+ * Read under the root's OWN stored result schema, which it carries in meta — so
+ * the writing version's view of its data is recoverable without its source, and
+ * without this replay having to decide what that view should be. Relaxed at its
+ * `unknown` positions first — see `schemaRelaxedForComparison` for what that
+ * buys and why it is still the writer's own schema.
+ */
 export async function readVintageState(
   vintage: VintageRuntime,
   space: string,


### PR DESCRIPTION
I (an agent working on behalf of @danfuzz) swept the repository for doc comments
separated from the declaration they document, after the rule for this landed in
`docs/development/code-comment-style.md` ("Where one goes"). This covers
`memory`, `piece`, `cli` and `cf-harness`; other packages follow separately.

Ten sites. In most, a definition had been added directly beneath an existing
doc comment, so the comment attached to the newcomer and the declaration it was
written for was left with none.

Where the subject was not self-evident from the wording I confirmed it against
`git log -S` on the comment's own text, rather than attaching it to whatever
declaration happened to be nearest:

| Comment | Original subject | Now on |
| --- | --- | --- |
| "Applies a sequence of RFC 6902 JSON Patch operations…" | `applyPatch` (`e496c9c44`) | `applyPatch` |
| "After an ACL change, drop live sessions…" | `#revokeDeauthorizedSessions` (`eaadf59df`) | `#revokeDeauthorizedSessions` |
| "The single target table of a write…" | `parseWriteTable` (`3c8413a95`) | `parseWriteTable` |
| "`gpt-*` models reason by default…" | `assertSupportedToolCombination` (`d7ca6c917`) | `assertSupportedToolCombination` |

`write-targets.ts` is worth a note: the defect was born in the same commit that
added the comment — `blankWriteSql` was written directly underneath
`parseWriteTable`'s doc.

Also moved, where the wording names its subject unambiguously:
`readVintageState` (`piece/test/state-continuity-harness.ts`, stranded when
`readStoredResultSchema` was split out of it) and `collectTokensInRange`
(`cli/lib/view/languages/typescript/parse.ts`).

## Held back: `cli/lib/piece.ts`

"Enumerate every callable a piece exposes…" is `listPieceCallables`'s doc
(`b88c0c758`), taken over by `listingMarks`. Moving it back overlaps #5629,
which edits both of those functions, so the two conflict whichever lands
first. That file is reverted here — one comment moved twenty lines is not
worth making a feature PR care about merge order. Worth re-applying on top
once #5629 lands.

## Two that are not moves

- **`piece/src/ops/piece-controller.ts`** — three functions each carried a doc
  comment *plus* a separate `/** @internal Exported for focused … tests. */`.
  Only the `@internal` line reaches rendered documentation, so the real
  description was invisible on all three. Each pair is merged, `@internal`
  becoming a tag on the surviving comment.
- **`cli/lib/fuse.ts`** — `readDarwinMountpoints`'s doc headed the
  `GetfsstatFn` type, whose own description was a `//` note below it. The two
  comment blocks are swapped so each declaration carries its own, and the note
  becomes a doc comment (the type has no body to hold it). The declarations
  themselves do not move — `GetfsstatFn` preceded `readDarwinMountpoints`
  before and still does.

## One blank line

`isDeclaredTable`'s doc was separated from the function by a stray blank line
(`memory/v2/server.ts`).

## Verification

`deno task check`, `deno lint`, `deno fmt --check`, and the full suites for
each touched package: `memory` 494 passed, `cf-harness` 607, `piece` 36,
`cli` 174 — 0 failed. Every change in this PR is to a comment.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


