### PR TITLE
refactor(ci): walk baseline runs lazily for the coverage ratchet

### DIFF
--- a/docs/development/COVERAGE.md
+++ b/docs/development/COVERAGE.md
@@ -294,25 +294,42 @@ NEW_COVERAGE_BASELINE
 ```
 
 When that PR merges, the main run's coverage metrics become the new ratchet
-baseline for later PRs. The check still requires the full expected coverage
-artifact set during that reset cycle. Jobs with no reportable covered files
-upload an empty LCOV report, so a missing artifact means the report upload
-itself failed.
+baseline for later PRs, and no run before it is one: the accepted level is what
+later runs are held to, and nothing older can undo it. That floor applies to the
+metrics the acceptance named, or to every coverage metric for the broad reset
+marker. It reaches only the PRs whose base-branch commit already contains the
+acceptance; a PR whose run started earlier is gated against the ancestry it does
+contain, and picks the floor up when a later run of it merges the acceptance. The
+check still requires the full expected coverage artifact set during that reset
+cycle. Jobs with no reportable covered files upload an empty LCOV report, so a
+missing artifact means the report upload itself failed.
 
 Each run writes a per-run baseline artifact recording its coverage-debt metrics
 and its compile cache states. It is named `perf-metrics` for historical reasons
 — it once also carried CI timing metrics for the removed performance gate — and
 keeps that name so the ratchet needs no migration; a run from before the gate
-was removed reads as a valid baseline unchanged. A later PR run reads its ratchet
-baseline from the `perf-metrics` artifact of the `main` run for the base-branch
-commit it merged, or of the nearest ancestor of that commit which has one; there
-is no separate history store. The workflow downloads the current run's
-`coverage-profile-*` artifacts before starting `tasks/coverage-check.ts`.
-`COVERAGE_ARTIFACTS_DIR` points the script at one subdirectory per artifact. The
-download step checks the artifact digests. The script separately checks the
-expected artifact names (`EXPECTED_COVERAGE_ARTIFACT_NAMES`). It also rejects an
-artifact containing no coverage files. A manual run without the environment
-variable uses the GitHub API download path instead.
+was removed reads as a valid baseline unchanged. The file records each metric's
+uncovered-line count under a `durationSeconds` key, for the same reason the
+artifact keeps its name.
+
+A later PR run reads its ratchet baseline from the `perf-metrics` artifact of the
+`main` run for the base-branch commit it merged, or of the nearest ancestor of
+that commit which has one; there is no separate history store. It finds that run
+by ordering the recent `main` runs from the nearest ancestor of that commit
+outwards — leaving out the runs for commits it does not contain — and then
+reading one run at a time, stopping as soon as every metric has a baseline.
+Usually the nearest run measured every metric, and that is the only baseline
+artifact read; reading further back happens when a run uploaded nothing, ran
+cold, or measured a metric no nearer run did. The runs the walk read are the
+ones the "Baseline source runs" log group names.
+
+The workflow downloads the current run's `coverage-profile-*` artifacts before
+starting `tasks/coverage-check.ts`. `COVERAGE_ARTIFACTS_DIR` points the script at
+one subdirectory per artifact. The download step checks the artifact digests. The
+script separately checks the expected artifact names
+(`EXPECTED_COVERAGE_ARTIFACT_NAMES`). It also rejects an artifact containing no
+coverage files. A manual run without the environment variable uses the GitHub API
+download path instead.
 
 ## Compile cache state and cold runs
 

--- a/tasks/ci-check-lib.test.ts
+++ b/tasks/ci-check-lib.test.ts
@@ -7,9 +7,10 @@ import {
   assertThrows,
 } from "@std/assert";
 import {
+  acceptsCoverageDebt,
   aggregateCacheStates,
-  applyBaselineOverrides,
   type Artifact,
+  type BaselineSample,
   buildCoverageDebtSuggestionComment,
   buildCoverageResolvedComment,
   type CompileCacheStates,
@@ -26,64 +27,103 @@ import {
   githubGet,
   githubPatch,
   githubPost,
-  latestNonColdSample,
   newestArtifactsByName,
   parseAddedLinesFromPatch,
   parseBaselineOverrides,
   parseCacheStateFiles,
-  parseCoverageBaseline,
   parseCoverageBaselineDetailed,
+  REPO,
   serializeCoverageBaseline,
   shouldGateCoverageDebtMetric,
-  type TimingSample,
 } from "./ci-check-lib.ts";
 
 Deno.test("coverage baseline files round-trip stable metric samples", () => {
-  const metrics = new Map([
-    [
-      "step: Type check",
-      {
-        runId: 123,
-        runUrl: "https://example.test/run/123",
-        sha: "abc123",
-        createdAt: "2026-01-01T00:00:00Z",
-        durationSeconds: 42.5,
-      },
-    ],
-    [
-      "job: Check",
-      {
-        runId: 123,
-        runUrl: "https://example.test/run/123",
-        sha: "abc123",
-        createdAt: "2026-01-01T00:00:00Z",
-        durationSeconds: 60,
-      },
-    ],
+  const metrics = new Map<string, BaselineSample>([
+    ["coverage-debt: packages/runner uncovered lines", {
+      runId: 123,
+      sha: "abc123",
+      createdAt: "2026-01-01T00:00:00Z",
+      uncoveredLines: 42,
+    }],
+    ["coverage-debt: packages/memory uncovered lines", {
+      runId: 123,
+      sha: "abc123",
+      createdAt: "2026-01-01T00:00:00Z",
+      uncoveredLines: 60,
+    }],
   ]);
 
   const serialized = serializeCoverageBaseline(metrics);
   assertEquals(
     serialized.metrics.map((metric) => metric.name),
-    ["job: Check", "step: Type check"],
+    [
+      "coverage-debt: packages/memory uncovered lines",
+      "coverage-debt: packages/runner uncovered lines",
+    ],
+  );
+
+  // The file keeps the keys it has always carried, so a run whose checkout
+  // predates the in-memory rename still reads a file this run writes.
+  assertEquals(serialized.metrics[0].durationSeconds, 60);
+  assertEquals(
+    serialized.metrics[0].runUrl,
+    `https://github.com/${REPO}/actions/runs/123`,
   );
 
   assertEquals(
-    parseCoverageBaseline(JSON.stringify(serialized)),
+    parseCoverageBaselineDetailed(JSON.stringify(serialized)).metrics,
     metrics,
   );
 });
 
