### PR TITLE
Add space ACL controls to the piece context menu

### DIFF
--- a/docs/common/components/COMPONENTS.md
+++ b/docs/common/components/COMPONENTS.md
@@ -466,6 +466,12 @@ from the menu are accepted-for-delivery acknowledgements (the commit is
 asynchronous) and are not renderer-trusted, so a handler gated on UI
 provenance will refuse them.
 
+The piece-specific entries are followed by a divider and **Space access
+rights...**. That dialog lists the space ACL for every reader. A principal with
+`OWNER` access can add identities, change their `READ`, `WRITE`, or `OWNER`
+capability, and remove entries. The memory server validates every change and
+requires the ACL to retain at least one concrete owner.
+
 The menu comes with `cf-render`. Importing the component registers it. It mounts
 itself on `document.body` so a piece's clipping or a tile's scaling cannot reach
 it. While the menu or one of its panels is open, the addressed piece carries an

--- a/docs/features/host-embedding.md
+++ b/docs/features/host-embedding.md
@@ -159,6 +159,14 @@ menu. The menu reads and changes the piece through
 `RuntimeClient.getPieceSource()` and `RuntimeClient.updatePieceSource()` on the
 runtime the piece already runs in.
 
+After the piece-specific entries, a divider separates **Space access rights...**.
+The dialog reads the target space's ACL through `RuntimeClient.getSpaceAcl()`.
+Every principal that can read the space sees the entries. A principal whose
+effective ACL capability is `OWNER` also gets controls backed by
+`RuntimeClient.setSpaceAclEntry()` and `RuntimeClient.removeSpaceAclEntry()`.
+The runtime uses `ACLManager` for these mutations, so the memory server remains
+the authority that accepts owner changes and preserves a concrete owner.
+
 Calling `RuntimeClient.createPage()` with an HTTP or HTTPS `URL` creates a
 followed piece. The runtime records the canonical URL and retained initial
 source in one creation transaction. Calling it with a source string or

--- a/packages/runner/src/acl-manager.ts
+++ b/packages/runner/src/acl-manager.ts
@@ -48,21 +48,24 @@ export class ACLManager {
     return cloneIfNecessary(aclData) as ACL;
   }
 
-  async set(user: ACLUser, capability: Capability): Promise<void> {
+  async set(user: ACLUser, capability: Capability): Promise<ACL> {
     await this.get();
     // Initialization authority is enforced by the memory server. This lets a
     // space identity or service DID create the first concrete OWNER through
     // the management API while an ordinary public-compatibility principal is
     // still rejected server-side.
-    await this.#write((acl) => ({ ...(acl ?? {}), [user]: capability }));
+    return await this.#write((acl) => ({
+      ...(acl ?? {}),
+      [user]: capability,
+    }));
   }
 
-  async remove(user: ACLUser): Promise<void> {
+  async remove(user: ACLUser): Promise<ACL> {
     const acl = await this.get();
     if (acl === null) {
       throw new Error("No ACL initialized for space.");
     }
-    await this.#write((current) => {
+    return await this.#write((current) => {
       if (current === null) {
         throw new Error("No ACL initialized for space.");
       }
@@ -71,7 +74,7 @@ export class ACLManager {
     });
   }
 
-  async #write(mutate: (current: ACL | null) => ACL): Promise<void> {
+  async #write(mutate: (current: ACL | null) => ACL): Promise<ACL> {
     // The memory server requires an ACL mutation to be a single whole-document
     // `set` on `of:<space>`, rejecting anything else with "ACL mutations must
     // replace the space-scoped ACL document". Writing through the value
@@ -99,6 +102,7 @@ export class ACLManager {
         | { readonly value?: unknown }
         | undefined;
       const current = this.#validateStoredACL(envelope?.value);
+      const next = mutate(current);
       // Spread the stored envelope rather than writing a bare `{ value }`: a
       // whole-document write replaces every sibling field, so constructing the
       // envelope from scratch would silently drop `["cfc"]` (the persisted
@@ -107,8 +111,9 @@ export class ACLManager {
       // way to erase a label on every grant.
       tx.writeOrThrow(address, {
         ...(envelope ?? {}),
-        value: mutate(current),
+        value: next,
       } as FabricValue);
+      return next;
     });
     if (result.error) {
       const error = new Error(result.error.message, { cause: result.error });
@@ -117,6 +122,7 @@ export class ACLManager {
     }
     await this.#runtime.idle();
     await this.#runtime.storageManager.synced();
+    return result.ok;
   }
 
   #getCell(): Cell<unknown> {

--- a/packages/runner/test/memory-v2-acl-mutation.test.ts
+++ b/packages/runner/test/memory-v2-acl-mutation.test.ts
@@ -668,3 +668,23 @@ Deno.test("ACL mutation still cannot remove the last concrete owner", async () =
     await ctx.dispose();
   }
 });
+
+Deno.test("ACLManager returns the committed ACL when an owner removes themself", async () => {
+  const ctx = await withGenesisedSpace("runner-acl-mutation-self-remove");
+  const bob = await Identity.fromPassphrase(
+    "runner-acl-mutation-self-remove bob",
+  );
+  try {
+    await ctx.acl.remove("*");
+    await ctx.acl.set(bob.did(), "OWNER");
+
+    const committed = await ctx.acl.remove(ctx.user.did());
+
+    assertEquals(committed, {
+      [bob.did()]: "OWNER",
+    });
+    assertEquals(await ctx.readStoredAcl(), committed);
+  } finally {
+    await ctx.dispose();
+  }
+});

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -637,6 +637,81 @@ describe("space ACL state", () => {
     expect(response.access.canEdit).toBe(false);
   });
 
+  it("routes valid ACL mutations and returns each committed ACL", async () => {
+    const { runtime, storageManager } = createRuntime();
+    const space = "did:key:z6Mk-runtime-processor-acl-mutations" as MemorySpace;
+    const owner = cfcSigner.did();
+    const writer = "did:key:z6Mk-runtime-processor-added-writer" as const;
+    try {
+      const tx = runtime.edit();
+      tx.writeOrThrow({
+        space,
+        id: `of:${space}` as URI,
+        type: "application/json",
+        path: [],
+      }, {
+        value: { [owner]: "OWNER", "*": "READ" },
+      });
+      await tx.commit();
+      await runtime.idle();
+      await storageManager.synced();
+
+      const processor = {
+        runtime,
+        getSpaceCtx: () => ({ getSpace: () => space }),
+        handleSpaceGetAcl: RuntimeProcessor.prototype.handleSpaceGetAcl,
+        handleSpaceSetAclEntry:
+          RuntimeProcessor.prototype.handleSpaceSetAclEntry,
+        handleSpaceRemoveAclEntry:
+          RuntimeProcessor.prototype.handleSpaceRemoveAclEntry,
+      } as unknown as RuntimeProcessor;
+
+      const added = await RuntimeProcessor.prototype.handleRequest.call(
+        processor,
+        {
+          type: RequestType.SpaceSetAclEntry,
+          space,
+          user: writer,
+          capability: "WRITE",
+        },
+      );
+      expect(added).toEqual({
+        access: {
+          space,
+          principal: owner,
+          acl: { [owner]: "OWNER", "*": "READ", [writer]: "WRITE" },
+          canEdit: true,
+        },
+      });
+
+      const read = await RuntimeProcessor.prototype.handleRequest.call(
+        processor,
+        { type: RequestType.SpaceGetAcl, space },
+      );
+      expect(read).toEqual(added);
+
+      const removed = await RuntimeProcessor.prototype.handleRequest.call(
+        processor,
+        {
+          type: RequestType.SpaceRemoveAclEntry,
+          space,
+          user: writer,
+        },
+      );
+      expect(removed).toEqual({
+        access: {
+          space,
+          principal: owner,
+          acl: { [owner]: "OWNER", "*": "READ" },
+          canEdit: true,
+        },
+      });
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
   it("rejects malformed ACL mutations before opening the space", async () => {
     const processor = {
       getSpaceCtx: () => {
@@ -666,6 +741,16 @@ describe("space ACL state", () => {
         },
       ),
     ).rejects.toThrow("capability must be `READ`, `WRITE`, or `OWNER`");
+    await expect(
+      (RuntimeProcessor.prototype as any).handleSpaceRemoveAclEntry.call(
+        processor,
+        {
+          type: RequestType.SpaceRemoveAclEntry,
+          space: "did:key:z6Mk-runtime-processor-acl",
+          user: "not-a-did",
+        },
+      ),
+    ).rejects.toThrow("user must be `*` or a valid DID");
   });
 });
 

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -581,6 +581,94 @@ describe("piece source state", () => {
   });
 });
 
