### PR TITLE
docs(ts-transformers,js-compiler,tasks): reattach doc comments to their declarations

### DIFF
--- a/packages/js-compiler/source-map.ts
+++ b/packages/js-compiler/source-map.ts
@@ -259,20 +259,6 @@ function composeBundleSourceMapTextual(
 }
 
 /**
- * Compose a single bundle source map for the concatenated module bodies
- * (`[...bodies].join("\n")`) from each module's own source map, offsetting each
- * module's generated lines by its starting line in the concatenation.
- *
- * The module-record loader resolves a function's location by `indexOf`-ing
- * its source into the concatenated bundle `script`, then calling
- * `mapPosition(bundleFilename, line, col)`. Without a registered map that stays
- * a raw bundle coordinate (`<loadId>.js:..`), which CFC verified-source identity
- * rejects. Registering this composed map resolves it back to the original
- * authored source (e.g. `/main.tsx:6:2`).
- *
- * Returns `undefined` if no module contributed a map.
- */
-/**
  * A module's contribution to a composed bundle map. Exactly one of `body` /
  * `bodyLineCount` must describe the module's generated-line extent —
  * composition only ever needs the LINE COUNT of the body, so callers that
@@ -293,6 +279,20 @@ export function getComposeBundleSourceMapCallsForTesting(): number {
   return composeCallsForTesting;
 }
 
+/**
+ * Compose a single bundle source map for the concatenated module bodies
+ * (`[...bodies].join("\n")`) from each module's own source map, offsetting each
+ * module's generated lines by its starting line in the concatenation.
+ *
+ * The module-record loader resolves a function's location by `indexOf`-ing
+ * its source into the concatenated bundle `script`, then calling
+ * `mapPosition(bundleFilename, line, col)`. Without a registered map that stays
+ * a raw bundle coordinate (`<loadId>.js:..`), which CFC verified-source identity
+ * rejects. Registering this composed map resolves it back to the original
+ * authored source (e.g. `/main.tsx:6:2`).
+ *
+ * Returns `undefined` if no module contributed a map.
+ */
 export function composeBundleSourceMap(
   // `source`, when set, overrides the map's recorded source path for ALL of that
   // module's mappings. The per-module compiler maps record only the basename

--- a/packages/js-compiler/typescript/options.ts
+++ b/packages/js-compiler/typescript/options.ts
@@ -7,25 +7,25 @@ export const TARGET = ScriptTarget.ES2023;
 
 export const getCompilerOptions = (): CompilerOptions => {
   return {
-    /**
-     * Typechecking
-     */
+    //
+    // Typechecking
+    //
 
     strict: true,
     strictNullChecks: true,
     strictFunctionTypes: true,
 
-    /**
-     * Module
-     */
+    //
+    // Module
+    //
 
     // Per-module CommonJS bodies — the inputs the ESM module-record loader
     // and verifier consume.
     module: MODULE_KIND,
 
-    /**
-     * Emit
-     */
+    //
+    // Emit
+    //
 
     removeComments: true,
     // Belt-and-suspenders on authoring paths; the pipeline's explicit checks
@@ -57,9 +57,9 @@ export const getCompilerOptions = (): CompilerOptions => {
     // Generate separate source map instead of inline
     inlineSourceMap: false,
 
-    /**
-     * JavaScript
-     */
+    //
+    // JavaScript
+    //
 
     allowJs: true,
     // Authored `.js` sources emit their compiled body under the SAME name
@@ -71,17 +71,17 @@ export const getCompilerOptions = (): CompilerOptions => {
     // collide on one output, e.g. `/a.ts` + `/a.js`.)
     suppressOutputPathCheck: true,
 
-    /**
-     * Interop
-     */
+    //
+    // Interop
+    //
 
     forceConsistentCasingInFileNames: true,
     esModuleInterop: true,
     isolatedModules: false,
 
-    /**
-     * Language and Environment
-     */
+    //
+    // Language and Environment
+    //
 
     jsx: JsxEmit.React,
     jsxFactory: "h",

--- a/packages/ts-transformers/src/policy/callback-boundary.ts
+++ b/packages/ts-transformers/src/policy/callback-boundary.ts
@@ -84,14 +84,6 @@ function isWithinJsxExpression(node: ts.Node): boolean {
   return false;
 }
 
-/**
- * True when `patternCall` (a `pattern(...)` call) is the first argument of an
- * enclosing `patternTool(...)` call — the canonical CT-1655 shape
- * `patternTool(pattern(cb), extraParams?)`. Used to give such a pattern's
- * callback a patternTool boundary (function creation allowed in the
- * surrounding restricted context) rather than the restricted pattern-builder
- * boundary a bare `pattern(...)` gets.
- */
 /** True when `callee` is the SQLite `table()` builder (the `commonfabric`
  *  export or `cfSqlite.table`) — recognized by name plus the
  *  `SqliteTableFunction` type alias, so local rebinding keeps working and an
@@ -121,6 +113,14 @@ function isSqliteTableCallee(
   });
 }
 
+/**
+ * True when `patternCall` (a `pattern(...)` call) is the first argument of an
+ * enclosing `patternTool(...)` call — the canonical CT-1655 shape
+ * `patternTool(pattern(cb), extraParams?)`. Used to give such a pattern's
+ * callback a patternTool boundary (function creation allowed in the
+ * surrounding restricted context) rather than the restricted pattern-builder
+ * boundary a bare `pattern(...)` gets.
+ */
 function isPatternToolPatternArgument(
   patternCall: ts.CallExpression,
   checker: ts.TypeChecker,

--- a/packages/ts-transformers/src/transformers/schema-injection.ts
+++ b/packages/ts-transformers/src/transformers/schema-injection.ts
@@ -2635,13 +2635,6 @@ function shouldReportPermissiveInferredPatternResult(
   return isAnyOrUnknownType(resultType);
 }
 
-/**
- * Handler for pattern schema injection.
- * Argument order is function-first: [function, inputSchema, resultSchema]
- *
- * @returns The transformed node, or undefined if no transformation was performed
- */
-
 function reportAnyResultSchema(
   context: TransformationContext,
   node: ts.CallExpression,
@@ -2738,6 +2731,12 @@ function isMapWithPatternCallbackPatternCall(node: ts.CallExpression): boolean {
     arrayMethodInfo.family === "map";
 }
 
+/**
+ * Handler for pattern schema injection.
+ * Argument order is function-first: [function, inputSchema, resultSchema]
+ *
+ * @returns The transformed node, or undefined if no transformation was performed
+ */
 function handlePatternSchemaInjection(
   node: ts.CallExpression,
   context: TransformationContext,

--- a/packages/ts-transformers/src/transformers/verb-return-validation.ts
+++ b/packages/ts-transformers/src/transformers/verb-return-validation.ts
@@ -117,11 +117,6 @@ function verbCallback(
 }
 
 /**
- * `return <expr>` statements that return from the verb body itself — nested
- * function-likes return to their own callers and are not descended into. The
- * literal `undefined` counts as control flow, not a value.
- */
-/**
  * The shapes a forgotten result declaration actually takes: expressions that
  * are plain data by construction. Calls, identifiers, property reads, JSX,
  * `new`, and anything else stay unjudged — those are the launch/navigation/
@@ -172,6 +167,11 @@ function isDefinitelyPlainShaped(expr: ts.Expression): boolean {
     expr.kind === ts.SyntaxKind.NullKeyword;
 }
 
+/**
+ * `return <expr>` statements that return from the verb body itself — nested
+ * function-likes return to their own callers and are not descended into. The
+ * literal `undefined` counts as control flow, not a value.
+ */
 function topLevelValueReturns(body: ts.Block): ts.ReturnStatement[] {
   const found: ts.ReturnStatement[] = [];
   const walk = (node: ts.Node): void => {

--- a/scripts/ab-harness.ts
+++ b/scripts/ab-harness.ts
@@ -68,7 +68,6 @@ const { dataUriFromValue } = await import(
   "@commonfabric/data-model/data-uri-codec"
 );
 
-/** The module serializer, under whichever name the tree spells it. */
 /** Identity on a tree with no preflight, so the same probe runs on both. */
 let flatten: (v: unknown) => unknown = (v) => v;
 try {

--- a/tasks/coverage-check.ts
+++ b/tasks/coverage-check.ts
@@ -631,10 +631,6 @@ export function resolveMetricBaselines(
   return resolved;
 }
 
-/**
- * Reports which commit each baseline was measured at, and how far back from the
- * base-branch commit that sits.
- */
 /** Names the groups no baseline could speak to, and why they are not gated. */
 export function reportUngatedGroups(
   groups: Set<string>,
@@ -650,6 +646,10 @@ export function reportUngatedGroups(
   );
 }
 
+/**
+ * Reports which commit each baseline was measured at, and how far back from the
+ * base-branch commit that sits.
+ */
 export function reportBaselineDistance(
   baselineShas: Set<string>,
   baseSha: string,


### PR DESCRIPTION
I (an agent working on behalf of @danfuzz) swept the repository for doc comments
separated from the declaration they document, after the rule for this landed in
`docs/development/code-comment-style.md` ("Where one goes"). This covers
`ts-transformers`, `js-compiler`, `tasks/` and `scripts/`; other packages
follow separately.

## Five straight moves

Each of these doc comments had been taken over by a definition added directly
beneath it, leaving its own declaration with none:

| Comment | Now on |
| --- | --- |
| "True when `patternCall` … is the first argument of an enclosing `patternTool(...)` call" | `isPatternToolPatternArgument` |
| "`return <expr>` statements that return from the verb body itself" | `topLevelValueReturns` |
| "Handler for pattern schema injection" | `handlePatternSchemaInjection` |
| "Compose a single bundle source map for the concatenated module bodies" | `composeBundleSourceMap` |
| "Reports which commit each baseline was measured at" | `reportBaselineDistance` |

The schema-injection one needed history to place. The comment was written
against `handleBuilderSchemaInjection` (`e141e3e41`), which is the same
function under its current name: it returns `ts.Node | undefined`, matching the
`@returns The transformed node, or undefined if no transformation was
performed` the comment carries. `reportAnyResultSchema`, which it had come to
sit on, returns void — so the `@returns` was describing a function two
definitions away.

## Six section banners

`js-compiler/typescript/options.ts` titles regions of the compiler-options
literal — Typechecking, Module, Emit, JavaScript, Interop, Language and
Environment — with doc comments that document nothing. They become `//`
section markers, which is the form `code-comment-style.md` specifies for
titling a region.

## One deletion

`scripts/ab-harness.ts` opened `flatten` with two doc comments. The second
describes it. The first — "The module serializer, under whichever name the
tree spells it" — has no subject: `d7653447d` added both lines at once and
never declared a module serializer, and `flatten` is the preflight flattener,
with the name-fallback phrasing borrowed from `patternForm` further down.
Deleted rather than reattached.

## Verification

`deno task check`, `deno lint`, `deno fmt --check`, and the full suites:
`js-compiler` 11 passed, `ts-transformers` 1137, `tasks/` 497 — 0 failed.
Every change in this PR is to a comment.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