+Deno.test("coverage baseline files read a file the performance gate wrote", () => {
+  // Written when the artifact also carried CI timing metrics: the file names
+  // the run's page, and the uncovered-line count sits under `durationSeconds`.
+  const legacy = JSON.stringify({
+    version: 1,
+    generatedAt: "2026-01-01T00:00:00Z",
+    metrics: [
+      {
+        name: "coverage-debt: packages/runner uncovered lines",
+        runId: 7,
+        runUrl: "https://example.test/run/7",
+        sha: "abc123",
+        createdAt: "2026-01-01T00:00:00Z",
+        durationSeconds: 5740,
+      },
+      {
+        name: "job: Check",
+        runId: 7,
+        runUrl: "https://example.test/run/7",
+        sha: "abc123",
+        createdAt: "2026-01-01T00:00:00Z",
+        durationSeconds: 61.5,
+      },
+    ],
+  });
+
+  const parsed = parseCoverageBaselineDetailed(legacy);
+  assertEquals(
+    parsed.metrics.get("coverage-debt: packages/runner uncovered lines"),
+    {
+      runId: 7,
+      sha: "abc123",
+      createdAt: "2026-01-01T00:00:00Z",
+      uncoveredLines: 5740,
+    },
+  );
+  assertEquals(parsed.compileCacheStates, null);
+});
+
 Deno.test("coverage baseline files round-trip compile cache states", () => {
-  const metrics = new Map<string, TimingSample>([
+  const metrics = new Map<string, BaselineSample>([
     [
       "job: Check",
       {
         runId: 123,
-        runUrl: "https://example.test/run/123",
         sha: "abc123",
         createdAt: "2026-01-01T00:00:00Z",
-        durationSeconds: 60,
+        uncoveredLines: 60,
       },
     ],
   ]);
@@ -97,9 +137,6 @@ Deno.test("coverage baseline files round-trip compile cache states", () => {
   const detailed = parseCoverageBaselineDetailed(serialized);
   assertEquals(detailed.metrics, metrics);
   assertEquals(detailed.compileCacheStates, states);
-
-  // The tagged file stays version 1, so the legacy parser still accepts it.
-  assertEquals(parseCoverageBaseline(serialized), metrics);
 });
 
 Deno.test("parseCoverageBaselineDetailed treats legacy files as untagged", () => {
@@ -204,27 +241,6 @@ Deno.test("cache state parsing keeps valid unknown-family records inert", () => 
   });
 });
 
-Deno.test("latestNonColdSample skips trailing cold runs and falls back when all are cold", () => {
-  const sample = (runId: number): TimingSample => ({
-    runId,
-    runUrl: `https://example.test/run/${runId}`,
-    sha: `sha${runId}`,
-    createdAt: `2026-01-0${runId}T00:00:00Z`,
-    durationSeconds: runId,
-  });
-  const samples = [sample(1), sample(2), sample(3)];
-  const coldRuns = new Set([2, 3]);
-
-  assertEquals(
-    latestNonColdSample(samples, (runId) => coldRuns.has(runId))?.runId,
-    1,
-  );
-  // All-cold: fall back to the last sample so override-truncation resets
-  // still take effect.
-  assertEquals(latestNonColdSample(samples, () => true)?.runId, 3);
-  assertEquals(latestNonColdSample([], () => false), undefined);
-});
-
 Deno.test("coverage debt metrics format and parse line units", () => {
   const metric = "coverage-debt: workspace uncovered lines";
   assertEquals(formatOverrideSuggestion(12.2), "13 lines");
@@ -301,57 +317,32 @@ Deno.test("coverage baseline reset marker parses from PR body", () => {
   assertEquals(overrides.metrics.size, 0);
 });
 
-Deno.test("coverage baseline reset truncates coverage timelines only", () => {
-  const coverageMetric = "coverage-debt: workspace uncovered lines";
-  const jobMetric = "job: Check";
-  const sample = (
-    sha: string,
-    day: number,
-    durationSeconds: number,
-  ): TimingSample => ({
-    runId: day,
-    runUrl: `https://example.test/run/${day}`,
-    sha,
-    createdAt: `2026-01-0${day}T00:00:00Z`,
-    durationSeconds,
-  });
-  const oldCoverage = sample("old", 1, 9);
-  const resetCoverage = sample("reset", 2, 12);
-  const newCoverage = sample("new", 3, 10);
-  const oldJob = sample("old", 1, 20);
-  const resetJob = sample("reset", 2, 21);
-  const newJob = sample("new", 3, 22);
-  const timelines = new Map([
-    [
-      coverageMetric,
-      {
-        name: coverageMetric,
-        samples: [oldCoverage, resetCoverage, newCoverage],
-      },
-    ],
-    [
-      jobMetric,
-      { name: jobMetric, samples: [oldJob, resetJob, newJob] },
-    ],
-  ]);
-
-  applyBaselineOverrides(
-    timelines,
-    new Map([
-      [
-        "reset",
-        { metrics: new Map(), coverageBaselineReset: true },
-      ],
-    ]),
-  );
+Deno.test("a merged reset accepts coverage-debt metrics only", () => {
+  const reset = { metrics: new Map(), coverageBaselineReset: true };
 
   assertEquals(
-    timelines.get(coverageMetric)?.samples.map((s) => s.sha),
-    ["reset", "new"],
+    acceptsCoverageDebt(reset, "coverage-debt: workspace uncovered lines"),
+    true,
+  );
+  assertEquals(acceptsCoverageDebt(reset, "job: Check"), false);
+
+  const perMetric = {
+    metrics: new Map([["coverage-debt: packages/runner uncovered lines", 12]]),
+    coverageBaselineReset: false,
+  };
+  assertEquals(
+    acceptsCoverageDebt(
+      perMetric,
+      "coverage-debt: packages/runner uncovered lines",
+    ),
+    true,
   );
   assertEquals(
-    timelines.get(jobMetric)?.samples.map((s) => s.sha),
-    ["old", "reset", "new"],
+    acceptsCoverageDebt(
+      perMetric,
+      "coverage-debt: packages/memory uncovered lines",
+    ),
+    false,
   );
 });
 

--- a/tasks/ci-check-lib.ts
+++ b/tasks/ci-check-lib.ts
@@ -93,9 +93,6 @@ export const COVERAGE_LOCAL_CHECK_COMMAND = [
   '  --profile-dir="$(pwd)/coverage/raw/local" --root="$(pwd)"',
 ].join("\n");
 
-/** Concurrency limit for API calls. */
-export const API_CONCURRENCY = 5;
-
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -121,16 +118,29 @@ interface ArtifactsResponse {
   artifacts: Artifact[];
 }
 
-export interface TimingSample {
+/** What one `main` run measured for one coverage-debt metric. */
+export interface BaselineSample {
+  runId: number;
+  sha: string;
+  createdAt: string;
+  uncoveredLines: number;
+}
+
+/**
+ * One metric as the baseline artifact stores it. The `durationSeconds` and
+ * `runUrl` keys are the ones that file has always carried: `durationSeconds`
+ * holds the uncovered-line count, and `runUrl` is the run's GitHub page. Both
+ * are kept so a file written before the performance gate was removed still
+ * parses, and a file written now still parses in a checkout that predates this
+ * shape.
+ */
+export interface MetricRecord {
+  name: string;
   runId: number;
   runUrl: string;
   sha: string;
   createdAt: string;
   durationSeconds: number;
-}
-
-export interface MetricRecord extends TimingSample {
-  name: string;
 }
 
 /**
@@ -186,11 +196,6 @@ export interface CoverageBaselineFile {
    * when no cache-state artifact recorded for the run.
    */
   compileCacheStates?: CompileCacheStates;
-}
-
-export interface MetricTimeline {
-  name: string;
-  samples: TimingSample[];
 }
 
 export interface PRInfo {
@@ -368,31 +373,6 @@ export async function githubPatch<T>(
 }
 
 // ---------------------------------------------------------------------------
-// Concurrency limiter
-// ---------------------------------------------------------------------------
-
-export async function mapConcurrent<T, R>(
-  items: T[],
-  limit: number,
-  fn: (item: T) => Promise<R>,
-): Promise<R[]> {
-  const results: R[] = new Array(items.length);
-  let next = 0;
-
-  async function worker() {
-    while (next < items.length) {
-      const idx = next++;
-      results[idx] = await fn(items[idx]);
-    }
-  }
-
-  await Promise.all(
-    Array.from({ length: Math.min(limit, items.length) }, worker),
-  );
-  return results;
-}
-
-// ---------------------------------------------------------------------------
 // Fetch artifacts
 // ---------------------------------------------------------------------------
 
@@ -441,8 +421,13 @@ export function newestArtifactsByName(artifacts: Artifact[]): Artifact[] {
   return [...byName.values()];
 }
 
+/** The GitHub page of a workflow run, as the baseline file records it. */
+function workflowRunUrl(runId: number): string {
+  return `https://github.com/${REPO}/actions/runs/${runId}`;
+}
+
 export function serializeCoverageBaseline(
-  metrics: Map<string, TimingSample>,
+  metrics: Map<string, BaselineSample>,
   compileCacheStates?: CompileCacheStates,
 ): CoverageBaselineFile {
   const file: CoverageBaselineFile = {
@@ -457,48 +442,23 @@ export function serializeCoverageBaseline(
 }
 
 function metricsToRecords(
-  metrics: Map<string, TimingSample>,
+  metrics: Map<string, BaselineSample>,
 ): MetricRecord[] {
   return [...metrics.entries()]
-    .map(([name, sample]) => ({ name, ...sample }))
+    .map(([name, sample]) => ({
+      name,
+      runId: sample.runId,
+      runUrl: workflowRunUrl(sample.runId),
+      sha: sample.sha,
+      createdAt: sample.createdAt,
+      durationSeconds: sample.uncoveredLines,
+    }))
     .sort((a, b) => a.name.localeCompare(b.name));
-}
-
-export function parseCoverageBaseline(
-  content: string,
-): Map<string, TimingSample> {
-  const parsed = JSON.parse(content) as Partial<CoverageBaselineFile>;
-  if (parsed.version !== 1 || !Array.isArray(parsed.metrics)) {
-    throw new Error("Unsupported coverage baseline file format.");
-  }
-
-  const metrics = new Map<string, TimingSample>();
-  for (const metric of parsed.metrics) {
-    if (
-      typeof metric.name !== "string" ||
-      typeof metric.runId !== "number" ||
-      typeof metric.runUrl !== "string" ||
-      typeof metric.sha !== "string" ||
-      typeof metric.createdAt !== "string" ||
-      typeof metric.durationSeconds !== "number"
-    ) {
-      throw new Error("Invalid coverage baseline metric record.");
-    }
-
-    metrics.set(metric.name, {
-      runId: metric.runId,
-      runUrl: metric.runUrl,
-      sha: metric.sha,
-      createdAt: metric.createdAt,
-      durationSeconds: metric.durationSeconds,
-    });
-  }
-  return metrics;
 }
 
 /** Parsed coverage baseline plus the run's compile cache states, when tagged. */
 export interface CoverageBaselineDetailed {
-  metrics: Map<string, TimingSample>;
+  metrics: Map<string, BaselineSample>;
   /** Null when the file recorded no compile cache states. */
   compileCacheStates: CompileCacheStates | null;
 }
@@ -508,16 +468,40 @@ const COMPILE_CACHE_FAMILY_SET: ReadonlySet<string> = new Set(
 );
 
 /**
- * Parse a perf metrics file, also surfacing its optional compile cache
- * states. Metric validation matches {@link parseCoverageBaseline}; unknown
- * families and invalid state values are dropped rather than failing, so a
- * malformed tag degrades to "unknown" instead of losing the run's metrics.
+ * Parse a baseline artifact file into its metrics and its optional compile
+ * cache states. A metric record missing a field the ratchet reads fails the
+ * whole file, because a baseline that silently lost a metric would read as a
+ * group with no debt to beat. Unknown cache families and invalid state values
+ * are dropped instead, so a malformed tag degrades to "unknown" rather than
+ * losing the run's metrics.
  */
 export function parseCoverageBaselineDetailed(
   content: string,
 ): CoverageBaselineDetailed {
-  const metrics = parseCoverageBaseline(content);
   const parsed = JSON.parse(content) as Partial<CoverageBaselineFile>;
+  if (parsed.version !== 1 || !Array.isArray(parsed.metrics)) {
+    throw new Error("Unsupported coverage baseline file format.");
+  }
+
+  const metrics = new Map<string, BaselineSample>();
+  for (const metric of parsed.metrics) {
+    if (
+      typeof metric.name !== "string" ||
+      typeof metric.runId !== "number" ||
+      typeof metric.sha !== "string" ||
+      typeof metric.createdAt !== "string" ||
+      typeof metric.durationSeconds !== "number"
+    ) {
+      throw new Error("Invalid coverage baseline metric record.");
+    }
+
+    metrics.set(metric.name, {
+      runId: metric.runId,
+      sha: metric.sha,
+      createdAt: metric.createdAt,
+      uncoveredLines: metric.durationSeconds,
+    });
+  }
 
   const rawStates = parsed.compileCacheStates;
   if (rawStates === undefined || rawStates === null) {
@@ -537,7 +521,7 @@ export function parseCoverageBaselineDetailed(
 
 export async function writeCoverageBaselineFile(
   path: string,
-  metrics: Map<string, TimingSample>,
+  metrics: Map<string, BaselineSample>,
   compileCacheStates?: CompileCacheStates,
 ): Promise<void> {
   await Deno.writeTextFile(
@@ -1309,76 +1293,14 @@ export function formatOverrideSuggestion(value: number): string {
   return `${rounded} ${rounded === 1 ? "line" : "lines"}`;
 }
 
-// ---------------------------------------------------------------------------
-// Timeline helpers
-// ---------------------------------------------------------------------------
-
-/** Add a sample to a timeline map, creating the timeline if necessary. */
-export function addSample(
-  timelines: Map<string, MetricTimeline>,
-  name: string,
-  sample: TimingSample,
-): void {
-  let timeline = timelines.get(name);
-  if (!timeline) {
-    timeline = { name, samples: [] };
-    timelines.set(name, timeline);
-  }
-  timeline.samples.push(sample);
-}
-
 /**
- * Apply baseline overrides to timelines by truncating samples before the
- * latest override point.
- *
- * `overridesBySha` maps commit SHA -> BaselineOverrides parsed from the
- * merged PR for that commit.  When a commit has a per-metric override, or a
- * whole-coverage reset for coverage-debt metrics, we discard all samples for
- * the affected metrics that precede that commit (keeping the override commit's
- * sample and everything after).
+ * Whether a merged PR's overrides accept the debt one metric carries, either
+ * with a per-metric acceptance or with the whole-coverage reset marker.
  */
-export function applyBaselineOverrides(
-  timelines: Map<string, MetricTimeline>,
-  overridesBySha: Map<string, BaselineOverrides>,
-): void {
-  // Find the latest override commit index for each metric
-  for (const [metricName, timeline] of timelines) {
-    let latestOverrideIdx = -1;
-
-    for (let i = 0; i < timeline.samples.length; i++) {
-      const sha = timeline.samples[i].sha;
-      const overrides = overridesBySha.get(sha);
-      if (!overrides) continue;
-
-      if (
-        overrides.metrics.has(metricName) ||
-        (overrides.coverageBaselineReset &&
-          isCoverageDebtMetric(metricName))
-      ) {
-        latestOverrideIdx = i;
-      }
-    }
-
-    if (latestOverrideIdx > 0) {
-      timeline.samples = timeline.samples.slice(latestOverrideIdx);
-    }
-  }
-}
-
-/**
- * The latest sample whose run is not known-cold, for the coverage-debt ratchet
- * that compares against the most recent baseline. A cold main run covers
- * cold-compile-only branches, so ratcheting against its lower debt would fail
- * later warm PRs with phantom regressions. Falls back to the last sample when
- * every sample is known-cold, preserving the override-truncation reset
- * semantics of `samples.at(-1)`.
- */
-export function latestNonColdSample(
-  samples: TimingSample[],
-  isRunCold: (runId: number) => boolean,
-): TimingSample | undefined {
-  for (let i = samples.length - 1; i >= 0; i--) {
-    if (!isRunCold(samples[i].runId)) return samples[i];
-  }
-  return samples.at(-1);
+export function acceptsCoverageDebt(
+  overrides: BaselineOverrides,
+  metric: string,
+): boolean {
+  return overrides.metrics.has(metric) ||
+    (overrides.coverageBaselineReset && isCoverageDebtMetric(metric));
 }

--- a/tasks/coverage-check.test.ts
+++ b/tasks/coverage-check.test.ts
@@ -7,17 +7,17 @@ import {
 import * as path from "@std/path";
 import {
   type Artifact,
+  type BaselineSample,
   COVERAGE_SUGGESTION_MARKER,
   type CoverageCommentPayload,
   PERF_METRICS_ARTIFACT_NAME,
   type PRInfo,
-  type TimingSample,
   type WorkflowRun,
 } from "./ci-check-lib.ts";
 import {
-  addCoverageBaselineFromArtifacts,
   type BaselineRunContext,
-  buildBaselineRunContexts,
+  type BaselineRunReading,
+  buildBaselineRunContext,
   buildCoverageRows,
   collectCurrentCacheStates,
   copyCoverageArtifactFiles,
@@ -42,9 +42,7 @@ import {
   isComparableBaseline,
   logBaselineSourceRuns,
   main,
-  metricDisplayParts,
   metricTableRows,
-  nearestUsableBaseline,
   newestArtifactNamed,
   parseCoverageBaselineFromArtifacts,
   parseMergedBaselineOverrides,
@@ -56,12 +54,12 @@ import {
   reportBaselineRunAvailability,
   reportPRLookupResults,
   reportUngatedGroups,
-  resolveMetricBaselines,
   type Row,
   selectBaselines,
   selectMergedPRForCommit,
   summarizeBaselinePRLookups,
   validateBaselineRunsForMainHead,
+  walkBaselineRuns,
   workflowRunsPathForBaseline,
   writeCoverageComment,
   writeCoverageDebtSuggestion,
@@ -100,13 +98,12 @@ function makeArtifact(
   };
 }
 
-function makeSample(run = makeRun(1)): TimingSample {
+function makeSample(run = makeRun(1)): BaselineSample {
   return {
     runId: run.id,
-    runUrl: run.html_url,
     sha: run.head_sha,
     createdAt: run.created_at,
-    durationSeconds: 1.5,
+    uncoveredLines: 2,
   };
 }
 
@@ -424,16 +421,10 @@ Deno.test("merged PR legacy coverage-debt acceptance is honored", () => {
 function coverageRow(
   metric: string,
   current: number,
-  median?: number,
-  status: Row["status"] = median === undefined ? "n/a" : "OK",
+  baseline?: number,
+  status: Row["status"] = baseline === undefined ? "n/a" : "OK",
 ): Row {
-  return {
-    metric,
-    status,
-    current,
-    median,
-    n: 1,
-  };
+  return { metric, status, current, baseline };
 }
 
 /**
@@ -578,7 +569,7 @@ Deno.test("writeCoverageResolved reports zero improvement without a workspace ba
 
 Deno.test("writeCoverageDebtSuggestion writes nothing when no coverage group resolves", async () => {
   const failures: Row[] = [
-    { metric: "job: Check", status: "OVER", current: 5, median: 3, n: 1 },
+    { metric: "job: Check", status: "OVER", current: 5, baseline: 3 },
   ];
   const payload = await payloadFrom(() =>
     writeCoverageDebtSuggestion(4211, failures, [], "")
@@ -804,7 +795,9 @@ Deno.test("formatErrorForLog keeps the first line only", () => {
 });
 
 Deno.test("githubApiOrSkip writes metrics and exits on rate limits", async () => {
-  const metrics = new Map<string, TimingSample>([["job: Check", makeSample()]]);
+  const metrics = new Map<string, BaselineSample>([
+    ["job: Check", makeSample()],
+  ]);
 
   try {
     const captured = await captureConsoleAsync(() =>
@@ -843,53 +836,40 @@ Deno.test("githubApiOrSkip rethrows non-rate-limit errors", async () => {
   );
 });
 
-Deno.test("metric table helpers format task and metric details", () => {
-  const coverageRow = {
+Deno.test("metric table helpers name the group and its change", () => {
+  const row: Row = {
     metric: "coverage-debt: tasks uncovered lines",
-    status: "OK" as const,
+    status: "OK",
     current: 12.4,
-    median: 10,
-    n: 5,
+    baseline: 10,
     pctIncrease: 24,
   };
-  const pendingRow = {
-    metric: "job: Check",
-    status: "n/a" as const,
+  const pendingRow: Row = {
+    metric: "coverage-debt: tasks uncovered lines",
+    status: "n/a",
     current: 9,
-    n: 0,
   };
 
-  assertEquals(formatMetricValueForTable(coverageRow.current), "12");
+  assertEquals(formatMetricValueForTable(row.current), "12");
   assertEquals(formatMetricValueForTable(undefined), "-");
   assertEquals(formatMetricDelta(pendingRow), "-");
-  assertEquals(formatMetricDelta(coverageRow), "+2 (+24%)");
-  assertEquals(metricDisplayParts("coverage-debt: tasks uncovered lines"), {
-    task: "coverage-debt",
-    metric: "tasks",
-  });
-  assertEquals(metricDisplayParts("coverage-debt: custom metric"), {
-    task: "coverage-debt",
-    metric: "custom metric",
-  });
-  assertEquals(metricDisplayParts("uncategorized"), {
-    task: "other",
-    metric: "uncategorized",
-  });
-  assertEquals(metricDisplayParts("job: Check"), {
-    task: "job",
-    metric: "Check",
-  });
-  assertEquals(metricTableRows([coverageRow], true)[0][0], "OK");
-  assertEquals(metricTableRows([coverageRow], false)[0][0], "10");
+  assertEquals(formatMetricDelta(row), "+2 (+24%)");
+  assertEquals(metricTableRows([row], true)[0], [
+    "OK",
+    "10",
+    "12",
+    "+2 (+24%)",
+    "tasks",
+  ]);
+  assertEquals(metricTableRows([row], false)[0][0], "10");
 });
 
 Deno.test("printMetricTable renders status and non-status tables", () => {
-  const row = {
-    metric: "job: Check",
-    status: "OK" as const,
+  const row: Row = {
+    metric: "coverage-debt: tasks uncovered lines",
+    status: "OK",
     current: 9,
-    median: 8,
-    n: 5,
+    baseline: 8,
     pctIncrease: 12.5,
   };
 
@@ -1154,15 +1134,14 @@ Deno.test("fetchArtifactsForRunBestEffort returns artifacts or an empty fallback
   assertStringIncludes(warnings.join("\n"), "artifact API failed");
 });
 
-Deno.test("buildBaselineRunContexts collects artifacts, PRs, and commit distance", async () => {
+Deno.test("buildBaselineRunContext collects artifacts, PRs, and commit distance", async () => {
   const run = makeRun(11, SHA_A);
   const artifact = makeArtifact(5, PERF_METRICS_ARTIFACT_NAME);
   const pr = makePR(11, "2026-06-18T00:00:00Z");
 
-  const contexts = await buildBaselineRunContexts({
-    baselineRuns: [run],
+  const context = await buildBaselineRunContext({
+    run,
     mainHeadSha: SHA_B,
-    concurrency: 1,
     fetchArtifactsForRun: (requestedRun) => {
       assertEquals(requestedRun, run);
       return Promise.resolve([artifact]);
@@ -1178,20 +1157,18 @@ Deno.test("buildBaselineRunContexts collects artifacts, PRs, and commit distance
     },
   });
 
-  assertEquals(contexts, [
-    {
-      run,
-      artifacts: [artifact],
-      pr,
-      prLookupError: null,
-      commitsBehindMain: 4,
-    },
-  ]);
+  assertEquals(context, {
+    run,
+    artifacts: [artifact],
+    pr,
+    prLookupError: null,
+    commitsBehindMain: 4,
+  });
 });
 
 Deno.test("parseCoverageBaselineFromArtifacts uses newest coverage baseline artifact", async () => {
   const parsed = {
-    metrics: new Map<string, TimingSample>([["job: Check", makeSample()]]),
+    metrics: new Map<string, BaselineSample>([["job: Check", makeSample()]]),
     compileCacheStates: { "pattern-unit": "warm" as const },
   };
   let parsedArtifactId = 0;
@@ -1215,51 +1192,6 @@ Deno.test("parseCoverageBaselineFromArtifacts uses newest coverage baseline arti
       throw new Error("should not parse without an artifact");
     }),
     null,
-  );
-});
-
-Deno.test("addCoverageBaselineFromArtifacts adds parsed samples to timelines", async () => {
-  const artifacts = [makeArtifact(1, PERF_METRICS_ARTIFACT_NAME)];
-  const sample = makeSample();
-  const timelines = new Map();
-
-  assertEquals(
-    await addCoverageBaselineFromArtifacts(
-      timelines,
-      artifacts,
-      (requested) => {
-        assertEquals(requested, artifacts);
-        return Promise.resolve({
-          metrics: new Map([["job: Check", sample]]),
-          compileCacheStates: { "generated-patterns": "cold" as const },
-        });
-      },
-    ),
-    { added: true, compileCacheStates: { "generated-patterns": "cold" } },
-  );
-  assertEquals(timelines.get("job: Check")?.samples, [sample]);
-
-  // An untagged (pre-rollout) artifact still adds samples, with null states.
-  assertEquals(
-    await addCoverageBaselineFromArtifacts(
-      timelines,
-      artifacts,
-      () =>
-        Promise.resolve({
-          metrics: new Map([["job: Check", sample]]),
-          compileCacheStates: null,
-        }),
-    ),
-    { added: true, compileCacheStates: null },
-  );
-
-  assertEquals(
-    await addCoverageBaselineFromArtifacts(
-      timelines,
-      [],
-      () => Promise.resolve(null),
-    ),
-    { added: false, compileCacheStates: null },
   );
 });
 
@@ -1537,95 +1469,269 @@ function makeBaselineSample(
   sha: string,
   createdAt: string,
   uncoveredLines: number,
-): TimingSample {
-  return {
-    runId,
-    runUrl: `https://github.com/commontoolsinc/labs/actions/runs/${runId}`,
-    sha,
-    createdAt,
-    durationSeconds: uncoveredLines,
-  };
+): BaselineSample {
+  return { runId, sha, createdAt, uncoveredLines };
 }
-
-const NEVER_COLD = () => false;
 
 /** Ancestry of base-branch commit `SHA_C`, newest first. */
 const RANKS = new Map([[SHA_C, 0], [SHA_B, 1], [SHA_A, 2]]);
 
-Deno.test("nearestUsableBaseline prefers the base-branch commit's own run", () => {
-  const samples = [
-    makeBaselineSample(1, SHA_A, "2026-08-04T10:00:00Z", 5740),
-    makeBaselineSample(2, SHA_B, "2026-08-04T10:20:00Z", 5746),
-    makeBaselineSample(3, SHA_C, "2026-08-04T10:40:00Z", 5760),
-  ];
+const RUNNER_METRIC = "coverage-debt: packages/runner uncovered lines";
+const MEMORY_METRIC = "coverage-debt: packages/memory uncovered lines";
 
-  assertEquals(
-    nearestUsableBaseline(samples, NEVER_COLD, RANKS)?.durationSeconds,
-    5760,
-  );
+/** One baseline run's contribution to the walk. */
+function reading(
+  run: WorkflowRun,
+  samples: Record<string, number>,
+  options: { cold?: boolean; accepts?: string[]; reset?: boolean } = {},
+): BaselineRunReading {
+  const accepts = options.accepts ?? [];
+  return {
+    samples: new Map(
+      Object.entries(samples).map(([metric, uncoveredLines]) => [
+        metric,
+        makeBaselineSample(
+          run.id,
+          run.head_sha,
+          run.created_at,
+          uncoveredLines,
+        ),
+      ]),
+    ),
+    overrides: accepts.length > 0 || options.reset
+      ? {
+        metrics: new Map(accepts.map((metric) => [metric, 0])),
+        coverageBaselineReset: options.reset ?? false,
+      }
+      : null,
+    cold: options.cold ?? false,
+  };
+}
+
+/**
+ * Walk `readings` newest first, reporting which runs the walk actually read.
+ * Each entry is a run and what reading it would give.
+ */
+async function walk(
+  readings: [WorkflowRun, BaselineRunReading][],
+  ancestorRank: Map<string, number> | null,
+  metrics: string[] = [RUNNER_METRIC],
+): Promise<{ lines: Record<string, number | undefined>; read: number[] }> {
+  const read: number[] = [];
+  const baselines = await walkBaselineRuns({
+    metrics,
+    runs: readings.map(([run]) => run),
+    ancestorRank,
+    readRun: (run) => {
+      read.push(run.id);
+      const found = readings.find(([candidate]) => candidate.id === run.id);
+      return Promise.resolve(found![1]);
+    },
+  });
+
+  const lines: Record<string, number | undefined> = {};
+  for (const metric of metrics) {
+    lines[metric] = baselines.get(metric)?.uncoveredLines;
+  }
+  return { lines, read };
+}
+
+/** Three `main` runs, newest first, along the ancestry `RANKS` describes. */
+const RUN_AT_BASE = makeRun(3, SHA_C, "2026-08-04T10:40:00Z");
+const RUN_ONE_BACK = makeRun(2, SHA_B, "2026-08-04T10:20:00Z");
+const RUN_TWO_BACK = makeRun(1, SHA_A, "2026-08-04T10:00:00Z");
+
+Deno.test("walkBaselineRuns prefers the base-branch commit's own run", async () => {
+  const walked = await walk([
+    [RUN_AT_BASE, reading(RUN_AT_BASE, { [RUNNER_METRIC]: 5760 })],
+    [RUN_ONE_BACK, reading(RUN_ONE_BACK, { [RUNNER_METRIC]: 5746 })],
+    [RUN_TWO_BACK, reading(RUN_TWO_BACK, { [RUNNER_METRIC]: 5740 })],
+  ], RANKS);
+
+  assertEquals(walked.lines[RUNNER_METRIC], 5760);
+  // The newest run answered every metric, so the older ones are never read.
+  assertEquals(walked.read, [3]);
 });
 
-Deno.test("nearestUsableBaseline falls back to the nearest ancestor with a run", () => {
-  // Nothing has measured SHA_C, the base-branch commit, so its parent stands
-  // in rather than the gate giving up.
-  const samples = [
-    makeBaselineSample(1, SHA_A, "2026-08-04T10:00:00Z", 5740),
-    makeBaselineSample(2, SHA_B, "2026-08-04T10:20:00Z", 5746),
-  ];
+Deno.test("walkBaselineRuns falls back to the nearest ancestor with a run", async () => {
+  // The base-branch commit's run uploaded no baseline artifact, so its parent
+  // stands in rather than the gate giving up.
+  const walked = await walk([
+    [RUN_AT_BASE, reading(RUN_AT_BASE, {})],
+    [RUN_ONE_BACK, reading(RUN_ONE_BACK, { [RUNNER_METRIC]: 5746 })],
+    [RUN_TWO_BACK, reading(RUN_TWO_BACK, { [RUNNER_METRIC]: 5740 })],
+  ], RANKS);
 
-  assertEquals(
-    nearestUsableBaseline(samples, NEVER_COLD, RANKS)?.durationSeconds,
-    5746,
-  );
+  assertEquals(walked.lines[RUNNER_METRIC], 5746);
+  assertEquals(walked.read, [3, 2]);
 });
 
-Deno.test("nearestUsableBaseline ignores a run that is not an ancestor", () => {
-  const sibling = "dddddddddddddddddddddddddddddddddddddddd";
-  const samples = [
-    makeBaselineSample(1, SHA_B, "2026-08-04T10:20:00Z", 5746),
-    // Landed after this run started, so it measured code the run lacks.
-    makeBaselineSample(2, sibling, "2026-08-04T10:50:00Z", 5700),
-  ];
+Deno.test("walkBaselineRuns ranks the ancestry rather than trusting run order", async () => {
+  // The nearer ancestor's run arrives second, as a history rewrite or two
+  // pushes in one second can leave it. The nearer commit still wins.
+  const walked = await walk([
+    [RUN_TWO_BACK, reading(RUN_TWO_BACK, { [RUNNER_METRIC]: 5740 })],
+    [RUN_AT_BASE, reading(RUN_AT_BASE, { [RUNNER_METRIC]: 5760 })],
+  ], RANKS);
 
-  assertEquals(
-    nearestUsableBaseline(samples, NEVER_COLD, RANKS)?.durationSeconds,
-    5746,
-  );
+  assertEquals(walked.lines[RUNNER_METRIC], 5760);
+  assertEquals(walked.read, [3]);
 });
 
-Deno.test("nearestUsableBaseline skips a cold ancestor for a warm one", () => {
-  const samples = [
-    makeBaselineSample(1, SHA_A, "2026-08-04T10:00:00Z", 5740),
-    makeBaselineSample(2, SHA_B, "2026-08-04T10:20:00Z", 5600),
-  ];
+Deno.test("walkBaselineRuns reads the first of two runs for one commit", async () => {
+  const rerun = makeRun(9, SHA_C, "2026-08-04T12:00:00Z");
+  const walked = await walk([
+    [rerun, reading(rerun, { [RUNNER_METRIC]: 5770 })],
+    [RUN_AT_BASE, reading(RUN_AT_BASE, { [RUNNER_METRIC]: 5760 })],
+  ], RANKS);
 
-  assertEquals(
-    nearestUsableBaseline(samples, (runId) => runId === 2, RANKS)
-      ?.durationSeconds,
-    5740,
-  );
+  assertEquals(walked.lines[RUNNER_METRIC], 5760);
+  assertEquals(walked.read, [3]);
 });
 
-Deno.test("nearestUsableBaseline takes a cold ancestor when every ancestor is cold", () => {
-  const samples = [makeBaselineSample(2, SHA_B, "2026-08-04T10:20:00Z", 5600)];
+Deno.test("walkBaselineRuns ignores a run that is not an ancestor", async () => {
+  // Landed after this run started, so it measured code the run lacks.
+  const sibling = makeRun(4, "dddddddddddddddddddddddddddddddddddddddd");
+  const walked = await walk([
+    [sibling, reading(sibling, { [RUNNER_METRIC]: 5700 })],
+    [RUN_ONE_BACK, reading(RUN_ONE_BACK, { [RUNNER_METRIC]: 5746 })],
+  ], RANKS);
 
-  assertEquals(
-    nearestUsableBaseline(samples, () => true, RANKS)?.durationSeconds,
-    5600,
-  );
+  assertEquals(walked.lines[RUNNER_METRIC], 5746);
 });
 
-Deno.test("nearestUsableBaseline falls back to the latest run without ancestry", () => {
-  const samples = [
-    makeBaselineSample(1, SHA_A, "2026-08-04T10:00:00Z", 5740),
-    makeBaselineSample(2, SHA_B, "2026-08-04T10:20:00Z", 5746),
-  ];
+Deno.test("walkBaselineRuns skips a cold ancestor for a warm one", async () => {
+  const walked = await walk([
+    [
+      RUN_ONE_BACK,
+      reading(RUN_ONE_BACK, { [RUNNER_METRIC]: 5600 }, { cold: true }),
+    ],
+    [RUN_TWO_BACK, reading(RUN_TWO_BACK, { [RUNNER_METRIC]: 5740 })],
+  ], RANKS);
 
-  assertEquals(
-    nearestUsableBaseline(samples, NEVER_COLD, null)?.durationSeconds,
-    5746,
+  assertEquals(walked.lines[RUNNER_METRIC], 5740);
+});
+
+Deno.test("walkBaselineRuns takes a cold ancestor when every ancestor is cold", async () => {
+  const walked = await walk([
+    [
+      RUN_ONE_BACK,
+      reading(RUN_ONE_BACK, { [RUNNER_METRIC]: 5600 }, { cold: true }),
+    ],
+    [
+      RUN_TWO_BACK,
+      reading(RUN_TWO_BACK, { [RUNNER_METRIC]: 5740 }, { cold: true }),
+    ],
+  ], RANKS);
+
+  // The nearest of them, not the oldest.
+  assertEquals(walked.lines[RUNNER_METRIC], 5600);
+});
+
+Deno.test("walkBaselineRuns ignores an acceptance that is not an ancestor", async () => {
+  // A reset that merged after this run's base-branch commit is not in this
+  // run's code, so it sets no floor here and the ancestry still gates.
+  const later = makeRun(4, "dddddddddddddddddddddddddddddddddddddddd");
+  const walked = await walk([
+    [later, reading(later, { [RUNNER_METRIC]: 7000 }, { reset: true })],
+    [RUN_AT_BASE, reading(RUN_AT_BASE, { [RUNNER_METRIC]: 5760 })],
+  ], RANKS);
+
+  assertEquals(walked.lines[RUNNER_METRIC], 5760);
+  // The run that is no baseline is never read either.
+  assertEquals(walked.read, [3]);
+});
+
+Deno.test("walkBaselineRuns falls back to the latest run without ancestry", async () => {
+  const walked = await walk([
+    [RUN_ONE_BACK, reading(RUN_ONE_BACK, { [RUNNER_METRIC]: 5746 })],
+    [RUN_TWO_BACK, reading(RUN_TWO_BACK, { [RUNNER_METRIC]: 5740 })],
+  ], null);
+
+  assertEquals(walked.lines[RUNNER_METRIC], 5746);
+
+  const nothing = await walk([], RANKS);
+  assertEquals(nothing.lines[RUNNER_METRIC], undefined);
+});
+
+Deno.test("walkBaselineRuns takes the latest cold run without ancestry", async () => {
+  const walked = await walk([
+    [
+      RUN_ONE_BACK,
+      reading(RUN_ONE_BACK, { [RUNNER_METRIC]: 5746 }, { cold: true }),
+    ],
+    [
+      RUN_TWO_BACK,
+      reading(RUN_TWO_BACK, { [RUNNER_METRIC]: 5740 }, { cold: true }),
+    ],
+  ], null);
+
+  assertEquals(walked.lines[RUNNER_METRIC], 5746);
+});
+
+Deno.test("walkBaselineRuns stops at the run whose PR accepted the debt", async () => {
+  // The middle run's merged pull request accepted the runner group's debt, so
+  // nothing older may serve as that group's baseline: the accepted level is
+  // what later runs are held to. Every run that measured it is cold, so the
+  // accepting run stands as the baseline rather than the metric losing one.
+  // The memory group was not accepted, so its walk carries on to the warm run.
+  const walked = await walk(
+    [
+      [RUN_AT_BASE, reading(RUN_AT_BASE, {}, { cold: true })],
+      [
+        RUN_ONE_BACK,
+        reading(
+          RUN_ONE_BACK,
+          { [RUNNER_METRIC]: 5746, [MEMORY_METRIC]: 410 },
+          { cold: true, accepts: [RUNNER_METRIC] },
+        ),
+      ],
+      [
+        RUN_TWO_BACK,
+        reading(RUN_TWO_BACK, { [RUNNER_METRIC]: 5740, [MEMORY_METRIC]: 400 }),
+      ],
+    ],
+    RANKS,
+    [RUNNER_METRIC, MEMORY_METRIC],
   );
-  assertEquals(nearestUsableBaseline([], NEVER_COLD, RANKS), undefined);
+
+  assertEquals(walked.lines[RUNNER_METRIC], 5746);
+  assertEquals(walked.lines[MEMORY_METRIC], 400);
+});
+
+Deno.test("walkBaselineRuns stops every coverage metric at a merged reset", async () => {
+  const walked = await walk(
+    [
+      [
+        RUN_ONE_BACK,
+        reading(
+          RUN_ONE_BACK,
+          { [RUNNER_METRIC]: 5746, [MEMORY_METRIC]: 410 },
+          { cold: true, reset: true },
+        ),
+      ],
+      [
+        RUN_TWO_BACK,
+        reading(RUN_TWO_BACK, { [RUNNER_METRIC]: 5740, [MEMORY_METRIC]: 400 }),
+      ],
+    ],
+    RANKS,
+    [RUNNER_METRIC, MEMORY_METRIC],
+  );
+
+  assertEquals(walked.lines[RUNNER_METRIC], 5746);
+  assertEquals(walked.lines[MEMORY_METRIC], 410);
+});
+
+Deno.test("walkBaselineRuns walks past an acceptance that measured nothing", async () => {
+  // The accepting run uploaded no baseline artifact, so it has no level to
+  // hold later runs to and the search continues past it.
+  const walked = await walk([
+    [RUN_ONE_BACK, reading(RUN_ONE_BACK, {}, { accepts: [RUNNER_METRIC] })],
+    [RUN_TWO_BACK, reading(RUN_TWO_BACK, { [RUNNER_METRIC]: 5740 })],
+  ], RANKS);
+
+  assertEquals(walked.lines[RUNNER_METRIC], 5740);
 });
 
 Deno.test("fetchAncestorRanks ranks commits by distance from the base", async () => {
@@ -1670,9 +1776,6 @@ Deno.test("fetchGroupsChangedOnBase compares nothing against the base itself", a
 
   assertEquals(groups.size, 0);
 });
-
-const RUNNER_METRIC = "coverage-debt: packages/runner uncovered lines";
-const MEMORY_METRIC = "coverage-debt: packages/memory uncovered lines";
 
 Deno.test("isComparableBaseline withholds only the groups the base branch moved", () => {
   const sample = makeBaselineSample(1, SHA_A, "2026-08-04T10:00:00Z", 5740);
@@ -1726,7 +1829,7 @@ Deno.test("isComparableBaseline reads the moved groups of its own baseline", () 
     [SHA_A, new Set(["packages/runner"])],
     [SHA_C, new Set<string>()],
   ]);
-  const at = (sample: TimingSample) =>
+  const at = (sample: BaselineSample) =>
     isComparableBaseline({
       sample,
       metric: RUNNER_METRIC,
@@ -1739,46 +1842,45 @@ Deno.test("isComparableBaseline reads the moved groups of its own baseline", () 
   assertEquals(at(older), false);
 });
 
-Deno.test("resolveMetricBaselines picks a baseline and its gating for each metric", () => {
-  const timelines = new Map([
-    [RUNNER_METRIC, {
-      name: RUNNER_METRIC,
-      samples: [
-        makeBaselineSample(1, SHA_A, "2026-08-04T10:00:00Z", 5740),
-        makeBaselineSample(3, SHA_C, "2026-08-04T10:40:00Z", 5746),
-      ],
-    }],
-    // Only an older run measured this metric, and the base branch moved its
-    // group since, so it is reported and not gated.
-    [MEMORY_METRIC, {
-      name: MEMORY_METRIC,
-      samples: [makeBaselineSample(1, SHA_A, "2026-08-04T10:00:00Z", 400)],
-    }],
-  ]);
+Deno.test("selectBaselines picks a baseline and its gating for each metric", async () => {
+  const runs: [WorkflowRun, BaselineRunReading][] = [
+    [RUN_AT_BASE, reading(RUN_AT_BASE, { [RUNNER_METRIC]: 5746 })],
+    // Only an older run measured the memory group, and the base branch moved
+    // that group since, so it is reported and not gated.
+    [
+      RUN_TWO_BACK,
+      reading(RUN_TWO_BACK, { [RUNNER_METRIC]: 5740, [MEMORY_METRIC]: 400 }),
+    ],
+  ];
 
-  const resolved = resolveMetricBaselines({
+  const resolved = await selectBaselines({
     metrics: [
       RUNNER_METRIC,
       MEMORY_METRIC,
       "coverage-debt: gone uncovered lines",
     ],
-    timelines,
-    isRunCold: NEVER_COLD,
-    ancestorRank: RANKS,
-    groupsChangedByBaseline: new Map([
-      [SHA_A, new Set(["packages/memory"])],
-      [SHA_C, new Set<string>()],
-    ]),
-    baseSha: SHA_C,
+    runs: runs.map(([run]) => run),
+    readRun: (run) =>
+      Promise.resolve(runs.find(([candidate]) => candidate.id === run.id)![1]),
     isPullRequest: true,
+    readBaseSha: () => Promise.resolve(SHA_C),
+    fetchRanks: () => Promise.resolve(RANKS),
+    fetchChangedGroups: (baselineSha) =>
+      Promise.resolve(
+        baselineSha === SHA_A
+          ? new Set(["packages/memory"])
+          : new Set<string>(),
+      ),
+    log: () => {},
   });
 
-  assertEquals(resolved.get(RUNNER_METRIC)?.sample?.durationSeconds, 5746);
+  assertEquals(resolved.size, 3);
+  assertEquals(resolved.get(RUNNER_METRIC)?.sample?.uncoveredLines, 5746);
   assertEquals(resolved.get(RUNNER_METRIC)?.comparable, true);
-  assertEquals(resolved.get(MEMORY_METRIC)?.sample?.durationSeconds, 400);
+  assertEquals(resolved.get(MEMORY_METRIC)?.sample?.uncoveredLines, 400);
   assertEquals(resolved.get(MEMORY_METRIC)?.comparable, false);
 
-  // A metric with no timeline at all has nothing to be gated against.
+  // A metric no baseline run measured has nothing to be gated against.
   const missing = resolved.get("coverage-debt: gone uncovered lines");
   assertEquals(missing?.sample, undefined);
   assertEquals(missing?.comparable, false);
@@ -1823,27 +1925,32 @@ Deno.test("reportBaselineDistance reports an ancestry it could not read", () => 
   );
 });
 
-function timelineOf(metric: string, samples: TimingSample[]) {
-  return { name: metric, samples };
+/** The three-run ancestry above, with one metric measured at each commit. */
+function runnerReadings(): [WorkflowRun, BaselineRunReading][] {
+  return [
+    [RUN_AT_BASE, reading(RUN_AT_BASE, { [RUNNER_METRIC]: 5746 })],
+    [RUN_TWO_BACK, reading(RUN_TWO_BACK, { [RUNNER_METRIC]: 5740 })],
+  ];
+}
+
+function readerFor(
+  readings: [WorkflowRun, BaselineRunReading][],
+): (run: WorkflowRun) => Promise<BaselineRunReading> {
+  return (run) =>
+    Promise.resolve(
+      readings.find(([candidate]) => candidate.id === run.id)![1],
+    );
 }
 
 Deno.test("selectBaselines chooses each metric's baseline against the base commit", async () => {
-  const timelines = new Map([
-    [
-      RUNNER_METRIC,
-      timelineOf(RUNNER_METRIC, [
-        makeBaselineSample(1, SHA_A, "2026-08-04T10:00:00Z", 5740),
-        makeBaselineSample(3, SHA_C, "2026-08-04T10:40:00Z", 5746),
-      ]),
-    ],
-  ]);
+  const readings = runnerReadings();
   const compared: string[] = [];
 
   const captured = await captureConsoleAsync(() =>
     selectBaselines({
       metrics: [RUNNER_METRIC],
-      timelines,
-      isRunCold: NEVER_COLD,
+      runs: readings.map(([run]) => run),
+      readRun: readerFor(readings),
       isPullRequest: true,
       readBaseSha: () => Promise.resolve(SHA_C),
       fetchRanks: (baseSha) => {
@@ -1858,7 +1965,7 @@ Deno.test("selectBaselines chooses each metric's baseline against the base commi
   );
 
   assertEquals(
-    captured.result.get(RUNNER_METRIC)?.sample?.durationSeconds,
+    captured.result.get(RUNNER_METRIC)?.sample?.uncoveredLines,
     5746,
   );
   assertEquals(captured.result.get(RUNNER_METRIC)?.comparable, true);
@@ -1871,20 +1978,13 @@ Deno.test("selectBaselines chooses each metric's baseline against the base commi
 });
 
 Deno.test("selectBaselines gates nothing when the base commit cannot be read", async () => {
-  const timelines = new Map([
-    [
-      RUNNER_METRIC,
-      timelineOf(RUNNER_METRIC, [
-        makeBaselineSample(1, SHA_A, "2026-08-04T10:00:00Z", 5740),
-      ]),
-    ],
-  ]);
+  const readings = runnerReadings();
 
   const captured = await captureConsoleAsync(() =>
     selectBaselines({
       metrics: [RUNNER_METRIC],
-      timelines,
-      isRunCold: NEVER_COLD,
+      runs: readings.map(([run]) => run),
+      readRun: readerFor(readings),
       isPullRequest: true,
       readBaseSha: () => Promise.resolve(null),
       fetchRanks: () => {
@@ -1898,8 +1998,8 @@ Deno.test("selectBaselines gates nothing when the base commit cannot be read", a
 
   // The fallback still names a sample, but nothing may be failed against it.
   assertEquals(
-    captured.result.get(RUNNER_METRIC)?.sample?.durationSeconds,
-    5740,
+    captured.result.get(RUNNER_METRIC)?.sample?.uncoveredLines,
+    5746,
   );
   assertEquals(captured.result.get(RUNNER_METRIC)?.comparable, false);
   assertStringIncludes(
@@ -1909,19 +2009,12 @@ Deno.test("selectBaselines gates nothing when the base commit cannot be read", a
 });
 
 Deno.test("selectBaselines reports against whatever it has for a push run", async () => {
-  const timelines = new Map([
-    [
-      RUNNER_METRIC,
-      timelineOf(RUNNER_METRIC, [
-        makeBaselineSample(1, SHA_A, "2026-08-04T10:00:00Z", 5740),
-      ]),
-    ],
-  ]);
+  const readings = runnerReadings();
 
   const resolved = await selectBaselines({
     metrics: [RUNNER_METRIC],
-    timelines,
-    isRunCold: NEVER_COLD,
+    runs: readings.map(([run]) => run),
+    readRun: readerFor(readings),
     isPullRequest: false,
     readBaseSha: () => {
       throw new Error("a push run has no base-branch commit to read");
@@ -2019,17 +2112,12 @@ Deno.test("readHeadCommitObject returns null when git cannot be run", async () =
 Deno.test("selectBaselines routes its GitHub calls through the guard", async () => {
   const guarded: string[] = [];
 
+  const readings = runnerReadings();
+
   await selectBaselines({
     metrics: [RUNNER_METRIC],
-    timelines: new Map([
-      [
-        RUNNER_METRIC,
-        timelineOf(RUNNER_METRIC, [
-          makeBaselineSample(1, SHA_C, "2026-08-04T10:40:00Z", 5746),
-        ]),
-      ],
-    ]),
-    isRunCold: NEVER_COLD,
+    runs: readings.map(([run]) => run),
+    readRun: readerFor(readings),
     isPullRequest: true,
     readBaseSha: () => Promise.resolve(SHA_C),
     fetchRanks: () => Promise.resolve(RANKS),
@@ -2070,7 +2158,6 @@ function rowsFor(
   );
   return buildCoverageRows({
     currentMetrics,
-    timelines: new Map(),
     baselineByMetric,
     overrides: NO_OVERRIDES,
     changedCoverageGroups: new Set(["packages/runner", "packages/memory"]),
@@ -2085,7 +2172,7 @@ Deno.test("buildCoverageRows fails a gated group above its baseline", () => {
   );
 
   assertEquals(rows[0].status, "OVER");
-  assertEquals(rows[0].median, 5746);
+  assertEquals(rows[0].baseline, 5746);
   assertEquals(rows[0].baselineSha, SHA_A);
   assertEquals(failures.length, 1);
 });
@@ -2107,7 +2194,7 @@ Deno.test("buildCoverageRows reports an incomparable baseline without failing it
   );
 
   assertEquals(rows[0].status, "excl");
-  assertEquals(rows[0].median, 5746);
+  assertEquals(rows[0].baseline, 5746);
   assertEquals(failures, []);
   assertEquals([...ungatedGroups], ["packages/runner"]);
 });
@@ -2156,7 +2243,7 @@ Deno.test("buildCoverageRows bootstraps a metric with no baseline", () => {
     { [RUNNER_METRIC]: { comparable: true } },
   );
   assertEquals(fresh.rows[0].status, "OVER");
-  assertEquals(fresh.rows[0].median, 0);
+  assertEquals(fresh.rows[0].baseline, 0);
   assertEquals(fresh.failures.length, 1);
 
   const empty = rowsFor(

--- a/tasks/coverage-check.ts
+++ b/tasks/coverage-check.ts
@@ -20,12 +20,11 @@
  */
 
 import {
-  addSample,
+  acceptsCoverageDebt,
   aggregateCacheStates,
-  API_CONCURRENCY,
-  applyBaselineOverrides,
   type Artifact,
   type BaselineOverrides,
+  type BaselineSample,
   buildCoverageDebtSuggestionComment,
   CACHE_STATE_ARTIFACT_PREFIX,
   COMPILE_CACHE_FAMILIES,
@@ -47,10 +46,6 @@ import {
   fetchPRFiles,
   formatOverrideSuggestion,
   githubGet,
-  isCoverageDebtMetric,
-  latestNonColdSample,
-  mapConcurrent,
-  type MetricTimeline,
   newestArtifactsByName,
   parseAddedLinesFromPatch,
   parseBaselineOverrides,
@@ -62,7 +57,6 @@ import {
   readAndParseEvent,
   REPO,
   shouldGateCoverageDebtMetric,
-  type TimingSample,
   walkFiles,
   WORKFLOW_FILE,
   type WorkflowRun,
@@ -119,7 +113,7 @@ function isGitHubRateLimitError(error: unknown): boolean {
 export async function githubApiOrSkip<T>(
   description: string,
   operation: () => Promise<T>,
-  metricsForArtifact: Map<string, TimingSample>,
+  metricsForArtifact: Map<string, BaselineSample>,
 ): Promise<T> {
   try {
     return await operation();
@@ -370,8 +364,35 @@ export async function fetchAncestorRanks(
   return new Map(commits.map((commit, index) => [commit.sha, index]));
 }
 
+/** One baseline run, as much of it as choosing a baseline needs. */
+export interface BaselineRunReading {
+  /** The run's uncovered-line count per metric, from its baseline artifact. */
+  samples: Map<string, BaselineSample>;
+  /** What the run's merged pull request accepted, when it has one. */
+  overrides: BaselineOverrides | null;
+  /** True when the run compiled patterns from scratch. */
+  cold: boolean;
+}
+
+export interface WalkBaselineRunsOptions {
+  /**
+   * The metrics to find a baseline for. An array rather than any iterable,
+   * because a one-shot iterator would leave a second pass over it empty.
+   */
+  metrics: readonly string[];
+  /** Recent `main` runs, newest first. */
+  runs: WorkflowRun[];
+  /** Reads one run. Called only for the runs the walk reaches. */
+  readRun: (run: WorkflowRun) => Promise<BaselineRunReading>;
+  /**
+   * How far back from the base-branch commit this run merged each recent commit
+   * sits, or null when there is no base-branch commit to measure against.
+   */
+  ancestorRank: Map<string, number> | null;
+}
+
 /**
- * Returns the ratchet baseline for one metric: the run for the nearest
+ * Chooses every metric's ratchet baseline: the `main` run for the nearest
  * ancestor of the base-branch commit this run merged.
  *
  * The base-branch commit's own run is the ideal baseline, because it measured
@@ -380,47 +401,91 @@ export async function fetchAncestorRanks(
  * still going or one that failed leaves the nearest ancestor with a usable run
  * standing in for it. Whatever the base branch changed in between is then in
  * this run and not in the baseline, so `isComparableBaseline()` withholds
- * gating from the groups it touched.
+ * gating from the groups it touched. A run for a commit that is not an ancestor
+ * is never a baseline: it landed after this run started, so it measured code
+ * this run does not contain.
  *
- * Prefers a non-cold run: a cold run covers cold-compile-only branches, and its
- * lower debt would hold a warm pull request to an unreachable bar. Takes the
- * nearest ancestor regardless when every ancestor is cold, which keeps the
- * reset semantics of an override-truncated timeline.
+ * A non-cold run wins: a cold run covers cold-compile-only branches, and its
+ * lower debt would hold a warm pull request to an unreachable bar. When every
+ * ancestor is cold the nearest one stands, so a metric never loses its baseline
+ * to coldness alone.
  *
- * Falls back to the latest non-cold run when there is no ancestry to work from
- * — a `main` push run, a checkout that is not a merge, or a commit listing that
- * could not be fetched.
+ * A merged pull request that accepted a metric's debt, with a per-metric
+ * acceptance or the whole-coverage reset marker, sets the floor: its own run is
+ * the oldest baseline the ratchet may reach for that metric, so the accepted
+ * level is what later runs are held to and nothing older undoes it. Only a run
+ * that both carries the acceptance and measured the metric stops the walk —
+ * an acceptance whose run uploaded no baseline artifact leaves the search to
+ * continue past it. An acceptance that merged onto a commit this run does not
+ * contain sets no floor here, for the same reason such a run is no baseline.
+ *
+ * Runs are read one at a time in the order `baselineWalkOrder()` gives, and the
+ * walk stops as soon as every metric has its baseline, so a run that measured
+ * every metric is the only one read.
  */
-export function nearestUsableBaseline(
-  samples: TimingSample[],
-  isRunCold: (runId: number) => boolean,
-  ancestorRank: Map<string, number> | null,
-): TimingSample | undefined {
-  if (ancestorRank === null) return latestNonColdSample(samples, isRunCold);
+export async function walkBaselineRuns(
+  options: WalkBaselineRunsOptions,
+): Promise<Map<string, BaselineSample>> {
+  const pending = new Set(options.metrics);
+  const chosen = new Map<string, BaselineSample>();
+  const coldFallback = new Map<string, BaselineSample>();
 
-  let nearest: TimingSample | undefined;
-  let nearestRank = Infinity;
-  let nearestCold: TimingSample | undefined;
-  let nearestColdRank = Infinity;
+  for (const run of baselineWalkOrder(options.runs, options.ancestorRank)) {
+    if (pending.size === 0) break;
 
-  for (const sample of samples) {
-    const rank = ancestorRank.get(sample.sha);
-    if (rank === undefined) continue;
+    const reading = await options.readRun(run);
 
-    if (isRunCold(sample.runId)) {
-      if (rank < nearestColdRank) {
-        nearestCold = sample;
-        nearestColdRank = rank;
+    for (const metric of [...pending]) {
+      const sample = reading.samples.get(metric);
+      if (sample === undefined) continue;
+
+      if (!reading.cold) {
+        chosen.set(metric, sample);
+        pending.delete(metric);
+        continue;
       }
-      continue;
-    }
-    if (rank < nearestRank) {
-      nearest = sample;
-      nearestRank = rank;
+      if (!coldFallback.has(metric)) coldFallback.set(metric, sample);
+
+      if (reading.overrides && acceptsCoverageDebt(reading.overrides, metric)) {
+        pending.delete(metric);
+      }
     }
   }
 
-  return nearest ?? nearestCold;
+  for (const [metric, sample] of coldFallback) {
+    if (!chosen.has(metric)) chosen.set(metric, sample);
+  }
+  return chosen;
+}
+
+/**
+ * The order the walk reads runs in: the run for the base-branch commit itself
+ * first, then its ancestors from nearest to furthest, and runs whose commit is
+ * not an ancestor left out entirely. Two runs for one commit read oldest first,
+ * matching how a ranked search settles that tie.
+ *
+ * Ranking rather than trusting the order the runs arrive in matters because the
+ * walk takes the first answer it finds and stops. Run creation follows the push
+ * order that ancestry describes, but not through a history rewrite, and not
+ * across two pushes that land in the same second.
+ *
+ * Without an ancestry to rank against — a `main` push run, a checkout that is
+ * not a merge, or a commit listing that could not be fetched — the runs stand
+ * as given, newest first, and the newest usable one wins.
+ */
+function baselineWalkOrder(
+  runs: WorkflowRun[],
+  ancestorRank: Map<string, number> | null,
+): WorkflowRun[] {
+  if (ancestorRank === null) return runs;
+
+  return runs
+    .filter((run) => ancestorRank.has(run.head_sha))
+    .sort((a, b) =>
+      ancestorRank.get(a.head_sha)! - ancestorRank.get(b.head_sha)! ||
+      a.created_at.localeCompare(b.created_at) ||
+      a.id - b.id
+    );
 }
 
 /**
@@ -477,7 +542,7 @@ export async function fetchGroupsChangedOnBase(
  */
 export function isComparableBaseline(
   options: {
-    sample: TimingSample | undefined;
+    sample: BaselineSample | undefined;
     metric: string;
     baseSha: string | null;
     groupsChangedByBaseline: Map<string, Set<string>>;
@@ -495,25 +560,18 @@ export function isComparableBaseline(
 }
 
 export interface MetricBaseline {
-  sample?: TimingSample;
+  sample?: BaselineSample;
   /** Whether the ratchet may fail this metric against that sample. */
   comparable: boolean;
 }
 
-export interface ResolveMetricBaselinesOptions {
-  metrics: Iterable<string>;
-  timelines: Map<string, MetricTimeline>;
-  isRunCold: (runId: number) => boolean;
-  ancestorRank: Map<string, number> | null;
-  groupsChangedByBaseline: Map<string, Set<string>>;
-  baseSha: string | null;
-  isPullRequest: boolean;
-}
-
 export interface SelectBaselinesOptions {
-  metrics: Iterable<string>;
-  timelines: Map<string, MetricTimeline>;
-  isRunCold: (runId: number) => boolean;
+  /** The metrics to gate; an array, as in {@link WalkBaselineRunsOptions}. */
+  metrics: readonly string[];
+  /** Recent `main` runs, newest first. */
+  runs: WorkflowRun[];
+  /** Reads one baseline run; called only for the runs the walk reaches. */
+  readRun: (run: WorkflowRun) => Promise<BaselineRunReading>;
   isPullRequest: boolean;
   readBaseSha?: () => Promise<string | null>;
   fetchRanks?: (baseSha: string) => Promise<Map<string, number>>;
@@ -521,7 +579,7 @@ export interface SelectBaselinesOptions {
     baselineSha: string,
     baseSha: string,
   ) => Promise<Set<string>>;
-  /** Wraps each GitHub call so a rate limit skips the check (see main). */
+  /** Wraps the GitHub calls made here so a rate limit skips the check. */
   guard?: <T>(description: string, operation: () => Promise<T>) => Promise<T>;
   log?: (message: string) => void;
   warn?: (message: string) => void;
@@ -531,9 +589,9 @@ export interface SelectBaselinesOptions {
  * Chooses every metric's ratchet baseline against the base-branch commit this
  * run merged, and reports what it chose.
  *
- * Reads the base-branch commit, ranks its ancestry, asks which coverage groups
- * the base branch moved since each baseline the metrics would take, and hands
- * the answers to `resolveMetricBaselines()`.
+ * Reads the base-branch commit, ranks its ancestry, walks the recent `main`
+ * runs for each metric's baseline, and asks which coverage groups the base
+ * branch moved since each baseline the walk picked.
  */
 export async function selectBaselines(
   options: SelectBaselinesOptions,
@@ -565,19 +623,19 @@ export async function selectBaselines(
     () => fetchRanks(baseSha),
   );
 
-  // Which baseline each metric would take, before asking what moved since.
-  const candidateShas = new Set<string>();
-  for (const metric of options.metrics) {
-    const timeline = options.timelines.get(metric);
-    const sample = timeline
-      ? nearestUsableBaseline(timeline.samples, options.isRunCold, ancestorRank)
-      : undefined;
-    if (sample) candidateShas.add(sample.sha);
-  }
+  const baselines = await walkBaselineRuns({
+    metrics: options.metrics,
+    runs: options.runs,
+    readRun: options.readRun,
+    ancestorRank,
+  });
 
   const groupsChangedByBaseline = new Map<string, Set<string>>();
   if (baseSha !== null) {
-    for (const sha of candidateShas) {
+    const baselineShas = new Set(
+      [...baselines.values()].map((sample) => sample.sha),
+    );
+    for (const sha of baselineShas) {
       groupsChangedByBaseline.set(
         sha,
         await guard(
@@ -586,48 +644,23 @@ export async function selectBaselines(
         ),
       );
     }
-    reportBaselineDistance(candidateShas, baseSha, ancestorRank, log);
+    reportBaselineDistance(baselineShas, baseSha, ancestorRank, log);
   }
 
-  return resolveMetricBaselines({
-    metrics: options.metrics,
-    timelines: options.timelines,
-    isRunCold: options.isRunCold,
-    ancestorRank,
-    groupsChangedByBaseline,
-    baseSha,
-    isPullRequest: options.isPullRequest,
-  });
-}
-
-/** Picks each metric's baseline and says whether the ratchet may act on it. */
-export function resolveMetricBaselines(
-  options: ResolveMetricBaselinesOptions,
-): Map<string, MetricBaseline> {
   const resolved = new Map<string, MetricBaseline>();
-
   for (const metric of options.metrics) {
-    const timeline = options.timelines.get(metric);
-    const sample = timeline
-      ? nearestUsableBaseline(
-        timeline.samples,
-        options.isRunCold,
-        options.ancestorRank,
-      )
-      : undefined;
-
+    const sample = baselines.get(metric);
     resolved.set(metric, {
       sample,
       comparable: isComparableBaseline({
         sample,
         metric,
-        baseSha: options.baseSha,
-        groupsChangedByBaseline: options.groupsChangedByBaseline,
+        baseSha,
+        groupsChangedByBaseline,
         isPullRequest: options.isPullRequest,
       }),
     });
   }
-
   return resolved;
 }
 
@@ -840,7 +873,7 @@ export async function fetchArtifactsForRunBestEffort(
 }
 
 export async function fetchBaselineRunsForCheck(
-  metricsForArtifact: Map<string, TimingSample>,
+  metricsForArtifact: Map<string, BaselineSample>,
   baselineRunCount = BASELINE_RUNS,
   log: (message: string) => void = console.log,
 ): Promise<{ mainHeadSha: string; baselineRuns: WorkflowRun[] }> {
@@ -890,8 +923,8 @@ export function reportBaselineRunAvailability(
   return baselineMainHead;
 }
 
-export interface BuildBaselineRunContextsOptions {
-  baselineRuns: WorkflowRun[];
+export interface BuildBaselineRunContextOptions {
+  run: WorkflowRun;
   mainHeadSha: string;
   fetchArtifactsForRun?: (run: WorkflowRun) => Promise<Artifact[]>;
   fetchPRForCommit?: (sha: string) => Promise<PRLookupResult>;
@@ -899,36 +932,30 @@ export interface BuildBaselineRunContextsOptions {
     baselineSha: string,
     mainHeadSha: string,
   ) => Promise<number | null>;
-  concurrency?: number;
 }
 
-export async function buildBaselineRunContexts(
-  options: BuildBaselineRunContextsOptions,
-): Promise<BaselineRunContext[]> {
+/** Reads everything one baseline run contributes: its artifacts and its PR. */
+export async function buildBaselineRunContext(
+  options: BuildBaselineRunContextOptions,
+): Promise<BaselineRunContext> {
   const fetchArtifacts = options.fetchArtifactsForRun ??
     fetchArtifactsForRunBestEffort;
   const fetchPR = options.fetchPRForCommit ?? fetchPRForCommitWithError;
   const fetchCommitDistance = options.fetchCommitsBehindMain ??
     fetchCommitsBehindMain;
 
-  return await mapConcurrent(
-    options.baselineRuns,
-    options.concurrency ?? API_CONCURRENCY,
-    async (run): Promise<BaselineRunContext> => {
-      const [artifacts, prLookup, commitsBehindMain] = await Promise.all([
-        fetchArtifacts(run),
-        fetchPR(run.head_sha),
-        fetchCommitDistance(run.head_sha, options.mainHeadSha),
-      ]);
-      return {
-        run,
-        artifacts,
-        pr: prLookup.pr,
-        prLookupError: prLookup.error,
-        commitsBehindMain,
-      };
-    },
-  );
+  const [artifacts, prLookup, commitsBehindMain] = await Promise.all([
+    fetchArtifacts(options.run),
+    fetchPR(options.run.head_sha),
+    fetchCommitDistance(options.run.head_sha, options.mainHeadSha),
+  ]);
+  return {
+    run: options.run,
+    artifacts,
+    pr: prLookup.pr,
+    prLookupError: prLookup.error,
+    commitsBehindMain,
+  };
 }
 
 export function reportBaselineContextResults(
@@ -959,29 +986,6 @@ export async function parseCoverageBaselineFromArtifacts(
   if (!artifact) return null;
 
   return await parseMetrics(artifact.id);
-}
-
-export interface AddCoverageBaselineResult {
-  added: boolean;
-  /** Null when the run has no perf-metrics artifact or an untagged one. */
-  compileCacheStates: CompileCacheStates | null;
-}
-
-export async function addCoverageBaselineFromArtifacts(
-  timelines: Map<string, MetricTimeline>,
-  artifacts: Artifact[],
-  parseMetrics: (
-    artifacts: Artifact[],
-  ) => Promise<CoverageBaselineDetailed | null> =
-    parseCoverageBaselineFromArtifacts,
-): Promise<AddCoverageBaselineResult> {
-  const detailed = await parseMetrics(artifacts);
-  if (!detailed) return { added: false, compileCacheStates: null };
-
-  for (const [name, sample] of detailed.metrics) {
-    addSample(timelines, name, sample);
-  }
-  return { added: true, compileCacheStates: detailed.compileCacheStates };
 }
 
 /**
@@ -1076,13 +1080,15 @@ const EXPECTED_COVERAGE_ARTIFACT_NAMES = [
   ...[1, 2, 3, 4, 5].map((chunk) => `coverage-profile-pattern-unit-${chunk}`),
 ];
 
-function sampleForRun(run: WorkflowRun, value: number): TimingSample {
+function sampleForRun(
+  run: WorkflowRun,
+  uncoveredLines: number,
+): BaselineSample {
   return {
     runId: run.id,
-    runUrl: run.html_url,
     sha: run.head_sha,
     createdAt: run.created_at,
-    durationSeconds: value,
+    uncoveredLines,
   };
 }
 
@@ -1212,9 +1218,9 @@ export function formatMetricValueForTable(
 }
 
 export function formatMetricDelta(row: Row): string {
-  if (row.median === undefined || row.pctIncrease === undefined) return "-";
+  if (row.baseline === undefined || row.pctIncrease === undefined) return "-";
 
-  const delta = row.current - row.median;
+  const delta = row.current - row.baseline;
   const sign = delta >= 0 ? "+" : "-";
   const formattedAbsolute = `${Math.round(Math.abs(delta))}`;
   const pctSign = row.pctIncrease >= 0 ? "+" : "";
@@ -1226,34 +1232,14 @@ export function formatMetricDelta(row: Row): string {
   }%)`;
 }
 
-export function metricDisplayParts(
-  metric: string,
-): { task: string; metric: string } {
-  const colon = metric.indexOf(":");
-  if (colon < 0) return { task: "other", metric };
-
-  const kind = metric.slice(0, colon);
-  const rest = metric.slice(colon + 1).trim();
-
-  if (kind === "coverage-debt") {
-    return {
-      task: kind,
-      metric: coverageMetricGroupName(metric) ?? rest,
-    };
-  }
-
-  return { task: kind, metric: rest };
-}
-
 export interface Row {
   metric: string;
   status: Status;
   current: number;
-  /** Latest non-cold `main` ratchet baseline (uncovered lines). */
-  median?: number;
+  /** Uncovered lines the chosen `main` run measured for this metric. */
+  baseline?: number;
   /** Head SHA of the run that baseline came from. */
   baselineSha?: string;
-  n: number;
   pctIncrease?: number;
 }
 
@@ -1262,21 +1248,18 @@ export function metricTableRows(
   includeStatus: boolean,
 ): string[][] {
   return rows.map((row) => {
-    const display = metricDisplayParts(row.metric);
     const cells = [
-      formatMetricValueForTable(row.median),
+      formatMetricValueForTable(row.baseline),
       formatMetricValueForTable(row.current),
       formatMetricDelta(row),
-      display.task,
-      display.metric,
+      coverageMetricGroupName(row.metric) ?? row.metric,
     ];
     return includeStatus ? [row.status, ...cells] : cells;
   });
 }
 
 export interface BuildCoverageRowsOptions {
-  currentMetrics: Map<string, TimingSample>;
-  timelines: Map<string, MetricTimeline>;
+  currentMetrics: Map<string, BaselineSample>;
   baselineByMetric: Map<string, MetricBaseline>;
   overrides: BaselineOverrides;
   /** Undefined when the PR's changed files could not be read. */
@@ -1307,11 +1290,10 @@ export function buildCoverageRows(
   const ungatedGroups = new Set<string>();
 
   for (const [metric, currentSample] of options.currentMetrics) {
-    const current = currentSample.durationSeconds;
-    const n = options.timelines.get(metric)?.samples.length ?? 0;
+    const current = currentSample.uncoveredLines;
     const resolvedBaseline = options.baselineByMetric.get(metric);
     const baselineSample = resolvedBaseline?.sample;
-    const latestBaseline = baselineSample?.durationSeconds;
+    const latestBaseline = baselineSample?.uncoveredLines;
     const override = options.overrides.metrics.get(metric);
     const coverageReset = options.overrides.coverageBaselineReset;
     const comparable = resolvedBaseline?.comparable ?? false;
@@ -1326,22 +1308,21 @@ export function buildCoverageRows(
       if (
         coverageReset || (override !== undefined && current <= override)
       ) {
-        rows.push({ metric, status: "ovrd", current, n });
+        rows.push({ metric, status: "ovrd", current });
       } else if (!shouldGateCoverage) {
-        rows.push({ metric, status: "excl", current, n });
+        rows.push({ metric, status: "excl", current });
       } else if (current > 0) {
         const row: Row = {
           metric,
           status: "OVER",
           current,
-          median: 0,
-          n,
+          baseline: 0,
           pctIncrease: 100,
         };
         rows.push(row);
         failures.push(row);
       } else {
-        rows.push({ metric, status: "n/a", current, n });
+        rows.push({ metric, status: "n/a", current });
       }
       continue;
     }
@@ -1350,32 +1331,32 @@ export function buildCoverageRows(
       ? current > 0 ? 100 : 0
       : ((current - latestBaseline) / latestBaseline) * 100;
     const stats = {
-      median: latestBaseline,
+      baseline: latestBaseline,
       baselineSha: baselineSample?.sha,
       pctIncrease,
     };
 
     if (coverageReset) {
-      rows.push({ metric, status: "ovrd", current, n, ...stats });
+      rows.push({ metric, status: "ovrd", current, ...stats });
       continue;
     }
 
     if (override !== undefined && current <= override) {
-      rows.push({ metric, status: "ovrd", current, n, ...stats });
+      rows.push({ metric, status: "ovrd", current, ...stats });
       continue;
     }
 
     if (!shouldGateCoverage) {
-      rows.push({ metric, status: "excl", current, n, ...stats });
+      rows.push({ metric, status: "excl", current, ...stats });
       continue;
     }
 
     if (current > latestBaseline) {
-      const row: Row = { metric, status: "OVER", current, n, ...stats };
+      const row: Row = { metric, status: "OVER", current, ...stats };
       rows.push(row);
       failures.push(row);
     } else {
-      rows.push({ metric, status: "OK", current, n, ...stats });
+      rows.push({ metric, status: "OK", current, ...stats });
     }
   }
 
@@ -1384,11 +1365,11 @@ export function buildCoverageRows(
 
 export function printMetricTable(rows: Row[], includeStatus = false): void {
   const headers = includeStatus
-    ? ["Status", "Baseline", "Current", "Change", "Task", "Metric"]
-    : ["Baseline", "Current", "Change", "Task", "Metric"];
+    ? ["Status", "Baseline", "Current", "Change", "Group"]
+    : ["Baseline", "Current", "Change", "Group"];
   const align = includeStatus
-    ? ["left", "right", "right", "right", "left", "left"] as TableAlign[]
-    : ["right", "right", "right", "left", "left"] as TableAlign[];
+    ? ["left", "right", "right", "right", "left"] as TableAlign[]
+    : ["right", "right", "right", "left"] as TableAlign[];
   printTextTable(headers, metricTableRows(rows, includeStatus), align);
 }
 
@@ -1396,8 +1377,8 @@ async function extractCoverageDebtSamples(
   run: WorkflowRun,
   artifacts: Artifact[],
   coverageArtifactsDir?: string,
-): Promise<{ samples: Map<string, TimingSample>; lcov: string }> {
-  const metrics = new Map<string, TimingSample>();
+): Promise<{ samples: Map<string, BaselineSample>; lcov: string }> {
+  const metrics = new Map<string, BaselineSample>();
   const coverageArtifacts = newestArtifactsByName(artifacts.filter(
     (artifact) =>
       artifact.name.startsWith(COVERAGE_PROFILE_ARTIFACT_PREFIX) &&
@@ -1522,7 +1503,7 @@ export async function writeCoverageDebtSuggestion(
   const groups = coverageFailures
     .map((failure) => ({
       group: coverageMetricGroupName(failure.metric),
-      target: Math.round(failure.median ?? 0),
+      target: Math.round(failure.baseline ?? 0),
       current: Math.round(failure.current),
     }))
     .filter((group): group is CoverageSuggestionGroup => group.group !== null);
@@ -1607,8 +1588,8 @@ export async function writeCoverageResolved(
   prFiles: PRFile[],
 ): Promise<void> {
   const improvedLines = coverageRows.reduce((sum, row) => {
-    if (row.status !== "OK" || row.median === undefined) return sum;
-    return sum + Math.max(0, Math.round(row.median - row.current));
+    if (row.status !== "OK" || row.baseline === undefined) return sum;
+    return sum + Math.max(0, Math.round(row.baseline - row.current));
   }, 0);
 
   // Summarize the source groups this PR changed — the per-group ratchet the
@@ -1620,7 +1601,7 @@ export async function writeCoverageResolved(
   const groups: CoverageResolvedGroup[] = coverageRows
     .map((row) => ({
       group: coverageMetricGroupName(row.metric),
-      baseline: Math.round(row.median ?? 0),
+      baseline: Math.round(row.baseline ?? 0),
       current: Math.round(row.current),
     }))
     .filter((group): group is CoverageResolvedGroup =>
@@ -1721,7 +1702,7 @@ export async function main() {
 
   // 2. Extract the current run's coverage.
   const runIdNum = parseInt(runId);
-  const currentMetrics = new Map<string, TimingSample>();
+  const currentMetrics = new Map<string, BaselineSample>();
 
   // The event payload has the metadata needed for samples, so avoid spending
   // an API request on the current workflow run.
@@ -1847,33 +1828,22 @@ export async function main() {
   );
   reportBaselineRunAvailability(baselineRuns, mainHeadSha);
 
-  console.log(`Using ${baselineRuns.length} main-branch runs as baseline.`);
-
-  // 4. Read each recent main run's coverage metrics and compile cache states
-  // as the ratchet baseline, and pick up any coverage ratchet resets or
-  // per-metric acceptances from the merged PRs.
-  const timelines = new Map<string, MetricTimeline>();
-  const overridesBySha = new Map<string, BaselineOverrides>();
-  const prInfoBySha = new Map<string, PRInfo>();
-  // Compile cache states per baseline run, from tagged perf-metrics
-  // artifacts. Runs with no artifact stay absent (unknown).
-  const cacheStatesByRunId = new Map<number, CompileCacheStates>();
-
-  const baselineContexts = await githubApiOrSkip(
-    "fetching baseline run context",
-    () => buildBaselineRunContexts({ baselineRuns, mainHeadSha }),
-    currentMetrics,
+  console.log(
+    `Scanning up to ${baselineRuns.length} main-branch runs for the baseline.`,
   );
 
-  reportBaselineContextResults(baselineContexts, currentRunInfo.created_at);
-
-  // For each baseline run, its predecessor in the (newest-first) baseline
-  // list — the run whose saved compile cache it would have restored. Fuels
-  // retro-classification of a run whose perf-metrics artifact carries no
-  // recorded cache state.
+  // 4. Read recent main runs, newest first, until every metric has a ratchet
+  // baseline. A run's artifacts, compile cache state and merged-PR acceptances
+  // are fetched only when the walk reaches it, so a run whose newest baseline
+  // serves every metric reads one run rather than all of them.
   const runsNewestFirst = [...baselineRuns].sort((a, b) =>
     b.created_at.localeCompare(a.created_at) || b.id - a.id
   );
+
+  // For each baseline run, its predecessor in the newest-first list — the run
+  // whose saved compile cache it would have restored. Fuels retro-
+  // classification of a run whose perf-metrics artifact carries no recorded
+  // cache state.
   const predecessorShaByRunId = new Map<number, string>();
   for (let i = 0; i < runsNewestFirst.length - 1; i++) {
     predecessorShaByRunId.set(
@@ -1882,82 +1852,85 @@ export async function main() {
     );
   }
 
-  await githubApiOrSkip(
-    "building baseline timelines",
-    () =>
-      mapConcurrent(baselineContexts, API_CONCURRENCY, async (context) => {
-        const { run, artifacts, pr } = context;
-
-        if (pr) {
-          prInfoBySha.set(run.head_sha, pr);
-          const overrides = parseMergedBaselineOverrides(pr);
-          if (
-            overrides &&
-            (overrides.metrics.size > 0 || overrides.coverageBaselineReset)
-          ) {
-            overridesBySha.set(run.head_sha, overrides);
-          }
-        }
-
-        const artifactResult = await addCoverageBaselineFromArtifacts(
-          timelines,
-          artifacts,
-        );
-        if (artifactResult.added && artifactResult.compileCacheStates) {
-          cacheStatesByRunId.set(run.id, artifactResult.compileCacheStates);
-        } else {
-          // A run whose perf-metrics artifact is missing or carries no
-          // recorded cache state: retro-classify it from the compile
-          // fingerprint against its predecessor, so a cold main run is not
-          // picked as the coverage ratchet baseline (see
-          // recordUnstampedBaselineRunState).
-          await recordUnstampedBaselineRunState(
-            cacheStatesByRunId,
-            run,
-            predecessorShaByRunId.get(run.id),
-            pr ? `PR #${pr.number}` : run.head_sha.slice(0, 8),
-          );
-        }
-      }),
-    currentMetrics,
-  );
-
-  // Sort timelines chronologically
-  for (const timeline of timelines.values()) {
-    timeline.samples.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
-  }
-
+  // Compile cache states per baseline run, from tagged perf-metrics
+  // artifacts. Runs with no artifact stay absent (unknown).
+  const cacheStatesByRunId = new Map<number, CompileCacheStates>();
   const isRunCold = (runId: number): boolean => {
     const states = cacheStatesByRunId.get(runId);
     return states !== undefined && Object.values(states).includes("cold");
   };
 
-  const coverageBaselineAvailable = [...timelines.keys()].some(
-    isCoverageDebtMetric,
-  );
+  // What the walk read, for the diagnostics below.
+  const visitedContexts: BaselineRunContext[] = [];
+  let acceptingRuns = 0;
 
-  // Apply baseline overrides from merged PRs
-  if (overridesBySha.size > 0) {
-    console.log(
-      `Found ${overridesBySha.size} coverage baseline override(s) from merged PRs.`,
-    );
-    applyBaselineOverrides(timelines, overridesBySha);
-  }
+  const readBaselineRun = (run: WorkflowRun): Promise<BaselineRunReading> =>
+    githubApiOrSkip("reading a baseline run", async () => {
+      const context = await buildBaselineRunContext({ run, mainHeadSha });
+      visitedContexts.push(context);
+
+      const baseline = await parseCoverageBaselineFromArtifacts(
+        context.artifacts,
+      );
+      if (baseline?.compileCacheStates) {
+        cacheStatesByRunId.set(run.id, baseline.compileCacheStates);
+      } else {
+        // A run whose perf-metrics artifact is missing or carries no recorded
+        // cache state: retro-classify it from the compile fingerprint against
+        // its predecessor, so a cold main run is not picked as the coverage
+        // ratchet baseline (see recordUnstampedBaselineRunState).
+        await recordUnstampedBaselineRunState(
+          cacheStatesByRunId,
+          run,
+          predecessorShaByRunId.get(run.id),
+          context.pr ? `PR #${context.pr.number}` : run.head_sha.slice(0, 8),
+        );
+      }
+
+      const overrides = context.pr
+        ? parseMergedBaselineOverrides(context.pr)
+        : null;
+      if (
+        overrides &&
+        (overrides.metrics.size > 0 || overrides.coverageBaselineReset)
+      ) {
+        acceptingRuns++;
+      }
+
+      return {
+        samples: baseline?.metrics ?? new Map(),
+        overrides,
+        cold: isRunCold(run.id),
+      };
+    }, currentMetrics);
 
   // 5. Compare the current run's coverage debt against the ratchet baseline.
 
+  // Reported in `finally` so a baseline run that could not be read still says
+  // which runs it got to before it gave up.
   const baselineByMetric = await selectBaselines({
-    metrics: currentMetrics.keys(),
-    timelines,
-    isRunCold,
+    metrics: [...currentMetrics.keys()],
+    runs: runsNewestFirst,
+    readRun: readBaselineRun,
     isPullRequest: prNumber !== null,
     guard: (description, operation) =>
       githubApiOrSkip(description, operation, currentMetrics),
-  });
+  }).finally(() =>
+    reportBaselineContextResults(visitedContexts, currentRunInfo.created_at)
+  );
+
+  if (acceptingRuns > 0) {
+    console.log(
+      `Found ${acceptingRuns} coverage baseline override(s) from merged PRs.`,
+    );
+  }
+
+  const coverageBaselineAvailable = [...baselineByMetric.values()].some(
+    (baseline) => baseline.sample !== undefined,
+  );
 
   const { rows, failures, ungatedGroups } = buildCoverageRows({
     currentMetrics,
-    timelines,
     baselineByMetric,
     overrides: prOverrides,
     changedCoverageGroups,


### PR DESCRIPTION
The coverage-debt gate inherited its data model from the CI performance gate that was removed alongside it. That gate computed medians over timelines of timing samples drawn from twenty recent `main` runs, and the coverage gate kept the whole apparatus: it fetched artifacts, merged-PR metadata and compare-API context for all twenty runs up front, built a map of metric name to a multi-sample timeline, sorted every timeline chronologically, truncated each one at the newest commit whose merged pull request accepted that metric's debt, and then read exactly one value out of each timeline. Twenty artifact downloads and sixty API calls produced one number per metric.

The names had drifted just as far. An uncovered-line count travelled in a field called `durationSeconds`, the ratchet baseline was a field called `median`, `Row.n` recorded a sample count that no table ever printed, and `runUrl` was stored and validated on every metric record without ever being displayed. A `prInfoBySha` map was filled in and never read.

Replace the timelines with a walk. The recent `main` runs are ordered by how far back from the base-branch commit each one measured, nearest first, with runs for commits this run does not contain left out. They are then read one at a time, and each metric takes the first sample from a run that did not compile patterns from scratch. A run whose merged pull request accepted a metric's debt is the oldest baseline that metric may reach, so the walk stops there for it. When every run that measured a metric was cold, the nearest of them stands, so a metric never loses its baseline to coldness alone. The walk ends as soon as every metric has an answer, which for a typical run means reading one baseline artifact instead of twenty.

Ordering by ancestry rather than by when the runs were created is what makes stopping early safe. The two orders agree whenever each `main` run starts at the push of its commit, but not through a history rewrite and not across two pushes that land in the same second, and the old code compared ancestry distances rather than relying on it.

The walk reads runs one after another, where the old code fetched them five at a time. A run that has to walk the whole list — a pull request adding a coverage group that no `main` run has measured leaves that metric searching to the end — therefore takes longer in elapsed time than the old batched fetch did, for the same number of requests. Every other run makes a fraction of the requests, which matters beyond speed: a GitHub rate limit makes the gate skip itself entirely.

Two subtleties of the old truncation carry over. Only a run that both carries the acceptance and measured the metric closes the search, so an acceptance whose run uploaded no baseline artifact does not strand the metric. And the all-cold fallback is the newest sample within the window, not the accepting run's sample.

One acceptance case changes deliberately. A pull request that accepts coverage debt and merges while another pull request's run is still going lands on a commit that run does not contain. The old truncation applied it anyway, discarding every sample older than it — which, since all of them are older, left that run with no baseline for any coverage metric and gated nothing at all. Restricting the walk to ancestors drops that acceptance along with the run carrying it, so the run stays gated against the ancestry it does contain.

Rename the in-memory fields to say what they hold: `TimingSample` becomes `BaselineSample` with an `uncoveredLines` count, and `Row.median` becomes `Row.baseline`. The artifact on disk is untouched. It still records `durationSeconds` and `runUrl` for each metric, because a pull request branched before this change reads artifacts that runs after it write, and a run before this change wrote artifacts this code must read. `runUrl` is now derived from the run id at serialization time rather than carried through the program.

Along the way, fix a live defect this rewrite ran into. `selectBaselines()` iterated its `metrics` argument twice, and `main()` passed it `currentMetrics.keys()`. A map iterator is spent after one pass, so the second iteration saw nothing and every metric came back with no baseline and marked not comparable — which the gate reports as `excl` and never fails. The coverage ratchet has therefore been inert since the ancestry-based baseline selection landed. Both `metrics` fields are now typed as arrays, so an iterator cannot be passed at all, and the caller materializes the list.

Accepted changes to what the gate prints:

- The "Baseline source runs" group and the PR-lookup summary now describe the runs the walk actually read rather than all twenty, and they print after the walk rather than before it.
- A run that a GitHub rate limit cuts short now stops before printing either, where the old code printed them ahead of the timeline build. A baseline run that fails to read for any other reason still reports what it got to.
- `Using N main-branch runs as baseline` now reads `Scanning up to N`, because the walk usually reads one of them.
- The metric tables lose the "Task" column, which held the constant `coverage-debt` once the timing metrics went away, and the "Metric" column is now "Group". The "Change" column is unaffected.

Also delete `mapConcurrent` and `API_CONCURRENCY`, which the lazy walk leaves with no callers, and collapse the two `JSON.parse` calls that `parseCoverageBaselineDetailed()` made over the same file content.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

