### PR TITLE
docs(common): make the verb-session walkthrough match what the runtime does

### DIFF
--- a/docs/common/verb-session-walkthrough.md
+++ b/docs/common/verb-session-walkthrough.md
@@ -31,7 +31,32 @@ and its own verbs, so the thing a create hands back is itself callable.
 
 ```tsx
 // Shown for illustration only.
-/** One work item. */
+
+// ── The board ──────────────────────────────────────────────────────────────
+
+/** What a caller supplies at creation. Everything else the board derives. */
+interface BoardInput {
+  items?: ItemOutput[];
+}
+
+/** The board holds ROOT items only. Everything deeper is reached through an
+ *  item's `children`, which is why an unshaped read of `items` expands the
+ *  whole tree — the cost shaped reads exist to bound. */
+interface BoardOutput {
+  items: ItemOutput[];
+  addItem: Stream<{ title: string }, { item: ItemOutput }>;
+}
+
+// ── An item ────────────────────────────────────────────────────────────────
+
+/** What a caller supplies. `status`, `notes`, `children` and `blockedOn` are
+ *  the pattern's own state, not inputs — a caller changes them through verbs. */
+interface ItemInput {
+  title: string;
+  parent?: ItemOutput | null;
+}
+
+/** One work item, as the board projects it. */
 interface ItemOutput {
   title: string;
   /** "open" until a verb changes it — "done" or "archived". */
@@ -48,12 +73,14 @@ interface ItemOutput {
   blockedOn: ItemOutput[];
 }
 
-/** The board holds ROOT items only. Everything deeper is reached through
- *  `children`, which is why an unshaped read of `items` expands the whole
- *  tree — the cost shaped reads exist to bound. */
-interface BoardOutput {
-  items: ItemOutput[];
-  addItem: Stream<{ title: string }, { item: ItemOutput }>;
+/** An item is itself callable. This is what a create hands back, so the
+ *  address the board returns is one you can immediately call verbs on. */
+interface ItemVerbs extends ItemOutput {
+  addChild: Stream<{ title: string }, { item: ItemOutput }>;
+  recordNote: Stream<{ body: string }, { note: Note; noteCount: number }>;
+  finish: Stream<{ body?: string }, { at: number; openBelow: number }>;
+  blockOn: Stream<{ on: ItemOutput }, { blocked: ItemOutput; on: ItemOutput }>;
+  archive: Stream<void>;
 }
 ```
 

--- a/docs/common/verb-session-walkthrough.md
+++ b/docs/common/verb-session-walkthrough.md
@@ -122,12 +122,9 @@ verb's result, because
 bytes unshaped, 140 with `--select 'item.title'`.
 
 **The prose above does not reach a caller.** Each verb carries a doc comment
-saying what it is for, which is where that documentation belongs — and a
-comment on a `Stream` property is dropped in emission, so `cf piece verbs` can
-list a verb and never say what it does. Measured on this pattern: the data
-property `items` keeps "Root items only…", the verb `addItem` keeps nothing.
-It is one of three sites where an author's prose goes nowhere; step 2 has the
-full picture.
+saying what it is for, which is where that documentation belongs — and it is
+emitted correctly and then lost, so `cf piece verbs` can list a verb and never
+say what it does. Step 2 has the measurement.
 
 
 ## 1. Arrive with a slug **[today]**
@@ -188,24 +185,27 @@ The structural half needs nothing authored per pattern: `parseInputFlags`
 builds a descriptor per input-schema property, so `--title <string> Required.`
 falls out of the type. That is why the page exists at all.
 
-The prose half is dropped in emission, at three separate sites:
+The prose half is **emitted and then lost**, which is worth stating precisely
+because the obvious guess sends the fix to the wrong place:
 
-| An author writes… | Reaches the compiled pattern? | Reaches `cf`? |
+| An author writes… | In the compiled pattern | Served to `cf` |
 | --- | --- | --- |
-| a comment on an **event field** (what `title` means) | yes — `$defs.<Event>.properties.title.description` | **no, stripped** |
-| a comment on the **event interface** (what the verb is for) | **no** | no |
-| a comment on the **verb itself**, as in the model above | **no** | no |
+| a comment on an **event field** (what `title` means) | **yes** — `$defs.<Event>.properties.title.description` | no |
+| a comment on the **verb itself**, as in the model above | **yes** — beside the `$ref` | no |
+| a comment on the **event interface** (what the verb is for) | no | no |
 
