### PR TITLE
docs: specify hosted pattern authoring

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -22,6 +22,9 @@ a record: archive it to `docs/history/plans/` following the procedure in
 - [First-class serializable factories](first-class-serializable-factories.md)
   sequences the implementation of durable pattern, module, and handler
   factories.
+- [Hosted pattern authoring](hosted-pattern-authoring.md) sequences the shared
+  server operation and the piece menu, Home, and `cf` entry points for changing
+  a piece or creating a space from a request.
 - [Ingest channels and the journal sink](ingest-channels-journal-sink.md)
   proposes a minted, bearer-authed inbound endpoint that accumulates what it
   receives as a provenance-marked, append-only log — the shared capability

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -25,6 +25,9 @@ a record: archive it to `docs/history/plans/` following the procedure in
 - [Hosted pattern authoring](hosted-pattern-authoring.md) sequences the shared
   server operation and the piece menu, Home, and `cf` entry points for changing
   a piece or creating a space from a request.
+- [Developer-tooling feedback for hosted authoring](hosted-pattern-authoring-tooling-feedback.md)
+  adds a separate, non-blocking way for an authoring agent to report missing or
+  defective development capabilities.
 - [Ingest channels and the journal sink](ingest-channels-journal-sink.md)
   proposes a minted, bearer-authed inbound endpoint that accumulates what it
   receives as a provenance-marked, append-only log — the shared capability

--- a/docs/plans/hosted-pattern-authoring-tooling-feedback.md
+++ b/docs/plans/hosted-pattern-authoring-tooling-feedback.md
@@ -1,0 +1,53 @@
+# Developer-tooling feedback for hosted authoring
+
+Add a safe way for a hosted authoring agent to report what its development
+environment is missing. This is a follow-up to
+[`hosted-pattern-authoring.md`](hosted-pattern-authoring.md), not a dependency
+of its piece-change or new-space steel threads.
+
+## Status
+
+Not started.
+
+## Goal
+
+The authoring tool set includes `report_developer_tooling_need`. The agent uses
+it when a missing or defective capability makes its work slower, less reliable,
+or impossible. Reports can cover compiler bugs or poor diagnostics, missing
+`cf` behavior, missing Unix tools, documentation gaps, sandbox restrictions,
+browser tooling, or anything else needed to produce a good pattern.
+
+The tool records the need. It does not install software, grant a capability,
+change the sandbox, publish source, or waive a verification gate. The agent
+continues with available tools when possible. A blocked session references the
+report in its failure result.
+
+## Plan
+
+- [ ] Add `report_developer_tooling_need` as a mediated `cf-harness` tool. Its
+  input contains a category, summary, impact, expected behavior, and minimal
+  evidence.
+- [ ] Add the authoring session, environment versions, and relevant tool
+  invocation identifiers in trusted service code rather than model-authored
+  input.
+- [ ] Store the full report as a durable session artifact carrying the combined
+  CFC labels of its request, evidence, tool results, and session context.
+- [ ] Show the local report through the same CFC-checked access as other session
+  artifacts.
+- [ ] Define a trusted automatic-export projection limited to enumerated
+  category and impact values, tool and environment versions, and stable
+  diagnostic codes.
+- [ ] Reject free text, source, request text, paths, identifiers, commands,
+  arguments, and raw results from automatic export.
+- [ ] Send the bounded projection to the developer-tooling triage sink only
+  after its CFC flow check passes.
+- [ ] Require an authorized person's explicit declassification before sending
+  a full report or other free text.
+- [ ] Test that reporting cannot expand the tool set, change the sandbox,
+  publish source, or satisfy a failed verification gate.
+- [ ] Test that the full report retains sensitive labels, the projection rejects
+  every disallowed field, and permitted diagnostic metadata reaches the triage
+  sink only after the CFC check passes.
+
+Success means an agent can report a missing or defective tool without gaining
+authority or creating a new path for source, request, or session data to leave.

