### PR TITLE
test(data-model,runner): drop two test comments that describe a past

### DIFF
--- a/packages/data-model/test/codecs.test.ts
+++ b/packages/data-model/test/codecs.test.ts
@@ -236,23 +236,6 @@ describe("codecs", () => {
     it("explicit `undefined` runtime is equivalent to omission", () => {
       expect(valueFromJson('fvj1:{"a":1}', undefined)).toEqual({ a: 1 });
     });
-
-    // (B) fold-in: the no-runtime fallback is a decode-framed empty context
-    // (`JSON_DECODE_EMPTY_CONTEXT`) instead of the bare singleton. This is
-    // message-only and behavior-preserving: every no-cell-ref decode above
-    // must still succeed unchanged (covered by the cases in this describe),
-    // and the round-trip with a runtime is unaffected. The decode-framed
-    // throw message itself is asserted on the exported class (see
-    // `EmptyReconstructionContext (exported class)` below) since a cell-ref
-    // decode requires runner-owned wire machinery not available here.
-    it("(B) no-runtime decode behavior is unchanged (round-trips, no cell ref)", () => {
-      // Same payloads as above, asserted as a single behavior-preservation
-      // checkpoint tied to the (B) fold-in.
-      expect(valueFromJson("fvj1:42")).toBe(42);
-      expect(valueFromJson('fvj1:{"a":1}')).toEqual({ a: 1 });
-      expect(valueFromJson('fvj1:{"\/Undefined@1":null}')).toBe(undefined);
-      expect(roundTrip(7)).toBe(7);
-    });
   });
 
   describe("plainObjectFromJson", () => {

--- a/packages/runner/test/cell-core.test.ts
+++ b/packages/runner/test/cell-core.test.ts
@@ -1212,28 +1212,7 @@ describe("Cell raw methods: frozen-or-not", () => {
 // end-to-end correctness of the standard result meta link round-trip: the
 // round-trip preserves the result-link object, and a raw `tx.read` of
 // `path: ["result"]` returns it as an object link record (with own-property
-//  `"/"`), never as a string.
-//
-// Historical context: these tests were authored alongside the deletion of
-// two defensive `JSON.parse` blocks that previously existed in
-// the storage transaction read path and `runner/src/cell.ts`
-// (in the old source metadata path). Both blocks guarded a parse with the same shape —
-// `typeof value === "string" && value.startsWith('{"/":')` — and were
-// originally added (PRs #1472, #1562) to handle string-form values
-// returned from a previous shape of the storage layer. PR #2971 in
-// March 2026 wired `valueFromJson` into the storage-boundary read path
-// (`memory/space.ts`): `valueFromJson` unconditionally decodes the `is`
-// column to an object (stripping the codec prefix) before reaching
-// either defensive parse. From that point on, neither guard could fire
-// through the standard public API, and the defensive parses became
-// orphaned — which is what motivated their deletion.
-//
-// The tests below pin the round-trip behavior that, post-deletion, is the
-// observable contract. They serve as a passive regression net for any future
-// change that might re-introduce a non-object value at `path: ["result"]`.
-//
-// See `coordination/docs/2026-04-30-fvj1-parse-site-kickoff.md` (project
-// kickoff doc, session 2026-067) for the full liveness analysis.
+// `"/"`), never as a string.
 describe(`Cell result-meta round-trip`, () => {
   let runtime: Runtime;
   let storageManager: ReturnType<typeof StorageManager.emulate>;


### PR DESCRIPTION
I (an agent working on behalf of @danfuzz) found two test comments that describe
the repository's own past rather than the system as it stands. Both sit outside
what the earlier doc-comment sweep covered.

## `packages/data-model/test/codecs.test.ts`

A `// (B) fold-in:` block and an `it("(B) no-runtime decode behavior is
unchanged ...")`. "(B)" names a step in a plan no reader can reach, and
"unchanged" is a claim about a version of the code that is gone. The comment's
one forward pointer -- "asserted on the exported class (see
`EmptyReconstructionContext (exported class)` below)" -- resolves to nothing in
this file.

The test goes with its framing, because its framing was all it had. Its four
assertions are:

* `valueFromJson("fvj1:42")` -- identical to `it("decodes a primitive")`
* `valueFromJson('fvj1:{"a":1}')` -- identical to `it("decodes a plain object")`
* `valueFromJson('fvj1:{"/Undefined@1":null}')` -- identical to the first line
  of `it("decodes tagged values that don't need cell reconstruction")`
* `roundTrip(7)` -- goes through the mock runtime, so it is not a no-runtime
  case at all, and JSON-safe-primitive round-tripping is already covered
  earlier in the file

Its own comment said as much: "Same payloads as above, asserted as a single
behavior-preservation checkpoint tied to the (B) fold-in." Renamed, it would
have to take a name one of the three above it already holds.

## `packages/runner/test/cell-core.test.ts`

The result-meta suite opened with the history of two deleted `JSON.parse`
guards: the PRs that added them, the PR that rendered them dead, and a pointer
to a `coordination/docs/` kickoff document this repository does not contain.
The live first paragraph -- what the tests actually assert -- stays, with a
stray leading space fixed.

## Testing

`deno task test` in `packages/data-model` (52 files), and
`test/cell-core.test.ts` in `packages/runner`. Both green.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

