### PR TITLE
docs: mechanics stays a `//` comment, doc comments carry the contract

### DIFF
--- a/docs/development/code-comment-style.md
+++ b/docs/development/code-comment-style.md
@@ -327,11 +327,11 @@ adjacency, and so does a reader.
 
 Three shapes break this, each of which looks harmless while being written:
 
-- **A `//` note about the whole declaration, written above it.** The doc
-  comment now reads as a description of the note, and the contract is visually
-  detached from the thing it is a contract for. Open the declaration's body
-  with the note instead. When the declaration has no body — a type, an
-  interface property — fold what the note says into the doc comment.
+- **A `//` note about the whole declaration, where the declaration has a body
+  to hold it.** The doc comment reads as a description of the note, and the
+  contract is visually detached from the thing it is a contract for. Open the
+  body with the note instead — a `TODO` about a function goes inside the
+  function.
 - **A new definition placed directly under an existing doc comment.** The doc
   comment now documents the new definition, and the declaration it was written
   for is left with none. Adding a definition means placing it after the whole
@@ -340,11 +340,19 @@ Three shapes break this, each of which looks harmless while being written:
   declaration, so the other is invisible wherever documentation is rendered.
   Merge them if both say something worth keeping.
 
-Two things are exceptions. A tool directive — `// deno-lint-ignore`,
+Three things are exceptions. A tool directive — `// deno-lint-ignore`,
 `// deno-fmt-ignore`, `// @ts-types` — has to sit on the line immediately
 before the code it governs, and so has nowhere else to go.
 
-The other is narrower than it first sounds. One doc comment covers a whole
+The second is mechanics with no body to go in. A type, an interface property,
+or an overload list has no inside, so a `//` note about how that declaration
+is put together stays beside it. Do not fold it into the doc comment to get it
+out of the way: the split this document opens with holds here too, and a
+caller reading the rendered documentation is owed the contract and nothing
+else. What folds in is a note that turns out to be contract after all — what
+the type admits, what a caller may pass.
+
+The third is narrower than it first sounds. One doc comment covers a whole
 overload set, and `//` labels say which signature is which. Every label but
 one follows a declaration, so the rule never reached them; the exception is
 for the first label alone, which has nowhere to sit but between the doc
@@ -378,8 +386,10 @@ signatures are hard to tell apart at a glance. One that only restates the
 signature beneath it is not doing that work, and goes — even if it leaves the
 rest of a numbered series behind, because the numbering was never the point.
 
-A remark about the set as a whole is not a label, whichever line it sits on.
-It belongs in the doc comment, which is the thing that covers the set.
+A remark about the list itself — why it is written as five signatures rather
+than one recursive type, or that a second copy of it elsewhere has to be kept
+in step — stays with the list too. It is not a label, but it is mechanics, and
+what a caller needs is the only thing the doc comment owes them.
 
 A doc comment with no declaration under it at all is the same defect from the
 other direction. To title a region of a file or a class, use a section marker,

--- a/docs/development/code-comment-style.md
+++ b/docs/development/code-comment-style.md
@@ -352,6 +352,10 @@ caller reading the rendered documentation is owed the contract and nothing
 else. What folds in is a note that turns out to be contract after all — what
 the type admits, what a caller may pass.
 
+Such a note goes below the doc comment rather than above it. A doc comment is
+a header, so a `//` sitting on top of one reads as a remark about the header
+instead of about the code underneath.
+
 The third is narrower than it first sounds. One doc comment covers a whole
 overload set, and `//` labels say which signature is which. Every label but
 one follows a declaration, so the rule never reached them; the exception is

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -5299,18 +5299,17 @@ export class Runner {
    * replace the order with `[child2, parent]`, dropping `child1` to after the
    * parent (orderedCommitSpaces appends unlisted written spaces), which would
    * make the parent's link to `child1` durable before `child1`'s target.
-   *
-   * Public so the pattern builder (builder/pattern.ts
-   * `optIntoInSpaceMultiSpaceCommit`) can opt a transaction into a multi-space
-   * commit the moment a handler's `.inSpace(...)` target resolves — before the
-   * cross-space write executes (e.g. appending to the home `profiles` list,
-   * whose elements live in their own spaces).
    */
   enableCrossSpaceChildCommit(
     tx: IExtendedStorageTransaction,
     childSpace: MemorySpace,
     parentSpace: MemorySpace,
   ): void {
+    // Public so the pattern builder (builder/pattern.ts
+    // `optIntoInSpaceMultiSpaceCommit`) can opt a transaction into a
+    // multi-space commit the moment a handler's `.inSpace(...)` target
+    // resolves — before the cross-space write executes (e.g. appending to the
+    // home `profiles` list, whose elements live in their own spaces).
     let childSpaces = this.crossSpaceChildSpaces.get(tx);
     if (childSpaces === undefined) {
       childSpaces = [];


### PR DESCRIPTION
I (an agent working on behalf of @danfuzz) wrote the "Where one goes" section
in `code-comment-style.md`, and one of its sentences is wrong. This corrects
it, and the one landed site that followed the bad advice.

## The bad sentence

> When the declaration has no body — a type, an interface property — fold what
> the note says into the doc comment.

That decides placement by whether there is a body, when the question is what
kind of thing the note is. It is wrong in the direction that does damage: it
promotes implementation notes into rendered documentation, where a caller
reading the contract has no use for them.

`// Overloads to avoid recursive type evaluation which causes stack overflow`
on `IKeyable.key` is the case that exposed it. Why the list is written as five
signatures rather than one recursive type is commentary on the declaration, not
part of what `key()` promises — but the type has no body, so the sentence said
to fold it in, and I did.

## The correction

Placement now turns on contract versus mechanics — the split this document
opens with — rather than on the presence of a body:

- The first of the three broken shapes is narrowed to the case where there
  genuinely is somewhere better: a note about a declaration **that has a body**
  belongs inside it.
- A third exception joins the tool-directive and overload-label ones:
  mechanics with no body to go in stays a `//` comment beside the declaration.
  What folds into the doc comment is a note that turns out to be contract after
  all — what the type admits, what a caller may pass.
- The overload-list paragraph follows the same line. It previously said a
  set-level remark "belongs in the doc comment"; it now says such a remark
  stays with the list, for the same reason the labels do.

## The site that followed the bad advice

`runner.ts` folded the reason `enableCrossSpaceChildCommit` is public into its
doc comment — when the method has a body that could hold it perfectly well.
Moved into the body.

Three other landed folds were re-judged and stand, because they are contract
rather than mechanics: `AtomPattern`'s "NOT a `CfcAtom`" (what the type
admits), `lift`'s function-first calling convention (argument order, and the
`lift(fn, false)` form), and `GetfsstatFn`'s description in `cli/lib/fuse.ts`,
which is that type's only documentation.

The corresponding reverts in the still-open PRs go there rather than here:
`#5620` for `IKeyable.key`, `IKeyableOpaque.key` and `ActionFunction`, `#5627`
for `RECOMMENDATIONS_SCHEMA` and the two `authorProfile` fixtures.

## Why the note sits below the doc comment

These `//` notes sit between the doc comment and the declaration, which is
where they already were. The alternative — above the doc comment — would
satisfy the adjacency rule more literally, but it reads wrong: a doc comment
is a header, so a `//` on top of one binds to the header rather than to the
code underneath. The document now says that, so the placement is reasoned
rather than asserted.

## Verification

`deno task check-docs` (538 blocks), `deno task check-skill-facts`,
`deno fmt --check`, `deno check` on `runner.ts`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