--- a/docs/plans/hosted-pattern-authoring.md
+++ b/docs/plans/hosted-pattern-authoring.md
@@ -1,0 +1,279 @@
+# Hosted pattern authoring implementation plan
+
+Implement the product contract in
+[`../specs/hosted-pattern-authoring.md`](../specs/hosted-pattern-authoring.md).
+The smallest useful system has one hosted agent session, two authoring
+operations, and three thin entry points. It does not require the Pattern
+Factory phase machine or server-primary pattern execution.
+
+## Status
+
+Not started.
+
+## Working rules
+
+- Keep the browser and CLI outside the authoring implementation. They submit a
+  request, render events, and present the result.
+- Use one persistent `cf-harness` session per request.
+- Keep target authority, verification, and publication outside the model.
+- Land service work dark. Do not grant production publication until CFC
+  enforcement and the end-to-end negative tests pass.
+- Build the existing-piece path first because its target, expected revision,
+  compatibility gate, and source history make the safety boundary observable.
+- Reuse the piece source lifecycle. Do not introduce another source or revision
+  store for authored results.
+
+## Prerequisites
+
+The service contract and non-publishing harness work can begin before these
+land. Existing-piece or new-space publication cannot ship until:
+
+- the piece source lifecycle retains the complete authored-program manifest,
+  including unreachable files and the public-subpath map, for generated-create
+  and direct-edit revisions;
+- the source lifecycle can materialize that exact retained program for an edit;
+- the space-root interface validator required by the source lifecycle is
+  available to the ordinary creation path.
+
+Add focused lifecycle tests for those capabilities instead of reproducing them
+inside the authoring service.
+
+## Stage 1: shared service contract
+
+- [ ] Define the two target shapes, start request, session snapshot, append-only
+  events, terminal results, and stable error codes in a package usable by the
+  server, runtime client, and CLI.
+- [ ] Resolve all caller-supplied addresses on the trusted server. Store
+  canonical space and piece identifiers in the session record.
+- [ ] Bind existing-piece requests to the current source revision before
+  queueing the session.
+- [ ] Add authenticated start, read, event-stream, and cancel endpoints.
+- [ ] Restrict session reads, events, and cancellation to the creating
+  principal. Add a separately audited operational support role if operators
+  need access.
+- [ ] Apply CFC read checks to session snapshots, events, and retained
+  artifacts.
+- [ ] Make request creation idempotent through a caller-supplied operation
+  identifier. Do not implement automatic retries.
+- [ ] Add a fake executor test that drives every state transition without an
+  LLM provider.
+- [ ] Prove browser and CLI clients can use the same protocol types without
+  importing server implementation code.
+
+Success means a fake session can be started, observed, reconnected, cancelled,
+and recovered after a service restart. No stage can publish source yet.
+
+## Stage 2: one autonomous harness session
+
+- [ ] Add a hosted-authoring adapter for `cf-harness`.
+- [ ] Create a writable workspace containing the candidate and a read-only
+  mount containing the selected Labs source and documentation.
+- [ ] For an existing piece, materialize the exact retained authored source and
+  record the expected source revision. Fail before model invocation when exact
+  source is unavailable.
+- [ ] Give the session the Pattern Factory build guide, `cf` skill, and only the
+  development tools needed to inspect, edit, compile, test, and perform allowed
+  runtime checks.
+- [ ] Instruct the agent to add or update focused pattern tests for behavior it
+  changes. Require an explicit evidence-based explanation when a behavior
+  cannot usefully be covered by a pattern test.
+- [ ] Include every authored test file in the complete authored-program
+  manifest so source retrieval, history, and revert preserve it with the
+  pattern even when it is outside the runtime import graph.
+- [ ] Build an edit candidate from the complete predecessor manifest. Preserve
+  unchanged test files and require the final report to name deliberate test
+  deletion or replacement.
+- [ ] Add `report_developer_tooling_need` as a mediated harness tool. Accept a
+  category, summary, impact, expected behavior, and minimal evidence, then add
+  session and environment context outside the model.
+- [ ] Store each full tooling report as a durable session artifact carrying the
+  combined labels of its request, evidence, tool results, and session context.
+- [ ] Define a trusted export projection limited to enumerated category and
+  impact values, tool and environment versions, and stable diagnostic codes.
+  Reject free text, source, request text, paths, identifiers, commands,
+  arguments, and raw results from automatic export.
+- [ ] Send that bounded projection to the developer-tooling triage sink only
+  after its CFC flow check passes. Require an authorized person's explicit
+  declassification to send full reports or free text.
+- [ ] Prove the feedback tool cannot install software, expand the tool set,
+  alter the sandbox, publish source, or satisfy a verification gate.
+- [ ] Test that the local report retains sensitive labels, the automatic
+  projection rejects every disallowed field, and permitted diagnostic metadata
+  reaches the triage sink only after the CFC check passes.
+- [ ] Disable general outbound network access. Represent the model provider,
+  local runtime, browser lease, and any approved fetch as separate mediated
+  capabilities with fixed destinations.
+- [ ] Enforce admission and per-session limits for model tokens, tool calls,
+  CPU, memory, and disk. A limit failure must not publish.
+- [ ] Use one prompt that states the requested outcome, available tools, target
+  kind, and completion gates. Do not add phase prompts or separate repair
+  sessions.
+- [ ] Preserve the workspace, transcript, tool evidence, and observed CFC
+  provenance in the durable session record.
+- [ ] Attach the person's request provenance at trusted ingress and combine it
+  with every other model observation in candidate files and model messages.
+- [ ] Resume the same session after process interruption. Refuse resume when
+  policy no longer permits its observations or outputs.
+- [ ] Add provider-independent fixtures for compile failure, test failure,
+  repair followed by success, cancellation, and process recovery.
+
+Success means a server-hosted session can produce a candidate and objective
+verification evidence. The target remains unchanged.
+
+## Stage 3: guarded existing-piece publication
+
+- [ ] Verify the complete authored-program manifest prerequisite and retained
+  program materialization path with an end-to-end lifecycle fixture.
+- [ ] Add a target-bound publication capability that the harness can invoke
+  without learning its token or changing its target.
+- [ ] Recompile and verify the candidate outside the agent sandbox.
+- [ ] In one serializable transaction, check current authority and
+  compatibility against the actual retained input, compare the captured source
+  revision, and publish the direct edit.
+- [ ] Include authorization state, retained input, current pattern, active
+  origin, and source revision in the transaction's read basis.
+- [ ] Clear the active origin and append a detached revision with the authoring
+  session as its cause in that same transaction.
+- [ ] Keep the candidate and report a stable stale-target error after a
+  concurrent edit. Do not merge or overwrite.
+- [ ] Reject incompatible candidates in the first version.
+- [ ] Apply CFC flow checks before source crosses a space boundary. Keep
+  production publication disabled while any required check is observe-only.
+- [ ] Test prompt injection that asks tools to publish to another piece or
+  space. Prove the bound target cannot change.
+- [ ] Test that identity keys, provider credentials, and publication secrets
+  are absent from the model-visible filesystem, environment, prompts, and tool
+  results.
+- [ ] Test that unmediated network access fails and every resource limit ends
+  the session without publication.
+- [ ] Linearize cancellation against the transition to `publishing`. Test both
+  race outcomes and report `too_late` when publication wins.
+
+Success means an authorized compatible candidate changes the intended piece
+once and every failure leaves it unchanged.
+
+## Stage 4: existing-piece entry points
+
+- [ ] Add **Request a change** to the shared piece context menu.
+- [ ] Ask the service whether a complete retained authored program is available.
+  Disable the menu item with an explanation when it is not.
+- [ ] Add the request form, durable progress view, verification result, failure
+  evidence, and cancel action.
+- [ ] Render emitted progress summaries, changed files, incremental diffs, tool
+  activity, and verification results from the durable event stream as they
+  arrive. Tool-activity events expose only the tool name, state, and bounded
+  outcome. Keep raw arguments and results out of progress events.
+- [ ] Give every durable event a stable sequence identifier. Reconnect from one
+  cursor with an atomic replay-to-follow handoff, with no gaps or duplicate
+  entries.
+- [ ] Test that source-diff events require session-source read authority and
+  that tool-activity events contain no arguments, results, credentials, paths,
+  or internal identifiers.
+- [ ] Reopen the active or latest relevant session from the same piece menu.
+- [ ] Add `cf piece change <piece>`, request text from `--request` or standard
+  input, attached event output, `--detach`, and `--json`.
+- [ ] Route both clients through the shared start and session APIs.
+- [ ] Add one browser test and one CLI test that assert the same service request
+  and final source revision.
+
+Success means the menu and CLI complete the same existing-piece steel thread
+without either client running an agent or performing publication.
+
+## Stage 5: new-space publication
+
+- [ ] Verify the space-root interface validator prerequisite with a focused
+  ordinary-creation fixture.
+- [ ] Extend the adapter with a clean top-level pattern workspace and an
+  isolated test space.
+- [ ] Reuse the same compile, pattern-test, runtime, evidence, and CFC gates as
+  the existing-piece path.
+- [ ] Reject a candidate that does not expose the operations and state required
+  of a space root.
+- [ ] Add a trusted publication operation that creates the space and root piece
+  through the ordinary creation path.
+- [ ] Initialize the root, `defaultPattern`, and detached generated-create
+  revision with the authoring session as its cause in one transaction.
+- [ ] Create no final space until the root candidate is verified. Clean up or
+  retain internal staging data according to the service retention policy.
+- [ ] Return the canonical space and root piece addresses in the terminal
+  result.
+- [ ] Prove failed and cancelled sessions create no visible Home entry.
+- [ ] Replay the same operation identifier before and after an interrupted
+  response and prove only one session and final space exist.
+
+Success means a natural-language request produces one usable new space and no
+partial product state is visible on failure.
+
+## Stage 6: Home and command-line entry points
+
+- [ ] Add the **Create from a request** section to the default Home pattern's
+  Spaces tab, with optional space name, request, progress, result, and cancel
+  controls.
+- [ ] Reuse the same live, replayable session-progress component as the piece
+  menu instead of implementing a Home-specific event view.
+- [ ] On success, add the canonical space to Home's spaces list and navigate to
+  it.
+- [ ] Keep the existing add-or-open-by-name field and default pattern URL
+  setting unchanged.
+- [ ] Add `cf space create`, request text from `--request` or standard input,
+  optional `--name`, attached event output, `--detach`, and `--json`.
+- [ ] Route Home and the CLI through the same start and session APIs.
+- [ ] Add one browser test and one CLI test that assert the same service request
+  and final created-space result.
+
+Success means Home and the CLI complete the same new-space steel thread.
+
+## Stage 7: end-to-end gate and rollout
+
+- [ ] Run existing-piece and new-space tests against a real `cf-harness`
+  provider adapter in a non-production environment.
+- [ ] Cover fresh deployment with browser smoke testing for a pattern whose
+  behavior depends on browser events or navigation.
+- [ ] Restart the authoring service during a working session and prove the same
+  session resumes with its event and CFC history.
+- [ ] Revoke caller authority before publication and prove the target remains
+  unchanged.
+- [ ] Change the target piece concurrently and prove the candidate is retained
+  but not published.
+- [ ] Inspect retained source, active origin, source revision cause, and revert
+  behavior after an authored piece change.
+- [ ] Retrieve and revert authored pieces whose test files are outside the
+  runtime import graph. Prove those tests remain attached to every relevant
+  source revision.
+- [ ] Edit a pattern without changing one of its existing tests. Prove the next
+  revision retains that unchanged test, and that a deliberate deletion is
+  named in the final report.
+- [ ] Confirm operator-visible metrics cover queue depth, active sessions,
+  terminal outcomes, gate failures, stale targets, policy denials, and
+  publication latency without exposing source or request text.
+- [ ] Implement deletion of terminal workspaces, requests, transcripts, tool
+  payloads, and model responses after a configured finite retention window.
+  Keep only a minimal result record without those payloads.
+- [ ] Resolve the default window and storage collection mechanism with
+  [`retention-and-provenance.md`](retention-and-provenance.md). Keep production
+  start disabled until both are configured.
+- [ ] Enable production publication only after the security and lifecycle
+  owners approve the enforcement evidence.
+- [ ] Update the hosted authoring specification's status and archive this plan
+  when every stage is complete.
+
+## Explicitly outside this plan
+
+Do not add multiple-agent orchestration, mandatory Pattern Factory phases,
+automatic repository following, scheduled source updates, automatic stale
+candidate merging, or an agent-controlled compatibility override. This plan
+can grow only when a concrete product requirement or measured failure of the
+single-session design requires one of those mechanisms.
+
+## Required documentation updates while implementing
+
+- Update
+  [`../specs/piece-source-lifecycle.md`](../specs/piece-source-lifecycle.md)
+  when the LLM-backed create and edit status changes.
+- Update the `cf-harness` implementation profile when the hosted adapter changes
+  its claimed execution or CFC behavior.
+- Add operator documentation for provider configuration, session retention,
+  cancellation, and production enablement before rollout.
+- Add a feature guide after the first complete entry point ships. The guide
+  belongs under `docs/features/`; this plan is not a substitute for user-facing
+  instructions.

