### PR TITLE
docs(cli): reattach `listPieceCallables`'s doc comment

### DIFF
--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -1687,16 +1687,6 @@ export function partitionVerbListing(
   return { shown, wrapper, deprecated };
 }
 
-/**
- * Enumerate every callable a piece exposes (verb contract: Verb discovery,
- * docs/plans/pattern-verb-contract.md). Everything in the durable schema is
- * listed — hiding is a display default driven by the listing marks
- * (`tier: "wrapper"`, `deprecated: true`), never a capability boundary: the
- * rows carry the marks, `partitionVerbListing` decides the default view, and
- * `--all` shows the full surface. Walks result then input with the same classification
- * `cf piece call` resolves through, so the listing and the dispatcher can
- * never disagree about what is callable.
- */
 /** The listing marks as they appear on the durable schema's property. */
 function listingMarks(
   rootSchema: unknown,
@@ -1711,6 +1701,16 @@ function listingMarks(
   };
 }
 
+/**
+ * Enumerate every callable a piece exposes (verb contract: Verb discovery,
+ * docs/plans/pattern-verb-contract.md). Everything in the durable schema is
+ * listed — hiding is a display default driven by the listing marks
+ * (`tier: "wrapper"`, `deprecated: true`), never a capability boundary: the
+ * rows carry the marks, `partitionVerbListing` decides the default view, and
+ * `--all` shows the full surface. Walks result then input with the same classification
+ * `cf piece call` resolves through, so the listing and the dispatcher can
+ * never disagree about what is callable.
+ */
 export async function listPieceCallables(
   config: PieceConfig,
   deps: PieceCallableDependencies = {},


### PR DESCRIPTION
I (an agent working on behalf of @danfuzz) am reinstating the one file held out
of #5623.

The comment describing what a piece's callable listing contains — everything in
the durable schema is listed, hiding is a display default rather than a
capability boundary, the walk goes result then input — was written against
`listPieceCallables` in `b88c0c758`. `listingMarks` was later inserted directly
beneath it, taking the comment over and leaving the enumerator with none. The
comment moves back to its subject.

## On #5629

This was originally pulled out of #5623 so that #5629 (`feat(cli): a verb
listing row carries the handler's declared result`) would not have to care about
merge order — it edits both `listingMarks` and `listPieceCallables`, so the two
touch the same span whichever lands first.

Dan's call is to land this now and have #5629 rebase over it. The conflict, if
git raises one, is a doc comment that moved twenty lines down; resolving it
means keeping the comment on `export async function listPieceCallables` and
letting #5629's changes to both functions apply around it.

## Verification

`deno fmt --check`, and the full `cli` suite: 174 passed, 0 failed. The change
is a comment relocation with no other edit to the file.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

