### PR TITLE
docs(html,llm,pure-json,toolshed,+3): file headers across seven small packages

### DIFF
--- a/packages/background-piece-service/test/set-bg-piece.test.ts
+++ b/packages/background-piece-service/test/set-bg-piece.test.ts
@@ -1,9 +1,11 @@
-// `setBGPiece()` against a real `Runtime`, because the thing worth testing is
-// transactional: registering the same (`space`, `pieceId`) pair twice must land
-// on one entry. The fakes in `service-modules.test.ts` cannot show that -- their
-// `withTx()` is the identity function and their `editWithRetry()` calls its
-// callback once and never conflicts -- so they exercise the shape of the calls
-// without their semantics.
+/**
+ * `setBGPiece()` against a real `Runtime`, because the thing worth testing is
+ * transactional: registering the same (`space`, `pieceId`) pair twice must land
+ * on one entry. The fakes in `service-modules.test.ts` cannot show that -- their
+ * `withTx()` is the identity function and their `editWithRetry()` calls its
+ * callback once and never conflicts -- so they exercise the shape of the calls
+ * without their semantics.
+ */
 
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { assertEquals, assertRejects } from "@std/assert";

--- a/packages/html/test/debug.test.ts
+++ b/packages/html/test/debug.test.ts
@@ -1,7 +1,9 @@
-// What `formatTree()` does with a `FabricSpecialObject`. Such a value keeps
-// its state in private fields and has zero enumerable own properties, so
-// `JSON.stringify()` renders one as `{}` -- silently, since it does not throw
-// on one and the `catch` around it never fires. Both arms are named instead.
+/**
+ * What `formatTree()` does with a `FabricSpecialObject`. Such a value keeps
+ * its state in private fields and has zero enumerable own properties, so
+ * `JSON.stringify()` renders one as `{}` -- silently, since it does not throw
+ * on one and the `catch` around it never fires. Both arms are named instead.
+ */
 
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";

--- a/packages/html/test/render-utils.test.ts
+++ b/packages/html/test/render-utils.test.ts
@@ -1,3 +1,20 @@
+/**
+ * The two render-utility contracts a renderer depends on and neither the name
+ * nor the signature states.
+ *
+ * `setPropDefault` compares under `Object.is` rather than `===`, which decides
+ * two cases that differ from each other: `NaN` over a stored `NaN` is
+ * unchanged and must not assign, while `-0` over `0` is a change and must.
+ * The bound matters because a custom element commonly re-renders on any
+ * property assignment, so a redundant write is a visible cost rather than a
+ * wasted one.
+ *
+ * `styleObjectToCssString` is pinned across the cases where a plausible
+ * implementation quietly does the wrong thing: a unitless property, a zero, a
+ * vendor prefix, a custom property (which keeps its case and takes no unit),
+ * and a `null` or `undefined` value, which drops rather than rendering.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { setPropDefault, styleObjectToCssString } from "../src/render-utils.ts";

--- a/packages/llm/src/schema-transport.test.ts
+++ b/packages/llm/src/schema-transport.test.ts
@@ -1,3 +1,15 @@
+/**
+ * What `assertJsonTransportSafe` puts in the error, which is the whole reason
+ * it exists as a separate assertion rather than a bare boolean check.
+ *
+ * The value it rejects is about to cross into an external LLM provider, where
+ * the loss would surface as altered output rather than as a failure, so the
+ * throw has to be actionable on its own: it names the label it was given, the
+ * JSON pointer to each offending value, and why that value cannot survive
+ * ordinary JSON serialization. It reports every offender rather than stopping
+ * at the first, so one round of fixes can address the whole value.
+ */
+
 import { assertEquals, assertThrows } from "@std/assert";
 
 import { assertJsonTransportSafe } from "./schema-transport.ts";

