### PR TITLE
feat(cli): a verb listing row carries the handler's declared result

### DIFF
--- a/docs/common/verbs-over-the-cli.md
+++ b/docs/common/verbs-over-the-cli.md
@@ -78,6 +78,28 @@ before relying on any of its behavior.
 cf piece verbs --piece <piece> --json
 ```
 
+Each row carries the verb's input schema and, when the verb declares a result,
+the schema of what it hands back — so both halves of "what may I send, and what
+do I get" are answerable before the first call rather than by making one:
+
+```json
+{
+  "name": "addNote",
+  "kind": "handler",
+  "on": "result",
+  "inputSchema": { "…": "…" },
+  "outputSchema": {
+    "type": "object",
+    "properties": { "note": { "$ref": "#/$defs/NoteOutput" } },
+    "required": ["note"],
+    "$defs": { "…": "…" }
+  }
+}
+```
+
+A value-less verb carries no `outputSchema` at all, which is how a caller tells
+the two apart without calling.
+
 ### Call a verb and read its result
 
 `cf piece call` prints one settled **Invocation JSON** object on stdout:

--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -340,7 +340,10 @@ merges as-is, amends `closedWorldEventRejection`, or retreats — all three are
 costed on #5307 — and it owes an item renumber, then a baseline re-record as its
 final step. A caller naming a reference (item 11, #5560) waits on confirming
 that a sigil resolves through a *declared* event field rather than an untyped
-one.
+one; it decides nothing item 1 decides — a declared result makes an *output*
+self-describing, this is what an *input* accepts — but it shares
+`schema-injection.ts` with that emission, so the one-file rule applies to the
+pair and one holder suits both.
 
 **Carried alongside, not sequenced.** A capability probe that covers nothing
 (#5534) is a test asserting something it cannot observe, so it reports green

--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -357,13 +357,25 @@ CLI:
 | the event interface itself | **absent** |
 
 So only the third is an emission gap. The first two are emitted and lost
-between the pattern and the caller, and the shape of the first is the reason to
-suspect where: a `description` beside a `$ref` is ignored under JSON Schema's
-own semantics, so any consumer that resolves the reference and substitutes its
-target drops the sibling. That is a hypothesis about the loss point rather than
-a located defect — what is established is that the emitter is not where two of
-the three go missing, so a patch aimed there would close one symptom and leave
-two.
+between the pattern and the caller: the schema a caller is served is the
+resolved form — no `$defs`, no `$ref`, the target inlined — and both
+descriptions are absent from it.
+
+*The obvious explanation is not the explanation.* A `description` beside a
+`$ref` is ignored under JSON Schema's own semantics, so a resolver that
+substitutes the target would drop it. This one does not:
+`resolveCfcSchemaRefsUncached` (`packages/runner/src/cfc/schema-refs.ts`)
+collects ref-site siblings and merges them over the resolved target on purpose.
+That rules out the tidy answer for the verb, and it never explained the event
+field, whose description sits inside the `$def` rather than beside the ref.
+
+*A lead, unverified.* `resolveSchema` (`packages/runner/src/schema.ts`) calls
+`resolveSchemaRefs(schema)` with one argument, so the document consulted for
+`#/$defs/...` defaults to the property schema itself — and a verb property
+carries the `$ref` while the `$defs` live at the pattern's result-schema root.
+Whoever takes this should confirm or discard that before assuming a single
+cause: what is established is only that the emitter is not where two of the
+three go missing, so a patch aimed there would close one symptom and leave two.
 
 **Carried alongside, not sequenced.** A capability probe that covers nothing
 (#5534) is a test asserting something it cannot observe, so it reports green

--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -39,7 +39,6 @@ a driver needs to know what is already moving before scheduling anything new.
 | PR | What | State |
 | --- | --- | --- |
 | #5629 | a verb listing row carries the handler's declared result | item 10, the consumer half of the declared result. Collides with #5623, which relocates a doc comment in the same region of `packages/cli/lib/piece.ts`; the collision is a real git conflict rather than a silent merge, and whichever lands second keeps both |
-| #5609 | a rejected position is not a required one | split out of #5504, because the defect it fixes is on main. A `$link` marker beside any other projection key returns nothing: the rejected position stays in the source's `required`, so the projected schema is unsatisfiable and the whole selection reads as absent |
 | #5307 | closed-world verb event schemas | parked on #5589; the minting is built, and what stays red is a renderer-semantics ruling rather than an implementation gap |
 
 **Most of the read layer has landed.** #5309, #5459, #5468, #5470, #5497 and
@@ -48,24 +47,16 @@ folded into #5470's squash; the shared read step it factored out is on main as
 `packages/cli/lib/cell-selection.ts`. A reader who goes looking for #5458 should
 not conclude the step was dropped.
 
-**Two are back out: #5469 and #5505 were reverted by #5582.** They merged
-twenty-six seconds apart, each green on a base that did not contain the other,
-and the tree they made together type-failed — #5469 replaced `invocationId`
-with an `invocation: {id, session}` pair, and #5505 added nine `piece call`
-selection tests written against the old name. The revert restored the 22 files
-they touched byte-for-byte.
+**The invocation pair and call selection are both on main**, re-landed together
+by #5610. `scopeCallerEventId` takes the `{id, session}` pair rather than the id
+alone, so two callers choosing the same word — `add-comment-1` is the word two
+agents both pick — no longer compute one address and read one receipt. `piece
+call` takes `--select` / `--schema` / `--filter` beside it.
 
-Two consequences a driver has to carry:
-
-- **`piece call` has no `--select` / `--schema` / `--filter` again.** That is a
-  landed piece of item 6 going back out, not just a test fix.
-- **The address change is no longer underneath anything.** `scopeCallerEventId`
-  derives from `{caller, id, path, space}` with no identity in the address, so
-  two callers choosing the same word — `add-comment-1` is the word two agents
-  both pick — compute one address and read one receipt, and the second is told
-  its call settled when it never ran. Item 4 was sequenced after item 7
-  precisely so that a published address had stopped moving. **That precondition
-  is gone, and item 4 must not start until it returns.**
+**So item 4's precondition holds: a published receipt address has stopped
+moving.** That is what item 4 was sequenced after item 7 to wait for, and the
+wait is over. What it cost to get there is the merge-race hazard recorded under
+"How this is driven" below, which is the part worth carrying forward.
 
 ## The decision that was waiting, and the condition it carries
 
@@ -254,17 +245,15 @@ caller.
 
 ## Landed, and what consumes it
 
-**6. The read layer.** The shared read step, address markers with the
-deepest-link rule, container inference, the flag split, entity-URI intake and
-the `@` suffix are on main. One piece is not: call selection went back out with
-#5505's revert.
+**6. The read layer.** On main in full: the shared read step, address markers
+with the deepest-link rule, container inference, the flag split, entity-URI
+intake, the `@` suffix, and call selection.
 
-**7. Session-scoped invocation ids.** **Reverted** — #5469 is out of main
-again. It is the one address-changing commit, and the whole plan is ordered
-around landing it before anything publishes a receipt address. Until it is
-back, a receipt address is derived without identity in it, so it is not yet
-something a caller can safely be handed. Item 4 depends on this; nothing else
-does.
+**7. Session-scoped invocation ids.** On main (#5610). It is the one
+address-changing commit, and the whole plan is ordered around landing it before
+anything publishes a receipt address — so a receipt address now carries
+identity and is something a caller can safely be handed. Item 4 depends on
+this; nothing else does.
 
 **8. Descriptive receipt schemas.** On main. Plain results only — a verb
 returning anything reactive gets none, which is what item 1 decides.
@@ -295,8 +284,8 @@ joins them.
 
 | Item | After | Why |
 | --- | --- | --- |
-| 6 | — | landed but for call selection, which #5582 reverted |
-| 7 | — | **reverted; must land again before 4 can start** |
+| 6 | — | landed |
+| 7 | — | landed; item 4's precondition holds |
 | 8, 9 | — | independent |
 | 2 | 6 | changes what the flags accept |
 | 3 | 6 | completes the suppression property |

--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -320,11 +320,12 @@ its own track.
 
 | # | Step | Delivers | After | Why here |
 | --- | --- | --- | --- | --- |
-| 1 | The doubly-linked tracker fixture | repro for #5577, #5632, #5633; item 11's subject | — | Four things verify against a piece that holds a back-reference, and none of them can be demonstrated until one exists |
+| 1 | The doubly-linked tracker fixture and its walkthrough | #5639 with #5631; repro for #5577, #5632, #5633, #5637; item 11's subject | — | Five things verify against a piece that holds a back-reference, and none of them can be demonstrated until one exists. The two land together or the doc first: the walkthrough names the verbs, so a fixture arriving alone leaves main describing verbs it does not have |
 | 2 | A projected read survives a handler | #5633 | 1 | Breaks call-then-read-shaped, which is the loop items 4, 5, 10 and #5577 all demonstrate against. Diagnose before estimating: if it sits in runner materialization rather than the read path, it moves after step 7 rather than holding the line |
 | 3 | Listing rows carry a handler's declared result | item 10, #5619 | — | The consumer half of item 1 |
 | 4 | The forced-stream fallback stops inventing verbs | #5576 | 3 | Same file as step 3. It narrows the listing, so sweep the open branches for writers first |
-| 5 | The help page stops lying and starts describing | #5558 (the false claim), #5559 | — | `Output: No output on success.` is wrong for a declared verb, and the author's JSDoc is already on the wire. Neither half needs a schema or a decision, which is why they precede the half that does |
+| 5 | The help page stops claiming a verb returns nothing | #5558 (the false claim) | — | `Output: No output on success.` is wrong for a declared verb. Asserting there is no output is worse than saying nothing, and stopping it needs no schema and no decision, which is why it precedes the half that does |
+| 5a | An author's prose reaches the caller | #5637 | 1 | Separate lane — what is missing is not in the CLI. See the measurement below: two of the three symptoms are emitted correctly and lost afterwards, so a fix aimed at the emitter would miss them |
 | 6 | Help enumerates what a verb returns | #5558 (the missing fields) | 3, 5 | Step 3 builds the declared-result lookup; this is its second consumer, at the call path rather than the listing |
 | 7 | A returned piece reads back through its own cycle | #5577 | 6 | The derived default selection bounds the readback, which is what turns the crash into a result |
 | 8 | `receipt` as a top-level envelope field | item 4 | — | Its precondition is met, it touches the call envelope alone, and it is what gives items 8 and 9 a consumer. Runs beside steps 5-7 |
@@ -344,6 +345,25 @@ one; it decides nothing item 1 decides — a declared result makes an *output*
 self-describing, this is what an *input* accepts — but it shares
 `schema-injection.ts` with that emission, so the one-file rule applies to the
 pair and one holder suits both.
+
+**Where a doc comment actually goes, measured against the compile pipeline.**
+Step 5a rests on this, and it is not what either symptom looked like from the
+CLI:
+
+| An author writes it on | In the compiled pattern |
+| --- | --- |
+| a verb (`Stream` property) | **present** — `resultSchema.properties.<verb>.description`, as a sibling of the `$ref` to the event's definition |
+| an event field | **present** — `$defs.<Event>.properties.<field>.description` |
+| the event interface itself | **absent** |
+
+So only the third is an emission gap. The first two are emitted and lost
+between the pattern and the caller, and the shape of the first is the reason to
+suspect where: a `description` beside a `$ref` is ignored under JSON Schema's
+own semantics, so any consumer that resolves the reference and substitutes its
+target drops the sibling. That is a hypothesis about the loss point rather than
+a located defect — what is established is that the emitter is not where two of
+the three go missing, so a patch aimed there would close one symptom and leave
+two.
 
 **Carried alongside, not sequenced.** A capability probe that covers nothing
 (#5534) is a test asserting something it cannot observe, so it reports green
@@ -479,7 +499,7 @@ from a plan is one nobody schedules, which is the whole reason for this table.
 | #5619 | listing rows carry a handler's declared result | step 3 |
 | #5576 | `cf piece verbs` lists data fields as handlers, so discovery reports what cannot be called | step 4 |
 | #5558 | `piece call --help` claims every handler returns nothing, including one that declares a result | steps 5 and 6 — the false claim needs nothing, enumerating the fields needs the lookup |
-| #5559 | a verb's purpose never reaches its help page, though the description is already in the schema | step 5 |
+| #5637 | an author's prose does not reach a caller: on a verb, on an event field, and on the event interface | step 5a — it absorbed #5559, which described one symptom and had its cause backwards |
 | #5577 | a verb returning a child piece in a doubly-linked tree crashes readback on a cycle | step 7 |
 | #5523 | two identical `piece get` projections in one runtime collide on the transform result cell | step 10 |
 | #5632 | `--show-links` and a `$link` read return different entity ids for the same piece | step 11 |

--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -33,6 +33,28 @@ belongs in one document even when the reasoning belongs in two.
 
 ## State
 
+Where every item stands. The sections below carry the detail and are what to
+read before picking one up; this is the roll-up, so a driver can see the shape
+without reconstructing it.
+
+| Item | Status |
+| --- | --- |
+| 1. a verb's declared result reaches the runtime | on main (#5501) |
+| 6. the read layer | on main, in full |
+| 7. session-scoped invocation ids | on main (#5610) |
+| 8. descriptive receipt schemas | on main |
+| 9a. listing marks | on main (#5309) |
+| 10. listing rows carry a handler's declared result | in review (#5629) |
+| 9b. closed-world event emission | built, parked on #5589 (#5307) |
+| 4. `receipt` as a top-level envelope field | not started — and its precondition now holds |
+| 2. an unrecognized projection key is refused | not started |
+| 3. a rejection propagates up through what holds it | not started |
+| 5. `cf wish` and `cf exec` take the read options | not started |
+
+Item 9 is split because its two halves have different fates: the marks landed,
+the emission is parked. A further item 11 arrives with #5617, which is not yet
+on main.
+
 These pull requests remain open against this work. They are listed here because
 a driver needs to know what is already moving before scheduling anything new.
 
@@ -76,14 +98,14 @@ was open when that one was not.
 yet.** It was given as: if it is easy to add now, go for it; but if it creates
 more things to chase down, revisit rather than push through.
 
-The producer half satisfies that already — #5501 is built and green. **The
-unknown is the consumer half, item 10.** A tool's pattern rides in the callable
-cell's own value, so its branch just reads it; a handler's module lives in the
-compiled graph, so the handler branch needs the verb's node looked up there.
-That lookup is new code rather than a field already sitting in reach. If it
-turns awkward, that is exactly the case the condition names, and the instruction
-is to raise it rather than absorb it. Raising it early costs nothing; absorbing
-it quietly spends the goodwill this decision was made on.
+Both halves satisfy it. The producer is on main (#5501). The consumer, item 10,
+is the lookup the condition was aimed at — a handler's module lives in the
+compiled graph rather than sitting in reach the way a tool's pattern does — and
+it cost one structural match and no change to `callableCommandSpec`'s
+signature. What it did not reach is the command surface: `cf piece call <verb>
+--help --json` still shows a handler no output, because serving it there needs
+the graph at `resolvePieceCallable` too. That is raised rather than absorbed,
+which is what the condition asks for.
 
 *What this unblocks.* Items 8 and 10 stop being provisional, and verb discovery
 closes — `cf piece verbs` can answer both halves of its question.
@@ -258,9 +280,11 @@ this; nothing else does.
 **8. Descriptive receipt schemas.** On main. Plain results only — a verb
 returning anything reactive gets none, which is what item 1 decides.
 
-**9. Closed-world event schemas and listing marks.** #5307 and #5309, from the
-verb contract arc. Both unblocked; both wanted a courtesy review rather than a
-gate.
+**9. Closed-world event schemas and listing marks.** Half landed: the listing
+marks are on main (#5309). Closed-world emission (#5307) is built but parked on
+#5589 — closing a verb's `$event` closes it against the browser too, and
+whether a renderer's DOM-event envelope is governed by the verb's schema is a
+semantics ruling rather than an implementation gap.
 
 **10. Listing rows carry a handler's declared result.** *(S)* `cf piece verbs`
 reports an `outputSchema` per row for a handler as well as for a tool, so verb

--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -50,17 +50,17 @@ without reconstructing it.
 | 2. an unrecognized projection key is refused | not started |
 | 3. a rejection propagates up through what holds it | not started |
 | 5. `cf wish` and `cf exec` take the read options | not started |
+| 11. a caller may name a reference | not started; sequenced, gated on one measurement |
 
 Item 9 is split because its two halves have different fates: the marks landed,
-the emission is parked. A further item 11 arrives with #5617, which is not yet
-on main.
+the emission is parked.
 
 These pull requests remain open against this work. They are listed here because
 a driver needs to know what is already moving before scheduling anything new.
 
 | PR | What | State |
 | --- | --- | --- |
-| #5629 | a verb listing row carries the handler's declared result | item 10, the consumer half of the declared result. Collides with #5623, which relocates a doc comment in the same region of `packages/cli/lib/piece.ts`; the collision is a real git conflict rather than a silent merge, and whichever lands second keeps both |
+| #5629 | a verb listing row carries the handler's declared result | item 10, the consumer half of the declared result |
 | #5307 | closed-world verb event schemas | parked on #5589; the minting is built, and what stays red is a renderer-semantics ruling rather than an implementation gap |
 
 **Most of the read layer has landed.** #5309, #5459, #5468, #5470, #5497 and
@@ -320,7 +320,7 @@ its own track.
 
 | # | Step | Delivers | After | Why here |
 | --- | --- | --- | --- | --- |
-| 1 | The doubly-linked tracker fixture and its walkthrough | #5639 with #5631; repro for #5577, #5632, #5633, #5637; item 11's subject | — | Five things verify against a piece that holds a back-reference, and none of them can be demonstrated until one exists. The two land together or the doc first: the walkthrough names the verbs, so a fixture arriving alone leaves main describing verbs it does not have |
+| 1 | The doubly-linked tracker fixture and its walkthrough | **on main** (#5639, #5631) — repro for #5577, #5632, #5633, #5637; item 11's subject | — | Five things verify against a piece that holds a back-reference, and none could be demonstrated until one existed. `verb-session-gaps.sh` is where they are asserted, and four of its assertions expect a gap and fail loudly the day it closes — so a capability arriving announces itself instead of quietly turning a check green |
 | 2 | A projected read survives a handler | #5633 | 1 | Breaks call-then-read-shaped, which is the loop items 4, 5, 10 and #5577 all demonstrate against. Diagnose before estimating: if it sits in runner materialization rather than the read path, it moves after step 7 rather than holding the line |
 | 3 | Listing rows carry a handler's declared result | item 10, #5619 | — | The consumer half of item 1 |
 | 4 | The forced-stream fallback stops inventing verbs | #5576 | 3 | Same file as step 3. It narrows the listing, so sweep the open branches for writers first |

--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -275,10 +275,15 @@ verb contract arc. Both unblocked; both wanted a courtesy review rather than a
 gate.
 
 **10. Listing rows carry a handler's declared result.** *(S)* `cf piece verbs`
-already reports an `outputSchema` per row, and the type says why it is empty for
-handlers: *"Tools only, until handlers gain declared results."* Item 1 is what
-supplies them. This is the deferred half of verb discovery finally closing, and
-it is a consumer change — the plumbing is built.
+reports an `outputSchema` per row for a handler as well as for a tool, so verb
+discovery answers both halves of its question: what a caller may send, and what
+it gets back. A tool's result schema rides its callable cell and its branch
+just reads it. A handler's rides the node it compiled to, so the listing
+resolves the piece's pattern once and matches each handler node's `$event`
+input against the result property exposing the same stream — one structural
+comparison inside one compiled object. A stream two handler nodes share names
+no single result, and a piece whose pattern will not resolve keeps every row
+and loses only the schema.
 
 *A terminology collision made this look like more than it is.* A pattern's
 **result-schema literal** is where its stream properties live, and the listing

--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -306,21 +306,46 @@ joins them.
 
 ## Ordering
 
-| Item | After | Why |
-| --- | --- | --- |
-| 6 | — | landed |
-| 7 | — | landed; item 4's precondition holds |
-| 8, 9 | — | independent |
-| 2 | 6 | changes what the flags accept |
-| 3 | 6 | completes the suppression property |
-| 4 | 7 | publishes an address, so the address must have stopped moving |
-| 5 | 4 | the fourth and fifth arrivals inherit whatever a read costs |
-| 10 | 1 | listing rows carry a handler's `outputSchema`; the plumbing exists for tools already |
-| 1 | — | decided; 8 and 10 are no longer provisional, and item 10 carries the revisit condition |
-| 11 | — | independent of 1 in what it decides — declared results make an *output* self-describing, this is what an *input* accepts — but shares `schema-injection.ts` with item 1's emission (#5501), so one holder suits both |
+**A defect this plan's own items caused is not a separate queue.** The items
+build a verb surface; the issues below are that surface failing where it is
+already built. Sequencing them apart would mean shipping items 4 and 5 onto a
+read path known to break after a handler runs, so they are interleaved here and
+each step names what it delivers.
 
-Items 2, 3 and 5 touch one file heavily and want to land one at a time rather
-than in parallel. Item 4 is the only one that touches the call envelope.
+Two rules set the order. **One file at a time** — two branches open on one file
+is the merge race under "How this is driven", so steps sharing a file are
+strictly sequential while separate files run in parallel. **A blocked step never
+gates an unblocked one**, which is why everything waiting on a ruling sits in
+its own track.
+
+| # | Step | Delivers | After | Why here |
+| --- | --- | --- | --- | --- |
+| 1 | The doubly-linked tracker fixture | repro for #5577, #5632, #5633; item 11's subject | — | Four things verify against a piece that holds a back-reference, and none of them can be demonstrated until one exists |
+| 2 | A projected read survives a handler | #5633 | 1 | Breaks call-then-read-shaped, which is the loop items 4, 5, 10 and #5577 all demonstrate against. Diagnose before estimating: if it sits in runner materialization rather than the read path, it moves after step 7 rather than holding the line |
+| 3 | Listing rows carry a handler's declared result | item 10, #5619 | — | The consumer half of item 1 |
+| 4 | The forced-stream fallback stops inventing verbs | #5576 | 3 | Same file as step 3. It narrows the listing, so sweep the open branches for writers first |
+| 5 | The help page stops lying and starts describing | #5558 (the false claim), #5559 | — | `Output: No output on success.` is wrong for a declared verb, and the author's JSDoc is already on the wire. Neither half needs a schema or a decision, which is why they precede the half that does |
+| 6 | Help enumerates what a verb returns | #5558 (the missing fields) | 3, 5 | Step 3 builds the declared-result lookup; this is its second consumer, at the call path rather than the listing |
+| 7 | A returned piece reads back through its own cycle | #5577 | 6 | The derived default selection bounds the readback, which is what turns the crash into a result |
+| 8 | `receipt` as a top-level envelope field | item 4 | — | Its precondition is met, it touches the call envelope alone, and it is what gives items 8 and 9 a consumer. Runs beside steps 5-7 |
+| 9 | A rejection propagates up through what holds it | item 3 | — | First of the projection work; the mask's asymmetry is what makes a marked field below a link load every element |
+| 10 | Two identical projections stop colliding | #5523 | 9 | Same file. Reachable the moment anything long-lived reads twice, which the command surface invites |
+| 11 | One piece, one address | #5632, #5498 | — | Trace where each id is minted; the outcome is a fix or a statement that they are aliases. Must precede step 13, which spreads the address vocabulary to two more commands |
+| 12 | An unrecognized projection key is refused | item 2 | 9 | The largest remaining step and the only one with design surface, since it couples the projection reader to the compatibility checker's annotation keys |
+| 13 | `cf wish` and `cf exec` take the read options | item 5 | 11, 12 | Last by construction: it spreads the vocabulary to two more starting points, so the vocabulary should have stopped moving |
+
+**Waiting on a ruling, and running beside all of the above.** Closed-world event
+emission (item 9b) is built and parked on #5589. When that answers, the branch
+merges as-is, amends `closedWorldEventRejection`, or retreats — all three are
+costed on #5307 — and it owes an item renumber, then a baseline re-record as its
+final step. A caller naming a reference (item 11, #5560) waits on confirming
+that a sigil resolves through a *declared* event field rather than an untyped
+one.
+
+**Carried alongside, not sequenced.** A capability probe that covers nothing
+(#5534) is a test asserting something it cannot observe, so it reports green
+continuously until fixed; it belongs to whoever next touches that suite rather
+than to a step here.
 
 ## How this is driven
 
@@ -338,13 +363,13 @@ plan as their PRs land — is the collision the per-agent split exists to avoid.
 Two rules earn their place, both from what went wrong when this was three
 plans:
 
-**#5307 and #5501 reconcile rather than order.** They touch no common source
-file and neither depends on the other — a declared result rides a trailing
-options argument, while event stamping keys on the first. But #5501's
-handler-schema fixtures were compiled before event schemas closed, so once
-#5307 lands they gain `additionalProperties: false` on their event literals.
-Whichever merges second owes a golden regeneration. That is a note on the pair,
-not an edge in the table above.
+**#5307 owes a golden regeneration, and it is the only thing it owes #5501.**
+The two touch no common source file — a declared result rides a trailing
+options argument, while event stamping keys on the first — so this is a note on
+the pair rather than an edge in the sequence. But #5501's handler-schema
+fixtures were compiled while event schemas were still open, so closing them
+gives those fixtures `additionalProperties: false` on their event literals. The
+second to land regenerates, and #5501 landed first.
 
 **Two PRs can each be green and still break main together.** CI judges a PR
 against a base, so when one branch narrows a type and another still writes to
@@ -374,8 +399,17 @@ read *returns*, wants a live-server case before it is believed.
 This is the same shape as the rejected-position defect split out as #5609: the
 `boardSchema` fixture declares no `required` while a generated pattern schema
 does, so every fixture in that file agreed with the bug and the suite could
-only confirm it. Twice now the fixture has been the thing that was wrong. When
-a test cannot fail, the fixture is the first place to look.
+only confirm it. It is also the shape that hides in a double: a compiled
+pattern is callable, so a double written as a plain object passes a guard that
+rejects what the runtime actually hands over, and the suite stays green while
+every real listing comes back empty.
+
+Three instances make it a mechanism rather than a run of bad luck, and the
+general form is worth more than any of them: **when a double stands in for
+something the runtime constructs, check what the runtime constructs.** A
+fixture is a claim about the world, and an unchecked one is the cheapest way to
+build a test that cannot fail. When a test cannot fail, look at the fixture
+first.
 
 **A squash merge invalidates the fork point of everything stacked on it.**
 Rebasing a child with `git rebase <new-base>` then replays commits the base
@@ -409,10 +443,11 @@ July result-schema work, and what #5309 got right by hand.
 
 ## What comes after
 
-This plan is exhausted when items 1-5 are decided or built and the open pull
-requests have landed. Two arcs are queued behind it, and naming their
-triggers here is what keeps them from being dropped when this document stops
-being read.
+This plan is exhausted when the sequence above is walked and the issue tail is
+empty — the items build the surface, and the tail is that surface failing where
+it is already built, so neither alone finishes it. Two arcs are queued behind
+it, and naming their triggers here is what keeps them from being dropped when
+this document stops being read.
 
 **The command surface** —
 [The CLI surface](cli-surface-implementation.md), already sequenced. Its first
@@ -429,6 +464,33 @@ happened. Nothing in this plan advances it, and nothing in it blocks this plan.
 Whoever drives this document owns that queue, not just this list. A plan that
 finishes without naming its successor is how an arc goes quiet with work left
 in it.
+
+## The issue tail
+
+Every open defect against this surface, and where it attaches. A defect absent
+from a plan is one nobody schedules, which is the whole reason for this table.
+
+| Issue | What | Attaches at |
+| --- | --- | --- |
+| #5633 | a projected read fails after an unrelated handler runs, while the same path unshaped succeeds | step 2 |
+| #5619 | listing rows carry a handler's declared result | step 3 |
+| #5576 | `cf piece verbs` lists data fields as handlers, so discovery reports what cannot be called | step 4 |
+| #5558 | `piece call --help` claims every handler returns nothing, including one that declares a result | steps 5 and 6 — the false claim needs nothing, enumerating the fields needs the lookup |
+| #5559 | a verb's purpose never reaches its help page, though the description is already in the schema | step 5 |
+| #5577 | a verb returning a child piece in a doubly-linked tree crashes readback on a cycle | step 7 |
+| #5523 | two identical `piece get` projections in one runtime collide on the transform result cell | step 10 |
+| #5632 | `--show-links` and a `$link` read return different entity ids for the same piece | step 11 |
+| #5498 | `getEntityId()` strips the entity URI scheme, collapsing two kinds to one identity | step 11, if it proves to be the same root |
+| #5589 | ruling: does a closed verb schema govern the renderer's DOM-event envelope? | the parked track — it is what unparks item 9b |
+| #5560 | an address a call returns cannot be passed back as a verb argument | item 11 |
+| #5534 | a capability probe passes while covering nothing: a dispatch rejection is not a synchronous throw | carried alongside |
+
+**Filed against neighbouring subsystems, and not sequenced here.** `{ proxy:
+true }` never reaching `module.writableProxy` for a transformed pattern
+(#5502), an unnormalized external piece id upserting twice (#5499), and a
+create that drops its navigation (#5530). Each is real and none is about the
+verb surface; they are recorded so that reading this plan does not imply they
+were triaged away.
 
 ## Out of scope
 

--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -33,13 +33,12 @@ belongs in one document even when the reasoning belongs in two.
 
 ## State
 
-Four pull requests remain open against this work. They are listed here because
+These pull requests remain open against this work. They are listed here because
 a driver needs to know what is already moving before scheduling anything new.
 
 | PR | What | State |
 | --- | --- | --- |
-| #5501 | a verb's declared result reaches its module | ready; the decision below is made, and the producer half is green |
-| #5504 | `@` marks a position in a field list | green, walkthrough 38/38 against a live toolshed. The two `notes@` assertions that failed there were the feature, not the test: a pattern result stores each field as a redirect link into the argument document, so the compose walk never saw the array. Markers now align against the source schema, as the mask already did |
+| #5629 | a verb listing row carries the handler's declared result | item 10, the consumer half of the declared result. Collides with #5623, which relocates a doc comment in the same region of `packages/cli/lib/piece.ts`; the collision is a real git conflict rather than a silent merge, and whichever lands second keeps both |
 | #5609 | a rejected position is not a required one | split out of #5504, because the defect it fixes is on main. A `$link` marker beside any other projection key returns nothing: the rejected position stays in the source's `required`, so the projected schema is unsatisfiable and the whole selection reads as absent |
 | #5307 | closed-world verb event schemas | parked on #5589; the minting is built, and what stays red is a renderer-semantics ruling rather than an implementation gap |
 
@@ -256,9 +255,9 @@ caller.
 ## Landed, and what consumes it
 
 **6. The read layer.** The shared read step, address markers with the
-deepest-link rule, container inference, the flag split, and entity-URI intake
-are on main. Two pieces are not: the `@` suffix (#5504) is still open, and call
-selection went back out with #5505's revert.
+deepest-link rule, container inference, the flag split, entity-URI intake and
+the `@` suffix are on main. One piece is not: call selection went back out with
+#5505's revert.
 
 **7. Session-scoped invocation ids.** **Reverted** — #5469 is out of main
 again. It is the one address-changing commit, and the whole plan is ordered
@@ -296,7 +295,7 @@ joins them.
 
 | Item | After | Why |
 | --- | --- | --- |
-| 6 | — | landed but for #5504, and for call selection, which #5582 reverted |
+| 6 | — | landed but for call selection, which #5582 reverted |
 | 7 | — | **reverted; must land again before 4 can start** |
 | 8, 9 | — | independent |
 | 2 | 6 | changes what the flags accept |

--- a/packages/cli/integration/verbs-over-the-cli.sh
+++ b/packages/cli/integration/verbs-over-the-cli.sh
@@ -79,6 +79,20 @@ VERBS=$($CF piece verbs --piece "$BOARD" $ARGS --json 2>/dev/null)
 echo "$VERBS" | jq -r '.verbs[]? | "    " + .name' 2>/dev/null | head -10
 echo "$VERBS" | jq -e '[.verbs[]?.name] | index("createNote")' >/dev/null 2>&1 &&
   ok "createNote is listed" || bad "createNote missing from the verb listing"
+# A declared result rides the listing, so a caller learns the shape of what it
+# will get back WITHOUT calling — the half of verb discovery that makes a call
+# something you can prepare for rather than discover by trying.
+check "note" "$(echo "$VERBS" | jq -r '.verbs[] |
+  select(.name == "createNote") | .outputSchema.properties | keys | join(",")' \
+  2>/dev/null)" "createNote advertises the result it declared"
+check "label,revision" "$(echo "$VERBS" | jq -r '.verbs[] |
+  select(.name == "setLabel") | .outputSchema.properties | keys | join(",")' \
+  2>/dev/null)" "setLabel advertises every field of its declared result"
+# The value-less shape says so by carrying no result at all, rather than an
+# empty one a caller would have to interpret.
+check "false" "$(echo "$VERBS" | jq -r '.verbs[] |
+  select(.name == "touch") | has("outputSchema")' 2>/dev/null)" \
+  "a value-less verb advertises no result"
 
 step "3. A create hands back the piece it created"
 R=$($CF piece call --quiet --piece "$BOARD" $ARGS --invocation create-1 \

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -4,6 +4,7 @@ import { caseFold } from "unicode-case-folding";
 import { loadIdentity } from "./identity.ts";
 import {
   Cell,
+  deepEqual,
   entityIdFrom,
   experimentalOptionsFromEnv,
   formatFabricRef,
@@ -1659,7 +1660,9 @@ export interface PieceCallableListing {
   /** The verb's input schema — the same schema `call <verb> --help --json`
    * serves. `true` means unconstrained. */
   inputSchema: JSONSchema | true;
-  /** Tools only, until handlers gain declared results (verb contract WS-C). */
+  /** What the verb hands back: a tool's pattern result schema, a handler's
+   * declared result. Absent when the verb declares none — the value-less
+   * shape, which is the common one. */
   outputSchema?: JSONSchema;
   /** Listing mark: a UI affordance outside the headless contract (inferred
    * from session-scoped handler bindings at compile time). Hidden from the
@@ -1701,6 +1704,63 @@ function listingMarks(
   };
 }
 
+/** Whether two links written in a compiled pattern's own terms address the
+ * same cell. An alias's identity is its cause, path and scope; the schema it
+ * carries is fidelity for whoever reads through it, and one cell reached from
+ * two positions can carry a different one at each. Anything that is not a pair
+ * of aliases falls back to whole-link equality, which can only miss — and a
+ * miss costs a row its `outputSchema`, never gives it the wrong one. */
+function samePatternLink(left: unknown, right: unknown): boolean {
+  if (!isRecord(left) || !isRecord(right)) return false;
+  const leftAlias = left.$alias;
+  const rightAlias = right.$alias;
+  if (!isRecord(leftAlias) || !isRecord(rightAlias)) {
+    return deepEqual(left, right);
+  }
+  return deepEqual(leftAlias.partialCause, rightAlias.partialCause) &&
+    deepEqual(leftAlias.path ?? [], rightAlias.path ?? []) &&
+    leftAlias.scope === rightAlias.scope;
+}
+
+/** A compiled pattern's declared verb results, keyed by the result property
+ * each verb is exposed under.
+ *
+ * A handler node's `$event` input and the result property exposing that
+ * handler's stream are one cell written twice in the pattern's own terms, so
+ * the property matching a node's `$event` names the verb that node implements
+ * — a structural comparison inside one compiled object, with no live cell to
+ * resolve. The declared result rides on that node's module, which is where
+ * `Stream<E, R>`'s `R` is lowered (verb contract WS-C). A stream two handler
+ * nodes share names no single result and so contributes none.
+ *
+ * A compiled pattern is CALLABLE, so it is not a record and must not be tested
+ * as one; only its `result` and `nodes` are read here. */
+function declaredVerbResults(
+  pattern: { result?: unknown; nodes?: unknown } | null | undefined,
+): Map<string, JSONSchema> {
+  const declared = new Map<string, JSONSchema>();
+  const result = pattern?.result;
+  if (!isRecord(result)) return declared;
+  const nodes = Array.isArray(pattern?.nodes) ? pattern.nodes : [];
+  for (const [name, link] of Object.entries(result)) {
+    let resultSchema: JSONSchema | undefined;
+    let matched = 0;
+    for (const node of nodes) {
+      if (!isRecord(node) || !isRecord(node.inputs)) continue;
+      if (!samePatternLink(link, node.inputs.$event)) continue;
+      matched++;
+      const module = node.module;
+      if (isRecord(module) && module.resultSchema !== undefined) {
+        resultSchema = module.resultSchema as JSONSchema;
+      }
+    }
+    if (matched === 1 && resultSchema !== undefined) {
+      declared.set(name, resultSchema);
+    }
+  }
+  return declared;
+}
+
 /**
  * Enumerate every callable a piece exposes (verb contract: Verb discovery,
  * docs/plans/pattern-verb-contract.md). Everything in the durable schema is
@@ -1722,6 +1782,20 @@ export async function listPieceCallables(
       pattern = (await piece.getPatternRef()) ?? null;
     } catch {
       pattern = null; // Identity is advisory; the listing itself still holds.
+    }
+  }
+
+  // A tool's result schema rides its callable cell, but a handler's declared
+  // result lives on its node in the compiled graph — so the listing resolves
+  // the pattern once and matches nodes to result properties. Resolution is
+  // cached by identity, so this costs one load per listing, not one per row.
+  let declaredResults = new Map<string, JSONSchema>();
+  if (typeof piece.getPattern === "function") {
+    try {
+      declaredResults = declaredVerbResults(await piece.getPattern());
+    } catch {
+      // Advisory in the same way the identity above is: a piece with no
+      // reachable pattern still lists every verb it exposes.
     }
   }
 
@@ -1753,14 +1827,17 @@ export async function listPieceCallables(
       rejected.delete(name);
       const spec = callableCommandSpec(callableCell, kind);
       const marks = listingMarks(schema, name);
+      // The declared results are keyed by the PATTERN's result properties, so
+      // only a result-cell row can claim one: a same-named verb reached on the
+      // input cell is a different stream that merely shares its name.
+      const outputSchema = spec.outputSchemaSummary ??
+        (cellProp === "result" ? declaredResults.get(name) : undefined);
       listings.set(name, {
         name,
         kind,
         on: cellProp,
         inputSchema: spec.inputSchema,
-        ...(spec.outputSchemaSummary !== undefined
-          ? { outputSchema: spec.outputSchemaSummary }
-          : {}),
+        ...(outputSchema !== undefined ? { outputSchema } : {}),
         ...marks,
       });
     }
@@ -1785,11 +1862,13 @@ export async function listPieceCallables(
       if (!probeForcedStreamCell(pieceCell, name)) continue;
       const callableCell = resultRoot.key(name).asSchemaFromLinks();
       const spec = callableCommandSpec(callableCell, "handler");
+      const outputSchema = declaredResults.get(name);
       listings.set(name, {
         name,
         kind: "handler",
         on: "result",
         inputSchema: spec.inputSchema,
+        ...(outputSchema !== undefined ? { outputSchema } : {}),
       });
     }
   }

--- a/packages/cli/test/piece-verbs.test.ts
+++ b/packages/cli/test/piece-verbs.test.ts
@@ -61,6 +61,29 @@ const SEARCH_RESULT: JSONSchema = {
   properties: { summary: { type: "string" } },
 };
 
+const CREATE_NOTE_RESULT: JSONSchema = {
+  type: "object",
+  properties: { note: { type: "object" } },
+  required: ["note"],
+};
+
+/** One compiled result property as the builder serializes a stream: an alias
+ * to a derived internal cell, named by its cause. Taken from what
+ * `patternManager.compilePattern` actually emits for a CTS `action` — both the
+ * result property and the handler node's `$event` carry this same shape. */
+function streamAlias(cause: unknown, schema: JSONSchema | true = true) {
+  return { $alias: { partialCause: cause, scope: "space", path: [], schema } };
+}
+
+/** A compiled pattern double. `getPattern()` resolves a real `Pattern`, which
+ * is CALLABLE with `result`/`nodes` hung off it — a plain object here would
+ * pass a lister that rejects the shape the runtime actually hands it. */
+function compiledPattern(
+  graph: { result: Record<string, unknown>; nodes: unknown[] },
+) {
+  return Object.assign(() => {}, graph);
+}
+
 describe("listPieceCallables", () => {
   it("lists handlers and tools with schemas; excludes data; result shadows input", async () => {
     const resultRoot = cell(
@@ -177,6 +200,137 @@ describe("listPieceCallables", () => {
     expect(setup.on).toBe("input");
     // Plain data is not a verb.
     expect(verbs.some((v) => v.name === "topicCount")).toBe(false);
+  });
+
+  it("reports a handler's declared result as its outputSchema", async () => {
+    // A handler's declared result is not on its cell — it rides the module of
+    // the node the handler compiled to. The listing finds that node by
+    // matching its `$event` input against the result property exposing the
+    // same stream, so `publicName` below resolves through its CAUSE and not
+    // through its property name: the two deliberately disagree, because a
+    // name-keyed lookup would answer every other case in this test correctly.
+    const resultRoot = cell(
+      {
+        createNote: { $stream: true },
+        touch: { $stream: true },
+        publicName: { $stream: true },
+        shared: { $stream: true },
+      },
+      {
+        type: "object",
+        properties: {
+          createNote: ADD_TOPIC_EVENT,
+          touch: { type: "object" },
+          publicName: { type: "object" },
+          shared: { type: "object" },
+        },
+      },
+    );
+    const pattern = compiledPattern({
+      result: {
+        createNote: streamAlias({ stream: "createNote" }, ADD_TOPIC_EVENT),
+        touch: streamAlias({ stream: "touch" }),
+        publicName: streamAlias({ stream: "internalCause" }),
+        shared: streamAlias({ stream: "shared" }),
+        noteCount: streamAlias("noteCount", { type: "number" }),
+      },
+      nodes: [
+        {
+          module: { wrapper: "handler", resultSchema: CREATE_NOTE_RESULT },
+          // The event link carries the schema for the position it is read at;
+          // identity is the cause, so a differing schema must not defeat the
+          // match.
+          inputs: { $event: streamAlias({ stream: "createNote" }) },
+          outputs: {},
+        },
+        // Declares nothing: the value-less shape.
+        {
+          module: { wrapper: "handler" },
+          inputs: { $event: streamAlias({ stream: "touch" }) },
+          outputs: {},
+        },
+        {
+          module: { wrapper: "handler", resultSchema: SEARCH_RESULT },
+          inputs: { $event: streamAlias({ stream: "internalCause" }) },
+          outputs: {},
+        },
+        // Two handlers on one stream: nothing names a single verb's result,
+        // so the row keeps none rather than picking a winner.
+        {
+          module: { wrapper: "handler", resultSchema: SEARCH_RESULT },
+          inputs: { $event: streamAlias({ stream: "shared" }) },
+          outputs: {},
+        },
+        {
+          module: { wrapper: "handler" },
+          inputs: { $event: streamAlias({ stream: "shared" }) },
+          outputs: {},
+        },
+        // A compute node over ordinary data — no `$event` at all.
+        {
+          module: { type: "javascript", resultSchema: { type: "number" } },
+          inputs: { list: streamAlias("notes") },
+          outputs: streamAlias("noteCount"),
+        },
+      ],
+    });
+    const piece = {
+      result: { getCell: () => Promise.resolve(resultRoot) },
+      input: { getCell: () => Promise.resolve(cell(undefined, undefined)) },
+      getPattern: () => Promise.resolve(pattern),
+    };
+    const listing = await listPieceCallables(
+      {
+        apiUrl: "http://localhost:8000",
+        identity: "/tmp/test-identity.pem",
+        piece: "fid1:piece-789",
+        space: "home",
+      },
+      {
+        loadPieces: () => Promise.resolve({} as never),
+        loadPiece: () => Promise.resolve(piece as never),
+      },
+    );
+
+    const byName = new Map(listing.verbs.map((verb) => [verb.name, verb]));
+    expect(byName.get("createNote")?.outputSchema).toEqual(CREATE_NOTE_RESULT);
+    expect(byName.get("publicName")?.outputSchema).toEqual(SEARCH_RESULT);
+    expect(byName.get("touch")?.outputSchema).toBeUndefined();
+    expect(byName.get("shared")?.outputSchema).toBeUndefined();
+    // A declared result is an own property only when there is one: a row with
+    // no result must not carry the key at all.
+    expect(Object.hasOwn(byName.get("touch")!, "outputSchema")).toBe(false);
+    // Data stays out of the listing whatever its node declares.
+    expect(byName.has("noteCount")).toBe(false);
+  });
+
+  it("lists a piece whose pattern cannot be resolved", async () => {
+    // The graph is advisory the way the source identity is: without it a row
+    // loses its declared result, never its place in the listing.
+    const resultRoot = cell(
+      { createNote: { $stream: true } },
+      { type: "object", properties: { createNote: ADD_TOPIC_EVENT } },
+    );
+    const piece = {
+      result: { getCell: () => Promise.resolve(resultRoot) },
+      input: { getCell: () => Promise.resolve(cell(undefined, undefined)) },
+      getPattern: () =>
+        Promise.reject(new Error("piece missing pattern identity")),
+    };
+    const listing = await listPieceCallables(
+      {
+        apiUrl: "http://localhost:8000",
+        identity: "/tmp/test-identity.pem",
+        piece: "fid1:piece-790",
+        space: "home",
+      },
+      {
+        loadPieces: () => Promise.resolve({} as never),
+        loadPiece: () => Promise.resolve(piece as never),
+      },
+    );
+    expect(listing.verbs.map((verb) => verb.name)).toEqual(["createNote"]);
+    expect(listing.verbs[0].outputSchema).toBeUndefined();
   });
 
   it("returns an empty list for a piece with no callables", async () => {


### PR DESCRIPTION
## Why

`cf piece verbs` answered only half of verb discovery's question. It reported an
`outputSchema` for a tool and never for a handler, and the type said why:
*"Tools only, until handlers gain declared results."* So an agent could learn
what it was allowed to send, but could only learn what a call hands back by
making the call — which is exactly the thing a caller wants to know *before*
committing to a mutation.

#5501 (`ff1316c6d`) supplied the producer half: a verb's declared `R` now rides
its module. This is the consumer half, and it closes verb discovery. Item 10 of
[the verbs plan](https://github.com/commontoolsinc/labs/blob/main/docs/plans/verbs-implementation.md);
route specced in #5619.

## What Changed

- **`declaredVerbResults`** (`packages/cli/lib/piece.ts`) maps each result
  property to the declared result of the handler node implementing it. A handler
  node's `$event` input and the result property exposing that handler's stream
  are one cell written twice in the pattern's own terms, so the property
  matching a node's `$event` names the verb — one structural comparison inside
  one compiled object, no live-cell resolution and no link rewriting.
- **`listPieceCallables`** resolves `piece.getPattern()` once per listing and
  feeds both row builders. `callableCommandSpec`'s signature is unchanged; no
  call site of it moved.
- Walkthrough, `docs/common/verbs-over-the-cli.md`, and the plan's item 10
  updated. The `"Tools only"` comment is retired.

Three properties worth naming, each pinned by a test:

- **Identity is the alias's cause, path and scope** — the schema it carries is
  fidelity for whoever reads through it, so it stays out of the comparison. The
  repo's `deepEqual`-on-`partialCause` idiom, as `pattern-binding.ts` and
  `builder/pattern.ts` already match descriptors.
- **A stream two handler nodes share names no single result**, so it contributes
  none rather than picking a winner.
- **The graph is advisory**, like the source identity beside it: a piece whose
  pattern will not resolve keeps every row and loses only the schema.

## Test plan

- `packages/cli` — 174 passed, 0 failed, on the rebased tree.
- Repo-wide `deno fmt --check`, `deno lint`, `check-docs` (537 blocks),
  `check-skill-facts` — all green.
- `verbs-over-the-cli.sh` step 2 now asserts `createNote` and `setLabel`
  advertise their declared results and that `touch` carries none. Verified by
  compiling the walkthrough's own fixture through the real pipeline
  (`patternManager.compilePattern`): `createNote` → `{note}` with `$defs`,
  `setLabel` → `{label, revision}`, `touch` → matched but undeclared, data
  properties → unmatched.

**Every new assertion was checked red first**, by reverting the change and
watching it fail — per #5619's guidance after five same-day defects whose cause
was a check that could not fail.

That guidance earned its keep here. The first implementation passed its unit
test and was **wrong**: it guarded with `isRecord(pattern)`, but a compiled
`Pattern` is *callable*, so the guard returned early and every real listing
silently got nothing. The unit double was a plain object, so it agreed with the
bug. Compiling the real fixture is what caught it; the double is now a function,
and re-introducing the guard turns the test red.

The fixture also deliberately disagrees with the implementation in two places a
lazier one would not: a verb whose property name and stream cause differ (so a
name-keyed lookup fails), and an `$event` link whose schema differs from the
result property's (so a whole-alias comparison fails).

## Not in scope, and why

`cf piece call <verb> --help --json` still shows no `Output:` for a handler.
Serving it there needs the graph at `resolvePieceCallable` too, which is the
"more things to chase down" #5501's conditional approval names. Raising rather
than absorbing it, per that condition — happy to do it here or separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