--- a/docs/plans/hosted-pattern-authoring.md
+++ b/docs/plans/hosted-pattern-authoring.md
@@ -36,7 +36,9 @@ land. Existing-piece or new-space publication cannot ship until:
   available to the ordinary creation path.
 
 Add focused lifecycle tests for those capabilities instead of reproducing them
-inside the authoring service.
+inside the authoring service. Repeatable `--test` packaging and FUSE preservation
+of attached `sourceRoots` are already implemented. Reuse that foundation; it is
+not a replacement for the complete manifest prerequisite.
 
 ## Stage 1: shared service contract
 
@@ -66,40 +68,36 @@ and recovered after a service restart. No stage can publish source yet.
 ## Stage 2: one autonomous harness session
 
 - [ ] Add a hosted-authoring adapter for `cf-harness`.
+- [ ] Use `cf-harness` capability discovery and configuration validation for
+  the selected run profile. Establish provider availability through the
+  session's selected provider request and record any failure on that session;
+  do not probe unrelated configured models.
 - [ ] Create a writable workspace containing the candidate and a read-only
   mount containing the selected Labs source and documentation.
 - [ ] For an existing piece, materialize the exact retained authored source and
   record the expected source revision. Fail before model invocation when exact
   source is unavailable.
-- [ ] Give the session the Pattern Factory build guide, `cf` skill, and only the
-  development tools needed to inspect, edit, compile, test, and perform allowed
-  runtime checks.
+- [ ] Give the session the general pattern-development and testing guidance,
+  the current `cf`, `pattern-dev`, `pattern-test`, and `pattern-deploy` skills,
+  and only the development tools needed to inspect, edit, compile, test, and
+  perform allowed runtime checks.
+- [ ] Load current authoring and deployment skill resources at session start.
+  Do not duplicate their `cf test` or test-attachment command syntax in the
+  adapter prompt.
 - [ ] Instruct the agent to add or update focused pattern tests for behavior it
   changes. Require an explicit evidence-based explanation when a behavior
   cannot usefully be covered by a pattern test.
 - [ ] Include every authored test file in the complete authored-program
   manifest so source retrieval, history, and revert preserve it with the
   pattern even when it is outside the runtime import graph.
