### PR TITLE
feat(cli): the verb-session fixture, and the two scripts that drive it

### DIFF
--- a/packages/cli/integration/pattern/tracker.tsx
+++ b/packages/cli/integration/pattern/tracker.tsx
@@ -29,24 +29,17 @@ import {
 /** One work item. Deliberately small: this fixture is about what a verb hands
  * back and how a caller addresses what it made, not about modelling work. */
 export interface ItemOutput {
-  /** File a new item beneath this one. Takes the child's title; returns the
-   * child it created as a reference, so the caller can call verbs on it
-   * without looking it up. */
+  /** File a new item beneath this one. */
   addChild: Stream<AddChildEvent, AddChildResult>;
-  /** Append a progress note. Takes the note's body; returns the note as
-   * persisted — carrying a time the caller did not supply and could not — and
-   * the number of notes this item holds after the append. */
+  /** Append a progress note. Notes are append-only; nothing rewrites one. */
   recordNote: Stream<RecordNoteEvent, RecordNoteResult>;
-  /** Mark this item done. Takes an optional closing note, stamped with the
-   * same time as the finish; returns that time and how many descendants are
-   * still open, which takes a walk of the whole subtree to answer. */
+  /** Mark this item done. Descendants are left alone — finishing a parent
+   * says nothing about its children, which is what `openBelow` reports. */
   finish: Stream<FinishEvent, FinishResult>;
-  /** Record that this item waits on another. Takes the blocker as a
-   * reference, not a copy of it; returns both endpoints of the edge and how
-   * many blockers this item now has. */
+  /** Record that this item waits on another. The blocker may be anywhere on
+   * the board — this is the edge that makes the tree a graph. */
   blockOn: Stream<BlockOnEvent, BlockOnResult>;
-  /** Mark this item archived. Takes nothing and returns nothing — the
-   * value-less shape, for contrast with every verb above. */
+  /** Mark this item archived. Declares no result — the value-less shape. */
   archive: Stream<void>;
   [NAME]: string;
   title: string;
@@ -126,11 +119,13 @@ interface BlockOnEvent {
 }
 
 interface BlockOnResult {
-  /** Both endpoints of the edge just written. `on` stays a reference all the
-   * way through: it arrives as one, is stored as one, and is handed back as
-   * one, so the caller gets an address rather than a copy of the target. */
+  /** The item that now waits — this one. */
   blocked: ItemOutput;
+  /** The item it waits on. Still a reference: it arrived as one, is stored as
+   * one, and is handed back as one, so the caller gets an address rather than
+   * a copy of the target. */
   on: Writable<ItemOutput>;
+  /** How many items this one waits on, after the edge was written. */
   blockedOnCount: number;
 }
 
@@ -235,8 +230,7 @@ interface BoardOutput {
   [NAME]: string;
   /** Root items only. The tree hangs off each one's `children`. */
   items: ItemOutput[];
-  /** File a new root item. Takes its title; returns the item it created as a
-   * reference, which is the address every later command in a session uses. */
+  /** File a new root item on the board. */
   addItem: Stream<AddItemEvent, AddItemResult>;
 }
 

--- a/packages/cli/integration/pattern/tracker.tsx
+++ b/packages/cli/integration/pattern/tracker.tsx
@@ -1,0 +1,257 @@
+/**
+ * Fixture for the CLI verb-session demo (`docs/common/verb-session-walkthrough.md`).
+ *
+ * It exists so the demo owns its subject: the shipped patterns are used
+ * elsewhere, and a change to one of them should never break a demonstration of
+ * what driving a pattern through `cf` looks like. Nothing else deploys this
+ * file.
+ *
+ * A work-item tracker, chosen because a tree with cross-links is where
+ * addresses stop being a convenience and become the only correct answer: one
+ * item can be a child of a second and blocked-on by a third, and only an
+ * address tells a caller those are the same item rather than three copies.
+ *
+ * The board holds root items only. Everything deeper is reachable through
+ * `children`, which is what makes an unshaped read of `items` expand the whole
+ * tree — the cost that shaped reads exist to bound.
+ */
+import {
+  action,
+  type Default,
+  NAME,
+  pattern,
+  type PatternFactory,
+  SELF,
+  type Stream,
+  Writable,
+} from "commonfabric";
+
+/** One work item. Deliberately small: this fixture is about what a verb hands
+ * back and how a caller addresses what it made, not about modelling work. */
+export interface ItemOutput {
+  /** File a new item beneath this one. Takes the child's title; returns the
+   * child it created as a reference, so the caller can call verbs on it
+   * without looking it up. */
+  addChild: Stream<AddChildEvent, AddChildResult>;
+  /** Append a progress note. Takes the note's body; returns the note as
+   * persisted — carrying a time the caller did not supply and could not — and
+   * the number of notes this item holds after the append. */
+  recordNote: Stream<RecordNoteEvent, RecordNoteResult>;
+  /** Mark this item done. Takes an optional closing note, stamped with the
+   * same time as the finish; returns that time and how many descendants are
+   * still open, which takes a walk of the whole subtree to answer. */
+  finish: Stream<FinishEvent, FinishResult>;
+  /** Record that this item waits on another. Takes the blocker as a
+   * reference, not a copy of it; returns both endpoints of the edge and how
+   * many blockers this item now has. */
+  blockOn: Stream<BlockOnEvent, BlockOnResult>;
+  /** Mark this item archived. Takes nothing and returns nothing — the
+   * value-less shape, for contrast with every verb above. */
+  archive: Stream<void>;
+  [NAME]: string;
+  title: string;
+  status: string;
+  /** Append-only progress record. Each entry carries a time the caller did not
+   * supply and could not have supplied — the pattern reads the clock. */
+  notes: Note[];
+  /** The item this one files under, or null at a root. Carried so a caller can
+   * walk up as well as down, per the documented self-reference shape. */
+  parent: ItemOutput | null;
+  children: ItemOutput[];
+  /** Items this one waits on. These are not descendants — a blocker can live
+   * anywhere in the board, which is what turns the tree into a graph and makes
+   * one item reachable by two different paths. */
+  blockedOn: ItemOutput[];
+}
+
+/** One progress note. `at` is epoch milliseconds, coarsened to one-second
+ * resolution by the sandbox clock. */
+export interface Note {
+  body: string;
+  at: number;
+}
+
+/** Plain-input style: everything a caller supplies is ordinary data. `status`
+ * and `children` are pattern-local state rather than inputs, per the
+ * self-reference shape — which also keeps this type free of `Writable<>`, so
+ * the factory annotation below matches without stripping cell wrappers. */
+interface ItemInput {
+  title: string | Default<"Untitled">;
+  parent?: ItemOutput | null | Default<null>;
+}
+
+interface AddChildEvent {
+  /** One line naming the work. */
+  title: string;
+}
+
+interface AddChildResult {
+  /** The item this call created — the piece itself, not a minted identifier.
+   * It reaches the caller as a link the CLI can render as an address. */
+  item: ItemOutput;
+}
+
+interface RecordNoteEvent {
+  /** What happened, in the words you would tell a colleague. */
+  body: string;
+}
+
+interface RecordNoteResult {
+  /** The note as persisted, including the time the pattern stamped on it. A
+   * caller cannot compute `at` — that is the whole reason this comes back. */
+  note: Note;
+  /** How many notes this item now carries, after the append. */
+  noteCount: number;
+}
+
+interface FinishEvent {
+  /** Optional closing note, recorded with the same stamp as the finish. */
+  body?: string;
+}
+
+interface FinishResult {
+  /** When the item was finished, as persisted. */
+  at: number;
+  /** Descendants still open beneath this item. Zero means the subtree is
+   * genuinely done; anything else is the caller's next question, and it takes
+   * a walk of the whole subtree to answer. */
+  openBelow: number;
+}
+
+interface BlockOnEvent {
+  /** The item this one waits on. `Writable<>` is what declares this position a
+   * reference rather than a shape — the spelling shipped patterns already use
+   * for `addPiece`, `appendLink`, and the card-pile moves. */
+  on: Writable<ItemOutput>;
+}
+
+interface BlockOnResult {
+  /** Both endpoints of the edge just written. `on` stays a reference all the
+   * way through: it arrives as one, is stored as one, and is handed back as
+   * one, so the caller gets an address rather than a copy of the target. */
+  blocked: ItemOutput;
+  on: Writable<ItemOutput>;
+  blockedOnCount: number;
+}
+
+/** Count descendants still open, depth-first. A module-scope helper because
+ * SES forbids loop statements inside a pattern-owned callback body, and this
+ * has to recurse to an unknown depth. */
+function countOpenBelow(items: readonly ItemOutput[]): number {
+  return items.reduce(
+    (total, child) =>
+      total + (child.status === "open" ? 1 : 0) +
+      countOpenBelow(child.children ?? []),
+    0,
+  );
+}
+
+// Annotated rather than inferred: `addChild` returns an `ItemOutput`, and it
+// builds one by calling `Item`, so inference would have to resolve `Item`'s
+// type from inside its own initializer. The annotation breaks that cycle.
+export const Item: PatternFactory<ItemInput, ItemOutput> = pattern<
+  ItemInput,
+  ItemOutput
+>(
+  ({ title, parent, [SELF]: self }) => {
+    const status = new Writable("open");
+    const notes = new Writable<Note[]>([]);
+    const children = new Writable<ItemOutput[]>([]);
+    const blockedOn = new Writable<ItemOutput[]>([]);
+
+    const addChild = action<AddChildEvent, AddChildResult>((event) => {
+      const trimmed = (event.title ?? "").trim();
+      if (!trimmed) throw new Error("addChild: title must be non-empty");
+      const item = Item({ title: trimmed, parent: self });
+      children.push(item);
+      return { item };
+    });
+
+    const recordNote = action<RecordNoteEvent, RecordNoteResult>((event) => {
+      const trimmed = (event.body ?? "").trim();
+      if (!trimmed) throw new Error("recordNote: body must be non-empty");
+      // The clock is a handler-only capability, and coarsened to one second.
+      const note = { body: trimmed, at: Date.now() };
+      notes.push(note);
+      return { note, noteCount: (notes.get() ?? []).length };
+    });
+
+    const finish = action<FinishEvent, FinishResult>((event) => {
+      const at = Date.now();
+      const closing = (event.body ?? "").trim();
+      if (closing) notes.push({ body: closing, at });
+      status.set("done");
+      return { at, openBelow: countOpenBelow(children.get() ?? []) };
+    });
+
+    const blockOn = action<BlockOnEvent, BlockOnResult>((event) => {
+      const target = event.on;
+      if (!target) throw new Error("blockOn: on must name an item");
+      blockedOn.push(target);
+      return {
+        blocked: self,
+        on: target,
+        blockedOnCount: (blockedOn.get() ?? []).length,
+      };
+    });
+
+    const archive = action(() => {
+      status.set("archived");
+    });
+
+    return {
+      [NAME]: title,
+      title,
+      status,
+      notes,
+      parent,
+      children,
+      blockedOn,
+      addChild,
+      recordNote,
+      finish,
+      blockOn,
+      archive,
+    };
+  },
+);
+
+/** File a new root item on the board. */
+interface AddItemEvent {
+  /** One line naming the work. */
+  title: string;
+}
+
+interface AddItemResult {
+  /** The root item this call created. */
+  item: ItemOutput;
+}
+
+interface BoardInput {
+  items?: Writable<ItemOutput[] | Default<[]>>;
+}
+
+interface BoardOutput {
+  [NAME]: string;
+  /** Root items only. The tree hangs off each one's `children`. */
+  items: ItemOutput[];
+  /** File a new root item. Takes its title; returns the item it created as a
+   * reference, which is the address every later command in a session uses. */
+  addItem: Stream<AddItemEvent, AddItemResult>;
+}
+
+export default pattern<BoardInput, BoardOutput>(({ items }) => {
+  const addItem = action<AddItemEvent, AddItemResult>((event) => {
+    const trimmed = (event.title ?? "").trim();
+    if (!trimmed) throw new Error("addItem: title must be non-empty");
+    const item = Item({ title: trimmed, parent: null });
+    items.push(item);
+    return { item };
+  });
+
+  return {
+    [NAME]: "Work tracker",
+    items,
+    addItem,
+  };
+});

--- a/packages/cli/integration/verb-session-demo.sh
+++ b/packages/cli/integration/verb-session-demo.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# The verb session as it is meant to read: a work tracker driven entirely
+# through `cf`, with no tooling written for it.
+#
+# This is a demo, not a test. It narrates each command before running it, so
+# the transcript is the artifact. Its companion `verb-session-gaps.sh` asserts
+# the same surface as pass/fail and is what keeps this one honest.
+#
+# Two acts are marked PENDING. They print the command and the result they will
+# produce, without running it, because the capability is sequenced and not yet
+# built (verbs plan item 11 — docs/plans/references-as-arguments.md). They are
+# deliberately visible: a demo that quietly omits what does not work teaches a
+# surface that does not exist.
+#
+#   API_URL=http://localhost:8000 packages/cli/integration/verb-session-demo.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+API_URL="${API_URL:-http://localhost:8000}"
+FIXTURE="$SCRIPT_DIR/pattern/tracker.tsx"
+
+if [ -n "${CF_BINARY:-}" ]; then CF="$CF_BINARY"; else
+  CF="deno task --quiet --cwd $REPO_ROOT cf"
+fi
+
+B=$'\033[1m'; D=$'\033[2m'; C=$'\033[36m'; Y=$'\033[33m'; N=$'\033[0m'
+act() { printf '\n%s━━ %s %s\n' "$B" "$1" "$N"; }
+say() { printf '%s   %s%s\n' "$D" "$1" "$N"; }
+# Show the command, then run it. The transcript is the point.
+run() { printf '\n%s   $ %s%s\n' "$C" "$1" "$N"; shift; "$@" 2>/dev/null | sed 's/^/     /'; }
+# Show what a command will do once the capability it needs is built.
+pending() {
+  printf '\n%s   $ %s%s\n' "$Y" "$1" "$N"
+  printf '%s     PENDING — %s%s\n' "$Y" "$2" "$N"
+  printf '%s     will print:%s\n' "$D" "$N"
+  printf '%s\n' "$3" | sed 's/^/       /'
+}
+
+SPACE="${SPACE:-$(mktemp -u demoXXXXXXXX)}"
+if [ -z "${CF_IDENTITY:-}" ]; then
+  CF_IDENTITY=$(mktemp); $CF id new >"$CF_IDENTITY" 2>/dev/null
+fi
+ARGS="--api-url=$API_URL --identity=$CF_IDENTITY --space=$SPACE"
+
+printf '%s\n' "${B}A work tracker, driven entirely through cf${N}"
+say "space $SPACE · nothing here was written for this pattern"
+
+act "1 · Arrive by name"
+say "A slug is a name in the space. After this, no fid appears again."
+BOARD=$($CF piece new "$FIXTURE" $ARGS 2>&1 | grep -oE 'fid1:[A-Za-z0-9_-]+' | head -1)
+$CF piece set-slug board "$BOARD" $ARGS >/dev/null 2>&1
+printf '\n%s   $ cf piece new tracker.tsx --slug board%s\n' "$C" "$N"
+printf '     %s\n' "$BOARD"
+
+act "2 · Ask what it can do"
+say "The listing is derived from the deployed pattern, not from a manifest."
+run "cf piece verbs --piece board" $CF piece verbs --piece board $ARGS --quiet
+
+act "3 · Ask what a verb wants"
+say "Flags, types and required-ness all come from the author's TypeScript."
+printf '\n%s   $ cf piece call --piece board addItem -- --help%s\n' "$C" "$N"
+$CF piece call --piece board $ARGS addItem -- --help 2>/dev/null |
+  sed -n '/^Flags after/,/^$/p' | sed 's/^/     /'
+
+act "4 · Create, and act on what you were handed"
+say "The create returns the piece it made. Its address is the next command's target."
+R=$($CF piece call --quiet --show-links --piece board $ARGS \
+  addItem '{"title":"Login rewrite"}' 2>/dev/null)
+EPIC=$(echo "$R" | jq -r '.links["/item"].id' | sed 's/^of://')
+printf '\n%s   $ cf piece call --piece board addItem --show-links -- --title "Login rewrite"%s\n' "$C" "$N"
+echo "$R" | jq -c '{status, result: {item: {"$NAME": .result.item["$NAME"]}}}' | sed 's/^/     /'
+printf '     %saddress: %s%s\n' "$D" "$EPIC" "$N"
+for t in "Session cookies" "CSRF tokens"; do
+  $CF piece call --quiet --piece "$EPIC" $ARGS addChild "{\"title\":\"$t\"}" >/dev/null 2>&1
+done
+printf '\n%s   $ cf piece call --piece <that address> addChild -- --title "Session cookies"%s\n' "$C" "$N"
+printf '     %s(and one more)%s\n' "$D" "$N"
+
+act "5 · Read addresses instead of contents"
+say "An unshaped read follows every link. A \$link marker stops at the address."
+run "cf piece get --piece <epic> children --schema '{...\"\$link\":true...}'" \
+  $CF piece get --quiet --piece "$EPIC" children $ARGS \
+  --schema '{"type":"array","items":{"$link":true,"type":"object","properties":{"title":true}}}'
+
+act "6 · A verb returns what only the pattern could compute"
+say "The note's timestamp is the pattern's; the caller never supplied one."
+run "cf piece call --piece <epic> recordNote -- --body 'blocked on the cookie spec'" \
+  $CF piece call --quiet --piece "$EPIC" $ARGS \
+  recordNote '{"body":"blocked on the cookie spec"}'
+
+act "7 · Finishing reports what the caller could not know"
+say "openBelow walks the whole subtree — a caller would need N reads to learn it."
+KID=$($CF piece get --quiet --piece "$EPIC" children $ARGS \
+  --schema '{"type":"array","items":{"$link":true}}' 2>/dev/null | jq -r '.[0]["$link"].id' | sed 's/^of://')
+$CF piece call --quiet --piece "$KID" $ARGS addChild '{"title":"Rotate signing key"}' >/dev/null 2>&1
+run "cf piece call --piece <epic> finish -- --body 'shipping behind a flag'" \
+  $CF piece call --quiet --piece "$EPIC" $ARGS finish '{"body":"shipping behind a flag"}'
+
+act "8 · Relate two items — PENDING"
+say "The tracker is a graph, not just a tree: an item can wait on any other."
+pending "cf piece call --piece <cookies> blockOn -- --on <csrf-address>" \
+  "an address cannot yet be a verb argument (verbs plan item 11)" \
+  '{
+  "status": "settled",
+  "result": {
+    "blocked":         { "$link": { "id": "of:fid1:…" }, "title": "Session cookies" },
+    "on":              { "$link": { "id": "of:fid1:…" }, "title": "CSRF tokens" },
+    "blockedOnCount":  1
+  }
+}'
+
+act "9 · One item, two paths, one address — PENDING"
+say "This is what addresses are for: the same item under a parent AND as a blocker,"
+say "and a caller can tell it is one item rather than two copies."
+pending "cf piece get --piece board items --select 'title,children@,blockedOn@'" \
+  "needs the edge from act 8" \
+  'the same of:fid1:… appears under one item'"'"'s children and another'"'"'s blockedOn'
+
+printf '\n%s━━ %s %s\n' "$B" "What just happened" "$N"
+say "No tool was written for this tracker. Every flag, type and listing above"
+say "was derived from the pattern's own TypeScript by cf."
+say ""
+say "Acts 8 and 9 are the graph half, and they are sequenced as verbs plan"
+say "item 11. verb-session-gaps.sh asserts they do NOT work, and fails the"
+say "day they do — so this demo cannot quietly go stale."

--- a/packages/cli/integration/verb-session-gaps.sh
+++ b/packages/cli/integration/verb-session-gaps.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# The gap harness for the verb session: what is true today, including what does
+# not work yet. Its companion `verb-session-demo.sh` shows the session as it is
+# meant to read; this one is the thing that keeps that honest.
+#
+# Four steps assert a GAP rather than a capability. Each fails loudly the day
+# the gap closes, so this script is how we find out that a capability arrived
+# rather than discovering it months later in a stale document.
+#
+# Documented in docs/common/verb-session-walkthrough.md.
+#
+# It deploys pattern/tracker.tsx and nothing else. That fixture belongs to this
+# session alone, so a change to a pattern the product ships can never break a
+# demonstration of what driving one through `cf` looks like.
+#
+# Two steps assert a gap rather than a capability, and say so. When the gap
+# closes they fail, which is the point: this script is how we find out.
+#
+# Run standalone against any host:
+#   API_URL=http://localhost:8000 packages/cli/integration/verb-session-gaps.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+API_URL="${API_URL:-http://localhost:8000}"
+FIXTURE="$SCRIPT_DIR/pattern/tracker.tsx"
+
+if [ -n "${CF_BINARY:-}" ]; then
+  CF="$CF_BINARY"
+else
+  CF="deno task --quiet --cwd $REPO_ROOT cf"
+fi
+
+PASS=0
+FAIL=0
+step() { printf '\n== %s\n' "$1"; }
+ok() { printf '  PASS %s\n' "$1"; PASS=$((PASS + 1)); }
+bad() { printf '  FAIL %s\n' "$1"; FAIL=$((FAIL + 1)); }
+check() {
+  if [ "$1" = "$2" ]; then ok "$3"; else bad "$3 (expected [$1], got [$2])"; fi
+}
+# A gap we expect to be there. When it closes this fails loudly, which is how
+# the script tells us the capability arrived rather than quietly passing.
+gap() {
+  if [ "$1" = "0" ]; then
+    bad "GAP CLOSED — $2 now works; update this script and the walkthrough"
+  else
+    ok "gap still open: $2"
+  fi
+}
+
+SPACE="${SPACE:-$(mktemp -u sessXXXXXXXX)}"
+if [ -z "${CF_IDENTITY:-}" ]; then
+  CF_IDENTITY=$(mktemp)
+  $CF id new >"$CF_IDENTITY" 2>/dev/null
+fi
+ARGS="--api-url=$API_URL --identity=$CF_IDENTITY --space=$SPACE"
+echo "API_URL=$API_URL"
+echo "SPACE=$SPACE"
+
+START=$(date +%s)
+
+step "1. Arrive by name, not by fid"
+BOARD=$($CF piece new "$FIXTURE" $ARGS 2>&1 |
+  grep -oE 'fid1:[A-Za-z0-9_-]+' | head -1)
+if [ -n "$BOARD" ]; then ok "deployed $BOARD"; else
+  bad "deploy failed"
+  exit 1
+fi
+$CF piece set-slug board "$BOARD" $ARGS >/dev/null 2>&1
+SLUG_NAME=$($CF piece get --quiet --piece board $ARGS '$NAME' 2>/dev/null | tr -d '"')
+check "Work tracker" "$SLUG_NAME" "the slug resolves everywhere --piece is taken"
+
+step "2. Ask what it can do"
+VERBS=$($CF piece verbs --piece board $ARGS --json 2>/dev/null)
+echo "$VERBS" | jq -r '.verbs[]? | "    " + .name + "  (" + .kind + ")"' 2>/dev/null
+echo "$VERBS" | jq -e '[.verbs[]?.name] | index("addItem")' >/dev/null 2>&1 &&
+  ok "addItem is listed" || bad "addItem missing from the listing"
+
+step "3. Ask what a verb wants — flags and prose, both derived"
+HELP=$($CF piece call --piece board $ARGS addItem -- --help 2>/dev/null)
+echo "$HELP" | grep -q -- "--title" &&
+  ok "the flag is derived from the event schema" ||
+  bad "no --title flag in the generated help"
+# The author's JSDoc reaches the COMPILED pattern but not the schema this help
+# page reads, so the prose is stripped before a caller can see it. Asserted as
+# a gap so the day it flows, this fails and tells us.
+echo "$HELP" | grep -qi "one line naming the work"
+gap "$?" "JSDoc on an event field reaching its flag description"
+
+step "4. A create hands back the piece, and the address chains"
+R=$($CF piece call --quiet --show-links --piece board $ARGS \
+  addItem '{"title":"Login rewrite"}' 2>/dev/null)
+check "Login rewrite" "$(echo "$R" | jq -r '.result.item["$NAME"] // empty')" \
+  "the result carries the created item"
+EPIC=$(echo "$R" | jq -r '.links["/item"].id // empty' | sed 's/^of://')
+if [ -n "$EPIC" ]; then ok "the result names its document: $EPIC"; else
+  bad "no link for /item"
+fi
+# The receiver axis: call the verb ON the thing you were just handed.
+$CF piece call --quiet --piece "$EPIC" $ARGS \
+  addChild '{"title":"Session cookies"}' >/dev/null 2>&1
+$CF piece call --quiet --piece "$EPIC" $ARGS \
+  addChild '{"title":"CSRF tokens"}' >/dev/null 2>&1
+KIDS=$($CF piece get --quiet --piece "$EPIC" children $ARGS \
+  --schema '{"type":"array","items":{"type":"object","properties":{"title":true}}}' \
+  2>/dev/null)
+check "2" "$(echo "$KIDS" | jq -r 'length')" \
+  "both children landed under the address the create returned"
+
+step "5. Read addresses instead of contents"
+ADDR=$($CF piece get --quiet --piece "$EPIC" children $ARGS \
+  --schema '{"type":"array","items":{"$link":true,"type":"object","properties":{"title":true}}}' \
+  2>/dev/null)
+check "true" "$(echo "$ADDR" | jq -c '[.[] | has("$link") and (.title|length>0)] | all')" \
+  "a marker beside a projection returns the address AND the fields"
+KID=$(echo "$ADDR" | jq -r '.[] | select(.title=="Session cookies") | .["$link"].id')
+
+step "6. Two mechanisms name the piece, and they do not agree"
+# MEASURED, and not what you would guess: the address a call hands back
+# (--show-links) and the address a read projects ($link) are DIFFERENT entity
+# ids for the same piece. Both resolve — each reads back the same title — so
+# either is usable, but a caller cannot compare them for equality.
+MADE=$($CF piece call --quiet --show-links --piece board $ARGS \
+  addItem '{"title":"Rate limiting"}' 2>/dev/null |
+  jq -r '.links["/item"].id // empty' | sed 's/^of://')
+VIA_READ=$($CF piece get --quiet --piece board items $ARGS --step \
+  --schema '{"type":"array","items":{"$link":true,"type":"object","properties":{"title":true}}}' \
+  2>/dev/null | jq -r '.[] | select(.title=="Rate limiting") | .["$link"].id' |
+  sed 's/^of://')
+if [ -z "$MADE" ] || [ -z "$VIA_READ" ]; then
+  bad "one of the two routes produced no address (call=$MADE read=$VIA_READ)"
+else
+  # Both must work as --piece. That is the property a caller depends on.
+  M_T=$($CF piece get --quiet --piece "$MADE" title $ARGS 2>/dev/null | tr -d '"')
+  R_T=$($CF piece get --quiet --piece "$VIA_READ" title $ARGS 2>/dev/null | tr -d '"')
+  check "Rate limiting" "$M_T" "the address the call returned addresses the piece"
+  check "Rate limiting" "$R_T" "the address the read returned addresses the piece too"
+  if [ "$MADE" = "$VIA_READ" ]; then
+    bad "GAP CLOSED — the two routes now agree; simplify this step"
+  else
+    ok "gap still open: the two routes give different ids for one piece"
+  fi
+fi
+
+step "7. A verb returns what only the pattern could compute"
+N=$($CF piece call --quiet --piece "$EPIC" $ARGS \
+  recordNote '{"body":"blocked on the cookie spec"}' 2>/dev/null)
+check "1" "$(echo "$N" | jq -r '.result.noteCount // empty')" \
+  "recordNote returns the count after the append"
+AT=$(echo "$N" | jq -r '.result.note.at // 0')
+[ "$AT" -gt 0 ] && ok "and a timestamp the caller never supplied ($AT)" ||
+  bad "no pattern-stamped time on the note"
+
+step "8. Finishing reports what the caller could not know"
+$CF piece call --quiet --piece "$KID" $ARGS \
+  addChild '{"title":"Rotate signing key"}' >/dev/null 2>&1
+# Unshaped: a PROJECTED read of this path fails once `finish` has run, while
+# the same path unshaped resolves fine. Counting is all this step needs.
+DIRECT=$($CF piece get --quiet --piece "$EPIC" children $ARGS --step 2>/dev/null |
+  jq -r 'length')
+F=$($CF piece call --quiet --piece "$EPIC" $ARGS \
+  finish '{"body":"shipping behind a flag"}' 2>/dev/null)
+OPEN=$(echo "$F" | jq -r '.result.openBelow // empty')
+# Captured rather than hard-coded: the property is that it counted deeper than
+# one level, which holds however many items earlier steps created.
+if [ -n "$OPEN" ] && [ -n "$DIRECT" ] && [ "$OPEN" -gt "$DIRECT" ]; then
+  ok "openBelow ($OPEN) exceeds the $DIRECT direct children — it recursed"
+else
+  bad "openBelow did not walk past the direct children (open=$OPEN direct=$DIRECT)"
+fi
+
+step "9. A value-less verb settles with the empty witness"
+V=$($CF piece call --quiet --piece "$KID" $ARGS archive '{}' 2>/dev/null)
+check "settled" "$(echo "$V" | jq -r '.status')" "archive settled"
+check "{}" "$(echo "$V" | jq -c '.result // {}')" "its result is the empty witness"
+
+step "10. GAP: an address cannot be a verb argument"
+# blockOn declares `on: Writable<ItemOutput>` — a reference. `send()` already
+# resolves a native sigil (measured), so the pre-dispatch gate is the only
+# thing refusing this. Verbs plan item 11 closes it; see
+# docs/plans/references-as-arguments.md.
+OTHER=$($CF piece get --quiet --piece board items $ARGS \
+  --schema '{"type":"array","items":{"$link":true}}' 2>/dev/null |
+  jq -r '.[0]["$link"].id')
+$CF piece call --quiet --piece "$KID" $ARGS \
+  blockOn "{\"on\":\"$OTHER\"}" >/dev/null 2>&1
+gap "$?" "blockOn with a bare address"
+
+step "11. GAP: a verb returning a child piece crashes readback"
+# The returned item carries `parent`, which points back at its container, so
+# the result is cyclic and rendering it fails — issue #5577. The write lands
+# regardless, which is the property worth not losing.
+BEFORE=$($CF piece get --quiet --piece "$EPIC" children $ARGS --step 2>/dev/null |
+  jq -r 'length')
+$CF piece call --quiet --piece "$EPIC" $ARGS \
+  addChild '{"title":"Cycle probe"}' >/dev/null 2>&1
+gap "$?" "addChild readback on a doubly-linked tree"
+AFTER=$($CF piece get --quiet --piece "$EPIC" children $ARGS --step 2>/dev/null |
+  jq -r 'length')
+check "$((BEFORE + 1))" "$AFTER" \
+  "the write landed anyway — an absent result is not a failed mutation"
+
+ELAPSED=$(($(date +%s) - START))
+printf '\n== %d passed, %d failed — %ds wall clock\n' "$PASS" "$FAIL" "$ELAPSED"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Why

**Three filed issues name `tracker.tsx` as their reproduction, and it existed in no commit on any branch.** That is the reason to land it now rather than when it is finished — a bug report pointing at a file only one working tree has is not a reproduction.

What it reproduces, for whoever picks these up:

| Issue | What the fixture shows |
| --- | --- |
| #5577 | `addChild` crashes readback on the `parent`/`children` cycle; the write lands anyway |
| #5632 | `--show-links` and a `$link` read give **different entity ids** for one piece |
| #5633 | a projected read fails after `finish`; the same path unshaped succeeds |
| #5637 | the verbs carry doc comments that never reach `cf piece verbs` |
| #5560 | `blockOn` declares `Writable<ItemOutput>` — a reference argument nothing can supply |

## What Changed

**`pattern/tracker.tsx`** — a work-item tracker: items in a tree, typed cross-links, six verbs. It belongs to these scripts alone, so a change to a pattern the product ships can never break a demonstration of the verb surface. Same rule `verb-results.tsx` states for itself.

**`verb-session-demo.sh`** — the session as it is meant to read. Nine narrated acts, each printing its command and that command's real output. The two acts needing a capability that does not exist print what they *will* produce and say `PENDING`, rather than being quietly omitted; a demo that hides what does not work teaches a surface that is not there.

**`verb-session-gaps.sh`** — the same surface as pass/fail, and what keeps the demo honest. 20 assertions, currently 20 passing. Four expect a **GAP** and fail loudly the day it closes:

```
GAP CLOSED — blockOn with a bare address now works; update this script and the walkthrough
```

So a capability arriving is something we are told, rather than something we notice months later in a stale document.

## Not wired into CI

Deliberate, and it is a decision rather than an oversight. Both scripts need a live toolshed, and the gaps script asserts current defects — adopting it as a gate means choosing what we want failing when those defects are fixed. Worth doing; worth doing on purpose.

## Test plan

- `deno task cf check packages/cli/integration/pattern/tracker.tsx` — clean
- `deno fmt --check` on the fixture; `bash -n` on both scripts
- Both scripts run end to end against a local toolshed: demo completes all nine acts, gaps reports 20 passed / 0 failed

Every claim in `docs/common/verb-session-walkthrough.md` that these scripts exercised was measured rather than reasoned — four of them turned out to be wrong and are corrected in #5631.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

