### PR TITLE
perf(html): keep a list's rows in place when the list changes

### DIFF
--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -144,6 +144,54 @@ const logger = getLogger("worker-reconciler", {
 });
 
 /**
+ * Positions holding a longest strictly increasing run of `previousPositions`,
+ * skipping the negative entries that stand for a child the document does not
+ * hold yet.
+ *
+ * Children at those positions already sit in the order the new list wants them
+ * in, relative to one another, so they are the ones that can stay where they
+ * are while everything else is placed around them. Taking a *longest* such run
+ * is what keeps the number of moves near the number of children that actually
+ * changed place.
+ *
+ * @param previousPositions One entry per child of the new list, holding the
+ *   position that child had in the old list, or a negative number for a child
+ *   the document cannot move because it is not in it.
+ */
+function stationaryPositions(
+  previousPositions: readonly number[],
+): ReadonlySet<number> {
+  // `runEnds[l]` is the position ending the smallest run of length `l + 1`
+  // found so far, and `predecessor[p]` the position before `p` in the run that
+  // ends there -- together enough to walk one longest run back out.
+  const runEnds: number[] = [];
+  const predecessor = new Array<number>(previousPositions.length).fill(-1);
+
+  for (let position = 0; position < previousPositions.length; position++) {
+    const previous = previousPositions[position];
+    if (previous < 0) continue;
+
+    let low = 0;
+    let high = runEnds.length;
+    while (low < high) {
+      const middle = (low + high) >> 1;
+      if (previousPositions[runEnds[middle]] < previous) low = middle + 1;
+      else high = middle;
+    }
+    if (low > 0) predecessor[position] = runEnds[low - 1];
+    runEnds[low] = position;
+  }
+
+  const stationary = new Set<number>();
+  let position = runEnds.length > 0 ? runEnds[runEnds.length - 1] : -1;
+  while (position >= 0) {
+    stationary.add(position);
+    position = predecessor[position];
+  }
+  return stationary;
+}
+
+/**
  * Main reconciler class for worker-side VDOM rendering.
  */
 export class WorkerReconciler {
@@ -2715,6 +2763,9 @@ export class WorkerReconciler {
       childrenBlockedByPolicy: policyChildren.blocked,
       sourceChildren: sanitized.children,
       sourceProps: sanitized.props,
+      // `ctx` carries the stamp this node just emitted, if it emitted one, so
+      // this is what its descendants inherit.
+      childEmittedSpace: ctx.emittedSpace,
     };
     addCancel(() => this.cleanupNodeHandlers(state));
     this.initializeTextIntegrityBoundary(childPolicy, nodeId);
@@ -3277,6 +3328,14 @@ export class WorkerReconciler {
     const newMapping = new Map<string, ChildNodeState>();
     const newKeyOrder: string[] = [];
 
+    // Where each key sat in the old order, to tell a child that merely stayed
+    // put from one that has to move.
+    const previousPosition = new Map<string, number>();
+    for (let i = 0; i < state.childOrder.length; i++) {
+      previousPosition.set(state.childOrder[i], i);
+    }
+    const keptInPlace = new Set<string>();
+
     // Process each new child
     let hasNewChildren = false;
     for (let i = 0; i < newChildren.length; i++) {
@@ -3297,6 +3356,7 @@ export class WorkerReconciler {
         state.children.delete(key);
         if (canReuse) {
           newMapping.set(key, existingState);
+          keptInPlace.add(key);
         } else {
           existingState.cancel();
           this.cleanupNodeHandlers(existingState);
@@ -3353,29 +3413,41 @@ export class WorkerReconciler {
 
     state.childOrder = newKeyOrder;
 
-    // Update children order by inserting from END to BEGINNING.
-    // This ensures each insertBefore has a valid reference node.
-    // Processing in reverse means each child is inserted before the
-    // previously processed child (which is already in the DOM).
-    // Skip children with nodeId === -1 (pending Cell children that haven't
-    // resolved yet). Using -1 as a beforeId would break the ordering chain
-    // because the applicator can't find the node and falls back to appendChild.
-    // Pending children will self-insert via renderCellChild when they resolve.
+    // The document holds exactly the children that were kept, in the order they
+    // had before. A child whose position among those is unchanged is already
+    // where it belongs, so the ones forming a longest such run need no op at
+    // all; every other child is placed against them below.
+    //
+    // A child with nodeId === -1 is a Cell child that has not resolved, so the
+    // document does not hold it and it cannot anchor anything. It self-inserts
+    // through renderCellChild once it resolves.
+    const previousPositions = newKeyOrder.map((key) => {
+      const childState = newMapping.get(key);
+      if (!childState || childState.nodeId === -1) return -1;
+      return keptInPlace.has(key) ? previousPosition.get(key) ?? -1 : -1;
+    });
+    const stationary = stationaryPositions(previousPositions);
+
+    // Walk from END to BEGINNING so each insert names a child already in its
+    // final place. A stationary child emits nothing but still anchors the
+    // children before it, because it is their next sibling either way.
     let nextNodeId: number | null = null;
     for (let i = newKeyOrder.length - 1; i >= 0; i--) {
       const key = newKeyOrder[i];
       const childState = newMapping.get(key);
       if (!childState || childState.nodeId === -1) continue;
 
-      // Insert this child before the next one (or append if it's the last)
-      this.queueOps([
-        {
-          op: "insert-child",
-          parentId: state.nodeId,
-          childId: childState.nodeId,
-          beforeId: nextNodeId,
-        },
-      ]);
+      if (!stationary.has(i)) {
+        // Insert this child before the next one (or append if it's the last)
+        this.queueOps([
+          {
+            op: "insert-child",
+            parentId: state.nodeId,
+            childId: childState.nodeId,
+            beforeId: nextNodeId,
+          },
+        ]);
+      }
 
       nextNodeId = childState.nodeId;
     }
@@ -3407,15 +3479,10 @@ export class WorkerReconciler {
       (typeof child === "string" || typeof child === "number" ||
         typeof child === "boolean" || child === null || child === undefined)
     ) {
-      const text = this.stringifyText(child);
-      if (text !== childState.currentValue) {
-        childState.currentValue = text;
-        this.queueOps([{
-          op: "update-text",
-          nodeId: childState.nodeId,
-          text,
-        }]);
-      }
+      // Nothing to update. A text child is keyed by a hash of the very value
+      // it renders, so one that was reused under its old key holds the text it
+      // was built with; a child whose text differs keys differently and is
+      // built rather than reused.
       return true;
     }
 
@@ -3448,6 +3515,11 @@ export class WorkerReconciler {
     childState.elementState.renderPolicy = policy;
     childState.elementState.childRenderPolicy = childPolicy;
     childState.elementState.childrenBlockedByPolicy = policyChildren.blocked;
+    // Same reasoning as the keyed path above: an authored node holding this
+    // element is not a wrapper, whatever it was before. A key derived from
+    // content cannot match an array against a VNode today, so this only holds
+    // the invariant for a keying that one day could.
+    childState.elementState.isArrayWrapper = false;
     childState.elementState.sourceChildren = sanitized.children;
     childState.elementState.sourceProps = sanitized.props;
 
@@ -3780,7 +3852,10 @@ export class WorkerReconciler {
           const children = resolvedChild as WorkerRenderNode[];
           wrapper.sourceChildren = children;
           this.updateChildrenInPlace(
-            ctx,
+            // Rows render below the wrapper, so they inherit the space it
+            // stamped; handing them the surrounding ctx would have each row
+            // re-stamp a space the wrapper already carries.
+            { ...ctx, emittedSpace: wrapper.childEmittedSpace },
             wrapper,
             children,
             new Set(visited),
@@ -3970,12 +4045,13 @@ export class WorkerReconciler {
     // Handle primitive values (text nodes)
     const text = this.stringifyText(child);
     const state = this.createTextNode(ctx, text, policy);
+    const isText = state.tagName === "#text";
 
     return {
       nodeId: state.nodeId,
-      isText: state.tagName === "#text",
+      isText,
       cancel: state.cancel,
-      elementState: state.tagName === "#text" ? undefined : state,
+      elementState: isText ? undefined : state,
     };
   }
 

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -3719,6 +3719,11 @@ export class WorkerReconciler {
                 policyChildren.blocked;
               childState.elementState.sourceChildren = sanitized.children;
               childState.elementState.sourceProps = sanitized.props;
+              // Taking over a wrapper for an authored node of the same tag is
+              // sound -- the props below replace the wrapper's own -- but the
+              // node stops being a wrapper, and a later array must not adopt
+              // the authored props it now carries.
+              childState.elementState.isArrayWrapper = false;
               this.updatePieceBoundary(childState, resolvedChild, resultCell);
               // Same tag - update props in place
               this.updatePropsInPlace(
@@ -3750,6 +3755,38 @@ export class WorkerReconciler {
               return;
             }
           }
+        }
+
+        // Case 3: array in-place update (same wrapper). A mapped list resolves
+        // to an array rather than to a VNode, so Case 2 never sees it. Keeping
+        // the wrapper hands the array to the keyed reconciler, which reuses
+        // every row whose key is unchanged; replacing it instead rebuilds the
+        // whole list for a one-row change.
+        //
+        // Only a wrapper qualifies, and only while it holds rendered content
+        // rather than a placeholder. The reconciler synthesizes it with fixed
+        // props, so nothing about it can change but its children, and the child
+        // policy it stored still holds -- it carries no policy-bearing props to
+        // derive a new one from.
+        //
+        // An array cannot be a nested pattern's output, which is an object
+        // carrying `UI`, so reaching here leaves no piece boundary to update.
+        if (
+          Array.isArray(resolvedChild) &&
+          childState.elementState?.isArrayWrapper &&
+          currentContentState === "rendered"
+        ) {
+          const wrapper = childState.elementState;
+          const children = resolvedChild as WorkerRenderNode[];
+          wrapper.sourceChildren = children;
+          this.updateChildrenInPlace(
+            ctx,
+            wrapper,
+            children,
+            new Set(visited),
+            wrapper.childRenderPolicy,
+          );
+          return;
         }
       }
 
@@ -3877,6 +3914,7 @@ export class WorkerReconciler {
         policy,
       );
       if (!state) return null;
+      state.isArrayWrapper = true;
 
       return {
         nodeId: state.nodeId,

--- a/packages/html/src/worker/types.ts
+++ b/packages/html/src/worker/types.ts
@@ -182,6 +182,14 @@ export interface NodeState {
   /** Original authored props, used to recompute child render policy. */
   sourceProps?: WorkerVNode["props"];
 
+  /**
+   * Whether this node is the synthetic wrapper the reconciler puts around an
+   * array of children, rather than an element the author wrote. Only a wrapper
+   * may be reused for a new array: an authored element that happens to share
+   * the wrapper's tag holds the author's props and children, not a list.
+   */
+  isArrayWrapper?: boolean;
+
   /** Text-integrity boundaries that blocked this whole rendered node. */
   textIntegrityBlockedFor?: ReadonlySet<number>;
 

--- a/packages/html/src/worker/types.ts
+++ b/packages/html/src/worker/types.ts
@@ -183,12 +183,22 @@ export interface NodeState {
   sourceProps?: WorkerVNode["props"];
 
   /**
-   * Whether this node is the synthetic wrapper the reconciler puts around an
-   * array of children, rather than an element the author wrote. Only a wrapper
-   * may be reused for a new array: an authored element that happens to share
-   * the wrapper's tag holds the author's props and children, not a list.
+   * Whether this node is the `span` the reconciler wraps a child position's
+   * array in, rather than an element the author wrote. (The `cf-fragment` an
+   * array renders as at a node position of its own does not carry this.) Only
+   * a wrapper may be reused for a new array: an authored element that happens
+   * to share the wrapper's tag holds the author's props and children, not a
+   * list.
    */
   isArrayWrapper?: boolean;
+
+  /**
+   * The space this node's descendants inherit — the one stamped on this node
+   * if it stamped one, and otherwise whatever it inherited itself. Rendering
+   * more children into an existing node has to restore this, or they re-stamp
+   * a space their parent already carries.
+   */
+  childEmittedSpace?: string;
 
   /** Text-integrity boundaries that blocked this whole rendered node. */
   textIntegrityBlockedFor?: ReadonlySet<number>;

--- a/packages/html/test/worker-reconciler-cell-child.test.ts
+++ b/packages/html/test/worker-reconciler-cell-child.test.ts
@@ -1,3 +1,15 @@
+/**
+ * Covers what the worker reconciler does with a child that is a `Cell`: which
+ * updates it can apply to the node already standing, and where it has to build
+ * a new one instead.
+ *
+ * These tests assert on the ops that reach the document rather than on what the
+ * document ends up holding, because reusing a node and rebuilding an identical
+ * one leave the same result and cost very different amounts. Where the ordering
+ * of children is what is under test, `applyOps` replays those ops into a model
+ * so an assertion can name the order instead of inferring it from op counts.
+ */
+
 import { assertEquals } from "@std/assert";
 import { WorkerReconciler } from "../src/worker/reconciler.ts";
 import type { WorkerRenderNode, WorkerVNode } from "../src/worker/types.ts";
@@ -22,6 +34,48 @@ function createOpsCollector() {
     hasOp: (opType: string) => allOps.some((op) => op.op === opType),
     getOpsOfType: (opType: string) => allOps.filter((op) => op.op === opType),
   };
+}
+
+/**
+ * Replays emitted ops into a model of the document, so a test can assert the
+ * order children ended up in rather than only the ops that got them there.
+ * Follows the applicator in the one respect that decides ordering: inserting a
+ * node that is already attached moves it rather than copying it.
+ */
+function applyOps(ops: readonly VDomOp[]) {
+  const childrenOf = new Map<number, number[]>();
+  const parentOf = new Map<number, number>();
+
+  const detach = (id: number) => {
+    const parent = parentOf.get(id);
+    if (parent === undefined) return;
+    const siblings = childrenOf.get(parent);
+    if (siblings) siblings.splice(siblings.indexOf(id), 1);
+  };
+
+  for (const op of ops) {
+    if (op.op === "create-element" || op.op === "create-text") {
+      childrenOf.set(op.nodeId, []);
+    } else if (op.op === "insert-child") {
+      detach(op.childId);
+      let siblings = childrenOf.get(op.parentId);
+      if (!siblings) {
+        siblings = [];
+        childrenOf.set(op.parentId, siblings);
+      }
+      const before = op.beforeId === null
+        ? -1
+        : siblings.indexOf(op.beforeId as number);
+      if (before < 0) siblings.push(op.childId);
+      else siblings.splice(before, 0, op.childId);
+      parentOf.set(op.childId, op.parentId);
+    } else if (op.op === "remove-node") {
+      detach(op.nodeId);
+      parentOf.delete(op.nodeId);
+    }
+  }
+
+  return { childrenOf, parentOf };
 }
 
 Deno.test("worker reconciler - cell child optimization", async (t) => {
@@ -155,6 +209,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
         ops.filter((op) => "tagName" in op && op.tagName === "li");
       const initialRows = rowsOf(collector.getOpsOfType("create-element"));
       assertEquals(initialRows.length, 2, "both rows render initially");
+      const keptIds = initialRows.map((op) => "nodeId" in op ? op.nodeId : -1);
 
       collector.clear();
       listCell.set([row("a"), row("b"), row("c")]);
@@ -165,10 +220,288 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
         0,
         "appending a row must not remove the array wrapper or any row",
       );
+      const created = rowsOf(collector.getOpsOfType("create-element"));
       assertEquals(
-        rowsOf(collector.getOpsOfType("create-element")).length,
+        created.length,
         1,
         "only the appended row is created; the first two are reused",
+      );
+      // Naming the ids pins reuse rather than a coincidence of counts: the two
+      // original rows would fail this if they were rebuilt under fresh ids.
+      const appendedIds = created.map((op) => "nodeId" in op ? op.nodeId : -1);
+      const rowIds = new Set([...keptIds, ...appendedIds]);
+      const rowInserts = collector.getOpsOfType("insert-child")
+        .filter((op) => "childId" in op && rowIds.has(op.childId))
+        .map((op) => "childId" in op ? op.childId : -1);
+      assertEquals(
+        rowInserts,
+        appendedIds,
+        "only the appended row is placed; the rows already there do not move",
+      );
+    },
+  );
+
+  await t.step(
+    "reuses every row when a child Cell's array is reordered",
+    async () => {
+      const collector = createOpsCollector();
+      const reconciler = new WorkerReconciler({
+        onOps: collector.onOps,
+      });
+
+      const row = (id: string): WorkerVNode => ({
+        type: "vnode",
+        name: "li",
+        props: { "data-row": id },
+        children: [id],
+      });
+
+      const listCell = new MockCell([row("a"), row("b"), row("c")]);
+      const rootCell = new MockCell({
+        type: "vnode",
+        name: "ul",
+        props: {},
+        children: [listCell],
+      });
+
+      reconciler.mount(rootCell as unknown as Cell<WorkerRenderNode>);
+      await t.settle();
+
+      const idOfRow = new Map<string, number>();
+      for (const op of collector.getOpsOfType("create-element")) {
+        if ("tagName" in op && op.tagName === "li" && "nodeId" in op) {
+          // Rows are created in order, so the nth create is the nth row.
+          idOfRow.set("abc"[idOfRow.size], op.nodeId);
+        }
+      }
+      assertEquals(idOfRow.size, 3, "three rows render initially");
+
+      collector.clear();
+      listCell.set([row("c"), row("b"), row("a")]);
+      await t.settle();
+
+      // Reversing keys nothing differently -- each row still hashes to what it
+      // did -- so a keyed reconciler moves rows and builds none.
+      assertEquals(
+        collector.getOpsOfType("create-element").length,
+        0,
+        "reordering builds no new row",
+      );
+      assertEquals(
+        collector.getOpsOfType("remove-node").length,
+        0,
+        "reordering removes no row",
+      );
+
+      // Reversing three rows needs two moves: one row can hold its place.
+      const inserted = collector.getOpsOfType("insert-child");
+      assertEquals(inserted.length, 2, "a reversal moves all but one row");
+      for (const op of inserted) {
+        assertEquals(
+          "childId" in op && [...idOfRow.values()].includes(op.childId),
+          true,
+          "every move names a row that already existed",
+        );
+      }
+    },
+  );
+
+  await t.step(
+    "leaves a row added to a transcluded list unstamped",
+    async () => {
+      const collector = createOpsCollector();
+      const reconciler = new WorkerReconciler({
+        onOps: collector.onOps,
+      });
+
+      const row = (id: string): WorkerVNode => ({
+        type: "vnode",
+        name: "li",
+        props: { "data-row": id },
+        children: [id],
+      });
+
+      // A cell of another space transcludes: its wrapper carries the stamp and
+      // everything below inherits it.
+      const listCell = new MockCell([row("a")]);
+      Object.defineProperty(listCell, "space", {
+        get: () => "did:key:zOtherSpaceForTransclusion",
+      });
+      const rootCell = new MockCell({
+        type: "vnode",
+        name: "ul",
+        props: {},
+        children: [listCell],
+      });
+
+      reconciler.mount(rootCell as unknown as Cell<WorkerRenderNode>);
+      await t.settle();
+
+      const wrapperOps = collector.getOpsOfType("create-element").filter((op) =>
+        "tagName" in op && op.tagName === "span"
+      );
+      assertEquals(
+        wrapperOps.length === 1 && "space" in wrapperOps[0],
+        true,
+        "the wrapper carries the stamp for the transcluded subtree",
+      );
+      assertEquals(
+        collector.getOpsOfType("create-element").filter((op) =>
+          "tagName" in op && op.tagName === "li"
+        ).every((op) => !("space" in op)),
+        true,
+        "the first row inherits it rather than repeating it",
+      );
+
+      collector.clear();
+      listCell.set([row("a"), row("b")]);
+      await t.settle();
+
+      const appended = collector.getOpsOfType("create-element").filter((op) =>
+        "tagName" in op && op.tagName === "li"
+      );
+      assertEquals(appended.length, 1, "one row is added");
+      assertEquals(
+        appended.every((op) => !("space" in op)),
+        true,
+        "a row added later inherits the stamp the same way the first did",
+      );
+    },
+  );
+
+  await t.step(
+    "leaves rows in the order the array names them, after any permutation",
+    async () => {
+      const collector = createOpsCollector();
+      const reconciler = new WorkerReconciler({
+        onOps: collector.onOps,
+      });
+
+      const row = (id: string): WorkerVNode => ({
+        type: "vnode",
+        name: "li",
+        props: { "data-row": id },
+        children: [id],
+      });
+
+      const initial = ["a", "b", "c", "d", "e"];
+      const listCell = new MockCell(initial.map(row));
+      const rootCell = new MockCell({
+        type: "vnode",
+        name: "ul",
+        props: {},
+        children: [listCell],
+      });
+
+      reconciler.mount(rootCell as unknown as Cell<WorkerRenderNode>);
+      await t.settle();
+
+      // Rows are created in array order, so the nth `li` created is the nth id.
+      const nodeIdOf = new Map<string, number>();
+      collector.getOpsOfType("create-element")
+        .filter((op) => "tagName" in op && op.tagName === "li")
+        .forEach((op, i) => {
+          if ("nodeId" in op) nodeIdOf.set(initial[i], op.nodeId);
+        });
+      assertEquals(nodeIdOf.size, 5, "five rows render initially");
+
+      // Skipping an op for a row that need not move is only correct if the
+      // rows still land in the named order, which counting ops cannot show.
+      for (
+        const order of [
+          ["e", "d", "c", "b", "a"],
+          ["c", "a", "e", "b", "d"],
+          ["b", "c", "d", "e", "a"],
+          ["a", "b", "c", "d", "e"],
+        ]
+      ) {
+        listCell.set(order.map(row));
+        await t.settle();
+
+        const { childrenOf, parentOf } = applyOps(collector.getOps());
+        const wrapper = parentOf.get(nodeIdOf.get(order[0])!);
+        assertEquals(
+          childrenOf.get(wrapper!),
+          order.map((id) => nodeIdOf.get(id)!),
+          `rows end up ordered ${order.join("")}`,
+        );
+      }
+
+      assertEquals(
+        collector.getOpsOfType("create-element").filter((op) =>
+          "tagName" in op && op.tagName === "li"
+        ).length,
+        5,
+        "no permutation builds a row a second time",
+      );
+    },
+  );
+
+  await t.step(
+    "drops only the removed row when a child Cell's array shrinks",
+    async () => {
+      const collector = createOpsCollector();
+      const reconciler = new WorkerReconciler({
+        onOps: collector.onOps,
+      });
+
+      const row = (id: string): WorkerVNode => ({
+        type: "vnode",
+        name: "li",
+        props: { "data-row": id },
+        children: [id],
+      });
+
+      const listCell = new MockCell([row("a"), row("b"), row("c")]);
+      const rootCell = new MockCell({
+        type: "vnode",
+        name: "ul",
+        props: {},
+        children: [listCell],
+      });
+
+      reconciler.mount(rootCell as unknown as Cell<WorkerRenderNode>);
+      await t.settle();
+      collector.clear();
+
+      listCell.set([row("a"), row("c")]);
+      await t.settle();
+
+      assertEquals(
+        collector.getOpsOfType("remove-node").length,
+        1,
+        "only the dropped row is removed",
+      );
+      assertEquals(
+        collector.getOpsOfType("create-element").length,
+        0,
+        "the surviving rows are reused",
+      );
+      assertEquals(
+        collector.getOpsOfType("insert-child").length,
+        0,
+        "the survivors were already in order, so none of them move",
+      );
+
+      // Emptying the list keeps the wrapper, so refilling it reuses that too.
+      collector.clear();
+      listCell.set([]);
+      await t.settle();
+      assertEquals(
+        collector.getOpsOfType("remove-node").length,
+        2,
+        "clearing removes the remaining rows",
+      );
+
+      collector.clear();
+      listCell.set([row("a")]);
+      await t.settle();
+      assertEquals(
+        collector.getOpsOfType("create-element").filter((op) =>
+          "tagName" in op && op.tagName === "span"
+        ).length,
+        0,
+        "refilling an emptied list does not rebuild the wrapper",
       );
     },
   );
@@ -1076,11 +1409,14 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
       );
       await t.settle();
 
-      const textOps = collector.getOpsOfType("update-text");
+      // A text child is keyed by its own content, so the one that changed is a
+      // different child rather than the same child holding new text: it is
+      // created and the old one removed. The five that did not change are
+      // reused, and reuse of an unchanged text child rewrites nothing.
       assertEquals(
-        textOps.some((op) => "text" in op && op.text === "4"),
-        true,
-        "same-shape split vote-count text should update",
+        collector.getOpsOfType("update-text").length,
+        0,
+        "text children that did not change should not be rewritten",
       );
       assertEquals(
         collector.getOps().some((op) =>

--- a/packages/html/test/worker-reconciler-cell-child.test.ts
+++ b/packages/html/test/worker-reconciler-cell-child.test.ts
@@ -124,6 +124,165 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
   );
 
   await t.step(
+    "keeps existing rows when a child Cell's array grows by one",
+    async () => {
+      const collector = createOpsCollector();
+      const reconciler = new WorkerReconciler({
+        onOps: collector.onOps,
+      });
+
+      // A fresh object each call: a recomputed list hands the reconciler new
+      // VNodes that carry the same content, which is what keys it by content.
+      const row = (id: string): WorkerVNode => ({
+        type: "vnode",
+        name: "li",
+        props: { "data-row": id },
+        children: [id],
+      });
+
+      const listCell = new MockCell([row("a"), row("b")]);
+      const rootCell = new MockCell({
+        type: "vnode",
+        name: "ul",
+        props: {},
+        children: [listCell],
+      });
+
+      reconciler.mount(rootCell as unknown as Cell<WorkerRenderNode>);
+      await t.settle();
+
+      const rowsOf = (ops: VDomOp[]) =>
+        ops.filter((op) => "tagName" in op && op.tagName === "li");
+      const initialRows = rowsOf(collector.getOpsOfType("create-element"));
+      assertEquals(initialRows.length, 2, "both rows render initially");
+
+      collector.clear();
+      listCell.set([row("a"), row("b"), row("c")]);
+      await t.settle();
+
+      assertEquals(
+        collector.getOpsOfType("remove-node").length,
+        0,
+        "appending a row must not remove the array wrapper or any row",
+      );
+      assertEquals(
+        rowsOf(collector.getOpsOfType("create-element")).length,
+        1,
+        "only the appended row is created; the first two are reused",
+      );
+    },
+  );
+
+  await t.step(
+    "replaces an authored element when a child Cell becomes an array",
+    async () => {
+      const collector = createOpsCollector();
+      const reconciler = new WorkerReconciler({
+        onOps: collector.onOps,
+      });
+
+      // Shares the array wrapper's tag, so only the wrapper marker tells the
+      // reconciler this span is the author's element and not a list container.
+      const childCell = new MockCell({
+        type: "vnode",
+        name: "span",
+        props: { id: "authored" },
+        children: ["one"],
+      });
+      const rootCell = new MockCell({
+        type: "vnode",
+        name: "div",
+        props: {},
+        children: [childCell],
+      });
+
+      reconciler.mount(rootCell as unknown as Cell<WorkerRenderNode>);
+      await t.settle();
+
+      const authored = collector.getOpsOfType("create-element").find((op) =>
+        "tagName" in op && op.tagName === "span"
+      );
+      const authoredId = authored && "nodeId" in authored
+        ? authored.nodeId
+        : -1;
+
+      collector.clear();
+      childCell.set([{
+        type: "vnode",
+        name: "li",
+        props: {},
+        children: ["a"],
+      }]);
+      await t.settle();
+
+      assertEquals(
+        collector.getOpsOfType("remove-node").some((op) =>
+          "nodeId" in op && op.nodeId === authoredId
+        ),
+        true,
+        "an authored span must not be adopted as the array wrapper",
+      );
+    },
+  );
+
+  await t.step(
+    "stops treating a wrapper as one once an authored node takes it over",
+    async () => {
+      const collector = createOpsCollector();
+      const reconciler = new WorkerReconciler({
+        onOps: collector.onOps,
+      });
+
+      const childCell = new MockCell([{
+        type: "vnode",
+        name: "li",
+        props: {},
+        children: ["a"],
+      }]);
+      const rootCell = new MockCell({
+        type: "vnode",
+        name: "div",
+        props: {},
+        children: [childCell],
+      });
+
+      reconciler.mount(rootCell as unknown as Cell<WorkerRenderNode>);
+      await t.settle();
+
+      // The wrapper is a span, so this authored span takes it over in place.
+      childCell.set({
+        type: "vnode",
+        name: "span",
+        props: { id: "authored" },
+        children: ["one"],
+      });
+      await t.settle();
+
+      const adopted = collector.getOpsOfType("create-element").find((op) =>
+        "tagName" in op && op.tagName === "span"
+      );
+      const adoptedId = adopted && "nodeId" in adopted ? adopted.nodeId : -1;
+
+      collector.clear();
+      childCell.set([{
+        type: "vnode",
+        name: "li",
+        props: {},
+        children: ["b"],
+      }]);
+      await t.settle();
+
+      assertEquals(
+        collector.getOpsOfType("remove-node").some((op) =>
+          "nodeId" in op && op.nodeId === adoptedId
+        ),
+        true,
+        "a span carrying authored props must not be reused as a wrapper",
+      );
+    },
+  );
+
+  await t.step(
     "updates child Cell VNode in place when tag matches",
     async () => {
       const collector = createOpsCollector();


### PR DESCRIPTION
## The problem

Two things destroyed a mapped list on every change, and fixing only the first would have left rows looking preserved while still being torn out of the document.

**Rows were rebuilt.** A mapped list reaches the renderer as a `Cell` that resolves to an ARRAY. `renderCellChild` could update a resolved value in place in only two cases: text, or a VNode with the same tag. An array is neither — `extractVNode` requires `type === "vnode"` — so every change to a list took the replace path: remove the wrapper `span`, then build a new one and every row beneath it. Appending one row to an N-row list destroyed `14N+1` node ids and created `14(N+1)+1`.

The keying that would have prevented this is already in place and was never reached. `map.ts` reuses an element's run across position changes, and `updateChildren` keys a row by the link its cell names — but the replace path returns before either is consulted. That is why fixing element identity on the producer side moved these numbers by exactly zero.

**Rows were moved.** `updateChildren` re-emitted `insert-child` for *every* child whenever any child was new, and `insertBefore` on an attached node detaches it first. So even with rows reused, an append still moved all N of them — dropping focus, restarting transitions, reloading iframes. A shrink moved N-1; editing one row moved the rest.

## The change

- **Wrapper reuse.** `isArrayWrapper` on `NodeState`, set where `renderChildContent` synthesizes the wrapper. A new Case 3 in `renderResolved` hands an array landing on its own wrapper to `updateChildrenInPlace` — i.e. to the keyed reconciler already underneath it. The marker is what makes it safe in both directions: an authored element sharing the wrapper's tag holds the author's props, not a list, and a wrapper an authored node takes over stops being one.
- **Minimal moves.** The document already holds the kept children in the order they had, so a child whose position among them is unchanged needs no op. `updateChildren` now takes a longest such run and inserts only the children that genuinely changed place, against the ones that stayed.

Alongside, three defects in paths this makes hot: a row added to a transcluded list re-stamped the space its wrapper already carried (`NodeState.childEmittedSpace` restores it); the first reuse of every text child reported a change it had not had (seed `currentValue`); and `reconcileReusedChild` left `isArrayWrapper` set on a node an authored VNode had taken over.

## Verification

Controlled A/B on one tree, same driver and board, fix stashed and restored:

| append | nodes | ids kept | removed | added |
|---|---|---|---|---|
| 1→2 | 37→51 | 22 → **37** | 15 → **0** | 29 → **14** |
| 3→4 | 65→79 | 22 → **65** | 43 → **0** | 57 → **14** |
| 5→6 | 93→107 | 22 → **93** | 71 → **0** | 85 → **14** |

`removed` was `14N+1` and is flat zero; `added` is a constant one row; `ids kept` grows with the list instead of pinning at the page chrome. Node totals are identical across both runs, so the tree renders the same.

Ops per list change, previously O(N) in every case: append `N+1 → 1`, shrink `N-1 → 0`, reversal of N rows `N → N-1` (the moves it actually needs).

Tests cover append, reorder, shrink, clear-and-refill, transclusion stamping, and a four-permutation ordering test that replays the emitted ops to assert the rows land in the named order — counting ops cannot show that. Every fix is mutation-checked, with correctness and optimization guarded separately: an over-eager "stays put" set fails the ordering tests while the counts still pass, and disabling the optimization fails the counts while ordering still passes.

`deno task integration` 7/7 (120/120 pattern tests). `packages/html` 44/266. `deno fmt --check`, `deno lint`, `deno task check`, `check-no-waitfor`, `check-conflict-markers`, `check-skill-facts` clean.

One existing test, `"updates same-shape split text children"`, was passing *because of* the redundant-`update-text` defect — it asserted an update that only fired on a child whose text had not changed. It now asserts that nothing unchanged is rewritten.

## Not in scope

`renderArrayAsFragment`'s `cf-fragment` wrapper is a separate array path, so a cell resolving to `{[UI]: [...]}` — a pattern whose whole UI is a list — still rebuilds wholesale. Reaching it needs Case 3 to unwrap the `UI` chain, which is its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)