### PR TITLE
fix(integration): aim a trusted click at a point the page has

### DIFF
--- a/docs/development/UI_TESTING.md
+++ b/docs/development/UI_TESTING.md
@@ -240,9 +240,12 @@ happens.
 two consecutive rendering frames. It measures the marked control again just
 before dispatch. If that final measurement finds that the control moved or was
 replaced, the helper settles and marks the current control before dispatching
-one trusted click. A page that moves the control after even that last
-measurement is caught as well: the helper stops an interaction that misses
-before the page sees it, and aims again.
+one trusted click. It aims at the middle of the part of the control's box that
+lies inside the page, so a control the edge of the page cuts off is clicked
+inside the page rather than at a point past the edge, and a control with no part
+of it inside the page is reported rather than clicked. A page that moves the
+control after even that last measurement is caught as well: the helper stops an
+interaction that misses before the page sees it, and aims again.
 `docs/development/waiting-in-tests.md` describes how.
 
 **Use `awaitViewSettled(page)`** from `@commonfabric/integration` as the

--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -176,10 +176,23 @@ between. The hold is frame-driven and drops its baseline whenever the box
 disappears. A control hidden partway through is picked up once it returns rather
 than clicked mid-shift. The stuck-condition net bounds a box that never settles.
 
+The point that measurement answers is the middle of the part of the control's
+box that lies inside the page, which for a control the page has room for is the
+middle of the whole box. A control reaching past the edge of the page — a
+surface positioned towards that edge in a narrow viewport, a control wider than
+the space it is drawn in — can have the middle of its whole box outside the
+page. The browser accepts a trusted click dispatched outside the page, delivers
+it to nothing, and reports no error for having done so, so a click aimed there
+leaves the caller told that a control was pressed which never was. A control
+with no part of it inside the page has no point to aim at, and `clickMarked`
+reports it, naming the control's box and the size of the page. What the page
+shows of a control is a wider question than this one: an ancestor's overflow can
+clip it, and anything painted over it can cover it. Neither moves this point.
+
 The page can move again after that first measurement. An interaction observer
 also runs before the trusted click and can give the page time to change. Just
 before dispatch, `clickMarked` resolves the marked control in one page turn and
-reads its current center. If the control has moved or disappeared, the helper
+reads its current point. If the control has moved or disappeared, the helper
 settles it again and applies the caller's tagging predicate to any replacement.
 It takes one final current measurement after that settle, then dispatches the
 single trusted click at that point.

