### PR TITLE
docs(plan): item 10 lands, and closed-world emission is ruled against

### DIFF
--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -45,7 +45,8 @@ without reconstructing it.
 | 8. descriptive receipt schemas | on main |
 | 9a. listing marks | on main (#5309) |
 | 10. listing rows carry a handler's declared result | on main (#5629) |
-| 9b. closed-world event emission | built, parked on #5589 (#5307) |
+| 9b. closed-world event emission | **ruled against** (#5589); does not land |
+| 12. `cf` refuses an undeclared field on a call | not started — where the ruling puts this capability |
 | 4. `receipt` as a top-level envelope field | not started — and its precondition now holds |
 | 2. an unrecognized projection key is refused | not started |
 | 3. a rejection propagates up through what holds it | not started |
@@ -60,7 +61,7 @@ a driver needs to know what is already moving before scheduling anything new.
 
 | PR | What | State |
 | --- | --- | --- |
-| #5307 | closed-world verb event schemas | parked on #5589; the minting is built, and what stays red is a renderer-semantics ruling rather than an implementation gap |
+| #5307 | closed-world verb event schemas | **ruled against** on #5589 and in review. Retreating leaves nothing to land — the emission and the goldens and baselines recording it are the whole branch — so this closes rather than merges |
 
 **Most of the read layer has landed.** #5309, #5459, #5468, #5470, #5497 and
 #5500 are on main. #5458 is closed rather than merged because its rename was
@@ -264,6 +265,29 @@ the piece — the root pattern's own verb, reachable today by `pieces.add` from
 inside the runtime and by a model through the dialog builtin, and by no other
 caller.
 
+**12. `cf` refuses an undeclared field on a call.** *(S)* A payload carrying a
+field the verb does not declare is accepted, the field is dropped on the way in,
+and the caller is told the call settled — the silent-strip failure, which is
+what a caller writing JSON by hand or by model hits and a TypeScript author
+never does.
+
+*This is item 2's shape, one surface over.* There a projection key in neither
+denylist is accepted and ignored; here an event field the schema does not
+declare is accepted and ignored. Both are the CLI declining to refuse what it
+cannot honour, and both are fixed by the CLI refusing it — not by a schema
+forbidding it, which is the distinction #5589 turns on. Worth building the two
+with the same vocabulary for what a refusal says, since a caller meets both
+through the same command.
+
+*The check has a home already.* `verbInputSchemaError`
+(`packages/cli/lib/callable.ts`) validates a payload against the verb's declared
+event schema before dispatch. What it does not do is treat an undeclared field
+as a reason to refuse — and the schema it validates against names exactly the
+fields the verb declares, so the comparison needs no new source of truth.
+
+*Exit:* a call naming a field the verb does not declare is refused, the message
+names the field, and the invocation id is not spent.
+
 ## Landed, and what consumes it
 
 **6. The read layer.** On main in full: the shared read step, address markers
@@ -279,11 +303,26 @@ this; nothing else does.
 **8. Descriptive receipt schemas.** On main. Plain results only — a verb
 returning anything reactive gets none, which is what item 1 decides.
 
-**9. Closed-world event schemas and listing marks.** Half landed: the listing
-marks are on main (#5309). Closed-world emission (#5307) is built but parked on
-#5589 — closing a verb's `$event` closes it against the browser too, and
-whether a renderer's DOM-event envelope is governed by the verb's schema is a
-semantics ruling rather than an implementation gap.
+**9. Closed-world event schemas and listing marks.** The listing marks are on
+main (#5309). **Closed-world emission is ruled against** and does not land: an
+event schema is not to carry `additionalProperties: false`, because absence
+already denies a handler an undeclared field, while `false` rejects the whole
+event over a field the handler would not have received either way — and it
+locks the schema permanently, since the compatibility rules cannot take a
+closure back (#5589, and the review on #5307).
+
+*The capability is not refused, only its location.* Refusing a call whose
+payload carries a field the verb does not declare is an ergonomic property of
+`cf`, not something to enforce in the runtime. In TypeScript the compiler
+already says so at authoring time without foreclosing a later field, so what is
+missing is the check for callers who never see a type — which is the CLI. That
+is item 12.
+
+*Two mechanisms on main are left with nothing to do*, and retiring them is a
+question for whoever owns the runtime rather than a step here:
+`closedWorldEventRejection` (`packages/runner/src/runner.ts`) is a dispatch gate
+no schema can now trigger, and #5302's verb-event-role compatibility rule
+governs an open-to-closed transition that will not happen.
 
 **10. Listing rows carry a handler's declared result.** *(S)* `cf piece verbs`
 reports an `outputSchema` per row for a handler as well as for a tool, so verb
@@ -332,13 +371,10 @@ its own track.
 | 10 | Two identical projections stop colliding | #5523 | 9 | Same file. Reachable the moment anything long-lived reads twice, which the command surface invites |
 | 11 | One piece, one address | #5632, #5498 | — | Trace where each id is minted; the outcome is a fix or a statement that they are aliases. Must precede step 13, which spreads the address vocabulary to two more commands |
 | 12 | An unrecognized projection key is refused | item 2 | 9 | The largest remaining step and the only one with design surface, since it couples the projection reader to the compatibility checker's annotation keys |
+| 12a | `cf` refuses an undeclared field on a call | item 12 | — | Same refusal shape as the step above and independent of it, so it can go either side; building them together is what keeps one vocabulary for what a refusal says |
 | 13 | `cf wish` and `cf exec` take the read options | item 5 | 11, 12 | Last by construction: it spreads the vocabulary to two more starting points, so the vocabulary should have stopped moving |
 
-**Waiting on a ruling, and running beside all of the above.** Closed-world event
-emission (item 9b) is built and parked on #5589. When that answers, the branch
-merges as-is, amends `closedWorldEventRejection`, or retreats — all three are
-costed on #5307 — and it owes an item renumber, then a baseline re-record as its
-final step. A caller naming a reference (item 11, #5560) waits on confirming
+**Running beside all of the above.** A caller naming a reference (item 11, #5560) waits on confirming
 that a sigil resolves through a *declared* event field rather than an untyped
 one; it decides nothing item 1 decides — a declared result makes an *output*
 self-describing, this is what an *input* accepts — but it shares
@@ -396,14 +432,6 @@ plan as their PRs land — is the collision the per-agent split exists to avoid.
 
 Two rules earn their place, both from what went wrong when this was three
 plans:
-
-**#5307 owes a golden regeneration, and it is the only thing it owes #5501.**
-The two touch no common source file — a declared result rides a trailing
-options argument, while event stamping keys on the first — so this is a note on
-the pair rather than an edge in the sequence. But #5501's handler-schema
-fixtures were compiled while event schemas were still open, so closing them
-gives those fixtures `additionalProperties: false` on their event literals. The
-second to land regenerates, and #5501 landed first.
 
 **Two PRs can each be green and still break main together.** CI judges a PR
 against a base, so when one branch narrows a type and another still writes to
@@ -514,7 +542,7 @@ from a plan is one nobody schedules, which is the whole reason for this table.
 | #5523 | two identical `piece get` projections in one runtime collide on the transform result cell | step 10 |
 | #5632 | `--show-links` and a `$link` read return different entity ids for the same piece | step 11 |
 | #5498 | `getEntityId()` strips the entity URI scheme, collapsing two kinds to one identity | step 11, if it proves to be the same root |
-| #5589 | ruling: does a closed verb schema govern the renderer's DOM-event envelope? | the parked track — it is what unparks item 9b |
+| #5589 | ruling: does a closed verb schema govern the renderer's DOM-event envelope? | **answered** — no. Item 9b does not land, and the capability moves to item 12 |
 | #5560 | an address a call returns cannot be passed back as a verb argument | item 11 |
 | #5534 | a capability probe passes while covering nothing: a dispatch rejection is not a synchronous throw | carried alongside |
 

--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -44,7 +44,7 @@ without reconstructing it.
 | 7. session-scoped invocation ids | on main (#5610) |
 | 8. descriptive receipt schemas | on main |
 | 9a. listing marks | on main (#5309) |
-| 10. listing rows carry a handler's declared result | in review (#5629) |
+| 10. listing rows carry a handler's declared result | on main (#5629) |
 | 9b. closed-world event emission | built, parked on #5589 (#5307) |
 | 4. `receipt` as a top-level envelope field | not started — and its precondition now holds |
 | 2. an unrecognized projection key is refused | not started |
@@ -60,7 +60,6 @@ a driver needs to know what is already moving before scheduling anything new.
 
 | PR | What | State |
 | --- | --- | --- |
-| #5629 | a verb listing row carries the handler's declared result | item 10, the consumer half of the declared result |
 | #5307 | closed-world verb event schemas | parked on #5589; the minting is built, and what stays red is a renderer-semantics ruling rather than an implementation gap |
 
 **Most of the read layer has landed.** #5309, #5459, #5468, #5470, #5497 and
@@ -322,8 +321,8 @@ its own track.
 | --- | --- | --- | --- | --- |
 | 1 | The doubly-linked tracker fixture and its walkthrough | **on main** (#5639, #5631) — repro for #5577, #5632, #5633, #5637; item 11's subject | — | Five things verify against a piece that holds a back-reference, and none could be demonstrated until one existed. `verb-session-gaps.sh` is where they are asserted, and four of its assertions expect a gap and fail loudly the day it closes — so a capability arriving announces itself instead of quietly turning a check green |
 | 2 | A projected read survives a handler | #5633 | 1 | Breaks call-then-read-shaped, which is the loop items 4, 5, 10 and #5577 all demonstrate against. Diagnose before estimating: if it sits in runner materialization rather than the read path, it moves after step 7 rather than holding the line |
-| 3 | Listing rows carry a handler's declared result | item 10, #5619 | — | The consumer half of item 1 |
-| 4 | The forced-stream fallback stops inventing verbs | #5576 | 3 | Same file as step 3. It narrows the listing, so sweep the open branches for writers first |
+| 3 | Listing rows carry a handler's declared result | **on main** (#5629) — item 10, #5619 | — | The consumer half of item 1 |
+| 4 | The forced-stream fallback stops inventing verbs | #5576 | 3 | Same file as step 3, which has landed, so this is the front of the queue. It narrows the listing, so sweep the open branches for writers first |
 | 5 | The help page stops claiming a verb returns nothing | #5558 (the false claim) | — | `Output: No output on success.` is wrong for a declared verb. Asserting there is no output is worse than saying nothing, and stopping it needs no schema and no decision, which is why it precedes the half that does |
 | 5a | An author's prose reaches the caller | #5637 | 1 | Separate lane — what is missing is not in the CLI. See the measurement below: two of the three symptoms are emitted correctly and lost afterwards, so a fix aimed at the emitter would miss them |
 | 6 | Help enumerates what a verb returns | #5558 (the missing fields) | 3, 5 | Step 3 builds the declared-result lookup; this is its second consumer, at the call path rather than the listing |
@@ -508,7 +507,6 @@ from a plan is one nobody schedules, which is the whole reason for this table.
 | Issue | What | Attaches at |
 | --- | --- | --- |
 | #5633 | a projected read fails after an unrelated handler runs, while the same path unshaped succeeds | step 2 |
-| #5619 | listing rows carry a handler's declared result | step 3 |
 | #5576 | `cf piece verbs` lists data fields as handlers, so discovery reports what cannot be called | step 4 |
 | #5558 | `piece call --help` claims every handler returns nothing, including one that declares a result | steps 5 and 6 — the false claim needs nothing, enumerating the fields needs the lookup |
 | #5637 | an author's prose does not reach a caller: on a verb, on an event field, and on the event interface | step 5a — it absorbed #5559, which described one symptom and had its cause backwards |

--- a/docs/plans/verbs-implementation.md
+++ b/docs/plans/verbs-implementation.md
@@ -412,10 +412,14 @@ Whoever takes this should confirm or discard that before assuming a single
 cause: what is established is only that the emitter is not where two of the
 three go missing, so a patch aimed there would close one symptom and leave two.
 
-**Carried alongside, not sequenced.** A capability probe that covers nothing
-(#5534) is a test asserting something it cannot observe, so it reports green
-continuously until fixed; it belongs to whoever next touches that suite rather
-than to a step here.
+**Carried alongside, not sequenced.** Two defects that no gate can see, which
+is why they are written down rather than left to be met again. A capability
+probe that covers nothing (#5534) asserts something it cannot observe, so it
+reports green continuously until fixed. And the renderer writes a click count
+into `detail` and a cell-ref into `target.value`, both slots patterns declare
+with other types (#5589) — closed event schemas were the only thing that ever
+compared the two, and ruling against them removed the detector rather than the
+mismatch.
 
 ## How this is driven
 
@@ -542,7 +546,7 @@ from a plan is one nobody schedules, which is the whole reason for this table.
 | #5523 | two identical `piece get` projections in one runtime collide on the transform result cell | step 10 |
 | #5632 | `--show-links` and a `$link` read return different entity ids for the same piece | step 11 |
 | #5498 | `getEntityId()` strips the entity URI scheme, collapsing two kinds to one identity | step 11, if it proves to be the same root |
-| #5589 | ruling: does a closed verb schema govern the renderer's DOM-event envelope? | **answered** — no. Item 9b does not land, and the capability moves to item 12 |
+| #5589 | a click's `detail` and a `cf-select`'s `target.value` reach a handler as types no pattern declares | carried alongside — it belongs to whoever next touches `packages/html`. The ruling that closed item 9b also removed the only thing that ever compared the renderer's output against an author's declared type, so this has no detector left |
 | #5560 | an address a call returns cannot be passed back as a verb argument | item 11 |
 | #5534 | a capability probe passes while covering nothing: a dispatch rejection is not a synchronous throw | carried alongside |
 


### PR DESCRIPTION
## Why

Three things moved under the plan in one afternoon, and it misdescribed all of them. A plan that is wrong about its own front is the document a driver reaches for first.

**Item 10 landed** (#5629, `ac0497dae`) while the plan still called it "in review" and listed a merged PR as open.

**#5589 answered, and against.** An event schema is not to carry `additionalProperties: false`: absence already denies a handler an undeclared field, `false` rejects the whole event over a field the handler would not have received either way, and a closure cannot be taken back once the compatibility rules record it. The plan had that work parked pending a ruling.

**#5589 then became a defect rather than a question.** The ruling answered it by removing its premise, and what remains in it is the mismatch that closure exposed — a click count delivered into `detail`, a cell-ref into `target.value`, both slots patterns declare with other types.

## What Changed

- **Item 10** → on main, across the roll-up, the open-PR table, the sequence and the issue tail. Step 4 (#5576) becomes the front of the queue, and its file contention is now with main rather than an open branch, which changes how it rebases rather than merely when.
- **Item 9b** → ruled against, with the reasoning recorded rather than just the verdict. #5307 closes rather than merges: the emission and the goldens and baselines recording it are the whole branch, so retreating leaves nothing to land.
- **Item 12 added** — `cf` refuses an undeclared field on a call. Written as item 2's shape one surface over: both are the CLI declining to refuse what it cannot honour, and both are fixed by the CLI refusing rather than by a schema forbidding, which is the distinction the ruling turns on. `verbInputSchemaError` already validates the payload against the declared event schema, so it needs no new source of truth.
- **#5589 recorded as a carried-alongside defect**, beside #5534, for the property they share: closed event schemas were the only thing that ever compared the renderer's output against an author's declared type, so ruling against them removed the detector rather than the mismatch. Both are defects no gate can see, which is why they are written down.
- **Two mechanisms on main are recorded as left with nothing to trigger** — `closedWorldEventRejection` and #5302's verb-event-role compatibility rule. Flagged as a question for whoever owns the runtime rather than answered here.
- Drops the #5307/#5501 golden-regeneration note, which describes work neither will now do.

## Test plan

`deno task check-docs` — 547 blocks, on the rebased tree. Documentation only; no source files touched.

## Known gap, not addressed here

`docs/plans/pattern-verb-contract.md:254` still states design rule 1 as *"An undeclared field is a typed rejection, never ignored: input schemas are closed-world."* After the ruling the runtime drops undeclared fields by design and rejection belongs to `cf`, so the design document now describes behaviour the runtime does not have. Amending a design is not a plan edit, so it is named rather than done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)