### PR TITLE
refactor(piece): the vintage harness addresses exactly one root

### DIFF
--- a/packages/piece/test/state-continuity-harness.ts
+++ b/packages/piece/test/state-continuity-harness.ts
@@ -415,9 +415,6 @@ async function seedSpaceStore(
   await Deno.copyFile(snapshotPath, target);
 }
 
-/** The root key a fixture uses when it holds exactly one pattern. */
-export const DEFAULT_VINTAGE_ROOT_KEY = "vintage-root";
-
 /**
  * The cause of a captured space's root cell — shared by the harness helper
  * below and by the capture, which pins the test pattern's result cell to it.
@@ -429,30 +426,24 @@ export const DEFAULT_VINTAGE_ROOT_KEY = "vintage-root";
  * `Date.now()` into its cause for the same reason, so a root fixture has to go
  * around that path.)
  *
- * `key` is what keeps that determinism from becoming ALIASING. `getCell`
- * derives the entity id as `createRef({}, cause)` (`runtime.ts`), and that
- * derivation does not include the space — so a single fixed cause would give
- * every root in every fixture the same entity id. Within one space store that
- * is a silent collision: materializing a second pattern would stamp its
- * identity over the first pattern's root, no error, and the fixture would
- * replay something nobody captured. One key per pattern keeps roots distinct
- * while each stays addressable across captures.
+ * A fixture pins exactly one root under this cause. `getCell` derives the
+ * entity id as `createRef({}, cause)` (`runtime.ts`), and that derivation does
+ * not include the space, so two roots caused this way in one space store are
+ * one cell. The other patterns a fixture holds are reached by the cell ids its
+ * manifest records, through `materializeOnCell`.
  */
-export function vintageRootCause(
-  key: string = DEFAULT_VINTAGE_ROOT_KEY,
-): { stateContinuity: string } {
-  return { stateContinuity: key };
+export function vintageRootCause(): { stateContinuity: string } {
+  return { stateContinuity: "vintage-root" };
 }
 
 /** A stable root cell for a captured space, addressable across captures. */
 export function vintageRoot<T>(
   vintage: VintageRuntime,
   schema: unknown,
-  key: string = DEFAULT_VINTAGE_ROOT_KEY,
 ): Cell<T> {
   return vintage.runtime.getCell<T>(
     vintage.space as never,
-    vintageRootCause(key),
+    vintageRootCause(),
     schema as never,
   );
 }
@@ -582,13 +573,8 @@ export async function readVintageManifest(
 export async function vintageArgumentLink(
   vintage: VintageRuntime,
   resultSchema: unknown,
-  rootKey: string = DEFAULT_VINTAGE_ROOT_KEY,
 ): Promise<NormalizedFullLink> {
-  const root = vintageRoot<Record<string, unknown>>(
-    vintage,
-    resultSchema,
-    rootKey,
-  );
+  const root = vintageRoot<Record<string, unknown>>(vintage, resultSchema);
   await root.sync();
   const link = getMetaLink(root as never, "argument");
   if (link === undefined) {
@@ -1274,13 +1260,8 @@ export async function vintageHoldsRoot(
  */
 export async function vintageRootHasState(
   vintage: VintageRuntime,
-  rootKey: string = DEFAULT_VINTAGE_ROOT_KEY,
 ): Promise<boolean> {
-  const root = vintageRoot<Record<string, unknown>>(
-    vintage,
-    undefined,
-    rootKey,
-  );
+  const root = vintageRoot<Record<string, unknown>>(vintage, undefined);
   await root.sync();
   try {
     return isPresentRootValue(root.get());
@@ -1384,12 +1365,11 @@ export interface MaterializeOutcome {
 export async function materializeOver(
   vintage: VintageRuntime,
   program: RuntimeProgram,
-  rootKey: string = DEFAULT_VINTAGE_ROOT_KEY,
 ): Promise<MaterializeOutcome> {
   return await materializeOnCell(
     vintage,
     program,
-    (v, schema) => vintageRoot<Record<string, unknown>>(v, schema, rootKey),
+    (v, schema) => vintageRoot<Record<string, unknown>>(v, schema),
   );
 }
 


### PR DESCRIPTION
Five helpers in the state-continuity harness each took a root-key parameter that defaulted to the same constant: vintageRootCause, vintageRoot, vintageArgumentLink, vintageRootHasState and materializeOver. No caller anywhere passed anything but the default. The parameter therefore had one reachable value, and threading it through four call layers bought nothing.

The comment above the pair made this harder to read rather than easier. Twenty lines explained that the key was what stopped a fixed cause from aliasing roots together, and described materializing a second pattern stamping its identity over the first pattern's root. That hazard is real, but the key was never the thing holding it off, because there was only ever one key. A reader came away believing several keys were in use and that the harness could hold more than one caused root per fixture. Neither is so.

Drop the parameters and build the cause from the single key. Delete the DEFAULT_VINTAGE_ROOT_KEY constant with them: nothing outside the five defaults referred to it, and a name carrying "DEFAULT" says there is a non-default somewhere to contrast with. The key is now a literal in vintageRootCause, which is the one place that builds the cause, so the capture and the replay still agree on it by construction.

Rewrite the third paragraph of the comment to state what actually holds. A fixture pins exactly one root under this cause, and the entity-id derivation is why: getCell derives the id from the cause without the space, so two roots caused this way in one space store are one cell. The patterns a fixture holds beyond that root are reached by the cell ids its manifest records, through materializeOnCell, which is the route the replay already takes.

No call site changed, since every one of them already relied on the default. Should a fixture ever need a second caused root, widening these signatures back out is mechanical.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