+- [ ] Carry the complete test-entry set from the existing `sourceRoots`
+  packaging path into complete-manifest construction on every candidate create
+  or update. Never publish from `sourceRoots` or a reachable closure alone. Add
+  an integration test equivalent to repeatable CLI `--test` flags and to FUSE
+  root preservation.
 - [ ] Build an edit candidate from the complete predecessor manifest. Preserve
   unchanged test files and require the final report to name deliberate test
   deletion or replacement.
-- [ ] Add `report_developer_tooling_need` as a mediated harness tool. Accept a
-  category, summary, impact, expected behavior, and minimal evidence, then add
-  session and environment context outside the model.
-- [ ] Store each full tooling report as a durable session artifact carrying the
-  combined labels of its request, evidence, tool results, and session context.
-- [ ] Define a trusted export projection limited to enumerated category and
-  impact values, tool and environment versions, and stable diagnostic codes.
-  Reject free text, source, request text, paths, identifiers, commands,
-  arguments, and raw results from automatic export.
-- [ ] Send that bounded projection to the developer-tooling triage sink only
-  after its CFC flow check passes. Require an authorized person's explicit
-  declassification to send full reports or free text.
-- [ ] Prove the feedback tool cannot install software, expand the tool set,
-  alter the sandbox, publish source, or satisfy a verification gate.
-- [ ] Test that the local report retains sensitive labels, the automatic
-  projection rejects every disallowed field, and permitted diagnostic metadata
-  reaches the triage sink only after the CFC check passes.
 - [ ] Disable general outbound network access. Represent the model provider,
   local runtime, browser lease, and any approved fetch as separate mediated
   capabilities with fixed destinations.
@@ -155,6 +153,10 @@ once and every failure leaves it unchanged.
 ## Stage 4: existing-piece entry points
 
 - [ ] Add **Request a change** to the shared piece context menu.
+- [ ] Use the menu's existing nearest whole-piece resolution. Prove a request
+  from a nested piece targets that inner piece, a field-level renderer is not a
+  target, and a retargeted or disconnected renderer closes the unsubmitted
+  form.
 - [ ] Ask the service whether a complete retained authored program is available.
   Disable the menu item with an explanation when it is not.
 - [ ] Add the request form, durable progress view, verification result, failure
@@ -264,6 +266,10 @@ automatic repository following, scheduled source updates, automatic stale
 candidate merging, or an agent-controlled compatibility override. This plan
 can grow only when a concrete product requirement or measured failure of the
 single-session design requires one of those mechanisms.
+
+Developer-tooling feedback is tracked independently in
+[`hosted-pattern-authoring-tooling-feedback.md`](hosted-pattern-authoring-tooling-feedback.md).
+It does not block this plan.
 
 ## Required documentation updates while implementing
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -30,6 +30,7 @@ decision is reversed or superseded).
 - [Content-addressed action identity](content-addressed-action-identity.md)
 - [Content-addressed module loading](module-loading.md)
 - [Piece source lifecycle](piece-source-lifecycle.md)
+- [Hosted pattern authoring](hosted-pattern-authoring.md)
 - [Scoped cell instances](scoped-cell-instances.md)
 
 ### Data, storage, and execution

