### PR TITLE
Add shared fading dashboard message

### DIFF
--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -45,6 +45,7 @@ dashboard/
   favicon-png.generated.ts  generated runtime PNG favicon copies
   favicon-artwork.ts  build/test-only SVG source for those favicon copies
   version.ts    the browser/server compatibility version a page reloads on
+  dashboard-message.ts  shared message storage and fade timing
   render.ts     renderTile(view) + the page shell/CSS
   server.ts     generic runtime: scheduler, SSE, route mounting, page assembly
   registry.ts   THE ONE REGISTRATION POINT — the array of tiles
@@ -68,6 +69,13 @@ A tile whose `collect()` throws is desaturated to a gray "unknown" — it keeps
 its last-known value and shows a short reason (e.g. "source unreachable"), with
 the full error in the server log — so one unreachable source never blanks or
 breaks the board.
+
+The text field centered between the dashboard identity and freshness indicator
+is a shared message. Editing the field and leaving it saves the text for every
+connected dashboard and persists it in the dashboard cache. The message remains
+fully visible for two hours. It then fades linearly for four hours, after which
+the server replaces it with the empty string. A new edit starts the timing
+again.
 
 GitHub CI tiles declare the workflow snapshots they read in `runSources`. The
 scheduler fetches each workflow independently. When a workflow fetch completes,

--- a/packages/dashboard/dashboard-message-client.browser.test.ts
+++ b/packages/dashboard/dashboard-message-client.browser.test.ts
@@ -1,0 +1,92 @@
+import { assertEquals } from "@std/assert";
+import { paintDashboardMessageInput } from "./dashboard-message-client.ts";
+
+const VISIBLE_MS = 2 * 60 * 60 * 1_000;
+const FADE_MS = 4 * 60 * 60 * 1_000;
+
+function editor(value: string): HTMLInputElement {
+  const input = document.createElement("input");
+  input.value = value;
+  document.body.append(input);
+  input.focus();
+  return input;
+}
+
+Deno.test("a focused saved message fades and expires", () => {
+  const input = editor("Saved message");
+  const state = {
+    savedText: input.value,
+    updatedAt: 1_000 as number | null,
+    draftProtected: false,
+  };
+  try {
+    paintDashboardMessageInput(
+      input,
+      state,
+      1_000 + VISIBLE_MS + FADE_MS / 2,
+      VISIBLE_MS,
+      FADE_MS,
+    );
+    assertEquals(document.activeElement, input);
+    assertEquals(input.style.opacity, "0.5");
+
+    paintDashboardMessageInput(
+      input,
+      state,
+      1_000 + VISIBLE_MS + FADE_MS,
+      VISIBLE_MS,
+      FADE_MS,
+    );
+    assertEquals(input.value, "");
+    assertEquals(input.style.opacity, "1");
+    assertEquals(state, {
+      savedText: "",
+      updatedAt: null,
+      draftProtected: false,
+    });
+  } finally {
+    input.remove();
+  }
+});
+
+for (const protectedState of ["dirty", "pending"] as const) {
+  Deno.test(`a ${protectedState} message stays visible past expiry`, () => {
+    const input = editor("Local draft");
+    const state = {
+      savedText: "Saved message",
+      updatedAt: 1_000,
+      draftProtected: true,
+    };
+    try {
+      paintDashboardMessageInput(
+        input,
+        state,
+        1_000 + VISIBLE_MS + FADE_MS,
+        VISIBLE_MS,
+        FADE_MS,
+      );
+      assertEquals(input.value, "Local draft");
+      assertEquals(input.style.opacity, "1");
+      assertEquals(state.savedText, "Saved message");
+      assertEquals(state.updatedAt, 1_000);
+    } finally {
+      input.remove();
+    }
+  });
+}
+
+Deno.test("an empty message remains ready for editing", () => {
+  const input = editor("");
+  const state = {
+    savedText: "",
+    updatedAt: null,
+    draftProtected: false,
+  };
+  try {
+    input.style.opacity = "0.2";
+    paintDashboardMessageInput(input, state, 1_000, VISIBLE_MS, FADE_MS);
+    assertEquals(input.style.opacity, "1");
+  } finally {
+    input.remove();
+  }
+});

--- a/packages/dashboard/dashboard-message-client.test.ts
+++ b/packages/dashboard/dashboard-message-client.test.ts
@@ -1,0 +1,37 @@
+import { assertEquals } from "@std/assert";
+import { paintDashboardMessageInput } from "./dashboard-message-client.ts";
+
+const input = (value: string) => ({
+  value,
+  style: { opacity: "" },
+}) as HTMLInputElement;
+
+Deno.test("message painter fades saved text and preserves drafts", () => {
+  const visibleMs = 10;
+  const fadeMs = 20;
+  const saved = {
+    savedText: "Saved",
+    updatedAt: 100 as number | null,
+    draftProtected: false,
+  };
+  const field = input(saved.savedText);
+
+  paintDashboardMessageInput(field, saved, 120, visibleMs, fadeMs);
+  assertEquals(field.style.opacity, "0.5");
+
+  saved.draftProtected = true;
+  field.value = "Draft";
+  paintDashboardMessageInput(field, saved, 130, visibleMs, fadeMs);
+  assertEquals(field.value, "Draft");
+  assertEquals(field.style.opacity, "1");
+
+  saved.draftProtected = false;
+  paintDashboardMessageInput(field, saved, 130, visibleMs, fadeMs);
+  assertEquals(saved.savedText, "");
+  assertEquals(saved.updatedAt, null);
+  assertEquals(field.value, "");
+  assertEquals(field.style.opacity, "1");
+
+  paintDashboardMessageInput(field, saved, 140, visibleMs, fadeMs);
+  assertEquals(field.style.opacity, "1");
+});

--- a/packages/dashboard/dashboard-message-client.ts
+++ b/packages/dashboard/dashboard-message-client.ts
@@ -1,0 +1,39 @@
+import { dashboardMessageOpacity } from "./dashboard-message.ts";
+
+export interface DashboardMessagePaintState {
+  savedText: string;
+  updatedAt: number | null;
+  draftProtected: boolean;
+}
+
+/** Paints the saved message while preserving a draft or pending save. */
+export function paintDashboardMessageInput(
+  input: HTMLInputElement,
+  state: DashboardMessagePaintState,
+  now: number,
+  visibleMs: number,
+  fadeMs: number,
+): void {
+  if (state.draftProtected) {
+    input.style.opacity = "1";
+    return;
+  }
+  if (state.updatedAt === null || state.savedText === "") {
+    input.style.opacity = "1";
+    return;
+  }
+  const opacity = dashboardMessageOpacity(
+    state.updatedAt,
+    now,
+    visibleMs,
+    fadeMs,
+  );
+  if (opacity === 0) {
+    state.savedText = "";
+    state.updatedAt = null;
+    input.value = "";
+    input.style.opacity = "1";
+    return;
+  }
+  input.style.opacity = String(opacity);
+}

