### PR TITLE
refactor(cli,common): one interface for the note fixture, and the rule where an author meets it

### DIFF
--- a/docs/common/concepts/self-reference.md
+++ b/docs/common/concepts/self-reference.md
@@ -63,6 +63,13 @@ interface Input { title: string | Default<"Untitled">; }
 - **Both type params required:** Use `pattern<Input, Output>()` - single param `pattern<Input>()` will error if you access SELF
 - **`self` is typed as the output** - the instantiated piece itself, enabling recursive structures
 - **Inputs need defaults:** If an input feeds into the output, use `T | Default<V>` so `self` can bind
+- **A recursive field takes the whole output type, verbs included:** a child in
+  `children` is a full piece, so declaring that field as a narrower verb-free
+  interface is a claim the runtime contradicts — ask that child what it can do
+  and it lists every verb. The expensive unshaped read that leaves you with is
+  answered by naming what you want (`--select 'title,status'`), not by
+  narrowing the type; the measurement is in
+  [What you are driving](../verb-session-walkthrough.md#what-you-are-driving).
 
 ## See Also
 

--- a/packages/cli/integration/pattern/verb-results.tsx
+++ b/packages/cli/integration/pattern/verb-results.tsx
@@ -27,14 +27,16 @@ import {
   type Writable,
 } from "commonfabric";
 
-/** A note as the board projects it. Deliberately small: this fixture is about
- * what a verb hands back, not about modelling notes. */
+/** One note. Deliberately small: this fixture is about what a verb hands back,
+ * not about modelling notes. */
 export interface NoteOutput {
   [NAME]: string;
   title: string;
   body: string;
-  /** Bumped by `retitle`, so a caller can tell a write happened. */
+  /** Bumped by `append`, so a caller can tell a write happened. */
   revision: number;
+  /** Append a line to the body. */
+  append: Stream<AppendEvent, AppendResult>;
 }
 
 interface NoteInput {
@@ -52,15 +54,11 @@ interface AppendResult {
   body: string;
 }
 
-interface NoteVerbs extends NoteOutput {
-  append: Stream<AppendEvent, AppendResult>;
-}
-
 /** One note, deployed as a child of the board below. It carries a verb of its
  * own so the walkthrough can do the thing a reference result exists for: take
  * the piece a create handed back, resolve its address with `--show-links`, and
  * call it. */
-export const Note = pattern<NoteInput, NoteVerbs>(
+export const Note = pattern<NoteInput, NoteOutput>(
   ({ title, body, revision }) => {
     const append = action<AppendEvent, AppendResult>((event) => {
       const addition = (event.text ?? "").trim();


### PR DESCRIPTION
## Why

#5631 ruled against splitting a pattern's output into a data interface and a
satellite verbs interface: *"declaring it any narrower would be a claim the
runtime contradicts — ask that child what it can do and it lists all five."* It
removed the split from `tracker.tsx`. `verb-results.tsx` still had one, because
it was authored on 2026-08-03 (#5289) and predates the decision.

It is the sharper instance of the two, because the fixture's own walkthrough
disproves the type it declared. `notes: NoteOutput[]` said a note is not
callable; steps 5 and 6 of `verbs-over-the-cli.sh` do nothing but take a note
out of that array and call `append` on it.

The rule also had a discoverability problem worth fixing in the same change. It
lives in `verb-session-walkthrough.md`, a narrative walkthrough of one fixture,
while `docs/common/README.md` routes "Build a pattern" somewhere else entirely.
Nobody designing an Output interface lands on a session walkthrough — which is
roughly how this instance survived a week of the rule existing.

## What Changed

**`packages/cli/integration/pattern/verb-results.tsx`** — `append` moves into
`NoteOutput`; `NoteVerbs` is deleted; `Note` becomes
`pattern<NoteInput, NoteOutput>`. Also fixes a doc comment crediting `revision`
to a `retitle` verb — no such verb exists, and that comment was the only
occurrence of the word in the repository.

Worth flagging for review: **this is a schema change, not a rename.** Interface
members are non-optional, so `append` lands in `required` on `NoteOutput`
everywhere it embeds — including the board's argument schema via
`BoardInput.notes`. Harmless here (nothing else deploys this fixture, and every
run takes a fresh space), but the same edit to a shipped pattern would not be.

**`docs/common/concepts/self-reference.md`** — the rule as a fourth Key Rule.
That is where the decision presents itself: the doc's worked example is
`children: TreeNodeOutput[]` and it said nothing about verbs, leaving a reader
to invent the narrow type. It is a pointer, not a second copy — the argument and
the numbers stay in the walkthrough, per `.claude/rules/README.md`'s "a rule that
paraphrases a document is a second copy, and the two will disagree eventually."

The bullet carries the cost deliberately. One interface is what makes an
unshaped read expensive, so a bare "use one interface" is a rule someone will
rationally break while fixing a real read-size problem; it needs the
`--select` answer attached.

## Test plan

- Deployed the fixture and ran the walkthrough against a local toolshed:
  `API_URL=http://localhost:8000 packages/cli/integration/verbs-over-the-cli.sh`
  → **38 passed, 0 failed**. Steps 5 and 6 are the ones that would catch a bad
  merge of the interfaces; both pass.
- `cf check --pattern-json` diffed before/after to establish what the schema
  change actually is (above).
- `deno check` on the fixture; repo-wide `deno fmt --check` and `deno lint`.
- `deno task check-docs` (546 blocks), `check-skill-facts`,
  `check-conflict-markers`.
- Link target and `#what-you-are-driving` anchor verified by hand. `deno fmt`
  does not apply to `docs/` — it is in the exclude list — so the new bullet is
  hand-wrapped to the 80 columns `docs/development/DEVELOPMENT.md` specifies.

## Notes for review

No mechanical gate enforces this rule, and I did not add one. It is one
violation that predates the decision, and a checker would have to distinguish
`Verbs extends Output` from the legitimate `TopicOutput extends TopicPiece`
projection shape, which extends in the opposite direction. If a second instance
appears, that is the signal to reconsider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