--- a/docs/specs/hosted-pattern-authoring.md
+++ b/docs/specs/hosted-pattern-authoring.md
@@ -1,0 +1,442 @@
+# Hosted pattern authoring
+
+How a person asks an agent to change an existing piece or create a new space,
+how that coding session runs on the server, and how its result enters the
+piece source lifecycle.
+
+This document specifies the product operation and its entry points. The
+[piece source lifecycle](piece-source-lifecycle.md) remains the design of
+record for retaining source, recording revisions, checking compatibility, and
+detaching a directly edited piece. The
+[`cf-harness` implementation profile](../../packages/cf-harness/docs/IMPLEMENTATION_PROFILE.md)
+describes the agent runtime used by the operation.
+
+## Status
+
+Design. Labs contains the agent harness, authoring guidance, source lifecycle,
+and source replacement machinery needed by this design. It does not yet expose
+a hosted authoring service or the product entry points specified here.
+
+## Last updated
+
+2026-08-11
+
+## Goal
+
+A person can describe an outcome instead of supplying pattern source. The
+server hosts one coding session that can read the Labs documentation and use
+the `cf` development tools. The session builds and verifies a candidate. A
+trusted service publishes the candidate only after the required checks pass.
+
+There are two operations:
+
+1. Change the pattern source of an existing piece while preserving its data.
+2. Create a new space whose root is a newly authored pattern.
+
+The browser and command-line interfaces are thin clients of the same service.
+They do not contain their own prompting, repair, testing, or publication logic.
+
+## Product entry points
+
+### Request a change from a piece
+
+Every piece context menu has a **Request a change** item. Selecting it opens a
+form with:
+
+- the selected piece shown as a fixed target;
+- a multiline **What should change?** field;
+- a **Start** button.
+
+The item is disabled with an explanation when the service reports that the
+piece has no complete retained authored program. It stays visible so the
+absence of the operation is not mistaken for a permissions or loading failure.
+
+The piece identity is taken from the menu context. The person does not type or
+paste it into the request. This keeps authority over the target outside the
+model's text.
+
+Submitting starts an existing-piece authoring session. The form changes to a
+session view that shows the current activity, verification results, final
+outcome, and a cancel action. The person can leave the view and return to it
+from the same piece menu while a session is active or awaiting attention.
+
+While the view is open, it updates from the session event stream in real time.
+It shows the agent's emitted progress summaries, files created or changed,
+incremental source diffs, safe tool-activity summaries, and compile, test, and
+runtime results. Tool summaries contain the tool name, state, and a bounded
+outcome. They exclude raw arguments, raw results, credentials, request text,
+source, internal paths, and identifiers. Source diffs use a separate CFC-checked
+event visible only to a caller authorized to read the session source. The view
+does not expose private model reasoning. Reopening it uses a stable event
+sequence cursor to replay and then follow without missing or duplicating an
+event.
+
+The first version accepts only source changes compatible with the piece's
+current pattern and retained input. An incompatible candidate is not
+published. A later design may add an explicit confirmation flow, but an agent
+must never approve that warning for the person.
+
+### Create a space from Home
+
+The default Home pattern's Spaces tab has a **Create from a request** section.
+It contains:
+
+- an optional **Space name** field;
+- a multiline **What should this space do?** field;
+- a **Create** button.
+
+This is separate from the existing field that adds or opens a space by name.
+Submitting starts a new-space authoring session. Home shows the session's
+activity and verification results in the same section.
+
+The service does not add an empty or failed space to Home. It builds and tests
+the candidate in an isolated workspace and test space. After successful
+publication, the new space is added to Home's spaces list and Home navigates to
+it. If the person supplied a display name, the new space uses that name. The
+trusted service chooses all durable identifiers.
+
+### Command line
+
+The matching commands are:
+
+```console
+cf piece change <piece> --request "Add a compact weekly view"
+cf space create --request "A shared meal planner for four people" \
+  --name "Meal planner"
+```
+
+The ordinary `--identity` and `--api-url` options select the caller and server.
+Long requests can be read from standard input by omitting `--request`:
+
+```console
+cf piece change <piece> < request.md
+cf space create --name "Meal planner" < request.md
+```
+
+Supplying both `--request` and non-empty standard input is an error. An empty
+request is an error.
+
+By default, the command stays attached to the server event stream and exits
+when the session reaches a terminal state. `--detach` returns after the server
+accepts the request. Both modes print the authoring session identifier. `--json`
+uses the same event and result shapes as the service protocol.
+
+The command line does not start a local agent and does not call `cf piece
+setsrc` itself. It submits the same operation as the browser, using the same
+server checks and publication path.
+
+## One hosted operation
+
+Clients start the operation with one of these request shapes:
+
+```ts
+type AuthoringRequestTarget =
+  | {
+    kind: "change-piece";
+    piece: string;
+  }
+  | {
+    kind: "create-space";
+    requestedName?: string;
+  };
+
+type StartAuthoringRequest = {
+  operationId: string;
+  target: AuthoringRequestTarget;
+  request: string;
+};
+```
+
+These are logical protocol fields, not a required wire encoding. The piece
+field accepts the same address syntax as the rest of the `cf` command line.
+The authenticated server resolves that address to canonical space and piece
+identifiers and captures the current source revision. It stores those trusted
+bindings in the session. The agent receives an opaque, target-bound publication
+capability. It cannot replace the target by printing another piece or space
+identifier.
+
+The client creates one stable `operationId` for a submission and reuses it if
+the start response is lost. While the session record is retained, submitting
+the same operation identifier as the same principal returns that session.
+Submitting it with different content is an error. This prevents transport
+replay from starting a second agent or creating a second space.
+
+The operation returns a durable session identifier. A session has one of these
+states:
+
+- `queued`: accepted but not yet assigned to a harness;
+- `working`: the agent can inspect, edit, and run development tools;
+- `verifying`: required checks are running;
+- `publishing`: the trusted service is committing the verified candidate;
+- `succeeded`: publication completed;
+- `failed`: the session stopped with a recorded error;
+- `cancelled`: the person cancelled it before publication began.
+
+Clients may subscribe to the append-only session event stream and may read the
+current snapshot at any time. Reconnecting resumes after the last received
+event. Correctness does not depend on polling intervals, retries, or client
+uptime.
+
+Only the principal that created a session can read its snapshot, subscribe to
+its events, or cancel it. An operational support role may receive separately
+defined, audited access. Reads also pass the CFC check for the stored record's
+labels. Knowing a session identifier grants no authority.
+
+Only one service implementation owns session creation, harness invocation,
+verification, and publication. The menu, Home pattern, and CLI adapt their
+local addresses and presentation to that operation.
+
+## Authoring session
+
+Each request gets one persistent `cf-harness` session. The session has:
+
+- a writable candidate workspace;
+- the relevant current pattern source, if changing a piece;
+- Labs source and documentation mounted read-only;
+- the Pattern Factory build guide and the `cf` skill;
+- `cf check`, `cf test`, and the other explicitly allowed development tools;
+- an isolated runtime target for checks that need a running piece;
+- no readable user key, provider credential, or publication credential.
+
+The authoring profile has no general outbound network access. Access to a
+model provider, local test runtime, browser lease, or approved fetch operation
+is a mediated capability with a fixed destination and result policy. The
+service sets limits for concurrent sessions, model tokens, tool invocations,
+CPU, memory, and disk. Reaching a limit fails the session without publication.
+Queued sessions wait for admission; clients do not create retry loops.
+
+The initial instruction states the requested outcome and the acceptance gates.
+The agent decides how to inspect, implement, test, and repair its work. The
+service does not divide the work into mandatory design, implementation,
+critique, repair, or finalization phases. Separate sessions are used only when
+access policy requires different information boundaries.
+
+The session can finish successfully only after it has produced:
+
+- the complete authored program needed by the candidate, including its test
+  files;
+- focused new or updated pattern tests for behavior changed by the request, or
+  the recorded explanation and named alternative evidence described below;
+- passing `cf check` results;
+- passing pattern tests;
+- any required runtime or browser smoke evidence;
+- a concise summary and the recorded verification results.
+
+Test files are part of the retained authored-program manifest even when the
+deployed pattern does not import them. Publication attaches them to the source
+revision alongside the runtime source. Source retrieval, history, and revert
+therefore preserve the tests with the pattern. The runtime does not execute
+the test files as part of the deployed piece; the authoring verification gate
+runs them before publication.
+
+An edit starts from the complete retained manifest. The candidate preserves
+every existing test file unless the agent deliberately deletes or replaces it
+and records that change in the final report. Publication never constructs a
+new manifest from the runtime import graph, because doing so would silently
+drop tests and other authored files that the deployed export does not import.
+
+When a behavior change cannot usefully be covered by a pattern test, the final
+report records why and names the runtime or browser evidence that covers it.
+Omitting tests merely because the agent ran out of time or context is not a
+successful result.
+
+Browser smoke testing is required when behavior depends on rendering, browser
+events, navigation, or a freshly deployed runtime. It is not a ritual for
+source-only changes that are completely exercised by pattern tests.
+
+The service records the request, session events, tool results, candidate
+artifacts, and final result so a failed or interrupted session can be inspected
+without relying on the model's last message.
+
+### Developer-tooling feedback
+
+The session tool set includes `report_developer_tooling_need`. The agent uses
+it whenever a missing or defective development capability makes the work
+slower, less reliable, or impossible. Reports can cover compiler bugs or poor
+diagnostics, missing `cf` behavior, missing Unix tools, documentation gaps,
+sandbox restrictions, browser tooling, or any other obstacle to producing a
+good pattern.
+
+A report contains a category, short summary, impact, expected behavior, and
+the smallest useful evidence. The service adds the authoring session,
+environment versions, and relevant tool invocation identifiers. The full
+local artifact receives the combined CFC labels of the request, evidence, tool
+results, and session context. The person can see it through the same
+CFC-checked session access as other authoring artifacts.
+
+Automatic submission to the developer-tooling triage sink uses a bounded
+projection made by trusted code. It can contain only enumerated category and
+impact values, tool and environment versions, and stable diagnostic codes. It
+cannot contain model-authored free text, source, request text, paths, session
+or piece identifiers, commands, arguments, or raw results. The projection must
+also pass its CFC flow check. Sending the full report or other free text
+requires an authorized person to review and explicitly release it through the
+ordinary declassification path. A report that cannot be exported remains with
+the session and is marked as not exported.
+
+The tool does not install software, grant a capability, change the sandbox, or
+waive a verification gate. The agent continues with available tools when it
+can. If the missing capability blocks completion, the failed result references
+the feedback report.
+
+## Publication
+
+The agent never writes directly to the target. It writes a candidate. The
+trusted service validates and publishes that candidate.
+
+For an existing piece, publication first verifies the complete candidate
+source outside the agent sandbox. It then uses one serializable transaction to:
+
+1. check the caller's current source-update authority;
+2. read and check the piece's actual retained input and pattern contract;
+3. compare the current source revision with the revision captured when the
+   session started;
+4. apply one direct-edit source transition;
+5. clear the active origin and append a detached source revision whose cause
+   identifies the authoring session.
+
+The transaction's read basis includes the retained input, authorization state,
+source revision, current pattern, and active origin. A change to any of them
+before commit rejects the transaction.
+
+A concurrent source change makes step 3 fail. The service keeps the candidate
+and reports that the target changed. It does not merge, rebase, overwrite, or
+silently start again.
+
+For a new space, publication:
+
+1. verifies the complete candidate source again outside the agent sandbox;
+2. verifies that the candidate exposes the operations and state required of a
+   space root;
+3. checks the caller's current space-creation authority;
+4. atomically initializes the final space, root piece, `defaultPattern`, and
+   detached generated-create source revision through the ordinary creation
+   path;
+5. returns the completed space's canonical address.
+
+The service publishes no final space until it has a verified root. A failed
+authoring session therefore leaves no empty product space. Internal staging
+data follows the service retention policy. After a Home-started operation
+succeeds, Home adds the returned canonical space to its list and navigates to
+it. If that Home update fails, the completed space still exists and the session
+result still contains its address.
+
+Published source is a snapshot. It does not follow the repository or the
+authoring workspace. Later repository edits and later agent edits do not update
+the piece. A person can request another change or use the ordinary source
+origin controls when they intentionally want following behavior.
+
+## Authorization and contextual flow control
+
+Starting a change requires read and source-update authority for the selected
+piece. Creating a space requires the caller's ordinary space-creation
+authority. The service checks authority again inside publication's trusted
+transaction.
+
+The host, not the model, chooses the identity, target, expected revision, test
+space, and publication capability. Instructions found in pattern source,
+space data, imported documentation, tool output, or the person's request
+cannot change those bindings.
+
+The trusted ingress attaches CFC provenance to the person's request before it
+enters model context. The request, source, space data, documentation, and tool
+output are observations by the model. The harness records their combined CFC
+provenance. Candidate files and model messages are `LlmDerived` from all of
+those observations. Before data or source crosses a space boundary, the
+service applies the ordinary CFC flow check and fails closed if the destination
+is not allowed.
+
+The model cannot read identity keys, provider credentials, server tokens, or
+the raw publication capability. Tool calls that need authority are mediated by
+the harness. The runner remains authoritative for CFC semantics; the harness
+transports labels and enforces the allowed tool surface.
+
+This feature must not be enabled for production publication while relevant
+CFC checks are observe-only. A development deployment may exercise the entire
+flow without granting a production publication capability.
+
+## Failure and cancellation
+
+A failed compile, test, runtime check, policy check, or publication check leaves
+the target unchanged. The failure result includes the failed gate and its
+evidence. Agent narration cannot turn a failed gate into success.
+
+Cancellation and the transition to `publishing` are ordered by one atomic state
+change. If cancellation wins, the session becomes `cancelled`, further tool use
+is revoked, and publication cannot start. If publication wins, cancellation
+returns `too_late` and the session does not report itself as cancelled. A
+completed commit is not undone. The ordinary source history provides the
+explicit revert operation for an existing piece.
+
+Provider interruption or server restart preserves the session record and
+workspace. Resume continues the same harness session when its access labels and
+credentials still permit it. It does not create a second session that lacks
+the first session's observed-information record.
+
+Workspace files, request text, transcripts, tool payloads, and model responses
+are retained while a session can resume. After a terminal result they are
+deleted at the end of a configured finite retention window. The creating
+principal can request earlier deletion, subject to the ordinary audit policy.
+A minimal result record may remain, but it contains no request text, source,
+transcript, or tool payload. Production start is disabled until a default
+window and storage collection mechanism are configured. The shared
+[retention and execution provenance plan](../plans/retention-and-provenance.md)
+owns the unresolved default duration and CFC review.
+
+## Relationship to nearby systems
+
+Pattern Factory is useful prior art and can remain an experimental client of
+the harness. Its phase ordering, separate repair passes, and finalization pass
+are not part of this product contract. The required boundary is simpler: an
+autonomous session produces a candidate, deterministic gates verify it, and a
+trusted service publishes it.
+
+Server-primary pattern execution is complementary. It determines where
+deployed patterns run. Hosted pattern authoring determines where a coding
+agent works before deployment. One does not depend on the other.
+
+The background piece service and the runtime `wish()` builtin do not author
+pattern source. `wish()` discovers existing pieces. Neither is reused as the
+authoring scheduler.
+
+## Acceptance criteria
+
+The feature is complete when automated tests prove all of the following:
+
+- **Request a change** starts a session bound to the selected piece.
+- A compatible candidate passes verification, replaces that piece once,
+  detaches it from any origin, and appends a restorable source revision.
+- Every generated-create or direct-edit source revision retains all applicable
+  tests, including unchanged tests and files outside the runtime import graph.
+  Deliberate removal is recorded in the final report.
+- A stale revision, incompatible candidate, failed gate, denied flow, or
+  cancelled session leaves the piece unchanged.
+- **Create from a request** produces a new root pattern, creates one visible
+  space, adds it to Home, and navigates to it.
+- A failed new-space session adds no visible space to Home.
+- Replaying a start request with the same operation identifier starts no second
+  agent and creates no second space.
+- `cf piece change` and `cf space create` submit the same request shapes and
+  receive the same event and result shapes as their browser counterparts.
+- The piece and Home session views show durable authoring progress as it
+  arrives without exposing private model reasoning.
+- A developer-tooling report records useful evidence and grants no new
+  authority. Its full artifact retains the evidence labels, and only the
+  bounded projection reaches the triage sink without explicit human release.
+- A request or observed source that names another target cannot redirect
+  publication.
+- The model cannot read caller or provider credentials.
+- The agent has no unmediated outbound network path and cannot exceed its
+  configured resource limits.
+- A cancel that wins the publication race leaves the target unchanged; a
+  losing cancel reports `too_late` rather than `cancelled`.
+- A server restart can resume a nonterminal session without losing its event
+  history or observed-information record.
+
+## Deliberately deferred
+
+The first version does not include multiple cooperating agents, mandatory
+authoring phases, automatic merging after a concurrent edit, automatic
+repository tracking, scheduled self-improvement, or model-approved schema
+incompatibility. These can be proposed separately if evidence from the single
+session flow shows they are needed.

