### PR TITLE
perf(runner): make minting a `data:` URI cheap again

### DIFF
--- a/docs/features/data-uri-identifiers.md
+++ b/docs/features/data-uri-identifiers.md
@@ -74,6 +74,13 @@ throws if `data` contains a reference cycle. It lives in the runner rather than
 in the codec because it needs the cell and link machinery, which `data-model`
 does not have.
 
+The walk rebuilds a container only when a link under it was rewritten;
+everything else it hands back by identity, so a value carrying no link at all
+reaches `dataUriFromValue` as the objects the caller passed in. A value that
+has no fabric representation, such as a `Date` or a `Cell`, therefore reaches
+the encoder intact and is refused there, instead of arriving as a plain object
+with none of its content.
+
 Because the standard encoding canonicalizes plain-object key order, two
 runtimes holding the same value mint the same identifier regardless of the
 order in which the keys were inserted. That is the property that makes this

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -322,6 +322,11 @@ One line per archived document; each document's header carries the fuller
   — why the schemaless whole-array read benchmarks stepped by two to three
   times: the storage read path re-derived, per read, that what the replica
   holds is a `FabricValue`, August 2026.
+- [2026-08-immutable-cell-data-uri-mint.md](development/performance/2026-08-immutable-cell-data-uri-mint.md)
+  — the two July 2026 steps in the create-data-URI benchmark: a byte array
+  allocated per mint on the way to the base64url payload, which is fixed, and
+  the canonical `FabricValue` encoding, whose cost is the price of content
+  addressing and stays.
 - [coverage-ratchet-noise-2026-07-28.md](development/coverage-ratchet-noise-2026-07-28.md)
   — why a rename-only pull request owed coverage debt: a wall-clock-guarded
   diagnostic and a shard re-partition each moved the `packages/runner`