--- a/packages/integration/page.ts
+++ b/packages/integration/page.ts
@@ -637,7 +637,7 @@ export class Page extends EventTarget {
 export type AimResult =
   | { x: number; y: number }
   | {
-    unclickable: "detached" | "not-rendered" | "unresolvable";
+    unclickable: "detached" | "not-rendered" | "off-page" | "unresolvable";
     tag?: string;
     id?: string;
     rootHost?: string;
@@ -658,8 +658,18 @@ export type AimResult =
  * Doing both in the page means the coordinates describe the element as it was
  * at one instant, and the only remaining gap is the one dispatch that follows.
  *
- * An element with no layout box yields `unclickable` naming what is wrong with
- * it, rather than an empty measurement the caller has to guess at.
+ * The point is the middle of the part of the element's box that lies inside the
+ * page, which for an element the page has room for is the middle of the whole
+ * box. An element reaching past the edge of the page can have its middle
+ * outside the page, and the browser accepts a trusted click dispatched there,
+ * delivers it to nothing, and reports no error for having done so. What the
+ * page shows of an element is a wider question than this: an ancestor's
+ * overflow can clip it, and anything painted over it can cover it. Neither
+ * moves this point.
+ *
+ * An element with no layout box, and one with no part of it inside the page,
+ * yield `unclickable` naming what is wrong with it, rather than an empty
+ * measurement the caller has to guess at.
  */
 async function aimAtElement(
   element: AstralElementHandle,
@@ -703,9 +713,39 @@ async function aimAtElement(
             height: rect.height,
           };
         }
-        return offsetX === null || offsetY === null
-          ? { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 }
+        // The area a click can land in, in the same coordinates the rect is
+        // reported in. The root element's client box rather than the window,
+        // because a classic scrollbar takes columns the window counts and a
+        // click cannot reach.
+        const pageWidth = document.documentElement.clientWidth;
+        const pageHeight = document.documentElement.clientHeight;
+        const left = Math.max(rect.x, 0);
+        const right = Math.min(rect.x + rect.width, pageWidth);
+        const top = Math.max(rect.y, 0);
+        const bottom = Math.min(rect.y + rect.height, pageHeight);
+        // A caller's offset names a point on the element, so it is used as
+        // given; what it names still has to be a point the page has.
+        const point = offsetX === null || offsetY === null
+          ? { x: (left + right) / 2, y: (top + bottom) / 2 }
           : { x: rect.x + offsetX, y: rect.y + offsetY };
+        if (
+          right <= left || bottom <= top ||
+          point.x < 0 || point.x >= pageWidth ||
+          point.y < 0 || point.y >= pageHeight
+        ) {
+          return {
+            unclickable: "off-page",
+            ...describe(),
+            width: rect.width,
+            height: rect.height,
+            detail: `box ${JSON.stringify(rect)}, ` +
+              `point ${JSON.stringify(point)}, ` +
+              `page ${
+                JSON.stringify({ width: pageWidth, height: pageHeight })
+              }`,
+          };
+        }
+        return point;
       },
       { args: [offset?.x ?? null, offset?.y ?? null] },
     );
