### PR TITLE
Cover failed interval clock writes deterministically

### DIFF
--- a/packages/runner/test/wish-now-interval.test.ts
+++ b/packages/runner/test/wish-now-interval.test.ts
@@ -5,6 +5,7 @@ import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { createBuilder } from "../src/builder/factory.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
 import { Runtime } from "../src/runtime.ts";
+import type { CommitError } from "../src/storage/interface.ts";
 
 const signer = await Identity.fromPassphrase("wish built-in tests");
 const space = signer.did();
@@ -74,6 +75,55 @@ describe("interval #now wish", () => {
     expect(updated! % 1000).toBe(0);
 
     runtime.runner.stop(resultCell);
+  });
+
+  it("reports a failed #now interval tick", async () => {
+    const wishPattern = pattern(() => {
+      return { nowValue: wish({ query: "#now/1" }) };
+    });
+
+    const resultCell = runtime.getCell<{ nowValue?: { result?: number } }>(
+      space,
+      "failed interval now result",
+      undefined,
+      tx,
+    );
+    const result = runtime.run(tx, wishPattern, {}, resultCell);
+    await tx.commit();
+    tx = runtime.edit();
+
+    await result.pull();
+
+    const failure = {
+      name: "StorageTransactionAborted" as const,
+      message: "interval tick failed",
+      reason: "interval tick failed",
+    } satisfies CommitError;
+    const reported: unknown[][] = [];
+    const originalEditWithRetry = runtime.editWithRetry.bind(runtime);
+    const originalConsoleError = console.error;
+    runtime.editWithRetry =
+      (() =>
+        Promise.resolve({ error: failure })) as typeof runtime.editWithRetry;
+    console.error = (...args: unknown[]) => {
+      if (args[0] === "[wish] #now interval tick failed:") {
+        reported.push(args);
+      } else {
+        originalConsoleError(...args);
+      }
+    };
+
+    try {
+      await clock.tick(1000);
+      expect(reported).toEqual([[
+        "[wish] #now interval tick failed:",
+        failure,
+      ]]);
+    } finally {
+      runtime.editWithRetry = originalEditWithRetry;
+      console.error = originalConsoleError;
+      runtime.runner.stop(resultCell);
+    }
   });
 
   it("#now interval keeps ticking when other dependencies change", async () => {


### PR DESCRIPTION
The interval clock error-reporting branch was covered only when a timer raced with test teardown and attempted to write through a closed memory client. This made the runner coverage count depend on test timing.

Add an isolated fake-clock test that replaces the retrying write with a typed failure, advances exactly one interval boundary, and verifies the error report. Restore the runtime and console methods before stopping the result so the test cannot leak replacements into later cases.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