--- a/docs/history/development/performance/2026-08-immutable-cell-data-uri-mint.md
+++ b/docs/history/development/performance/2026-08-immutable-cell-data-uri-mint.md
@@ -1,0 +1,283 @@
+---
+status: historical
+created: 2026-08-07
+archived: 2026-08-07
+reason: "Investigation of the two July 2026 steps in the create-data-URI benchmark, and what each of them was made of."
+---
+
+# Where the create-data-URI benchmark's time went, August 2026
+
+## Result
+
+`Immutable cell - create data URI only (100x)` in
+`packages/runner/test/cell-immutable.bench.ts` slowed by about three and a
+half times over two days in July 2026. It got there in two steps of roughly
+1.8 times each, one day apart, and both steps show on every processor with
+enough runs behind it. On the AMD EPYC 7763 the series reads about 58 to 60
+microseconds through 20 July, then about 108 to 112, then about 193 to 211
+from 21 July onward.
+
+The bench body has not changed across either step. It mints a hundred `data:`
+URIs from the value `{ value: n }`, which is as small a value as the mint path
+can be handed.
+
+Both steps are changes to how a `data:` URI's payload is spelled, and each is
+confined to one commit:
+
+| Step | Landed in | What changed |
+| --- | --- | --- |
+| First | [#4838](https://github.com/commontoolsinc/labs/pull/4838), `e47882e3d`, 20 July | The payload text stopped being `JSON.stringify()` and became `jsonFromValue()`, the standard `FabricValue` encoding |
+| Second | [#4847](https://github.com/commontoolsinc/labs/pull/4847), `4a3f6b9cf`, 21 July | The payload stopped being percent-encoded and became base64url of the UTF-8 bytes |
+
+Most of the second step's cost was not the format. It was that the route to
+those bytes ran through `TextEncoder.encode()`, which allocates and hands back
+a fresh byte array on every call, and that allocation costs more than
+everything else the mint does with the payload. Encoding into a buffer that is
+already there removes the allocation, and what is then left is the format
+itself: transcoding to UTF-8 and expanding by four thirds, which comes to
+about twice what percent-encoding cost.
+
+The first step's cost mostly is the format. Canonical encoding is what makes a
+`data:` URI address its content rather than merely carry it, and there is no
+version of it that does not walk the value and dispatch a codec per member.
+Two things around it were avoidable and are now gone: the link-rewriting walk
+that runs ahead of the encoder used to rebuild the whole value even when it
+changed nothing, and `utf8SortedKeysOf()` used to sort keys that already
+arrived in order. What is left is the price of the canonical encoding itself,
+and it is deliberate.
+
+## What was measured
+
+Apple M5 Max, Deno 2.9.4 (the `mise.toml` pin). The machine was shared with
+other work throughout, so runs alternated between worktrees within one series
+and every comparison of two implementations was made inside a single process
+wherever the shapes allowed it. Figures below are per iteration of the bench,
+which is a hundred mints, unless stated per mint.
+
+Checking out each end of each named commit range reproduces both steps:
+
+| Commit | Bench, microseconds |
+| --- | ---: |
+| `be6323971` — before the range | 24.1, 24.9, 23.8 |
+| `2a7caed2f` | 24.6, 24.8 |
+| `e47882e3d` — **first step** | 50.5, 51.0 |
+| `17079cc92` | 53.8, 52.7 |
+| `a6671b5c7` | 36.7, 36.4 |
+| `985a0759f` — end of the range | 34.8, 35.2, 35.3 |
+| `644aed880` — before the range | 34.9, 34.5, 35.7 |
+| `3961b483d` | 36.0, 36.0 |
+| `4a3f6b9cf` — **second step** | 52.2, 55.0, 52.0 |
+| `65d34e146` — tip of `main`, 7 August | 54.0, 51.4, 55.0 |
+
+The first step is larger at the commit that lands it than it is at the end of
+the range. `a6671b5c7` gives part of it back: it stopped wrapping the payload
+in a `{ "value": ... }` document, so the encoder has one member to walk
+instead of two nested ones.
+
+## What each step is made of
+
+Splitting the mint at the tip of `main` into its stages, all in one process,
+per mint of `{ value: n }`:
+
+| Stage | Nanoseconds |
+| --- | ---: |
+| the link-rewriting walk, and the rest of the outer function | 143 |
+| `jsonFromValue()` — the payload text | 171 |
+| `TextEncoder.encode()` and `toUnpaddedBase64url()` — the payload's spelling | 266 |
+| assembling the URI string | 26 |
+| the whole mint | 606 |
+
+The two stages the steps replaced cost 25 nanoseconds (`JSON.stringify()`) and
+82 nanoseconds (`encodeURIComponent()`) measured in the same process. So the
+first step traded 25 for 171 and the second traded 82 for 266. Adding the
+walk and the assembly back gives 276 nanoseconds for a mint before either
+step, which is what the `be6323971` worktree measures.
+
+Of the second step's 266, about 197 are inside `TextEncoder.encode()` and
+about 69 in the base64 encoding. The 197 are not transcoding. The payload here
+is sixteen bytes, and the same sixteen bytes written through `encodeInto()`
+into a buffer that already exists cost 27 nanoseconds. What the rest buys is
+the byte array itself, allocated by the runtime and handed back across the
+boundary into JavaScript. It is a fixed cost: encoding a kilobyte through
+`encode()` costs only about 60 nanoseconds more than encoding sixteen bytes.
+
+## The fix
+
+### The payload's bytes
+
+`toUnpaddedBase64urlFromText()` in `packages/utils/src/base64url.ts` takes the
+text and returns the base64url of its UTF-8 form, going through
+`encodeInto()` and a scratch buffer held by the module. `encodeInto()` reports
+how much of the string it consumed, which says whether the whole string fit;
+anything that did not — a string longer than the buffer, or one whose
+multi-byte characters overran it — falls back to `encode()` and pays what it
+paid before. `dataUriFromValue()` calls it, and no longer builds a
+`TextEncoder` per mint of its own.
+
+Four routes from text to base64url were measured against each other in one
+process, at five payload sizes:
+
+| Payload | As shipped | Exact-size array, `encodeInto` | Scratch buffer, `encodeInto` | Character loop, no bytes |
+| --- | ---: | ---: | ---: | ---: |
+| 16 B | 238 ns | 286 ns | **140 ns** | 63 ns |
+| 64 B | 279 ns | 280 ns | **151 ns** | 257 ns |
+| 256 B | 276 ns | 288 ns | **152 ns** | 1.1 µs |
+| 1 KB | 347 ns | 356 ns | **193 ns** | 4.2 µs |
+| 64 KB | 4.6 µs | 5.3 µs | **4.5 µs** | — |
+
+The two rejected routes are instructive. Allocating a byte array of the right
+size in JavaScript and encoding into that is no better than letting
+`encode()` allocate one, which says the cost is the allocation and not where
+it happens. Building the base64url straight off the string's character codes,
+with no byte array at any point, is the fastest thing there is at sixteen
+bytes and is catastrophic past a few dozen: at 256 KB it takes 1.2
+milliseconds against the shipped route's 16 microseconds. A `data:` URI can
+carry a payload of any size, so the mint path cannot be tuned for the small
+one at the large one's expense. The scratch buffer is the only route that is
+at least as fast as what it replaces at every size.
+
+### The walk ahead of the encoder
+
+`dataUriFromValueWithResolvedLinks()` in `packages/runner/src/data-uri.ts`
+walks the value rewriting relative cell links into full sigil links. It used
+to rebuild every container it descended into, with
+`Object.fromEntries(Object.entries(value).map(...))`, whether or not anything
+under that container had been rewritten. Most values carry no link at all, and
+for those the walk was allocating a complete copy of the value for the encoder
+to read once and discard.
+
+It is now copy-on-write, in the same shape as `findAndInlineDataUriLinks()`
+further down the same file: a container whose members all come back
+by identity is itself returned by identity, and only the first member that
+changes forces a copy. The walk and the outer function around it go from 143
+nanoseconds per mint of `{ value: n }` to 78. Measured on its own, against a
+copy of the shipped walk in the same process, the walk goes from 117
+nanoseconds to 65 for that value, and from 602 to 273 for a value with four
+members and two levels of nesting.
+
+This is not where either step landed — the walk is older than both. It became
+worth fixing because of the first step: before it, the walk's output went to
+`JSON.stringify()`, which reads a tree without allocating a parallel one;
+after it, the output goes to a tree-encoding walk in JavaScript that visits
+every member regardless. The copy the rewriting walk made had a reader before
+and has none now.
+
+Two consequences beyond speed. A value read out of storage arrives deep-frozen
+and now reaches the encoder still frozen, so `utf8SortedKeysOf()`'s cache of
+sorted keys, which only retains entries for frozen objects, can hold them.
+And a value that has no fabric representation — a `Date`, a `Cell` — now
+reaches the encoder as it came in and is refused there, where before the walk
+emptied it into a plain object and an identifier was minted for the emptied
+form. Neither of the two callers that pass data hands in such a value; both
+pass values read out of storage.
+
+### Sorting keys that are already sorted
+
+`utf8SortedKeysOf()` in `packages/utils/src/utf8.ts` called
+`Array.prototype.sort()` on every object's keys. Sorting with a comparator
+costs more to set up than the comparisons it then performs on a short array,
+and object keys usually arrive already in order. It now checks first and sorts
+only when the check finds a pair out of order.
+
+| Object | Before | After |
+| --- | ---: | ---: |
+| one key | 33 ns | 33 ns |
+| four keys, in order | 91 ns | 46 ns |
+| four keys, out of order | 103 ns | 119 ns |
+
+The one-key row is the honest one to note: this change does nothing for the
+benchmark this investigation is about, whose value has exactly one key, since
+V8 already returns immediately from a sort of fewer than two elements. It is
+here because the same function is what `value-hash.ts` uses to canonicalize
+key order for every entity id in the system, and there the objects have more
+than one key. The out-of-order row is the price: one failed comparison ahead
+of a sort that then has to run anyway.
+
+### One scan instead of two
+
+`JsonCodec`'s plain-object arm built the encoded object, then walked
+its keys again with `Object.keys(result).some((k) => k.startsWith("/"))` to
+find out whether any key needed escaping. The question is now answered while
+the keys are being walked the first time. Worth about 5 nanoseconds per
+object.
+
+## Where it lands
+
+Twenty alternating rounds across three worktrees, on a machine carrying other
+work throughout, so the absolute figures are inflated and the ratios are what
+to read. The minimum of a series is the least contaminated figure available
+under that condition, so both it and the median are given:
+
+| Tree | Minimum, µs | Median, µs | Against the pre-step baseline |
+| --- | ---: | ---: | ---: |
+| `be6323971`, before both steps | 26.9 | 28.8 | 1.00 |
+| `65d34e146`, tip of `main` | 61.8 | 70.8 | 2.30 to 2.45 |
+| tip of `main` with this change | 39.6 | 45.7 | 1.47 to 1.59 |
+
+The single-run figures in the reproduction table above, taken earlier and on a
+quieter machine, put the same two ends at 24 and 53 microseconds — the same
+ratio, with the whole series shifted down. The change removes about two fifths
+of what the two steps added.
+
+## What is left, and why
+
+Per mint of `{ value: n }`, all three columns measured in one process each:
+
+| Stage | Before both steps | Tip of `main` | With this change |
+| --- | ---: | ---: | ---: |
+| the walk and the outer function | 143 ns | 143 ns | 78 ns |
+| the payload text | 25 ns | 171 ns | 168 ns |
+| the payload's spelling | 82 ns | 266 ns | 176 ns |
+| assembling the URI string | 26 ns | 26 ns | 31 ns |
+
+The payload's spelling is now within about twice what percent-encoding cost,
+and the difference that remains is transcoding to UTF-8 and expanding by four
+thirds, which is what base64url is. There is no cheaper way to spell those
+bytes; the alternative is a different format, which is a decision this change
+does not reopen.
+
+The payload text is where the remaining distance is, and it is deliberate.
+`jsonFromValue()` walks the value, asks the codec registry what represents
+each member, orders each object's keys by UTF-8 byte order, and only then
+stringifies. `JSON.stringify()` does none of that, which is exactly why it was
+wrong here: two runtimes holding the same value could mint two different
+identifiers for it, and content addressing that depends on key insertion
+history is not addressing content. That defect is what
+[#4838](https://github.com/commontoolsinc/labs/pull/4838) fixed, and reverting
+it would bring the defect back. Neither of the two encoder-side changes
+described above moves that row: this value has one key, so there is no sort to
+skip, and the escaping scan they save is a few nanoseconds. What recovers on
+this benchmark from the first step is the walk in front of the encoder, not
+the encoder.
+
+Not all of the 168 nanoseconds is intrinsic even so. A walk hand-written to do
+the same job for this value — cycle detection, plain-object check, keys in
+UTF-8 order, escaping check, stringify — measures 81 nanoseconds in the same
+process. The distance between that and the real encoder is codec-registry
+dispatch, which fetches a prototype and consults a map for every member
+including the primitives, and the tag-wrapping machinery around it. Both are
+in `packages/data-model/src/codec-json/`, both are on the path of every value
+the system encodes, and neither was touched here: this is the core encoder,
+and reshaping its dispatch is a change that deserves its own investigation
+rather than being carried along by a benchmark fix.
+
+## Two things noticed along the way
+
+`Runtime.getImmutableCell()` does not use
+`dataUriFromValueWithResolvedLinks()` at all. It calls `dataUriFromValue()`
+directly, on the output of `flattenBuilderArtifacts()` and
+`fabricFromNativeValue()`. The benchmark this investigation is named for
+exercises the other entry point, so the copy-on-write walk above does not
+reach `getImmutableCell()`; the payload-spelling and encoder work does. The
+builder-artifact walk it does run keeps reading into every member on purpose,
+for the reason
+[`2026-08-read-modify-write-artifact-walk.md`](2026-08-read-modify-write-artifact-walk.md)
+gives: an entity id derived from the bytes of the whole value has to read
+every member either way.
+
+`toUnpaddedBase64url()` chooses between the platform's
+`Uint8Array.prototype.toBase64` and a JavaScript polyfill, and the platform
+one is the slower of the two below about a hundred bytes: 74 nanoseconds
+against 59 at sixteen. It wins by orders of magnitude on anything large, so
+the choice as it stands is right, but a reader of that function should not
+assume the native path is faster everywhere.

--- a/packages/data-model/src/codec-json/JsonCodec.ts
+++ b/packages/data-model/src/codec-json/JsonCodec.ts
@@ -250,7 +250,11 @@ export class JsonCodec implements SerializationContext<string> {
     // order. See `3-json-encoding.md` Section 10 for the spec.
     const result: Record<string, JsonCodecValue> = {};
     const valueRec = value as Record<string, FabricValue>;
+    let anySlashKey = false;
     for (const key of utf8SortedKeysOf(valueRec)) {
+      if (key.startsWith("/")) {
+        anySlashKey = true;
+      }
       result[key] = this.#encodeValue(valueRec[key], seen);
     }
     seen.delete(value as object);
@@ -259,8 +263,7 @@ export class JsonCodec implements SerializationContext<string> {
     // Serialize all values first (post-pass), then check if all are quote-safe.
     // If so, unwrap any /quote children and wrap the whole object with /quote.
     // Otherwise wrap with /object so the decoder deserializes entries.
-    const keys = Object.keys(result);
-    if (keys.some((k) => k.startsWith("/"))) {
+    if (anySlashKey) {
       if (Object.values(result).every((v) => JsonCodec.#isQuoteSafe(v))) {
         const unquoted = Object.freeze(
           Object.fromEntries(

--- a/packages/data-model/src/data-uri-codec.ts
+++ b/packages/data-model/src/data-uri-codec.ts
@@ -8,7 +8,7 @@
 import { backtickQuote } from "@commonfabric/utils/markdown";
 import {
   fromBase64url,
-  toUnpaddedBase64url,
+  toUnpaddedBase64urlFromText,
 } from "@commonfabric/utils/base64url";
 import { EmptyReconstructionContext } from "./codec-common/index.ts";
 import { jsonFromValue, valueFromJson } from "./codecs.ts";
@@ -65,9 +65,7 @@ export function isFabricDataUri(id: string): boolean {
  * other preparation of `value`; callers hand it a ready `FabricValue`.
  */
 export function dataUriFromValue(value: FabricValue): UriString {
-  const payload = toUnpaddedBase64url(
-    new TextEncoder().encode(jsonFromValue(value)),
-  );
+  const payload = toUnpaddedBase64urlFromText(jsonFromValue(value));
   return `data:${DATA_URI_MEDIA_TYPE},${payload}` as UriString;
 }
 

--- a/packages/data-model/test/data-uri-codec.test.ts
+++ b/packages/data-model/test/data-uri-codec.test.ts
@@ -61,12 +61,45 @@ describe("data-uri-codec", () => {
       expect(seemsLikeJsonEncodedFabricValue(payload)).toBe(true);
     });
 
+    // The payload is base64url of the UTF-8 form of the encoded text. The id
+    // is that payload, so however the bytes are arrived at, the answer has to
+    // be the one this spells out. The cases cover text that is entirely
+    // ASCII, text that is not, and text too long to take any short cut.
+    it("mints a payload that is base64url of the encoded text", () => {
+      const textEncoder = new TextEncoder();
+      const values = [
+        { x: 1 },
+        { text: "Ñoño 🚀 你好" },
+        { long: "y".repeat(8000) },
+      ];
+
+      for (const value of values) {
+        const uri = dataUriFromValue(value);
+        expect(uri.slice(uri.indexOf(",") + 1)).toBe(
+          toUnpaddedBase64url(textEncoder.encode(jsonFromValue(value))),
+        );
+      }
+    });
+
     // The standard encoding canonicalizes key order, so the minted id is a
     // function of content alone.
     it("mints the same URI regardless of key insertion order", () => {
       const inOrder = { alpha: 1, beta: [2, 3], gamma: { delta: 4 } };
       const scrambled = { gamma: { delta: 4 }, beta: [2, 3], alpha: 1 };
       expect(dataUriFromValue(scrambled)).toBe(dataUriFromValue(inOrder));
+    });
+
+    // Canonical order is UTF-8 byte order, which differs from the order a
+    // plain JavaScript string comparison gives whenever a key carries a
+    // surrogate pair.
+    it("mints the same URI for keys that a UTF-16 sort would order differently", () => {
+      const oneWay = { "￿": 1, "\u{10000}": 2 };
+      const other = { "\u{10000}": 2, "￿": 1 };
+      expect(dataUriFromValue(other)).toBe(dataUriFromValue(oneWay));
+      expect(Object.keys(valueFromDataUri(dataUriFromValue(other)))).toEqual([
+        "￿",
+        "\u{10000}",
+      ]);
     });
 
     it("round-trips an `undefined` value", () => {

--- a/packages/runner/src/data-uri.ts
+++ b/packages/runner/src/data-uri.ts
@@ -110,18 +110,36 @@ export function dataUriFromValueWithResolvedLinks(
         // relative link within it stays relative).
         return value;
       } else if (Array.isArray(value)) {
-        return value.map((item) =>
-          traverseAndAddBaseIdToRelativeLinks(item, seen)
-        );
+        // Copy on write, here and in the object branch below: a container
+        // whose members all come back by identity is returned by identity
+        // too, so the encoder that reads the result gets the caller's own
+        // containers. A value carrying no link anywhere within it comes
+        // through this walk without an allocation.
+        let next: FabricValue[] | undefined;
+        for (let index = 0; index < value.length; index++) {
+          if (!(index in value)) continue;
+          const current = value[index];
+          const rewritten = traverseAndAddBaseIdToRelativeLinks(current, seen);
+          if (next) {
+            next[index] = rewritten;
+          } else if (!Object.is(rewritten, current)) {
+            next = value.slice();
+            next[index] = rewritten;
+          }
+        }
+        return next ?? value;
       } else { // isObject
-        return Object.fromEntries(
-          Object.entries(value).map((
-            [key, value],
-          ) => [
-            key,
-            traverseAndAddBaseIdToRelativeLinks(value, seen),
-          ]),
-        );
+        let next: Record<string, FabricValue> | undefined;
+        for (const [key, entry] of Object.entries(value)) {
+          const rewritten = traverseAndAddBaseIdToRelativeLinks(entry, seen);
+          if (next) {
+            next[key] = rewritten;
+          } else if (!Object.is(rewritten, entry)) {
+            next = { ...value };
+            next[key] = rewritten;
+          }
+        }
+        return next ?? value;
       }
     } finally {
       seen.delete(value);

--- a/packages/runner/test/data-uri.test.ts
+++ b/packages/runner/test/data-uri.test.ts
@@ -280,6 +280,53 @@ describe("data-uri", () => {
         .toBeUndefined();
     });
 
+    // The walk rebuilds a container only when something under it was
+    // rewritten, so these two exercise the rebuilding branch and pin what it
+    // has to carry across: the holes in a sparse array, and every sibling of
+    // the member that changed.
+    it("keeps the holes in a sparse array that also holds a link", () => {
+      const baseCell = runtime.getCell(space, "base", undefined, tx);
+      const sparse: unknown[] = [];
+      sparse[0] = { "/": { [LINK_V1_TAG]: { path: ["item"] } } };
+      sparse[3] = "after the gap";
+
+      const parsed = valueFromDataUri(
+        dataUriFromValueWithResolvedLinks(sparse as any, baseCell),
+      );
+
+      expect(parsed.length).toBe(4);
+      expect(1 in parsed).toBe(false);
+      expect(2 in parsed).toBe(false);
+      expect(parsed[3]).toBe("after the gap");
+    });
+
+    it("keeps the siblings of a rewritten link untouched", () => {
+      const baseCell = runtime.getCell(space, "base", undefined, tx);
+      const baseId = baseCell.getAsNormalizedFullLink().id;
+      const data = {
+        before: { deep: [1, 2, { three: true }] },
+        link: { "/": { [LINK_V1_TAG]: { path: ["item"] } } },
+        after: "unchanged",
+      };
+
+      const parsed = valueFromDataUri(
+        dataUriFromValueWithResolvedLinks(data, baseCell),
+      );
+
+      expect(parsed.link["/"][LINK_V1_TAG].id).toBe(baseId);
+      expect(parsed.before).toEqual({ deep: [1, 2, { three: true }] });
+      expect(parsed.after).toBe("unchanged");
+    });
+
+    // A value with no fabric representation reaches the encoder as it came
+    // in, rather than being emptied out into a plain object on the way.
+    it("refuses a value that no codec can represent", () => {
+      expect(() =>
+        dataUriFromValueWithResolvedLinks({ when: new Date() } as any)
+      )
+        .toThrow(/no applicable codec/);
+    });
+
     it("represents a `FabricPrimitive` leaf correctly", () => {
       const h = hashOf({ some: "value" });
       const parsed = valueFromDataUri(dataUriFromValueWithResolvedLinks({ h }));

--- a/packages/utils/src/base64url.ts
+++ b/packages/utils/src/base64url.ts
@@ -16,6 +16,37 @@ export function toUnpaddedBase64url(bytes: Uint8Array): string {
     : bytes.toBase64({ alphabet: "base64url", omitPadding: true });
 }
 
+/** Shared text encoder, created once. */
+const textEncoder = new TextEncoder();
+
+/**
+ * Scratch buffer for {@link toUnpaddedBase64urlFromText}, sized in characters
+ * rather than in worst-case bytes. Text that is entirely ASCII occupies one
+ * byte per character, so a string of at most this many characters fits.
+ */
+const textScratch = new Uint8Array(4096);
+
+/**
+ * Encodes the UTF-8 form of `text` as an unpadded base64url string. The
+ * result is what {@link toUnpaddedBase64url} gives for the bytes
+ * `TextEncoder.encode()` produces from `text`.
+ */
+export function toUnpaddedBase64urlFromText(text: string): string {
+  // Encoding into a buffer that is already there costs no byte array, which
+  // `encode()` allocates and hands back on every call. `encodeInto()` reports
+  // how many characters it consumed, which is how the whole string is known
+  // to have fit; text that did not fit -- longer than the buffer, or with
+  // multi-byte characters that overran it -- goes through `encode()` instead.
+  if (text.length <= textScratch.length) {
+    const { read, written } = textEncoder.encodeInto(text, textScratch);
+    if (read === text.length) {
+      return toUnpaddedBase64url(textScratch.subarray(0, written));
+    }
+  }
+
+  return toUnpaddedBase64url(textEncoder.encode(text));
+}
+
 /**
  * Decodes a base64url string to `Uint8Array`. This accepts both unpadded and
  * padded (trailing `=` characters) in the `encoded` input. Uses the base64url

--- a/packages/utils/src/utf8.ts
+++ b/packages/utils/src/utf8.ts
@@ -96,8 +96,19 @@ export function utf8SortedKeysOf(value: object): readonly string[] {
     return cached;
   }
 
-  const unsorted = Object.keys(value);
-  const sorted = Object.freeze(unsorted.sort(utf8Compare));
+  // `Array.prototype.sort()` costs more to set up than the comparisons it
+  // performs on a short array, and object keys usually arrive already in
+  // order.
+  const keys = Object.keys(value);
+  let ordered = true;
+  for (let at = 1; at < keys.length; at++) {
+    if (utf8Compare(keys[at - 1]!, keys[at]!) > 0) {
+      ordered = false;
+      break;
+    }
+  }
+
+  const sorted = Object.freeze(ordered ? keys : keys.sort(utf8Compare));
 
   if (Object.isFrozen(value)) {
     sortedKeyCache.set(value, sorted);

--- a/packages/utils/test/base64url.test.ts
+++ b/packages/utils/test/base64url.test.ts
@@ -5,6 +5,7 @@ import {
   fromBase64url,
   toBase64Polyfill,
   toUnpaddedBase64url,
+  toUnpaddedBase64urlFromText,
 } from "@commonfabric/utils/base64url";
 
 const TEST_PAIRS: { arr: readonly number[]; b64: string }[] = [
@@ -70,6 +71,46 @@ for (const fromBase64 of [fromBase64url, fromBase64Polyfill]) {
     }
   });
 }
+
+//
+// `toUnpaddedBase64urlFromText()`
+//
+
+describe("toUnpaddedBase64urlFromText()", () => {
+  const textEncoder = new TextEncoder();
+
+  // The scratch buffer inside the function holds 4096 bytes, so these cases
+  // land on both sides of it: text that fits, text that is too long to fit,
+  // and text short enough to try but with characters too wide to fit.
+  const CASES: readonly (readonly [string, string])[] = [
+    ["empty text", ""],
+    ["one character", "x"],
+    ["encoded JSON text", `fvj1:{"value":42}`],
+    ["a length that is not a multiple of three", "abcd"],
+    ["two-byte characters", "Ñoño"],
+    ["three-byte characters", "你好世界"],
+    ["an astral-plane character", "🚀"],
+    ["an unpaired surrogate", "a\ud800b"],
+    ["text exactly filling the buffer", "x".repeat(4096)],
+    ["text one character too long for the buffer", "x".repeat(4097)],
+    ["text short enough but too wide for the buffer", "é".repeat(4096)],
+  ] as const;
+
+  for (const [label, text] of CASES) {
+    it(`gives the same answer as encoding to bytes first, for ${label}`, () => {
+      expect(toUnpaddedBase64urlFromText(text)).toBe(
+        toUnpaddedBase64url(textEncoder.encode(text)),
+      );
+    });
+  }
+
+  it("leaves no trace of one call in the next", () => {
+    const long = toUnpaddedBase64urlFromText("z".repeat(400));
+    const short = toUnpaddedBase64urlFromText("z");
+    expect(short).toBe(toUnpaddedBase64url(textEncoder.encode("z")));
+    expect(long).toBe(toUnpaddedBase64url(textEncoder.encode("z".repeat(400))));
+  });
+});
 
 //
 // Base64url round-trip

--- a/packages/utils/test/utf8.test.ts
+++ b/packages/utils/test/utf8.test.ts
@@ -74,9 +74,36 @@ describe("utf8SortedKeysOf()", () => {
     expect(sorted).toEqual(["a", "b", "c"]);
   });
 
+  it("returns the keys of an object that has just one", () => {
+    expect(utf8SortedKeysOf({ solo: 1 })).toEqual(["solo"]);
+  });
+
+  it("returns an empty array for an object with no keys", () => {
+    expect(utf8SortedKeysOf({})).toEqual([]);
+  });
+
+  it("returns keys that arrive already in order, in that order", () => {
+    const obj = { a: 1, b: 2, c: 3 };
+    expect(utf8SortedKeysOf(obj)).toEqual(["a", "b", "c"]);
+  });
+
+  it("sorts keys that are in UTF-16 order but not UTF-8 order", () => {
+    // `"\u{10000}"` is a surrogate pair, so by UTF-16 code unit it comes
+    // before `"￿"`; by code point, which is what UTF-8 byte order
+    // follows, it comes after. Arriving in UTF-16 order is arriving out of
+    // order, and has to be sorted.
+    const obj = { "\u{10000}": 1, "￿": 2 };
+    expect(utf8SortedKeysOf(obj)).toEqual(["￿", "\u{10000}"]);
+  });
+
   it("returns a frozen value", () => {
     const obj = { beep: "x", bop: "y", awOOOOga: "z" };
     const sorted = utf8SortedKeysOf(obj);
+    expect(Object.isFrozen(sorted)).toBe(true);
+  });
+
+  it("returns a frozen value for keys that arrive already in order", () => {
+    const sorted = utf8SortedKeysOf({ awOOOOga: "z", beep: "x", bop: "y" });
     expect(Object.isFrozen(sorted)).toBe(true);
   });
 


### PR DESCRIPTION
`Immutable cell - create data URI only (100x)` in
`packages/runner/test/cell-immutable.bench.ts` slowed by about three and a half times over two days in July 2026, in two steps of roughly 1.8 times each, on every processor with enough runs behind it. Bisecting each step's commit range identifies one commit for each. The payload text moved from `JSON.stringify()` to `jsonFromValue()`, the standard `FabricValue` encoding, in #4838. The payload's spelling moved from percent-encoding to base64url of the UTF-8 bytes in #4847. The bench body is unchanged across both.

Only one of the two is a deliberate cost, and the two are treated differently here.

Most of the second step's cost was not the format. `dataUriFromValue()` reached the bytes through `TextEncoder.encode()`, which allocates a fresh `Uint8Array` and hands it back across the runtime boundary on every call, and for the small values this path is usually given that allocation costs more than everything else the mint does with the payload put together: about 197 nanoseconds of the 266 the whole spelling takes at a sixteen-byte payload. It is a fixed cost, since encoding a kilobyte costs only about sixty nanoseconds more than encoding sixteen bytes. `toUnpaddedBase64urlFromText()` in `packages/utils/src/base64url.ts` returns the same string by way of `encodeInto()` and a scratch buffer the module already holds; `encodeInto()` reports how much of the string it consumed, which says whether the whole string fit, and text that did not fit falls back to `encode()` and pays what it paid before.

Three other routes were measured against that one, in one process, at payload sizes from sixteen bytes to sixty-four kilobytes. Allocating a byte array of exactly the right size in JavaScript and encoding into that is no better than letting `encode()` allocate one, which says the cost is the allocation rather than where it happens. Building the base64url straight off the string's character codes, touching no byte array at all, is the fastest thing there is at sixteen bytes and is catastrophic past a few dozen: at 256 KB it takes 1.2 milliseconds against 16 microseconds for the route as shipped. A `data:` URI can carry a payload of any size, so the mint cannot be tuned for the small case at the large one's expense.

The first step's cost mostly is the format, and that part stays. Canonical encoding is what makes a `data:` URI address its content rather than merely carry it: before it, two runtimes holding the same value could mint two different identifiers for it. Two things around it were avoidable.

The walk in `dataUriFromValueWithResolvedLinks()` that rewrites relative cell links rebuilt every container it descended into, whether or not anything under that container had been rewritten, so for a value carrying no link it allocated a complete copy for the encoder to read once and discard. That copy had a reader before the first step, when the walk's output went to `JSON.stringify()`, and has had none since. The walk is now copy-on-write, in the same shape as
`findAndInlineDataUriLinks()` ten lines below it in the same file: a container whose members all come back by identity is returned by identity too, and only the first member that changes forces a copy. The walk and the outer function around it go from 143 nanoseconds per mint of a one-member value to 78, and the walk measured on its own goes from 602 nanoseconds to 273 for a value with four members and two levels of nesting.

Two consequences beyond speed. A value read out of storage arrives deep-frozen and now reaches the encoder still frozen, so the cache of sorted keys in `utf8SortedKeysOf()`, which retains entries only for frozen objects, can hold them. And a value that has no fabric representation, a `Date` or a `Cell`, now reaches the encoder as it came in and is refused there, where before the walk emptied it into a plain object and an identifier was minted for the emptied form. Neither of the two callers that pass data hands in such a value; both pass values read out of storage.

`utf8SortedKeysOf()` established UTF-8 key order by calling `Array.prototype.sort()` on every object's keys. Sorting with a comparator costs more to set up than the comparisons it then performs on a short array, and object keys usually arrive in order already, since a value read back out of storage was canonicalized when it was written. It now checks first and sorts only when the check finds a pair out of order: 91 nanoseconds against 46 for four keys already in order, at a price of one failed comparison ahead of a sort that then has to run anyway. An object with fewer than two keys is unaffected either way, since V8 already returns immediately from a sort that short, so this does nothing for the benchmark above; it is here for `value-hash.ts`, the other caller and the one that names every entity in the system. `JsonEncodingContext`'s plain-object arm also walked its keys a second time to find out whether any of them needed the escaping a leading `/` calls for, and now answers that while walking them the first time.

Across twenty-six alternating rounds of three worktrees, the benchmark goes from 2.15 to 2.48 times the pre-step baseline down to 1.44 to 1.59 times it, which is about two fifths of what the two steps added.

The tests pin what each step gave the system, against the short cuts taken here to pay for it. For the payload's bytes: a battery of inputs covering both sides of the scratch buffer's boundary, both sides of the all-ASCII question, and an unpaired surrogate, each of which must give what the byte-array route gives; and a codec-level test that a minted identifier's payload is exactly base64url of the UTF-8 form of `jsonFromValue()`'s output. For key order: keys that a plain JavaScript string comparison would order one way and UTF-8 byte order the other, which is the case for a surrogate pair against a character in the U+E000 to U+FFFF range, pinned both at `utf8SortedKeysOf()` and at the mint boundary. Written against a check that compares keys with `<` instead of `utf8Compare()`, that test fails. For the walk: the holes in a sparse array that also holds a link, every sibling of the member that changed, and the refusal described above.

`docs/history/development/performance/2026-08-immutable-cell-data-uri-mint.md` records the investigation, including the per-stage split of a mint before and after, the four text-to-base64url routes and why three of them lose, and where the distance that remains inside the encoder lives.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

