### PR TITLE
refactor(tasks): collapse the baseline-run diagnostics into one logger

### DIFF
--- a/tasks/coverage-check.test.ts
+++ b/tasks/coverage-check.test.ts
@@ -25,22 +25,16 @@ import {
   fetchAncestorRanks,
   fetchArtifactsForRunBestEffort,
   fetchBaselineRunsForCheck,
-  fetchCommitsBehindMain,
   fetchGroupsChangedOnBase,
   fetchLatestBaselineRunSha,
   fetchMainHeadSha,
   fetchPRForCommitWithError,
-  formatBaselineSourceRunAge,
-  formatCommitDistance,
   formatCompileCacheStates,
   formatErrorForLog,
   formatMetricDelta,
   formatMetricValueForTable,
-  formatRelativeAge,
-  formatRelativeDuration,
   githubApiOrSkip,
   isComparableBaseline,
-  logBaselineSourceRuns,
   main,
   metricTableRows,
   newestArtifactNamed,
@@ -52,12 +46,10 @@ import {
   reportBaselineContextResults,
   reportBaselineDistance,
   reportBaselineRunAvailability,
-  reportPRLookupResults,
   reportUngatedGroups,
   type Row,
   selectBaselines,
   selectMergedPRForCommit,
-  summarizeBaselinePRLookups,
   validateBaselineRunsForMainHead,
   walkBaselineRuns,
   workflowRunsPathForBaseline,
@@ -659,97 +651,6 @@ Deno.test("fetchBaselineRunsForCheck fetches main head and baseline runs", async
   assertStringIncludes(logs.join("\n"), "Current main head");
 });
 
-Deno.test("relative duration formatting uses two readable parts", () => {
-  assertEquals(formatRelativeDuration(45), "45 seconds");
-  assertEquals(formatRelativeDuration(65), "1 minute 5 seconds");
-  assertEquals(
-    formatRelativeDuration(2 * 60 * 60 + 3 * 60 + 4),
-    "2 hours 3 minutes",
-  );
-  assertEquals(
-    formatRelativeDuration(3 * 24 * 60 * 60 + 2 * 60 * 60),
-    "3 days 2 hours",
-  );
-  assertEquals(formatRelativeDuration(Number.NaN), "unknown");
-});
-
-Deno.test("relative age formatting compares two timestamps", () => {
-  assertEquals(
-    formatRelativeAge(
-      "2026-06-18T10:00:00Z",
-      "2026-06-18T12:03:04Z",
-    ),
-    "2 hours 3 minutes",
-  );
-  assertEquals(
-    formatRelativeAge("not a date", "2026-06-18T12:03:04Z"),
-    "unknown",
-  );
-});
-
-Deno.test("commit distance formatting handles known and unknown values", () => {
-  assertEquals(formatCommitDistance(0), "0 commits");
-  assertEquals(formatCommitDistance(1), "1 commit");
-  assertEquals(formatCommitDistance(12), "12 commits");
-  assertEquals(formatCommitDistance(null), "an unknown number of commits");
-});
-
-Deno.test("baseline source run age combines time and commit distance", () => {
-  assertEquals(
-    formatBaselineSourceRunAge(
-      "2026-06-18T10:00:00Z",
-      "2026-06-18T12:03:04Z",
-      7,
-    ),
-    "created 2 hours 3 minutes ago; 7 commits behind current main",
-  );
-  assertEquals(
-    formatBaselineSourceRunAge("not a date", "2026-06-18T12:03:04Z", null),
-    "age unknown; an unknown number of commits behind current main",
-  );
-});
-
-Deno.test("fetchCommitsBehindMain reports zero for the current main commit", async () => {
-  assertEquals(await fetchCommitsBehindMain(SHA_A, SHA_A), 0);
-});
-
-Deno.test("fetchCommitsBehindMain reads GitHub compare distance", async () => {
-  const result = await withMockFetch(
-    (input) => {
-      assertStringIncludes(String(input), `/compare/${SHA_A}...${SHA_B}`);
-      return new Response(JSON.stringify({ ahead_by: 3 }));
-    },
-    () => fetchCommitsBehindMain(SHA_A, SHA_B),
-  );
-
-  assertEquals(result, 3);
-});
-
-Deno.test("fetchCommitsBehindMain treats malformed compare data as unknown", async () => {
-  const result = await withMockFetch(
-    () => new Response(JSON.stringify({ ahead_by: "3" })),
-    () => fetchCommitsBehindMain(SHA_A, SHA_B),
-  );
-
-  assertEquals(result, null);
-});
-
-Deno.test("fetchCommitsBehindMain warns and continues after compare failure", async () => {
-  const captured = await captureConsoleAsync(() =>
-    withMockFetch(
-      () => new Response("missing", { status: 404 }),
-      () => fetchCommitsBehindMain(SHA_A, SHA_B),
-    )
-  );
-
-  assertEquals(captured.result, null);
-  assertStringIncludes(
-    captured.warnings.join("\n"),
-    "could not compare baseline",
-  );
-  assertStringIncludes(captured.warnings.join("\n"), SHA_A.slice(0, 8));
-});
-
 Deno.test("fetchPRForCommitWithError returns selected PR metadata", async () => {
   const pr = makePR(42, "2026-06-18T00:00:00Z");
   const result = await withMockFetch(
@@ -908,7 +809,7 @@ Deno.test("currentWorkflowRunFromEvent reads event and environment metadata", ()
   }
 });
 
-Deno.test("logBaselineSourceRuns prints age, PR, lookup, and artifact details", () => {
+Deno.test("reportBaselineContextResults lists each run's PR and artifact", () => {
   const contexts: BaselineRunContext[] = [
     {
       run: makeRun(1, SHA_A, "2026-06-18T10:00:00Z"),
@@ -919,94 +820,56 @@ Deno.test("logBaselineSourceRuns prints age, PR, lookup, and artifact details", 
       ],
       pr: makePR(10, "2026-06-18T00:00:00Z"),
       prLookupError: null,
-      commitsBehindMain: 0,
     },
     {
       run: makeRun(2, SHA_B, "2026-06-18T11:00:00Z"),
       artifacts: [],
       pr: null,
-      prLookupError: new Error("lookup failed\nsecond line"),
-      commitsBehindMain: null,
-    },
-    {
-      run: makeRun(3, SHA_C, "2026-06-18T11:30:00Z"),
-      artifacts: [],
-      pr: null,
       prLookupError: null,
-      commitsBehindMain: 5,
     },
   ];
 
-  const captured = captureConsole(() =>
-    logBaselineSourceRuns(contexts, "2026-06-18T12:00:00Z")
-  );
+  const captured = captureConsole(() => reportBaselineContextResults(contexts));
   const output = captured.logs.join("\n");
 
   assertStringIncludes(output, "Baseline source runs:");
   assertStringIncludes(
     output,
-    "created 2 hours ago; 0 commits behind current main",
+    `2026-06-18T10:00:00Z run 1 ${
+      SHA_A.slice(0, 8)
+    } PR #10; perf-metrics artifact 2`,
   );
-  assertStringIncludes(output, "PR #10");
-  assertStringIncludes(output, "perf-metrics artifact 2");
-  assertStringIncludes(output, "PR lookup failed");
   assertStringIncludes(
     output,
-    "an unknown number of commits behind current main",
+    `2026-06-18T11:00:00Z run 2 ${
+      SHA_B.slice(0, 8)
+    } no PR found; no perf-metrics artifact`,
   );
-  assertStringIncludes(output, "no PR found");
-  assertStringIncludes(output, "no perf-metrics artifact");
+  assertEquals(captured.warnings, []);
 });
 
-Deno.test("reportPRLookupResults logs clean and failed lookup summaries", () => {
-  const clean = captureConsole(() =>
-    reportPRLookupResults([
-      {
-        run: makeRun(1),
-        artifacts: [],
-        pr: makePR(1),
-        prLookupError: null,
-        commitsBehindMain: 0,
-      },
-    ])
-  );
-  assertEquals(clean.result, 0);
-  assertStringIncludes(clean.logs.join("\n"), "0 failed");
+Deno.test("reportBaselineContextResults names each failed PR lookup", () => {
+  const contexts: BaselineRunContext[] = [
+    {
+      run: makeRun(1, SHA_A),
+      artifacts: [],
+      pr: makePR(10, "2026-06-18T00:00:00Z"),
+      prLookupError: null,
+    },
+    {
+      run: makeRun(2, SHA_B),
+      artifacts: [],
+      pr: null,
+      prLookupError: new Error("lookup failed\nsecond line"),
+    },
+  ];
 
-  const failed = captureConsole(() =>
-    reportPRLookupResults([
-      {
-        run: makeRun(2, SHA_B),
-        artifacts: [],
-        pr: null,
-        prLookupError: new Error("boom\nsecond line"),
-        commitsBehindMain: null,
-      },
-    ])
-  );
-  assertEquals(failed.result, 1);
-  assertStringIncludes(
-    failed.warnings.join("\n"),
-    "failed to fetch PR metadata",
-  );
-  assertStringIncludes(failed.warnings.join("\n"), "boom");
-});
+  const captured = captureConsole(() => reportBaselineContextResults(contexts));
 
-Deno.test("reportBaselineContextResults logs incomplete PR metadata warning", () => {
-  const context: BaselineRunContext = {
-    run: makeRun(1),
-    artifacts: [],
-    pr: null,
-    prLookupError: new Error("lookup failed"),
-    commitsBehindMain: null,
-  };
-
-  const captured = captureConsole(() =>
-    reportBaselineContextResults([context], "2026-06-18T12:00:00Z")
-  );
-
-  assertEquals(captured.result, 1);
-  assertStringIncludes(captured.warnings.join("\n"), "incomplete PR metadata");
+  assertStringIncludes(captured.logs.join("\n"), "PR lookup failed;");
+  assertEquals(captured.warnings, [
+    `  Warning: run 2 (${SHA_B.slice(0, 8)}) PR lookup failed: lookup failed`,
+  ]);
 });
 
 Deno.test("baseline main validation reports stale newest run", () => {
@@ -1134,14 +997,13 @@ Deno.test("fetchArtifactsForRunBestEffort returns artifacts or an empty fallback
   assertStringIncludes(warnings.join("\n"), "artifact API failed");
 });
 
-Deno.test("buildBaselineRunContext collects artifacts, PRs, and commit distance", async () => {
+Deno.test("buildBaselineRunContext collects artifacts and PRs", async () => {
   const run = makeRun(11, SHA_A);
   const artifact = makeArtifact(5, PERF_METRICS_ARTIFACT_NAME);
   const pr = makePR(11, "2026-06-18T00:00:00Z");
 
   const context = await buildBaselineRunContext({
     run,
-    mainHeadSha: SHA_B,
     fetchArtifactsForRun: (requestedRun) => {
       assertEquals(requestedRun, run);
       return Promise.resolve([artifact]);
@@ -1150,11 +1012,6 @@ Deno.test("buildBaselineRunContext collects artifacts, PRs, and commit distance"
       assertEquals(sha, SHA_A);
       return Promise.resolve({ pr, error: null });
     },
-    fetchCommitsBehindMain: (baselineSha, mainHeadSha) => {
-      assertEquals(baselineSha, SHA_A);
-      assertEquals(mainHeadSha, SHA_B);
-      return Promise.resolve(4);
-    },
   });
 
   assertEquals(context, {
@@ -1162,7 +1019,6 @@ Deno.test("buildBaselineRunContext collects artifacts, PRs, and commit distance"
     artifacts: [artifact],
     pr,
     prLookupError: null,
-    commitsBehindMain: 4,
   });
 });
 
@@ -1424,19 +1280,6 @@ Deno.test("selectMergedPRForCommit falls back to the first PR", () => {
 
   assertEquals(selectMergedPRForCommit(prs)?.number, 1);
   assertEquals(selectMergedPRForCommit([]), null);
-});
-
-Deno.test("baseline PR lookup summary counts found, missing, and failed lookups", () => {
-  const pr = { number: 1, merged_at: "2026-06-18T00:00:00Z" } as PRInfo;
-
-  assertEquals(
-    summarizeBaselinePRLookups([
-      { pr, prLookupError: null },
-      { pr: null, prLookupError: null },
-      { pr: null, prLookupError: new Error("boom") },
-    ]),
-    { found: 1, noPR: 1, failed: 1 },
-  );
 });
 
 Deno.test("readBaseBranchSha reads the first parent of a merge checkout", async () => {

--- a/tasks/coverage-check.ts
+++ b/tasks/coverage-check.ts
@@ -218,60 +218,6 @@ function pluralize(value: number, unit: string): string {
   return `${value} ${unit}${value === 1 ? "" : "s"}`;
 }
 
-export function formatRelativeDuration(seconds: number): string {
-  if (!Number.isFinite(seconds)) return "unknown";
-
-  let remaining = Math.max(0, Math.floor(seconds));
-  const parts: string[] = [];
-  const units = [
-    { seconds: 24 * 60 * 60, unit: "day" },
-    { seconds: 60 * 60, unit: "hour" },
-    { seconds: 60, unit: "minute" },
-    { seconds: 1, unit: "second" },
-  ];
-
-  for (const unit of units) {
-    const value = Math.floor(remaining / unit.seconds);
-    if (value > 0) {
-      parts.push(pluralize(value, unit.unit));
-      remaining -= value * unit.seconds;
-    }
-    if (parts.length === 2) break;
-  }
-
-  return parts.length > 0 ? parts.join(" ") : "0 seconds";
-}
-
-export function formatRelativeAge(fromIso: string, toIso: string): string {
-  const fromMs = Date.parse(fromIso);
-  const toMs = Date.parse(toIso);
-  if (!Number.isFinite(fromMs) || !Number.isFinite(toMs)) return "unknown";
-
-  return formatRelativeDuration((toMs - fromMs) / 1_000);
-}
-
-export function formatCommitDistance(commitsBehindMain: number | null): string {
-  return commitsBehindMain === null
-    ? "an unknown number of commits"
-    : pluralize(commitsBehindMain, "commit");
-}
-
-export function formatBaselineSourceRunAge(
-  runCreatedAt: string,
-  currentCreatedAt: string,
-  commitsBehindMain: number | null,
-): string {
-  const age = formatRelativeAge(runCreatedAt, currentCreatedAt);
-  const timePart = age === "unknown" ? "age unknown" : `created ${age} ago`;
-  return `${timePart}; ${
-    formatCommitDistance(commitsBehindMain)
-  } behind current main`;
-}
-
-interface GitHubCompareResponse {
-  ahead_by?: unknown;
-}
-
 export async function readHeadCommitObject(
   cwd?: string,
 ): Promise<string | null> {
@@ -713,30 +659,6 @@ export function reportBaselineDistance(
   }
 }
 
-export async function fetchCommitsBehindMain(
-  baselineSha: string,
-  mainHeadSha: string,
-): Promise<number | null> {
-  if (baselineSha === mainHeadSha) return 0;
-
-  try {
-    const comparison = await githubGet<GitHubCompareResponse>(
-      `/repos/${REPO}/compare/${encodeURIComponent(baselineSha)}...${
-        encodeURIComponent(mainHeadSha)
-      }`,
-    );
-    return typeof comparison.ahead_by === "number" ? comparison.ahead_by : null;
-  } catch (error) {
-    console.warn(
-      `  Warning: could not compare baseline ${baselineSha.slice(0, 8)} ` +
-        `to current main ${mainHeadSha.slice(0, 8)}: ${
-          formatErrorForLog(error)
-        }`,
-    );
-    return null;
-  }
-}
-
 export function selectMergedPRForCommit(prs: PRInfo[]): PRInfo | null {
   return prs.find((pr) => pr.merged_at !== null) ?? prs[0] ?? null;
 }
@@ -751,7 +673,6 @@ export interface BaselineRunContext {
   artifacts: Artifact[];
   pr: PRInfo | null;
   prLookupError: unknown | null;
-  commitsBehindMain: number | null;
 }
 
 export async function fetchPRForCommitWithError(
@@ -779,84 +700,6 @@ export function newestArtifactNamed(
 export function formatErrorForLog(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
   return message.split("\n")[0];
-}
-
-export function logBaselineSourceRuns(
-  contexts: BaselineRunContext[],
-  currentRunCreatedAt: string,
-): void {
-  console.log("\n::group::Baseline source runs:\n");
-  for (
-    const { run, artifacts, pr, prLookupError, commitsBehindMain } of contexts
-  ) {
-    const baselineArtifact = newestArtifactNamed(
-      artifacts,
-      PERF_METRICS_ARTIFACT_NAME,
-    );
-    const prLabel = pr
-      ? `PR #${pr.number}`
-      : prLookupError
-      ? "PR lookup failed"
-      : "no PR found";
-    const artifactLabel = baselineArtifact
-      ? `perf-metrics artifact ${baselineArtifact.id}`
-      : "no perf-metrics artifact";
-    const ageLabel = formatBaselineSourceRunAge(
-      run.created_at,
-      currentRunCreatedAt,
-      commitsBehindMain,
-    );
-    console.log(
-      `  ${run.created_at} run ${run.id} ${run.head_sha.slice(0, 8)} ` +
-        `${ageLabel}; ${prLabel}; ${artifactLabel}`,
-    );
-  }
-  console.log("\n::endgroup::\n");
-}
-
-export interface BaselinePRLookupSummary {
-  found: number;
-  noPR: number;
-  failed: number;
-}
-
-export function summarizeBaselinePRLookups(
-  contexts: { pr: PRInfo | null; prLookupError: unknown | null }[],
-): BaselinePRLookupSummary {
-  const failed = contexts.filter((context) => context.prLookupError).length;
-  const found = contexts.filter((context) => context.pr).length;
-  return {
-    found,
-    noPR: contexts.length - found - failed,
-    failed,
-  };
-}
-
-export function reportPRLookupResults(
-  contexts: BaselineRunContext[],
-): number {
-  const summary = summarizeBaselinePRLookups(contexts);
-  const failures = contexts.filter((context) => context.prLookupError);
-
-  console.log(
-    `Baseline PR lookup: found ${summary.found}/${contexts.length}; ` +
-      `${summary.noPR} had no associated PR; ${summary.failed} failed.`,
-  );
-
-  if (summary.failed === 0) return 0;
-
-  console.warn(
-    `  Warning: failed to fetch PR metadata for ${summary.failed} baseline run(s).`,
-  );
-  for (const { run, prLookupError } of failures) {
-    console.warn(
-      `  Warning: run ${run.id} (${
-        run.head_sha.slice(0, 8)
-      }) PR lookup failed: ${formatErrorForLog(prLookupError)}`,
-    );
-  }
-
-  return summary.failed;
 }
 
 export async function fetchArtifactsForRunBestEffort(
@@ -925,13 +768,8 @@ export function reportBaselineRunAvailability(
 
 export interface BuildBaselineRunContextOptions {
   run: WorkflowRun;
-  mainHeadSha: string;
   fetchArtifactsForRun?: (run: WorkflowRun) => Promise<Artifact[]>;
   fetchPRForCommit?: (sha: string) => Promise<PRLookupResult>;
-  fetchCommitsBehindMain?: (
-    baselineSha: string,
-    mainHeadSha: string,
-  ) => Promise<number | null>;
 }
 
 /** Reads everything one baseline run contributes: its artifacts and its PR. */
@@ -941,35 +779,59 @@ export async function buildBaselineRunContext(
   const fetchArtifacts = options.fetchArtifactsForRun ??
     fetchArtifactsForRunBestEffort;
   const fetchPR = options.fetchPRForCommit ?? fetchPRForCommitWithError;
-  const fetchCommitDistance = options.fetchCommitsBehindMain ??
-    fetchCommitsBehindMain;
 
-  const [artifacts, prLookup, commitsBehindMain] = await Promise.all([
+  const [artifacts, prLookup] = await Promise.all([
     fetchArtifacts(options.run),
     fetchPR(options.run.head_sha),
-    fetchCommitDistance(options.run.head_sha, options.mainHeadSha),
   ]);
   return {
     run: options.run,
     artifacts,
     pr: prLookup.pr,
     prLookupError: prLookup.error,
-    commitsBehindMain,
   };
 }
 
+/**
+ * Logs one line per baseline run: when it ran, the commit it measured, the
+ * pull request that merged that commit, and whether it carries a perf-metrics
+ * artifact. Names each run whose pull-request lookup failed a second time
+ * after the group, with the error.
+ */
 export function reportBaselineContextResults(
   contexts: BaselineRunContext[],
-  currentRunCreatedAt: string,
-): number {
-  logBaselineSourceRuns(contexts, currentRunCreatedAt);
-  const prLookupFailures = reportPRLookupResults(contexts);
-  if (prLookupFailures > 0) {
-    console.warn(
-      "  Warning: running the coverage check with incomplete PR metadata. Some merged baseline overrides may be missing.",
+): void {
+  console.log("\n::group::Baseline source runs:\n");
+  for (const { run, artifacts, pr, prLookupError } of contexts) {
+    const baselineArtifact = newestArtifactNamed(
+      artifacts,
+      PERF_METRICS_ARTIFACT_NAME,
+    );
+    const prLabel = pr
+      ? `PR #${pr.number}`
+      : prLookupError
+      ? "PR lookup failed"
+      : "no PR found";
+    const artifactLabel = baselineArtifact
+      ? `perf-metrics artifact ${baselineArtifact.id}`
+      : "no perf-metrics artifact";
+    console.log(
+      `  ${run.created_at} run ${run.id} ${run.head_sha.slice(0, 8)} ` +
+        `${prLabel}; ${artifactLabel}`,
     );
   }
-  return prLookupFailures;
+  console.log("\n::endgroup::\n");
+
+  // The gate reads accepted coverage debt out of the merged pull request body,
+  // so a run whose lookup failed contributes no overrides.
+  for (const { run, prLookupError } of contexts) {
+    if (!prLookupError) continue;
+    console.warn(
+      `  Warning: run ${run.id} (${
+        run.head_sha.slice(0, 8)
+      }) PR lookup failed: ${formatErrorForLog(prLookupError)}`,
+    );
+  }
 }
 
 export async function parseCoverageBaselineFromArtifacts(
@@ -1868,7 +1730,7 @@ export async function main() {
 
   const readBaselineRun = (run: WorkflowRun): Promise<BaselineRunReading> =>
     githubApiOrSkip("reading a baseline run", async () => {
-      const context = await buildBaselineRunContext({ run, mainHeadSha });
+      const context = await buildBaselineRunContext({ run });
       visitedContexts.push(context);
 
       const baseline = await parseCoverageBaselineFromArtifacts(
@@ -1917,9 +1779,7 @@ export async function main() {
     isPullRequest: prNumber !== null,
     guard: (description, operation) =>
       githubApiOrSkip(description, operation, currentMetrics),
-  }).finally(() =>
-    reportBaselineContextResults(visitedContexts, currentRunInfo.created_at)
-  );
+  }).finally(() => reportBaselineContextResults(visitedContexts));
 
   if (acceptingRuns > 0) {
     console.log(


### PR DESCRIPTION
The coverage gate lists the `main` runs it read its ratchet baseline from, inside a collapsed `::group::` block in the CI log. Producing that listing had grown into a subsystem of its own: ten exported symbols, an extra GitHub API request per baseline run, and around two hundred lines of tests, all for text nothing reads back.

Each line of the listing carried a clause saying how far behind current `main` the run's commit was. Getting that number meant a call to the GitHub compare API for every run the baseline walk reached, issued alongside the artifact and pull-request lookups the gate genuinely needs, and counting against the same rate limit that makes the gate skip itself when it runs out. Rendering the number, together with the run's age, went through four chained formatting functions with their own unit table and pluralization helper.

The reporting itself was three layers deep. One function printed the grouped listing, a second counted the pull-request lookups into a summary record and printed a tally of how many found a pull request plus an aggregate warning, and a third called both and appended a further warning saying the tally was non-zero. The gate discards the count all three cooperate to produce.

Replace the whole stack with a single function that prints one line per run — timestamp, run id, short commit, pull request or lookup outcome, and whether the run has a perf-metrics artifact — and then names each failed lookup with its error after the group closes. The per-run failure notice stays because the gate reads accepted coverage debt out of the merged pull request body: a lookup that failed silently drops that run's overrides, and that warning is what explains an override that did not apply. The aggregate tally and the two warnings derived from it say nothing the per-run lines do not.

The commit distance is gone entirely, along with the compare request that fetched it and the formatting stack that rendered it. Reading one baseline run's context therefore no longer needs `main`'s head commit, which reached it only to be compared against. The run timestamp already sits at the front of every line, so a reader can see how old a baseline is without a computed age.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