--- a/packages/llm/src/schema-transport.ts
+++ b/packages/llm/src/schema-transport.ts
@@ -1,20 +1,22 @@
-// Guards a value against the one lossy step between the runner and an external
-// LLM provider: the request is sent as ordinary JSON (`JSON.stringify`), so any
-// value it carries that plain JSON cannot represent faithfully reaches the
-// provider altered, dropped, or not at all -- or crashes the serialization.
-//
-// The Common Fabric value model is a superset of JSON, so a generated schema
-// (a `generateObject` schema, or a tool's `inputSchema`) may legitimately hold
-// values JSON cannot carry. Those are fine internally. Crossing to a provider,
-// they are not.
-//
-// The generic detection of JSON-unfaithful values lives in
-// `@commonfabric/pure-json`; this module adds only the provider-framed
-// assertion that refuses such a value at the transport boundary.
-//
-// A minor diagnostic point: the thrown message renders the root pointer as `/`.
-// Under RFC 6901 the root is `""` and `/` names a property whose key is the
-// empty string; the message trades that strict accuracy for legibility.
+/**
+ * Guards a value against the one lossy step between the runner and an external
+ * LLM provider: the request is sent as ordinary JSON (`JSON.stringify`), so any
+ * value it carries that plain JSON cannot represent faithfully reaches the
+ * provider altered, dropped, or not at all -- or crashes the serialization.
+ *
+ * The Common Fabric value model is a superset of JSON, so a generated schema
+ * (a `generateObject` schema, or a tool's `inputSchema`) may legitimately hold
+ * values JSON cannot carry. Those are fine internally. Crossing to a provider,
+ * they are not.
+ *
+ * The generic detection of JSON-unfaithful values lives in
+ * `@commonfabric/pure-json`; this module adds only the provider-framed
+ * assertion that refuses such a value at the transport boundary.
+ *
+ * A minor diagnostic point: the thrown message renders the root pointer as `/`.
+ * Under RFC 6901 the root is `""` and `/` names a property whose key is the
+ * empty string; the message trades that strict accuracy for legibility.
+ */
 
 import { findJsonUnfaithfulValues } from "@commonfabric/pure-json";
 