+describe("space ACL state", () => {
+  it("reports owner controls from the active principal's ACL entry", async () => {
+    const space = "did:key:z6Mk-runtime-processor-acl" as const;
+    const owner = "did:key:z6Mk-runtime-processor-owner" as const;
+    const runtime = {
+      userIdentityDID: owner,
+      storageManager: { synced: () => Promise.resolve() },
+      getCellFromLink: () => ({
+        sync: () => Promise.resolve(),
+        get: () => ({ [owner]: "OWNER", "*": "WRITE" }),
+      }),
+    };
+    const processor = {
+      getSpaceCtx: () => ({ getSpace: () => space }),
+      runtime,
+    };
+
+    const response = await (RuntimeProcessor.prototype as any)
+      .handleSpaceGetAcl.call(processor, {
+        type: RequestType.SpaceGetAcl,
+        space,
+      });
+
+    expect(response.access).toEqual({
+      space,
+      principal: owner,
+      acl: { [owner]: "OWNER", "*": "WRITE" },
+      canEdit: true,
+    });
+  });
+
+  it("keeps wildcard writers read-only in the ACL view", async () => {
+    const space = "did:key:z6Mk-runtime-processor-acl" as const;
+    const owner = "did:key:z6Mk-runtime-processor-owner" as const;
+    const writer = "did:key:z6Mk-runtime-processor-writer" as const;
+    const processor = {
+      getSpaceCtx: () => ({ getSpace: () => space }),
+      runtime: {
+        userIdentityDID: writer,
+        storageManager: { synced: () => Promise.resolve() },
+        getCellFromLink: () => ({
+          sync: () => Promise.resolve(),
+          get: () => ({ [owner]: "OWNER", "*": "WRITE" }),
+        }),
+      },
+    };
+
+    const response = await (RuntimeProcessor.prototype as any)
+      .handleSpaceGetAcl.call(processor, {
+        type: RequestType.SpaceGetAcl,
+        space,
+      });
+
+    expect(response.access.canEdit).toBe(false);
+  });
+
+  it("rejects malformed ACL mutations before opening the space", async () => {
+    const processor = {
+      getSpaceCtx: () => {
+        throw new Error("space must not be opened");
+      },
+    };
+
+    await expect(
+      (RuntimeProcessor.prototype as any).handleSpaceSetAclEntry.call(
+        processor,
+        {
+          type: RequestType.SpaceSetAclEntry,
+          space: "did:key:z6Mk-runtime-processor-acl",
+          user: "not-a-did",
+          capability: "WRITE",
+        },
+      ),
+    ).rejects.toThrow("user must be `*` or a valid DID");
+    await expect(
+      (RuntimeProcessor.prototype as any).handleSpaceSetAclEntry.call(
+        processor,
+        {
+          type: RequestType.SpaceSetAclEntry,
+          space: "did:key:z6Mk-runtime-processor-acl",
+          user: "did:key:z6Mk-runtime-processor-reader",
+          capability: "ADMIN",
+        },
+      ),
+    ).rejects.toThrow("capability must be `READ`, `WRITE`, or `OWNER`");
+  });
+});
+
 describe("page slug metadata", () => {
   it("reads slug metadata from the page document root", async () => {
     const reads: unknown[] = [];

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -3,6 +3,7 @@ import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { FabricSpecialObject } from "@commonfabric/data-model/fabric-value";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { newDefaultJsonCodec } from "@commonfabric/data-model/codecs";
+import { type ACL, isACLUser, isCapability } from "@commonfabric/memory/acl";
 import {
   PieceController,
   PiecesController,
@@ -20,6 +21,7 @@ import {
   resetAllTimingBaselines,
 } from "@commonfabric/utils/logger";
 import {
+  ACLManager,
   type BrowserWorkerPresetParams,
   type Cancel,
   type Cell,
@@ -131,7 +133,11 @@ import {
   type SetTriggerTraceEnabledRequest,
   type SetWriteStackTraceMatchersRequest,
   type SlugResponse,
+  type SpaceAclResponse,
+  type SpaceGetAclRequest,
+  type SpaceRemoveAclEntryRequest,
   type SpaceResponse,
+  type SpaceSetAclEntryRequest,
   type TriggerTraceResponse,
   type UploadBlobRequest,
   type UploadBlobResponse,
@@ -174,6 +180,25 @@ import {
 
 const MAX_SERIALIZATION_DEPTH = 5;
 const blobUploadCodec = newDefaultJsonCodec();
+
+function spaceAclResponse(
+  runtime: Runtime,
+  space: DID,
+  acl: ACL | null,
+): SpaceAclResponse {
+  const principal = runtime.userIdentityDID;
+  const capability = principal === space
+    ? "OWNER"
+    : acl?.[principal] ?? acl?.["*"];
+  return {
+    access: {
+      space,
+      principal,
+      acl: { ...(acl ?? {}) } as SpaceAclResponse["access"]["acl"],
+      canEdit: capability === "OWNER",
+    },
+  };
+}
 
 // Split-timing for the CFC label IPC path. Counts/timing are readable via
 // getLoggerCounts(); enabled silently so the hot path pays only the timestamp.
@@ -1420,6 +1445,49 @@ export class RuntimeProcessor {
     };
   }
 
+  async handleSpaceGetAcl(
+    request: SpaceGetAclRequest,
+  ): Promise<SpaceAclResponse> {
+    this.getSpaceCtx(request.space);
+    const acl = await new ACLManager(this.runtime, request.space).get();
+    return spaceAclResponse(this.runtime, request.space, acl);
+  }
+
+  async handleSpaceSetAclEntry(
+    request: SpaceSetAclEntryRequest,
+  ): Promise<SpaceAclResponse> {
+    if (!isACLUser(request.user)) {
+      throw new Error("user must be `*` or a valid DID");
+    }
+    if (!isCapability(request.capability)) {
+      throw new Error("capability must be `READ`, `WRITE`, or `OWNER`");
+    }
+    this.getSpaceCtx(request.space);
+    const manager = new ACLManager(this.runtime, request.space);
+    const acl = await manager.set(request.user, request.capability);
+    return spaceAclResponse(
+      this.runtime,
+      request.space,
+      acl,
+    );
+  }
+
+  async handleSpaceRemoveAclEntry(
+    request: SpaceRemoveAclEntryRequest,
+  ): Promise<SpaceAclResponse> {
+    if (!isACLUser(request.user)) {
+      throw new Error("user must be `*` or a valid DID");
+    }
+    this.getSpaceCtx(request.space);
+    const manager = new ACLManager(this.runtime, request.space);
+    const acl = await manager.remove(request.user);
+    return spaceAclResponse(
+      this.runtime,
+      request.space,
+      acl,
+    );
+  }
+
   handleRegisterSpaceHost(
     request: RegisterSpaceHostRequest,
   ): BooleanResponse {
@@ -1735,6 +1803,12 @@ export class RuntimeProcessor {
         return await this.handlePieceGetSource(request);
       case RequestType.PieceUpdateSource:
         return await this.handlePieceUpdateSource(request);
+      case RequestType.SpaceGetAcl:
+        return await this.handleSpaceGetAcl(request);
+      case RequestType.SpaceSetAclEntry:
+        return await this.handleSpaceSetAclEntry(request);
+      case RequestType.SpaceRemoveAclEntry:
+        return await this.handleSpaceRemoveAclEntry(request);
       case RequestType.PageSynced:
         return await this.handlePageSynced(request);
       case RequestType.RuntimeSynced:

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -91,6 +91,9 @@ export enum RequestType {
   PageSynced = "page:synced",
   PieceGetSource = "piece:getSource",
   PieceUpdateSource = "piece:updateSource",
+  SpaceGetAcl = "space:getAcl",
+  SpaceSetAclEntry = "space:setAclEntry",
+  SpaceRemoveAclEntry = "space:removeAclEntry",
 
   // VDOM operations (main -> worker)
   VDomMount = "vdom:mount",
@@ -765,6 +768,43 @@ export interface PieceUpdateSourceResponse extends PieceSourceResponse {
   executionWarning?: string;
 }
 
+/** One access level in a space ACL. */
+export type SpaceAclCapability = "READ" | "WRITE" | "OWNER";
+
+/** The space ACL and the current principal's ability to administer it. */
+export interface SpaceAclView {
+  space: DID;
+  principal: DID;
+  acl: Record<string, SpaceAclCapability>;
+  canEdit: boolean;
+}
+
+/** Response carrying a space's access-control view. */
+export interface SpaceAclResponse {
+  access: SpaceAclView;
+}
+
+/** Reads the ACL for one space. */
+export interface SpaceGetAclRequest extends BaseRequest {
+  type: RequestType.SpaceGetAcl;
+  space: DID;
+}
+
+/** Adds or replaces one explicit ACL entry in a space. */
+export interface SpaceSetAclEntryRequest extends BaseRequest {
+  type: RequestType.SpaceSetAclEntry;
+  space: DID;
+  user: string;
+  capability: SpaceAclCapability;
+}
+
+/** Removes one explicit ACL entry from a space. */
+export interface SpaceRemoveAclEntryRequest extends BaseRequest {
+  type: RequestType.SpaceRemoveAclEntry;
+  space: DID;
+  user: string;
+}
+
 /** Common shape for one-way main -> worker notifications. */
 export interface BaseClientNotification {
   type: ClientNotificationType;
@@ -917,6 +957,9 @@ export type IPCClientRequest =
   | PageSyncedRequest
   | PieceGetSourceRequest
   | PieceUpdateSourceRequest
+  | SpaceGetAclRequest
+  | SpaceSetAclEntryRequest
+  | SpaceRemoveAclEntryRequest
   | RuntimeSyncedRequest
   | ResolveSpaceNameRequest
   | RegisterSpaceHostRequest
@@ -1083,6 +1126,7 @@ export type RemoteResponse =
   | PageResponse
   | PieceSourceResponse
   | PieceUpdateSourceResponse
+  | SpaceAclResponse
   | SlugResponse
   | SpaceResponse
   | VDomMountResponse
@@ -1281,6 +1325,18 @@ export type Commands = {
   [RequestType.PieceUpdateSource]: {
     request: PieceUpdateSourceRequest;
     response: PieceUpdateSourceResponse;
+  };
+  [RequestType.SpaceGetAcl]: {
+    request: SpaceGetAclRequest;
+    response: SpaceAclResponse;
+  };
+  [RequestType.SpaceSetAclEntry]: {
+    request: SpaceSetAclEntryRequest;
+    response: SpaceAclResponse;
+  };
+  [RequestType.SpaceRemoveAclEntry]: {
+    request: SpaceRemoveAclEntryRequest;
+    response: SpaceAclResponse;
   };
   [RequestType.GetSpaceRootPattern]: {
     request: PageGetSpaceDefault;

--- a/packages/runtime-client/runtime-client.test.ts
+++ b/packages/runtime-client/runtime-client.test.ts
@@ -158,6 +158,59 @@ describe("RuntimeClient.updatePieceSource", () => {
   });
 });
 
+describe("RuntimeClient space ACL methods", () => {
+  it("sends read, set, and remove requests to the worker", async () => {
+    const access = {
+      space: "did:key:z6Mk-runtime-client-acl",
+      principal: "did:key:z6Mk-runtime-client-owner",
+      acl: { "did:key:z6Mk-runtime-client-owner": "OWNER" },
+      canEdit: true,
+    };
+    const requests: unknown[] = [];
+    const conn = {
+      on: () => {},
+      request: (message: unknown) => {
+        requests.push(message);
+        return Promise.resolve({ access });
+      },
+    } as unknown as never;
+    const client = new (RuntimeClient as unknown as {
+      new (conn: never, options: unknown): RuntimeClient;
+    })(conn, {});
+    const space = access.space as never;
+
+    expect(await client.getSpaceAcl(space)).toBe(access);
+    expect(
+      await client.setSpaceAclEntry(
+        space,
+        "did:key:z6Mk-runtime-client-reader",
+        "READ",
+      ),
+    ).toBe(access);
+    expect(
+      await client.removeSpaceAclEntry(
+        space,
+        "did:key:z6Mk-runtime-client-reader",
+      ),
+    ).toBe(access);
+
+    expect(requests).toEqual([
+      { type: RequestType.SpaceGetAcl, space },
+      {
+        type: RequestType.SpaceSetAclEntry,
+        space,
+        user: "did:key:z6Mk-runtime-client-reader",
+        capability: "READ",
+      },
+      {
+        type: RequestType.SpaceRemoveAclEntry,
+        space,
+        user: "did:key:z6Mk-runtime-client-reader",
+      },
+    ]);
+  });
+});
+
 describe("RuntimeClient.resolveSpaceName", () => {
   it("resolves the name inside the worker runtime", async () => {
     const space = "did:key:z6Mk-runtime-client-named-space";

--- a/packages/runtime-client/runtime-client.ts
+++ b/packages/runtime-client/runtime-client.ts
@@ -39,6 +39,8 @@ import {
   type PieceSourceView,
   type PieceUpdateSourceResponse,
   RequestType,
+  type SpaceAclCapability,
+  type SpaceAclView,
   TelemetryNotification,
   type UploadBlobResponse,
 } from "./protocol/mod.ts";
@@ -338,6 +340,43 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
         ? {}
         : { confirmationToken: options.confirmationToken }),
     });
+  }
+
+  /** Read a space's ACL and whether the active principal may change it. */
+  async getSpaceAcl(space: DID): Promise<SpaceAclView> {
+    const response = await this.#conn.request<RequestType.SpaceGetAcl>({
+      type: RequestType.SpaceGetAcl,
+      space,
+    });
+    return response.access;
+  }
+
+  /** Add or replace one entry in a space ACL. */
+  async setSpaceAclEntry(
+    space: DID,
+    user: string,
+    capability: SpaceAclCapability,
+  ): Promise<SpaceAclView> {
+    const response = await this.#conn.request<RequestType.SpaceSetAclEntry>({
+      type: RequestType.SpaceSetAclEntry,
+      space,
+      user,
+      capability,
+    });
+    return response.access;
+  }
+
+  /** Remove one entry from a space ACL. */
+  async removeSpaceAclEntry(
+    space: DID,
+    user: string,
+  ): Promise<SpaceAclView> {
+    const response = await this.#conn.request<RequestType.SpaceRemoveAclEntry>({
+      type: RequestType.SpaceRemoveAclEntry,
+      space,
+      user,
+    });
+    return response.access;
   }
 
   async getPageSlug(pageId: string, space: DID): Promise<string | undefined> {

--- a/packages/shell/integration/piece-menu.test.ts
+++ b/packages/shell/integration/piece-menu.test.ts
@@ -450,6 +450,75 @@ async function waitForPanelText(
   );
 }
 
+/** Wait until the current identity's access row shows the expected level. */
+async function waitForCurrentIdentityAccess(
+  page: ReturnType<ShellIntegration["page"]>,
+  expected: "READ" | "WRITE" | "OWNER",
+): Promise<void> {
+  await waitForCondition(page, (probe, access: string) => {
+    const root = document.querySelector("cf-piece-menu")?.shadowRoot;
+    const row = [...(root?.querySelectorAll("tbody tr") ?? [])].find((entry) =>
+      probe.deepText(entry).includes("(you)")
+    );
+    return row?.querySelector<HTMLSelectElement>(".access-select")?.value ===
+      access;
+  }, { args: [expected] });
+}
+
+/** Choose an access level in the current identity's rendered ACL row. */
+async function changeCurrentIdentityAccess(
+  page: ReturnType<ShellIntegration["page"]>,
+  access: "READ" | "WRITE" | "OWNER",
+): Promise<void> {
+  await page.evaluate((nextAccess: string) => {
+    const root = document.querySelector("cf-piece-menu")?.shadowRoot;
+    const row = [...(root?.querySelectorAll("tbody tr") ?? [])].find((entry) =>
+      entry.textContent?.includes("(you)")
+    );
+    const select = row?.querySelector<HTMLSelectElement>(".access-select");
+    if (!select) throw new Error("current identity access row is unavailable");
+    select.value = nextAccess;
+    select.dispatchEvent(
+      new Event("change", { bubbles: true, composed: true }),
+    );
+  }, { args: [access] });
+}
+
+/** Add one ACL entry through the rendered access form. */
+async function addSpaceAccessEntry(
+  page: ReturnType<ShellIntegration["page"]>,
+  user: string,
+): Promise<void> {
+  await page.evaluate((identity: string) => {
+    const root = document.querySelector("cf-piece-menu")?.shadowRoot;
+    const input = root?.querySelector<HTMLInputElement>(".access-input");
+    const form = root?.querySelector<HTMLFormElement>(".access-add-form");
+    if (!input || !form) throw new Error("space access form is unavailable");
+    input.value = identity;
+    input.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+    form.requestSubmit();
+  }, { args: [user] });
+}
+
+/** Remove the ACL row for `user` through its rendered button. */
+async function removeSpaceAccessEntry(
+  page: ReturnType<ShellIntegration["page"]>,
+  user: string,
+): Promise<void> {
+  await waitForCondition(page, (probe, identity: string) => {
+    const root = document.querySelector("cf-piece-menu")?.shadowRoot;
+    const row = [...(root?.querySelectorAll("tbody tr") ?? [])].find((entry) =>
+      probe.deepText(entry).includes(identity)
+    );
+    const button = row?.querySelector<HTMLButtonElement>(
+      '[test-id="space-access-remove"]',
+    );
+    if (!button || button.disabled) return false;
+    button.click();
+    return true;
+  }, { args: [user] });
+}
+
 describe("piece context menu", () => {
   const shell = new ShellIntegration();
   shell.bindLifecycle();
@@ -457,7 +526,7 @@ describe("piece context menu", () => {
   // The menu and its panels are cf-piece-menu's, mounted on document.body by
   // cf-render. Driving them through a real right-click is what proves the
   // announcement, the portalled overlay, and the worker read all line up.
-  it("shows a piece's source and the origin it records", async () => {
+  it("shows a piece's source, origin, and space access rights", async () => {
     const page = shell.page();
     const { identity } = await writeTempIdentity({ implementation: "noble" });
 
@@ -530,6 +599,37 @@ describe("piece context menu", () => {
       page,
       "piece-panel-origin",
       "/api/patterns/system/default-app.tsx",
+    );
+
+    await rightClickRenderedPiece(page);
+    await clickPierce(page, '[test-id="piece-menu-space-access"]');
+    await waitForPanelText(
+      page,
+      "piece-panel-access",
+      "you have OWNER access",
+    );
+    await waitForCurrentIdentityAccess(page, "OWNER");
+    await waitForPanelText(page, "piece-panel-access", "Anyone (*)");
+
+    await changeCurrentIdentityAccess(page, "READ");
+    await waitForPanelText(
+      page,
+      "piece-panel-access",
+      "Could not change access rights",
+    );
+    await waitForCurrentIdentityAccess(page, "OWNER");
+
+    const reader = "did:key:z6Mk-piece-menu-integration-reader";
+    await addSpaceAccessEntry(page, reader);
+    await waitForPanelText(page, "piece-panel-access", reader);
+    await removeSpaceAccessEntry(page, reader);
+    await waitForCondition(
+      page,
+      (probe, identity: string) =>
+        probe.collect('[test-id="piece-panel-access"]').some((panel) =>
+          probe.isRendered(panel) && !probe.deepText(panel).includes(identity)
+        ),
+      { args: [reader] },
     );
 
     expect(await closePieceMenu(page)).toEqual({

--- a/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.test.ts
+++ b/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.test.ts
@@ -94,6 +94,42 @@ function clickTestId(menu: CFPieceMenu, testId: string): unknown {
   return handler();
 }
 
+/** Find a rendered event handler on the element identified by `marker`. */
+function eventHandler(
+  menu: CFPieceMenu,
+  marker: string,
+  eventName: string,
+): (event: Event) => unknown {
+  let handler: ((event: Event) => unknown) | undefined;
+  const visit = (node: unknown): void => {
+    if (Array.isArray(node)) {
+      for (const child of node) visit(child);
+      return;
+    }
+    if (node === null || typeof node !== "object") return;
+    const template = node as {
+      strings?: readonly string[];
+      values?: unknown[];
+    };
+    if (!template.strings || !template.values) return;
+    const index = template.strings.findIndex((part) =>
+      part.includes(`@${eventName}="`)
+    );
+    if (
+      template.strings.join("").includes(marker) && index >= 0 &&
+      typeof template.values[index] === "function"
+    ) {
+      handler = template.values[index] as (event: Event) => unknown;
+    }
+    for (const child of template.values) visit(child);
+  };
+  visit((menu as unknown as { render(): unknown }).render());
+  if (!handler) {
+    throw new Error(`no ${eventName} handler found for ${marker}`);
+  }
+  return handler;
+}
+
 const SPACE = "did:key:z6Mk-piece-menu" as const;
 const OWNER = "did:key:z6Mk-piece-menu-owner" as const;
 const VIEWER = "did:key:z6Mk-piece-menu-viewer" as const;
@@ -376,6 +412,10 @@ describe("the menu a right-click opens", () => {
     await read;
 
     expect(shows(menu)).toBe("");
+    expect(
+      (menu as unknown as { spaceAccess: SpaceAclView | undefined })
+        .spaceAccess,
+    ).toBeUndefined();
   });
 
   it("draws a clipped fixed highlight over a nested pattern root", () => {
@@ -511,6 +551,178 @@ describe("the space access panel", () => {
       { kind: "set", space: SPACE, user: reader, capability: "READ" },
       { kind: "remove", space: SPACE, user: reader },
     ]);
+  });
+
+  it("submits a new ACL entry from the rendered form", async () => {
+    const reader = "did:key:z6Mk-piece-menu-form-reader";
+    const mutations: unknown[] = [];
+    const menu = openMenu(pieceCell(undefined, {
+      setAccess: (space, user, capability) => {
+        mutations.push({ space, user, capability });
+        return Promise.resolve({
+          ...OWNER_ACCESS,
+          acl: { ...OWNER_ACCESS.acl, [user]: capability },
+        });
+      },
+    }));
+    await menu.showPanel("access");
+
+    eventHandler(menu, "Identity DID or wildcard", "input")({
+      currentTarget: { value: ` ${reader} ` },
+    } as unknown as Event);
+    eventHandler(menu, "Access level for new entry", "change")({
+      currentTarget: { value: "WRITE" },
+    } as unknown as Event);
+    let prevented = false;
+    eventHandler(menu, 'test-id="space-access-add-form"', "submit")({
+      preventDefault: () => {
+        prevented = true;
+      },
+    } as unknown as Event);
+    await Promise.resolve();
+
+    expect(prevented).toBe(true);
+    expect(mutations).toEqual([
+      { space: SPACE, user: reader, capability: "WRITE" },
+    ]);
+    expect(shows(menu)).toContain(reader);
+    expect(
+      (menu as unknown as { newAccessUser: string }).newAccessUser,
+    ).toBe("");
+  });
+
+  it("reports access reads and mutations that fail", async () => {
+    const readFailure = openMenu(pieceCell(undefined, {
+      getAccess: () => Promise.reject(new Error("ACL read denied")),
+    }));
+    await readFailure.showPanel("access");
+    expect(shows(readFailure)).toContain("ACL read denied");
+
+    const mutationFailure = openMenu(pieceCell(undefined, {
+      setAccess: () => Promise.reject(new Error("ACL write denied")),
+      removeAccess: () => Promise.reject("ACL removal denied"),
+    }));
+    await mutationFailure.showPanel("access");
+    await mutationFailure.setSpaceAccessEntry("did:key:reader", "READ");
+    expect(shows(mutationFailure)).toContain("ACL write denied");
+    await mutationFailure.removeSpaceAccessEntry("did:key:reader");
+    expect(shows(mutationFailure)).toContain("ACL removal denied");
+  });
+
+  it("ignores cancelled ACL reads and mutations", async () => {
+    const menu = openMenu(pieceCell(undefined, {
+      aborted: true,
+      getAccess: () => Promise.reject(new Error("cancelled read")),
+      setAccess: () => Promise.reject(new Error("cancelled set")),
+      removeAccess: () => Promise.reject(new Error("cancelled removal")),
+    }));
+
+    await menu.showPanel("access");
+    await menu.setSpaceAccessEntry("did:key:reader", "READ");
+    await menu.removeSpaceAccessEntry("did:key:reader");
+
+    expect(shows(menu)).not.toContain("cancelled");
+  });
+
+  it("drops ACL mutation results after another piece opens", async () => {
+    let resolveSet!: (access: SpaceAclView) => void;
+    let resolveRemoval!: (access: SpaceAclView) => void;
+    const menu = openMenu(pieceCell(undefined, {
+      setAccess: () =>
+        new Promise((resolve) => {
+          resolveSet = resolve;
+        }),
+    }));
+    await menu.showPanel("access");
+
+    const staleSet = menu.setSpaceAccessEntry("did:key:stale", "READ");
+    menu.open({ cell: pieceCell(), x: 0, y: 0 });
+    resolveSet({
+      ...OWNER_ACCESS,
+      acl: { ...OWNER_ACCESS.acl, "did:key:stale": "READ" },
+    });
+    await staleSet;
+    expect(
+      (menu as unknown as { spaceAccess: SpaceAclView | undefined })
+        .spaceAccess,
+    ).toBeUndefined();
+
+    const removalMenu = openMenu(pieceCell(undefined, {
+      removeAccess: () =>
+        new Promise((resolve) => {
+          resolveRemoval = resolve;
+        }),
+    }));
+    await removalMenu.showPanel("access");
+    const staleRemoval = removalMenu.removeSpaceAccessEntry(OWNER);
+    removalMenu.open({ cell: pieceCell(), x: 0, y: 0 });
+    resolveRemoval({ ...OWNER_ACCESS, acl: {} });
+    await staleRemoval;
+    expect(
+      (removalMenu as unknown as {
+        spaceAccess: SpaceAclView | undefined;
+      }).spaceAccess,
+    ).toBeUndefined();
+  });
+
+  it("does not overlap ACL mutations or accept an empty identity", async () => {
+    let resolveSet!: (access: SpaceAclView) => void;
+    let sets = 0;
+    let removals = 0;
+    const menu = openMenu(pieceCell(undefined, {
+      setAccess: () => {
+        sets++;
+        return new Promise((resolve) => {
+          resolveSet = resolve;
+        });
+      },
+      removeAccess: () => {
+        removals++;
+        return Promise.resolve(OWNER_ACCESS);
+      },
+    }));
+    await menu.showPanel("access");
+
+    await menu.setSpaceAccessEntry("   ", "READ");
+    const pending = menu.setSpaceAccessEntry("did:key:first", "READ");
+    await menu.setSpaceAccessEntry("did:key:second", "WRITE");
+    await menu.removeSpaceAccessEntry(OWNER);
+    expect(sets).toBe(1);
+    expect(removals).toBe(0);
+
+    resolveSet(OWNER_ACCESS);
+    await pending;
+    await menu.removeSpaceAccessEntry(OWNER);
+    expect(removals).toBe(1);
+
+    menu.close();
+    await menu.setSpaceAccessEntry("did:key:no-piece", "READ");
+    await menu.removeSpaceAccessEntry(OWNER);
+    expect(sets).toBe(1);
+    expect(removals).toBe(1);
+  });
+
+  it("shows an empty ACL and consistently orders the wildcard", async () => {
+    const empty = openMenu(pieceCell(undefined, {
+      getAccess: () => Promise.resolve({ ...OWNER_ACCESS, acl: {} }),
+    }));
+    await empty.showPanel("access");
+    expect(shows(empty)).toContain("No ACL entries");
+
+    const wildcardFirst = openMenu(pieceCell(undefined, {
+      getAccess: () =>
+        Promise.resolve({
+          ...OWNER_ACCESS,
+          acl: { [OWNER]: "OWNER", "*": "WRITE" },
+        }),
+    }));
+    await wildcardFirst.showPanel("access");
+    const rendered = shows(wildcardFirst);
+    expect(rendered).toContain("Anyone (*)");
+    expect(rendered).toContain(OWNER);
+    expect(rendered.indexOf("Anyone (*)")).toBeLessThan(
+      rendered.indexOf(OWNER),
+    );
   });
 });
 

--- a/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.test.ts
+++ b/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.test.ts
@@ -5,6 +5,7 @@ import type {
   CellRef,
   PieceSourceView,
   RuntimeClient,
+  SpaceAclView,
 } from "@commonfabric/runtime-client";
 import {
   CFPieceMenu,
@@ -94,6 +95,21 @@ function clickTestId(menu: CFPieceMenu, testId: string): unknown {
 }
 
 const SPACE = "did:key:z6Mk-piece-menu" as const;
+const OWNER = "did:key:z6Mk-piece-menu-owner" as const;
+const VIEWER = "did:key:z6Mk-piece-menu-viewer" as const;
+
+const OWNER_ACCESS: SpaceAclView = {
+  space: SPACE,
+  principal: OWNER,
+  acl: { [OWNER]: "OWNER", "*": "WRITE" },
+  canEdit: true,
+};
+
+const VIEWER_ACCESS: SpaceAclView = {
+  ...OWNER_ACCESS,
+  principal: VIEWER,
+  canEdit: false,
+};
 
 const SOURCE: PieceSourceView = {
   space: SPACE,
@@ -118,6 +134,9 @@ function pieceCell(
   {
     aborted = false,
     update = () => Promise.resolve({ source: SOURCE }),
+    getAccess = () => Promise.resolve(OWNER_ACCESS),
+    setAccess = () => Promise.resolve(OWNER_ACCESS),
+    removeAccess = () => Promise.resolve(OWNER_ACCESS),
   }: {
     aborted?: boolean | (() => boolean);
     update?: (
@@ -131,6 +150,16 @@ function pieceCell(
       confirmationToken?: string;
       executionWarning?: string;
     }>;
+    getAccess?: () => Promise<SpaceAclView>;
+    setAccess?: (
+      space: typeof SPACE,
+      user: string,
+      capability: "READ" | "WRITE" | "OWNER",
+    ) => Promise<SpaceAclView>;
+    removeAccess?: (
+      space: typeof SPACE,
+      user: string,
+    ) => Promise<SpaceAclView>;
   } = {},
 ): CellHandle {
   return {
@@ -139,6 +168,9 @@ function pieceCell(
     runtime: () => ({
       getPieceSource: read,
       updatePieceSource: update,
+      getSpaceAcl: getAccess,
+      setSpaceAclEntry: setAccess,
+      removeSpaceAclEntry: removeAccess,
       signal: {
         aborted: typeof aborted === "function" ? aborted() : aborted,
       },
@@ -233,6 +265,19 @@ describe("the menu a right-click opens", () => {
       expect(rendered).toContain(entry.label);
       expect(rendered).toContain(entry.testId);
     }
+    expect(rendered).toContain("menu-divider");
+    expect(rendered).toContain("Space access rights...");
+    expect(rendered).toContain("piece-menu-space-access");
+  });
+
+  it("places space access after the piece actions and divider", () => {
+    const rendered = shows(openMenu());
+    expect(rendered.indexOf("Actions")).toBeLessThan(
+      rendered.indexOf("menu-divider"),
+    );
+    expect(rendered.indexOf("menu-divider")).toBeLessThan(
+      rendered.indexOf("Space access rights..."),
+    );
   });
 
   it("shows nothing until it is opened, or once closed", () => {
@@ -299,7 +344,7 @@ describe("the menu a right-click opens", () => {
     expect(piece.has("data-cf-piece-menu-open")).toBe(false);
   });
 
-  it("removes the highlight when its overlay disconnects", () => {
+  it("closes and removes the highlight when its overlay disconnects", () => {
     const menu = newMenu();
     const piece = highlightProbe();
     menu.open({
@@ -312,6 +357,25 @@ describe("the menu a right-click opens", () => {
     menu.disconnectedCallback();
 
     expect(piece.has("data-cf-piece-menu-open")).toBe(false);
+    expect(shows(menu)).toBe("");
+  });
+
+  it("drops an access read that resolves after disconnect", async () => {
+    let resolveAccess!: (access: SpaceAclView) => void;
+    const menu = openMenu(pieceCell(undefined, {
+      getAccess: () =>
+        new Promise((resolve) => {
+          resolveAccess = resolve;
+        }),
+    }));
+    const read = menu.showPanel("access");
+    expect(shows(menu)).toContain("Reading access rights");
+
+    menu.disconnectedCallback();
+    resolveAccess(OWNER_ACCESS);
+    await read;
+
+    expect(shows(menu)).toBe("");
   });
 
   it("draws a clipped fixed highlight over a nested pattern root", () => {
@@ -388,6 +452,65 @@ describe("the menu a right-click opens", () => {
     const rendered = shows(menu);
     expect(rendered).toContain("Stop following source");
     expect(rendered).toContain("piece-menu-detach-source");
+  });
+});
+
+describe("the space access panel", () => {
+  it("shows the ACL without editing controls to a non-owner", async () => {
+    const menu = openMenu(pieceCell(undefined, {
+      getAccess: () => Promise.resolve(VIEWER_ACCESS),
+    }));
+
+    await menu.showPanel("access");
+
+    const rendered = shows(menu);
+    expect(rendered).toContain("Space access rights");
+    expect(rendered).toContain(OWNER);
+    expect(rendered).toContain("Anyone (*)");
+    expect(rendered).toContain("Only a space owner can change them");
+    expect(rendered).not.toContain("space-access-add-form");
+    expect(rendered).not.toContain("space-access-remove");
+  });
+
+  it("shows ACL editing controls to an owner", async () => {
+    const menu = openMenu();
+
+    await menu.showPanel("access");
+
+    const rendered = shows(menu);
+    expect(rendered).toContain("you have OWNER access");
+    expect(rendered).toContain("space-access-add-form");
+    expect(rendered).toContain("space-access-remove");
+    expect(rendered).toContain(`${OWNER} (you)`);
+  });
+
+  it("updates the rendered ACL after setting and removing entries", async () => {
+    const reader = "did:key:z6Mk-piece-menu-reader";
+    const mutations: unknown[] = [];
+    const withReader: SpaceAclView = {
+      ...OWNER_ACCESS,
+      acl: { ...OWNER_ACCESS.acl, [reader]: "READ" },
+    };
+    const menu = openMenu(pieceCell(undefined, {
+      setAccess: (space, user, capability) => {
+        mutations.push({ kind: "set", space, user, capability });
+        return Promise.resolve(withReader);
+      },
+      removeAccess: (space, user) => {
+        mutations.push({ kind: "remove", space, user });
+        return Promise.resolve(OWNER_ACCESS);
+      },
+    }));
+    await menu.showPanel("access");
+
+    await menu.setSpaceAccessEntry(reader, "READ");
+    expect(shows(menu)).toContain(reader);
+    await menu.removeSpaceAccessEntry(reader);
+    expect(shows(menu)).not.toContain(reader);
+    expect(mutations).toEqual([
+      { kind: "set", space: SPACE, user: reader, capability: "READ" },
+      { kind: "remove", space: SPACE, user: reader },
+    ]);
   });
 });
 

--- a/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.ts
+++ b/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.ts
@@ -1,5 +1,6 @@
 import { css, html, nothing, type TemplateResult } from "lit";
 import { state } from "lit/decorators.js";
+import { live } from "lit/directives/live.js";
 import { BaseElement } from "../../core/base-element.ts";
 import {
   $conn,
@@ -12,6 +13,8 @@ import type {
   PieceSourceAction,
   PieceSourceRevisionView,
   PieceSourceView,
+  SpaceAclCapability,
+  SpaceAclView,
 } from "@commonfabric/runtime-client";
 import {
   getPieceBoundary,
@@ -27,7 +30,7 @@ import {
 export const PIECE_MENU_OPEN_ATTRIBUTE = "data-cf-piece-menu-open";
 
 /** Which panel is showing, if any. */
-export type Panel = "source" | "origin" | "data" | "actions";
+export type Panel = "source" | "origin" | "data" | "actions" | "access";
 
 /** One entry in the menu, and the panel it opens. */
 interface MenuEntry {
@@ -53,6 +56,13 @@ const PANEL_TITLES: Record<Panel, string> = {
   origin: "Origin and history",
   data: "Data",
   actions: "Actions",
+  access: "Space access rights",
+};
+
+const SPACE_ACCESS_ENTRY: MenuEntry = {
+  label: "Space access rights...",
+  testId: "piece-menu-space-access",
+  panel: "access",
 };
 
 const DETACH_ENTRY = {
@@ -190,7 +200,8 @@ export function payloadHint(action: PieceAction): string | undefined {
  * CFPieceMenu — the menu a right-click on a piece opens, with the panels for
  * what it can show and do about that piece: its authored source, the origin
  * and history it records, its live argument and result data, and the handler
- * streams an event can be dispatched to.
+ * streams an event can be dispatched to. It also shows the containing space's
+ * access rights and lets space owners change them.
  *
  * @element cf-piece-menu
  *
@@ -265,6 +276,11 @@ export class CFPieceMenu extends BaseElement {
       max-width: 18rem;
       overflow: hidden;
       text-overflow: ellipsis;
+    }
+
+    .menu-divider {
+      margin: 0.25rem 0.5rem;
+      border-top: 1px solid var(--cf-theme-color-border, rgba(0, 0, 0, 0.1));
     }
 
     .panel {
@@ -608,6 +624,82 @@ export class CFPieceMenu extends BaseElement {
       margin: 0 0 0.625rem;
       white-space: pre-wrap;
     }
+
+    .access-summary {
+      margin: 0 0 1rem;
+      font-size: 0.8125rem;
+    }
+
+    .access-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.8125rem;
+    }
+
+    .access-table th,
+    .access-table td {
+      padding: 0.5rem;
+      border-bottom: 1px solid var(--cf-theme-color-border, rgba(0, 0, 0, 0.1));
+      text-align: left;
+      vertical-align: middle;
+    }
+
+    .access-table th {
+      color: var(--cf-theme-color-text-muted, #6b7280);
+      font-size: 0.6875rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+
+    .access-user {
+      overflow-wrap: anywhere;
+      font-family: var(--cf-theme-font-mono, "SF Mono", monospace);
+    }
+
+    .access-controls {
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+      gap: 0.5rem;
+    }
+
+    .access-select,
+    .access-input,
+    .access-remove,
+    .access-add {
+      padding: 0.375rem 0.5rem;
+      border: 1px solid var(--cf-theme-color-border, rgba(0, 0, 0, 0.15));
+      border-radius: 6px;
+      background: var(--cf-theme-color-surface, #ffffff);
+      color: inherit;
+      font: inherit;
+      font-size: 0.75rem;
+    }
+
+    .access-remove,
+    .access-add {
+      cursor: pointer;
+    }
+
+    .access-remove:disabled,
+    .access-add:disabled,
+    .access-select:disabled,
+    .access-input:disabled {
+      cursor: default;
+      opacity: 0.55;
+    }
+
+    .access-add-form {
+      display: grid;
+      grid-template-columns: minmax(12rem, 1fr) auto auto;
+      gap: 0.5rem;
+      margin-top: 1rem;
+    }
+
+    .access-input {
+      min-width: 0;
+      font-family: var(--cf-theme-font-mono, "SF Mono", monospace);
+    }
   `;
 
   /** The piece the menu addresses. */
@@ -673,9 +765,25 @@ export class CFPieceMenu extends BaseElement {
     }
     | undefined = undefined;
 
+  @state()
+  private accessor spaceAccess: SpaceAclView | undefined = undefined;
+
+  @state()
+  private accessor accessError: string | undefined = undefined;
+
+  @state()
+  private accessor accessActionPending = false;
+
+  @state()
+  private accessor newAccessUser = "";
+
+  @state()
+  private accessor newAccessCapability: SpaceAclCapability = "READ";
+
   /** Identifies the read a late response belongs to, so a stale one is dropped. */
   private readToken = 0;
   private sourceRead: Promise<void> | undefined;
+  private accessRead: Promise<void> | undefined;
 
   /** Set once a data/actions panel has started its piece-state read. */
   #dataRequested = false;
@@ -730,8 +838,7 @@ export class CFPieceMenu extends BaseElement {
 
   override disconnectedCallback() {
     globalThis.removeEventListener("keydown", this.#onKeyDown);
-    this.#setHighlightedPiece(undefined, undefined);
-    this.#resetPieceState();
+    this.close();
     super.disconnectedCallback();
   }
 
@@ -768,6 +875,7 @@ export class CFPieceMenu extends BaseElement {
     this.sourceActionError = undefined;
     this.sourceExecutionWarning = undefined;
     this.compatibilityWarning = undefined;
+    this.#resetAccessState();
     this.readToken++;
     this.hidden = false;
     void this.#readSource(cell);
@@ -786,6 +894,7 @@ export class CFPieceMenu extends BaseElement {
     this.sourceActionError = undefined;
     this.sourceExecutionWarning = undefined;
     this.compatibilityWarning = undefined;
+    this.#resetAccessState();
     this.readToken++;
   }
 
@@ -1023,6 +1132,15 @@ export class CFPieceMenu extends BaseElement {
     });
   }
 
+  #resetAccessState(): void {
+    this.spaceAccess = undefined;
+    this.accessError = undefined;
+    this.accessActionPending = false;
+    this.newAccessUser = "";
+    this.newAccessCapability = "READ";
+    this.accessRead = undefined;
+  }
+
   /** Drop everything the data/actions panels read, and their subscriptions. */
   #resetPieceState(): void {
     // Invalidate first: an in-flight read must see the new generation before
@@ -1082,9 +1200,101 @@ export class CFPieceMenu extends BaseElement {
       await this.#readPieceState(cell);
       return;
     }
+    if (panel === "access") {
+      await this.#readSpaceAccess(cell);
+      return;
+    }
     if (this.source !== undefined) return;
     await this.#readSource(cell);
   }
+
+  #readSpaceAccess(cell: CellHandle): Promise<void> {
+    this.accessRead ??= this.#performSpaceAccessRead(cell);
+    return this.accessRead;
+  }
+
+  async #performSpaceAccessRead(cell: CellHandle): Promise<void> {
+    const token = this.readToken;
+    try {
+      const access = await cell.runtime().getSpaceAcl(cell.space());
+      if (token !== this.readToken) return;
+      this.spaceAccess = access;
+    } catch (error) {
+      if (token !== this.readToken || cell.runtime().signal.aborted) return;
+      this.accessError = error instanceof Error ? error.message : String(error);
+    }
+  }
+
+  /** Add or replace one explicit entry in the current space's ACL. */
+  async setSpaceAccessEntry(
+    user: string,
+    capability: SpaceAclCapability,
+  ): Promise<void> {
+    const cell = this.cell;
+    const normalizedUser = user.trim();
+    if (!cell || this.accessActionPending || normalizedUser.length === 0) {
+      return;
+    }
+    const token = this.readToken;
+    this.accessActionPending = true;
+    this.accessError = undefined;
+    try {
+      const access = await cell.runtime().setSpaceAclEntry(
+        cell.space(),
+        normalizedUser,
+        capability,
+      );
+      if (token !== this.readToken) return;
+      this.spaceAccess = access;
+      if (this.newAccessUser.trim() === normalizedUser) {
+        this.newAccessUser = "";
+      }
+    } catch (error) {
+      if (token !== this.readToken || cell.runtime().signal.aborted) return;
+      this.accessError = error instanceof Error ? error.message : String(error);
+    } finally {
+      if (token === this.readToken) this.accessActionPending = false;
+    }
+  }
+
+  /** Remove one explicit entry from the current space's ACL. */
+  async removeSpaceAccessEntry(user: string): Promise<void> {
+    const cell = this.cell;
+    if (!cell || this.accessActionPending) return;
+    const token = this.readToken;
+    this.accessActionPending = true;
+    this.accessError = undefined;
+    try {
+      const access = await cell.runtime().removeSpaceAclEntry(
+        cell.space(),
+        user,
+      );
+      if (token !== this.readToken) return;
+      this.spaceAccess = access;
+    } catch (error) {
+      if (token !== this.readToken || cell.runtime().signal.aborted) return;
+      this.accessError = error instanceof Error ? error.message : String(error);
+    } finally {
+      if (token === this.readToken) this.accessActionPending = false;
+    }
+  }
+
+  #onNewAccessUser = (event: Event): void => {
+    this.newAccessUser = (event.currentTarget as HTMLInputElement).value;
+  };
+
+  #onNewAccessCapability = (event: Event): void => {
+    this.newAccessCapability = (event.currentTarget as HTMLSelectElement)
+      .value as SpaceAclCapability;
+  };
+
+  #addSpaceAccessEntry = (event: SubmitEvent): void => {
+    event.preventDefault();
+    void this.setSpaceAccessEntry(
+      this.newAccessUser,
+      this.newAccessCapability,
+    );
+  };
 
   #readSource(cell: CellHandle): Promise<void> {
     this.sourceRead ??= this.#performSourceRead(cell);
@@ -1403,7 +1613,7 @@ export class CFPieceMenu extends BaseElement {
     // clamps it back into view.
     const entries = pieceMenuEntries(this.source?.origin !== undefined);
     const width = 240;
-    const height = 40 + entries.length * 34;
+    const height = 49 + (entries.length + 1) * 34;
     const left = Math.max(
       4,
       Math.min(this.x, globalThis.innerWidth - width - 4),
@@ -1436,13 +1646,24 @@ export class CFPieceMenu extends BaseElement {
             </button>
           `
         )}
+        <div class="menu-divider" role="separator"></div>
+        <button
+          class="menu-item"
+          role="menuitem"
+          test-id="${SPACE_ACCESS_ENTRY.testId}"
+          @click="${() => this.showPanel(SPACE_ACCESS_ENTRY.panel)}"
+        >
+          ${SPACE_ACCESS_ENTRY.label}
+        </button>
       </div>
     `;
   }
 
   #renderPanel(panel: Panel): TemplateResult {
     const title = PANEL_TITLES[panel];
-    const subject = this.source?.name ?? this.cell?.id() ?? "";
+    const subject = panel === "access"
+      ? this.cell?.space() ?? ""
+      : this.source?.name ?? this.cell?.id() ?? "";
     return html`
       <div class="backdrop dimmed" @click="${() => this.close()}"></div>
       <div
@@ -1460,7 +1681,9 @@ export class CFPieceMenu extends BaseElement {
         </div>
         ${panel === "source" ? this.#renderSourceTabs() : nothing}
         <div class="panel-body">
-          ${panel === "data"
+          ${panel === "access"
+            ? this.#renderSpaceAccess()
+            : panel === "data"
             ? this.#renderData()
             : panel === "actions"
             ? this.#renderActions()
@@ -1479,6 +1702,169 @@ export class CFPieceMenu extends BaseElement {
             : this.#renderOrigin(this.source)}
         </div>
       </div>
+    `;
+  }
+
+  #renderSpaceAccess(): TemplateResult {
+    if (this.spaceAccess === undefined) {
+      return this.accessError
+        ? html`
+          <p class="error">
+            Could not read this space's access rights: ${this.accessError}
+          </p>
+        `
+        : html`
+          <p>Reading access rights…</p>
+        `;
+    }
+    const access = this.spaceAccess;
+    const entries = Object.entries(access.acl).sort(([left], [right]) => {
+      if (left === "*") return -1;
+      if (right === "*") return 1;
+      return left.localeCompare(right);
+    });
+    return html`
+      <p class="access-summary">
+        ${access.canEdit
+          ? "You can change these rights because you have OWNER access."
+          : "You can view these rights. Only a space owner can change them."}
+      </p>
+      <table class="access-table">
+        <thead>
+          <tr>
+            <th scope="col">Identity</th>
+            <th scope="col">Access</th>
+            ${access.canEdit
+              ? html`
+                <th scope="col">Actions</th>
+              `
+              : nothing}
+          </tr>
+        </thead>
+        <tbody>
+          ${entries.length === 0
+            ? html`
+              <tr>
+                <td colspan="${access.canEdit ? 3 : 2}">No ACL entries.</td>
+              </tr>
+            `
+            : entries.map(([user, capability]) =>
+              this.#renderSpaceAccessEntry(access, user, capability)
+            )}
+        </tbody>
+      </table>
+      ${this.accessError
+        ? html`
+          <p class="error">Could not change access rights: ${this
+            .accessError}</p>
+        `
+        : nothing} ${access.canEdit
+        ? html`
+          <form
+            class="access-add-form"
+            test-id="space-access-add-form"
+            @submit="${this.#addSpaceAccessEntry}"
+          >
+            <input
+              class="access-input"
+              aria-label="Identity DID or wildcard"
+              placeholder="did:key:... or *"
+              .value="${this.newAccessUser}"
+              ?disabled="${this.accessActionPending}"
+              @input="${this.#onNewAccessUser}"
+            />
+            <select
+              class="access-select"
+              aria-label="Access level for new entry"
+              ?disabled="${this.accessActionPending}"
+              @change="${this.#onNewAccessCapability}"
+            >
+              ${this.#renderCapabilityOptions(this.newAccessCapability)}
+            </select>
+            <button
+              class="access-add"
+              type="submit"
+              test-id="space-access-add"
+              ?disabled="${this.accessActionPending ||
+                this.newAccessUser.trim().length === 0}"
+            >
+              Add
+            </button>
+          </form>
+        `
+        : nothing}
+      <p class="note">
+        READ can view the space. WRITE can also change its pieces. OWNER can also
+        change these access rights. The <code>*</code> entry applies to every
+        authenticated identity without a more specific entry.
+      </p>
+    `;
+  }
+
+  #renderSpaceAccessEntry(
+    access: SpaceAclView,
+    user: string,
+    capability: SpaceAclCapability,
+  ): TemplateResult {
+    return html`
+      <tr>
+        <td class="access-user">
+          ${user === "*" ? "Anyone (*)" : user}${user === access.principal
+            ? " (you)"
+            : ""}
+        </td>
+        <td>
+          ${access.canEdit
+            ? html`
+              <select
+                class="access-select"
+                aria-label="Access level for ${user}"
+                ?disabled="${this.accessActionPending}"
+                @change="${(event: Event) =>
+                  this.setSpaceAccessEntry(
+                    user,
+                    (event.currentTarget as HTMLSelectElement)
+                      .value as SpaceAclCapability,
+                  )}"
+              >
+                ${this.#renderCapabilityOptions(capability)}
+              </select>
+            `
+            : capability}
+        </td>
+        ${access.canEdit
+          ? html`
+            <td>
+              <div class="access-controls">
+                <button
+                  class="access-remove"
+                  type="button"
+                  aria-label="Remove ${user}"
+                  test-id="space-access-remove"
+                  ?disabled="${this.accessActionPending}"
+                  @click="${() => this.removeSpaceAccessEntry(user)}"
+                >
+                  Remove
+                </button>
+              </div>
+            </td>
+          `
+          : nothing}
+      </tr>
+    `;
+  }
+
+  #renderCapabilityOptions(selected: SpaceAclCapability): TemplateResult {
+    return html`
+      <option value="READ" .selected="${live(
+        selected === "READ",
+      )}">READ</option>
+      <option value="WRITE" .selected="${live(
+        selected === "WRITE",
+      )}">WRITE</option>
+      <option value="OWNER" .selected="${live(
+        selected === "OWNER",
+      )}">OWNER</option>
     `;
   }
 


### PR DESCRIPTION
Add a dedicated access-rights panel after the piece-specific menu entries. Space readers can inspect the ACL, while owners can add, change, and remove entries.

Expose typed runtime operations for reading and changing ACLs. Route mutations through ACLManager so the memory server remains the authority. Return the ACL produced by a successful transaction so an owner who removes their own access does not attempt another read after revocation.

Keep the access dropdowns synchronized with stored ACL capabilities during their initial render and after rejected mutations. This prevents the browser from displaying READ for OWNER or WRITE entries.

Cover the menu and panel states with component tests. Exercise real ACL changes and displayed capabilities through browser integration tests, and preserve self-removal behavior with a memory-server regression test.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

