### PR TITLE
feat(ui): mint mentions as references when given a map

### DIFF
--- a/packages/html/src/jsx.d.ts
+++ b/packages/html/src/jsx.d.ts
@@ -4024,6 +4024,9 @@ interface CFCodeEditorAttributes<T> extends CFHTMLAttributes<T> {
   "timingDelay"?: number;
   "$mentionable"?: CellLike<Piece[]> | CellLike<Piece[] | undefined>;
   "$mentioned"?: CellLike<Piece[]> | CellLike<Piece[] | undefined>;
+  "$references"?: CellLike<
+    Record<string, { destination: unknown; modifiedTitle: boolean }>
+  >;
   "$pattern"?: CellLike<any>;
   "pattern"?: any;
   "wordWrap"?: boolean;
@@ -4042,6 +4045,7 @@ interface CFCodeEditorAttributes<T> extends CFHTMLAttributes<T> {
   "oncf-error"?: any;
   "onbacklink-click"?: any;
   "onbacklink-create"?: any;
+  "onmention-ref-label-changed"?: any;
 }
 
 interface CFAutostartAttributes<T> extends CFHTMLAttributes<T> {

--- a/packages/ui/docs/mentionable-internals.md
+++ b/packages/ui/docs/mentionable-internals.md
@@ -61,12 +61,20 @@ cannot represent.
 
 ## Link Formats
 
-The system uses two link formats for mentions, depending on context:
+The system uses three link formats for mentions, depending on context:
 
-| Format        | Example                   | Used by                                      |
-| ------------- | ------------------------- | -------------------------------------------- |
-| Markdown link | `[Note](/of:fid1:abc123)` | `cf-prompt-input`, LLM dialog, `cf-markdown` |
-| Wiki-link     | `[[Note (fid1:abc123)]]`  | `cf-code-editor`, `note-md.tsx`              |
+| Format         | Example                   | Used by                                             |
+| -------------- | ------------------------- | --------------------------------------------------- |
+| Markdown link  | `[Note](/of:fid1:abc123)` | `cf-prompt-input`, LLM dialog, `cf-markdown`        |
+| Wiki-link      | `[[Note (fid1:abc123)]]`  | `cf-code-editor`, `note-md.tsx`                     |
+| Reference link | `[Note][a3f9zz]`          | `cf-code-editor` given `$references`, `note-md.tsx` |
+
+Which of the latter two `cf-code-editor` **mints** depends on whether it was
+given a `$references` cell; it **reads** both either way, so a document holding
+a mixture works. The reference form's key is local to one document and resolves
+through that cell, which is what lets a destination be any cell rather than
+something a bare id can name — see
+[`../src/v2/components/cf-code-editor/docs/mention-refs.md`](../src/v2/components/cf-code-editor/docs/mention-refs.md).
 
 ### Markdown links (`/of:...`)
 
@@ -112,11 +120,12 @@ wish("#mentionable")  ──►  $mentionable prop    ──►  @link array
                     │             │
                     ▼             ▼
              @-mention        [[-mention
-             [Name](/of:id)   [[Name (id)]]
-                    │             │
+             [Name](/of:id)   [[Name (id)]]   ← no $references
+                    │         [Name][a3f9zz]  ← given $references,
+                    │             │              destination in that cell
                     ▼             ▼
              LLM sees links   note-md.tsx converts
-             in user message  to [Name](/of:id)
+             in user message  either form to [Name](/of:id)
                                   │
                                   ▼
                               cf-markdown renders

--- a/packages/ui/docs/mentionable-internals.md
+++ b/packages/ui/docs/mentionable-internals.md
@@ -63,17 +63,22 @@ cannot represent.
 
 The system uses three link formats for mentions, depending on context:
 
-| Format         | Example                   | Used by                                             |
-| -------------- | ------------------------- | --------------------------------------------------- |
-| Markdown link  | `[Note](/of:fid1:abc123)` | `cf-prompt-input`, LLM dialog, `cf-markdown`        |
-| Wiki-link      | `[[Note (fid1:abc123)]]`  | `cf-code-editor`, `note-md.tsx`                     |
-| Reference link | `[Note][a3f9zz]`          | `cf-code-editor` given `$references`, `note-md.tsx` |
+| Format         | Example                   | Used by                                      |
+| -------------- | ------------------------- | -------------------------------------------- |
+| Markdown link  | `[Note](/of:fid1:abc123)` | `cf-prompt-input`, LLM dialog, `cf-markdown` |
+| Wiki-link      | `[[Note (fid1:abc123)]]`  | `cf-code-editor`, `note-md.tsx`              |
+| Reference link | `[Note][a3f9zz]`          | `cf-code-editor` given `$references`         |
 
-Which of the latter two `cf-code-editor` **mints** depends on whether it was
-given a `$references` cell; it **reads** both either way, so a document holding
-a mixture works. The reference form's key is local to one document and resolves
-through that cell, which is what lets a destination be any cell rather than
-something a bare id can name — see
+The `$references` cell is what switches the editor between them, and it switches
+**reading** as well as minting. Given one, the editor mints reference links and
+reads both forms, so a document holding a mixture works. Given none, it mints
+wiki-links and reads only those: a `[Label][key]` is then deliberately plain
+text — unprotected, no pill, absent from `$mentioned` — because the key resolves
+through the cell that is not there. A caller migrating a host pattern has to
+pass the map to keep reference behavior, not merely to gain it.
+
+The reference form's key is local to one document, which is what lets a
+destination be any cell rather than something a bare id can name — see
 [`../src/v2/components/cf-code-editor/docs/mention-refs.md`](../src/v2/components/cf-code-editor/docs/mention-refs.md).
 
 ### Markdown links (`/of:...`)
@@ -125,7 +130,7 @@ wish("#mentionable")  ──►  $mentionable prop    ──►  @link array
                     │             │              destination in that cell
                     ▼             ▼
              LLM sees links   note-md.tsx converts
-             in user message  either form to [Name](/of:id)
+             in user message  a wiki-link to [Name](/of:id)
                                   │
                                   ▼
                               cf-markdown renders

--- a/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.test.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.test.ts
@@ -136,3 +136,105 @@ describe("CFCodeEditor backlink disposal handling", () => {
     expect(spy.calls.length).toBe(0);
   });
 });
+
+describe("CFCodeEditor reference-map housekeeping", () => {
+  // The map lives beside the document and has to stay in step with it. Both
+  // behaviors below are about NOT losing something: a key another editor
+  // minted, and a deletion still sitting in the debounce. Exercised against a
+  // minimal `this`, so no CodeMirror or DOM is constructed.
+
+  const KEY = "a3f9zz";
+  const OTHER = "b7k2m1";
+
+  function editorThis(doc: string, map: Record<string, unknown>) {
+    const deleted: string[] = [];
+    let flushed = 0;
+    return {
+      deleted,
+      flushes: () => flushed,
+      self: {
+        _editorView: { state: { doc: { toString: () => doc } } },
+        references: {
+          get: () => map,
+          key: (k: string) => ({
+            set: (v: unknown) => {
+              if (v === undefined) deleted.push(k);
+            },
+          }),
+        },
+        _refKeysAtLoad: new Set<string>(),
+        _cellController: { flush: () => flushed++ },
+        _refMap() {
+          return map;
+        },
+      } as Record<string, unknown>,
+    };
+  }
+
+  function call(name: string, self: unknown, ...args: unknown[]): unknown {
+    const fn = (CFCodeEditor.prototype as unknown as Record<
+      string,
+      (this: unknown, ...a: unknown[]) => unknown
+    >)[name];
+    return fn.call(self, ...args);
+  }
+
+  describe("_takenRefKeys()", () => {
+    it("returns the map's keys and the document's together", () => {
+      // A key pasted into the text is spoken for even before the map has it,
+      // and minting over it would point two mentions at one entry.
+      const { self } = editorThis(`[A][${OTHER}]`, { [KEY]: {} });
+      expect(call("_takenRefKeys", self)).toEqual(new Set([KEY, OTHER]));
+    });
+  });
+
+  describe("_collectUnreferencedRefEntries()", () => {
+    it("removes an entry whose token has left the document", () => {
+      const t = editorThis("no tokens left", { [KEY]: {} });
+      (t.self._refKeysAtLoad as Set<string>).add(KEY);
+      call("_collectUnreferencedRefEntries", t.self);
+      expect(t.deleted).toEqual([KEY]);
+    });
+
+    it("keeps a key it never saw at load", () => {
+      // Another editor added it while this one was open; this editor has no
+      // reason to believe it was ever in its document.
+      const t = editorThis("no tokens left", { [KEY]: {} });
+      call("_collectUnreferencedRefEntries", t.self);
+      expect(t.deleted).toEqual([]);
+    });
+
+    it("keeps every entry while the token is still there", () => {
+      const t = editorThis(`[A][${KEY}]`, { [KEY]: {} });
+      (t.self._refKeysAtLoad as Set<string>).add(KEY);
+      call("_collectUnreferencedRefEntries", t.self);
+      expect(t.deleted).toEqual([]);
+    });
+
+    it("collects nothing against a document that has not loaded", () => {
+      // An empty document names nothing, which is not the same as a document
+      // that names nothing — reading it as the latter empties the map.
+      const t = editorThis("", { [KEY]: {} });
+      (t.self._refKeysAtLoad as Set<string>).add(KEY);
+      call("_collectUnreferencedRefEntries", t.self);
+      expect(t.deleted).toEqual([]);
+    });
+
+    it("flushes the pending document write before removing anything", () => {
+      // The deletion that made the entry collectable is still in the
+      // debounce; losing it after the entry is gone leaves a token with no
+      // destination in the durable document.
+      const t = editorThis("no tokens left", { [KEY]: {} });
+      (t.self._refKeysAtLoad as Set<string>).add(KEY);
+      call("_collectUnreferencedRefEntries", t.self);
+      expect(t.flushes()).toBe(1);
+    });
+
+    it("does not flush when there is nothing to collect", () => {
+      const t = editorThis(`[A][${KEY}]`, { [KEY]: {} });
+      (t.self._refKeysAtLoad as Set<string>).add(KEY);
+      call("_collectUnreferencedRefEntries", t.self);
+      expect(t.flushes()).toBe(0);
+    });
+  });
+});

--- a/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.test.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.test.ts
@@ -19,6 +19,8 @@ describe("CFCodeEditor", () => {
     expect(element.timingDelay).toBe(500);
     expect(element.autofocus).toBe(false);
     expect(element.cursorPosition).toBe("start");
+    // No reference map, so mentions are minted as wiki-links.
+    expect(element.references).toBe(null);
   });
 
   it("should have MimeType constants", () => {

--- a/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
@@ -427,9 +427,14 @@ export class CFCodeEditor extends BaseElement {
           apply: (view, _completion, from, to) => {
             // If auto-close added ]], extend replacement to include them
             const replaceTo = hasAutoCloseBrackets ? to + 2 : to;
-            if (this._refMode) {
-              // `from` sits after the `[[` that opened the query, and the
-              // reference form replaces those two characters too.
+            // `from` sits after the `[[` that opened the query, and the
+            // reference form replaces those two characters too. Read rather
+            // than assumed: were they anything else, extending the replacement
+            // backwards would eat two characters of the user's prose, and do
+            // it silently.
+            const opensQuery = view.state.doc.sliceString(from - 2, from) ===
+              "[[";
+            if (this._refMode && opensQuery) {
               const key = this._createRefEntry(index);
               if (key) {
                 this._insertRefToken(view, from - 2, replaceTo, pieceName, key);

--- a/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
@@ -309,8 +309,13 @@ export class CFCodeEditor extends BaseElement {
   private _referencesUnsub: (() => void) | null = null;
   // Label text last seen for each reference key, to detect a user's edit.
   private _previousRefLabels = new Map<string, string>();
-  // Subscriptions to each referenced destination.
-  private _refDestinationSubscriptions = new Map<string, () => void>();
+  // Subscriptions to each referenced destination, carrying the identity they
+  // were opened against so a key repointed at a different piece resubscribes
+  // rather than keeping the old one alive.
+  private _refDestinationSubscriptions = new Map<
+    string,
+    { id: string; unsub: () => void }
+  >();
   // Each referenced destination's name, as its subscription last delivered it.
   private _refNames = new Map<string, string>();
   // Keys the document held when it loaded, plus those this editor minted.
@@ -607,10 +612,18 @@ export class CFCodeEditor extends BaseElement {
     return key;
   }
 
-  /** Record the mentionable item at `index` as a destination. */
+  /**
+   * Record the mentionable item at `index` as a destination, or refuse.
+   *
+   * Only a RESOLVED cell will do. `mentionable.key(index)` addresses a
+   * position in a list rather than a piece: the list recomputes, and a mention
+   * persisted against that path would later name whatever had moved into the
+   * slot. `_resolvePieceIds` follows the indirection; until it has, this
+   * returns null and the caller mints a wiki-link instead — the older form,
+   * but one whose id comes from the same resolution.
+   */
   private _createRefEntry(index: number): string | null {
-    const destination = this._resolvedPieceCells.get(index) ??
-      this.mentionable?.key(index);
+    const destination = this._resolvedPieceCells.get(index);
     if (!destination) return null;
     return this._writeRefEntry(destination as CellHandle<unknown>);
   }
@@ -663,8 +676,11 @@ export class CFCodeEditor extends BaseElement {
    * Create a piece for a mention that matched nothing, and reference it.
    *
    * The token goes in first, with a key the map does not hold yet, so it reads
-   * as ordinary text for as long as the create takes. If the create fails the
-   * token is unwound to the bare label, which is what the user typed.
+   * as ordinary text for as long as the create takes. That window belongs to
+   * the user: the token is unprotected, so it can be edited or deleted before
+   * the create returns. Both ends therefore find the token by its KEY rather
+   * than by the text that was inserted — an edited label still matches — and
+   * treat its absence as the user having removed the mention.
    */
   private async _createMentionRefFromPattern(
     view: EditorView,
@@ -703,39 +719,71 @@ export class CFCodeEditor extends BaseElement {
       );
       if (!page) throw new Error("Could not create piece.");
 
-      const destination = page.cell() as unknown as CellHandle<unknown>;
-      this.references?.key(key).set(
-        { destination, modifiedTitle: false } as unknown as MentionRef,
-      );
-      this._refKeysAtLoad?.add(key);
-
+      // The piece exists whether or not its token survived, so the host hears
+      // about it either way and can register it.
       this.emit("backlink-create", {
         text: label,
         pieceId: page.id(),
         piece: page.cell(),
         navigate: false,
       });
+
+      // Its token is gone, so an entry would name nothing. Skipping the write
+      // is what keeps a mention the user abandoned from persisting as a map
+      // entry no key in the document reaches.
+      if (!this._findRefToken(key)) return;
+
+      const destination = page.cell() as unknown as CellHandle<unknown>;
+      this.references?.key(key).set(
+        { destination, modifiedTitle: false } as unknown as MentionRef,
+      );
+      this._refKeysAtLoad?.add(key);
     } catch (error) {
       // A disposal race (logout, runtime swap) cancels the create; that is
       // cancellation, not a failure to surface.
       if (rt.signal.aborted) return;
       console.error("Error creating mention reference:", error);
-      this._removeRefToken(key, label);
+      this._removeRefToken(key);
     }
   }
 
-  /** Unwind a reference token to its bare label. */
-  private _removeRefToken(key: string, label: string): void {
+  /**
+   * Locate a reference token by its key, whatever its label now reads.
+   *
+   * The label is ordinary editable text, so the only durable handle on a token
+   * is the key inside it. Finding it by the string that was inserted would
+   * miss a token the user has since retyped.
+   */
+  private _findRefToken(
+    key: string,
+  ): { from: number; to: number; label: string } | null {
     const view = this._editorView;
-    if (!view) return;
+    if (!view) return null;
 
-    const token = `[${label}][${key}]`;
-    const index = view.state.doc.toString().indexOf(token);
+    const match = new RegExp(`\\[([^\\]\\n]*)\\]\\[${key}\\]`).exec(
+      view.state.doc.toString(),
+    );
+    if (!match) return null;
+
+    return {
+      from: match.index,
+      to: match.index + match[0].length,
+      label: match[1],
+    };
+  }
+
+  /**
+   * Unwind a reference token to its bare label, leaving the words the user
+   * typed. A token the user has already removed leaves nothing to unwind.
+   */
+  private _removeRefToken(key: string): void {
     this._previousRefLabels.delete(key);
-    if (index === -1) return;
 
-    view.dispatch({
-      changes: { from: index, to: index + token.length, insert: label },
+    const token = this._findRefToken(key);
+    if (!token || !this._editorView) return;
+
+    this._editorView.dispatch({
+      changes: { from: token.from, to: token.to, insert: token.label },
     });
   }
 
@@ -825,6 +873,15 @@ export class CFCodeEditor extends BaseElement {
     const destination = this._refMap()[key]?.destination;
     if (!isCellHandle(destination)) return null;
     return destination.asSchema<Mentionable>(MentionableSchema);
+  }
+
+  /**
+   * Which piece a key currently names, as a string that changes when the
+   * destination does. Empty when the map holds no destination for it.
+   */
+  private _refDestinationId(key: string): string {
+    const destination = this._refMap()[key]?.destination;
+    return isCellHandle(destination) ? destination.id() : "";
   }
 
   /**
@@ -1263,7 +1320,7 @@ export class CFCodeEditor extends BaseElement {
   }
 
   private _cleanupRefDestinationSubscriptions(): void {
-    for (const unsub of this._refDestinationSubscriptions.values()) unsub();
+    for (const { unsub } of this._refDestinationSubscriptions.values()) unsub();
     this._refDestinationSubscriptions.clear();
     this._refNames.clear();
   }
@@ -2017,8 +2074,14 @@ export class CFCodeEditor extends BaseElement {
   private _updateMentionedWithRefs(content: string): void {
     const refs = this._documentRefs();
     const wikiIds = this._extractMentionedIds(content);
+    // The signature carries each key's DESTINATION, not just the key. A host
+    // that repoints a key at another piece changes nothing about the document,
+    // so a key-only signature would match and leave `$mentioned` — and every
+    // consumer indexing off it — attached to the piece that is no longer named.
     const signature = `${[...wikiIds].join(",")}|${
-      refs.map((ref) => ref.key).join(",")
+      refs.map((ref) => `${ref.key}=${this._refDestinationId(ref.key)}`).join(
+        ",",
+      )
     }`;
     if (signature === this._lastMentionedSignature) return;
 
@@ -2236,9 +2299,15 @@ export class CFCodeEditor extends BaseElement {
       // With no name to compare against, an edit is taken as divergence: the
       // reading that keeps the user's wording is the safe one.
       const modifiedTitle = name === undefined ? true : ref.label !== name;
-      if (!!entry.modifiedTitle === modifiedTitle) continue;
 
-      map.key(ref.key).key("modifiedTitle").set(modifiedTitle);
+      // Only the WRITE is conditional. Every label edit is an edit, including
+      // one custom wording replacing another, and a listener told the event
+      // fires on a label change would otherwise stop hearing about a mention
+      // after the first time the user renamed it.
+      if (!!entry.modifiedTitle !== modifiedTitle) {
+        map.key(ref.key).key("modifiedTitle").set(modifiedTitle);
+      }
+
       this.emit("mention-ref-label-changed", {
         key: ref.key,
         label: ref.label,
@@ -2253,10 +2322,10 @@ export class CFCodeEditor extends BaseElement {
   /**
    * Drop map entries whose token has left the document.
    *
-   * Only keys this editor saw at load or minted itself are eligible, because
-   * removing a key means writing the whole map back: a key another client
-   * added since is one this editor cannot distinguish from a key it deleted,
-   * and the conservative reading keeps it.
+   * Only keys this editor saw at load or minted itself are eligible. A key
+   * another client added while this one was open is one this editor has no
+   * reason to believe was ever in its document, and the conservative reading
+   * keeps it.
    */
   private _collectUnreferencedRefEntries(): void {
     const map = this.references;
@@ -2269,20 +2338,27 @@ export class CFCodeEditor extends BaseElement {
 
     const present = scanRefKeys(doc);
     const entries = this._refMap();
-    const removable = new Set(
-      [...this._refKeysAtLoad].filter((key) =>
-        !present.has(key) && key in entries
-      ),
+    const removable = [...this._refKeysAtLoad].filter((key) =>
+      !present.has(key) && key in entries
     );
-    if (removable.size === 0) return;
+    if (removable.length === 0) return;
 
-    const remaining: MentionRefMap = {};
-    for (const [key, entry] of Object.entries(entries)) {
-      if (!removable.has(key)) remaining[key] = entry;
+    // Removal inverts the map-first ordering that inserting a mention uses.
+    // The deletion that made these entries collectable is sitting in the
+    // content cell's debounce, or waiting on blur; dropping the entries now
+    // and then losing that write to a disconnect would leave the durable
+    // document holding a token whose destination this just deleted. Flushing
+    // first means the worst interruption leaves an unreferenced entry, which
+    // the next collection removes.
+    this._cellController.flush();
+
+    for (const key of removable) {
+      // Per key, rather than writing the whole map back. A blind write of a
+      // snapshot would take an entry another client added between the read
+      // and the write down with it.
+      map.key(key).set(undefined as unknown as MentionRef);
+      this._refKeysAtLoad.delete(key);
     }
-
-    map.set(remaining);
-    for (const key of removable) this._refKeysAtLoad.delete(key);
   }
 
   /**
@@ -2304,26 +2380,37 @@ export class CFCodeEditor extends BaseElement {
 
     for (const ref of this._documentRefs()) {
       activeKeys.add(ref.key);
-      if (this._refDestinationSubscriptions.has(ref.key)) continue;
+
+      const id = this._refDestinationId(ref.key);
+      const existing = this._refDestinationSubscriptions.get(ref.key);
+      // A key whose destination has been repointed keeps its subscription to
+      // the piece it used to name: renames of the old piece would rewrite this
+      // label, and renames of the new one would never arrive.
+      if (existing) {
+        if (existing.id === id) continue;
+        existing.unsub();
+        this._refDestinationSubscriptions.delete(ref.key);
+        this._refNames.delete(ref.key);
+      }
 
       const destination = this._refDestination(ref.key);
       if (!destination) continue;
 
       const key = ref.key;
-      this._refDestinationSubscriptions.set(
-        key,
-        destination.subscribe((value) => {
+      this._refDestinationSubscriptions.set(key, {
+        id,
+        unsub: destination.subscribe((value) => {
           const name = (value as Mentionable | undefined)?.[NAME];
           if (typeof name !== "string" || name.length === 0) return;
           this._refNames.set(key, name);
           this._handleExternalRefTitleChange(key, name);
         }),
-      );
+      });
     }
 
-    for (const [key, unsub] of this._refDestinationSubscriptions) {
+    for (const [key, subscription] of this._refDestinationSubscriptions) {
       if (!activeKeys.has(key)) {
-        unsub();
+        subscription.unsub();
         this._refDestinationSubscriptions.delete(key);
         this._refNames.delete(key);
       }

--- a/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
@@ -1367,6 +1367,9 @@ export class CFCodeEditor extends BaseElement {
       if (this.mentioned) {
         this.mentioned = this.mentioned.asSchema(MentionableArraySchema);
       }
+      // A new cell has none of the old one's contents, so the signature that
+      // described what was last written to the old one says nothing about it.
+      this._lastMentionedSignature = null;
       this._setupMentionedSyncHandler();
       this._updateMentionedFromContent();
     }
@@ -1377,6 +1380,7 @@ export class CFCodeEditor extends BaseElement {
       this._cleanupRefDestinationSubscriptions();
       this._previousRefLabels.clear();
       this._refKeysAtLoad = null;
+      this._lastMentionedSignature = null;
       this._setupReferencesSyncHandler();
       this._publishKnownRefKeys();
       this._initializeRefTracking();
@@ -1391,6 +1395,8 @@ export class CFCodeEditor extends BaseElement {
     if (changedProperties.has("value")) {
       // Cancel pending debounced updates from old Cell to prevent race condition
       this._cellController.cancel();
+      // A different document has a different set of mentions in it.
+      this._lastMentionedSignature = null;
       // Clean up old Cell subscription and set up new one
       this._cleanupCellSyncHandler();
       this._cellController.bind(this.value, stringSchema);

--- a/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
@@ -77,14 +77,38 @@ import {
   Mentionable,
   MentionableArray,
   MentionableArraySchema,
+  MentionableSchema,
 } from "../../core/mentionable.ts";
+import {
+  type MentionRef,
+  type MentionRefMap,
+  MentionRefMapSchema,
+  mintRefKey,
+} from "../../core/mention-refs.ts";
 import {
   atomicBacklinkRanges,
   backlinkEditFilter,
   backlinkField,
   createBacklinkDecorationPlugin,
 } from "./features/backlinks.ts";
+import {
+  atomicMentionRefRanges,
+  createMentionRefDecorationPlugin,
+  mentionRefEditFilter,
+  mentionRefField,
+  type MentionRefInfo,
+  mentionRefs,
+  scanRefKeys,
+  setKnownRefKeys,
+} from "./features/mention-refs.ts";
 import { createProseMarkdownPlugin } from "./features/prose-markdown.ts";
+
+/** A unique noteId, so notes created from a mention do not collide. */
+function generateNoteId(): string {
+  return `${Date.now().toString(36)}-${
+    Math.random().toString(36).slice(2, 11)
+  }`;
+}
 
 function escapeMarkdownImageAltText(text: string): string {
   return text.replace(/\\/g, "\\\\")
@@ -149,6 +173,10 @@ const getLangExtFromMimeType = (mime: MimeType) => {
  * @attr {number} timingDelay - Delay in milliseconds for debounce/throttle (default: 500)
  * @attr {CellHandle<MentionableArray>} mentionable - Cell of mentionable items for @/@[[ completion
  * @attr {Array} mentioned - Optional Cell of live Pieces mentioned in content
+ * @attr {CellHandle<MentionRefMap>} references - Optional Cell of the document's
+ *   mention references. Given one, a new mention is written as `[Label][key]`
+ *   and its destination lives in the map; without one, mentions stay
+ *   `[[Name (id)]]` wiki-links.
  * @attr {boolean} wordWrap - Enable soft line wrapping (default: true)
  * @attr {boolean} lineNumbers - Show line numbers gutter (default: false)
  * @attr {number|string} maxLineWidth - Optional max line width. Numbers are
@@ -167,6 +195,8 @@ const getLangExtFromMimeType = (mime: MimeType) => {
  * @fires backlink-create - Fired when a novel backlink is activated (Cmd/Ctrl+Click)
  *   or confirmed with Enter during autocomplete with no matches. Detail:
  *   { text: string, pieceId: any, piece: Cell<MentionablePiece>, navigate: boolean }
+ * @fires mention-ref-label-changed - Fired when a mention's label is edited in
+ *   reference mode, with detail: { key, label, modifiedTitle, destination }
  *
  * @example
  * <cf-code-editor language="text/javascript" placeholder="Enter code..."></cf-code-editor>
@@ -184,6 +214,7 @@ export class CFCodeEditor extends BaseElement {
     timingDelay: { type: Number },
     mentionable: { type: Object },
     mentioned: { type: Array },
+    references: { type: Object },
     pattern: { type: Object },
     // New editor configuration props
     wordWrap: { type: Boolean },
@@ -220,6 +251,12 @@ export class CFCodeEditor extends BaseElement {
    */
   declare mentionable?: CellHandle<MentionableArray> | null;
   declare mentioned?: CellHandle<MentionableArray>;
+  /**
+   * The document's mention references. Its presence selects the reference
+   * form for newly minted mentions; wiki-links already in the document keep
+   * working either way.
+   */
+  declare references?: CellHandle<MentionRefMap> | null;
   declare pattern: CellHandle<string>;
   declare wordWrap: boolean;
   declare lineNumbers: boolean;
@@ -266,6 +303,25 @@ export class CFCodeEditor extends BaseElement {
   // Cache of resolved piece cell IDs: index in mentionable array → stable piece cell ID.
   // Populated asynchronously when mentionable changes via resolveAsCell().
   private _resolvedPieceIds = new Map<number, string>();
+  // The resolved cell behind each mentionable entry, which a reference stores
+  // directly rather than by id. Populated by the same pass.
+  private _resolvedPieceCells = new Map<number, CellHandle<Mentionable>>();
+  private _referencesUnsub: (() => void) | null = null;
+  // Label text last seen for each reference key, to detect a user's edit.
+  private _previousRefLabels = new Map<string, string>();
+  // Subscriptions to each referenced destination.
+  private _refDestinationSubscriptions = new Map<string, () => void>();
+  // Each referenced destination's name, as its subscription last delivered it.
+  private _refNames = new Map<string, string>();
+  // Keys the document held when it loaded, plus those this editor minted.
+  // Collection only removes entries from this set, so a key another client
+  // added while this one was open is never swept away. Null until the
+  // document has loaded, which is what keeps an empty editor from collecting
+  // the whole map.
+  private _refKeysAtLoad: Set<string> | null = null;
+  // Signature of the last `$mentioned` write in reference mode; null forces
+  // the next attempt, which is how an unresolved key gets retried.
+  private _lastMentionedSignature: string | null = null;
 
   // Transaction annotation to mark Cell-originated updates.
   // This is the idiomatic CodeMirror 6 way to distinguish programmatic
@@ -310,6 +366,17 @@ export class CFCodeEditor extends BaseElement {
     this.autofocus = false;
     this.cursorPosition = "start";
     this.mentionable = null;
+    this.references = null;
+  }
+
+  /** Whether a reference map is available to mint mentions into. */
+  private get _refMode(): boolean {
+    return !!this.references;
+  }
+
+  /** The reference map's current contents. */
+  private _refMap(): MentionRefMap {
+    return (this.references?.get() ?? {}) as MentionRefMap;
   }
 
   /**
@@ -355,6 +422,15 @@ export class CFCodeEditor extends BaseElement {
           apply: (view, _completion, from, to) => {
             // If auto-close added ]], extend replacement to include them
             const replaceTo = hasAutoCloseBrackets ? to + 2 : to;
+            if (this._refMode) {
+              // `from` sits after the `[[` that opened the query, and the
+              // reference form replaces those two characters too.
+              const key = this._createRefEntry(index);
+              if (key) {
+                this._insertRefToken(view, from - 2, replaceTo, pieceName, key);
+                return;
+              }
+            }
             view.dispatch({
               changes: { from, to: replaceTo, insert: insertText + "]]" },
               selection: { anchor: from + insertText.length + 2 },
@@ -492,6 +568,178 @@ export class CFCodeEditor extends BaseElement {
   }
 
   /**
+   * The mentions the document currently holds, as parsed against the map.
+   */
+  private _documentRefs(): MentionRefInfo[] {
+    return this._editorView ? mentionRefs(this._editorView.state) : [];
+  }
+
+  /**
+   * Every key already spoken for: the map's own, plus any in the document that
+   * the map has not caught up with (a pasted token, or one this editor minted
+   * moments ago).
+   */
+  private _takenRefKeys(): Set<string> {
+    const taken = new Set(Object.keys(this._refMap()));
+    const doc = this._editorView?.state.doc.toString();
+    if (doc) { for (const key of scanRefKeys(doc)) taken.add(key); }
+    return taken;
+  }
+
+  /**
+   * Record a destination in the reference map and return the key naming it.
+   *
+   * The entry is written before the token reaches the document. An entry no
+   * token names is inert; a token no entry resolves is a dead link, so if only
+   * one of the two writes lands it should be this one.
+   */
+  private _writeRefEntry(destination: CellHandle<unknown>): string | null {
+    const map = this.references;
+    if (!map) return null;
+
+    const key = mintRefKey(this._takenRefKeys());
+    map.key(key).set(
+      { destination, modifiedTitle: false } as unknown as MentionRef,
+    );
+    // Ours to collect: a key this editor minted can be swept when its token
+    // goes, without waiting for a reload to observe it.
+    this._refKeysAtLoad?.add(key);
+    return key;
+  }
+
+  /** Record the mentionable item at `index` as a destination. */
+  private _createRefEntry(index: number): string | null {
+    const destination = this._resolvedPieceCells.get(index) ??
+      this.mentionable?.key(index);
+    if (!destination) return null;
+    return this._writeRefEntry(destination as CellHandle<unknown>);
+  }
+
+  /** Replace a range with a mention in reference form. */
+  private _insertRefToken(
+    view: EditorView,
+    from: number,
+    to: number,
+    label: string,
+    key: string,
+  ): void {
+    const token = `[${label}][${key}]`;
+    view.dispatch({
+      changes: { from, to, insert: token },
+      selection: { anchor: from + token.length },
+    });
+    this._previousRefLabels.set(key, label);
+  }
+
+  /**
+   * Complete a mention in reference form, replacing the `[[query` the user
+   * typed (and any brackets auto-close added after it).
+   */
+  private _completeMentionRef(
+    view: EditorView,
+    label: string,
+    index: number,
+  ): boolean {
+    const pos = view.state.selection.main.head;
+    const doc = view.state.doc.toString();
+    const bracketPos = doc.slice(0, pos).lastIndexOf("[[");
+    if (bracketPos === -1) return false;
+
+    const key = this._createRefEntry(index);
+    if (!key) return false;
+
+    const hasAutoClose = doc.slice(pos, pos + 2) === "]]";
+    this._insertRefToken(
+      view,
+      bracketPos,
+      hasAutoClose ? pos + 2 : pos,
+      label,
+      key,
+    );
+    return true;
+  }
+
+  /**
+   * Create a piece for a mention that matched nothing, and reference it.
+   *
+   * The token goes in first, with a key the map does not hold yet, so it reads
+   * as ordinary text for as long as the create takes. If the create fails the
+   * token is unwound to the bare label, which is what the user typed.
+   */
+  private async _createMentionRefFromPattern(
+    view: EditorView,
+    label: string,
+  ): Promise<void> {
+    const pos = view.state.selection.main.head;
+    const doc = view.state.doc.toString();
+    const bracketPos = doc.slice(0, pos).lastIndexOf("[[");
+    if (bracketPos === -1) return;
+
+    const key = mintRefKey(this._takenRefKeys());
+    const hasAutoClose = doc.slice(pos, pos + 2) === "]]";
+    this._insertRefToken(
+      view,
+      bracketPos,
+      hasAutoClose ? pos + 2 : pos,
+      label,
+      key,
+    );
+
+    const rt = this.pattern.runtime();
+    try {
+      const program = this.pattern.get();
+      if (!program) throw new Error("Could not read pattern.");
+
+      // Same input bag the wiki-link path builds, and typed the same way.
+      const inputs: Record<string, unknown> = {
+        title: label,
+        content: "",
+        noteId: generateNoteId(),
+      };
+      const page = await rt.createPage(
+        JSON.parse(program),
+        this.pattern.space(),
+        inputs,
+      );
+      if (!page) throw new Error("Could not create piece.");
+
+      const destination = page.cell() as unknown as CellHandle<unknown>;
+      this.references?.key(key).set(
+        { destination, modifiedTitle: false } as unknown as MentionRef,
+      );
+      this._refKeysAtLoad?.add(key);
+
+      this.emit("backlink-create", {
+        text: label,
+        pieceId: page.id(),
+        piece: page.cell(),
+        navigate: false,
+      });
+    } catch (error) {
+      // A disposal race (logout, runtime swap) cancels the create; that is
+      // cancellation, not a failure to surface.
+      if (rt.signal.aborted) return;
+      console.error("Error creating mention reference:", error);
+      this._removeRefToken(key, label);
+    }
+  }
+
+  /** Unwind a reference token to its bare label. */
+  private _removeRefToken(key: string, label: string): void {
+    const view = this._editorView;
+    if (!view) return;
+
+    const token = `[${label}][${key}]`;
+    const index = view.state.doc.toString().indexOf(token);
+    this._previousRefLabels.delete(key);
+    if (index === -1) return;
+
+    view.dispatch({
+      changes: { from: index, to: index + token.length, insert: label },
+    });
+  }
+
+  /**
    * Handle backlink clicks:
    * - Click on pill: navigate to linked piece
    * - Click when expanded (editing mode): places cursor normally
@@ -499,8 +747,13 @@ export class CFCodeEditor extends BaseElement {
   private createBacklinkClickHandler() {
     return EditorView.domEventHandlers({
       mousedown: (event, view) => {
-        // Check if clicking on a collapsed pill (cm-backlink-pill)
         const target = event.target as HTMLElement;
+        if (target.closest(".cm-mention-ref-pill")) {
+          event.preventDefault();
+          setTimeout(() => this.handleRefPillClick(view, event), 0);
+          return true;
+        }
+        // Check if clicking on a collapsed pill (cm-backlink-pill)
         if (target.closest(".cm-backlink-pill")) {
           // Navigate to the backlink
           event.preventDefault();
@@ -560,6 +813,42 @@ export class CFCodeEditor extends BaseElement {
       }
     }
   }
+  /**
+   * The destination behind a reference key, shaped so its name can be read.
+   *
+   * `destination` is stored as a cell, and the client hydrates the link it
+   * receives into a `CellHandle`. The `asSchema` is what makes reads of the
+   * target's own fields materialize: under the map's schema the destination is
+   * an opaque cell, and naming a field on it would come back undefined.
+   */
+  private _refDestination(key: string): CellHandle<Mentionable> | null {
+    const destination = this._refMap()[key]?.destination;
+    if (!isCellHandle(destination)) return null;
+    return destination.asSchema<Mentionable>(MentionableSchema);
+  }
+
+  /**
+   * Navigate to the destination of the reference pill under the pointer.
+   */
+  private handleRefPillClick(view: EditorView, event: MouseEvent): void {
+    const pos = view.posAtCoords({ x: event.clientX, y: event.clientY });
+    if (pos === null) return;
+
+    for (const ref of this._documentRefs()) {
+      if (pos < ref.labelFrom || pos > ref.labelTo) continue;
+
+      const destination = this._refDestination(ref.key);
+      if (!destination) return;
+
+      this.emit("backlink-click", {
+        id: ref.key,
+        text: ref.label,
+        piece: destination,
+      });
+      return;
+    }
+  }
+
   /**
    * Handle backlink activation (Cmd/Ctrl+Click on a backlink)
    */
@@ -623,9 +912,6 @@ export class CFCodeEditor extends BaseElement {
     // `this.runtime` (which RootView clears to undefined on logout).
     const rt = this.pattern.runtime();
     try {
-      // Simple random ID generator for noteId (matches pattern used in note.tsx)
-      const generateId = () =>
-        `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 11)}`;
       const program = this.pattern.get();
       if (!program) return;
       const pattern = JSON.parse(program);
@@ -634,7 +920,7 @@ export class CFCodeEditor extends BaseElement {
       const inputs: Record<string, unknown> = {
         title: backlinkText,
         content: "",
-        noteId: generateId(), // Ensure notes created via [[mention]] have unique IDs
+        noteId: generateNoteId(),
       };
 
       // The note is created in the same space as the pattern it backlinks
@@ -764,6 +1050,7 @@ export class CFCodeEditor extends BaseElement {
     // Keep a reference to the current mentionable to detect staleness
     const currentMentionable = this.mentionable;
     const newResolved = new Map<number, string>();
+    const newCells = new Map<number, CellHandle<Mentionable>>();
 
     // Resolve all piece IDs in parallel
     const promises = mentionableData.map(async (item, i) => {
@@ -771,6 +1058,7 @@ export class CFCodeEditor extends BaseElement {
       try {
         const subCell = handle.key(i);
         const resolved = await subCell.resolveAsCell();
+        newCells.set(i, resolved as CellHandle<Mentionable>);
         const resolvedId = resolved.id();
         if (resolvedId) {
           newResolved.set(i, resolvedId);
@@ -785,6 +1073,7 @@ export class CFCodeEditor extends BaseElement {
     // Only apply if mentionable hasn't changed while we were resolving
     if (this.mentionable === currentMentionable) {
       this._resolvedPieceIds = newResolved;
+      this._resolvedPieceCells = newCells;
       // Re-resolve mentioned from content now that we have stable IDs
       this._updateMentionedFromContent();
     }
@@ -843,6 +1132,11 @@ export class CFCodeEditor extends BaseElement {
       annotations: CFCodeEditor._cellSyncAnnotation.of(true),
     });
 
+    // Content that arrived from outside replaces what "already there" means,
+    // so the reference baseline is retaken against it.
+    this._initializeRefTracking();
+    this._setupRefDestinationSubscriptions();
+
     // Ensure mentioned pieces reflect external value changes
     this._updateMentionedFromContent();
   }
@@ -898,6 +1192,7 @@ export class CFCodeEditor extends BaseElement {
       .subscribe((_value) => {
         // Clear stale resolved IDs and re-resolve asynchronously
         this._resolvedPieceIds.clear();
+        this._resolvedPieceCells.clear();
         this._resolvePieceIds();
         this._updateMentionedFromContent();
       });
@@ -925,11 +1220,61 @@ export class CFCodeEditor extends BaseElement {
     this._mentionedUnsub = unsubscribe;
   }
 
+  /**
+   * Subscribe to the reference map so the editor learns which keys resolve.
+   * Until a key is in the map its token is ordinary text, so this subscription
+   * is what turns a freshly loaded document's mentions into pills.
+   */
+  private _setupReferencesSyncHandler(): void {
+    if (this._referencesUnsub) {
+      this._referencesUnsub();
+      this._referencesUnsub = null;
+    }
+
+    if (!this.references) return;
+    // this.references is already wrapped with asSchema(MentionRefMapSchema)
+    // in willUpdate.
+    this._referencesUnsub = this.references.subscribe(() => {
+      this._publishKnownRefKeys();
+      // A reference the map has just made visible was not there to be tracked
+      // when the document loaded. Without this, its first label edit reads as
+      // a reference with no history and is passed over.
+      this._seedRefLabelBaseline();
+      this._setupRefDestinationSubscriptions();
+      this._updateMentionedFromContent();
+    });
+  }
+
+  /** Record the current label of any reference not already being tracked. */
+  private _seedRefLabelBaseline(): void {
+    for (const ref of this._documentRefs()) {
+      if (!this._previousRefLabels.has(ref.key)) {
+        this._previousRefLabels.set(ref.key, ref.label);
+      }
+    }
+  }
+
+  /** Tell the editor state which keys the map holds. */
+  private _publishKnownRefKeys(): void {
+    if (!this._editorView) return;
+    this._editorView.dispatch({
+      effects: setKnownRefKeys.of(Object.keys(this._refMap())),
+    });
+  }
+
+  private _cleanupRefDestinationSubscriptions(): void {
+    for (const unsub of this._refDestinationSubscriptions.values()) unsub();
+    this._refDestinationSubscriptions.clear();
+    this._refNames.clear();
+  }
+
   private _cleanup(): void {
     this._cancelAutofocus();
     this._cleanupCellSyncHandler();
     this._cleanupPieceNameSubscriptions();
+    this._cleanupRefDestinationSubscriptions();
     this._resolvedPieceIds.clear();
+    this._resolvedPieceCells.clear();
     if (this._mentionableUnsub) {
       this._mentionableUnsub();
       this._mentionableUnsub = null;
@@ -937,6 +1282,10 @@ export class CFCodeEditor extends BaseElement {
     if (this._mentionedUnsub) {
       this._mentionedUnsub();
       this._mentionedUnsub = null;
+    }
+    if (this._referencesUnsub) {
+      this._referencesUnsub();
+      this._referencesUnsub = null;
     }
     this._cleanupFns.forEach((fn) => fn());
     this._cleanupFns = [];
@@ -952,6 +1301,7 @@ export class CFCodeEditor extends BaseElement {
         this.mentionable = this.mentionable.asSchema(MentionableArraySchema);
       }
       this._resolvedPieceIds.clear();
+      this._resolvedPieceCells.clear();
       this._resolvePieceIds();
       this._setupMentionableSyncHandler();
       this._updateMentionedFromContent();
@@ -961,6 +1311,18 @@ export class CFCodeEditor extends BaseElement {
         this.mentioned = this.mentioned.asSchema(MentionableArraySchema);
       }
       this._setupMentionedSyncHandler();
+      this._updateMentionedFromContent();
+    }
+    if (changedProperties.has("references")) {
+      if (this.references) {
+        this.references = this.references.asSchema(MentionRefMapSchema);
+      }
+      this._cleanupRefDestinationSubscriptions();
+      this._previousRefLabels.clear();
+      this._refKeysAtLoad = null;
+      this._setupReferencesSyncHandler();
+      this._publishKnownRefKeys();
+      this._initializeRefTracking();
       this._updateMentionedFromContent();
     }
   }
@@ -1115,10 +1477,13 @@ export class CFCodeEditor extends BaseElement {
     // Set up mentionable sync handler and initialize mentioned list
     this._setupMentionableSyncHandler();
     this._setupMentionedSyncHandler();
+    this._setupReferencesSyncHandler();
+    this._publishKnownRefKeys();
     this._updateMentionedFromContent();
 
     // Initialize backlink name tracking for sync detection
     this._initializeBacklinkNameTracking();
+    this._initializeRefTracking();
 
     // Set up subscriptions for bidirectional NAME sync
     this._setupPieceNameSubscriptions();
@@ -1314,6 +1679,12 @@ export class CFCodeEditor extends BaseElement {
       backlinkField,
       atomicBacklinkRanges,
       backlinkEditFilter,
+      // The same four blocks for the reference form. They are inert until the
+      // map announces a key, so an editor with no `references` cell carries
+      // them at the cost of an empty parse.
+      mentionRefField,
+      atomicMentionRefRanges,
+      mentionRefEditFilter,
       // Tab indentation keymap (toggleable)
       this._tabIndentComp.of(this.tabIndent ? keymap.of([indentWithTab]) : []),
       this._lang.of(getLangExtFromMimeType(this.language)),
@@ -1369,6 +1740,8 @@ export class CFCodeEditor extends BaseElement {
           this._detectAndSyncNameChanges();
           // Refresh subscriptions for any new backlinks
           this._setupPieceNameSubscriptions();
+          // Reconcile the reference map with the edited document
+          this._syncMentionRefs();
         }
       }),
       // Handle focus/blur events
@@ -1398,6 +1771,8 @@ export class CFCodeEditor extends BaseElement {
       this.createBacklinkClickHandler(),
       // Add backlink decoration plugin to visually style [[backlinks]]
       createBacklinkDecorationPlugin(),
+      // ...and the same for [Label][key] references
+      createMentionRefDecorationPlugin(),
       // Add autocompletion with backlink support
       autocompletion({
         override: [this.createBacklinkCompletionSource()],
@@ -1425,6 +1800,14 @@ export class CFCodeEditor extends BaseElement {
           const pos = view.state.selection.main.head;
           const backlinks = view.state.field(backlinkField);
 
+          // Enter inside a reference exits it, the same as inside a backlink
+          for (const ref of mentionRefs(view.state)) {
+            if (pos >= ref.from && pos < ref.to) {
+              view.dispatch({ selection: { anchor: ref.to } });
+              return true;
+            }
+          }
+
           // Check if cursor is inside a complete backlink (from [[ up to but not after ]])
           // Enter inside backlink exits editing; Enter after ]] allows normal newline
           for (const bl of backlinks) {
@@ -1449,15 +1832,24 @@ export class CFCodeEditor extends BaseElement {
               if (exactMatch) {
                 // Found exact match - insert complete backlink with stable piece ID
                 const [matchCell, matchIndex] = exactMatch;
-                const pieceId = this._getPieceId(matchIndex);
                 const pieceName = matchCell.key(NAME).get() || text;
-                this._completeBacklinkWithId(view, text, pieceName, pieceId);
+                if (
+                  !this._refMode ||
+                  !this._completeMentionRef(view, pieceName, matchIndex)
+                ) {
+                  const pieceId = this._getPieceId(matchIndex);
+                  this._completeBacklinkWithId(view, text, pieceName, pieceId);
+                }
               } else if (this.pattern) {
                 // No exact match - create new piece without navigating
-                // First complete the backlink text, then create the piece
-                this._completeBacklinkText(view);
-                // createBacklinkFromPattern will insert the ID and emit event
-                this.createBacklinkFromPattern(text, false);
+                if (this._refMode) {
+                  this._createMentionRefFromPattern(view, text);
+                } else {
+                  // First complete the backlink text, then create the piece
+                  this._completeBacklinkText(view);
+                  // createBacklinkFromPattern will insert the ID and emit event
+                  this.createBacklinkFromPattern(text, false);
+                }
               }
               return true;
             }
@@ -1582,6 +1974,11 @@ export class CFCodeEditor extends BaseElement {
 
     const content = this.getValue() || "";
 
+    if (this._refMode) {
+      this._updateMentionedWithRefs(content);
+      return;
+    }
+
     // Extract IDs from content
     const newIds = this._extractMentionedIds(content);
 
@@ -1606,6 +2003,36 @@ export class CFCodeEditor extends BaseElement {
     const newMentioned = this._extractMentionedPieces(content);
     this.mentioned.set(newMentioned);
     this._setupPieceNameSubscriptions();
+  }
+
+  /**
+   * Write `$mentioned` from both mention forms at once.
+   *
+   * A document mid-migration holds wiki-links and references together, and a
+   * destination reached either way is mentioned either way. The signature
+   * guard stands in for the wiki-link path's id comparison, which cannot see a
+   * reference: it stays unset while any key is still unresolved, so the write
+   * is retried once the map catches up.
+   */
+  private _updateMentionedWithRefs(content: string): void {
+    const refs = this._documentRefs();
+    const wikiIds = this._extractMentionedIds(content);
+    const signature = `${[...wikiIds].join(",")}|${
+      refs.map((ref) => ref.key).join(",")
+    }`;
+    if (signature === this._lastMentionedSignature) return;
+
+    const destinations = this._refMentionedPieces(refs);
+    const resolvedEverything = destinations.length ===
+      new Set(refs.map((ref) => ref.key)).size;
+    this._lastMentionedSignature = resolvedEverything ? signature : null;
+
+    this.mentioned?.set([
+      ...this._extractMentionedPieces(content),
+      ...destinations,
+    ]);
+    this._setupPieceNameSubscriptions();
+    this._setupRefDestinationSubscriptions();
   }
 
   /**
@@ -1755,6 +2182,196 @@ export class CFCodeEditor extends BaseElement {
       unsub();
     }
     this._pieceNameSubscriptions.clear();
+  }
+
+  /**
+   * Take the document's references as the baseline for label changes and for
+   * collection. Called when the map binding changes and whenever content
+   * arrives from outside, both of which replace what "already there" means.
+   */
+  private _initializeRefTracking(): void {
+    if (!this.references || !this._editorView) return;
+
+    this._refKeysAtLoad = scanRefKeys(this._editorView.state.doc.toString());
+    this._previousRefLabels = new Map(
+      this._documentRefs().map((ref) => [ref.key, ref.label]),
+    );
+  }
+
+  /** Reconcile the reference map with the document after an edit. */
+  private _syncMentionRefs(): void {
+    if (!this.references || !this._editorView) return;
+
+    this._detectRefLabelChanges();
+    this._collectUnreferencedRefEntries();
+    this._setupRefDestinationSubscriptions();
+  }
+
+  /**
+   * Record a label the user edited.
+   *
+   * A label that no longer reads as the destination's name is the user's
+   * wording, and `modifiedTitle` is what says so: while it is set, a change to
+   * the destination's title leaves the label alone. Editing the label back
+   * into agreement clears it again, so the flag tracks divergence rather than
+   * accumulating a history of edits.
+   */
+  private _detectRefLabelChanges(): void {
+    const map = this.references;
+    if (!map) return;
+
+    const entries = this._refMap();
+    const current = new Map<string, string>();
+
+    for (const ref of this._documentRefs()) {
+      current.set(ref.key, ref.label);
+
+      const previous = this._previousRefLabels.get(ref.key);
+      if (previous === undefined || previous === ref.label) continue;
+
+      const entry = entries[ref.key];
+      if (!entry) continue;
+
+      const name = this._refNames.get(ref.key);
+      // With no name to compare against, an edit is taken as divergence: the
+      // reading that keeps the user's wording is the safe one.
+      const modifiedTitle = name === undefined ? true : ref.label !== name;
+      if (!!entry.modifiedTitle === modifiedTitle) continue;
+
+      map.key(ref.key).key("modifiedTitle").set(modifiedTitle);
+      this.emit("mention-ref-label-changed", {
+        key: ref.key,
+        label: ref.label,
+        modifiedTitle,
+        destination: this._refDestination(ref.key),
+      });
+    }
+
+    this._previousRefLabels = current;
+  }
+
+  /**
+   * Drop map entries whose token has left the document.
+   *
+   * Only keys this editor saw at load or minted itself are eligible, because
+   * removing a key means writing the whole map back: a key another client
+   * added since is one this editor cannot distinguish from a key it deleted,
+   * and the conservative reading keeps it.
+   */
+  private _collectUnreferencedRefEntries(): void {
+    const map = this.references;
+    if (!map || this._refKeysAtLoad === null || !this._editorView) return;
+
+    const doc = this._editorView.state.doc.toString();
+    // A document that has not loaded names nothing, which is not the same as
+    // a document that names nothing.
+    if (doc.length === 0) return;
+
+    const present = scanRefKeys(doc);
+    const entries = this._refMap();
+    const removable = new Set(
+      [...this._refKeysAtLoad].filter((key) =>
+        !present.has(key) && key in entries
+      ),
+    );
+    if (removable.size === 0) return;
+
+    const remaining: MentionRefMap = {};
+    for (const [key, entry] of Object.entries(entries)) {
+      if (!removable.has(key)) remaining[key] = entry;
+    }
+
+    map.set(remaining);
+    for (const key of removable) this._refKeysAtLoad.delete(key);
+  }
+
+  /**
+   * Subscribe to each referenced destination, so a rename elsewhere reaches
+   * the label here.
+   *
+   * The subscription is on the destination rather than on its `title`, and
+   * that is what makes the name readable at all: a destination arrives here as
+   * a bare link with nothing cached, so `key(NAME).get()` on it has no value
+   * to return until a subscription under a schema naming NAME has delivered
+   * one. The wiki-link form's reason for watching `title` instead — that it
+   * writes NAME's source and would otherwise hear its own echo — does not
+   * apply here, because this form never writes the destination.
+   */
+  private _setupRefDestinationSubscriptions(): void {
+    if (!this.references || !this._editorView) return;
+
+    const activeKeys = new Set<string>();
+
+    for (const ref of this._documentRefs()) {
+      activeKeys.add(ref.key);
+      if (this._refDestinationSubscriptions.has(ref.key)) continue;
+
+      const destination = this._refDestination(ref.key);
+      if (!destination) continue;
+
+      const key = ref.key;
+      this._refDestinationSubscriptions.set(
+        key,
+        destination.subscribe((value) => {
+          const name = (value as Mentionable | undefined)?.[NAME];
+          if (typeof name !== "string" || name.length === 0) return;
+          this._refNames.set(key, name);
+          this._handleExternalRefTitleChange(key, name);
+        }),
+      );
+    }
+
+    for (const [key, unsub] of this._refDestinationSubscriptions) {
+      if (!activeKeys.has(key)) {
+        unsub();
+        this._refDestinationSubscriptions.delete(key);
+        this._refNames.delete(key);
+      }
+    }
+  }
+
+  /**
+   * Rewrite a label after its destination was renamed elsewhere — unless the
+   * user has claimed that label, which is the whole point of `modifiedTitle`.
+   */
+  private _handleExternalRefTitleChange(key: string, name: string): void {
+    if (!this._editorView) return;
+    if (this._refMap()[key]?.modifiedTitle) return;
+
+    const ref = this._documentRefs().find((candidate) => candidate.key === key);
+    if (!ref || ref.label === name) return;
+
+    // Update tracking BEFORE the dispatch, so the label-change detector does
+    // not read this rewrite as the user's own edit and flip the flag.
+    this._previousRefLabels.set(key, name);
+
+    this._editorView.dispatch({
+      changes: { from: ref.labelFrom, to: ref.labelTo, insert: name },
+      annotations: CFCodeEditor._cellSyncAnnotation.of(true),
+    });
+
+    // Record the rewrite through the CellController so it merges with any
+    // pending debounced edit, then flush: this is a remote change rather than
+    // user input, and the blur strategy would otherwise hold it until the next
+    // focus/blur cycle.
+    this.setValue(this._editorView.state.doc.toString());
+    this._cellController.flush();
+  }
+
+  /** The destinations of the document's references, as live cells. */
+  private _refMentionedPieces(refs: MentionRefInfo[]): Mentionable[] {
+    const seen = new Set<string>();
+    const result: Mentionable[] = [];
+
+    for (const ref of refs) {
+      if (seen.has(ref.key)) continue;
+      const destination = this._refDestination(ref.key);
+      if (!destination) continue;
+      seen.add(ref.key);
+      result.push(destination as unknown as Mentionable);
+    }
+
+    return result;
   }
 
   /**

--- a/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
@@ -2333,9 +2333,13 @@ export class CFCodeEditor extends BaseElement {
       if (!entry) continue;
 
       const name = this._refNames.get(ref.key);
-      // With no name to compare against, an edit is taken as divergence: the
-      // reading that keeps the user's wording is the safe one.
-      const modifiedTitle = name === undefined ? true : ref.label !== name;
+      // Against the name AS A LABEL, not the raw name: a destination named
+      // with a `]` is written into the token in the shape the parser reads,
+      // and comparing against the raw form would find every such mention
+      // permanently diverged and stop its renames from ever arriving.
+      const modifiedTitle = name === undefined
+        ? true
+        : ref.label !== labelForToken(name);
 
       // Only the WRITE is conditional. Every label edit is an edit, including
       // one custom wording replacing another, and a listener told the event

--- a/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
@@ -80,6 +80,7 @@ import {
   MentionableSchema,
 } from "../../core/mentionable.ts";
 import {
+  labelForToken,
   type MentionRef,
   type MentionRefMap,
   MentionRefMapSchema,
@@ -102,6 +103,25 @@ import {
   setKnownRefKeys,
 } from "./features/mention-refs.ts";
 import { createProseMarkdownPlugin } from "./features/prose-markdown.ts";
+
+/**
+ * One entry per destination, keeping the first of each. Identity is the cell's
+ * own id, which is what makes a piece reached through two different keys — or
+ * through both mention forms — a single mention of one piece.
+ */
+function dedupeByDestination(pieces: Mentionable[]): Mentionable[] {
+  const seen = new Set<string>();
+  const result: Mentionable[] = [];
+  for (const piece of pieces) {
+    const id = isCellHandle(piece) ? piece.id() : undefined;
+    if (id !== undefined) {
+      if (seen.has(id)) continue;
+      seen.add(id);
+    }
+    result.push(piece);
+  }
+  return result;
+}
 
 /** A unique noteId, so notes created from a mention do not collide. */
 function generateNoteId(): string {
@@ -641,12 +661,13 @@ export class CFCodeEditor extends BaseElement {
     label: string,
     key: string,
   ): void {
-    const token = `[${label}][${key}]`;
+    const safe = labelForToken(label);
+    const token = `[${safe}][${key}]`;
     view.dispatch({
       changes: { from, to, insert: token },
       selection: { anchor: from + token.length },
     });
-    this._previousRefLabels.set(key, label);
+    this._previousRefLabels.set(key, safe);
   }
 
   /**
@@ -2101,10 +2122,15 @@ export class CFCodeEditor extends BaseElement {
       new Set(refs.map((ref) => ref.key)).size;
     this._lastMentionedSignature = resolvedEverything ? signature : null;
 
-    this.mentioned?.set([
-      ...this._extractMentionedPieces(content),
-      ...destinations,
-    ]);
+    // One entry per destination, however many mentions name it. The backlinks
+    // index pushes a backlink per entry, so a piece mentioned twice — or once
+    // in each form — would otherwise be linked back twice.
+    this.mentioned?.set(
+      dedupeByDestination([
+        ...this._extractMentionedPieces(content),
+        ...destinations,
+      ]),
+    );
     this._setupPieceNameSubscriptions();
     this._setupRefDestinationSubscriptions();
   }
@@ -2437,14 +2463,15 @@ export class CFCodeEditor extends BaseElement {
     if (this._refMap()[key]?.modifiedTitle) return;
 
     const ref = this._documentRefs().find((candidate) => candidate.key === key);
-    if (!ref || ref.label === name) return;
+    if (!ref || ref.label === labelForToken(name)) return;
 
     // Update tracking BEFORE the dispatch, so the label-change detector does
     // not read this rewrite as the user's own edit and flip the flag.
-    this._previousRefLabels.set(key, name);
+    const safe = labelForToken(name);
+    this._previousRefLabels.set(key, safe);
 
     this._editorView.dispatch({
-      changes: { from: ref.labelFrom, to: ref.labelTo, insert: name },
+      changes: { from: ref.labelFrom, to: ref.labelTo, insert: safe },
       annotations: CFCodeEditor._cellSyncAnnotation.of(true),
     });
 

--- a/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
@@ -80,6 +80,7 @@ import {
   MentionableSchema,
 } from "../../core/mentionable.ts";
 import {
+  dedupeByDestination,
   labelForToken,
   type MentionRef,
   type MentionRefMap,
@@ -95,6 +96,7 @@ import {
 import {
   atomicMentionRefRanges,
   createMentionRefDecorationPlugin,
+  findRefToken,
   mentionRefEditFilter,
   mentionRefField,
   type MentionRefInfo,
@@ -103,25 +105,6 @@ import {
   setKnownRefKeys,
 } from "./features/mention-refs.ts";
 import { createProseMarkdownPlugin } from "./features/prose-markdown.ts";
-
-/**
- * One entry per destination, keeping the first of each. Identity is the cell's
- * own id, which is what makes a piece reached through two different keys — or
- * through both mention forms — a single mention of one piece.
- */
-function dedupeByDestination(pieces: Mentionable[]): Mentionable[] {
-  const seen = new Set<string>();
-  const result: Mentionable[] = [];
-  for (const piece of pieces) {
-    const id = isCellHandle(piece) ? piece.id() : undefined;
-    if (id !== undefined) {
-      if (seen.has(id)) continue;
-      seen.add(id);
-    }
-    result.push(piece);
-  }
-  return result;
-}
 
 /** A unique noteId, so notes created from a mention do not collide. */
 function generateNoteId(): string {
@@ -784,18 +767,7 @@ export class CFCodeEditor extends BaseElement {
     key: string,
   ): { from: number; to: number; label: string } | null {
     const view = this._editorView;
-    if (!view) return null;
-
-    const match = new RegExp(`\\[([^\\]\\n]*)\\]\\[${key}\\]`).exec(
-      view.state.doc.toString(),
-    );
-    if (!match) return null;
-
-    return {
-      from: match.index,
-      to: match.index + match[0].length,
-      label: match[1],
-    };
+    return view ? findRefToken(view.state.doc.toString(), key) : null;
   }
 
   /**
@@ -2126,10 +2098,10 @@ export class CFCodeEditor extends BaseElement {
     // index pushes a backlink per entry, so a piece mentioned twice — or once
     // in each form — would otherwise be linked back twice.
     this.mentioned?.set(
-      dedupeByDestination([
-        ...this._extractMentionedPieces(content),
-        ...destinations,
-      ]),
+      dedupeByDestination(
+        [...this._extractMentionedPieces(content), ...destinations],
+        (piece) => isCellHandle(piece) ? piece.id() : undefined,
+      ),
     );
     this._setupPieceNameSubscriptions();
     this._setupRefDestinationSubscriptions();

--- a/packages/ui/src/v2/components/cf-code-editor/docs/backlinks.md
+++ b/packages/ui/src/v2/components/cf-code-editor/docs/backlinks.md
@@ -5,6 +5,11 @@ Backlinks are inline references stored directly in the document text as
 the name is the human-readable label. The user never sees the ID — it is hidden
 by decorations.
 
+This is one of the editor's two mention forms. Given a `$references` cell it
+mints the other, described in [`mention-refs.md`](mention-refs.md), which keeps
+the destination in that cell rather than in the text. Both forms are read
+whichever is being minted, so a document holding either works.
+
 ## The four CM6 building blocks
 
 The implementation uses four distinct CodeMirror 6 features stacked on top of

--- a/packages/ui/src/v2/components/cf-code-editor/docs/mention-refs.md
+++ b/packages/ui/src/v2/components/cf-code-editor/docs/mention-refs.md
@@ -74,7 +74,15 @@ Editing the label ends that. `_detectRefLabelChanges` compares the edited label
 against the destination's current name, and sets `modifiedTitle` when they
 differ — the user has chosen a wording, and a later rename leaves it alone.
 Editing the label back into agreement clears the flag, so it tracks divergence
-rather than accumulating a history of edits.
+rather than accumulating a history of edits. Only the map write is conditional
+on the flag changing: `mention-ref-label-changed` fires on every label edit,
+including one custom wording replacing another.
+
+A key whose destination is repointed at a different piece gets a new
+subscription. `_setupRefDestinationSubscriptions` records the identity each
+subscription was opened against, because a key-only check would keep listening
+to the piece the mention used to name — rewriting this label on ITS rename, and
+never hearing the new one's.
 
 The destination is never renamed from here. In the wiki-link form editing a pill
 writes `destination.title`, which makes every local wording a rename; in the
@@ -83,10 +91,21 @@ reference form the label is local and the destination is untouched.
 ## Collection
 
 An entry whose token has left the document is removed by
-`_collectUnreferencedRefEntries`. Removing a key means writing the whole map
-back, so only keys this editor saw when the document loaded, or minted itself,
-are eligible: a key another client added since is one this editor cannot tell
-apart from a key it deleted, and the conservative reading keeps it.
+`_collectUnreferencedRefEntries`. Only keys this editor saw when the document
+loaded, or minted itself, are eligible: a key another client added while this
+one was open is one this editor has no reason to think was ever in its document,
+and the conservative reading keeps it.
+
+Entries go **one key at a time**, not by writing back a filtered copy of the
+map. A blind write of a snapshot takes any entry that arrived between the read
+and the write down with it.
+
+Collection also **flushes the content write first**, inverting the ordering an
+insertion uses. The deletion that made an entry collectable is still sitting in
+the content cell's debounce, or waiting on blur; dropping the entry now and then
+losing that write to a disconnect leaves the durable document holding a token
+whose destination is gone. Flushed first, the worst interruption leaves an
+unreferenced entry, which the next collection takes.
 
 The collector will not run against an empty document. A document that has not
 loaded names nothing, which is not the same as a document that names nothing.
@@ -102,10 +121,27 @@ destination until the create resolves. The token goes in first with a key the
 map does not hold, so it reads as ordinary text for as long as the create takes,
 and is unwound to the bare label if the create fails.
 
+That window belongs to the user: an unresolved token is unprotected, so it can
+be edited or deleted before the create returns. Both ends of the create
+therefore find the token by its KEY (`_findRefToken`) rather than by the text
+that was inserted, so an edited label still matches — and a token that has gone
+means the mention was abandoned, so no entry is written for it.
+
+A completion whose destination has not been resolved yet mints a **wiki-link
+instead**. `mentionable.key(index)` addresses a position in a list rather than a
+piece, and a mention persisted against that path would later name whatever moved
+into the slot; the older form's id comes from the same resolution, so falling
+back to it costs the form and not the target.
+
 ## What the form gives up
 
 `[[Name (id)]]` survives being copied anywhere. `[Label][a3f9zz]` means nothing
-without the map, so text pasted into another document arrives as a label with no
-destination, and a consumer reading raw content sees the same. Emitting the map
-as a markdown reference-definition block is what makes an exported document
-whole; a paste between two live documents is not recovered.
+without the map, so text pasted into another document reads as ordinary text
+there, and a consumer reading raw content sees a label with no destination.
+
+Neither is recovered. Emitting the map as the markdown reference-definition
+block it resembles would make an exported document whole, but not through
+`[FS]`: `writeFsFile` (`packages/fuse/cell-bridge.ts`) writes the entire edited
+body back to `$FS.content`, so emitted definitions would return as note text on
+the first edit through the filesystem. That needs a read-only projection
+surface, or an `[FS]` write-back that strips a generated section.

--- a/packages/ui/src/v2/components/cf-code-editor/docs/mention-refs.md
+++ b/packages/ui/src/v2/components/cf-code-editor/docs/mention-refs.md
@@ -1,0 +1,111 @@
+# Mention references in cf-code-editor
+
+A mention can take either of two forms in the document. The wiki-link form,
+`[[Name (id)]]`, carries its destination inside the sentence and is described in
+[`backlinks.md`](backlinks.md). The reference form carries a short local key
+instead, and the destination lives in a cell the host pattern owns:
+
+```text
+Doc text:    I read [Attention Framework][a3f9zz] last night.
+
+$references: { a3f9zz: { destination: <cell>, modifiedTitle: false } }
+```
+
+The editor mints reference-form mentions when it is given a `$references` cell,
+and wiki-links when it is not. Both forms are read whichever way it was given,
+so a document part-way through a migration works.
+
+## What a key is
+
+Six characters over `[0-9a-z]`, minted by `mintRefKey` (`core/mention-refs.ts`)
+against the keys the map already holds and the keys already in the document. It
+is local to one document and means nothing outside it, which is what lets it be
+short.
+
+## Membership, not shape, decides
+
+A token is a mention when **the map holds its key**. A token that looks like one
+but whose key the map does not hold is ordinary text: not styled, not protected,
+not collected. This is what keeps a hand-written reference link —
+`[the docs][readme]` — editable, and it is worth being deliberate about, because
+the alternative rule is tempting and wrong. Deciding by shape would capture that
+link, make its `][readme]` unreachable from the keyboard, and give the user no
+way to fix it.
+
+The cost is a window: a document whose text has loaded but whose map has not
+shows its mentions as plain text until the map arrives. The `setKnownRefKeys`
+effect is what closes it — the field reparses on the effect as well as on a
+document change.
+
+## The four CM6 building blocks
+
+The same four the wiki-link form uses, over `features/mention-refs.ts`:
+
+| Part                                 | Job                                              |
+| ------------------------------------ | ------------------------------------------------ |
+| `mentionRefField` (`StateField`)     | parses the document against the known keys       |
+| `mentionRefEditFilter`               | blocks or truncates edits reaching into `][key]` |
+| `atomicMentionRefRanges`             | the cursor skips `[` and `][key]`                |
+| `createMentionRefDecorationPlugin()` | hides both, so the user sees a pill              |
+
+Only `][key]` needs protecting. The label is ordinary text and stays fully
+editable, which is the point of the form.
+
+| Cursor position     | What the user sees             |
+| ------------------- | ------------------------------ |
+| Outside the mention | the label, styled as a pill    |
+| Inside the mention  | `[Label]`, with the key hidden |
+
+## `modifiedTitle`
+
+A mention's label starts as the destination's name and is kept in step with it:
+`_setupRefDestinationSubscriptions` subscribes to each destination, and a rename
+elsewhere rewrites the label here.
+
+That subscription is on the destination rather than on its `title`, and it is
+what makes the name readable at all. A destination arrives as a bare link with
+nothing cached, so reading NAME off it returns undefined until a subscription
+under a schema naming NAME has delivered a value. The wiki-link form watches
+`title` for the opposite reason — it writes NAME's source and would otherwise
+hear its own echo — which does not arise here, because this form never writes
+the destination.
+
+Editing the label ends that. `_detectRefLabelChanges` compares the edited label
+against the destination's current name, and sets `modifiedTitle` when they
+differ — the user has chosen a wording, and a later rename leaves it alone.
+Editing the label back into agreement clears the flag, so it tracks divergence
+rather than accumulating a history of edits.
+
+The destination is never renamed from here. In the wiki-link form editing a pill
+writes `destination.title`, which makes every local wording a rename; in the
+reference form the label is local and the destination is untouched.
+
+## Collection
+
+An entry whose token has left the document is removed by
+`_collectUnreferencedRefEntries`. Removing a key means writing the whole map
+back, so only keys this editor saw when the document loaded, or minted itself,
+are eligible: a key another client added since is one this editor cannot tell
+apart from a key it deleted, and the conservative reading keeps it.
+
+The collector will not run against an empty document. A document that has not
+loaded names nothing, which is not the same as a document that names nothing.
+
+## Ordering, when a mention is made
+
+The map entry is written **before** the token reaches the document. If only one
+of the two writes lands, an entry no token names is inert, while a token no
+entry resolves is a dead link.
+
+Creating a piece for a novel mention cannot follow that order — there is no
+destination until the create resolves. The token goes in first with a key the
+map does not hold, so it reads as ordinary text for as long as the create takes,
+and is unwound to the bare label if the create fails.
+
+## What the form gives up
+
+`[[Name (id)]]` survives being copied anywhere. `[Label][a3f9zz]` means nothing
+without the map, so text pasted into another document arrives as a label with no
+destination, and a consumer reading raw content sees the same. Emitting the map
+as a markdown reference-definition block is what makes an exported document
+whole; a paste between two live documents is not recovered.

--- a/packages/ui/src/v2/components/cf-code-editor/features/mention-refs.test.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/features/mention-refs.test.ts
@@ -215,6 +215,26 @@ describe("mention-refs", () => {
       expect(caret <= ref.labelTo || caret >= ref.to).toBe(true);
     });
 
+    it("truncates an edit running from the label to the token's edge", () => {
+      // The edge case a `toA < ref.to` bound misses: this deletes `][key]`
+      // and leaves `[Note` behind.
+      const state = createState(`[Note][${KEY}]`);
+      const ref = mentionRefs(state)[0];
+      const edited = state.update({
+        changes: { from: 3, to: ref.to, insert: "" },
+      });
+      expect(edited.state.doc.toString()).toBe(`[No][${KEY}]`);
+    });
+
+    it("applies an edit covering the whole token", () => {
+      const state = createState(`x [Note][${KEY}] y`);
+      const ref = mentionRefs(state)[0];
+      const edited = state.update({
+        changes: { from: ref.from, to: ref.to, insert: "" },
+      });
+      expect(edited.state.doc.toString()).toBe("x  y");
+    });
+
     it("keeps an outside change while dropping a key edit in the same transaction", () => {
       const state = createState(`prefix [A][${KEY}] suffix`);
       const ref = mentionRefs(state)[0];

--- a/packages/ui/src/v2/components/cf-code-editor/features/mention-refs.test.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/features/mention-refs.test.ts
@@ -226,6 +226,26 @@ describe("mention-refs", () => {
       expect(edited.state.doc.toString()).toBe(`[No][${KEY}]`);
     });
 
+    it("cuts at the first key when one edit reaches into a later one", () => {
+      // The boundary has to be the earliest match: taking the last would move
+      // the cut past the first mention's key and delete it.
+      const state = createState(
+        `[One][${KEY}] and [Two][${OTHER_KEY}]`,
+        [KEY, OTHER_KEY],
+      );
+      const [first, second] = mentionRefs(state);
+      const edited = state.update({
+        changes: {
+          from: first.labelFrom + 1,
+          to: second.labelTo + 2,
+          insert: "",
+        },
+      });
+      // Both keys survive; only label text between them is gone.
+      expect(edited.state.doc.toString()).toContain(`[${KEY}]`);
+      expect(edited.state.doc.toString()).toContain(`[${OTHER_KEY}]`);
+    });
+
     it("applies an edit covering the whole token", () => {
       const state = createState(`x [Note][${KEY}] y`);
       const ref = mentionRefs(state)[0];

--- a/packages/ui/src/v2/components/cf-code-editor/features/mention-refs.test.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/features/mention-refs.test.ts
@@ -202,6 +202,19 @@ describe("mention-refs", () => {
       expect(edited.state.doc.toString()).toBe("[the docs][rXadme]");
     });
 
+    it("leaves the caret outside the key when an edit into it is dropped", () => {
+      const state = createState(`[Note][${KEY}]`);
+      const ref = mentionRefs(state)[0];
+      // What typing inside the hidden key looks like: a change plus the
+      // selection it would have produced.
+      const edited = state.update({
+        changes: { from: ref.labelTo + 2, to: ref.labelTo + 2, insert: "X" },
+        selection: { anchor: ref.labelTo + 3 },
+      });
+      const caret = edited.state.selection.main.head;
+      expect(caret <= ref.labelTo || caret >= ref.to).toBe(true);
+    });
+
     it("keeps an outside change while dropping a key edit in the same transaction", () => {
       const state = createState(`prefix [A][${KEY}] suffix`);
       const ref = mentionRefs(state)[0];

--- a/packages/ui/src/v2/components/cf-code-editor/features/mention-refs.test.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/features/mention-refs.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { EditorState } from "@codemirror/state";
 import {
+  findRefToken,
   mentionRefEditFilter,
   mentionRefField,
   type MentionRefInfo,
@@ -98,6 +99,36 @@ describe("mention-refs", () => {
 
     it("returns an empty set for text with no reference links", () => {
       expect(scanRefKeys("plain prose")).toEqual(new Set());
+    });
+  });
+
+  describe("findRefToken()", () => {
+    it("returns the token's range and label", () => {
+      const doc = `See [My Note][${KEY}] here`;
+      const found = findRefToken(doc, KEY);
+      expect(found).toEqual({ from: 4, to: 21, label: "My Note" });
+      expect(doc.slice(found!.from, found!.to)).toBe(`[My Note][${KEY}]`);
+    });
+
+    it("returns a token whose label has been retyped since", () => {
+      // The window an in-flight create leaves open: the label is editable, so
+      // the key is the only durable handle on the token.
+      expect(findRefToken(`[something else][${KEY}]`, KEY)?.label)
+        .toBe("something else");
+    });
+
+    it("returns a token whose label is empty", () => {
+      expect(findRefToken(`[][${KEY}]`, KEY)?.label).toBe("");
+    });
+
+    it("returns null when the key is not in the document", () => {
+      expect(findRefToken(`[A][${OTHER_KEY}]`, KEY)).toBeNull();
+      expect(findRefToken("no tokens here", KEY)).toBeNull();
+    });
+
+    it("returns the token for the key asked for, not another", () => {
+      const doc = `[One][${KEY}] and [Two][${OTHER_KEY}]`;
+      expect(findRefToken(doc, OTHER_KEY)?.label).toBe("Two");
     });
   });
 

--- a/packages/ui/src/v2/components/cf-code-editor/features/mention-refs.test.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/features/mention-refs.test.ts
@@ -1,0 +1,217 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { EditorState } from "@codemirror/state";
+import {
+  mentionRefEditFilter,
+  mentionRefField,
+  type MentionRefInfo,
+  mentionRefs,
+  parseMentionRefs,
+  scanRefKeys,
+  setKnownRefKeys,
+} from "./mention-refs.ts";
+
+const KEY = "a3f9zz";
+const OTHER_KEY = "b7k2m1";
+
+/** A headless state whose map holds `keys`. */
+function createState(doc: string, keys: string[] = [KEY]): EditorState {
+  const state = EditorState.create({
+    doc,
+    extensions: [mentionRefField, mentionRefEditFilter],
+  });
+  return state.update({ effects: setKnownRefKeys.of(keys) }).state;
+}
+
+describe("mention-refs", () => {
+  describe("parseMentionRefs()", () => {
+    const known = new Set([KEY]);
+
+    it("returns an empty array for an empty string", () => {
+      expect(parseMentionRefs("", known)).toEqual([]);
+    });
+
+    it("returns an empty array when no key is known", () => {
+      expect(parseMentionRefs(`See [Note][${KEY}].`, new Set())).toEqual([]);
+    });
+
+    it("parses a token whose key the map holds", () => {
+      const refs = parseMentionRefs(`See [My Note][${KEY}] for more`, known);
+      expect(refs).toHaveLength(1);
+
+      const ref = refs[0];
+      expect(ref.label).toBe("My Note");
+      expect(ref.key).toBe(KEY);
+      expect(ref.from).toBe(4);
+      expect(ref.labelFrom).toBe(5);
+      expect(ref.labelTo).toBe(12);
+      expect(ref.to).toBe(21);
+    });
+
+    it("returns positions that slice back to the original token", () => {
+      const doc = `x [My Note][${KEY}] y`;
+      const ref = parseMentionRefs(doc, known)[0];
+      expect(doc.slice(ref.from, ref.to)).toBe(`[My Note][${KEY}]`);
+      expect(doc.slice(ref.labelFrom, ref.labelTo)).toBe("My Note");
+    });
+
+    it("returns nothing for a token whose key the map does not hold", () => {
+      expect(parseMentionRefs("See [the docs][readme] here", known)).toEqual(
+        [],
+      );
+    });
+
+    it("returns nothing for a reference link with an over-long key", () => {
+      const doc = "[label][averylongreferencename]";
+      expect(parseMentionRefs(doc, new Set(["averylongreferencename"])))
+        .toEqual([]);
+    });
+
+    it("parses several tokens in one string", () => {
+      const doc = `[A][${KEY}] and [B][${OTHER_KEY}]`;
+      const refs = parseMentionRefs(doc, new Set([KEY, OTHER_KEY]));
+      expect(refs.map((ref: MentionRefInfo) => ref.label)).toEqual(["A", "B"]);
+      expect(refs.map((ref: MentionRefInfo) => ref.key)).toEqual([
+        KEY,
+        OTHER_KEY,
+      ]);
+    });
+
+    it("parses a token with an empty label", () => {
+      const refs = parseMentionRefs(`[][${KEY}]`, known);
+      expect(refs).toHaveLength(1);
+      expect(refs[0].label).toBe("");
+      expect(refs[0].labelFrom).toBe(refs[0].labelTo);
+    });
+
+    it("returns nothing for a label broken across lines", () => {
+      expect(parseMentionRefs(`[My\nNote][${KEY}]`, known)).toEqual([]);
+    });
+  });
+
+  describe("scanRefKeys()", () => {
+    it("returns keys the map does not hold", () => {
+      expect(scanRefKeys(`[A][${KEY}] [B][${OTHER_KEY}]`)).toEqual(
+        new Set([KEY, OTHER_KEY]),
+      );
+    });
+
+    it("returns an empty set for text with no reference links", () => {
+      expect(scanRefKeys("plain prose")).toEqual(new Set());
+    });
+  });
+
+  describe("mentionRefField", () => {
+    it("holds no references until keys are announced", () => {
+      const state = EditorState.create({
+        doc: `[A][${KEY}]`,
+        extensions: [mentionRefField],
+      });
+      expect(mentionRefs(state)).toEqual([]);
+    });
+
+    it("parses references once keys are announced", () => {
+      expect(mentionRefs(createState(`[A][${KEY}]`))).toHaveLength(1);
+    });
+
+    it("drops a reference whose key leaves the map", () => {
+      const state = createState(`[A][${KEY}]`);
+      const narrowed = state.update({ effects: setKnownRefKeys.of([]) }).state;
+      expect(mentionRefs(narrowed)).toEqual([]);
+    });
+
+    it("updates positions when text is inserted before a reference", () => {
+      const state = createState(`x [A][${KEY}]`);
+      expect(mentionRefs(state)[0].from).toBe(2);
+
+      const moved = state.update({ changes: { from: 0, to: 0, insert: "yy" } });
+      expect(mentionRefs(moved.state)[0].from).toBe(4);
+    });
+
+    it("detects a reference added by an edit", () => {
+      const state = createState("Hello ", [KEY]);
+      expect(mentionRefs(state)).toEqual([]);
+
+      const typed = state.update({
+        changes: { from: 6, to: 6, insert: `[New][${KEY}]` },
+      });
+      expect(mentionRefs(typed.state)).toHaveLength(1);
+      expect(mentionRefs(typed.state)[0].label).toBe("New");
+    });
+
+    it("returns the same value for a selection-only transaction", () => {
+      const state = createState(`[A][${KEY}]`);
+      const before = state.field(mentionRefField);
+      const after = state.update({ selection: { anchor: 2 } }).state.field(
+        mentionRefField,
+      );
+      expect(after).toBe(before);
+    });
+  });
+
+  describe("mentionRefEditFilter", () => {
+    it("applies an edit outside every reference", () => {
+      const state = createState(`Hello [A][${KEY}] end`);
+      const edited = state.update({
+        changes: { from: 0, to: 5, insert: "Hi" },
+      });
+      expect(edited.state.doc.toString()).toBe(`Hi [A][${KEY}] end`);
+    });
+
+    it("applies an edit inside the label", () => {
+      const state = createState(`[Note][${KEY}]`);
+      const edited = state.update({
+        changes: { from: 3, to: 3, insert: "X" },
+      });
+      expect(edited.state.doc.toString()).toBe(`[NoXte][${KEY}]`);
+    });
+
+    it("drops an edit starting inside the key", () => {
+      const state = createState(`[Note][${KEY}]`);
+      const ref = mentionRefs(state)[0];
+      const edited = state.update({
+        changes: { from: ref.labelTo + 2, to: ref.labelTo + 3, insert: "X" },
+      });
+      expect(edited.state.doc.toString()).toBe(`[Note][${KEY}]`);
+    });
+
+    it("truncates an edit running from the label into the key", () => {
+      const state = createState(`[Note][${KEY}]`);
+      const ref = mentionRefs(state)[0];
+      const edited = state.update({
+        changes: { from: 4, to: ref.labelTo + 3, insert: "X" },
+      });
+      expect(edited.state.doc.toString()).toBe(`[NotX][${KEY}]`);
+    });
+
+    it("applies an edit deleting a whole reference", () => {
+      const state = createState(`before [Note][${KEY}] after`);
+      const ref = mentionRefs(state)[0];
+      const edited = state.update({
+        changes: { from: ref.from, to: ref.to, insert: "" },
+      });
+      expect(edited.state.doc.toString()).toBe("before  after");
+      expect(mentionRefs(edited.state)).toEqual([]);
+    });
+
+    it("applies an edit inside a reference link the map does not hold", () => {
+      const state = createState("[the docs][readme]");
+      const edited = state.update({
+        changes: { from: 12, to: 13, insert: "X" },
+      });
+      expect(edited.state.doc.toString()).toBe("[the docs][rXadme]");
+    });
+
+    it("keeps an outside change while dropping a key edit in the same transaction", () => {
+      const state = createState(`prefix [A][${KEY}] suffix`);
+      const ref = mentionRefs(state)[0];
+      const edited = state.update({
+        changes: [
+          { from: 0, to: 6, insert: "pre" },
+          { from: ref.labelTo + 2, to: ref.labelTo + 3, insert: "X" },
+        ],
+      });
+      expect(edited.state.doc.toString()).toBe(`pre [A][${KEY}] suffix`);
+    });
+  });
+});

--- a/packages/ui/src/v2/components/cf-code-editor/features/mention-refs.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/features/mention-refs.ts
@@ -1,0 +1,249 @@
+import { EditorState, Range, StateEffect, StateField } from "@codemirror/state";
+import {
+  Decoration,
+  DecorationSet,
+  EditorView,
+  ViewPlugin,
+  ViewUpdate,
+} from "@codemirror/view";
+import { MENTION_REF_KEY_SOURCE } from "../../../core/mention-refs.ts";
+
+/**
+ * A mention written as a markdown reference link, `[Label][key]`, whose key
+ * resolves through the document's reference map.
+ */
+export interface MentionRefInfo {
+  from: number; // Start of [
+  to: number; // End of ]
+  labelFrom: number; // Start of the label (after [)
+  labelTo: number; // End of the label (the ] closing it)
+  key: string; // The reference key
+  label: string; // The display text
+}
+
+/**
+ * A token has to look like a reference before anything reads it, and the
+ * label cannot span a line, so a mention is always a single-line range.
+ */
+const REF_TOKEN = new RegExp(
+  String.raw`\[([^\]\n]*)\]\[(${MENTION_REF_KEY_SOURCE})\]`,
+  "g",
+);
+
+const NO_KEYS: ReadonlySet<string> = new Set();
+
+/**
+ * Every key in the document that could name a mention, whether or not the map
+ * holds it. The mint reads this so a pasted token's key is never handed out a
+ * second time.
+ */
+export function scanRefKeys(doc: string): Set<string> {
+  const keys = new Set<string>();
+  REF_TOKEN.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = REF_TOKEN.exec(doc)) !== null) {
+    keys.add(match[2]);
+  }
+  return keys;
+}
+
+/**
+ * Parse the mentions in a document.
+ *
+ * A token is a mention when the map holds its key, and ordinary text
+ * otherwise. Membership rather than shape is what decides, so a hand-written
+ * reference link — `[the docs][readme]` — is never captured, protected, or
+ * styled. The cost is that a token whose entry has not arrived yet reads as
+ * plain text until it does.
+ */
+export function parseMentionRefs(
+  doc: string,
+  knownKeys: ReadonlySet<string>,
+): MentionRefInfo[] {
+  if (knownKeys.size === 0) return [];
+
+  const refs: MentionRefInfo[] = [];
+  REF_TOKEN.lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = REF_TOKEN.exec(doc)) !== null) {
+    const key = match[2];
+    if (!knownKeys.has(key)) continue;
+
+    const label = match[1];
+    const from = match.index;
+    const labelFrom = from + 1;
+
+    refs.push({
+      from,
+      to: from + match[0].length,
+      labelFrom,
+      labelTo: labelFrom + label.length,
+      key,
+      label,
+    });
+  }
+
+  return refs;
+}
+
+/** Announce the keys the document's reference map currently holds. */
+export const setKnownRefKeys = StateEffect.define<readonly string[]>();
+
+interface MentionRefState {
+  keys: ReadonlySet<string>;
+  refs: MentionRefInfo[];
+}
+
+/**
+ * The mentions in the document, reparsed when either the text or the set of
+ * known keys changes. Everything else reads from here rather than scanning the
+ * document again.
+ */
+export const mentionRefField = StateField.define<MentionRefState>({
+  create() {
+    return { keys: NO_KEYS, refs: [] };
+  },
+  update(value, tr) {
+    let keys = value.keys;
+    for (const effect of tr.effects) {
+      if (effect.is(setKnownRefKeys)) keys = new Set(effect.value);
+    }
+    if (keys === value.keys && !tr.docChanged) return value;
+    return { keys, refs: parseMentionRefs(tr.newDoc.toString(), keys) };
+  },
+});
+
+/** The mentions in a state, for readers outside this module. */
+export function mentionRefs(state: EditorState): MentionRefInfo[] {
+  return state.field(mentionRefField).refs;
+}
+
+/**
+ * Make the cursor skip the parts of a mention that are not its label: the
+ * opening `[`, and the `][key]` that closes it.
+ */
+export const atomicMentionRefRanges = EditorView.atomicRanges.of((view) => {
+  const decorations: Range<Decoration>[] = [];
+
+  for (const ref of mentionRefs(view.state)) {
+    decorations.push(Decoration.mark({}).range(ref.from, ref.labelFrom));
+    decorations.push(Decoration.mark({}).range(ref.labelTo, ref.to));
+  }
+
+  decorations.sort((a, b) => a.from - b.from);
+  return Decoration.set(decorations);
+});
+
+/**
+ * Keep edits out of the `][key]` that carries a mention's identity: an edit
+ * starting inside it is dropped, and one running into it from the label is
+ * truncated at the label's end. A change spanning the whole mention still
+ * deletes it, which is how a mention is removed.
+ */
+export const mentionRefEditFilter = EditorState.transactionFilter.of((tr) => {
+  if (!tr.docChanged) return tr;
+
+  const refs = tr.startState.field(mentionRefField).refs;
+  if (refs.length === 0) return tr;
+
+  let needsModification = false;
+
+  tr.changes.iterChanges((fromA, toA) => {
+    for (const ref of refs) {
+      if (fromA > ref.labelTo && fromA < ref.to) {
+        needsModification = true;
+        return;
+      }
+      if (fromA <= ref.labelTo && toA > ref.labelTo && toA < ref.to) {
+        needsModification = true;
+        return;
+      }
+    }
+  });
+
+  if (!needsModification) return tr;
+
+  const specs: { from: number; to: number; insert: string }[] = [];
+
+  tr.changes.iterChanges((fromA, toA, _fromB, _toB, inserted) => {
+    let adjustedTo = toA;
+    let shouldInclude = true;
+
+    for (const ref of refs) {
+      if (fromA > ref.labelTo && fromA < ref.to) {
+        shouldInclude = false;
+        break;
+      }
+      if (fromA <= ref.labelTo && toA > ref.labelTo && toA < ref.to) {
+        adjustedTo = ref.labelTo;
+      }
+    }
+
+    if (shouldInclude) {
+      specs.push({ from: fromA, to: adjustedTo, insert: inserted.toString() });
+    }
+  });
+
+  return { changes: specs, selection: tr.selection, effects: tr.effects };
+});
+
+/**
+ * Render a mention as a pill, and reveal `[Label]` when the cursor is in it.
+ * The key is never shown: it is a local token with nothing to say to a reader.
+ */
+export function createMentionRefDecorationPlugin() {
+  const pillMark = Decoration.mark({ class: "cm-mention-ref-pill" });
+  const hiddenReplace = Decoration.replace({});
+
+  return ViewPlugin.fromClass(
+    class {
+      decorations: DecorationSet;
+
+      constructor(view: EditorView) {
+        this.decorations = this.getMentionRefDecorations(view);
+      }
+
+      update(update: ViewUpdate) {
+        if (
+          update.docChanged || update.viewportChanged ||
+          update.selectionSet || update.focusChanged ||
+          update.transactions.some((tr) =>
+            tr.effects.some((effect) => effect.is(setKnownRefKeys))
+          )
+        ) {
+          this.decorations = this.getMentionRefDecorations(update.view);
+        }
+      }
+
+      getMentionRefDecorations(view: EditorView) {
+        const decorations: Range<Decoration>[] = [];
+        const hasFocus = view.hasFocus;
+        const { head, from: selectionFrom, to: selectionTo } = view.state
+          .selection.main;
+
+        for (const ref of mentionRefs(view.state)) {
+          const cursorInside = hasFocus && head >= ref.from && head <= ref.to;
+          const selectionOverlaps = hasFocus && selectionFrom < ref.to &&
+            selectionTo > ref.from;
+
+          if (cursorInside || selectionOverlaps) {
+            // Editing: show [Label], hide only the [key] that follows it.
+            decorations.push(hiddenReplace.range(ref.labelTo + 1, ref.to));
+          } else {
+            decorations.push(hiddenReplace.range(ref.from, ref.labelFrom));
+            decorations.push(pillMark.range(ref.labelFrom, ref.labelTo));
+            decorations.push(hiddenReplace.range(ref.labelTo, ref.to));
+          }
+        }
+
+        decorations.sort((a, b) => a.from - b.from || a.to - b.to);
+
+        return Decoration.set(decorations);
+      }
+    },
+    {
+      decorations: (v) => v.decorations,
+    },
+  );
+}

--- a/packages/ui/src/v2/components/cf-code-editor/features/mention-refs.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/features/mention-refs.ts
@@ -194,7 +194,12 @@ export const mentionRefEditFilter = EditorState.transactionFilter.of((tr) => {
         shouldInclude = false;
         break;
       }
-      if (reachesIntoKey(ref, fromA, toA)) adjustedTo = ref.labelTo;
+      // The EARLIEST boundary wins. One change can reach from inside one
+      // mention's label into a later mention's key, and taking the last
+      // match would move the cut past the first mention's key and delete it.
+      if (reachesIntoKey(ref, fromA, toA)) {
+        adjustedTo = Math.min(adjustedTo, ref.labelTo);
+      }
     }
 
     if (shouldInclude) {

--- a/packages/ui/src/v2/components/cf-code-editor/features/mention-refs.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/features/mention-refs.ts
@@ -135,6 +135,29 @@ export const atomicMentionRefRanges = EditorView.atomicRanges.of((view) => {
   return Decoration.set(decorations);
 });
 
+/** An edit that begins inside `][key]` — dropped, since it edits identity. */
+function startsInsideKey(ref: MentionRefInfo, fromA: number): boolean {
+  return fromA > ref.labelTo && fromA < ref.to;
+}
+
+/**
+ * An edit that begins at or before the label's end and runs into the key.
+ *
+ * A change covering the mention from before its start to at or past its end
+ * is exempt: that is how a mention is deleted, and truncating it would leave
+ * the key behind. Anything else is truncated at the label's end — including a
+ * change that ends exactly at the token's edge, which would otherwise take
+ * `][key]` with it and leave `[Label` behind as malformed text.
+ */
+function reachesIntoKey(
+  ref: MentionRefInfo,
+  fromA: number,
+  toA: number,
+): boolean {
+  if (fromA <= ref.from && toA >= ref.to) return false;
+  return fromA <= ref.labelTo && toA > ref.labelTo;
+}
+
 /**
  * Keep edits out of the `][key]` that carries a mention's identity: an edit
  * starting inside it is dropped, and one running into it from the label is
@@ -151,11 +174,7 @@ export const mentionRefEditFilter = EditorState.transactionFilter.of((tr) => {
 
   tr.changes.iterChanges((fromA, toA) => {
     for (const ref of refs) {
-      if (fromA > ref.labelTo && fromA < ref.to) {
-        needsModification = true;
-        return;
-      }
-      if (fromA <= ref.labelTo && toA > ref.labelTo && toA < ref.to) {
+      if (startsInsideKey(ref, fromA) || reachesIntoKey(ref, fromA, toA)) {
         needsModification = true;
         return;
       }
@@ -171,13 +190,11 @@ export const mentionRefEditFilter = EditorState.transactionFilter.of((tr) => {
     let shouldInclude = true;
 
     for (const ref of refs) {
-      if (fromA > ref.labelTo && fromA < ref.to) {
+      if (startsInsideKey(ref, fromA)) {
         shouldInclude = false;
         break;
       }
-      if (fromA <= ref.labelTo && toA > ref.labelTo && toA < ref.to) {
-        adjustedTo = ref.labelTo;
-      }
+      if (reachesIntoKey(ref, fromA, toA)) adjustedTo = ref.labelTo;
     }
 
     if (shouldInclude) {

--- a/packages/ui/src/v2/components/cf-code-editor/features/mention-refs.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/features/mention-refs.ts
@@ -185,7 +185,12 @@ export const mentionRefEditFilter = EditorState.transactionFilter.of((tr) => {
     }
   });
 
-  return { changes: specs, selection: tr.selection, effects: tr.effects };
+  // No selection is carried over. The original one was computed for changes
+  // that are no longer being applied, so reusing it puts the caret where the
+  // rejected edit would have left it — inside the hidden `][key]`, for a
+  // keystroke that never landed. Omitting it lets CodeMirror map the previous
+  // selection through the changes that did survive.
+  return { changes: specs, effects: tr.effects };
 });
 
 /**

--- a/packages/ui/src/v2/components/cf-code-editor/features/mention-refs.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/features/mention-refs.ts
@@ -87,6 +87,29 @@ export function parseMentionRefs(
   return refs;
 }
 
+/**
+ * Where a key's token sits in a document, whatever its label now reads.
+ *
+ * The label is ordinary editable text, so the only durable handle on a token
+ * is the key inside it. Finding one by the string that was inserted would miss
+ * a token the user has since retyped — which is exactly the window an
+ * in-flight create leaves open.
+ */
+export function findRefToken(
+  doc: string,
+  key: string,
+): { from: number; to: number; label: string } | null {
+  // The key comes from the mint, whose alphabet holds no metacharacters.
+  const match = new RegExp(`\\[([^\\]\\n]*)\\]\\[${key}\\]`).exec(doc);
+  if (!match) return null;
+
+  return {
+    from: match.index,
+    to: match.index + match[0].length,
+    label: match[1],
+  };
+}
+
 /** Announce the keys the document's reference map currently holds. */
 export const setKnownRefKeys = StateEffect.define<readonly string[]>();
 

--- a/packages/ui/src/v2/components/cf-code-editor/styles.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/styles.ts
@@ -308,8 +308,9 @@ export const styles = css`
     position: relative;
   }
 
-  /* Collapsed pill view - complete backlink with ID (click to navigate) */
-  .cm-backlink-pill {
+  /* Collapsed pill view - a resolved mention in either form (click to navigate) */
+  .cm-backlink-pill,
+  .cm-mention-ref-pill {
     background-color: var(
       --cf-code-editor-color-primary-100,
       hsla(212, 100%, 47%, 0.15)
@@ -325,7 +326,8 @@ export const styles = css`
       var(--cf-code-editor-transition-ease, ease);
   }
 
-  .cm-backlink-pill:hover {
+  .cm-backlink-pill:hover,
+  .cm-mention-ref-pill:hover {
     background-color: var(
       --cf-code-editor-color-primary-200,
       hsla(212, 100%, 47%, 0.25)

--- a/packages/ui/src/v2/core/mention-refs.test.ts
+++ b/packages/ui/src/v2/core/mention-refs.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {
+  dedupeByDestination,
   labelForToken,
   MENTION_REF_KEY_SOURCE,
   MentionRefMapSchema,
@@ -70,6 +71,33 @@ describe("mention-refs", () => {
     it("returns a name on one line", () => {
       expect(labelForToken("Two\nLines")).toBe("Two Lines");
       expect(labelForToken("Two\r\nLines")).toBe("Two Lines");
+    });
+  });
+
+  describe("dedupeByDestination()", () => {
+    const idOf = (piece: { id?: string }) => piece.id;
+
+    it("returns a list with no duplicate destination", () => {
+      const a = { id: "of:fid1:aaa" };
+      expect(dedupeByDestination([a, { id: "of:fid1:bbb" }, a], idOf).length)
+        .toBe(2);
+    });
+
+    it("returns the first of each destination", () => {
+      const first = { id: "of:fid1:aaa", which: "first" };
+      const second = { id: "of:fid1:aaa", which: "second" };
+      expect(dedupeByDestination([first, second], idOf)[0].which).toBe("first");
+    });
+
+    it("returns everything the identity cannot name", () => {
+      // Dropping these would lose a mention rather than deduplicate one.
+      const plain = { name: "no identity" };
+      expect(dedupeByDestination([plain, plain], () => undefined).length)
+        .toBe(2);
+    });
+
+    it("returns an empty list unchanged", () => {
+      expect(dedupeByDestination([], idOf)).toEqual([]);
     });
   });
 

--- a/packages/ui/src/v2/core/mention-refs.test.ts
+++ b/packages/ui/src/v2/core/mention-refs.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {
+  labelForToken,
   MENTION_REF_KEY_SOURCE,
   MentionRefMapSchema,
   MentionRefSchema,
@@ -54,6 +55,21 @@ describe("mention-refs", () => {
       expect(() => mintRefKey(taken)).toThrow(
         /no free mention reference key/,
       );
+    });
+  });
+
+  describe("labelForToken()", () => {
+    it("returns an ordinary name unchanged", () => {
+      expect(labelForToken("My Note")).toBe("My Note");
+    });
+
+    it("returns a name with no `]`, which the parser cannot read past", () => {
+      expect(labelForToken("A]B")).toBe("A)B");
+    });
+
+    it("returns a name on one line", () => {
+      expect(labelForToken("Two\nLines")).toBe("Two Lines");
+      expect(labelForToken("Two\r\nLines")).toBe("Two Lines");
     });
   });
 

--- a/packages/ui/src/v2/core/mention-refs.test.ts
+++ b/packages/ui/src/v2/core/mention-refs.test.ts
@@ -1,0 +1,79 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  MENTION_REF_KEY_SOURCE,
+  MentionRefMapSchema,
+  MentionRefSchema,
+  mintRefKey,
+} from "./mention-refs.ts";
+
+describe("mention-refs", () => {
+  describe("mintRefKey()", () => {
+    it("returns a six-character key when nothing is taken", () => {
+      expect(mintRefKey(new Set())).toMatch(/^[0-9a-z]{6}$/);
+    });
+
+    it("returns a key matching MENTION_REF_KEY_SOURCE", () => {
+      const shape = new RegExp(`^${MENTION_REF_KEY_SOURCE}$`);
+      for (let i = 0; i < 32; i++) {
+        expect(mintRefKey(new Set())).toMatch(shape);
+      }
+    });
+
+    it("returns a key nothing in the taken set holds", () => {
+      const taken = new Set<string>();
+      for (let i = 0; i < 64; i++) {
+        const key = mintRefKey(taken);
+        expect(taken.has(key)).toBe(false);
+        taken.add(key);
+      }
+      expect(taken.size).toBe(64);
+    });
+
+    it("widens the key when every six-character sample is taken", () => {
+      // Standing in for an exhausted length: the set claims every key of six
+      // characters, so the mint has to reach seven to find a free one.
+      const taken = {
+        has: (key: string) => key.length === 6,
+        get size() {
+          return 36 ** 6;
+        },
+      } as unknown as ReadonlySet<string>;
+
+      expect(mintRefKey(taken).length).toBe(7);
+    });
+
+    it("throws when no length up to the maximum is free", () => {
+      const taken = {
+        has: () => true,
+        get size() {
+          return Infinity;
+        },
+      } as unknown as ReadonlySet<string>;
+
+      expect(() => mintRefKey(taken)).toThrow(
+        /no free mention reference key/,
+      );
+    });
+  });
+
+  describe("MentionRefSchema", () => {
+    it("reads destination as a cell rather than a value", () => {
+      expect(MentionRefSchema.properties.destination.asCell).toEqual(["cell"]);
+    });
+
+    it("defaults modifiedTitle to false", () => {
+      expect(MentionRefSchema.properties.modifiedTitle.default).toBe(false);
+    });
+
+    it("requires a destination", () => {
+      expect(MentionRefSchema.required).toEqual(["destination"]);
+    });
+  });
+
+  describe("MentionRefMapSchema", () => {
+    it("shapes every entry as a MentionRef", () => {
+      expect(MentionRefMapSchema.additionalProperties).toBe(MentionRefSchema);
+    });
+  });
+});

--- a/packages/ui/src/v2/core/mention-refs.ts
+++ b/packages/ui/src/v2/core/mention-refs.ts
@@ -56,6 +56,32 @@ export const MENTION_REF_KEY_SOURCE =
   `[0-9a-z]{${KEY_LENGTH},${MAX_KEY_LENGTH}}`;
 
 /**
+ * One entry per destination, keeping the first of each.
+ *
+ * What counts as the same destination is the caller's to say — here it is a
+ * cell's own id, which is what makes a piece reached through two different
+ * keys, or through both mention forms at once, a single mention of one piece.
+ * An entry `identityOf` cannot name is kept as it came: it has nothing to
+ * compare, and dropping it would lose a mention rather than deduplicate one.
+ */
+export function dedupeByDestination<T>(
+  pieces: T[],
+  identityOf: (piece: T) => string | undefined,
+): T[] {
+  const seen = new Set<string>();
+  const result: T[] = [];
+  for (const piece of pieces) {
+    const id = identityOf(piece);
+    if (id !== undefined) {
+      if (seen.has(id)) continue;
+      seen.add(id);
+    }
+    result.push(piece);
+  }
+  return result;
+}
+
+/**
  * A label the parser will read back.
  *
  * The token's label may hold anything but `]` and a newline, and a piece is

--- a/packages/ui/src/v2/core/mention-refs.ts
+++ b/packages/ui/src/v2/core/mention-refs.ts
@@ -1,0 +1,89 @@
+import { type JSONSchema } from "@commonfabric/runner/shared";
+
+/**
+ * One mention in a document: where it points, and whether the label carrying
+ * it in the text is the user's own wording.
+ */
+export interface MentionRef {
+  /**
+   * The mention's destination. Typed `unknown` because a mention may address
+   * any piece; read it through `asSchema` before naming fields on it, since an
+   * object read under an unknown schema comes back undefined.
+   */
+  destination: unknown;
+  /**
+   * Whether the label in the document and the destination's name have
+   * deliberately diverged. While it is set, a change to the destination's
+   * title leaves the label alone.
+   */
+  modifiedTitle: boolean;
+}
+
+/**
+ * A document's mentions, keyed by the token that appears in its text. The
+ * keys are local to one document: they carry no meaning anywhere else, which
+ * is what lets them be short.
+ */
+export type MentionRefMap = Record<string, MentionRef>;
+
+export const MentionRefSchema = {
+  type: "object",
+  properties: {
+    destination: { type: "object", properties: {}, asCell: ["cell"] },
+    modifiedTitle: { type: "boolean", default: false },
+  },
+  required: ["destination"],
+} as const satisfies JSONSchema;
+
+export const MentionRefMapSchema = {
+  type: "object",
+  additionalProperties: MentionRefSchema,
+} as const satisfies JSONSchema;
+
+/** Length of a freshly minted key. */
+const KEY_LENGTH = 6;
+/** Longest key {@link mintRefKey} widens to before it gives up. */
+const MAX_KEY_LENGTH = 10;
+const KEY_ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyz";
+/** Samples drawn at one length before widening. */
+const SAMPLES_PER_LENGTH = 4;
+
+/**
+ * The shape of a reference key, as a regular-expression fragment, so that the
+ * parser and the mint cannot drift apart on the alphabet or the length.
+ */
+export const MENTION_REF_KEY_SOURCE =
+  `[0-9a-z]{${KEY_LENGTH},${MAX_KEY_LENGTH}}`;
+
+/**
+ * Mint a reference key that nothing in `taken` holds.
+ *
+ * Six characters over a 36-symbol alphabet is 2.2 billion keys against a map
+ * holding one entry per mention in one document, so widening is about
+ * termination rather than expected cost: the work is bounded at
+ * {@link SAMPLES_PER_LENGTH} samples per length instead of resampling one
+ * length forever.
+ *
+ * The modulo below biases four symbols of the alphabet slightly. A key is an
+ * opaque local token rather than a secret, so uniformity buys nothing that
+ * would pay for the rejection loop.
+ */
+export function mintRefKey(taken: ReadonlySet<string>): string {
+  const bytes = new Uint8Array(MAX_KEY_LENGTH);
+
+  for (let length = KEY_LENGTH; length <= MAX_KEY_LENGTH; length++) {
+    for (let sample = 0; sample < SAMPLES_PER_LENGTH; sample++) {
+      crypto.getRandomValues(bytes.subarray(0, length));
+      let key = "";
+      for (let i = 0; i < length; i++) {
+        key += KEY_ALPHABET[bytes[i] % KEY_ALPHABET.length];
+      }
+      if (!taken.has(key)) return key;
+    }
+  }
+
+  throw new Error(
+    `no free mention reference key at ${MAX_KEY_LENGTH} characters ` +
+      `(${taken.size} taken)`,
+  );
+}

--- a/packages/ui/src/v2/core/mention-refs.ts
+++ b/packages/ui/src/v2/core/mention-refs.ts
@@ -56,6 +56,18 @@ export const MENTION_REF_KEY_SOURCE =
   `[0-9a-z]{${KEY_LENGTH},${MAX_KEY_LENGTH}}`;
 
 /**
+ * A label the parser will read back.
+ *
+ * The token's label may hold anything but `]` and a newline, and a piece is
+ * free to be named with either. Left verbatim, such a name mints a token no
+ * parse recognizes: unprotected text, no pill, and absent from `$mentioned`
+ * while its map entry sits there naming a destination nothing reaches.
+ */
+export function labelForToken(name: string): string {
+  return name.replace(/\r?\n/g, " ").replace(/\]/g, ")");
+}
+
+/**
  * Mint a reference key that nothing in `taken` holds.
  *
  * Six characters over a 36-symbol alphabet is 2.2 billion keys against a map


### PR DESCRIPTION
## Why

Stacked on #5658 (the plan), which this implements Stage 1 of. Review that
first for the reasoning; this is the editor half.

A mention carries its destination inside the sentence: `[[Name (id)]]`. Putting
identity in the prose is what forces everything around it — a transaction filter
protecting a substring of the document from the person typing in it, an atomic
range so the cursor cannot reach it, a decoration layer hiding it again. It also
caps what a destination may be: `mentionIdFromCellId` strips `of:` and throws on
`computed:`, because a bare hash in prose cannot carry a URI scheme.

And it leaves an edited label with no standing. Editing a pill renames the
destination, so there is no way to say "call it this, here" — every local
wording is a rename, and every rename propagates.

Given a `$references` cell, a mention is written `[Label][key]` and its
destination lives in that cell as a live cell rather than a stringified id. The
label is ordinary text; only `][key]` is protected. Editing the label sets
`modifiedTitle` and leaves the destination alone — and while that is set, a
rename elsewhere leaves the label alone too.

**Without the cell, nothing changes.** The reference field parses an empty key
set, produces no decorations, and mentions stay wiki-links. Both forms are read
either way, so a document part-way through a migration works. No pattern passes
a map yet, so this lands inert.

## What Changed

- `core/mention-refs.ts` — `MentionRef`, `MentionRefMap`, their schemas
  (`destination` as `asCell: ["cell"]`), and `mintRefKey`.
- `features/mention-refs.ts` — the structural twin of `features/backlinks.ts`:
  `StateField` + `transactionFilter` + `atomicRanges` + decoration `ViewPlugin`,
  over `][key]` rather than `(id)]]`.
- `cf-code-editor.ts` — the `$references` property and its lifecycle: completion
  and novel-mention creation minting reference form, `$mentioned` drawn from both
  forms, label edits setting the flag, destination subscriptions honoring it,
  conservative collection of entries whose token has gone.
- `packages/html/src/jsx.d.ts`, `styles.ts` (the pill selector gains the second
  class), docs for both forms.

Three decisions worth a reviewer's attention, all argued in
`docs/mention-refs.md`:

1. **Membership, not shape, decides what is a mention.** Six lowercase
   characters is a shape ordinary prose reaches — deciding by shape would
   capture a hand-written `[the docs][readme]` and put its `][readme]` beyond
   the keyboard. The cost is a window where mentions read as plain text until
   the map arrives, closed by the `setKnownRefKeys` effect.
2. **The map entry is written before the token.** An entry no token names is
   inert; a token no entry resolves is a dead link. The novel-mention path
   cannot follow that order (there is no destination until `createPage`
   resolves), so it unwinds the token to the bare label on failure.
3. **The destination subscription is on the destination, not its `title`.** A
   destination arrives as a bare link with nothing cached, so reading NAME off
   it returns `undefined` until a subscription under a schema naming NAME has
   delivered one — the `unknown`-typed-field gotcha, which type-checks and fails
   silently. The wiki-link form's reason for watching `title` (it writes NAME's
   source and would hear its own echo) does not apply, since this form never
   writes the destination.

## Test plan

- New: `core/mention-refs.test.ts` (minting, widening, schema shape) and
  `features/mention-refs.test.ts` (parse, membership, positions, empty label,
  newline rejection, field effects, and every edit-filter case). 40 steps.
- The retained-behavior guard is in the feature tests: the field holds no
  references until keys are announced, and the filter leaves an unknown-key
  token fully editable.
- `packages/ui` suite: 157 passed / 911 steps, plus the browser half (52).
- `deno task check`, `check-docs`, `check-no-waitfor`, `check-conflict-markers`,
  `check-skill-facts`, `check-single-copy-deps`, `check-unused-deps`,
  `check-deno-pins`, `check-baselines-append-only` — all clean.
- `deno fmt` / `deno lint` clean on every touched path.

Not covered by tests: the completion, collection, and title-sync paths need a
live runtime, so they belong with the Stage 3 adoption rather than here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Coverage

`packages/ui` uncovered lines rise here, and the ratchet is right to flag it:
this puts a feature inside a Lit component that needs a DOM and a runtime to
reach, so much of it cannot be exercised by a unit test.

What could be reduced was, rather than accepted: `findRefToken` moved to the
parser that knows the token's shape, `dedupeByDestination` took an identity
function instead of reaching for `isCellHandle` (an `instanceof` check no test
can satisfy without a runtime), and the map's housekeeping — collection keeping
a key another editor minted, and flushing the pending write before it removes
anything — is now covered against a minimal `this`.

The remainder is the component itself: subscriptions, decorations, the
completion source, and the title-sync rewrite. Accepting it rather than
pretending otherwise:

ACCEPT_COVERAGE_DEBT: coverage-debt: packages/ui uncovered lines = 15336 lines

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