--- a/packages/memory/test/v2-patch.test.ts
+++ b/packages/memory/test/v2-patch.test.ts
@@ -1,3 +1,15 @@
+/**
+ * `patch.ts` deep-clones incoming op values for isolation. It MUST preserve
+ * fabric wrapper classes: it previously used `structuredClone()`, which
+ * silently demotes class instances to plain objects, so a `FabricError`
+ * (or any `FabricInstance`/`FabricPrimitive`) round-tripped through a patch
+ * op came back as a plain object and was then serialized lossily (PR #3613).
+ * These tests pin the property directly at the `patch.ts` layer, exercising
+ * every op that clones a value (`replace`, `add`, `splice`, and the
+ * `add`-via-`move` path), plus a second `applyPatch` pass to mimic the
+ * engine replaying a stored patch sequence over an already-deep-frozen base.
+ */
+
 import {
   assert,
   assertEquals,
@@ -9,16 +21,6 @@ import { FabricError } from "@commonfabric/data-model/fabric-instances";
 import { FabricInstance } from "@commonfabric/data-model/fabric-value";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { FabricEpochNsec } from "@commonfabric/data-model/fabric-primitives";
-
-// `patch.ts` deep-clones incoming op values for isolation. It MUST preserve
-// fabric wrapper classes: it previously used `structuredClone()`, which
-// silently demotes class instances to plain objects, so a `FabricError`
-// (or any `FabricInstance`/`FabricPrimitive`) round-tripped through a patch
-// op came back as a plain object and was then serialized lossily (PR #3613).
-// These tests pin the property directly at the `patch.ts` layer, exercising
-// every op that clones a value (`replace`, `add`, `splice`, and the
-// `add`-via-`move` path), plus a second `applyPatch` pass to mimic the
-// engine replaying a stored patch sequence over an already-deep-frozen base.
 
 Deno.test("memory v2 patch preserves `FabricInstance` values with full fidelity", () => {
   const placements = [

--- a/packages/pure-json/src/json-faithfulness.ts
+++ b/packages/pure-json/src/json-faithfulness.ts
@@ -1,50 +1,52 @@
-// Reports every part of a runtime value that ordinary JSON serialization
-// (`JSON.stringify`) would silently alter, drop, or fail to represent -- so a
-// caller that must hand a value across a JSON boundary can refuse or repair it
-// before the loss happens, rather than discovering a mangled value downstream.
-//
-// This is a positive whitelist, not a search for known-bad leaves. Only the
-// shapes JSON round-trips by identity are accepted -- `null`, booleans,
-// strings, finite numbers other than `-0`, dense arrays of accepted values,
-// and plain objects whose values are accepted. Everything else is reported:
-// `undefined` (dropped from an object, `null` in an array), `NaN` and
-// `±Infinity` (both become `null`), `-0` (loses its sign), `bigint` /
-// `symbol` / `function` (not representable), array holes (`null`), a
-// non-index property on an array (dropped), symbol-keyed properties
-// (dropped), a `toJSON` hook (replaces the value before JSON sees it),
-// non-plain objects such as a class instance (flattened -- `JSON.stringify`
-// finds no data in its private fields), and cycles (`JSON.stringify` throws).
-//
-// A blacklist that only hunted bad numbers would pass every one of those: they
-// leave no offending numeric leaf, yet JSON still alters them. Whitelisting is
-// the only framing that makes an empty result actually mean "JSON serialization
-// will not change this."
-//
-// Known limitations. The walk reads enumerable own keys (`Object.keys` /
-// `Object.entries`) and an own `toJSON` data property, which certifies the
-// ordinary values it is meant for. It does _not_ fully certify
-// adversarially-shaped objects, so for these the empty result is not a
-// guarantee (all confirmed to pass here while `JSON.stringify` alters them):
-//
-//   - A non-enumerable string data property on a _plain object_ is dropped by
-//     JSON but not seen here (that walk is enumerable-only). An array's
-//     properties are read with `Object.getOwnPropertyNames`, so the same
-//     property on an array _is_ reported.
-//   - An accessor-based `toJSON` (a getter) is missed: the own-descriptor check
-//     matches a data property whose value is a function, not an accessor -- and
-//     a plain read could fire the getter, which the check avoids on purpose.
-//   - An inherited `toJSON` (e.g. on a custom array prototype) is missed: the
-//     check looks at own descriptors only.
-//   - The array-hole test uses `i in obj`, which consults the prototype, so an
-//     inherited numeric property masks a hole; this also does not match JSON's
-//     own-vs-inherited element read.
-//
-// TODO(danfuzz): Close those four gaps, by inspecting own property
-// descriptors for plain objects instead of using `Object.entries`, rejecting
-// accessors and non-enumerable data properties, using `Object.hasOwn` for
-// array slots, and rejecting a nonstandard array prototype or an inherited
-// `toJSON`. Required once a caller has to certify a value it did not
-// construct.
+/**
+ * Reports every part of a runtime value that ordinary JSON serialization
+ * (`JSON.stringify`) would silently alter, drop, or fail to represent -- so a
+ * caller that must hand a value across a JSON boundary can refuse or repair it
+ * before the loss happens, rather than discovering a mangled value downstream.
+ *
+ * This is a positive whitelist, not a search for known-bad leaves. Only the
+ * shapes JSON round-trips by identity are accepted -- `null`, booleans,
+ * strings, finite numbers other than `-0`, dense arrays of accepted values,
+ * and plain objects whose values are accepted. Everything else is reported:
+ * `undefined` (dropped from an object, `null` in an array), `NaN` and
+ * `±Infinity` (both become `null`), `-0` (loses its sign), `bigint` /
+ * `symbol` / `function` (not representable), array holes (`null`), a
+ * non-index property on an array (dropped), symbol-keyed properties
+ * (dropped), a `toJSON` hook (replaces the value before JSON sees it),
+ * non-plain objects such as a class instance (flattened -- `JSON.stringify`
+ * finds no data in its private fields), and cycles (`JSON.stringify` throws).
+ *
+ * A blacklist that only hunted bad numbers would pass every one of those: they
+ * leave no offending numeric leaf, yet JSON still alters them. Whitelisting is
+ * the only framing that makes an empty result actually mean "JSON serialization
+ * will not change this."
+ *
+ * Known limitations. The walk reads enumerable own keys (`Object.keys` /
+ * `Object.entries`) and an own `toJSON` data property, which certifies the
+ * ordinary values it is meant for. It does _not_ fully certify
+ * adversarially-shaped objects, so for these the empty result is not a
+ * guarantee (all confirmed to pass here while `JSON.stringify` alters them):
+ *
+ *   - A non-enumerable string data property on a _plain object_ is dropped by
+ *     JSON but not seen here (that walk is enumerable-only). An array's
+ *     properties are read with `Object.getOwnPropertyNames`, so the same
+ *     property on an array _is_ reported.
+ *   - An accessor-based `toJSON` (a getter) is missed: the own-descriptor check
+ *     matches a data property whose value is a function, not an accessor -- and
+ *     a plain read could fire the getter, which the check avoids on purpose.
+ *   - An inherited `toJSON` (e.g. on a custom array prototype) is missed: the
+ *     check looks at own descriptors only.
+ *   - The array-hole test uses `i in obj`, which consults the prototype, so an
+ *     inherited numeric property masks a hole; this also does not match JSON's
+ *     own-vs-inherited element read.
+ *
+ * TODO(danfuzz): Close those four gaps, by inspecting own property
+ * descriptors for plain objects instead of using `Object.entries`, rejecting
+ * accessors and non-enumerable data properties, using `Object.hasOwn` for
+ * array slots, and rejecting a nonstandard array prototype or an inherited
+ * `toJSON`. Required once a caller has to certify a value it did not
+ * construct.
+ */
 
 import type { JSONValue } from "@commonfabric/api";
 

--- a/packages/pure-json/test/json-faithfulness.test.ts
+++ b/packages/pure-json/test/json-faithfulness.test.ts
@@ -1,3 +1,21 @@
+/**
+ * The corpus that holds `findJsonUnfaithfulValues` to a whitelist rather than
+ * a hunt for bad numbers.
+ *
+ * Most of these cases carry no offending numeric leaf at all and are still
+ * altered by `JSON.stringify`: a dropped `undefined`, an array hole, a
+ * symbol-keyed or non-index property, a `toJSON` hook, a class instance whose
+ * data lives in private fields, a cycle. A blacklist passes every one of them,
+ * so they are what distinguishes the two designs and why they are here.
+ *
+ * Several pin a boundary in the other direction, where reporting would be
+ * wrong: an array's own `length`, a non-enumerable index, and a shared (but
+ * acyclic) reference are all faithful. Pointers are checked for nesting and
+ * for `~` and `/` escaping, since an unactionable pointer makes a correct
+ * report useless. `isPureJson` is asserted to agree with the list rather than
+ * being tested independently, so the two cannot drift.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 

--- a/packages/pure-json/test/json-faithfulness.test.ts
+++ b/packages/pure-json/test/json-faithfulness.test.ts
@@ -2,18 +2,20 @@
  * The corpus that holds `findJsonUnfaithfulValues` to a whitelist rather than
  * a hunt for bad numbers.
  *
- * Most of these cases carry no offending numeric leaf at all and are still
- * altered by `JSON.stringify`: a dropped `undefined`, an array hole, a
- * symbol-keyed or non-index property, a `toJSON` hook, a class instance whose
- * data lives in private fields, a cycle. A blacklist passes every one of them,
- * so they are what distinguishes the two designs and why they are here.
+ * Most of these cases carry no offending numeric leaf at all and are still not
+ * carried faithfully by `JSON.stringify`: a dropped `undefined`, an array
+ * hole, a symbol-keyed or non-index property, a `toJSON` hook, a class
+ * instance whose data lives in private fields, a cycle (which throws rather
+ * than altering anything). A blacklist passes every one of them, so they are
+ * what distinguishes the two designs and why they are here.
  *
  * Several pin a boundary in the other direction, where reporting would be
  * wrong: an array's own `length`, a non-enumerable index, and a shared (but
  * acyclic) reference are all faithful. Pointers are checked for nesting and
  * for `~` and `/` escaping, since an unactionable pointer makes a correct
- * report useless. `isPureJson` is asserted to agree with the list rather than
- * being tested independently, so the two cannot drift.
+ * report useless. `isPureJson` delegates to `findJsonUnfaithfulValues`, so the
+ * two cannot disagree by construction; the cases here pin its boolean surface
+ * directly, and one spot-checks the delegation.
  */
 
 import { describe, it } from "@std/testing/bdd";

--- a/packages/pure-json/test/json-faithfulness.test.ts
+++ b/packages/pure-json/test/json-faithfulness.test.ts
@@ -14,8 +14,8 @@
  * acyclic) reference are all faithful. Pointers are checked for nesting and
  * for `~` and `/` escaping, since an unactionable pointer makes a correct
  * report useless. `isPureJson` delegates to `findJsonUnfaithfulValues`, so the
- * two cannot disagree by construction; the cases here pin its boolean surface
- * directly, and one spot-checks the delegation.
+ * two cannot disagree by construction; two of the cases here pin its boolean
+ * surface directly, and the third spot-checks the delegation.
  */
 
 import { describe, it } from "@std/testing/bdd";

--- a/packages/state-inspector/test/entities.test.ts
+++ b/packages/state-inspector/test/entities.test.ts
@@ -1,7 +1,9 @@
-// Hermetic test for the unified entity model + encoded commit decoding. Seeds a
-// modern piece (patternIdentity → module, argument, internal manifest), an
-// owned cell, a stream, and a free cell, then checks classification + lineage.
-// Side-effect free.
+/**
+ * Hermetic test for the unified entity model + encoded commit decoding. Seeds a
+ * modern piece (patternIdentity → module, argument, internal manifest), an
+ * owned cell, a stream, and a free cell, then checks classification + lineage.
+ * Side-effect free.
+ */
 
 import { assert, assertEquals } from "@std/assert";
 import { Database } from "@db/sqlite";

--- a/packages/toolshed/routes/webhooks/webhooks.delivery.test.ts
+++ b/packages/toolshed/routes/webhooks/webhooks.delivery.test.ts
@@ -1,3 +1,14 @@
+/**
+ * End-to-end check of the part of the webhook flow this PR actually changes: a
+ * cell link serialized to the `fcl1:` wire string (as `CellHandle.toWireString`
+ * produces it) must decode, resolve to the right cell, and deliver a payload to
+ * that cell's inbox stream. This mirrors `sendToStream`'s decode -> resolve ->
+ * send path; that function reaches the `@/index.ts` runtime singleton (which is
+ * uninitialized in tests), so it can't be called directly here, but the logic
+ * exercised is identical, against the house in-memory `StorageManager.emulate`
+ * runtime.
+ */
+
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
@@ -10,15 +21,6 @@ import {
   linkRefPayloadFromString,
   linkRefPayloadToString,
 } from "@commonfabric/runner/shared";
-
-// End-to-end check of the part of the webhook flow this PR actually changes: a
-// cell link serialized to the `fcl1:` wire string (as `CellHandle.toWireString`
-// produces it) must decode, resolve to the right cell, and deliver a payload to
-// that cell's inbox stream. This mirrors `sendToStream`'s decode -> resolve ->
-// send path; that function reaches the `@/index.ts` runtime singleton (which is
-// uninitialized in tests), so it can't be called directly here, but the logic
-// exercised is identical, against the house in-memory `StorageManager.emulate`
-// runtime.
 
 const STREAM_SCHEMA: JSONSchema = {
   asCell: ["stream"],

--- a/packages/toolshed/routes/webhooks/webhooks.routes.test.ts
+++ b/packages/toolshed/routes/webhooks/webhooks.routes.test.ts
@@ -1,3 +1,14 @@
+/**
+ * Smoke tests: confirm each route is mounted and its first-line validation
+ * returns a sensible error. These deliberately hit only the fast-fail paths
+ * (bad input / missing auth) that reject *before* any runtime/storage access,
+ * so they need no runtime fixture. End-to-end delivery is covered separately.
+ *
+ * Driven through the real `app` (not a freshly-mounted router) because the
+ * webhook handlers import the `runtime` singleton from `@/index.ts`, which
+ * imports `@/app.ts` — re-mounting the router standalone hits that import cycle.
+ */
+
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import env from "@/env.ts";
@@ -6,15 +17,6 @@ import app from "@/app.ts";
 if (env.ENV !== "test") {
   throw new Error("ENV must be 'test'");
 }
-
-// Smoke tests: confirm each route is mounted and its first-line validation
-// returns a sensible error. These deliberately hit only the fast-fail paths
-// (bad input / missing auth) that reject *before* any runtime/storage access,
-// so they need no runtime fixture. End-to-end delivery is covered separately.
-//
-// Driven through the real `app` (not a freshly-mounted router) because the
-// webhook handlers import the `runtime` singleton from `@/index.ts`, which
-// imports `@/app.ts` — re-mounting the router standalone hits that import cycle.
 
 describe("Webhook routes (smoke: wired up + error paths)", () => {
   it("POST /api/webhooks rejects an invalid cellLink with 400", async () => {


### PR DESCRIPTION
First in a series conforming files to the file-header rule added in #5647. The
series covers the violations attributable to @danfuzz, split along package
lines; this one takes the seven packages small enough to combine.

## What changed

Eleven files, three kinds of fix, no behavior change.

| kind | files | what |
| --- | ---: | --- |
| form | 5 | header written as a `//` block, now a doc comment |
| placement | 3 | header sitting below the imports, now at the top |
| missing | 3 | no header at all, now written |

The form and placement fixes carry their prose across **byte for byte**. `// `
and ` * ` are both three characters, so wrapping is preserved exactly; a script
did the conversion and refused anything it could not verify, and an independent
check confirmed the extracted prose matches on both sides. That check was
proved able to fail, on a control with a single word altered, before its green
was trusted.

The three new headers say what the file's own name and signatures do not: the
render-utility contracts `Object.is` decides in `render-utils.test.ts`, what
`assertJsonTransportSafe` puts in its error and why that is the whole reason it
is an assertion rather than a boolean, and the corpus that holds
`findJsonUnfaithfulValues` to a whitelist rather than a hunt for bad numbers.

One of the placement fixes, in `webhooks.routes.test.ts`, had its header below
an `env` guard as well as below the imports.

## Left deliberately alone

Two of the relocated headers carry content the file-header rule does not reach.
One narrates the code's own past and cites a pull request number; the other
refers to "this PR", which has no referent for anyone reading the file later.
Both are ruled out by "Describe the system as it is" in the same document.

They are moved unchanged anyway. Rewording a behavioral sentence during a style
pass is how a false claim gets laundered — the sentence about `structuredClone`
would have to be checked against what the code does now, which is a different
change with a different risk profile. Flagging rather than fixing.

## Checks

`deno fmt` and `deno lint` on the touched files. Full `deno task test` in every
package touched: `html`, `llm`, `pure-json`, `state-inspector`,
`background-piece-service`, `memory` all pass, and `toolshed` reports
`ok | 122 passed (247 steps) | 0 failed`.

Every new or moved header was checked to be followed by a blank line, so none
of them binds to the declaration underneath as its doc comment.

## A correction worth recording

An earlier count of this series said 135 files. It is 134. `scripts/ab-harness.ts`
was a false positive: it opens with a `deno-lint-ignore-file` pragma that wraps
onto three continuation lines, and the classifier read that as a `//` header
while the file's actual JSDoc header sat just below. `scripts/` leaves the
series entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWSRsoxPqARrkCgLz5Smww


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

