### PR TITLE
Stop piece highlights after one animation

### DIFF
--- a/packages/shell/integration/piece-menu.test.ts
+++ b/packages/shell/integration/piece-menu.test.ts
@@ -512,7 +512,7 @@ describe("piece context menu", () => {
       expect(highlight.visual.animationName).toBe("none");
     } else {
       expect(highlight.visual.animationName).toBe("cf-piece-menu-shine");
-      expect(highlight.visual.animationIterationCount).toBe("infinite");
+      expect(highlight.visual.animationIterationCount).toBe("1");
     }
     await clickPierce(page, '[test-id="piece-menu-source"]');
     // The space root runs the default app, so its entry file is that pattern.
@@ -741,7 +741,7 @@ describe("piece context menu", () => {
         expect(result.visual.animationName).toBe(
           "cf-nested-piece-menu-shine",
         );
-        expect(result.visual.animationIterationCount).toBe("infinite");
+        expect(result.visual.animationIterationCount).toBe("1");
       }
     } finally {
       await Deno.remove(identityPath).catch(() => {});

--- a/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.ts
+++ b/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.ts
@@ -299,7 +299,7 @@ export class CFPieceMenu extends BaseElement {
       background-repeat: no-repeat;
       background-size: 250% 100%;
       box-shadow: inset 0 0 2.5rem rgba(129, 140, 248, 0.38);
-      animation: cf-nested-piece-menu-shine 1.7s ease-in-out infinite;
+      animation: cf-nested-piece-menu-shine 1.7s ease-in-out;
     }
 
     @keyframes cf-nested-piece-menu-shine {

--- a/packages/ui/src/v2/components/cf-render/cf-render.ts
+++ b/packages/ui/src/v2/components/cf-render/cf-render.ts
@@ -183,7 +183,7 @@ export class CFRender extends BaseElement {
       background-repeat: no-repeat;
       background-size: 250% 100%;
       box-shadow: inset 0 0 2.5rem rgba(129, 140, 248, 0.38);
-      animation: cf-piece-menu-shine 1.7s ease-in-out infinite;
+      animation: cf-piece-menu-shine 1.7s ease-in-out;
     }
 
     @keyframes cf-piece-menu-shine {


### PR DESCRIPTION
Right-clicking a piece applies a shine animation to the selected piece. The animation used an infinite iteration count, so it continued for as long as the context menu remained open.

Use the CSS default single iteration for top-level and nested highlights. Update the browser integration assertions to enforce one iteration.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

