### PR TITLE
feat(inspect): support complete nested value output

### DIFF
--- a/packages/cli/commands/inspect.ts
+++ b/packages/cli/commands/inspect.ts
@@ -56,6 +56,7 @@ import {
   spaceParticipants,
   type SpaceRef,
   spaceTimeline,
+  stringifyInspectorJson,
   subgraphAround,
   summarize,
   summarizeSpace,
@@ -72,8 +73,17 @@ function humanSize(bytes: number): string {
   return `${(bytes / 1024 / 1024 / 1024).toFixed(1)}G`;
 }
 
-function out(json: boolean, data: unknown, render: () => void): void {
-  if (json) console.log(JSON.stringify(data, null, 2));
+type OutputStringifier = (value: unknown) => string | undefined;
+
+const prettyJson: OutputStringifier = (value) => JSON.stringify(value, null, 2);
+
+function out(
+  json: boolean,
+  data: unknown,
+  render: () => void,
+  stringify: OutputStringifier = prettyJson,
+): void {
+  if (json) console.log(stringify(data));
   else render();
 }
 
@@ -1245,6 +1255,10 @@ export const inspect = new Command()
   .option("--session <sid:string>", "With --as: a specific session id.")
   .option("--branch <branch:string>", "Branch (default: '').")
   .option("--doc", "Show the whole document, not just value.")
+  .option(
+    "--full-depth",
+    "Do not truncate nested values while producing annotated output.",
+  )
   .action(async (options, space, entity) => {
     const path = parsePathOptions(options);
     if (options.as !== undefined && options.as.length === 0) {
@@ -1263,6 +1277,9 @@ export const inspect = new Command()
     }
     const s = await openByToken(space, options);
     try {
+      const fullDepth = options.fullDepth === true;
+      const annotationDepth = fullDepth ? Number.POSITIVE_INFINITY : 8;
+      const stringify = fullDepth ? stringifyInspectorJson : prettyJson;
       // --as composes the per-identity overlay; otherwise a single raw scope.
       if (options.as !== undefined) {
         const r = valueAsIdentity(s, {
@@ -1273,6 +1290,7 @@ export const inspect = new Command()
           atSeq: options.seq,
           path: options.doc ? undefined : path,
           doc: !!options.doc,
+          annotationDepth,
         });
         out(!!options.json, r, () => {
           if (!r.exists) {
@@ -1288,8 +1306,8 @@ export const inspect = new Command()
               `(most-specific stored; NOT a runtime read — see \`overlay\`)` +
               (r.overrides ? "  (overrides a more-general scope)" : ""),
           );
-          console.log(JSON.stringify(r.value, null, 2));
-        });
+          console.log(stringify(r.value));
+        }, stringify);
         return;
       }
       const res = getValueAt(
@@ -1304,15 +1322,17 @@ export const inspect = new Command()
       );
       const shown = options.doc ? res.document : res.value;
       const pathExists = options.doc ? res.exists : res.pathExists;
+      const annotated = annotate(shown, annotationDepth);
       out(
         !!options.json,
-        { exists: res.exists, pathExists, value: annotate(shown) },
+        { exists: res.exists, pathExists, value: annotated },
         () => {
           if (!res.exists) console.log("(absent at this seq)");
           else if (!pathExists) {
             console.log("(entity present, but nothing at that path)");
-          } else console.log(JSON.stringify(annotate(shown), null, 2));
+          } else console.log(stringify(annotated));
         },
+        stringify,
       );
     } finally {
       s.close();

--- a/packages/cli/test/inspect-remote.test.ts
+++ b/packages/cli/test/inspect-remote.test.ts
@@ -6,11 +6,13 @@
 
 import { afterAll, afterEach, beforeAll, describe, it } from "@std/testing/bdd";
 import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
+import { expect } from "@std/expect";
 import { Database } from "@db/sqlite";
 import { ValidationError } from "@cliffy/command";
 import { Identity } from "@commonfabric/identity";
 import { defaultCacheDir } from "@commonfabric/state-inspector";
 import { jsonFromValue } from "@commonfabric/data-model/codecs";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { inspect } from "../commands/inspect.ts";
 
 const DUMP_BASE = "/api/storage/memory/dump";
@@ -55,6 +57,8 @@ async function buildDbBytes(): Promise<Uint8Array> {
   const path = `${dir}/space.sqlite`;
   const db = new Database(path, { create: true });
   db.exec(SCHEMA);
+  let deep: FabricValue = { leaf: "complete" };
+  for (let depth = 0; depth < 12; depth++) deep = { child: deep };
   db.prepare(
     `INSERT INTO "commit" (seq, session_id, local_seq, original, resolution)
      VALUES (1, 'session:did:key:zX:u', 1, '{"reads":{"confirmed":[],"pending":[]}}', '{}')`,
@@ -65,6 +69,7 @@ async function buildDbBytes(): Promise<Uint8Array> {
   ).run(jsonFromValue({
     value: {
       n: 1,
+      deep,
       "a/b": "literal slash key",
       a: { b: "nested keys" },
       "": "empty key",
@@ -82,6 +87,7 @@ async function buildDbBytes(): Promise<Uint8Array> {
   ).run(jsonFromValue({
     value: {
       n: 2,
+      deep,
       "a/b": "identity slash key",
       "": "identity empty key",
       nested: { leaf: "identity nested key" },
@@ -104,6 +110,7 @@ async function buildDbBytes(): Promise<Uint8Array> {
   ).run(jsonFromValue({
     value: {
       n: 1,
+      deep,
       "a/b": "literal slash key changed",
       a: { b: "nested keys changed" },
       "": "empty key changed",
@@ -262,6 +269,54 @@ describe("cf inspect --remote", () => {
     const s = JSON.parse(out);
     assertEquals(s.commits, 2);
     assertEquals(s.entities, 1);
+  });
+
+  it("preserves every nested value with `value-at --full-depth`", async () => {
+    stubFetch();
+    const shallow = JSON.parse(
+      await run([
+        "value-at",
+        DID_A,
+        "of:a",
+        "--remote",
+        BASE,
+        "--json",
+      ]),
+    );
+    expect(JSON.stringify(shallow.value.deep)).toContain('"…"');
+
+    const full = JSON.parse(
+      await run([
+        "value-at",
+        DID_A,
+        "of:a",
+        "--remote",
+        BASE,
+        "--full-depth",
+        "--json",
+      ]),
+    );
+    let nested = full.value.deep;
+    for (let depth = 0; depth < 12; depth++) nested = nested.child;
+    expect(nested).toEqual({ leaf: "complete" });
+
+    const identityView = JSON.parse(
+      await run([
+        "value-at",
+        DID_A,
+        "of:a",
+        "--remote",
+        BASE,
+        "--as",
+        VIEWER_DID,
+        "--full-depth",
+        "--json",
+      ]),
+    );
+    expect(identityView.resolvedKind).toBe("user");
+    nested = identityView.value.deep;
+    for (let depth = 0; depth < 12; depth++) nested = nested.child;
+    expect(nested).toEqual({ leaf: "complete" });
   });
 
   it("value-at applies exact and slash paths to identity views", async () => {

--- a/packages/state-inspector/README.md
+++ b/packages/state-inspector/README.md
@@ -119,6 +119,7 @@ deno task cf inspect hot      z6Mkqa41 --limit 10
 deno task cf inspect churn    z6Mkqa41 [--bucket 60] [--since '2026-07-22 10:00:00'] [--top 10]
 deno task cf inspect history  z6Mkqa41 of:fid1:…
 deno task cf inspect value-at z6Mkqa41 of:fid1:… --path value/count [--seq N]
+deno task cf inspect value-at z6Mkqa41 of:fid1:… --full-depth # preserve every nested value
 
 # the entity graph (relationships between pieces/cells/modules)
 deno task cf inspect graph    z6Mkqa41 [--root of:fid1:… --depth 2] [--dot]

--- a/packages/state-inspector/cli.ts
+++ b/packages/state-inspector/cli.ts
@@ -9,7 +9,7 @@
 //   inspect hot      <db> [--limit <n>] [--branch <b>]
 //   inspect history  <db> <entity-id> [--scope <s>] [--branch <b>]
 //   inspect value-at <db> <entity-id> [--seq <n>] [--path a/b/c]
-//                    [--path-json '["a/b",""]'] [--doc]
+//                    [--path-json '["a/b",""]'] [--doc] [--full-depth]
 // Multi-space (cross-space convergence):
 //   inspect converge      <entity-id> --spaces a.sqlite,b.sqlite [--path a/b/c]
 //                        [--path-json '["a/b",""]']
@@ -17,7 +17,12 @@
 //   inspect converge-scan --dir <dir> [--limit <n>] [--branch <b>]
 
 import { openSpace } from "./db.ts";
-import { annotate, escapeTerminalText, summarize } from "./decode.ts";
+import {
+  annotate,
+  escapeTerminalText,
+  stringifyInspectorJson,
+  summarize,
+} from "./decode.ts";
 import {
   entityHistory,
   hotEntities,
@@ -40,7 +45,7 @@ interface Args {
 }
 
 /** Flags that never take a value — so `--json <db>` doesn't eat the db arg. */
-const BOOLEAN_FLAGS = new Set(["json", "doc", "help"]);
+const BOOLEAN_FLAGS = new Set(["json", "doc", "full-depth", "help"]);
 
 /** Value-taking flags for which an empty string has defined semantics. */
 const FLAGS_ALLOWING_EMPTY_VALUES = new Set(["branch", "path", "scope"]);
@@ -59,6 +64,7 @@ const COMMAND_FLAGS = new Map<string, ReadonlySet<string>>([
       "scope",
       "branch",
       "doc",
+      "full-depth",
       "json",
     ]),
   ],
@@ -206,8 +212,17 @@ function parsePathFlags(flags: Record<string, string | boolean>): string[] {
   return parsed;
 }
 
-function out(json: boolean, data: unknown, render: () => void) {
-  if (json) console.log(JSON.stringify(data, null, 2));
+type OutputStringifier = (value: unknown) => string | undefined;
+
+const prettyJson: OutputStringifier = (value) => JSON.stringify(value, null, 2);
+
+function out(
+  json: boolean,
+  data: unknown,
+  render: () => void,
+  stringify: OutputStringifier = prettyJson,
+) {
+  if (json) console.log(stringify(data));
   else render();
 }
 
@@ -220,7 +235,7 @@ single-space:
   history  <db> <entity-id> [--scope <s>] [--branch <b>] [--limit <n>] [--json]
   value-at <db> <entity-id> [--seq <n>] [--path a/b/c] [--scope <s>]
                             [--path-json '["a/b",""]'] [--branch <b>]
-                            [--doc] [--json]
+                            [--doc] [--full-depth] [--json]
 
 cross-space convergence:
   converge      <entity-id> (--spaces a,b,… | --dir <dir>) [--path a/b/c]
@@ -563,9 +578,15 @@ export function main(argv: string[]): number {
         );
         const shown = flags.doc === true ? res.document : res.value;
         const pathExists = flags.doc === true ? res.exists : res.pathExists;
+        const fullDepth = flags["full-depth"] === true;
+        const annotated = annotate(
+          shown,
+          fullDepth ? Number.POSITIVE_INFINITY : 8,
+        );
+        const stringify = fullDepth ? stringifyInspectorJson : prettyJson;
         out(
           json,
-          { exists: res.exists, pathExists, value: annotate(shown) },
+          { exists: res.exists, pathExists, value: annotated },
           () => {
             if (!res.exists) {
               console.log("(absent at this seq)");
@@ -575,8 +596,9 @@ export function main(argv: string[]): number {
               console.log("(entity present, but nothing at that path)");
               return;
             }
-            console.log(JSON.stringify(annotate(shown), null, 2));
+            console.log(stringify(annotated));
           },
+          stringify,
         );
         return 0;
       }

--- a/packages/state-inspector/decode.ts
+++ b/packages/state-inspector/decode.ts
@@ -181,81 +181,319 @@ export function summarizeLink(link: DecodedLink): string {
   return `🔗 ${id}${path}${space}${schema}`;
 }
 
+interface AnnotationVisit {
+  kind: "visit";
+  value: Json;
+  depth: number;
+  target: Record<string, Json>;
+  key: string;
+}
+
+interface AnnotationLeave {
+  kind: "leave";
+  value: object;
+}
+
+type AnnotationFrame = AnnotationVisit | AnnotationLeave;
+
 /**
- * Recursively transform a stored value into an annotated, JSON-printable form:
- * links become `{ $link: … }`, entity refs `{ $ref: … }`, streams `"$stream"`.
- * `maxDepth` guards against deep/cyclic-looking structures.
+ * Transform a stored value into an annotated, JSON-printable form. Links
+ * become `{ $link: … }`, entity refs become `{ $ref: … }`, and streams become
+ * `"$stream"`. `maxDepth` limits how many nested containers are retained.
  */
 export function annotate(v: Json, maxDepth = 8): Json {
-  if (maxDepth < 0) return "…";
+  const root: Record<string, Json> = {};
+  const detectCycles = !Number.isFinite(maxDepth);
+  const ancestors = new WeakSet<object>();
+  const work: AnnotationFrame[] = [{
+    kind: "visit",
+    value: v,
+    depth: maxDepth,
+    target: root,
+    key: "value",
+  }];
 
-  const link = decodedLinkOf(v);
-  if (link) {
-    return {
-      $link: {
-        id: link.id,
-        ...(link.path && link.path.length ? { path: link.path } : {}),
-        ...(link.space ? { space: link.space } : {}),
-        ...(link.scope ? { scope: link.scope } : {}),
-        ...(link.hasSchema ? { schema: true } : {}),
-      },
-    };
-  }
-  if (isStream(v)) return "$stream";
-  const ref = parseEntityRef(v);
-  if (ref !== null) return { $ref: ref };
+  while (work.length > 0) {
+    const frame = work.pop()!;
+    if (frame.kind === "leave") {
+      ancestors.delete(frame.value);
+      continue;
+    }
 
-  // Lower non-JSON-safe Fabric leaves to a stable, printable form so the bundle
-  // (and every JSON.stringify export path that consumes it — HTML, CLI --json)
-  // can't throw on a BigInt, render a Fabric instance as an opaque `{}`, or
-  // SILENTLY DROP a stored `undefined` (which JSON.stringify omits — losing the
-  // present-undefined vs absent-key distinction the data model preserves).
-  if (v === undefined) return { $undefined: true };
-  if (typeof v === "bigint") return { $bigint: v.toString() };
-  if (typeof v === "symbol") return String(v);
-  if (typeof v === "function") return "[function]";
+    const assign = (value: Json) => setOwn(frame.target, frame.key, value);
+    if (frame.depth < 0) {
+      assign("…");
+      continue;
+    }
 
-  if (Array.isArray(v)) {
-    const keys = Object.keys(v);
-    if (
-      keys.length === v.length && keys.every(isArrayIndexPropertyName)
-    ) {
-      return v.map((x) => annotate(x, maxDepth - 1));
+    const link = decodedLinkOf(frame.value);
+    if (link) {
+      assign({
+        $link: {
+          id: link.id,
+          ...(link.path && link.path.length ? { path: link.path } : {}),
+          ...(link.space ? { space: link.space } : {}),
+          ...(link.scope ? { scope: link.scope } : {}),
+          ...(link.hasSchema ? { schema: true } : {}),
+        },
+      });
+      continue;
     }
-    const entries: Record<string, Json> = {};
-    const properties: Record<string, Json> = {};
-    for (const key of keys) {
-      const target = isArrayIndexPropertyName(key) ? entries : properties;
-      setOwn(
-        target,
-        key,
-        annotate(
-          (v as unknown as Record<string, Json>)[key],
-          maxDepth - 1,
-        ),
-      );
+    if (isStream(frame.value)) {
+      assign("$stream");
+      continue;
     }
-    return {
-      $sparseArray: {
-        length: v.length,
-        entries,
-        ...(Object.keys(properties).length > 0 ? { properties } : {}),
-      },
-    };
-  }
-  if (isNameWalkable(v)) {
-    const out: Record<string, Json> = {};
-    for (const [k, val] of Object.entries(v)) {
-      setOwn(out, k, annotate(val, maxDepth - 1));
+    const ref = parseEntityRef(frame.value);
+    if (ref !== null) {
+      assign({ $ref: ref });
+      continue;
     }
-    return out;
+
+    // Lower non-JSON-safe Fabric leaves to a stable, printable form so the
+    // bundle and its JSON output retain every stored value.
+    if (frame.value === undefined) {
+      assign({ $undefined: true });
+      continue;
+    }
+    if (typeof frame.value === "bigint") {
+      assign({ $bigint: frame.value.toString() });
+      continue;
+    }
+    if (typeof frame.value === "symbol") {
+      assign(String(frame.value));
+      continue;
+    }
+    if (typeof frame.value === "function") {
+      assign("[function]");
+      continue;
+    }
+
+    if (Array.isArray(frame.value)) {
+      if (detectCycles && ancestors.has(frame.value)) {
+        assign("…");
+        continue;
+      }
+      if (detectCycles) {
+        ancestors.add(frame.value);
+        work.push({ kind: "leave", value: frame.value });
+      }
+
+      const keys = Object.keys(frame.value);
+      if (
+        keys.length === frame.value.length &&
+        keys.every(isArrayIndexPropertyName)
+      ) {
+        const output = new Array<Json>(frame.value.length);
+        assign(output);
+        const target = output as unknown as Record<string, Json>;
+        for (let index = frame.value.length - 1; index >= 0; index--) {
+          work.push({
+            kind: "visit",
+            value: frame.value[index],
+            depth: frame.depth - 1,
+            target,
+            key: String(index),
+          });
+        }
+        continue;
+      }
+
+      const entries: Record<string, Json> = {};
+      const properties: Record<string, Json> = {};
+      const sparseArray: Record<string, Json> = {};
+      setOwn(sparseArray, "length", frame.value.length);
+      setOwn(sparseArray, "entries", entries);
+      if (keys.some((key) => !isArrayIndexPropertyName(key))) {
+        setOwn(sparseArray, "properties", properties);
+      }
+      assign({ $sparseArray: sparseArray });
+      const source = frame.value as unknown as Record<string, Json>;
+      for (let index = keys.length - 1; index >= 0; index--) {
+        const key = keys[index];
+        work.push({
+          kind: "visit",
+          value: source[key],
+          depth: frame.depth - 1,
+          target: isArrayIndexPropertyName(key) ? entries : properties,
+          key,
+        });
+      }
+      continue;
+    }
+
+    if (isNameWalkable(frame.value)) {
+      if (detectCycles && ancestors.has(frame.value)) {
+        assign("…");
+        continue;
+      }
+      if (detectCycles) {
+        ancestors.add(frame.value);
+        work.push({ kind: "leave", value: frame.value });
+      }
+
+      const output: Record<string, Json> = {};
+      assign(output);
+      const entries = Object.entries(frame.value);
+      for (let index = entries.length - 1; index >= 0; index--) {
+        const [key, value] = entries[index];
+        work.push({
+          kind: "visit",
+          value,
+          depth: frame.depth - 1,
+          target: output,
+          key,
+        });
+      }
+      continue;
+    }
+
+    // A Fabric instance has no enumerable state to walk by property name.
+    if (typeof frame.value === "object" && frame.value !== null) {
+      assign({ $fabric: toCompactDebugString(frame.value) });
+      continue;
+    }
+    assign(frame.value);
   }
-  // A non-plain object (a Fabric instance — bytes/regexp/epoch/hash/…) has no
-  // enumerable own keys; render its canonical debug string instead of `{}`.
-  if (typeof v === "object" && v !== null) {
-    return { $fabric: toCompactDebugString(v) };
+
+  return root.value;
+}
+
+interface JsonValueFrame {
+  kind: "value";
+  value: Json;
+  depth: number;
+}
+
+interface JsonTextFrame {
+  kind: "text";
+  value: string;
+}
+
+interface JsonLeaveFrame {
+  kind: "leave";
+  value: object;
+}
+
+type JsonFrame = JsonValueFrame | JsonTextFrame | JsonLeaveFrame;
+
+const INSPECTOR_JSON_INDENTS = Array.from(
+  { length: 33 },
+  (_, depth) => "  ".repeat(depth),
+);
+
+function inspectorJsonIndent(depth: number): string {
+  return INSPECTOR_JSON_INDENTS[Math.min(depth, 32)];
+}
+
+function omittedJsonObjectValue(value: Json): boolean {
+  return value === undefined || typeof value === "function" ||
+    typeof value === "symbol";
+}
+
+/**
+ * Serialize annotated inspector data without recursive descent. Indentation
+ * stops growing after 32 levels so deeply nested output stays linear in size.
+ */
+export function stringifyInspectorJson(value: Json): string {
+  const output: string[] = [];
+  const ancestors = new WeakSet<object>();
+  const work: JsonFrame[] = [{
+    kind: "value",
+    value,
+    depth: 0,
+  }];
+
+  while (work.length > 0) {
+    const frame = work.pop()!;
+    if (frame.kind === "text") {
+      output.push(frame.value);
+      continue;
+    }
+    if (frame.kind === "leave") {
+      ancestors.delete(frame.value);
+      continue;
+    }
+
+    if (frame.value === null) {
+      output.push("null");
+      continue;
+    }
+    switch (typeof frame.value) {
+      case "string":
+      case "boolean":
+      case "number":
+        output.push(JSON.stringify(frame.value));
+        continue;
+      case "undefined":
+      case "function":
+      case "symbol":
+        output.push("null");
+        continue;
+      case "bigint":
+        throw new TypeError("Inspector JSON contains an unannotated BigInt.");
+    }
+
+    if (ancestors.has(frame.value)) {
+      throw new TypeError("Inspector JSON contains a circular structure.");
+    }
+    ancestors.add(frame.value);
+    work.push({ kind: "leave", value: frame.value });
+
+    if (Array.isArray(frame.value)) {
+      output.push("[");
+      if (frame.value.length === 0) {
+        output.push("]");
+        continue;
+      }
+      work.push({
+        kind: "text",
+        value: `\n${inspectorJsonIndent(frame.depth)}]`,
+      });
+      for (let index = frame.value.length - 1; index >= 0; index--) {
+        work.push({
+          kind: "value",
+          value: frame.value[index],
+          depth: frame.depth + 1,
+        });
+        work.push({
+          kind: "text",
+          value: `${index === 0 ? "\n" : ",\n"}${
+            inspectorJsonIndent(frame.depth + 1)
+          }`,
+        });
+      }
+      continue;
+    }
+
+    const keys = Object.keys(frame.value).filter((key) =>
+      !omittedJsonObjectValue((frame.value as Record<string, Json>)[key])
+    );
+    output.push("{");
+    if (keys.length === 0) {
+      output.push("}");
+      continue;
+    }
+    work.push({
+      kind: "text",
+      value: `\n${inspectorJsonIndent(frame.depth)}}`,
+    });
+    for (let index = keys.length - 1; index >= 0; index--) {
+      const key = keys[index];
+      work.push({
+        kind: "value",
+        value: (frame.value as Record<string, Json>)[key],
+        depth: frame.depth + 1,
+      });
+      work.push({
+        kind: "text",
+        value: `${index === 0 ? "\n" : ",\n"}${
+          inspectorJsonIndent(frame.depth + 1)
+        }${JSON.stringify(key)}: `,
+      });
+    }
   }
-  return v;
+
+  return output.join("");
 }
 
 /** Compact one-line summary of any value, for table cells. */

--- a/packages/state-inspector/scopes.ts
+++ b/packages/state-inspector/scopes.ts
@@ -194,6 +194,8 @@ export function valueAsIdentity(
     path?: string[];
     /** Return the resolved document instead of selecting within its value. */
     doc?: boolean;
+    /** Maximum depth retained in annotated output. Defaults to eight. */
+    annotationDepth?: number;
   },
 ): SelectedIdentityValue {
   if (opts.doc && opts.path !== undefined) {
@@ -230,7 +232,9 @@ export function valueAsIdentity(
       resolvedScope: scope,
       resolvedKind: parseScope(scope).kind,
       pathExists: selected.found,
-      value: doc === undefined ? undefined : annotate(selected.value),
+      value: doc === undefined
+        ? undefined
+        : annotate(selected.value, opts.annotationDepth),
       overrides,
       approximation: true,
     };

--- a/packages/state-inspector/test/cli.test.ts
+++ b/packages/state-inspector/test/cli.test.ts
@@ -4,8 +4,10 @@
 // must not swallow the path.
 
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import { expect } from "@std/expect";
 import { Database } from "@db/sqlite";
 import { jsonFromValue } from "@commonfabric/data-model/codecs";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 
 import { main } from "../cli.ts";
 
@@ -31,9 +33,13 @@ CREATE TABLE branch (
 INSERT INTO branch (name, head_seq, status) VALUES ('', 2, 'active');
 `;
 
+const STACK_SAFE_DEPTH = 20_000;
+
 function seed(path: string) {
   const db = new Database(path, { create: true });
   db.exec(SCHEMA);
+  let deep: FabricValue = { leaf: "complete" };
+  for (let depth = 0; depth < 12; depth++) deep = { child: deep };
   const commit = db.prepare(
     `INSERT INTO "commit" (seq, session_id, local_seq, original, resolution)
      VALUES (?, 'session:did:key:zX:u', ?, '{"reads":{"confirmed":[],"pending":[]}}', '{}')`,
@@ -50,6 +56,7 @@ function seed(path: string) {
     jsonFromValue({
       value: {
         n: 1,
+        deep,
         "a/b": "literal slash key",
         a: { b: "nested key" },
         "": "empty key",
@@ -493,6 +500,55 @@ Deno.test("cli: single-space commands dispatch over a seeded DB", async (t) => {
     await t.step("--help exits successfully without a command", () => {
       assertEquals(run(["--help"]).code, 0);
     });
+
+    await t.step(
+      "preserves every nested value with `value-at --full-depth`",
+      () => {
+        const shallow = JSON.parse(
+          run(["value-at", db, "of:a", "--json"]).out,
+        );
+        expect(JSON.stringify(shallow.value.deep)).toContain('"…"');
+        const full = JSON.parse(
+          run(["value-at", db, "of:a", "--full-depth", "--json"]).out,
+        );
+        let nested = full.value.deep;
+        for (let depth = 0; depth < 12; depth++) nested = nested.child;
+        expect(nested).toEqual({ leaf: "complete" });
+      },
+    );
+
+    await t.step(
+      "full-depth output survives deeply nested stored values",
+      () => {
+        const deeplyNested = `${
+          '{"child":'.repeat(STACK_SAFE_DEPTH)
+        }{"leaf":"complete"}${"}".repeat(STACK_SAFE_DEPTH)}`;
+        const writable = new Database(db);
+        try {
+          writable.prepare(
+            `INSERT INTO revision
+               (id, seq, op_index, op, data, commit_seq)
+             VALUES ('of:deep', 1, 0, 'set', ?, 1)`,
+          ).run(`{"value":${deeplyNested}}`);
+        } finally {
+          writable.close();
+        }
+
+        const result = run([
+          "value-at",
+          db,
+          "of:deep",
+          "--full-depth",
+          "--json",
+        ]);
+        expect(result.code).toBe(0);
+        let nested = JSON.parse(result.out).value;
+        for (let depth = 0; depth < STACK_SAFE_DEPTH; depth++) {
+          nested = nested.child;
+        }
+        expect(nested).toEqual({ leaf: "complete" });
+      },
+    );
 
     await t.step("hot + history + commits succeed", () => {
       for (

--- a/packages/state-inspector/test/decode.test.ts
+++ b/packages/state-inspector/test/decode.test.ts
@@ -20,6 +20,7 @@ import {
   annotate,
   collectLinks,
   decodedLinkOf,
+  stringifyInspectorJson,
   summarize,
   summarizeLink,
 } from "../decode.ts";
@@ -82,6 +83,39 @@ Deno.test("decode: BigInt is JSON-safe after annotate", () => {
   // the whole thing must JSON.stringify without throwing (the HTML/CLI export path)
   const json = JSON.stringify(annotated);
   assert(json.includes('"$bigint"'), "bigint lowered to a tagged record");
+});
+
+Deno.test("decode: inspector JSON matches ordinary pretty output", () => {
+  const annotated = annotate({
+    text: "value",
+    list: [1, true, null],
+    nested: { leaf: "complete" },
+  });
+  assertEquals(
+    stringifyInspectorJson(annotated),
+    JSON.stringify(annotated, null, 2),
+  );
+});
+
+Deno.test("decode: full-depth output survives deeply nested values", () => {
+  const depth = 20_000;
+  let value: unknown = { leaf: "complete" };
+  for (let index = 0; index < depth; index++) value = { child: value };
+
+  const serialized = stringifyInspectorJson({
+    value: annotate(value, Number.POSITIVE_INFINITY),
+  });
+  let nested = (JSON.parse(serialized) as { value: unknown }).value;
+  for (let index = 0; index < depth; index++) {
+    nested = (nested as { child: unknown }).child;
+  }
+  assertEquals(nested, { leaf: "complete" });
+});
+
+Deno.test("decode: full-depth annotation marks cycles", () => {
+  const value: Record<string, unknown> = {};
+  value.self = value;
+  assertEquals(annotate(value, Number.POSITIVE_INFINITY), { self: "…" });
 });
 
 Deno.test("decode: annotate lowers a `FabricPrimitive` to its debug string", () => {


### PR DESCRIPTION
Inspector value output stops annotating nested values after eight levels by default. This keeps ordinary output compact. It also prevents operators from requesting a complete deeply nested value.

Add `--full-depth` to `value-at` in the workspace CLI and standalone inspector. Carry the requested annotation depth through raw views and views assembled for an identity. Preserve exact path selection and `pathExists` results from the current inspector API.

Walk annotation and full-depth JSON output with explicit work lists. This keeps complete output from exhausting the JavaScript call stack on deeply nested stored values. Cycles use the existing ellipsis marker. Indentation stops growing after 32 levels.

Cover local, remote, and identity-scoped output. Exercise a 20,000-level stored value while keeping ordinary eight-level output unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