--- a/packages/dashboard/dashboard-message.ts
+++ b/packages/dashboard/dashboard-message.ts
@@ -1,0 +1,208 @@
+import { dashboardCacheFile } from "./history-files.ts";
+
+/** The period during which a saved message remains fully visible. */
+export const DASHBOARD_MESSAGE_VISIBLE_MS = 2 * 60 * 60 * 1_000;
+/** The linear fade period after the fully visible period. */
+export const DASHBOARD_MESSAGE_FADE_MS = 4 * 60 * 60 * 1_000;
+/** The total time from saving a message until it expires. */
+export const DASHBOARD_MESSAGE_LIFETIME_MS = DASHBOARD_MESSAGE_VISIBLE_MS +
+  DASHBOARD_MESSAGE_FADE_MS;
+/** The largest message accepted by the shared editor. */
+export const DASHBOARD_MESSAGE_MAX_LENGTH = 500;
+
+/** The dashboard message and the time its current text was saved. */
+export interface DashboardMessage {
+  text: string;
+  updatedAt: number | null;
+  revision: number;
+}
+
+/** The result of checking the stored message at the current time. */
+export interface DashboardMessageRefresh {
+  message: DashboardMessage;
+  expired: boolean;
+}
+
+interface StoredDashboardMessage {
+  version: 1;
+  text: string;
+  updatedAt: number | null;
+  revision?: number;
+}
+
+interface DashboardMessageStoreOptions {
+  file?: string;
+  now?: () => number;
+  readTextFile?: typeof Deno.readTextFile;
+  writeTextFile?: typeof Deno.writeTextFile;
+  rename?: typeof Deno.rename;
+  reportError?: (message: string) => void;
+}
+
+const emptyMessage = (revision = 0): DashboardMessage => ({
+  text: "",
+  updatedAt: null,
+  revision,
+});
+
+function isStoredDashboardMessage(
+  value: unknown,
+): value is StoredDashboardMessage {
+  if (typeof value !== "object" || value === null) return false;
+  const message = value as StoredDashboardMessage;
+  return message.version === 1 &&
+    typeof message.text === "string" &&
+    message.text.length <= DASHBOARD_MESSAGE_MAX_LENGTH &&
+    (message.revision === undefined ||
+      (typeof message.revision === "number" &&
+        Number.isSafeInteger(message.revision) && message.revision >= 0)) &&
+    ((message.text === "" && message.updatedAt === null) ||
+      (message.text !== "" && Number.isFinite(message.updatedAt) &&
+        Number.isInteger(message.updatedAt) && message.updatedAt! >= 0));
+}
+
+/** Returns the message opacity at a given wall-clock time. */
+export function dashboardMessageOpacity(
+  updatedAt: number,
+  now: number,
+  visibleMs = DASHBOARD_MESSAGE_VISIBLE_MS,
+  fadeMs = DASHBOARD_MESSAGE_FADE_MS,
+): number {
+  const fadeAge = Math.max(0, now - updatedAt - visibleMs);
+  return Math.max(0, 1 - fadeAge / fadeMs);
+}
+
+/** Normalizes text accepted by the shared message endpoint. */
+export function normalizeDashboardMessageText(text: string): string {
+  const normalized = text.replace(/\s*[\r\n]+\s*/g, " ").trim();
+  if (normalized.length > DASHBOARD_MESSAGE_MAX_LENGTH) {
+    throw new RangeError(
+      `Dashboard messages are limited to ${DASHBOARD_MESSAGE_MAX_LENGTH} characters.`,
+    );
+  }
+  return normalized;
+}
+
+/** Stores the shared dashboard message and expires it after its fade completes. */
+export class DashboardMessageStore {
+  readonly #file: string;
+  readonly #now: () => number;
+  readonly #readTextFile: typeof Deno.readTextFile;
+  readonly #writeTextFile: typeof Deno.writeTextFile;
+  readonly #rename: typeof Deno.rename;
+  readonly #reportError: (message: string) => void;
+  #message = emptyMessage();
+  #loaded = false;
+  #operation = Promise.resolve();
+
+  constructor(options: DashboardMessageStoreOptions = {}) {
+    this.#file = options.file ??
+      dashboardCacheFile("fabric-wall-message.json");
+    this.#now = options.now ?? (() => Date.now());
+    this.#readTextFile = options.readTextFile ?? Deno.readTextFile;
+    this.#writeTextFile = options.writeTextFile ?? Deno.writeTextFile;
+    this.#rename = options.rename ?? Deno.rename;
+    this.#reportError = options.reportError ??
+      ((message) => console.error(message));
+  }
+
+  async #run<T>(operation: () => Promise<T>): Promise<T> {
+    const previous = this.#operation;
+    let release = () => {};
+    this.#operation = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+
+  async #load(): Promise<void> {
+    if (this.#loaded) return;
+    this.#loaded = true;
+    try {
+      const stored: unknown = JSON.parse(await this.#readTextFile(this.#file));
+      if (isStoredDashboardMessage(stored)) {
+        this.#message = {
+          text: stored.text,
+          updatedAt: stored.updatedAt,
+          revision: stored.revision ?? 0,
+        };
+      }
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        this.#reportError(
+          `dashboard message: could not load the stored message: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+    }
+  }
+
+  async #save(): Promise<void> {
+    const temporary = `${this.#file}.tmp`;
+    const stored: StoredDashboardMessage & { revision: number } = {
+      version: 1,
+      ...this.#message,
+    };
+    try {
+      await this.#writeTextFile(temporary, JSON.stringify(stored));
+      await this.#rename(temporary, this.#file);
+    } catch (error) {
+      throw new Error(
+        `Could not save the dashboard message: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        { cause: error },
+      );
+    }
+  }
+
+  /** Returns the current message and clears one whose fade has completed. */
+  refresh(): Promise<DashboardMessageRefresh> {
+    return this.#run(async () => {
+      await this.#load();
+      const updatedAt = this.#message.updatedAt;
+      const expired = updatedAt !== null &&
+        this.#now() - updatedAt >= DASHBOARD_MESSAGE_LIFETIME_MS;
+      if (expired) {
+        const previous = this.#message;
+        this.#message = emptyMessage(previous.revision + 1);
+        try {
+          await this.#save();
+        } catch (error) {
+          this.#message = previous;
+          throw error;
+        }
+      }
+      return { message: { ...this.#message }, expired };
+    });
+  }
+
+  /** Replaces the current message and starts its visible period. */
+  set(text: string): Promise<DashboardMessage> {
+    return this.#run(async () => {
+      await this.#load();
+      const normalized = normalizeDashboardMessageText(text);
+      const previous = this.#message;
+      this.#message = normalized === ""
+        ? emptyMessage(previous.revision + 1)
+        : {
+          text: normalized,
+          updatedAt: this.#now(),
+          revision: previous.revision + 1,
+        };
+      try {
+        await this.#save();
+      } catch (error) {
+        this.#message = previous;
+        throw error;
+      }
+      return { ...this.#message };
+    });
+  }
+}

--- a/packages/dashboard/dashboard-message.ts
+++ b/packages/dashboard/dashboard-message.ts
@@ -36,7 +36,6 @@ interface DashboardMessageStoreOptions {
   readTextFile?: typeof Deno.readTextFile;
   writeTextFile?: typeof Deno.writeTextFile;
   rename?: typeof Deno.rename;
-  reportError?: (message: string) => void;
 }
 
 const emptyMessage = (revision = 0): DashboardMessage => ({
@@ -90,7 +89,6 @@ export class DashboardMessageStore {
   readonly #readTextFile: typeof Deno.readTextFile;
   readonly #writeTextFile: typeof Deno.writeTextFile;
   readonly #rename: typeof Deno.rename;
-  readonly #reportError: (message: string) => void;
   #message = emptyMessage();
   #loaded = false;
   #operation = Promise.resolve();
@@ -102,8 +100,6 @@ export class DashboardMessageStore {
     this.#readTextFile = options.readTextFile ?? Deno.readTextFile;
     this.#writeTextFile = options.writeTextFile ?? Deno.writeTextFile;
     this.#rename = options.rename ?? Deno.rename;
-    this.#reportError = options.reportError ??
-      ((message) => console.error(message));
   }
 
   async #run<T>(operation: () => Promise<T>): Promise<T> {
@@ -122,25 +118,30 @@ export class DashboardMessageStore {
 
   async #load(): Promise<void> {
     if (this.#loaded) return;
-    this.#loaded = true;
+    let stored: unknown;
     try {
-      const stored: unknown = JSON.parse(await this.#readTextFile(this.#file));
-      if (isStoredDashboardMessage(stored)) {
-        this.#message = {
-          text: stored.text,
-          updatedAt: stored.updatedAt,
-          revision: stored.revision ?? 0,
-        };
-      }
+      stored = JSON.parse(await this.#readTextFile(this.#file));
     } catch (error) {
-      if (!(error instanceof Deno.errors.NotFound)) {
-        this.#reportError(
-          `dashboard message: could not load the stored message: ${
-            error instanceof Error ? error.message : String(error)
-          }`,
-        );
+      if (error instanceof Deno.errors.NotFound) {
+        this.#loaded = true;
+        return;
       }
+      throw new Error(
+        `Could not load the dashboard message: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        { cause: error },
+      );
     }
+    if (!isStoredDashboardMessage(stored)) {
+      throw new Error("Could not load the dashboard message: invalid stored data.");
+    }
+    this.#message = {
+      text: stored.text,
+      updatedAt: stored.updatedAt,
+      revision: stored.revision ?? 0,
+    };
+    this.#loaded = true;
   }
 
   async #save(): Promise<void> {

--- a/packages/dashboard/deno.jsonc
+++ b/packages/dashboard/deno.jsonc
@@ -14,7 +14,7 @@
     // A task line runs the Deno running the task, so asking that Deno for its
     // own path allows exactly the one binary the tests start.
     "test-favicon-raster": "deno test --allow-read --allow-write --allow-run=$(deno eval \"console.log(Deno.execPath())\") --allow-ffi --allow-sys=cpus,networkInterfaces,hostname favicon-raster.test.ts regenerate-favicons.test.ts",
-    "test-browser": "deno run --allow-env --allow-read --allow-write --allow-run --allow-net ../deno-web-test/cli.ts favicon-client.browser.test.ts theme.browser.test.ts",
+    "test-browser": "deno run --allow-env --allow-read --allow-write --allow-run --allow-net ../deno-web-test/cli.ts dashboard-message-client.browser.test.ts favicon-client.browser.test.ts theme.browser.test.ts",
     "regenerate-favicons": "deno run --allow-read --allow-write=favicon-png.generated.ts --allow-ffi --allow-sys=cpus,networkInterfaces,hostname regenerate-favicons.ts"
   }
 }