-One emitter is dropping all three
-([#5637](https://github.com/commontoolsinc/labs/issues/5637)), and for two of
-them that is the whole fix: `specificFlagLines` reads a `description` through
-`schemaDescription` and would print one the moment it were given one, and a
-listing row would carry one as soon as the emitter supplied it.
+So the generator handles two of the three correctly — one pattern here carries
+descriptions on 36 `Stream` properties. What the CLI is served is the
+*resolved* form of the event schema, with no `$defs` and no `$ref`, and the
+descriptions are not in it. The loss is in that resolution, not in emission
+([#5637](https://github.com/commontoolsinc/labs/issues/5637)).
 
-The verb's *purpose* is the exception, and needs a second change. Even with a
-description on the event schema's root, `renderPieceCallHelp` has nowhere to
-put it — the page runs Usage, JSON input, Flags, Output, with no summary line,
-and `schemaDescription` is consulted only from the per-property loop.
+The renderer is ready for two of the three: `specificFlagLines` reads a
+`description` through `schemaDescription` and would print one the moment it
+were given one, and a listing row would carry one as soon as it were supplied.
+The verb's *purpose* needs a second change on top, because
+`renderPieceCallHelp` has nowhere to put it — the page runs Usage, JSON input,
+Flags, Output, with no summary line.
 
 So the help page shows `--title <string>  Required.` and stops.
 
@@ -254,10 +254,10 @@ prints the fixed string regardless.
 **A flag's prose never arrives**, per the measurement above — the renderer is
 ready for it and the generator does not supply it.
 
-**The verb's purpose is absent**, and unlike the flags it is absent from the
-source of truth as well: an event interface's own doc comment is dropped in
-emission, so there is nothing downstream to render. `cf` can say what `addItem`
-takes and not what it is for.
+**The verb's purpose is absent**, and unlike the other two it never reaches the
+compiled pattern at all, so there is nothing downstream to render even once the
+resolution is fixed. `cf` can say what `addItem` takes and not what it is
+for.
 
 ## 3. Complete against the live piece **[today]**
 
@@ -357,9 +357,9 @@ Declared results make an **output** self-describing; this is about what an
 | Gap | Needs |
 | --- | --- |
 | `Output:` claims a handler returns nothing | Nothing — it is wrong, not missing |
-| A flag's prose absent from its help page | An emission fix — the renderer already reads a `description`; the schema the CLI is served has none |
-| A verb's purpose absent from its help page | An emission fix, then a renderer one — an event interface's doc comment reaches neither, and the page has no summary line |
-| A verb's own doc comment absent everywhere | An emission fix — JSDoc survives on a data property and is dropped on a `Stream` one |
+| A flag's prose absent from its help page | Same loss as the row below — emitted into the `$def`, absent from the resolved schema the CLI is served |
+| A verb's purpose absent from its help page | A genuine emission gap, then a renderer one — an event interface's comment never compiles, and the page has no summary line |
+| A verb's own doc comment absent everywhere | Not emission — it is emitted and lost when the event `$ref` is resolved for the CLI |
 | A result field's prose | Item 1 first — there is no declared result on the wire to hang it on |
 | Result fields listed in help | A declared result |
 | `--select` completion, and refusal before the call | A declared result |

--- a/docs/common/verb-session-walkthrough.md
+++ b/docs/common/verb-session-walkthrough.md
@@ -48,9 +48,21 @@ interface BoardInput {
  *  item's `children`. */
 interface BoardOutput {
   items: ItemOutput[];
-  /** File a new root item. Takes its title; returns the item it created as a
-   *  reference, which is the address every later command in a session uses. */
-  addItem: Stream<{ title: string }, { item: ItemOutput }>;
+  /** File a new root item on the board. */
+  addItem: Stream<AddItemEvent, AddItemResult>;
+}
+
+/** A verb's event and result are named interfaces, not inline shapes, so each
+ *  parameter has somewhere to be documented. This is the only pair spelled out
+ *  here; the rest follow it. */
+interface AddItemEvent {
+  /** One line naming the work. */
+  title: string;
+}
+
+interface AddItemResult {
+  /** The root item this call created. */
+  item: ItemOutput;
 }
 
 /** What a caller supplies. `status`, `notes`, `children` and `blockedOn` are
@@ -76,30 +88,27 @@ interface ItemOutput {
    *  descendant — which is what makes one item reachable by two paths. */
   blockedOn: ItemOutput[];
 
-  /** File a new item beneath this one. Takes the child's title; returns the
-   *  child it created as a reference, so the caller can call verbs on it
-   *  without looking it up. */
-  addChild: Stream<{ title: string }, { item: ItemOutput }>;
-  /** Append a progress note. Takes the note's body; returns the note as
-   *  persisted — carrying a time the caller did not supply and could not —
-   *  and the number of notes this item holds after the append. */
-  recordNote: Stream<{ body: string }, { note: Note; noteCount: number }>;
-  /** Mark this item done. Takes an optional closing note, stamped with the
-   *  same time as the finish; returns that time and how many descendants are
-   *  still open, which takes a walk of the whole subtree to answer. */
-  finish: Stream<{ body?: string }, { at: number; openBelow: number }>;
-  /** Record that this item waits on another. Takes the blocker as a
-   *  reference, not a copy of it; returns both endpoints of the edge and how
-   *  many blockers this item now has. */
-  blockOn: Stream<
-    { on: Writable<ItemOutput> },
-    { blocked: ItemOutput; on: Writable<ItemOutput>; blockedOnCount: number }
-  >;
-  /** Mark this item archived. Takes nothing and returns nothing — the
-   *  value-less shape, for contrast with every verb above. */
+  /** File a new item beneath this one. */
+  addChild: Stream<AddChildEvent, AddChildResult>;
+  /** Append a progress note. Notes are append-only; nothing rewrites one. */
+  recordNote: Stream<RecordNoteEvent, RecordNoteResult>;
+  /** Mark this item done. Descendants are left alone — finishing a parent says
+   *  nothing about its children, which is what `openBelow` reports. */
+  finish: Stream<FinishEvent, FinishResult>;
+  /** Record that this item waits on another. The blocker may be anywhere on
+   *  the board — this is the edge that makes the tree a graph. */
+  blockOn: Stream<BlockOnEvent, BlockOnResult>;
+  /** Mark this item archived. Declares no result — the value-less shape. */
   archive: Stream<void>;
 }
 ```
+
+**A verb says what it does; its parameters describe themselves.** The comment
+on `addItem` does not restate what it takes or returns, because
+`AddItemEvent.title` and `AddItemResult.item` already say so where they are
+declared — which is also where `--help` would source a flag's prose and an
+`Output:` line. Restating it in the verb comment would be the same content
+twice, and the copy that goes stale when a parameter changes.
 
 **One interface, holding both.** An item's fields and its verbs sit together
 because that is what an item *is*: a child in `children` is a full item, and

--- a/docs/common/verb-session-walkthrough.md
+++ b/docs/common/verb-session-walkthrough.md
@@ -90,6 +90,42 @@ matter here — the same item can sit under one item's `children` and in
 another's `blockedOn`, and only an address tells a reader those are one item
 rather than two.
 
+### How a holder of an `ItemOutput` knows it can call these
+
+It does not — not from the type. `children` is declared `ItemOutput[]`, which
+carries no verbs, so a consumer holding an element cannot statically call
+`addChild` on it. That narrowing is deliberate: a receiving contract is kept to
+what it actually reads, because importing a producer's full shape couples far
+more than the relationship needs
+([composition](patterns/composition.md#keep-external-data-contracts-narrow)).
+
+**Over the CLI the question dissolves, because a caller holds an address and
+asks the piece.** Discovery is against the deployed pattern, not inferred from
+whatever type the parent used to declare the field:
+
+```bash
+cf piece verbs --piece <a child's address>
+```
+
+```text
+PATTERN cf:module/U7iaSZ…#Item
+NAME        KIND     ON
+addChild    handler  result
+archive     handler  result
+blockOn     handler  result
+finish      handler  result
+recordNote  handler  result
+```
+
+Every verb is there, and the listing names the pattern the piece is running so
+a caller can tell which version it is talking to. This is the whole reason the
+session below never needs to know a pattern's types in advance: it asks.
+
+One wrinkle a reader will hit running that command — the real listing also
+reports `$NAME`, `children`, `notes`, `parent` and `blockedOn` as handlers.
+They are data, not callables; the listing over-reports
+([#5576](https://github.com/commontoolsinc/labs/issues/5576)).
+
 The verbs, and what each one is for:
 
 | On | Verb | Changes | Hands back |

--- a/docs/common/verb-session-walkthrough.md
+++ b/docs/common/verb-session-walkthrough.md
@@ -209,6 +209,42 @@ and `schemaDescription` is consulted only from the per-property loop.
 
 So the help page shows `--title <string>  Required.` and stops.
 
+### What the page becomes **[blocked]**
+
+Nothing here needs a mechanism that does not exist — only the emitter reaching
+the sites it skips, and a verb declaring its result. Written out, because a
+surface worth building is worth being able to picture:
+
+```text
+Usage:
+  cf piece call --piece board addItem -- --title <string>
+
+File a new root item. Takes its title; returns the item it created as a
+reference, which is the address every later command in a session uses.
+
+JSON input:
+  { title: string }
+
+Flags after `--`:
+  --title <string>    Required. One line naming the work.
+
+Output:
+  item     the item this call created, as an address you can call verbs on
+```
+
+Three changes get there, and they are not one piece of work:
+
+| Line | Needs |
+| --- | --- |
+| the summary under Usage | emission of the event interface's comment, **and** a summary line in `renderPieceCallHelp` |
+| the prose beside `--title` | emission only — the renderer already prints a `description` |
+| the `Output:` fields | a verb's declared result reaching the runtime (verbs plan item 1), then emission of the result fields' comments |
+
+The first two are unblocked. The third has a prerequisite: a handler has no
+declared result on the wire at all yet, so there is nowhere to hang a result
+field's description even if the emitter kept one
+([#5637](https://github.com/commontoolsinc/labs/issues/5637)).
+
 Three things are wrong with that page rather than missing from it.
 
 **`Output:` is false.** `addItem` declares a result and returns one; the value
@@ -322,8 +358,9 @@ Declared results make an **output** self-describing; this is about what an
 | --- | --- |
 | `Output:` claims a handler returns nothing | Nothing — it is wrong, not missing |
 | A flag's prose absent from its help page | An emission fix — the renderer already reads a `description`; the schema the CLI is served has none |
-| A verb's purpose absent from its help page | An emission fix, then a renderer one — an event interface's doc comment reaches neither |
+| A verb's purpose absent from its help page | An emission fix, then a renderer one — an event interface's doc comment reaches neither, and the page has no summary line |
 | A verb's own doc comment absent everywhere | An emission fix — JSDoc survives on a data property and is dropped on a `Stream` one |
+| A result field's prose | Item 1 first — there is no declared result on the wire to hang it on |
 | Result fields listed in help | A declared result |
 | `--select` completion, and refusal before the call | A declared result |
 | An address accepted as an argument | The round-trip property above |

--- a/docs/common/verb-session-walkthrough.md
+++ b/docs/common/verb-session-walkthrough.md
@@ -8,8 +8,11 @@ into the next.
 This walks a whole session using it, and marks where the surface is still
 incomplete.
 
-The subject is a work-item tracker — items in a tree, plus typed cross-links —
-sketched here rather than deployed. No pattern file backs it yet.
+The subject is a work-item tracker — items in a tree, plus typed cross-links.
+It is a real pattern: `packages/cli/integration/pattern/tracker.tsx`, which
+belongs to this document and the two scripts beside it, so a change to a
+pattern the product ships can never break a demonstration of the verb surface.
+Every measurement below was taken against it on a local toolshed.
 
 **Every step is marked for what is real.** The point of the document is the
 line between them.
@@ -17,8 +20,11 @@ line between them.
 | Mark | Meaning |
 | --- | --- |
 | **[today]** | works against a current build |
-| **[stack]** | built and merging incrementally: the `$link` marker has landed, so these steps are reachable today through a full `--schema`. What is pending is the concise `--select` spelling and its arrival on `piece call` ([the verbs plan](../plans/verbs-implementation.md) tracks the order) |
 | **[blocked]** | needs something decided or built |
+
+The read layer this document was drafted against has since landed in full: the
+concise `--select` spelling, the `@` address suffix, and their arrival on
+`piece call` all work today, so no step here is merely pending.
 
 Section headers inside the help output below are the literal strings
 `renderPieceCallHelp` emits (`packages/cli/lib/exec-schema.ts`). Their contents
@@ -137,12 +143,20 @@ cf piece verbs --piece board
 ```
 
 ```text
-pattern  tracker.tsx @ src:9f2a…
-NAME     KIND     ON
-$NAME    handler  result
-addItem  handler  result
-items    handler  result
+PATTERN cf:module/ZPxyGdkkv-YmizdHdNx5DIlqlpc9JRSm5iXTl4Tb2T0#default
+NAME    KIND    ON     MARKS
+$NAME   handler result
+addItem handler result
+items   handler result
 ```
+
+**Two of those three rows are not verbs.** `items` is the board's array of root
+items and `$NAME` is its display name — data, not callables, and
+`cf piece call --piece board items` will not do anything useful. The listing
+over-reports: its forced-stream fallback answers the cast for values that are
+not streams
+([#5576](https://github.com/commontoolsinc/labs/issues/5576)). Only `addItem`
+is real here.
 
 Slug resolution sits on the shared path (`resolvePieceConfigWithPieces`,
 `packages/cli/lib/piece.ts`), so every command below takes `board` too.
@@ -181,8 +195,9 @@ can currently say about a verb, and the split is worth holding onto:
 | flag name, placeholder, required-ness | the event's **type** — `{ title: string }` | **yes** |
 | what `title` means, what the verb is for | the author's **doc comments** | **no** |
 
-The structural half needs nothing authored per pattern: `parseInputFlags`
-builds a descriptor per input-schema property, so `--title <string> Required.`
+The structural half needs nothing authored per pattern:
+`parseObjectInput` builds a `FlagDescriptor` per input-schema property, so
+`--title <string> Required.`
 falls out of the type. That is why the page exists at all.
 
 The prose half is **emitted and then lost**, which is worth stating precisely
@@ -273,7 +288,7 @@ Verb names and piece addresses complete against the space
 What does not complete is a result field — `--select 'it<TAB>'` has nothing to
 offer, because nothing in the system knows the result has a field called `item`.
 
-## 4. Create, and carry the address forward **[stack]**
+## 4. Create, and carry the address forward **[today]**
 
 ```bash
 EPIC=$(cf piece call --piece board addItem -- --title "Login rewrite" \
@@ -297,12 +312,22 @@ position renders the address and suppresses the fetch without consulting a
 source schema at all. What a declared result would add is that `cf` could
 derive the selection instead of the caller supplying it.
 
-## 5. Read the tree back, bounded **[stack]**
+## 5. Read the tree back, bounded **[today]**
 
 ```bash
-cf piece get --piece board items \
-  --select 'title,status,children@' \
+cf piece get --piece board items --select 'title,status,children@'
+
+cf piece get --piece board items --select 'title,status' \
   --filter '.status != "done"'
+```
+
+Two commands rather than one, because **an `@` suffix and `--filter` are
+refused together**, with a reason worth keeping:
+
+```text
+--filter cannot be combined with an `@` suffix in --select: a filtered array's
+elements no longer say which positions they came from, and an address names a
+position
 ```
 
 `--filter` runs before projection, so `status` decides membership and need not
@@ -365,8 +390,7 @@ Declared results make an **output** self-describing; this is about what an
 | `--select` completion, and refusal before the call | A declared result |
 | An address accepted as an argument | The round-trip property above |
 
-Three of the six need no decision at all, and three of them are the same
-mechanism seen from different sides: an author writes prose about a verb — on
-its event interface, on an event field, on the verb itself — and none of it
-reaches a caller. That is one emission gap with three symptoms, not three
-bugs.
+Eight rows, six distinct gaps: the three prose rows are one problem seen from
+three sides — an author writes about a verb on its event interface, on an event
+field, or on the verb itself, and none of it reaches a caller. Of the six,
+three need no decision from anyone.

--- a/docs/common/verb-session-walkthrough.md
+++ b/docs/common/verb-session-walkthrough.md
@@ -226,9 +226,9 @@ So the help page shows `--title <string>  Required.` and stops.
 
 ### What the page becomes **[blocked]**
 
-Nothing here needs a mechanism that does not exist — only the emitter reaching
-the sites it skips, and a verb declaring its result. Written out, because a
-surface worth building is worth being able to picture:
+Every line below already exists as a doc comment in `tracker.tsx`. Nothing here
+is invented for the illustration — this is that file's own prose, reaching a
+caller:
 
 ```text
 Usage:
@@ -244,21 +244,27 @@ Flags after `--`:
   --title <string>    Required. One line naming the work.
 
 Output:
-  item     the item this call created, as an address you can call verbs on
+  item     The root item this call created.
 ```
 
-Three changes get there, and they are not one piece of work:
+Where each line comes from, and what stands between it and the page:
 
-| Line | Needs |
-| --- | --- |
-| the summary under Usage | emission of the event interface's comment, **and** a summary line in `renderPieceCallHelp` |
-| the prose beside `--title` | emission only — the renderer already prints a `description` |
-| the `Output:` fields | a verb's declared result reaching the runtime (verbs plan item 1), then emission of the result fields' comments |
+| Line | Its source in `tracker.tsx` | What is in the way |
+| --- | --- | --- |
+| the summary | the comment on the **verb** — `addItem: Stream<…>` | it is emitted, beside the `$ref`, and lost when that ref is resolved for the CLI; the page also has no summary line to print it on |
+| the prose beside `--title` | the comment on the **event field** — `AddItemEvent.title` | the same resolution loss; the renderer is already ready for it |
+| the `Output:` field | the comment on the **result field** — `AddItemResult.item` | no declared result reaches the runtime yet, so there is nowhere for it to travel (verbs plan item 1) |
 
-The first two are unblocked. The third has a prerequisite: a handler has no
-declared result on the wire at all yet, so there is nowhere to hang a result
-field's description even if the emitter kept one
+Two of the three are the same loss and would come back together. The third
+waits on item 1 — a handler has no declared result on the wire at all, so the
+comment has nothing to ride on
 ([#5637](https://github.com/commontoolsinc/labs/issues/5637)).
+
+The summary is worth one more note. An event *interface's* comment would be the
+other candidate for that line, and it is the one thing here that genuinely
+never compiles — so sourcing the summary from the verb's own comment, which is
+already emitted, is both the smaller change and the better place for an author
+to write it.
 
 Three things are wrong with that page rather than missing from it.
 
@@ -267,12 +273,12 @@ arrives on `invocation.result`. The handler branch of `renderPieceCallHelp`
 prints the fixed string regardless.
 
 **A flag's prose never arrives**, per the measurement above — the renderer is
-ready for it and the generator does not supply it.
+ready for it and the resolution does not carry it.
 
-**The verb's purpose is absent**, and unlike the other two it never reaches the
-compiled pattern at all, so there is nothing downstream to render even once the
-resolution is fixed. `cf` can say what `addItem` takes and not what it is
-for.
+**The verb's purpose is absent** for the same reason, not a different one: its
+comment is emitted and lost in the same step, and the page has no summary line
+to print it on even once it survives. `cf` can say what `addItem` takes and not
+what it is for.
 
 ## 3. Complete against the live piece **[today]**
 

--- a/docs/common/verb-session-walkthrough.md
+++ b/docs/common/verb-session-walkthrough.md
@@ -66,36 +66,49 @@ JSON input:
   { title: string; parent?: string }
 
 Flags after `--`:
-  --title <string>    Required. One line naming the work.
-  --parent <string>   Optional. Where the item files. Omit for a root item.
+  --title <string>    Required.
+  --parent <string>   Optional.
 
 Output:
   No output on success.
 ```
 
-The flags, their types, their required-ness and their descriptions are all
-derived. Nothing is authored per pattern: `parseInputFlags` builds a descriptor
-per input-schema property, and the prose comes from the author's JSDoc, which
-the schema generator attaches as `description`.
+The flags, their types and their required-ness are derived. Nothing is authored
+per pattern: `parseInputFlags` builds a descriptor per input-schema property.
+
+**The prose is not there, and that is measured.** `specificFlagLines` *would*
+render a `description` beside each flag — it reads one through
+`schemaDescription` — but no description ever reaches it. Write both kinds of
+JSDoc on an event and neither arrives:
 
 ```tsx
 // Shown as interface or class members.
 /** One line naming the work. */
 title: string;
-/** Where the item files. Omit for a root item. */
-parent?: string;
 ```
 
-Two things are wrong with that page rather than missing from it.
+- A **property** comment reaches the compiled pattern, where
+  `$defs.<Event>.properties.title.description` carries it, and is **stripped**
+  from the schema `cf piece call … --help` reads. Same schema, no description.
+- An **interface-level** comment — the one that would say what the verb is
+  *for* — does not reach the compiled pattern at all. Its `$defs.<Event>`
+  entry has no `description`.
+
+So the help page shows `--title <string>  Required.` and stops.
+
+Three things are wrong with that page rather than missing from it.
 
 **`Output:` is false.** `add` declares a result and returns one; the value
 arrives on `invocation.result`. The handler branch of `renderPieceCallHelp`
 prints the fixed string regardless.
 
-**The verb's purpose is absent.** A JSDoc comment on the event interface becomes
-a root-level `description` on the schema, and `cf piece verbs --json` carries it
-over the wire — but `schemaDescription` is consulted only per property, so the
-rendered page drops it. `cf` can say what `add` takes and not what it is for.
+**A flag's prose never arrives**, per the measurement above — the renderer is
+ready for it and the generator does not supply it.
+
+**The verb's purpose is absent**, and unlike the flags it is absent from the
+source of truth as well: an event interface's own doc comment is dropped in
+emission, so there is nothing downstream to render. `cf` can say what `add`
+takes and not what it is for.
 
 ## 3. Complete against the live piece **[today]**
 
@@ -195,7 +208,8 @@ Declared results make an **output** self-describing; this is about what an
 | Gap | Needs |
 | --- | --- |
 | `Output:` claims a handler returns nothing | Nothing — it is wrong, not missing |
-| A verb's purpose absent from its help page | Nothing — the description is already in the schema and on the wire |
+| A flag's prose absent from its help page | An emission fix — the renderer already reads a `description`; the schema the CLI is served has none |
+| A verb's purpose absent from its help page | An emission fix, then a renderer one — an event interface's doc comment reaches neither |
 | Result fields listed in help | A declared result |
 | `--select` completion, and refusal before the call | A declared result |
 | An address accepted as an argument | The round-trip property above |

--- a/docs/common/verb-session-walkthrough.md
+++ b/docs/common/verb-session-walkthrough.md
@@ -26,13 +26,12 @@ are illustrative.
 
 ## What you are driving
 
-Two patterns. A **board** holds root items; an **item** holds its own subtree
-and its own verbs, so the thing a create hands back is itself callable.
+Two patterns. A **board** holds root items; an **item** holds its own subtree,
+its own graph edges, and its own verbs — so the thing a create hands back is
+itself callable, with no separate lookup.
 
 ```tsx
 // Shown for illustration only.
-
-// ── The board ──────────────────────────────────────────────────────────────
 
 /** What a caller supplies at creation. Everything else the board derives. */
 interface BoardInput {
@@ -40,14 +39,12 @@ interface BoardInput {
 }
 
 /** The board holds ROOT items only. Everything deeper is reached through an
- *  item's `children`, which is why an unshaped read of `items` expands the
- *  whole tree — the cost shaped reads exist to bound. */
+ *  item's `children`. */
 interface BoardOutput {
   items: ItemOutput[];
+  /** File a new root item. Returns the item it created. */
   addItem: Stream<{ title: string }, { item: ItemOutput }>;
 }
-
-// ── An item ────────────────────────────────────────────────────────────────
 
 /** What a caller supplies. `status`, `notes`, `children` and `blockedOn` are
  *  the pattern's own state, not inputs — a caller changes them through verbs. */
@@ -56,7 +53,7 @@ interface ItemInput {
   parent?: ItemOutput | null;
 }
 
-/** One work item, as the board projects it. */
+/** One work item: what it holds, and what it can do. */
 interface ItemOutput {
   title: string;
   /** "open" until a verb changes it — "done" or "archived". */
@@ -71,75 +68,54 @@ interface ItemOutput {
   /** The graph. A blocker is any item anywhere on the board, not a
    *  descendant — which is what makes one item reachable by two paths. */
   blockedOn: ItemOutput[];
-}
 
-/** An item is itself callable. This is what a create hands back, so the
- *  address the board returns is one you can immediately call verbs on. */
-interface ItemVerbs extends ItemOutput {
+  /** File a new item beneath this one. Returns the item it created. */
   addChild: Stream<{ title: string }, { item: ItemOutput }>;
+  /** Append a progress note. Returns it with the time the pattern stamped. */
   recordNote: Stream<{ body: string }, { note: Note; noteCount: number }>;
+  /** Mark this done. Returns how many descendants are still open. */
   finish: Stream<{ body?: string }, { at: number; openBelow: number }>;
+  /** Record that this item waits on another. Returns both endpoints. */
   blockOn: Stream<{ on: ItemOutput }, { blocked: ItemOutput; on: ItemOutput }>;
+  /** Mark archived. Returns nothing — the value-less shape. */
   archive: Stream<void>;
 }
 ```
 
-Every field above is a **reference**, not a copy: `children` holds links to
-item pieces, and so does `blockedOn`. That is the whole reason addresses
-matter here — the same item can sit under one item's `children` and in
-another's `blockedOn`, and only an address tells a reader those are one item
-rather than two.
+**One interface, holding both.** An item's fields and its verbs sit together
+because that is what an item *is*: a child in `children` is a full item, and
+declaring it any narrower would be a claim the runtime contradicts — ask that
+child what it can do and it lists all five.
 
-### How a holder of an `ItemOutput` knows it can call these
+**Every field is a reference, not a copy.** `children` holds links to item
+pieces, and so does `blockedOn`. That is the whole reason addresses matter
+here: the same item can sit under one item's `children` and in another's
+`blockedOn`, and only an address tells a reader those are one item rather than
+two.
 
-It does not — not from the type. `children` is declared `ItemOutput[]`, which
-carries no verbs, so a consumer holding an element cannot statically call
-`addChild` on it. That narrowing is deliberate: a receiving contract is kept to
-what it actually reads, because importing a producer's full shape couples far
-more than the relationship needs
-([composition](patterns/composition.md#keep-external-data-contracts-narrow)).
-
-**Over the CLI the question dissolves, because a caller holds an address and
-asks the piece.** Discovery is against the deployed pattern, not inferred from
-whatever type the parent used to declare the field:
+**Which makes an unshaped read expensive, on purpose.** Reading `children` with
+no selection carries every field *and* a link envelope per verb per element —
+measured at 3183 bytes for a single child on this pattern. Naming what you want
+brings it to 51:
 
 ```bash
-cf piece verbs --piece <a child's address>
+cf piece get --piece <item> children --select 'title,status'
 ```
 
-```text
-PATTERN cf:module/U7iaSZ…#Item
-NAME        KIND     ON
-addChild    handler  result
-archive     handler  result
-blockOn     handler  result
-finish      handler  result
-recordNote  handler  result
-```
+That is not a workaround; it is the read model working. A schema is a query,
+and a caller who names nothing has asked for everything. The same flags shape a
+verb's result, because
+[a result is a read on a different cell](../plans/fabric-read-model.md) — 1743
+bytes unshaped, 140 with `--select 'item.title'`.
 
-Every verb is there, and the listing names the pattern the piece is running so
-a caller can tell which version it is talking to. This is the whole reason the
-session below never needs to know a pattern's types in advance: it asks.
+**The prose above does not reach a caller.** Each verb carries a doc comment
+saying what it is for, which is where that documentation belongs — and none of
+it survives emission. A JSDoc comment on a *data* property reaches the compiled
+pattern; on a `Stream` property it is dropped. Measured on this pattern:
+`items` keeps "Root items only…", `addItem` keeps nothing. So `cf piece verbs`
+can list a verb and never say what it does. See step 2 for the two related
+losses on the input side.
 
-One wrinkle a reader will hit running that command — the real listing also
-reports `$NAME`, `children`, `notes`, `parent` and `blockedOn` as handlers.
-They are data, not callables; the listing over-reports
-([#5576](https://github.com/commontoolsinc/labs/issues/5576)).
-
-The verbs, and what each one is for:
-
-| On | Verb | Changes | Hands back |
-| --- | --- | --- | --- |
-| board | `addItem` | files a new root item | the item it created |
-| item | `addChild` | files an item beneath this one | the item it created |
-| item | `recordNote` | appends a note | the note, with the time it stamped |
-| item | `finish` | marks done, optionally notes why | the time, and how many descendants are still open |
-| item | `blockOn` | records that this waits on another item | both endpoints of the edge |
-| item | `archive` | marks archived | nothing — the value-less shape |
-
-`finish` is worth singling out: **`openBelow` is the count of open items
-anywhere beneath this one**, which a caller cannot compute without walking the
-whole subtree. That is the shape of thing a verb result is for.
 
 ## 1. Arrive with a slug **[today]**
 
@@ -324,8 +300,13 @@ Declared results make an **output** self-describing; this is about what an
 | `Output:` claims a handler returns nothing | Nothing — it is wrong, not missing |
 | A flag's prose absent from its help page | An emission fix — the renderer already reads a `description`; the schema the CLI is served has none |
 | A verb's purpose absent from its help page | An emission fix, then a renderer one — an event interface's doc comment reaches neither |
+| A verb's own doc comment absent everywhere | An emission fix — JSDoc survives on a data property and is dropped on a `Stream` one |
 | Result fields listed in help | A declared result |
 | `--select` completion, and refusal before the call | A declared result |
 | An address accepted as an argument | The round-trip property above |
 
-Three of the five need no decision.
+Three of the six need no decision at all, and three of them are the same
+mechanism seen from different sides: an author writes prose about a verb — on
+its event interface, on an event field, on the verb itself — and none of it
+reaches a caller. That is one emission gap with three symptoms, not three
+bugs.

--- a/docs/common/verb-session-walkthrough.md
+++ b/docs/common/verb-session-walkthrough.md
@@ -42,7 +42,8 @@ interface BoardInput {
  *  item's `children`. */
 interface BoardOutput {
   items: ItemOutput[];
-  /** File a new root item. Returns the item it created. */
+  /** File a new root item. Takes its title; returns the item it created as a
+   *  reference, which is the address every later command in a session uses. */
   addItem: Stream<{ title: string }, { item: ItemOutput }>;
 }
 
@@ -69,15 +70,27 @@ interface ItemOutput {
    *  descendant — which is what makes one item reachable by two paths. */
   blockedOn: ItemOutput[];
 
-  /** File a new item beneath this one. Returns the item it created. */
+  /** File a new item beneath this one. Takes the child's title; returns the
+   *  child it created as a reference, so the caller can call verbs on it
+   *  without looking it up. */
   addChild: Stream<{ title: string }, { item: ItemOutput }>;
-  /** Append a progress note. Returns it with the time the pattern stamped. */
+  /** Append a progress note. Takes the note's body; returns the note as
+   *  persisted — carrying a time the caller did not supply and could not —
+   *  and the number of notes this item holds after the append. */
   recordNote: Stream<{ body: string }, { note: Note; noteCount: number }>;
-  /** Mark this done. Returns how many descendants are still open. */
+  /** Mark this item done. Takes an optional closing note, stamped with the
+   *  same time as the finish; returns that time and how many descendants are
+   *  still open, which takes a walk of the whole subtree to answer. */
   finish: Stream<{ body?: string }, { at: number; openBelow: number }>;
-  /** Record that this item waits on another. Returns both endpoints. */
-  blockOn: Stream<{ on: ItemOutput }, { blocked: ItemOutput; on: ItemOutput }>;
-  /** Mark archived. Returns nothing — the value-less shape. */
+  /** Record that this item waits on another. Takes the blocker as a
+   *  reference, not a copy of it; returns both endpoints of the edge and how
+   *  many blockers this item now has. */
+  blockOn: Stream<
+    { on: Writable<ItemOutput> },
+    { blocked: ItemOutput; on: Writable<ItemOutput>; blockedOnCount: number }
+  >;
+  /** Mark this item archived. Takes nothing and returns nothing — the
+   *  value-less shape, for contrast with every verb above. */
   archive: Stream<void>;
 }
 ```

--- a/docs/common/verb-session-walkthrough.md
+++ b/docs/common/verb-session-walkthrough.md
@@ -234,8 +234,7 @@ caller:
 Usage:
   cf piece call --piece board addItem -- --title <string>
 
-File a new root item. Takes its title; returns the item it created as a
-reference, which is the address every later command in a session uses.
+File a new root item on the board.
 
 JSON input:
   { title: string }
@@ -247,18 +246,31 @@ Output:
   item     The root item this call created.
 ```
 
-Where each line comes from, and what stands between it and the page:
+**Three levels of documentation, three different fates.** An author writes each
+one where the thing it describes is declared — the verb says what it does, and
+each parameter describes itself:
 
-| Line | Its source in `tracker.tsx` | What is in the way |
-| --- | --- | --- |
-| the summary | the comment on the **verb** — `addItem: Stream<…>` | it is emitted, beside the `$ref`, and lost when that ref is resolved for the CLI; the page also has no summary line to print it on |
-| the prose beside `--title` | the comment on the **event field** — `AddItemEvent.title` | the same resolution loss; the renderer is already ready for it |
-| the `Output:` field | the comment on the **result field** — `AddItemResult.item` | no declared result reaches the runtime yet, so there is nowhere for it to travel (verbs plan item 1) |
+| Level | Written on | Compiled? | Reaches `cf`? |
+| --- | --- | --- | --- |
+| the verb — *what it does* | the `Stream` property | **yes**, beside the `$ref` | no |
+| an **input** parameter | a field of the event interface | **yes**, in `$defs.<Event>.properties` | no |
+| an **output** parameter | a field of the result interface | **no** | no |
 
-Two of the three are the same loss and would come back together. The third
-waits on item 1 — a handler has no declared result on the wire at all, so the
-comment has nothing to ride on
+The first two are the same loss: emitted, then absent from the resolved schema
+the CLI is served, so they come back together
 ([#5637](https://github.com/commontoolsinc/labs/issues/5637)).
+
+The third is different in kind, and it is the one worth understanding. There is
+no structured description of an output parameter *anywhere*, no matter what the
+author writes — because the result type is not compiled at all. `Stream<E, R>`
+compiles `E` and drops `R`, so `$defs` on this pattern holds
+`AddItemEvent`, `AddChildEvent`, `BlockOnEvent`, `FinishEvent`,
+`RecordNoteEvent` and no `Result` interface of any kind. A comment on
+`AddItemResult.item` has nothing to be attached to.
+
+That is verbs plan item 1 — a verb's declared result reaching the runtime —
+and until it lands, output documentation has no home rather than a broken
+pipe.
 
 The summary is worth one more note. An event *interface's* comment would be the
 other candidate for that line, and it is the one thing here that genuinely

--- a/docs/common/verb-session-walkthrough.md
+++ b/docs/common/verb-session-walkthrough.md
@@ -122,12 +122,12 @@ verb's result, because
 bytes unshaped, 140 with `--select 'item.title'`.
 
 **The prose above does not reach a caller.** Each verb carries a doc comment
-saying what it is for, which is where that documentation belongs — and none of
-it survives emission. A JSDoc comment on a *data* property reaches the compiled
-pattern; on a `Stream` property it is dropped. Measured on this pattern:
-`items` keeps "Root items only…", `addItem` keeps nothing. So `cf piece verbs`
-can list a verb and never say what it does. See step 2 for the two related
-losses on the input side.
+saying what it is for, which is where that documentation belongs — and a
+comment on a `Stream` property is dropped in emission, so `cf piece verbs` can
+list a verb and never say what it does. Measured on this pattern: the data
+property `items` keeps "Root items only…", the verb `addItem` keeps nothing.
+It is one of three sites where an author's prose goes nowhere; step 2 has the
+full picture.
 
 
 ## 1. Arrive with a slug **[today]**
@@ -176,26 +176,36 @@ Output:
   No output on success.
 ```
 
-The flags, their types and their required-ness are derived. Nothing is authored
-per pattern: `parseInputFlags` builds a descriptor per input-schema property.
+**Structure is published; prose is not.** That line is the whole of what `cf`
+can currently say about a verb, and the split is worth holding onto:
 
-**The prose is not there, and that is measured.** `specificFlagLines` *would*
-render a `description` beside each flag — it reads one through
-`schemaDescription` — but no description ever reaches it. Write both kinds of
-JSDoc on an event and neither arrives:
+| | Where it comes from | Survives? |
+| --- | --- | --- |
+| flag name, placeholder, required-ness | the event's **type** — `{ title: string }` | **yes** |
+| what `title` means, what the verb is for | the author's **doc comments** | **no** |
 
-```tsx
-// Shown as interface or class members.
-/** One line naming the work. */
-title: string;
-```
+The structural half needs nothing authored per pattern: `parseInputFlags`
+builds a descriptor per input-schema property, so `--title <string> Required.`
+falls out of the type. That is why the page exists at all.
 
-- A **property** comment reaches the compiled pattern, where
-  `$defs.<Event>.properties.title.description` carries it, and is **stripped**
-  from the schema `cf piece call … --help` reads. Same schema, no description.
-- An **interface-level** comment — the one that would say what the verb is
-  *for* — does not reach the compiled pattern at all. Its `$defs.<Event>`
-  entry has no `description`.
+The prose half is dropped in emission, at three separate sites:
+
+| An author writes… | Reaches the compiled pattern? | Reaches `cf`? |
+| --- | --- | --- |
+| a comment on an **event field** (what `title` means) | yes — `$defs.<Event>.properties.title.description` | **no, stripped** |
+| a comment on the **event interface** (what the verb is for) | **no** | no |
+| a comment on the **verb itself**, as in the model above | **no** | no |
+
+One emitter is dropping all three
+([#5637](https://github.com/commontoolsinc/labs/issues/5637)), and for two of
+them that is the whole fix: `specificFlagLines` reads a `description` through
+`schemaDescription` and would print one the moment it were given one, and a
+listing row would carry one as soon as the emitter supplied it.
+
+The verb's *purpose* is the exception, and needs a second change. Even with a
+description on the event schema's root, `renderPieceCallHelp` has nowhere to
+put it — the page runs Usage, JSON input, Flags, Output, with no summary line,
+and `schemaDescription` is consulted only from the per-property loop.
 
 So the help page shows `--title <string>  Required.` and stops.
 

--- a/docs/common/verb-session-walkthrough.md
+++ b/docs/common/verb-session-walkthrough.md
@@ -24,6 +24,60 @@ Section headers inside the help output below are the literal strings
 `renderPieceCallHelp` emits (`packages/cli/lib/exec-schema.ts`). Their contents
 are illustrative.
 
+## What you are driving
+
+Two patterns. A **board** holds root items; an **item** holds its own subtree
+and its own verbs, so the thing a create hands back is itself callable.
+
+```tsx
+// Shown for illustration only.
+/** One work item. */
+interface ItemOutput {
+  title: string;
+  /** "open" until a verb changes it — "done" or "archived". */
+  status: string;
+  /** Append-only. Each entry carries a time the pattern stamped, not the
+   *  caller: reading the clock is a handler capability. */
+  notes: { body: string; at: number }[];
+  /** Null at a root. Carried so a caller can walk up as well as down. */
+  parent: ItemOutput | null;
+  /** The tree. */
+  children: ItemOutput[];
+  /** The graph. A blocker is any item anywhere on the board, not a
+   *  descendant — which is what makes one item reachable by two paths. */
+  blockedOn: ItemOutput[];
+}
+
+/** The board holds ROOT items only. Everything deeper is reached through
+ *  `children`, which is why an unshaped read of `items` expands the whole
+ *  tree — the cost shaped reads exist to bound. */
+interface BoardOutput {
+  items: ItemOutput[];
+  addItem: Stream<{ title: string }, { item: ItemOutput }>;
+}
+```
+
+Every field above is a **reference**, not a copy: `children` holds links to
+item pieces, and so does `blockedOn`. That is the whole reason addresses
+matter here — the same item can sit under one item's `children` and in
+another's `blockedOn`, and only an address tells a reader those are one item
+rather than two.
+
+The verbs, and what each one is for:
+
+| On | Verb | Changes | Hands back |
+| --- | --- | --- | --- |
+| board | `addItem` | files a new root item | the item it created |
+| item | `addChild` | files an item beneath this one | the item it created |
+| item | `recordNote` | appends a note | the note, with the time it stamped |
+| item | `finish` | marks done, optionally notes why | the time, and how many descendants are still open |
+| item | `blockOn` | records that this waits on another item | both endpoints of the edge |
+| item | `archive` | marks archived | nothing — the value-less shape |
+
+`finish` is worth singling out: **`openBelow` is the count of open items
+anywhere beneath this one**, which a caller cannot compute without walking the
+whole subtree. That is the shape of thing a verb result is for.
+
 ## 1. Arrive with a slug **[today]**
 
 An address a person can type, rather than a fid from a previous command.
@@ -36,11 +90,9 @@ cf piece verbs --piece board
 ```text
 pattern  tracker.tsx @ src:9f2a…
 NAME     KIND     ON
-add      handler  result
-block    handler  result
-note     handler  result
-remove   handler  result
-rollup   tool     result
+$NAME    handler  result
+addItem  handler  result
+items    handler  result
 ```
 
 Slug resolution sits on the shared path (`resolvePieceConfigWithPieces`,
@@ -52,22 +104,21 @@ client tells it is talking to a newer pattern than it was written against.
 ## 2. Ask what a verb wants **[today]**
 
 ```bash
-cf piece call --piece board add --help
+cf piece call --piece board addItem -- --help
 ```
 
 ```text
 Usage:
-  cf piece call --piece board add --help
-  cf piece call --piece board add <json>
-  cf piece call --piece board add -- --title <string> [--parent <string>]
+  cf piece call --piece board addItem -- --help
+  cf piece call --piece board addItem <json>
+  cf piece call --piece board addItem -- --title <string>
 
 JSON input:
   Pass inline JSON as one positional argument or after `--json`.
-  { title: string; parent?: string }
+  { title: string }
 
 Flags after `--`:
   --title <string>    Required.
-  --parent <string>   Optional.
 
 Output:
   No output on success.
@@ -98,7 +149,7 @@ So the help page shows `--title <string>  Required.` and stops.
 
 Three things are wrong with that page rather than missing from it.
 
-**`Output:` is false.** `add` declares a result and returns one; the value
+**`Output:` is false.** `addItem` declares a result and returns one; the value
 arrives on `invocation.result`. The handler branch of `renderPieceCallHelp`
 prints the fixed string regardless.
 
@@ -107,14 +158,14 @@ ready for it and the generator does not supply it.
 
 **The verb's purpose is absent**, and unlike the flags it is absent from the
 source of truth as well: an event interface's own doc comment is dropped in
-emission, so there is nothing downstream to render. `cf` can say what `add`
+emission, so there is nothing downstream to render. `cf` can say what `addItem`
 takes and not what it is for.
 
 ## 3. Complete against the live piece **[today]**
 
 ```bash
 cf piece call --piece board <TAB>
-add  block  note  remove  rollup
+addItem  items  $NAME
 ```
 
 Verb names and piece addresses complete against the space
@@ -127,11 +178,11 @@ offer, because nothing in the system knows the result has a field called `item`.
 ## 4. Create, and carry the address forward **[stack]**
 
 ```bash
-EPIC=$(cf piece call --piece board add -- --title "Login rewrite" \
+EPIC=$(cf piece call --piece board addItem -- --title "Login rewrite" \
        --select 'item@' | jq -r '.result.item."$link".id')
 
-cf piece call --piece "$EPIC" add -- --title "Session cookie handling"
-cf piece call --piece "$EPIC" note -- --body "Blocked on the cookie spec"
+cf piece call --piece "$EPIC" addChild -- --title "Session cookie handling"
+cf piece call --piece "$EPIC" recordNote -- --body "Blocked on the cookie spec"
 ```
 
 **This is the composition the surface exists for.** A create hands back the
@@ -168,7 +219,7 @@ read layer, several arrivals.
 ## 6. Relate two items **[blocked]**
 
 ```bash
-cf piece call --piece "$EPIC" block --on "$OTHER"
+cf piece call --piece "$EPIC" blockOn -- --on "$OTHER"
 ```
 
 This is where the session stops.
@@ -190,7 +241,7 @@ arrives as a string the pattern cannot resolve into a reference.
 A tree mostly hides this, because the natural shape is to call the verb *on* the
 parent — the receiver carries the relationship, so no address needs to be an
 argument. It surfaces the moment two items must be related to each other:
-`block`, `duplicates`, `move`, or a `remove` that names a child rather than an
+`blockOn`, a `duplicates` edge, a `move`, or a removal that names a child rather than an
 index. Indices are not addresses; a position shifts under concurrent writes.
 
 [CLI surface shape](../plans/cli-surface-shape.md) states the property for


### PR DESCRIPTION
One file, `docs/common/verb-session-walkthrough.md`. It grew past its original scope — it began as a single correction and became most of a rewrite, because building the demo it describes kept measuring claims that turned out to be false.

## Why

The document was written before the fixture existed, and the fixture then moved without it. Four things in it were wrong, and three of them were the kind a reader would act on.

**A flag's prose does not come from JSDoc**, and the document illustrated a help page showing prose that never appears. Measured on `tracker.tsx`:

| An author writes… | Reaches the compiled pattern? | Reaches `cf`? |
| --- | --- | --- |
| a comment on an **event field** | yes — `$defs.<Event>.properties.title.description` | **no, stripped** |
| a comment on the **event interface** | **no** | no |
| a comment on the **verb itself** | **no** | no |

The renderer is ready for two of the three — `specificFlagLines` prints a `description` when given one. One emitter drops all of them (#5637).

**The verbs were not the verbs.** It illustrated `add`, `block`, `note`, `remove` and a `rollup` tool. The fixture has `addItem` on the board and `addChild`, `recordNote`, `finish`, `blockOn`, `archive` on an item, and no tool. Five places named verbs that do not exist, including a `--parent` flag `addItem` never took.

**The model was never shown.** A reader met `addItem` and `blockOn` with no idea what a board or an item holds, and several steps turn on a property *of the model*.

**The split between `ItemOutput` and `ItemVerbs` was a claim the runtime contradicts.** `children` was declared as the narrow type, saying a child is not callable. Ask that child and it lists all five verbs.

## What Changed

- **A "What you are driving" section**, before the session: both patterns, both sides, verbs documented where they are declared. One `ItemOutput` now carries fields and verbs together, because that is what an item is.
- **The cost of that, with numbers.** An unshaped read of `children` is 3183 bytes; `--select 'title,status'` is 51. A verb result is 1743 unshaped and 140 with `--select`. Framed as the read model working — a schema is a query, and naming nothing asks for everything.
- **The structure/meaning split named.** `cf` publishes a verb's shape completely and its meaning not at all, and the first comes from the *types* rather than the comments. Without that distinction a reader cannot tell where the help page comes from.
- **The page this surface becomes**, written out, with a table costing each of its three lines — because the summary, the flag prose, and the `Output:` section are three pieces of work, and only the first two are unblocked.
- **Verb docs say what they take**, not only what they return. `recordNote` described one result field of two and neither input.
- **Verb names, signatures and the `--parent` flag** reconciled with the fixture.

## Related

- #5639 — the fixture and scripts this document describes. **Merging that alone leaves main describing verbs it does not have**, so this should land first or with it.
- #5637 — the emission gap, with the note that its input half ships independently while the output half waits on item 1.
- #5559 — folded into #5637; its premise was wrong and I had written it.

## Test plan

Documentation only.

- `deno task check-docs` — 536 blocks
- `deno task docs-links --orphan`
- `deno task check-conflict-markers`
- Every claim it now makes about runtime behavior was measured against a local toolshed rather than reasoned from source

🤖 Generated with [Claude Code](https://claude.com/claude-code)