### PR TITLE
docs(comment-style): a file header is a doc comment above the imports

### DIFF
--- a/docs/development/code-comment-style.md
+++ b/docs/development/code-comment-style.md
@@ -396,11 +396,15 @@ in step — stays with the list too. It is not a label, but it is mechanics, and
 what a caller needs is the only thing the doc comment owes them.
 
 A doc comment with no declaration under it at all is the same defect from the
-other direction. To title a region of a file or a class, use a section marker,
-which is a `//` block; see [Section markers](#section-markers) above.
+other direction, with one exception: the file header documents the file rather
+than any declaration in it, and is written as a doc comment for that reason;
+see [File headers](#file-headers) below. Everything else in that shape is the
+defect. To title a region of a file or a class, use a section marker, which is
+a `//` block; see [Section markers](#section-markers) above.
 
 ### What gets one
 
+- Every file, as a header; see [File headers](#file-headers) below.
 - Every exported symbol: variable, function, class, type.
 - Every class and every public member of one, including the constructor,
   whether or not the class is exported.
@@ -483,6 +487,65 @@ phrase: `Writes the donut preferences to stable storage.` Special cases:
 **Variables and properties** start with a noun phrase, usually without an
 article: `Special designation category of the donut.` Use "the" for something
 singleton-ish: `The cache of all known donut manufacturers.`
+
+### File headers
+
+A file gets a doc comment of its own, and it goes at the very top: above the
+first `import`, above the first `export`, above every declaration, with nothing
+between it and them but a blank line. Only a shebang or a file-scoped pragma
+such as `deno-lint-ignore-file` precedes it.
+
+It is the one doc comment whose subject is the file rather than the code
+beneath it, which is why [Where one goes](#where-one-goes) excepts it and
+nothing else. The blank line is load-bearing for that same reason: it is what
+keeps the header from being read as the doc comment of the first declaration
+under it.
+
+Every file with logic or type declarations in it gets one. A re-export barrel
+and a test fixture whose content is the point are the exceptions.
+
+Two placements look close enough to pass and are not. A `//` block is not an
+alternative form of a header: it reads as a note about the line beneath it,
+which is what makes it right for local mechanics and wrong for a statement
+about the whole file. And a header below the import block fails twice over — it
+is separated from what it describes by the longest stretch of unrelated text in
+the file, and it sits exactly where a reader expects the doc comment of the
+first declaration.
+
+A file header takes the same three things as any other doc comment: what the
+file is, why it exists, and the bound on anything it claims. Two shapes waste
+the slot:
+
+- **A title.** `Shopping List Pattern` above `shopping-list.tsx` restates the
+  filename, and a doc comment that restates the name has added nothing. Open
+  with a claim, in a full sentence.
+- **Tag scaffolding.** No `@fileoverview` and no `@module`. Which file the
+  comment heads is not in doubt, and the tags crowd out the sentence that would
+  have carried the content.
+
+```ts
+// Shown for illustration only.
+
+// Wrong: below the imports, in the `//` form, and titled rather than stated.
+
+import { FryerCat } from "./fryer-cat.ts";
+
+// Fryer Scheduling
+```
+
+```ts
+// Shown for illustration only.
+
+// Right.
+
+/**
+ * Assigns donuts to fryers. The order is not first-come: a fritter leaves the
+ * oil unusable for anything else in the same shift, so fritters are batched
+ * last. Scheduling only — nothing here starts a fryer.
+ */
+
+import { FryerCat } from "./fryer-cat.ts";
+```
 
 ## Error and log messages
 

--- a/docs/development/code-comment-style.md
+++ b/docs/development/code-comment-style.md
@@ -404,7 +404,8 @@ a `//` block; see [Section markers](#section-markers) above.
 
 ### What gets one
 
-- Every file, as a header; see [File headers](#file-headers) below.
+- Every file with logic or type declarations in it, as a header; see
+  [File headers](#file-headers) below.
 - Every exported symbol: variable, function, class, type.
 - Every class and every public member of one, including the constructor,
   whether or not the class is exported.

--- a/skills/cf-review/SKILL.md
+++ b/skills/cf-review/SKILL.md
@@ -212,6 +212,13 @@ is allowed. Two doc comments in a row are the loudest tell — only the nearer o
 survives into rendered documentation. See
 `docs/development/code-comment-style.md`, "Where one goes".
 
+**A missing or misplaced file header** is that same defect one level up, and is
+equally a thing a diff shows you. A file header is a doc comment at the very
+top, above the first `import` and the first `export`; a new file carrying none,
+or carrying one written as a `//` block or parked below the import block, is a
+finding nothing else in the file will point you at. See the same document, "File
+headers".
+
 ### 6. Craft & conventions
 
 Mostly Improvement / Nit — don't drown the report in these. Dead code, unused
@@ -283,6 +290,8 @@ summary. Skip posting when it isn't worth it.
   `docs/development/skill-authoring.md`
 - Pattern rules + severity taxonomy: `docs/common/ai/pattern-critique-guide.md`
 - Design principles & idioms: `docs/development/DEVELOPMENT.md`
+- Comment style, `//` and JSDoc alike, file headers included:
+  `docs/development/code-comment-style.md`
 - Transformer semantics: `docs/specs/ts-transformer/README.md`
 - Reactivity model: `docs/common/concepts/reactivity.md`
 - Debugging & gotchas: `docs/development/debugging/README.md`


### PR DESCRIPTION
## What

`docs/development/code-comment-style.md` had nothing to say about the comment at
the top of a file. This adds a `### File headers` section that settles the form,
and wires the rule into the code-review skill.

The rule: a file header is a **doc comment at the very top**, above the first
`import` and the first `export`, with only a shebang or a file-scoped pragma
ahead of it. Every file with logic or type declarations in it gets one,
excepting a re-export barrel and a fixture whose content is the point. Two
shapes waste the slot and are named as such -- a title that restates the
filename, and `@fileoverview` / `@module` scaffolding.

## Why

A census of the tree, which is what prompted this. Of 4,062 authored `.ts` /
`.tsx` files (excluding `packages/generated-patterns/`), 1,141 carry a header:

| form | files | share of headers |
| --- | ---: | ---: |
| JSDoc `/** */` | 753 | 66% |
| `//` block | 388 | 34% |
| plain `/* */` | 0 | -- |

JSDoc leads two to one, but `//` is the form that is growing. Blaming each
header's own first line puts the JSDoc median at 2026-04-03 against 2026-06-30
for `//`; surviving headers by quarter written run 255 / 208 / 178 for JSDoc
across 2026Q1-Q3 against 53 / 124 / 193 for `//`. The choice is per-package
rather than per-file -- `state-inspector`, `dashboard`, `fuse` and
`schema-generator` are wholly `//`, while `patterns`, `ui`, `cli` and
`ts-transformers` are wholly JSDoc -- and it is spread across the team rather
than traceable to one author, which is the case a written rule can actually fix.

Neither form is more thorough by weight: median length is 52 words against 51,
and p90 is 158 against 172. They fail differently instead. A JSDoc header opens
with a bare title fragment 35% of the time against 11% for `//`; conversely 23%
of `//` headers are two lines or fewer against 1% of JSDoc. So the title card is
JSDoc's failure mode and the stub is `//`'s, and the new section rules out both.

## The placement half

A further **257 files** that the count above treats as having no header do have
one -- it sits immediately below the import block, separated by a blank line
from what follows, so it cannot be the doc comment of the next declaration. 240
are 15 words or more, and a hand-read 24-file spread across packages rated 23 of
24 unambiguous file headers. They cluster in `runner` (114), `ui` (32),
`ts-transformers` (30) and `patterns` (28), and 170 of the 257 are test files.

That makes real header coverage about 34% rather than 28%, and puts roughly
**18% of every file header in this repository below its imports**. Those skew
*newer* than the correctly-placed ones, so it is current habit rather than
legacy. The likely cause is mechanical: import blocks here are long and sorted,
so a header written at line 1 ends up far from the code it describes.

## Interaction with "Where one goes"

That section rules out a doc comment with no declaration under it, and a file
header is exactly that -- a doc comment separated by a blank line from the
imports below it. Left alone, the two sections would contradict each other. It
now names the file header as its one exception and points at the new section,
and the new section points back and says why the blank line is load-bearing.

## Review-skill linkage

`cf-review` cited `code-comment-style.md` only for detached doc comments, and
routed everything else about comments through `DEVELOPMENT.md` at one remove.
The file-header tell now sits in "Changeset hygiene" beside the
detached-doc-comment paragraph it belongs with -- both are "the doc comment is
in the wrong place", and both are visible in a diff -- and the document joins
the canonical references.

## Checks

`deno fmt --check` (4363 files) and `deno lint` (4352 files) clean;
`check-docs`, `check-skill-facts` and `check-conflict-markers` all pass. Note
that `docs/` is excluded from `deno fmt`, so the 80-column width there was
verified separately by character count.

The unit suites were not run: the diff is two Markdown files with no code in
them, and both new code blocks are marked `// Shown for illustration only.` --
an example about placement *relative to the imports* cannot compile inside any
of the fragment scaffolds `docs/check.md` defines.

## Not included

The rule ships as prose with no mechanical gate, and that is a decision rather
than an omission. Both rejected shapes are cheaply detectable -- the census
script behind these numbers scans the whole tree in about a second -- so a gate
remains available later if the convention turns out not to hold on its own. For
now it is a convention people follow, not a check that fails a build.

No bulk sweep of the 388 `//` headers or the 257 stranded ones either. The
document already says how that goes: an edit conforms the area around it, and
converting a whole file is its own deliberate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWSRsoxPqARrkCgLz5Smww


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