--- a/packages/dashboard/render.test.ts
+++ b/packages/dashboard/render.test.ts
@@ -199,6 +199,75 @@ Deno.test("shell: the grid and the wide tiles land in their own slots", () => {
   assertStringIncludes(html, "</body></html>");
 });
 
+Deno.test("shell: the shared message is directly editable in the header center", () => {
+  const html = shell(
+    "",
+    "",
+    0,
+    45_000,
+    TEST_VERSION,
+    "good",
+    null,
+    null,
+    {
+      text: `Ship <today> & "celebrate"`,
+      updatedAt: 12_345,
+      revision: 7,
+    },
+  );
+  assertStringIncludes(html, `id="dashboard-message-form"`);
+  assertStringIncludes(html, `id="dashboard-message"`);
+  assert(!html.includes(`placeholder=`), "the empty editor has no hint text");
+  assertStringIncludes(
+    html,
+    `value="Ship &lt;today&gt; &amp; &quot;celebrate&quot;"`,
+  );
+  assertStringIncludes(html, `let messageUpdatedAt = 12345;`);
+  assertStringIncludes(html, `let messageRevision = 7;`);
+  assertStringIncludes(html, `if (next.revision < messageRevision) return;`);
+  assertStringIncludes(html, `const saveSequence = ++messageSaveSequence;`);
+  assertStringIncludes(
+    html,
+    `if (!messageDirty && !messageSavePending) messageInput.value = next.text;`,
+  );
+  assertStringIncludes(html, `messageSavePending = true;`);
+  assertStringIncludes(html, `messageSavePending = false;`);
+  assertStringIncludes(
+    html,
+    `if (!messageDirty) messageInput.value = savedMessageText;`,
+  );
+  assertStringIncludes(
+    html,
+    `if (saveSequence !== messageSaveSequence) return;`,
+  );
+  assertStringIncludes(html, `fetch('/message'`);
+  assertStringIncludes(html, `method: 'PUT'`);
+  assertStringIncludes(html, `aria-describedby="dashboard-message-status"`);
+  assertStringIncludes(html, `role="status" aria-live="polite"`);
+  assertStringIncludes(html, `Message could not be saved.`);
+  const brandAt = html.indexOf(`class="brand"`);
+  const messageAt = html.indexOf(`id="dashboard-message-form"`);
+  const freshnessAt = html.indexOf(`class="top-actions"`);
+  assert(
+    brandAt < messageAt && messageAt < freshnessAt,
+    "the shared message sits between the left and right header content",
+  );
+  assertStringIncludes(
+    html,
+    `.top{display:grid;grid-template-columns:max-content minmax(0,1fr) max-content`,
+  );
+  assertStringIncludes(html, `.message-form{position:relative;width:min(100%,480px)`);
+  assertStringIncludes(html, `text-align:center`);
+  assertStringIncludes(
+    html,
+    `@media(max-width:560px){.top{grid-template-columns:minmax(0,1fr) max-content`,
+  );
+  assertStringIncludes(
+    html,
+    `.message-form{grid-column:1/-1;grid-row:2;width:100%}`,
+  );
+});
+
 Deno.test("shell: the freshness age and the refresh interval reach both the text and the script", () => {
   const html = shell("", "", 7, 45_000, TEST_VERSION, "good");
   assertStringIncludes(html, `<span id="agotext">updated 7s ago</span>`);

--- a/packages/dashboard/render.test.ts
+++ b/packages/dashboard/render.test.ts
@@ -232,6 +232,15 @@ Deno.test("shell: the shared message is directly editable in the header center",
   );
   assertStringIncludes(html, `messageSavePending = true;`);
   assertStringIncludes(html, `messageSavePending = false;`);
+  assertStringIncludes(html, `if (messageDirty || messageSavePending) {`);
+  assert(
+    !html.includes(`document.activeElement === messageInput`),
+    "focus alone does not suspend message fading",
+  );
+  assert(
+    !html.includes(`outline:none;opacity:1!important`),
+    "focus does not override the faded opacity",
+  );
   assertStringIncludes(
     html,
     `if (!messageDirty) messageInput.value = savedMessageText;`,

--- a/packages/dashboard/render.test.ts
+++ b/packages/dashboard/render.test.ts
@@ -232,15 +232,19 @@ Deno.test("shell: the shared message is directly editable in the header center",
   );
   assertStringIncludes(html, `messageSavePending = true;`);
   assertStringIncludes(html, `messageSavePending = false;`);
-  assertStringIncludes(html, `if (messageDirty || messageSavePending) {`);
+  assertStringIncludes(
+    html,
+    `draftProtected: messageDirty || messageSavePending,`,
+  );
   assert(
     !html.includes(`document.activeElement === messageInput`),
     "focus alone does not suspend message fading",
   );
-  assert(
-    !html.includes(`outline:none;opacity:1!important`),
-    "focus does not override the faded opacity",
+  assertStringIncludes(
+    html,
+    `.message-form:focus-within{background:var(--surface);box-shadow:`,
   );
+  assertStringIncludes(html, `.message-input:focus{outline:none}`);
   assertStringIncludes(
     html,
     `if (!messageDirty) messageInput.value = savedMessageText;`,

--- a/packages/dashboard/render.ts
+++ b/packages/dashboard/render.ts
@@ -12,6 +12,13 @@ import { faviconHref, faviconLink, type FaviconStatus } from "./favicon.ts";
 import { paintStatusFavicon } from "./favicon-client.ts";
 import { liveUpdateStream } from "./stream-client.ts";
 import {
+  DASHBOARD_MESSAGE_FADE_MS,
+  DASHBOARD_MESSAGE_MAX_LENGTH,
+  DASHBOARD_MESSAGE_VISIBLE_MS,
+  dashboardMessageOpacity,
+  type DashboardMessage,
+} from "./dashboard-message.ts";
+import {
   DASHBOARD_THEME_CLIENT,
   DASHBOARD_THEME_HEAD,
   DASHBOARD_THEME_STYLES,
@@ -27,6 +34,7 @@ const FAVICON_PNG_HREFS = JSON.stringify({
 });
 const PAINT_STATUS_FAVICON = paintStatusFavicon.toString();
 const LIVE_UPDATE_STREAM = liveUpdateStream.toString();
+const DASHBOARD_MESSAGE_OPACITY = dashboardMessageOpacity.toString();
 
 // How long past the refresh interval the freshness indicator stays orange before
 // it turns red. The page treats the same span of silence from the server as a
@@ -217,6 +225,7 @@ function renderShell(
   status: FaviconStatus,
   serverRedSince: number | null = null,
   serverRedAgeMs: number | null = null,
+  message: DashboardMessage = { text: "", updatedAt: null, revision: 0 },
 ): string {
   return `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>Fabric wall — LIVE</title>
 ${DASHBOARD_THEME_HEAD}
@@ -224,12 +233,19 @@ ${faviconLink(status)}
 <style>
 ${DASHBOARD_THEME_STYLES}
   body{margin:0;background:var(--page);color:var(--text);font-family:-apple-system,Segoe UI,Roboto,sans-serif;padding:18px 20px 26px;max-width:1100px;margin:0 auto}
-  .top{display:flex;justify-content:space-between;align-items:center;margin-bottom:14px}
+  .top{display:grid;grid-template-columns:max-content minmax(0,1fr) max-content;align-items:center;gap:18px;margin-bottom:14px}
   .brand b{font-size:16px;font-weight:600}.brand span{font-size:12px;color:var(--text-faint);margin-left:8px}
   .badge{font-size:11px;color:var(--status-good-text);border:1px solid ${
     statusLayer("good", 0.4)
   };border-radius:6px;padding:2px 8px;margin-left:8px}
   .top-actions{display:flex;align-items:center;gap:12px}.live{font-size:12px;color:var(--text-muted)}
+  .message-form{position:relative;width:min(100%,480px);min-width:0;margin:0;justify-self:center}
+  .message-input{box-sizing:border-box;width:100%;border:1px solid transparent;border-radius:8px;background:transparent;color:var(--text);font:500 16px/1.4 -apple-system,Segoe UI,Roboto,sans-serif;padding:4px 9px;text-align:center;transition:border-color .12s,background-color .12s}
+  .message-input::placeholder{color:var(--text-faint);font-weight:400}
+  .message-input:hover{border-color:var(--border)}
+  .message-input:focus{background:var(--surface);border-color:var(--border-hover);outline:none;opacity:1!important}
+  .message-input[aria-invalid="true"]{border-color:var(--status-bad)}
+  .message-status{position:absolute;top:100%;left:9px;right:9px;color:var(--status-bad-text);font-size:11px;text-align:center}
   .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:12px;margin-bottom:12px}
   .tile{background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:14px 16px;position:relative;isolation:isolate;overflow:hidden}
   .tile.wide{margin-bottom:12px}
@@ -293,10 +309,13 @@ ${TILE_RULES}
   .swatch{display:inline-block;width:8px;height:8px;border-radius:2px;vertical-align:middle}
   .note{font-size:11px;color:var(--text-faint);margin-top:14px}
   code{background:var(--surface-code);padding:1px 5px;border-radius:4px}
-  @media(max-width:560px){.top{align-items:flex-start;gap:10px}.brand span:last-child{display:none}.top-actions{gap:8px}}
+  @media(max-width:560px){.top{grid-template-columns:minmax(0,1fr) max-content;gap:8px 12px}.brand span:last-child{display:none}.top-actions{gap:8px}.message-form{grid-column:1/-1;grid-row:2;width:100%}.message-input{font-size:14px;padding-inline:5px}}
 </style></head><body>
   <div class="top">
     <div class="brand"><b>Fabric wall</b><span class="badge" id="livebadge">● LIVE</span><span>go/fabricwall</span></div>
+    <form class="message-form" id="dashboard-message-form"><input class="message-input" id="dashboard-message" aria-label="Shared dashboard message" aria-describedby="dashboard-message-status" maxlength="${DASHBOARD_MESSAGE_MAX_LENGTH}" value="${
+      escapeHtml(message.text)
+    }"><span class="message-status" id="dashboard-message-status" role="status" aria-live="polite"></span></form>
     <div class="top-actions"><div class="live"><span class="dot green" id="freshdot"></span> <span id="agotext">updated ${ago}s ago</span></div></div>
   </div>
   <div class="grid" id="dashboard-grid">${gridHtml}</div>
@@ -324,10 +343,14 @@ ${DASHBOARD_THEME_CLIENT}
   const FAVICONS = ${FAVICON_PNG_HREFS};
   const FAVICON_CRY_AFTER_MS = ${FAVICON_CRY_AFTER_MS};
   const paintStatusFavicon = ${PAINT_STATUS_FAVICON};
+  const dashboardMessageOpacity = ${DASHBOARD_MESSAGE_OPACITY};
   const liveUpdateStream = ${LIVE_UPDATE_STREAM};
   const badge = document.getElementById('livebadge');
   const dot = document.getElementById('freshdot');
   const agotext = document.getElementById('agotext');
+  const messageForm = document.getElementById('dashboard-message-form');
+  const messageInput = document.getElementById('dashboard-message');
+  const messageStatus = document.getElementById('dashboard-message-status');
   ${formatViewerTimes.toString()}
   formatViewerTimes();
   const grid = document.getElementById('dashboard-grid');
@@ -337,6 +360,86 @@ ${DASHBOARD_THEME_CLIENT}
   let faviconServerRedSince = ${serverRedSince};
   let faviconServerRedAgeMs = ${serverRedAgeMs};
   let faviconStartedAt = performance.now();
+  let savedMessageText = messageInput.value;
+  let messageUpdatedAt = ${message.updatedAt};
+  let messageRevision = ${message.revision};
+  let messageDirty = false;
+  let messageSaveSequence = 0;
+  let messageSavePending = false;
+  function paintDashboardMessage(now) {
+    if (document.activeElement === messageInput || messageDirty || messageSavePending) {
+      messageInput.style.opacity = '1';
+      return;
+    }
+    if (messageUpdatedAt === null || savedMessageText === '') {
+      messageInput.style.opacity = '1';
+      return;
+    }
+    const opacity = dashboardMessageOpacity(
+      messageUpdatedAt,
+      now,
+      ${DASHBOARD_MESSAGE_VISIBLE_MS},
+      ${DASHBOARD_MESSAGE_FADE_MS},
+    );
+    if (opacity === 0) {
+      savedMessageText = '';
+      messageUpdatedAt = null;
+      messageInput.value = '';
+      messageInput.style.opacity = '1';
+      return;
+    }
+    messageInput.style.opacity = String(opacity);
+  }
+  function applyDashboardMessage(next) {
+    if (next.revision < messageRevision) return;
+    savedMessageText = next.text;
+    messageUpdatedAt = next.updatedAt;
+    messageRevision = next.revision;
+    if (!messageDirty && !messageSavePending) messageInput.value = next.text;
+    paintDashboardMessage(Date.now());
+  }
+  async function saveDashboardMessage() {
+    const saveSequence = ++messageSaveSequence;
+    const text = messageInput.value;
+    messageDirty = false;
+    messageSavePending = true;
+    messageStatus.textContent = 'Saving…';
+    messageInput.style.opacity = '1';
+    try {
+      const response = await fetch('/message', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ text }),
+      });
+      if (!response.ok) throw new Error('Message save failed');
+      const saved = await response.json();
+      applyDashboardMessage(saved);
+      if (saveSequence !== messageSaveSequence) return;
+      messageSavePending = false;
+      if (!messageDirty) messageInput.value = savedMessageText;
+      messageInput.removeAttribute('aria-invalid');
+      messageStatus.textContent = '';
+    } catch {
+      if (saveSequence !== messageSaveSequence) return;
+      messageSavePending = false;
+      messageDirty = true;
+      messageInput.setAttribute('aria-invalid', 'true');
+      messageStatus.textContent = 'Message could not be saved.';
+    }
+  }
+  messageForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    messageInput.blur();
+  });
+  messageInput.addEventListener('input', () => {
+    messageDirty = true;
+    messageInput.style.opacity = '1';
+    messageInput.removeAttribute('aria-invalid');
+    messageStatus.textContent = '';
+  });
+  messageInput.addEventListener('blur', () => {
+    if (messageDirty) void saveDashboardMessage();
+  });
   function paint() {
     const now = Date.now();
     const ago = base + Math.floor((now - t0) / 1000);
@@ -361,6 +464,7 @@ ${DASHBOARD_THEME_CLIENT}
       faviconServerRedAgeMs,
       faviconStartedAt,
     );
+    paintDashboardMessage(now);
   }
   function reconcileTiles(container, html) {
     const template = document.createElement('template');
@@ -418,6 +522,7 @@ ${DASHBOARD_THEME_CLIENT}
       faviconServerRedSince = update.faviconRedSince;
       faviconServerRedAgeMs = update.faviconRedAgeMs;
       faviconStartedAt = performance.now();
+      applyDashboardMessage(update.message);
       paint();
     });
     return es;
@@ -441,6 +546,7 @@ export function shell(
   status: FaviconStatus,
   serverRedSince: number | null = null,
   serverRedAgeMs: number | null = null,
+  message: DashboardMessage = { text: "", updatedAt: null, revision: 0 },
 ): string {
   return renderShell(
     gridHtml,
@@ -451,5 +557,6 @@ export function shell(
     status,
     serverRedSince,
     serverRedAgeMs,
+    message,
   );
 }

--- a/packages/dashboard/render.ts
+++ b/packages/dashboard/render.ts
@@ -11,6 +11,7 @@ import {
 import { faviconHref, faviconLink, type FaviconStatus } from "./favicon.ts";
 import { paintStatusFavicon } from "./favicon-client.ts";
 import { liveUpdateStream } from "./stream-client.ts";
+import { paintDashboardMessageInput } from "./dashboard-message-client.ts";
 import {
   DASHBOARD_MESSAGE_FADE_MS,
   DASHBOARD_MESSAGE_MAX_LENGTH,
@@ -35,6 +36,7 @@ const FAVICON_PNG_HREFS = JSON.stringify({
 const PAINT_STATUS_FAVICON = paintStatusFavicon.toString();
 const LIVE_UPDATE_STREAM = liveUpdateStream.toString();
 const DASHBOARD_MESSAGE_OPACITY = dashboardMessageOpacity.toString();
+const PAINT_DASHBOARD_MESSAGE_INPUT = paintDashboardMessageInput.toString();
 
 // How long past the refresh interval the freshness indicator stays orange before
 // it turns red. The page treats the same span of silence from the server as a
@@ -239,11 +241,12 @@ ${DASHBOARD_THEME_STYLES}
     statusLayer("good", 0.4)
   };border-radius:6px;padding:2px 8px;margin-left:8px}
   .top-actions{display:flex;align-items:center;gap:12px}.live{font-size:12px;color:var(--text-muted)}
-  .message-form{position:relative;width:min(100%,480px);min-width:0;margin:0;justify-self:center}
+  .message-form{position:relative;width:min(100%,480px);min-width:0;margin:0;justify-self:center;border-radius:8px}
+  .message-form:focus-within{background:var(--surface);box-shadow:0 0 0 1px var(--border-hover)}
   .message-input{box-sizing:border-box;width:100%;border:1px solid transparent;border-radius:8px;background:transparent;color:var(--text);font:500 16px/1.4 -apple-system,Segoe UI,Roboto,sans-serif;padding:4px 9px;text-align:center;transition:border-color .12s,background-color .12s}
   .message-input::placeholder{color:var(--text-faint);font-weight:400}
   .message-input:hover{border-color:var(--border)}
-  .message-input:focus{background:var(--surface);border-color:var(--border-hover);outline:none}
+  .message-input:focus{outline:none}
   .message-input[aria-invalid="true"]{border-color:var(--status-bad)}
   .message-status{position:absolute;top:100%;left:9px;right:9px;color:var(--status-bad-text);font-size:11px;text-align:center}
   .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:12px;margin-bottom:12px}
@@ -344,6 +347,7 @@ ${DASHBOARD_THEME_CLIENT}
   const FAVICON_CRY_AFTER_MS = ${FAVICON_CRY_AFTER_MS};
   const paintStatusFavicon = ${PAINT_STATUS_FAVICON};
   const dashboardMessageOpacity = ${DASHBOARD_MESSAGE_OPACITY};
+  const paintDashboardMessageInput = ${PAINT_DASHBOARD_MESSAGE_INPUT};
   const liveUpdateStream = ${LIVE_UPDATE_STREAM};
   const badge = document.getElementById('livebadge');
   const dot = document.getElementById('freshdot');
@@ -367,28 +371,20 @@ ${DASHBOARD_THEME_CLIENT}
   let messageSaveSequence = 0;
   let messageSavePending = false;
   function paintDashboardMessage(now) {
-    if (messageDirty || messageSavePending) {
-      messageInput.style.opacity = '1';
-      return;
-    }
-    if (messageUpdatedAt === null || savedMessageText === '') {
-      messageInput.style.opacity = '1';
-      return;
-    }
-    const opacity = dashboardMessageOpacity(
-      messageUpdatedAt,
+    const state = {
+      savedText: savedMessageText,
+      updatedAt: messageUpdatedAt,
+      draftProtected: messageDirty || messageSavePending,
+    };
+    paintDashboardMessageInput(
+      messageInput,
+      state,
       now,
       ${DASHBOARD_MESSAGE_VISIBLE_MS},
       ${DASHBOARD_MESSAGE_FADE_MS},
     );
-    if (opacity === 0) {
-      savedMessageText = '';
-      messageUpdatedAt = null;
-      messageInput.value = '';
-      messageInput.style.opacity = '1';
-      return;
-    }
-    messageInput.style.opacity = String(opacity);
+    savedMessageText = state.savedText;
+    messageUpdatedAt = state.updatedAt;
   }
   function applyDashboardMessage(next) {
     if (next.revision < messageRevision) return;

--- a/packages/dashboard/render.ts
+++ b/packages/dashboard/render.ts
@@ -243,7 +243,7 @@ ${DASHBOARD_THEME_STYLES}
   .message-input{box-sizing:border-box;width:100%;border:1px solid transparent;border-radius:8px;background:transparent;color:var(--text);font:500 16px/1.4 -apple-system,Segoe UI,Roboto,sans-serif;padding:4px 9px;text-align:center;transition:border-color .12s,background-color .12s}
   .message-input::placeholder{color:var(--text-faint);font-weight:400}
   .message-input:hover{border-color:var(--border)}
-  .message-input:focus{background:var(--surface);border-color:var(--border-hover);outline:none;opacity:1!important}
+  .message-input:focus{background:var(--surface);border-color:var(--border-hover);outline:none}
   .message-input[aria-invalid="true"]{border-color:var(--status-bad)}
   .message-status{position:absolute;top:100%;left:9px;right:9px;color:var(--status-bad-text);font-size:11px;text-align:center}
   .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:12px;margin-bottom:12px}
@@ -367,7 +367,7 @@ ${DASHBOARD_THEME_CLIENT}
   let messageSaveSequence = 0;
   let messageSavePending = false;
   function paintDashboardMessage(now) {
-    if (document.activeElement === messageInput || messageDirty || messageSavePending) {
+    if (messageDirty || messageSavePending) {
       messageInput.style.opacity = '1';
       return;
     }

--- a/packages/dashboard/server.test.ts
+++ b/packages/dashboard/server.test.ts
@@ -33,6 +33,7 @@ import { TILES } from "./registry.ts";
 import { labsCi } from "./tiles/main-build.ts";
 import type { Ctx, Run, RunSource, Tile, TileView } from "./types.ts";
 import { DASHBOARD_MESSAGE_LIFETIME_MS } from "./dashboard-message.ts";
+import { dashboardCacheFile } from "./history-files.ts";
 
 const req = (path: string) => new Request(`http://localhost${path}`);
 
@@ -1224,6 +1225,16 @@ Deno.test("message: an edit is saved and sent to every connected dashboard", asy
 });
 
 Deno.test("message: malformed edits are rejected without changing the message", async () => {
+  const malformedJson = await handle(new Request("http://localhost/message", {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: "{",
+  }));
+  assertEquals(malformedJson.status, 400);
+  assertEquals(await malformedJson.json(), {
+    error: "Expected a JSON request body.",
+  });
+
   const missingText = await handle(new Request("http://localhost/message", {
     method: "PUT",
     headers: { "content-type": "application/json" },
@@ -1240,9 +1251,68 @@ Deno.test("message: malformed edits are rejected without changing the message", 
     assertEquals(response.status, 400);
   }
 
+  const tooLong = await handle(new Request("http://localhost/message", {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ text: "x".repeat(501) }),
+  }));
+  assertEquals(tooLong.status, 400);
+  assertEquals(await tooLong.json(), {
+    error: "Messages are limited to 500 characters.",
+  });
+
   const wrongMethod = await handle(req("/message"));
   assertEquals(wrongMethod.status, 405);
   assertEquals(wrongMethod.headers.get("allow"), "PUT");
+});
+
+Deno.test("message: a persistence failure returns an error", async () => {
+  const temporary = `${dashboardCacheFile("fabric-wall-message.json")}.tmp`;
+  await Deno.mkdir(temporary);
+  try {
+    const response = await handle(new Request("http://localhost/message", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ text: "Cannot persist" }),
+    }));
+    assertEquals(response.status, 500);
+    assertEquals(await response.json(), {
+      error: "Could not save the dashboard message.",
+    });
+  } finally {
+    await Deno.remove(temporary);
+  }
+});
+
+Deno.test("message: a failed expiry write retains the saved text", async () => {
+  const realNow = Date.now;
+  let now = realNow();
+  Date.now = () => now;
+  const temporary = `${dashboardCacheFile("fabric-wall-message.json")}.tmp`;
+  try {
+    const saved = await handle(new Request("http://localhost/message", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ text: "Still visible" }),
+    }));
+    assertEquals(saved.status, 200);
+    await Deno.mkdir(temporary);
+    now += DASHBOARD_MESSAGE_LIFETIME_MS;
+
+    await serveTick(() => {});
+    assertStringIncludes(
+      await (await handle(req("/"))).text(),
+      `value="Still visible"`,
+    );
+  } finally {
+    Date.now = realNow;
+    await Deno.remove(temporary);
+    await handle(new Request("http://localhost/message", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ text: "" }),
+    }));
+  }
 });
 
 Deno.test("message: the serving clock clears text after its fade completes", async () => {

--- a/packages/dashboard/server.test.ts
+++ b/packages/dashboard/server.test.ts
@@ -32,6 +32,7 @@ import {
 import { TILES } from "./registry.ts";
 import { labsCi } from "./tiles/main-build.ts";
 import type { Ctx, Run, RunSource, Tile, TileView } from "./types.ts";
+import { DASHBOARD_MESSAGE_LIFETIME_MS } from "./dashboard-message.ts";
 
 const req = (path: string) => new Request(`http://localhost${path}`);
 
@@ -101,6 +102,7 @@ interface TestUpdate {
   faviconStatus: "good" | "warn" | "bad";
   faviconRedSince: number | null;
   faviconRedAgeMs: number | null;
+  message: { text: string; updatedAt: number | null; revision: number };
 }
 
 function updateFromEvent(event: string): TestUpdate {
@@ -1190,6 +1192,89 @@ Deno.test("sse: /events opens a stream, tick pushes new tile markup, disconnect 
   assertEquals(clients.size, 0, "a disconnected browser is not kept as a client");
 });
 
+Deno.test("message: an edit is saved and sent to every connected dashboard", async () => {
+  const events = await handle(req("/events"));
+  const reader = events.body!.getReader();
+  await chunk(reader);
+  await chunk(reader);
+  try {
+    const response = await handle(new Request("http://localhost/message", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ text: "  Deploying <main>  " }),
+    }));
+    assertEquals(response.status, 200);
+    const saved = await response.json();
+    assertEquals(saved.text, "Deploying <main>");
+    assertEquals(typeof saved.updatedAt, "number");
+    assertEquals(typeof saved.revision, "number");
+
+    const update = updateFromEvent(await chunk(reader));
+    assertEquals(update.message, saved);
+    const html = await (await handle(req("/"))).text();
+    assertStringIncludes(html, `value="Deploying &lt;main&gt;"`);
+  } finally {
+    await handle(new Request("http://localhost/message", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ text: "" }),
+    }));
+    await reader.cancel();
+  }
+});
+
+Deno.test("message: malformed edits are rejected without changing the message", async () => {
+  const missingText = await handle(new Request("http://localhost/message", {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ message: "wrong field" }),
+  }));
+  assertEquals(missingText.status, 400);
+
+  for (const body of ["null", "42", "[]"]) {
+    const response = await handle(new Request("http://localhost/message", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body,
+    }));
+    assertEquals(response.status, 400);
+  }
+
+  const wrongMethod = await handle(req("/message"));
+  assertEquals(wrongMethod.status, 405);
+  assertEquals(wrongMethod.headers.get("allow"), "PUT");
+});
+
+Deno.test("message: the serving clock clears text after its fade completes", async () => {
+  const realNow = Date.now;
+  let now = realNow();
+  Date.now = () => now;
+  const events = await handle(req("/events"));
+  const reader = events.body!.getReader();
+  await chunk(reader);
+  await chunk(reader);
+  try {
+    const saved = await (await handle(new Request("http://localhost/message", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ text: "Fading announcement" }),
+    }))).json();
+    assertEquals(updateFromEvent(await chunk(reader)).message.text, "Fading announcement");
+
+    now += DASHBOARD_MESSAGE_LIFETIME_MS;
+    await serveTick(() => {});
+    assertStringIncludes(await chunk(reader), "event: ping\n");
+    assertEquals(updateFromEvent(await chunk(reader)).message, {
+      text: "",
+      updatedAt: null,
+      revision: saved.revision + 1,
+    });
+  } finally {
+    Date.now = realNow;
+    await reader.cancel();
+  }
+});
+
 Deno.test("sse: every serving tick sends a heartbeat, so silence means a broken stream", async () => {
   const res = await handle(req("/events"));
   const reader = res.body!.getReader();
@@ -1241,6 +1326,7 @@ Deno.test("broadcast: a client whose stream is gone is dropped rather than throw
     faviconStatus: "good",
     faviconRedSince: null,
     faviconRedAgeMs: null,
+    message: { text: "", updatedAt: null, revision: 0 },
   });
   assertEquals(clients.size, 0);
 });

