### PR TITLE
refactor: move pattern test steps to the reserved [TESTS] key

### DIFF
--- a/docs/check.vocabulary.json
+++ b/docs/check.vocabulary.json
@@ -12,6 +12,7 @@
     "FabricSpecialObject",
     "NAME",
     "Stream",
+    "TESTS",
     "UI",
     "UiAction",
     "Writable",

--- a/docs/common/ai/pattern-testing-guide.md
+++ b/docs/common/ai/pattern-testing-guide.md
@@ -84,7 +84,7 @@ export default pattern(() => {
   const assertAfterAction = assert(() => instance.someField === newValue);
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assertInitialState },
       { action: actionDoSomething },
       { assertion: assertAfterAction },
@@ -161,7 +161,7 @@ explicit render step after the action that creates that state:
 const subject = Pattern({});
 
 return {
-  tests: [
+  [TESTS]: [
     { action: actionReachLateState },
     { render: subject[UI] },
     { assertion: assertLateState },
@@ -189,7 +189,7 @@ the subject's UI from its own descriptor:
 // Shown for illustration only.
 return {
   [UI]: subject[UI],
-  tests: [
+  [TESTS]: [
     { action: actionReachLateState },
     { assertion: assertLateState },
   ],
@@ -229,7 +229,7 @@ returned descriptor — each flag covers only its own level:
 ```tsx
 // Shown inside a pattern body.
 return {
-  tests: [/* ... */],
+  [TESTS]: [/* ... */],
   allowConsoleErrors: true, // expected console/logger errors don't fail
   allowConsoleWarnings: true, // expected console/logger warnings don't fail
 };
@@ -268,7 +268,7 @@ export const alice = pattern<{ setup: Setup }>(({ setup }) => {
   const save = action(() => setup.chat.saveProfile.send());
   const sees_bob = computed(() => /* ... */);
   return {
-    tests: [
+    [TESTS]: [
       { action: save },
       { label: "alice-saved" }, //  announce a marker
       { await: "bob-saved" }, //    park until bob announces

--- a/docs/common/workflows/pattern-testing.md
+++ b/docs/common/workflows/pattern-testing.md
@@ -31,7 +31,7 @@ Test patterns are patterns that test other patterns. They:
 - Import and instantiate the pattern under test
 - Define test actions using `action()`
 - Define assertions using `assert(() => boolean)`
-- Return a `tests` array that the runner executes sequentially
+- Return a `[TESTS]` array that the runner executes sequentially
 
 Test files end in `.test.tsx` and are run with `deno task cf test`.
 
@@ -55,9 +55,9 @@ export default pattern(() => {
   const assert_is_zero = assert(() => counter.value === 0);
   const assert_is_one = assert(() => counter.value === 1);
 
-  // 4. Return tests array
+  // 4. Return the test steps under the [TESTS] key
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_is_zero },
       { action: action_increment },
       { assertion: assert_is_one },
@@ -88,7 +88,7 @@ Tests use a **discriminated union** format:
 ```tsx
 // Shown inside a pattern body.
 return {
-  tests: [
+  [TESTS]: [
     { action: action_do_something },     // Runner calls .send()
     { assertion: assert_something },     // Runner checks === true
   ],
@@ -182,7 +182,7 @@ export default pattern(() => {
     }
   });
 
-  return { tests: [{ action: action_add_area }], subject };
+  return { [TESTS]: [{ action: action_add_area }], subject };
 });
 ```
 
@@ -312,7 +312,7 @@ Put actions before the assertions that depend on them:
 ```tsx
 // Shown inside a pattern body.
 return {
-  tests: [
+  [TESTS]: [
     // Initial state
     { assertion: assert_starts_empty },
 
@@ -359,10 +359,11 @@ deno task cf piece inspect --piece <PIECE_ID>
 # Get specific values
 deno task cf piece get subject/items --piece <PIECE_ID>
 
-# Step through manually
-deno task cf piece call tests/0/action --piece <PIECE_ID>
+# Step through manually (the reserved key is the literal `$TESTS`, quoted so
+# the shell does not expand it)
+deno task cf piece call '$TESTS/0/action' --piece <PIECE_ID>
 deno task cf piece step --piece <PIECE_ID>
-deno task cf piece get tests/1/assertion --piece <PIECE_ID>
+deno task cf piece get '$TESTS/1/assertion' --piece <PIECE_ID>
 ```
 
 This diagnostic command deliberately deploys the test pattern as the executable
@@ -377,7 +378,7 @@ Add extra fields to your test pattern for debugging:
 ```tsx
 // Shown for illustration only.
 return {
-  tests: [...],
+  [TESTS]: [...],
   // Expose internals for debugging
   subject,
   debugState: computed(() => ({
@@ -399,7 +400,7 @@ const assert_initial_count = assert(() => counter.value === 0);
 const assert_initial_empty = assert(() => list.items.length === 0);
 
 return {
-  tests: [
+  [TESTS]: [
     { assertion: assert_initial_count },
     { assertion: assert_initial_empty },
     // ... actions and more assertions
@@ -419,7 +420,7 @@ const assert_playing = assert(() => game.phase === "playing");
 const assert_paused = assert(() => game.phase === "paused");
 
 return {
-  tests: [
+  [TESTS]: [
     { action: action_start },
     { assertion: assert_playing },
     { action: action_pause },

--- a/docs/specs/PATTERN_TESTING_SPEC.md
+++ b/docs/specs/PATTERN_TESTING_SPEC.md
@@ -75,7 +75,10 @@ A test pattern is a regular pattern file with `.test.tsx` extension that:
 
 ### Test Step Format (Discriminated Union)
 
-The `[TESTS]` array uses a discriminated union to avoid TypeScript declaration emit issues:
+The `[TESTS]` array is a discriminated union — each step is exactly one of the
+shapes below. Keeping an assertion's `Cell` and an action's `Stream` in
+separate members, rather than mixing the two in one array element, is what
+avoids the declaration-emit errors TypeScript raises for such a mix:
 
 ```typescript
 // Shown at module scope.
@@ -88,9 +91,6 @@ type TestStep =
   | { render: VNode }                  // one headless VDOM demand window
   | { settle: true };                  // wait for full async settlement
 ```
-
-This format keeps `action()` streams and assertion cells separate in the type
-system.
 
 An `assert(...)` assertion carries an `AssertRecord` — `{ ok, source, parts }` —
 rather than a bare boolean. The transformer rewrites its body to record each

--- a/docs/specs/PATTERN_TESTING_SPEC.md
+++ b/docs/specs/PATTERN_TESTING_SPEC.md
@@ -71,11 +71,11 @@ A test pattern is a regular pattern file with `.test.tsx` extension that:
 2. **Instantiates it with test data**
 3. **Defines test actions using `action()`** (for triggering events on the pattern)
 4. **Defines assertions as `assert(() => boolean)`** computed from pattern state
-5. **Returns a `tests` array** of discriminated union objects
+5. **Returns a `[TESTS]` array** of discriminated union objects
 
 ### Test Step Format (Discriminated Union)
 
-The `tests` array uses a discriminated union to avoid TypeScript declaration emit issues:
+The `[TESTS]` array uses a discriminated union to avoid TypeScript declaration emit issues:
 
 ```typescript
 // Shown at module scope.
@@ -153,9 +153,9 @@ export default pattern(() => {
     return byCategory.food === 5 && byCategory.transport === 40;
   });
 
-  // 4. Return tests array using discriminated union format
+  // 4. Return the test steps under the [TESTS] key
   return {
-    tests: [
+    [TESTS]: [
       { action: action_add_expense },       // Runner calls .send()
       { assertion: assert_has_one_expense }, // Runner checks its `ok`
       { action: action_add_another },
@@ -170,9 +170,9 @@ export default pattern(() => {
 
 ### Test Execution Flow
 
-The `cf test` runner processes the `tests` array **in order**:
+The `cf test` runner processes the `[TESTS]` array **in order**:
 
-1. For each item in `tests`:
+1. For each item in `[TESTS]`:
    - If it has `action` key: call `.send()`, then `await runtime.idle()`
    - If it has `assertion` key: read `.get()`; an `AssertRecord` passes when
      its `ok` is true, any other value passes when it equals `true`
@@ -181,12 +181,12 @@ The `cf test` runner processes the `tests` array **in order**:
 
 ```
 ┌──────────────────────────────────────────────────────────────┐
-│  tests: [                                                     │
-│    { action: action1 },                                       │
-│    { assertion: assert1 },                                    │
-│    { action: action2 },                                       │
-│    { assertion: assert2 },                                    │
-│  ]                                                            │
+│  [TESTS]: [                                                  │
+│    { action: action1 },                                      │
+│    { assertion: assert1 },                                   │
+│    { action: action2 },                                      │
+│    { assertion: assert2 },                                   │
+│  ]                                                           │
 └──────────────────────────────────────────────────────────────┘
                               │
                               ▼
@@ -297,11 +297,11 @@ async function runTestPattern(testPath: string, options: TestOptions): Promise<T
   // No renderer is mounted by default. Values run only when a test step
   // explicitly demands them.
 
-  // 4. Get the tests array from pattern output
-  const testsCell = patternResult.key("tests") as Cell<unknown>;
+  // 4. Get the [TESTS] array from pattern output
+  const testsCell = patternResult.key(TESTS) as Cell<unknown>;
   const testsValue = testsCell.get();
   if (!Array.isArray(testsValue)) {
-    throw new Error("Test pattern must return { tests: TestStep[] }");
+    throw new Error("Test pattern must return { [TESTS]: TestStep[] }");
   }
 
   // 5. Process tests in order using discriminated union format
@@ -439,7 +439,7 @@ Wrap actions and assertions in their respective object format:
 // Shown inside a pattern body.
 // ✅ Good - discriminated union format
 return {
-  tests: [
+  [TESTS]: [
     { action: action_add_item },
     { assertion: assert_has_one_item },
     { action: action_remove_item },
@@ -449,7 +449,7 @@ return {
 
 // ❌ Bad - flat array (causes TypeScript declaration emit issues)
 return {
-  tests: [action_add_item, assert_has_one_item, action_remove_item, assert_empty],
+  [TESTS]: [action_add_item, assert_has_one_item, action_remove_item, assert_empty],
 };
 ```
 
@@ -460,7 +460,7 @@ Put actions before the assertions that depend on them:
 ```tsx
 // Shown inside a pattern body.
 return {
-  tests: [
+  [TESTS]: [
     { action: action_add_item },     // First, add an item
     { assertion: assert_has_one_item }, // Then, verify it was added
     { action: action_remove_item },  // Then, remove it
@@ -628,7 +628,7 @@ export default pattern(() => {
   const assert_is_two = assert(() => counter.value === 2);
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_starts_at_zero },  // Initial state check
       { action: action_increment },
       { assertion: assert_is_one },          // After 1 increment

--- a/docs/tutorial/06-workflow.md
+++ b/docs/tutorial/06-workflow.md
@@ -136,12 +136,13 @@ streams, same cells. The browser shell is just one more client.
 ## Testing patterns
 
 Tests are patterns that test patterns: instantiate the subject, alternate
-`action` steps and `computed(() => boolean)` assertions, and return them as
-a `tests` array. From `packages/patterns/counter/counter.test.tsx`:
+`action` steps and `computed(() => boolean)` assertions, and return them
+under the reserved `[TESTS]` key. From
+`packages/patterns/counter/counter.test.tsx`:
 
 ```tsx
 // Shown at module scope.
-import { action, computed, pattern } from "commonfabric";
+import { action, computed, pattern, TESTS } from "commonfabric";
 import Counter from "./counter.tsx";
 
 export default pattern(() => {
@@ -155,7 +156,7 @@ export default pattern(() => {
   const assert_value_is_1 = computed(() => counter.value === 1);
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_initial_value_is_0 },
       { action: action_increment },
       { assertion: assert_value_is_1 },

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -352,6 +352,7 @@ export declare const UI: "$UI";
 export declare const TILE_UI: "$TILE_UI";
 export declare const CHIP_UI: "$CHIP_UI";
 export declare const FS: "$FS";
+export declare const TESTS: "$TESTS";
 
 /**
  * The size/representation spectrum a piece can be rendered at (CT-1321):

--- a/packages/cli/fixtures/test-memory-version.test.tsx
+++ b/packages/cli/fixtures/test-memory-version.test.tsx
@@ -1,7 +1,7 @@
-import { computed, pattern } from "commonfabric";
+import { computed, pattern, TESTS } from "commonfabric";
 
 export default pattern(() => ({
-  tests: [
+  [TESTS]: [
     { assertion: computed(() => true) },
   ],
 }));

--- a/packages/cli/lib/multi-user-test-runner.ts
+++ b/packages/cli/lib/multi-user-test-runner.ts
@@ -6,7 +6,7 @@
  * ```tsx
  * export const setup = pattern(() => ({ chat: GroupChatDemo({}) }));
  * export const alice = pattern<{ setup: Setup }>(({ setup }) => ({
- *   tests: [
+ *   [TESTS]: [
  *     { action: action_save_alice },
  *     { label: "alice-saved" },
  *     { await: "bob-saved" },
@@ -14,7 +14,7 @@
  *   ],
  * }));
  * export const bob = pattern<{ setup: Setup }>(({ setup }) => ({
- *   tests: [
+ *   [TESTS]: [
  *     { await: "alice-saved" },
  *     { assertion: assert_sees_alice },
  *     { action: action_save_bob },

--- a/packages/cli/lib/multi-user-test-worker.ts
+++ b/packages/cli/lib/multi-user-test-worker.ts
@@ -38,6 +38,7 @@ import {
   patternCoverageOutputPath,
   Runtime,
   runtimePresets,
+  TESTS,
   writePatternCoverageLcov,
 } from "@commonfabric/runner";
 import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
@@ -419,7 +420,7 @@ const handlers: Record<
     }
     await settle();
 
-    const stepsValue = resultCell.key("tests").asSchema(
+    const stepsValue = resultCell.key(TESTS).asSchema(
       {
         type: "array",
         items: { type: "object", asCell: ["cell"] },
@@ -428,7 +429,7 @@ const handlers: Record<
     ).get();
     if (!Array.isArray(stepsValue)) {
       throw new Error(
-        `Participant "${args.participant}" must return { tests: TestStep[] }`,
+        `Participant "${args.participant}" must return { [TESTS]: TestStep[] }`,
       );
     }
     stepCells = stepsValue as Cell<unknown>[];

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -1242,8 +1242,9 @@ export async function runTestPattern(
     // Validate it's an array
     if (!Array.isArray(testSteps)) {
       throw new Error(
-        "Test pattern must return { [TESTS]: TestStep[] }. Got: " +
-          toCompactDebugString(typeof testSteps),
+        "Test pattern must return its steps under the reserved [TESTS] key " +
+          "(import TESTS from commonfabric); a plain `tests` field is no " +
+          "longer read. Got: " + toCompactDebugString(typeof testSteps),
       );
     }
 

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -4,7 +4,7 @@
  * Test patterns (.test.tsx) are patterns that:
  * 1. Import and instantiate the pattern under test
  * 2. Define test steps as an array of { assertion } or { action } objects
- * 3. Return { tests: TestStep[] }
+ * 3. Return { [TESTS]: TestStep[] } under the reserved `[TESTS]` output key
  *
  * TestStep is a discriminated union:
  * - { assertion: Reactive<boolean> } from computed(() => condition)
@@ -14,7 +14,7 @@
  * that occur when mixing Cell and Stream types in the same array.
  *
  * Example:
- * tests: [
+ * [TESTS]: [
  *   { assertion: computed(() => game.phase === "playing") },
  *   { action: action(() => game.start.send(undefined)) },
  *   { assertion: computed(() => game.phase === "started") },

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -36,6 +36,7 @@ import {
   Runtime,
   type RuntimeOptions,
   runtimePresets,
+  TESTS,
   writePatternCoverageLcov,
 } from "@commonfabric/runner";
 import type {
@@ -1228,10 +1229,10 @@ export async function runTestPattern(
       await runtime.idle();
     });
 
-    // 4. Get the tests array from pattern output
+    // 4. Get the tests array from pattern output (the reserved [TESTS] key)
     const testsCell = await withPhase(
       ["runTestPattern", "testsCell"],
-      () => patternResult.key("tests") as Cell<unknown>,
+      () => patternResult.key(TESTS) as Cell<unknown>,
     );
     const testSteps = await withPhase(
       ["runTestPattern", "testsValue"],
@@ -1241,7 +1242,7 @@ export async function runTestPattern(
     // Validate it's an array
     if (!Array.isArray(testSteps)) {
       throw new Error(
-        "Test pattern must return { tests: TestStep[] }. Got: " +
+        "Test pattern must return { [TESTS]: TestStep[] }. Got: " +
           toCompactDebugString(typeof testSteps),
       );
     }

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -1242,9 +1242,8 @@ export async function runTestPattern(
     // Validate it's an array
     if (!Array.isArray(testSteps)) {
       throw new Error(
-        "Test pattern must return its steps under the reserved [TESTS] key " +
-          "(import TESTS from commonfabric); a plain `tests` field is no " +
-          "longer read. Got: " + toCompactDebugString(typeof testSteps),
+        "Test pattern must return { [TESTS]: TestStep[] }. Got: " +
+          toCompactDebugString(typeof testSteps),
       );
     }
 

--- a/packages/cli/test/fixtures/assert-diagnostics/call-shapes.test.tsx
+++ b/packages/cli/test/fixtures/assert-diagnostics/call-shapes.test.tsx
@@ -4,7 +4,7 @@
  * arguments say nothing. Run by assert-diagnostics.test.ts, which expects the
  * failures; it is not a pattern under test.
  */
-import { assert, cell, pattern } from "commonfabric";
+import { assert, cell, pattern, TESTS } from "commonfabric";
 
 function allPositive(...values: number[]): boolean {
   return values.every((value) => value > 0);
@@ -14,7 +14,7 @@ export default pattern(() => {
   const nums = cell<number[]>([1, -2, 3]);
 
   return {
-    tests: [
+    [TESTS]: [
       // Fails: -2 is not positive. Recording the spread would pass only the
       // first element and turn this into `allPositive(1)`, which is true.
       { assertion: assert(() => allPositive(...nums.get())) },

--- a/packages/cli/test/fixtures/assert-diagnostics/computed.test.tsx
+++ b/packages/cli/test/fixtures/assert-diagnostics/computed.test.tsx
@@ -3,7 +3,7 @@
  * be checked alongside the `assert(...)` one. Run by assert-diagnostics.test.ts,
  * which expects the failure; it is not a pattern under test.
  */
-import { cell, computed, pattern } from "commonfabric";
+import { cell, computed, pattern, TESTS } from "commonfabric";
 
 export default pattern(() => {
   const a = cell<number>(1);
@@ -11,7 +11,7 @@ export default pattern(() => {
   const c = cell<number>(2);
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: computed(() => a.get() + b.get() <= c.get()) },
     ],
     a,

--- a/packages/cli/test/fixtures/assert-diagnostics/control-flow.test.tsx
+++ b/packages/cli/test/fixtures/assert-diagnostics/control-flow.test.tsx
@@ -4,14 +4,14 @@
  * assert-diagnostics.test.ts, which expects the failures; it is not a pattern
  * under test.
  */
-import { assert, cell, pattern } from "commonfabric";
+import { assert, cell, pattern, TESTS } from "commonfabric";
 
 export default pattern(() => {
   const a = cell<number>(-1);
   const b = cell<number>(20);
 
   return {
-    tests: [
+    [TESTS]: [
       // Fails on the left conjunct, so the right one never evaluates.
       { assertion: assert(() => a.get() > 0 && b.get() < 10) },
       // Both disjuncts evaluate, and both are false.

--- a/packages/cli/test/fixtures/assert-diagnostics/failing.test.tsx
+++ b/packages/cli/test/fixtures/assert-diagnostics/failing.test.tsx
@@ -3,7 +3,7 @@
  * `assert(...)` can be checked. Run by assert-diagnostics.test.ts, which
  * expects the failures; it is not a pattern under test.
  */
-import { assert, cell, pattern } from "commonfabric";
+import { assert, cell, pattern, TESTS } from "commonfabric";
 
 function inRange(value: number, low: number, high: number): boolean {
   return value >= low && value <= high;
@@ -15,7 +15,7 @@ export default pattern(() => {
   const c = cell<number>(2);
 
   return {
-    tests: [
+    [TESTS]: [
       // 1 + 2 is 3, which is not <= 2.
       { assertion: assert(() => a.get() + b.get() <= c.get()) },
       // 5 is outside 2..2.

--- a/packages/cli/test/fixtures/assert-diagnostics/proxy-idiom.test.tsx
+++ b/packages/cli/test/fixtures/assert-diagnostics/proxy-idiom.test.tsx
@@ -5,7 +5,7 @@
  * covers recording around them. Run by assert-diagnostics.test.ts, which
  * expects the failures; it is not a pattern under test.
  */
-import { action, assert, pattern } from "commonfabric";
+import { action, assert, pattern, TESTS } from "commonfabric";
 import Subject from "./subject.tsx";
 
 export default pattern(() => {
@@ -16,7 +16,7 @@ export default pattern(() => {
   });
 
   return {
-    tests: [
+    [TESTS]: [
       { action: action_add },
       // Fails: the list has one item, not seven.
       { assertion: assert(() => list.items.filter(() => true).length === 7) },

--- a/packages/cli/test/fixtures/console-capture/console-error-allowed.test.tsx
+++ b/packages/cli/test/fixtures/console-capture/console-error-allowed.test.tsx
@@ -2,7 +2,7 @@
  * Fixture: console.error with allowConsoleErrors: true.
  * The test runner must NOT fail this despite the error.
  */
-import { action, computed, pattern, Writable } from "commonfabric";
+import { action, computed, pattern, TESTS, Writable } from "commonfabric";
 
 export default pattern(() => {
   const triggered = new Writable(false);
@@ -14,7 +14,7 @@ export default pattern(() => {
   });
 
   return {
-    tests: [
+    [TESTS]: [
       { action: triggerError },
       { assertion: didTrigger },
     ],

--- a/packages/cli/test/fixtures/console-capture/console-error-unallowed.test.tsx
+++ b/packages/cli/test/fixtures/console-capture/console-error-unallowed.test.tsx
@@ -2,7 +2,7 @@
  * Fixture: console.error in a computed handler with NO allowConsoleErrors flag.
  * The test runner must fail this even though the assertion passes.
  */
-import { action, computed, pattern, Writable } from "commonfabric";
+import { action, computed, pattern, TESTS, Writable } from "commonfabric";
 
 export default pattern(() => {
   const triggered = new Writable(false);
@@ -14,7 +14,7 @@ export default pattern(() => {
   });
 
   return {
-    tests: [
+    [TESTS]: [
       { action: triggerError },
       { assertion: didTrigger },
     ],

--- a/packages/cli/test/fixtures/console-capture/console-warn-allowed.test.tsx
+++ b/packages/cli/test/fixtures/console-capture/console-warn-allowed.test.tsx
@@ -2,7 +2,7 @@
  * Fixture: console.warn with allowConsoleWarnings: true.
  * The test runner must NOT fail this despite the warning.
  */
-import { action, computed, pattern, Writable } from "commonfabric";
+import { action, computed, pattern, TESTS, Writable } from "commonfabric";
 
 export default pattern(() => {
   const triggered = new Writable(false);
@@ -14,7 +14,7 @@ export default pattern(() => {
   });
 
   return {
-    tests: [
+    [TESTS]: [
       { action: triggerWarn },
       { assertion: didTrigger },
     ],

--- a/packages/cli/test/fixtures/console-capture/console-warn-unallowed.test.tsx
+++ b/packages/cli/test/fixtures/console-capture/console-warn-unallowed.test.tsx
@@ -2,7 +2,7 @@
  * Fixture: console.warn in a computed handler with NO allowConsoleWarnings flag.
  * The test runner must fail this even though the assertion passes.
  */
-import { action, computed, pattern, Writable } from "commonfabric";
+import { action, computed, pattern, TESTS, Writable } from "commonfabric";
 
 export default pattern(() => {
   const triggered = new Writable(false);
@@ -14,7 +14,7 @@ export default pattern(() => {
   });
 
   return {
-    tests: [
+    [TESTS]: [
       { action: triggerWarn },
       { assertion: didTrigger },
     ],

--- a/packages/cli/test/fixtures/default-piece-registration/registration.test.tsx
+++ b/packages/cli/test/fixtures/default-piece-registration/registration.test.tsx
@@ -3,6 +3,7 @@ import {
   assert,
   pattern,
   type Stream,
+  TESTS,
   wish,
   Writable,
 } from "commonfabric";
@@ -45,7 +46,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: startsEmpty },
       { action: sendMissingPiece },
       { assertion: missingPieceIsIgnored },

--- a/packages/cli/test/fixtures/expect-non-idempotent/expected-and-violating.test.tsx
+++ b/packages/cli/test/fixtures/expect-non-idempotent/expected-and-violating.test.tsx
@@ -3,7 +3,7 @@
  * (same shape as packages/patterns/test/non-idempotent/accumulator.test.tsx).
  * The detected violation satisfies the expectation, so this test must PASS.
  */
-import { computed, pattern, Writable } from "commonfabric";
+import { computed, pattern, TESTS, Writable } from "commonfabric";
 
 export default pattern(() => {
   const value = new Writable("hello");
@@ -18,7 +18,7 @@ export default pattern(() => {
   const hasEntries = computed(() => log.get().length > 0);
 
   return {
-    tests: [{ assertion: hasEntries }],
+    [TESTS]: [{ assertion: hasEntries }],
     expectNonIdempotent: true,
   };
 });

--- a/packages/cli/test/fixtures/expect-non-idempotent/expected-but-idempotent.test.tsx
+++ b/packages/cli/test/fixtures/expect-non-idempotent/expected-but-idempotent.test.tsx
@@ -5,7 +5,7 @@
  * FAIL with "expected non-idempotent computation(s), none detected" — a
  * silent pass here is exactly the detection regression the flag guards.
  */
-import { computed, pattern, Writable } from "commonfabric";
+import { computed, pattern, TESTS, Writable } from "commonfabric";
 
 export default pattern(() => {
   const value = new Writable("hello");
@@ -13,7 +13,7 @@ export default pattern(() => {
   const ok = computed(() => value.get() === "hello");
 
   return {
-    tests: [{ assertion: ok }],
+    [TESTS]: [{ assertion: ok }],
     expectNonIdempotent: true,
   };
 });

--- a/packages/cli/test/fixtures/expect-non-idempotent/multi-user-expected-but-idempotent.test.tsx
+++ b/packages/cli/test/fixtures/expect-non-idempotent/multi-user-expected-but-idempotent.test.tsx
@@ -3,13 +3,19 @@
  * trivially idempotent. No flagged participant sees a violation, so the run
  * must FAIL with the synthetic "expectNonIdempotent" result.
  */
-import { computed, multiUserTest, pattern, Writable } from "commonfabric";
+import {
+  computed,
+  multiUserTest,
+  pattern,
+  TESTS,
+  Writable,
+} from "commonfabric";
 
 export const alice = pattern(() => {
   const value = new Writable("alice");
   const ok = computed(() => value.get() === "alice");
   return {
-    tests: [{ assertion: ok }],
+    [TESTS]: [{ assertion: ok }],
     expectNonIdempotent: true,
   };
 });
@@ -18,7 +24,7 @@ export const bob = pattern(() => {
   const value = new Writable("bob");
   const ok = computed(() => value.get() === "bob");
   return {
-    tests: [{ assertion: ok }],
+    [TESTS]: [{ assertion: ok }],
   };
 });
 

--- a/packages/cli/test/fixtures/expect-non-idempotent/multi-user-expected-one-violation.test.tsx
+++ b/packages/cli/test/fixtures/expect-non-idempotent/multi-user-expected-one-violation.test.tsx
@@ -5,7 +5,13 @@
  * seeing a violation satisfies the expectation — the run must PASS even
  * though bob (also flagged) saw none.
  */
-import { computed, multiUserTest, pattern, Writable } from "commonfabric";
+import {
+  computed,
+  multiUserTest,
+  pattern,
+  TESTS,
+  Writable,
+} from "commonfabric";
 
 export const alice = pattern(() => {
   const value = new Writable("alice");
@@ -19,7 +25,7 @@ export const alice = pattern(() => {
 
   const hasEntries = computed(() => log.get().length > 0);
   return {
-    tests: [{ assertion: hasEntries }],
+    [TESTS]: [{ assertion: hasEntries }],
     expectNonIdempotent: true,
   };
 });
@@ -28,7 +34,7 @@ export const bob = pattern(() => {
   const value = new Writable("bob");
   const ok = computed(() => value.get() === "bob");
   return {
-    tests: [{ assertion: ok }],
+    [TESTS]: [{ assertion: ok }],
     expectNonIdempotent: true,
   };
 });

--- a/packages/cli/test/fixtures/expect-non-idempotent/unexpected-violation.test.tsx
+++ b/packages/cli/test/fixtures/expect-non-idempotent/unexpected-violation.test.tsx
@@ -2,7 +2,7 @@
  * A non-idempotent accumulator WITHOUT expectNonIdempotent. The detected
  * violation must FAIL the test (the long-standing default behavior).
  */
-import { computed, pattern, Writable } from "commonfabric";
+import { computed, pattern, TESTS, Writable } from "commonfabric";
 
 export default pattern(() => {
   const value = new Writable("hello");
@@ -17,6 +17,6 @@ export default pattern(() => {
   const hasEntries = computed(() => log.get().length > 0);
 
   return {
-    tests: [{ assertion: hasEntries }],
+    [TESTS]: [{ assertion: hasEntries }],
   };
 });

--- a/packages/cli/test/fixtures/expect-runtime-errors/expected-and-throwing.test.tsx
+++ b/packages/cli/test/fixtures/expect-runtime-errors/expected-and-throwing.test.tsx
@@ -2,7 +2,7 @@
  * Fixture: a throwing action with expectRuntimeErrors: 1.
  * The runner must treat the error as required-and-satisfied — no failure.
  */
-import { action, computed, pattern, Writable } from "commonfabric";
+import { action, computed, pattern, TESTS, Writable } from "commonfabric";
 
 export default pattern(() => {
   const untouched = new Writable(true);
@@ -13,7 +13,7 @@ export default pattern(() => {
   });
 
   return {
-    tests: [
+    [TESTS]: [
       { action: throwingAction },
       { assertion: stillUntouched },
     ],

--- a/packages/cli/test/fixtures/expect-runtime-errors/expected-but-silent.test.tsx
+++ b/packages/cli/test/fixtures/expect-runtime-errors/expected-but-silent.test.tsx
@@ -3,7 +3,7 @@
  * The expectation asserts the loudness FIRES — zero errors must fail the run,
  * so a rejection quietly reverting to a silent return cannot pass.
  */
-import { action, computed, pattern, Writable } from "commonfabric";
+import { action, computed, pattern, TESTS, Writable } from "commonfabric";
 
 export default pattern(() => {
   const fine = new Writable(true);
@@ -14,7 +14,7 @@ export default pattern(() => {
   });
 
   return {
-    tests: [
+    [TESTS]: [
       { action: silentAction },
       { assertion: stillFine },
     ],

--- a/packages/cli/test/fixtures/expect-runtime-errors/expected-count-mismatch.test.tsx
+++ b/packages/cli/test/fixtures/expect-runtime-errors/expected-count-mismatch.test.tsx
@@ -2,7 +2,7 @@
  * Fixture: expectRuntimeErrors: 2 but only one throw occurs.
  * A numeric expectation is exact — a count mismatch must fail the run.
  */
-import { action, computed, pattern, Writable } from "commonfabric";
+import { action, computed, pattern, TESTS, Writable } from "commonfabric";
 
 export default pattern(() => {
   const fine = new Writable(true);
@@ -13,7 +13,7 @@ export default pattern(() => {
   });
 
   return {
-    tests: [
+    [TESTS]: [
       { action: throwsOnce },
       { assertion: stillFine },
     ],

--- a/packages/cli/test/fixtures/multi-user-markers/crosswise-markers.test.tsx
+++ b/packages/cli/test/fixtures/multi-user-markers/crosswise-markers.test.tsx
@@ -5,7 +5,7 @@
  * writes its own marker document, so announcing in that order is
  * conflict-free and both markers arrive.
  */
-import { assert, multiUserTest, pattern, Writable } from "commonfabric";
+import { assert, multiUserTest, pattern, TESTS, Writable } from "commonfabric";
 
 export interface MarkerSetup {
   note: Writable<string>;
@@ -16,7 +16,7 @@ export const setup = pattern<Record<string, never>, MarkerSetup>(() => ({
 }));
 
 export const alice = pattern<{ setup: MarkerSetup }>(({ setup }) => ({
-  tests: [
+  [TESTS]: [
     { label: "alice-1" },
     { await: "bob-1" },
     { assertion: assert(() => setup.note.get() === "") },
@@ -24,7 +24,7 @@ export const alice = pattern<{ setup: MarkerSetup }>(({ setup }) => ({
 }));
 
 export const bob = pattern<{ setup: MarkerSetup }>(({ setup }) => ({
-  tests: [
+  [TESTS]: [
     { label: "bob-1" },
     { await: "alice-1" },
     { assertion: assert(() => setup.note.get() === "") },

--- a/packages/cli/test/fixtures/multi-user-markers/false-assertion.test.tsx
+++ b/packages/cli/test/fixtures/multi-user-markers/false-assertion.test.tsx
@@ -4,7 +4,14 @@
  * compares it against something she never wrote, so the value is settled and
  * the comparison is the failure.
  */
-import { action, assert, multiUserTest, pattern, Writable } from "commonfabric";
+import {
+  action,
+  assert,
+  multiUserTest,
+  pattern,
+  TESTS,
+  Writable,
+} from "commonfabric";
 
 export interface MarkerSetup {
   note: Writable<string>;
@@ -15,14 +22,14 @@ export const setup = pattern<Record<string, never>, MarkerSetup>(() => ({
 }));
 
 export const alice = pattern<{ setup: MarkerSetup }>(({ setup }) => ({
-  tests: [
+  [TESTS]: [
     { action: action(() => setup.note.set("from alice")) },
     { label: "alice-wrote" },
   ],
 }));
 
 export const bob = pattern<{ setup: MarkerSetup }>(({ setup }) => ({
-  tests: [
+  [TESTS]: [
     { await: "alice-wrote" },
     { assertion: assert(() => setup.note.get() === "from nobody") },
   ],

--- a/packages/cli/test/fixtures/multi-user-markers/false-computed.test.tsx
+++ b/packages/cli/test/fixtures/multi-user-markers/false-computed.test.tsx
@@ -9,6 +9,7 @@ import {
   computed,
   multiUserTest,
   pattern,
+  TESTS,
   Writable,
 } from "commonfabric";
 
@@ -21,14 +22,14 @@ export const setup = pattern<Record<string, never>, MarkerSetup>(() => ({
 }));
 
 export const alice = pattern<{ setup: MarkerSetup }>(({ setup }) => ({
-  tests: [
+  [TESTS]: [
     { action: action(() => setup.note.set("from alice")) },
     { label: "alice-wrote" },
   ],
 }));
 
 export const bob = pattern<{ setup: MarkerSetup }>(({ setup }) => ({
-  tests: [
+  [TESTS]: [
     { await: "alice-wrote" },
     { assertion: computed(() => setup.note.get() === "from nobody") },
   ],

--- a/packages/cli/test/fixtures/multi-user-markers/marker-barrier.test.tsx
+++ b/packages/cli/test/fixtures/multi-user-markers/marker-barrier.test.tsx
@@ -4,7 +4,14 @@
  * `{ label }`. Bob's assertion is read once, so it passes only when the
  * marker brought Alice's write with it.
  */
-import { action, assert, multiUserTest, pattern, Writable } from "commonfabric";
+import {
+  action,
+  assert,
+  multiUserTest,
+  pattern,
+  TESTS,
+  Writable,
+} from "commonfabric";
 
 export interface MarkerSetup {
   note: Writable<string>;
@@ -15,14 +22,14 @@ export const setup = pattern<Record<string, never>, MarkerSetup>(() => ({
 }));
 
 export const alice = pattern<{ setup: MarkerSetup }>(({ setup }) => ({
-  tests: [
+  [TESTS]: [
     { action: action(() => setup.note.set("from alice")) },
     { label: "alice-wrote" },
   ],
 }));
 
 export const bob = pattern<{ setup: MarkerSetup }>(({ setup }) => ({
-  tests: [
+  [TESTS]: [
     { await: "alice-wrote" },
     { assertion: assert(() => setup.note.get() === "from alice") },
   ],

--- a/packages/cli/test/fixtures/multi-user-markers/unannounced-marker.test.tsx
+++ b/packages/cli/test/fixtures/multi-user-markers/unannounced-marker.test.tsx
@@ -4,7 +4,7 @@
  * only unfinished participant and nothing left to release him, which the
  * orchestrator reports as a deadlock.
  */
-import { assert, multiUserTest, pattern, Writable } from "commonfabric";
+import { assert, multiUserTest, pattern, TESTS, Writable } from "commonfabric";
 
 export interface MarkerSetup {
   note: Writable<string>;
@@ -15,11 +15,11 @@ export const setup = pattern<Record<string, never>, MarkerSetup>(() => ({
 }));
 
 export const alice = pattern<{ setup: MarkerSetup }>(({ setup }) => ({
-  tests: [{ assertion: assert(() => setup.note.get() === "") }],
+  [TESTS]: [{ assertion: assert(() => setup.note.get() === "") }],
 }));
 
 export const bob = pattern<{ setup: MarkerSetup }>(({ setup }) => ({
-  tests: [
+  [TESTS]: [
     { await: "never-announced" },
     { assertion: assert(() => setup.note.get() === "") },
   ],

--- a/packages/cli/test/fixtures/pattern-coverage/subject.tsx
+++ b/packages/cli/test/fixtures/pattern-coverage/subject.tsx
@@ -1,4 +1,4 @@
-import { action, computed, pattern, Writable } from "commonfabric";
+import { action, computed, pattern, TESTS, Writable } from "commonfabric";
 
 function incrementCount(count: Writable<number>): void {
   count.set(count.get() + 1);
@@ -22,7 +22,7 @@ export const singlePattern = pattern(() => {
   const isOne = computed(() => countIsOne(count));
 
   return {
-    tests: [
+    [TESTS]: [
       { action: increment },
       { assertion: isOne },
     ],
@@ -34,7 +34,7 @@ export const alice = pattern(() => {
   const isAlice = computed(() => isAliceName(name));
 
   return {
-    tests: [{ assertion: isAlice }],
+    [TESTS]: [{ assertion: isAlice }],
   };
 });
 
@@ -43,6 +43,6 @@ export const bob = pattern(() => {
   const isBob = computed(() => isBobName(name));
 
   return {
-    tests: [{ assertion: isBob }],
+    [TESTS]: [{ assertion: isBob }],
   };
 });

--- a/packages/cli/test/fixtures/render-step/continuous-multi-user.test.tsx
+++ b/packages/cli/test/fixtures/render-step/continuous-multi-user.test.tsx
@@ -3,6 +3,7 @@ import {
   computed,
   multiUserTest,
   pattern,
+  TESTS,
   UI,
   Writable,
 } from "commonfabric";
@@ -24,7 +25,7 @@ const alice = pattern(() => {
 
   return {
     [UI]: view,
-    tests: [
+    [TESTS]: [
       { action: advance },
       { assertion: isLate },
     ],

--- a/packages/cli/test/fixtures/render-step/continuous-ui.test.tsx
+++ b/packages/cli/test/fixtures/render-step/continuous-ui.test.tsx
@@ -1,4 +1,4 @@
-import { action, computed, pattern, UI, Writable } from "commonfabric";
+import { action, computed, pattern, TESTS, UI, Writable } from "commonfabric";
 import { lateVDOMBranch } from "./subject.tsx";
 
 export default pattern(() => {
@@ -17,7 +17,7 @@ export default pattern(() => {
 
   return {
     [UI]: view,
-    tests: [
+    [TESTS]: [
       { action: advance },
       { assertion: isLate },
     ],

--- a/packages/cli/test/fixtures/render-step/direct-array-render.test.tsx
+++ b/packages/cli/test/fixtures/render-step/direct-array-render.test.tsx
@@ -1,7 +1,7 @@
-import { computed, pattern } from "commonfabric";
+import { computed, pattern, TESTS } from "commonfabric";
 
 export default pattern(() => ({
-  tests: [
+  [TESTS]: [
     { render: [null, undefined, "text", 1, true, false, []] },
     { assertion: computed(() => true) },
   ],

--- a/packages/cli/test/fixtures/render-step/invalid-continuous-ui.test.tsx
+++ b/packages/cli/test/fixtures/render-step/invalid-continuous-ui.test.tsx
@@ -1,8 +1,8 @@
-import { computed, pattern, UI, type VNode } from "commonfabric";
+import { computed, pattern, TESTS, UI, type VNode } from "commonfabric";
 
 export default pattern(() => ({
   // Deliberately not a real VNode at run time: this fixture feeds the runner
   // an invalid continuous-UI value to check how it reports one.
   [UI]: {} as VNode,
-  tests: [{ assertion: computed(() => true) }],
+  [TESTS]: [{ assertion: computed(() => true) }],
 }));

--- a/packages/cli/test/fixtures/render-step/invalid-render.test.tsx
+++ b/packages/cli/test/fixtures/render-step/invalid-render.test.tsx
@@ -1,5 +1,5 @@
-import { pattern } from "commonfabric";
+import { pattern, TESTS } from "commonfabric";
 
 export default pattern(() => ({
-  tests: [{ render: {} }],
+  [TESTS]: [{ render: {} }],
 }));

--- a/packages/cli/test/fixtures/render-step/multi-user.test.tsx
+++ b/packages/cli/test/fixtures/render-step/multi-user.test.tsx
@@ -3,6 +3,7 @@ import {
   computed,
   multiUserTest,
   pattern,
+  TESTS,
   Writable,
 } from "commonfabric";
 import { lateVDOMBranch } from "./subject.tsx";
@@ -22,7 +23,7 @@ const alice = pattern(() => {
   const isLate = computed(() => phase.get() === "late");
 
   return {
-    tests: [
+    [TESTS]: [
       { action: advance },
       { render: view },
       { assertion: isLate },

--- a/packages/cli/test/fixtures/render-step/no-render.test.tsx
+++ b/packages/cli/test/fixtures/render-step/no-render.test.tsx
@@ -1,4 +1,4 @@
-import { action, computed, pattern, Writable } from "commonfabric";
+import { action, computed, pattern, TESTS, Writable } from "commonfabric";
 import { lateVDOMBranch } from "./subject.tsx";
 
 export default pattern(() => {
@@ -17,7 +17,7 @@ export default pattern(() => {
   void view;
 
   return {
-    tests: [
+    [TESTS]: [
       { action: advance },
       { assertion: isLate },
     ],

--- a/packages/cli/test/fixtures/render-step/primitive-render.test.tsx
+++ b/packages/cli/test/fixtures/render-step/primitive-render.test.tsx
@@ -1,7 +1,7 @@
-import { computed, pattern } from "commonfabric";
+import { computed, pattern, TESTS } from "commonfabric";
 
 export default pattern(() => ({
-  tests: [
+  [TESTS]: [
     { render: null },
     { render: "text" },
     { render: 1 },

--- a/packages/cli/test/fixtures/render-step/render-cleanup.test.tsx
+++ b/packages/cli/test/fixtures/render-step/render-cleanup.test.tsx
@@ -1,4 +1,4 @@
-import { action, computed, pattern, Writable } from "commonfabric";
+import { action, computed, pattern, TESTS, Writable } from "commonfabric";
 import { afterRenderBranch, lateVDOMBranch } from "./subject.tsx";
 
 export default pattern(() => {
@@ -21,7 +21,7 @@ export default pattern(() => {
   const isAfterRender = computed(() => phase.get() === "after-render");
 
   return {
-    tests: [
+    [TESTS]: [
       { action: reachLate },
       { render: view },
       { action: advanceAfterRender },

--- a/packages/cli/test/fixtures/render-step/render-step.test.tsx
+++ b/packages/cli/test/fixtures/render-step/render-step.test.tsx
@@ -1,4 +1,4 @@
-import { action, computed, pattern, Writable } from "commonfabric";
+import { action, computed, pattern, TESTS, Writable } from "commonfabric";
 import { lateVDOMBranch } from "./subject.tsx";
 
 export default pattern(() => {
@@ -16,7 +16,7 @@ export default pattern(() => {
   const isLate = computed(() => phase.get() === "late");
 
   return {
-    tests: [
+    [TESTS]: [
       { action: advance },
       { render: view },
       { assertion: isLate },

--- a/packages/cli/test/fixtures/render-step/skipped-render.test.tsx
+++ b/packages/cli/test/fixtures/render-step/skipped-render.test.tsx
@@ -1,4 +1,4 @@
-import { action, computed, pattern, Writable } from "commonfabric";
+import { action, computed, pattern, TESTS, Writable } from "commonfabric";
 import { lateVDOMBranch } from "./subject.tsx";
 
 export default pattern(() => {
@@ -16,7 +16,7 @@ export default pattern(() => {
   const isLate = computed(() => phase.get() === "late");
 
   return {
-    tests: [
+    [TESTS]: [
       { action: advance },
       { render: view, skip: true },
       { assertion: isLate },

--- a/packages/cli/test/fixtures/settle/invalid-step.test.tsx
+++ b/packages/cli/test/fixtures/settle/invalid-step.test.tsx
@@ -2,11 +2,11 @@
  * Fixture: a step with no `action` / `assertion` / `settle` key. The runner must
  * reject it; the error surfaces as a file-level error on the run result.
  */
-import { pattern } from "commonfabric";
+import { pattern, TESTS } from "commonfabric";
 
 export default pattern(() => {
   return {
     // deno-lint-ignore no-explicit-any
-    tests: [{ notAValidStep: true } as any],
+    [TESTS]: [{ notAValidStep: true } as any],
   };
 });

--- a/packages/cli/test/fixtures/settle/settle-step.test.tsx
+++ b/packages/cli/test/fixtures/settle/settle-step.test.tsx
@@ -4,7 +4,7 @@
  * step. The settle step is transparent: it produces no assertion result and the
  * run passes.
  */
-import { action, computed, pattern, Writable } from "commonfabric";
+import { action, computed, pattern, TESTS, Writable } from "commonfabric";
 
 export default pattern(() => {
   const flag = new Writable(false);
@@ -12,7 +12,7 @@ export default pattern(() => {
   const isSet = computed(() => flag.get() === true);
 
   return {
-    tests: [
+    [TESTS]: [
       { action: setFlag },
       // Full settle between the action and the assertion.
       { settle: true },

--- a/packages/cli/test/fixtures/storage-host/counter.test.tsx
+++ b/packages/cli/test/fixtures/storage-host/counter.test.tsx
@@ -4,7 +4,7 @@
  * pattern actually reached to find — which is the whole point of the option
  * (the pattern-vintage capture snapshots the store afterwards).
  */
-import { action, computed, pattern, Writable } from "commonfabric";
+import { action, computed, pattern, TESTS, Writable } from "commonfabric";
 
 export default pattern(() => {
   const count = new Writable(0).for("count");
@@ -12,7 +12,7 @@ export default pattern(() => {
 
   return {
     count,
-    tests: [
+    [TESTS]: [
       { action: bump },
       { action: bump },
       { assertion: computed(() => count.get() === 2) },

--- a/packages/patterns/airtable/airtable-importer.test.tsx
+++ b/packages/patterns/airtable/airtable-importer.test.tsx
@@ -6,7 +6,7 @@
  *
  * Run: deno task cf test packages/patterns/airtable/airtable-importer.test.tsx --root packages/patterns --verbose
  */
-import { assert, pattern, UI } from "commonfabric";
+import { assert, pattern, TESTS, UI } from "commonfabric";
 import { hasText } from "../test/vnode-helpers.ts";
 import AirtableImporter from "./airtable-importer.tsx";
 
@@ -43,7 +43,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_initial_data_empty },
       { assertion: assert_selected_names_empty },
       { assertion: assert_waiting_message_is_rendered },

--- a/packages/patterns/airtable/core/util/airtable-auth-manager.test.tsx
+++ b/packages/patterns/airtable/core/util/airtable-auth-manager.test.tsx
@@ -5,7 +5,7 @@
  *
  * Run: deno task cf test packages/patterns/airtable/core/util/airtable-auth-manager.test.tsx --root packages/patterns --verbose
  */
-import { assert, pattern } from "commonfabric";
+import { assert, pattern, TESTS } from "commonfabric";
 import { hasText } from "../../../test/vnode-helpers.ts";
 import {
   AirtableAuthManager,
@@ -13,7 +13,7 @@ import {
 } from "./airtable-auth-manager.tsx";
 
 interface TestOutput {
-  tests: unknown[];
+  [TESTS]: unknown[];
   manager: AirtableAuthManagerOutput;
 }
 
@@ -44,7 +44,7 @@ export default pattern<Record<string, never>, TestOutput>(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_loading_state },
       { assertion: assert_availability_is_loading },
       { assertion: assert_auth_info_matches_availability },

--- a/packages/patterns/auth/create-auth-manager.test.tsx
+++ b/packages/patterns/auth/create-auth-manager.test.tsx
@@ -6,7 +6,7 @@
  *
  * Run: deno task cf test packages/patterns/auth/create-auth-manager.test.tsx --verbose
  */
-import { action, assert, pattern } from "commonfabric";
+import { action, assert, pattern, TESTS } from "commonfabric";
 import type { AuthManagerDescriptor } from "./auth-manager-descriptor.ts";
 import { AuthManagerBase } from "./create-auth-manager.tsx";
 import { hasText } from "../test/vnode-helpers.ts";
@@ -83,7 +83,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_loading_state },
       { assertion: assert_availability_is_loading },
       { assertion: assert_auth_info_matches_state },

--- a/packages/patterns/auth/ready-auth.test.tsx
+++ b/packages/patterns/auth/ready-auth.test.tsx
@@ -6,7 +6,14 @@
  *
  * Run: deno task cf test packages/patterns/auth/ready-auth.test.tsx --verbose
  */
-import { action, assert, computed, pattern, Writable } from "commonfabric";
+import {
+  action,
+  assert,
+  computed,
+  pattern,
+  TESTS,
+  Writable,
+} from "commonfabric";
 import {
   type AuthAvailability,
   authIsReady,
@@ -94,7 +101,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_auth_unavailable },
       { action: mark_needs_login },
       { assertion: assert_auth_unavailable },

--- a/packages/patterns/battleship/multiplayer/lobby.test.tsx
+++ b/packages/patterns/battleship/multiplayer/lobby.test.tsx
@@ -10,7 +10,7 @@
  *
  * Run: deno task cf test packages/patterns/battleship/multiplayer/lobby.test.tsx --verbose
  */
-import { action, assert, pattern, Writable } from "commonfabric";
+import { action, assert, pattern, TESTS, Writable } from "commonfabric";
 import BattleshipLobby from "./lobby.tsx";
 import {
   createInitialShots,
@@ -203,7 +203,7 @@ export default pattern(() => {
   // Test Sequence
   // ==========================================================================
   return {
-    tests: [
+    [TESTS]: [
       // === Initial State Tests ===
       { assertion: assert_initial_game_name },
       { assertion: assert_initial_player1_null },

--- a/packages/patterns/battleship/multiplayer/multi-user.test.tsx
+++ b/packages/patterns/battleship/multiplayer/multi-user.test.tsx
@@ -11,7 +11,7 @@
  * Joins go through the programmatic `joinWithName` stream (the headless seam
  * kept by the profile migration); the profile-wish UI path needs a browser.
  */
-import { action, computed, multiUserTest, pattern } from "commonfabric";
+import { action, computed, multiUserTest, pattern, TESTS } from "commonfabric";
 import BattleshipLobby, { type LobbyOutput } from "./lobby.tsx";
 
 interface Setup {
@@ -45,7 +45,7 @@ export const alice = pattern<{ setup: Setup }>(({ setup }) => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { action: action_join },
       { assertion: assert_joined_slot_1 },
       { label: "alice-joined" },
@@ -80,7 +80,7 @@ export const bob = pattern<{ setup: Setup }>(({ setup }) => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { await: "alice-joined" },
       { assertion: assert_sees_alice },
       { assertion: assert_not_joined_yet },

--- a/packages/patterns/battleship/multiplayer/room.test.tsx
+++ b/packages/patterns/battleship/multiplayer/room.test.tsx
@@ -11,7 +11,14 @@
  *
  * Run: deno task cf test packages/patterns/battleship/multiplayer/room.test.tsx --root packages/patterns/battleship --verbose
  */
-import { action, assert, computed, pattern, Writable } from "commonfabric";
+import {
+  action,
+  assert,
+  computed,
+  pattern,
+  TESTS,
+  Writable,
+} from "commonfabric";
 import BattleshipRoom from "./room.tsx";
 import {
   createInitialShots,
@@ -188,7 +195,7 @@ export default pattern(() => {
   // Test Sequence
   // ==========================================================================
   return {
-    tests: [
+    [TESTS]: [
       // === Initial State ===
       { assertion: assert_initial_turn_is_player1 },
       { assertion: assert_initial_phase_playing },

--- a/packages/patterns/battleship/pass-and-play/main.test.tsx
+++ b/packages/patterns/battleship/pass-and-play/main.test.tsx
@@ -29,7 +29,7 @@
  *
  * Run: deno task cf test packages/patterns/battleship/pass-and-play/main.test.tsx --verbose
  */
-import { action, assert, pattern } from "commonfabric";
+import { action, assert, pattern, TESTS } from "commonfabric";
 import Battleship, { type SquareState } from "./main.tsx";
 
 export default pattern(() => {
@@ -152,7 +152,7 @@ export default pattern(() => {
   // Test Sequence - array of { assertion } or { action } objects
   // ==========================================================================
   return {
-    tests: [
+    [TESTS]: [
       // === Test 1: Initial state ===
       { assertion: assert_initial_phase_playing },
       { assertion: assert_initial_turn_player1 },

--- a/packages/patterns/budget-tracker/expense-form.test.tsx
+++ b/packages/patterns/budget-tracker/expense-form.test.tsx
@@ -20,6 +20,7 @@ import {
   equals,
   handler,
   pattern,
+  TESTS,
   Writable,
 } from "commonfabric";
 import ExpenseForm from "./expense-form.tsx";
@@ -117,7 +118,7 @@ export default pattern(() => {
   // Test Sequence
   // ==========================================================================
   return {
-    tests: [
+    [TESTS]: [
       // Create
       { action: action_set_food_budget },
       { assertion: assert_food_created },

--- a/packages/patterns/calendar/calendar.test.tsx
+++ b/packages/patterns/calendar/calendar.test.tsx
@@ -12,7 +12,7 @@
  *
  * Run: deno task cf test packages/patterns/calendar/calendar.test.tsx --verbose
  */
-import { action, assert, pattern } from "commonfabric";
+import { action, assert, pattern, TESTS } from "commonfabric";
 import Calendar from "./calendar.tsx";
 
 export default pattern(() => {
@@ -140,7 +140,7 @@ export default pattern(() => {
   // Test Sequence
   // ==========================================================================
   return {
-    tests: [
+    [TESTS]: [
       // === Initial state ===
       { assertion: assert_initial_empty },
 

--- a/packages/patterns/calendar/event-detail.test.tsx
+++ b/packages/patterns/calendar/event-detail.test.tsx
@@ -7,7 +7,7 @@
  *
  * Run: deno task cf test packages/patterns/calendar/event-detail.test.tsx --verbose
  */
-import { action, assert, NAME, pattern } from "commonfabric";
+import { action, assert, NAME, pattern, TESTS } from "commonfabric";
 import EventDetail from "./event-detail.tsx";
 
 export default pattern(() => {
@@ -83,7 +83,7 @@ export default pattern(() => {
   // Test Sequence
   // ==========================================================================
   return {
-    tests: [
+    [TESTS]: [
       // === Initial state ===
       { assertion: assert_name },
       { assertion: assert_initial_title },

--- a/packages/patterns/card-piles/main.test.tsx
+++ b/packages/patterns/card-piles/main.test.tsx
@@ -14,7 +14,7 @@
  *
  * Run: deno task cf test packages/patterns/card-piles/main.test.tsx --verbose
  */
-import { action, assert, pattern } from "commonfabric";
+import { action, assert, pattern, TESTS } from "commonfabric";
 import CardPiles, { defaultPile1, defaultPile2 } from "./main.tsx";
 
 export default pattern(() => {
@@ -267,7 +267,7 @@ export default pattern(() => {
   // Test sequence
   // =========================================================================
   return {
-    tests: [
+    [TESTS]: [
       // --- Initial state: defaults ---
       { assertion: assert_defaults_pile1_count },
       { assertion: assert_defaults_pile2_count },

--- a/packages/patterns/catalog/stories/cf-calendar-story.test.tsx
+++ b/packages/patterns/catalog/stories/cf-calendar-story.test.tsx
@@ -1,4 +1,4 @@
-import { assert, NAME, pattern, UI } from "commonfabric";
+import { assert, NAME, pattern, TESTS, UI } from "commonfabric";
 import CalendarStory from "./cf-calendar-story.tsx";
 
 // Lane-2 pattern test (run by `cf test`): instantiating the story runs its body
@@ -19,5 +19,5 @@ export default pattern(() => {
     story[NAME] === "cf-calendar Story" &&
     story[UI] != null
   );
-  return { tests: [{ assertion: assert_story_built }] };
+  return { [TESTS]: [{ assertion: assert_story_built }] };
 });

--- a/packages/patterns/catalog/stories/cf-submit-input-story.test.tsx
+++ b/packages/patterns/catalog/stories/cf-submit-input-story.test.tsx
@@ -1,4 +1,4 @@
-import { assert, NAME, pattern, UI } from "commonfabric";
+import { assert, NAME, pattern, TESTS, UI } from "commonfabric";
 import SubmitInputStory from "./cf-submit-input-story.tsx";
 
 // Lane-2 pattern test (run by `cf test`): instantiating the story runs its body
@@ -12,5 +12,5 @@ export default pattern(() => {
     story[UI] != null &&
     story.controls != null
   );
-  return { tests: [{ assertion: assert_story_built }] };
+  return { [TESTS]: [{ assertion: assert_story_built }] };
 });

--- a/packages/patterns/cfc-authorized-save/main.test.tsx
+++ b/packages/patterns/cfc-authorized-save/main.test.tsx
@@ -1,4 +1,4 @@
-import { assert, handler, pattern, Writable } from "commonfabric";
+import { assert, handler, pattern, TESTS, Writable } from "commonfabric";
 import {
   SAVE_TITLE_ACTION,
   TRUSTED_SAVE_SURFACE,
@@ -53,7 +53,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_initial_saved_empty },
       { action: action_set_first_draft },
       { assertion: assert_first_draft_visible },

--- a/packages/patterns/cfc-authorship-chat/main.test.tsx
+++ b/packages/patterns/cfc-authorship-chat/main.test.tsx
@@ -1,4 +1,4 @@
-import { assert, pattern } from "commonfabric";
+import { assert, pattern, TESTS } from "commonfabric";
 import AuthorshipChat from "./main.tsx";
 
 export default pattern(() => {
@@ -15,7 +15,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_verified_fixture_names_alice },
       { assertion: assert_forged_fixture_names_bob },
       { assertion: assert_unsigned_fixture_names_casey },

--- a/packages/patterns/cfc-exchange-rules/direct-release.test.tsx
+++ b/packages/patterns/cfc-exchange-rules/direct-release.test.tsx
@@ -1,4 +1,4 @@
-import { assert, pattern } from "commonfabric";
+import { assert, pattern, TESTS } from "commonfabric";
 import DirectRelease from "./direct-release.tsx";
 
 export default pattern(() => {
@@ -13,7 +13,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_default_message },
       { assertion: assert_custom_message },
     ],

--- a/packages/patterns/cfc-exchange-rules/imported-policy.test.tsx
+++ b/packages/patterns/cfc-exchange-rules/imported-policy.test.tsx
@@ -1,4 +1,4 @@
-import { assert, pattern } from "commonfabric";
+import { assert, pattern, TESTS } from "commonfabric";
 import ImportedPolicy from "./imported-policy.tsx";
 
 export default pattern(() => {
@@ -6,7 +6,7 @@ export default pattern(() => {
   const customPolicy = ImportedPolicy({ message: "Imported policy message" });
 
   return {
-    tests: [
+    [TESTS]: [
       {
         assertion: assert(() =>
           defaultPolicy.message ===

--- a/packages/patterns/cfc-group-chat-demo/main.test.tsx
+++ b/packages/patterns/cfc-group-chat-demo/main.test.tsx
@@ -1,4 +1,12 @@
-import { action, assert, Default, pattern, UI, Writable } from "commonfabric";
+import {
+  action,
+  assert,
+  Default,
+  pattern,
+  TESTS,
+  UI,
+  Writable,
+} from "commonfabric";
 import {
   findNodeById,
   findNodeByProp,
@@ -327,7 +335,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_initially_empty },
       { assertion: assert_admin_view_waits_for_profile },
       { action: action_set_profile_alice },

--- a/packages/patterns/cfc-group-chat-demo/multi-user.test.tsx
+++ b/packages/patterns/cfc-group-chat-demo/multi-user.test.tsx
@@ -17,6 +17,7 @@ import {
   type Default,
   multiUserTest,
   pattern,
+  TESTS,
   type Writable,
 } from "commonfabric";
 import {
@@ -90,7 +91,7 @@ export const alice = pattern<{ setup: Setup }>(({ setup }) => {
   const assert_is_admin = computed(() => chat.currentUserIsAdmin === true);
 
   return {
-    tests: [
+    [TESTS]: [
       { action: action_set_name },
       { action: chat.saveProfile, trustedUi: profileGesture },
       { assertion: assert_named_alice },
@@ -148,7 +149,7 @@ export const bob = pattern<{ setup: Setup }>(({ setup }) => {
   const assert_not_admin = computed(() => chat.currentUserIsAdmin === false);
 
   return {
-    tests: [
+    [TESTS]: [
       { await: "alice-saved" },
       { assertion: assert_draft_empty },
       { assertion: assert_unnamed },

--- a/packages/patterns/cfc-render-policy-demo/main.test.tsx
+++ b/packages/patterns/cfc-render-policy-demo/main.test.tsx
@@ -1,4 +1,11 @@
-import { assert, handler, pattern, Stream, Writable } from "commonfabric";
+import {
+  assert,
+  handler,
+  pattern,
+  Stream,
+  TESTS,
+  Writable,
+} from "commonfabric";
 import RenderPolicyDemo, { TrustedHealthDisclosureSurface } from "./main.tsx";
 
 const trigger = handler<void, { stream: Stream<unknown> }>((_, { stream }) => {
@@ -21,7 +28,7 @@ export default pattern(() => {
   const assert_concealed = assert(() => revealSensitive.get() === false);
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_initially_hidden },
       { action: action_reveal },
       { assertion: assert_revealed },

--- a/packages/patterns/cfc-spec-gallery/main.test.tsx
+++ b/packages/patterns/cfc-spec-gallery/main.test.tsx
@@ -1,4 +1,4 @@
-import { assert, handler, pattern, Stream } from "commonfabric";
+import { assert, handler, pattern, Stream, TESTS } from "commonfabric";
 import Gallery from "./main.tsx";
 
 const trigger = handler<void, { stream: Stream<void> }>((_, { stream }) => {
@@ -91,7 +91,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_count },
       { action: action_change_forward_recipient },
       { action: action_prepare_forward },

--- a/packages/patterns/cfc-staged-publish/main.test.tsx
+++ b/packages/patterns/cfc-staged-publish/main.test.tsx
@@ -1,4 +1,4 @@
-import { assert, handler, pattern, Writable } from "commonfabric";
+import { assert, handler, pattern, TESTS, Writable } from "commonfabric";
 import {
   PUBLISH_SNAPSHOT_ACTION,
   REVIEW_SNAPSHOT_ACTION,
@@ -80,7 +80,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_initial_stage },
       { action: action_set_draft },
       // Each stage's write is gated on its reviewed surface's trusted

--- a/packages/patterns/cfc-trusted-component-examples/confirmation-release-examples.test.tsx
+++ b/packages/patterns/cfc-trusted-component-examples/confirmation-release-examples.test.tsx
@@ -1,4 +1,4 @@
-import { assert, handler, pattern } from "commonfabric";
+import { assert, handler, pattern, TESTS } from "commonfabric";
 import {
   CustomerSupportRecipientConfirmExample,
   FinanceRecipientConfirmExample,
@@ -74,7 +74,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { action: runRecipientConfirm({ suite: finance }) },
       { assertion: assert_finance_confirmed },
       { action: runSupportConfirm({ suite: support }) },

--- a/packages/patterns/cfc-trusted-component-examples/disclaimer-examples.test.tsx
+++ b/packages/patterns/cfc-trusted-component-examples/disclaimer-examples.test.tsx
@@ -1,4 +1,4 @@
-import { assert, handler, pattern, Writable } from "commonfabric";
+import { assert, handler, pattern, TESTS, Writable } from "commonfabric";
 import {
   DISCLAIMER_EXAMPLE_COUNT,
   DISCLAIMER_RENDERED_EXAMPLE_COUNT,
@@ -136,7 +136,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { action: runAck({ suite: influence }) },
       { assertion: assert_influence_disclosure_is_render_only },
       { action: runProvenance({ suite: provenance }) },

--- a/packages/patterns/cfc-trusted-component-examples/main.test.tsx
+++ b/packages/patterns/cfc-trusted-component-examples/main.test.tsx
@@ -1,4 +1,4 @@
-import { assert, pattern } from "commonfabric";
+import { assert, pattern, TESTS } from "commonfabric";
 import TrustedComponentExamples from "./main.tsx";
 
 export default pattern(() => {
@@ -6,7 +6,7 @@ export default pattern(() => {
   const assert_total_examples = assert(() => gallery.totalExamples === 52);
 
   return {
-    tests: [{ assertion: assert_total_examples }],
+    [TESTS]: [{ assertion: assert_total_examples }],
     gallery,
   };
 });

--- a/packages/patterns/cfc-trusted-component-examples/process-examples.test.tsx
+++ b/packages/patterns/cfc-trusted-component-examples/process-examples.test.tsx
@@ -1,4 +1,4 @@
-import { assert, handler, pattern } from "commonfabric";
+import { assert, handler, pattern, TESTS } from "commonfabric";
 import {
   BatchPhotoUploadJobExample,
   CalendarAvailabilityPolicyExample,
@@ -66,7 +66,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { action: runSong({ suite: song }) },
       { assertion: assert_song_id_only },
       { action: runPolicy({ suite: policy }) },

--- a/packages/patterns/cfc-trusted-component-examples/send-publish-examples.test.tsx
+++ b/packages/patterns/cfc-trusted-component-examples/send-publish-examples.test.tsx
@@ -1,4 +1,4 @@
-import { assert, handler, pattern } from "commonfabric";
+import { assert, handler, pattern, TESTS } from "commonfabric";
 import {
   ChatThreadSendExample,
   DirectMessageSendExample,
@@ -77,7 +77,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { action: runChatThread({ suite: chatThread }) },
       { assertion: assertChatThread },
       { action: runProjectUpdate({ suite: projectUpdate }) },

--- a/packages/patterns/cfc/trusted-surfaces/main.test.tsx
+++ b/packages/patterns/cfc/trusted-surfaces/main.test.tsx
@@ -1,4 +1,11 @@
-import { assert, handler, pattern, Stream, Writable } from "commonfabric";
+import {
+  assert,
+  handler,
+  pattern,
+  Stream,
+  TESTS,
+  Writable,
+} from "commonfabric";
 import {
   SAVE_DRAFT_ACTION,
   SAVE_TITLE_ACTION,
@@ -390,7 +397,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { action: action_set_title },
       // The `savedTitle` / `savedBody` writes carry TrustedAction UI
       // contracts: send the renderer-trusted gesture for the reviewed surface

--- a/packages/patterns/contacts/contact-book.test.tsx
+++ b/packages/patterns/contacts/contact-book.test.tsx
@@ -10,7 +10,7 @@
  *
  * Run: deno task cf test packages/patterns/counter/counter.test.tsx --verbose
  */
-import { action, assert, pattern } from "commonfabric";
+import { action, assert, pattern, TESTS } from "commonfabric";
 import { default as ContactBook, matchesSearch } from "./contact-book.tsx";
 import { type Contact } from "./contact-detail.tsx";
 
@@ -61,7 +61,7 @@ export default pattern(() => {
   // Test Sequence
   // ==========================================================================
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_empty_query_matches_all },
       { assertion: assert_name_query_matches },
       { assertion: assert_email_query_matches },

--- a/packages/patterns/counter/counter.test.tsx
+++ b/packages/patterns/counter/counter.test.tsx
@@ -10,7 +10,7 @@
  *
  * Run: deno task cf test packages/patterns/counter/counter.test.tsx --verbose
  */
-import { action, assert, pattern } from "commonfabric";
+import { action, assert, pattern, TESTS } from "commonfabric";
 import Counter from "./counter.tsx";
 
 export default pattern(() => {
@@ -92,7 +92,7 @@ export default pattern(() => {
   // Test Sequence
   // ==========================================================================
   return {
-    tests: [
+    [TESTS]: [
       // === Test 1: Initial state ===
       { assertion: assert_initial_value_is_0 },
       { assertion: assert_initial_value_is_5 },

--- a/packages/patterns/cozy-poll/main.test.tsx
+++ b/packages/patterns/cozy-poll/main.test.tsx
@@ -11,7 +11,7 @@
  * are covered by multi-user.test.tsx.
  */
 
-import { action, assert, pattern } from "commonfabric";
+import { action, assert, pattern, TESTS } from "commonfabric";
 import CozyPoll from "./main.tsx";
 
 export default pattern(() => {
@@ -145,7 +145,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       // Admin-gated handlers are no-ops before anyone joins (myName empty).
       // The handler bails on `if (!me || me !== admin) return`. No
       // separate assertion here — downstream assertions (e.g. only

--- a/packages/patterns/cozy-poll/multi-user.test.tsx
+++ b/packages/patterns/cozy-poll/multi-user.test.tsx
@@ -14,7 +14,7 @@
  * Cross-runtime reads use INLINE literal accesses — see
  * scrabble/multi-user.test.tsx.
  */
-import { action, computed, multiUserTest, pattern } from "commonfabric";
+import { action, computed, multiUserTest, pattern, TESTS } from "commonfabric";
 import CozyPoll, { type CozyPollOutput } from "./main.tsx";
 
 interface Setup {
@@ -62,7 +62,7 @@ export const alice = pattern<{ setup: Setup }>(({ setup }) => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { action: action_join },
       { assertion: assert_joined_as_host },
       { action: action_add_ramen },
@@ -122,7 +122,7 @@ export const bob = pattern<{ setup: Setup }>(({ setup }) => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { await: "alice-set-up" },
       { assertion: assert_sees_alice_setup },
       { assertion: assert_not_joined_yet },

--- a/packages/patterns/dice.test.tsx
+++ b/packages/patterns/dice.test.tsx
@@ -1,4 +1,4 @@
-import { action, assert, pattern } from "commonfabric";
+import { action, assert, pattern, TESTS } from "commonfabric";
 import Dice from "./dice.tsx";
 
 // The roll handler draws from Math.random(), which the capability gate allows in
@@ -36,7 +36,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { action: action_roll_default },
       { assertion: assert_default_roll_is_a_d6 },
       { action: action_roll_d20 },

--- a/packages/patterns/do-list/do-list.test.tsx
+++ b/packages/patterns/do-list/do-list.test.tsx
@@ -19,7 +19,7 @@
  *
  * Run: deno task cf test packages/patterns/do-list/do-list.test.tsx --verbose
  */
-import { action, assert, equals, pattern, Writable } from "commonfabric";
+import { action, assert, equals, pattern, TESTS, Writable } from "commonfabric";
 import DoList, { type DoItem } from "./do-list.tsx";
 
 export default pattern(() => {
@@ -194,7 +194,7 @@ export default pattern(() => {
   // Test Sequence
   // ==========================================================================
   return {
-    tests: [
+    [TESTS]: [
       // Initial empty
       { assertion: assert_initial_empty },
 

--- a/packages/patterns/examples/clock.test.tsx
+++ b/packages/patterns/examples/clock.test.tsx
@@ -1,4 +1,4 @@
-import { assert, pattern } from "commonfabric";
+import { assert, pattern, TESTS } from "commonfabric";
 import Clock from "./clock.tsx";
 
 // The clock's labels derive from the reactive #now clock. They read the
@@ -14,7 +14,7 @@ export default pattern(() => {
   const assert_date_is_non_empty = assert(() => clock.date.length > 0);
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_time_is_clock_shaped },
       { assertion: assert_date_is_non_empty },
     ],

--- a/packages/patterns/examples/fetch-delay.test.tsx
+++ b/packages/patterns/examples/fetch-delay.test.tsx
@@ -2,7 +2,7 @@
 // a mock can return after a fixed real-time delay, so a fetchJson isn't resolved
 // instantly. `runtime.settled()` (driven by `{ settle: true }`) still awaits the
 // delayed fetch, so the result is observed deterministically once it lands.
-import { assert, computed, fetchJson, pattern } from "commonfabric";
+import { assert, computed, fetchJson, pattern, TESTS } from "commonfabric";
 
 export const fetchMocks = [
   {
@@ -18,7 +18,7 @@ export default pattern(() => {
   const fetched = fetchJson<{ v: number }>({ url });
   const result_is_7 = assert(() => fetched.result?.v === 7);
   return {
-    tests: [
+    [TESTS]: [
       { settle: true }, // awaits the delayed fetch to completion
       { assertion: result_is_7 },
     ],

--- a/packages/patterns/examples/fetch-mock.test.tsx
+++ b/packages/patterns/examples/fetch-mock.test.tsx
@@ -7,7 +7,7 @@
 //
 // LLM calls (generateText/generateObject) mock separately via @commonfabric/llm;
 // this seam is for generic `fetchJson` HTTP.
-import { assert, computed, fetchJson, pattern } from "commonfabric";
+import { assert, computed, fetchJson, pattern, TESTS } from "commonfabric";
 
 export const fetchMocks = [
   {
@@ -34,7 +34,7 @@ export default pattern(() => {
   const no_error = assert(() => fetched.error === undefined);
 
   return {
-    tests: [
+    [TESTS]: [
       // Drive the in-flight fetchJson (mutex -> mock fetch -> result write) to
       // completion before the assertions read the result.
       { settle: true },

--- a/packages/patterns/examples/instantiate-pattern.test.tsx
+++ b/packages/patterns/examples/instantiate-pattern.test.tsx
@@ -1,4 +1,4 @@
-import { assert, NAME, pattern } from "commonfabric";
+import { assert, NAME, pattern, TESTS } from "commonfabric";
 import Factory, { Counter } from "./instantiate-pattern.tsx";
 
 // Covers both patterns this example file defines: the Counter it hands to
@@ -20,7 +20,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_counter_reports_its_value },
       { assertion: assert_counter_name_tracks_the_value },
       { assertion: assert_factory_instantiates },

--- a/packages/patterns/examples/reactive-now.test.tsx
+++ b/packages/patterns/examples/reactive-now.test.tsx
@@ -1,4 +1,4 @@
-import { action, assert, pattern } from "commonfabric";
+import { action, assert, pattern, TESTS } from "commonfabric";
 import ReactiveNow from "./reactive-now.tsx";
 
 // The time labels derive from the reactive #now clock: they read "…" until #now
@@ -37,7 +37,7 @@ export default pattern(() => {
   const assert_echo = assert(() => demo.echo === "HELLO");
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_loaded_at_is_clock_shaped },
       { assertion: assert_now_is_clock_shaped },
       { assertion: assert_since_load_is_ago_shaped },

--- a/packages/patterns/experimental/chat-note.test.tsx
+++ b/packages/patterns/experimental/chat-note.test.tsx
@@ -1,4 +1,12 @@
-import { action, assert, pattern, UI, wish, Writable } from "commonfabric";
+import {
+  action,
+  assert,
+  pattern,
+  TESTS,
+  UI,
+  wish,
+  Writable,
+} from "commonfabric";
 import { findNode, propsOf } from "../test/vnode-helpers.ts";
 import ChatNote from "./chat-note.tsx";
 
@@ -54,7 +62,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_starts_unlinked },
       { action: action_create_backlink },
       { assertion: assert_backlink_registers_and_mentions_piece },

--- a/packages/patterns/experimental/email-task-engine.test.tsx
+++ b/packages/patterns/experimental/email-task-engine.test.tsx
@@ -4,6 +4,7 @@ import {
   handler,
   pattern,
   type Stream,
+  TESTS,
   Writable,
 } from "commonfabric";
 import Note from "../notes/note.tsx";
@@ -80,7 +81,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_engine_starts_without_tasks },
       { action: action_register_existing_note },
       { action: action_edit_note },

--- a/packages/patterns/experimental/folksonomy-aggregator.test.tsx
+++ b/packages/patterns/experimental/folksonomy-aggregator.test.tsx
@@ -16,7 +16,7 @@
  * instead of action() closures to avoid "reactive reference outside
  * reactive context" errors when accessing reactive proxy objects.
  */
-import { assert, Cell, handler, pattern, Stream } from "commonfabric";
+import { assert, Cell, handler, pattern, Stream, TESTS } from "commonfabric";
 import AggregatorPattern from "./folksonomy-aggregator.tsx";
 
 export interface TagEvent {
@@ -575,7 +575,7 @@ export default pattern(() => {
   // ========================================================================
 
   return {
-    tests: [
+    [TESTS]: [
       // === Initial state: empty ===
       { assertion: assert_initial_empty },
 

--- a/packages/patterns/factory-outputs/lot-watch/main.test.tsx
+++ b/packages/patterns/factory-outputs/lot-watch/main.test.tsx
@@ -22,7 +22,7 @@
  *
  * NOTE: Uses .filter(() => true).length for array lengths per reactivity tracking note.
  */
-import { action, assert, pattern, Writable } from "commonfabric";
+import { action, assert, pattern, TESTS, Writable } from "commonfabric";
 import LotWatch from "./main.tsx";
 import type { KnownVehicle, PlateGroup, Sighting } from "./main.tsx";
 import { classifyPlate, plateKey } from "./main.tsx";
@@ -769,7 +769,7 @@ export default pattern(() => {
   // Test sequence
   // ============================================================
   return {
-    tests: [
+    [TESTS]: [
       // S1: Capture — plate normalization
       { assertion: assert_s1_empty },
       { action: action_s1_capture_lowercase_plate },

--- a/packages/patterns/factory-outputs/parking-coordinator/main.test.tsx
+++ b/packages/patterns/factory-outputs/parking-coordinator/main.test.tsx
@@ -14,7 +14,15 @@
  *
  * NOTE: Uses .filter(() => true).length for array lengths per reactivity tracking note.
  */
-import { action, assert, computed, pattern, UI, wish } from "commonfabric";
+import {
+  action,
+  assert,
+  computed,
+  pattern,
+  TESTS,
+  UI,
+  wish,
+} from "commonfabric";
 import {
   findNodeById,
   findNodeByProp,
@@ -973,7 +981,7 @@ export default pattern(() => {
   // ============================================================
 
   return {
-    tests: [
+    [TESTS]: [
       // People management
       { assertion: assert_s1_no_people },
       { assertion: assert_s1_three_spots },

--- a/packages/patterns/fair-share/main.test.tsx
+++ b/packages/patterns/fair-share/main.test.tsx
@@ -27,6 +27,7 @@ import {
   equals,
   handler,
   pattern,
+  TESTS,
   Writable,
 } from "commonfabric";
 import { joinWithProfile } from "./main.tsx";
@@ -156,7 +157,7 @@ export default pattern(() => {
   // Test Sequence
   // ==========================================================================
   return {
-    tests: [
+    [TESTS]: [
       // Join as a new (avatar-less) person
       { action: action_join_ann_no_avatar },
       { assertion: assert_ann_added },

--- a/packages/patterns/gideon-tests/array-length-repro.test.tsx
+++ b/packages/patterns/gideon-tests/array-length-repro.test.tsx
@@ -10,7 +10,7 @@
  *
  * Run: deno task cf test packages/patterns/gideon-tests/array-length-repro.test.tsx --verbose
  */
-import { action, assert, pattern } from "commonfabric";
+import { action, assert, pattern, TESTS } from "commonfabric";
 import ArrayLengthRepro from "./array-length-repro.tsx";
 
 export default pattern(() => {
@@ -58,7 +58,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       // Initial state - all approaches
       { assertion: assert_initial_length_direct },
       { assertion: assert_initial_length_filter },

--- a/packages/patterns/gideon-tests/ct-1811-mapped-subpattern-derived-output.test.tsx
+++ b/packages/patterns/gideon-tests/ct-1811-mapped-subpattern-derived-output.test.tsx
@@ -29,6 +29,7 @@ import {
   computed,
   NAME,
   pattern,
+  TESTS,
   UI,
   type VNode,
   Writable,
@@ -126,7 +127,7 @@ export default pattern(() => {
   return {
     [NAME]: "ct-1811-mapped-subpattern-derived-output",
     [UI]: ui,
-    tests: [
+    [TESTS]: [
       { assertion: rendered },
     ],
   };

--- a/packages/patterns/gideon-tests/notebook-nest-bug/main.test.tsx
+++ b/packages/patterns/gideon-tests/notebook-nest-bug/main.test.tsx
@@ -1,4 +1,4 @@
-import { action, assert, pattern, wish, Writable } from "commonfabric";
+import { action, assert, pattern, TESTS, wish, Writable } from "commonfabric";
 import type { MinimalPiece } from "../../notes/schemas.tsx";
 import NotebookNestBug from "./main.tsx";
 
@@ -18,7 +18,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_starts_empty },
       { action: action_create_nested_notebooks },
       { assertion: assert_registers_complete_tree },

--- a/packages/patterns/gideon-tests/proxy-length-repro.test.tsx
+++ b/packages/patterns/gideon-tests/proxy-length-repro.test.tsx
@@ -11,7 +11,7 @@
  *
  * Run: deno task cf test packages/patterns/gideon-tests/proxy-length-repro.test.tsx --verbose
  */
-import { action, assert, pattern } from "commonfabric";
+import { action, assert, pattern, TESTS } from "commonfabric";
 import ProxyLengthRepro from "./proxy-length-repro.tsx";
 
 export default pattern(() => {
@@ -92,7 +92,7 @@ export default pattern(() => {
   const assert_count_after = assert(() => subject.itemCount === 1);
 
   return {
-    tests: [
+    [TESTS]: [
       // === Initial state ===
       { assertion: assert_items_length_direct },
       { assertion: assert_items_length_spread },

--- a/packages/patterns/gideon-tests/test-handler-capture-key-equals.test.tsx
+++ b/packages/patterns/gideon-tests/test-handler-capture-key-equals.test.tsx
@@ -11,7 +11,7 @@
  * Run:
  *   deno task cf test packages/patterns/gideon-tests/test-handler-capture-key-equals.test.tsx --verbose
  */
-import { action, assert, pattern } from "commonfabric";
+import { action, assert, pattern, TESTS } from "commonfabric";
 import {
   CellInboxItemCapturePattern,
   WritableInboxItemCapturePattern,
@@ -82,7 +82,7 @@ export default pattern(() => {
   });
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_writable_initial_handlers },
       { assertion: assert_writable_initial_items },
       { action: action_remove_middle_writable },

--- a/packages/patterns/gideon-tests/test-reactivity-jsx-automatic.test.tsx
+++ b/packages/patterns/gideon-tests/test-reactivity-jsx-automatic.test.tsx
@@ -7,7 +7,7 @@
  *
  * Run: deno task cf test packages/patterns/gideon-tests/test-reactivity-jsx-automatic.test.tsx --root packages/patterns --verbose
  */
-import { action, assert, pattern, UI } from "commonfabric";
+import { action, assert, pattern, TESTS, UI } from "commonfabric";
 import {
   findElementByText,
   propsOf,
@@ -72,7 +72,7 @@ export default pattern(() => {
   const assert_count_after_third = assert(() => subject.count === 3);
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_initial_count },
       { assertion: assert_initial_user },
       { assertion: assert_initial_items },

--- a/packages/patterns/gideon-tests/wish-default.test.tsx
+++ b/packages/patterns/gideon-tests/wish-default.test.tsx
@@ -12,6 +12,7 @@ import {
   computed,
   NAME,
   pattern,
+  TESTS,
   wish,
   Writable,
 } from "commonfabric";
@@ -48,7 +49,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       // pieceRegistry should be defined (wish resolved successfully)
       { assertion: assert_piece_registry_exists },
       // pieceRegistry should start empty

--- a/packages/patterns/google/core/auth-pieces.test.tsx
+++ b/packages/patterns/google/core/auth-pieces.test.tsx
@@ -6,7 +6,7 @@
  *
  * Run: deno task cf test packages/patterns/google/core/auth-pieces.test.tsx --root packages/patterns --verbose
  */
-import { assert, pattern, UI, Writable } from "commonfabric";
+import { assert, pattern, TESTS, UI, Writable } from "commonfabric";
 import AirtableAuth, {
   type AirtableAuth as AirtableAuthData,
 } from "../../airtable/core/airtable-auth.tsx";
@@ -121,7 +121,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_google_scopes_include_selected_permissions },
       { assertion: assert_personal_and_work_wrappers_show_account_type },
       { assertion: assert_switcher_prompts_for_classification },

--- a/packages/patterns/google/core/experimental/calendar-event-manager.test.tsx
+++ b/packages/patterns/google/core/experimental/calendar-event-manager.test.tsx
@@ -5,7 +5,7 @@
  *
  * Run: deno task cf test packages/patterns/google/core/experimental/calendar-event-manager.test.tsx --root packages/patterns --verbose
  */
-import { assert, pattern, UI } from "commonfabric";
+import { assert, pattern, TESTS, UI } from "commonfabric";
 import {
   findElementByText,
   hasText,
@@ -48,7 +48,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_auth_requirement_is_visible },
       { assertion: assert_create_button_disabled_without_auth },
       { assertion: assert_confirmation_is_not_rendered_without_auth },

--- a/packages/patterns/google/core/experimental/gmail-agentic-search.test.tsx
+++ b/packages/patterns/google/core/experimental/gmail-agentic-search.test.tsx
@@ -10,7 +10,7 @@
  *
  * Run: deno task cf test packages/patterns/google/core/experimental/gmail-agentic-search.test.tsx --root packages/patterns --verbose
  */
-import { assert, pattern, Writable } from "commonfabric";
+import { assert, pattern, TESTS, Writable } from "commonfabric";
 import GmailAgenticSearch, { type Auth } from "./gmail-agentic-search.tsx";
 
 const gmailScope = "https://www.googleapis.com/auth/gmail.readonly";
@@ -132,7 +132,7 @@ export default pattern(() => {
   // Test Sequence
   // ==========================================================================
   return {
-    tests: [
+    [TESTS]: [
       // === Initial state checks ===
       { assertion: assert_not_scanning },
       { assertion: assert_progress_idle },

--- a/packages/patterns/google/core/experimental/gmail-label-manager.test.tsx
+++ b/packages/patterns/google/core/experimental/gmail-label-manager.test.tsx
@@ -6,7 +6,7 @@
  *
  * Run: deno task cf test packages/patterns/google/core/experimental/gmail-label-manager.test.tsx --root packages/patterns --verbose
  */
-import { action, assert, pattern, UI } from "commonfabric";
+import { action, assert, pattern, TESTS, UI } from "commonfabric";
 import {
   findElementByExactText,
   findElementByText,
@@ -80,7 +80,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_waiting_message_is_rendered },
       { assertion: assert_refresh_control_is_hidden },
       { assertion: assert_apply_button_disabled_without_auth },

--- a/packages/patterns/google/core/experimental/gmail-sender.test.tsx
+++ b/packages/patterns/google/core/experimental/gmail-sender.test.tsx
@@ -5,7 +5,7 @@
  *
  * Run: deno task cf test packages/patterns/google/core/experimental/gmail-sender.test.tsx --root packages/patterns --verbose
  */
-import { action, assert, pattern, UI } from "commonfabric";
+import { action, assert, pattern, TESTS, UI } from "commonfabric";
 import {
   findElementByText,
   propsOf,
@@ -66,7 +66,7 @@ export default pattern(() => {
   });
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_result_initially_empty },
       { assertion: assert_review_button_disabled_without_auth },
       { action: action_open_confirmation },

--- a/packages/patterns/google/core/experimental/google-docs-comment-orchestrator.test.tsx
+++ b/packages/patterns/google/core/experimental/google-docs-comment-orchestrator.test.tsx
@@ -6,7 +6,7 @@
  *
  * Run: deno task cf test packages/patterns/google/core/experimental/google-docs-comment-orchestrator.test.tsx --root packages/patterns --verbose
  */
-import { assert, pattern, UI, Writable } from "commonfabric";
+import { assert, pattern, TESTS, UI, Writable } from "commonfabric";
 import { hasText } from "../../../test/vnode-helpers.ts";
 import GoogleDocsCommentOrchestrator from "./google-docs-comment-orchestrator.tsx";
 
@@ -52,7 +52,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_fetch_waits_for_auth },
       { assertion: assert_auth_ui_explains_required_scopes },
       { assertion: assert_no_comments_initially },

--- a/packages/patterns/google/core/extractor-building-blocks.test.tsx
+++ b/packages/patterns/google/core/extractor-building-blocks.test.tsx
@@ -7,7 +7,7 @@
  *
  * Run: deno task cf test packages/patterns/google/core/extractor-building-blocks.test.tsx --root packages/patterns/google --verbose
  */
-import { assert, pattern, wish, Writable } from "commonfabric";
+import { assert, pattern, TESTS, wish, Writable } from "commonfabric";
 import BillExtractor, { processBills } from "./bill-extractor/index.tsx";
 import { createBillKey } from "./bill-extractor/helpers.ts";
 import GmailExtractor, {
@@ -234,7 +234,7 @@ export default pattern(() => {
   });
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_gmail_extractor_starts_disconnected },
       { assertion: assert_gmail_extractor_ui_bundle_exists },
       { assertion: assert_bill_extractor_starts_empty },

--- a/packages/patterns/google/core/gmail-importer.test.tsx
+++ b/packages/patterns/google/core/gmail-importer.test.tsx
@@ -11,7 +11,7 @@
  *
  * Run: deno task cf test packages/patterns/google/core/gmail-importer.test.tsx --root packages/patterns --verbose
  */
-import { assert, pattern, UI, Writable } from "commonfabric";
+import { assert, pattern, TESTS, UI, Writable } from "commonfabric";
 import GmailImporter, { type Auth } from "./gmail-importer.tsx";
 import { hasText } from "../../test/vnode-helpers.ts";
 
@@ -107,7 +107,7 @@ export default pattern(() => {
   // Test Sequence
   // ==========================================================================
   return {
-    tests: [
+    [TESTS]: [
       // === Initial state checks ===
       { assertion: assert_emails_empty },
       { assertion: assert_count_zero },

--- a/packages/patterns/google/core/google-calendar-importer.test.tsx
+++ b/packages/patterns/google/core/google-calendar-importer.test.tsx
@@ -6,7 +6,7 @@
  *
  * Run: deno task cf test packages/patterns/google/core/google-calendar-importer.test.tsx --root packages/patterns --verbose
  */
-import { assert, pattern, UI, Writable } from "commonfabric";
+import { assert, pattern, TESTS, UI, Writable } from "commonfabric";
 import { hasText } from "../../test/vnode-helpers.ts";
 import GoogleCalendarImporter, {
   type Auth,
@@ -51,7 +51,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_initial_data_empty },
       { assertion: assert_direct_auth_exposes_fetch_control },
     ],

--- a/packages/patterns/google/core/util/google-auth-manager.test.tsx
+++ b/packages/patterns/google/core/util/google-auth-manager.test.tsx
@@ -11,7 +11,7 @@
  *
  * Run: deno task cf test packages/patterns/google/core/util/google-auth-manager.test.tsx --verbose
  */
-import { assert, pattern } from "commonfabric";
+import { assert, pattern, TESTS } from "commonfabric";
 import {
   GoogleAuthManager,
   type GoogleAuthManagerOutput,
@@ -19,7 +19,7 @@ import {
 import { hasText } from "../../../test/vnode-helpers.ts";
 
 export interface TestOutput {
-  tests: unknown[];
+  [TESTS]: unknown[];
   authDefault: GoogleAuthManagerOutput;
   authWithScopes: GoogleAuthManagerOutput;
   authDebug: GoogleAuthManagerOutput;
@@ -109,7 +109,7 @@ export default pattern<Record<string, never>, TestOutput>(() => {
   // Test Sequence
   // ==========================================================================
   return {
-    tests: [
+    [TESTS]: [
       // === Initial state checks ===
       { assertion: assert_default_not_ready },
       { assertion: assert_default_state_initial },

--- a/packages/patterns/google/extractors/auth-availability.test.tsx
+++ b/packages/patterns/google/extractors/auth-availability.test.tsx
@@ -5,7 +5,7 @@
  * branch. Empty auth keeps API calls inactive while exercising their initial
  * missing-auth state.
  */
-import { assert, pattern, Writable } from "commonfabric";
+import { assert, pattern, TESTS, Writable } from "commonfabric";
 import type { Auth } from "../core/gmail-importer.tsx";
 import EmailNotes from "./email-notes.tsx";
 import ExpectResponseFollowup from "./expect-response-followup.tsx";
@@ -45,7 +45,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_notes_start_empty },
       { assertion: assert_followups_start_empty },
       { assertion: assert_task_engine_starts_empty },

--- a/packages/patterns/google/extractors/email-pattern-launcher.test.tsx
+++ b/packages/patterns/google/extractors/email-pattern-launcher.test.tsx
@@ -12,7 +12,7 @@
  *
  * Run: deno task cf test packages/patterns/google/extractors/email-pattern-launcher.test.tsx --root packages/patterns/google --verbose
  */
-import { assert, pattern } from "commonfabric";
+import { assert, pattern, TESTS } from "commonfabric";
 
 // =============================================================================
 // HELPER FUNCTIONS (duplicated for testing - same as in main pattern)
@@ -191,7 +191,7 @@ export default pattern(() => {
   // Test Sequence
   // ==========================================================================
   return {
-    tests: [
+    [TESTS]: [
       // === Email pattern matching ===
       { assertion: assert_wildcard_matches_domain },
       { assertion: assert_wildcard_matches_different_user },

--- a/packages/patterns/google/extractors/email-style-extractor.test.tsx
+++ b/packages/patterns/google/extractors/email-style-extractor.test.tsx
@@ -5,7 +5,7 @@
  *
  * Run: deno task cf test packages/patterns/google/extractors/email-style-extractor.test.tsx --root packages/patterns --verbose
  */
-import { assert, pattern, UI } from "commonfabric";
+import { assert, pattern, TESTS, UI } from "commonfabric";
 import { hasText } from "../../test/vnode-helpers.ts";
 import EmailStyleExtractor from "./email-style-extractor.tsx";
 
@@ -25,7 +25,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_initial_state_empty },
       { assertion: assert_waiting_for_auth },
     ],

--- a/packages/patterns/google/extractors/wrapper-patterns.test.tsx
+++ b/packages/patterns/google/extractors/wrapper-patterns.test.tsx
@@ -4,7 +4,7 @@
  * Exercises the thin extractor wrappers that pass a shared Google auth cell
  * through to GmailImporter, GmailExtractor, and BillExtractor children.
  */
-import { assert, NAME, pattern, Writable } from "commonfabric";
+import { assert, NAME, pattern, TESTS, Writable } from "commonfabric";
 import type { Auth } from "../core/gmail-importer.tsx";
 import BofABillTracker from "./bofa-bill-tracker.tsx";
 import ChaseBillTracker from "./chase-bill-tracker.tsx";
@@ -40,7 +40,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [{ assertion: assert_bill_wrappers_start_empty }],
+    [TESTS]: [{ assertion: assert_bill_wrappers_start_empty }],
     bofa,
     chase,
     pge,

--- a/packages/patterns/habit-tracker/habit-tracker.test.tsx
+++ b/packages/patterns/habit-tracker/habit-tracker.test.tsx
@@ -26,6 +26,7 @@ import {
   equals,
   handler,
   pattern,
+  TESTS,
   Writable,
 } from "commonfabric";
 import HabitTracker from "./habit-tracker.tsx";
@@ -244,7 +245,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       // Initial state
       { assertion: assert_initial_no_habits },
       { assertion: assert_initial_no_logs },

--- a/packages/patterns/lobby/main.test.tsx
+++ b/packages/patterns/lobby/main.test.tsx
@@ -1,4 +1,4 @@
-import { assert, computed, pattern, UI, Writable } from "commonfabric";
+import { assert, computed, pattern, TESTS, UI, Writable } from "commonfabric";
 import Lobby, {
   addSelfToLobby,
   commitTrustedLobbyAction,
@@ -260,7 +260,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_selected_profile_drives_viewer_state },
       { action: selectedAddSelf },
       { assertion: assert_selected_profile_joined },

--- a/packages/patterns/lobby/multi-user.test.tsx
+++ b/packages/patterns/lobby/multi-user.test.tsx
@@ -1,5 +1,11 @@
 /// <cts-enable />
-import { computed, multiUserTest, pattern, Writable } from "commonfabric";
+import {
+  computed,
+  multiUserTest,
+  pattern,
+  TESTS,
+  Writable,
+} from "commonfabric";
 import {
   addSelfToLobby,
   commitTrustedLobbyAction,
@@ -79,7 +85,7 @@ export const alice = pattern<{ setup: LobbyMultiUserSetup }>(({ setup }) => {
   });
 
   return {
-    tests: [
+    [TESTS]: [
       { action: addSelf },
       { label: "alice-joined" },
       { await: "bob-joined" },
@@ -141,7 +147,7 @@ export const bob = pattern<{ setup: LobbyMultiUserSetup }>(({ setup }) => {
   });
 
   return {
-    tests: [
+    [TESTS]: [
       { await: "alice-joined" },
       { action: addSelf },
       { label: "bob-joined" },

--- a/packages/patterns/lunch-poll/art-sync.test.tsx
+++ b/packages/patterns/lunch-poll/art-sync.test.tsx
@@ -16,7 +16,7 @@
  * the sub-pattern level in generated-art.test.tsx.
  */
 
-import { action, computed, pattern, UI } from "commonfabric";
+import { action, computed, pattern, TESTS, UI } from "commonfabric";
 import {
   findElement,
   findNodeByProp,
@@ -85,7 +85,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { action: action_join_as_host },
       { action: action_add_sushi },
       { assertion: assert_option_added },

--- a/packages/patterns/lunch-poll/generated-art.test.tsx
+++ b/packages/patterns/lunch-poll/generated-art.test.tsx
@@ -1,4 +1,4 @@
-import { computed, pattern, UI } from "commonfabric";
+import { computed, pattern, TESTS, UI } from "commonfabric";
 import {
   findElement,
   findNodeByProp,
@@ -156,7 +156,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_safe_image_url_accepts_web_urls },
       { assertion: assert_safe_image_url_rejects_unsafe_or_invalid_urls },
       { assertion: assert_generated_url_encodes_title_and_size },

--- a/packages/patterns/lunch-poll/lunch-stats.test.tsx
+++ b/packages/patterns/lunch-poll/lunch-stats.test.tsx
@@ -15,7 +15,7 @@
  *   - pre-yellow query had no `yellows` field at all (=> undefined !== 1)
  */
 
-import { action, assert, pattern } from "commonfabric";
+import { action, assert, pattern, TESTS } from "commonfabric";
 import CozyPoll from "./main.tsx";
 
 export default pattern(() => {
@@ -57,7 +57,7 @@ export default pattern(() => {
   });
 
   return {
-    tests: [
+    [TESTS]: [
       { action: join },
       { action: add_thai },
       { action: add_chipotle },

--- a/packages/patterns/lunch-poll/main.test.tsx
+++ b/packages/patterns/lunch-poll/main.test.tsx
@@ -11,7 +11,15 @@
  * are covered by multi-user.test.tsx.
  */
 
-import { action, assert, computed, pattern, UI, wish } from "commonfabric";
+import {
+  action,
+  assert,
+  computed,
+  pattern,
+  TESTS,
+  UI,
+  wish,
+} from "commonfabric";
 import {
   findNodeByProp,
   hasExactText,
@@ -685,7 +693,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       // Admin-gated handlers are no-ops before anyone joins (myName empty).
       // The handler bails on `if (!me || me !== admin) return`. No
       // separate assertion here — downstream assertions (e.g. only

--- a/packages/patterns/lunch-poll/multi-user.test.tsx
+++ b/packages/patterns/lunch-poll/multi-user.test.tsx
@@ -18,7 +18,7 @@
  * loop-variable indexing, and helper calls over another runtime's arrays do
  * not resolve before a local write (see scrabble/multi-user.test.tsx).
  */
-import { action, computed, multiUserTest, pattern } from "commonfabric";
+import { action, computed, multiUserTest, pattern, TESTS } from "commonfabric";
 import LunchPoll, { type CozyPollOutput } from "./main.tsx";
 
 interface Setup {
@@ -76,7 +76,7 @@ export const alice = pattern<{ setup: Setup }>(({ setup }) => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { action: action_join },
       { assertion: assert_joined_as_host },
       { action: action_add_sushi },
@@ -145,7 +145,7 @@ export const bob = pattern<{ setup: Setup }>(({ setup }) => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { await: "alice-set-up" },
       { assertion: assert_sees_alice_setup },
       { assertion: assert_not_joined_yet },

--- a/packages/patterns/lunch-poll/participant-identity-card.test.tsx
+++ b/packages/patterns/lunch-poll/participant-identity-card.test.tsx
@@ -4,6 +4,7 @@ import {
   Default,
   equals,
   pattern,
+  TESTS,
   UI,
   Writable,
 } from "commonfabric";
@@ -241,7 +242,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_initial },
       { assertion: assert_guest_setup_renders },
       { assertion: assert_profile_first_renders },

--- a/packages/patterns/lunch-poll/poll-option-card.test.tsx
+++ b/packages/patterns/lunch-poll/poll-option-card.test.tsx
@@ -5,6 +5,7 @@ import {
   handler,
   pattern,
   type Stream,
+  TESTS,
   UI,
   Writable,
 } from "commonfabric";
@@ -254,7 +255,7 @@ export default pattern(() => {
   });
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_my_green_vote_label_renders },
       { assertion: assert_unset_rank_renders_placeholder },
       { action: action_resolve_rank },

--- a/packages/patterns/map-demo.test.tsx
+++ b/packages/patterns/map-demo.test.tsx
@@ -10,7 +10,7 @@
  *
  * Run: deno task cf test packages/patterns/map-demo.test.tsx --root packages/patterns --verbose
  */
-import { action, assert, pattern, UI } from "commonfabric";
+import { action, assert, pattern, TESTS, UI } from "commonfabric";
 import { findElementByText, propsOf } from "./test/vnode-helpers.ts";
 import MapDemo from "./map-demo.tsx";
 
@@ -120,7 +120,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_no_areas_initially },
       { assertion: assert_fit_bounds_not_triggered },
 

--- a/packages/patterns/notes/note-md.test.tsx
+++ b/packages/patterns/notes/note-md.test.tsx
@@ -12,7 +12,7 @@
  *
  * Run: deno task cf test packages/patterns/notes/note-md.test.tsx --verbose
  */
-import { action, assert, NAME, pattern, Writable } from "commonfabric";
+import { action, assert, NAME, pattern, TESTS, Writable } from "commonfabric";
 import NoteMd from "./note-md.tsx";
 import Note from "./note.tsx";
 
@@ -397,7 +397,7 @@ export default pattern(() => {
   // Test Sequence
   // ==========================================================================
   return {
-    tests: [
+    [TESTS]: [
       // === Static properties ===
       { assertion: assert_is_hidden },
       { assertion: assert_is_not_mentionable },

--- a/packages/patterns/notes/note.test.tsx
+++ b/packages/patterns/notes/note.test.tsx
@@ -15,6 +15,7 @@ import {
   assert,
   NAME,
   pattern,
+  TESTS,
   UI,
   wish,
   Writable,
@@ -353,7 +354,7 @@ export default pattern(() => {
   // Test Sequence
   // ==========================================================================
   return {
-    tests: [
+    [TESTS]: [
       // === Initial state ===
       { assertion: assert_name },
       { assertion: assert_initial_title },

--- a/packages/patterns/notes/notebook-drop.test.tsx
+++ b/packages/patterns/notes/notebook-drop.test.tsx
@@ -14,7 +14,7 @@
  *
  * Run: deno task cf test packages/patterns/notes/notebook-drop.test.tsx --root packages/patterns --verbose
  */
-import { action, assert, pattern, UI } from "commonfabric";
+import { action, assert, pattern, TESTS, UI } from "commonfabric";
 import { findNode, propsOf, readValue } from "../test/vnode-helpers.ts";
 import Notebook from "./notebook.tsx";
 import Note from "./note.tsx";
@@ -139,7 +139,7 @@ export default pattern(() => {
   const assert_loose_note_hidden = assert(() => looseNote.isHidden === true);
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_initial_order },
 
       { action: action_drop_existing_note_onto_row },

--- a/packages/patterns/notes/notebook.test.tsx
+++ b/packages/patterns/notes/notebook.test.tsx
@@ -21,7 +21,7 @@
  *
  * Run: deno task cf test packages/patterns/notes/notebook.test.tsx --verbose
  */
-import { action, assert, NAME, pattern } from "commonfabric";
+import { action, assert, NAME, pattern, TESTS } from "commonfabric";
 import Notebook from "./notebook.tsx";
 import Note from "./note.tsx";
 
@@ -437,7 +437,7 @@ export default pattern(() => {
   // Test Sequence
   // ==========================================================================
   return {
-    tests: [
+    [TESTS]: [
       // === Initial state ===
       { assertion: assert_initial_title },
       { assertion: assert_initial_note_count },

--- a/packages/patterns/project-list/main.test.tsx
+++ b/packages/patterns/project-list/main.test.tsx
@@ -18,6 +18,7 @@ import {
   equals,
   handler,
   pattern,
+  TESTS,
   Writable,
 } from "commonfabric";
 import ProjectList, { toggleItem } from "./main.tsx";
@@ -125,7 +126,7 @@ export default pattern(() => {
   // Test Sequence
   // ==========================================================================
   return {
-    tests: [
+    [TESTS]: [
       { action: action_seed },
       { assertion: assert_seeded },
 

--- a/packages/patterns/reading-list/reading-item-detail.test.tsx
+++ b/packages/patterns/reading-list/reading-item-detail.test.tsx
@@ -11,7 +11,7 @@
  *
  * Run: deno task cf test packages/patterns/reading-list/reading-item-detail.test.tsx --verbose
  */
-import { action, assert, pattern } from "commonfabric";
+import { action, assert, pattern, TESTS } from "commonfabric";
 import ReadingItemDetail from "./reading-item-detail.tsx";
 
 export default pattern(() => {
@@ -113,7 +113,7 @@ export default pattern(() => {
   // Test Sequence
   // ==========================================================================
   return {
-    tests: [
+    [TESTS]: [
       // === Initial state ===
       { assertion: assert_initial_title },
       { assertion: assert_initial_author },

--- a/packages/patterns/reading-list/reading-list.test.tsx
+++ b/packages/patterns/reading-list/reading-list.test.tsx
@@ -13,7 +13,7 @@
  *
  * Run: deno task cf test packages/patterns/reading-list/reading-list.test.tsx --verbose
  */
-import { action, assert, pattern } from "commonfabric";
+import { action, assert, pattern, TESTS } from "commonfabric";
 import ReadingList from "./reading-list.tsx";
 
 export default pattern(() => {
@@ -283,7 +283,7 @@ export default pattern(() => {
   // Test Sequence
   // ==========================================================================
   return {
-    tests: [
+    [TESTS]: [
       // === Initial state ===
       { assertion: assert_initial_empty },
       { assertion: assert_initial_filter_all },

--- a/packages/patterns/record-backup.test.tsx
+++ b/packages/patterns/record-backup.test.tsx
@@ -1,4 +1,12 @@
-import { action, assert, pattern, UI, wish, Writable } from "commonfabric";
+import {
+  action,
+  assert,
+  pattern,
+  TESTS,
+  UI,
+  wish,
+  Writable,
+} from "commonfabric";
 import { findElementByText, hasText, propsOf } from "./test/vnode-helpers.ts";
 import RecordBackup, { type RecordPiece } from "./record-backup.tsx";
 
@@ -83,7 +91,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_starts_empty },
       { action: action_import },
       { assertion: assert_each_imported_record_is_registered },

--- a/packages/patterns/record-llm-streams.test.tsx
+++ b/packages/patterns/record-llm-streams.test.tsx
@@ -31,7 +31,7 @@
  *
  * Run: deno task cf test packages/patterns/record-llm-streams.test.tsx --root packages/patterns --verbose
  */
-import { action, assert, pattern, Writable } from "commonfabric";
+import { action, assert, pattern, TESTS, Writable } from "commonfabric";
 import RecordPattern from "./record.tsx";
 
 interface ModuleTypeInfo {
@@ -238,7 +238,7 @@ export default pattern(() => {
   });
 
   return {
-    tests: [
+    [TESTS]: [
       { action: action_list_types },
       { assertion: assert_list_types },
 

--- a/packages/patterns/record-module-fields.test.tsx
+++ b/packages/patterns/record-module-fields.test.tsx
@@ -41,7 +41,15 @@
  *
  * Run: deno task cf test packages/patterns/record-module-fields.test.tsx --root packages/patterns --verbose
  */
-import { action, assert, NAME, pattern, UI, Writable } from "commonfabric";
+import {
+  action,
+  assert,
+  NAME,
+  pattern,
+  TESTS,
+  UI,
+  Writable,
+} from "commonfabric";
 import RecordPattern from "./record.tsx";
 
 interface AddResult {
@@ -244,7 +252,7 @@ export default pattern(() => {
   });
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_plain_name },
 
       { action: action_add_icon_module },

--- a/packages/patterns/record-trash-restore.test.tsx
+++ b/packages/patterns/record-trash-restore.test.tsx
@@ -34,7 +34,7 @@
  *
  * Run: deno task cf test packages/patterns/record-trash-restore.test.tsx --root packages/patterns --verbose
  */
-import { action, assert, pattern, UI, Writable } from "commonfabric";
+import { action, assert, pattern, TESTS, UI, Writable } from "commonfabric";
 import { findElementByText, propsOf } from "./test/vnode-helpers.ts";
 import RecordPattern from "./record.tsx";
 
@@ -141,7 +141,7 @@ export default pattern(() => {
   });
 
   return {
-    tests: [
+    [TESTS]: [
       { action: action_add_email },
       { assertion: assert_email_added },
       { render: subject[UI] },

--- a/packages/patterns/record.test.tsx
+++ b/packages/patterns/record.test.tsx
@@ -29,7 +29,7 @@
  *
  * Run: deno task cf test packages/patterns/record.test.tsx --root packages/patterns --verbose
  */
-import { action, assert, pattern, UI, Writable } from "commonfabric";
+import { action, assert, pattern, TESTS, UI, Writable } from "commonfabric";
 import RecordPattern from "./record.tsx";
 
 interface AddResult {
@@ -241,7 +241,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       // Seeding: empty until the module list is rendered, then the default
       // Notes + TypePicker pair appears, and a later add lands after them.
       { assertion: assert_rendered_starts_empty },

--- a/packages/patterns/record/extraction/schema-discovery.test.tsx
+++ b/packages/patterns/record/extraction/schema-discovery.test.tsx
@@ -10,7 +10,7 @@
  *
  * Run: deno task cf test packages/patterns/record/extraction/schema-discovery.test.tsx --root packages/patterns --verbose
  */
-import { computed, pattern } from "commonfabric";
+import { computed, pattern, TESTS } from "commonfabric";
 import { getSchemaForType } from "./schema-utils.ts";
 import { getFieldToTypeMapping } from "../registry.ts";
 import Note from "../../notes/note.tsx";
@@ -59,7 +59,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_real_piece_built },
       { assertion: assert_notes_content_discoverable },
       { assertion: assert_address_has_fields },

--- a/packages/patterns/regression/ct1639-equals-removal.test.tsx
+++ b/packages/patterns/regression/ct1639-equals-removal.test.tsx
@@ -23,6 +23,7 @@ import {
   equals,
   handler,
   pattern,
+  TESTS,
   Writable,
 } from "commonfabric";
 
@@ -94,7 +95,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assertStartsThree },
       { action: removeMiddle },
       { assertion: assertTwoAfterRemove },

--- a/packages/patterns/scoped-group-chat/main.test.tsx
+++ b/packages/patterns/scoped-group-chat/main.test.tsx
@@ -1,4 +1,4 @@
-import { action, assert, pattern, Writable } from "commonfabric";
+import { action, assert, pattern, TESTS, Writable } from "commonfabric";
 import ScopedGroupChat, {
   type Conversation,
   type SelectedRoom,
@@ -51,7 +51,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_initial_scoped_fields },
       { action: action_add_new_room },
       { assertion: assert_added_room_is_selected },

--- a/packages/patterns/scoped-user-directory/main.test.tsx
+++ b/packages/patterns/scoped-user-directory/main.test.tsx
@@ -14,7 +14,7 @@
  *
  * Run: deno task cf test packages/patterns/scoped-user-directory/main.test.tsx
  */
-import { action, assert, pattern, Writable } from "commonfabric";
+import { action, assert, pattern, TESTS, Writable } from "commonfabric";
 import ScopedUserDirectory, {
   type Directory,
   type UserPointer,
@@ -63,7 +63,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       // Initial state
       { assertion: assert_users_empty },
       { assertion: assert_me_undefined },

--- a/packages/patterns/scrabble/multi-user.test.tsx
+++ b/packages/patterns/scrabble/multi-user.test.tsx
@@ -22,7 +22,7 @@
  *
  * Join order is deterministic (markers): Alice first, then Bob.
  */
-import { action, computed, multiUserTest, pattern } from "commonfabric";
+import { action, computed, multiUserTest, pattern, TESTS } from "commonfabric";
 import Scrabble, { type GameOutput } from "./scrabble.tsx";
 
 interface Setup {
@@ -59,7 +59,7 @@ export const alice = pattern<{ setup: Setup }>(({ setup }) => {
   const assert_bag_consumed = computed(() => game.bagIndex === 14);
 
   return {
-    tests: [
+    [TESTS]: [
       { action: action_join },
       { assertion: assert_joined },
       { label: "alice-joined" },
@@ -102,7 +102,7 @@ export const bob = pattern<{ setup: Setup }>(({ setup }) => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { await: "alice-joined" },
       { assertion: assert_sees_alice },
       { assertion: assert_not_joined_yet },

--- a/packages/patterns/scrabble/scrabble.test.tsx
+++ b/packages/patterns/scrabble/scrabble.test.tsx
@@ -1,4 +1,4 @@
-import { action, assert, computed, pattern } from "commonfabric";
+import { action, assert, computed, pattern, TESTS } from "commonfabric";
 import Scrabble, { type Letter } from "./scrabble.tsx";
 
 const tile = (char: string, id: string): Letter => ({
@@ -121,7 +121,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { action: action_join_alice },
       { action: action_try_rename_after_join },
       { assertion: assert_joined_name_is_immutable },

--- a/packages/patterns/self-improving-classifier.test.tsx
+++ b/packages/patterns/self-improving-classifier.test.tsx
@@ -11,7 +11,7 @@
  * instead of action() with closures to avoid "reactive reference outside
  * reactive context" errors when accessing proxy objects like subject.submitItem.
  */
-import { assert, Cell, handler, pattern, Stream } from "commonfabric";
+import { assert, Cell, handler, pattern, Stream, TESTS } from "commonfabric";
 import SelfImprovingClassifier, {
   type ClassificationRule,
   type LabeledExample,
@@ -181,7 +181,7 @@ export default pattern(() => {
 
   // Return tests array using discriminated union format
   return {
-    tests: [
+    [TESTS]: [
       // Test 1: Initial state is empty
       { assertion: assert_initial_examples_empty },
       { assertion: assert_initial_rules_empty },

--- a/packages/patterns/self.test.tsx
+++ b/packages/patterns/self.test.tsx
@@ -14,7 +14,14 @@
  *
  * Run: deno task cf test packages/patterns/self.test.tsx --verbose
  */
-import { assert, computed, handler, pattern, Writable } from "commonfabric";
+import {
+  assert,
+  computed,
+  handler,
+  pattern,
+  TESTS,
+  Writable,
+} from "commonfabric";
 import Self, {
   addValueCardFromForm,
   appendResponse,
@@ -481,7 +488,7 @@ export default pattern(() => {
   // Test Sequence
   // =========================================================================
   return {
-    tests: [
+    [TESTS]: [
       // === A1: upsertNeurotype — append to empty ===
       { assertion: assert_append_count },
       { assertion: assert_append_result },

--- a/packages/patterns/shopping-list.test.tsx
+++ b/packages/patterns/shopping-list.test.tsx
@@ -22,6 +22,7 @@ import {
   equals,
   handler,
   pattern,
+  TESTS,
   Writable,
 } from "commonfabric";
 import ShoppingList, { removeItem, selectAisle } from "./shopping-list.tsx";
@@ -234,7 +235,7 @@ Fresh vegetables and fruits
   // Test Sequence
   // ==========================================================================
   return {
-    tests: [
+    [TESTS]: [
       // === Test 1: Initial empty state ===
       { assertion: assert_initial_empty },
       { assertion: assert_initial_total_zero },

--- a/packages/patterns/simple-list/simple-list.test.tsx
+++ b/packages/patterns/simple-list/simple-list.test.tsx
@@ -11,7 +11,7 @@
  *
  * Run: deno task cf test packages/patterns/simple-list/simple-list.test.tsx --verbose
  */
-import { action, assert, pattern } from "commonfabric";
+import { action, assert, pattern, TESTS } from "commonfabric";
 import SimpleListModule from "./simple-list.tsx";
 
 export default pattern(() => {
@@ -173,7 +173,7 @@ export default pattern(() => {
   // Test Sequence
   // ==========================================================================
   return {
-    tests: [
+    [TESTS]: [
       // Initial state
       { assertion: assert_initial_empty },
 

--- a/packages/patterns/store-mapper.test.tsx
+++ b/packages/patterns/store-mapper.test.tsx
@@ -31,6 +31,7 @@ import {
   equals,
   handler,
   pattern,
+  TESTS,
   Writable,
 } from "commonfabric";
 import StoreMapper, {
@@ -458,7 +459,7 @@ export default pattern(() => {
   // Test Sequence
   // ==========================================================================
   return {
-    tests: [
+    [TESTS]: [
       // === Test 1: Initial state ===
       { assertion: assert_initial_store_name },
       { assertion: assert_initial_no_aisles },

--- a/packages/patterns/system/backlinks-index.test.tsx
+++ b/packages/patterns/system/backlinks-index.test.tsx
@@ -1,4 +1,12 @@
-import { action, assert, handler, NAME, pattern, Writable } from "commonfabric";
+import {
+  action,
+  assert,
+  handler,
+  NAME,
+  pattern,
+  TESTS,
+  Writable,
+} from "commonfabric";
 import BacklinksIndex, {
   type MentionableCell,
   type MentionablePiece,
@@ -38,7 +46,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_registry_is_mentionable },
       { action: action_add_mention },
       { assertion: assert_mention_populates_backlink },

--- a/packages/patterns/system/default-app-ben.test.tsx
+++ b/packages/patterns/system/default-app-ben.test.tsx
@@ -1,4 +1,4 @@
-import { action, assert, pattern, UI } from "commonfabric";
+import { action, assert, pattern, TESTS, UI } from "commonfabric";
 import {
   findElementByExactText,
   findElementByText,
@@ -43,7 +43,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_starts_empty },
       { action: action_register_pieces },
       { assertion: assert_add_piece_registers_both },

--- a/packages/patterns/system/default-app.test.tsx
+++ b/packages/patterns/system/default-app.test.tsx
@@ -11,7 +11,7 @@
  *
  * Run: deno task cf test packages/patterns/system/default-app.test.tsx --root packages/patterns --verbose
  */
-import { action, assert, pattern, UI } from "commonfabric";
+import { action, assert, pattern, TESTS, UI } from "commonfabric";
 import { findElementByExactText, propsOf } from "../test/vnode-helpers.ts";
 import DefaultApp from "./default-app.tsx";
 import Note from "../notes/note.tsx";
@@ -71,7 +71,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_starts_empty },
 
       { action: action_register_note },

--- a/packages/patterns/system/home.test.tsx
+++ b/packages/patterns/system/home.test.tsx
@@ -1,4 +1,4 @@
-import { action, assert, NAME, pattern, Writable } from "commonfabric";
+import { action, assert, NAME, pattern, TESTS, Writable } from "commonfabric";
 import Home from "./home.tsx";
 
 export default pattern(() => {
@@ -64,7 +64,7 @@ export default pattern(() => {
   });
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_initial_profile_missing },
       { action: action_add_favorite },
       { action: action_remove_favorite },

--- a/packages/patterns/system/piece-registry-migration.test.tsx
+++ b/packages/patterns/system/piece-registry-migration.test.tsx
@@ -1,4 +1,4 @@
-import { assert, computed, pattern, Writable } from "commonfabric";
+import { assert, computed, pattern, TESTS, Writable } from "commonfabric";
 import { migratePieceRegistry } from "./piece-registry-migration.ts";
 
 export default pattern(() => {
@@ -39,7 +39,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_legacy_registry_is_copied },
       { assertion: assert_canonical_registry_wins },
       { assertion: assert_completed_migration_does_not_run },

--- a/packages/patterns/system/profile-create.test.tsx
+++ b/packages/patterns/system/profile-create.test.tsx
@@ -26,7 +26,7 @@
  *
  * Run: deno task cf test packages/patterns/system/profile-create.test.tsx --verbose
  */
-import { assert, pattern, UI, Writable } from "commonfabric";
+import { assert, pattern, TESTS, UI, Writable } from "commonfabric";
 import ProfileCreate, {
   TRUSTED_PROFILE_CREATE_ACTION,
 } from "./profile-create.tsx";
@@ -137,7 +137,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       // No defaultName → no prefill, wiring unchanged
       { assertion: assert_no_default_has_no_initial_value },
       { assertion: assert_no_default_action_wired },

--- a/packages/patterns/system/profile-embed.test.tsx
+++ b/packages/patterns/system/profile-embed.test.tsx
@@ -1,4 +1,4 @@
-import { action, assert, pattern } from "commonfabric";
+import { action, assert, pattern, TESTS } from "commonfabric";
 import ProfileEmbed from "./profile-embed.tsx";
 import ProfileHome from "./profile-home.tsx";
 
@@ -78,7 +78,7 @@ export default pattern(() => {
   const assert_bio_cleared = assert(() => profile.bio === "");
 
   return {
-    tests: [
+    [TESTS]: [
       // (1) Fallback branch — no profile resolves in the harness.
       { assertion: assert_no_profile_in_harness },
       { assertion: assert_not_editing_by_default },

--- a/packages/patterns/system/profile-home.test.tsx
+++ b/packages/patterns/system/profile-home.test.tsx
@@ -1,4 +1,4 @@
-import { action, assert, pattern } from "commonfabric";
+import { action, assert, pattern, TESTS } from "commonfabric";
 import ProfileHome from "./profile-home.tsx";
 
 export default pattern(() => {
@@ -143,7 +143,7 @@ export default pattern(() => {
   const assert_removed_element = assert(() => profile.elements.length === 0);
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_initial_state },
       // CT-1748: a freshly-visited profile starts in the read-only
       // presentation, not the edit form.

--- a/packages/patterns/system/quick-capture.test.tsx
+++ b/packages/patterns/system/quick-capture.test.tsx
@@ -1,4 +1,4 @@
-import { action, assert, pattern, Writable } from "commonfabric";
+import { action, assert, pattern, TESTS, Writable } from "commonfabric";
 import type { MentionablePiece } from "./backlinks-index.tsx";
 import { createNotebookHandler, createNoteHandler } from "./quick-capture.tsx";
 
@@ -28,7 +28,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { action: action_create_note },
       { assertion: assert_note_is_registered },
       { action: action_create_notebook },

--- a/packages/patterns/test/non-idempotent/accumulator.test.tsx
+++ b/packages/patterns/test/non-idempotent/accumulator.test.tsx
@@ -7,7 +7,7 @@
  *
  * Run: deno task cf test packages/patterns/test/non-idempotent/accumulator.test.tsx --verbose
  */
-import { assert, computed, pattern, Writable } from "commonfabric";
+import { assert, computed, pattern, TESTS, Writable } from "commonfabric";
 
 export default pattern(() => {
   const value = new Writable("hello");
@@ -23,7 +23,7 @@ export default pattern(() => {
   const hasEntries = assert(() => log.get().length > 0);
 
   return {
-    tests: [{ assertion: hasEntries }],
+    [TESTS]: [{ assertion: hasEntries }],
     expectNonIdempotent: true,
   };
 });

--- a/packages/patterns/test/non-idempotent/set-to-array.test.tsx
+++ b/packages/patterns/test/non-idempotent/set-to-array.test.tsx
@@ -15,7 +15,7 @@
  *
  * Run: deno task cf test packages/patterns/test/non-idempotent/set-to-array.test.tsx --verbose
  */
-import { assert, computed, pattern, Writable } from "commonfabric";
+import { assert, computed, pattern, TESTS, Writable } from "commonfabric";
 
 export default pattern(() => {
   const items = new Writable([
@@ -41,7 +41,7 @@ export default pattern(() => {
   const hasTags = assert(() => uniqueTags.get().length > 0);
 
   return {
-    tests: [{ assertion: hasTags }],
+    [TESTS]: [{ assertion: hasTags }],
     expectNonIdempotent: true,
   };
 });

--- a/packages/patterns/test/non-idempotent/shuffle.test.tsx
+++ b/packages/patterns/test/non-idempotent/shuffle.test.tsx
@@ -12,7 +12,7 @@
  *
  * Run: deno task cf test packages/patterns/test/non-idempotent/shuffle.test.tsx --verbose
  */
-import { assert, computed, pattern, Writable } from "commonfabric";
+import { assert, computed, pattern, TESTS, Writable } from "commonfabric";
 
 export default pattern(() => {
   const items = new Writable(["alpha", "bravo", "charlie", "delta", "echo"]);
@@ -41,7 +41,7 @@ export default pattern(() => {
   const hasItems = assert(() => shuffled.get().length > 0);
 
   return {
-    tests: [{ assertion: hasItems }],
+    [TESTS]: [{ assertion: hasItems }],
     expectNonIdempotent: true,
   };
 });

--- a/packages/patterns/test/non-idempotent/timestamp.test.tsx
+++ b/packages/patterns/test/non-idempotent/timestamp.test.tsx
@@ -10,7 +10,7 @@
  *
  * Run: deno task cf test packages/patterns/test/non-idempotent/timestamp.test.tsx --verbose
  */
-import { assert, computed, pattern, Writable } from "commonfabric";
+import { assert, computed, pattern, TESTS, Writable } from "commonfabric";
 
 export default pattern(() => {
   const items = new Writable([{ title: "Task A" }, { title: "Task B" }]);
@@ -33,7 +33,7 @@ export default pattern(() => {
   const hasItems = assert(() => processed.get().length > 0);
 
   return {
-    tests: [{ assertion: hasItems }],
+    [TESTS]: [{ assertion: hasItems }],
     expectNonIdempotent: true,
   };
 });

--- a/packages/patterns/todo-list/todo-list.test.tsx
+++ b/packages/patterns/todo-list/todo-list.test.tsx
@@ -11,7 +11,7 @@
  *
  * Run: deno task cf test packages/patterns/todo-list/todo-list.test.tsx --verbose
  */
-import { action, assert, pattern } from "commonfabric";
+import { action, assert, pattern, TESTS } from "commonfabric";
 import TodoList from "./todo-list.tsx";
 
 export default pattern(() => {
@@ -170,7 +170,7 @@ export default pattern(() => {
   // Test Sequence
   // ==========================================================================
   return {
-    tests: [
+    [TESTS]: [
       // === Test 1: Initial state ===
       { assertion: assert_initial_empty },
       { assertion: assert_initial_count_0 },

--- a/packages/patterns/topics/multi-user.test.tsx
+++ b/packages/patterns/topics/multi-user.test.tsx
@@ -15,7 +15,7 @@
  * arrays do not resolve before a local write (see lunch-poll and scrabble
  * multi-user tests).
  */
-import { action, computed, multiUserTest, pattern } from "commonfabric";
+import { action, computed, multiUserTest, pattern, TESTS } from "commonfabric";
 import Topics, { type TopicsOutput } from "./main.tsx";
 
 interface Setup {
@@ -64,7 +64,7 @@ export const gideon = pattern<{ setup: Setup }>(({ setup }) => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { action: action_start_topic },
       { assertion: assert_topic_created },
       { action: action_comment },
@@ -113,7 +113,7 @@ export const fable = pattern<{ setup: Setup }>(({ setup }) => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { await: "gideon-commented" },
       { assertion: assert_sees_sol_setup },
       { action: action_comment },

--- a/packages/patterns/topics/topics-rejections.test.tsx
+++ b/packages/patterns/topics/topics-rejections.test.tsx
@@ -8,7 +8,7 @@
  * composer wrappers, whose silent guards are correct behavior (an empty draft
  * is a non-event in a composer, not a headless mutation).
  */
-import { action, assert } from "commonfabric";
+import { action, assert, TESTS } from "commonfabric";
 import { pattern } from "commonfabric";
 import Topics from "./main.tsx";
 
@@ -100,7 +100,7 @@ export default pattern(() => {
     // verb quietly reverting to a silent early-return fails this suite; the
     // no-write assertions then prove the throw also blocked the write.
     expectRuntimeErrors: 9,
-    tests: [
+    [TESTS]: [
       { action: action_seed_topic },
       { assertion: assert_seeded },
       { action: action_add_blank_title },

--- a/packages/patterns/topics/topics.test.tsx
+++ b/packages/patterns/topics/topics.test.tsx
@@ -10,7 +10,15 @@
  * in bodies, comments, and link URLs; never persisted), and the exported pure
  * helpers. UI composer wrappers keep silent guards, exercised here.
  */
-import { action, assert, Default, NAME, UI, Writable } from "commonfabric";
+import {
+  action,
+  assert,
+  Default,
+  NAME,
+  TESTS,
+  UI,
+  Writable,
+} from "commonfabric";
 import { pattern } from "commonfabric";
 import Topics, {
   crossrefLinkRow,
@@ -774,7 +782,7 @@ export default pattern(() => {
     // shared-safe TopicPiece projection and exposes no [UI]; the topic detail
     // page is driven through its own render step.
     [UI]: board[UI],
-    tests: [
+    [TESTS]: [
       { assertion: assert_initial },
       { action: action_link_unsigned_mixed_version_sibling },
       { assertion: assert_explicit_undefined_author_projection },

--- a/packages/patterns/type-picker.test.tsx
+++ b/packages/patterns/type-picker.test.tsx
@@ -1,4 +1,4 @@
-import { action, assert, pattern, UI, Writable } from "commonfabric";
+import { action, assert, pattern, TESTS, UI, Writable } from "commonfabric";
 import TypePickerModule from "./type-picker.tsx";
 import type { SubPieceEntry, TrashedSubPieceEntry } from "./record/types.ts";
 import { findElementByText, propsOf } from "./test/vnode-helpers.ts";
@@ -56,7 +56,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { assertion: assert_starts_undismissed },
       { action: action_dismiss },
       { assertion: assert_dismissed_follows_the_cell },

--- a/packages/patterns/weekly-calendar/weekly-calendar.test.tsx
+++ b/packages/patterns/weekly-calendar/weekly-calendar.test.tsx
@@ -1,4 +1,4 @@
-import { action, assert, pattern, wish, Writable } from "commonfabric";
+import { action, assert, pattern, TESTS, wish, Writable } from "commonfabric";
 import {
   createEventAndContinue,
   createEventHandler,
@@ -74,7 +74,7 @@ export default pattern(() => {
   );
 
   return {
-    tests: [
+    [TESTS]: [
       { action: action_create_from_stream },
       { assertion: assert_stream_registers_event },
       { action: action_create_another_from_prompt },

--- a/packages/runner/src/builder/factory.ts
+++ b/packages/runner/src/builder/factory.ts
@@ -18,6 +18,7 @@ import {
   NAME,
   schema as schemaIdentity,
   SELF,
+  TESTS,
   TILE_UI,
   TYPE,
   UI,
@@ -278,6 +279,7 @@ export const createBuilder = (options: CreateBuilderOptions = {}): {
     TILE_UI,
     CHIP_UI,
     FS,
+    TESTS,
 
     // Schema utilities
     schema: runtimeSchema,

--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -89,6 +89,9 @@ export const UI = "$UI";
 export const TILE_UI = "$TILE_UI";
 export const CHIP_UI = "$CHIP_UI";
 export const FS = "$FS";
+// The reserved key a test pattern addresses its test steps under; the test
+// runner reads `[TESTS]` off the pattern output.
+export const TESTS = "$TESTS";
 
 // Symbol for accessing self-reference in patterns
 export const SELF: typeof SELFSymbol = Symbol("SELF") as any;

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -220,6 +220,7 @@ export {
   schema,
   type SchemaWithoutCell,
   type StreamValue,
+  TESTS,
   TILE_UI,
   type toJSON,
   TYPE,

--- a/tasks/pattern-vintage-run.test.ts
+++ b/tasks/pattern-vintage-run.test.ts
@@ -230,7 +230,7 @@ const undeclaredSource = (storageKey: string, trailer = "") =>
  * key, which is the one the cases below are about.
  */
 const undeclaredTest = [
-  "import { action, assert, pattern } from 'commonfabric';",
+  "import { action, assert, pattern, TESTS } from 'commonfabric';",
   `import Subject from './${UNDECLARED_KEY}';`,
   "export default pattern(() => {",
   "  const subject = Subject({});",
@@ -242,7 +242,7 @@ const undeclaredTest = [
   "    subject.scribble.send({ text: 'noted' });",
   "  });",
   "  return {",
-  "    tests: [{ action: add }, { assertion: added }, { action: write }],",
+  "    [TESTS]: [{ action: add }, { assertion: added }, { action: write }],",
   "    subject,",
   "  };",
   "});",
@@ -335,7 +335,7 @@ const crossSource = (
  * what lets a case there tell a moved storage key from an intact one.
  */
 const crossTest = [
-  "import { action, assert, pattern } from 'commonfabric';",
+  "import { action, assert, pattern, TESTS } from 'commonfabric';",
   `import Subject from './${CROSS_KEY}';`,
   "export default pattern(() => {",
   "  const subject = Subject({});",
@@ -349,7 +349,7 @@ const crossTest = [
   "  });",
   "  const wrote = assert(() => subject.child.note.get() === 'written');",
   "  return {",
-  "    tests: [",
+  "    [TESTS]: [",
   "      { action: add },",
   "      { assertion: added },",
   "      { assertion: noted },",
@@ -364,7 +364,7 @@ const crossTest = [
 
 const nestedTest = (key: string) =>
   [
-    "import { action, assert, pattern } from 'commonfabric';",
+    "import { action, assert, pattern, TESTS } from 'commonfabric';",
     `import Subject from './${key}';`,
     "export default pattern(() => {",
     "  const subject = Subject({});",
@@ -378,7 +378,7 @@ const nestedTest = (key: string) =>
     "    subject.rows.length === 1 && subject.rows[0].shout === 'captured'",
     "  );",
     "  return {",
-    "    tests: [{ action: add }, { assertion: added }, { assertion: mapped }],",
+    "    [TESTS]: [{ action: add }, { assertion: added }, { assertion: mapped }],",
     "    subject,",
     "  };",
     "});",
@@ -395,7 +395,7 @@ const nestedTest = (key: string) =>
  * never record a state the pattern does not actually reach.
  */
 const SUBJECT_TEST = [
-  "import { action, assert, pattern } from 'commonfabric';",
+  "import { action, assert, pattern, TESTS } from 'commonfabric';",
   `import Subject from './${KEY}';`,
   "export default pattern(() => {",
   "  const subject = Subject({});",
@@ -404,7 +404,7 @@ const SUBJECT_TEST = [
   "  });",
   "  const added = assert(() => subject.items.get().length === 1);",
   "  return {",
-  "    tests: [{ action: add }, { assertion: added }],",
+  "    [TESTS]: [{ action: add }, { assertion: added }],",
   "    subject,",
   "  };",
   "});",
@@ -1618,12 +1618,12 @@ describe("the vintage gate, end to end", () => {
       // later generation would be replayed against it.
       await setSubjectTest(
         [
-          "import { assert, pattern } from 'commonfabric';",
+          "import { assert, pattern, TESTS } from 'commonfabric';",
           `import Subject from './${KEY}';`,
           "export default pattern(() => {",
           "  const subject = Subject({});",
           "  const never = assert(() => subject.items.get().length === 99);",
-          "  return { tests: [{ assertion: never }], subject };",
+          "  return { [TESTS]: [{ assertion: never }], subject };",
           "});",
           "",
         ].join("\n"),
@@ -1649,11 +1649,11 @@ describe("the vintage gate, end to end", () => {
       // makes a green replay meaningless.
       await setSubjectTest(
         [
-          "import { pattern } from 'commonfabric';",
+          "import { pattern, TESTS } from 'commonfabric';",
           `import Subject from './${KEY}';`,
           "export default pattern(() => {",
           "  const subject = Subject({});",
-          "  return { tests: [], subject };",
+          "  return { [TESTS]: [], subject };",
           "});",
           "",
         ].join("\n"),


### PR DESCRIPTION
The pattern test runner reads a pattern's test steps off a plain `tests` output field, which collides with any `tests` field an author might want. Reserve `[TESTS]` ("$TESTS") as an output key and move every usage to it, the same mechanism the other reserved keys (`[UI]`, `[NAME]`) already use, so a plain `tests` output field is free again.

Reserve the key: define `TESTS` in the runner builder, declare it in the api (the type surface patterns import as `commonfabric`), wire it into the commonfabric module the builder assembles — the emitted pattern keeps `[TESTS]` as a computed key, so it materializes as the `$TESTS` property only if `TESTS` resolves to `"$TESTS"` at run time — and re-export it through `@commonfabric/runner`. The single-user runner and the multi-user participant worker both read the reserved key instead of `"tests"`.

Rename the usages: every test pattern and cli test fixture moves its `tests:` return key to `[TESTS]:` and imports `TESTS`, and the two auth-manager test output interfaces rename their `tests` field to `[TESTS]` to match.

This is the rename alone. The `[TESTS]` array is not typed against `TestStep`, assertions are not narrowed to the assert record, and nothing else changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