--- a/docs/specs/hosted-pattern-authoring.md
+++ b/docs/specs/hosted-pattern-authoring.md
@@ -15,7 +15,12 @@ describes the agent runtime used by the operation.
 
 Design. Labs contains the agent harness, authoring guidance, source lifecycle,
 and source replacement machinery needed by this design. It does not yet expose
-a hosted authoring service or the product entry points specified here.
+a hosted authoring service or the product entry points specified here. Local
+`cf piece new` and `cf piece setsrc` now accept repeatable `--test` entries,
+package and type-check those tests, and retain them as source roots. FUSE source
+writeback preserves the attached roots. Those are foundations for the test
+retention contract below, but they do not run the tests or provide the complete
+authored-program manifest still required by the piece source lifecycle.
 
 ## Last updated
 
@@ -54,6 +59,14 @@ absence of the operation is not mistaken for a permissions or loading failure.
 The piece identity is taken from the menu context. The person does not type or
 paste it into the request. This keeps authority over the target outside the
 model's text.
+
+The target is the same whole piece that the existing context menu resolves. A
+right-click inside nested rendered pieces selects the innermost piece boundary,
+not the outer container. A renderer showing a field inside a piece does not
+become a piece target. If the renderer disconnects or changes its target before
+submission, the menu closes instead of submitting the stale selection. Once a
+session starts, its canonical target remains fixed even if that renderer later
+changes.
 
 Submitting starts an existing-piece authoring session. The form changes to a
 session view that shows the current activity, verification results, final