--- a/packages/dashboard/server.ts
+++ b/packages/dashboard/server.ts
@@ -124,8 +124,12 @@ function dashboardUpdate(currentViews: ReadonlyMap<string, TileView> = views): D
 async function refreshDashboardMessage(): Promise<boolean> {
   try {
     const refreshed = await dashboardMessageStore.refresh();
+    const previous = dashboardMessage;
     dashboardMessage = refreshed.message;
-    return refreshed.expired;
+    return refreshed.expired ||
+      previous.text !== dashboardMessage.text ||
+      previous.updatedAt !== dashboardMessage.updatedAt ||
+      previous.revision !== dashboardMessage.revision;
   } catch (error) {
     console.error(error instanceof Error ? error.message : String(error));
     return false;

--- a/packages/dashboard/server.ts
+++ b/packages/dashboard/server.ts
@@ -29,6 +29,11 @@ import type { FaviconStatus } from "./favicon.ts";
 import { renderTile, shell } from "./render.ts";
 import type { Ctx, Run, RunSource, Tile, TileView } from "./types.ts";
 import { dashboardVersion } from "./version.ts";
+import {
+  DASHBOARD_MESSAGE_MAX_LENGTH,
+  type DashboardMessage,
+  DashboardMessageStore,
+} from "./dashboard-message.ts";
 
 const ctx = makeCtx();
 const views = new Map<string, TileView>();
@@ -45,6 +50,12 @@ const activeTileUpdates = new Map<string, ActiveTileUpdate>();
 const activeRunSourceUpdates = new Set<string>();
 let lastChange = 0;
 let faviconRedSince: number | null = null;
+const dashboardMessageStore = new DashboardMessageStore();
+let dashboardMessage: DashboardMessage = {
+  text: "",
+  updatedAt: null,
+  revision: 0,
+};
 
 export function nextFaviconRedSince(
   current: number | null,
@@ -74,6 +85,7 @@ interface DashboardUpdate {
   faviconStatus: FaviconStatus;
   faviconRedSince: number | null;
   faviconRedAgeMs: number | null;
+  message: DashboardMessage;
 }
 
 function dashboardUpdate(currentViews: ReadonlyMap<string, TileView> = views): DashboardUpdate {
@@ -105,7 +117,19 @@ function dashboardUpdate(currentViews: ReadonlyMap<string, TileView> = views): D
     faviconRedAgeMs: faviconRedSince === null
       ? null
       : Math.max(0, now - faviconRedSince),
+    message: { ...dashboardMessage },
   };
+}
+
+async function refreshDashboardMessage(): Promise<boolean> {
+  try {
+    const refreshed = await dashboardMessageStore.refresh();
+    dashboardMessage = refreshed.message;
+    return refreshed.expired;
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return false;
+  }
 }
 
 export const clients = new Set<ReadableStreamDefaultController<Uint8Array>>();
@@ -420,6 +444,7 @@ export function page(currentViews: ReadonlyMap<string, TileView> = views): strin
     update.faviconStatus,
     update.faviconRedSince,
     update.faviconRedAgeMs,
+    update.message,
   );
 }
 
