### PR TITLE
fix(piece): prevent data fields from appearing as callable verbs in listing

### DIFF
--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -1845,18 +1845,14 @@ export async function listPieceCallables(
 
   // Third resolution path, mirrored from resolvePieceCallable: a handler whose
   // schema lost the stream marker still dispatches via the forced stream cast
-  // (tryResolvePieceHandler). Probe every rejected name the same way so a
-  // callable-by-name verb can never be absent from the listing.
+  // (tryResolvePieceHandler). Probe only names that detectCallableKind
+  // explicitly rejected on the result/input walk — do NOT sweep every key of
+  // the piece root, because probeForcedStreamCell answers from the schema it
+  // manufactures, so probing data fields reports them as handlers.
   const pieceCell = typeof piece.getCell === "function"
     ? piece.getCell()
     : undefined;
   if (pieceCell && typeof pieceCell.asSchema === "function") {
-    const pieceValue = pieceCell.get?.();
-    if (isRecord(pieceValue)) {
-      for (const name of Object.keys(pieceValue)) {
-        if (!listings.has(name)) rejected.add(name);
-      }
-    }
     for (const name of rejected) {
       if (listings.has(name)) continue;
       if (!probeForcedStreamCell(pieceCell, name)) continue;


### PR DESCRIPTION
## Summary

Fixes #5662 — `cf piece verbs` lists every data field as a callable verb with a fabricated input schema, and calling one is a silent no-op.

## Root Cause

The third resolution path in `listPieceCallables` (lines 1850-1874) swept every key of the piece root value through `probeForcedStreamCell`. The probe manufactures the condition it tests: it casts the cell to a schema asserting "this is a stream," then asks the cell whether it is one. `Cell.isStream()` answers from the schema the cell carries, so the probe's cast schema survives resolution and every name passes.

Result: every data field (`label`, `noteCount`, `revision`, `notes`, `$NAME`) was reported as a callable handler with a plausible-looking input schema (the data field's own schema). An agent reading this listing is told the piece has N callables and handed a payload shape for each. Following that advice is **accepted rather than refused** — the event is dropped with a scheduler WARN the caller never sees, a silent no-op the agent believes succeeded.

## Fix

Remove the sweep of `pieceValue` keys (lines 1854-1859). The forced-stream probe now runs only on names that `detectCallableKind` explicitly rejected on the result/input walk. This preserves the marker-loss fallback (a handler whose schema lost the stream marker still dispatches via the forced cast) without falsely listing plain data fields as callables.

The probe remains on the call path (`tryResolvePieceHandler`) where a force-cast is a last-resort dispatch attempt that fails harmlessly when wrong. Only in a listing does over-permissiveness become a false statement about what exists.

## Test Plan

- [ ] Deploy a pattern with data fields (e.g., `label`, `noteCount`, `revision`)
- [ ] Run `cf piece verbs --piece <piece>` — data fields should NOT appear
- [ ] Run `cf piece verbs --piece <piece> --all` — data fields should NOT appear
- [ ] Verify actual handlers (`createNote`, `setLabel`, `touch`) still listed correctly
- [ ] Test marker-loss case: a handler whose schema lost the stream marker should still be listed and callable

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comment added for non-obvious logic (the probe's over-permissiveness rationale)
- [ ] No new warnings generated
- [ ] Tests added/updated (requires real `Cell` double from compiled fixture, not the current hard-coded `isStream` mock — see issue #5662 "Decision needed" section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