@@ -193,10 +206,17 @@ Each request gets one persistent `cf-harness` session. The session has:
 - a writable candidate workspace;
 - the relevant current pattern source, if changing a piece;
 - Labs source and documentation mounted read-only;
-- the Pattern Factory build guide and the `cf` skill;
+- the general pattern-development and testing guidance and the current `cf`,
+  `pattern-dev`, `pattern-test`, and `pattern-deploy` skills;
 - `cf check`, `cf test`, and the other explicitly allowed development tools;
 - an isolated runtime target for checks that need a running piece;
 - no readable user key, provider credential, or publication credential.
+
+The current `cf`, `pattern-dev`, `pattern-test`, and `pattern-deploy` skills
+already tell an agent to run every authored test and attach every test entry to
+each source revision. The hosted adapter loads those live resources. It does
+not copy their command syntax into a separate prompt that can drift from the
+CLI.
 
 The authoring profile has no general outbound network access. Access to a
 model provider, local test runtime, browser lease, or approved fetch operation
@@ -229,6 +249,15 @@ therefore preserve the tests with the pattern. The runtime does not execute
 the test files as part of the deployed piece; the authoring verification gate
 runs them before publication.
 
+Current source packaging represents attached tests as additional source roots.
+The complete manifest records those entry paths and directly retains their
+files along with every other authored file and the public-subpath map. Hosted
+authoring supplies the full root set on every create or update, just as the CLI
+requires every `--test` entry on each `piece new` or `piece setsrc`. It never
+treats `sourceRoots` or the reachable source closure as a substitute for the
+complete manifest. The service does not invoke those CLI commands to publish,
+but it uses the same program and source-lifecycle representation beneath them.
+
 An edit starts from the complete retained manifest. The candidate preserves
 every existing test file unless the agent deliberately deletes or replaces it
 and records that change in the final report. Publication never constructs a