@@ -433,7 +458,49 @@ export async function handle(req: Request): Promise<Response> {
       },
     });
   }
+  if (url.pathname === "/message") {
+    if (req.method !== "PUT") {
+      return new Response("Method not allowed", {
+        status: 405,
+        headers: { allow: "PUT" },
+      });
+    }
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      return Response.json({ error: "Expected a JSON request body." }, {
+        status: 400,
+      });
+    }
+    if (
+      typeof body !== "object" || body === null || Array.isArray(body) ||
+      typeof (body as { text?: unknown }).text !== "string"
+    ) {
+      return Response.json({ error: "Message text must be a string." }, {
+        status: 400,
+      });
+    }
+    const text = (body as { text: string }).text;
+    if (text.length > DASHBOARD_MESSAGE_MAX_LENGTH) {
+      return Response.json({
+        error:
+          `Messages are limited to ${DASHBOARD_MESSAGE_MAX_LENGTH} characters.`,
+      }, { status: 400 });
+    }
+    try {
+      dashboardMessage = await dashboardMessageStore.set(text);
+    } catch (error) {
+      console.error(error instanceof Error ? error.message : String(error));
+      return Response.json({ error: "Could not save the dashboard message." }, {
+        status: 500,
+      });
+    }
+    broadcast(dashboardUpdate());
+    return Response.json(dashboardMessage);
+  }
   if (url.pathname === "/events") {
+    await refreshDashboardMessage();
     let controller: ReadableStreamDefaultController<Uint8Array> | undefined;
     const stream = new ReadableStream<Uint8Array>({
       start(c) {
@@ -452,6 +519,7 @@ export async function handle(req: Request): Promise<Response> {
   for (const r of routes) {
     if (url.pathname === r.path) return await r.handler(req, url);
   }
+  await refreshDashboardMessage();
   return new Response(page(), { headers: { "content-type": "text/html; charset=utf-8" } });
 }
 
@@ -461,6 +529,7 @@ export async function serveTick(
   collect: () => void | Promise<void> = tick,
 ): Promise<void> {
   heartbeat();
+  if (await refreshDashboardMessage()) broadcast(dashboardUpdate());
   await collect();
 }
 

--- a/packages/dashboard/test/dashboard-message.test.ts
+++ b/packages/dashboard/test/dashboard-message.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  DASHBOARD_MESSAGE_LIFETIME_MS,
+  DASHBOARD_MESSAGE_VISIBLE_MS,
+  dashboardMessageOpacity,
+  DashboardMessageStore,
+  normalizeDashboardMessageText,
+} from "../dashboard-message.ts";
+
+describe("dashboard-message", () => {
+  const directories: string[] = [];
+
+  afterEach(async () => {
+    for (const directory of directories.splice(0)) {
+      await Deno.remove(directory, { recursive: true });
+    }
+  });
+
+  describe("dashboardMessageOpacity()", () => {
+    it("returns full opacity through the first two hours", () => {
+      expect(dashboardMessageOpacity(1_000, 1_000)).toBe(1);
+      expect(
+        dashboardMessageOpacity(
+          1_000,
+          1_000 + DASHBOARD_MESSAGE_VISIBLE_MS,
+        ),
+      ).toBe(1);
+    });
+
+    it("returns half opacity halfway through the four-hour fade", () => {
+      expect(
+        dashboardMessageOpacity(
+          1_000,
+          1_000 + DASHBOARD_MESSAGE_VISIBLE_MS + 2 * 60 * 60 * 1_000,
+        ),
+      ).toBe(0.5);
+    });
+
+    it("returns zero opacity after the six-hour lifetime", () => {
+      expect(
+        dashboardMessageOpacity(
+          1_000,
+          1_000 + DASHBOARD_MESSAGE_LIFETIME_MS,
+        ),
+      ).toBe(0);
+    });
+  });
+
+  describe("normalizeDashboardMessageText()", () => {
+    it("returns trimmed single-line text", () => {
+      expect(normalizeDashboardMessageText("  hello\n  dashboard  ")).toBe(
+        "hello dashboard",
+      );
+    });
+  });
+
+  describe("DashboardMessageStore", () => {
+    it("reloads the saved message from the dashboard cache", async () => {
+      const directory = await Deno.makeTempDir({
+        prefix: "dashboard-message-",
+      });
+      directories.push(directory);
+      const file = `${directory}/message.json`;
+      const now = 12_345;
+      const first = new DashboardMessageStore({ file, now: () => now });
+
+      expect(await first.set("Team lunch at noon")).toEqual({
+        text: "Team lunch at noon",
+        updatedAt: now,
+        revision: 1,
+      });
+
+      const reloaded = new DashboardMessageStore({ file, now: () => now });
+      expect((await reloaded.refresh()).message).toEqual({
+        text: "Team lunch at noon",
+        updatedAt: now,
+        revision: 1,
+      });
+    });
+
+    it("loads a version-one message written before revisions were added", async () => {
+      const directory = await Deno.makeTempDir({
+        prefix: "dashboard-message-",
+      });
+      directories.push(directory);
+      const file = `${directory}/message.json`;
+      await Deno.writeTextFile(
+        file,
+        JSON.stringify({
+          version: 1,
+          text: "Existing announcement",
+          updatedAt: 12_345,
+        }),
+      );
+
+      const store = new DashboardMessageStore({ file, now: () => 12_345 });
+      expect((await store.refresh()).message).toEqual({
+        text: "Existing announcement",
+        updatedAt: 12_345,
+        revision: 0,
+      });
+    });
+
+    it("replaces expired text with the persisted empty string", async () => {
+      const directory = await Deno.makeTempDir({
+        prefix: "dashboard-message-",
+      });
+      directories.push(directory);
+      const file = `${directory}/message.json`;
+      let now = 12_345;
+      const store = new DashboardMessageStore({ file, now: () => now });
+      await store.set("Deploying");
+
+      now += DASHBOARD_MESSAGE_LIFETIME_MS;
+      expect(await store.refresh()).toEqual({
+        message: { text: "", updatedAt: null, revision: 2 },
+        expired: true,
+      });
+      expect(JSON.parse(await Deno.readTextFile(file))).toEqual({
+        version: 1,
+        text: "",
+        updatedAt: null,
+        revision: 2,
+      });
+    });
+
+    it("keeps the prior message when persistence fails", async () => {
+      const store = new DashboardMessageStore({
+        file: "/missing/dashboard-message.json",
+        reportError: () => {},
+      });
+
+      await expect(store.set("Not persisted")).rejects.toThrow(
+        "Could not save the dashboard message",
+      );
+      expect((await store.refresh()).message).toEqual({
+        text: "",
+        updatedAt: null,
+        revision: 0,
+      });
+    });
+  });
+});

--- a/packages/dashboard/test/dashboard-message.test.ts
+++ b/packages/dashboard/test/dashboard-message.test.ts
@@ -53,6 +53,12 @@ describe("dashboard-message", () => {
         "hello dashboard",
       );
     });
+
+    it("rejects text longer than the editor limit", () => {
+      expect(() => normalizeDashboardMessageText("x".repeat(501))).toThrow(
+        "Dashboard messages are limited to 500 characters.",
+      );
+    });
   });
 
   describe("DashboardMessageStore", () => {
@@ -128,7 +134,6 @@ describe("dashboard-message", () => {
     it("keeps the prior message when persistence fails", async () => {
       const store = new DashboardMessageStore({
         file: "/missing/dashboard-message.json",
-        reportError: () => {},
       });
 
       await expect(store.set("Not persisted")).rejects.toThrow(
@@ -138,6 +143,111 @@ describe("dashboard-message", () => {
         text: "",
         updatedAt: null,
         revision: 0,
+      });
+    });
+
+    it("retries a failed cache read before saving", async () => {
+      let reads = 0;
+      const writes: string[] = [];
+      const store = new DashboardMessageStore({
+        file: "/dashboard-message.json",
+        now: () => 12_345,
+        readTextFile: (() => {
+          reads++;
+          if (reads === 1) throw new Deno.errors.PermissionDenied("denied");
+          return Promise.resolve(JSON.stringify({
+            version: 1,
+            text: "Stored message",
+            updatedAt: 10_000,
+            revision: 4,
+          }));
+        }) as typeof Deno.readTextFile,
+        writeTextFile: ((_file: string | URL, data: string) => {
+          writes.push(data);
+          return Promise.resolve();
+        }) as typeof Deno.writeTextFile,
+        rename: (() => Promise.resolve()) as typeof Deno.rename,
+      });
+
+      await expect(store.refresh()).rejects.toThrow(
+        "Could not load the dashboard message: denied",
+      );
+      expect(await store.set("Replacement")).toEqual({
+        text: "Replacement",
+        updatedAt: 12_345,
+        revision: 5,
+      });
+      expect(reads).toBe(2);
+      expect(JSON.parse(writes[0])).toEqual({
+        version: 1,
+        text: "Replacement",
+        updatedAt: 12_345,
+        revision: 5,
+      });
+    });
+
+    it("retries invalid stored data instead of overwriting it", async () => {
+      let reads = 0;
+      const writes: string[] = [];
+      const store = new DashboardMessageStore({
+        file: "/dashboard-message.json",
+        now: () => 12_345,
+        readTextFile: (() => Promise.resolve([
+          "null",
+          JSON.stringify({ version: 2, text: "Unknown format" }),
+          JSON.stringify({
+            version: 1,
+            text: "Stored message",
+            updatedAt: 10_000,
+            revision: 8,
+          }),
+        ][reads++])) as typeof Deno.readTextFile,
+        writeTextFile: ((_file: string | URL, data: string) => {
+          writes.push(data);
+          return Promise.resolve();
+        }) as typeof Deno.writeTextFile,
+        rename: (() => Promise.resolve()) as typeof Deno.rename,
+      });
+
+      await expect(store.set("Replacement")).rejects.toThrow(
+        "Could not load the dashboard message: invalid stored data",
+      );
+      await expect(store.set("Replacement")).rejects.toThrow(
+        "Could not load the dashboard message: invalid stored data",
+      );
+      expect(writes).toEqual([]);
+      expect(await store.set("Replacement")).toEqual({
+        text: "Replacement",
+        updatedAt: 12_345,
+        revision: 9,
+      });
+      expect(reads).toBe(3);
+    });
+
+    it("keeps an expired message when clearing it cannot be saved", async () => {
+      let now = 12_345;
+      let failWrites = false;
+      const store = new DashboardMessageStore({
+        file: "/dashboard-message.json",
+        now: () => now,
+        readTextFile: (() => Promise.reject(new Deno.errors.NotFound())) as
+          typeof Deno.readTextFile,
+        writeTextFile: (() => failWrites
+          ? Promise.reject(new Deno.errors.PermissionDenied("denied"))
+          : Promise.resolve()) as typeof Deno.writeTextFile,
+        rename: (() => Promise.resolve()) as typeof Deno.rename,
+      });
+      await store.set("Still stored");
+      now += DASHBOARD_MESSAGE_LIFETIME_MS;
+      failWrites = true;
+
+      await expect(store.refresh()).rejects.toThrow(
+        "Could not save the dashboard message: denied",
+      );
+      failWrites = false;
+      expect(await store.refresh()).toEqual({
+        message: { text: "", updatedAt: null, revision: 2 },
+        expired: true,
       });
     });
   });

--- a/packages/dashboard/test/runner.ts
+++ b/packages/dashboard/test/runner.ts
@@ -10,6 +10,7 @@ export const TEST_COMMANDS = [
     "--allow-write",
     `--allow-run=${Deno.execPath()},git`,
     "--ignore=favicon-client.browser.test.ts",
+    "--ignore=dashboard-message-client.browser.test.ts",
     "--ignore=theme.browser.test.ts",
     "--ignore=favicon-raster.test.ts",
     "--ignore=regenerate-favicons.test.ts",


### PR DESCRIPTION
Add a shared inline message editor to the dashboard header so connected viewers can leave and update a short note without obscuring the identity or freshness information. Keep the editor centered in the available gap on larger screens and move it to a full-width row on phones.

Persist the message in the dashboard cache and publish edits through the existing server-sent event stream. Keep text fully visible for two hours, fade it linearly over four hours, and clear it when the fade completes.

Order local saves and server revisions independently so delayed responses and live updates cannot replace newer text. Preserve drafts during saves, leave failed text available for retry, and report persistence failures to the editor.

Validate request bodies, escape rendered text, and retain an accessible label without showing a hint in the empty field. Cover storage, timing, rendering, validation, live broadcasts, overlapping saves, expiration, and responsive layout behavior.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