@@ -729,6 +769,9 @@ function describeAimTarget(aim: Extract<AimResult, { unclickable: string }>) {
       return `${named}${inside}: it has no layout box ` +
         `(display: ${aim.display}, visibility: ${aim.visibility}, ` +
         `${aim.width}x${aim.height})`;
+    case "off-page":
+      return `${named}${inside}: the point to click lies outside the page, ` +
+        `so a click there would reach nothing (${aim.detail})`;
     default:
       return `the element: its handle no longer resolves to a node ` +
         `(${aim.detail})`;

--- a/packages/integration/test/astral-adapter.test.ts
+++ b/packages/integration/test/astral-adapter.test.ts
@@ -1,4 +1,9 @@
-import { assert, assertEquals, assertRejects } from "@std/assert";
+import {
+  assert,
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "@std/assert";
 import { launch } from "@astral/astral";
 import { closeAstralBrowser } from "../astral-adapter.ts";
 import { Browser } from "../browser.ts";
@@ -1423,6 +1428,123 @@ Deno.test("Page preserves Common Tools behavior on published Astral", async () =
       "beforeType",
       "afterType",
     ]);
+  } finally {
+    await closeTestBrowser(page, browser);
+  }
+});
+
+Deno.test("Page clicks the part of an element that lies inside the page", async () => {
+  // An element can reach past the edge of the page it is drawn on: a surface
+  // positioned towards the right of a narrow viewport, a control wider than the
+  // column it sits in. The middle of such an element's box is a point the page
+  // does not have, and a trusted click dispatched there is delivered to the
+  // browser, lands outside the page, and reaches nothing at all.
+  const observed: { x: number; y: number }[] = [];
+  const browser = await launch({ headless: true });
+  const astralPage = await browser.newPage();
+  const page = new Page(astralPage, { timeout: 10_000 });
+  page.setInteractionObserver({
+    afterClick: (_element, point) =>
+      void observed.push({ x: point.x, y: point.y }),
+  });
+
+  try {
+    await page.setViewportSize({ width: 800, height: 600 });
+    await page.evaluate(() => {
+      // Fixed, so the element cannot be brought into the page by scrolling to
+      // it: the part of it inside the page is the whole of what a click has to
+      // work with. It spans 700 to 1100 in a page 800 wide, so the middle of
+      // the whole box is at 900, a hundred columns past the last column the
+      // page has.
+      const button = document.createElement("button");
+      button.id = "clipped-target";
+      button.textContent = "Continue as guest";
+      Object.assign(button.style, {
+        position: "fixed",
+        left: "700px",
+        top: "300px",
+        width: "400px",
+        height: "40px",
+      });
+      let clicked = 0;
+      button.addEventListener("click", () => {
+        clicked++;
+      });
+      document.body.append(button);
+      (globalThis as typeof globalThis & {
+        __clippedClicks: () => number;
+      }).__clippedClicks = () => clicked;
+    });
+
+    const target = await page.waitForSelector("#clipped-target");
+    await target.click();
+
+    assertEquals(
+      await page.evaluate(() =>
+        (globalThis as typeof globalThis & {
+          __clippedClicks: () => number;
+        }).__clippedClicks()
+      ),
+      1,
+      "the click never landed on the part of the element inside the page",
+    );
+    // The part of the box inside the page spans 700 to 800 across and 300 to
+    // 340 down, so the point to click is 750,320.
+    assertEquals(observed, [{ x: 750, y: 320 }]);
+  } finally {
+    await closeTestBrowser(page, browser);
+  }
+});
+
+Deno.test("Page reports an element with no part of it inside the page", async () => {
+  // Every point on the element is outside the page, so there is nowhere to aim
+  // that a click can reach. Saying so is the only honest answer: a click
+  // dispatched past the edge of the page reaches nothing, and returning from
+  // that tells the caller the element was pressed.
+  const browser = await launch({ headless: true });
+  const astralPage = await browser.newPage();
+  const page = new Page(astralPage, { timeout: 10_000 });
+
+  try {
+    await page.setViewportSize({ width: 800, height: 600 });
+    await page.evaluate(() => {
+      const button = document.createElement("button");
+      button.id = "off-page-target";
+      button.textContent = "Continue as guest";
+      Object.assign(button.style, {
+        position: "fixed",
+        left: "900px",
+        top: "300px",
+        width: "200px",
+        height: "40px",
+      });
+      let clicked = 0;
+      button.addEventListener("click", () => {
+        clicked++;
+      });
+      document.body.append(button);
+      (globalThis as typeof globalThis & {
+        __offPageClicks: () => number;
+      }).__offPageClicks = () => clicked;
+    });
+
+    const target = await page.waitForSelector("#off-page-target");
+    const error = await assertRejects(() => target.click(), Error);
+    assertStringIncludes(error.message, "outside the page");
+    assertStringIncludes(error.message, "button#off-page-target");
+    // The size of the page, so a message that names some other 800 cannot
+    // satisfy this.
+    assertStringIncludes(error.message, 'page {"width":800,"height":600}');
+
+    assertEquals(
+      await page.evaluate(() =>
+        (globalThis as typeof globalThis & {
+          __offPageClicks: () => number;
+        }).__offPageClicks()
+      ),
+      0,
+      "a click reached an element with no part of it inside the page",
+    );
   } finally {
     await closeTestBrowser(page, browser);
   }

--- a/packages/patterns/integration/cfc-browser-helpers.test.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.test.ts
@@ -2184,4 +2184,223 @@ describe("CFC browser helpers", () => {
       await background.close();
     }
   });
+
+  it("clicks the part of a control that lies inside the page", async () => {
+    // A control can reach past the edge of the page it is drawn on: a surface
+    // positioned towards the right of a narrow viewport, a control wider than
+    // the column it sits in. The middle of such a control's box is a point the
+    // page does not have, and a trusted click dispatched there is delivered to
+    // the browser, lands outside the page, and reaches nothing at all.
+    //
+    // The control the mark is placed on is counted as well as clicked. The aim
+    // and the measurement taken just before dispatch answer the point
+    // separately, and a click whose two answers disagree clears its mark and
+    // places it again on a control that never moved.
+    const observed: { x: number; y: number }[] = [];
+    const narrow = await browser.newPage();
+    narrow.setInteractionObserver({
+      afterClick: (_element, point) =>
+        void observed.push({ x: point.x, y: point.y }),
+    });
+    try {
+      await narrow.setViewportSize({ width: 800, height: 600 });
+      await narrow.evaluate((clickTargetAttr: string) => {
+        const host = document.createElement("div");
+        const root = host.attachShadow({ mode: "open" });
+        // Fixed, so the control cannot be brought into the page by scrolling
+        // to it: the part of it inside the page is the whole of what a click
+        // has to work with.
+        const surface = document.createElement("div");
+        Object.assign(surface.style, {
+          position: "fixed",
+          left: "700px",
+          top: "300px",
+          width: "420px",
+        });
+        // Spans 700 to 1100 in a page 800 wide. The middle of the whole box is
+        // at 900, a hundred columns past the last column the page has; the
+        // middle of the part inside the page is at 750.
+        const button = document.createElement("button");
+        button.id = "clipped-guest-button";
+        button.textContent = "Continue as guest";
+        Object.assign(button.style, {
+          display: "block",
+          width: "400px",
+          height: "40px",
+        });
+        let clicked = 0;
+        button.addEventListener("click", () => {
+          clicked++;
+        });
+        surface.append(button);
+        root.append(surface);
+        document.body.append(host);
+
+        let marks = 0;
+        const observer = new MutationObserver(() => {
+          if (button.hasAttribute(clickTargetAttr)) marks++;
+        });
+        observer.observe(button, {
+          attributes: true,
+          attributeFilter: [clickTargetAttr],
+        });
+
+        (globalThis as typeof globalThis & {
+          commonfabric: { viewSettled: () => Promise<void> };
+        }).commonfabric = { viewSettled: () => Promise.resolve() };
+        (globalThis as typeof globalThis & {
+          __clippedClicks: () => { clicks: number; marks: number };
+        }).__clippedClicks = () => ({ clicks: clicked, marks });
+      }, { args: [CLICK_TARGET_ATTR] });
+
+      await clickCfButton(narrow, "#clipped-guest-button");
+
+      const result = await narrow.evaluate(() =>
+        (globalThis as typeof globalThis & {
+          __clippedClicks: () => { clicks: number; marks: number };
+        }).__clippedClicks()
+      );
+      assertEquals(
+        result.clicks,
+        1,
+        "the click never landed on the part of the control inside the page",
+      );
+      assertEquals(
+        result.marks,
+        1,
+        "the control was marked again for a click that had not moved",
+      );
+      // The part of the box inside the page spans 700 to 800 across and 300 to
+      // 340 down, so the point to click is 750,320.
+      assertEquals(observed, [{ x: 750, y: 320 }]);
+    } finally {
+      narrow.setInteractionObserver(undefined);
+      await narrow.close();
+    }
+  });
+
+  it("clicks a control the left-hand edge of the page cuts off", async () => {
+    // The edge a control reaches past can be any of the four. A control that
+    // starts to the left of the page has a negative middle, which is as
+    // unreachable as one past the right-hand edge.
+    const observed: { x: number; y: number }[] = [];
+    const narrow = await browser.newPage();
+    narrow.setInteractionObserver({
+      afterClick: (_element, point) =>
+        void observed.push({ x: point.x, y: point.y }),
+    });
+    try {
+      await narrow.setViewportSize({ width: 800, height: 600 });
+      await narrow.evaluate(() => {
+        const host = document.createElement("div");
+        const root = host.attachShadow({ mode: "open" });
+        // Spans -300 to 100 across and -20 to 20 down, so the middle of the
+        // whole box is at -100,0 and the middle of the part inside the page is
+        // at 50,10.
+        const button = document.createElement("button");
+        button.id = "left-clipped-button";
+        button.textContent = "Continue as guest";
+        Object.assign(button.style, {
+          position: "fixed",
+          left: "-300px",
+          top: "-20px",
+          width: "400px",
+          height: "40px",
+          margin: "0",
+        });
+        let clicked = 0;
+        button.addEventListener("click", () => {
+          clicked++;
+        });
+        root.append(button);
+        document.body.append(host);
+
+        (globalThis as typeof globalThis & {
+          commonfabric: { viewSettled: () => Promise<void> };
+        }).commonfabric = { viewSettled: () => Promise.resolve() };
+        (globalThis as typeof globalThis & {
+          __leftClippedClicks: () => number;
+        }).__leftClippedClicks = () => clicked;
+      });
+
+      await clickCfButton(narrow, "#left-clipped-button");
+
+      assertEquals(
+        await narrow.evaluate(() =>
+          (globalThis as typeof globalThis & {
+            __leftClippedClicks: () => number;
+          }).__leftClippedClicks()
+        ),
+        1,
+        "the click never landed on the part of the control inside the page",
+      );
+      assertEquals(observed, [{ x: 50, y: 10 }]);
+    } finally {
+      narrow.setInteractionObserver(undefined);
+      await narrow.close();
+    }
+  });
+
+  it("reports a control with no part of it inside the page", async () => {
+    // Every point on the control is outside the page, so there is nowhere to
+    // aim that a click can reach. Saying so is the only honest answer: a click
+    // dispatched past the edge of the page reaches nothing, and a helper that
+    // returns from that has told its caller the control was pressed.
+    const narrow = await browser.newPage();
+    try {
+      await narrow.setViewportSize({ width: 800, height: 600 });
+      await narrow.evaluate(() => {
+        const host = document.createElement("div");
+        const root = host.attachShadow({ mode: "open" });
+        const surface = document.createElement("div");
+        Object.assign(surface.style, {
+          position: "fixed",
+          left: "900px",
+          top: "300px",
+          width: "220px",
+        });
+        const button = document.createElement("button");
+        button.id = "offscreen-guest-button";
+        button.textContent = "Continue as guest";
+        Object.assign(button.style, {
+          display: "block",
+          width: "200px",
+          height: "40px",
+        });
+        let clicked = 0;
+        button.addEventListener("click", () => {
+          clicked++;
+        });
+        surface.append(button);
+        root.append(surface);
+        document.body.append(host);
+
+        (globalThis as typeof globalThis & {
+          commonfabric: { viewSettled: () => Promise<void> };
+        }).commonfabric = { viewSettled: () => Promise.resolve() };
+        (globalThis as typeof globalThis & {
+          __offscreenClicks: () => number;
+        }).__offscreenClicks = () => clicked;
+      });
+
+      const error = await assertRejects(
+        () => clickCfButton(narrow, "#offscreen-guest-button"),
+        Error,
+      );
+      assertStringIncludes(error.message, "outside the page");
+      // The size of the page, so a message that names some other 800 cannot
+      // satisfy this.
+      assertStringIncludes(error.message, '"width": 800');
+      assertStringIncludes(error.message, '"height": 600');
+
+      const clicks = await narrow.evaluate(() =>
+        (globalThis as typeof globalThis & {
+          __offscreenClicks: () => number;
+        }).__offscreenClicks()
+      );
+      assertEquals(clicks, 0, "a click reached a control the page cannot show");
+    } finally {
+      await narrow.close();
+    }
+  });
 });