@@ -248,36 +277,15 @@ The service records the request, session events, tool results, candidate
 artifacts, and final result so a failed or interrupted session can be inspected
 without relying on the model's last message.
 
-### Developer-tooling feedback
+### Developer-tooling feedback follow-up
 
-The session tool set includes `report_developer_tooling_need`. The agent uses
-it whenever a missing or defective development capability makes the work
-slower, less reliable, or impossible. Reports can cover compiler bugs or poor
-diagnostics, missing `cf` behavior, missing Unix tools, documentation gaps,
-sandbox restrictions, browser tooling, or any other obstacle to producing a
-good pattern.
-
-A report contains a category, short summary, impact, expected behavior, and
-the smallest useful evidence. The service adds the authoring session,
-environment versions, and relevant tool invocation identifiers. The full
-local artifact receives the combined CFC labels of the request, evidence, tool
-results, and session context. The person can see it through the same
-CFC-checked session access as other authoring artifacts.
-
-Automatic submission to the developer-tooling triage sink uses a bounded
-projection made by trusted code. It can contain only enumerated category and
-impact values, tool and environment versions, and stable diagnostic codes. It
-cannot contain model-authored free text, source, request text, paths, session
-or piece identifiers, commands, arguments, or raw results. The projection must
-also pass its CFC flow check. Sending the full report or other free text
-requires an authorized person to review and explicitly release it through the
-ordinary declassification path. A report that cannot be exported remains with
-the session and is marked as not exported.
-
-The tool does not install software, grant a capability, change the sandbox, or
-waive a verification gate. The agent continues with available tools when it
-can. If the missing capability blocks completion, the failed result references
-the feedback report.
+The authoring environment should eventually let its agent report compiler
+bugs, poor diagnostics, missing `cf` behavior, missing Unix tools,
+documentation gaps, sandbox restrictions, browser-tooling gaps, and anything
+else it lacks to do good work. This is independent of changing or publishing a
+pattern. The separate
+[developer-tooling feedback plan](../plans/hosted-pattern-authoring-tooling-feedback.md)
+defines the proposed `report_developer_tooling_need` tool and its CFC boundary.
 
 ## Publication
 
@@ -420,9 +428,6 @@ The feature is complete when automated tests prove all of the following:
   receive the same event and result shapes as their browser counterparts.
 - The piece and Home session views show durable authoring progress as it
   arrives without exposing private model reasoning.
-- A developer-tooling report records useful evidence and grants no new
-  authority. Its full artifact retains the evidence labels, and only the
-  bounded projection reaches the triage sink without explicit human release.
 - A request or observed source that names another target cannot redirect
   publication.
 - The model cannot read caller or provider credentials.
@@ -440,3 +445,7 @@ authoring phases, automatic merging after a concurrent edit, automatic
 repository tracking, scheduled self-improvement, or model-approved schema
 incompatibility. These can be proposed separately if evidence from the single
 session flow shows they are needed.
+
+The developer-tooling feedback follow-up improves the environment without
+changing the authoring or publication steel thread. Its separate plan is linked
+above.


### PR DESCRIPTION
Define one server-hosted authoring operation for changing an existing piece or creating a new space from a request. Give the piece menu, Home pattern, and cf CLI explicit entry points that share the service.

Keep the design to one autonomous harness session with deterministic verification and trusted publication. Require generated and edited patterns to retain their tests in the authored-program manifest, and show safe real-time progress in the piece and Home dialogs.

Define source-lifecycle and root-validation prerequisites, CFC propagation, target binding, atomic publication, cancellation ordering, session access, resource limits, retention, and a mediated developer tooling feedback channel.

Add a staged implementation plan and index both documents.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

