### PR TITLE
refactor(utils,data-model): `bigint` <-> base64url in one step

### DIFF
--- a/packages/data-model/src/codec-json/BigIntCodec.ts
+++ b/packages/data-model/src/codec-json/BigIntCodec.ts
@@ -1,10 +1,6 @@
 import {
-  fromBase64url,
-  toUnpaddedBase64url,
-} from "@commonfabric/utils/base64url";
-import {
-  bigintFromMinimalTwosComplement,
-  bigintToMinimalTwosComplement,
+  bigintFromUnpaddedBase64url,
+  bigintToUnpaddedBase64url,
 } from "@commonfabric/utils/bigint";
 import type { Constructor } from "@commonfabric/utils/types";
 
@@ -40,7 +36,7 @@ export class BigIntCodec extends BaseFabricCodec {
 
   /** @inheritDoc */
   encode(value: bigint): FabricValue {
-    return toUnpaddedBase64url(bigintToMinimalTwosComplement(value));
+    return bigintToUnpaddedBase64url(value);
   }
 
   /** @inheritDoc */
@@ -57,7 +53,7 @@ export class BigIntCodec extends BaseFabricCodec {
       );
     }
     try {
-      return bigintFromMinimalTwosComplement(fromBase64url(state));
+      return bigintFromUnpaddedBase64url(state);
     } catch {
       return new ProblematicValue(
         typeTag,

--- a/packages/data-model/src/fabric-primitives/FabricEpochDays.ts
+++ b/packages/data-model/src/fabric-primitives/FabricEpochDays.ts
@@ -3,12 +3,8 @@ import type {
   FabricEpochDaysConstructor as ApiFabricEpochDaysConstructor,
 } from "@commonfabric/api";
 import {
-  fromBase64url,
-  toUnpaddedBase64url,
-} from "@commonfabric/utils/base64url";
-import {
-  bigintFromMinimalTwosComplement,
-  bigintToMinimalTwosComplement,
+  bigintFromUnpaddedBase64url,
+  bigintToUnpaddedBase64url,
 } from "@commonfabric/utils/bigint";
 
 import type { FabricValue } from "@/interface.ts";
@@ -57,7 +53,7 @@ export class FabricEpochDays extends BaseFabricPrimitive
 
       /** @inheritDoc */
       encode(value: FabricEpochDays): FabricValue {
-        return toUnpaddedBase64url(bigintToMinimalTwosComplement(value.#value));
+        return bigintToUnpaddedBase64url(value.#value);
       }
 
       /** @inheritDoc */
@@ -74,9 +70,7 @@ export class FabricEpochDays extends BaseFabricPrimitive
           );
         }
         try {
-          return new FabricEpochDays(
-            bigintFromMinimalTwosComplement(fromBase64url(state)),
-          );
+          return new FabricEpochDays(bigintFromUnpaddedBase64url(state));
         } catch {
           return new ProblematicValue(
             typeTag,

--- a/packages/data-model/src/fabric-primitives/FabricEpochNsec.ts
+++ b/packages/data-model/src/fabric-primitives/FabricEpochNsec.ts
@@ -3,12 +3,8 @@ import type {
   FabricEpochNsecConstructor as ApiFabricEpochNsecConstructor,
 } from "@commonfabric/api";
 import {
-  fromBase64url,
-  toUnpaddedBase64url,
-} from "@commonfabric/utils/base64url";
-import {
-  bigintFromMinimalTwosComplement,
-  bigintToMinimalTwosComplement,
+  bigintFromUnpaddedBase64url,
+  bigintToUnpaddedBase64url,
 } from "@commonfabric/utils/bigint";
 
 import type { FabricValue } from "@/interface.ts";
@@ -63,7 +59,7 @@ export class FabricEpochNsec extends BaseFabricPrimitive
 
       /** @inheritDoc */
       encode(value: FabricEpochNsec): FabricValue {
-        return toUnpaddedBase64url(bigintToMinimalTwosComplement(value.#value));
+        return bigintToUnpaddedBase64url(value.#value);
       }
 
       /** @inheritDoc */
@@ -80,9 +76,7 @@ export class FabricEpochNsec extends BaseFabricPrimitive
           );
         }
         try {
-          return new FabricEpochNsec(
-            bigintFromMinimalTwosComplement(fromBase64url(state)),
-          );
+          return new FabricEpochNsec(bigintFromUnpaddedBase64url(state));
         } catch {
           return new ProblematicValue(
             typeTag,

--- a/packages/utils/bench/bigint.bench.ts
+++ b/packages/utils/bench/bigint.bench.ts
@@ -31,10 +31,12 @@
  * (`bigintToUnpaddedBase64url()` / `bigintFromUnpaddedBase64url()`) against the
  * two steps it composes, so that the cost of the composition itself -- the
  * intermediate `Uint8Array` and the hand-off -- reads directly as the gap
- * between `combined` and the sum of the two parts. It sweeps a sparse set of
- * sizes: the base64url layer is linear in byte count with no branch structure
- * of its own, so the dense sweep the first section needs would only repeat
- * itself here.
+ * between `combined` and the sum of the two parts. It sweeps every size up to
+ * 33 bytes and then doubles out to 1 MiB: the base64url layer is linear in byte
+ * count with no branch structure of its own, so past the crossovers in the
+ * layer below it, reach matters more than resolution. Its batch size shrinks as
+ * values grow, and so is stated per benchmark rather than being BATCH
+ * throughout.
  *
  * Run with: deno bench --no-check bench/bigint.bench.ts
  */
@@ -212,34 +214,54 @@ for (const { name: implName, biToMtc, biFromMtc } of IMPLS) {
 //
 
 /**
- * Byte sizes for the base64url benchmarks: the whole small-value range, both
- * sides of the 8-byte and 32-byte crossovers in the underlying encoders, and a
- * doubling sweep out to 1 KiB.
+ * Byte sizes for the base64url benchmarks: every size from 1 to 33 inclusive,
+ * which brackets both the 8-byte and the 32-byte crossover in the underlying
+ * encoders, and then a doubling sweep out to 1 MiB.
  */
-const B64_BYTE_SIZES: readonly number[] = [
-  1,
-  2,
-  3,
-  4,
-  5,
-  6,
-  7,
-  8,
-  9,
-  16,
-  32,
-  33,
-  64,
-  128,
-  256,
-  512,
-  1024,
-];
+const B64_BYTE_SIZES: readonly number[] = (() => {
+  const result: number[] = [];
+  for (let i = 1; i <= 33; i++) result.push(i);
+  for (let i = 64; i <= (1 << 20); i *= 2) result.push(i);
+  return result;
+})();
+
+/**
+ * Payload budget per benchmark, in bytes. The batch shrinks as values grow, so
+ * that the megabyte end of the sweep measures a single operation rather than
+ * allocating 64 MiB of them. Each benchmark's name carries its own batch size,
+ * since it is no longer `BATCH` throughout.
+ */
+const B64_BATCH_BYTES = 1 << 18;
+
+/** Returns the batch size for `bytes`-sized values. */
+function b64BatchFor(bytes: number): number {
+  return Math.max(1, Math.min(BATCH, Math.floor(B64_BATCH_BYTES / bytes)));
+}
+
+/**
+ * Returns the minimal two's-complement encoding of a positive value that needs
+ * exactly `bytes` bytes. The leading byte lands in `[0x40, 0x7f]`, so the value
+ * sits in the upper half of its band -- the same guarantee `makePositive()`
+ * gives -- while staying linear to build at megabyte sizes, where repeated
+ * bigint shifting is not.
+ */
+function makePositiveBytes(bytes: number, rng: () => number): Uint8Array {
+  const out = new Uint8Array(bytes);
+  for (let i = 0; i < bytes; i++) {
+    out[i] = rng() & 0xff;
+  }
+  out[0] = 0x40 | (out[0]! & 0x3f);
+  return out;
+}
 
 // Warm up all six measured paths, for the same reason the first section does.
 {
-  const warmVals = makeBatch(8, 1n, 3);
-  const warmBytes = warmVals.map((v) => bigintToMinimalTwosComplement(v));
+  const rng = makeRng(7);
+  const warmBytes = Array.from(
+    { length: BATCH },
+    () => makePositiveBytes(8, rng),
+  );
+  const warmVals = warmBytes.map((b) => bigintFromMinimalTwosComplement(b));
   const warmStrings = warmBytes.map((b) => toUnpaddedBase64url(b));
   for (let i = 0; i < 200; i++) {
     for (const v of warmVals) {
@@ -261,72 +283,77 @@ for (const bytes of B64_BYTE_SIZES) {
   // Negatives are not tracked separately here: sign changes the cost of the
   // two's-complement step, which the first section already measures both ways,
   // and leaves the base64url step's cost untouched.
-  const values = makeBatch(bytes, 1n, bytes * 37 + 3);
-  const encodedBytes = values.map((v) => bigintToMinimalTwosComplement(v));
+  const batch = b64BatchFor(bytes);
+  const rng = makeRng(bytes * 37 + 3);
+  const encodedBytes = Array.from(
+    { length: batch },
+    () => makePositiveBytes(bytes, rng),
+  );
+  const values = encodedBytes.map((b) => bigintFromMinimalTwosComplement(b));
   const encodedStrings = encodedBytes.map((b) => toUnpaddedBase64url(b));
   // Pad the group key so Deno bench's grouped output sorts in size order.
-  const groupKey = String(bytes).padStart(4, "0");
+  const groupKey = String(bytes).padStart(7, "0");
   const encodeGroup = `b64-encode-${groupKey}B`;
   const decodeGroup = `b64-decode-${groupKey}B`;
   const label = `${bytes}B`;
 
   Deno.bench({
-    name: `b64 encode ${label} two's-complement step (${BATCH} ops)`,
+    name: `b64 encode ${label} two's-complement step (${batch} ops)`,
     group: encodeGroup,
     baseline: true,
     fn() {
-      for (let i = 0; i < BATCH; i++) {
+      for (let i = 0; i < batch; i++) {
         bigintToMinimalTwosComplement(values[i]!);
       }
     },
   });
 
   Deno.bench({
-    name: `b64 encode ${label} base64url step (${BATCH} ops)`,
+    name: `b64 encode ${label} base64url step (${batch} ops)`,
     group: encodeGroup,
     fn() {
-      for (let i = 0; i < BATCH; i++) {
+      for (let i = 0; i < batch; i++) {
         toUnpaddedBase64url(encodedBytes[i]!);
       }
     },
   });
 
   Deno.bench({
-    name: `b64 encode ${label} combined (${BATCH} ops)`,
+    name: `b64 encode ${label} combined (${batch} ops)`,
     group: encodeGroup,
     fn() {
-      for (let i = 0; i < BATCH; i++) {
+      for (let i = 0; i < batch; i++) {
         bigintToUnpaddedBase64url(values[i]!);
       }
     },
   });
 
   Deno.bench({
-    name: `b64 decode ${label} two's-complement step (${BATCH} ops)`,
+    name: `b64 decode ${label} two's-complement step (${batch} ops)`,
     group: decodeGroup,
     baseline: true,
     fn() {
-      for (let i = 0; i < BATCH; i++) {
+      for (let i = 0; i < batch; i++) {
         bigintFromMinimalTwosComplement(encodedBytes[i]!);
       }
     },
   });
 
   Deno.bench({
-    name: `b64 decode ${label} base64url step (${BATCH} ops)`,
+    name: `b64 decode ${label} base64url step (${batch} ops)`,
     group: decodeGroup,
     fn() {
-      for (let i = 0; i < BATCH; i++) {
+      for (let i = 0; i < batch; i++) {
         fromBase64url(encodedStrings[i]!);
       }
     },
   });
 
   Deno.bench({
-    name: `b64 decode ${label} combined (${BATCH} ops)`,
+    name: `b64 decode ${label} combined (${batch} ops)`,
     group: decodeGroup,
     fn() {
-      for (let i = 0; i < BATCH; i++) {
+      for (let i = 0; i < batch; i++) {
         bigintFromUnpaddedBase64url(encodedStrings[i]!);
       }
     },

--- a/packages/utils/bench/bigint.bench.ts
+++ b/packages/utils/bench/bigint.bench.ts
@@ -34,9 +34,10 @@
  * between `combined` and the sum of the two parts. It sweeps every size up to
  * 33 bytes and then doubles out to 1 MiB: the base64url layer is linear in byte
  * count with no branch structure of its own, so past the crossovers in the
- * layer below it, reach matters more than resolution. Its batch size shrinks as
- * values grow, and so is stated per benchmark rather than being BATCH
- * throughout.
+ * layer below it, reach matters more than resolution. Positive and negative
+ * tracks sit in one group per (size, direction), so the sign's effect reads off
+ * the same table as the layering. Its batch size shrinks as values grow, and so
+ * is stated per benchmark rather than being BATCH throughout.
  *
  * Run with: deno bench --no-check bench/bigint.bench.ts
  */
@@ -239,28 +240,33 @@ function b64BatchFor(bytes: number): number {
 }
 
 /**
- * Returns the minimal two's-complement encoding of a positive value that needs
- * exactly `bytes` bytes. The leading byte lands in `[0x40, 0x7f]`, so the value
+ * Returns the minimal two's-complement encoding of a value of the given sign
+ * that needs exactly `bytes` bytes. The leading byte lands in `[0x40, 0x7f]`
+ * for a positive value and `[0x80, 0xbf]` for a negative one, so the magnitude
  * sits in the upper half of its band -- the same guarantee `makePositive()`
  * gives -- while staying linear to build at megabyte sizes, where repeated
  * bigint shifting is not.
  */
-function makePositiveBytes(bytes: number, rng: () => number): Uint8Array {
+function makeBandBytes(
+  bytes: number,
+  sign: 1n | -1n,
+  rng: () => number,
+): Uint8Array {
   const out = new Uint8Array(bytes);
   for (let i = 0; i < bytes; i++) {
     out[i] = rng() & 0xff;
   }
-  out[0] = 0x40 | (out[0]! & 0x3f);
+  out[0] = (sign === 1n ? 0x40 : 0x80) | (out[0]! & 0x3f);
   return out;
 }
 
 // Warm up all six measured paths, for the same reason the first section does.
 {
   const rng = makeRng(7);
-  const warmBytes = Array.from(
-    { length: BATCH },
-    () => makePositiveBytes(8, rng),
-  );
+  const warmBytes = [
+    ...Array.from({ length: BATCH }, () => makeBandBytes(8, 1n, rng)),
+    ...Array.from({ length: BATCH }, () => makeBandBytes(8, -1n, rng)),
+  ];
   const warmVals = warmBytes.map((b) => bigintFromMinimalTwosComplement(b));
   const warmStrings = warmBytes.map((b) => toUnpaddedBase64url(b));
   for (let i = 0; i < 200; i++) {
@@ -280,82 +286,86 @@ function makePositiveBytes(bytes: number, rng: () => number): Uint8Array {
 }
 
 for (const bytes of B64_BYTE_SIZES) {
-  // Negatives are not tracked separately here: sign changes the cost of the
-  // two's-complement step, which the first section already measures both ways,
-  // and leaves the base64url step's cost untouched.
   const batch = b64BatchFor(bytes);
-  const rng = makeRng(bytes * 37 + 3);
-  const encodedBytes = Array.from(
-    { length: batch },
-    () => makePositiveBytes(bytes, rng),
-  );
-  const values = encodedBytes.map((b) => bigintFromMinimalTwosComplement(b));
-  const encodedStrings = encodedBytes.map((b) => toUnpaddedBase64url(b));
   // Pad the group key so Deno bench's grouped output sorts in size order.
   const groupKey = String(bytes).padStart(7, "0");
   const encodeGroup = `b64-encode-${groupKey}B`;
   const decodeGroup = `b64-decode-${groupKey}B`;
   const label = `${bytes}B`;
 
-  Deno.bench({
-    name: `b64 encode ${label} two's-complement step (${batch} ops)`,
-    group: encodeGroup,
-    baseline: true,
-    fn() {
-      for (let i = 0; i < batch; i++) {
-        bigintToMinimalTwosComplement(values[i]!);
-      }
-    },
-  });
+  for (const sign of [1n, -1n] as const) {
+    const signLabel = sign === 1n ? "positive" : "negative";
+    const isBaselineSign = sign === 1n;
+    const rng = makeRng(bytes * 37 + (sign === 1n ? 3 : 5));
+    const encodedBytes = Array.from(
+      { length: batch },
+      () => makeBandBytes(bytes, sign, rng),
+    );
+    const values = encodedBytes.map((b) => bigintFromMinimalTwosComplement(b));
+    const encodedStrings = encodedBytes.map((b) => toUnpaddedBase64url(b));
 
-  Deno.bench({
-    name: `b64 encode ${label} base64url step (${batch} ops)`,
-    group: encodeGroup,
-    fn() {
-      for (let i = 0; i < batch; i++) {
-        toUnpaddedBase64url(encodedBytes[i]!);
-      }
-    },
-  });
+    Deno.bench({
+      name:
+        `b64 encode ${signLabel} ${label} two's-complement step (${batch} ops)`,
+      group: encodeGroup,
+      baseline: isBaselineSign,
+      fn() {
+        for (let i = 0; i < batch; i++) {
+          bigintToMinimalTwosComplement(values[i]!);
+        }
+      },
+    });
 
-  Deno.bench({
-    name: `b64 encode ${label} combined (${batch} ops)`,
-    group: encodeGroup,
-    fn() {
-      for (let i = 0; i < batch; i++) {
-        bigintToUnpaddedBase64url(values[i]!);
-      }
-    },
-  });
+    Deno.bench({
+      name: `b64 encode ${signLabel} ${label} base64url step (${batch} ops)`,
+      group: encodeGroup,
+      fn() {
+        for (let i = 0; i < batch; i++) {
+          toUnpaddedBase64url(encodedBytes[i]!);
+        }
+      },
+    });
 
-  Deno.bench({
-    name: `b64 decode ${label} two's-complement step (${batch} ops)`,
-    group: decodeGroup,
-    baseline: true,
-    fn() {
-      for (let i = 0; i < batch; i++) {
-        bigintFromMinimalTwosComplement(encodedBytes[i]!);
-      }
-    },
-  });
+    Deno.bench({
+      name: `b64 encode ${signLabel} ${label} combined (${batch} ops)`,
+      group: encodeGroup,
+      fn() {
+        for (let i = 0; i < batch; i++) {
+          bigintToUnpaddedBase64url(values[i]!);
+        }
+      },
+    });
 
-  Deno.bench({
-    name: `b64 decode ${label} base64url step (${batch} ops)`,
-    group: decodeGroup,
-    fn() {
-      for (let i = 0; i < batch; i++) {
-        fromBase64url(encodedStrings[i]!);
-      }
-    },
-  });
+    Deno.bench({
+      name:
+        `b64 decode ${signLabel} ${label} two's-complement step (${batch} ops)`,
+      group: decodeGroup,
+      baseline: isBaselineSign,
+      fn() {
+        for (let i = 0; i < batch; i++) {
+          bigintFromMinimalTwosComplement(encodedBytes[i]!);
+        }
+      },
+    });
 
-  Deno.bench({
-    name: `b64 decode ${label} combined (${batch} ops)`,
-    group: decodeGroup,
-    fn() {
-      for (let i = 0; i < batch; i++) {
-        bigintFromUnpaddedBase64url(encodedStrings[i]!);
-      }
-    },
-  });
+    Deno.bench({
+      name: `b64 decode ${signLabel} ${label} base64url step (${batch} ops)`,
+      group: decodeGroup,
+      fn() {
+        for (let i = 0; i < batch; i++) {
+          fromBase64url(encodedStrings[i]!);
+        }
+      },
+    });
+
+    Deno.bench({
+      name: `b64 decode ${signLabel} ${label} combined (${batch} ops)`,
+      group: decodeGroup,
+      fn() {
+        for (let i = 0; i < batch; i++) {
+          bigintFromUnpaddedBase64url(encodedStrings[i]!);
+        }
+      },
+    });
+  }
 }

--- a/packages/utils/bench/bigint.bench.ts
+++ b/packages/utils/bench/bigint.bench.ts
@@ -27,9 +27,25 @@
  * bigints, so the encode and decode benchmarks for a given (size, sign)
  * exercise inverse operations on matching data.
  *
+ * A second section measures the base64url convenience pair
+ * (`bigintToUnpaddedBase64url()` / `bigintFromUnpaddedBase64url()`) against the
+ * two steps it composes, so that the cost of the composition itself -- the
+ * intermediate `Uint8Array` and the hand-off -- reads directly as the gap
+ * between `combined` and the sum of the two parts. It sweeps a sparse set of
+ * sizes: the base64url layer is linear in byte count with no branch structure
+ * of its own, so the dense sweep the first section needs would only repeat
+ * itself here.
+ *
  * Run with: deno bench --no-check bench/bigint.bench.ts
  */
 
+import { fromBase64url, toUnpaddedBase64url } from "../src/base64url.ts";
+import {
+  bigintFromMinimalTwosComplement,
+  bigintFromUnpaddedBase64url,
+  bigintToMinimalTwosComplement,
+  bigintToUnpaddedBase64url,
+} from "../src/bigint.ts";
 import {
   bigintFromMtcDirect,
   bigintToMtcDirect,
@@ -189,4 +205,130 @@ for (const { name: implName, biToMtc, biFromMtc } of IMPLS) {
       },
     });
   }
+}
+
+//
+// The base64url convenience pair
+//
+
+/**
+ * Byte sizes for the base64url benchmarks: the whole small-value range, both
+ * sides of the 8-byte and 32-byte crossovers in the underlying encoders, and a
+ * doubling sweep out to 1 KiB.
+ */
+const B64_BYTE_SIZES: readonly number[] = [
+  1,
+  2,
+  3,
+  4,
+  5,
+  6,
+  7,
+  8,
+  9,
+  16,
+  32,
+  33,
+  64,
+  128,
+  256,
+  512,
+  1024,
+];
+
+// Warm up all six measured paths, for the same reason the first section does.
+{
+  const warmVals = makeBatch(8, 1n, 3);
+  const warmBytes = warmVals.map((v) => bigintToMinimalTwosComplement(v));
+  const warmStrings = warmBytes.map((b) => toUnpaddedBase64url(b));
+  for (let i = 0; i < 200; i++) {
+    for (const v of warmVals) {
+      bigintToMinimalTwosComplement(v);
+      bigintToUnpaddedBase64url(v);
+    }
+    for (const b of warmBytes) {
+      toUnpaddedBase64url(b);
+      bigintFromMinimalTwosComplement(b);
+    }
+    for (const s of warmStrings) {
+      fromBase64url(s);
+      bigintFromUnpaddedBase64url(s);
+    }
+  }
+}
+
+for (const bytes of B64_BYTE_SIZES) {
+  // Negatives are not tracked separately here: sign changes the cost of the
+  // two's-complement step, which the first section already measures both ways,
+  // and leaves the base64url step's cost untouched.
+  const values = makeBatch(bytes, 1n, bytes * 37 + 3);
+  const encodedBytes = values.map((v) => bigintToMinimalTwosComplement(v));
+  const encodedStrings = encodedBytes.map((b) => toUnpaddedBase64url(b));
+  // Pad the group key so Deno bench's grouped output sorts in size order.
+  const groupKey = String(bytes).padStart(4, "0");
+  const encodeGroup = `b64-encode-${groupKey}B`;
+  const decodeGroup = `b64-decode-${groupKey}B`;
+  const label = `${bytes}B`;
+
+  Deno.bench({
+    name: `b64 encode ${label} two's-complement step (${BATCH} ops)`,
+    group: encodeGroup,
+    baseline: true,
+    fn() {
+      for (let i = 0; i < BATCH; i++) {
+        bigintToMinimalTwosComplement(values[i]!);
+      }
+    },
+  });
+
+  Deno.bench({
+    name: `b64 encode ${label} base64url step (${BATCH} ops)`,
+    group: encodeGroup,
+    fn() {
+      for (let i = 0; i < BATCH; i++) {
+        toUnpaddedBase64url(encodedBytes[i]!);
+      }
+    },
+  });
+
+  Deno.bench({
+    name: `b64 encode ${label} combined (${BATCH} ops)`,
+    group: encodeGroup,
+    fn() {
+      for (let i = 0; i < BATCH; i++) {
+        bigintToUnpaddedBase64url(values[i]!);
+      }
+    },
+  });
+
+  Deno.bench({
+    name: `b64 decode ${label} two's-complement step (${BATCH} ops)`,
+    group: decodeGroup,
+    baseline: true,
+    fn() {
+      for (let i = 0; i < BATCH; i++) {
+        bigintFromMinimalTwosComplement(encodedBytes[i]!);
+      }
+    },
+  });
+
+  Deno.bench({
+    name: `b64 decode ${label} base64url step (${BATCH} ops)`,
+    group: decodeGroup,
+    fn() {
+      for (let i = 0; i < BATCH; i++) {
+        fromBase64url(encodedStrings[i]!);
+      }
+    },
+  });
+
+  Deno.bench({
+    name: `b64 decode ${label} combined (${BATCH} ops)`,
+    group: decodeGroup,
+    fn() {
+      for (let i = 0; i < BATCH; i++) {
+        bigintFromUnpaddedBase64url(encodedStrings[i]!);
+      }
+    },
+  });
 }

--- a/packages/utils/bench/bigint.bench.ts
+++ b/packages/utils/bench/bigint.bench.ts
@@ -28,10 +28,19 @@
  * exercise inverse operations on matching data.
  *
  * A second section measures the base64url convenience pair
- * (`bigintToUnpaddedBase64url()` / `bigintFromUnpaddedBase64url()`) against the
- * two steps it composes, so that the cost of the composition itself -- the
- * intermediate `Uint8Array` and the hand-off -- reads directly as the gap
- * between `combined` and the sum of the two parts. It sweeps every size up to
+ * (`bigintToUnpaddedBase64url()` / `bigintFromUnpaddedBase64url()`). Each of
+ * its groups carries four tracks. The two's-complement step and the base64url
+ * step, measured alone, show where the time goes. Then `two-step inline` --
+ * the same two calls written out in one loop -- against `combined`, which is
+ * the pair that answers whether wrapping them costs anything.
+ *
+ * Read the composition's cost off that pair, NOT off `combined` against the
+ * sum of the two step tracks. Summing two tracks double-counts the batch loop,
+ * and each step track is handed a pre-built input where the composition
+ * allocates its intermediate one step earlier -- so the sum is biased by a
+ * loop iteration and describes different allocation behavior besides.
+ *
+ * It sweeps every size up to
  * 33 bytes and then doubles out to 1 MiB: the base64url layer is linear in byte
  * count with no branch structure of its own, so past the crossovers in the
  * layer below it, reach matters more than resolution. Positive and negative
@@ -327,6 +336,16 @@ for (const bytes of B64_BYTE_SIZES) {
     });
 
     Deno.bench({
+      name: `b64 encode ${signLabel} ${label} two-step inline (${batch} ops)`,
+      group: encodeGroup,
+      fn() {
+        for (let i = 0; i < batch; i++) {
+          toUnpaddedBase64url(bigintToMinimalTwosComplement(values[i]!));
+        }
+      },
+    });
+
+    Deno.bench({
       name: `b64 encode ${signLabel} ${label} combined (${batch} ops)`,
       group: encodeGroup,
       fn() {
@@ -354,6 +373,16 @@ for (const bytes of B64_BYTE_SIZES) {
       fn() {
         for (let i = 0; i < batch; i++) {
           fromBase64url(encodedStrings[i]!);
+        }
+      },
+    });
+
+    Deno.bench({
+      name: `b64 decode ${signLabel} ${label} two-step inline (${batch} ops)`,
+      group: decodeGroup,
+      fn() {
+        for (let i = 0; i < batch; i++) {
+          bigintFromMinimalTwosComplement(fromBase64url(encodedStrings[i]!));
         }
       },
     });

--- a/packages/utils/src/bigint.ts
+++ b/packages/utils/src/bigint.ts
@@ -7,6 +7,7 @@
  * except as needed for sign extension.
  */
 
+import { fromBase64url, toUnpaddedBase64url } from "./base64url.ts";
 import {
   bigintFromMtcDirect,
   bigintToMtcDirect,
@@ -45,4 +46,23 @@ export function bigintFromMinimalTwosComplement(bytes: Uint8Array): bigint {
   return useUint8ArrayToFromHex
     ? bigintFromMtcHex(bytes)
     : bigintFromMtcDirect(bytes);
+}
+
+/**
+ * Converts a bigint to the unpadded base64url encoding of its minimal
+ * two's-complement big-endian byte representation. This is the string form the
+ * JSON wire format uses for bigint-valued state.
+ */
+export function bigintToUnpaddedBase64url(value: bigint): string {
+  return toUnpaddedBase64url(bigintToMinimalTwosComplement(value));
+}
+
+/**
+ * Interprets a base64url string as the minimal two's-complement big-endian
+ * byte representation of an integer, and returns the corresponding bigint.
+ * Trailing `=` padding is accepted but not required. Input that isn't valid
+ * base64url, and input that decodes to zero bytes, both throw.
+ */
+export function bigintFromUnpaddedBase64url(encoded: string): bigint {
+  return bigintFromMinimalTwosComplement(fromBase64url(encoded));
 }

--- a/packages/utils/test/bigint.test.ts
+++ b/packages/utils/test/bigint.test.ts
@@ -2,7 +2,9 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {
   bigintFromMinimalTwosComplement,
+  bigintFromUnpaddedBase64url,
   bigintToMinimalTwosComplement,
+  bigintToUnpaddedBase64url,
 } from "@commonfabric/utils/bigint";
 import {
   bigintFromMtcDirect,
@@ -320,3 +322,86 @@ for (
     });
   });
 }
+
+//
+// The base64url-string convenience pair
+//
+
+/**
+ * Fixtures for the base64url convenience functions. The strings are written
+ * out directly, so that neither `toUnpaddedBase64url()` nor the reference
+ * encoder above is trusted to produce them.
+ */
+const base64urlFixtures: readonly { value: bigint; encoded: string }[] = [
+  { value: 0n, encoded: "AA" },
+  { value: 1n, encoded: "AQ" },
+  { value: -1n, encoded: "_w" },
+  { value: 42n, encoded: "Kg" },
+  { value: 127n, encoded: "fw" },
+  { value: 128n, encoded: "AIA" },
+  { value: -128n, encoded: "gA" },
+  { value: -129n, encoded: "_38" },
+  { value: 255n, encoded: "AP8" },
+  { value: 256n, encoded: "AQA" },
+  { value: -256n, encoded: "_wA" },
+  { value: 0x0123_4567_89ab_cdefn, encoded: "ASNFZ4mrze8" },
+];
+
+describe("bigintToUnpaddedBase64url()", () => {
+  it("encodes all base64url fixtures as expected", () => {
+    for (const { value, encoded } of base64urlFixtures) {
+      try {
+        expect(bigintToUnpaddedBase64url(value)).toBe(encoded);
+      } catch (e) {
+        throw new Error(`Failed on ${value}n.`, { cause: e });
+      }
+    }
+  });
+
+  it("encodes all fixtures as the reference encoding does, in base64url", () => {
+    for (const { value, encoded, label } of fixtures) {
+      try {
+        expect(bigintToUnpaddedBase64url(value))
+          .toBe(toUnpaddedBase64url(encoded));
+      } catch (e) {
+        throw new Error(`Failed on ${label}.`, { cause: e });
+      }
+    }
+  });
+});
+
+describe("bigintFromUnpaddedBase64url()", () => {
+  it("decodes all base64url fixtures as expected", () => {
+    for (const { value, encoded } of base64urlFixtures) {
+      try {
+        expect(bigintFromUnpaddedBase64url(encoded)).toBe(value);
+      } catch (e) {
+        throw new Error(`Failed on ${value}n.`, { cause: e });
+      }
+    }
+  });
+
+  it("decodes all fixtures from the reference encoding, via base64url", () => {
+    for (const { value, encoded, label } of fixtures) {
+      try {
+        expect(bigintFromUnpaddedBase64url(toUnpaddedBase64url(encoded)))
+          .toBe(value);
+      } catch (e) {
+        throw new Error(`Failed on ${label}.`, { cause: e });
+      }
+    }
+  });
+
+  it("accepts padded input", () => {
+    expect(bigintFromUnpaddedBase64url("AA==")).toBe(0n);
+    expect(bigintFromUnpaddedBase64url("AP8=")).toBe(255n);
+  });
+
+  it("throws on an empty string", () => {
+    expect(() => bigintFromUnpaddedBase64url("")).toThrow("empty input");
+  });
+
+  it("throws on a non-base64url character", () => {
+    expect(() => bigintFromUnpaddedBase64url("A/8")).toThrow();
+  });
+});


### PR DESCRIPTION
I (an agent working on behalf of @danfuzz) noticed that three codecs each spell
out the same two-step combination by hand, so this adds the combined form to
`@commonfabric/utils/bigint` and switches them over.

New in `packages/utils/src/bigint.ts`:

* `bigintToUnpaddedBase64url(value)` --
  `toUnpaddedBase64url(bigintToMinimalTwosComplement(value))`
* `bigintFromUnpaddedBase64url(encoded)` --
  `bigintFromMinimalTwosComplement(fromBase64url(encoded))`

Switched over: the `bigint` codec (`codec-json/BigIntCodec.ts`), and the
`[JSON_CODEC]`s of `FabricEpochNsec` and `FabricEpochDays`. Each of those three
now imports one module where it imported two.

Behavior is unchanged -- the new functions are exactly what the call sites were
composing, including which errors escape. `value-hash.ts` keeps using
`bigintToMinimalTwosComplement()` directly, since it hashes the bytes rather
than a string.

## Testing

Six new cases in `packages/utils/test/bigint.test.ts`. Two are driven by a
hand-written table of base64url strings, so that neither
`toUnpaddedBase64url()` nor the file's reference encoder is trusted to produce
the expected value; the table includes negatives, whose encodings (`_w`, `_38`,
`_wA`) pin the base64url alphabet rather than plain base64. Two more run the
full fixture set (~7000 values) against the reference encoder. The remaining
three cover padded input, an empty string, and a non-base64url character.

Ablation: adding `+ 1n` inside each new function turns all five value-asserting
cases red; restoring makes them green.

## Benchmarks

`packages/utils/bench/bigint.bench.ts` gains a second section for the new pair.
Each group carries four tracks: the two's-complement step and the base64url
step measured alone, which show where the time goes; and then `two-step
inline` -- the two calls written out in one loop -- against `combined`, which
is the pair that answers whether wrapping them costs anything. The
composition's cost reads off THAT pair and not off `combined` against the sum
of the two step tracks, since summing two tracks double-counts the batch loop
and each step track is fed a pre-built input where the composition allocates
its intermediate one step earlier. It sweeps every byte length from 1 to 33
inclusive and then doubles out to 1 MiB, with a positive and a negative track
sharing each group.

The batch shrinks with value size against a fixed byte budget, so the megabyte
end measures one operation rather than allocating 64 MiB of them; each
benchmark's name states its own batch. Values there are built byte-first,
because assembling a megabyte-wide bigint by repeated shifting is quadratic;
the leading byte is constrained so the magnitude still lands in the upper half
of its band, exactly as `makePositive()` guarantees for the first section.

Nothing here gates anything; it is there for whenever these implementations are
worth optimizing.

A full run of the section (one pass, on a laptop that was not otherwise idle,
so only order-of-magnitude effects are worth reading off it) says two things.
`combined` and `two-step inline` agree to within noise where sampled -- 8 bytes
and 1 KiB, both directions -- so the wrapper costs nothing measurable, and any
optimization has to come out of one of the two steps. And the two directions
have opposite shapes that cross somewhere around 64 to 128 bytes:
encoding is bound by the two's-complement step almost throughout, while
decoding is bound by the base64url step below the crossover, and steeply so at
the bottom -- at one byte the base64url step is some 33x the two's-complement
step. That floor is roughly flat in value size, so every `bigint` on the wire
pays it whatever its magnitude, which is where the leverage is if these ever
want optimizing.

The sign tracks earn their place by pinning something the code guarantees
structurally. Above 8 bytes a negative value costs an extra ones-complement of
the whole bigint plus an extra full pass over the resulting bytes to undo it
(`bigint-uint8-hex-string.ts:96`), where a positive value goes straight from
hex string to bytes; at or below 8 bytes both signs run the same fixed-size
code. The measured penalty accordingly switches on exactly at the 8-to-9 byte
boundary and holds from there out to 1 MiB.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->