--- a/packages/patterns/integration/cfc-browser-helpers.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.ts
@@ -1028,7 +1028,12 @@ export async function clickNthCfButton(
 // not be aimed at.
 type ClickAim =
   | { x: number; y: number; targetId: number }
-  | { missing: true; sawTarget: boolean };
+  | { missing: true; sawTarget: boolean }
+  | {
+    offPage: true;
+    box: { x: number; y: number; width: number; height: number };
+    page: { width: number; height: number };
+  };
 
 /**
  * What became of the trusted click the aim armed for.
@@ -1064,6 +1069,13 @@ type ClickLanding = {
 // just declared settled, so the measurement found no box and the click reported
 // "Unable to get stable box model to click on". Deciding and measuring in the
 // same turn leaves nothing between them.
+//
+// The point is the middle of the part of the control's box that lies inside
+// the page, which for a control the page has room for is the middle of the
+// whole box. A control with no part of it inside the page is reported: the
+// browser accepts a click dispatched outside the page, delivers it to nothing,
+// and reports no error for having done so, so aiming there would leave a caller
+// told the control was pressed.
 //
 // A mark that is absent from the start is reported rather than waited on: the
 // caller placed it a moment ago, so its absence means the control it names was
@@ -1268,6 +1280,36 @@ const aimAtMarkedTarget = async (
     return { x, y, width, height };
   };
 
+  // The area a click can land in, in the same coordinates a bounding rect is
+  // reported in. The root element's client box rather than the window, because
+  // a classic scrollbar takes columns the window counts and a click cannot
+  // reach.
+  const pageBox = (): { width: number; height: number } => ({
+    width: document.documentElement.clientWidth,
+    height: document.documentElement.clientHeight,
+  });
+
+  // The point to aim a click at on a control's box: the middle of the part of
+  // the box that lies inside the page. A control can reach past the edge of the
+  // page, and the middle of the whole box is then further out than the middle
+  // of the part inside it, far enough out to be a point the page does not have.
+  // The browser accepts a click dispatched there and delivers it to nothing.
+  //
+  // What the page shows of a control is a wider question than this: an
+  // ancestor's overflow can clip it, and anything painted over it can cover it.
+  // Neither moves this point.
+  const pointOnPage = (
+    rect: { x: number; y: number; width: number; height: number },
+  ): { x: number; y: number } | null => {
+    const page = pageBox();
+    const left = Math.max(rect.x, 0);
+    const right = Math.min(rect.x + rect.width, page.width);
+    const top = Math.max(rect.y, 0);
+    const bottom = Math.min(rect.y + rect.height, page.height);
+    if (right <= left || bottom <= top) return null;
+    return { x: (left + right) / 2, y: (top + bottom) / 2 };
+  };
+
   for (;;) {
     if (find() === undefined) {
       if (remark === null) {
@@ -1325,17 +1367,34 @@ const aimAtMarkedTarget = async (
       behavior: "instant",
     });
     const rect = target.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) {
+      // Collapsed between the settle and this measurement. A control with no
+      // box is one the settle holds for, so hold for this one too.
+      diag.phase = "no-box-before-aim";
+      await nextFrame();
+      continue;
+    }
+    const point = pointOnPage(rect);
+    if (point === null) {
+      return {
+        offPage: true,
+        box: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+        page: pageBox(),
+      };
+    }
+    // After the point, so a click that is never dispatched leaves no
+    // interceptor on the page.
     arm();
     diag.phase = "aimed";
     return {
-      x: rect.x + rect.width / 2,
-      y: rect.y + rect.height / 2,
+      x: point.x,
+      y: point.y,
       targetId: identify(target),
     };
   }
 };
 
-// Read the marked control's current center in one page turn for a coordinate
+// Read the marked control's current point in one page turn for a coordinate
 // refresh after any interaction observer has finished.
 const readMarkedClickPoint = async (
   page: Page,
@@ -1380,9 +1439,19 @@ const readMarkedClickPoint = async (
     ) {
       return undefined;
     }
+    // The middle of the part of the box inside the page, the same point the aim
+    // answers, so a control that has not moved reads back as unchanged and the
+    // click keeps the point it settled on.
+    const pageWidth = document.documentElement.clientWidth;
+    const pageHeight = document.documentElement.clientHeight;
+    const left = Math.max(rect.x, 0);
+    const right = Math.min(rect.x + rect.width, pageWidth);
+    const top = Math.max(rect.y, 0);
+    const bottom = Math.min(rect.y + rect.height, pageHeight);
+    if (right <= left || bottom <= top) return undefined;
     return {
-      x: rect.x + rect.width / 2,
-      y: rect.y + rect.height / 2,
+      x: (left + right) / 2,
+      y: (top + bottom) / 2,
       targetId,
     };
   }, { args: [selector, identityKey] });
@@ -1484,6 +1553,18 @@ export async function clickMarked(
             `Aim reached: ${toIndentedDebugString(progress)}. ` +
             `Last probe: ${toIndentedDebugString(probe)}`,
           { cause },
+        );
+      }
+      if (aim !== undefined && "offPage" in aim) {
+        const probe = await readTextProbe(page, markSelector).catch(() =>
+          undefined
+        );
+        throw new Error(
+          `The control marked for click lies outside the page, so there is ` +
+            `no point on it a click can reach. Its box is ` +
+            `${toIndentedDebugString(aim.box)} and the page is ` +
+            `${toIndentedDebugString(aim.page)}. ` +
+            `Last probe: ${toIndentedDebugString(probe)}`,
         );
       }
       if (aim === undefined || "missing" in aim) {


### PR DESCRIPTION
A click is aimed at the middle of the control's box, and nothing checks that the middle of the box is a point the page has. A control can reach past the edge of the page it is drawn on — a surface positioned towards that edge in a narrow viewport, a control wider than the space it is drawn in — and the middle of its box is then far enough out to be a point the page does not have. The browser accepts a trusted click dispatched there, delivers it to nothing, and reports no error for having done so.

Which controls this reaches depends on how wide the page is, and a page takes whatever viewport the browser it launches happens to default to unless the suite says otherwise. That is 800 columns where continuous integration runs and wider on a developer's machine, so a control that is pressed at its middle every time on a desktop can be a control continuous integration never presses at all.

Two aims have this, and they fail differently. `Page`'s own aim is behind every click on an element handle, and it has nothing watching where the click landed, so the click resolves as though the control had been pressed and what fails is the step after it, waiting for the effect of a press that never happened. The marked-click helpers in the patterns package have their own aim, because it runs inside the page alongside the settle that decides the control is ready, and a function serialized into the page cannot reach module scope. That one arms an interceptor, so the miss is caught: the click is aimed again at the same pixel, which no dispatch has reached, and the helper reports a control that keeps taking the click nowhere. The control is still never pressed, and the report names a pixel without saying that the page does not extend that far.

Both aims now answer the middle of the part of the control's box that lies inside the page, which for a control the page has room for is the middle of the whole box, arrived at the same way as before.

The area a click can land in is the root element's client box rather than the window, because a classic scrollbar takes columns the window counts and a click cannot reach.

What the page shows of a control is a wider question than this one: an ancestor's overflow can clip it, and anything painted over it can cover it. Neither moves this point, and the comments and the two documents that describe the click helpers say so rather than claiming the point is somewhere the control is visible.

A control with no part of it inside the page has no point to aim at. That is reported, naming the control's box and the size of the page, rather than dispatched past the edge. For `Page` it joins the conditions its aim already names: detached from the document, no layout box, a handle that no longer resolves. A caller's offset names a point on the control, so it is still used as given rather than moved onto the page, and an offset naming a point the page does not have is reported the same way. The marked click decides this before it arms its interceptor, so a click that is never dispatched leaves nothing watching the page for it.

A control whose box collapses between the settle and the measurement taken after it has no area rather than no place on the page. A control with no box is one the settle holds for, so this one is held for too, the same way a control the page rebuilds under the settle is.

The marked click answers the point twice, once when it settles the control and once in one page turn just before it dispatches, and the second answer has to match the first for a control that has not moved. A click whose two answers disagree still lands, because the mismatch sends it through the settle and the caller's re-marking, so what it costs is that re-marking rather than the click.

The tests place their controls in a page whose size they set, so the geometry means the same thing on every machine, and each one is wide enough that the middle of its box is a hundred columns outside the page rather than one. Both suites cover a control the edge of the page cuts off and a control with no part of it inside the page, and both assert the point the click was dispatched at rather than only that something was pressed. The marked-click suite also covers the left-hand edge, since the aim clamps on all four, and asserts that the control it lands on is marked once, which is what a disagreement between the two answers would cost.

deflaked by Hixie's agent (Claude Opus 5)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

